### PR TITLE
perf: Reduce duplication and allocation churn

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3531,11 +3531,14 @@ impl Client {
     }
 
     /// Creates a normalized StanzaKey by resolving PN to LID JIDs.
-    pub(crate) async fn make_stanza_key(&self, chat: Jid, id: String) -> StanzaKey {
+    pub(crate) async fn make_stanza_key(&self, chat: &Jid, id: &str) -> StanzaKey {
         // Resolve chat JID to LID if possible
-        let chat = self.resolve_encryption_jid(&chat).await;
+        let chat = self.resolve_encryption_jid(chat).await;
 
-        StanzaKey { chat, id }
+        StanzaKey {
+            chat,
+            id: id.to_owned(),
+        }
     }
 
     // get_phone_number_from_lid is in client/lid_pn.rs

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -7,6 +7,48 @@ use waproto::whatsapp as wa;
 use super::Client;
 
 impl Client {
+    pub(crate) async fn set_sender_key_status_for_devices(
+        &self,
+        group_jid: &str,
+        device_jids: &[Jid],
+        has_key: bool,
+        exclude_own_devices: bool,
+    ) -> Result<()> {
+        let (own_lid_user, own_pn_user) = if exclude_own_devices {
+            let snapshot = self.persistence_manager.get_device_snapshot().await;
+            (
+                snapshot.lid.as_ref().map(|j| j.user.clone()),
+                snapshot.pn.as_ref().map(|j| j.user.clone()),
+            )
+        } else {
+            (None, None)
+        };
+
+        let device_ids: Vec<String> = device_jids
+            .iter()
+            .filter(|jid| {
+                !exclude_own_devices
+                    || !(own_lid_user.as_deref().is_some_and(|u| u == jid.user)
+                        || own_pn_user.as_deref().is_some_and(|u| u == jid.user))
+            })
+            .map(ToString::to_string)
+            .collect();
+
+        if device_ids.is_empty() {
+            return Ok(());
+        }
+
+        let entries: Vec<(&str, bool)> = device_ids
+            .iter()
+            .map(|jid| (jid.as_str(), has_key))
+            .collect();
+        self.persistence_manager
+            .set_sender_key_status(group_jid, &entries)
+            .await?;
+        self.sender_key_device_cache.invalidate(group_jid).await;
+        Ok(())
+    }
+
     /// Mark device JIDs as needing fresh SKDM (has_key = false).
     /// Filters out our own devices (WA Web: `!isMeDevice(e)` check).
     /// Called from handle_retry_receipt for group/status messages.
@@ -15,37 +57,16 @@ impl Client {
         group_jid: &str,
         device_jids: &[Jid],
     ) -> Result<()> {
-        let snapshot = self.persistence_manager.get_device_snapshot().await;
-        let own_lid_user = snapshot.lid.as_ref().map(|j| j.user.as_str());
-        let own_pn_user = snapshot.pn.as_ref().map(|j| j.user.as_str());
-
-        let filtered: Vec<String> = device_jids
-            .iter()
-            .filter(|jid| {
-                let is_own = own_lid_user.is_some_and(|u| u == jid.user)
-                    || own_pn_user.is_some_and(|u| u == jid.user);
-                !is_own
-            })
-            .map(|jid| jid.to_string())
-            .collect();
-
-        if filtered.is_empty() {
-            return Ok(());
-        }
-
-        let entries: Vec<(&str, bool)> = filtered.iter().map(|s| (s.as_str(), false)).collect();
-        self.persistence_manager
-            .set_sender_key_status(group_jid, &entries)
+        self.set_sender_key_status_for_devices(group_jid, device_jids, false, true)
             .await?;
-        self.sender_key_device_cache.invalidate(group_jid).await;
         Ok(())
     }
 
     /// Take a sent message for retry handling. Checks L1 cache first (if enabled),
     /// then falls back to DB. Matches WA Web's getMessageTable().get() pattern.
-    pub(crate) async fn take_recent_message(&self, to: Jid, id: String) -> Option<wa::Message> {
+    pub(crate) async fn take_recent_message(&self, to: &Jid, id: &str) -> Option<wa::Message> {
         use prost::Message;
-        let key = self.make_stanza_key(to.clone(), id.clone()).await;
+        let key = self.make_stanza_key(to, id).await;
         let chat_str = key.chat.to_string();
         let has_l1_cache = self.cache_config.recent_messages.capacity > 0;
 
@@ -106,7 +127,7 @@ impl Client {
     /// is enabled (capacity > 0) also stores in-memory for fast retrieval.
     /// In DB-only mode (capacity = 0), the DB write is awaited to guarantee persistence.
     /// With L1 cache, the DB write is backgrounded since the cache serves reads immediately.
-    pub(crate) async fn add_recent_message(&self, to: Jid, id: String, msg: &wa::Message) {
+    pub(crate) async fn add_recent_message(&self, to: &Jid, id: &str, msg: &wa::Message) {
         use prost::Message;
         let key = self.make_stanza_key(to, id).await;
         let bytes = msg.encode_to_vec();
@@ -114,12 +135,10 @@ impl Client {
 
         if has_l1_cache {
             // L1 cache serves reads immediately; DB write can be backgrounded
-            self.recent_messages
-                .insert(key.clone(), bytes.clone())
-                .await;
-            let backend = self.persistence_manager.backend();
             let chat_str = key.chat.to_string();
             let msg_id = key.id.clone();
+            self.recent_messages.insert(key, bytes.clone()).await;
+            let backend = self.persistence_manager.backend();
             self.runtime
                 .spawn(Box::pin(async move {
                     if let Err(e) = backend.store_sent_message(&chat_str, &msg_id, &bytes).await {

--- a/src/features/tctoken.rs
+++ b/src/features/tctoken.rs
@@ -45,20 +45,7 @@ impl<'a> TcToken<'a> {
 
         let spec = IssuePrivacyTokensSpec::new(jids);
         let response = self.client.execute(spec).await?;
-        let backend = self.client.persistence_manager.backend();
-        let now = wacore::time::now_secs();
-
-        for received in &response.tokens {
-            let entry = TcTokenEntry {
-                token: received.token.clone(),
-                token_timestamp: received.timestamp,
-                sender_timestamp: Some(now),
-            };
-
-            if let Err(e) = backend.put_tc_token(&received.jid.user, &entry).await {
-                log::warn!(target: "Client/TcToken", "Failed to store issued tc_token for {}: {e}", received.jid);
-            }
-        }
+        self.client.store_issued_tc_tokens(&response.tokens).await;
 
         Ok(response.tokens)
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -136,20 +136,17 @@ impl Client {
     /// message are rare and a double-send is benign (recipients deduplicate
     /// by message ID).
     async fn increment_retry_count(&self, cache_key: &str) -> Option<u8> {
-        let current = self.message_retry_counts.get(&cache_key.to_string()).await;
+        let cache_key = cache_key.to_owned();
+        let current = self.message_retry_counts.get(&cache_key).await;
         match current {
             Some(count) if count >= MAX_DECRYPT_RETRIES => None,
             Some(count) => {
                 let new_count = count + 1;
-                self.message_retry_counts
-                    .insert(cache_key.to_string(), new_count)
-                    .await;
+                self.message_retry_counts.insert(cache_key, new_count).await;
                 Some(new_count)
             }
             None => {
-                self.message_retry_counts
-                    .insert(cache_key.to_string(), 1_u8)
-                    .await;
+                self.message_retry_counts.insert(cache_key, 1_u8).await;
                 Some(1)
             }
         }
@@ -286,16 +283,14 @@ impl Client {
 
         let participants = node.get_optional_child_by_tag(&["participants"]);
         if let Some(participants_node) = participants {
-            let own_jid_str = self.get_pn().await.map(|j| j.to_string());
+            let own_jid = self.get_pn().await;
             let to_nodes = participants_node.get_children_by_tag("to");
             for to_node in to_nodes {
-                let to_jid = match to_node.attrs().optional_string("jid") {
+                let to_jid = match to_node.attrs().optional_jid("jid") {
                     Some(jid) => jid,
                     None => continue,
                 };
-                if let Some(ref ours) = own_jid_str
-                    && *to_jid == **ours
-                {
+                if own_jid.as_ref().is_some_and(|ours| *ours == to_jid) {
                     let enc_children = to_node.get_children_by_tag("enc");
                     all_enc_nodes.extend(enc_children);
                 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -140,7 +140,7 @@ impl Client {
         });
 
         let original_msg = match self
-            .take_recent_message(receipt.source.chat.clone(), message_id.clone())
+            .take_recent_message(&receipt.source.chat, &message_id)
             .await
         {
             Some(msg) => msg,
@@ -156,12 +156,8 @@ impl Client {
         // take_recent_message consumed it; without this a second participant's
         // retry would silently fail with "not found in cache".
         if is_group_or_status {
-            self.add_recent_message(
-                receipt.source.chat.clone(),
-                message_id.clone(),
-                &original_msg,
-            )
-            .await;
+            self.add_recent_message(&receipt.source.chat, &message_id, &original_msg)
+                .await;
         }
 
         // Reuse the participant string extracted earlier (same source: node's
@@ -923,14 +919,10 @@ mod tests {
         };
 
         // Insert via the new async API
-        client
-            .add_recent_message(chat.clone(), msg_id.clone(), &msg)
-            .await;
+        client.add_recent_message(&chat, &msg_id, &msg).await;
 
         // First take should return and remove it from cache
-        let taken = client
-            .take_recent_message(chat.clone(), msg_id.clone())
-            .await;
+        let taken = client.take_recent_message(&chat, &msg_id).await;
         assert!(taken.is_some());
         assert_eq!(
             taken
@@ -941,7 +933,7 @@ mod tests {
         );
 
         // Second take should return None
-        let taken_again = client.take_recent_message(chat, msg_id).await;
+        let taken_again = client.take_recent_message(&chat, &msg_id).await;
         assert!(taken_again.is_none());
     }
 
@@ -1820,26 +1812,18 @@ mod tests {
         };
 
         // Add message to cache
-        client
-            .add_recent_message(chat.clone(), msg_id.clone(), &msg)
-            .await;
+        client.add_recent_message(&chat, &msg_id, &msg).await;
 
         // First device takes the message
-        let taken = client
-            .take_recent_message(chat.clone(), msg_id.clone())
-            .await;
+        let taken = client.take_recent_message(&chat, &msg_id).await;
         assert!(taken.is_some(), "First take should succeed");
 
         // Re-add for subsequent retries (simulating the status broadcast fix)
         let taken_msg = taken.unwrap();
-        client
-            .add_recent_message(chat.clone(), msg_id.clone(), &taken_msg)
-            .await;
+        client.add_recent_message(&chat, &msg_id, &taken_msg).await;
 
         // Second device should also be able to take the message
-        let taken2 = client
-            .take_recent_message(chat.clone(), msg_id.clone())
-            .await;
+        let taken2 = client.take_recent_message(&chat, &msg_id).await;
         assert!(
             taken2.is_some(),
             "Second take should succeed after re-add (status broadcast multi-device retry)"

--- a/src/send.rs
+++ b/src/send.rs
@@ -349,8 +349,7 @@ impl Client {
             group_info.participants.push(own_base);
         }
 
-        self.add_recent_message(to.clone(), request_id.clone(), &message)
-            .await;
+        self.add_recent_message(&to, &request_id, &message).await;
 
         let device_store_arc = self.persistence_manager.get_device_arc().await;
         let to_str = to.to_string();
@@ -593,14 +592,8 @@ impl Client {
             return;
         }
 
-        // Write to DB first, then invalidate cache. Next read reloads from
-        // DB with the authoritative state. This avoids the clone+modify race
-        // where concurrent writers can overwrite each other's mutations.
-        let strs: Vec<String> = devices.iter().map(|j| j.to_string()).collect();
-        let entries: Vec<(&str, bool)> = strs.iter().map(|s| (s.as_str(), true)).collect();
         if let Err(e) = self
-            .persistence_manager
-            .set_sender_key_status(group_jid, &entries)
+            .set_sender_key_status_for_devices(group_jid, devices, true, false)
             .await
         {
             log::warn!(
@@ -883,8 +876,7 @@ impl Client {
                 .ok_or_else(|| anyhow!("LID not set, cannot send to group"))?;
 
             // Store serialized message bytes for retry (lightweight)
-            self.add_recent_message(to.clone(), request_id.clone(), message)
-                .await;
+            self.add_recent_message(&to, &request_id, message).await;
 
             let device_store_arc = self.persistence_manager.get_device_arc().await;
             let to_str = to.to_string();
@@ -1006,8 +998,7 @@ impl Client {
             // Per-device locking to match decrypt path (message.rs:684),
             // preventing ratchet desync on concurrent send/receive.
 
-            self.add_recent_message(to.clone(), request_id.clone(), message)
-                .await;
+            self.add_recent_message(&to, &request_id, message).await;
 
             let device_snapshot = self.persistence_manager.get_device_snapshot().await;
             let own_jid = device_snapshot
@@ -1294,7 +1285,7 @@ impl Client {
     }
 
     /// Returns true if at least one token was persisted.
-    async fn store_issued_tc_tokens(
+    pub(crate) async fn store_issued_tc_tokens(
         &self,
         tokens: &[wacore::iq::tctoken::ReceivedTcToken],
     ) -> bool {

--- a/tests/e2e/tests/media.rs
+++ b/tests/e2e/tests/media.rs
@@ -5,15 +5,38 @@ use whatsapp_rust::download::{Downloadable, MediaType};
 use whatsapp_rust::upload::UploadResponse;
 use whatsapp_rust::waproto::whatsapp as wa;
 
+struct UploadedMediaParts {
+    url: String,
+    direct_path: String,
+    media_key: Vec<u8>,
+    file_sha256: Vec<u8>,
+    file_enc_sha256: Vec<u8>,
+    file_length: u64,
+}
+
+impl From<&UploadResponse> for UploadedMediaParts {
+    fn from(upload: &UploadResponse) -> Self {
+        Self {
+            url: upload.url.clone(),
+            direct_path: upload.direct_path.clone(),
+            media_key: upload.media_key.to_vec(),
+            file_sha256: upload.file_sha256.to_vec(),
+            file_enc_sha256: upload.file_enc_sha256.to_vec(),
+            file_length: upload.file_length,
+        }
+    }
+}
+
 /// Helper: build an ImageMessage from an UploadResponse.
 fn build_image_message(upload: &UploadResponse, caption: Option<&str>) -> wa::Message {
+    let upload = UploadedMediaParts::from(upload);
     wa::Message {
         image_message: Some(Box::new(wa::message::ImageMessage {
-            url: Some(upload.url.clone()),
-            direct_path: Some(upload.direct_path.clone()),
-            media_key: Some(upload.media_key.to_vec()),
-            file_sha256: Some(upload.file_sha256.to_vec()),
-            file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
+            url: Some(upload.url),
+            direct_path: Some(upload.direct_path),
+            media_key: Some(upload.media_key),
+            file_sha256: Some(upload.file_sha256),
+            file_enc_sha256: Some(upload.file_enc_sha256),
             file_length: Some(upload.file_length),
             mimetype: Some("image/jpeg".to_string()),
             caption: caption.map(|c| c.to_string()),
@@ -29,13 +52,14 @@ fn build_video_message(
     caption: Option<&str>,
     seconds: u32,
 ) -> wa::Message {
+    let upload = UploadedMediaParts::from(upload);
     wa::Message {
         video_message: Some(Box::new(wa::message::VideoMessage {
-            url: Some(upload.url.clone()),
-            direct_path: Some(upload.direct_path.clone()),
-            media_key: Some(upload.media_key.to_vec()),
-            file_sha256: Some(upload.file_sha256.to_vec()),
-            file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
+            url: Some(upload.url),
+            direct_path: Some(upload.direct_path),
+            media_key: Some(upload.media_key),
+            file_sha256: Some(upload.file_sha256),
+            file_enc_sha256: Some(upload.file_enc_sha256),
             file_length: Some(upload.file_length),
             mimetype: Some("video/mp4".to_string()),
             seconds: Some(seconds),
@@ -48,13 +72,14 @@ fn build_video_message(
 
 /// Helper: build a DocumentMessage from an UploadResponse.
 fn build_document_message(upload: &UploadResponse, filename: &str, mimetype: &str) -> wa::Message {
+    let upload = UploadedMediaParts::from(upload);
     wa::Message {
         document_message: Some(Box::new(wa::message::DocumentMessage {
-            url: Some(upload.url.clone()),
-            direct_path: Some(upload.direct_path.clone()),
-            media_key: Some(upload.media_key.to_vec()),
-            file_sha256: Some(upload.file_sha256.to_vec()),
-            file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
+            url: Some(upload.url),
+            direct_path: Some(upload.direct_path),
+            media_key: Some(upload.media_key),
+            file_sha256: Some(upload.file_sha256),
+            file_enc_sha256: Some(upload.file_enc_sha256),
             file_length: Some(upload.file_length),
             mimetype: Some(mimetype.to_string()),
             file_name: Some(filename.to_string()),
@@ -66,13 +91,14 @@ fn build_document_message(upload: &UploadResponse, filename: &str, mimetype: &st
 
 /// Helper: build an AudioMessage from an UploadResponse.
 fn build_audio_message(upload: &UploadResponse, ptt: bool, seconds: u32) -> wa::Message {
+    let upload = UploadedMediaParts::from(upload);
     wa::Message {
         audio_message: Some(Box::new(wa::message::AudioMessage {
-            url: Some(upload.url.clone()),
-            direct_path: Some(upload.direct_path.clone()),
-            media_key: Some(upload.media_key.to_vec()),
-            file_sha256: Some(upload.file_sha256.to_vec()),
-            file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
+            url: Some(upload.url),
+            direct_path: Some(upload.direct_path),
+            media_key: Some(upload.media_key),
+            file_sha256: Some(upload.file_sha256),
+            file_enc_sha256: Some(upload.file_enc_sha256),
             file_length: Some(upload.file_length),
             mimetype: Some(if ptt {
                 "audio/ogg; codecs=opus".to_string()


### PR DESCRIPTION
## What changed
- extracted a shared helper for sender-key device status persistence so send and retry paths stop repeating the same string conversion and cache invalidation flow
- reused the issued tc-token persistence path instead of maintaining the same storage loop in both the feature API and send path
- changed recent-message cache helpers to borrow `&Jid` and `&str`, which removes repeated cloning at send and retry call sites
- removed a string allocation in incoming message participant matching by comparing parsed JIDs directly
- simplified the e2e media message builders by centralizing repeated `UploadResponse` field fan-out in one local helper

## Why
This came from a DRY and allocation audit focused on message send/receive and adjacent code. The duplicated blocks were small but recurring, and the cache-key / JID stringification patterns were adding avoidable allocations on hotter paths.

## Impact
- less clone-heavy message retry and send bookkeeping
- one place to maintain sender-key status persistence behavior
- one place to maintain issued tc-token persistence behavior
- lower maintenance cost in the e2e media builders

## Validation
- `cargo fmt --all`
- `cargo clippy --all --tests`
- `cargo test --all --exclude e2e-tests`

## Notes
- e2e tests were intentionally excluded from the final test run per request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal API signatures to reduce memory allocations and improve performance efficiency.
  * Streamlined message caching and sender-key management for better resource utilization.

* **Tests**
  * Enhanced test helper functions for improved media handling.

**Note:** This release contains internal optimizations with no visible end-user feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->