### PR TITLE
fix: clear unacknowledged prekey items after first send

### DIFF
--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -154,6 +154,12 @@ pub async fn message_encrypt(
         )?)
     };
 
+    // Clear prekey items after first use — subsequent sends should use regular SignalMessage.
+    // (Items are also cleared on the receiver side in message_decrypt.)
+    if matches!(&message, CiphertextMessage::PreKeySignalMessage(_)) {
+        session_state.clear_unacknowledged_pre_key_message();
+    }
+
     session_state.set_sender_chain_key(&next_chain_key);
 
     // XXX why is this check after everything else?!!


### PR DESCRIPTION
Closes #403. After building a `PreKeySignalMessage`, clear the unacknowledged prekey items from the session state so subsequent encryptions produce regular SignalMessage instead of repeated PreKeySignalMessage.

Without this fix, every outgoing message uses pkmsg encryption even after sessions are established, because the items are only cleared on the receiver side (in message_decrypt) but never on the sender side.

I think in 0.3.0 I was not seeing this behaviour because of the cache flow, not sure tho.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pre-key message state during encryption to ensure proper cleanup and state management, enhancing the reliability of secure signal protocol operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->