### PR TITLE
refactor: make privacy settings API type-safe and WA Web compliant

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1601,7 +1601,7 @@ impl Client {
         &self,
         category: wacore::iq::privacy::PrivacyCategory,
         value: wacore::iq::privacy::PrivacyValue,
-    ) -> Result<(), crate::request::IqError> {
+    ) -> Result<wacore::iq::privacy::SetPrivacySettingResponse, crate::request::IqError> {
         use wacore::iq::privacy::SetPrivacySettingSpec;
         self.execute(SetPrivacySettingSpec::new(category, value))
             .await
@@ -1610,11 +1610,12 @@ impl Client {
     /// Set a privacy setting to `contact_blacklist` with a disallowed list update.
     ///
     /// Only `Last`, `Profile`, `Status`, `GroupAdd` support disallowed lists.
+    /// Returns the server's updated dhash for use in subsequent updates.
     pub async fn set_privacy_disallowed_list(
         &self,
         category: wacore::iq::privacy::PrivacyCategory,
         update: wacore::iq::privacy::DisallowedListUpdate,
-    ) -> Result<(), crate::request::IqError> {
+    ) -> Result<wacore::iq::privacy::SetPrivacySettingResponse, crate::request::IqError> {
         use wacore::iq::privacy::SetPrivacySettingSpec;
         self.execute(SetPrivacySettingSpec::with_disallowed_list(
             category, update,

--- a/wacore/src/iq/privacy.rs
+++ b/wacore/src/iq/privacy.rs
@@ -245,6 +245,13 @@ pub struct DisallowedListUpdate {
     pub users: Vec<DisallowedListUserEntry>,
 }
 
+/// Response from setting a privacy category.
+/// Mirrors `WAWebSetPrivacyJob` setPrivacyParser which extracts `{name, value, dhash}`.
+#[derive(Debug, Clone, Default)]
+pub struct SetPrivacySettingResponse {
+    pub dhash: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct SetPrivacySettingSpec {
     pub category: PrivacyCategory,
@@ -283,7 +290,7 @@ impl SetPrivacySettingSpec {
 }
 
 impl IqSpec for SetPrivacySettingSpec {
-    type Response = ();
+    type Response = SetPrivacySettingResponse;
 
     fn build_iq(&self) -> InfoQuery<'static> {
         let mut category_node = NodeBuilder::new("category")
@@ -310,7 +317,6 @@ impl IqSpec for SetPrivacySettingSpec {
                 .collect();
 
             category_node = category_node.children(user_nodes);
-            // LID addressing mode per WAWebSetPrivacyJob function `f`
             privacy_node = privacy_node.attr("addressing_mode", "lid");
         }
 
@@ -323,8 +329,19 @@ impl IqSpec for SetPrivacySettingSpec {
         )
     }
 
-    fn parse_response(&self, _response: &Node) -> Result<Self::Response, anyhow::Error> {
-        Ok(())
+    /// Parse the SET response. WA Web's `setPrivacyParser` extracts `{name, value, dhash}`
+    /// per category; we only need the dhash for disallowed-list conflict resolution.
+    fn parse_response(&self, response: &Node) -> Result<Self::Response, anyhow::Error> {
+        use crate::iq::node::optional_attr;
+
+        let dhash = response.get_optional_child("privacy").and_then(|privacy| {
+            privacy
+                .get_children_by_tag("category")
+                .next()
+                .and_then(|cat| optional_attr(cat, "dhash").map(|c| c.into_owned()))
+        });
+
+        Ok(SetPrivacySettingResponse { dhash })
     }
 }
 
@@ -653,6 +670,42 @@ mod tests {
         assert_eq!(users.len(), 2);
         assert_eq!(attr_str(users[0], "action").as_deref(), Some("add"));
         assert_eq!(attr_str(users[1], "action").as_deref(), Some("remove"));
+    }
+
+    #[test]
+    fn test_set_privacy_parse_response_with_dhash() {
+        let spec =
+            SetPrivacySettingSpec::new(PrivacyCategory::Last, PrivacyValue::ContactBlacklist);
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy")
+                .children([NodeBuilder::new("category")
+                    .attr("name", "last")
+                    .attr("value", "contact_blacklist")
+                    .attr("dhash", "updated_hash_456")
+                    .build()])
+                .build()])
+            .build();
+
+        let result = spec.parse_response(&response).unwrap();
+        assert_eq!(result.dhash.as_deref(), Some("updated_hash_456"));
+    }
+
+    #[test]
+    fn test_set_privacy_parse_response_without_dhash() {
+        let spec = SetPrivacySettingSpec::new(PrivacyCategory::Online, PrivacyValue::MatchLastSeen);
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy")
+                .children([NodeBuilder::new("category")
+                    .attr("name", "online")
+                    .attr("value", "match_last_seen")
+                    .build()])
+                .build()])
+            .build();
+
+        let result = spec.parse_response(&response).unwrap();
+        assert!(result.dhash.is_none());
     }
 
     // --- Validation tests ---


### PR DESCRIPTION
## Summary
- **Type safety**: `SetPrivacySettingSpec` and `Client::set_privacy_setting()` now accept `PrivacyCategory` + `PrivacyValue` enums instead of raw strings, preventing typos and invalid values at compile time
- **Missing categories/values**: Added `CallAdd`, `Messages`, `DefenseMode` categories and `Known`, `Off`, `OnStandard` values to match WhatsApp Web (`WAWebPrivacySettings`)
- **Per-category validation**: `PrivacyCategory::is_valid_value()` validates category/value combinations per WA Web rules (e.g. `online` only accepts `all | match_last_seen`)
- **Disallowed list support**: New `SetPrivacySettingSpec::with_disallowed_list()` + `Client::set_privacy_disallowed_list()` for `contact_blacklist` mode with LID addressing, dhash, and user add/remove entries

All categories and values verified against captured WA Web JS: `WAWebPrivacySettings`, `WAWebQueryPrivacySettingsJob`, `WAWebSetPrivacyJob`, `WAWebSchemaPrivacyDisallowedList`.

### Breaking change
`Client::set_privacy_setting()` signature changed from `(&str, &str)` to `(PrivacyCategory, PrivacyValue)`.

## Test plan
- [x] All 10 privacy unit tests pass (`cargo test -p wacore --lib iq::privacy`)
- [x] `cargo clippy --all --tests` clean (0 warnings)