### PR TITLE
fix: use while loop for app state sync pagination

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1376,8 +1376,17 @@ impl Client {
 
         let mut has_more = true;
         let mut want_snapshot = full_sync;
+        // Safety cap to prevent infinite loops if the server keeps returning
+        // has_more_patches=true without advancing the version (WA Web uses 500).
+        const MAX_PAGINATION_ITERATIONS: u32 = 500;
+        let mut iteration = 0u32;
 
         while has_more {
+            iteration += 1;
+            if iteration > MAX_PAGINATION_ITERATIONS {
+                warn!(target: "Client/AppState", "App state sync for {:?} exceeded {} iterations, aborting", name, MAX_PAGINATION_ITERATIONS);
+                break;
+            }
             debug!(target: "Client/AppState", "Fetching app state patch batch: name={:?} want_snapshot={want_snapshot} version={} full_sync={} has_more_previous={}", name, state.version, full_sync, has_more);
 
             let mut collection_builder = NodeBuilder::new("collection")


### PR DESCRIPTION
The app state sync in `process_app_state_sync_task` used `if has_more` instead of `while has_more`, causing only the first batch to be fetched when the server returns `has_more_patches = true`. This silently dropped patches beyond the first batch.

Also ensures `want_snapshot` is set to false after the first batch so subsequent fetches request incremental patches with the updated version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved app-state synchronization by optimizing batch processing logic. The state patching mechanism now handles multiple batches more efficiently, with enhanced state tracking and logging to ensure reliable incremental updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->