### PR TITLE
fix: unwrap DeviceSentMessage before dispatch

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1161,16 +1161,12 @@ impl Client {
         );
 
         match wa::Message::decode(plaintext_slice) {
-            Ok(mut original_msg) => {
+            Ok(original_msg) => {
                 // Unwrap DeviceSentMessage wrapper (self-sent messages synced from
                 // the primary device). The actual content (reactions, text, etc.)
                 // is nested inside device_sent_message.message and must be
                 // extracted before protocol checks or dispatch.
-                let mut msg = if let Some(dsm) = original_msg.device_sent_message.take() {
-                    dsm.message.map_or(original_msg, |inner| *inner)
-                } else {
-                    original_msg
-                };
+                let mut msg = unwrap_device_sent(original_msg);
 
                 // Post-decryption logic (SKDM, sync keys, etc.)
                 if let Some(skdm) = &msg.sender_key_distribution_message
@@ -1554,6 +1550,22 @@ impl Client {
             );
         }
     }
+}
+
+/// Unwraps a `DeviceSentMessage` wrapper, returning the inner message.
+///
+/// Self-sent messages synced from the primary device arrive with the actual
+/// content (reactions, text, etc.) nested inside `device_sent_message.message`.
+/// This extracts the inner message when present, or returns the original
+/// message unchanged when there is no wrapper or the wrapper has no inner message.
+fn unwrap_device_sent(mut msg: wa::Message) -> wa::Message {
+    if let Some(mut dsm) = msg.device_sent_message.take() {
+        if let Some(inner) = dsm.message.take() {
+            return *inner;
+        }
+        msg.device_sent_message = Some(dsm);
+    }
+    msg
 }
 
 /// Returns `true` if the message contains only a SenderKey distribution
@@ -4229,38 +4241,72 @@ mod tests {
         }));
     }
 
-    /// Test: a reaction wrapped in DeviceSentMessage is not treated as SKDM-only,
-    /// confirming it would be dispatched after DSM unwrapping in handle_decrypted_plaintext.
+    /// Test: unwrap_device_sent extracts a reaction from a DeviceSentMessage wrapper.
     #[test]
-    fn test_dsm_wrapped_reaction_not_skdm_only() {
-        // Simulate what arrives after DSM unwrapping: the inner message with a reaction
-        let inner = wa::Message {
-            reaction_message: Some(wa::message::ReactionMessage {
-                text: Some("\u{2764}".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-        assert!(
-            !is_sender_key_distribution_only(&inner),
-            "unwrapped reaction should not be filtered as SKDM-only"
-        );
-
-        // Before the fix: the outer wrapper has no visible content fields set,
-        // but is_sender_key_distribution_only returns false for it too (no SKDM).
-        // The real problem was that dispatch sent the outer wrapper with all-None fields.
-        let outer = wa::Message {
+    fn test_unwrap_device_sent_extracts_reaction() {
+        let wrapped = wa::Message {
             device_sent_message: Some(Box::new(wa::message::DeviceSentMessage {
                 destination_jid: Some("5511999999999@s.whatsapp.net".to_string()),
-                message: Some(Box::new(inner)),
+                message: Some(Box::new(wa::Message {
+                    reaction_message: Some(wa::message::ReactionMessage {
+                        text: Some("\u{2764}".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })),
                 phash: None,
             })),
             ..Default::default()
         };
+
+        let unwrapped = unwrap_device_sent(wrapped);
         assert!(
-            !is_sender_key_distribution_only(&outer),
-            "DSM wrapper should not be filtered as SKDM-only"
+            unwrapped.device_sent_message.is_none(),
+            "DSM wrapper should be removed"
         );
+        assert_eq!(
+            unwrapped
+                .reaction_message
+                .as_ref()
+                .and_then(|r| r.text.as_deref()),
+            Some("\u{2764}"),
+            "reaction should be accessible after unwrapping"
+        );
+        assert!(
+            !is_sender_key_distribution_only(&unwrapped),
+            "unwrapped reaction should not be filtered as SKDM-only"
+        );
+    }
+
+    /// Test: unwrap_device_sent preserves the wrapper when inner message is None.
+    #[test]
+    fn test_unwrap_device_sent_preserves_empty_wrapper() {
+        let wrapped = wa::Message {
+            device_sent_message: Some(Box::new(wa::message::DeviceSentMessage {
+                destination_jid: Some("5511999999999@s.whatsapp.net".to_string()),
+                message: None,
+                phash: None,
+            })),
+            ..Default::default()
+        };
+
+        let result = unwrap_device_sent(wrapped);
+        assert!(
+            result.device_sent_message.is_some(),
+            "empty DSM wrapper should be preserved"
+        );
+    }
+
+    /// Test: unwrap_device_sent passes through a plain message unchanged.
+    #[test]
+    fn test_unwrap_device_sent_passthrough() {
+        let msg = wa::Message {
+            conversation: Some("hello".to_string()),
+            ..Default::default()
+        };
+
+        let result = unwrap_device_sent(msg);
+        assert_eq!(result.conversation.as_deref(), Some("hello"));
     }
 
     #[tokio::test]

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -197,36 +197,24 @@ impl MessageExt for wa::Message {
     }
 
     fn into_base_message(mut self) -> wa::Message {
-        if let Some(dsm) = self.device_sent_message.take()
-            && let Some(msg) = dsm.message
-        {
-            self = *msg;
+        macro_rules! peel_wrapper {
+            ($field:ident) => {
+                if let Some(mut wrapper) = self.$field.take() {
+                    if let Some(msg) = wrapper.message.take() {
+                        self = *msg;
+                    } else {
+                        self.$field = Some(wrapper);
+                    }
+                }
+            };
         }
-        if let Some(wrapper) = self.ephemeral_message.take()
-            && let Some(msg) = wrapper.message
-        {
-            self = *msg;
-        }
-        if let Some(wrapper) = self.view_once_message.take()
-            && let Some(msg) = wrapper.message
-        {
-            self = *msg;
-        }
-        if let Some(wrapper) = self.view_once_message_v2.take()
-            && let Some(msg) = wrapper.message
-        {
-            self = *msg;
-        }
-        if let Some(wrapper) = self.document_with_caption_message.take()
-            && let Some(msg) = wrapper.message
-        {
-            self = *msg;
-        }
-        if let Some(wrapper) = self.edited_message.take()
-            && let Some(msg) = wrapper.message
-        {
-            self = *msg;
-        }
+
+        peel_wrapper!(device_sent_message);
+        peel_wrapper!(ephemeral_message);
+        peel_wrapper!(view_once_message);
+        peel_wrapper!(view_once_message_v2);
+        peel_wrapper!(document_with_caption_message);
+        peel_wrapper!(edited_message);
         self
     }
 
@@ -1275,9 +1263,11 @@ mod tests {
         };
 
         let unwrapped = msg.into_base_message();
-        // With no inner message the outer message is returned as-is
-        // (device_sent_message was consumed by take())
-        assert!(unwrapped.device_sent_message.is_none());
+        // With no inner message the wrapper is preserved
+        assert!(
+            unwrapped.device_sent_message.is_some(),
+            "empty DSM wrapper should be preserved"
+        );
         assert!(unwrapped.conversation.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #336 — self-sent reactions (and other messages) from the official WhatsApp client arriving as empty `wa::Message`
- Unwraps `DeviceSentMessage` wrapper in `handle_decrypted_plaintext()` before protocol checks (SKDM, sync keys, PDO, history sync) and event dispatch
- Adds `into_base_message()` consuming method to `MessageExt` trait for zero-clone wrapper unwrapping

## Root cause
Self-sent messages synced from the primary device are wrapped in `DeviceSentMessage { message: Some(actual_content) }`. The decryption path decoded the outer wrapper and dispatched it directly — consumers saw all-None fields instead of the nested reaction/text content.

## Test plan
- [x] Unit tests for `into_base_message()` (DSM+reaction, DSM+ephemeral, passthrough, empty DSM)
- [x] Unit test confirming DSM-wrapped reactions pass through `is_sender_key_distribution_only` check
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all --tests` clean (no new warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling and dispatch of reactions and other messages synced from your devices; improved processing of nested wrappers (device-synced, ephemeral, view-once, edited, captioned) to ensure correct delivery.
* **Tests**
  * Added comprehensive tests covering unwrapping of nested message structures, device-synced reactions, and edge cases (empty wrappers and passthrough).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->