### PR TITLE
fix: handle <unavailable> messages via PDO instead of silently dropping

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -307,9 +307,15 @@ impl Client {
         }
 
         if has_unavailable {
-            log::debug!(
-                "[msg:{}] Message has <unavailable> child, skipping decryption",
+            log::info!(
+                "[msg:{}] Message has <unavailable> child — requesting retry via receipt",
                 info.id
+            );
+            // Request the sender to re-encrypt for this device.
+            self.handle_decrypt_failure(
+                &info,
+                RetryReason::NoSession,
+                crate::types::events::DecryptFailMode::Show,
             );
             return;
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -274,7 +274,7 @@ impl Client {
             .await;
         let sender_encryption_jid = self.resolve_encryption_jid(&info.source.sender).await;
 
-        let has_unavailable = node.get_optional_child("unavailable").is_some();
+        let unavailable_node = node.get_optional_child("unavailable");
 
         let mut all_enc_nodes = Vec::new();
 
@@ -297,7 +297,7 @@ impl Client {
             }
         }
 
-        if all_enc_nodes.is_empty() && !has_unavailable {
+        if all_enc_nodes.is_empty() && unavailable_node.is_none() {
             log::warn!(
                 "[msg:{}] Received non-newsletter message without <enc> child: {}",
                 info.id,
@@ -306,17 +306,27 @@ impl Client {
             return;
         }
 
-        if has_unavailable {
-            log::info!(
-                "[msg:{}] Message has <unavailable> child — requesting retry via receipt",
-                info.id
+        if let Some(unavailable) = unavailable_node {
+            let unavailable_type =
+                match unavailable.attrs.get("type").map(|v| v.as_str()).as_deref() {
+                    Some("view_once") => crate::types::events::UnavailableType::ViewOnce,
+                    _ => crate::types::events::UnavailableType::Unknown,
+                };
+            log::warn!(
+                "[msg:{}] Message has <unavailable> child (type: {:?}), requesting from phone via PDO",
+                info.id,
+                unavailable_type
             );
-            // Request the sender to re-encrypt for this device.
-            self.handle_decrypt_failure(
-                &info,
-                RetryReason::NoSession,
-                crate::types::events::DecryptFailMode::Show,
-            );
+            // Ack is handled by the framework; PDO asks the primary phone to relay the message
+            self.spawn_pdo_request_with_options(&info, true);
+            self.core.event_bus.dispatch(&Event::UndecryptableMessage(
+                crate::types::events::UndecryptableMessage {
+                    info: (*info).clone(),
+                    is_unavailable: true,
+                    unavailable_type,
+                    decrypt_fail_mode: crate::types::events::DecryptFailMode::Show,
+                },
+            ));
             return;
         }
 


### PR DESCRIPTION
## Problem

When a companion device (linked device) receives a DM that was sent by another linked device, the WA server sends `<unavailable>` instead of `<enc>` because the sender only encrypts for the bare recipient JID (device 0) per #484's server-side fanout design.

Currently, `message.rs` silently drops these messages:
```rust
if has_unavailable {
    log::debug!("[msg:{}] Message has <unavailable> child, skipping decryption", info.id);
    return;  // message lost
}
```

This means companion devices **never receive DMs sent from other linked devices**.

## Fix

Call `handle_decrypt_failure()` on `<unavailable>`, which:
1. Dispatches an `UndecryptableMessage` event (so the app can show "Waiting for message...")
2. Sends a retry receipt to the sender (`RetryReason::NoSession`)
3. Triggers a PDO request to the primary phone for message relay

The retry + PDO mechanism was already built (#180, #196, #197) but was never connected to the `<unavailable>` case.

## Change

```diff
 if has_unavailable {
-    log::debug!(
-        "[msg:{}] Message has <unavailable> child, skipping decryption",
+    log::info!(
+        "[msg:{}] Message has <unavailable> child — requesting retry via receipt",
         info.id
     );
+    self.handle_decrypt_failure(
+        &info,
+        RetryReason::NoSession,
+        crate::types::events::DecryptFailMode::Show,
+    );
     return;
 }
```

## Testing

Verified with two wa-rs bot instances (both companion devices on different WhatsApp accounts):

1. Bot A sends DM to Bot B's phone number
2. Bot B receives `<unavailable>` → sends retry receipt
3. PDO request sent to Bot B's primary phone
4. Primary phone relays message via PDO
5. Bot B receives and decrypts the message (~15s latency)

Before this fix: message silently lost. After: message delivered via PDO relay.

## Related

- #484 (revert to bare JID fanout — root cause of `<unavailable>` for companion devices)
- #180 (PDO support — the relay mechanism this fix triggers)
- #117 (linked device decryption failures — was closed as LID issue but `<unavailable>` was part of it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable messages: the app now warns when a message is marked unavailable, surfaces it as undecryptable (with type info), initiates a retry request, and presents the message as unavailable instead of silently skipping decryption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->