### PR TITLE
fix: reduce log noise during reconnect and offload buffered decrypt

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -951,7 +951,14 @@ impl Client {
             self.expected_disconnect.store(false, Ordering::Relaxed);
 
             if let Err(connect_err) = self.connect().await {
-                error!("Failed to connect: {connect_err:#}. Will retry...");
+                let is_transient = connect_err
+                    .downcast_ref::<crate::handshake::HandshakeError>()
+                    .is_some_and(|e| e.is_transient());
+                if is_transient {
+                    debug!("Transient connect failure, will retry: {connect_err:#}");
+                } else {
+                    error!("Failed to connect: {connect_err:#}. Will retry...");
+                }
             } else {
                 let unexpected_disconnect = if self.read_messages_loop().await.is_err() {
                     // Check intentional_reconnect AFTER read loop exits — reconnect()
@@ -1638,10 +1645,11 @@ impl Client {
             }
         } else {
             let this = self.clone();
-            // Node is already in Arc - just clone the Arc (cheap), not the Node
             self.runtime
                 .spawn(Box::pin(async move {
-                    if let Err(e) = this.send_ack_for(&node).await {
+                    if let Err(e) = this.send_ack_for(&node).await
+                        && !matches!(e, ClientError::NotConnected)
+                    {
                         warn!("Failed to send ack: {e:?}");
                     }
                 }))

--- a/src/download.rs
+++ b/src/download.rs
@@ -492,42 +492,47 @@ impl Client {
             return Ok((writer, Err(err)));
         }
 
-        if let Err(e) = writer.seek(SeekFrom::Start(0)) {
-            return Ok((writer, Err(DownloadRequestError::other(e))));
-        }
+        let decryption = request.decryption.clone();
 
-        let decryption = &request.decryption;
-        let result = (|| -> std::result::Result<(), DownloadRequestError> {
-            let reader = std::io::Cursor::new(resp.body);
-            match decryption {
-                MediaDecryption::Encrypted {
-                    media_key,
-                    media_type,
-                } => {
-                    DownloadUtils::decrypt_stream_to_writer(
-                        reader,
-                        media_key,
-                        *media_type,
-                        &mut writer,
-                    )
-                    .map_err(DownloadRequestError::other)?;
-                }
-                MediaDecryption::Plaintext { file_sha256 } => {
-                    DownloadUtils::copy_and_validate_plaintext_to_writer(
-                        reader,
-                        file_sha256,
-                        &mut writer,
-                    )
-                    .map_err(DownloadRequestError::other)?;
-                }
+        // Offload blocking decrypt+write to avoid stalling the async executor
+        Ok(wacore::runtime::blocking(&*self.runtime, move || {
+            if let Err(e) = writer.seek(SeekFrom::Start(0)) {
+                return (writer, Err(DownloadRequestError::other(e)));
             }
-            writer
-                .seek(SeekFrom::Start(0))
-                .map_err(DownloadRequestError::other)?;
-            Ok(())
-        })();
 
-        Ok((writer, result))
+            let result = (|| -> std::result::Result<(), DownloadRequestError> {
+                let reader = std::io::Cursor::new(resp.body);
+                match &decryption {
+                    MediaDecryption::Encrypted {
+                        media_key,
+                        media_type,
+                    } => {
+                        DownloadUtils::decrypt_stream_to_writer(
+                            reader,
+                            media_key,
+                            *media_type,
+                            &mut writer,
+                        )
+                        .map_err(DownloadRequestError::other)?;
+                    }
+                    MediaDecryption::Plaintext { file_sha256 } => {
+                        DownloadUtils::copy_and_validate_plaintext_to_writer(
+                            reader,
+                            file_sha256,
+                            &mut writer,
+                        )
+                        .map_err(DownloadRequestError::other)?;
+                    }
+                }
+                writer
+                    .seek(SeekFrom::Start(0))
+                    .map_err(DownloadRequestError::other)?;
+                Ok(())
+            })();
+
+            (writer, result)
+        })
+        .await)
     }
 }
 

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -21,8 +21,20 @@ pub enum HandshakeError {
     Core(#[from] CoreHandshakeError),
     #[error("Timed out waiting for handshake response")]
     Timeout,
+    #[error("Disconnected during handshake")]
+    Disconnected,
     #[error("Unexpected event during handshake: {0}")]
     UnexpectedEvent(String),
+}
+
+impl HandshakeError {
+    /// Transient errors that are expected during reconnect and will resolve on retry.
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport(_) | Self::Timeout | Self::Disconnected
+        )
+    }
 }
 
 type Result<T> = std::result::Result<T, HandshakeError>;
@@ -86,9 +98,7 @@ pub async fn do_handshake(
                 continue;
             }
             Ok(Ok(TransportEvent::Disconnected)) => {
-                return Err(HandshakeError::UnexpectedEvent(
-                    "Disconnected during handshake".to_string(),
-                ));
+                return Err(HandshakeError::Disconnected);
             }
             Ok(Err(_)) => return Err(HandshakeError::Timeout), // Channel closed
             Err(_) => return Err(HandshakeError::Timeout),

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -149,7 +149,9 @@ impl Client {
             if info.category == MessageCategory::Peer { "peer_msg" } else { "delivery" },
             info.id, info.source.sender);
 
-        if let Err(e) = self.send_node(receipt_node).await {
+        if let Err(e) = self.send_node(receipt_node).await
+            && !matches!(e, crate::client::ClientError::NotConnected)
+        {
             log::warn!(target: "Client/Receipt", "Failed to send delivery receipt for message {}: {:?}", info.id, e);
         }
     }


### PR DESCRIPTION
## Summary

Reduces spurious error/warning logs during reconnect cycles, offloads the buffered download decrypt path to the blocking runtime, and adds typed handshake error classification.

## Changes

### Typed handshake errors (`src/handshake.rs`)
- New `HandshakeError::Disconnected` variant — replaces the string-typed `UnexpectedEvent("Disconnected during handshake")`
- New `HandshakeError::is_transient()` method: `Transport | Timeout | Disconnected` → true, `Core | UnexpectedEvent` → false
- Callers use `is_transient()` to decide log level instead of blanket matching

### Reconnect log levels (`src/client.rs`)
- Transient handshake failures (transport, timeout, disconnected) → `debug!`
- Permanent failures (crypto/protocol `Core`, unexpected events) → `error!`
- Ack send failures: match `ClientError::NotConnected` instead of TOCTOU `is_connected()` check

### Receipt send failures (`src/receipt.rs`)
- Removed early `is_connected()` bail-out — let `send_node` be source of truth
- Suppress warning only for `ClientError::NotConnected`, not based on racy connection state check

### Buffered decrypt offload (`src/download.rs`)
- The decrypt+write loop in `buffered_download_and_decrypt` now runs inside `wacore::runtime::blocking` instead of on the async executor

## Test plan

- [x] Unit tests pass
- [x] 0 clippy warnings (`-D warnings`)
- [x] No behavioral changes — only log levels, error typing, and task scheduling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error/warning logs for transient connection failures; suppressed ACK/receipt send warnings when the client is disconnected.

* **Performance**
  * Offloaded blocking download/decrypt work to a dedicated blocking executor to avoid impacting the async runtime.

* **Behavior**
  * Improved classification of handshake disconnects as transient to enable quieter, retry-friendly handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->