### PR TITLE
Registers an external event handler to the core event bus. 

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -380,6 +380,11 @@ impl Client {
         router
     }
 
+    /// Registers an external event handler to the core event bus.
+    pub fn register_handler(&self, handler: Arc<dyn wacore::types::events::EventHandler>) {
+        self.core.event_bus.add_handler(handler);
+    }
+
     pub async fn run(self: &Arc<Self>) {
         if self.is_running.swap(true, Ordering::SeqCst) {
             warn!("Client `run` method called while already running.");


### PR DESCRIPTION
Hi! I'm using your library in a wrapper application and needed a way to listen to events (like QR Code, Messages, etc.) from outside the Client struct.

I've added a simple public method register_handler to Client that forwards the handler to the internal CoreEventBus.

This small change makes the library much more usable for external applications without exposing the entire CoreClient internals. Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new mechanism to register external event handlers, enabling enhanced customization and integration capabilities for the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->