### PR TITLE
fix: process group messages from unknown devices instead of discarding

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1025,17 +1025,16 @@ impl Client {
 
             match decrypt_result {
                 Ok(padded_plaintext) => {
-                    // WA Web: isFromKnownDevice() in preProcessMsg
-                    // Uses the actual device ID from the participant JID
-                    // (e.g., device 33 for sender:33@lid, device 0 for bare sender@lid).
+                    // Sync device list if sender is unknown, but still process
+                    // the message. Signal decryption success already proves the
+                    // sender holds the session key — discarding would only add
+                    // latency via an unnecessary retry round-trip.
                     if !self.is_from_known_device(&info.source.sender).await {
-                        warn!(
+                        debug!(
                             "[msg:{}] Unknown device {}, triggering device sync",
                             info.id, info.source.sender
                         );
                         self.handle_unknown_device_sync(info).await;
-                        self.spawn_retry_receipt(info, RetryReason::UnknownCompanionNoPrekey);
-                        continue;
                     }
 
                     if let Err(e) = self


### PR DESCRIPTION
## Summary

When a group `skmsg` is successfully decrypted but the sender's device isn't in the local device registry, we were discarding the plaintext and sending a retry receipt (`UnknownCompanionNoPrekey`). This is unnecessary — Signal decryption success already proves the sender holds the session key.

Now we process the message normally and trigger device sync in the background.

### Real scenario this fixes

After pairing a new device or reconnecting after offline, group messages from other participants arrive with both `pkmsg` (SKDM) and `skmsg`. The two-pass decrypt processes the pkmsg first (establishing the sender key), then decrypts the skmsg successfully. But the sender's device isn't in the registry yet (usync hasn't completed), so the successfully-decrypted message was thrown away and a retry receipt sent.

From a real session log — 5 senders triggered unnecessary retries:
```
15:29:19 Successfully decrypted pkmsg from 161542494531587:32@lid ✓
15:29:19 Successfully processed SKDM for group ✓
15:29:19 Successfully decrypted skmsg ✓
15:29:19 Unknown device → DISCARD + retry ✗  ← this is what we fix
```

The sender then re-sends via retry response (~60s later), adding avoidable latency.

### Security analysis

| Check | Protects against | Practical value |
|-------|-----------------|-----------------|
| Signal decryption (session keys) | Sender impersonation | High — cryptographic proof |
| ADV device list (isFromKnownDevice) | Unverified device injection | Low — session establishment already validates device identity |

WA Web does reject unknown-device messages as defense-in-depth for their closed client. Whatsmeow (Go) has no such check and processes all successfully-decrypted messages. For a library, the Signal protocol guarantees are sufficient.

### What changed

- `src/message.rs`: On successful `group_decrypt`, if device is unknown: log at DEBUG level, trigger device sync in background, **continue processing** instead of discarding + retry
- The decrypt-failure path (`NoSenderKeyState`) still correctly uses `UnknownCompanionNoPrekey` reason for retries — that's unchanged

## Test plan

- [x] `cargo test -p whatsapp-rust` — 345 tests pass
- [x] Clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of messages from unknown devices in group conversations. Messages now process immediately instead of triggering immediate retry cycles, while still maintaining proper device acknowledgment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->