### PR TITLE
fix: gate Connected event behind critical app state sync on pairing

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1321,6 +1321,10 @@ impl Client {
                     }
                 }
 
+                // Re-check generation after awaits to avoid dispatching Connected
+                // for an outdated connection that was replaced mid-await.
+                check_generation!();
+
                 client_clone
                     .core
                     .event_bus


### PR DESCRIPTION
During fresh pairing, the Connected event was dispatched before app state sync started. This meant bot code could start processing before blocklist, privacy settings, and pushname were applied.

Now on initial sync (fresh pairing):
1. Await CriticalBlock + CriticalUnblockLow collections (blocking)
2. Send presence (pushname is now available from critical sync)
3. Dispatch Connected event
4. Spawn remaining non-critical collections (RegularLow/High/Regular)

On reconnection (already paired), behavior is unchanged: presence and Connected are dispatched immediately since settings are already cached.

Matches WhatsApp Web's syncCriticalData() which awaits critical collections before firing criticalSyncDone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the login initialization flow to synchronize critical user data before app activation.
  * Improved reconnection handling to efficiently manage presence and connection states during synchronization.
  * Refactored synchronization control flow and background operations to prevent stale task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->