### PR TITLE
chore(deps): update sha1, sha2, hkdf, hmac to digest 0.11 ecosystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,11 +180,11 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -419,7 +419,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -567,13 +566,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -944,18 +943,18 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -1417,16 +1416,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
 ]
 
 [[package]]
@@ -1900,23 +1889,23 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -2395,7 +2384,6 @@ dependencies = [
  "log",
  "md5",
  "once_cell",
- "pbkdf2",
  "portable-atomic",
  "prost",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 getrandom = { version = "0.4", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-hkdf = { version = "0.12.3", default-features = false }
-hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
+hkdf = { version = "0.13.0", default-features = false }
+hmac = { version = "0.13.0", default-features = false }
 iai-callgrind = "0.16"
 log = "0.4"
 portable-atomic = { version = "1", default-features = false, features = ["fallback"] }
@@ -67,8 +67,8 @@ rand = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = "0.5"
 serde_json = { version = "1.0", default-features = false }
-sha1 = { version = "0.10.6", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
+sha1 = { version = "0.11.0", default-features = false }
+sha2 = { version = "0.11.0", default-features = false }
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", default-features = false }
 uuid = { version = "1", default-features = false }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -37,7 +37,6 @@ hmac = { workspace = true }
 log = { workspace = true }
 md5 = "0.8.0"
 once_cell = { version = "1.21", default-features = false, features = ["std"] }
-pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 portable-atomic = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = { workspace = true }
 cbc = { version = "0.1.2", features = ["alloc"] }
 chrono = { workspace = true, features = ["now", "serde"] }
 ctr = { workspace = true }
-curve25519-dalek = { version = "4.1.3", features = ["digest"] }
+curve25519-dalek = "4.1.3"
 derive_more = { version = "2.1.0", features = ["from", "into", "try_from"] }
 displaydoc = "0.2.5"
 ghash = "0.6.0"

--- a/wacore/libsignal/src/core/curve/curve25519.rs
+++ b/wacore/libsignal/src/core/curve/curve25519.rs
@@ -222,7 +222,7 @@ impl PrivateKey {
         }
         hash1.update(&random_bytes[..]);
 
-        let r = Scalar::from_hash(hash1);
+        let r = Scalar::from_bytes_mod_order_wide(&hash1.finalize().into());
         let cap_r = (&r * ED25519_BASEPOINT_TABLE).compress();
 
         // hash = SHA512(R || edPubKey || message)
@@ -233,7 +233,7 @@ impl PrivateKey {
             hash.update(message_piece);
         }
 
-        let h = Scalar::from_hash(hash);
+        let h = Scalar::from_bytes_mod_order_wide(&hash.finalize().into());
         let s = (h * self.scalar) + r;
 
         let mut result = [0u8; SIGNATURE_LENGTH];
@@ -273,7 +273,7 @@ impl PrivateKey {
         for message_piece in message {
             hash.update(message_piece);
         }
-        let h = Scalar::from_hash(hash);
+        let h = Scalar::from_bytes_mod_order_wide(&hash.finalize().into());
 
         let cap_r_check_point = EdwardsPoint::vartime_double_scalar_mul_basepoint(
             &h,

--- a/wacore/libsignal/src/crypto/hash.rs
+++ b/wacore/libsignal/src/crypto/hash.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use hmac::{Hmac, Mac};
+use hmac::{HmacReset, KeyInit, Mac};
 use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha512};
 
@@ -16,22 +16,22 @@ pub const SHA512_OUTPUT_SIZE: usize = 64;
 
 #[derive(Clone)]
 pub enum CryptographicMac {
-    HmacSha256(Hmac<Sha256>),
-    HmacSha1(Hmac<Sha1>),
-    HmacSha512(Hmac<Sha512>),
+    HmacSha256(HmacReset<Sha256>),
+    HmacSha1(HmacReset<Sha1>),
+    HmacSha512(HmacReset<Sha512>),
 }
 
 impl CryptographicMac {
     pub fn new(algo: &str, key: &[u8]) -> Result<Self> {
         match algo {
             "HMACSha1" | "HmacSha1" => Ok(Self::HmacSha1(
-                Hmac::<Sha1>::new_from_slice(key).expect("HMAC accepts any key length"),
+                HmacReset::<Sha1>::new_from_slice(key).expect("HMAC accepts any key length"),
             )),
             "HMACSha256" | "HmacSha256" => Ok(Self::HmacSha256(
-                Hmac::<Sha256>::new_from_slice(key).expect("HMAC accepts any key length"),
+                HmacReset::<Sha256>::new_from_slice(key).expect("HMAC accepts any key length"),
             )),
             "HMACSha512" | "HmacSha512" => Ok(Self::HmacSha512(
-                Hmac::<Sha512>::new_from_slice(key).expect("HMAC accepts any key length"),
+                HmacReset::<Sha512>::new_from_slice(key).expect("HMAC accepts any key length"),
             )),
             _ => Err(Error::UnknownAlgorithm("MAC", algo.to_string())),
         }

--- a/wacore/libsignal/src/protocol/crypto.rs
+++ b/wacore/libsignal/src/protocol/crypto.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 pub(crate) fn hmac_sha256(key: &[u8], input: &[u8]) -> [u8; 32] {

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use prost::Message;
 use rand::{CryptoRng, Rng};
 use sha2::Sha256;

--- a/wacore/libsignal/src/protocol/ratchet/keys.rs
+++ b/wacore/libsignal/src/protocol/ratchet/keys.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use arrayref::array_ref;
 
-use hmac::{Hmac, Mac};
+use hmac::{HmacReset, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::protocol::{PrivateKey, PublicKey, Result, crypto, stores::session_structure};
@@ -211,7 +211,7 @@ impl ChainKey {
     /// Compute both message keys and next chain key in one call, reusing HMAC key setup.
     #[inline]
     pub fn step_with_message_keys(&self) -> crate::protocol::Result<(MessageKeyGenerator, Self)> {
-        let mut hmac = Hmac::<Sha256>::new_from_slice(&self.key)
+        let mut hmac = HmacReset::<Sha256>::new_from_slice(&self.key)
             .expect("HMAC-SHA256 should accept any size key");
 
         hmac.update(&Self::MESSAGE_KEY_SEED);

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 
 use prost::Message;
 
-use hmac::{Hmac, Mac};
+use hmac::{HmacReset, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::protocol::crypto::hmac_sha256;
@@ -133,7 +133,7 @@ impl SenderChainKey {
             )
         })?;
 
-        let mut hmac = Hmac::<Sha256>::new_from_slice(&self.chain_key)
+        let mut hmac = HmacReset::<Sha256>::new_from_slice(&self.chain_key)
             .expect("HMAC-SHA256 should accept any size key");
 
         hmac.update(&[Self::MESSAGE_KEY_SEED]);

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -384,7 +384,7 @@ impl DownloadUtils {
 
         let (iv, cipher_key, mac_key) = Self::get_media_keys(media_key, app_info)?;
 
-        let mut hmac = <Hmac<Sha256> as hmac::Mac>::new_from_slice(&mac_key)
+        let mut hmac = <Hmac<Sha256> as hmac::KeyInit>::new_from_slice(&mac_key)
             .map_err(|_| anyhow!("Failed to init HMAC"))?;
         hmac.update(&iv);
 

--- a/wacore/src/iq/tctoken.rs
+++ b/wacore/src/iq/tctoken.rs
@@ -359,7 +359,7 @@ pub fn parse_privacy_token_notification(
 /// `salt` — NCT salt from app state sync (raw bytes, not base64).
 /// `recipient_lid` — The recipient's bare account LID string (e.g. `"12345@lid"`).
 pub fn compute_cs_token(salt: &[u8], recipient_lid: &str) -> Vec<u8> {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
 
     let mut mac = Hmac::<Sha256>::new_from_slice(salt).expect("HMAC-SHA256 accepts any key length");

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -114,14 +114,12 @@ impl PairUtils {
         let is_hosted_account = hmac_container.account_type.is_some()
             && hmac_container.account_type() == AdvEncryptionType::Hosted;
 
-        let mut mac =
-            <HmacSha256 as Mac>::new_from_slice(&device_state.adv_secret_key).map_err(|e| {
-                PairCryptoError {
-                    code: 500,
-                    text: "internal-error",
-                    source: e.into(),
-                }
-            })?;
+        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(&device_state.adv_secret_key)
+            .map_err(|e| PairCryptoError {
+            code: 500,
+            text: "internal-error",
+            source: e.into(),
+        })?;
         // Get details and hmac as slices, handling potential None values
         let details_bytes = hmac_container
             .details
@@ -290,7 +288,7 @@ impl PairUtils {
         let adv_key = &device_state.adv_secret_key;
         let identity_key = &device_state.identity_key;
 
-        let mut mac = <HmacSha256 as Mac>::new_from_slice(adv_key)
+        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(adv_key)
             .map_err(|e| anyhow::anyhow!("Failed to init HMAC for master pairing: {e}"))?;
         mac.update(ADV_PREFIX_ACCOUNT_SIGNATURE);
         mac.update(dut_identity_pub);

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -26,6 +26,7 @@ use aes_gcm::Aes256Gcm;
 use aes_gcm::aead::{Aead, KeyInit};
 use ctr::Ctr128BE;
 use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
 use rand::RngExt;
 use sha2::Sha256;
 use wacore_binary::builder::NodeBuilder;
@@ -48,6 +49,32 @@ const PAIR_CODE_IV_SIZE: usize = 16;
 /// Crockford Base32 alphabet used for pair codes.
 /// Excludes 0, I, O, U to prevent visual confusion.
 const CROCKFORD_ALPHABET: &[u8; 32] = b"123456789ABCDEFGHJKLMNPQRSTVWXYZ";
+
+/// RFC 2898 PBKDF2 using HMAC-SHA256. Replaces the `pbkdf2` crate dependency
+/// which hasn't released a digest 0.11-compatible stable version yet.
+fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u8]) {
+    use hmac::KeyInit as _;
+    for (i, chunk) in output.chunks_mut(32).enumerate() {
+        let mut u = {
+            let mut mac =
+                Hmac::<Sha256>::new_from_slice(password).expect("HMAC accepts any key length");
+            mac.update(salt);
+            mac.update(&((i as u32) + 1).to_be_bytes());
+            let result: [u8; 32] = mac.finalize().into_bytes().into();
+            result
+        };
+        chunk.copy_from_slice(&u[..chunk.len()]);
+        for _ in 1..rounds {
+            let mut mac =
+                Hmac::<Sha256>::new_from_slice(password).expect("HMAC accepts any key length");
+            mac.update(&u);
+            u = mac.finalize().into_bytes().into();
+            for (a, b) in chunk.iter_mut().zip(u.iter()) {
+                *a ^= b;
+            }
+        }
+    }
+}
 
 /// Validity duration for pair codes (approximately).
 const PAIR_CODE_VALIDITY_SECS: u64 = 180;
@@ -193,7 +220,7 @@ impl PairCodeUtils {
     /// Consider wrapping in `spawn_blocking` for async contexts.
     pub fn derive_key(code: &str, salt: &[u8; PAIR_CODE_SALT_SIZE]) -> [u8; 32] {
         let mut key = [0u8; 32];
-        pbkdf2::pbkdf2_hmac::<Sha256>(code.as_bytes(), salt, PAIR_CODE_PBKDF2_ITERATIONS, &mut key);
+        pbkdf2_hmac_sha256(code.as_bytes(), salt, PAIR_CODE_PBKDF2_ITERATIONS, &mut key);
         key
     }
 

--- a/wacore/src/reporting_token.rs
+++ b/wacore/src/reporting_token.rs
@@ -19,7 +19,7 @@
 
 use anyhow::{Result, anyhow};
 use hkdf::Hkdf;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use prost::Message;
 use sha2::Sha256;
 use wacore_binary::builder::NodeBuilder;


### PR DESCRIPTION
## Summary

Updates cryptographic dependencies to the digest 0.11 ecosystem:
- `sha1` 0.10.6 → 0.11.0
- `sha2` 0.10.6 → 0.11.0
- `hkdf` 0.12.3 → 0.13.0
- `hmac` 0.12.1 → 0.13.0

`rand` was already at 0.10 — no changes needed.

Closes #467, #466, #465, #283

### Breaking changes fixed

**hmac 0.13**: `Hmac<D>` no longer implements `FixedOutputReset`. Changed to `HmacReset<D>` in 3 files where `finalize_reset()` is used (signal chain key stepping, MAC computation).

**hmac 0.13**: `Mac::new_from_slice` moved to `KeyInit` trait. Added `KeyInit` imports in 7 files. Used fully-qualified `hmac::KeyInit` where `aes_gcm::aead::KeyInit` was already imported (pair.rs, pair_code.rs, download.rs).

**curve25519-dalek**: `Scalar::from_hash()` requires digest 0.10. Replaced with `Scalar::from_bytes_mod_order_wide(&hasher.finalize().into())` (functionally identical, 3 call sites).

**pbkdf2**: No digest 0.11 compatible release exists. Replaced with inline `pbkdf2_hmac_sha256` (~20 lines, RFC 2898) in pair_code.rs. Removed `pbkdf2` dependency from wacore.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all --tests` — 0 warnings
- [x] `cargo test --workspace --exclude e2e-tests` — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core cryptographic library dependencies (hkdf, hmac, sha1, sha2) to latest stable versions for improved security, performance, and platform compatibility across systems.
  * Modernized internal cryptographic operation patterns and refactored HMAC initialization for consistency.
  * Enhanced internal key derivation implementation with improved cryptographic standards support.
  * Updated elliptic curve cryptography library configuration for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->