### PR TITLE
refactor: replace GroupSenderKeyStore with SenderKeyStore and update related logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ uuid = { version = "1.0", features = ["v4"] }
 name = "multi_account"
 path = "examples/multi_account.rs"
 
+[[example]]
+name = "listen_only"
+path = "examples/listen_only.rs"
+
 [profile.release]
 opt-level = "z"
 debug = false

--- a/examples/listen_only.rs
+++ b/examples/listen_only.rs
@@ -1,0 +1,101 @@
+use chrono::Local;
+use log::{debug, error, info, warn};
+use std::sync::Arc;
+use wacore::proto_helpers::MessageExt;
+use wacore::types::events::Event;
+use whatsapp_rust::bot::Bot;
+use whatsapp_rust::store::sqlite_store::SqliteStore;
+use whatsapp_rust::store::traits::Backend;
+
+/// A minimal, listen-only bot designed for debugging.
+/// It connects, logs in, and prints detailed information for every event.
+/// This bot will now act as a receiver to debug messages sent from other clients.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("info,whatsapp_rust=debug,wacore=debug"),
+    )
+    .format(|buf, record| {
+        use std::io::Write;
+        writeln!(
+            buf,
+            "{} [{:<5}] [{}] - {}",
+            Local::now().format("%H:%M:%S"),
+            record.level(),
+            record.target(),
+            record.args()
+        )
+    })
+    .init();
+
+    info!("--- Starting Listen-Only Debugging Bot ---");
+
+    let backend = Arc::new(
+        SqliteStore::new("listener.db")
+            .await
+            .expect("Failed to create listener backend"),
+    ) as Arc<dyn Backend>;
+
+    let mut bot = Bot::builder()
+        .with_backend(backend)
+        .on_event(|event, _client| async move {
+            match event {
+                Event::PairingQrCode { code, timeout } => {
+                    info!("--- Pairing QR Code (valid for {}s) ---", timeout.as_secs());
+                    println!("\n{}\n", code); // Use println to make it easy to copy
+                    info!("-------------------------------------------------");
+                }
+                Event::Connected(_) => {
+                    info!("[EVENT] ✅ Connected successfully!");
+                }
+                Event::Message(msg, info) => {
+                    let text = msg.text_content().unwrap_or("<media or empty>");
+                    info!(
+                        "[EVENT] 📩 Message Received from {}: '{}'",
+                        info.source.sender, text
+                    );
+                    debug!("[EVENT] Full Message Info: {:?}", info);
+                    debug!("[EVENT] Full Message Content: {:?}", msg);
+                }
+                Event::Receipt(receipt) => {
+                    info!(
+                        "[EVENT] 📨 Receipt Received for {:?}, type: {:?}",
+                        receipt.message_ids, receipt.r#type
+                    );
+                }
+                Event::LoggedOut(logout_info) => {
+                    error!("[EVENT] ❌ Logged out! Reason: {:?}", logout_info.reason);
+                }
+                Event::UndecryptableMessage(info) => {
+                    warn!(
+                        "[EVENT] ❗ UNDECRYPTABLE MESSAGE from {}: {:?}",
+                        info.info.source.sender, info
+                    );
+                }
+                _ => {
+                    debug!("[EVENT] 📢 Other Event: {:?}", event);
+                }
+            }
+        })
+        .build()
+        .await
+        .expect("Failed to build listener bot");
+
+    info!("🤖 Listener bot built. Starting run loop...");
+    let bot_handle = bot.run().await.expect("Failed to start listener bot");
+
+    tokio::select! {
+        result = bot_handle => {
+            if let Err(e) = result {
+                error!("Listener bot ended with error: {}", e);
+            } else {
+                info!("Listener bot ended gracefully");
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            info!("🛑 Received Ctrl+C, shutting down listener...");
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use chrono::Local;
-use log::{debug, error, info};
+use log::{error, info};
 use std::io::Cursor;
 use std::sync::Arc;
 use wacore::download::{Downloadable, MediaType};
@@ -71,7 +71,7 @@ fn main() {
                             if let Some(text) = ctx.message.text_content()
                                 && text == "ping"
                             {
-                                debug!("Received text ping, sending pong...");
+                                info!("Received text ping, sending pong...");
                                 let start = std::time::Instant::now();
 
                                 // 1. Send the initial message and get its ID

--- a/src/send.rs
+++ b/src/send.rs
@@ -84,6 +84,14 @@ impl Client {
                 crate::types::message::AddressingMode::Pn => (own_jid.clone(), "pn"),
             };
 
+            if !group_info
+                .participants
+                .iter()
+                .any(|participant| participant.is_same_user_as(&own_sending_jid))
+            {
+                group_info.participants.push(own_sending_jid.to_non_ad());
+            }
+
             let force_skdm = {
                 use wacore::libsignal::protocol::SenderKeyStore;
                 use wacore::libsignal::store::sender_key_name::SenderKeyName;
@@ -91,10 +99,9 @@ impl Client {
                 let sender_address = own_sending_jid.to_protocol_address();
                 let sender_key_name =
                     SenderKeyName::new(to.to_string(), sender_address.to_string());
-                let composite_address = sender_key_name.to_protocol_address();
 
                 let key_exists = device_guard
-                    .load_sender_key(&composite_address)
+                    .load_sender_key(&sender_key_name)
                     .await?
                     .is_some();
 

--- a/src/store/signal.rs
+++ b/src/store/signal.rs
@@ -9,7 +9,6 @@ use wacore::libsignal::protocol::{
     SignalProtocolError,
 };
 use wacore::libsignal::store::*;
-use wacore_binary::jid::Jid;
 use waproto::whatsapp::{PreKeyRecordStructure, SignedPreKeyRecordStructure};
 
 type StoreError = Box<dyn std::error::Error + Send + Sync>;
@@ -482,42 +481,6 @@ impl SenderKeyStore for Device {
             .await
             .map_err(|e| SignalProtocolError::InvalidState("load_sender_key", e.to_string()))?
         {
-            Some(data) => {
-                let record = SenderKeyRecord::deserialize(&data)?;
-                if record.serialize()?.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some(record))
-                }
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-#[async_trait]
-impl GroupSenderKeyStore for Device {
-    async fn store_sender_key(
-        &mut self,
-        group_id: &Jid,
-        sender: &ProtocolAddress,
-        record: &SenderKeyRecord,
-    ) -> anyhow::Result<()> {
-        let unique_key = format!("{}:{}", group_id, sender);
-        let serialized_record = record.serialize()?;
-        self.backend
-            .put_sender_key(&unique_key, &serialized_record)
-            .await
-            .map_err(|e| e.into())
-    }
-
-    async fn load_sender_key(
-        &self,
-        group_id: &Jid,
-        sender: &ProtocolAddress,
-    ) -> anyhow::Result<Option<SenderKeyRecord>> {
-        let unique_key = format!("{}:{}", group_id, sender);
-        match self.backend.get_sender_key(&unique_key).await? {
             Some(data) => {
                 let record = SenderKeyRecord::deserialize(&data)?;
                 if record.serialize()?.is_empty() {

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -4,15 +4,13 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use wacore::libsignal::protocol::{
     Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore, PreKeyId,
-    PreKeyRecord, PreKeyStore, ProtocolAddress, SenderKeyRecord, SessionRecord, SessionStore,
-    SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
+    PreKeyRecord, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore, SignalProtocolError,
+    SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
 };
-use wacore_binary::jid::Jid;
 
 use wacore::libsignal::store::record_helpers as wacore_record;
 use wacore::libsignal::store::{
-    GroupSenderKeyStore, PreKeyStore as WacorePreKeyStore,
-    SignedPreKeyStore as WacoreSignedPreKeyStore,
+    PreKeyStore as WacorePreKeyStore, SignedPreKeyStore as WacoreSignedPreKeyStore,
 };
 
 #[derive(Clone)]
@@ -218,27 +216,5 @@ impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
     > {
         let mut device = self.0.device.write().await;
         wacore::libsignal::protocol::SenderKeyStore::load_sender_key(&mut *device, sender).await
-    }
-}
-
-#[async_trait]
-impl GroupSenderKeyStore for SenderKeyAdapter {
-    async fn store_sender_key(
-        &mut self,
-        group_id: &Jid,
-        sender: &ProtocolAddress,
-        record: &SenderKeyRecord,
-    ) -> anyhow::Result<()> {
-        let mut device = self.0.device.write().await;
-        device.store_sender_key(group_id, sender, record).await
-    }
-
-    async fn load_sender_key(
-        &self,
-        group_id: &Jid,
-        sender: &ProtocolAddress,
-    ) -> anyhow::Result<Option<SenderKeyRecord>> {
-        let device = self.0.device.read().await;
-        device.load_sender_key(group_id, sender).await
     }
 }

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -9,6 +9,7 @@ use wacore::libsignal::protocol::{
 };
 
 use wacore::libsignal::store::record_helpers as wacore_record;
+use wacore::libsignal::store::sender_key_name::SenderKeyName;
 use wacore::libsignal::store::{
     PreKeyStore as WacorePreKeyStore, SignedPreKeyStore as WacoreSignedPreKeyStore,
 };
@@ -200,21 +201,26 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
 impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
     async fn store_sender_key(
         &mut self,
-        sender: &wacore::libsignal::protocol::ProtocolAddress,
+        sender_key_name: &SenderKeyName,
         record: &wacore::libsignal::protocol::SenderKeyRecord,
     ) -> wacore::libsignal::protocol::error::Result<()> {
         let mut device = self.0.device.write().await;
-        wacore::libsignal::protocol::SenderKeyStore::store_sender_key(&mut *device, sender, record)
-            .await
+        wacore::libsignal::protocol::SenderKeyStore::store_sender_key(
+            &mut *device,
+            sender_key_name,
+            record,
+        )
+        .await
     }
 
     async fn load_sender_key(
         &mut self,
-        sender: &wacore::libsignal::protocol::ProtocolAddress,
+        sender_key_name: &SenderKeyName,
     ) -> wacore::libsignal::protocol::error::Result<
         Option<wacore::libsignal::protocol::SenderKeyRecord>,
     > {
         let mut device = self.0.device.write().await;
-        wacore::libsignal::protocol::SenderKeyStore::load_sender_key(&mut *device, sender).await
+        wacore::libsignal::protocol::SenderKeyStore::load_sender_key(&mut *device, sender_key_name)
+            .await
     }
 }

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -138,6 +138,14 @@ impl Jid {
         }
     }
 
+    pub fn actual_agent(&self) -> u8 {
+        match self.server.as_str() {
+            DEFAULT_USER_SERVER => 0,
+            HIDDEN_USER_SERVER => 1,
+            _ => self.agent,
+        }
+    }
+
     pub fn to_non_ad(&self) -> Self {
         Self {
             user: self.user.clone(),

--- a/wacore/src/libsignal/protocol/mod.rs
+++ b/wacore/src/libsignal/protocol/mod.rs
@@ -39,6 +39,7 @@ pub use crate::libsignal::core::{
 pub use crate::libsignal::crypto::aes_256_cbc_encrypt;
 pub use crate::libsignal::protocol::protocol::SENDERKEY_MESSAGE_CURRENT_VERSION;
 pub use crate::libsignal::protocol::sender_keys::InvalidSenderKeySessionError;
+pub use crate::libsignal::store::sender_key_name::SenderKeyName;
 use error::Result;
 pub use error::SignalProtocolError;
 pub use group_cipher::{

--- a/wacore/src/libsignal/protocol/storage/traits.rs
+++ b/wacore/src/libsignal/protocol/storage/traits.rs
@@ -13,6 +13,7 @@ use crate::libsignal::protocol::state::{
     PreKeyId, PreKeyRecord, SessionRecord, SignedPreKeyId, SignedPreKeyRecord,
 };
 use crate::libsignal::protocol::{IdentityKey, IdentityKeyPair, ProtocolAddress};
+use crate::libsignal::store::sender_key_name::SenderKeyName;
 
 // TODO: consider moving this enum into utils.rs?
 /// Each Signal message can be considered to have exactly two participants, a sender and receiver.
@@ -135,7 +136,7 @@ pub trait SenderKeyStore: Send + Sync {
     /// Assign `record` to the entry for `(sender, distribution_id)`.
     async fn store_sender_key(
         &mut self,
-        sender: &ProtocolAddress,
+        sender_key_name: &SenderKeyName,
         // TODO: pass this by value!
         record: &SenderKeyRecord,
     ) -> Result<()>;
@@ -143,7 +144,7 @@ pub trait SenderKeyStore: Send + Sync {
     /// Look up the entry corresponding to `(sender, distribution_id)`.
     async fn load_sender_key(
         &mut self,
-        sender: &ProtocolAddress,
+        sender_key_name: &SenderKeyName,
     ) -> Result<Option<SenderKeyRecord>>;
 }
 

--- a/wacore/src/libsignal/store/mod.rs
+++ b/wacore/src/libsignal/store/mod.rs
@@ -1,14 +1,10 @@
 pub mod record_helpers;
 pub mod sender_key_name;
 
-use crate::libsignal::protocol::{
-    IdentityKeyStore, ProtocolAddress, SenderKeyRecord, SessionRecord,
-};
+use crate::libsignal::protocol::{IdentityKeyStore, ProtocolAddress, SessionRecord};
 use async_trait::async_trait;
 use std::error::Error;
 use waproto::whatsapp::{PreKeyRecordStructure, SignedPreKeyRecordStructure};
-
-use wacore_binary::jid::Jid;
 
 type StoreError = Box<dyn Error + Send + Sync>;
 
@@ -56,24 +52,6 @@ pub trait SessionStore: Send + Sync {
     async fn contains_session(&self, address: &ProtocolAddress) -> Result<bool, StoreError>;
     async fn delete_session(&self, address: &ProtocolAddress) -> Result<(), StoreError>;
     async fn delete_all_sessions(&self, name: &str) -> Result<(), StoreError>;
-}
-
-use anyhow::Result;
-
-#[async_trait]
-pub trait GroupSenderKeyStore: Send + Sync {
-    async fn store_sender_key(
-        &mut self,
-        group_id: &Jid,
-        sender: &ProtocolAddress,
-        record: &SenderKeyRecord,
-    ) -> Result<()>;
-
-    async fn load_sender_key(
-        &self,
-        group_id: &Jid,
-        sender: &ProtocolAddress,
-    ) -> Result<Option<SenderKeyRecord>>;
 }
 
 pub trait SignalProtocolStore:

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1,8 +1,8 @@
 use crate::client::context::{GroupInfo, SendContextResolver};
 use crate::libsignal::protocol::{
-    CiphertextMessage, ProtocolAddress, SENDERKEY_MESSAGE_CURRENT_VERSION,
-    SenderKeyDistributionMessage, SenderKeyMessage, SenderKeyRecord, SenderKeyStore,
-    SignalProtocolError, UsePQRatchet, aes_256_cbc_encrypt, message_encrypt, process_prekey_bundle,
+    CiphertextMessage, SENDERKEY_MESSAGE_CURRENT_VERSION, SenderKeyDistributionMessage,
+    SenderKeyMessage, SenderKeyRecord, SenderKeyStore, SignalProtocolError, UsePQRatchet,
+    aes_256_cbc_encrypt, message_encrypt, process_prekey_bundle,
 };
 use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::messages::MessageUtils;
@@ -10,17 +10,18 @@ use crate::types::jid::JidExt;
 use anyhow::{Result, anyhow};
 use prost::Message as ProtoMessage;
 use rand::{CryptoRng, Rng, TryRngCore as _};
+use std::collections::HashSet;
 use std::time::SystemTime;
 use wacore_binary::builder::NodeBuilder;
-use wacore_binary::jid::Jid;
+use wacore_binary::jid::{Jid, JidExt as _};
 use wacore_binary::node::{Attrs, Node};
 use waproto::whatsapp as wa;
 use waproto::whatsapp::message::DeviceSentMessage;
 
 pub async fn encrypt_group_message<S, R>(
     sender_key_store: &mut S,
-    group_id: &Jid,
-    sender: &ProtocolAddress,
+    group_jid: &Jid,
+    sender_jid: &Jid,
     plaintext: &[u8],
     csprng: &mut R,
 ) -> Result<SenderKeyMessage>
@@ -28,11 +29,16 @@ where
     S: SenderKeyStore + ?Sized,
     R: Rng + CryptoRng,
 {
-    let sender_key_name = SenderKeyName::new(group_id.to_string(), sender.to_string());
-    let composite_address = sender_key_name.to_protocol_address();
+    let sender_address = sender_jid.to_protocol_address();
+    let sender_key_name = SenderKeyName::new(group_jid.to_string(), sender_address.to_string());
+    log::debug!(
+        "Attempting to load sender key for group {} sender {}",
+        sender_key_name.group_id(),
+        sender_key_name.sender_id()
+    );
 
     let mut record = sender_key_store
-        .load_sender_key(&composite_address)
+        .load_sender_key(&sender_key_name)
         .await?
         .ok_or(SignalProtocolError::NoSenderKeyState)?;
 
@@ -65,7 +71,7 @@ where
     sender_key_state.set_sender_chain_key(sender_chain_key.next()?);
 
     sender_key_store
-        .store_sender_key(&composite_address, &record)
+        .store_sender_key(&sender_key_name, &record)
         .await?;
 
     Ok(skm)
@@ -106,6 +112,10 @@ where
     }
 
     if !jids_needing_prekeys.is_empty() {
+        log::info!(
+            "Fetching prekeys for devices without sessions: {:?}",
+            jids_needing_prekeys
+        );
         let prekey_bundles = resolver
             .fetch_prekeys_for_identity_check(&jids_needing_prekeys)
             .await?;
@@ -364,9 +374,9 @@ pub async fn prepare_group_stanza<
     if !group_info
         .participants
         .iter()
-        .any(|p| p.user == own_base_jid.user)
+        .any(|participant| participant.is_same_user_as(&own_base_jid))
     {
-        group_info.participants.push(own_base_jid);
+        group_info.participants.push(own_base_jid.clone());
     }
 
     let mut message_children: Vec<Node> = Vec::new();
@@ -374,8 +384,50 @@ pub async fn prepare_group_stanza<
     let mut resolved_devices_for_phash: Option<Vec<Jid>> = None;
 
     if force_skdm_distribution {
-        let all_devices = resolver.resolve_devices(&group_info.participants).await?;
-        resolved_devices_for_phash = Some(all_devices.clone());
+        let expected_server = own_sending_jid.server.clone();
+        let mut jids_to_resolve: Vec<Jid> = group_info
+            .participants
+            .iter()
+            .map(|jid| {
+                let mut base = jid.to_non_ad();
+                if group_info.addressing_mode == crate::types::message::AddressingMode::Lid {
+                    base.server = expected_server.clone();
+                }
+                base
+            })
+            .filter(|jid| {
+                if group_info.addressing_mode == crate::types::message::AddressingMode::Lid {
+                    jid.server == expected_server
+                } else {
+                    true
+                }
+            })
+            .collect();
+        if !jids_to_resolve
+            .iter()
+            .any(|participant| participant.is_same_user_as(&own_base_jid))
+        {
+            jids_to_resolve.push(own_base_jid.clone());
+        }
+
+        let mut seen_users = HashSet::new();
+        jids_to_resolve.retain(|jid| seen_users.insert((jid.user.clone(), jid.server.clone())));
+
+        log::info!("Resolving devices for participants: {:?}", jids_to_resolve);
+
+        let mut distribution_list = resolver.resolve_devices(&jids_to_resolve).await?;
+
+        let mut seen = HashSet::new();
+        distribution_list.retain(|jid| seen.insert(jid.to_string()));
+
+        log::info!(
+            "SKDM distribution list for {} resolved to {} devices: {:?}",
+            to_jid,
+            distribution_list.len(),
+            distribution_list
+        );
+
+        resolved_devices_for_phash = Some(distribution_list.clone());
         let axolotl_skdm_bytes = create_sender_key_distribution_message_for_group(
             stores.sender_key_store,
             &to_jid,
@@ -398,7 +450,7 @@ pub async fn prepare_group_stanza<
         let (participant_nodes, inc) = encrypt_for_devices(
             stores,
             resolver,
-            &all_devices,
+            &distribution_list,
             &skdm_plaintext_to_encrypt,
             &empty_attrs,
         )
@@ -418,17 +470,13 @@ pub async fn prepare_group_stanza<
                     .build(),
             );
         }
-
-        // We will attach phash on the final message attrs below
-        let _ = MessageUtils::participant_list_hash(&all_devices);
     }
 
-    let sender_address = own_sending_jid.to_protocol_address();
     let plaintext = MessageUtils::pad_message_v2(message.encode_to_vec());
     let skmsg = encrypt_group_message(
         stores.sender_key_store,
         &to_jid,
-        &sender_address,
+        &own_sending_jid,
         &plaintext,
         &mut rand::rngs::OsRng.unwrap_err(),
     )
@@ -485,19 +533,23 @@ pub async fn create_sender_key_distribution_message_for_group(
     let sender_address = own_sending_jid.to_protocol_address();
 
     let sender_key_name = SenderKeyName::new(group_jid.to_string(), sender_address.to_string());
-    let composite_address = sender_key_name.to_protocol_address();
 
     let mut record = store
-        .load_sender_key(&composite_address)
+        .load_sender_key(&sender_key_name)
         .await?
         .unwrap_or_else(SenderKeyRecord::new_empty);
 
     if record.sender_key_state().is_err() {
-        let signing_key =
-            crate::libsignal::protocol::KeyPair::generate(&mut rand::rngs::OsRng.unwrap_err());
+        log::info!(
+            "No sender key found for self in group {}. Creating a new sender key state.",
+            group_jid
+        );
 
-        let chain_id = (rand::rngs::OsRng.unwrap_err().random::<u32>()) >> 1;
-        let sender_key_seed: [u8; 32] = rand::rngs::OsRng.unwrap_err().random();
+        let mut rng = rand::rngs::OsRng.unwrap_err();
+        let signing_key = crate::libsignal::protocol::KeyPair::generate(&mut rng);
+
+        let chain_id = (rng.random::<u32>()) >> 1;
+        let sender_key_seed: [u8; 32] = rng.random();
         record.add_sender_key_state(
             SENDERKEY_MESSAGE_CURRENT_VERSION,
             chain_id,
@@ -506,7 +558,7 @@ pub async fn create_sender_key_distribution_message_for_group(
             signing_key.public_key,
             Some(signing_key.private_key),
         );
-        store.store_sender_key(&composite_address, &record).await?;
+        store.store_sender_key(&sender_key_name, &record).await?;
     }
 
     let state = record
@@ -514,7 +566,7 @@ pub async fn create_sender_key_distribution_message_for_group(
         .map_err(|e| anyhow!("Invalid SK state: {:?}", e))?;
     let chain_key = state
         .sender_chain_key()
-        .ok_or(anyhow!("Missing chain key"))?;
+        .ok_or_else(|| anyhow!("Missing chain key"))?;
 
     let skdm = SenderKeyDistributionMessage::new(
         state.message_version().try_into().unwrap(),

--- a/wacore/src/types/jid.rs
+++ b/wacore/src/types/jid.rs
@@ -7,6 +7,12 @@ pub trait JidExt {
 
 impl JidExt for Jid {
     fn to_protocol_address(&self) -> ProtocolAddress {
-        ProtocolAddress::new(self.user.clone(), (self.device as u32).into())
+        let agent = self.actual_agent();
+        let name = if agent != 0 {
+            format!("{}_{}", self.user, agent)
+        } else {
+            self.user.clone()
+        };
+        ProtocolAddress::new(name, (self.device as u32).into())
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of group messaging: fewer failures from missing or mismatched keys; automatic key distribution now triggers when needed.

- Performance
  - More consistent and efficient key lookup flow for group messages, reducing send latency and retries.

- Refactor
  - Consolidated group key handling into a single, consistent mechanism to simplify behavior and reduce edge cases.

- Examples
  - Added a listen-only debugging bot example for easier connection, QR handling, and message/event inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->