### PR TITLE
fix: auto-detect stanza metadata for pin/poll/event messages

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -1493,4 +1493,71 @@ mod tests {
 
         assert_eq!(new_devices.len(), 10);
     }
+
+    mod infer_stanza {
+        use super::*;
+
+        #[test]
+        fn regular_message_returns_none() {
+            let msg = wa::Message {
+                conversation: Some("hello".into()),
+                ..Default::default()
+            };
+            let (edit, node) = infer_stanza_metadata(&msg);
+            assert!(edit.is_none());
+            assert!(node.is_none());
+        }
+
+        #[test]
+        fn pin_returns_edit_attribute() {
+            let msg = wa::Message {
+                pin_in_chat_message: Some(wa::message::PinInChatMessage::default()),
+                ..Default::default()
+            };
+            let (edit, node) = infer_stanza_metadata(&msg);
+            assert_eq!(edit, Some(EditAttribute::PinInChat));
+            assert!(node.is_none());
+        }
+
+        #[test]
+        fn poll_creation_v3_returns_meta_node() {
+            let msg = wa::Message {
+                poll_creation_message_v3: Some(Box::default()),
+                ..Default::default()
+            };
+            let (edit, node) = infer_stanza_metadata(&msg);
+            assert!(edit.is_none());
+            let node = node.expect("should have meta node");
+            assert_eq!(node.tag, "meta");
+            let mut attrs = node.attrs();
+            assert_eq!(
+                attrs.optional_string("polltype").unwrap().as_ref(),
+                "creation"
+            );
+        }
+
+        #[test]
+        fn event_returns_meta_node() {
+            let msg = wa::Message {
+                event_message: Some(Box::default()),
+                ..Default::default()
+            };
+            let (edit, node) = infer_stanza_metadata(&msg);
+            assert!(edit.is_none());
+            let node = node.expect("should have meta node");
+            assert_eq!(node.tag, "meta");
+            let mut attrs = node.attrs();
+            assert_eq!(
+                attrs.optional_string("event_type").unwrap().as_ref(),
+                "creation"
+            );
+        }
+
+        #[test]
+        fn empty_message_returns_none() {
+            let (edit, node) = infer_stanza_metadata(&wa::Message::default());
+            assert!(edit.is_none());
+            assert!(node.is_none());
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`send_message()` / `send_message_with_options()` now inspects the proto content and automatically sets the required stanza attributes and meta child nodes for special message types.

### Bug fixed

`Polls::create()` calls `send_message()` directly (not `send_message_impl`), so poll creation was missing the `<meta polltype="creation"/>` node that WA Web always includes. This could cause the server to mishandle the message.

### What's inferred

| Message content | Stanza metadata added |
|---|---|
| `pin_in_chat_message` | `edit="2"` (PinInChat) |
| `poll_creation_message` / v2 / v3 | `<meta polltype="creation"/>` |
| `event_message` | `<meta event_type="creation"/>` |

### Performance

The common path (regular text/media) returns `(None, None)` with zero allocation. Only pin/poll/event messages allocate the meta node. Caller-provided `extra_stanza_nodes` are passed through directly when no inference is needed.

### What's unchanged

Typed methods (`pin_message`, `revoke_message`, `edit_message`) call `send_message_impl` directly with explicit parameters and bypass inference entirely.

### No breaking changes

## Test plan
- [x] `cargo clippy --all --tests` clean
- [x] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved message-sending metadata handling so pin messages, poll creations, and event creations include the correct stanza metadata when sent.
* **Tests**
  * Added unit tests covering regular/empty messages, pin messages, poll creation, and event creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->