### PR TITLE
feat: add skip_history_sync option to BotBuilder and Client for ignoring history sync notifications

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -226,12 +226,25 @@ pub struct Client {
     /// Version override for testing or manual specification
     pub(crate) override_version: Option<(u32, u32, u32)>,
 
-    /// When true, history sync notifications are silently ignored.
-    /// Set via `BotBuilder::skip_history_sync()`. Can also be toggled at runtime.
-    pub skip_history_sync: AtomicBool,
+    /// When true, history sync notifications are acknowledged but not downloaded
+    /// or processed. Set via `BotBuilder::skip_history_sync()`.
+    pub(crate) skip_history_sync: AtomicBool,
 }
 
 impl Client {
+    /// Enable or disable skipping of history sync notifications at runtime.
+    ///
+    /// When enabled, the client will acknowledge incoming history sync
+    /// notifications but will not download or process the data.
+    pub fn set_skip_history_sync(&self, enabled: bool) {
+        self.skip_history_sync.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if history sync notifications are currently being skipped.
+    pub fn skip_history_sync_enabled(&self) -> bool {
+        self.skip_history_sync.load(Ordering::Relaxed)
+    }
+
     pub async fn new(
         persistence_manager: Arc<PersistenceManager>,
         transport_factory: Arc<dyn crate::transport::TransportFactory>,

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -12,15 +12,22 @@ impl Client {
         message_id: String,
         notification: HistorySyncNotification,
     ) {
-        if self
-            .skip_history_sync
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
+        if self.skip_history_sync_enabled() {
             log::debug!(
                 "Skipping history sync for message {} (Type: {:?})",
                 message_id,
                 notification.sync_type()
             );
+            // Send receipt so the phone considers this chunk delivered and stops
+            // retrying. This intentionally diverges from WhatsApp Web's AB prop
+            // drop path (which sends no receipt) because bots will never process
+            // history, and without the receipt the phone would keep re-uploading
+            // blobs that will never be consumed.
+            self.send_protocol_receipt(
+                message_id,
+                crate::types::presence::ReceiptType::HistorySync,
+            )
+            .await;
             return;
         }
 


### PR DESCRIPTION
Closes https://github.com/jlucaso1/whatsapp-rust/issues/276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add an option to skip history synchronization so the bot can acknowledge history sync notifications without processing them.
  * Allow toggling this behavior at runtime so the client can enable/disable skipping as needed.

* **Bug Fixes / Behavior**
  * When skipping, the system now still sends an acknowledgement for history sync chunks to preserve protocol behavior.

* **Tests**
  * Added tests covering the new skip behavior and default (disabled) state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->