### PR TITLE
Add group management IQs and participant types

### DIFF
--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -12,8 +12,9 @@ pub use chatstate::{ChatStateType, Chatstate};
 pub use contacts::{ContactInfo, Contacts, IsOnWhatsAppResult, ProfilePicture, UserInfo};
 
 pub use groups::{
-    CreateGroupResult, GroupCreateOptions, GroupMetadata, GroupParticipant,
-    GroupParticipantOptions, Groups, MemberAddMode, MemberLinkMode, MembershipApprovalMode,
+    CreateGroupResult, GroupCreateOptions, GroupDescription, GroupMetadata, GroupParticipant,
+    GroupParticipantOptions, GroupSubject, Groups, MemberAddMode, MemberLinkMode,
+    MembershipApprovalMode, ParticipantChangeResponse,
 };
 
 pub use mex::{Mex, MexError, MexErrorExtensions, MexGraphQLError, MexRequest, MexResponse};

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -37,14 +37,13 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
                 let dirty_type = match attrs.optional_string("type") {
                     Some(t) => t.to_string(),
                     None => {
-                        warn!(target: "Client", "Dirty notification missing 'type' attribute");
+                        warn!("Dirty notification missing 'type' attribute");
                         continue;
                     }
                 };
                 let timestamp = attrs.optional_string("timestamp").map(|s| s.to_string());
 
                 info!(
-                    target: "Client",
                     "Received dirty state notification for type: '{dirty_type}'. Sending clean IQ."
                 );
 
@@ -55,7 +54,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
                         .clean_dirty_bits(&dirty_type, timestamp.as_deref())
                         .await
                     {
-                        warn!(target: "Client", "Failed to send clean dirty bits IQ: {e:?}");
+                        warn!("Failed to send clean dirty bits IQ: {e:?}");
                     }
                 });
             }
@@ -67,7 +66,6 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
                     if let Some(NodeContent::Bytes(routing_bytes)) = &routing_info_node.content {
                         if !routing_bytes.is_empty() {
                             info!(
-                                target: "Client",
                                 "Received edge routing info ({} bytes), storing for reconnection",
                                 routing_bytes.len()
                             );
@@ -79,13 +77,13 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
                                 })
                                 .await;
                         } else {
-                            info!(target: "Client", "Received empty edge routing info, ignoring");
+                            info!("Received empty edge routing info, ignoring");
                         }
                     } else {
-                        info!(target: "Client", "Edge routing info node has no bytes content");
+                        info!("Edge routing info node has no bytes content");
                     }
                 } else {
-                    info!(target: "Client", "Edge routing stanza has no routing_info child");
+                    info!("Edge routing stanza has no routing_info child");
                 }
             }
             "offline_preview" => {
@@ -135,10 +133,10 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
             }
             "thread_metadata" => {
                 // Present in some sessions; safe to ignore for now until feature implemented.
-                info!(target: "Client", "Received thread metadata, ignoring for now.");
+                info!("Received thread metadata, ignoring for now.");
             }
             _ => {
-                warn!(target: "Client", "Unhandled ib child: <{}>", child.tag);
+                warn!("Unhandled ib child: <{}>", child.tag);
             }
         }
     }

--- a/src/handlers/iq.rs
+++ b/src/handlers/iq.rs
@@ -24,7 +24,7 @@ impl StanzaHandler for IqHandler {
 
     async fn handle(&self, client: Arc<Client>, node: Arc<Node>, _cancelled: &mut bool) -> bool {
         if !client.handle_iq(&node).await {
-            warn!(target: "Client", "Received unhandled IQ: {}", DisplayableNode(&node));
+            warn!("Received unhandled IQ: {}", DisplayableNode(&node));
         }
         true
     }

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -100,7 +100,7 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
             handle_business_notification(client, node).await;
         }
         _ => {
-            warn!(target: "Client", "TODO: Implement handler for <notification type='{notification_type}'>");
+            warn!("TODO: Implement handler for <notification type='{notification_type}'>");
             client
                 .core
                 .event_bus
@@ -126,7 +126,7 @@ async fn handle_devices_notification(client: &Arc<Client>, node: &Node) {
     let notification = match DeviceNotification::try_parse(node) {
         Ok(n) => n,
         Err(e) => {
-            warn!(target: "Client", "Failed to parse device notification: {e}");
+            warn!("Failed to parse device notification: {e}");
             return;
         }
     };
@@ -137,21 +137,18 @@ async fn handle_devices_notification(client: &Arc<Client>, node: &Node) {
             .add_lid_pn_mapping(lid, pn, LearningSource::DeviceNotification)
             .await
     {
-        warn!(target: "Client", "Failed to add LID-PN mapping from device notification: {e}");
+        warn!("Failed to add LID-PN mapping from device notification: {e}");
     }
 
     // Process the single operation (per WhatsApp Web: one operation per notification)
     let op = &notification.operation;
     debug!(
-        target: "Client",
         "Device notification: user={}, type={:?}, devices={:?}",
         notification.user(),
         op.operation_type,
         op.device_ids()
     );
 
-    // Invalidate the device cache for this user
-    // This ensures the next lookup fetches fresh data
     client.invalidate_device_cache(notification.user()).await;
 
     // Dispatch event to notify application layer

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -49,15 +49,9 @@ pub async fn do_handshake(
     let (header, used_edge_routing) =
         build_handshake_header(device.core.edge_routing_info.as_deref());
     if used_edge_routing {
-        debug!(
-            target: "Client",
-            "Sending edge routing pre-intro for optimized reconnection"
-        );
+        debug!("Sending edge routing pre-intro for optimized reconnection");
     } else if device.core.edge_routing_info.is_some() {
-        warn!(
-            target: "Client",
-            "Edge routing info provided but not used (possibly too large)"
-        );
+        warn!("Edge routing info provided but not used (possibly too large)");
     }
 
     // First message includes the WA connection header (with optional edge routing)
@@ -104,7 +98,7 @@ pub async fn do_handshake(
     transport.send(framed).await?;
 
     let (write_key, read_key) = handshake_state.finish()?;
-    info!(target: "Client", "Handshake complete, switching to encrypted communication");
+    info!("Handshake complete, switching to encrypted communication");
 
     Ok(Arc::new(NoiseSocket::new(transport, write_key, read_key)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub use wacore::{proto_helpers, store::traits};
 pub use wacore_binary::builder::NodeBuilder;
+pub use wacore_binary::jid::Jid;
 pub use waproto;
 
 pub mod http;
@@ -39,10 +40,10 @@ pub mod usync;
 pub mod features;
 pub use features::{
     Blocking, BlocklistEntry, ChatStateType, Chatstate, ContactInfo, Contacts, CreateGroupResult,
-    GroupCreateOptions, GroupMetadata, GroupParticipant, GroupParticipantOptions, Groups,
-    IsOnWhatsAppResult, MemberAddMode, MemberLinkMode, MembershipApprovalMode, Mex, MexError,
-    MexErrorExtensions, MexRequest, MexResponse, Presence, PresenceStatus, ProfilePicture,
-    UserInfo,
+    GroupCreateOptions, GroupDescription, GroupMetadata, GroupParticipant, GroupParticipantOptions,
+    GroupSubject, Groups, IsOnWhatsAppResult, MemberAddMode, MemberLinkMode,
+    MembershipApprovalMode, Mex, MexError, MexErrorExtensions, MexRequest, MexResponse,
+    ParticipantChangeResponse, Presence, PresenceStatus, ProfilePicture, UserInfo,
 };
 
 pub mod bot;


### PR DESCRIPTION
Implement multiple group management IqSpecs and helpers: SetGroupSubject,
SetGroupDescription, LeaveGroup, Add/Remove/Promote/DemoteParticipants, GetGroupInviteLink and ParticipantChangeResponse with parsing/builders.

Add DownloadParams in download.rs implementing Downloadable for raw media parameters.

Simplify logging calls by removing explicit target="Client" arguments.

Re-export Jid from crate root, update imports, and expose new group types
in features mod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Extended group management with subject and description editing, participant management (add, remove, promote, demote), group departure, and invite link retrieval
* Introduced raw parameter-based download capability independent of message context
* Added message read receipt marking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->