### PR TITLE
feat: MediaEncryptor streaming API + PortableCache fixes

### DIFF
--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -364,7 +364,12 @@ where
         guard.map.retain(|_, entry| !self.is_expired(entry, now_ms));
 
         // Rebuild insertion_order to only contain live keys.
-        guard.insertion_order.retain(|k| guard.map.contains_key(k));
+        // Borrow fields separately to satisfy the borrow checker.
+        let CacheInner {
+            map,
+            insertion_order,
+        } = &mut *guard;
+        insertion_order.retain(|k| map.contains_key(k));
 
         drop(guard);
 

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -135,8 +135,8 @@ impl MediaEncryptor {
             }
             // Complete the partial block from remainder + head of plaintext.
             self.remainder.extend_from_slice(&plaintext[..need]);
-            self.encrypt_and_emit(&self.remainder.clone(), &mut emit);
-            self.remainder.clear();
+            let completed = std::mem::take(&mut self.remainder);
+            self.encrypt_and_emit(&completed, &mut emit);
             &plaintext[need..]
         } else {
             plaintext


### PR DESCRIPTION
## Summary

### Commit 1: MediaEncryptor — chunk-based streaming encryption

Adds `MediaEncryptor`, a chunk-based AES-256-CBC state machine that processes plaintext incrementally without requiring sync `Read`. Enables use with async streams, network sources, or any chunk-at-a-time producer.

**Two output modes, zero duplicated crypto logic** (shared via `emit` callback + `encrypt_and_emit`):

| Method | Output | Use case |
|--------|--------|----------|
| `update()` / `finalize()` | Append to `Vec<u8>` | Async callers |
| `update_to_writer()` / `finalize_to_writer()` | Write directly | Sync `encrypt_media_streaming` (zero buffer) |

**Memory-efficient `feed()`**: Processes full blocks directly from the input slice without copying into `remainder` first. Only the trailing partial block (≤15 bytes) is buffered across calls.

**Safety**:
- `#[must_use]` — compiler warns if `finalize` is never called
- `with_key()` documents the security expectation (32 random bytes)
- Error doc on `update_to_writer` — state is unspecified after I/O error

**No breaking changes**: `encrypt_media_streaming` reimplemented on top using the writer path. Same signature, same behavior, same crypto. Zero overhead vs the original.

**Tests**: 10 tests including single-byte chunks, 1MB single chunk, block boundary, empty input, and roundtrip decrypt verification.

### Commit 2: PortableCache fixes

- **Borrow checker fix**: Destructure `CacheInner` in `run_pending_tasks()` to borrow `map` and `insertion_order` independently (fixes compilation on WASM).
- **`VecDeque`** for insertion order — O(1) eviction vs O(n) `Vec::remove(0)`.
- **`get_with_by_ref`** accepts `&Q` (e.g. `&str` for `Cache<String, V>`), matching moka's API. Only allocates owned key on miss.
- **`insert_and_return`** — 1 clone instead of 2 on insert-and-return path.
- **`get()` with TTI** uses single write lock instead of read lock + write lock upgrade.

## Test plan
- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo fmt --all`
- [x] `cargo test` — all 10 upload tests pass
- [ ] WASM build verification