### PR TITLE
feat: add message_id to SendOptions

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -9,10 +9,13 @@ use wacore_binary::jid::{DeviceKey, Jid, JidExt as _};
 use wacore_binary::node::Node;
 use waproto::whatsapp as wa;
 
-/// Options for sending messages with additional customization.
+/// Options for [`Client::send_message_with_options`].
 #[derive(Debug, Clone, Default)]
 pub struct SendOptions {
-    /// Extra XML nodes to add to the message stanza.
+    /// Override the auto-generated message ID.
+    /// Useful for resending a failed message with the same ID or idempotency.
+    pub message_id: Option<String>,
+    /// Extra XML child nodes on the message stanza.
     pub extra_stanza_nodes: Vec<Node>,
 }
 
@@ -48,18 +51,22 @@ impl Client {
         message: wa::Message,
         options: SendOptions,
     ) -> Result<String, anyhow::Error> {
-        let request_id = self.generate_message_id().await;
+        let request_id = match options.message_id {
+            Some(id) => id,
+            None => self.generate_message_id().await,
+        };
+        let returned_id = request_id.clone();
         self.send_message_impl(
             to,
             &message,
-            Some(request_id.clone()),
+            Some(request_id),
             false,
             false,
             None,
             options.extra_stanza_nodes,
         )
         .await?;
-        Ok(request_id)
+        Ok(returned_id)
     }
 
     /// Send a status/story update to the given recipients using sender key encryption.


### PR DESCRIPTION
## Summary

Adds `message_id: Option<String>` to `SendOptions`, allowing callers to override the auto-generated message ID when sending via `send_message_with_options()`.

### Why not the full proposal?

The original proposal suggested exposing `additional_attributes`, `edit`, `peer`, and `force_key_distribution`. After review:

- **`additional_attributes: Vec<(String, String)>`**: The only stanza attribute that varies is `edit`, already modeled as a typed `EditAttribute` enum. A raw string map bypasses the type system and invites protocol-breaking misuse.
- **`edit` in SendOptions**: `edit_message()` and `revoke_message()` already compose the correct protocol messages with proper key structure and participant resolution. Exposing `edit` alone without the corresponding message construction would produce messages the server rejects.
- **`peer`**: Changes encryption mode. Exposing it lets callers break group encryption.
- **`force_key_distribution`**: Overrides automatic SKDM state. The client handles this correctly.

The only real gap was `message_id`. One field solves the legitimate use cases (resend, idempotency) without creating unsafe escape hatches.

### Use cases
- Resending a failed message with the same ID
- Deterministic ID schemes for idempotency
- Replaying a pre-built message with a known ID

### No breaking changes
`SendOptions::default()` still works identically. `send_message()` unchanged.

## Test plan
- [x] `cargo clippy --all --tests` clean
- [x] CI