### PR TITLE
refactor!: add TaskTracker for structured task lifecycle management

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -650,7 +650,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
                 .map_err(|e| anyhow::anyhow!("Failed to create persistence manager: {}", e))?,
         );
 
-        persistence_manager
+        let bg_saver_handle = persistence_manager
             .clone()
             .run_background_saver(runtime.clone(), std::time::Duration::from_secs(30));
 
@@ -686,6 +686,9 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             self.cache_config,
         )
         .await;
+
+        // Track the background saver on the client's lifetime
+        client.client_tasks.track(bg_saver_handle);
 
         // Register custom enc handlers
         for (enc_type, handler) in self.custom_enc_handlers {

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,6 +156,9 @@ pub struct MemoryDiagnostics {
     // -- Misc --
     pub chatstate_handlers: usize,
     pub custom_enc_handlers: usize,
+    // -- Task trackers --
+    pub connection_tasks: usize,
+    pub client_tasks: usize,
 }
 
 #[cfg(feature = "debug-diagnostics")]
@@ -225,6 +228,9 @@ impl std::fmt::Display for MemoryDiagnostics {
         writeln!(f, "--- Misc ---")?;
         writeln!(f, "  chatstate_handlers:     {}", self.chatstate_handlers)?;
         writeln!(f, "  custom_enc_handlers:    {}", self.custom_enc_handlers)?;
+        writeln!(f, "--- Task trackers ---")?;
+        writeln!(f, "  connection_tasks:       {}", self.connection_tasks)?;
+        writeln!(f, "  client_tasks:           {}", self.client_tasks)?;
         Ok(())
     }
 }
@@ -446,6 +452,11 @@ pub struct Client {
     /// Cache configuration for TTL and capacity of all caches.
     /// Stored for use by lazily-initialized caches (group_cache).
     pub(crate) cache_config: CacheConfig,
+
+    /// Tasks aborted on disconnect (keepalive, app state sync, QR rotation, etc.).
+    pub(crate) connection_tasks: wacore::runtime::TaskTracker,
+    /// Tasks that live for the Client's lifetime (persistence saver, device registry cleanup).
+    pub(crate) client_tasks: wacore::runtime::TaskTracker,
 }
 
 impl Client {
@@ -699,27 +710,31 @@ impl Client {
             override_version,
             skip_history_sync: AtomicBool::new(false),
             cache_config,
+            connection_tasks: wacore::runtime::TaskTracker::new(),
+            client_tasks: wacore::runtime::TaskTracker::new(),
         };
 
         let arc = Arc::new(this);
 
         // Warm up the LID-PN cache from persistent storage
         let warm_up_arc = arc.clone();
-        arc.runtime
-            .spawn(Box::pin(async move {
+        arc.client_tasks.spawn(
+            &*arc.runtime,
+            Box::pin(async move {
                 if let Err(e) = warm_up_arc.warm_up_lid_pn_cache().await {
                     warn!("Failed to warm up LID-PN cache: {e}");
                 }
-            }))
-            .detach();
+            }),
+        );
 
         // Start background task to clean up stale device registry entries
         let cleanup_arc = arc.clone();
-        arc.runtime
-            .spawn(Box::pin(async move {
+        arc.client_tasks.spawn(
+            &*arc.runtime,
+            Box::pin(async move {
                 cleanup_arc.device_registry_cleanup_loop().await;
-            }))
-            .detach();
+            }),
+        );
 
         (arc, rx)
     }
@@ -992,9 +1007,10 @@ impl Client {
         self.socket_ready_notifier.notify(usize::MAX);
 
         let client_clone = self.clone();
-        self.runtime
-            .spawn(Box::pin(async move { client_clone.keepalive_loop().await }))
-            .detach();
+        self.connection_tasks.spawn(
+            &*self.runtime,
+            Box::pin(async move { client_clone.keepalive_loop().await }),
+        );
 
         Ok(())
     }
@@ -1092,11 +1108,13 @@ impl Client {
         // sent_node_waiters ARE cleared because they match pre-encryption
         // outgoing stanzas, which are transport-scoped.
         self.clear_sent_node_waiters();
+        // Abort all connection-scoped tasks (keepalive, app state sync, etc.)
+        // before tearing down transport so they don't race on stale state.
+        self.connection_tasks.abort_all();
         self.is_logged_in.store(false, Ordering::Relaxed);
         self.is_ready.store(false, Ordering::Relaxed);
         // Signal the keepalive loop (and any other tasks) to exit promptly.
-        // Without this, a stale keepalive loop can overlap with the next one
-        // after reconnect, causing duplicate pings.
+        // Kept as belt-and-suspenders alongside connection_tasks.abort_all().
         self.shutdown_notifier.notify(usize::MAX);
         *self.transport.lock().await = None;
         *self.transport_events.lock().await = None;
@@ -1106,6 +1124,8 @@ impl Client {
         // checks the socket, but this ordering avoids a confusing state window.
         self.is_connected.store(false, Ordering::Release);
         self.retried_group_messages.invalidate_all();
+        // Drop per-chat message queue senders so workers exit via channel close.
+        self.message_queues.invalidate_all();
         // Clear pending retries so stale keys from detached scopeguard
         // cleanup don't suppress the first retry after reconnect.
         self.pending_retries
@@ -1214,6 +1234,8 @@ impl Client {
             signal_cache_sender_keys: sig_sender_keys,
             chatstate_handlers: self.chatstate_handlers.read().await.len(),
             custom_enc_handlers: self.custom_enc_handlers.read().await.len(),
+            connection_tasks: self.connection_tasks.len(),
+            client_tasks: self.client_tasks.len(),
         }
     }
 
@@ -1282,9 +1304,9 @@ impl Client {
                                             self.process_decrypted_node(node).await;
                                         } else {
                                             let client = self.clone();
-                                            self.runtime.spawn(Box::pin(async move {
+                                            self.connection_tasks.spawn(&*self.runtime, Box::pin(async move {
                                                 client.process_decrypted_node(node).await;
-                                            })).detach();
+                                            }));
                                         }
                                     }
 
@@ -1778,7 +1800,7 @@ impl Client {
 
         let client_clone = self.clone();
         let task_generation = current_generation;
-        self.runtime.spawn(Box::pin(async move {
+        self.connection_tasks.spawn(&*self.runtime, Box::pin(async move {
             // Macro to check if this task is still valid (connection hasn't been replaced)
             macro_rules! check_generation {
                 () => {
@@ -1873,7 +1895,7 @@ impl Client {
             // Background initialization queries (can run in parallel, non-blocking)
             let bg_client = client_clone.clone();
             let bg_generation = task_generation;
-            client_clone.runtime.spawn(Box::pin(async move {
+            client_clone.connection_tasks.spawn(&*client_clone.runtime, Box::pin(async move {
                 // Check connection and generation before starting background queries
                 if bg_client.connection_generation.load(Ordering::SeqCst) != bg_generation {
                     debug!("Skipping background init queries: connection generation changed");
@@ -1919,7 +1941,7 @@ impl Client {
                 {
                     warn!("Background init: Failed to prune expired tc_tokens: {e:?}");
                 }
-            })).detach();
+            }));
 
             check_generation!();
 
@@ -2030,7 +2052,7 @@ impl Client {
                 // Spawn remaining non-critical collections in background
                 let sync_client = client_clone.clone();
                 let sync_generation = task_generation;
-                client_clone.runtime.spawn(Box::pin(async move {
+                client_clone.connection_tasks.spawn(&*client_clone.runtime, Box::pin(async move {
                     if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
                         debug!("App state sync cancelled: connection generation changed");
                         return;
@@ -2051,7 +2073,7 @@ impl Client {
                         .needs_initial_full_sync
                         .store(false, Ordering::Relaxed);
                     debug!(target: "Client/AppState", "Initial App State Sync Completed.");
-                })).detach();
+                }));
             } else {
                 // === Reconnection path ===
                 // Pushname is already known, send presence and Connected immediately.
@@ -2074,7 +2096,7 @@ impl Client {
 
                 client_clone.dispatch_connected();
             }
-        })).detach();
+        }));
     }
 
     /// Handles incoming `<ack/>` stanzas by resolving pending response waiters.
@@ -3341,15 +3363,16 @@ impl Client {
         ));
 
         let client_clone = self.clone();
-        self.runtime
-            .spawn(Box::pin(async move {
+        self.connection_tasks.spawn(
+            &*self.runtime,
+            Box::pin(async move {
                 if let Err(e) = client_clone.presence().set_available().await {
                     log::warn!("Failed to send presence after push name update: {:?}", e);
                 } else {
                     log::debug!("Sent presence after push name update.");
                 }
-            }))
-            .detach();
+            }),
+        );
     }
 
     pub async fn get_push_name(&self) -> String {

--- a/src/client.rs
+++ b/src/client.rs
@@ -950,6 +950,11 @@ impl Client {
             return Err(ClientError::AlreadyConnected.into());
         }
 
+        // Drain stale handles from the previous connection cycle. By this
+        // point, cooperative tasks have already received shutdown_notifier and
+        // the generation has been bumped, so abort is safe for any stragglers.
+        self.connection_tasks.abort_all();
+
         // Reset login state for new connection attempt. This ensures that
         // handle_success will properly process the <success> stanza even if
         // a previous connection's post-login task bailed out early.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1108,13 +1108,14 @@ impl Client {
         // sent_node_waiters ARE cleared because they match pre-encryption
         // outgoing stanzas, which are transport-scoped.
         self.clear_sent_node_waiters();
-        // Abort all connection-scoped tasks (keepalive, app state sync, etc.)
-        // before tearing down transport so they don't race on stale state.
-        self.connection_tasks.abort_all();
         self.is_logged_in.store(false, Ordering::Relaxed);
         self.is_ready.store(false, Ordering::Relaxed);
         // Signal the keepalive loop (and any other tasks) to exit promptly.
-        // Kept as belt-and-suspenders alongside connection_tasks.abort_all().
+        // Tasks detect staleness cooperatively via connection_generation,
+        // is_shutting_down(), and this notifier. Forceful abort is intentionally
+        // NOT used here — tasks like the post-login sequence must survive 515
+        // reconnect cycles to dispatch Connected. TaskTracker::Drop handles
+        // final cleanup when the Client is dropped.
         self.shutdown_notifier.notify(usize::MAX);
         *self.transport.lock().await = None;
         *self.transport_events.lock().await = None;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1303,10 +1303,12 @@ impl Client {
                                         if process_inline {
                                             self.process_decrypted_node(node).await;
                                         } else {
+                                            // Per-stanza processing: fire-and-forget since
+                                            // the message loop itself exits on disconnect.
                                             let client = self.clone();
-                                            self.connection_tasks.spawn(&*self.runtime, Box::pin(async move {
+                                            self.runtime.spawn(Box::pin(async move {
                                                 client.process_decrypted_node(node).await;
-                                            }));
+                                            })).detach();
                                         }
                                     }
 

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -67,9 +67,9 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
                 let client_clone = client.clone();
 
                 // Groups/newsletter_metadata: wait for offline sync per WAWebHandleDirtyBits.
-                client
-                    .runtime
-                    .spawn(Box::pin(async move {
+                client.connection_tasks.spawn(
+                    &*client.runtime,
+                    Box::pin(async move {
                         if needs_offline_wait {
                             client_clone.wait_for_offline_delivery_end().await;
                         }
@@ -98,8 +98,8 @@ async fn handle_ib_impl(client: Arc<Client>, node: &Node) {
                                 warn!("App state re-sync after dirty notification failed: {e:?}");
                             }
                         }
-                    }))
-                    .detach();
+                    }),
+                );
             }
             "edge_routing" => {
                 // Edge routing info is used for optimized reconnection to WhatsApp servers.

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -98,7 +98,7 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
                 let generation = client
                     .connection_generation
                     .load(std::sync::atomic::Ordering::SeqCst);
-                client.runtime.spawn(Box::pin(async move {
+                client.connection_tasks.spawn(&*client.runtime, Box::pin(async move {
                     // Check if connection was replaced before starting sync
                     if client_clone
                         .connection_generation
@@ -150,7 +150,7 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
                             );
                         }
                     }
-                })).detach();
+                }));
             }
         }
         "account_sync" => {
@@ -244,9 +244,9 @@ async fn handle_prekey_low(client: &Arc<Client>) {
         .store(false, std::sync::atomic::Ordering::Relaxed);
 
     let client_clone = client.clone();
-    client
-        .runtime
-        .spawn(Box::pin(async move {
+    client.connection_tasks.spawn(
+        &*client.runtime,
+        Box::pin(async move {
             // Wait for offline delivery to complete first (matches WA Web's waitForOfflineDeliveryEnd).
             // Done BEFORE acquiring the lock so the lock isn't held during an
             // indefinite wait that could block digest-key or other upload paths.
@@ -279,8 +279,8 @@ async fn handle_prekey_low(client: &Arc<Client>) {
                     e
                 );
             }
-        }))
-        .detach();
+        }),
+    );
 }
 
 /// Handle encrypt/digest notification (Digest Key validation).
@@ -293,15 +293,15 @@ async fn handle_prekey_low(client: &Arc<Client>) {
 /// preventing concurrent uploads that could race on prekey ID allocation.
 fn handle_digest_key(client: &Arc<Client>) {
     let client_clone = client.clone();
-    client
-        .runtime
-        .spawn(Box::pin(async move {
+    client.connection_tasks.spawn(
+        &*client.runtime,
+        Box::pin(async move {
             let _guard = client_clone.prekey_upload_lock.lock().await;
             if let Err(e) = client_clone.validate_digest_key().await {
                 warn!("Digest key validation failed: {:?}", e);
             }
-        }))
-        .detach();
+        }),
+    );
 }
 
 /// Handle device list change notifications.

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -180,11 +180,12 @@ impl Client {
                 let _ = result_tx.send(result);
             }));
             // Drive the blocking future to completion in the background
-            self.runtime
-                .spawn(Box::pin(async move {
+            self.connection_tasks.spawn(
+                &*self.runtime,
+                Box::pin(async move {
                     blocking_fut.await;
-                }))
-                .detach();
+                }),
+            );
 
             // Receive and dispatch lazy conversations as they come in
             let mut conv_count = 0usize;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -145,11 +145,11 @@ impl Client {
                                 let backend = self.persistence_manager.backend();
                                 let cutoff = wacore::time::now_secs()
                                     - sent_msg_ttl as i64;
-                                self.runtime.spawn(Box::pin(async move {
+                                self.connection_tasks.spawn(&*self.runtime, Box::pin(async move {
                                     if let Err(e) = backend.delete_expired_sent_messages(cutoff).await {
                                         log::debug!(target: "Client/Keepalive", "Sent message cleanup error: {e}");
                                     }
-                                })).detach();
+                                }));
                             }
                         }
                         KeepaliveResult::FatalFailure => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -192,7 +192,7 @@ impl Client {
         let client = Arc::clone(self);
         let info = info.clone();
 
-        self.runtime.spawn(Box::pin(async move {
+        self.connection_tasks.spawn(&*self.runtime, Box::pin(async move {
             let cache_key = client
                 .make_retry_cache_key(&info.source.chat, &info.id, &info.source.sender)
                 .await;
@@ -247,7 +247,7 @@ impl Client {
             if retry_count == 1 {
                 client.spawn_pdo_request(&info);
             }
-        })).detach();
+        }));
     }
 
     pub(crate) async fn handle_incoming_message(self: Arc<Self>, node: Arc<Node>) {
@@ -434,8 +434,9 @@ impl Client {
                 let enc_node_clone = Arc::new(enc_node.clone());
                 let enc_type_owned = enc_type.to_string();
 
-                self.runtime
-                    .spawn(Box::pin(async move {
+                self.connection_tasks.spawn(
+                    &*self.runtime,
+                    Box::pin(async move {
                         if let Err(e) = handler_clone
                             .handle(client_clone, &enc_node_clone, &info_arc)
                             .await
@@ -445,8 +446,8 @@ impl Client {
                                 enc_type_owned
                             );
                         }
-                    }))
-                    .detach();
+                    }),
+                );
                 continue;
             }
 

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -64,9 +64,9 @@ pub async fn handle_iq(client: &Arc<Client>, node: &Node) -> bool {
                     let codes_clone = codes.clone();
                     let client_clone = client.clone();
 
-                    client
-                        .runtime
-                        .spawn(Box::pin(async move {
+                    client.connection_tasks.spawn(
+                        &*client.runtime,
+                        Box::pin(async move {
                             // The rotation logic is now inside the library
                             let mut is_first = true;
 
@@ -99,8 +99,8 @@ pub async fn handle_iq(client: &Arc<Client>, node: &Node) -> bool {
                             }
                             info!("All QR codes for this session have expired.");
                             client_clone.disconnect().await;
-                        }))
-                        .detach();
+                        }),
+                    );
 
                     *client.pairing_cancellation_tx.lock().await = Some(stop_tx);
 
@@ -291,12 +291,12 @@ async fn handle_pair_success(client: &Arc<Client>, request_node: &Node, success_
             }
 
             let client_for_unified = client.clone();
-            client
-                .runtime
-                .spawn(Box::pin(async move {
+            client.connection_tasks.spawn(
+                &*client.runtime,
+                Box::pin(async move {
                     client_for_unified.send_unified_session().await;
-                }))
-                .detach();
+                }),
+            );
 
             // --- START: FIX ---
             // Set the flag to trigger a full sync on the next successful connection.

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -438,8 +438,9 @@ impl Client {
         let client_clone = Arc::clone(self);
         let info_clone = info.clone();
 
-        self.runtime
-            .spawn(Box::pin(async move {
+        self.connection_tasks.spawn(
+            &*self.runtime,
+            Box::pin(async move {
                 if !immediate {
                     // Add a small delay to allow the retry receipt to be processed first
                     // This avoids overwhelming the phone with simultaneous requests
@@ -455,8 +456,8 @@ impl Client {
                         info_clone.id, info_clone.source.sender, e
                     );
                 }
-            }))
-            .detach();
+            }),
+        );
     }
 
     /// Spawns a PDO request for a message that failed to decrypt.

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -67,8 +67,9 @@ impl Client {
             let client_clone = Arc::clone(self);
             // Arc clone is cheap - just reference count increment
             let node_clone = Arc::clone(&node);
-            self.runtime
-                .spawn(Box::pin(async move {
+            self.connection_tasks.spawn(
+                &*self.runtime,
+                Box::pin(async move {
                     if let Err(e) = client_clone
                         .handle_retry_receipt(&receipt, &node_clone)
                         .await
@@ -79,8 +80,8 @@ impl Client {
                             e
                         );
                     }
-                }))
-                .detach();
+                }),
+            );
         } else if receipt_type == ReceiptType::EncRekeyRetry {
             // WA Web: both "retry" and "enc_rekey_retry" route through
             // handleMessageRetryRequest, but enc_rekey_retry branches to the

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -128,39 +128,42 @@ impl PersistenceManager {
         }
     }
 
-    pub fn run_background_saver(self: Arc<Self>, runtime: Arc<dyn Runtime>, interval: Duration) {
+    pub fn run_background_saver(
+        self: Arc<Self>,
+        runtime: Arc<dyn Runtime>,
+        interval: Duration,
+    ) -> wacore::runtime::AbortHandle {
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);
         drop(self); // Release the strong reference; the caller's Arc keeps it alive
-        runtime
-            .spawn(Box::pin(async move {
-                loop {
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    // Create the listener BEFORE the event can fire to avoid missing notifications.
-                    let listener = this.save_notify.listen();
-                    drop(this); // Don't hold strong ref while sleeping
+        let handle = runtime.spawn(Box::pin(async move {
+            loop {
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
+                // Create the listener BEFORE the event can fire to avoid missing notifications.
+                let listener = this.save_notify.listen();
+                drop(this); // Don't hold strong ref while sleeping
 
-                    futures::select! {
-                        _ = listener.fuse() => {
-                            debug!("Save notification received.");
-                        }
-                        _ = rt.sleep(interval).fuse() => {}
+                futures::select! {
+                    _ = listener.fuse() => {
+                        debug!("Save notification received.");
                     }
-
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    if let Err(e) = this.save_to_disk().await {
-                        error!("Error saving device state in background: {e}");
-                    }
+                    _ = rt.sleep(interval).fuse() => {}
                 }
-            }))
-            .detach();
+
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
+                if let Err(e) = this.save_to_disk().await {
+                    error!("Error saving device state in background: {e}");
+                }
+            }
+        }));
         debug!("Background saver task started with interval {interval:?}");
+        handle
     }
 }
 

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -64,6 +64,7 @@ pub trait Runtime: Send + Sync + 'static {
 /// Uses `std::sync::Mutex` internally so that the handle is `Send + Sync`,
 /// which is required because it may be stored inside structs shared across
 /// tasks (e.g. `NoiseSocket` behind an `Arc`).
+#[must_use = "dropping an AbortHandle aborts the task; use .detach() for fire-and-forget or track it via TaskTracker"]
 pub struct AbortHandle {
     abort_fn: std::sync::Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
 }
@@ -108,6 +109,81 @@ impl AbortHandle {
 impl Drop for AbortHandle {
     fn drop(&mut self) {
         self.abort();
+    }
+}
+
+/// Tracks spawned tasks and aborts them all on demand or when dropped.
+///
+/// Two intended scopes:
+/// - **Connection-scoped**: aborted on disconnect via `abort_all()`.
+/// - **Client-scoped**: aborted when the owning struct is dropped.
+pub struct TaskTracker {
+    handles: std::sync::Mutex<Vec<AbortHandle>>,
+}
+
+impl TaskTracker {
+    pub fn new() -> Self {
+        Self {
+            handles: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Store an existing `AbortHandle` so it will be aborted on `abort_all()` / drop.
+    pub fn track(&self, handle: AbortHandle) {
+        self.handles
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(handle);
+    }
+
+    /// Abort every tracked task and clear the list.
+    pub fn abort_all(&self) {
+        let handles = std::mem::take(&mut *self.handles.lock().unwrap_or_else(|p| p.into_inner()));
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    /// Number of tracked handles (includes already-completed tasks).
+    pub fn len(&self) -> usize {
+        self.handles.lock().unwrap_or_else(|p| p.into_inner()).len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for TaskTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for TaskTracker {
+    fn drop(&mut self) {
+        self.abort_all();
+    }
+}
+
+/// Convenience methods that depend on `Runtime`. Cfg-gated for Send bounds.
+#[cfg(not(target_arch = "wasm32"))]
+impl TaskTracker {
+    /// Spawn a future via the given runtime and track the handle.
+    pub fn spawn(
+        &self,
+        rt: &dyn Runtime,
+        future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+    ) {
+        self.track(rt.spawn(future));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TaskTracker {
+    /// Spawn a future via the given runtime and track the handle.
+    pub fn spawn(&self, rt: &dyn Runtime, future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
+        self.track(rt.spawn(future));
     }
 }
 

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -6,7 +6,7 @@
 //! `Backend` reference. That version should eventually be consolidated into this
 //! one once the `Device` wrapper is unified.
 
-use crate::runtime::Runtime;
+use crate::runtime::{AbortHandle, Runtime};
 use crate::store::commands::{DeviceCommand, apply_command_to_device};
 use crate::store::device::Device;
 use crate::store::error::{StoreError, db_err};
@@ -138,38 +138,41 @@ impl PersistenceManager {
     // flushed by a periodic tick will be lost. A proper fix requires adding an
     // explicit `shutdown()` method that callers invoke before dropping, which is
     // a larger design change tracked separately.
-    pub fn run_background_saver(self: Arc<Self>, runtime: Arc<dyn Runtime>, interval: Duration) {
+    pub fn run_background_saver(
+        self: Arc<Self>,
+        runtime: Arc<dyn Runtime>,
+        interval: Duration,
+    ) -> AbortHandle {
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);
         drop(self); // Release the strong reference; the caller's Arc keeps it alive
-        runtime
-            .spawn(Box::pin(async move {
-                loop {
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    let listener = this.save_notify.listen();
-                    drop(this); // Don't hold strong ref while sleeping
+        let handle = runtime.spawn(Box::pin(async move {
+            loop {
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
+                let listener = this.save_notify.listen();
+                drop(this); // Don't hold strong ref while sleeping
 
-                    futures::select! {
-                        _ = listener.fuse() => {
-                            debug!("Save notification received.");
-                        }
-                        _ = rt.sleep(interval).fuse() => {}
+                futures::select! {
+                    _ = listener.fuse() => {
+                        debug!("Save notification received.");
                     }
-
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    if let Err(e) = this.save_to_disk().await {
-                        error!("Error saving device state in background: {e}");
-                    }
+                    _ = rt.sleep(interval).fuse() => {}
                 }
-            }))
-            .detach();
+
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
+                if let Err(e) = this.save_to_disk().await {
+                    error!("Error saving device state in background: {e}");
+                }
+            }
+        }));
         debug!("Background saver task started with interval {interval:?}");
+        handle
     }
 
     pub async fn process_command(&self, command: DeviceCommand) {


### PR DESCRIPTION
## Summary

- Add `TaskTracker` to `wacore::runtime` — a lightweight container that stores `AbortHandle`s and aborts them all on demand or when dropped
- Add `#[must_use]` to `AbortHandle` so the compiler warns when a spawned task's handle is silently dropped (forces explicit `.detach()` or tracking)
- Add `connection_tasks` / `client_tasks` fields to `Client`:
  - **connection_tasks**: tracked for diagnostics and drained at the start of each `connect()` call to prevent unbounded handle accumulation across reconnects. Tasks exit cooperatively via `connection_generation`, `is_shutting_down()`, and `shutdown_notifier` — no forceful abort on disconnect (tasks like the post-login sequence must survive 515 reconnect cycles)
  - **client_tasks**: aborted when `Client` drops — covers LID-PN cache warm-up, device registry cleanup, persistence background saver
- Invalidate `message_queues` on disconnect (bug fix: stale per-chat workers survived reconnects)
- `run_background_saver` now returns `AbortHandle` instead of detaching internally
- 14 `.detach()` calls remain as intentional fire-and-forget (event dispatch callbacks, best-effort acks/receipts, transport disconnect teardown, background DB writes, sync worker with Weak ref, per-stanza processing)

## Breaking changes

- `PersistenceManager::run_background_saver()` now returns `AbortHandle` instead of `()`. Callers must either track the handle (e.g., via `client_tasks.track()`) or call `.detach()` to preserve the old fire-and-forget behavior.

## Test plan
- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo test --all --exclude e2e-tests` — all 1090 tests pass
- [x] Verified `#[must_use]` produces a warning when `runtime.spawn()` result is unused
- [x] Verified remaining 14 `.detach()` calls are all intentional fire-and-forget
- [x] Verified `connection_tasks.abort_all()` is called at start of `connect()` (not during `cleanup_connection_state`) to avoid aborting the post-login task during 515 reconnect cycles
- [x] Verified `message_queues.invalidate_all()` closes channels so per-chat workers exit
- [x] Verified cooperative cancellation via `connection_generation` / `shutdown_notifier` handles staleness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added background task activity monitoring to diagnostics output

**Improvements**
- Enhanced cleanup of stale background tasks during connection state transitions
- Improved background task lifecycle management by assigning appropriate ownership scopes
- Refined task handling during reconnection cycles to prevent leftover operations from prior sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->