### PR TITLE
fix: route session migration through signal cache instead of backend

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -169,7 +169,10 @@ impl Client {
     }
 
     /// Migrate Signal sessions and identity keys from PN to LID address.
-    /// WA Web never stores sessions under PN when a LID mapping is known.
+    ///
+    /// All reads/writes go through `signal_cache` to avoid reading stale data
+    /// from the backend when the cache has unflushed mutations (e.g., after
+    /// SKDM encryption ratcheted the session).
     pub(crate) async fn migrate_signal_sessions_on_lid_discovery(&self, pn: &str, lid: &str) {
         use log::{info, warn};
         use wacore::types::jid::JidExt;
@@ -182,47 +185,56 @@ impl Client {
 
             let pn_proto = pn_jid.to_protocol_address();
             let lid_proto = lid_jid.to_protocol_address();
-            let pn_addr_key = pn_proto.as_str();
-            let lid_addr_key = lid_proto.as_str();
 
-            // Migrate session if PN session exists
-            if let Ok(Some(session_data)) = backend.get_session(pn_addr_key).await {
-                match backend.get_session(lid_addr_key).await {
-                    Ok(Some(_)) => {
-                        if let Err(e) = backend.delete_session(pn_addr_key).await {
-                            warn!("Failed to delete stale PN session {pn_addr_key}: {e}");
-                        }
-                        self.signal_cache.delete_session(&pn_proto).await;
-                        info!("Deleted stale PN session {pn_addr_key} (LID exists)");
-                    }
-                    Ok(None) => {
-                        if let Err(e) = backend.put_session(lid_addr_key, &session_data).await {
-                            warn!("Failed to write LID session {lid_addr_key}: {e}");
-                        } else {
-                            if let Err(e) = backend.delete_session(pn_addr_key).await {
-                                warn!("Failed to delete PN session {pn_addr_key}: {e}");
-                            }
-                            self.signal_cache.delete_session(&pn_proto).await;
-                            info!("Migrated session {pn_addr_key} -> {lid_addr_key}");
-                        }
-                    }
-                    Err(e) => warn!("Failed to check LID session {lid_addr_key}: {e}"),
-                }
-            }
-
-            // Migrate identity independently of session (can outlive deleted sessions)
-            if let Ok(Some(identity_data)) = backend.load_identity(pn_addr_key).await
-                && let Ok(None) = backend.load_identity(lid_addr_key).await
+            // Migrate session: read from cache (authoritative), write to cache
+            if let Ok(Some(session)) = self
+                .signal_cache
+                .get_session(&pn_proto, backend.as_ref())
+                .await
             {
-                let Ok(key): Result<[u8; 32], _> = identity_data.as_slice().try_into() else {
-                    continue;
-                };
-                if let Err(e) = backend.put_identity(lid_addr_key, key).await {
-                    warn!("Failed to migrate identity {pn_addr_key} -> {lid_addr_key}: {e}");
-                } else if let Err(e) = backend.delete_identity(pn_addr_key).await {
-                    warn!("Failed to delete PN identity {pn_addr_key}: {e}");
+                if self
+                    .signal_cache
+                    .get_session(&lid_proto, backend.as_ref())
+                    .await
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    self.signal_cache.delete_session(&pn_proto).await;
+                    info!("Deleted stale PN session {} (LID exists)", pn_proto);
+                } else {
+                    self.signal_cache.put_session(&lid_proto, session).await;
+                    self.signal_cache.delete_session(&pn_proto).await;
+                    info!("Migrated session {} -> {}", pn_proto, lid_proto);
                 }
             }
+
+            // Migrate identity: same cache-first pattern
+            if let Ok(Some(identity_data)) = self
+                .signal_cache
+                .get_identity(&pn_proto, backend.as_ref())
+                .await
+            {
+                if self
+                    .signal_cache
+                    .get_identity(&lid_proto, backend.as_ref())
+                    .await
+                    .ok()
+                    .flatten()
+                    .is_none()
+                {
+                    self.signal_cache
+                        .put_identity(&lid_proto, &identity_data)
+                        .await;
+                    info!("Migrated identity {} -> {}", pn_proto, lid_proto);
+                }
+                self.signal_cache.delete_identity(&pn_proto).await;
+            }
+        }
+
+        // Flush migrated state to backend so it survives restarts
+        if let Err(e) = self.signal_cache.flush(backend.as_ref()).await {
+            warn!("Failed to flush signal cache after migration: {e:?}");
         }
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1244,20 +1244,7 @@ impl Client {
         self.migrate_signal_sessions_on_lid_discovery(&pn, &sender_jid.user)
             .await;
 
-        // Reload into cache (replacing negative cache entries)
-        let backend = self.persistence_manager.backend();
-        let addr_key = signal_address.as_str();
-        if let Ok(Some(session_data)) = backend.get_session(addr_key).await
-            && let Ok(record) =
-                wacore::libsignal::protocol::SessionRecord::deserialize(&session_data)
-        {
-            self.signal_cache.put_session(signal_address, record).await;
-        }
-        if let Ok(Some(identity_data)) = backend.load_identity(addr_key).await {
-            self.signal_cache
-                .put_identity(signal_address, &identity_data)
-                .await;
-        }
+        // Migration now goes through signal_cache, so no manual reload needed
 
         match message_decrypt(
             parsed_message,


### PR DESCRIPTION
## Summary

Route `migrate_signal_sessions_on_lid_discovery()` through `SignalStoreCache` instead of accessing the backend directly. Also removes the now-redundant backend reload in `try_pn_to_lid_migration_decrypt()`.

## Context

`migrate_signal_sessions_on_lid_discovery()` reads sessions/identities directly from the backend store, bypassing the `SignalStoreCache`. On backends where the cache is authoritative (MemoryStore, future WASM stores), the backend contains stale serialized data from the last flush. If the session ratcheted since then (e.g., SKDM encryption during a group send), the migration reads stale bytes and writes them to the LID address, corrupting the session.

**Reproduction (MemoryStore):**
1. DM user A → works (session created in cache at PN address)
2. Create group with user A, send group message → works (usync discovers LID, triggers migration)
3. DM user A again → `NoSession` or `BadMac` (migrated session has wrong ratchet state)

**Why invisible on SqliteStore:** The SQL database is always current because every `put_session` during encryption writes directly to it. The cache is just a performance layer, not the source of truth.

WA Web doesn't even copy/move sessions during PN→LID migration — it resolves the address at lookup time via `createSignalAddress()` using the cached LID mapping. Our approach (physical migration) is valid but must go through the cache to read current state.

## Changes

- `src/client/lid_pn.rs`: All session/identity reads go through `signal_cache.get_session()/get_identity()` (cache-first with backend fallback). All writes go through `signal_cache.put_session()/put_identity()` (marks dirty for flush). Flush after migration to persist.
- `src/message.rs`: Removed redundant backend reload in `try_pn_to_lid_migration_decrypt()` — migration now populates the cache directly.

## Test plan

- [x] `cargo clippy --all --tests` clean
- [x] All tests pass (0 failures)
- [ ] On MemoryStore: DM → group send (triggers migration) → DM again should work
- [ ] On SqliteStore: no behavior change (cache falls through to backend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced session and identity data migration handling to use more efficient caching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->