### PR TITLE
fix: include meta node in newsletter sends (WA Web parity)

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -189,11 +189,13 @@ impl Client {
         if to.is_newsletter() {
             use prost::Message as _;
             let stanza_type = wacore::send::stanza_type_from_message(&message);
+            let (_, meta_node) = infer_stanza_metadata(&message);
             let mut plaintext_builder = NodeBuilder::new("plaintext");
             if let Some(mt) = wacore::send::media_type_from_message(&message) {
                 plaintext_builder = plaintext_builder.attr("mediatype", mt);
             }
             let mut children = vec![plaintext_builder.bytes(message.encode_to_vec()).build()];
+            children.extend(meta_node);
             children.extend(options.extra_stanza_nodes);
             let stanza = NodeBuilder::new("message")
                 .attr("to", to)


### PR DESCRIPTION
## Summary

Include `<meta>` stanza child (polltype/event_type) in newsletter sends, matching WA Web's SMAX ContentType mixins.

## Problem

The newsletter early-return path in `send_message_with_options` skipped `infer_stanza_metadata()`, so polls sent to newsletters had `type="poll"` but no `<meta polltype="creation">` child. WA Web's `ContentTypePollCreationMixin` always includes this node.

## Fix

Run `infer_stanza_metadata()` before the newsletter early return and include the `<meta>` node when present.

```diff
+let (_, meta_node) = infer_stanza_metadata(&message);
 let mut children = vec![plaintext_builder.bytes(...).build()];
+children.extend(meta_node);
 children.extend(options.extra_stanza_nodes);
```

## Test plan

- [x] `cargo clippy --all --tests -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing metadata in newsletter message sends, ensuring consistency with other message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->