### PR TITLE
refactor: forward media via CDN reuse, simplify main.rs

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -227,6 +227,11 @@ where
 }
 
 impl Client {
+    /// Downloads and decrypts media from WhatsApp's CDN into memory.
+    ///
+    /// Only needed when you need the plaintext bytes (processing, transcoding,
+    /// re-upload). To forward existing media unchanged, reuse the original
+    /// message's CDN fields directly, no round-trip required.
     pub async fn download(&self, downloadable: &dyn Downloadable) -> Result<Vec<u8>> {
         download_media_with_retry(
             |force| self.prepare_requests(downloadable, force),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use chrono::{Local, Utc};
 use log::{error, info};
-use std::io::Cursor;
 use std::sync::Arc;
-use wacore::download::{Downloadable, MediaType};
 use wacore::proto_helpers::MessageExt;
 use wacore::types::events::Event;
 use waproto::whatsapp as wa;
@@ -10,7 +8,6 @@ use whatsapp_rust::TokioRuntime;
 use whatsapp_rust::bot::{Bot, MessageContext};
 use whatsapp_rust::pair_code::PairCodeOptions;
 use whatsapp_rust::store::SqliteStore;
-use whatsapp_rust::upload::UploadResponse;
 use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
 use whatsapp_rust_ureq_http_client::UreqHttpClient;
 
@@ -18,8 +15,6 @@ const PING_TRIGGER: &str = "🦀ping";
 const PONG_TEXT: &str = "🏓 Pong!";
 const REACTION_EMOJI: &str = "🏓";
 
-// This is a demo of a simple ping-pong bot with every type of media.
-//
 // Usage:
 //   cargo run                                      # QR code pairing only
 //   cargo run -- --phone 15551234567               # Pair code + QR code (concurrent)
@@ -28,7 +23,6 @@ const REACTION_EMOJI: &str = "🏓";
 //   cargo run -- -p 15551234567 -c MYCODE12        # Short form
 
 fn main() {
-    // Parse CLI arguments for phone number and optional custom code
     let args: Vec<String> = std::env::args().collect();
     let phone_number = parse_arg(&args, "--phone", "-p");
     let custom_code = parse_arg(&args, "--code", "-c");
@@ -77,10 +71,7 @@ fn main() {
             .with_transport_factory(transport_factory)
             .with_http_client(http_client)
             .with_runtime(TokioRuntime);
-        // Optional: Override the WhatsApp version (normally auto-fetched)
-        // builder = builder.with_version((2, 3000, 1027868167));
 
-        // Add pair code authentication if phone number provided
         if let Some(phone) = phone_number {
             builder = builder.with_pair_code(PairCodeOptions {
                 phone_number: phone,
@@ -90,210 +81,44 @@ fn main() {
         }
 
         let mut bot = builder
-            .on_event(move |event, client| {
-                async move {
-                    match event {
-                        Event::PairingQrCode { code, timeout } => {
-                            info!("----------------------------------------");
-                            info!(
-                                "QR code received (valid for {} seconds):",
-                                timeout.as_secs()
-                            );
-                            info!("\n{}\n", code);
-                            info!("----------------------------------------");
-                        }
-                        Event::PairingCode { code, timeout } => {
-                            info!("========================================");
-                            info!("PAIR CODE (valid for {} seconds):", timeout.as_secs());
-                            info!("Enter this code on your phone:");
-                            info!("WhatsApp > Linked Devices > Link a Device");
-                            info!("> Link with phone number instead");
-                            info!("");
-                            info!("    >>> {} <<<", code);
-                            info!("");
-                            info!("========================================");
-                        }
-
-                        Event::Message(msg, info) => {
-                            let ctx = MessageContext {
-                                message: msg,
-                                info,
-                                client,
-                            };
-
-                            if let Some(media_ping_request) = get_pingable_media(&ctx.message) {
-                                handle_media_ping(&ctx, media_ping_request).await;
-                            }
-
-                            if let Some(text) = ctx.message.text_content() {
-                                // Profile commands (temporary for testing)
-                                if let Some(new_name) = text.strip_prefix("!setname ") {
-                                    let new_name = new_name.trim();
-                                    if !new_name.is_empty() {
-                                        info!("Setting push name to: {}", new_name);
-                                        match ctx.client.profile().set_push_name(new_name).await {
-                                            Ok(()) => {
-                                                info!("Push name set successfully");
-                                                let _ = ctx
-                                                    .send_message(wa::Message {
-                                                        conversation: Some(format!(
-                                                            "✅ Name set to: {}",
-                                                            new_name
-                                                        )),
-                                                        ..Default::default()
-                                                    })
-                                                    .await;
-                                            }
-                                            Err(e) => {
-                                                error!("Failed to set push name: {}", e);
-                                                let _ = ctx
-                                                    .send_message(wa::Message {
-                                                        conversation: Some(format!(
-                                                            "❌ Failed: {}",
-                                                            e
-                                                        )),
-                                                        ..Default::default()
-                                                    })
-                                                    .await;
-                                            }
-                                        }
-                                    }
-                                } else if let Some(new_status) = text.strip_prefix("!setstatus ") {
-                                    let new_status = new_status.trim();
-                                    info!("Setting status text to: {}", new_status);
-                                    match ctx.client.profile().set_status_text(new_status).await {
-                                        Ok(()) => {
-                                            info!("Status text set successfully");
-                                            let _ = ctx
-                                                .send_message(wa::Message {
-                                                    conversation: Some(format!(
-                                                        "✅ Status set to: {}",
-                                                        new_status
-                                                    )),
-                                                    ..Default::default()
-                                                })
-                                                .await;
-                                        }
-                                        Err(e) => {
-                                            error!("Failed to set status text: {}", e);
-                                            let _ = ctx
-                                                .send_message(wa::Message {
-                                                    conversation: Some(format!("❌ Failed: {}", e)),
-                                                    ..Default::default()
-                                                })
-                                                .await;
-                                        }
-                                    }
-                                }
-                            }
-
-                            if let Some(text) = ctx.message.text_content()
-                                && text == PING_TRIGGER
-                            {
-                                info!("Received text ping, sending pong...");
-
-                                let message_key = wa::MessageKey {
-                                    remote_jid: Some(ctx.info.source.chat.to_string()),
-                                    id: Some(ctx.info.id.clone()),
-                                    from_me: Some(ctx.info.source.is_from_me),
-                                    participant: if ctx.info.source.is_group {
-                                        Some(ctx.info.source.sender.to_string())
-                                    } else {
-                                        None
-                                    },
-                                };
-
-                                let reaction_message = wa::message::ReactionMessage {
-                                    key: Some(message_key),
-                                    text: Some(REACTION_EMOJI.to_string()),
-                                    sender_timestamp_ms: Some(Utc::now().timestamp_millis()),
-                                    ..Default::default()
-                                };
-
-                                let final_message_to_send = wa::Message {
-                                    reaction_message: Some(reaction_message),
-                                    ..Default::default()
-                                };
-
-                                if let Err(e) = ctx.send_message(final_message_to_send).await {
-                                    error!("Failed to send reaction: {}", e);
-                                }
-
-                                let start = std::time::Instant::now();
-
-                                let context_info = ctx.build_quote_context();
-
-                                let reply_message = wa::Message {
-                                    extended_text_message: Some(Box::new(
-                                        wa::message::ExtendedTextMessage {
-                                            text: Some(PONG_TEXT.to_string()),
-                                            context_info: Some(Box::new(context_info)),
-                                            ..Default::default()
-                                        },
-                                    )),
-                                    ..Default::default()
-                                };
-
-                                let sent_msg_id = match ctx.send_message(reply_message).await {
-                                    Ok(id) => id,
-                                    Err(e) => {
-                                        error!("Failed to send initial pong message: {}", e);
-                                        return;
-                                    }
-                                };
-
-                                let duration = start.elapsed();
-                                let duration_str = format!("{:.2?}", duration);
-
-                                info!(
-                                    "Send took {}. Editing message {}...",
-                                    duration_str, &sent_msg_id
-                                );
-
-                                // WhatsApp Web does NOT resend quote context on edits.
-                                // The edit only carries new content — no stanza_id,
-                                // participant, or quoted_message.
-                                let updated_content = wa::Message {
-                                    extended_text_message: Some(Box::new(
-                                        wa::message::ExtendedTextMessage {
-                                            text: Some(format!(
-                                                "{}\n`{}`",
-                                                PONG_TEXT, duration_str
-                                            )),
-                                            ..Default::default()
-                                        },
-                                    )),
-                                    ..Default::default()
-                                };
-
-                                if let Err(e) =
-                                    ctx.edit_message(sent_msg_id.clone(), updated_content).await
-                                {
-                                    error!("Failed to edit message {}: {}", sent_msg_id, e);
-                                } else {
-                                    info!("Successfully sent edit for message {}.", sent_msg_id);
-                                }
-                            }
-                        }
-                        Event::Connected(_) => {
-                            info!("✅ Bot connected successfully!");
-                        }
-                        Event::Receipt(_receipt) => {}
-                        Event::LoggedOut(_) => {
-                            error!("❌ Bot was logged out!");
-                        }
-                        _ => {
-                            // debug!("Received unhandled event: {:?}", event);
-                        }
+            .on_event(move |event, client| async move {
+                match event {
+                    Event::PairingQrCode { code, timeout } => {
+                        info!("----------------------------------------");
+                        info!(
+                            "QR code received (valid for {} seconds):",
+                            timeout.as_secs()
+                        );
+                        info!("\n{}\n", code);
+                        info!("----------------------------------------");
                     }
+                    Event::PairingCode { code, timeout } => {
+                        info!("========================================");
+                        info!("PAIR CODE (valid for {} seconds):", timeout.as_secs());
+                        info!("Enter this code on your phone:");
+                        info!("WhatsApp > Linked Devices > Link a Device");
+                        info!("> Link with phone number instead");
+                        info!("");
+                        info!("    >>> {} <<<", code);
+                        info!("");
+                        info!("========================================");
+                    }
+                    Event::Message(msg, info) => {
+                        let ctx = MessageContext {
+                            message: msg,
+                            info,
+                            client,
+                        };
+                        handle_message(&ctx).await;
+                    }
+                    Event::Connected(_) => info!("✅ Bot connected successfully!"),
+                    Event::LoggedOut(_) => error!("❌ Bot was logged out!"),
+                    _ => {}
                 }
             })
             .build()
             .await
             .expect("Failed to build bot");
-
-        // If you want and need, you can get the client:
-        // let client = bot.client();
 
         let client = bot.client();
 
@@ -325,139 +150,112 @@ fn main() {
     });
 }
 
-trait MediaPing: Downloadable {
-    fn media_type(&self) -> MediaType;
-
-    fn build_pong_reply(&self, upload: UploadResponse) -> wa::Message;
-}
-
-impl MediaPing for wa::message::ImageMessage {
-    fn media_type(&self) -> MediaType {
-        MediaType::Image
-    }
-
-    fn build_pong_reply(&self, upload: UploadResponse) -> wa::Message {
-        wa::Message {
-            image_message: Some(Box::new(wa::message::ImageMessage {
-                mimetype: self.mimetype.clone(),
-                caption: Some(PONG_TEXT.to_string()),
-                url: Some(upload.url),
-                direct_path: Some(upload.direct_path),
-                media_key: Some(upload.media_key),
-                file_enc_sha256: Some(upload.file_enc_sha256),
-                file_sha256: Some(upload.file_sha256),
-                file_length: Some(upload.file_length),
-                media_key_timestamp: Some(upload.media_key_timestamp),
-                jpeg_thumbnail: self.jpeg_thumbnail.clone(),
-                height: self.height,
-                width: self.width,
-                ..Default::default()
-            })),
-            ..Default::default()
+async fn handle_message(ctx: &MessageContext) {
+    if let Some(reply) = build_media_pong(&ctx.message) {
+        info!("Received media ping from {}", ctx.info.source.sender);
+        if let Err(e) = ctx.send_message(reply).await {
+            error!("Failed to send media pong: {}", e);
         }
-    }
-}
-
-impl MediaPing for wa::message::VideoMessage {
-    fn media_type(&self) -> MediaType {
-        MediaType::Video
-    }
-
-    fn build_pong_reply(&self, upload: UploadResponse) -> wa::Message {
-        wa::Message {
-            video_message: Some(Box::new(wa::message::VideoMessage {
-                mimetype: self.mimetype.clone(),
-                caption: Some(PONG_TEXT.to_string()),
-                url: Some(upload.url),
-                direct_path: Some(upload.direct_path),
-                media_key: Some(upload.media_key),
-                file_enc_sha256: Some(upload.file_enc_sha256),
-                file_sha256: Some(upload.file_sha256),
-                file_length: Some(upload.file_length),
-                media_key_timestamp: Some(upload.media_key_timestamp),
-                jpeg_thumbnail: self.jpeg_thumbnail.clone(),
-                gif_playback: self.gif_playback,
-                height: self.height,
-                width: self.width,
-                seconds: self.seconds,
-                gif_attribution: self.gif_attribution,
-                ..Default::default()
-            })),
-            ..Default::default()
-        }
-    }
-}
-
-fn get_pingable_media<'a>(message: &'a wa::Message) -> Option<&'a (dyn MediaPing + 'a)> {
-    let base_message = message.get_base_message();
-
-    if let Some(msg) = &base_message.image_message
-        && msg.caption.as_deref() == Some(PING_TRIGGER)
-    {
-        return Some(&**msg);
-    }
-    if let Some(msg) = &base_message.video_message
-        && msg.caption.as_deref() == Some(PING_TRIGGER)
-    {
-        return Some(&**msg);
-    }
-
-    None
-}
-
-async fn handle_media_ping(ctx: &MessageContext, media: &(dyn MediaPing + '_)) {
-    info!(
-        "Received {:?} ping from {}",
-        media.media_type(),
-        ctx.info.source.sender
-    );
-
-    let mut data_buffer = Cursor::new(Vec::new());
-    if let Err(e) = ctx.client.download_to_file(media, &mut data_buffer).await {
-        error!("Failed to download media: {}", e);
-        let _ = ctx
-            .send_message(wa::Message {
-                conversation: Some("Failed to download your media.".to_string()),
-                ..Default::default()
-            })
-            .await;
         return;
     }
 
-    info!(
-        "Successfully downloaded media. Size: {} bytes. Now uploading...",
-        data_buffer.get_ref().len()
-    );
-    let plaintext_data = data_buffer.into_inner();
-    let upload_response = match ctx.client.upload(plaintext_data, media.media_type()).await {
-        Ok(resp) => resp,
+    if ctx.message.text_content() == Some(PING_TRIGGER) {
+        handle_text_ping(ctx).await;
+    }
+}
+
+async fn handle_text_ping(ctx: &MessageContext) {
+    info!("Received text ping, sending pong...");
+
+    let key = wa::MessageKey {
+        remote_jid: Some(ctx.info.source.chat.to_string()),
+        id: Some(ctx.info.id.clone()),
+        from_me: Some(ctx.info.source.is_from_me),
+        participant: ctx
+            .info
+            .source
+            .is_group
+            .then(|| ctx.info.source.sender.to_string()),
+    };
+    let reaction = wa::Message {
+        reaction_message: Some(wa::message::ReactionMessage {
+            key: Some(key),
+            text: Some(REACTION_EMOJI.to_string()),
+            sender_timestamp_ms: Some(Utc::now().timestamp_millis()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    if let Err(e) = ctx.send_message(reaction).await {
+        error!("Failed to send reaction: {}", e);
+    }
+
+    let start = std::time::Instant::now();
+    let context_info = ctx.build_quote_context();
+    let reply = wa::Message {
+        extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
+            text: Some(PONG_TEXT.to_string()),
+            context_info: Some(Box::new(context_info)),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+
+    let sent_id = match ctx.send_message(reply).await {
+        Ok(id) => id,
         Err(e) => {
-            error!("Failed to upload media: {}", e);
-            let _ = ctx
-                .send_message(wa::Message {
-                    conversation: Some("Failed to re-upload the media.".to_string()),
-                    ..Default::default()
-                })
-                .await;
+            error!("Failed to send pong: {}", e);
             return;
         }
     };
 
-    info!("Successfully uploaded media. Constructing reply message...");
-    let reply_msg = media.build_pong_reply(upload_response);
+    let duration = format!("{:.2?}", start.elapsed());
+    info!("Send took {}. Editing message {}...", duration, &sent_id);
 
-    if let Err(e) = ctx.send_message(reply_msg).await {
-        error!("Failed to send media pong reply: {}", e);
-    } else {
-        info!("Media pong reply sent successfully.");
+    let edit = wa::Message {
+        extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
+            text: Some(format!("{PONG_TEXT}\n`{duration}`")),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    if let Err(e) = ctx.edit_message(sent_id.clone(), edit).await {
+        error!("Failed to edit message {}: {}", sent_id, e);
     }
 }
 
-/// Parse a CLI argument by its long and short flags.
-/// Supports: --flag VALUE, -f VALUE, --flag=VALUE
+/// Reuses the original CDN blob, only swaps the caption. Instant regardless of file size.
+fn build_media_pong(message: &wa::Message) -> Option<wa::Message> {
+    let base = message.get_base_message();
+
+    if let Some(img) = &base.image_message
+        && img.caption.as_deref() == Some(PING_TRIGGER)
+    {
+        return Some(wa::Message {
+            image_message: Some(Box::new(wa::message::ImageMessage {
+                caption: Some(PONG_TEXT.to_string()),
+                ..*img.clone()
+            })),
+            ..Default::default()
+        });
+    }
+    if let Some(vid) = &base.video_message
+        && vid.caption.as_deref() == Some(PING_TRIGGER)
+    {
+        return Some(wa::Message {
+            video_message: Some(Box::new(wa::message::VideoMessage {
+                caption: Some(PONG_TEXT.to_string()),
+                ..*vid.clone()
+            })),
+            ..Default::default()
+        });
+    }
+    None
+}
+
 fn parse_arg(args: &[String], long: &str, short: &str) -> Option<String> {
     let long_prefix = format!("{}=", long);
-    let mut iter = args.iter().skip(1); // Skip program name
+    let mut iter = args.iter().skip(1);
     while let Some(arg) = iter.next() {
         if arg == long || arg == short {
             return iter.next().cloned();

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -245,6 +245,10 @@ struct RawUploadResponse {
 }
 
 impl Client {
+    /// Encrypts and uploads media to WhatsApp's CDN with a fresh key.
+    ///
+    /// Only needed for new or modified media. To forward existing media unchanged,
+    /// reuse the original message's CDN fields directly, no round-trip required.
     pub async fn upload(&self, data: Vec<u8>, media_type: MediaType) -> Result<UploadResponse> {
         let enc = wacore::runtime::blocking(&*self.runtime, {
             let data = data.clone();


### PR DESCRIPTION
## Summary

### Media ping-pong: 12s to instant
The bot was downloading, decrypting, re-encrypting, and re-uploading media for every ping-pong reply. Since the original file is already encrypted on WhatsApp's CDN, we can just clone the message's CDN fields and swap the caption. A 10MB video goes from ~12s to instant.

Before:
```
14:25:57 Received Video ping
14:26:06 Downloaded 10.2MB (9s)
14:26:09 Uploaded (3s)
14:26:09 Reply sent
```

After:
```
Received media ping → Reply sent (instant, no network I/O)
```

### Cleanup
- Removed `!setname` / `!setstatus` commands (not needed in demo)
- Extracted `handle_message` / `handle_text_ping` to reduce event handler nesting
- Merged `is_media_ping` + `build_media_pong` into a single `build_media_pong` that returns `Option<Message>` (check and build in one pass)
- Removed unused imports (`Cursor`, `Downloadable`, `MediaType`, `UploadResponse`)
- Added doc comments on `Client::upload` and `Client::download` explaining CDN reuse vs re-upload

### Net: -193 lines

## Test plan
- [x] `cargo clippy --all --tests` clean
- [x] Text ping still works (reaction + quote-reply + edit with duration)
- [x] Media ping (image/video) replies instantly with correct thumbnail and play button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined media message handling to improve performance and responsiveness.

* **Documentation**
  * Enhanced documentation for core API methods, clarifying functionality and usage guidelines for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->