### PR TITLE
feat: add unified session telemetry

### DIFF
--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -51,6 +51,10 @@ impl<'a> Presence<'a> {
             ));
         }
 
+        if status == PresenceStatus::Available {
+            self.client.send_unified_session().await;
+        }
+
         let presence_type = status.as_str();
 
         let node = NodeBuilder::new("presence")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod pdo;
 pub mod prekeys;
 pub mod receipt;
 pub mod retry;
+pub mod unified_session;
 
 pub mod appstate_sync;
 pub mod history_sync;

--- a/src/unified_session.rs
+++ b/src/unified_session.rs
@@ -1,0 +1,222 @@
+//! Unified session telemetry manager.
+//!
+//! Sends `<ib><unified_session id="..."/></ib>` stanzas to match WhatsApp Web behavior.
+//! Features: server time sync, duplicate prevention, sequence counter.
+
+use log::debug;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use tokio::sync::Mutex;
+use wacore::ib::{IbStanza, UnifiedSession};
+use wacore::protocol::ProtocolNode;
+use wacore_binary::node::Node;
+
+/// Manager for unified session telemetry.
+pub struct UnifiedSessionManager {
+    server_time_offset_ms: Arc<AtomicI64>,
+    last_sent_id: Arc<Mutex<Option<String>>>,
+    sequence: Arc<AtomicU64>,
+}
+
+impl Default for UnifiedSessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UnifiedSessionManager {
+    pub fn new() -> Self {
+        Self {
+            server_time_offset_ms: Arc::new(AtomicI64::new(0)),
+            last_sent_id: Arc::new(Mutex::new(None)),
+            sequence: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn server_time_offset_ms(&self) -> i64 {
+        self.server_time_offset_ms.load(Ordering::Relaxed)
+    }
+
+    pub fn sequence(&self) -> u64 {
+        self.sequence.load(Ordering::Relaxed)
+    }
+
+    /// Update server time offset from node's `t` attribute (Unix timestamp in seconds).
+    pub fn update_server_time_offset(&self, node: &Node) {
+        if let Some(t_str) = node.attrs.get("t")
+            && let Ok(server_time) = t_str.parse::<i64>()
+            && server_time > 0
+        {
+            let local_time = chrono::Utc::now().timestamp();
+            let offset_ms = (server_time - local_time) * 1000;
+            self.server_time_offset_ms
+                .store(offset_ms, Ordering::Relaxed);
+            debug!(target: "UnifiedSession", "Server time offset: {}ms", offset_ms);
+        }
+    }
+
+    pub fn calculate_session_id(&self) -> String {
+        let offset = self.server_time_offset_ms.load(Ordering::Relaxed);
+        UnifiedSession::calculate_id(offset)
+    }
+
+    /// Prepare to send unified session. Returns None if duplicate (already sent this ID).
+    pub async fn prepare_send(&self) -> Option<(Node, u64)> {
+        let session_id = self.calculate_session_id();
+
+        {
+            let mut last_id = self.last_sent_id.lock().await;
+            if let Some(ref prev_id) = *last_id
+                && prev_id == &session_id
+            {
+                debug!(target: "UnifiedSession", "Skipping duplicate id={}", session_id);
+                return None;
+            }
+
+            // Reset sequence when session ID changes (matches WhatsApp Web behavior)
+            if last_id.as_ref() != Some(&session_id) {
+                self.sequence.store(0, Ordering::Relaxed);
+            }
+            *last_id = Some(session_id.clone());
+        }
+
+        // Pre-increment to return 1 on first call (matches WhatsApp Web's ++$2)
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed) + 1;
+        let stanza = IbStanza::unified_session(UnifiedSession::new(&session_id));
+        let node = stanza.into_node();
+
+        debug!(target: "UnifiedSession", "Sending id={}, seq={}", session_id, sequence);
+
+        Some((node, sequence))
+    }
+
+    /// Clear last sent ID to allow retry on failure.
+    pub async fn clear_last_sent(&self) {
+        *self.last_sent_id.lock().await = None;
+    }
+
+    /// Reset state on disconnect (keeps sequence counter).
+    pub async fn reset(&self) {
+        self.server_time_offset_ms.store(0, Ordering::Relaxed);
+        *self.last_sent_id.lock().await = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wacore_binary::builder::NodeBuilder;
+
+    #[test]
+    fn test_manager_default() {
+        let manager = UnifiedSessionManager::new();
+        assert_eq!(manager.server_time_offset_ms(), 0);
+        assert_eq!(manager.sequence(), 0);
+    }
+
+    #[test]
+    fn test_update_server_time_offset() {
+        let manager = UnifiedSessionManager::new();
+
+        let server_time = chrono::Utc::now().timestamp() + 10;
+        let node = NodeBuilder::new("success")
+            .attr("t", server_time.to_string())
+            .build();
+
+        manager.update_server_time_offset(&node);
+
+        let offset = manager.server_time_offset_ms();
+        assert!(
+            (offset - 10000).abs() < 1000,
+            "Offset should be ~10000ms, got {}",
+            offset
+        );
+    }
+
+    #[test]
+    fn test_update_server_time_offset_invalid() {
+        let manager = UnifiedSessionManager::new();
+
+        let node = NodeBuilder::new("success").build();
+        manager.update_server_time_offset(&node);
+        assert_eq!(manager.server_time_offset_ms(), 0);
+
+        let node = NodeBuilder::new("success")
+            .attr("t", "not_a_number")
+            .build();
+        manager.update_server_time_offset(&node);
+        assert_eq!(manager.server_time_offset_ms(), 0);
+
+        let node = NodeBuilder::new("success").attr("t", "0").build();
+        manager.update_server_time_offset(&node);
+        assert_eq!(manager.server_time_offset_ms(), 0);
+    }
+
+    #[test]
+    fn test_calculate_session_id() {
+        let manager = UnifiedSessionManager::new();
+        let id = manager.calculate_session_id();
+
+        let id_num: i64 = id.parse().expect("Should be a valid number");
+        const WEEK_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+        assert!((0..WEEK_MS).contains(&id_num));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_send() {
+        let manager = UnifiedSessionManager::new();
+
+        let result = manager.prepare_send().await;
+        assert!(result.is_some());
+        let (node, seq) = result.unwrap();
+        assert_eq!(node.tag, "ib");
+        assert_eq!(
+            seq, 1,
+            "First sequence should be 1 (pre-increment like WhatsApp Web)"
+        );
+
+        let result2 = manager.prepare_send().await;
+        assert!(result2.is_none(), "Duplicate should be prevented");
+        assert_eq!(manager.sequence(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_clear_last_sent() {
+        let manager = UnifiedSessionManager::new();
+
+        let (_, seq1) = manager.prepare_send().await.unwrap();
+        assert_eq!(seq1, 1);
+        assert_eq!(manager.sequence(), 1);
+
+        manager.clear_last_sent().await;
+
+        // After clear, it's treated as a new session -> sequence resets
+        let result = manager.prepare_send().await;
+        assert!(result.is_some());
+        let (_, seq2) = result.unwrap();
+        assert_eq!(seq2, 1, "Sequence resets when session ID changes");
+        assert_eq!(manager.sequence(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reset() {
+        let manager = UnifiedSessionManager::new();
+
+        let node = NodeBuilder::new("success")
+            .attr("t", (chrono::Utc::now().timestamp() + 10).to_string())
+            .build();
+        manager.update_server_time_offset(&node);
+        let (_, seq1) = manager.prepare_send().await.unwrap();
+        assert_eq!(seq1, 1);
+
+        manager.reset().await;
+
+        assert_eq!(manager.server_time_offset_ms(), 0);
+        // Sequence persists until next prepare_send detects new session ID
+        assert_eq!(manager.sequence(), 1);
+
+        // After reset, next send will reset sequence since session ID changed
+        let (_, seq2) = manager.prepare_send().await.unwrap();
+        assert_eq!(seq2, 1, "Sequence resets on new session");
+    }
+}

--- a/wacore/src/ib.rs
+++ b/wacore/src/ib.rs
@@ -1,0 +1,179 @@
+//! IB stanza types for unified session telemetry.
+//!
+//! Wire format: `<ib><unified_session id="..."/></ib>`
+
+use crate::protocol::ProtocolNode;
+use anyhow::Result;
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::node::Node;
+
+/// Unified session telemetry node.
+///
+/// Session ID formula: `(now_ms + server_offset_ms + 3_DAYS_MS) % 7_DAYS_MS`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnifiedSession {
+    pub id: String,
+}
+
+impl UnifiedSession {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+
+    /// Calculate session ID from server time offset.
+    pub fn calculate_id(server_time_offset_ms: i64) -> String {
+        const DAY_MS: i64 = 24 * 60 * 60 * 1000;
+        const WEEK_MS: i64 = 7 * DAY_MS;
+        const OFFSET_MS: i64 = 3 * DAY_MS;
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let adjusted_now = now + server_time_offset_ms;
+        let id = (adjusted_now + OFFSET_MS) % WEEK_MS;
+        id.to_string()
+    }
+
+    pub fn from_offset(server_time_offset_ms: i64) -> Self {
+        Self::new(Self::calculate_id(server_time_offset_ms))
+    }
+}
+
+impl ProtocolNode for UnifiedSession {
+    fn tag(&self) -> &'static str {
+        "unified_session"
+    }
+
+    fn into_node(self) -> Node {
+        NodeBuilder::new("unified_session")
+            .attr("id", self.id)
+            .build()
+    }
+
+    fn try_from_node(node: &Node) -> Result<Self> {
+        if node.tag != "unified_session" {
+            return Err(anyhow::anyhow!(
+                "expected <unified_session>, got <{}>",
+                node.tag
+            ));
+        }
+        let id = node.attrs.get("id").cloned().unwrap_or_default();
+        Ok(Self { id })
+    }
+}
+
+/// IB stanza content types.
+#[derive(Debug, Clone)]
+pub enum IbContent {
+    UnifiedSession(UnifiedSession),
+}
+
+impl IbContent {
+    pub fn into_node(self) -> Node {
+        match self {
+            IbContent::UnifiedSession(us) => us.into_node(),
+        }
+    }
+}
+
+/// IB (Information Broadcast) stanza container.
+#[derive(Debug, Clone)]
+pub struct IbStanza {
+    pub content: IbContent,
+}
+
+impl IbStanza {
+    pub fn unified_session(session: UnifiedSession) -> Self {
+        Self {
+            content: IbContent::UnifiedSession(session),
+        }
+    }
+}
+
+impl ProtocolNode for IbStanza {
+    fn tag(&self) -> &'static str {
+        "ib"
+    }
+
+    fn into_node(self) -> Node {
+        NodeBuilder::new("ib")
+            .children([self.content.into_node()])
+            .build()
+    }
+
+    fn try_from_node(node: &Node) -> Result<Self> {
+        if node.tag != "ib" {
+            return Err(anyhow::anyhow!("expected <ib>, got <{}>", node.tag));
+        }
+
+        if let Some(children) = node.children() {
+            for child in children {
+                if child.tag == "unified_session" {
+                    return Ok(Self::unified_session(UnifiedSession::try_from_node(child)?));
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("unknown or missing <ib> content"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unified_session_into_node() {
+        let session = UnifiedSession::new("123456789");
+        let node = session.into_node();
+
+        assert_eq!(node.tag, "unified_session");
+        assert_eq!(node.attrs.get("id"), Some(&"123456789".to_string()));
+    }
+
+    #[test]
+    fn test_unified_session_try_from_node() {
+        let node = NodeBuilder::new("unified_session")
+            .attr("id", "123456789")
+            .build();
+
+        let session = UnifiedSession::try_from_node(&node).unwrap();
+        assert_eq!(session.id, "123456789");
+    }
+
+    #[test]
+    fn test_ib_stanza_into_node() {
+        let stanza = IbStanza::unified_session(UnifiedSession::new("123456789"));
+        let node = stanza.into_node();
+
+        assert_eq!(node.tag, "ib");
+        let children = node.children().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].tag, "unified_session");
+        assert_eq!(children[0].attrs.get("id"), Some(&"123456789".to_string()));
+    }
+
+    #[test]
+    fn test_unified_session_calculate_id() {
+        const WEEK_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+
+        let id = UnifiedSession::calculate_id(0);
+        let id_num: i64 = id.parse().unwrap();
+        assert!(id_num >= 0);
+        assert!(id_num < WEEK_MS);
+
+        let id_positive = UnifiedSession::calculate_id(5000);
+        let id_positive_num: i64 = id_positive.parse().unwrap();
+        assert!(id_positive_num >= 0);
+        assert!(id_positive_num < WEEK_MS);
+
+        let id_negative = UnifiedSession::calculate_id(-5000);
+        let id_negative_num: i64 = id_negative.parse().unwrap();
+        assert!(id_negative_num >= 0);
+        assert!(id_negative_num < WEEK_MS);
+    }
+
+    #[test]
+    fn test_unified_session_from_offset() {
+        let session = UnifiedSession::from_offset(1000);
+        assert!(!session.id.is_empty());
+    }
+}

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -14,6 +14,7 @@ pub mod protocol;
 pub use wacore_noise::framing;
 pub mod handshake;
 pub mod history_sync;
+pub mod ib;
 pub use wacore_libsignal as libsignal;
 pub mod messages;
 pub mod net;


### PR DESCRIPTION
## Summary
- Add `<ib><unified_session id="..."/>` stanza support matching WhatsApp Web behavior
- Server time sync, duplicate prevention, sequence counter (1-based, resets on new session)
- Type-safe ProtocolNode implementation in `wacore/src/ib.rs`
- Runtime manager in `src/unified_session.rs`

## Test plan
- [x] Unit tests for protocol nodes and manager
- [x] Integration tests in client.rs
- [x] Verified against captured WhatsApp Web JS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Unified session management added: automatically syncs server time, maintains a session ID and sequence, and transmits session info during login, pairing, and presence availability.

* **Behavioral Changes**
  - Session messages are sent automatically at key lifecycle events; duplicate sends are avoided and sequence numbers are tracked.

* **Tests**
  - Extensive unit and integration tests covering session ID, time sync, send behavior, and reset semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->