### PR TITLE
fix: persist Device.account through serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,12 +2665,10 @@ dependencies = [
  "diesel_migrations",
  "libsqlite3-sys",
  "log",
- "prost",
  "serde_json",
  "tokio",
  "wacore",
  "wacore-binary",
- "waproto",
 ]
 
 [[package]]

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -24,12 +24,10 @@ diesel_migrations = { version = "2.3.1", default-features = false, features = [
 ] }
 libsqlite3-sys = { version = "0.35", default-features = false, optional = true }
 log = { workspace = true }
-prost = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
 wacore = { workspace = true }
 wacore-binary = { workspace = true }
-waproto = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -8,7 +8,6 @@ use diesel::sqlite::SqliteConnection;
 use diesel::upsert::excluded;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use log::warn;
-use prost::Message;
 use std::sync::Arc;
 use wacore::appstate::hash::HashState;
 use wacore::appstate::processor::AppStateMutationMAC;
@@ -17,7 +16,6 @@ use wacore::store::Device as CoreDevice;
 use wacore::store::error::{Result, StoreError};
 use wacore::store::traits::*;
 use wacore_binary::jid::Jid;
-use waproto::whatsapp as wa;
 
 /// Internal error type that preserves the Diesel error for structured matching
 /// before converting to `StoreError`. Used in retry loops where we need to
@@ -301,7 +299,7 @@ impl SqliteStore {
         let account_data = device_data
             .account
             .as_ref()
-            .map(|account| account.encode_to_vec());
+            .map(wacore::store::device::account_serde::to_bytes);
         let registration_id = device_data.registration_id as i32;
         let signed_pre_key_id = device_data.signed_pre_key_id as i32;
         let signed_pre_key_signature: Vec<u8> = device_data.signed_pre_key_signature.to_vec();
@@ -545,7 +543,7 @@ impl SqliteStore {
 
             let account = account_data
                 .map(|data| {
-                    wa::AdvSignedDeviceIdentity::decode(&data[..])
+                    wacore::store::device::account_serde::from_bytes(&data)
                         .map_err(|e| StoreError::Serialization(e.to_string()))
                 })
                 .transpose()?;

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -6,6 +6,40 @@ use serde_big_array::BigArray;
 use wacore_binary::jid::Jid;
 use waproto::whatsapp as wa;
 
+/// Protobuf-bytes serde for `AdvSignedDeviceIdentity` (prost types lack `Deserialize`).
+pub mod account_serde {
+    use prost::Message;
+    use waproto::whatsapp as wa;
+
+    pub fn to_bytes(account: &wa::AdvSignedDeviceIdentity) -> Vec<u8> {
+        account.encode_to_vec()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<wa::AdvSignedDeviceIdentity, prost::DecodeError> {
+        wa::AdvSignedDeviceIdentity::decode(bytes)
+    }
+
+    pub fn serialize<S: serde::Serializer>(
+        val: &Option<wa::AdvSignedDeviceIdentity>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        match val {
+            Some(v) => s.serialize_some(&to_bytes(v)),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<wa::AdvSignedDeviceIdentity>, D::Error> {
+        let bytes: Option<Vec<u8>> = serde::Deserialize::deserialize(d)?;
+        match bytes {
+            Some(b) => from_bytes(&b).map(Some).map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
+
 pub mod key_pair_serde {
     use super::KeyPair;
     use crate::libsignal::protocol::{PrivateKey, PublicKey};
@@ -102,7 +136,7 @@ pub struct Device {
     #[serde(with = "BigArray")]
     pub signed_pre_key_signature: [u8; 64],
     pub adv_secret_key: [u8; 32],
-    #[serde(skip, default)]
+    #[serde(with = "account_serde", default)]
     pub account: Option<wa::AdvSignedDeviceIdentity>,
     pub push_name: String,
     pub app_version_primary: u32,
@@ -316,5 +350,51 @@ mod tests {
             device.identity_key.public_key.public_key_bytes(),
             restored.identity_key.public_key.public_key_bytes()
         );
+    }
+
+    /// Regression: #403
+    #[test]
+    fn test_device_serde_preserves_account() {
+        let mut device = Device::new();
+        device.account = Some(wa::AdvSignedDeviceIdentity {
+            details: Some(b"test-details".to_vec()),
+            account_signature_key: Some(vec![1; 32]),
+            account_signature: Some(vec![2; 64]),
+            device_signature: Some(vec![3; 64]),
+        });
+
+        let json = serde_json::to_string(&device).expect("serialize should succeed");
+        let restored: Device = serde_json::from_str(&json).expect("deserialize should succeed");
+
+        assert!(
+            restored.account.is_some(),
+            "account must survive serde roundtrip"
+        );
+        let acc = restored.account.unwrap();
+        assert_eq!(acc.details.as_deref(), Some(b"test-details".as_slice()));
+        assert_eq!(
+            acc.account_signature_key.as_deref(),
+            Some([1u8; 32].as_slice())
+        );
+        assert_eq!(acc.account_signature.as_deref(), Some([2u8; 64].as_slice()));
+        assert_eq!(acc.device_signature.as_deref(), Some([3u8; 64].as_slice()));
+    }
+
+    /// Backward compat: missing `account` field deserializes as `None`.
+    #[test]
+    fn test_device_serde_account_none_and_missing() {
+        // None roundtrip
+        let device = Device::new();
+        assert!(device.account.is_none());
+        let json = serde_json::to_string(&device).expect("serialize should succeed");
+        let restored: Device = serde_json::from_str(&json).expect("deserialize should succeed");
+        assert!(restored.account.is_none());
+
+        // Missing field in JSON (backward compat with old data)
+        let mut val: serde_json::Value = serde_json::from_str(&json).expect("parse as Value");
+        val.as_object_mut().unwrap().remove("account");
+        let restored: Device =
+            serde_json::from_value(val).expect("deserialize without account field");
+        assert!(restored.account.is_none());
     }
 }


### PR DESCRIPTION
Closes #403.

`#[serde(skip)]` on `Device.account` (added in #393) caused `AdvSignedDeviceIdentity` to be lost on restart for custom stores using serde. Without it, `<device-identity>` is missing from outgoing stanzas and recipients silently drop pkmsg from unverifiable companion devices.

Root cause found by @ricott1: commit 4a1d2ec added `serde(skip)` because prost types don't derive `Deserialize` (gated behind `serde-deserialize` feature). The built-in SQLite store was unaffected since it uses Diesel column mapping, not serde.

## Fix

Custom serde module (`account_serde`) that encodes `AdvSignedDeviceIdentity` as protobuf bytes — same format the SQLite store already uses. Shared `to_bytes`/`from_bytes` helpers keep it DRY across both serde and SQLite paths. Backward compatible: missing `account` field deserializes as `None`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced device account storage serialization mechanism for improved data reliability and code maintainability.
  * Removed obsolete dependencies to reduce overall codebase complexity.

* **Tests**
  * Implemented comprehensive regression tests to validate device account data integrity throughout storage and retrieval cycles, with complete backward compatibility verification for existing account data formats and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->