### PR TITLE
fix: add missing context to warning logs

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -254,7 +254,9 @@ impl Client {
         let info = match self.parse_message_info(&node).await {
             Ok(info) => Arc::new(info),
             Err(e) => {
-                log::warn!("Failed to parse message info: {e:?}");
+                let id = node.attrs.get("id").map(|v| v.as_str());
+                let from = node.attrs.get("from").map(|v| v.as_str());
+                log::warn!("Failed to parse message info (id={id:?}, from={from:?}): {e:?}");
                 return;
             }
         };
@@ -598,7 +600,12 @@ impl Client {
                         // Processed successfully or handled errors (e.g. sent retry receipt)
                     }
                     Err(e) => {
-                        log::warn!("Batch group decrypt encountered error (continuing): {e:?}");
+                        log::warn!(
+                            "[msg:{}] Batch group decrypt from {} in {} failed: {e:?}",
+                            info.id,
+                            info.source.sender,
+                            info.source.chat
+                        );
                     }
                 }
             } else {
@@ -780,7 +787,11 @@ impl Client {
                         )
                         .await
                     {
-                        log::warn!("Failed processing plaintext (batch session): {e:?}");
+                        log::warn!(
+                            "[msg:{}] Failed processing plaintext from {}: {e:?}",
+                            info.id,
+                            info.source.sender
+                        );
                     }
                 }
                 Err(e) => {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -251,7 +251,11 @@ impl Client {
             match self.groups().query_info(&receipt.source.chat).await {
                 Ok(info) => Some(info),
                 Err(e) => {
-                    log::warn!("Failed to fetch group info for retry: {e}");
+                    log::warn!(
+                        "Failed to fetch group info for retry of msg {} in {}: {e}",
+                        message_id,
+                        receipt.source.chat
+                    );
                     None
                 }
             }

--- a/src/send.rs
+++ b/src/send.rs
@@ -433,7 +433,11 @@ impl Client {
                         .clear_sender_key_devices(&to_str)
                         .await
                     {
-                        log::warn!("Failed to clear status SKDM recipients: {:?}", e);
+                        log::warn!(
+                            "Failed to clear status SKDM recipients for {}: {:?}",
+                            to_str,
+                            e
+                        );
                     }
                     self.sender_key_device_cache.invalidate(&to_str).await;
 
@@ -565,7 +569,11 @@ impl Client {
                 }
             }
             Err(e) => {
-                log::warn!("Failed to resolve devices for SKDM check: {:?}", e);
+                log::warn!(
+                    "Failed to resolve devices for SKDM check in {}: {:?}",
+                    group_jid,
+                    e
+                );
                 None
             }
         }
@@ -596,7 +604,11 @@ impl Client {
             .set_sender_key_status(group_jid, &entries)
             .await
         {
-            log::warn!("Failed to update sender key devices: {:?}", e);
+            log::warn!(
+                "Failed to update sender key devices for {}: {:?}",
+                group_jid,
+                e
+            );
         }
         self.sender_key_device_cache.invalidate(group_jid).await;
     }


### PR DESCRIPTION
## Summary
- Add message IDs, chat JIDs, and sender info to 7 warning logs that were previously missing context
- All context uses existing in-scope references — zero new allocations

### Changes
| File | Line | Before | After |
|---|---|---|---|
| `message.rs:257` | parse_message_info failure | no context | `id=..., from=...` from node attrs |
| `message.rs:601` | batch group decrypt error | no context | `[msg:ID] ... from SENDER in CHAT` |
| `message.rs:783` | plaintext processing error | no context | `[msg:ID] ... from SENDER` |
| `send.rs:436` | clear SKDM recipients failure | no context | `for GROUP_JID` |
| `send.rs:568` | resolve devices failure | no context | `in GROUP_JID` |
| `send.rs:599` | update sender key devices failure | no context | `for GROUP_JID` |
| `retry.rs:254` | fetch group info failure | no context | `msg MSG_ID in CHAT` |

## Test plan
- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo fmt --all` — clean
- [x] Verified all context variables are existing `&str`/`&Jid` references (Display trait, no heap allocation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging with improved contextual information across critical operations. Error and warning messages now include message IDs, sender details, and chat identifiers when issues occur during message processing, retry handling, or transmission. These improvements provide clearer diagnostics for faster troubleshooting and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->