### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Rust CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/jlucaso1/whatsapp-rust/security/code-scanning/3](https://github.com/jlucaso1/whatsapp-rust/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or at the job level (for more granular control). Since none of the jobs require write access, the minimal required permission is `contents: read`. The best way to fix this is to add the following block after the `name` field and before the `on` field in `.github/workflows/main.yml`:

```yaml
permissions:
  contents: read
```

This ensures that the `GITHUB_TOKEN` used by all jobs in this workflow will only have read access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
