### PR TITLE
fix: add #[must_use] to AbortHandle and clear message queues on disconnect

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1106,6 +1106,10 @@ impl Client {
         // checks the socket, but this ordering avoids a confusing state window.
         self.is_connected.store(false, Ordering::Release);
         self.retried_group_messages.invalidate_all();
+        // Drop per-chat message queue senders so workers exit via channel close.
+        // Without this, stale workers from the old connection survive reconnects
+        // holding outdated signal/crypto state.
+        self.message_queues.invalidate_all();
         // Clear pending retries so stale keys from detached scopeguard
         // cleanup don't suppress the first retry after reconnect.
         self.pending_retries

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -64,6 +64,7 @@ pub trait Runtime: Send + Sync + 'static {
 /// Uses `std::sync::Mutex` internally so that the handle is `Send + Sync`,
 /// which is required because it may be stored inside structs shared across
 /// tasks (e.g. `NoiseSocket` behind an `Arc`).
+#[must_use = "dropping an AbortHandle aborts the task; use .detach() for fire-and-forget"]
 pub struct AbortHandle {
     abort_fn: std::sync::Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
 }


### PR DESCRIPTION
## Summary

Minimal, targeted fixes from the resource management audit — only the changes that provide real value without adding complexity.

- **`#[must_use]` on `AbortHandle`**: The compiler now warns when a spawned task's handle is silently dropped (which would abort the task). Forces every spawn site to make an explicit choice: `.detach()` for fire-and-forget, or store the handle for lifecycle management. Zero runtime cost.
- **`message_queues.invalidate_all()` in `cleanup_connection_state()`**: Drops per-chat message queue senders on disconnect so workers exit via channel close. Without this, stale workers from the previous connection survived reconnects holding outdated signal/crypto state.

### Why not TaskTracker?

The original approach (PR #458) added a `TaskTracker` container for structured task lifecycle management. After thorough review, this was overengineered — the existing cooperative cancellation via `connection_generation`, `shutdown_notifier`, and `is_shutting_down()` already handles task lifecycle correctly (matching WhatsApp Web's AbortController pattern). The TaskTracker added complexity (Arc reference cycles, unbounded handle growth, abort timing issues with 515 reconnect cycles) without improving stability.

## Test plan
- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo test --all --exclude e2e-tests` — all pass
- [x] Verified `#[must_use]` produces compiler warning on unhandled `runtime.spawn()` result
- [x] Verified `message_queues.invalidate_all()` placement is after `is_connected = false` (workers see disconnected state on any in-flight sends)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cleanup to properly reset per-chat worker states during reconnection, preventing issues from outdated connection state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->