### PR TITLE
fix(wacore): use Vec<u8> in key_pair_serde::deserialize to fix JSON roundtrip

### DIFF
--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -29,7 +29,7 @@ pub mod key_pair_serde {
     where
         D: Deserializer<'de>,
     {
-        let bytes: &[u8] = serde::Deserialize::deserialize(deserializer)?;
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
         if bytes.len() != 64 {
             return Err(serde::de::Error::invalid_length(bytes.len(), &"64"));
         }
@@ -284,5 +284,25 @@ mod tests {
             assert!(device.registration_id >= 1);
             assert!(device.registration_id <= 2147483647);
         }
+    }
+
+    #[test]
+    fn test_device_serde_roundtrip() {
+        // Regression test: key_pair_serde::serialize uses serialize_bytes which
+        // produces a JSON integer array. deserialize must use Vec<u8> (not &[u8])
+        // to accept a sequence from serde_json; &[u8] would fail with
+        // "invalid type: sequence, expected a borrowed byte array".
+        let device = Device::new();
+        let json = serde_json::to_string(&device).expect("serialize should succeed");
+        let restored: Device = serde_json::from_str(&json).expect("deserialize should succeed");
+        assert_eq!(device.registration_id, restored.registration_id);
+        assert_eq!(
+            device.noise_key.public_key.public_key_bytes(),
+            restored.noise_key.public_key.public_key_bytes()
+        );
+        assert_eq!(
+            device.identity_key.public_key.public_key_bytes(),
+            restored.identity_key.public_key.public_key_bytes()
+        );
     }
 }


### PR DESCRIPTION
## Problem

`key_pair_serde::serialize` uses `serializer.serialize_bytes(&bytes)` which in `serde_json` produces a JSON integer array like `[1, 2, 3, ...]`.

`key_pair_serde::deserialize` then tries to deserialize into `&[u8]`, but `serde_json`'s visitor for `&[u8]` expects a base64-encoded string — not a sequence — and fails at runtime with:

```
invalid type: sequence, expected a borrowed byte array
```

This causes any sled-backed store (e.g. `moltis-whatsapp`) to fail on every restart when trying to load the persisted `Device`:

```
Failed to create persistence manager: Database operation error:
Serialization/deserialization error: invalid type: sequence,
expected a borrowed byte array at line 1 column 219
```

The session is written correctly on first run but can never be read back, requiring a full re-pair (QR scan) after every process restart.

## Fix

Change `&[u8]` to `Vec<u8>` in the deserializer. `Vec<u8>` uses `visit_seq` which correctly accepts a JSON integer array.

## Test

Added `test_device_serde_roundtrip` — a `serde_json` serialize → deserialize roundtrip on `Device`. This test would have caught the bug (it fails on the old code, passes on the fix).

## Validation

- [x] `cargo test -p wacore` passes
- [x] `test_device_serde_roundtrip` passes
- [x] No breaking changes — `at_ms` callers unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device registration stability through improved serialization handling.

* **Tests**
  * Added regression tests to verify device storage integrity across serialization cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->