### PR TITLE
perf: skip redundant signal store writes when data is unchanged

### DIFF
--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -84,49 +84,7 @@ impl SessionStore for SessionAdapter {
     ) -> Result<(), SignalProtocolError> {
         let addr_str = address.to_string();
         let record_bytes = record.serialize()?;
-
-        // Check for base key changes using cache (not DB) for logging
-        let device = self.0.device.read().await;
-        let existing_data = self
-            .0
-            .cache
-            .get_session(&addr_str, &*device.backend)
-            .await
-            .ok()
-            .flatten();
-        drop(device);
-
-        let existing_session = existing_data.and_then(|d| SessionRecord::deserialize(&d).ok());
-
-        if let (Some(existing), Some(new_state)) = (&existing_session, record.session_state()) {
-            if let Some(existing_state) = existing.session_state() {
-                let old_base_key = existing_state.alice_base_key();
-                let new_base_key = new_state.alice_base_key();
-
-                if old_base_key != new_base_key {
-                    log::debug!(
-                        target: "signal_session_store",
-                        "Session base key changed for {} (old_version={:?}, new_version={:?}, prev_sessions: {} -> {})",
-                        addr_str,
-                        existing_state.session_version(),
-                        new_state.session_version(),
-                        existing.previous_session_count(),
-                        record.previous_session_count(),
-                    );
-                }
-            }
-        } else if let (None, Some(state)) = (&existing_session, record.session_state()) {
-            log::debug!(
-                target: "signal_session_store",
-                "Creating new session for {}: base_key={}",
-                addr_str,
-                hex::encode(&state.alice_base_key()[..8.min(state.alice_base_key().len())])
-            );
-        }
-
-        // Write to cache only (deferred flush to DB)
         self.0.cache.put_session(&addr_str, &record_bytes).await;
-
         Ok(())
     }
 }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -40,6 +40,27 @@ impl StoreState {
         }
     }
 
+    /// Insert data, skipping if bytes are identical (avoids redundant dirty marks).
+    fn put(&mut self, address: &str, data: &[u8]) {
+        if let Some(Some(existing)) = self.cache.get(address)
+            && existing.as_ref() == data
+        {
+            return;
+        }
+        let addr: Arc<str> = Arc::from(address);
+        self.cache.insert(addr.clone(), Some(Arc::from(data)));
+        self.dirty.insert(addr.clone());
+        self.deleted.remove(&addr);
+    }
+
+    /// Mark an entry as deleted (negative-cached).
+    fn delete(&mut self, address: &str) {
+        let addr: Arc<str> = Arc::from(address);
+        self.cache.insert(addr.clone(), None);
+        self.deleted.insert(addr.clone());
+        self.dirty.remove(&addr);
+    }
+
     /// Clear all cached state, retaining allocated capacity for reuse.
     fn clear(&mut self) {
         self.cache.clear();
@@ -81,19 +102,11 @@ impl SignalStoreCache {
     }
 
     pub async fn put_session(&self, address: &str, data: &[u8]) {
-        let mut state = self.sessions.lock().await;
-        let addr: Arc<str> = Arc::from(address);
-        state.cache.insert(addr.clone(), Some(Arc::from(data)));
-        state.dirty.insert(addr.clone());
-        state.deleted.remove(&addr);
+        self.sessions.lock().await.put(address, data);
     }
 
     pub async fn delete_session(&self, address: &str) {
-        let mut state = self.sessions.lock().await;
-        let addr: Arc<str> = Arc::from(address);
-        state.cache.insert(addr.clone(), None);
-        state.deleted.insert(addr.clone());
-        state.dirty.remove(&addr);
+        self.sessions.lock().await.delete(address);
     }
 
     pub async fn has_session(&self, address: &str, backend: &dyn SignalStore) -> Result<bool> {
@@ -118,19 +131,11 @@ impl SignalStoreCache {
     }
 
     pub async fn put_identity(&self, address: &str, data: &[u8]) {
-        let mut state = self.identities.lock().await;
-        let addr: Arc<str> = Arc::from(address);
-        state.cache.insert(addr.clone(), Some(Arc::from(data)));
-        state.dirty.insert(addr.clone());
-        state.deleted.remove(&addr);
+        self.identities.lock().await.put(address, data);
     }
 
     pub async fn delete_identity(&self, address: &str) {
-        let mut state = self.identities.lock().await;
-        let addr: Arc<str> = Arc::from(address);
-        state.cache.insert(addr.clone(), None);
-        state.deleted.insert(addr.clone());
-        state.dirty.remove(&addr);
+        self.identities.lock().await.delete(address);
     }
 
     // === Sender Keys ===
@@ -151,11 +156,7 @@ impl SignalStoreCache {
     }
 
     pub async fn put_sender_key(&self, address: &str, data: &[u8]) {
-        let mut state = self.sender_keys.lock().await;
-        let addr: Arc<str> = Arc::from(address);
-        state.cache.insert(addr.clone(), Some(Arc::from(data)));
-        state.dirty.insert(addr.clone());
-        state.deleted.remove(&addr);
+        self.sender_keys.lock().await.put(address, data);
     }
 
     // === Flush ===


### PR DESCRIPTION
## Summary
- **Byte-equality dedup in `SignalStoreCache`**: `put_session`, `put_identity`, and `put_sender_key` now skip marking entries dirty when the serialized bytes are identical to what's already cached. Prevents unnecessary DB writes during flush on hot send/receive paths.
- **Remove `store_session` debug logging**: The old code acquired a device read lock, loaded the existing session from cache, deserialized it, and compared base keys — all just for debug log output. Removed to match WhatsApp Web's silent `storeSession` behavior.
- **DRY refactor**: Extracted duplicated `put`/`delete` logic (previously copy-pasted 3x each) into `StoreState::put()` and `StoreState::delete()` methods.

Net result: **-41 lines**, fewer allocations on every `store_session` call, fewer redundant DB writes on flush.

## Test plan
- [ ] `cargo clippy --all --tests` passes clean
- [ ] `cargo test --all` passes
- [ ] E2E message send/receive works correctly (sessions, identity, sender keys still persist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal session storage logic by removing unnecessary cache lookups and comparisons.
  * Centralized cache management helpers to improve code maintainability and reduce duplication across storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->