### PR TITLE
Feat edit message + caching devices

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -21,15 +21,22 @@ pub struct MessageContext {
 }
 
 impl MessageContext {
-    pub async fn send_message(&self, message: wa::Message) -> Result<(), anyhow::Error> {
-        let message_id = self.client.generate_message_id().await;
+    pub async fn send_message(&self, message: wa::Message) -> Result<String, anyhow::Error> {
         self.client
-            .send_message_impl(
+            .send_message(self.info.source.chat.clone(), message)
+            .await
+    }
+
+    pub async fn edit_message(
+        &self,
+        original_message_id: String,
+        new_message: wa::Message,
+    ) -> Result<String, anyhow::Error> {
+        self.client
+            .edit_message(
                 self.info.source.chat.clone(),
-                Arc::new(message),
-                message_id,
-                false,
-                false,
+                original_message_id,
+                new_message,
             )
             .await
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,7 @@ use wacore_binary::jid::SERVER_JID;
 use crate::appstate_sync::AppStateProcessor;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+
 use thiserror::Error;
 use tokio::sync::{Mutex, Notify, RwLock, mpsc, oneshot};
 use tokio::time::{Duration, sleep};
@@ -120,6 +121,7 @@ pub struct Client {
 
     pub(crate) chat_locks: Arc<DashMap<Jid, Arc<tokio::sync::Mutex<()>>>>,
     pub group_cache: Arc<DashMap<Jid, GroupInfo>>,
+    pub device_cache: Arc<DashMap<Jid, (Vec<Jid>, std::time::Instant)>>,
 
     pub(crate) expected_disconnect: Arc<AtomicBool>,
 
@@ -209,6 +211,7 @@ impl Client {
             id_counter: Arc::new(AtomicU64::new(0)),
             chat_locks: Arc::new(DashMap::new()),
             group_cache: Arc::new(DashMap::new()),
+            device_cache: Arc::new(DashMap::new()),
 
             expected_disconnect: Arc::new(AtomicBool::new(false)),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,12 @@ fn main() {
 
                                 // 3. Create the new content for the message
                                 let updated_content = wa::Message {
-                                    conversation: Some(format!("🏓 Pong!\n`{}`", duration_str)),
+                                    extended_text_message: Some(Box::new(
+                                        wa::message::ExtendedTextMessage {
+                                            text: Some(format!("🏓 Pong!\n`{}`", duration_str)),
+                                            ..Default::default()
+                                        },
+                                    )),
                                     ..Default::default()
                                 };
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -122,18 +122,20 @@ impl Client {
             self.send_message_impl(
                 receipt.source.chat.clone(),
                 Arc::clone(&original_msg_arc),
-                message_id,
+                Some(message_id.clone()), // Pass Some(message_id)
                 false,
                 true,
+                None,
             )
             .await?;
         } else {
             self.send_message_impl(
                 receipt.source.chat.clone(),
                 Arc::clone(&original_msg_arc),
-                message_id,
+                Some(message_id), // Pass Some(message_id)
                 false,
                 true,
+                None,
             )
             .await?;
         }

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -1,5 +1,7 @@
 use crate::client::Client;
 use log::debug;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
 use wacore_binary::jid::{Jid, SERVER_JID};
 use wacore_binary::node::NodeContent;
 
@@ -7,23 +9,63 @@ impl Client {
     pub(crate) async fn get_user_devices(&self, jids: &[Jid]) -> Result<Vec<Jid>, anyhow::Error> {
         debug!("get_user_devices: Using normal mode for {jids:?}");
 
-        let sid = self.generate_request_id();
-        let usync_node = wacore::usync::build_get_user_devices_query(jids, sid.as_str());
+        const CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour TTL
+        let mut jids_to_fetch: HashSet<Jid> = HashSet::new();
+        let mut all_devices = Vec::new();
 
-        let iq = crate::request::InfoQuery {
-            namespace: "usync",
-            query_type: crate::request::InfoQueryType::Get,
-            to: SERVER_JID.parse().unwrap(),
-            content: Some(NodeContent::Nodes(vec![usync_node])),
-            id: None,
-            target: None,
-            timeout: None,
-        };
+        // 1. Check the cache first
+        for jid in jids.iter().map(|j| j.to_non_ad()) {
+            if let Some(entry) = self.device_cache.get(&jid) {
+                let (cached_devices, fetched_at) = &*entry;
+                if fetched_at.elapsed() < CACHE_TTL {
+                    all_devices.extend_from_slice(cached_devices);
+                    continue; // Found fresh entry, skip network fetch
+                }
+            }
+            // Not in cache or stale, add to the fetch set (de-duplicated)
+            jids_to_fetch.insert(jid);
+        }
 
-        let resp_node = self.send_iq(iq).await?;
+        // 2. Fetch missing JIDs from the network
+        if !jids_to_fetch.is_empty() {
+            debug!(
+                "get_user_devices: Cache miss, fetching from network for {} unique users",
+                jids_to_fetch.len()
+            );
 
-        let devices = wacore::usync::parse_get_user_devices_response(&resp_node)?;
+            let sid = self.generate_request_id();
+            let jids_vec: Vec<Jid> = jids_to_fetch.into_iter().collect();
+            let usync_node = wacore::usync::build_get_user_devices_query(&jids_vec, sid.as_str());
 
-        Ok(devices)
+            let iq = crate::request::InfoQuery {
+                namespace: "usync",
+                query_type: crate::request::InfoQueryType::Get,
+                to: SERVER_JID.parse().unwrap(),
+                content: Some(NodeContent::Nodes(vec![usync_node])),
+                id: None,
+                target: None,
+                timeout: None,
+            };
+            let resp_node = self.send_iq(iq).await?;
+            let fetched_devices = wacore::usync::parse_get_user_devices_response(&resp_node)?;
+
+            // 3. Update the cache with the newly fetched data
+            let mut devices_by_user = HashMap::new();
+            for device in fetched_devices.iter() {
+                let user_jid = device.to_non_ad();
+                devices_by_user
+                    .entry(user_jid)
+                    .or_insert_with(Vec::new)
+                    .push(device.clone());
+            }
+
+            for (user_jid, devices) in devices_by_user {
+                self.device_cache
+                    .insert(user_jid, (devices, Instant::now()));
+            }
+            all_devices.extend(fetched_devices);
+        }
+
+        Ok(all_devices)
     }
 }

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -58,6 +58,20 @@ impl From<String> for EditAttribute {
     }
 }
 
+impl EditAttribute {
+    pub fn to_string_val(&self) -> &'static str {
+        match self {
+            Self::Empty => "",
+            Self::MessageEdit => "1",
+            Self::PinInChat => "2",
+            Self::AdminEdit => "3",
+            Self::SenderRevoke => "7",
+            Self::AdminRevoke => "8",
+            Self::Unknown(_) => "",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BotEditType {
     First,


### PR DESCRIPTION
This pull request introduces two major improvements: support for message editing in the bot and client APIs, and the addition of a caching mechanism for user device queries. The message editing feature allows sent messages to be updated after sending, and the device caching reduces redundant network requests, improving performance. Additionally, the pull request refactors the message sending pipeline to support edit operations and adds relevant protocol attributes for proper handling of message edits.

**Message Editing Support:**

- Added `edit_message` methods to both `MessageContext` and `Client`, allowing messages to be edited after being sent. The edit operation constructs and sends a protocol-compliant edit message, returning the edited message's ID. (`src/bot.rs` [[1]](diffhunk://#diff-5757fdfd4a121b0c598c290cdf4cdc2192cc58b8b6461f6e7612e1ed5a356cf5L24-R39) `src/client.rs` [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R1150-R1198)
- Updated the main bot logic to demonstrate message editing: after sending a "Pong" message, it is edited to include the round-trip duration. (`src/main.rs` [src/main.rsL63-R106](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL63-R106))

**Message Sending Pipeline Refactor:**

- Refactored `send_message` and `send_message_impl` to accept optional edit attributes and return message IDs. This enables tracking and referencing messages for editing. (`src/send.rs` [[1]](diffhunk://#diff-34b82ee305bb7c3edb631d229d9f03fd896824d74cdc1e2e56611383c20bd1f7L11-R36) [[2]](diffhunk://#diff-34b82ee305bb7c3edb631d229d9f03fd896824d74cdc1e2e56611383c20bd1f7R45-R49) [[3]](diffhunk://#diff-34b82ee305bb7c3edb631d229d9f03fd896824d74cdc1e2e56611383c20bd1f7R120) [[4]](diffhunk://#diff-34b82ee305bb7c3edb631d229d9f03fd896824d74cdc1e2e56611383c20bd1f7R152) [[5]](diffhunk://#diff-34b82ee305bb7c3edb631d229d9f03fd896824d74cdc1e2e56611383c20bd1f7R191); `src/client.rs` [[6]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L868-R876) `src/retry.rs` [[7]](diffhunk://#diff-aa2ccaf32abc1027719e2364bfcec48837b30d7b13302aae3054e7599bff04d1L125-R138)
- Updated the protocol message stanza generation to include edit-related attributes and to set `decrypt-fail="hide"` on encrypted nodes for edits, ensuring proper handling of edited messages on the receiving side. (`wacore/src/send.rs` [[1]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR84) [[2]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR151-R159) [[3]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR173) [[4]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR188) [[5]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR220-R248) [[6]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR269-R281) [[7]](diffhunk://#diff-32650a2fe3c2dc54480808f2f055432e88b9c5c656dba11be964874bc11fe3ddR353)

**User Device Cache:**

- Introduced a cache for user device lists in `Client`, with a 1-hour TTL, to avoid unnecessary network requests when fetching device information for message encryption. (`src/client.rs` [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R124) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R214); `src/usync.rs` [[3]](diffhunk://#diff-8c57f246fc9cf5e946067c0cb34c3e11e988b9b7e7dfd9c2068059393fd2a449R3-R41) [[4]](diffhunk://#diff-8c57f246fc9cf5e946067c0cb34c3e11e988b9b7e7dfd9c2068059393fd2a449L22-R72)

**Minor Dependency and Import Updates:**

- Added missing imports and minor cleanups to support new features. (`src/client.rs` [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R5-R9) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1R31); `src/send.rs` [[3]](diffhunk://#diff-34b82ee305bb7c3edb631d229d9f03fd896824d74cdc1e2e56611383c20bd1f7L11-R36)

These changes collectively provide a more robust and feature-complete messaging API, with improved efficiency and new capabilities for editing sent messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now edit previously sent messages; send operations return message IDs for tracking.

- Performance
  - Device lookups are cached (1-hour TTL) to reduce network requests and speed message delivery.

- Reliability
  - Message sending and retry flows use consistent request/message IDs and propagate edit metadata for more robust delivery.

- UI/UX
  - Quick “Pong!” is shown first, then the message updates in place with measured latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->