### PR TITLE
test: intentional benchmark regression

### DIFF
--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -7,7 +7,7 @@ use crate::{
     node::{NodeContent, NodeContentRef},
 };
 
-const DEFAULT_MARSHAL_CAPACITY: usize = 1024;
+const DEFAULT_MARSHAL_CAPACITY: usize = 32768;
 const AUTO_RESERVE_ATTRS_THRESHOLD: usize = 24;
 const AUTO_RESERVE_CHILDREN_THRESHOLD: usize = 64;
 const AUTO_RESERVE_SCALAR_THRESHOLD: usize = 8 * 1024;


### PR DESCRIPTION
## DO NOT MERGE

Intentional regression to validate the new `github-action-benchmark` CI.

Changes `DEFAULT_MARSHAL_CAPACITY` from 1024 to 32768 — should trigger a >5% regression alert on marshal benchmarks.

Will be closed after verifying the benchmark comment appears correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted default memory allocation size for internal marshaling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->