### PR TITLE
perf: remove upload buffer clone, DRY download params and error patterns

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3200,6 +3200,10 @@ impl Client {
         snapshot.lid.clone()
     }
 
+    pub(crate) async fn require_pn(&self) -> Result<Jid> {
+        self.get_pn().await.ok_or(ClientError::NotLoggedIn.into())
+    }
+
     /// Resolve our own JID for a group, respecting its addressing mode.
     ///
     /// Returns LID for LID-addressing groups, PN otherwise.

--- a/src/download.rs
+++ b/src/download.rs
@@ -262,14 +262,14 @@ impl Client {
         file_length: u64,
         media_type: MediaType,
     ) -> Result<Vec<u8>> {
-        let params = DownloadParams {
-            direct_path: direct_path.to_string(),
-            media_key: Some(media_key.to_vec()),
-            file_sha256: file_sha256.to_vec(),
-            file_enc_sha256: Some(file_enc_sha256.to_vec()),
+        let params = Self::build_download_params(
+            direct_path,
+            media_key,
+            file_sha256,
+            file_enc_sha256,
             file_length,
             media_type,
-        };
+        );
         self.download(&params).await
     }
 
@@ -363,15 +363,33 @@ impl Client {
         media_type: MediaType,
         writer: W,
     ) -> Result<W> {
-        let params = DownloadParams {
+        let params = Self::build_download_params(
+            direct_path,
+            media_key,
+            file_sha256,
+            file_enc_sha256,
+            file_length,
+            media_type,
+        );
+        self.download_to_writer(&params, writer).await
+    }
+
+    fn build_download_params(
+        direct_path: &str,
+        media_key: &[u8],
+        file_sha256: &[u8],
+        file_enc_sha256: &[u8],
+        file_length: u64,
+        media_type: MediaType,
+    ) -> DownloadParams {
+        DownloadParams {
             direct_path: direct_path.to_string(),
             media_key: Some(media_key.to_vec()),
             file_sha256: file_sha256.to_vec(),
             file_enc_sha256: Some(file_enc_sha256.to_vec()),
             file_length,
             media_type,
-        };
-        self.download_to_writer(&params, writer).await
+        }
     }
 
     /// Internal: stream download + decrypt to a writer in one blocking thread.

--- a/src/send.rs
+++ b/src/send.rs
@@ -86,7 +86,7 @@ impl Client {
         let own_jid = device_snapshot
             .pn
             .clone()
-            .ok_or_else(|| anyhow::Error::from(crate::client::ClientError::NotLoggedIn))?;
+            .ok_or(crate::client::ClientError::NotLoggedIn)?;
         // Status always uses PN addressing, so own_lid is only needed as a
         // fallback parameter for prepare_group_stanza (unused in PN mode).
         let own_lid = device_snapshot
@@ -427,10 +427,7 @@ impl Client {
         revoke_type: RevokeType,
     ) -> Result<(), anyhow::Error> {
         let message_id = message_id.into();
-        // Verify we're logged in
-        self.get_pn()
-            .await
-            .ok_or_else(|| anyhow::Error::from(crate::client::ClientError::NotLoggedIn))?;
+        self.require_pn().await?;
 
         let (from_me, participant, edit_attr) = match &revoke_type {
             RevokeType::Sender => {
@@ -568,7 +565,7 @@ impl Client {
             let own_jid = device_snapshot
                 .pn
                 .clone()
-                .ok_or_else(|| anyhow::Error::from(crate::client::ClientError::NotLoggedIn))?;
+                .ok_or(crate::client::ClientError::NotLoggedIn)?;
             let own_lid = device_snapshot
                 .lid
                 .clone()
@@ -808,7 +805,7 @@ impl Client {
             let own_jid = device_snapshot
                 .pn
                 .clone()
-                .ok_or_else(|| anyhow::Error::from(crate::client::ClientError::NotLoggedIn))?;
+                .ok_or(crate::client::ClientError::NotLoggedIn)?;
             let account_info = device_snapshot.account.clone();
 
             // Include tctoken in 1:1 messages (matches WhatsApp Web behavior).

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -250,16 +250,16 @@ impl Client {
     /// Only needed for new or modified media. To forward existing media unchanged,
     /// reuse the original message's CDN fields directly, no round-trip required.
     pub async fn upload(&self, data: Vec<u8>, media_type: MediaType) -> Result<UploadResponse> {
-        let enc = wacore::runtime::blocking(&*self.runtime, {
-            let data = data.clone();
-            move || wacore::upload::encrypt_media(&data, media_type)
+        let file_length = data.len() as u64;
+        let enc = wacore::runtime::blocking(&*self.runtime, move || {
+            wacore::upload::encrypt_media(&data, media_type)
         })
         .await?;
 
         upload_media_with_retry(
             &enc,
             media_type,
-            data.len() as u64,
+            file_length,
             wacore::time::now_secs(),
             |force| async move { self.refresh_media_conn(force).await.map_err(Into::into) },
             || async { self.invalidate_media_conn().await },

--- a/wacore/libsignal/src/store/sender_key_name.rs
+++ b/wacore/libsignal/src/store/sender_key_name.rs
@@ -4,7 +4,7 @@ use crate::protocol::ProtocolAddress;
 pub struct SenderKeyName {
     group_id: String,
     sender_id: String,
-    /// Pre-computed `"{group_id}:{sender_id}"` cache key — avoids allocation on every load/store.
+    /// Pre-computed `"{group_id}:{sender_id}"` cache key.
     cache_key: String,
 }
 

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -20,6 +20,19 @@ use waproto::whatsapp as wa;
 // Re-export Mutation from appstate for convenience
 pub use crate::appstate::Mutation;
 
+fn lookup_app_state_key(
+    keys_map: &HashMap<String, Arc<ExpandedAppStateKeys>>,
+    key_id: &[u8],
+) -> Result<ExpandedAppStateKeys, crate::appstate::AppStateError> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
+    let id_b64 = STANDARD_NO_PAD.encode(key_id);
+    keys_map
+        .get(&id_b64)
+        .map(|arc| (**arc).clone())
+        .ok_or(crate::appstate::AppStateError::KeyNotFound)
+}
+
 #[derive(Debug, Error)]
 pub enum AppStateSyncError {
     #[error("app state key not found: {0}")]
@@ -227,24 +240,11 @@ impl AppStateProcessor {
 
             // Offload CPU-intensive snapshot processing to a blocking thread
             let result = crate::runtime::blocking(&*self.runtime, move || {
-                let get_keys = |key_id: &[u8]| -> Result<
-                    ExpandedAppStateKeys,
-                    crate::appstate::AppStateError,
-                > {
-                    use base64::Engine;
-                    use base64::engine::general_purpose::STANDARD_NO_PAD;
-                    let id_b64 = STANDARD_NO_PAD.encode(key_id);
-                    keys_map
-                        .get(&id_b64)
-                        .map(|arc| (**arc).clone())
-                        .ok_or(crate::appstate::AppStateError::KeyNotFound)
-                };
-
                 let mut snapshot_state = HashState::default();
                 let result = process_snapshot(
                     &snapshot_clone,
                     &mut snapshot_state,
-                    get_keys,
+                    |key_id| lookup_app_state_key(&keys_map, key_id),
                     validate_macs,
                     &collection_name_owned,
                 )?;
@@ -312,18 +312,6 @@ impl AppStateProcessor {
 
             // Offload CPU-intensive patch processing to a blocking thread
             let result = crate::runtime::blocking(&*self.runtime, move || {
-                let get_keys = |key_id: &[u8]| -> Result<
-                    ExpandedAppStateKeys,
-                    crate::appstate::AppStateError,
-                > {
-                    use base64::Engine;
-                    use base64::engine::general_purpose::STANDARD_NO_PAD;
-                    let id_b64 = STANDARD_NO_PAD.encode(key_id);
-                    keys.get(&id_b64)
-                        .map(|arc| (**arc).clone())
-                        .ok_or(crate::appstate::AppStateError::KeyNotFound)
-                };
-
                 let get_prev_value_mac = |index_mac: &[u8]| -> Result<
                     Option<Vec<u8>>,
                     crate::appstate::AppStateError,
@@ -333,7 +321,7 @@ impl AppStateProcessor {
                 process_patch(
                     &patch_clone,
                     &mut state,
-                    get_keys,
+                    |key_id| lookup_app_state_key(&keys, key_id),
                     get_prev_value_mac,
                     validate_macs,
                     &coll,

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -564,23 +564,21 @@ pub async fn prepare_dm_stanza<
     let participants = vec![to_jid.clone(), own_jid.clone()];
     let all_devices = resolver.resolve_devices(&participants).await?;
 
-    let mut recipient_devices = Vec::new();
-    let mut own_other_devices = Vec::new();
+    let mut recipient_devices = Vec::with_capacity(all_devices.len());
+    let mut own_other_devices = Vec::with_capacity(4);
     for device_jid in &all_devices {
-        // Skip the current device (sender) to prevent self-encryption loops
         if device_jid.user == own_jid.user && device_jid.device == own_jid.device {
             continue;
         }
 
-        let is_own_device = device_jid.user == own_jid.user;
-        if is_own_device {
+        if device_jid.user == own_jid.user {
             own_other_devices.push(device_jid.clone());
         } else {
             recipient_devices.push(device_jid.clone());
         }
     }
 
-    let mut participant_nodes = Vec::new();
+    let mut participant_nodes = Vec::with_capacity(all_devices.len());
     let mut includes_prekey_message = false;
 
     // If this is an edit-like message, set decrypt-fail="hide" on enc nodes

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -29,8 +29,6 @@ struct SentMessageEntry {
 /// Key for pre-keys: `id`.
 struct PreKeyEntry {
     record: Vec<u8>,
-    #[allow(dead_code)]
-    uploaded: bool,
 }
 
 /// Key for base-key collision detection: `(address, message_id)`.
@@ -145,12 +143,11 @@ impl SignalStore for InMemoryBackend {
         Ok(())
     }
 
-    async fn store_prekey(&self, id: u32, record: &[u8], uploaded: bool) -> Result<()> {
+    async fn store_prekey(&self, id: u32, record: &[u8], _uploaded: bool) -> Result<()> {
         self.state.lock().await.prekeys.insert(
             id,
             PreKeyEntry {
                 record: record.to_vec(),
-                uploaded,
             },
         );
         Ok(())


### PR DESCRIPTION
## Summary

Codebase audit fixes across 8 files, focused on performance and DRY.

### Performance
- **Remove Vec\<u8\> clone in `Client::upload`**: was cloning the entire media buffer (could be MBs) before moving into blocking closure. Now captures `file_length` first and moves `data` directly.

### DRY
- **`build_download_params()`**: deduplicate identical `DownloadParams` construction in `download_from_params` / `download_from_params_to_writer`
- **`Client::require_pn()`**: replace 4x repeated `.ok_or_else(|| anyhow::Error::from(ClientError::NotLoggedIn))` with `.ok_or(ClientError::NotLoggedIn)?` and a helper
- **`lookup_app_state_key()`**: extract duplicate closure from appstate_sync snapshot/patch processing

### Cleanup
- `Vec::with_capacity` in send.rs device partition loop (size is known)
- Remove unused `PreKeyEntry.uploaded` field in in-memory store

## Test plan
- [x] `cargo clippy --all --tests` clean
- [x] All tests pass (0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified login validation error handling throughout the codebase.
  * Optimized memory allocation patterns for improved performance.
  * Centralized internal key lookup logic to reduce code duplication.
  * Removed unnecessary internal fields and unused variables.

* **Documentation**
  * Updated internal documentation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->