### PR TITLE
poc: jemmaloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cffc705424a344c054e135d12ee591402f4539245e8bbd64e6c9eaa9458b63c"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1380,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2522,6 +2559,8 @@ dependencies = [
  "dashmap",
  "env_logger",
  "hex",
+ "jemalloc-ctl",
+ "jemallocator",
  "log",
  "moka",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,12 @@ bytes = { version = "1.5", default-features = false }
 chrono = { version = "0.4" }
 dashmap = "6.1.0"
 env_logger = { version = "0.11", default-features = false }
-moka = { version = "0.12", features = ["future"] }
 
 hex = { version = "0.4", features = ["alloc"], default-features = false }
+jemalloc-ctl = "0.5.4"
+jemallocator = "0.5.4"
 log = "0.4.27"
+moka = { version = "0.12", features = ["future"] }
 prost = { version = "0.14.1", default-features = false }
 
 # Cryptography


### PR DESCRIPTION
This makes the internal memory management use only 3mb instead of 8mb. (RSS high up, but this is expected)

This is essential for production, but I'm thinking to not add default to the library (the user will evaluate)

+ 200kb in final binary size (worth)