### PR TITLE
refactor: return SendResult from status send methods

### DIFF
--- a/src/features/status.rs
+++ b/src/features/status.rs
@@ -3,6 +3,7 @@ use wacore_binary::jid::Jid;
 use waproto::whatsapp as wa;
 
 use crate::client::Client;
+use crate::send::SendResult;
 use crate::upload::UploadResponse;
 
 /// Privacy setting sent in the `<meta>` node of the status stanza.
@@ -49,7 +50,7 @@ impl<'a> Status<'a> {
         font: i32,
         recipients: Vec<Jid>,
         options: StatusSendOptions,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<SendResult, anyhow::Error> {
         let message = wa::Message {
             extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
                 text: Some(text.to_string()),
@@ -76,7 +77,7 @@ impl<'a> Status<'a> {
         caption: Option<&str>,
         recipients: Vec<Jid>,
         options: StatusSendOptions,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<SendResult, anyhow::Error> {
         let message = wa::Message {
             image_message: Some(Box::new(wa::message::ImageMessage {
                 url: Some(upload.url.clone()),
@@ -110,7 +111,7 @@ impl<'a> Status<'a> {
         caption: Option<&str>,
         recipients: Vec<Jid>,
         options: StatusSendOptions,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<SendResult, anyhow::Error> {
         let message = wa::Message {
             video_message: Some(Box::new(wa::message::VideoMessage {
                 url: Some(upload.url.clone()),
@@ -141,7 +142,7 @@ impl<'a> Status<'a> {
         message: wa::Message,
         recipients: Vec<Jid>,
         options: StatusSendOptions,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<SendResult, anyhow::Error> {
         self.client
             .send_status_message(message, recipients, options)
             .await
@@ -156,7 +157,7 @@ impl<'a> Status<'a> {
         message_id: impl Into<String>,
         recipients: Vec<Jid>,
         options: StatusSendOptions,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<SendResult, anyhow::Error> {
         let message_id = message_id.into();
         let to = Jid::status_broadcast();
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -277,7 +277,7 @@ impl Client {
         message: wa::Message,
         recipients: Vec<Jid>,
         options: crate::features::status::StatusSendOptions,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<SendResult, anyhow::Error> {
         use wacore::client::context::GroupInfo;
         use wacore_binary::builder::NodeBuilder;
 
@@ -485,7 +485,10 @@ impl Client {
             log::error!("Failed to flush signal cache after send_status_message: {e:?}");
         }
 
-        Ok(request_id)
+        Ok(SendResult {
+            message_id: request_id,
+            to,
+        })
     }
 
     /// Resolve which devices need SKDM by reading the per-device sender key map.


### PR DESCRIPTION
## Summary

`send_status_message` and all `Status` methods (`send_text`, `send_image`, `send_video`, `send_raw`, `revoke`) now return `Result<SendResult>` instead of `Result<String>`, consistent with `send_message` / `send_message_with_options`.

### BREAKING CHANGE

Callers that used the returned `String` directly need `.message_id` to get the old value.

### No new allocations

`request_id` and `to` (already owned at the return site) are moved into `SendResult` — zero extra clones.

## Test plan

- [x] `cargo clippy --all --tests` clean
- [x] `cargo fmt --all` clean
- [x] `cargo check --all --tests` passes