### PR TITLE
fix: complete identity change handler to match WA Web

### DIFF
--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -2101,15 +2101,19 @@ mod tests {
         handle_notification_impl(&client, &node).await;
 
         let backend = client.persistence_manager.backend();
-        let has = client
+        let has_session = client
             .signal_cache
             .has_session(&addr, &*backend)
             .await
             .unwrap();
-        assert!(
-            !has,
-            "primary session should be deleted after identity change"
-        );
+        assert!(!has_session, "primary session should be deleted");
+
+        let has_identity = client
+            .signal_cache
+            .get_identity(&addr, &*backend)
+            .await
+            .unwrap();
+        assert!(has_identity.is_none(), "identity key should be deleted");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Completes the identity change handler from PR #489 with three remaining gaps verified against `WAWebHandleIdentityChange`:

- **Delete primary device session + identity key** so a fresh session can be established (WA Web's `deleteRemoteInfo`)
- **Delete status@broadcast sender key** for forward secrecy on next status send (WA Web's `markStatusSenderKeyRotate`)
- **Spawn background `ensure_e2e_sessions`** to proactively re-establish session (self-defers when offline via `wait_for_offline_delivery_end`)
- Clean up verbose comments (explain why, not what)

## Test plan

- [x] `test_identity_change_deletes_primary_session` — session + identity removed from signal cache
- [x] `test_identity_change_rotates_status_sender_key` — status sender key deleted for forward secrecy
- [x] `test_identity_change_with_offline_attribute` — offline notification processed without error
- [x] All 345 tests pass, clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Identity-change handling now targets primary devices and avoids clearing local self-identity records.
  * Ensures thorough local cryptographic cleanup (primary session and sender keys) and flushes cached state when identities change.
  * Triggers background session re-establishment so secure communications recover automatically, including when offline.

* **Tests**
  * Added async tests for primary-session/identity removal, sender-key rotation, and offline identity-change processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->