### PR TITLE
fix: codebase audit with bug fixes, race condition mitigations, and perf improvements

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -253,9 +253,12 @@ impl Default for CacheConfig {
             message_retry_counts: CacheEntryConfig::new(five_min, 1_000),
             pdo_pending_requests: CacheEntryConfig::new(Some(Duration::from_secs(30)), 500),
             sender_key_devices_cache: CacheEntryConfig::new(one_hour, 500),
-            session_locks_capacity: 2_000,
-            message_queues_capacity: 2_000,
-            message_enqueue_locks_capacity: 2_000,
+            // Coordination caches hold live mutexes/senders; capacity eviction
+            // while a reference is held creates a second lock for the same key,
+            // breaking serialization. Size generously to avoid eviction pressure.
+            session_locks_capacity: 10_000,
+            message_queues_capacity: 5_000,
+            message_enqueue_locks_capacity: 5_000,
             sent_message_ttl_secs: 300,
             cache_stores: CacheStores::default(),
         }

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -178,11 +178,11 @@ pub struct CacheConfig {
     pub sender_key_devices_cache: CacheEntryConfig,
 
     // --- Coordination caches (capacity-only, no TTL) ---
-    /// Per-device Signal session lock capacity. Default: 2000.
+    /// Per-device Signal session lock capacity. Default: 10000.
     pub session_locks_capacity: u64,
-    /// Per-chat message processing queue capacity. Default: 2000.
+    /// Per-chat message processing queue capacity. Default: 5000.
     pub message_queues_capacity: u64,
-    /// Per-chat message enqueue lock capacity. Default: 2000.
+    /// Per-chat message enqueue lock capacity. Default: 5000.
     pub message_enqueue_locks_capacity: u64,
 
     // --- Sent message DB cleanup ---

--- a/src/client.rs
+++ b/src/client.rs
@@ -2568,35 +2568,7 @@ impl Client {
                         Vec::new()
                     }
                 };
-                if !missing.is_empty() {
-                    let mut to_request: Vec<Vec<u8>> = Vec::with_capacity(missing.len());
-                    let mut guard = self.app_state_key_requests.lock().await;
-                    let now = wacore::time::Instant::now();
-                    for key_id in missing {
-                        let hex_id = hex::encode(&key_id);
-                        let should = guard
-                            .get(&hex_id)
-                            .map(|t| t.elapsed() > std::time::Duration::from_secs(24 * 3600))
-                            .unwrap_or(true);
-                        if should {
-                            guard.insert(hex_id, now);
-                            to_request.push(key_id);
-                        }
-                    }
-                    // Evict stale entries to prevent unbounded growth over long sessions
-                    guard.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(24 * 3600));
-                    drop(guard);
-                    if !to_request.is_empty()
-                        && let Err(e) = self.request_app_state_keys(&to_request).await
-                    {
-                        warn!("Failed to send app state key request: {e}");
-                        // Remove stamps so these keys can be retried next sync
-                        let mut guard = self.app_state_key_requests.lock().await;
-                        for key_id in &to_request {
-                            guard.remove(&hex::encode(key_id));
-                        }
-                    }
-                }
+                self.request_missing_keys_with_dedup(missing).await;
 
                 // full_sync is true only when this collection had a snapshot
                 // (version was 0 before sync). This prevents server_sync-triggered
@@ -2782,35 +2754,7 @@ impl Client {
                     Vec::new()
                 }
             };
-            if !missing.is_empty() {
-                let mut to_request: Vec<Vec<u8>> = Vec::with_capacity(missing.len());
-                let mut guard = self.app_state_key_requests.lock().await;
-                let now = wacore::time::Instant::now();
-                for key_id in missing {
-                    let hex_id = hex::encode(&key_id);
-                    let should = guard
-                        .get(&hex_id)
-                        .map(|t| t.elapsed() > std::time::Duration::from_secs(24 * 3600))
-                        .unwrap_or(true);
-                    if should {
-                        guard.insert(hex_id, now);
-                        to_request.push(key_id);
-                    }
-                }
-                // Evict stale entries to prevent unbounded growth over long sessions
-                guard.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(24 * 3600));
-                drop(guard);
-                if !to_request.is_empty()
-                    && let Err(e) = self.request_app_state_keys(&to_request).await
-                {
-                    warn!("Failed to send app state key request: {e}");
-                    // Remove stamps so these keys can be retried next sync
-                    let mut guard = self.app_state_key_requests.lock().await;
-                    for key_id in &to_request {
-                        guard.remove(&hex::encode(key_id));
-                    }
-                }
-            }
+            self.request_missing_keys_with_dedup(missing).await;
 
             for m in mutations {
                 debug!(target: "Client/AppState", "Dispatching mutation kind={} index_len={} full_sync={}", m.index.first().map(|s| s.as_str()).unwrap_or(""), m.index.len(), full_sync);
@@ -2828,6 +2772,39 @@ impl Client {
 
         debug!(target: "Client/AppState", "Completed and saved app state sync for {:?} (final version={})", name, state.version);
         Ok(())
+    }
+
+    /// Request missing app-state keys with dedup stamps.
+    /// On send failure, removes stamps so keys can be retried next sync.
+    async fn request_missing_keys_with_dedup(&self, missing: Vec<Vec<u8>>) {
+        if missing.is_empty() {
+            return;
+        }
+        let mut to_request: Vec<Vec<u8>> = Vec::with_capacity(missing.len());
+        let mut guard = self.app_state_key_requests.lock().await;
+        let now = wacore::time::Instant::now();
+        for key_id in missing {
+            let hex_id = hex::encode(&key_id);
+            let should = guard
+                .get(&hex_id)
+                .map(|t| t.elapsed() > std::time::Duration::from_secs(24 * 3600))
+                .unwrap_or(true);
+            if should {
+                guard.insert(hex_id, now);
+                to_request.push(key_id);
+            }
+        }
+        guard.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(24 * 3600));
+        drop(guard);
+        if !to_request.is_empty()
+            && let Err(e) = self.request_app_state_keys(&to_request).await
+        {
+            warn!("Failed to send app state key request: {e}");
+            let mut guard = self.app_state_key_requests.lock().await;
+            for key_id in &to_request {
+                guard.remove(&hex::encode(key_id));
+            }
+        }
     }
 
     async fn request_app_state_keys(&self, raw_key_ids: &[Vec<u8>]) -> Result<(), anyhow::Error> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2586,8 +2586,15 @@ impl Client {
                     // Evict stale entries to prevent unbounded growth over long sessions
                     guard.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(24 * 3600));
                     drop(guard);
-                    if !to_request.is_empty() {
-                        self.request_app_state_keys(&to_request).await;
+                    if !to_request.is_empty()
+                        && let Err(e) = self.request_app_state_keys(&to_request).await
+                    {
+                        warn!("Failed to send app state key request: {e}");
+                        // Remove stamps so these keys can be retried next sync
+                        let mut guard = self.app_state_key_requests.lock().await;
+                        for key_id in &to_request {
+                            guard.remove(&hex::encode(key_id));
+                        }
                     }
                 }
 
@@ -2793,8 +2800,15 @@ impl Client {
                 // Evict stale entries to prevent unbounded growth over long sessions
                 guard.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(24 * 3600));
                 drop(guard);
-                if !to_request.is_empty() {
-                    self.request_app_state_keys(&to_request).await;
+                if !to_request.is_empty()
+                    && let Err(e) = self.request_app_state_keys(&to_request).await
+                {
+                    warn!("Failed to send app state key request: {e}");
+                    // Remove stamps so these keys can be retried next sync
+                    let mut guard = self.app_state_key_requests.lock().await;
+                    for key_id in &to_request {
+                        guard.remove(&hex::encode(key_id));
+                    }
                 }
             }
 
@@ -2816,14 +2830,14 @@ impl Client {
         Ok(())
     }
 
-    async fn request_app_state_keys(&self, raw_key_ids: &[Vec<u8>]) {
+    async fn request_app_state_keys(&self, raw_key_ids: &[Vec<u8>]) -> Result<(), anyhow::Error> {
         if raw_key_ids.is_empty() {
-            return;
+            return Ok(());
         }
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         let own_jid = match device_snapshot.pn.clone() {
             Some(j) => j,
-            None => return,
+            None => return Ok(()),
         };
         let key_ids: Vec<wa::message::AppStateSyncKeyId> = raw_key_ids
             .iter()
@@ -2839,20 +2853,17 @@ impl Client {
             })),
             ..Default::default()
         };
-        if let Err(e) = self
-            .send_message_impl(
-                own_jid,
-                &msg,
-                Some(self.generate_message_id().await),
-                true,
-                false,
-                None,
-                vec![],
-            )
-            .await
-        {
-            warn!("Failed to send app state key request: {e}");
-        }
+        self.send_message_impl(
+            own_jid,
+            &msg,
+            Some(self.generate_message_id().await),
+            true,
+            false,
+            None,
+            vec![],
+        )
+        .await?;
+        Ok(())
     }
 
     /// Send an app state patch to the server for a given collection.

--- a/src/client.rs
+++ b/src/client.rs
@@ -2837,7 +2837,11 @@ impl Client {
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         let own_jid = match device_snapshot.pn.clone() {
             Some(j) => j,
-            None => return Ok(()),
+            None => {
+                return Err(anyhow::anyhow!(
+                    "no own JID available for app-state key request"
+                ));
+            }
         };
         let key_ids: Vec<wa::message::AppStateSyncKeyId> = raw_key_ids
             .iter()

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -83,7 +83,9 @@ impl Client {
                 let mid = key.id.clone();
                 self.runtime
                     .spawn(Box::pin(async move {
-                        let _ = backend.take_sent_message(&cs, &mid).await;
+                        if let Err(e) = backend.take_sent_message(&cs, &mid).await {
+                            log::warn!("Failed to clean up sent message {cs}:{mid}: {e}");
+                        }
                     }))
                     .detach();
                 return Some(msg);

--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -172,8 +172,8 @@ impl<'a> Community<'a> {
             .execute(LinkSubgroupsIq::new(community_jid, subgroup_jids))
             .await?;
 
-        let mut linked_jids = Vec::new();
-        let mut failed_groups = Vec::new();
+        let mut linked_jids = Vec::with_capacity(response.groups.len());
+        let mut failed_groups = Vec::with_capacity(response.groups.len());
 
         for group in response.groups {
             if let Some(error) = group.error {
@@ -205,8 +205,8 @@ impl<'a> Community<'a> {
             ))
             .await?;
 
-        let mut unlinked_jids = Vec::new();
-        let mut failed_groups = Vec::new();
+        let mut unlinked_jids = Vec::with_capacity(response.groups.len());
+        let mut failed_groups = Vec::with_capacity(response.groups.len());
 
         for group in response.groups {
             if let Some(error) = group.error {
@@ -292,11 +292,13 @@ impl<'a> Community<'a> {
             .ok_or_else(|| MexError::PayloadParsing("missing data field".into()))?;
 
         let group_query = &data["xwa2_group_query_by_id"];
-        let mut counts = Vec::new();
+        let edges_ref = group_query
+            .get("sub_groups")
+            .and_then(|s| s.get("edges"))
+            .and_then(|e| e.as_array());
+        let mut counts = Vec::with_capacity(edges_ref.map_or(0, |e| e.len()));
 
-        if let Some(sub_groups) = group_query.get("sub_groups")
-            && let Some(edges) = sub_groups.get("edges").and_then(|e| e.as_array())
-        {
+        if let Some(edges) = edges_ref {
             for edge in edges {
                 if let Some(node) = edge.get("node") {
                     let id_str = node["id"].as_str().unwrap_or_default();

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -66,6 +66,9 @@ impl StanzaHandler for MessageHandler {
                 let (tx, rx) = async_channel::unbounded::<Arc<Node>>();
 
                 let client_for_worker = client.clone();
+                let spawn_generation = client
+                    .connection_generation
+                    .load(std::sync::atomic::Ordering::Acquire);
 
                 // Spawn a worker task that processes messages sequentially for this chat.
                 // The worker exits when all tx senders are dropped (cache TTI expiry drops
@@ -76,6 +79,15 @@ impl StanzaHandler for MessageHandler {
                     .runtime
                     .spawn(Box::pin(async move {
                         while let Ok(msg_node) = rx.recv().await {
+                            // Exit if the connection changed — prevents stale workers
+                            // from processing messages with outdated crypto state.
+                            if client_for_worker
+                                .connection_generation
+                                .load(std::sync::atomic::Ordering::Acquire)
+                                != spawn_generation
+                            {
+                                break;
+                            }
                             let start = wacore::time::now_millis() as u64;
                             let client = client_for_worker.clone();
                             Box::pin(client.handle_incoming_message(msg_node)).await;

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -86,6 +86,7 @@ impl StanzaHandler for MessageHandler {
                                 .load(std::sync::atomic::Ordering::Acquire)
                                 != spawn_generation
                             {
+                                log::debug!(target: "MessageQueue", "Stale worker exiting; remaining messages will be redelivered by server");
                                 break;
                             }
                             let start = wacore::time::now_millis() as u64;

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -104,12 +104,12 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
                 let client_clone = client.clone();
                 let generation = client
                     .connection_generation
-                    .load(std::sync::atomic::Ordering::SeqCst);
+                    .load(std::sync::atomic::Ordering::Acquire);
                 client.runtime.spawn(Box::pin(async move {
                     // Check if connection was replaced before starting sync
                     if client_clone
                         .connection_generation
-                        .load(std::sync::atomic::Ordering::SeqCst)
+                        .load(std::sync::atomic::Ordering::Acquire)
                         != generation
                     {
                         log::debug!(target: "Client/AppState", "server_sync task cancelled: connection generation changed");
@@ -152,7 +152,7 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
                         // against a stale connection after the awaited work above.
                         if client_clone
                             .connection_generation
-                            .load(std::sync::atomic::Ordering::SeqCst)
+                            .load(std::sync::atomic::Ordering::Acquire)
                             != generation
                         {
                             log::debug!(target: "Client/AppState", "server_sync task cancelled: connection generation changed during version check");

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -148,6 +148,16 @@ async fn handle_notification_impl(client: &Arc<Client>, node: &Node) {
                             log::debug!(target: "Client/AppState", "Skipping server_sync: client is shutting down");
                             return;
                         }
+                        // Re-check generation after version filtering to avoid syncing
+                        // against a stale connection after the awaited work above.
+                        if client_clone
+                            .connection_generation
+                            .load(std::sync::atomic::Ordering::SeqCst)
+                            != generation
+                        {
+                            log::debug!(target: "Client/AppState", "server_sync task cancelled: connection generation changed during version check");
+                            return;
+                        }
                         if let Err(e) = client_clone.sync_collections_batched(to_sync).await
                             && !client_clone.is_shutting_down()
                         {

--- a/src/send.rs
+++ b/src/send.rs
@@ -483,20 +483,21 @@ impl Client {
             .ensure_status_participants(prepared.node, &group_info)
             .await?;
 
-        let our_phash = stanza
+        let ack = if let Some(phash) = stanza
             .attrs()
             .optional_string("phash")
-            .map(|s| s.into_owned());
-        let ack_rx = if our_phash.is_some() {
-            Some(self.register_ack_waiter(&request_id).await)
+            .map(|s| s.into_owned())
+        {
+            let rx = self.register_ack_waiter(&request_id).await;
+            Some((rx, phash))
         } else {
             None
         };
 
         self.send_node(stanza).await?;
 
-        if let Some(rx) = ack_rx {
-            self.spawn_phash_validation(rx, our_phash.unwrap(), to.clone(), false);
+        if let Some((rx, phash)) = ack {
+            self.spawn_phash_validation(rx, phash, to.clone(), false, request_id.clone());
         }
 
         self.update_sender_key_devices(&to_str, &prepared.skdm_devices)
@@ -635,6 +636,7 @@ impl Client {
         our_phash: String,
         jid: Jid,
         invalidate_group_cache: bool,
+        message_id: String,
     ) {
         let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) else {
             return;
@@ -648,7 +650,11 @@ impl Client {
                 .await
                 {
                     Ok(Ok(node)) => node,
-                    _ => return,
+                    _ => {
+                        // Remove leaked waiter to prevent keepalive suppression
+                        client.response_waiters.lock().await.remove(&message_id);
+                        return;
+                    }
                 };
                 if let Some(server) = ack.attrs().optional_string("phash")
                     && *server != our_phash
@@ -1104,24 +1110,26 @@ impl Client {
             .await?
         };
 
-        let our_phash = stanza_to_send
+        let ack = if let Some(phash) = stanza_to_send
             .attrs()
             .optional_string("phash")
-            .map(|s| s.into_owned());
-        let ack_rx = if our_phash.is_some() {
-            let msg_id = stanza_to_send.attrs().optional_string("id");
-            Some(
-                self.register_ack_waiter(msg_id.as_deref().unwrap_or_default())
-                    .await,
-            )
+            .map(|s| s.into_owned())
+        {
+            let msg_id = stanza_to_send
+                .attrs()
+                .optional_string("id")
+                .map(|s| s.into_owned())
+                .unwrap_or_default();
+            let rx = self.register_ack_waiter(&msg_id).await;
+            Some((rx, phash, msg_id))
         } else {
             None
         };
 
         self.send_node(stanza_to_send).await?;
 
-        if let Some(rx) = ack_rx {
-            self.spawn_phash_validation(rx, our_phash.unwrap(), tc_issue_target.clone(), true);
+        if let Some((rx, phash, msg_id)) = ack {
+            self.spawn_phash_validation(rx, phash, tc_issue_target.clone(), true, msg_id);
         }
 
         if let Some(update) = skdm_update {

--- a/src/send.rs
+++ b/src/send.rs
@@ -494,7 +494,12 @@ impl Client {
             None
         };
 
-        self.send_node(stanza).await?;
+        if let Err(e) = self.send_node(stanza).await {
+            if ack.is_some() {
+                self.response_waiters.lock().await.remove(&request_id);
+            }
+            return Err(e.into());
+        }
 
         if let Some((rx, phash)) = ack {
             self.spawn_phash_validation(rx, phash, to.clone(), false, request_id.clone());
@@ -1126,7 +1131,12 @@ impl Client {
             None
         };
 
-        self.send_node(stanza_to_send).await?;
+        if let Err(e) = self.send_node(stanza_to_send).await {
+            if let Some((_, _, ref msg_id)) = ack {
+                self.response_waiters.lock().await.remove(msg_id);
+            }
+            return Err(e.into());
+        }
 
         if let Some((rx, phash, msg_id)) = ack {
             self.spawn_phash_validation(rx, phash, tc_issue_target.clone(), true, msg_id);

--- a/src/send.rs
+++ b/src/send.rs
@@ -1119,12 +1119,11 @@ impl Client {
             .attrs()
             .optional_string("phash")
             .map(|s| s.into_owned())
-        {
-            let msg_id = stanza_to_send
+            && let Some(msg_id) = stanza_to_send
                 .attrs()
                 .optional_string("id")
                 .map(|s| s.into_owned())
-                .unwrap_or_default();
+        {
             let rx = self.register_ack_waiter(&msg_id).await;
             Some((rx, phash, msg_id))
         } else {

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -164,9 +164,17 @@ where
                             });
                         }
                         UploadExistsResult::Resume { byte_offset } => {
-                            log::info!("Resuming upload from byte {byte_offset}/{total}");
-                            upload_data = &enc.data_to_upload[byte_offset as usize..];
-                            file_offset = Some(byte_offset);
+                            let offset = byte_offset as usize;
+                            if offset > enc.data_to_upload.len() {
+                                log::warn!(
+                                    "Server resume offset {offset} exceeds data length {}; uploading from start",
+                                    enc.data_to_upload.len()
+                                );
+                            } else {
+                                log::info!("Resuming upload from byte {byte_offset}/{total}");
+                                upload_data = &enc.data_to_upload[offset..];
+                                file_offset = Some(byte_offset);
+                            }
                         }
                         UploadExistsResult::NotFound => {}
                     }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -165,7 +165,7 @@ where
                         }
                         UploadExistsResult::Resume { byte_offset } => {
                             let offset = byte_offset as usize;
-                            if offset > enc.data_to_upload.len() {
+                            if offset >= enc.data_to_upload.len() {
                                 log::warn!(
                                     "Server resume offset {offset} exceeds data length {}; uploading from start",
                                     enc.data_to_upload.len()

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -56,7 +56,7 @@ impl Client {
                 );
             }
 
-            let mut fetched_devices = Vec::new();
+            let mut fetched_devices = Vec::with_capacity(response.device_lists.len());
 
             for user_list in &response.device_lists {
                 // Update device registry (single source of truth for device lists).

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
-use diesel::sql_query;
 use diesel::sqlite::SqliteConnection;
 use diesel::upsert::excluded;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
@@ -302,107 +301,124 @@ impl SqliteStore {
         device_id: i32,
         device_data: &CoreDevice,
     ) -> Result<()> {
-        let pool = self.pool.clone();
-        let noise_key_data = self.serialize_keypair(&device_data.noise_key)?;
-        let identity_key_data = self.serialize_keypair(&device_data.identity_key)?;
-        let signed_pre_key_data = self.serialize_keypair(&device_data.signed_pre_key)?;
-        let account_data = device_data
+        // Use Arc so retry clones are just atomic increments, not deep copies.
+        let noise_key_data: Arc<[u8]> = self.serialize_keypair(&device_data.noise_key)?.into();
+        let identity_key_data: Arc<[u8]> =
+            self.serialize_keypair(&device_data.identity_key)?.into();
+        let signed_pre_key_data: Arc<[u8]> =
+            self.serialize_keypair(&device_data.signed_pre_key)?.into();
+        let account_data: Option<Arc<[u8]>> = device_data
             .account
             .as_ref()
-            .map(wacore::store::device::account_serde::to_bytes);
+            .map(|a| Arc::from(wacore::store::device::account_serde::to_bytes(a)));
         let registration_id = device_data.registration_id as i32;
         let signed_pre_key_id = device_data.signed_pre_key_id as i32;
-        let signed_pre_key_signature: Vec<u8> = device_data.signed_pre_key_signature.to_vec();
-        let adv_secret_key: Vec<u8> = device_data.adv_secret_key.to_vec();
-        let push_name = device_data.push_name.clone();
+        let signed_pre_key_signature: Arc<[u8]> =
+            Arc::from(&device_data.signed_pre_key_signature[..]);
+        let adv_secret_key: Arc<[u8]> = Arc::from(&device_data.adv_secret_key[..]);
+        let push_name: Arc<str> = Arc::from(device_data.push_name.as_str());
         let app_version_primary = device_data.app_version_primary as i32;
         let app_version_secondary = device_data.app_version_secondary as i32;
         let app_version_tertiary = device_data.app_version_tertiary as i64;
         let app_version_last_fetched_ms = device_data.app_version_last_fetched_ms;
-        let edge_routing_info = device_data.edge_routing_info.clone();
-        let props_hash = device_data.props_hash.clone();
+        let edge_routing_info: Option<Arc<[u8]>> =
+            device_data.edge_routing_info.as_deref().map(Arc::from);
+        let props_hash: Option<Arc<str>> = device_data.props_hash.as_deref().map(Arc::from);
         let next_pre_key_id = device_data.next_pre_key_id as i32;
         let server_has_prekeys = device_data.server_has_prekeys;
-        let nct_salt = device_data.nct_salt.clone();
-        let new_lid = device_data
-            .lid
-            .as_ref()
-            .map(|j| j.to_string())
-            .unwrap_or_default();
-        let new_pn = device_data
-            .pn
-            .as_ref()
-            .map(|j| j.to_string())
-            .unwrap_or_default();
+        let nct_salt: Option<Arc<[u8]>> = device_data.nct_salt.as_deref().map(Arc::from);
+        let new_lid: Arc<str> = Arc::from(
+            device_data
+                .lid
+                .as_ref()
+                .map(|j| j.to_string())
+                .unwrap_or_default()
+                .as_str(),
+        );
+        let new_pn: Arc<str> = Arc::from(
+            device_data
+                .pn
+                .as_ref()
+                .map(|j| j.to_string())
+                .unwrap_or_default()
+                .as_str(),
+        );
 
-        tokio::task::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+        self.with_retry("save_device_data", || {
+            let noise_key_data = Arc::clone(&noise_key_data);
+            let identity_key_data = Arc::clone(&identity_key_data);
+            let signed_pre_key_data = Arc::clone(&signed_pre_key_data);
+            let account_data = account_data.clone();
+            let signed_pre_key_signature = Arc::clone(&signed_pre_key_signature);
+            let adv_secret_key = Arc::clone(&adv_secret_key);
+            let push_name = Arc::clone(&push_name);
+            let edge_routing_info = edge_routing_info.clone();
+            let props_hash = props_hash.clone();
+            let nct_salt = nct_salt.clone();
+            let new_lid = Arc::clone(&new_lid);
+            let new_pn = Arc::clone(&new_pn);
 
-            diesel::insert_into(device::table)
-                .values((
-                    device::id.eq(device_id),
-                    device::lid.eq(&new_lid),
-                    device::pn.eq(&new_pn),
-                    device::registration_id.eq(registration_id),
-                    device::noise_key.eq(&noise_key_data),
-                    device::identity_key.eq(&identity_key_data),
-                    device::signed_pre_key.eq(&signed_pre_key_data),
-                    device::signed_pre_key_id.eq(signed_pre_key_id),
-                    device::signed_pre_key_signature.eq(&signed_pre_key_signature[..]),
-                    device::adv_secret_key.eq(&adv_secret_key[..]),
-                    device::account.eq(account_data.clone()),
-                    device::push_name.eq(&push_name),
-                    device::app_version_primary.eq(app_version_primary),
-                    device::app_version_secondary.eq(app_version_secondary),
-                    device::app_version_tertiary.eq(app_version_tertiary),
-                    device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
-                    device::edge_routing_info.eq(edge_routing_info.clone()),
-                    device::props_hash.eq(props_hash.clone()),
-                    device::next_pre_key_id.eq(next_pre_key_id),
-                    device::server_has_prekeys.eq(server_has_prekeys),
-                    device::nct_salt.eq(nct_salt.clone()),
-                ))
-                .on_conflict(device::id)
-                .do_update()
-                .set((
-                    device::lid.eq(&new_lid),
-                    device::pn.eq(&new_pn),
-                    device::registration_id.eq(registration_id),
-                    device::noise_key.eq(&noise_key_data),
-                    device::identity_key.eq(&identity_key_data),
-                    device::signed_pre_key.eq(&signed_pre_key_data),
-                    device::signed_pre_key_id.eq(signed_pre_key_id),
-                    device::signed_pre_key_signature.eq(&signed_pre_key_signature[..]),
-                    device::adv_secret_key.eq(&adv_secret_key[..]),
-                    device::account.eq(account_data.clone()),
-                    device::push_name.eq(&push_name),
-                    device::app_version_primary.eq(app_version_primary),
-                    device::app_version_secondary.eq(app_version_secondary),
-                    device::app_version_tertiary.eq(app_version_tertiary),
-                    device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
-                    device::edge_routing_info.eq(edge_routing_info),
-                    device::props_hash.eq(props_hash),
-                    device::next_pre_key_id.eq(next_pre_key_id),
-                    device::server_has_prekeys.eq(server_has_prekeys),
-                    device::nct_salt.eq(nct_salt),
-                ))
-                .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
-
-            Ok(())
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::insert_into(device::table)
+                    .values((
+                        device::id.eq(device_id),
+                        device::lid.eq(&*new_lid),
+                        device::pn.eq(&*new_pn),
+                        device::registration_id.eq(registration_id),
+                        device::noise_key.eq(&*noise_key_data),
+                        device::identity_key.eq(&*identity_key_data),
+                        device::signed_pre_key.eq(&*signed_pre_key_data),
+                        device::signed_pre_key_id.eq(signed_pre_key_id),
+                        device::signed_pre_key_signature.eq(&*signed_pre_key_signature),
+                        device::adv_secret_key.eq(&*adv_secret_key),
+                        device::account.eq(account_data.as_deref()),
+                        device::push_name.eq(&*push_name),
+                        device::app_version_primary.eq(app_version_primary),
+                        device::app_version_secondary.eq(app_version_secondary),
+                        device::app_version_tertiary.eq(app_version_tertiary),
+                        device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
+                        device::edge_routing_info.eq(edge_routing_info.as_deref()),
+                        device::props_hash.eq(props_hash.as_deref()),
+                        device::next_pre_key_id.eq(next_pre_key_id),
+                        device::server_has_prekeys.eq(server_has_prekeys),
+                        device::nct_salt.eq(nct_salt.as_deref()),
+                    ))
+                    .on_conflict(device::id)
+                    .do_update()
+                    .set((
+                        device::lid.eq(&*new_lid),
+                        device::pn.eq(&*new_pn),
+                        device::registration_id.eq(registration_id),
+                        device::noise_key.eq(&*noise_key_data),
+                        device::identity_key.eq(&*identity_key_data),
+                        device::signed_pre_key.eq(&*signed_pre_key_data),
+                        device::signed_pre_key_id.eq(signed_pre_key_id),
+                        device::signed_pre_key_signature.eq(&*signed_pre_key_signature),
+                        device::adv_secret_key.eq(&*adv_secret_key),
+                        device::account.eq(account_data.as_deref()),
+                        device::push_name.eq(&*push_name),
+                        device::app_version_primary.eq(app_version_primary),
+                        device::app_version_secondary.eq(app_version_secondary),
+                        device::app_version_tertiary.eq(app_version_tertiary),
+                        device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
+                        device::edge_routing_info.eq(edge_routing_info.as_deref()),
+                        device::props_hash.eq(props_hash.as_deref()),
+                        device::next_pre_key_id.eq(next_pre_key_id),
+                        device::server_has_prekeys.eq(server_has_prekeys),
+                        device::nct_salt.eq(nct_salt.as_deref()),
+                    ))
+                    .execute(conn)
+                    .map(|_| ())
+            })
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
-
-        Ok(())
     }
 
     pub async fn create_new_device(&self) -> Result<i32> {
         use crate::schema::device;
 
         let pool = self.pool.clone();
+        let device_id = self.device_id;
         tokio::task::spawn_blocking(move || -> Result<i32> {
             let mut conn = pool
                 .get()
@@ -431,6 +447,7 @@ impl SqliteStore {
 
             diesel::insert_into(device::table)
                 .values((
+                    device::id.eq(device_id),
                     device::lid.eq(""),
                     device::pn.eq(""),
                     device::registration_id.eq(new_device.registration_id as i32),
@@ -454,19 +471,6 @@ impl SqliteStore {
                 ))
                 .execute(&mut conn)
                 .map_err(|e| StoreError::Database(e.to_string()))?;
-
-            use diesel::sql_types::Integer;
-
-            #[derive(QueryableByName)]
-            struct LastInsertedId {
-                #[diesel(sql_type = Integer)]
-                last_insert_rowid: i32,
-            }
-
-            let device_id: i32 = sql_query("SELECT last_insert_rowid() as last_insert_rowid")
-                .get_result::<LastInsertedId>(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?
-                .last_insert_rowid;
 
             Ok(device_id)
         })

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -386,26 +386,28 @@ impl SqliteStore {
                     .on_conflict(device::id)
                     .do_update()
                     .set((
-                        device::lid.eq(&*new_lid),
-                        device::pn.eq(&*new_pn),
-                        device::registration_id.eq(registration_id),
-                        device::noise_key.eq(&*noise_key_data),
-                        device::identity_key.eq(&*identity_key_data),
-                        device::signed_pre_key.eq(&*signed_pre_key_data),
-                        device::signed_pre_key_id.eq(signed_pre_key_id),
-                        device::signed_pre_key_signature.eq(&*signed_pre_key_signature),
-                        device::adv_secret_key.eq(&*adv_secret_key),
-                        device::account.eq(account_data.as_deref()),
-                        device::push_name.eq(&*push_name),
-                        device::app_version_primary.eq(app_version_primary),
-                        device::app_version_secondary.eq(app_version_secondary),
-                        device::app_version_tertiary.eq(app_version_tertiary),
-                        device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
-                        device::edge_routing_info.eq(edge_routing_info.as_deref()),
-                        device::props_hash.eq(props_hash.as_deref()),
-                        device::next_pre_key_id.eq(next_pre_key_id),
-                        device::server_has_prekeys.eq(server_has_prekeys),
-                        device::nct_salt.eq(nct_salt.as_deref()),
+                        device::lid.eq(excluded(device::lid)),
+                        device::pn.eq(excluded(device::pn)),
+                        device::registration_id.eq(excluded(device::registration_id)),
+                        device::noise_key.eq(excluded(device::noise_key)),
+                        device::identity_key.eq(excluded(device::identity_key)),
+                        device::signed_pre_key.eq(excluded(device::signed_pre_key)),
+                        device::signed_pre_key_id.eq(excluded(device::signed_pre_key_id)),
+                        device::signed_pre_key_signature
+                            .eq(excluded(device::signed_pre_key_signature)),
+                        device::adv_secret_key.eq(excluded(device::adv_secret_key)),
+                        device::account.eq(excluded(device::account)),
+                        device::push_name.eq(excluded(device::push_name)),
+                        device::app_version_primary.eq(excluded(device::app_version_primary)),
+                        device::app_version_secondary.eq(excluded(device::app_version_secondary)),
+                        device::app_version_tertiary.eq(excluded(device::app_version_tertiary)),
+                        device::app_version_last_fetched_ms
+                            .eq(excluded(device::app_version_last_fetched_ms)),
+                        device::edge_routing_info.eq(excluded(device::edge_routing_info)),
+                        device::props_hash.eq(excluded(device::props_hash)),
+                        device::next_pre_key_id.eq(excluded(device::next_pre_key_id)),
+                        device::server_has_prekeys.eq(excluded(device::server_has_prekeys)),
+                        device::nct_salt.eq(excluded(device::nct_salt)),
                     ))
                     .execute(conn)
                     .map(|_| ())

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2768,4 +2768,38 @@ mod tests {
         let g2 = store.get_sender_key_devices(group2).await.unwrap();
         assert!(g2.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_create_new_device_uses_configured_device_id() {
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+        static COUNTER: AtomicU64 = AtomicU64::new(100);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_name = format!(
+            "file:memdb_devid_{}_{}?mode=memory&cache=shared",
+            std::process::id(),
+            id
+        );
+
+        let device_id = 42;
+        let store = SqliteStore::new_for_device(&db_name, device_id)
+            .await
+            .expect("Failed to create test store");
+
+        assert!(!store.device_exists(device_id).await.unwrap());
+        let returned_id = store.create_new_device().await.unwrap();
+        assert_eq!(returned_id, device_id);
+        assert!(store.device_exists(device_id).await.unwrap());
+
+        // Row 1 should NOT exist (would if auto-increment was used)
+        if device_id != 1 {
+            assert!(!store.device_exists(1).await.unwrap());
+        }
+
+        let loaded = store.load_device_data_for_device(device_id).await.unwrap();
+        assert!(
+            loaded.is_some(),
+            "device data should be loadable by configured id"
+        );
+    }
 }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -415,67 +415,64 @@ impl SqliteStore {
     }
 
     pub async fn create_new_device(&self) -> Result<i32> {
-        use crate::schema::device;
-
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        tokio::task::spawn_blocking(move || -> Result<i32> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+        let new_device = wacore::store::Device::new();
 
-            let new_device = wacore::store::Device::new();
+        let noise_key_data: Arc<[u8]> = self.serialize_keypair(&new_device.noise_key)?.into();
+        let identity_key_data: Arc<[u8]> = self.serialize_keypair(&new_device.identity_key)?.into();
+        let signed_pre_key_data: Arc<[u8]> =
+            self.serialize_keypair(&new_device.signed_pre_key)?.into();
+        let registration_id = new_device.registration_id as i32;
+        let signed_pre_key_id = new_device.signed_pre_key_id as i32;
+        let signed_pre_key_signature: Arc<[u8]> =
+            Arc::from(&new_device.signed_pre_key_signature[..]);
+        let adv_secret_key: Arc<[u8]> = Arc::from(&new_device.adv_secret_key[..]);
+        let push_name: Arc<str> = Arc::from(new_device.push_name.as_str());
+        let app_version_primary = new_device.app_version_primary as i32;
+        let app_version_secondary = new_device.app_version_secondary as i32;
+        let app_version_tertiary = new_device.app_version_tertiary as i64;
+        let app_version_last_fetched_ms = new_device.app_version_last_fetched_ms;
+        let next_pre_key_id = new_device.next_pre_key_id as i32;
+        let server_has_prekeys = new_device.server_has_prekeys;
 
-            let noise_key_data = {
-                let mut bytes = Vec::with_capacity(64);
-                bytes.extend_from_slice(new_device.noise_key.private_key.serialize());
-                bytes.extend_from_slice(new_device.noise_key.public_key.public_key_bytes());
-                bytes
-            };
-            let identity_key_data = {
-                let mut bytes = Vec::with_capacity(64);
-                bytes.extend_from_slice(new_device.identity_key.private_key.serialize());
-                bytes.extend_from_slice(new_device.identity_key.public_key.public_key_bytes());
-                bytes
-            };
-            let signed_pre_key_data = {
-                let mut bytes = Vec::with_capacity(64);
-                bytes.extend_from_slice(new_device.signed_pre_key.private_key.serialize());
-                bytes.extend_from_slice(new_device.signed_pre_key.public_key.public_key_bytes());
-                bytes
-            };
+        self.with_retry("create_new_device", || {
+            let noise_key_data = Arc::clone(&noise_key_data);
+            let identity_key_data = Arc::clone(&identity_key_data);
+            let signed_pre_key_data = Arc::clone(&signed_pre_key_data);
+            let signed_pre_key_signature = Arc::clone(&signed_pre_key_signature);
+            let adv_secret_key = Arc::clone(&adv_secret_key);
+            let push_name = Arc::clone(&push_name);
 
-            diesel::insert_into(device::table)
-                .values((
-                    device::id.eq(device_id),
-                    device::lid.eq(""),
-                    device::pn.eq(""),
-                    device::registration_id.eq(new_device.registration_id as i32),
-                    device::noise_key.eq(&noise_key_data),
-                    device::identity_key.eq(&identity_key_data),
-                    device::signed_pre_key.eq(&signed_pre_key_data),
-                    device::signed_pre_key_id.eq(new_device.signed_pre_key_id as i32),
-                    device::signed_pre_key_signature.eq(&new_device.signed_pre_key_signature[..]),
-                    device::adv_secret_key.eq(&new_device.adv_secret_key[..]),
-                    device::account.eq(None::<Vec<u8>>),
-                    device::push_name.eq(&new_device.push_name),
-                    device::app_version_primary.eq(new_device.app_version_primary as i32),
-                    device::app_version_secondary.eq(new_device.app_version_secondary as i32),
-                    device::app_version_tertiary.eq(new_device.app_version_tertiary as i64),
-                    device::app_version_last_fetched_ms.eq(new_device.app_version_last_fetched_ms),
-                    device::edge_routing_info.eq(None::<Vec<u8>>),
-                    device::props_hash.eq(None::<String>),
-                    device::next_pre_key_id.eq(new_device.next_pre_key_id as i32),
-                    device::server_has_prekeys.eq(new_device.server_has_prekeys),
-                    device::nct_salt.eq(None::<Vec<u8>>),
-                ))
-                .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
-
-            Ok(device_id)
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::insert_into(device::table)
+                    .values((
+                        device::id.eq(device_id),
+                        device::lid.eq(""),
+                        device::pn.eq(""),
+                        device::registration_id.eq(registration_id),
+                        device::noise_key.eq(&*noise_key_data),
+                        device::identity_key.eq(&*identity_key_data),
+                        device::signed_pre_key.eq(&*signed_pre_key_data),
+                        device::signed_pre_key_id.eq(signed_pre_key_id),
+                        device::signed_pre_key_signature.eq(&*signed_pre_key_signature),
+                        device::adv_secret_key.eq(&*adv_secret_key),
+                        device::account.eq(None::<&[u8]>),
+                        device::push_name.eq(&*push_name),
+                        device::app_version_primary.eq(app_version_primary),
+                        device::app_version_secondary.eq(app_version_secondary),
+                        device::app_version_tertiary.eq(app_version_tertiary),
+                        device::app_version_last_fetched_ms.eq(app_version_last_fetched_ms),
+                        device::edge_routing_info.eq(None::<&[u8]>),
+                        device::props_hash.eq(None::<&str>),
+                        device::next_pre_key_id.eq(next_pre_key_id),
+                        device::server_has_prekeys.eq(server_has_prekeys),
+                        device::nct_salt.eq(None::<&[u8]>),
+                    ))
+                    .execute(conn)
+                    .map(|_| device_id)
+            })
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
     }
 
     pub async fn device_exists(&self, device_id: i32) -> Result<bool> {

--- a/wacore/appstate/src/patch_decode.rs
+++ b/wacore/appstate/src/patch_decode.rs
@@ -134,10 +134,12 @@ fn parse_single_collection(collection: &Node) -> Result<PatchList> {
     let snapshot = None; // external only currently
 
     // patches list
-    let mut patches: Vec<wa::SyncdPatch> = Vec::new();
-    if let Some(patches_node) = collection.get_optional_child("patches")
-        && let Some(children) = patches_node.children()
-    {
+    let children_ref = collection
+        .get_optional_child("patches")
+        .and_then(|n| n.children());
+    let mut patches: Vec<wa::SyncdPatch> =
+        Vec::with_capacity(children_ref.as_ref().map_or(0, |c| c.len()));
+    if let Some(children) = children_ref {
         for child in children {
             if child.tag == "patch"
                 && let Some(wacore_binary::node::NodeContent::Bytes(raw)) = &child.content

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -107,7 +107,7 @@ pub fn derive_protocol_node(input: TokenStream) -> TokenStream {
         }
     };
 
-    let mut attr_fields = Vec::new();
+    let mut attr_fields = Vec::with_capacity(fields.len());
     for field in fields {
         match extract_attr_info(field) {
             Ok(Some(attr_info)) => attr_fields.push(attr_info),
@@ -596,7 +596,7 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
         }
     };
 
-    let mut variant_infos = Vec::new();
+    let mut variant_infos = Vec::with_capacity(variants.len());
     let mut default_variant = None;
     let mut fallback_variant: Option<syn::Ident> = None;
     let mut seen_str_values: std::collections::HashMap<String, syn::Ident> =

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -441,7 +441,7 @@ impl AppStateProcessor {
 
     pub async fn get_missing_key_ids(&self, pl: &PatchList) -> Result<Vec<Vec<u8>>> {
         let key_ids = collect_key_ids_from_patch_list(pl.snapshot.as_ref(), &pl.patches);
-        let mut missing = Vec::new();
+        let mut missing = Vec::with_capacity(key_ids.len());
         for id in key_ids {
             if self.backend.get_sync_key(&id).await?.is_none() {
                 missing.push(id);

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -300,7 +300,7 @@ impl PairUtils {
             .private_key
             .calculate_agreement(&their_public_key)?;
 
-        let mut final_message = Vec::new();
+        let mut final_message = Vec::with_capacity(64 + 32 + 32);
         final_message.extend_from_slice(&account_signature);
         final_message.extend_from_slice(master_ephemeral.public_key.public_key_bytes());
         final_message.extend_from_slice(identity_key.public_key.public_key_bytes());

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -20,8 +20,8 @@ fn evict_clean_entries<V>(
     if overflow == 0 {
         return;
     }
-    let mut negative = Vec::new();
-    let mut positive = Vec::new();
+    let mut negative = Vec::with_capacity(overflow);
+    let mut positive = Vec::with_capacity(overflow);
     for (k, v) in cache.iter() {
         if dirty.contains(k.as_ref()) {
             continue;


### PR DESCRIPTION
## Summary

Comprehensive codebase audit addressing bugs, race conditions, resource leaks, and performance. 15 files changed across 8 commits.

## Bugs fixed

**Multi-account bootstrap broken on first boot (B1):** `create_new_device()` now inserts with the configured `device_id` instead of relying on SQLite auto-increment. Previously `SqliteStore::new_for_device(42)` created row 1 on first boot but all reads targeted row 42, orphaning credentials.

**Persistence saver halts permanently after transient SQLite contention (B2):** `save_device_data_for_device()` and `create_new_device()` now use `with_retry()` for semaphore serialization and retry on SQLITE_BUSY/locked errors (up to 5 attempts with exponential backoff). Previously these were the only write paths bypassing `with_retry`, so 10 transient failures would permanently halt the background saver. Uses `Arc<[u8]>`/`Arc<str>` so retry clones are atomic increments. The upsert path now uses diesel `excluded()` references instead of duplicating all 20 column assignments.

**ACK waiter leak disables keepalives (B3):** `spawn_phash_validation()` now removes its waiter from `response_waiters` on timeout/error. Previously it leaked the entry, which suppressed keepalive pings for the rest of the connection. Both send paths also clean up the waiter if `send_node()` fails before spawning the validator.

**App-state key-request dedupe suppresses retries for 24h after failure (B4):** `request_app_state_keys()` now returns `Result` so callers detect failures. On error, dedup stamps are removed so keys can be retried on the next sync. Also returns `Err` when own JID is unavailable (instead of silent `Ok(())`) so stamps don't persist when the request was never attempted. The duplicated dedup+request logic (~28 lines in two call sites) was extracted into `request_missing_keys_with_dedup()`.

**Upload resume offset not bounds-checked (B5):** Validates server resume offset before slicing upload data. Uses `>=` so offset-equal-to-length (zero bytes remaining) also falls back to full upload.

**Server-sync not generation-bound (B6):** Server-sync tasks now re-check `connection_generation` after the version comparison loop (which awaits DB reads), preventing stale tasks from continuing after a reconnect.

**Error swallowing in sender key cache (B8):** Replaced `let _ = backend.take_sent_message(...)` with explicit error logging.

## Race conditions mitigated

**Coordination cache eviction breaks serialization (R1):** Increased default capacity for `session_locks` (2k to 10k), `message_queues` and `message_enqueue_locks` (2k to 5k). These hold live mutexes and channel senders; capacity eviction while a reference is held creates a duplicate lock for the same key.

**Old per-chat workers survive reconnect (R2):** Message queue workers capture `connection_generation` at spawn and check it before processing each message. Workers from a previous connection exit with a debug log instead of processing messages with stale crypto state.

## Performance

**Pre-allocate Vecs (P2):** Replaced `Vec::new()` with `Vec::with_capacity()` in 13 sites where the final size is derivable from input (usync, community features, signal cache eviction, patch decoding, app state sync, pairing, derive macros).

## Code quality

- Normalized `connection_generation` atomic loads to `Acquire` ordering (was inconsistently `SeqCst` in notification.rs)
- Updated `CacheConfig` doc comments to reflect current defaults
- Eliminated `unwrap()` in phash validation callers via tuple destructuring

## Behavioral changes

Cache capacity defaults changed: `session_locks` from 2,000 to 10,000; `message_queues` and `message_enqueue_locks` from 2,000 to 5,000. Users who explicitly set these values are unaffected.

## Test plan

- [x] `cargo clippy --all --tests` passes with zero warnings
- [x] `cargo test --all --lib` passes
- [ ] E2E tests with mock server
- [ ] Manual test: multi-account bootstrap with `new_for_device(N)` where N > 1
- [ ] Manual test: verify keepalive pings continue after phash timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App-state key requests now properly surface send failures and are retried on subsequent syncs.
  * Background workers and sync tasks abort when connection/crypto state changes to avoid stale processing.
  * Upload resumption validates server offsets to avoid corrupted resumes.
  * DB cleanup and acknowledgement paths now remove leaked waiter/state and log unexpected errors.

* **Performance**
  * Increased coordination cache capacities for higher throughput.
  * Reduced allocations via targeted preallocation and buffer optimizations.

* **Tests**
  * Added a test ensuring device creation respects configured IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->