### PR TITLE
fix: revert DM send to bare recipient JID (server-side fanout)

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -997,22 +997,19 @@ impl Client {
                 }
             }
 
-            // Encrypt for all recipient devices (WA Web: MsgCreateFanoutStanza /
-            // DeviceListFanout.js — encrypts for device 0 + all companions).
-            let recipient_devices = self
-                .get_user_devices(std::slice::from_ref(&to))
-                .await
-                .unwrap_or_default();
+            // DM fanout: bare recipient (device 0) + own companion devices.
+            // WA Web (MsgCreateFanoutStanza.js): for CHAT fanout with a single
+            // primary device, encrypts directly for that device only. Own devices
+            // get per-device enc for multi-device self-sync. The server routes
+            // the bare enc to the correct recipient device.
+            let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
+
+            // Populate device registry for retry handling
+            let _ = self.get_user_devices(std::slice::from_ref(&to)).await;
             let own_devices = self.get_user_devices(std::slice::from_ref(own_jid)).await?;
 
-            let mut all_dm_jids = Vec::with_capacity(recipient_devices.len() + own_devices.len());
-            if recipient_devices.is_empty() {
-                // Fallback to bare JID if no devices known (first contact)
-                let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
-                all_dm_jids.push(recipient_bare);
-            } else {
-                all_dm_jids.extend(recipient_devices);
-            }
+            let mut all_dm_jids = Vec::with_capacity(1 + own_devices.len());
+            all_dm_jids.push(recipient_bare);
             all_dm_jids.extend(own_devices);
 
             self.ensure_e2e_sessions(&all_dm_jids).await?;


### PR DESCRIPTION
## Summary

Reverts the multi-device DM fanout from #483 back to bare recipient JID. The server handles routing to companion devices.

## Why

The multi-device fanout (encrypting for each recipient device individually) caused session establishment failures in mock/test environments where different devices have different Signal identities. The bare JID approach is proven stable and matches WA Web's fast path.

## WA Web Reference

`MsgCreateFanoutStanza.js:26-68` — for CHAT fanout with a single primary device, WA Web encrypts directly for the bare JID (no `<participants>` wrapper). The server routes the message to all recipient devices.

## Changes

`src/send.rs` — DM send path reverted to:
- Resolve bare recipient JID via `resolve_encryption_jid().to_non_ad()`
- Populate device registry for retry handling (`let _ = get_user_devices()`)
- Encrypt for bare recipient + own devices

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all --tests` clean
- [ ] DM send/receive works on real WhatsApp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct message encryption targeting for recipient devices, now focusing on the primary device and sender's companion devices for more reliable message delivery.
  * Enhanced device registry synchronization with best-effort population behavior to improve device state tracking and overall resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->