### PR TITLE
fix: validate phash from server ack to detect stale device lists

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3428,6 +3428,20 @@ impl Client {
         self.send_raw_bytes(plaintext_buf).await
     }
 
+    /// Register a oneshot waiter for a server ack by message ID.
+    /// Returns the receiver — caller sends the node separately and awaits this in background.
+    pub(crate) async fn register_ack_waiter(
+        &self,
+        message_id: &str,
+    ) -> futures::channel::oneshot::Receiver<wacore_binary::Node> {
+        let (tx, rx) = futures::channel::oneshot::channel();
+        self.response_waiters
+            .lock()
+            .await
+            .insert(message_id.to_string(), tx);
+        rx
+    }
+
     pub(crate) async fn update_push_name_and_notify(self: &Arc<Self>, new_name: String) {
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         let old_name = device_snapshot.push_name.clone();

--- a/src/send.rs
+++ b/src/send.rs
@@ -465,17 +465,29 @@ impl Client {
             .ensure_status_participants(prepared.node, &group_info)
             .await?;
 
+        let our_phash = stanza
+            .attrs()
+            .optional_string("phash")
+            .map(|s| s.into_owned());
+        let ack_rx = if our_phash.is_some() {
+            Some(self.register_ack_waiter(&request_id).await)
+        } else {
+            None
+        };
+
         self.send_node(stanza).await?;
+
+        if let Some(rx) = ack_rx {
+            self.spawn_phash_validation(rx, our_phash.unwrap(), to.clone(), false);
+        }
 
         self.update_sender_key_devices(&to_str, &prepared.skdm_devices)
             .await;
 
-        // Invalidate device registry for users whose devices returned 406
         for user in &prepared.stale_device_users {
             self.invalidate_device_cache(user).await;
         }
 
-        // Flush cached Signal state to DB after encryption
         if let Err(e) = self.flush_signal_cache().await {
             log::error!("Failed to flush signal cache after send_status_message: {e:?}");
         }
@@ -602,6 +614,47 @@ impl Client {
             );
         }
         self.sender_key_device_cache.invalidate(group_jid).await;
+    }
+
+    /// Spawn a background task to validate phash from server ack.
+    /// On mismatch, invalidates sender key device cache and group info cache.
+    fn spawn_phash_validation(
+        &self,
+        rx: futures::channel::oneshot::Receiver<wacore_binary::Node>,
+        our_phash: String,
+        jid: Jid,
+        invalidate_group_cache: bool,
+    ) {
+        let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) else {
+            return;
+        };
+        self.runtime
+            .spawn(Box::pin(async move {
+                let ack = match tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    rx,
+                )
+                .await
+                {
+                    Ok(Ok(node)) => node,
+                    _ => return,
+                };
+                if let Some(server) = ack.attrs().optional_string("phash")
+                    && *server != our_phash
+                {
+                    log::warn!(
+                        "Phash mismatch for {jid}: ours={our_phash}, server={server}. Invalidating caches."
+                    );
+                    client
+                        .sender_key_device_cache
+                        .invalidate(&jid.to_string())
+                        .await;
+                    if invalidate_group_cache {
+                        client.get_group_cache().await.invalidate(&jid).await;
+                    }
+                }
+            }))
+            .detach();
     }
 
     /// Ensure the status stanza has a <participants> node listing all recipient
@@ -1059,15 +1112,29 @@ impl Client {
             .await?
         };
 
+        let our_phash = stanza_to_send
+            .attrs()
+            .optional_string("phash")
+            .map(|s| s.into_owned());
+        let ack_rx = if our_phash.is_some() {
+            let msg_id = stanza_to_send.attrs().optional_string("id");
+            Some(
+                self.register_ack_waiter(msg_id.as_deref().unwrap_or_default())
+                    .await,
+            )
+        } else {
+            None
+        };
+
         self.send_node(stanza_to_send).await?;
 
-        // Update SKDM recipient cache AFTER server ACK (matches WhatsApp Web behavior).
-        // WA Web only calls markHasSenderKey() after the server confirms receipt.
+        if let Some(rx) = ack_rx {
+            self.spawn_phash_validation(rx, our_phash.unwrap(), tc_issue_target.clone(), true);
+        }
+
         if let Some(update) = skdm_update {
             self.update_sender_key_devices(&update.to_str, &update.devices)
                 .await;
-            // Invalidate device registry for users whose devices returned 406
-            // so the next send re-fetches from server (without stale devices)
             for user in &update.stale_users {
                 self.invalidate_device_cache(user).await;
             }


### PR DESCRIPTION
## Summary

When sending a group message, the server ack includes a `phash` (participant list hash). If it differs from ours, the participant/device list changed during the send — some devices may not have received the message. Previously we never read the server ack, so these mismatches were silently lost.

### How it works

```
send_node()          → fire-and-forget (no latency change)
     │
     └── background task waits for ack (10s timeout)
              │
              ├── phash matches → nothing to do
              ├── phash mismatch → invalidate sender_key_device_cache + group_cache
              └── timeout/disconnect → ignored (message was sent)
```

**Zero latency impact** — `send_message_impl` and `send_status_message` return immediately after writing to the socket, same as before. The phash validation happens in a detached background task.

### What changes on mismatch

- `sender_key_device_cache` invalidated → SKDM targets recomputed on next send
- Group info cache invalidated → participants re-fetched on next send
- Warning logged with both phash values

This matches whatsmeow's approach (`send.go:448-464`). WA Web does a full resend to missing devices (`Resend/GroupMsg.js`), but cache invalidation is sufficient — the next message reaches everyone.

### Files changed

- `src/client.rs` — `register_ack_waiter()`: registers oneshot waiter for server ack by message ID
- `src/send.rs` — `send_message_impl()` and `send_status_message()`: register waiter before send, spawn background phash validation

## Test plan

- [x] `cargo test -p whatsapp-rust` — 345 tests pass
- [x] Clippy clean
- [x] No latency regression (send is still fire-and-forget)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server acknowledgment validation (10s timeout) for messages that include delivery proof, confirming server-returned verification before proceeding.
* **Bug Fixes**
  * Cache handling adjusted to invalidate outdated keys only after validation failure, reducing stale-state collisions for direct, status, and group messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->