### PR TITLE
perf: Enhance signing performance by caching scalar representation in PrivateKey

### DIFF
--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -209,7 +209,7 @@ impl Client {
             pairing_ref,
             phone_jid: phone_number,
             pair_code: code.clone(),
-            ephemeral_keypair,
+            ephemeral_keypair: Box::new(ephemeral_keypair),
         };
 
         // Dispatch event for user to display the code

--- a/wacore/libsignal/src/core/curve.rs
+++ b/wacore/libsignal/src/core/curve.rs
@@ -329,9 +329,7 @@ impl PrivateKey {
     ) -> Result<[u8; 64], CurveError> {
         match &self.key {
             PrivateKeyData::DjbPrivateKey { key, .. } => {
-                // Get or compute the full signing cache (lazy initialization)
                 let cache = self.get_edwards_cache();
-                // Reconstruct with ALL cached values (no scalar computation after first call)
                 let private_key = curve25519::PrivateKey::from_bytes_with_cache(
                     *key,
                     cache.scalar,

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -122,7 +122,7 @@ pub enum PairCodeState {
         /// The 8-character pair code (needed to decrypt primary's ephemeral key).
         pair_code: String,
         /// Ephemeral keypair generated for this session.
-        ephemeral_keypair: KeyPair,
+        ephemeral_keypair: Box<KeyPair>,
     },
     /// Pairing completed (success or failure).
     Completed,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Further improved signing performance by caching the private scalar to avoid repeated recomputation.

* **Refactor**
  * Internal key state now stores ephemeral keys with indirection to reduce stack usage and change ownership semantics.

* **Behavior**
  * Some key constructors now require cached values for signing; attempting to sign with keys created without cache may fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->