### PR TITLE
Support stable Rust by removing portable_simd dependency

### DIFF
--- a/wacore/appstate/src/lib.rs
+++ b/wacore/appstate/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(portable_simd)]
 pub mod decode;
 pub mod errors;
 pub mod hash;

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -1,4 +1,3 @@
-use core::simd::u16x8;
 use hkdf::Hkdf;
 use sha2::Sha256;
 
@@ -41,28 +40,9 @@ impl LTHash {
 
 fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool) {
     assert_eq!(base.len(), input.len(), "length mismatch");
-    assert!(base.len().is_multiple_of(2), "slice lengths must be even");
+    assert!(base.len() % 2 == 0, "slice lengths must be even");
 
-    let (base_chunks, base_remainder) = base.as_chunks_mut::<16>();
-    let (input_chunks, input_remainder) = input.as_chunks::<16>();
-
-    for (base_chunk, input_chunk) in base_chunks.iter_mut().zip(input_chunks) {
-        let base_simd = u16x8::from_array(bytemuck::cast(*base_chunk));
-        let input_simd = u16x8::from_array(bytemuck::cast(*input_chunk));
-
-        let result_simd = if subtract {
-            base_simd - input_simd
-        } else {
-            base_simd + input_simd
-        };
-
-        *base_chunk = bytemuck::cast(result_simd.to_array());
-    }
-
-    for (base_pair, input_pair) in base_remainder
-        .chunks_exact_mut(2)
-        .zip(input_remainder.chunks_exact(2))
-    {
+    for (base_pair, input_pair) in base.chunks_exact_mut(2).zip(input.chunks_exact(2)) {
         let x = u16::from_le_bytes([base_pair[0], base_pair[1]]);
         let y = u16::from_le_bytes([input_pair[0], input_pair[1]]);
 

--- a/wacore/binary/src/lib.rs
+++ b/wacore/binary/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(portable_simd)]
-
 pub mod attrs;
 pub mod builder;
 pub mod consts;

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(portable_simd)]
 extern crate self as wacore;
 
 pub use aes_gcm;


### PR DESCRIPTION
The `portable_simd` API changed in recent nightly versions, causing build failures (`Mask::select` moved, type inference issues). 

This PR replaces the SIMD code with scalar implementations that pass all 54 existing tests. The project now builds on stable Rust.

Happy to discuss alternative approaches like a feature flag if you'd prefer to keep SIMD as an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed reliance on Rust nightly-only features so the project builds on stable Rust.
  * Replaced several SIMD-optimized code paths with simpler scalar implementations for hashing and binary encoding/decoding, preserving public APIs and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->