### PR TITLE
fix: include fresh prekeys on retry #1 for InvalidKeyId errors

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -730,13 +730,14 @@ impl Client {
             .bytes(registration_id_bytes)
             .build();
 
-        // WhatsApp Web only includes keys when retryCount >= 2.
-        // First retry gives the sender a chance to resend without full key exchange.
-        //
-        // WA Web includes keys at retryCount >= MIN_RETRY_COUNT_FOR_KEYS.
-        // Optimization for NoSession: include keys on retry#1 to reduce round-trips
-        // for skmsg-only failures where the sender needs our prekeys for SKDM.
-        let include_keys_early = reason == RetryReason::NoSession;
+        // WA Web includes keys at retryCount >= MIN_RETRY_COUNT_FOR_KEYS (=2).
+        // Optimization: include keys on retry #1 when the sender provably can't
+        // recover without them, to avoid a wasted round-trip:
+        // - NoSession: sender needs our prekeys for SKDM session establishment
+        // - InvalidKeyId: sender's prekey reference is consumed — they'll just
+        //   re-send with the same broken session without fresh keys
+        let include_keys_early =
+            reason == RetryReason::NoSession || reason == RetryReason::InvalidKeyId;
         let keys_node = if retry_count >= MIN_RETRY_COUNT_FOR_KEYS || include_keys_early {
             let device_store = self.persistence_manager.get_device_arc().await;
             let device_guard = device_store.read().await;
@@ -1603,7 +1604,8 @@ mod tests {
 
         for (retry_count, reason, should_include_keys, description) in test_cases {
             // Replicate the logic from send_retry_receipt
-            let include_keys_early = reason == RetryReason::NoSession;
+            let include_keys_early =
+                reason == RetryReason::NoSession || reason == RetryReason::InvalidKeyId;
             let would_include_keys = retry_count >= MIN_RETRY_COUNT_FOR_KEYS || include_keys_early;
 
             assert_eq!(
@@ -1656,7 +1658,8 @@ mod tests {
                 };
 
                 // Apply the optimization logic
-                let include_keys_early = reason == RetryReason::NoSession;
+                let include_keys_early =
+                    reason == RetryReason::NoSession || reason == RetryReason::InvalidKeyId;
                 let would_include_keys =
                     retry_count >= MIN_RETRY_COUNT_FOR_KEYS || include_keys_early;
 
@@ -1714,7 +1717,8 @@ mod tests {
         let reason = RetryReason::NoSession;
 
         // With optimization, we include keys on retry#1
-        let include_keys_early = reason == RetryReason::NoSession;
+        let include_keys_early =
+            reason == RetryReason::NoSession || reason == RetryReason::InvalidKeyId;
         let would_include_keys = retry_count >= MIN_RETRY_COUNT_FOR_KEYS || include_keys_early;
 
         assert!(


### PR DESCRIPTION
## Summary

When the sender references a consumed prekey (`InvalidPreKeyId`), retry #1 without `<keys>` is provably useless — the sender re-encrypts with the same broken session and fails again. Only retry #2 (at `retryCount >= 2`) includes keys, wasting a full round-trip (~3s).

## Root Cause Analysis

From production logs, a sender hit this exact scenario:

```
T+0s  — pkmsg with consumed prekey → InvalidPreKeyId
T+0s  — Retry #1 WITHOUT <keys> → sender re-sends with same broken prekey → fails
T+4s  — Retry #2 WITH <keys> → sender never processes them (gave up?)
T+23m — NEW status broadcast → STILL same broken prekey → fails
```

**6 consecutive decrypt failures, 0 recoveries via Signal.** PDO recovered 1 message via phone relay, but the E2E session remained permanently broken.

## WA Web Context

WA Web's `RetryReceiptJob` defines `d = 2` as the minimum retry count for including keys. This is a bandwidth optimization for errors where the sender might recover by simply re-sending (e.g., transient ratchet desync).

But for `InvalidKeyId` (error code 3), the sender's session references a prekey we no longer have. Without fresh prekeys, they **cannot** establish a new session — the retry is guaranteed to fail.

We already optimize for `NoSession` (error code 1) by including keys on retry #1. This extends the same pattern to `InvalidKeyId`.

## Change

```rust
// Before:
let include_keys_early = reason == RetryReason::NoSession;

// After:
let include_keys_early =
    reason == RetryReason::NoSession || reason == RetryReason::InvalidKeyId;
```

## Test plan
- [x] `cargo clippy --all --tests` — clean
- [x] All tests pass
- [ ] Deploy and verify: InvalidKeyId messages recover on retry #1 instead of requiring retry #2