### PR TITLE
fix: align ack type attribute handling with whatsmeow/WA Web

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4852,6 +4852,65 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_build_ack_node_for_receipt_with_type_echoes_type() {
+        // Receipt acks should echo the type attribute when present (e.g. "read", "played").
+        let incoming = NodeBuilder::new("receipt")
+            .attr("from", "156535032389744@lid")
+            .attr("id", "RCPT-WITH-TYPE")
+            .attr("type", "read")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net"
+            .parse()
+            .expect("own device PN JID should parse");
+
+        let ack = build_ack_node(&incoming, Some(&own_device_pn))
+            .expect("receipt ack should be buildable");
+
+        assert_eq!(
+            ack.attrs.get("class").and_then(|v| v.as_str()),
+            Some("receipt")
+        );
+        assert_eq!(
+            ack.attrs.get("type").and_then(|v| v.as_str()),
+            Some("read"),
+            "receipt ACK must echo the type attribute when present"
+        );
+        assert!(
+            !ack.attrs.contains_key("from"),
+            "receipt ACKs should not include our device PN"
+        );
+    }
+
+    #[test]
+    fn test_build_ack_node_for_receipt_without_type_omits_type() {
+        // Delivery receipts have no type attribute — the ack must also omit it.
+        // Sending type="delivery" in the ack causes stream:error disconnections.
+        let incoming = NodeBuilder::new("receipt")
+            .attr("from", "156535032389744@lid")
+            .attr("id", "RCPT-NO-TYPE")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net"
+            .parse()
+            .expect("own device PN JID should parse");
+
+        let ack = build_ack_node(&incoming, Some(&own_device_pn))
+            .expect("receipt ack should be buildable");
+
+        assert_eq!(
+            ack.attrs.get("class").and_then(|v| v.as_str()),
+            Some("receipt")
+        );
+        assert!(
+            !ack.attrs.contains_key("type"),
+            "receipt ACK must NOT contain type when the incoming receipt has no type attribute"
+        );
+        assert!(
+            !ack.attrs.contains_key("from"),
+            "receipt ACKs should not include our device PN"
+        );
+    }
+
     /// Smoke test: server ping with xmlns but no id attribute is handled.
     #[tokio::test]
     async fn test_handle_iq_ping_without_id() {


### PR DESCRIPTION
## Summary

- **Message acks** were incorrectly echoing the `type` attribute (e.g. `type="text"`). Whatsmeow (`receipt.go:169`) and WA Web both omit `type` for message acks — fixed by inverting the condition to `node.tag != "message"`.
- This misalignment could cause `<stream:error>` disconnections when the server receives unexpected type attributes in ack stanzas (observed: `<ack class="receipt" type="delivery"/>` triggering forced disconnect).
- Renamed `should_echo_type_in_ack` → `is_encrypt_identity_notification` for clarity.

### Evidence from WA Web captured JS

- `WAWebReceiptAck.buildReceiptAck()` (`cnub3BAEa6g.js:34309`): uses `MAYBE_CUSTOM_STRING(ackString)` where `ackString = maybeAttrString("type")` — type is only included when explicitly present on the incoming stanza.
- `MAYBE_CUSTOM_STRING(null)` returns `DROP_ATTR` (`1IPUUpcJg9V.js:9268`), omitting the attribute entirely.
- Delivery receipts have no `type` attribute (delivery is the default), so the ack correctly omits it.

### Evidence from whatsmeow

- `receipt.go:169`: `if receiptType, ok := node.Attrs["type"]; node.Tag != "message" && ok` — type is never echoed for message acks, only for receipt/notification/call acks when present.

## Test plan

- [x] `cargo test --all` passes (310 tests)
- [x] `cargo clippy --all --tests` clean
- [x] Verified against own logs: receipt acks without type (delivery) and with type (read) both work correctly
- [ ] Integration test: confirm no `stream:error` disconnections with the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined acknowledgment generation: message ACKs now include sender device info but omit the type attribute; receipts echo type when present; special identity-change notifications are handled so type is omitted appropriately.
  * Improved consistency of attributes (class, id, to, from, participant) across ACKs for different stanza types.

* **Tests**
  * Updated and expanded tests to validate the revised ACK behaviors and ensure protocol compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->