### PR TITLE
feat: update acknowledgment logic for incoming stanzas

### DIFF
--- a/wacore/src/libsignal/protocol/group_cipher.rs
+++ b/wacore/src/libsignal/protocol/group_cipher.rs
@@ -79,7 +79,7 @@ fn get_sender_key(state: &mut SenderKeyState, iteration: u32) -> Result<SenderMe
         if let Some(smk) = state.remove_sender_message_key(iteration) {
             return Ok(smk);
         } else {
-            log::info!("SenderKey Duplicate message for iteration: {iteration}");
+            log::debug!("SenderKey Duplicate message for iteration: {iteration}");
             return Err(SignalProtocolError::DuplicatedMessage(
                 current_iteration,
                 iteration,

--- a/wacore/src/libsignal/protocol/session_cipher.rs
+++ b/wacore/src/libsignal/protocol/session_cipher.rs
@@ -706,7 +706,7 @@ fn get_or_create_message_key(
         return match state.get_message_keys(their_ephemeral, counter)? {
             Some(keys) => Ok(keys),
             None => {
-                log::info!("{remote_address} Duplicate message for counter: {counter}");
+                log::debug!("{remote_address} Duplicate message for counter: {counter}");
                 Err(SignalProtocolError::DuplicatedMessage(chain_index, counter))
             }
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped acknowledging incoming message stanzas; acknowledgments continue for receipts, notifications, and calls to align behavior with expected delivery semantics.

* **Chores**
  * Reduced log verbosity for duplicate-message events to minimize noise in diagnostics.

* **Tests**
  * Added test coverage validating acknowledgment behavior across message, receipt, and notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->