### PR TITLE
fix: write correct domain_type in AD_JID binary encoding

### DIFF
--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -126,12 +126,22 @@ impl<'a> Decoder<'a> {
             .read_value_as_string()?
             .ok_or(BinaryError::InvalidNode)?;
 
+        // Domain type mapping — must mirror encoder's server_to_domain_type().
+        // WA Web: 0=WHATSAPP, 1=LID, even+bit7=HOSTED, 129=HOSTED_LID, else throw.
         let server = match agent {
             0 => Cow::Borrowed(crate::jid::DEFAULT_USER_SERVER),
             1 => Cow::Borrowed(crate::jid::HIDDEN_USER_SERVER),
             128 => Cow::Borrowed(crate::jid::HOSTED_SERVER),
             129 => Cow::Borrowed(crate::jid::HOSTED_LID_SERVER),
-            _ => Cow::Borrowed(crate::jid::HOSTED_SERVER),
+            n if (n & 128) != 0 && (n & 1) == 0 => {
+                // WA Web treats any even number with bit 7 set as HOSTED
+                Cow::Borrowed(crate::jid::HOSTED_SERVER)
+            }
+            _ => {
+                return Err(BinaryError::AttrParse(format!(
+                    "AD_JID invalid domain type: {agent}"
+                )));
+            }
         };
 
         Ok(JidRef {

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -1364,15 +1364,20 @@ mod tests {
     }
 
     /// Verify that string-encoded JIDs and direct Jid-encoded JIDs produce
-    /// identical bytes. This catches any divergence between the two encoding
-    /// paths (which was the root cause of the domain_type bug).
+    /// identical bytes AND decode back to the same JID. This catches any
+    /// divergence between the two encoding paths (root cause of the domain_type
+    /// bug) and ensures encode→decode round-trip fidelity for all server types.
     #[test]
     fn test_jid_string_vs_direct_encoding_matches() -> TestResult {
-        let test_cases = vec![
-            Jid::lid_device("236395184570386", 39), // LID with device
-            Jid::pn_device("559984726662", 33),     // PN with device
-            Jid::lid("236395184570386"),            // LID primary (device 0)
-            Jid::pn("559984726662"),                // PN primary (device 0)
+        use crate::decoder::Decoder;
+
+        let test_cases: Vec<Jid> = vec![
+            Jid::lid_device("236395184570386", 39),     // LID with device
+            Jid::pn_device("559984726662", 33),         // PN with device
+            Jid::lid("236395184570386"),                // LID primary (device 0)
+            Jid::pn("559984726662"),                    // PN primary (device 0)
+            "5511999887766:99@hosted".parse().unwrap(), // HOSTED device
+            "100000012345678:99@hosted.lid".parse().unwrap(), // HOSTED_LID device
         ];
 
         for jid in test_cases {
@@ -1391,6 +1396,29 @@ mod tests {
             assert_eq!(
                 buf_str, buf_jid,
                 "String vs direct Jid encoding must produce identical bytes for {jid}"
+            );
+
+            // Round-trip: decode the encoded bytes and verify the JID is preserved.
+            // Skip version byte (first byte) then decode.
+            let mut decoder = Decoder::new(&buf_jid[1..]);
+            let decoded_node = decoder.read_node_ref()?.to_owned();
+            let decoded_jid: Jid = decoded_node
+                .attrs()
+                .optional_jid("jid")
+                .expect("jid attr must round-trip as JID");
+
+            assert_eq!(
+                jid.user, decoded_jid.user,
+                "Round-trip user mismatch for {jid}"
+            );
+            assert_eq!(
+                jid.device, decoded_jid.device,
+                "Round-trip device mismatch for {jid}"
+            );
+            assert_eq!(
+                jid.server.as_ref(),
+                decoded_jid.server.as_ref(),
+                "Round-trip server mismatch for {jid}"
             );
         }
 


### PR DESCRIPTION
## Summary

- Fix `write_jid_ref` and `write_jid_owned` in the binary encoder to write the correct `domain_type` byte instead of `jid.agent` when encoding AD_JID (companion device) JIDs
- Extract `server_to_domain_type()` helper that maps server strings to their protocol domain_type byte (`lid` → 1, `hosted` → 128, `hosted.lid` → 129, default → 0)

## Problem

Introduced in #379 (`0e1ac85`), which changed participant `<to>` nodes from string-encoded JIDs (`.attr("jid", device_jid.to_string())`) to direct JID encoding (`.attr("jid", device_jid.clone())`). The string path correctly computed `domain_type` from the server name via `parse_jid_meta`, but the direct JID path wrote `jid.agent` (always 0) as the domain_type byte.

For LID JIDs (e.g. `236395184570386:39@lid`), this encoded `domain_type=0` (s.whatsapp.net) instead of `domain_type=1` (lid), causing the server to misinterpret the participant list. The server rejected group messages with **error 421** on the ack, and recipients saw **"Waiting for this message"** because the SKDM distribution entries had mangled JIDs.

## Wire format

```
AD_JID (0xF7) encoding:
  [0xF7] [domain_type] [device] [user_string]

Before (broken): [0xF7] [0x00=agent]  [0x27=device39] [user] → server thinks s.whatsapp.net
After  (fixed):  [0xF7] [0x01=lid]    [0x27=device39] [user] → server correctly sees lid
```

## Test plan

- [x] `cargo check --all` passes
- [x] Manual test: send message to LID-addressing group — no error 421, no "Waiting for this message", message decrypts on all companion devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal address encoding to ensure consistent domain-type mapping for serialized identities.
* **Bug Fixes**
  * Resolved edge cases that could produce mismatched or incorrect encoded addresses for certain server types.
* **Tests**
  * Added regression tests validating address encoding consistency and parity between string and direct encodings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->