### PR TITLE
feat: fetch and store whatsapp version

### DIFF
--- a/migrations/2025-08-14-035031_initial/up.sql
+++ b/migrations/2025-08-14-035031_initial/up.sql
@@ -48,7 +48,11 @@ CREATE TABLE device (
     signed_pre_key_signature BLOB NOT NULL,
     adv_secret_key BLOB NOT NULL,
     account BLOB,
-    push_name TEXT NOT NULL DEFAULT ''
+    push_name TEXT NOT NULL DEFAULT '',
+    app_version_primary INTEGER NOT NULL DEFAULT 0,
+    app_version_secondary INTEGER NOT NULL DEFAULT 0,
+    app_version_tertiary BIGINT NOT NULL DEFAULT 0,
+    app_version_last_fetched_ms BIGINT NOT NULL DEFAULT 0
 );
 
 CREATE TABLE signed_prekeys (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,4 @@ pub mod usync;
 
 pub mod bot;
 pub mod sync_task;
+pub mod version;

--- a/src/store/schema.rs
+++ b/src/store/schema.rs
@@ -36,6 +36,10 @@ diesel::table! {
         adv_secret_key -> Binary,
         account -> Nullable<Binary>,
         push_name -> Text,
+        app_version_primary -> Integer,
+        app_version_secondary -> Integer,
+        app_version_tertiary -> BigInt,
+        app_version_last_fetched_ms -> BigInt,
     }
 }
 

--- a/src/store/sqlite_store.rs
+++ b/src/store/sqlite_store.rs
@@ -142,6 +142,10 @@ impl SqliteStore {
                 device::adv_secret_key.eq(&device_data.adv_secret_key[..]),
                 device::account.eq(account_data.clone()),
                 device::push_name.eq(&device_data.push_name),
+                device::app_version_primary.eq(device_data.app_version_primary as i32),
+                device::app_version_secondary.eq(device_data.app_version_secondary as i32),
+                device::app_version_tertiary.eq(device_data.app_version_tertiary as i64),
+                device::app_version_last_fetched_ms.eq(device_data.app_version_last_fetched_ms),
             ))
             .on_conflict(device::lid)
             .do_update()
@@ -165,6 +169,10 @@ impl SqliteStore {
                 device::adv_secret_key.eq(&device_data.adv_secret_key[..]),
                 device::account.eq(account_data.clone()),
                 device::push_name.eq(&device_data.push_name),
+                device::app_version_primary.eq(device_data.app_version_primary as i32),
+                device::app_version_secondary.eq(device_data.app_version_secondary as i32),
+                device::app_version_tertiary.eq(device_data.app_version_tertiary as i64),
+                device::app_version_last_fetched_ms.eq(device_data.app_version_last_fetched_ms),
             ))
             .execute(&mut conn)
             .map_err(|e| StoreError::Database(e.to_string()))?;
@@ -188,6 +196,10 @@ impl SqliteStore {
                 Vec<u8>,
                 Option<Vec<u8>>,
                 String,
+                i32,
+                i32,
+                i64,
+                i64,
             )>(&mut conn)
             .optional()
             .map_err(|e| StoreError::Database(e.to_string()))?;
@@ -204,6 +216,10 @@ impl SqliteStore {
             adv_secret_key_data,
             account_data,
             push_name,
+            app_version_primary,
+            app_version_secondary,
+            app_version_tertiary,
+            app_version_last_fetched_ms,
         )) = result
         {
             let id = if !pn_str.is_empty() {
@@ -261,6 +277,10 @@ impl SqliteStore {
                 adv_secret_key,
                 account,
                 push_name,
+                app_version_primary: app_version_primary as u32,
+                app_version_secondary: app_version_secondary as u32,
+                app_version_tertiary: app_version_tertiary.try_into().unwrap_or(0u32),
+                app_version_last_fetched_ms,
             }))
         } else {
             Ok(None)

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,153 @@
+use crate::store::commands::DeviceCommand;
+use crate::store::persistence_manager::PersistenceManager;
+use anyhow::{Result, anyhow};
+use log::{info, warn};
+use std::io::Read;
+use std::sync::Arc;
+
+const SW_URL: &str = "https://web.whatsapp.com/sw.js";
+const REVISION_KEY: &str = "client_revision";
+const ASSETS_KEY: &str = "assets-manifest-";
+
+pub fn fetch_latest_app_version() -> Result<(u32, u32, u32)> {
+    let resp = ureq::get(SW_URL)
+        .call()
+        .map_err(|e| anyhow!("HTTP request to {} failed: {}", SW_URL, e))?;
+
+    let mut body = resp.into_body();
+    let mut reader = body.as_reader();
+
+    let mut body_str = String::new();
+    reader
+        .read_to_string(&mut body_str)
+        .map_err(|e| anyhow!("Failed to read response body: {}", e))?;
+
+    parse_sw_js(&body_str)
+        .ok_or_else(|| anyhow!("Could not find 'client_revision' version in sw.js response"))
+}
+
+fn parse_sw_js(s: &str) -> Option<(u32, u32, u32)> {
+    if let Some(start_index) = s.find(REVISION_KEY) {
+        let suffix = &s[start_index + REVISION_KEY.len()..];
+
+        if let Some(first_digit_index) = suffix.find(|c: char| c.is_ascii_digit()) {
+            let number_slice = &suffix[first_digit_index..];
+
+            let end_of_number_index = number_slice
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(number_slice.len());
+
+            let version_str = &number_slice[..end_of_number_index];
+
+            if let Ok(revision) = version_str.parse::<u32>() {
+                return Some((2, 3000, revision));
+            }
+        }
+    }
+
+    if let Some(start_index) = s.find(ASSETS_KEY) {
+        let suffix = &s[start_index + ASSETS_KEY.len()..];
+        if let Some(end_index) = suffix.find(|c: char| !c.is_ascii_digit()) {
+            let version_str = &suffix[..end_index];
+            if !s.contains(&format!("wa{}.canary", version_str)) {
+                return Some((2, 3000, 0));
+            }
+        }
+    }
+
+    None
+}
+
+pub async fn resolve_and_update_version(
+    persistence_manager: &Arc<PersistenceManager>,
+    override_version: Option<(u32, u32, u32)>,
+) {
+    if let Some((p, s, t)) = override_version {
+        info!("Using user-provided override version: {}.{}.{}", p, s, t);
+        persistence_manager
+            .process_command(DeviceCommand::SetAppVersion((p, s, t)))
+            .await;
+        return;
+    }
+
+    let device = persistence_manager.get_device_snapshot().await;
+    let last_fetched_ms = device.app_version_last_fetched_ms;
+
+    let needs_fetch = if last_fetched_ms == 0 {
+        true
+    } else {
+        match chrono::DateTime::from_timestamp_millis(last_fetched_ms) {
+            Some(last_fetched_dt) => {
+                chrono::Utc::now().signed_duration_since(last_fetched_dt)
+                    > chrono::Duration::hours(24)
+            }
+            None => true,
+        }
+    };
+
+    if needs_fetch {
+        info!("WhatsApp version is stale or missing, fetching latest...");
+        match tokio::task::spawn_blocking(fetch_latest_app_version).await {
+            Ok(Ok((p, s, t))) => {
+                info!("Fetched latest version: {}.{}.{}", p, s, t);
+                persistence_manager
+                    .process_command(DeviceCommand::SetAppVersion((p, s, t)))
+                    .await;
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    "Failed to fetch latest version, using cached/default: {}",
+                    e
+                );
+            }
+            Err(e) => {
+                warn!("Version fetch task panicked: {}", e);
+            }
+        }
+    } else {
+        info!(
+            "Using cached version: {}.{}.{}",
+            device.app_version_primary, device.app_version_secondary, device.app_version_tertiary
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sw_js_client_revision_quoted() {
+        let s = r#"var x = {"client_revision": "123456"};"#;
+        assert_eq!(parse_sw_js(s), Some((2, 3000, 123456)));
+    }
+
+    #[test]
+    fn test_parse_sw_js_client_revision_unquoted() {
+        let s = r#"client_revision:12345;"#;
+        assert_eq!(parse_sw_js(s), Some((2, 3000, 12345)));
+    }
+
+    #[test]
+    fn test_parse_sw_js_assets_fallback() {
+        let s = "... assets-manifest-98765 ...";
+        assert_eq!(parse_sw_js(s), Some((2, 3000, 0)));
+    }
+
+    #[test]
+    fn test_parse_sw_js_realistic_sw_js() {
+        let s = r#"__DEV__=0;/*FB_PKG_DELIM*/
+self.__swData=JSON.parse(/*BTDS*/"{\"dynamic_data\":{\"dynamic_modules\":{\"cr:375\":{\"__rc\":[\"WAWebFtsLightClient\",null]},\"cr:1126\":{\"__rc\":[\"TimeSliceSham\",null]},\"cr:4122\":{\"__rc\":[null,null]},\"cr:4324\":{\"__rc\":[null,null]},\"cr:4533\":{\"__rc\":[null,null]},\"cr:4722\":{\"__rc\":[null,null]},\"cr:4941\":{\"__rc\":[null,null]},\"cr:5151\":{\"__rc\":[null,null]},\"cr:5292\":{\"__rc\":[null,null]},\"cr:5411\":{\"__rc\":[null,null]},\"cr:5664\":{\"__rc\":[null,null]},\"cr:6640\":{\"__rc\":[null,null]},\"cr:8978\":{\"__rc\":[null,null]},\"cr:9565\":{\"__rc\":[null,null]},\"cr:10197\":{\"__rc\":[null,null]},\"cr:10198\":{\"__rc\":[null,null]},\"cr:17160\":{\"__rc\":[null,null]},\"cr:17219\":{\"__rc\":[null,null]},\"cr:21223\":{\"__rc\":[null,null]},\"IntlCurrentLocale\":{\"code\":\"en_US\"},\"WAWebSwResources\":{\"wa_default_notification_icon\":\"https:\\\/\\\/static.whatsapp.net\\\/rsrc.php\\\/v4\\\/yX\\\/r\\\/JYPizEwERE4.png\"},\"SiteData\":{\"server_revision\":1026131876,\"client_revision\":1026131876,\"push_phase\":\"C3\",\"pkg_cohort\":\"BP:DEFAULT\",\"haste_session\":\"20320.BP:DEFAULT.2.0...0\",\"pr\":1,\"manifest_base_uri\":\"https:\\\/\\\/static.whatsapp.net\",\"manifest_origin\":null,\"manifest_version_prefix\":null,\"be_one_ahead\":false,\"is_rtl\":false,\"is_experimental_tier\":false,\"is_jit_warmed_up\":true,\"hsi\":\"7540800780599698108\",\"semr_host_bucket\":\"3\",\"bl_hash_version\":2,\"comet_env\":0,\"wbloks_env\":false,\"ef_page\":null,\"compose_bootloads\":false,\"spin\":4,\"__spin_r\":1026131876,\"__spin_b\":\"trunk\",\"__spin_t\":1755729499,\"vip\":\"2a03:2880:f205:c5:face:b00c:0:167\"}},\"hsdp\":{\"bxData\":{\"32186\":{\"uri\":\"https:\\\/\\\/static.whatsapp.net\\\/rsrc.php\\\/v4\\\/yR\\\/r\\\/aCneqBxOSs-.png\"},\"32187\":{\"uri\":\"https:\\\/\\\/static.whatsapp.net\\\/rsrc.php\\\/v4\\\/yT\\\/r\\\/s0hoT-Vu8xP.png\"}},\"gkxData\":{\"4112\":{\"result\":false,\"hash\":null},\"5943\":{\"result\":false,\"hash\":null},\"7685\":{\"result\":false,\"hash\":null},\"10314\":{\"result\":false,\"hash\":null},\"16915\":{\"result\":false,\"hash\":null},\"16928\":{\"result\":false,\"hash\":null},\"17038\":{\"result\":false,\"hash\":null},\"26256\":{\"result\":false,\"hash\":null},\"26258\":{\"result\":true,\"hash\":null},\"26259\":{\"result\":false,\"hash\":null}},\"justknobxData\":{\"371\":{\"r\":true},\"1050\":{\"r\":false},\"1617\":{\"r\":165},\"1618\":{\"r\":8},\"1619\":{\"r\":1},\"1620\":{\"r\":2},\"1621\":{\"r\":4},\"1622\":{\"r\":0},\"1623\":{\"r\":6},\"1624\":{\"r\":1},\"1662\":{\"r\":2},\"1663\":{\"r\":14},\"1664\":{\"r\":2},\"1854\":{\"r\":false},\"2237\":{\"r\":false},\"2337\":{\"r\":false},\"2517\":{\"r\":true},\"3717\":{\"r\":1},\"4952\":{\"r\":true}}}}}");
+
+      if (self.trustedTypes && self.trustedTypes.createPolicy) {
+        const escapeScriptURLPolicy = self.trustedTypes.createPolicy("workerPolicy", {
+          createScriptURL: url => url
+        });
+        importScripts(escapeScriptURLPolicy.createScriptURL("https:\/\/static.whatsapp.net\/rsrc.php\/v4\/yq\/r\/odrxy-7zVX8.js"));
+      } else {
+         importScripts("https:\/\/static.whatsapp.net\/rsrc.php\/v4\/yq\/r\/odrxy-7zVX8.js");
+      }"#;
+
+        assert_eq!(parse_sw_js(s), Some((2, 3000, 1026131876)));
+    }
+}

--- a/wacore/src/libsignal/core/mod.rs
+++ b/wacore/src/libsignal/core/mod.rs
@@ -6,13 +6,11 @@
 mod address;
 // Not exporting the members because they have overly-generic names.
 pub mod curve;
-mod version;
 
 pub use address::{
     Aci, DeviceId, Pni, ProtocolAddress, ServiceId, ServiceIdFixedWidthBinaryBytes, ServiceIdKind,
     WrongKindOfServiceIdError,
 };
-pub use version::VERSION;
 
 /// Simple wrapper that invokes a lambda.
 ///

--- a/wacore/src/libsignal/core/version.rs
+++ b/wacore/src/libsignal/core/version.rs
@@ -1,8 +1,0 @@
-//
-// Copyright 2024 Signal Messenger, LLC.
-// SPDX-License-Identifier: AGPL-3.0-only
-//
-
-// The value of this constant is updated by the script
-// and should not be manually modified
-pub const VERSION: &str = "0.74.1";

--- a/wacore/src/store/commands.rs
+++ b/wacore/src/store/commands.rs
@@ -8,6 +8,7 @@ pub enum DeviceCommand {
     SetLid(Option<Jid>),
     SetPushName(String),
     SetAccount(Option<wa::AdvSignedDeviceIdentity>),
+    SetAppVersion((u32, u32, u32)),
 }
 
 pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
@@ -23,6 +24,12 @@ pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
         }
         DeviceCommand::SetAccount(account) => {
             device.account = account;
+        }
+        DeviceCommand::SetAppVersion((p, s, t)) => {
+            device.app_version_primary = p;
+            device.app_version_secondary = s;
+            device.app_version_tertiary = t;
+            device.app_version_last_fetched_ms = chrono::Utc::now().timestamp_millis();
         }
     }
 }


### PR DESCRIPTION
This pull request introduces app version management for the WhatsApp client, allowing the app version to be stored, overridden, and periodically updated from the official source. The changes span database schema updates, Rust struct and method additions, and new logic for fetching and persisting the app version. This enables the client to stay in sync with WhatsApp's latest supported version, improving compatibility and maintainability.

**App Version Management and Persistence:**

* Added new fields to the `device` table and related Rust structs to store `app_version_primary`, `app_version_secondary`, `app_version_tertiary`, and `app_version_last_fetched_ms`, enabling tracking and updating of the WhatsApp app version in the database and in-memory device state. [[1]](diffhunk://#diff-579bed5e36c2ad8dfe4a2ff548402430dae86ae01982299386a9e0b7e2974a54L51-R55) [[2]](diffhunk://#diff-dbfa67f9a2bba2a00b5239ea4e257296c2c7ba8966b87b5234e03f619389287dR39-R42) [[3]](diffhunk://#diff-42378bea8aa06499bf4395703987b4fb5887ac1eb5d23725092fed3a1443899fR109-R112) [[4]](diffhunk://#diff-42378bea8aa06499bf4395703987b4fb5887ac1eb5d23725092fed3a1443899fR155-R158)
* Updated `SqliteStore` logic to persist and retrieve the new app version fields during device save/load operations. [[1]](diffhunk://#diff-96fcf66c320cb93b4a8717a587757e51e7b02b6c14783df07e9d881626bdc0f8R145-R148) [[2]](diffhunk://#diff-96fcf66c320cb93b4a8717a587757e51e7b02b6c14783df07e9d881626bdc0f8R172-R175) [[3]](diffhunk://#diff-96fcf66c320cb93b4a8717a587757e51e7b02b6c14783df07e9d881626bdc0f8R199-R202) [[4]](diffhunk://#diff-96fcf66c320cb93b4a8717a587757e51e7b02b6c14783df07e9d881626bdc0f8R219-R222) [[5]](diffhunk://#diff-96fcf66c320cb93b4a8717a587757e51e7b02b6c14783df07e9d881626bdc0f8R280-R283)

**App Version Override and Fetching:**

* Added support for overriding the app version via the `BotBuilder::with_app_version` method, and implemented logic to periodically fetch and update the app version from WhatsApp's web assets (`sw.js`), using the new `version` module. [[1]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5R40-R56) [[2]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5R86-L82) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R33) [[4]](diffhunk://#diff-7bb693ee02aca4d9c13232347bb4e13cfad03f9573a547515b43800096e5ce7fR1-R153)

**Device Command and Propagation:**

* Introduced the `SetAppVersion` device command and updated the command application logic to update the app version fields and timestamp. [[1]](diffhunk://#diff-258518f18149f39b5cf00a7073544f611ca859e84a69b2c2e03046d696df833dR11) [[2]](diffhunk://#diff-258518f18149f39b5cf00a7073544f611ca859e84a69b2c2e03046d696df833dR28-R33)

**Client Payload Construction:**

* Refactored client payload construction to use the stored app version, ensuring all authentication and registration requests reflect the current version. [[1]](diffhunk://#diff-42378bea8aa06499bf4395703987b4fb5887ac1eb5d23725092fed3a1443899fL51-R58) [[2]](diffhunk://#diff-42378bea8aa06499bf4395703987b4fb5887ac1eb5d23725092fed3a1443899fL78-R77) [[3]](diffhunk://#diff-42378bea8aa06499bf4395703987b4fb5887ac1eb5d23725092fed3a1443899fL167-R194)

**Codebase Cleanup:**

* Removed legacy version constant and unused imports from `wacore/src/libsignal/core/`. [[1]](diffhunk://#diff-4c937056b189fc134e5e9f21a16ac23044979cceea119c8a5823aba82218c58aL9-L15) [[2]](diffhunk://#diff-33dc60d2f094afae67df6791072e8bcffde21415820bc6902c5e052a18e067f5L1-L8)

closes: https://github.com/jlucaso1/whatsapp-rust/issues/70