### PR TITLE
feat: batched multi-collection app state sync with incremental updates

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -142,19 +142,38 @@ impl AppStateProcessor {
             // Download external snapshot
             if pl.snapshot.is_none()
                 && let Some(ext) = &pl.snapshot_ref
-                && let Ok(data) = download(ext)
-                && let Ok(snapshot) = wa::SyncdSnapshot::decode(data.as_slice())
             {
-                pl.snapshot = Some(snapshot);
+                match download(ext) {
+                    Ok(data) => match wa::SyncdSnapshot::decode(data.as_slice()) {
+                        Ok(snapshot) => pl.snapshot = Some(snapshot),
+                        Err(e) => {
+                            log::warn!(target: "AppState", "Failed to decode external snapshot for {:?}: {e}", pl.name);
+                        }
+                    },
+                    Err(e) => {
+                        log::warn!(target: "AppState", "Failed to download external snapshot for {:?}: {e}", pl.name);
+                    }
+                }
             }
 
             // Download external mutations for each patch
             for patch in &mut pl.patches {
-                if let Some(ext) = &patch.external_mutations
-                    && let Ok(data) = download(ext)
-                    && let Ok(ext_mutations) = wa::SyncdMutations::decode(data.as_slice())
-                {
-                    patch.mutations = ext_mutations.mutations;
+                if let Some(ext) = &patch.external_mutations {
+                    match download(ext) {
+                        Ok(data) => match wa::SyncdMutations::decode(data.as_slice()) {
+                            Ok(ext_mutations) => {
+                                patch.mutations = ext_mutations.mutations;
+                            }
+                            Err(e) => {
+                                let v = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
+                                log::warn!(target: "AppState", "Failed to decode external mutations for {:?} v{}: {e}", pl.name, v);
+                            }
+                        },
+                        Err(e) => {
+                            let v = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
+                            log::warn!(target: "AppState", "Failed to download external mutations for {:?} v{}: {e}", pl.name, v);
+                        }
+                    }
                 }
             }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1469,8 +1469,6 @@ impl Client {
 
         while !pending.is_empty() && iteration < MAX_ITERATIONS {
             iteration += 1;
-            let is_first = iteration == 1;
-
             debug!(
                 target: "Client/AppState",
                 "Batched sync iteration {}/{}: {:?}",
@@ -1479,11 +1477,15 @@ impl Client {
 
             let backend = self.persistence_manager.backend();
 
-            // Build multi-collection IQ
+            // Build multi-collection IQ, tracking which collections need a snapshot
             let mut collection_nodes = Vec::with_capacity(pending.len());
+            let mut was_snapshot = std::collections::HashSet::new();
             for &name in &pending {
                 let state = backend.get_version(name.as_str()).await?;
                 let want_snapshot = state.version == 0;
+                if want_snapshot {
+                    was_snapshot.insert(name);
+                }
                 let mut builder = NodeBuilder::new("collection")
                     .attr("name", name.as_str())
                     .attr(
@@ -1628,8 +1630,10 @@ impl Client {
                     }
                 }
 
-                // Dispatch mutations
-                let full_sync = is_first;
+                // full_sync is true only when this collection had a snapshot
+                // (version was 0 before sync). This prevents server_sync-triggered
+                // incremental syncs from being incorrectly marked as full syncs.
+                let full_sync = was_snapshot.contains(&name);
                 for m in mutations {
                     self.dispatch_app_state_mutation(&m, full_sync).await;
                 }

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -81,7 +81,20 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
 
             if !collections.is_empty() {
                 let client_clone = client.clone();
+                let generation = client
+                    .connection_generation
+                    .load(std::sync::atomic::Ordering::SeqCst);
                 tokio::spawn(async move {
+                    // Check if connection was replaced before starting sync
+                    if client_clone
+                        .connection_generation
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                        != generation
+                    {
+                        log::debug!(target: "Client/AppState", "server_sync task cancelled: connection generation changed");
+                        return;
+                    }
+
                     // Filter by version comparison before syncing.
                     // Matches WA Web's markCollectionsForSync version comparison filter.
                     let backend = client_clone.persistence_manager.backend();

--- a/wacore/appstate/src/patch_decode.rs
+++ b/wacore/appstate/src/patch_decode.rs
@@ -88,10 +88,14 @@ pub fn parse_patch_list(node: &Node) -> Result<PatchList> {
 
 /// Parse all `<collection>` children from a `<sync>` response into PatchLists.
 /// Used for batched multi-collection IQ responses.
+/// Tolerates both `<iq><sync>...</sync></iq>` and bare `<sync>...</sync>` roots.
 pub fn parse_patch_lists(node: &Node) -> Result<Vec<PatchList>> {
-    let sync_node = node
-        .get_optional_child("sync")
-        .ok_or_else(|| anyhow!("missing sync node in response"))?;
+    let sync_node = if node.tag == "sync" {
+        node
+    } else {
+        node.get_optional_child("sync")
+            .ok_or_else(|| anyhow!("missing sync node in response"))?
+    };
 
     let Some(children) = sync_node.children() else {
         return Ok(Vec::new());
@@ -166,14 +170,20 @@ fn parse_collection_error(
         return None;
     }
 
-    let error_node = collection.get_optional_child("error")?;
-    let mut error_attrs = error_node.attrs();
-    let code_str = error_attrs.optional_string("code").unwrap_or("0");
-    let text = error_attrs
-        .optional_string("text")
-        .unwrap_or("")
-        .to_string();
-    let code: u16 = code_str.parse().unwrap_or(0);
+    // Parse error details from child node, or fall back to a default retryable
+    // error if the <error> child is missing/malformed.
+    let (code, text) = if let Some(error_node) = collection.get_optional_child("error") {
+        let mut error_attrs = error_node.attrs();
+        let code_str = error_attrs.optional_string("code").unwrap_or("0");
+        let text = error_attrs
+            .optional_string("text")
+            .unwrap_or("")
+            .to_string();
+        let code: u16 = code_str.parse().unwrap_or(0);
+        (code, text)
+    } else {
+        (0u16, "missing <error> child".to_string())
+    };
 
     Some(match code {
         409 => CollectionSyncError::Conflict {


### PR DESCRIPTION
- Sync app state on server_sync notifications (incremental, not full snapshot)
- Add version filter: skip collections where local_version >= server_version
- Add in-flight dedup via HashSet<WAPatchName> to prevent concurrent syncs
- Batch multiple collections into a single <sync> IQ request
- Per-collection error handling (409=Conflict, 400/404=Fatal, other=Retry)
- Outer refetch loop with has_more_patches pagination (max 5 iterations)
- Parse multi-collection responses in patch_decode