### PR TITLE
fix: PDO cache key mismatch and add response guards

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3517,7 +3517,7 @@ impl Client {
     }
 
     /// Creates a normalized ChatMessageId by resolving PN to LID JIDs.
-    pub(crate) async fn make_stanza_key(&self, chat: &Jid, id: &str) -> ChatMessageId {
+    pub(crate) async fn make_chat_message_id(&self, chat: &Jid, id: &str) -> ChatMessageId {
         // Resolve chat JID to LID if possible
         let chat = self.resolve_encryption_jid(chat).await;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -262,7 +262,7 @@ pub enum ClientError {
     NotLoggedIn,
 }
 
-use wacore::types::message::StanzaKey;
+use wacore::types::message::ChatMessageId;
 
 /// Metrics for tracking offline sync progress
 #[derive(Debug)]
@@ -370,7 +370,7 @@ pub struct Client {
 
     /// Cache for recent messages (serialized bytes) for retry functionality.
     /// Uses moka cache with TTL and max capacity for automatic eviction.
-    pub(crate) recent_messages: Cache<StanzaKey, Vec<u8>>,
+    pub(crate) recent_messages: Cache<ChatMessageId, Vec<u8>>,
 
     pub(crate) sender_key_device_cache: crate::sender_key_device_cache::SenderKeyDeviceCache,
 
@@ -436,9 +436,8 @@ pub struct Client {
     /// Each handler receives a `ChatStateEvent` describing the chat, optional participant and state.
     pub(crate) chatstate_handlers: Arc<RwLock<Vec<ChatStateHandler>>>,
 
-    /// Cache for pending PDO (Peer Data Operation) requests.
-    /// Maps message cache keys (chat:id) to pending request info.
-    pub(crate) pdo_pending_requests: Cache<String, crate::pdo::PendingPdoRequest>,
+    pub(crate) pdo_pending_requests:
+        Cache<wacore::types::message::ChatMessageId, crate::pdo::PendingPdoRequest>,
 
     /// LRU cache for device registry (matches WhatsApp Web's 5000 entry limit).
     /// Maps user ID to DeviceListRecord for fast device existence checks.
@@ -3517,12 +3516,12 @@ impl Client {
         })
     }
 
-    /// Creates a normalized StanzaKey by resolving PN to LID JIDs.
-    pub(crate) async fn make_stanza_key(&self, chat: &Jid, id: &str) -> StanzaKey {
+    /// Creates a normalized ChatMessageId by resolving PN to LID JIDs.
+    pub(crate) async fn make_stanza_key(&self, chat: &Jid, id: &str) -> ChatMessageId {
         // Resolve chat JID to LID if possible
         let chat = self.resolve_encryption_jid(chat).await;
 
-        StanzaKey {
+        ChatMessageId {
             chat,
             id: id.to_owned(),
         }

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -66,7 +66,7 @@ impl Client {
     /// then falls back to DB. Matches WA Web's getMessageTable().get() pattern.
     pub(crate) async fn take_recent_message(&self, to: &Jid, id: &str) -> Option<wa::Message> {
         use prost::Message;
-        let key = self.make_stanza_key(to, id).await;
+        let key = self.make_chat_message_id(to, id).await;
         let chat_str = key.chat.to_string();
         let has_l1_cache = self.cache_config.recent_messages.capacity > 0;
 
@@ -129,7 +129,7 @@ impl Client {
     /// With L1 cache, the DB write is backgrounded since the cache serves reads immediately.
     pub(crate) async fn add_recent_message(&self, to: &Jid, id: &str, msg: &wa::Message) {
         use prost::Message;
-        let key = self.make_stanza_key(to, id).await;
+        let key = self.make_chat_message_id(to, id).await;
         let bytes = msg.encode_to_vec();
         let has_l1_cache = self.cache_config.recent_messages.capacity > 0;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -3877,6 +3877,7 @@ mod tests {
             device_sent_meta: None,
             ephemeral_expiration: None,
             is_offline: false,
+            unavailable_request_id: None,
         }
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1192,7 +1192,9 @@ impl Client {
             self.handle_app_state_sync_key_share(keys).await;
         }
 
-        if let Some(protocol_msg) = &msg.protocol_message
+        // PDO responses come from our own account (is_from_me) via device 0 (primary phone)
+        if info.source.is_from_me
+            && let Some(protocol_msg) = &msg.protocol_message
             && let Some(pdo_response) = &protocol_msg.peer_data_operation_request_response_message
         {
             self.handle_pdo_response(pdo_response, info).await;

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -21,21 +21,19 @@ use log::{debug, info, warn};
 use prost::Message;
 use std::sync::Arc;
 use std::time::Duration;
-use wacore::types::message::{EditAttribute, MessageCategory, MessageSource, MsgMetaInfo};
+use wacore::types::message::{
+    ChatMessageId, EditAttribute, MessageCategory, MessageSource, MsgMetaInfo,
+};
 use wacore_binary::jid::{Jid, JidExt};
 use waproto::whatsapp as wa;
 
-/// Cache entry for pending PDO requests.
-/// Contains the original message info needed to properly dispatch the response.
 #[derive(Clone, Debug)]
 pub struct PendingPdoRequest {
     pub message_info: MessageInfo,
     pub requested_at: wacore::time::Instant,
 }
 
-/// Creates a new PDO request cache.
-/// The cache has a TTL of 30 seconds (phone should respond quickly) and limited capacity.
-pub fn new_pdo_cache() -> Cache<String, PendingPdoRequest> {
+pub fn new_pdo_cache() -> Cache<ChatMessageId, PendingPdoRequest> {
     Cache::builder()
         .time_to_live(Duration::from_secs(30))
         .max_capacity(500)
@@ -69,25 +67,28 @@ impl Client {
             .clone()
             .ok_or_else(|| anyhow::Error::from(crate::client::ClientError::NotLoggedIn))?;
 
-        // Create JID for device 0 (primary phone)
-        let primary_phone_jid = own_pn.with_device(0);
+        // Send to bare own JID (no device suffix); server routes to all devices
+        // including device 0. Matches whatsmeow's SendPeerMessage(ownID.ToNonAD()).
+        let peer_target = own_pn.to_non_ad();
 
-        // Resolve JIDs to LID for the MessageKey and cache key, matching WhatsApp Web's behavior.
-        // This ensures the cache key matches the JID that the phone will respond with (usually LID).
-        let remote_jid = self.resolve_encryption_jid(&info.source.chat).await;
+        // Resolve to LID for the MessageKey when LID-migrated, matching WA Web's
+        // NonMessageDataRequest.js:412-421 (toUserLid when isLidMigrated).
+        // The phone stores messages by LID after migration.
+        let resolved_jid = self.resolve_encryption_jid(&info.source.chat).await;
         let participant = if info.source.is_group {
             Some(self.resolve_encryption_jid(&info.source.sender).await)
         } else {
             None
         };
 
-        // Check-and-insert to avoid duplicate PDO requests for the same message.
-        let cache_key = format!("{}:{}", remote_jid, info.id);
+        // Cache key uses the original PN JID because the phone's response
+        // always contains PN JIDs in the WebMessageInfo key.
+        let cache_key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());
 
         if self.pdo_pending_requests.get(&cache_key).await.is_some() {
             debug!(
-                "PDO request already pending for message {} from {} (resolved: {})",
-                info.id, info.source.sender, remote_jid
+                "PDO request already pending for message {} from {}",
+                info.id, info.source.sender
             );
             return Ok(());
         }
@@ -100,9 +101,8 @@ impl Client {
             .insert(cache_key.clone(), pending)
             .await;
 
-        // Build the message key for the placeholder resend request
         let message_key = wa::MessageKey {
-            remote_jid: Some(remote_jid.to_string()),
+            remote_jid: Some(resolved_jid.to_string()),
             from_me: Some(info.source.is_from_me),
             id: Some(info.id.clone()),
             participant: participant.map(|p| p.to_string()),
@@ -136,16 +136,14 @@ impl Client {
         };
 
         info!(
-            "Sending PDO placeholder resend request for message {} from {} in {} to primary phone {}",
-            info.id, info.source.sender, info.source.chat, primary_phone_jid
+            "Sending PDO placeholder resend request for message {} from {} in {} to {}",
+            info.id, info.source.sender, info.source.chat, peer_target
         );
 
-        // Ensure E2E session exists before sending (matches WhatsApp Web behavior)
-        self.ensure_e2e_sessions(std::slice::from_ref(&primary_phone_jid))
+        self.ensure_e2e_sessions(std::slice::from_ref(&peer_target))
             .await?;
 
-        // Send the message to our primary phone (device 0)
-        match self.send_peer_message(primary_phone_jid, &msg).await {
+        match self.send_peer_message(peer_target, &msg).await {
             Ok(_) => {
                 debug!("PDO request sent successfully for message {}", info.id);
                 Ok(())
@@ -176,7 +174,7 @@ impl Client {
             .pn
             .clone()
             .ok_or_else(|| anyhow::Error::from(crate::client::ClientError::NotLoggedIn))?;
-        let primary_phone_jid = own_pn.with_device(0);
+        let peer_target = own_pn.to_non_ad();
 
         let pdo_request = wa::message::PeerDataOperationRequestMessage {
             peer_data_operation_request_type: Some(
@@ -209,13 +207,13 @@ impl Client {
         };
 
         info!(
-            "Sending PDO history sync on-demand request for chat {} (count={}) to primary phone {}",
-            chat_jid, count, primary_phone_jid
+            "Sending PDO history sync on-demand request for chat {} (count={}) to {}",
+            chat_jid, count, peer_target
         );
 
-        self.ensure_e2e_sessions(std::slice::from_ref(&primary_phone_jid))
+        self.ensure_e2e_sessions(std::slice::from_ref(&peer_target))
             .await?;
-        self.send_peer_message(primary_phone_jid, &msg).await
+        self.send_peer_message(peer_target, &msg).await
     }
 
     /// Sends a peer message (message to our own devices).
@@ -251,32 +249,42 @@ impl Client {
     pub async fn handle_pdo_response(
         self: &Arc<Self>,
         response: &wa::message::PeerDataOperationRequestResponseMessage,
-        _pdo_msg_info: &MessageInfo,
+        pdo_msg_info: &MessageInfo,
     ) {
+        // Only process PDO responses from device 0 (the primary phone)
+        if pdo_msg_info.source.sender.device != 0 {
+            debug!(
+                "Ignoring PDO response from non-primary device {}",
+                pdo_msg_info.source.sender
+            );
+            return;
+        }
+
+        let request_id = response.stanza_id.as_deref().unwrap_or("");
         debug!(
-            "Received PDO response with {} results",
+            "Received PDO response (request_id={}) with {} results",
+            request_id,
             response.peer_data_operation_result.len()
         );
 
         for result in &response.peer_data_operation_result {
             if let Some(placeholder_response) = &result.placeholder_message_resend_response {
-                self.handle_placeholder_resend_response(placeholder_response)
+                self.handle_placeholder_resend_response(placeholder_response, request_id)
                     .await;
             }
         }
     }
 
-    /// Handles a single placeholder message resend response from PDO.
     async fn handle_placeholder_resend_response(
         self: &Arc<Self>,
         response: &wa::message::peer_data_operation_request_response_message::peer_data_operation_result::PlaceholderMessageResendResponse,
+        request_id: &str,
     ) {
         let Some(web_message_info_bytes) = &response.web_message_info_bytes else {
             warn!("PDO placeholder response missing webMessageInfoBytes");
             return;
         };
 
-        // Decode the WebMessageInfo
         let web_msg_info = match wa::WebMessageInfo::decode(web_message_info_bytes.as_slice()) {
             Ok(info) => info,
             Err(e) => {
@@ -285,14 +293,21 @@ impl Client {
             }
         };
 
-        // Extract message key to find the original pending request
         let key = &web_msg_info.key;
-
-        let remote_jid = key.remote_jid.as_deref().unwrap_or("");
+        let remote_jid_str = key.remote_jid.as_deref().unwrap_or("");
         let msg_id = key.id.as_deref().unwrap_or("");
-        let cache_key = format!("{}:{}", remote_jid, msg_id);
 
-        // Remove from pending requests
+        let cache_key = match remote_jid_str.parse::<Jid>() {
+            Ok(jid) => ChatMessageId::new(jid, msg_id.to_owned()),
+            Err(_) => {
+                warn!(
+                    "PDO response has unparseable remote_jid: {}",
+                    remote_jid_str
+                );
+                return;
+            }
+        };
+
         let pending = self.pdo_pending_requests.remove(&cache_key).await;
 
         let elapsed = pending
@@ -305,11 +320,9 @@ impl Client {
             msg_id, elapsed
         );
 
-        // Build MessageInfo from the WebMessageInfo or use the pending request's info
         let mut message_info = if let Some(pending) = pending {
             pending.message_info
         } else {
-            // Reconstruct MessageInfo from WebMessageInfo if we don't have it cached
             match self.message_info_from_web_message_info(&web_msg_info).await {
                 Ok(info) => info,
                 Err(e) => {
@@ -334,9 +347,11 @@ impl Client {
                 message.get_base_message().get_ephemeral_expiration();
         }
 
+        message_info.unavailable_request_id = Some(request_id.to_owned());
+
         info!(
-            "Dispatching PDO-recovered message {} from {} via phone",
-            message_info.id, message_info.source.sender
+            "Dispatching PDO-recovered message {} from {} via phone (request_id={})",
+            message_info.id, message_info.source.sender, request_id
         );
 
         self.core
@@ -415,6 +430,7 @@ impl Client {
             device_sent_meta: None,
             ephemeral_expiration: None,
             is_offline: false,
+            unavailable_request_id: None,
         })
     }
 

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -140,24 +140,25 @@ impl Client {
             info.id, info.source.sender, info.source.chat, peer_target
         );
 
-        self.ensure_e2e_sessions(std::slice::from_ref(&peer_target))
-            .await?;
-
-        match self.send_peer_message(peer_target, &msg).await {
-            Ok(_) => {
-                debug!("PDO request sent successfully for message {}", info.id);
-                Ok(())
-            }
-            Err(e) => {
-                // Remove from pending cache on failure
-                self.pdo_pending_requests.remove(&cache_key).await;
-                warn!(
-                    "Failed to send PDO request for message {}: {:?}",
-                    info.id, e
-                );
-                Err(e)
-            }
+        if let Err(e) = self
+            .ensure_e2e_sessions(std::slice::from_ref(&peer_target))
+            .await
+        {
+            self.pdo_pending_requests.remove(&cache_key).await;
+            return Err(e);
         }
+
+        if let Err(e) = self.send_peer_message(peer_target, &msg).await {
+            self.pdo_pending_requests.remove(&cache_key).await;
+            warn!(
+                "Failed to send PDO request for message {}: {:?}",
+                info.id, e
+            );
+            return Err(e);
+        }
+
+        debug!("PDO request sent successfully for message {}", info.id);
+        Ok(())
     }
 
     /// Request on-demand message history from the primary phone via PDO.

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -81,9 +81,19 @@ impl Client {
             None
         };
 
-        // Cache key uses the original PN JID because the phone's response
-        // always contains PN JIDs in the WebMessageInfo key.
-        let cache_key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());
+        // Cache key must use PN JID because the phone's response always contains
+        // PN JIDs in WebMessageInfo.key. For LID-migrated DMs, info.source.chat
+        // can be LID while sender_alt holds the PN — prefer the PN form.
+        let cache_chat = if !info.source.is_group && info.source.chat.is_lid() {
+            info.source
+                .sender_alt
+                .as_ref()
+                .map(|jid| jid.to_non_ad())
+                .unwrap_or_else(|| info.source.chat.clone())
+        } else {
+            info.source.chat.clone()
+        };
+        let cache_key = ChatMessageId::new(cache_chat, info.id.clone());
 
         if self.pdo_pending_requests.get(&cache_key).await.is_some() {
             debug!(
@@ -348,7 +358,11 @@ impl Client {
                 message.get_base_message().get_ephemeral_expiration();
         }
 
-        message_info.unavailable_request_id = Some(request_id.to_owned());
+        message_info.unavailable_request_id = if request_id.is_empty() {
+            None
+        } else {
+            Some(request_id.to_owned())
+        };
 
         info!(
             "Dispatching PDO-recovered message {} from {} via phone (request_id={})",
@@ -489,31 +503,30 @@ mod tests {
     use wacore_binary::jid::{DEFAULT_USER_SERVER, Jid, JidExt};
 
     #[test]
-    fn test_pdo_primary_phone_jid_is_device_0() {
-        // PDO sends to device 0 (primary phone)
+    fn test_pdo_peer_target_is_device_0() {
         let own_pn = Jid::pn("559999999999");
-        let primary_phone_jid = own_pn.with_device(0);
+        let peer_target = own_pn.to_non_ad();
 
-        assert_eq!(primary_phone_jid.device, 0);
-        assert!(!primary_phone_jid.is_ad()); // Device 0 is NOT an additional device
+        assert_eq!(peer_target.device, 0);
+        assert!(!peer_target.is_ad());
     }
 
     #[test]
-    fn test_pdo_primary_phone_jid_preserves_user() {
+    fn test_pdo_peer_target_preserves_user() {
         let own_pn = Jid::pn("559999999999");
-        let primary_phone_jid = own_pn.with_device(0);
+        let peer_target = own_pn.to_non_ad();
 
-        assert_eq!(primary_phone_jid.user, "559999999999");
-        assert_eq!(primary_phone_jid.server, DEFAULT_USER_SERVER);
+        assert_eq!(peer_target.user, "559999999999");
+        assert_eq!(peer_target.server, DEFAULT_USER_SERVER);
     }
 
     #[test]
-    fn test_pdo_primary_phone_jid_from_linked_device() {
-        // Even if we're device 33, PDO should send to device 0
+    fn test_pdo_peer_target_from_linked_device() {
         let own_pn = Jid::pn_device("559999999999", 33);
-        let primary_phone_jid = own_pn.with_device(0);
+        let peer_target = own_pn.to_non_ad();
 
-        assert_eq!(primary_phone_jid.user, "559999999999");
-        assert_eq!(primary_phone_jid.device, 0);
+        assert_eq!(peer_target.user, "559999999999");
+        assert_eq!(peer_target.device, 0);
+        assert_eq!(peer_target.agent, 0);
     }
 }

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -5,15 +5,14 @@ use waproto::whatsapp as wa;
 
 use crate::StringEnum;
 
-/// Unique identifier for a message stanza within a chat.
-/// Used for deduplication and retry tracking.
+/// Identifies a specific message within a chat.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct StanzaKey {
+pub struct ChatMessageId {
     pub chat: Jid,
     pub id: MessageId,
 }
 
-impl StanzaKey {
+impl ChatMessageId {
     pub fn new(chat: Jid, id: MessageId) -> Self {
         Self { chat, id }
     }
@@ -148,6 +147,9 @@ pub struct MessageInfo {
     pub ephemeral_expiration: Option<u32>,
     /// Whether this message was delivered during offline sync.
     pub is_offline: bool,
+    /// Set when this message was recovered via PDO rather than normal decryption.
+    /// Contains the PDO request message ID.
+    pub unavailable_request_id: Option<String>,
 }
 
 impl MessageInfo {


### PR DESCRIPTION
## Summary
- Fix PDO cache key using LID-resolved JID while phone responds with PN JID (every lookup missed)
- Send PDO to bare own JID (`to_non_ad()`) instead of `with_device(0)`
- Add `is_from_me` + `device == 0` guards on PDO response processing
- Add `unavailable_request_id` to `MessageInfo` for PDO-recovered messages
- Rename `StanzaKey` to `ChatMessageId`, use as typed cache key instead of `format!()` strings

## Context

Debugging #508 revealed the PDO cache key was built with LID-resolved JIDs on the request side, but the phone's response always contains PN JIDs in the `WebMessageInfo` key. This caused every cache lookup to miss, falling through to the slower `message_info_from_web_message_info` reconstruction path.

Verified against WA Web (`NonMessageDataRequest.js:412-421`) which uses LID for the protobuf `MessageKey` but PN for internal tracking, and whatsmeow which sends PDO to `ownID.ToNonAD()` and guards responses with `info.Sender.Device == 0`.

## Test plan
- [x] Tested with two-account reproduction (sender wa-rust bot + receiver companion device)
- [x] `<unavailable>` triggers PDO, phone responds in ~1.3s, message delivered
- [x] Cache hit confirmed (no "Cache miss" in logs)
- [x] `cargo clippy --all` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDO/placeholder responses now processed only from the primary device, reducing duplicate/invalid recoveries.
  * Improved validation of response sources and JID parsing to ignore malformed entries.

* **Refactor**
  * Message caching and pending-request indexing moved to a unified message-ID key model for more consistent lookups.
  * PDO request targeting updated to use the primary non-ad addressing form for delivery.

* **New**
  * Recovered messages now include an explicit recovery-request identifier in their metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->