### PR TITLE
fix: signal keepalive loop shutdown on connection cleanup

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -802,6 +802,10 @@ impl Client {
     async fn cleanup_connection_state(&self) {
         self.is_logged_in.store(false, Ordering::Relaxed);
         self.is_ready.store(false, Ordering::Relaxed);
+        // Signal the keepalive loop (and any other tasks) to exit promptly.
+        // Without this, a stale keepalive loop can overlap with the next one
+        // after reconnect, causing duplicate pings.
+        self.shutdown_notifier.notify_waiters();
         *self.transport.lock().await = None;
         *self.transport_events.lock().await = None;
         *self.noise_socket.lock().await = None;


### PR DESCRIPTION
## Summary
- When the WebSocket connection drops unexpectedly, `cleanup_connection_state()` did not signal `shutdown_notifier`, so the old keepalive loop kept running while `connect()` spawned a new one
- This caused **duplicate keepalive pings** running concurrently after reconnect (visible in user logs as pings 0-5s apart instead of the expected 20-30s interval)
- Fix: call `self.shutdown_notifier.notify_waiters()` in `cleanup_connection_state()` so the old keepalive loop exits promptly before a new one is spawned

## Root cause (from user logs)
After a network disconnect (`Connection reset by peer`), the reconnect flow calls `cleanup_connection_state()` → `connect()`. Since `cleanup_connection_state` never signaled the shutdown notifier, the old keepalive task lingered until its next `is_connected()` check. Meanwhile `connect()` spawned a fresh keepalive loop, resulting in two loops sending pings simultaneously.

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo check` — passes
- [ ] Verify with a real connection that reconnect produces a single keepalive stream (no duplicate pings in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client reconnection stability by ensuring keepalive mechanisms properly terminate upon disconnection, preventing resource overlap and potential conflicts between stale and newly established connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->