### PR TITLE
perf: lazy ciphertext in SignalMessage, eliminate redundant allocation

### DIFF
--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -13,6 +13,19 @@ use subtle::ConstantTimeEq;
 use crate::protocol::state::{PreKeyId, SignedPreKeyId};
 use crate::protocol::{IdentityKey, PrivateKey, PublicKey, Result, SignalProtocolError, Timestamp};
 
+/// Get-or-init for `OnceLock<Box<[u8]>>` with a fallible initializer.
+fn get_or_try_init_bytes(
+    cache: &OnceLock<Box<[u8]>>,
+    init: impl FnOnce() -> Result<Box<[u8]>>,
+) -> Result<&[u8]> {
+    if let Some(val) = cache.get() {
+        return Ok(val);
+    }
+    let _ = cache.set(init()?);
+    // get() can't be None: even if a racing set() lost, the winner's value is stored
+    Ok(cache.get().expect("just set"))
+}
+
 // Signal's original implementation uses version 4, but WhatsApp Web,
 // Baileys (libsignal-node), and whatsmeow all use version 3.
 pub const CIPHERTEXT_MESSAGE_CURRENT_VERSION: u8 = 3;
@@ -59,15 +72,31 @@ impl CiphertextMessage {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SignalMessage {
     message_version: u8,
     sender_ratchet_key: PublicKey,
     counter: u32,
-    #[expect(dead_code)]
     previous_counter: u32,
-    ciphertext: Box<[u8]>,
     serialized: Box<[u8]>,
+    ciphertext_cache: OnceLock<Box<[u8]>>,
+}
+
+impl Clone for SignalMessage {
+    fn clone(&self) -> Self {
+        let ciphertext_cache = OnceLock::new();
+        if let Some(ct) = self.ciphertext_cache.get() {
+            let _ = ciphertext_cache.set(ct.clone());
+        }
+        Self {
+            message_version: self.message_version,
+            sender_ratchet_key: self.sender_ratchet_key,
+            counter: self.counter,
+            previous_counter: self.previous_counter,
+            serialized: self.serialized.clone(),
+            ciphertext_cache,
+        }
+    }
 }
 
 impl SignalMessage {
@@ -108,8 +137,8 @@ impl SignalMessage {
             sender_ratchet_key,
             counter,
             previous_counter,
-            ciphertext: ciphertext.into(),
             serialized,
+            ciphertext_cache: OnceLock::new(),
         })
     }
 
@@ -138,9 +167,18 @@ impl SignalMessage {
         self.serialized
     }
 
-    #[inline]
-    pub fn body(&self) -> &[u8] {
-        &self.ciphertext
+    pub fn body(&self) -> Result<&[u8]> {
+        get_or_try_init_bytes(&self.ciphertext_cache, || self.decode_ciphertext())
+    }
+
+    fn decode_ciphertext(&self) -> Result<Box<[u8]>> {
+        let proto_bytes = &self.serialized[1..self.serialized.len() - Self::MAC_LENGTH];
+        let proto = waproto::whatsapp::SignalMessage::decode(proto_bytes)
+            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+        proto
+            .ciphertext
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)
+            .map(|v| v.into_boxed_slice())
     }
 
     pub fn verify_mac(
@@ -228,13 +266,16 @@ impl TryFrom<&[u8]> for SignalMessage {
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
             .into_boxed_slice();
 
+        let ciphertext_cache = OnceLock::new();
+        let _ = ciphertext_cache.set(ciphertext);
+
         Ok(SignalMessage {
             message_version,
             sender_ratchet_key,
             counter,
             previous_counter,
-            ciphertext,
             serialized: Box::from(value),
+            ciphertext_cache,
         })
     }
 }
@@ -487,16 +528,7 @@ impl SenderKeyMessage {
     ///
     /// Callers should avoid calling this in hot loops when possible.
     pub fn ciphertext(&self) -> Result<&[u8]> {
-        if let Some(ciphertext) = self.ciphertext_cache.get() {
-            return Ok(ciphertext.as_ref());
-        }
-
-        let ciphertext = self.decode_ciphertext()?;
-        let _ = self.ciphertext_cache.set(ciphertext);
-        match self.ciphertext_cache.get() {
-            Some(ciphertext) => Ok(ciphertext.as_ref()),
-            None => Err(SignalProtocolError::InvalidProtobufEncoding),
-        }
+        get_or_try_init_bytes(&self.ciphertext_cache, || self.decode_ciphertext())
     }
 
     fn decode_ciphertext(&self) -> Result<Box<[u8]>> {

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -769,7 +769,7 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
         let mut buf_wrapper = buffer.borrow_mut();
         let buf = buf_wrapper.get_buffer();
         match aes_256_cbc_decrypt_into(
-            ciphertext.body(),
+            ciphertext.body()?,
             message_keys.cipher_key(),
             message_keys.iv(),
             buf,


### PR DESCRIPTION
## Summary

- Remove redundant `ciphertext: Box<[u8]>` field from `SignalMessage` — it stored the same bytes already embedded in `serialized`
- Replace with `OnceLock<Box<[u8]>>` lazy cache (mirrors existing `SenderKeyMessage` pattern)
- On **send path**: `.body()` is never called, so the cache stays empty — eliminates 1 heap allocation + memcpy of N ciphertext bytes per sent message (44% less struct heap memory)
- On **receive path**: `TryFrom` eagerly populates the cache, so `.body()` is still a zero-cost pointer return
- **Breaking**: `SignalMessage::body()` return type changes from `&[u8]` to `Result<&[u8]>` (only caller updated in `session_cipher.rs`)
- Adds iai-callgrind claim-validation benchmarks that isolate and measure each proposed optimization independently

## Benchmark results

| Path | Instructions | Change |
|------|-------------|--------|
| DM encrypt (subsequent) | 160,849 | +0.06% (noise) |
| DM encrypt (first) | 159,691 | -0.11% (noise) |
| DM decrypt (first) | 5,508,558 | +0.006% (noise) |

No measurable CPU regression on any real path.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo test -p wacore-libsignal` — 102 tests pass
- [x] `cargo test -p whatsapp-rust` — 345 tests pass
- [x] `cargo bench -p wacore-libsignal --bench libsignal_benchmark` — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Decryption now stops and surfaces errors encountered while retrieving or decoding message contents, preventing attempts to decrypt invalid data.

* **Refactor**
  - Message handling now defers decoding ciphertext and caches decoded data lazily.
  - Cloning preserves the original serialized form and only duplicates cached plaintext when it has already been initialized, reducing eager memory use and work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->