### PR TITLE
fix: use fresh stanza ID for edit_message to prevent server dedup

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1997,10 +1997,15 @@ impl Client {
             ..Default::default()
         };
 
+        // Use a new stanza ID instead of reusing the original message ID.
+        // The original message ID is already embedded in protocolMessage.key.id
+        // inside the encrypted payload. Reusing it as the outer stanza ID causes
+        // the server to deduplicate against the original message and silently
+        // drop the edit.
         self.send_message_impl(
             to,
             &edit_container_message,
-            Some(original_id.clone()),
+            None,
             false,
             false,
             Some(crate::types::message::EditAttribute::MessageEdit),


### PR DESCRIPTION
## Problem

`edit_message` passes `Some(original_id.clone())` as `request_id_override` to `send_message_impl`, reusing the original message's stanza ID as the outer stanza ID. The WhatsApp server deduplicates by stanza ID and silently drops the edit since it already saw that ID for the original message.

Edits appear to succeed (no error returned) but the recipient never sees the edited text.

## Fix

Pass `None` instead of `Some(original_id.clone())` so `send_message_impl` generates a fresh stanza ID. The original message ID is already correctly embedded in the encrypted payload at `protocolMessage.key.id`, so the server can still match the edit to its target.

This matches how `revoke_message` already works — it passes `None` for the stanza ID.

## Testing

Tested live with two WhatsApp accounts. Before fix: edits silently dropped. After fix: edits delivered correctly and visible on recipient's device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where message edits could be silently dropped or duplicated by the server. Message edits will now be reliably delivered and processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->