### PR TITLE
fix: sync own device list at login and parse server key-index in usync

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1944,8 +1944,12 @@ impl Client {
                 // Don't fail login - PDO will retry via ensure_e2e_sessions fallback
             }
 
-            // === Passive Tasks (mimics WhatsApp Web's PassiveTaskManager) ===
-            // WhatsApp Web executes passive tasks (like PreKey upload) BEFORE sending the active IQ.
+            // Sync own device list so DM fan-out includes all companions
+            check_generation!();
+            if let Err(e) = client_clone.sync_own_device_list().await {
+                client_clone.log_sync_error("sync own device list", &e);
+            }
+
             check_generation!();
             if !client_clone.is_connected() {
                 debug!("Skipping passive tasks: connection closed");

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -118,10 +118,13 @@ impl Client {
                     .iter()
                     .map(|d| wacore::store::traits::DeviceInfo {
                         device_id: d.device as u32,
-                        key_index: existing_key_indices
-                            .get(&(d.device as u32))
-                            .copied()
-                            .flatten(),
+                        // Server-returned key_index takes priority over cached
+                        key_index: d.key_index.or_else(|| {
+                            existing_key_indices
+                                .get(&(d.device as u32))
+                                .copied()
+                                .flatten()
+                        }),
                     })
                     .collect();
 
@@ -157,6 +160,35 @@ impl Client {
         }
 
         Ok(all_devices)
+    }
+
+    /// Sync own device list from the server, bypassing cache.
+    /// Matches WA Web's `syncMyDeviceList()` called during bootstrap.
+    pub(crate) async fn sync_own_device_list(&self) -> Result<(), anyhow::Error> {
+        let device_snapshot = self.persistence_manager.get_device_snapshot().await;
+
+        let mut jids = Vec::with_capacity(2);
+        if let Some(ref pn) = device_snapshot.pn {
+            let pn_bare = pn.to_non_ad();
+            self.invalidate_device_cache(&pn_bare.user).await;
+            jids.push(pn_bare);
+        }
+        if let Some(ref lid) = device_snapshot.lid {
+            let lid_bare = lid.to_non_ad();
+            self.invalidate_device_cache(&lid_bare.user).await;
+            jids.push(lid_bare);
+        }
+
+        if jids.is_empty() {
+            return Ok(());
+        }
+
+        let devices = self.get_user_devices(&jids).await?;
+        log::info!(
+            "Synced own device list from server: {} devices",
+            devices.len()
+        );
+        Ok(())
     }
 }
 

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -610,13 +610,16 @@ impl IqSpec for DeviceListSpec {
                     continue;
                 };
 
-                let mut device_jid = user_jid.clone();
-                device_jid.device = device_id;
-                devices.push(device_jid);
+                let key_index = device_node
+                    .attrs()
+                    .optional_string("key-index")
+                    .and_then(|s| s.parse::<u32>().ok());
+                devices.push(crate::usync::UsyncDevice {
+                    device: device_id,
+                    key_index,
+                });
             }
 
-            // WA Web: AdvForUsyncApi rejects usync results with companion
-            // devices but no signedKeyIndexBytes
             let has_companion = devices.iter().any(|d| d.device != 0);
             if has_companion && key_index_bytes.is_none() {
                 warn!(

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -12,16 +12,17 @@ pub struct UsyncLidMapping {
     pub lid: String,
 }
 
-/// Device list with optional phash from usync response
+#[derive(Debug, Clone)]
+pub struct UsyncDevice {
+    pub device: u16,
+    pub key_index: Option<u32>,
+}
+
 #[derive(Debug, Clone)]
 pub struct UserDeviceList {
-    /// The user JID (without device suffix)
     pub user: Jid,
-    /// List of device JIDs for this user
-    pub devices: Vec<Jid>,
-    /// Participant hash from device-list node (used for cache validation)
+    pub devices: Vec<UsyncDevice>,
     pub phash: Option<String>,
-    /// Signed key index bytes from `<key-index-list>` (for ADV device filtering)
     pub key_index_bytes: Option<Vec<u8>>,
 }
 
@@ -103,9 +104,14 @@ pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Ve
                 }
             };
 
-            let mut device_jid = user_jid.clone();
-            device_jid.device = device_id;
-            devices.push(device_jid);
+            let key_index = device_node
+                .attrs()
+                .optional_string("key-index")
+                .and_then(|s| s.parse::<u32>().ok());
+            devices.push(UsyncDevice {
+                device: device_id,
+                key_index,
+            });
         }
 
         // WA Web: WAWebHandleAdvForUsyncApi.handleADVSyncResult() rejects usync results
@@ -135,7 +141,14 @@ pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Ve
 pub fn parse_get_user_devices_response(resp_node: &Node) -> Result<Vec<Jid>> {
     Ok(parse_get_user_devices_response_with_phash(resp_node)?
         .into_iter()
-        .flat_map(|u| u.devices)
+        .flat_map(|u| {
+            let user_jid = u.user;
+            u.devices.into_iter().map(move |d| {
+                let mut jid = user_jid.clone();
+                jid.device = d.device;
+                jid
+            })
+        })
         .collect())
 }
 
@@ -414,5 +427,67 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].devices.len(), 0);
         assert_eq!(result[0].phash, Some("2:empty".to_string()));
+    }
+
+    #[test]
+    fn test_server_returned_key_index_is_parsed() {
+        // Build a response where devices have key-index attributes
+        // (matches real server: <device id="4" key-index="93"/>)
+        let device_nodes: Vec<Node> = vec![
+            NodeBuilder::new("device").attr("id", "0").build(),
+            NodeBuilder::new("device")
+                .attr("id", "4")
+                .attr("key-index", "93")
+                .build(),
+            NodeBuilder::new("device")
+                .attr("id", "24")
+                .attr("key-index", "113")
+                .build(),
+        ];
+
+        let ki_bytes = build_test_key_index_bytes(&[0, 4, 24]);
+        let device_list = NodeBuilder::new("device-list")
+            .children(device_nodes)
+            .build();
+        let devices_node = NodeBuilder::new("devices")
+            .children(vec![
+                device_list,
+                NodeBuilder::new("key-index-list")
+                    .attr("ts", "1000")
+                    .bytes(ki_bytes)
+                    .build(),
+            ])
+            .build();
+
+        let user_node = NodeBuilder::new("user")
+            .attr("jid", "559900001111@s.whatsapp.net")
+            .children(vec![devices_node])
+            .build();
+
+        let response = NodeBuilder::new("iq")
+            .children(vec![
+                NodeBuilder::new("usync")
+                    .children(vec![
+                        NodeBuilder::new("list").children(vec![user_node]).build(),
+                    ])
+                    .build(),
+            ])
+            .build();
+
+        let result = parse_get_user_devices_response_with_phash(&response).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].devices.len(), 3);
+
+        // Device 0: no key-index attribute → None
+        assert_eq!(result[0].devices[0].device, 0);
+        assert_eq!(result[0].devices[0].key_index, None);
+
+        // Device 4: key-index="93"
+        assert_eq!(result[0].devices[1].device, 4);
+        assert_eq!(result[0].devices[1].key_index, Some(93));
+
+        // Device 24: key-index="113"
+        assert_eq!(result[0].devices[2].device, 24);
+        assert_eq!(result[0].devices[2].key_index, Some(113));
     }
 }


### PR DESCRIPTION
## Summary

DM messages were not reaching WA Web and other companion devices. Two bugs:

1. **Own device list not synced at login** — WA Web calls `syncMyDeviceList()` during bootstrap. We weren't doing this, so companion devices added after pairing were missing from the DM fan-out.

2. **Server-returned `key-index` discarded** — The usync parser extracted device IDs but ignored `key-index` attributes. Without key-index, ADV filtering removed all companion devices.

## Changes

- `wacore/src/usync.rs`: New `UsyncDevice` struct with `device + key_index`. Parser extracts `key-index` attribute. Unit test added.
- `wacore/src/iq/usync.rs`: Same parser fix for the IQ-level response handler.
- `src/usync.rs`: Server key_index takes priority over cached. New `sync_own_device_list()`.
- `src/client.rs`: Call `sync_own_device_list()` during post-login init, uses `log_sync_error` for shutdown suppression.

## Test plan

- [x] `test_server_returned_key_index_is_parsed` — verifies key-index parsing from usync response
- [x] All unit tests pass
- [x] 0 clippy warnings
- [x] Verified: `Synced own device list from server: 8 devices`, DM fan-out includes WA Web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic device list synchronization during login to ensure local device information stays up-to-date.

* **Bug Fixes**
  * Improved device key index handling to prioritize server-provided values over cached data, ensuring more accurate device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->