### PR TITLE
refactor: architecture audit — cache bounds, circuit breaker, correctness fixes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1073,13 +1073,20 @@ impl Client {
 
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
 
-        let noise_socket = handshake::do_handshake(
+        let noise_socket = match handshake::do_handshake(
             self.runtime.clone(),
             &device_snapshot,
             transport.clone(),
             &mut transport_events,
         )
-        .await?;
+        .await
+        {
+            Ok(socket) => socket,
+            Err(e) => {
+                transport.disconnect().await;
+                return Err(e.into());
+            }
+        };
 
         *self.transport.lock().await = Some(transport);
         *self.transport_events.lock().await = Some(transport_events);
@@ -1594,7 +1601,7 @@ impl Client {
         }
 
         // Check generic node waiters (zero-cost when none registered)
-        if self.node_waiter_count.load(Ordering::Relaxed) > 0 {
+        if self.node_waiter_count.load(Ordering::Acquire) > 0 {
             self.resolve_node_waiters(&node);
         }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -155,17 +155,20 @@ impl Client {
         }
     }
 
-    /// Helper to generate consistent cache keys for retry logic.
-    /// Key format: "{chat}:{msg_id}:{sender}"
+    /// Generate consistent cache key for retry logic.
     pub(crate) async fn make_retry_cache_key(
         &self,
         chat: &Jid,
         msg_id: &str,
         sender: &Jid,
     ) -> String {
+        use std::fmt::Write;
         let chat = self.resolve_encryption_jid(chat).await;
         let sender = self.resolve_encryption_jid(sender).await;
-        format!("{}:{}:{}", chat, msg_id, sender)
+        let mut key =
+            String::with_capacity(chat.user.len() + msg_id.len() + sender.user.len() + 20);
+        let _ = write!(key, "{chat}:{msg_id}:{sender}");
+        key
     }
 
     /// Spawns a task that sends a retry receipt for a failed decryption.

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -242,9 +242,9 @@ impl Client {
                             signal_address, stored_reg_id, received_reg_id
                         );
                         self.signal_cache.delete_session(&signal_address).await;
-                        self.flush_signal_cache().await.unwrap_or_else(|e| {
+                        if let Err(e) = self.flush_signal_cache().await {
                             log::warn!("Failed to flush session deletion for reg ID mismatch: {e}");
-                        });
+                        }
                     }
                 }
             }
@@ -442,9 +442,7 @@ impl Client {
             // Delete the old session through the signal cache so encryption uses a fresh session.
             // IMPORTANT: Must go through cache, not backend, to avoid stale cached sessions.
             self.signal_cache.delete_session(&signal_address).await;
-            self.flush_signal_cache().await.unwrap_or_else(|e| {
-                log::warn!("Failed to flush signal cache after session delete: {e}");
-            });
+            self.flush_signal_cache().await?;
             info!("Deleted session for {signal_address} due to retry receipt");
         }
 
@@ -491,9 +489,7 @@ impl Client {
             .await?;
 
             self.send_node(stanza).await?;
-            self.flush_signal_cache().await.unwrap_or_else(|e| {
-                log::warn!("Failed to flush signal cache after group retry: {e}");
-            });
+            self.flush_signal_cache().await?;
         } else {
             // DM retry: re-encrypt via normal send path (already targets single recipient)
             self.send_message_impl(

--- a/src/send.rs
+++ b/src/send.rs
@@ -1416,9 +1416,10 @@ impl Client {
         }
     }
 
-    /// Build sorted, deduplicated per-device session lock keys for a set of device JIDs.
-    /// Keys match the decrypt path's format (message.rs:684) so send and receive
-    /// serialize on the same device's Signal session.
+    /// Build sorted, deduplicated per-device session lock keys.
+    /// INVARIANT: Keys are sorted to prevent deadlocks when acquiring multiple
+    /// session locks (e.g. DM sends that encrypt for recipient + own devices).
+    /// Keys match the decrypt path format so send and receive serialize correctly.
     pub(crate) async fn build_session_lock_keys(&self, device_jids: &[Jid]) -> Vec<String> {
         let mut keys = Vec::with_capacity(device_jids.len());
         for jid in device_jids {

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -15,6 +15,8 @@ pub struct PersistenceManager {
     backend: Arc<dyn Backend>,
     dirty: Arc<AtomicBool>,
     save_notify: Arc<Event>,
+    /// Set to true when the background saver halts due to repeated flush failures.
+    saver_halted: Arc<AtomicBool>,
 }
 
 impl PersistenceManager {
@@ -53,6 +55,7 @@ impl PersistenceManager {
             backend,
             dirty: Arc::new(AtomicBool::new(false)),
             save_notify: Arc::new(Event::new()),
+            saver_halted: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -66,6 +69,11 @@ impl PersistenceManager {
 
     pub fn backend(&self) -> Arc<dyn Backend> {
         self.backend.clone()
+    }
+
+    /// Returns true if the background saver halted due to repeated flush failures.
+    pub fn is_saver_halted(&self) -> bool {
+        self.saver_halted.load(Ordering::Acquire)
     }
 
     pub async fn modify_device<F, R>(&self, modifier: F) -> R
@@ -129,24 +137,24 @@ impl PersistenceManager {
     }
 
     pub fn run_background_saver(self: Arc<Self>, runtime: Arc<dyn Runtime>, interval: Duration) {
+        const MAX_CONSECUTIVE_FAILURES: u32 = 10;
+
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);
-        drop(self); // Release the strong reference; the caller's Arc keeps it alive
+        drop(self);
         runtime
             .spawn(Box::pin(async move {
+                let mut consecutive_failures: u32 = 0;
                 loop {
                     let Some(this) = weak.upgrade() else {
                         debug!("PersistenceManager dropped, exiting background saver.");
                         return;
                     };
-                    // Create the listener BEFORE the event can fire to avoid missing notifications.
                     let listener = this.save_notify.listen();
-                    drop(this); // Don't hold strong ref while sleeping
+                    drop(this);
 
                     futures::select! {
-                        _ = listener.fuse() => {
-                            debug!("Save notification received.");
-                        }
+                        _ = listener.fuse() => {}
                         _ = rt.sleep(interval).fuse() => {}
                     }
 
@@ -155,7 +163,18 @@ impl PersistenceManager {
                         return;
                     };
                     if let Err(e) = this.save_to_disk().await {
-                        error!("Error saving device state in background: {e}");
+                        consecutive_failures += 1;
+                        if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+                            this.saver_halted.store(true, Ordering::Release);
+                            error!(
+                                "Background saver: {consecutive_failures} consecutive flush failures, \
+                                 halting to prevent silent data loss. Last error: {e}"
+                            );
+                            return;
+                        }
+                        error!("Background saver flush failed ({consecutive_failures}/{MAX_CONSECUTIVE_FAILURES}): {e}");
+                    } else {
+                        consecutive_failures = 0;
                     }
                 }
             }))

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -8,19 +8,51 @@ use crate::libsignal::protocol::{ProtocolAddress, SenderKeyRecord, SessionRecord
 use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::store::traits::SignalStore;
 
-/// In-memory cache for Signal protocol state, matching WhatsApp Web's SignalStoreCache.
-///
-/// Sessions are cached as `SessionRecord` objects (not bytes), matching WA Web's pattern
-/// where the JS object IS the cache. Serialization only happens during `flush()`.
-///
-/// Identity and sender key stores use `Arc<[u8]>` byte caches with dedup checks.
-///
-/// Keys use `Arc<str>` so that cloning a key (needed for both cache and dirty/deleted sets)
-/// is an O(1) refcount bump instead of an O(n) heap allocation.
+/// Evict clean (non-dirty, non-deleted) entries from a cache HashMap.
+/// Negative entries (None values) are evicted first.
+fn evict_clean_entries<V>(
+    cache: &mut HashMap<Arc<str>, Option<V>>,
+    dirty: &HashSet<Arc<str>>,
+    deleted: Option<&HashSet<Arc<str>>>,
+    max_entries: usize,
+) {
+    let overflow = cache.len().saturating_sub(max_entries);
+    if overflow == 0 {
+        return;
+    }
+    let mut negative = Vec::new();
+    let mut positive = Vec::new();
+    for (k, v) in cache.iter() {
+        if dirty.contains(k.as_ref()) {
+            continue;
+        }
+        if let Some(del) = deleted
+            && del.contains(k.as_ref())
+        {
+            continue;
+        }
+        if v.is_none() {
+            negative.push(k.clone());
+        } else {
+            positive.push(k.clone());
+        }
+    }
+    for key in negative.into_iter().chain(positive).take(overflow) {
+        cache.remove(&key);
+    }
+}
+
+/// Default max entries per store before clean entry eviction triggers.
+const DEFAULT_MAX_CACHE_ENTRIES: usize = 10_000;
+
+/// In-memory write-back cache for Signal protocol state.
+/// Keys use `Arc<str>` for O(1) clone. Sessions cached as objects (serialized on flush).
+/// Capacity-bounded: evicts non-dirty entries when max_entries is exceeded.
 pub struct SignalStoreCache {
     sessions: Mutex<SessionStoreState>,
     identities: Mutex<ByteStoreState>,
     sender_keys: Mutex<SenderKeyStoreState>,
+    max_entries: usize,
 }
 
 // === Session object cache (no per-message serialize/deserialize) ===
@@ -69,6 +101,15 @@ impl SessionStoreState {
         self.dirty.clear();
         self.deleted.clear();
     }
+
+    fn evict_if_needed(&mut self, max_entries: usize) {
+        evict_clean_entries(
+            &mut self.cache,
+            &self.dirty,
+            Some(&self.deleted),
+            max_entries,
+        );
+    }
 }
 
 // === Sender key object cache (same pattern as sessions) ===
@@ -108,6 +149,10 @@ impl SenderKeyStoreState {
     fn clear(&mut self) {
         self.cache.clear();
         self.dirty.clear();
+    }
+
+    fn evict_if_needed(&mut self, max_entries: usize) {
+        evict_clean_entries(&mut self.cache, &self.dirty, None, max_entries);
     }
 }
 
@@ -170,6 +215,15 @@ impl ByteStoreState {
         self.dirty.clear();
         self.deleted.clear();
     }
+
+    fn evict_if_needed(&mut self, max_entries: usize) {
+        evict_clean_entries(
+            &mut self.cache,
+            &self.dirty,
+            Some(&self.deleted),
+            max_entries,
+        );
+    }
 }
 
 impl Default for SignalStoreCache {
@@ -180,10 +234,15 @@ impl Default for SignalStoreCache {
 
 impl SignalStoreCache {
     pub fn new() -> Self {
+        Self::with_max_entries(DEFAULT_MAX_CACHE_ENTRIES)
+    }
+
+    pub fn with_max_entries(max_entries: usize) -> Self {
         Self {
             sessions: Mutex::new(SessionStoreState::new()),
             identities: Mutex::new(ByteStoreState::new()),
             sender_keys: Mutex::new(SenderKeyStoreState::new()),
+            max_entries,
         }
     }
 
@@ -204,15 +263,20 @@ impl SignalStoreCache {
             None => None,
         };
         state.cache.insert(Arc::from(key), record.clone());
+        state.evict_if_needed(self.max_entries);
         Ok(record)
     }
 
     pub async fn put_session(&self, address: &ProtocolAddress, record: SessionRecord) {
-        self.sessions.lock().await.put(address.as_str(), record);
+        let mut state = self.sessions.lock().await;
+        state.put(address.as_str(), record);
+        state.evict_if_needed(self.max_entries);
     }
 
     pub async fn delete_session(&self, address: &ProtocolAddress) {
-        self.sessions.lock().await.delete(address.as_str());
+        let mut state = self.sessions.lock().await;
+        state.delete(address.as_str());
+        state.evict_if_needed(self.max_entries);
     }
 
     pub async fn has_session(
@@ -231,6 +295,7 @@ impl SignalStoreCache {
         };
         let exists = record.is_some();
         state.cache.insert(Arc::from(key), record);
+        state.evict_if_needed(self.max_entries);
         Ok(exists)
     }
 
@@ -249,18 +314,20 @@ impl SignalStoreCache {
         let data = backend.load_identity(key).await?;
         let arc_data = data.map(Arc::from);
         state.cache.insert(Arc::from(key), arc_data.clone());
+        state.evict_if_needed(self.max_entries);
         Ok(arc_data)
     }
 
     pub async fn put_identity(&self, address: &ProtocolAddress, data: &[u8]) {
-        self.identities
-            .lock()
-            .await
-            .put_dedup(address.as_str(), data);
+        let mut state = self.identities.lock().await;
+        state.put_dedup(address.as_str(), data);
+        state.evict_if_needed(self.max_entries);
     }
 
     pub async fn delete_identity(&self, address: &ProtocolAddress) {
-        self.identities.lock().await.delete(address.as_str());
+        let mut state = self.identities.lock().await;
+        state.delete(address.as_str());
+        state.evict_if_needed(self.max_entries);
     }
 
     // === Sender Keys ===
@@ -280,16 +347,20 @@ impl SignalStoreCache {
             None => None,
         };
         state.cache.insert(Arc::from(key), record.clone());
+        state.evict_if_needed(self.max_entries);
         Ok(record)
     }
 
     pub async fn put_sender_key(&self, name: &SenderKeyName, record: SenderKeyRecord) {
-        self.sender_keys.lock().await.put(name.cache_key(), record);
+        let mut state = self.sender_keys.lock().await;
+        state.put(name.cache_key(), record);
+        state.evict_if_needed(self.max_entries);
     }
 
-    /// Delete a sender key from cache and mark for backend deletion on flush.
     pub async fn delete_sender_key(&self, cache_key: &str) {
-        self.sender_keys.lock().await.delete(cache_key);
+        let mut state = self.sender_keys.lock().await;
+        state.delete(cache_key);
+        state.evict_if_needed(self.max_entries);
     }
 
     // === Flush ===
@@ -328,6 +399,7 @@ impl SignalStoreCache {
             for key in &deleted_keys {
                 state.deleted.remove(key);
             }
+            state.evict_if_needed(self.max_entries);
         }
 
         // Flush identities
@@ -357,6 +429,7 @@ impl SignalStoreCache {
             for key in &deleted_keys {
                 state.deleted.remove(key);
             }
+            state.evict_if_needed(self.max_entries);
         }
 
         // Flush sender keys
@@ -382,6 +455,7 @@ impl SignalStoreCache {
             for key in &dirty_keys {
                 state.dirty.remove(key);
             }
+            state.evict_if_needed(self.max_entries);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Addresses findings from a senior-level architecture audit of concurrency, error handling, memory, and correctness patterns.

## Changes

### P0: Signal cache capacity bound (`wacore/src/store/signal_cache.rs`)
- Add `max_entries` (default 10K per store) to `SignalStoreCache`
- New `with_max_entries()` constructor for custom limits
- `evict_if_needed()` uses O(n) two-vec partition (negative entries evicted first)
- Runtime-agnostic — plain HashMap with manual eviction, no new deps

### P0: Background saver circuit breaker (`src/store/persistence_manager.rs`)
- Halt after 10 consecutive flush failures to prevent silent data loss

### P1: Transport cleanup on handshake failure (`src/client.rs`)
- Explicit `transport.disconnect()` when `do_handshake()` fails

### P1: Propagate flush errors in retry path (`src/retry.rs`)
- `?` instead of `unwrap_or_else(warn)` on critical paths

### P2: Pre-sized retry cache key (`src/message.rs`)

### P3: Clear stale `app_state_key_requests` on reconnect (`src/client.rs`)

### P3: `Relaxed` → `Acquire` for `node_waiter_count` (`src/client.rs`)

### P3: Document lock ordering invariant (`src/send.rs`)

## Evaluated and deferred

| Item | Reason |
|---|---|
| Arc\<MessageInfo\> pipeline | Breaking public API. Clone cost negligible at real-world rates. |
| Streaming upload | Bottleneck is `HttpRequest.body: Vec<u8>`. Needs new HttpClient trait method. |
| Streaming history sync decompression | Parser needs full blob for `Bytes::slice()` zero-copy. |
| Lazy protobuf decoding | Breaking public API. Decode cost negligible at human rates. |

## Test plan

- [x] All unit tests pass
- [x] 0 clippy warnings (`-D warnings`)
- [x] Runtime-agnostic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection error handling to ensure proper cleanup on failed handshakes.
  * Enhanced retry handling so certain failures halt retry flows and surface errors.

* **Performance & Reliability**
  * Added safeguards to background persistence to stop after repeated failures.
  * Introduced capacity limits and eviction for in-memory signal caches to control memory growth.
  * Tightened synchronization for waiter resolution to ensure correct timing/visibility.

* **New**
  * Added a status accessor to report when the background saver has halted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->