### PR TITLE
Feat/os-info-override-api

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -142,6 +142,7 @@ pub struct BotBuilder {
     // The only way to configure storage
     backend: Option<Arc<dyn Backend>>,
     override_version: Option<(u32, u32, u32)>,
+    os_info: Option<(String, wa::device_props::AppVersion)>,
 }
 
 impl BotBuilder {
@@ -224,6 +225,36 @@ impl BotBuilder {
         self
     }
 
+    /// Override the OS information sent to WhatsApp servers.
+    /// This allows customizing the device properties that WhatsApp sees.
+    ///
+    /// # Arguments
+    /// * `os_name` - The OS name (e.g., "Android", "iOS", "Windows")
+    /// * `version` - The OS version as AppVersion struct
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// use waproto::whatsapp::device_props;
+    ///
+    /// let bot = Bot::builder()
+    ///     .with_backend(backend)
+    ///     .with_os_info(
+    ///         "Android".to_string(),
+    ///         device_props::AppVersion {
+    ///             primary: Some(10),
+    ///             secondary: Some(0),
+    ///             tertiary: Some(0),
+    ///             ..Default::default()
+    ///         }
+    ///     )
+    ///     .build()
+    ///     .await?;
+    /// ```
+    pub fn with_os_info(mut self, os_name: String, version: wa::device_props::AppVersion) -> Self {
+        self.os_info = Some((os_name, version));
+        self
+    }
+
     pub async fn build(self) -> Result<Bot> {
         let backend = self.backend.ok_or_else(|| {
             anyhow::anyhow!(
@@ -261,6 +292,16 @@ impl BotBuilder {
 
         crate::version::resolve_and_update_version(&persistence_manager, self.override_version)
             .await;
+
+        // Apply OS info override if specified
+        if let Some((os_name, version)) = self.os_info {
+            info!("Applying OS info override: {} {:?}", os_name, version);
+            persistence_manager
+                .modify_device(|device| {
+                    device.set_device_props(Some(os_name), Some(version));
+                })
+                .await;
+        }
 
         info!("Creating client...");
         let (client, sync_task_receiver) = Client::new(persistence_manager.clone()).await;
@@ -439,5 +480,33 @@ mod tests {
         assert_eq!(device_snapshot.app_version_primary, 2);
         assert_eq!(device_snapshot.app_version_secondary, 3000);
         assert_eq!(device_snapshot.app_version_tertiary, 123456789);
+    }
+
+    #[tokio::test]
+    async fn test_bot_builder_with_os_info_override() {
+        let backend = create_test_sqlite_backend().await;
+
+        let custom_os = "CustomOS".to_string();
+        let custom_version = wa::device_props::AppVersion {
+            primary: Some(99),
+            secondary: Some(88),
+            tertiary: Some(77),
+            ..Default::default()
+        };
+
+        let bot = Bot::builder()
+            .with_backend(backend)
+            .with_os_info(custom_os.clone(), custom_version)
+            .build()
+            .await
+            .expect("Failed to build bot with OS info override");
+
+        let client = bot.client();
+        let persistence_manager = client.persistence_manager();
+        let device = persistence_manager.get_device_snapshot().await;
+
+        // Verify the OS info was overridden
+        assert_eq!(device.device_props.os, Some(custom_os));
+        assert_eq!(device.device_props.version, Some(custom_version));
     }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -540,8 +540,11 @@ mod tests {
 
         // Verify only OS was overridden, version should be default
         assert_eq!(device.device_props.os, Some(custom_os));
-        // Version should be None (default) since we didn't override it
-        assert_eq!(device.device_props.version, None);
+        // Version should be the default since we didn't override it
+        assert_eq!(
+            device.device_props.version,
+            Some(wacore::store::Device::default_device_props_version())
+        );
     }
 
     #[tokio::test]
@@ -566,9 +569,12 @@ mod tests {
         let persistence_manager = client.persistence_manager();
         let device = persistence_manager.get_device_snapshot().await;
 
-        // Verify only version was overridden, OS should be default
+        // Verify only version was overridden, OS should be default ("rust")
         assert_eq!(device.device_props.version, Some(custom_version));
-        // OS should be None (default) since we didn't override it
-        assert_eq!(device.device_props.os, None);
+        // OS should be the default since we didn't override it
+        assert_eq!(
+            device.device_props.os,
+            Some(wacore::store::Device::default_os().to_string())
+        );
     }
 }

--- a/src/store/sqlite_store.rs
+++ b/src/store/sqlite_store.rs
@@ -402,7 +402,10 @@ impl SqliteStore {
                 app_version_secondary: app_version_secondary as u32,
                 app_version_tertiary: app_version_tertiary.try_into().unwrap_or(0u32),
                 app_version_last_fetched_ms,
-                device_props: wa::DeviceProps::default(),
+                device_props: {
+                    use wacore::store::device::DEVICE_PROPS;
+                    DEVICE_PROPS.clone()
+                },
             }))
         } else {
             Ok(None)
@@ -680,7 +683,10 @@ impl SqliteStore {
                 app_version_secondary: app_version_secondary as u32,
                 app_version_tertiary: app_version_tertiary.try_into().unwrap_or(0u32),
                 app_version_last_fetched_ms,
-                device_props: wa::DeviceProps::default(),
+                device_props: {
+                    use wacore::store::device::DEVICE_PROPS;
+                    DEVICE_PROPS.clone()
+                },
             }))
         } else {
             Ok(None)

--- a/src/store/sqlite_store.rs
+++ b/src/store/sqlite_store.rs
@@ -402,6 +402,7 @@ impl SqliteStore {
                 app_version_secondary: app_version_secondary as u32,
                 app_version_tertiary: app_version_tertiary.try_into().unwrap_or(0u32),
                 app_version_last_fetched_ms,
+                device_props: wa::DeviceProps::default(),
             }))
         } else {
             Ok(None)
@@ -679,6 +680,7 @@ impl SqliteStore {
                 app_version_secondary: app_version_secondary as u32,
                 app_version_tertiary: app_version_tertiary.try_into().unwrap_or(0u32),
                 app_version_last_fetched_ms,
+                device_props: wa::DeviceProps::default(),
             }))
         } else {
             Ok(None)

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -110,6 +110,8 @@ pub struct Device {
     pub app_version_secondary: u32,
     pub app_version_tertiary: u32,
     pub app_version_last_fetched_ms: i64,
+    #[serde(skip)]
+    pub device_props: wa::DeviceProps,
 }
 
 impl Default for Device {
@@ -156,11 +158,25 @@ impl Device {
             app_version_secondary: 3000,
             app_version_tertiary: 1023868176,
             app_version_last_fetched_ms: 0,
+            device_props: DEVICE_PROPS.clone(),
         }
     }
 
     pub fn is_ready_for_presence(&self) -> bool {
         self.pn.is_some() && !self.push_name.is_empty()
+    }
+
+    pub fn set_device_props(
+        &mut self,
+        os: Option<String>,
+        version: Option<wa::device_props::AppVersion>,
+    ) {
+        if let Some(os) = os {
+            self.device_props.os = Some(os);
+        }
+        if let Some(version) = version {
+            self.device_props.version = Some(version);
+        }
     }
 
     pub fn get_client_payload(&self) -> wa::ClientPayload {
@@ -193,7 +209,7 @@ impl Device {
         };
         let mut payload = build_base_client_payload(app_version);
 
-        let device_props_bytes = DEVICE_PROPS.encode_to_vec();
+        let device_props_bytes = self.device_props.encode_to_vec();
 
         let version = payload
             .user_agent

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -76,7 +76,7 @@ fn build_base_client_payload(
     }
 }
 
-static DEVICE_PROPS: Lazy<wa::DeviceProps> = Lazy::new(|| wa::DeviceProps {
+pub static DEVICE_PROPS: Lazy<wa::DeviceProps> = Lazy::new(|| wa::DeviceProps {
     os: Some("rust".to_string()),
     version: Some(wa::device_props::AppVersion {
         primary: Some(0),
@@ -159,6 +159,21 @@ impl Device {
             app_version_tertiary: 1023868176,
             app_version_last_fetched_ms: 0,
             device_props: DEVICE_PROPS.clone(),
+        }
+    }
+
+    /// Returns the default OS string used for device props
+    pub fn default_os() -> &'static str {
+        "rust"
+    }
+
+    /// Returns the default device props version
+    pub fn default_device_props_version() -> wa::device_props::AppVersion {
+        wa::device_props::AppVersion {
+            primary: Some(0),
+            secondary: Some(1),
+            tertiary: Some(0),
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added option to override the bot’s reported OS name and app version.
- Refactor
  - Device properties are now managed per device instance, improving consistency in registration and payload generation.
- Documentation
  - Added usage docs and examples for configuring OS/app version overrides.
- Tests
  - Added coverage for full and partial OS/app version override scenarios to ensure correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->