### PR TITLE
feat: enable multi-threading processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ flate2 = { version = "1.1.2", default-features = false, features = ["zlib-rs"] }
 rand = "0.9"
 rand_core = "0.9"
 thiserror = "2.0.15"
-tokio = { version = "1.4.1" }
+tokio = { version = "1.47.1" }
 wacore-binary = { path = "./wacore/binary" }
 waproto = { path = "./waproto" }
 
@@ -52,7 +52,7 @@ scopeguard = "1.2"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0"
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-websockets = { version = "0.12.0", features = ["client", "rustls-webpki-roots", "rand", "ring"] }
 ureq = { version = "3.1.0", default-features = false, features = ["rustls", "json"] }
 wacore = { path = "./wacore" }

--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -508,7 +508,7 @@ mod tests {
             Ok(false)
         }
     }
-    #[async_trait(?Send)]
+    #[async_trait]
     impl wacore::libsignal::store::PreKeyStore for MockBackend {
         async fn load_prekey(
             &self,
@@ -540,7 +540,7 @@ mod tests {
             Ok(())
         }
     }
-    #[async_trait(?Send)]
+    #[async_trait]
     impl wacore::libsignal::store::SignedPreKeyStore for MockBackend {
         async fn load_signed_prekey(
             &self,

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1,9 +1,7 @@
 use crate::client::Client;
 use crate::types::events::Event;
-// ...existing code...
 use log::{info, warn};
 use std::sync::Arc;
-use tokio::task;
 use wacore_binary::{jid::SERVER_JID, node::Node};
 
 pub async fn handle_notification(client: &Arc<Client>, node: &Node) {
@@ -15,7 +13,7 @@ pub async fn handle_notification(client: &Arc<Client>, node: &Node) {
                 && from == SERVER_JID
             {
                 let client_clone = client.clone();
-                task::spawn_local(async move {
+                tokio::spawn(async move {
                     if let Err(e) = client_clone.upload_pre_keys().await {
                         warn!("Failed to upload pre-keys after notification: {:?}", e);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use chrono::Local;
 use log::{debug, error, info};
 use std::io::Cursor;
-use tokio::task;
 use wacore::download::{Downloadable, MediaType};
 use wacore::proto_helpers::MessageExt;
 use wacore::types::events::Event;
@@ -26,13 +25,12 @@ fn main() {
         })
         .init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap();
 
-    let local = task::LocalSet::new();
-    local.block_on(&rt, async {
+    rt.block_on(async {
         let mut bot = Bot::builder()
             .on_event(move |event, client| {
                 async move {

--- a/src/message.rs
+++ b/src/message.rs
@@ -236,7 +236,7 @@ impl Client {
                     );
                     let client_clone = self.clone();
                     let info_clone = info.clone();
-                    tokio::task::spawn_local(async move {
+                    tokio::spawn(async move {
                         if let Err(e) = client_clone.send_retry_receipt(&info_clone).await {
                             log::error!("Failed to send retry receipt (batch): {:?}", e);
                         }
@@ -307,7 +307,7 @@ impl Client {
                         let client_clone = self.clone();
                         let history_sync_clone = history_sync.clone();
                         let msg_id = info.id.clone();
-                        tokio::task::spawn_local(async move {
+                        tokio::spawn(async move {
                             // Enqueue history sync task to dedicated worker
                             client_clone
                                 .handle_history_sync(msg_id, history_sync_clone)

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -58,7 +58,7 @@ pub async fn handle_iq(client: &Arc<Client>, node: &Node) -> bool {
                     let codes_clone = codes.clone();
                     let client_clone = client.clone();
 
-                    tokio::task::spawn_local(async move {
+                    tokio::spawn(async move {
                         // The rotation logic is now inside the library
                         let mut is_first = true;
                         let mut stop_rx_clone = stop_rx.clone();

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -3,7 +3,6 @@ use crate::types::events::{Event, Receipt};
 use crate::types::presence::ReceiptType;
 use log::info;
 use std::sync::Arc;
-use tokio::task;
 use wacore_binary::jid::JidExt as _;
 
 impl Client {
@@ -44,7 +43,7 @@ impl Client {
         if receipt_type == ReceiptType::Retry {
             let client_clone = Arc::clone(self);
             let node_clone = node.clone();
-            task::spawn_local(async move {
+            tokio::spawn(async move {
                 if let Err(e) = client_clone
                     .handle_retry_receipt(&receipt, &node_clone)
                     .await

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -33,7 +33,7 @@ impl Client {
             pending.insert(message_id.clone());
         }
         let _guard = scopeguard::guard((self.clone(), message_id.clone()), |(client, id)| {
-            tokio::task::spawn_local(async move {
+            tokio::spawn(async move {
                 client.pending_retries.lock().await.remove(&id);
             });
         });

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -118,7 +118,7 @@ impl PersistenceManager {
 
     pub fn run_background_saver(self: Arc<Self>, interval: Duration) {
         if self.backend.is_some() {
-            tokio::task::spawn_local(async move {
+            tokio::spawn(async move {
                 loop {
                     tokio::select! {
                         _ = self.save_notify.notified() => {

--- a/src/store/signal.rs
+++ b/src/store/signal.rs
@@ -16,7 +16,7 @@ type StoreError = Box<dyn std::error::Error + Send + Sync>;
 
 macro_rules! impl_store_wrapper {
     ($wrapper_ty:ty, $read_lock:ident, $write_lock:ident) => {
-        #[async_trait(?Send)]
+        #[async_trait]
         impl IdentityKeyStore for $wrapper_ty {
             async fn get_identity_key_pair(&self) -> SignalResult<IdentityKeyPair> {
                 self.0.$read_lock().await.get_identity_key_pair().await
@@ -59,7 +59,7 @@ macro_rules! impl_store_wrapper {
             }
         }
 
-        #[async_trait(?Send)]
+        #[async_trait]
         impl PreKeyStore for $wrapper_ty {
             async fn load_prekey(
                 &self,
@@ -90,7 +90,7 @@ macro_rules! impl_store_wrapper {
             }
         }
 
-        #[async_trait(?Send)]
+        #[async_trait]
         impl SignedPreKeyStore for $wrapper_ty {
             async fn load_signed_prekey(
                 &self,
@@ -141,7 +141,7 @@ macro_rules! impl_store_wrapper {
             }
         }
 
-        #[async_trait(?Send)]
+        #[async_trait]
         impl SessionStore for $wrapper_ty {
             async fn load_session(
                 &self,
@@ -188,7 +188,7 @@ macro_rules! impl_store_wrapper {
     };
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl IdentityKeyStore for Device {
     async fn get_identity_key_pair(&self) -> SignalResult<IdentityKeyPair> {
         let private_key_bytes = self.identity_key.private_key;
@@ -267,7 +267,7 @@ impl IdentityKeyStore for Device {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl PreKeyStore for Device {
     async fn load_prekey(
         &self,
@@ -294,7 +294,7 @@ impl PreKeyStore for Device {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SignedPreKeyStore for Device {
     async fn load_signed_prekey(
         &self,
@@ -354,7 +354,7 @@ impl SignedPreKeyStore for Device {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SessionStore for Device {
     async fn load_session(&self, address: &ProtocolAddress) -> Result<SessionRecord, StoreError> {
         let address_str = address.to_string();
@@ -456,7 +456,7 @@ impl Clone for DeviceStore {
 
 impl_store_wrapper!(DeviceStore, lock, lock);
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SenderKeyStore for Device {
     async fn store_sender_key(
         &mut self,
@@ -495,7 +495,7 @@ impl SenderKeyStore for Device {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl GroupSenderKeyStore for Device {
     async fn store_sender_key(
         &mut self,

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -54,7 +54,7 @@ impl SignalProtocolStoreAdapter {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SessionStore for SessionAdapter {
     async fn load_session(
         &self,
@@ -87,7 +87,7 @@ impl SessionStore for SessionAdapter {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl IdentityKeyStore for IdentityAdapter {
     async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
         let device = self.0.device.read().await;
@@ -147,7 +147,7 @@ impl IdentityKeyStore for IdentityAdapter {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl PreKeyStore for PreKeyAdapter {
     async fn get_pre_key(&self, prekey_id: PreKeyId) -> Result<PreKeyRecord, SignalProtocolError> {
         let device = self.0.device.read().await;
@@ -176,7 +176,7 @@ impl PreKeyStore for PreKeyAdapter {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl SignedPreKeyStore for SignedPreKeyAdapter {
     async fn get_signed_pre_key(
         &self,
@@ -198,7 +198,7 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
     async fn store_sender_key(
         &mut self,
@@ -221,7 +221,7 @@ impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl GroupSenderKeyStore for SenderKeyAdapter {
     async fn store_sender_key(
         &mut self,

--- a/src/store/sqlite_store.rs
+++ b/src/store/sqlite_store.rs
@@ -19,6 +19,23 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
 type SqlitePool = Pool<ConnectionManager<SqliteConnection>>;
 type SignalStoreError = Box<dyn std::error::Error + Send + Sync>;
+type DeviceRow = (
+    String,
+    String,
+    i32,
+    Vec<u8>,
+    Vec<u8>,
+    Vec<u8>,
+    i32,
+    Vec<u8>,
+    Vec<u8>,
+    Option<Vec<u8>>,
+    String,
+    i32,
+    i32,
+    i64,
+    i64,
+);
 
 #[derive(Clone)]
 pub struct SqliteStore {
@@ -32,17 +49,20 @@ impl SqliteStore {
             .build(manager)
             .map_err(|e| StoreError::Connection(e.to_string()))?;
 
-        {
-            let mut conn = pool
+        let pool_clone = pool.clone();
+        tokio::task::spawn_blocking(move || -> std::result::Result<(), StoreError> {
+            let mut conn = pool_clone
                 .get()
                 .map_err(|e| StoreError::Connection(e.to_string()))?;
             conn.run_pending_migrations(MIGRATIONS)
                 .map_err(|e| StoreError::Migration(e.to_string()))?;
-            // Concurrency / performance pragmas
             let _ = diesel::sql_query("PRAGMA journal_mode=WAL;").execute(&mut conn);
             let _ = diesel::sql_query("PRAGMA synchronous=NORMAL;").execute(&mut conn);
             let _ = diesel::sql_query("PRAGMA busy_timeout = 15000;").execute(&mut conn);
-        }
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
 
         Ok(Self { pool })
     }
@@ -110,17 +130,23 @@ impl SqliteStore {
     }
 
     pub async fn save_device_data(&self, device_data: &CoreDevice) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
+        let pool = self.pool.clone();
         let noise_key_data = self.serialize_keypair(&device_data.noise_key)?;
         let identity_key_data = self.serialize_keypair(&device_data.identity_key)?;
         let signed_pre_key_data = self.serialize_keypair(&device_data.signed_pre_key)?;
-
         let account_data = device_data
             .account
             .as_ref()
             .map(|account| account.encode_to_vec());
-
+        let registration_id = device_data.registration_id as i32;
+        let signed_pre_key_id = device_data.signed_pre_key_id as i32;
+        let signed_pre_key_signature: Vec<u8> = device_data.signed_pre_key_signature.to_vec();
+        let adv_secret_key: Vec<u8> = device_data.adv_secret_key.to_vec();
+        let push_name = device_data.push_name.clone();
+        let app_version_primary = device_data.app_version_primary as i32;
+        let app_version_secondary = device_data.app_version_secondary as i32;
+        let app_version_tertiary = device_data.app_version_tertiary as i64;
+        let app_version_last_fetched_ms = device_data.app_version_last_fetched_ms;
         let new_lid = device_data
             .lid
             .as_ref()
@@ -131,116 +157,100 @@ impl SqliteStore {
             .as_ref()
             .map(|j| j.to_string())
             .unwrap_or_default();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
 
-        if !new_lid.is_empty() {
-            let rows_affected = diesel::update(device::table.filter(device::lid.eq("")))
-                .set((
-                    device::lid.eq(&new_lid),
-                    device::pn.eq(&new_pn),
-                    device::registration_id.eq(device_data.registration_id as i32),
+            if !new_lid.is_empty() {
+                let rows_affected = diesel::update(device::table.filter(device::lid.eq("")))
+                    .set((
+                        device::lid.eq(&new_lid),
+                        device::pn.eq(&new_pn),
+                        device::registration_id.eq(registration_id),
+                        device::noise_key.eq(&noise_key_data),
+                        device::identity_key.eq(&identity_key_data),
+                        device::signed_pre_key.eq(&signed_pre_key_data),
+                        device::signed_pre_key_id.eq(signed_pre_key_id),
+                        device::signed_pre_key_signature.eq(&signed_pre_key_signature[..]),
+                        device::adv_secret_key.eq(&adv_secret_key[..]),
+                        device::account.eq(account_data.clone()),
+                        device::push_name.eq(&push_name),
+                        device::app_version_primary.eq(app_version_primary),
+                        device::app_version_secondary.eq(app_version_secondary),
+                        device::app_version_tertiary.eq(app_version_tertiary),
+                        device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
+                    ))
+                    .execute(&mut conn)
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+
+                if rows_affected > 0 {
+                    return Ok(());
+                }
+            }
+
+            diesel::insert_into(device::table)
+                .values((
+                    device::lid.eq(new_lid.clone()),
+                    device::pn.eq(new_pn.clone()),
+                    device::registration_id.eq(registration_id),
                     device::noise_key.eq(&noise_key_data),
                     device::identity_key.eq(&identity_key_data),
                     device::signed_pre_key.eq(&signed_pre_key_data),
-                    device::signed_pre_key_id.eq(device_data.signed_pre_key_id as i32),
-                    device::signed_pre_key_signature.eq(&device_data.signed_pre_key_signature[..]),
-                    device::adv_secret_key.eq(&device_data.adv_secret_key[..]),
+                    device::signed_pre_key_id.eq(signed_pre_key_id),
+                    device::signed_pre_key_signature.eq(&signed_pre_key_signature[..]),
+                    device::adv_secret_key.eq(&adv_secret_key[..]),
                     device::account.eq(account_data.clone()),
-                    device::push_name.eq(&device_data.push_name),
-                    device::app_version_primary.eq(device_data.app_version_primary as i32),
-                    device::app_version_secondary.eq(device_data.app_version_secondary as i32),
-                    device::app_version_tertiary.eq(device_data.app_version_tertiary as i64),
-                    device::app_version_last_fetched_ms.eq(device_data.app_version_last_fetched_ms),
+                    device::push_name.eq(&push_name),
+                    device::app_version_primary.eq(app_version_primary),
+                    device::app_version_secondary.eq(app_version_secondary),
+                    device::app_version_tertiary.eq(app_version_tertiary),
+                    device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
+                ))
+                .on_conflict(device::lid)
+                .do_update()
+                .set((
+                    device::lid.eq(new_lid),
+                    device::pn.eq(new_pn),
+                    device::registration_id.eq(registration_id),
+                    device::noise_key.eq(&noise_key_data),
+                    device::identity_key.eq(&identity_key_data),
+                    device::signed_pre_key.eq(&signed_pre_key_data),
+                    device::signed_pre_key_id.eq(signed_pre_key_id),
+                    device::signed_pre_key_signature.eq(&signed_pre_key_signature[..]),
+                    device::adv_secret_key.eq(&adv_secret_key[..]),
+                    device::account.eq(account_data.clone()),
+                    device::push_name.eq(&push_name),
+                    device::app_version_primary.eq(app_version_primary),
+                    device::app_version_secondary.eq(app_version_secondary),
+                    device::app_version_tertiary.eq(app_version_tertiary),
+                    device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
                 ))
                 .execute(&mut conn)
                 .map_err(|e| StoreError::Database(e.to_string()))?;
 
-            if rows_affected > 0 {
-                return Ok(());
-            }
-        }
-
-        diesel::insert_into(device::table)
-            .values((
-                device::lid.eq(device_data
-                    .lid
-                    .as_ref()
-                    .map(|j| j.to_string())
-                    .unwrap_or_default()),
-                device::pn.eq(device_data
-                    .pn
-                    .as_ref()
-                    .map(|j| j.to_string())
-                    .unwrap_or_default()),
-                device::registration_id.eq(device_data.registration_id as i32),
-                device::noise_key.eq(&noise_key_data),
-                device::identity_key.eq(&identity_key_data),
-                device::signed_pre_key.eq(&signed_pre_key_data),
-                device::signed_pre_key_id.eq(device_data.signed_pre_key_id as i32),
-                device::signed_pre_key_signature.eq(&device_data.signed_pre_key_signature[..]),
-                device::adv_secret_key.eq(&device_data.adv_secret_key[..]),
-                device::account.eq(account_data.clone()),
-                device::push_name.eq(&device_data.push_name),
-                device::app_version_primary.eq(device_data.app_version_primary as i32),
-                device::app_version_secondary.eq(device_data.app_version_secondary as i32),
-                device::app_version_tertiary.eq(device_data.app_version_tertiary as i64),
-                device::app_version_last_fetched_ms.eq(device_data.app_version_last_fetched_ms),
-            ))
-            .on_conflict(device::lid)
-            .do_update()
-            .set((
-                device::lid.eq(device_data
-                    .lid
-                    .as_ref()
-                    .map(|j| j.to_string())
-                    .unwrap_or_default()),
-                device::pn.eq(device_data
-                    .pn
-                    .as_ref()
-                    .map(|j| j.to_string())
-                    .unwrap_or_default()),
-                device::registration_id.eq(device_data.registration_id as i32),
-                device::noise_key.eq(&noise_key_data),
-                device::identity_key.eq(&identity_key_data),
-                device::signed_pre_key.eq(&signed_pre_key_data),
-                device::signed_pre_key_id.eq(device_data.signed_pre_key_id as i32),
-                device::signed_pre_key_signature.eq(&device_data.signed_pre_key_signature[..]),
-                device::adv_secret_key.eq(&device_data.adv_secret_key[..]),
-                device::account.eq(account_data.clone()),
-                device::push_name.eq(&device_data.push_name),
-                device::app_version_primary.eq(device_data.app_version_primary as i32),
-                device::app_version_secondary.eq(device_data.app_version_secondary as i32),
-                device::app_version_tertiary.eq(device_data.app_version_tertiary as i64),
-                device::app_version_last_fetched_ms.eq(device_data.app_version_last_fetched_ms),
-            ))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
 
         Ok(())
     }
 
     pub async fn load_device_data(&self) -> Result<Option<CoreDevice>> {
-        let mut conn = self.get_connection()?;
-
-        let result = device::table
-            .first::<(
-                String,
-                String,
-                i32,
-                Vec<u8>,
-                Vec<u8>,
-                Vec<u8>,
-                i32,
-                Vec<u8>,
-                Vec<u8>,
-                Option<Vec<u8>>,
-                String,
-                i32,
-                i32,
-                i64,
-                i64,
-            )>(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let row = tokio::task::spawn_blocking(move || -> Result<Option<DeviceRow>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            let result = device::table
+                .first::<DeviceRow>(&mut conn)
+                .optional()
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
 
         if let Some((
             lid_str,
@@ -258,14 +268,13 @@ impl SqliteStore {
             app_version_secondary,
             app_version_tertiary,
             app_version_last_fetched_ms,
-        )) = result
+        )) = row
         {
             let id = if !pn_str.is_empty() {
                 pn_str.parse().ok()
             } else {
                 None
             };
-
             let lid = if !lid_str.is_empty() {
                 lid_str.parse().ok()
             } else {
@@ -329,29 +338,43 @@ impl SqliteStore {
 #[async_trait]
 impl IdentityStore for SqliteStore {
     async fn put_identity(&self, address: &str, key: [u8; 32]) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
-        diesel::insert_into(identities::table)
-            .values((
-                identities::address.eq(address),
-                identities::key.eq(&key[..]),
-            ))
-            .on_conflict(identities::address)
-            .do_update()
-            .set(identities::key.eq(&key[..]))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(identities::table)
+                .values((
+                    identities::address.eq(address),
+                    identities::key.eq(&key[..]),
+                ))
+                .on_conflict(identities::address)
+                .do_update()
+                .set(identities::key.eq(&key[..]))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
     async fn delete_identity(&self, address: &str) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
-        diesel::delete(identities::table.filter(identities::address.eq(address)))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::delete(identities::table.filter(identities::address.eq(address)))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
@@ -361,14 +384,23 @@ impl IdentityStore for SqliteStore {
         key: &[u8; 32],
         _direction: Direction,
     ) -> Result<bool> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = identities::table
-            .select(identities::key)
-            .filter(identities::address.eq(address))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = identities::table
+                    .select(identities::key)
+                    .filter(identities::address.eq(address))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         match result {
             Some(stored_key) => Ok(stored_key.as_slice() == key),
@@ -377,14 +409,23 @@ impl IdentityStore for SqliteStore {
     }
 
     async fn load_identity(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = identities::table
-            .select(identities::key)
-            .filter(identities::address.eq(address))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = identities::table
+                    .select(identities::key)
+                    .filter(identities::address.eq(address))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         Ok(result)
     }
@@ -393,69 +434,108 @@ impl IdentityStore for SqliteStore {
 #[async_trait]
 impl SessionStore for SqliteStore {
     async fn get_session(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = sessions::table
-            .select(sessions::record)
-            .filter(sessions::address.eq(address))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = sessions::table
+                    .select(sessions::record)
+                    .filter(sessions::address.eq(address))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         Ok(result)
     }
 
     async fn put_session(&self, address: &str, session: &[u8]) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
-        diesel::insert_into(sessions::table)
-            .values((sessions::address.eq(address), sessions::record.eq(session)))
-            .on_conflict(sessions::address)
-            .do_update()
-            .set(sessions::record.eq(session))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let session = session.to_vec();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(sessions::table)
+                .values((sessions::address.eq(address), sessions::record.eq(&session)))
+                .on_conflict(sessions::address)
+                .do_update()
+                .set(sessions::record.eq(&session))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
     async fn delete_session(&self, address: &str) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
-        diesel::delete(sessions::table.filter(sessions::address.eq(address)))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::delete(sessions::table.filter(sessions::address.eq(address)))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
     async fn has_session(&self, address: &str) -> Result<bool> {
-        let mut conn = self.get_connection()?;
-
-        let count: i64 = sessions::table
-            .filter(sessions::address.eq(address))
-            .count()
-            .get_result(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let count: i64 = tokio::task::spawn_blocking(move || -> Result<i64> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            let cnt: i64 = sessions::table
+                .filter(sessions::address.eq(address))
+                .count()
+                .get_result(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(cnt)
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(count > 0)
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl libsignal::store::PreKeyStore for SqliteStore {
     async fn load_prekey(
         &self,
         prekey_id: u32,
     ) -> std::result::Result<Option<PreKeyRecordStructure>, SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = prekeys::table
-            .select(prekeys::key)
-            .filter(prekeys::id.eq(prekey_id as i32))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = prekeys::table
+                    .select(prekeys::key)
+                    .filter(prekeys::id.eq(prekey_id as i32))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         if let Some(key_data) = result {
             if let Ok(private_key) = PrivateKey::deserialize(&key_data) {
@@ -482,47 +562,64 @@ impl libsignal::store::PreKeyStore for SqliteStore {
         record: PreKeyRecordStructure,
         uploaded: bool,
     ) -> std::result::Result<(), SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
+        let pool = self.pool.clone();
         let private_key_bytes = record.private_key.unwrap_or_default();
-
-        diesel::insert_into(prekeys::table)
-            .values((
-                prekeys::id.eq(prekey_id as i32),
-                prekeys::key.eq(&private_key_bytes),
-                prekeys::uploaded.eq(uploaded),
-            ))
-            .on_conflict(prekeys::id)
-            .do_update()
-            .set((
-                prekeys::key.eq(&private_key_bytes),
-                prekeys::uploaded.eq(uploaded),
-            ))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(prekeys::table)
+                .values((
+                    prekeys::id.eq(prekey_id as i32),
+                    prekeys::key.eq(&private_key_bytes),
+                    prekeys::uploaded.eq(uploaded),
+                ))
+                .on_conflict(prekeys::id)
+                .do_update()
+                .set((
+                    prekeys::key.eq(&private_key_bytes),
+                    prekeys::uploaded.eq(uploaded),
+                ))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
     async fn contains_prekey(&self, prekey_id: u32) -> std::result::Result<bool, SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
-        let count: i64 = prekeys::table
-            .filter(prekeys::id.eq(prekey_id as i32))
-            .count()
-            .get_result(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let count: i64 = tokio::task::spawn_blocking(move || -> Result<i64> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            let cnt: i64 = prekeys::table
+                .filter(prekeys::id.eq(prekey_id as i32))
+                .count()
+                .get_result(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(cnt)
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(count > 0)
     }
 
     async fn remove_prekey(&self, prekey_id: u32) -> std::result::Result<(), SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
-        diesel::delete(prekeys::table.filter(prekeys::id.eq(prekey_id as i32)))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::delete(prekeys::table.filter(prekeys::id.eq(prekey_id as i32)))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 }
@@ -530,60 +627,91 @@ impl libsignal::store::PreKeyStore for SqliteStore {
 #[async_trait]
 impl SenderKeyStoreHelper for SqliteStore {
     async fn put_sender_key(&self, address: &str, record: &[u8]) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
-        diesel::insert_into(sender_keys::table)
-            .values((
-                sender_keys::address.eq(address),
-                sender_keys::record.eq(record),
-            ))
-            .on_conflict(sender_keys::address)
-            .do_update()
-            .set(sender_keys::record.eq(record))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let record_vec = record.to_vec();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(sender_keys::table)
+                .values((
+                    sender_keys::address.eq(address),
+                    sender_keys::record.eq(&record_vec),
+                ))
+                .on_conflict(sender_keys::address)
+                .do_update()
+                .set(sender_keys::record.eq(&record_vec))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
     async fn get_sender_key(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = sender_keys::table
-            .select(sender_keys::record)
-            .filter(sender_keys::address.eq(address))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = sender_keys::table
+                    .select(sender_keys::record)
+                    .filter(sender_keys::address.eq(address))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(result)
     }
 
     async fn delete_sender_key(&self, address: &str) -> Result<()> {
-        let mut conn = self.get_connection()?;
-
-        diesel::delete(sender_keys::table.filter(sender_keys::address.eq(address)))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let address = address.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::delete(sender_keys::table.filter(sender_keys::address.eq(address)))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl libsignal::store::SignedPreKeyStore for SqliteStore {
     async fn load_signed_prekey(
         &self,
         signed_prekey_id: u32,
     ) -> std::result::Result<Option<SignedPreKeyRecordStructure>, SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = signed_prekeys::table
-            .select(signed_prekeys::record)
-            .filter(signed_prekeys::id.eq(signed_prekey_id as i32))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = signed_prekeys::table
+                    .select(signed_prekeys::record)
+                    .filter(signed_prekeys::id.eq(signed_prekey_id as i32))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         if let Some(data) = result {
             let record = SignedPreKeyRecordStructure::decode(data.as_slice())
@@ -619,20 +747,26 @@ impl libsignal::store::SignedPreKeyStore for SqliteStore {
         signed_prekey_id: u32,
         record: SignedPreKeyRecordStructure,
     ) -> std::result::Result<(), SignalStoreError> {
-        let mut conn = self.get_connection()?;
+        let pool = self.pool.clone();
         let data = record.encode_to_vec();
-
-        diesel::insert_into(signed_prekeys::table)
-            .values((
-                signed_prekeys::id.eq(signed_prekey_id as i32),
-                signed_prekeys::record.eq(&data),
-            ))
-            .on_conflict(signed_prekeys::id)
-            .do_update()
-            .set(signed_prekeys::record.eq(&data))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(signed_prekeys::table)
+                .values((
+                    signed_prekeys::id.eq(signed_prekey_id as i32),
+                    signed_prekeys::record.eq(&data),
+                ))
+                .on_conflict(signed_prekeys::id)
+                .do_update()
+                .set(signed_prekeys::record.eq(&data))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
@@ -640,14 +774,20 @@ impl libsignal::store::SignedPreKeyStore for SqliteStore {
         &self,
         signed_prekey_id: u32,
     ) -> std::result::Result<bool, SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
-        let count: i64 = signed_prekeys::table
-            .filter(signed_prekeys::id.eq(signed_prekey_id as i32))
-            .count()
-            .get_result(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        let count: i64 = tokio::task::spawn_blocking(move || -> Result<i64> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            let cnt: i64 = signed_prekeys::table
+                .filter(signed_prekeys::id.eq(signed_prekey_id as i32))
+                .count()
+                .get_result(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(cnt)
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(count > 0)
     }
 
@@ -655,14 +795,20 @@ impl libsignal::store::SignedPreKeyStore for SqliteStore {
         &self,
         signed_prekey_id: u32,
     ) -> std::result::Result<(), SignalStoreError> {
-        let mut conn = self.get_connection()?;
-
-        diesel::delete(
-            signed_prekeys::table.filter(signed_prekeys::id.eq(signed_prekey_id as i32)),
-        )
-        .execute(&mut conn)
-        .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::delete(
+                signed_prekeys::table.filter(signed_prekeys::id.eq(signed_prekey_id as i32)),
+            )
+            .execute(&mut conn)
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 }
@@ -670,14 +816,23 @@ impl libsignal::store::SignedPreKeyStore for SqliteStore {
 #[async_trait]
 impl AppStateKeyStore for SqliteStore {
     async fn get_app_state_sync_key(&self, key_id: &[u8]) -> Result<Option<AppStateSyncKey>> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = app_state_keys::table
-            .select(app_state_keys::key_data)
-            .filter(app_state_keys::key_id.eq(key_id))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let key_id = key_id.to_vec();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = app_state_keys::table
+                    .select(app_state_keys::key_data)
+                    .filter(app_state_keys::key_id.eq(&key_id))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         if let Some(data) = result {
             let (key, _) = bincode::serde::decode_from_slice(&data, bincode::config::standard())
@@ -689,21 +844,28 @@ impl AppStateKeyStore for SqliteStore {
     }
 
     async fn set_app_state_sync_key(&self, key_id: &[u8], key: AppStateSyncKey) -> Result<()> {
-        let mut conn = self.get_connection()?;
+        let pool = self.pool.clone();
+        let key_id = key_id.to_vec();
         let data = bincode::serde::encode_to_vec(&key, bincode::config::standard())
             .map_err(|e| StoreError::Serialization(e.to_string()))?;
-
-        diesel::insert_into(app_state_keys::table)
-            .values((
-                app_state_keys::key_id.eq(key_id),
-                app_state_keys::key_data.eq(&data),
-            ))
-            .on_conflict(app_state_keys::key_id)
-            .do_update()
-            .set(app_state_keys::key_data.eq(&data))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(app_state_keys::table)
+                .values((
+                    app_state_keys::key_id.eq(&key_id),
+                    app_state_keys::key_data.eq(&data),
+                ))
+                .on_conflict(app_state_keys::key_id)
+                .do_update()
+                .set(app_state_keys::key_data.eq(&data))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 }
@@ -711,14 +873,23 @@ impl AppStateKeyStore for SqliteStore {
 #[async_trait]
 impl AppStateStore for SqliteStore {
     async fn get_app_state_version(&self, name: &str) -> Result<HashState> {
-        let mut conn = self.get_connection()?;
-
-        let result: Option<Vec<u8>> = app_state_versions::table
-            .select(app_state_versions::state_data)
-            .filter(app_state_versions::name.eq(name))
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let name = name.to_string();
+        let result: Option<Vec<u8>> =
+            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<Vec<u8>> = app_state_versions::table
+                    .select(app_state_versions::state_data)
+                    .filter(app_state_versions::name.eq(name))
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
 
         if let Some(data) = result {
             let (state, _) = bincode::serde::decode_from_slice(&data, bincode::config::standard())
@@ -730,21 +901,28 @@ impl AppStateStore for SqliteStore {
     }
 
     async fn set_app_state_version(&self, name: &str, state: HashState) -> Result<()> {
-        let mut conn = self.get_connection()?;
+        let pool = self.pool.clone();
+        let name = name.to_string();
         let data = bincode::serde::encode_to_vec(&state, bincode::config::standard())
             .map_err(|e| StoreError::Serialization(e.to_string()))?;
-
-        diesel::insert_into(app_state_versions::table)
-            .values((
-                app_state_versions::name.eq(name),
-                app_state_versions::state_data.eq(&data),
-            ))
-            .on_conflict(app_state_versions::name)
-            .do_update()
-            .set(app_state_versions::state_data.eq(&data))
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            diesel::insert_into(app_state_versions::table)
+                .values((
+                    app_state_versions::name.eq(name),
+                    app_state_versions::state_data.eq(&data),
+                ))
+                .on_conflict(app_state_versions::name)
+                .do_update()
+                .set(app_state_versions::state_data.eq(&data))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
@@ -758,27 +936,37 @@ impl AppStateStore for SqliteStore {
         if mutations.is_empty() {
             return Ok(());
         }
-        let mut conn = self.get_connection()?;
-        for m in mutations {
-            diesel::insert_into(app_state_mutation_macs::table)
-                .values((
-                    app_state_mutation_macs::name.eq(name),
-                    app_state_mutation_macs::version.eq(version as i64),
-                    app_state_mutation_macs::index_mac.eq(&m.index_mac),
-                    app_state_mutation_macs::value_mac.eq(&m.value_mac),
-                ))
-                .on_conflict((
-                    app_state_mutation_macs::name,
-                    app_state_mutation_macs::index_mac,
-                ))
-                .do_update()
-                .set((
-                    app_state_mutation_macs::version.eq(version as i64),
-                    app_state_mutation_macs::value_mac.eq(&m.value_mac),
-                ))
-                .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
-        }
+        let pool = self.pool.clone();
+        let name = name.to_string();
+        let mutations: Vec<AppStateMutationMAC> = mutations.to_vec();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            for m in mutations {
+                diesel::insert_into(app_state_mutation_macs::table)
+                    .values((
+                        app_state_mutation_macs::name.eq(&name),
+                        app_state_mutation_macs::version.eq(version as i64),
+                        app_state_mutation_macs::index_mac.eq(&m.index_mac),
+                        app_state_mutation_macs::value_mac.eq(&m.value_mac),
+                    ))
+                    .on_conflict((
+                        app_state_mutation_macs::name,
+                        app_state_mutation_macs::index_mac,
+                    ))
+                    .do_update()
+                    .set((
+                        app_state_mutation_macs::version.eq(version as i64),
+                        app_state_mutation_macs::value_mac.eq(&m.value_mac),
+                    ))
+                    .execute(&mut conn)
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
@@ -791,18 +979,28 @@ impl AppStateStore for SqliteStore {
         if index_macs.is_empty() {
             return Ok(());
         }
-        let mut conn = self.get_connection()?;
-        for idx in index_macs {
-            diesel::delete(
-                app_state_mutation_macs::table.filter(
-                    app_state_mutation_macs::name
-                        .eq(name)
-                        .and(app_state_mutation_macs::index_mac.eq(idx)),
-                ),
-            )
-            .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-        }
+        let pool = self.pool.clone();
+        let name = name.to_string();
+        let index_macs: Vec<Vec<u8>> = index_macs.to_vec();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(e.to_string()))?;
+            for idx in index_macs {
+                diesel::delete(
+                    app_state_mutation_macs::table.filter(
+                        app_state_mutation_macs::name
+                            .eq(&name)
+                            .and(app_state_mutation_macs::index_mac.eq(&idx)),
+                    ),
+                )
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(e.to_string()))?;
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(())
     }
 
@@ -812,21 +1010,32 @@ impl AppStateStore for SqliteStore {
         index_mac: &[u8],
     ) -> Result<Option<Vec<u8>>> {
         use crate::store::schema::app_state_mutation_macs;
-        let mut conn = self.get_connection()?;
-        let result: Option<(i64, Vec<u8>)> = app_state_mutation_macs::table
-            .select((
-                app_state_mutation_macs::version,
-                app_state_mutation_macs::value_mac,
-            ))
-            .filter(
-                app_state_mutation_macs::name
-                    .eq(name)
-                    .and(app_state_mutation_macs::index_mac.eq(index_mac)),
-            )
-            .order(app_state_mutation_macs::version.desc())
-            .first(&mut conn)
-            .optional()
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+        let pool = self.pool.clone();
+        let name = name.to_string();
+        let index_mac = index_mac.to_vec();
+        let result: Option<(i64, Vec<u8>)> =
+            tokio::task::spawn_blocking(move || -> Result<Option<(i64, Vec<u8>)>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                let res: Option<(i64, Vec<u8>)> = app_state_mutation_macs::table
+                    .select((
+                        app_state_mutation_macs::version,
+                        app_state_mutation_macs::value_mac,
+                    ))
+                    .filter(
+                        app_state_mutation_macs::name
+                            .eq(&name)
+                            .and(app_state_mutation_macs::index_mac.eq(&index_mac)),
+                    )
+                    .order(app_state_mutation_macs::version.desc())
+                    .first(&mut conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                Ok(res)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))??;
         Ok(result.map(|r| r.1))
     }
 }

--- a/wacore/src/libsignal/protocol/storage/traits.rs
+++ b/wacore/src/libsignal/protocol/storage/traits.rs
@@ -43,8 +43,8 @@ pub enum IdentityChange {
 /// Signal clients usually use the identity store in a [TOFU] manner, but this is not required.
 ///
 /// [TOFU]: https://en.wikipedia.org/wiki/Trust_on_first_use
-#[async_trait(?Send)]
-pub trait IdentityKeyStore {
+#[async_trait]
+pub trait IdentityKeyStore: Send + Sync {
     /// Return the single specific identity the store is assumed to represent, with private key.
     async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair>;
 
@@ -80,8 +80,8 @@ pub trait IdentityKeyStore {
 }
 
 /// Interface for storing pre-keys downloaded from a server.
-#[async_trait(?Send)]
-pub trait PreKeyStore {
+#[async_trait]
+pub trait PreKeyStore: Send + Sync {
     /// Look up the pre-key corresponding to `prekey_id`.
     async fn get_pre_key(&self, prekey_id: PreKeyId) -> Result<PreKeyRecord>;
 
@@ -93,8 +93,8 @@ pub trait PreKeyStore {
 }
 
 /// Interface for storing signed pre-keys downloaded from a server.
-#[async_trait(?Send)]
-pub trait SignedPreKeyStore {
+#[async_trait]
+pub trait SignedPreKeyStore: Send + Sync {
     /// Look up the signed pre-key corresponding to `signed_prekey_id`.
     async fn get_signed_pre_key(
         &self,
@@ -116,8 +116,8 @@ pub trait SignedPreKeyStore {
 /// forward-secret message chain in the [Double Ratchet] protocol.
 ///
 /// [Double Ratchet]: https://signal.org/docs/specifications/doubleratchet/
-#[async_trait(?Send)]
-pub trait SessionStore {
+#[async_trait]
+pub trait SessionStore: Send + Sync {
     /// Look up the session corresponding to `address`.
     async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
 
@@ -130,8 +130,8 @@ pub trait SessionStore {
 }
 
 /// Interface for storing sender key records, allowing multiple keys per user.
-#[async_trait(?Send)]
-pub trait SenderKeyStore {
+#[async_trait]
+pub trait SenderKeyStore: Send + Sync {
     /// Assign `record` to the entry for `(sender, distribution_id)`.
     async fn store_sender_key(
         &mut self,

--- a/wacore/src/libsignal/store/mod.rs
+++ b/wacore/src/libsignal/store/mod.rs
@@ -12,7 +12,7 @@ use wacore_binary::jid::Jid;
 
 type StoreError = Box<dyn Error + Send + Sync>;
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait PreKeyStore: Send + Sync {
     async fn load_prekey(
         &self,
@@ -28,7 +28,7 @@ pub trait PreKeyStore: Send + Sync {
     async fn remove_prekey(&self, prekey_id: u32) -> Result<(), StoreError>;
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait SignedPreKeyStore: Send + Sync {
     async fn load_signed_prekey(
         &self,
@@ -44,7 +44,7 @@ pub trait SignedPreKeyStore: Send + Sync {
     async fn remove_signed_prekey(&self, signed_prekey_id: u32) -> Result<(), StoreError>;
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait SessionStore: Send + Sync {
     async fn load_session(&self, address: &ProtocolAddress) -> Result<SessionRecord, StoreError>;
     async fn get_sub_device_sessions(&self, name: &str) -> Result<Vec<u32>, StoreError>;
@@ -60,7 +60,7 @@ pub trait SessionStore: Send + Sync {
 
 use anyhow::Result;
 
-#[async_trait(?Send)]
+#[async_trait]
 pub trait GroupSenderKeyStore: Send + Sync {
     async fn store_sender_key(
         &mut self,


### PR DESCRIPTION
This pull request modernizes the async runtime usage throughout the codebase by switching from single-threaded to multi-threaded Tokio, removes reliance on `task::spawn_local`, and enforces `Send` bounds on async handlers and futures. It also updates the Tokio dependency and ensures all async trait implementations are compatible with multi-threaded execution. These changes improve scalability, compatibility, and future maintenance.

**Async runtime and task spawning modernization:**

* Switched the Tokio runtime from single-threaded (`new_current_thread`) to multi-threaded (`new_multi_thread`) in `src/main.rs`, and replaced all uses of `tokio::task::spawn_local`/`task::spawn_local` with `tokio::spawn` across the codebase to support multi-threaded async execution. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL29-R33) [[2]](diffhunk://#diff-c59dfafd37f26ebec0a4213e92dba602e062ebab50f2acc6e170def5dc311a63L18-R16) [[3]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L310-R309) [[4]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L479-R478) [[5]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L541-R540) [[6]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L621-R620) [[7]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1210-R1209) [[8]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L239-R239) [[9]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L310-R310) [[10]](diffhunk://#diff-21cb694d6b2a8732a1269fa538e2f5ab30886b759ea80e1297d0c5d14eb4dccdL61-R61) [[11]](diffhunk://#diff-9c0ab75611da9b12f9e846f8177e83addf7eb95298e666baff79b53890505502L47-R46) [[12]](diffhunk://#diff-aa2ccaf32abc1027719e2364bfcec48837b30d7b13302aae3054e7599bff04d1L36-R36) [[13]](diffhunk://#diff-86c9066191d6ee8ad533af96ad336a7cd2bc843fcdb74b98a48f635396d1cd19L121-R121)

* Updated the Tokio dependency to version `1.47.1` in `Cargo.toml` and enabled the `rt-multi-thread` feature for workspace crates. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R14) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L55-R55)

**Async trait and handler improvements:**

* Removed the `?Send` bound from all `#[async_trait(?Send)]` usages, enforcing `Send` on async trait implementations for signal stores and test mocks, ensuring compatibility with the multi-threaded runtime. [[1]](diffhunk://#diff-8def5958c4ec1a726f0670fd6731dd47afb80abb548b1da15362ba384def6020L511-R511) [[2]](diffhunk://#diff-8def5958c4ec1a726f0670fd6731dd47afb80abb548b1da15362ba384def6020L543-R543) [[3]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L19-R19) [[4]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L62-R62) [[5]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L93-R93) [[6]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L144-R144) [[7]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L191-R191) [[8]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L270-R270) [[9]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L297-R297) [[10]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L357-R357) [[11]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L459-R459) [[12]](diffhunk://#diff-290ddbe02d94c70629dfdfbf6299b300d507af72404a5f4ee9681cde36d96ea2L498-R498) [[13]](diffhunk://#diff-16bd991624a18becf005cc10c0099d4c0864aa765c9f5176d926b3fe92560c5aL57-R57)

* Updated the `EventHandlerCallback` and related types to require `Future<Output = ()> + Send`, and updated event handler registration and spawning logic to use `tokio::spawn` instead of `spawn_local`. [[1]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5L39-R39) [[2]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5L53-R53) [[3]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5L78-R78) [[4]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5L110-R110) [[5]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5L133-R133)

**Cleanup and dependency maintenance:**

* Removed unused imports of `tokio::task` and `task` in several files as a result of the above changes. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L31) [[2]](diffhunk://#diff-c59dfafd37f26ebec0a4213e92dba602e062ebab50f2acc6e170def5dc311a63L3-L6) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL4) [[4]](diffhunk://#diff-9c0ab75611da9b12f9e846f8177e83addf7eb95298e666baff79b53890505502L6)

These updates collectively make the codebase ready for more robust, scalable, and maintainable async operations on a multi-threaded runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated to a multi-threaded runtime for better concurrency and stability.
  - Switched local task spawns to cross-thread spawns, improving event handling and background processing.
  - Ensured async operations are Send across stores and adapters, enhancing thread-safety.
  - Offloaded database work to background threads to reduce blocking and improve responsiveness.
  - Simplified startup flow for more reliable initialization.

- Chores
  - Upgraded runtime dependency to a newer version with multi-threading support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->