### PR TITLE
feat: buffered download fallback when streaming is unavailable

### DIFF
--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -87,6 +87,10 @@ impl HttpClient for UreqHttpClient {
         .await?
     }
 
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
     fn execute_streaming(&self, request: HttpRequest) -> Result<StreamingHttpResponse> {
         // Note: no spawn_blocking here — this is called FROM within spawn_blocking
         // by the streaming download code. The entire HTTP fetch + decrypt happens

--- a/src/download.rs
+++ b/src/download.rs
@@ -392,23 +392,26 @@ impl Client {
         }
     }
 
-    /// Internal: stream download + decrypt to a writer in one blocking thread.
-    /// Always returns the writer (even on failure) so the caller can retry.
+    /// Download + decrypt to a writer. Uses streaming when available,
+    /// falls back to buffered otherwise. Returns writer for retry.
     async fn streaming_download_and_decrypt<W: Write + Seek + Send + 'static>(
         &self,
         request: &wacore::download::DownloadRequest,
         writer: W,
     ) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
+        if !self.http_client.supports_streaming() {
+            return self.buffered_download_and_decrypt(request, writer).await;
+        }
+
         let http_client = self.http_client.clone();
         let url = request.url.clone();
         let decryption = request.decryption.clone();
 
-        wacore::runtime::blocking(&*self.runtime, move || {
+        Ok(wacore::runtime::blocking(&*self.runtime, move || {
             let mut writer = writer;
 
-            // Seek to start before each attempt so retries start fresh
             if let Err(e) = writer.seek(SeekFrom::Start(0)) {
-                return Ok((writer, Err(DownloadRequestError::other(e))));
+                return (writer, Err(DownloadRequestError::other(e)));
             }
 
             let result = (|| -> std::result::Result<(), DownloadRequestError> {
@@ -458,9 +461,73 @@ impl Client {
                 Ok(())
             })();
 
-            Ok((writer, result))
+            (writer, result)
         })
-        .await
+        .await)
+    }
+
+    /// Buffered fallback when streaming is not available.
+    async fn buffered_download_and_decrypt<W: Write + Seek + Send + 'static>(
+        &self,
+        request: &wacore::download::DownloadRequest,
+        mut writer: W,
+    ) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
+        let http_request = crate::http::HttpRequest::get(request.url.clone());
+        let resp = match self.http_client.execute(http_request).await {
+            Ok(r) => r,
+            Err(e) => return Ok((writer, Err(DownloadRequestError::other(e)))),
+        };
+
+        if resp.status_code >= 300 {
+            let err = if is_media_auth_error(resp.status_code) {
+                DownloadRequestError::auth(resp.status_code)
+            } else if matches!(resp.status_code, 404 | 410) {
+                DownloadRequestError::not_found(resp.status_code)
+            } else {
+                DownloadRequestError::other(anyhow!(
+                    "Download failed with status: {}",
+                    resp.status_code
+                ))
+            };
+            return Ok((writer, Err(err)));
+        }
+
+        if let Err(e) = writer.seek(SeekFrom::Start(0)) {
+            return Ok((writer, Err(DownloadRequestError::other(e))));
+        }
+
+        let decryption = &request.decryption;
+        let result = (|| -> std::result::Result<(), DownloadRequestError> {
+            let reader = std::io::Cursor::new(resp.body);
+            match decryption {
+                MediaDecryption::Encrypted {
+                    media_key,
+                    media_type,
+                } => {
+                    DownloadUtils::decrypt_stream_to_writer(
+                        reader,
+                        media_key,
+                        *media_type,
+                        &mut writer,
+                    )
+                    .map_err(DownloadRequestError::other)?;
+                }
+                MediaDecryption::Plaintext { file_sha256 } => {
+                    DownloadUtils::copy_and_validate_plaintext_to_writer(
+                        reader,
+                        file_sha256,
+                        &mut writer,
+                    )
+                    .map_err(DownloadRequestError::other)?;
+                }
+            }
+            writer
+                .seek(SeekFrom::Start(0))
+                .map_err(DownloadRequestError::other)?;
+            Ok(())
+        })();
+
+        Ok((writer, result))
     }
 }
 

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -106,11 +106,13 @@ pub trait HttpClient: Send + Sync {
     /// Executes a given HTTP request and returns the response.
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse>;
 
-    /// Synchronous streaming variant. Returns a reader over the response body
-    /// instead of buffering it all in memory.
-    ///
-    /// Must be called from a blocking context (e.g. inside `spawn_blocking`).
-    /// Override to enable streaming downloads.
+    /// Whether this client supports synchronous streaming downloads.
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    /// Synchronous streaming variant — returns a reader over the response body.
+    /// Must be called from a blocking context.
     fn execute_streaming(&self, _request: HttpRequest) -> Result<StreamingHttpResponse> {
         Err(anyhow::anyhow!(
             "Streaming not supported by this HTTP client"


### PR DESCRIPTION
## Summary

Adds a buffered download fallback for HTTP clients that don't support synchronous streaming (e.g. future WASM targets).

## Changes

- **`wacore/src/net.rs`**: Add `supports_streaming()` to `HttpClient` trait (defaults to `false`). Trim doc comments.
- **`http_clients/ureq-client/src/lib.rs`**: `UreqHttpClient` returns `true` — no behavior change for existing users.
- **`src/download.rs`**: `streaming_download_and_decrypt` checks `supports_streaming()` and dispatches to new `buffered_download_and_decrypt` when false. Buffered path uses async `execute()` + `Cursor` reader + same `decrypt_stream_to_writer` / `copy_and_validate_plaintext_to_writer` as the streaming path.

## Test plan

- [x] Existing download tests pass (streaming path unchanged)
- [x] 0 clippy warnings
- [x] No new allocations on native — `Cursor::new(resp.body)` takes ownership
- [x] Error handling mirrors streaming path (auth errors, 404/410, status codes)
- [x] Retry logic unchanged — both paths return `(W, Result<(), DownloadRequestError>)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP clients now declare streaming support capabilities, enabling automatic fallback to buffered downloads for clients without streaming support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->