### PR TITLE
fix: replace try_lock() in is_connected() with AtomicBool to prevent silent ack drops

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -972,7 +972,6 @@ impl Client {
     async fn cleanup_connection_state(&self) {
         self.is_logged_in.store(false, Ordering::Relaxed);
         self.is_ready.store(false, Ordering::Relaxed);
-        self.is_connected.store(false, Ordering::Release);
         // Signal the keepalive loop (and any other tasks) to exit promptly.
         // Without this, a stale keepalive loop can overlap with the next one
         // after reconnect, causing duplicate pings.
@@ -980,6 +979,10 @@ impl Client {
         *self.transport.lock().await = None;
         *self.transport_events.lock().await = None;
         *self.noise_socket.lock().await = None;
+        // Clear is_connected AFTER noise_socket is None, so no task can see
+        // is_connected==true with a cleared socket. send_node() independently
+        // checks the socket, but this ordering avoids a confusing state window.
+        self.is_connected.store(false, Ordering::Release);
         self.retried_group_messages.invalidate_all();
         // Clear signal cache so stale state doesn't leak across connections
         self.signal_cache.clear().await;
@@ -5113,8 +5116,15 @@ mod tests {
     /// contention. Before the fix, `try_lock()` would fail when another task held
     /// the noise_socket mutex, causing `is_connected()` to return `false` even
     /// though the connection was alive — silently dropping receipt acks.
+    ///
+    /// This test sets up a real NoiseSocket (same as socket unit tests) so it
+    /// accurately models the pre-fix scenario: socket is Some + mutex is held
+    /// by another task = old is_connected() returned false.
     #[tokio::test]
     async fn test_is_connected_not_affected_by_mutex_contention() {
+        use crate::socket::NoiseSocket;
+        use wacore::handshake::NoiseCipher;
+
         let backend = crate::test_utils::create_test_backend().await;
         let pm = Arc::new(
             PersistenceManager::new(backend)
@@ -5132,11 +5142,20 @@ mod tests {
         // Initially not connected
         assert!(!client.is_connected(), "should start disconnected");
 
-        // Simulate connection: set the AtomicBool
+        // Simulate a real connection: create a NoiseSocket and store it
+        let transport: Arc<dyn crate::transport::Transport> =
+            Arc::new(crate::transport::mock::MockTransport);
+        let key = [0u8; 32];
+        let write_key = NoiseCipher::new(&key).expect("valid key");
+        let read_key = NoiseCipher::new(&key).expect("valid key");
+        let noise_socket = NoiseSocket::new(transport, write_key, read_key);
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
         client.is_connected.store(true, Ordering::Release);
+
         assert!(client.is_connected(), "should report connected");
 
-        // Hold the noise_socket mutex — this used to make is_connected() return false
+        // Hold the noise_socket mutex — this used to make is_connected() return
+        // false via try_lock() even though the socket was Some(...)
         let _guard = client.noise_socket.lock().await;
         assert!(
             client.is_connected(),
@@ -5172,8 +5191,8 @@ mod tests {
 
         let result = client.send_ack_for(&receipt).await;
         assert!(
-            result.is_err(),
-            "send_ack_for must return Err when disconnected, not silently succeed"
+            matches!(result, Err(ClientError::NotConnected)),
+            "send_ack_for must return Err(NotConnected) when disconnected, got: {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `is_connected()` used `try_lock()` on the `noise_socket` mutex, which returns `false` when the mutex is contended — not just when disconnected. When two receipt acks raced concurrently, one held the mutex during `encrypt_and_send` while the other's `try_lock()` failed, causing `is_connected()` to spuriously return `false`. `send_ack_for()` then silently returned `Ok(())`, dropping the ack with zero log output.
- **Impact**: The server waited ~50 minutes for the missing ack, then disconnected with `<stream:error><ack class="receipt" type="delivery"/></stream:error>`.
- **Fix**: Replace `try_lock()` with an `AtomicBool` that's set on connect and cleared on disconnect — lock-free, no false negatives. Also make `send_ack_for()` return `Err(NotConnected)` instead of silent `Ok(())` so dropped acks are visible in logs.

### Bug timeline (from production logs)

```
18:00:24  WebSocket receives 151 bytes (1 WS message, 2 noise frames)
          ├── Frame 1: receipt id="AC15458C..." (delivery)
          └── Frame 2: receipt id="3EB08A4..." (delivery)

          Both spawned via tokio::spawn → each spawns another tokio::spawn for ack

          Ack Task A: send_node() → noise_socket.lock() ← HOLDS MUTEX
          Ack Task B: send_ack_for() → is_connected() → try_lock() FAILS
                      → returns Ok(())  ← ACK SILENTLY DROPPED

18:50:37  Server sends stream:error for the missing ack → disconnection
```

### Changes

| Location | What |
|----------|------|
| `Client` struct | Add `is_connected: Arc<AtomicBool>` field |
| `connect()` | Set `true` after noise_socket assigned, reset to `false` at start |
| `cleanup_connection_state()` | Set `false` before clearing socket |
| `is_connected()` | Read `AtomicBool` instead of `try_lock()` |
| `send_ack_for()` | Return `Err(NotConnected)` instead of silent `Ok(())` |
| Tests | 3 new tests proving the fix works |

## Test plan

- [x] `test_is_connected_not_affected_by_mutex_contention` — proves `is_connected()` returns `true` even while `noise_socket` mutex is held
- [x] `test_send_ack_for_returns_error_when_disconnected` — proves dropped acks now produce visible errors
- [x] `test_send_ack_for_returns_ok_on_expected_disconnect` — proves graceful shutdown path unchanged
- [x] All 880+ existing unit tests pass
- [x] Zero clippy warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of client connection status detection.
  * Enhanced error handling when attempting operations on a disconnected client.

* **Tests**
  * Added tests to verify connection state monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->