### PR TITLE
feat: handle stream error codes 401, 409, 429

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4636,26 +4636,9 @@ mod tests {
 
     // ── stream error tests ─────────────────────────────────────────────
 
-    async fn create_test_client() -> Arc<Client> {
-        let backend = crate::test_utils::create_test_backend().await;
-        let pm = Arc::new(
-            PersistenceManager::new(backend)
-                .await
-                .expect("persistence manager should initialize"),
-        );
-        let (client, _rx) = Client::new(
-            pm,
-            Arc::new(crate::transport::mock::MockTransportFactory::new()),
-            Arc::new(MockHttpClient),
-            None,
-        )
-        .await;
-        client
-    }
-
     #[tokio::test]
     async fn test_stream_error_401_disables_reconnect() {
-        let client = create_test_client().await;
+        let client = create_offline_sync_test_client().await;
         let node = NodeBuilder::new("stream:error").attr("code", "401").build();
         client.handle_stream_error(&node).await;
         assert!(
@@ -4666,7 +4649,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stream_error_409_disables_reconnect() {
-        let client = create_test_client().await;
+        let client = create_offline_sync_test_client().await;
         let node = NodeBuilder::new("stream:error").attr("code", "409").build();
         client.handle_stream_error(&node).await;
         assert!(
@@ -4677,7 +4660,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_stream_error_429_keeps_reconnect_with_backoff() {
-        let client = create_test_client().await;
+        let client = create_offline_sync_test_client().await;
         let before = client.auto_reconnect_errors.load(Ordering::Relaxed);
         let node = NodeBuilder::new("stream:error").attr("code", "429").build();
         client.handle_stream_error(&node).await;
@@ -4686,15 +4669,16 @@ mod tests {
             "429 should keep auto-reconnect enabled"
         );
         let after = client.auto_reconnect_errors.load(Ordering::Relaxed);
-        assert!(
-            after >= before + 5,
-            "429 should increase backoff: before={before}, after={after}"
+        assert_eq!(
+            after,
+            before + 5,
+            "429 should increase backoff by exactly 5: before={before}, after={after}"
         );
     }
 
     #[tokio::test]
     async fn test_stream_error_503_keeps_reconnect() {
-        let client = create_test_client().await;
+        let client = create_offline_sync_test_client().await;
         let node = NodeBuilder::new("stream:error").attr("code", "503").build();
         client.handle_stream_error(&node).await;
         assert!(


### PR DESCRIPTION
Fixes #342

## Summary
- **401** (unauthorized): disable auto-reconnect, dispatch `LoggedOut` — session is invalid
- **409** (conflict): disable auto-reconnect, dispatch `StreamReplaced` — another client connected
- **429** (rate limited): keep auto-reconnect, increase backoff by 5 fibonacci steps — server is throttling

Cross-referenced against WA Web `WAWebHandleStreamError` behavior.

## Test plan
- [x] 4 unit tests verifying auto-reconnect flag and backoff for each code
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all --tests` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic logout and disconnection on authentication failures
  * Automatic logout and disconnection when session is replaced
  * Rate limiting with intelligent backoff strategy for reconnection attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->