### PR TITLE
feat: add support for extra stanza nodes in message sending and editing

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1313,6 +1313,7 @@ impl Client {
                 true,
                 false,
                 None,
+                vec![],
             )
             .await
         {
@@ -1703,6 +1704,7 @@ impl Client {
             false,
             false,
             Some(crate::types::message::EditAttribute::MessageEdit),
+            vec![], // TODO: Support extra nodes for edit messages if needed
         )
         .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub use wacore::{proto_helpers, store::traits};
+pub use wacore_binary::builder::NodeBuilder;
 pub use waproto;
 
 pub mod http;
@@ -17,6 +18,7 @@ pub mod pair;
 pub mod pair_code;
 pub mod request;
 pub mod send;
+pub use send::SendOptions;
 pub mod session;
 pub mod socket;
 pub mod store;

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -176,6 +176,7 @@ impl Client {
             true,  // is_peer_message
             false, // is_retry
             None,
+            vec![], // No extra stanza nodes for peer messages
         )
         .await?;
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -332,6 +332,7 @@ impl Client {
             false,
             true, // is_retry: includes fresh SKDM for groups
             None,
+            vec![], // Extra nodes not preserved on retry - caller must resend with options if needed
         )
         .await?;
 

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -358,6 +358,7 @@ pub async fn prepare_dm_stanza<
     message: &wa::Message,
     request_id: String,
     edit: Option<crate::types::message::EditAttribute>,
+    extra_stanza_nodes: Vec<Node>,
 ) -> Result<Node> {
     // Generate reporting token if the message type supports it
     // For DMs, both sender_jid and remote_jid are the recipient (to_jid) per Baileys implementation
@@ -454,6 +455,9 @@ pub async fn prepare_dm_stanza<
         message_content_nodes.push(build_reporting_node(result));
     }
 
+    // Add any extra stanza nodes provided by the caller
+    message_content_nodes.extend(extra_stanza_nodes);
+
     let mut stanza_attrs = Attrs::new();
     stanza_attrs.insert("to".to_string(), to_jid.to_string());
     stanza_attrs.insert("id".to_string(), request_id);
@@ -534,6 +538,7 @@ pub async fn prepare_group_stanza<
     force_skdm_distribution: bool,
     skdm_target_devices: Option<Vec<Jid>>,
     edit: Option<crate::types::message::EditAttribute>,
+    extra_stanza_nodes: Vec<Node>,
 ) -> Result<Node> {
     let (own_sending_jid, _) = match group_info.addressing_mode {
         crate::types::message::AddressingMode::Lid => (own_lid.clone(), "lid"),
@@ -790,6 +795,9 @@ pub async fn prepare_group_stanza<
         }
     }
 
+    // Add any extra stanza nodes provided by the caller
+    message_children.extend(extra_stanza_nodes);
+
     let stanza = NodeBuilder::new("message")
         .attrs(stanza_attrs.into_iter())
         .children(message_children)
@@ -797,6 +805,7 @@ pub async fn prepare_group_stanza<
 
     Ok(stanza)
 }
+
 pub async fn create_sender_key_distribution_message_for_group(
     store: &mut (dyn SenderKeyStore + Send + Sync),
     group_jid: &Jid,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended message sending to support custom XML node attachments to stanzas
  * Added new API method enabling advanced message configuration via options
  * Made builder utilities and send options publicly accessible for developers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

close https://github.com/jlucaso1/whatsapp-rust/issues/212