### PR TITLE
fix: remove unecessary offline sequence

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -238,7 +238,6 @@ pub(crate) struct OfflineSyncMetrics {
     pub active: AtomicBool,
     pub total_messages: AtomicUsize,
     pub processed_messages: AtomicUsize,
-    pub next_expected_sequence: AtomicUsize,
     // Using simple std Mutex for timestamp as it's rarely contended and non-async
     pub start_time: std::sync::Mutex<Option<std::time::Instant>>,
 }
@@ -578,7 +577,6 @@ impl Client {
                 active: AtomicBool::new(false),
                 total_messages: AtomicUsize::new(0),
                 processed_messages: AtomicUsize::new(0),
-                next_expected_sequence: AtomicUsize::new(0),
                 start_time: std::sync::Mutex::new(None),
             }),
 
@@ -968,9 +966,6 @@ impl Client {
         self.offline_sync_metrics
             .processed_messages
             .store(0, Ordering::Release);
-        self.offline_sync_metrics
-            .next_expected_sequence
-            .store(0, Ordering::Release);
         match self.offline_sync_metrics.start_time.lock() {
             Ok(mut guard) => *guard = None,
             Err(poison) => *poison.into_inner() = None,
@@ -1224,9 +1219,6 @@ impl Client {
                         .processed_messages
                         .store(0, Ordering::Release);
                     self.offline_sync_metrics
-                        .next_expected_sequence
-                        .store(0, Ordering::Release);
-                    self.offline_sync_metrics
                         .active
                         .store(true, Ordering::Release);
                     match self.offline_sync_metrics.start_time.lock() {
@@ -1265,44 +1257,6 @@ impl Client {
                     .processed_messages
                     .fetch_add(1, Ordering::Release)
                     + 1;
-                match node
-                    .attrs
-                    .get("offline")
-                    .and_then(|v| v.as_str())
-                    .map(|value| value.parse::<usize>())
-                {
-                    Some(Ok(offline_sequence)) => {
-                        let expected = self
-                            .offline_sync_metrics
-                            .next_expected_sequence
-                            .load(Ordering::Acquire);
-                        if expected != 0 && offline_sequence != expected {
-                            log::warn!(
-                                target: "Client/OfflineSync",
-                                "Offline sync stanza arrived out of order: expected sequence {}, got {} (tag={}, from={:?}, id={:?})",
-                                expected,
-                                offline_sequence,
-                                node.tag,
-                                node.attrs.get("from").and_then(|v| v.as_str()),
-                                node.attrs.get("id").and_then(|v| v.as_str()),
-                            );
-                        }
-                        self.offline_sync_metrics
-                            .next_expected_sequence
-                            .store(offline_sequence.saturating_add(1), Ordering::Release);
-                    }
-                    Some(Err(_)) => {
-                        log::warn!(
-                            target: "Client/OfflineSync",
-                            "Offline sync stanza has non-numeric offline attribute (tag={}, from={:?}, id={:?}, offline={:?})",
-                            node.tag,
-                            node.attrs.get("from").and_then(|v| v.as_str()),
-                            node.attrs.get("id").and_then(|v| v.as_str()),
-                            node.attrs.get("offline").and_then(|v| v.as_str()),
-                        );
-                    }
-                    None => {}
-                }
                 let total = self
                     .offline_sync_metrics
                     .total_messages
@@ -4570,81 +4524,6 @@ mod tests {
                 .load(Ordering::Acquire),
             1,
             "offline message should increment processed count"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_offline_message_sequence_tracker_advances() {
-        let client = create_offline_sync_test_client().await;
-
-        let preview = NodeBuilder::new("ib")
-            .children([NodeBuilder::new("offline_preview")
-                .attr("count", "2")
-                .attr("message", "2")
-                .attr("notification", "0")
-                .attr("receipt", "0")
-                .attr("appdata", "0")
-                .build()])
-            .build();
-        client.process_node(Arc::new(preview)).await;
-
-        let first = NodeBuilder::new("message")
-            .attr("offline", "7")
-            .attr("from", "5551234567@s.whatsapp.net")
-            .attr("id", "TEST123")
-            .attr("t", "1772884671")
-            .attr("type", "text")
-            .build();
-        client.process_node(Arc::new(first)).await;
-        assert_eq!(
-            client
-                .offline_sync_metrics
-                .next_expected_sequence
-                .load(Ordering::Acquire),
-            8
-        );
-
-        let second = NodeBuilder::new("message")
-            .attr("offline", "8")
-            .attr("from", "5551234567@s.whatsapp.net")
-            .attr("id", "TEST124")
-            .attr("t", "1772884672")
-            .attr("type", "text")
-            .build();
-        client.process_node(Arc::new(second)).await;
-        assert_eq!(
-            client
-                .offline_sync_metrics
-                .next_expected_sequence
-                .load(Ordering::Acquire),
-            9
-        );
-    }
-
-    #[tokio::test]
-    async fn test_offline_sync_completion_resets_sequence_tracker() {
-        let client = create_offline_sync_test_client().await;
-        client
-            .offline_sync_metrics
-            .active
-            .store(true, Ordering::Release);
-        client
-            .offline_sync_metrics
-            .next_expected_sequence
-            .store(9, Ordering::Release);
-
-        let node = NodeBuilder::new("ib")
-            .children([NodeBuilder::new("offline").attr("count", "1").build()])
-            .build();
-
-        client.process_node(Arc::new(node)).await;
-        assert_eq!(
-            client
-                .offline_sync_metrics
-                .next_expected_sequence
-                .load(Ordering::Acquire),
-            0,
-            "offline sync completion should reset sequence tracking"
         );
     }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -18,9 +18,6 @@ impl Client {
         self.offline_sync_metrics
             .active
             .store(false, Ordering::Release);
-        self.offline_sync_metrics
-            .next_expected_sequence
-            .store(0, Ordering::Release);
         match self.offline_sync_metrics.start_time.lock() {
             Ok(mut guard) => *guard = None,
             Err(poison) => *poison.into_inner() = None,


### PR DESCRIPTION
This pull request removes the offline message sequence tracking logic from the `Client` implementation, simplifying the offline sync metrics and related code. The sequence tracking previously ensured offline messages were processed in order, but this functionality and its associated tests have been removed.

Offline sync metrics simplification:

* Removed the `next_expected_sequence` field from the `OfflineSyncMetrics` struct and all related initialization, reset, and update logic in `src/client.rs`. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L241) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L581)
* Eliminated code that tracked and validated the sequence of offline messages, including warning logs for out-of-order messages.

Code cleanup and test removal:

* Removed all test cases related to offline message sequence tracking, including tests for sequence advancement and reset on sync completion in `src/client.rs`.
* Deleted sequence reset logic from offline sync completion handlers in both `src/client.rs` and `src/client/sessions.rs`. [[1]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L971-L973) [[2]](diffhunk://#diff-7f93c4e263c4e9ec748f804c7fd04a3b2fde86ffd741fb5516d67e1097bae4c1L1226-L1228) [[3]](diffhunk://#diff-8f6f95aa672c1035fe97f45bed63cd83f30d6819de9215fb522456ca4699a535L21-L23)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified offline synchronization by removing sequence-based ordering validation and tracking mechanism. Offline sync behavior remains unchanged and now uses message count and timing metrics exclusively for completion detection. Associated validation checks, warning logs, and related tests have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->