### PR TITLE
chore: update nightly to 2026-04-05 and fix new clippy warnings

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
 
       - name: Install tools (protoc, valgrind, iai-callgrind-runner)
         uses: taiki-e/install-action@v2

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
 
       - name: Cache install-action tools
         uses: actions/cache@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
       - name: Install protoc
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
           components: clippy
       - name: Install protoc
         uses: taiki-e/install-action@v2
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
       - name: Install protoc
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-30
+          toolchain: nightly-2026-04-05
 
       - name: Install protoc
         uses: taiki-e/install-action@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-01-30"
+channel = "nightly-2026-04-05"
 components = ["rustfmt", "clippy"]

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -33,23 +33,11 @@ pub fn parse_jid_fast(s: &str) -> Option<ParsedJidParts<'_>> {
 
     for (i, &b) in bytes.iter().enumerate() {
         match b {
-            b'@' => {
-                if at_pos.is_none() {
-                    at_pos = Some(i);
-                }
-            }
-            b':' => {
-                // Only track colon in user part (before @)
-                if at_pos.is_none() {
-                    colon_pos = Some(i);
-                }
-            }
-            b'.' => {
-                // Only track dots in user part (before @ and before :)
-                if at_pos.is_none() && colon_pos.is_none() {
-                    last_dot_pos = Some(i);
-                }
-            }
+            b'@' if at_pos.is_none() => at_pos = Some(i),
+            // Only track colon in user part (before @)
+            b':' if at_pos.is_none() => colon_pos = Some(i),
+            // Only track dots in user part (before @ and before :)
+            b'.' if at_pos.is_none() && colon_pos.is_none() => last_dot_pos = Some(i),
             _ => {}
         }
     }

--- a/wacore/libsignal/src/protocol/state/bundle.rs
+++ b/wacore/libsignal/src/protocol/state/bundle.rs
@@ -66,9 +66,7 @@ impl TryFrom<PreKeyBundleContent> for PreKeyBundle {
             content.device_id.ok_or_else(|| {
                 SignalProtocolError::InvalidArgument("device_id is required".to_string())
             })?,
-            content
-                .pre_key_id
-                .and_then(|id| content.pre_key_public.map(|public| (id, public))),
+            content.pre_key_id.zip(content.pre_key_public),
             content.ec_pre_key_id.ok_or_else(|| {
                 SignalProtocolError::InvalidArgument("signed_pre_key_id is required".to_string())
             })?,


### PR DESCRIPTION
## Summary

- Update `rust-toolchain.toml` and all 5 CI workflows from `nightly-2026-01-30` to `nightly-2026-04-05`
- Fix 2 new clippy warnings from the updated nightly:
  - `collapsible_if` in JID parser — use match guards instead of nested `if` blocks
  - `manual Option::zip` in PreKeyBundle — use `.zip()`

## Test plan

- [x] `cargo clippy --workspace --exclude e2e-tests --tests` — 0 warnings
- [x] `cargo test --workspace --exclude e2e-tests` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust compiler toolchain version from nightly-2026-01-30 to nightly-2026-04-05 across all CI/CD workflows and project configuration for consistency.

* **Refactor**
  * Enhanced internal code organization through refactored conditional logic patterns and optimized API usage for improved code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->