### PR TITLE
Parallelize version fetch and transport connect in Client

### DIFF
--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -177,7 +177,8 @@ mod tests {
         let pm = PersistenceManager::new(backend).await.unwrap();
         let transport = Arc::new(crate::transport::mock::MockTransportFactory::new());
         let http_client = Arc::new(MockHttpClient);
-        let (client, _rx) = crate::client::Client::new(Arc::new(pm), transport, http_client).await;
+        let (client, _rx) =
+            crate::client::Client::new(Arc::new(pm), transport, http_client, None).await;
 
         let mut cancelled = false;
         let result = router.dispatch(client, &node_ref, &mut cancelled).await;
@@ -208,7 +209,8 @@ mod tests {
         let pm = PersistenceManager::new(backend).await.unwrap();
         let transport = Arc::new(crate::transport::mock::MockTransportFactory::new());
         let http_client = Arc::new(MockHttpClient);
-        let (client, _rx) = crate::client::Client::new(Arc::new(pm), transport, http_client).await;
+        let (client, _rx) =
+            crate::client::Client::new(Arc::new(pm), transport, http_client, None).await;
 
         let mut cancelled = false;
         let result = router.dispatch(client, &node_ref, &mut cancelled).await;

--- a/src/message.rs
+++ b/src/message.rs
@@ -792,7 +792,7 @@ mod tests {
                 .expect("Failed to create test backend"),
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
-        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client()).await;
+        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client(), None).await;
 
         let participant_jid_str = "556899336555:42@s.whatsapp.net";
         let status_broadcast_jid_str = "status@broadcast";
@@ -841,7 +841,7 @@ mod tests {
                 .expect("Failed to create test backend"),
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
-        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client()).await;
+        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client(), None).await;
 
         let sender_jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
         let info = MessageInfo {
@@ -905,7 +905,7 @@ mod tests {
                 .expect("Failed to create test backend"),
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
-        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client()).await;
+        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client(), None).await;
 
         let sender_jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
         let group_jid: Jid = "120363021033254949@g.us".parse().unwrap();
@@ -997,7 +997,7 @@ mod tests {
                 .expect("Failed to open whatsapp.db - ensure you have an authenticated session"),
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
-        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client()).await;
+        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client(), None).await;
 
         // Simulate a group message from a LID user we haven't chatted with 1-on-1
         let lid_sender: Jid = "236395184570386.1:75@lid".parse().unwrap();
@@ -1073,7 +1073,7 @@ mod tests {
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
         let (_client, _sync_rx) =
-            Client::new(pm.clone(), mock_transport(), mock_http_client()).await;
+            Client::new(pm.clone(), mock_transport(), mock_http_client(), None).await;
 
         // Simulate own LID: 236395184570386.1:75@lid (note: using device 75 to match real scenario)
         // Phone number: 559984726662:75@s.whatsapp.net
@@ -1180,7 +1180,7 @@ mod tests {
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
         let transport_factory = Arc::new(crate::transport::mock::MockTransportFactory::new());
         let (_client, _sync_rx) =
-            Client::new(pm.clone(), transport_factory, mock_http_client()).await;
+            Client::new(pm.clone(), transport_factory, mock_http_client(), None).await;
 
         let group_jid: Jid = "120363021033254949@g.us".parse().unwrap();
 
@@ -1359,7 +1359,7 @@ mod tests {
             device.lid = Some("236395184570386.1@lid".parse().unwrap());
         }
 
-        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client()).await;
+        let (client, _sync_rx) = Client::new(pm, mock_transport(), mock_http_client(), None).await;
 
         // Test case 1: LID group message with participant_pn
         let lid_group_node = NodeBuilder::new("message")
@@ -1564,7 +1564,7 @@ mod tests {
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
         let (_client, _sync_rx) =
-            Client::new(pm.clone(), mock_transport(), mock_http_client()).await;
+            Client::new(pm.clone(), mock_transport(), mock_http_client(), None).await;
 
         let group_jid: Jid = "120363021033254949@g.us".parse().unwrap();
         let display_jid: Jid = "236395184570386.1:75@lid".parse().unwrap();
@@ -1643,7 +1643,7 @@ mod tests {
         );
         let pm = Arc::new(PersistenceManager::new(backend).await.unwrap());
         let (client, _sync_rx) =
-            Client::new(pm.clone(), mock_transport(), mock_http_client()).await;
+            Client::new(pm.clone(), mock_transport(), mock_http_client(), None).await;
 
         let sender_jid: Jid = "236395184570386.1:75@lid".parse().unwrap();
         let group_jid: Jid = "120363021033254949@g.us".parse().unwrap();

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -306,6 +306,7 @@ mod tests {
             pm.clone(),
             Arc::new(crate::transport::mock::MockTransportFactory::new()),
             Arc::new(MockHttpClient),
+            None,
         )
         .await;
 

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -84,6 +84,7 @@ mod tests {
             pm.clone(),
             Arc::new(crate::transport::mock::MockTransportFactory::new()),
             Arc::new(MockHttpClient),
+            None,
         )
         .await;
 


### PR DESCRIPTION
Move version resolution to Client and run it concurrently with transport creation for faster startup. Update Client::new to accept override_version and propagate it throughout. Update tests for new Client::new signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional version override can be set during client setup.
* **Performance**
  * Faster startup by resolving version and initializing connection in parallel.
* **Reliability**
  * More predictable registration of custom encryption handlers.
* **Tests**
  * Tests updated to align with the new client setup and validation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->