### PR TITLE
perf!: use CompactString for NodeValue, NodeContent, and Jid.user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +289,21 @@ name = "cmov"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1806,6 +1830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2012,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2427,6 +2463,7 @@ dependencies = [
 name = "wacore-binary"
 version = "0.5.0"
 dependencies = [
+ "compact_str",
  "flate2",
  "iai-callgrind",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bytemuck = { version = "1.22", default-features = false }
 bytes = { version = "1.5", default-features = false, features = ["serde"] }
 chrono = { version = "0.4", default-features = false }
+compact_str = { version = "0.8", default-features = false }
 ctr = { version = "0.9", default-features = false }
 event-listener = { version = "5", default-features = false }
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -2,11 +2,11 @@ use chrono::Local;
 use log::{error, info};
 use std::sync::Arc;
 use wacore::proto_helpers::MessageExt;
+use wacore::store::InMemoryBackend;
 use wacore::types::events::Event;
 use waproto::whatsapp as wa;
 use whatsapp_rust::TokioRuntime;
 use whatsapp_rust::bot::{Bot, MessageContext};
-use whatsapp_rust::store::SqliteStore;
 use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
 use whatsapp_rust_ureq_http_client::UreqHttpClient;
 
@@ -31,14 +31,7 @@ fn main() {
         .expect("Failed to build tokio runtime");
 
     rt.block_on(async {
-        let backend = match SqliteStore::new("file::memory:?cache=shared").await {
-            Ok(store) => Arc::new(store),
-            Err(e) => {
-                error!("Failed to create SQLite backend: {}", e);
-                return;
-            }
-        };
-        info!("SQLite backend initialized successfully.");
+        let backend = Arc::new(InMemoryBackend::new().with_sent_message_ttl(30));
 
         let mut transport_factory = TokioWebSocketTransportFactory::new();
         if let Ok(ws_url) = std::env::var("WHATSAPP_WS_URL") {

--- a/src/client.rs
+++ b/src/client.rs
@@ -3603,7 +3603,7 @@ fn build_ack_node(node: &Node, own_device_pn: Option<&Jid>) -> Option<Node> {
     };
 
     let mut attrs = Attrs::new();
-    attrs.insert("class", NodeValue::String(node.tag.to_string()));
+    attrs.insert("class", NodeValue::from(node.tag.as_ref()));
     attrs.insert("id", id);
     attrs.insert("to", from);
 
@@ -3698,7 +3698,7 @@ mod tests {
         let receipt_node = Node::new(
             "receipt",
             receipt_attrs,
-            Some(NodeContent::String("test".to_string())),
+            Some(NodeContent::String("test".into())),
         );
 
         let mut notification_attrs = Attrs::new();
@@ -3707,7 +3707,7 @@ mod tests {
         let notification_node = Node::new(
             "notification",
             notification_attrs,
-            Some(NodeContent::String("test".to_string())),
+            Some(NodeContent::String("test".into())),
         );
 
         assert!(

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -146,7 +146,7 @@ impl Client {
             // PN JID - check if we have a LID mapping
             if let Some(lid_user) = self.lid_pn_cache.get_current_lid(&target.user).await {
                 let lid_jid = Jid {
-                    user: lid_user,
+                    user: lid_user.into(),
                     server: wacore_binary::jid::cow_server_from_str(lid_server),
                     device: target.device,
                     agent: target.agent,

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -140,19 +140,20 @@ impl<'a> Groups<'a> {
 
         let participants: Vec<Jid> = group.participants.iter().map(|p| p.jid.clone()).collect();
 
-        let lid_to_pn_map: HashMap<String, Jid> = if group.addressing_mode == AddressingMode::Lid {
-            group
-                .participants
-                .iter()
-                .filter_map(|p| {
-                    p.phone_number
-                        .as_ref()
-                        .map(|pn| (p.jid.user.clone(), pn.clone()))
-                })
-                .collect()
-        } else {
-            HashMap::new()
-        };
+        let lid_to_pn_map: HashMap<wacore_binary::CompactString, Jid> =
+            if group.addressing_mode == AddressingMode::Lid {
+                group
+                    .participants
+                    .iter()
+                    .filter_map(|p| {
+                        p.phone_number
+                            .as_ref()
+                            .map(|pn| (p.jid.user.clone(), pn.clone()))
+                    })
+                    .collect()
+            } else {
+                HashMap::new()
+            };
 
         let mut info = GroupInfo::new(participants, group.addressing_mode);
         if !lid_to_pn_map.is_empty() {
@@ -544,17 +545,14 @@ impl<'a> Groups<'a> {
     /// LID mapping return `None` instead of falling back to the PN user.
     async fn resolve_token_key(&self, jid: &Jid, only_lid: bool) -> Option<String> {
         if jid.is_lid() {
-            Some(jid.user.clone())
-        } else if only_lid {
-            self.client.lid_pn_cache.get_current_lid(&jid.user).await
+            Some(jid.user.to_string())
         } else {
-            Some(
-                self.client
-                    .lid_pn_cache
-                    .get_current_lid(&jid.user)
-                    .await
-                    .unwrap_or_else(|| jid.user.clone()),
-            )
+            let lid = self.client.lid_pn_cache.get_current_lid(&jid.user).await;
+            if only_lid {
+                lid
+            } else {
+                Some(lid.unwrap_or_else(|| jid.user.to_string()))
+            }
         }
     }
 

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -622,7 +622,7 @@ async fn handle_account_sync_devices(client: &Arc<Client>, node: &Node, devices_
     // Build DeviceListRecord for storage
     // Note: update_device_list() will automatically store under LID if mapping is known
     let device_list = DeviceListRecord {
-        user: from_jid.user.clone(),
+        user: from_jid.user.to_string(),
         devices: devices
             .iter()
             .map(|d| DeviceInfo {
@@ -683,37 +683,38 @@ async fn handle_privacy_token_notification(client: &Arc<Client>, node: &Node) {
 
     // Resolve the sender to a LID key for storage.
     // WA Web uses `sender_lid` attr if present, otherwise resolves from `from`.
-    let sender_lid = node
+    let sender_lid_jid = node
         .attrs()
         .optional_jid("sender_lid")
-        .map(|j| j.user.clone());
+        .filter(|j| !j.user.is_empty());
 
-    let sender_lid = match sender_lid {
-        Some(lid) if !lid.is_empty() => lid,
-        _ => {
-            // Fall back to resolving from the `from` JID via LID-PN cache
-            let from = match &from_jid {
-                Some(jid) => jid,
+    // Resolve to a LID key. We borrow from Jid.user (CompactString) or from
+    // get_current_lid (String), then pass as &str to the storage layer.
+    let resolved_lid: Option<String>;
+    let sender_lid: &str = if let Some(ref lid_jid) = sender_lid_jid {
+        &lid_jid.user
+    } else {
+        let from = match &from_jid {
+            Some(jid) => jid,
+            None => {
+                warn!(target: "Client/TcToken", "privacy_token notification missing 'from' attribute");
+                return;
+            }
+        };
+
+        if from.is_lid() {
+            &from.user
+        } else {
+            resolved_lid = client.lid_pn_cache.get_current_lid(&from.user).await;
+            match &resolved_lid {
+                Some(lid) => lid.as_str(),
                 None => {
-                    warn!(target: "Client/TcToken", "privacy_token notification missing 'from' attribute");
-                    return;
-                }
-            };
-
-            if from.is_lid() {
-                from.user.clone()
-            } else {
-                // Try to resolve phone number to LID
-                match client.lid_pn_cache.get_current_lid(&from.user).await {
-                    Some(lid) => lid,
-                    None => {
-                        debug!(
-                            target: "Client/TcToken",
-                            "Cannot resolve LID for privacy_token sender {}, storing under PN",
-                            from
-                        );
-                        from.user.clone()
-                    }
+                    debug!(
+                        target: "Client/TcToken",
+                        "Cannot resolve LID for privacy_token sender {}, storing under PN",
+                        from
+                    );
+                    &from.user
                 }
             }
         }
@@ -737,7 +738,7 @@ async fn handle_privacy_token_notification(client: &Arc<Client>, node: &Node) {
     let mut token_stored = false;
 
     for received in &received_tokens {
-        match backend.get_tc_token(&sender_lid).await {
+        match backend.get_tc_token(sender_lid).await {
             Ok(Some(existing)) => {
                 // Skip if token bytes are identical and timestamp hasn't advanced
                 if existing.token == received.token {
@@ -747,7 +748,7 @@ async fn handle_privacy_token_notification(client: &Arc<Client>, node: &Node) {
                             token_timestamp: received.timestamp,
                             ..existing
                         };
-                        if let Err(e) = backend.put_tc_token(&sender_lid, &refreshed).await {
+                        if let Err(e) = backend.put_tc_token(sender_lid, &refreshed).await {
                             warn!(target: "Client/TcToken", "Failed to refresh tc_token timestamp for {}: {e}", sender_lid);
                         }
                     }
@@ -771,7 +772,7 @@ async fn handle_privacy_token_notification(client: &Arc<Client>, node: &Node) {
                     sender_timestamp: existing.sender_timestamp,
                 };
 
-                if let Err(e) = backend.put_tc_token(&sender_lid, &entry).await {
+                if let Err(e) = backend.put_tc_token(sender_lid, &entry).await {
                     warn!(target: "Client/TcToken", "Failed to update tc_token for {}: {e}", sender_lid);
                 } else {
                     debug!(target: "Client/TcToken", "Updated tc_token for {} (t={})", sender_lid, received.timestamp);
@@ -786,7 +787,7 @@ async fn handle_privacy_token_notification(client: &Arc<Client>, node: &Node) {
                     sender_timestamp: None,
                 };
 
-                if let Err(e) = backend.put_tc_token(&sender_lid, &entry).await {
+                if let Err(e) = backend.put_tc_token(sender_lid, &entry).await {
                     warn!(target: "Client/TcToken", "Failed to store tc_token for {}: {e}", sender_lid);
                 } else {
                     debug!(target: "Client/TcToken", "Stored new tc_token for {} (t={})", sender_lid, received.timestamp);
@@ -1003,7 +1004,7 @@ fn handle_status_notification(client: &Arc<Client>, node: &Node) {
 
     if let Some(set_node) = node.get_optional_child("set") {
         let status_text = match &set_node.content {
-            Some(wacore_binary::node::NodeContent::String(s)) => s.clone(),
+            Some(wacore_binary::node::NodeContent::String(s)) => s.to_string(),
             Some(wacore_binary::node::NodeContent::Bytes(b)) => {
                 String::from_utf8_lossy(b).into_owned()
             }

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -149,7 +149,7 @@ mod tests {
         let node = Arc::new(Node::new(
             "test",
             attrs,
-            Some(NodeContent::String("test".to_string())),
+            Some(NodeContent::String("test".into())),
         ));
 
         // Create a minimal client for testing with an in-memory database
@@ -187,7 +187,7 @@ mod tests {
         let node = Arc::new(Node::new(
             "unknown",
             attrs,
-            Some(NodeContent::String("test".to_string())),
+            Some(NodeContent::String("test".into())),
         ));
 
         // Create a minimal client for testing with an in-memory database

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -348,20 +348,18 @@ impl Client {
             return;
         }
 
-        let token_key = if jid.is_lid() {
-            jid.user.clone()
+        let resolved_lid = if jid.is_lid() {
+            None
         } else {
-            self.lid_pn_cache
-                .get_current_lid(&jid.user)
-                .await
-                .unwrap_or_else(|| jid.user.clone())
+            self.lid_pn_cache.get_current_lid(&jid.user).await
         };
+        let token_key: &str = resolved_lid.as_deref().unwrap_or(&jid.user);
 
         let backend = self.persistence_manager.backend();
 
         // Avoid clobbering a newer local sender_timestamp from post-send issuance
         let incoming_sender_ts = conv.tc_token_sender_timestamp.map(|ts| ts as i64);
-        let merged_sender_ts = if let Ok(Some(existing)) = backend.get_tc_token(&token_key).await {
+        let merged_sender_ts = if let Ok(Some(existing)) = backend.get_tc_token(token_key).await {
             if (existing.token_timestamp as u64) > timestamp {
                 return;
             }
@@ -380,7 +378,7 @@ impl Client {
             sender_timestamp: merged_sender_ts,
         };
 
-        if let Err(e) = backend.put_tc_token(&token_key, &entry).await {
+        if let Err(e) = backend.put_tc_token(token_key, &entry).await {
             log::warn!(
                 target: "Client/TcToken",
                 "Failed to store history sync tctoken for {}: {e}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub use wacore::{
     iq::privacy as privacy_settings, proto_helpers, sticker_pack, store::traits, webp,
 };
+pub use wacore_binary::CompactString;
 pub use wacore_binary::builder::NodeBuilder;
 pub use wacore_binary::jid::Jid;
 pub use waproto;

--- a/src/message.rs
+++ b/src/message.rs
@@ -2343,13 +2343,13 @@ mod tests {
         // Simulate a LID group with phone number mappings
         let mut lid_to_pn_map = HashMap::new();
         lid_to_pn_map.insert(
-            "100000000000001.1".to_string(),
+            wacore_binary::CompactString::from("100000000000001.1"),
             "15551234567@s.whatsapp.net"
                 .parse()
                 .expect("test JID should be valid"),
         );
         lid_to_pn_map.insert(
-            "987654321000000.2".to_string(),
+            wacore_binary::CompactString::from("987654321000000.2"),
             "551234567890@s.whatsapp.net"
                 .parse()
                 .expect("test JID should be valid"),
@@ -2410,7 +2410,7 @@ mod tests {
 
         let mut lid_to_pn_map = HashMap::new();
         lid_to_pn_map.insert(
-            "100000000000001.1".to_string(),
+            wacore_binary::CompactString::from("100000000000001.1"),
             "15551234567@s.whatsapp.net"
                 .parse()
                 .expect("test JID should be valid"),
@@ -2473,7 +2473,7 @@ mod tests {
         let own_base_jid = own_lid.to_non_ad();
         let own_jid_to_check = if own_base_jid.is_lid() {
             lid_to_pn_map
-                .get(&own_base_jid.user)
+                .get(own_base_jid.user.as_str())
                 .map(|pn| pn.to_non_ad())
                 .unwrap_or_else(|| own_base_jid.clone())
         } else {
@@ -3590,7 +3590,7 @@ mod tests {
             } else if let Some(lid_user) = client.lid_pn_cache.get_current_lid(&sender.user).await {
                 // Use the cached LID
                 Jid {
-                    user: lid_user,
+                    user: lid_user.into(),
                     server: wacore_binary::jid::cow_server_from_str(lid_server),
                     device: sender.device,
                     agent: sender.agent,
@@ -3707,7 +3707,7 @@ mod tests {
             } else if let Some(lid_user) = client.lid_pn_cache.get_current_lid(&sender.user).await {
                 // This is the path we're testing - fallback to cached LID
                 Jid {
-                    user: lid_user,
+                    user: lid_user.into(),
                     server: wacore_binary::jid::cow_server_from_str(lid_server),
                     device: sender.device,
                     agent: sender.agent,
@@ -3809,7 +3809,7 @@ mod tests {
                 }
             } else if let Some(lid_user) = client.lid_pn_cache.get_current_lid(&sender.user).await {
                 Jid {
-                    user: lid_user,
+                    user: lid_user.into(),
                     server: wacore_binary::jid::cow_server_from_str(lid_server),
                     device: sender.device,
                     agent: sender.agent,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -954,7 +954,7 @@ mod tests {
         let node_str = Node {
             tag: Cow::Borrowed("test"),
             attrs: Attrs::new(),
-            content: Some(NodeContent::String("hello".to_string())),
+            content: Some(NodeContent::String("hello".into())),
         };
         assert_eq!(get_bytes_content(&node_str), None);
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -1216,18 +1216,23 @@ impl Client {
 
         // Resolve the destination to a LID user string once — reused for
         // tctoken lookup, issuance, and cstoken HMAC input.
-        let resolved_lid_user = if to.is_lid() {
-            Some(to.user.clone())
+        let cached_lid = if to.is_lid() {
+            None
         } else {
             self.lid_pn_cache.get_current_lid(&to.user).await
         };
-        let token_jid = resolved_lid_user.as_deref().unwrap_or(&to.user).to_string();
+        let resolved_lid_user: Option<&str> = if to.is_lid() {
+            Some(&to.user)
+        } else {
+            cached_lid.as_deref()
+        };
+        let token_jid: &str = resolved_lid_user.unwrap_or(&to.user);
 
         let backend = self.persistence_manager.backend();
         let tc_config = self.tc_token_config().await;
 
         // Look up existing tctoken
-        let existing = match backend.get_tc_token(&token_jid).await {
+        let existing = match backend.get_tc_token(token_jid).await {
             Ok(entry) => entry,
             Err(e) => {
                 log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_jid);
@@ -1255,7 +1260,7 @@ impl Client {
                         && !entry.token.is_empty() =>
                 {
                     extra_nodes.push(build_tc_token_node(&entry.token));
-                    return (should_issue_after_send, Some(token_jid));
+                    return (should_issue_after_send, Some(token_jid.to_string()));
                 }
                 _ => {
                     // cstoken fallback — gated by wa_nct_token_send_enabled
@@ -1271,7 +1276,7 @@ impl Client {
                         // HMAC input is "user@lid" (account LID without device suffix),
                         // matching WA Web's accountLid.toString()
                         let recipient_lid =
-                            wacore_binary::jid::Jid::new(lid_user, "lid").to_string();
+                            wacore_binary::jid::Jid::new(*lid_user, "lid").to_string();
                         let cs_token = compute_cs_token(salt, &recipient_lid);
                         extra_nodes.push(build_cs_token_node(&cs_token));
                         log::debug!(target: "Client/CsToken", "Attached cstoken for {} (NCT fallback)", to);
@@ -1409,17 +1414,15 @@ impl Client {
             return;
         };
 
-        let token_jid = if sender.is_lid() {
-            sender.user.clone()
+        let resolved_lid = if sender.is_lid() {
+            None
         } else {
-            match self.lid_pn_cache.get_current_lid(&sender.user).await {
-                Some(lid) => lid,
-                None => sender.user.clone(),
-            }
+            self.lid_pn_cache.get_current_lid(&sender.user).await
         };
+        let token_jid: &str = resolved_lid.as_deref().unwrap_or(&sender.user);
 
         let backend = self.persistence_manager.backend();
-        let entry = match backend.get_tc_token(&token_jid).await {
+        let entry = match backend.get_tc_token(token_jid).await {
             Ok(Some(e)) => e,
             _ => return,
         };
@@ -1469,18 +1472,16 @@ impl Client {
     pub(crate) async fn lookup_tc_token_for_jid(&self, jid: &Jid) -> Option<Vec<u8>> {
         use wacore::iq::tctoken::is_tc_token_expired_with;
 
-        let token_jid = if jid.is_lid() {
-            jid.user.clone()
+        let resolved_lid = if jid.is_lid() {
+            None
         } else {
-            match self.lid_pn_cache.get_current_lid(&jid.user).await {
-                Some(lid) => lid,
-                None => jid.user.clone(),
-            }
+            self.lid_pn_cache.get_current_lid(&jid.user).await
         };
+        let token_jid: &str = resolved_lid.as_deref().unwrap_or(&jid.user);
 
         let tc_config = self.tc_token_config().await;
         let backend = self.persistence_manager.backend();
-        match backend.get_tc_token(&token_jid).await {
+        match backend.get_tc_token(token_jid).await {
             Ok(Some(entry))
                 if !entry.token.is_empty()
                     && !is_tc_token_expired_with(entry.token_timestamp, &tc_config) =>

--- a/src/session.rs
+++ b/src/session.rs
@@ -222,7 +222,8 @@ mod tests {
                 |jid| jid.user == "has_session", // Only "has_session" has a session
                 move |batch| {
                     let jids = fetched_jids_clone.clone();
-                    let batch_users: Vec<String> = batch.iter().map(|j| j.user.clone()).collect();
+                    let batch_users: Vec<String> =
+                        batch.iter().map(|j| j.user.to_string()).collect();
                     async move {
                         jids.lock().unwrap().extend(batch_users);
                         Ok(())

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -142,7 +142,7 @@ impl Client {
                 }
 
                 let device_list = wacore::store::traits::DeviceListRecord {
-                    user: user_list.user.user.clone(),
+                    user: user_list.user.user.to_string(),
                     devices,
                     timestamp: wacore::time::now_secs(),
                     phash: user_list.phash.clone(),

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -209,13 +209,13 @@ impl TestClient {
     /// available, otherwise it falls back to the phone-number user part.
     pub async fn tc_token_key(&self) -> anyhow::Result<String> {
         if let Some(lid) = self.client.get_lid().await {
-            return Ok(lid.user);
+            return Ok(lid.user.to_string());
         }
 
         self.client
             .get_pn()
             .await
-            .map(|jid| jid.user)
+            .map(|jid| jid.user.to_string())
             .ok_or_else(|| anyhow::anyhow!("Client should have a JID after connect"))
     }
 

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -187,13 +187,7 @@ impl User {
                 .unwrap();
         });
 
-        let jid = Jid {
-            user: user.to_string(),
-            server: wacore_binary::jid::cow_server_from_str(server),
-            device: 0,
-            agent: 0,
-            integrator: 0,
-        };
+        let jid = Jid::new(user, server);
         let address = jid.to_protocol_address();
 
         Self {

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -16,9 +16,10 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["simd"]
 simd = []
-serde = ["dep:serde"]
+serde = ["dep:serde", "compact_str/serde"]
 
 [dependencies]
+compact_str = { workspace = true }
 flate2 = { workspace = true }
 phf = { version = "0.13.1", default-features = false }
 serde = { workspace = true, optional = true }

--- a/wacore/binary/src/builder.rs
+++ b/wacore/binary/src/builder.rs
@@ -51,7 +51,7 @@ impl NodeBuilder {
         self
     }
 
-    pub fn string_content(mut self, s: impl Into<String>) -> Self {
+    pub fn string_content(mut self, s: impl Into<crate::CompactString>) -> Self {
         self.content = Some(NodeContent::String(s.into()));
         self
     }

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -507,7 +507,7 @@ mod tests {
         let node = Node::new(
             "message",
             Attrs::new(),
-            Some(crate::node::NodeContent::String("receipt".to_string())),
+            Some(crate::node::NodeContent::String("receipt".into())),
         );
 
         let mut buffer = Vec::new();
@@ -537,7 +537,7 @@ mod tests {
         let node = Node::new(
             "test",
             Attrs::new(),
-            Some(crate::node::NodeContent::String(test_str.to_string())),
+            Some(crate::node::NodeContent::String(test_str.into())),
         );
 
         let mut buffer = Vec::new();

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -938,7 +938,7 @@ mod tests {
         let node = Node::new(
             "message",
             Attrs::new(),
-            Some(NodeContent::String("receipt".to_string())),
+            Some(NodeContent::String("receipt".into())),
         );
 
         let mut buffer = Vec::new();
@@ -958,7 +958,7 @@ mod tests {
         let node = Node::new(
             "test",
             Attrs::new(),
-            Some(NodeContent::String(test_str.to_string())),
+            Some(NodeContent::String(test_str.into())),
         );
 
         let mut buffer = Vec::new();
@@ -1166,7 +1166,7 @@ mod tests {
         attrs.insert("key", ""); // Empty value
         attrs.insert("", "value"); // Empty key
 
-        let node = Node::new("test", attrs, Some(NodeContent::String("".to_string())));
+        let node = Node::new("test", attrs, Some(NodeContent::String("".into())));
 
         let mut buffer = Vec::new();
         let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
@@ -1178,11 +1178,11 @@ mod tests {
         assert_eq!(decoded.tag, "test");
         assert_eq!(
             decoded.attrs.get("key"),
-            Some(&NodeValue::String("".to_string()))
+            Some(&NodeValue::String("".into()))
         );
         assert_eq!(
             decoded.attrs.get(""),
-            Some(&NodeValue::String("value".to_string()))
+            Some(&NodeValue::String("value".into()))
         );
 
         // Empty strings are encoded as BINARY_8 + 0, which decodes as empty bytes
@@ -1230,7 +1230,7 @@ mod tests {
         let node = Node::new(
             "msg",
             Attrs::new(),
-            Some(NodeContent::String(long_text.clone())),
+            Some(NodeContent::String(long_text.as_str().into())),
         );
         let mut buffer = Vec::new();
         let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
@@ -1257,11 +1257,7 @@ mod tests {
         use crate::decoder::Decoder;
 
         let value = "foo:bar@s.whatsapp.net";
-        let node = Node::new(
-            "msg",
-            Attrs::new(),
-            Some(NodeContent::String(value.to_string())),
-        );
+        let node = Node::new("msg", Attrs::new(), Some(NodeContent::String(value.into())));
 
         let mut buffer = Vec::new();
         let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
@@ -1281,11 +1277,7 @@ mod tests {
         use crate::decoder::Decoder;
 
         let value = "hello_world@s.whatsapp.net";
-        let node = Node::new(
-            "msg",
-            Attrs::new(),
-            Some(NodeContent::String(value.to_string())),
-        );
+        let node = Node::new("msg", Attrs::new(), Some(NodeContent::String(value.into())));
 
         let mut buffer = Vec::new();
         let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
@@ -269,7 +270,7 @@ pub trait JidExt {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Jid {
-    pub user: String,
+    pub user: CompactString,
     pub server: Cow<'static, str>,
     pub agent: u8,
     pub device: u16,
@@ -301,7 +302,7 @@ impl JidExt for Jid {
 }
 
 impl Jid {
-    pub fn new(user: impl Into<String>, server: &str) -> Self {
+    pub fn new(user: impl Into<CompactString>, server: &str) -> Self {
         Self {
             user: user.into(),
             server: cow_server_from_str(server),
@@ -310,7 +311,7 @@ impl Jid {
     }
 
     /// Create a phone number JID (s.whatsapp.net)
-    pub fn pn(user: impl Into<String>) -> Self {
+    pub fn pn(user: impl Into<CompactString>) -> Self {
         Self {
             user: user.into(),
             server: Cow::Borrowed(DEFAULT_USER_SERVER),
@@ -319,7 +320,7 @@ impl Jid {
     }
 
     /// Create a LID JID (lid server)
-    pub fn lid(user: impl Into<String>) -> Self {
+    pub fn lid(user: impl Into<CompactString>) -> Self {
         Self {
             user: user.into(),
             server: Cow::Borrowed(HIDDEN_USER_SERVER),
@@ -330,7 +331,7 @@ impl Jid {
     /// Creates the `status@broadcast` JID used for status/story updates.
     pub fn status_broadcast() -> Self {
         Self {
-            user: STATUS_BROADCAST_USER.to_string(),
+            user: CompactString::from(STATUS_BROADCAST_USER),
             server: Cow::Borrowed(BROADCAST_SERVER),
             agent: 0,
             device: 0,
@@ -339,7 +340,7 @@ impl Jid {
     }
 
     /// Create a group JID (g.us).
-    pub fn group(id: impl Into<String>) -> Self {
+    pub fn group(id: impl Into<CompactString>) -> Self {
         Self {
             user: id.into(),
             server: Cow::Borrowed(GROUP_SERVER),
@@ -348,7 +349,7 @@ impl Jid {
     }
 
     /// Create a newsletter (channel) JID (newsletter server).
-    pub fn newsletter(id: impl Into<String>) -> Self {
+    pub fn newsletter(id: impl Into<CompactString>) -> Self {
         Self {
             user: id.into(),
             server: Cow::Borrowed(NEWSLETTER_SERVER),
@@ -357,7 +358,7 @@ impl Jid {
     }
 
     /// Create a phone number JID with device ID
-    pub fn pn_device(user: impl Into<String>, device: u16) -> Self {
+    pub fn pn_device(user: impl Into<CompactString>, device: u16) -> Self {
         Self {
             user: user.into(),
             server: Cow::Borrowed(DEFAULT_USER_SERVER),
@@ -367,7 +368,7 @@ impl Jid {
     }
 
     /// Create a LID JID with device ID
-    pub fn lid_device(user: impl Into<String>, device: u16) -> Self {
+    pub fn lid_device(user: impl Into<CompactString>, device: u16) -> Self {
         Self {
             user: user.into(),
             server: Cow::Borrowed(HIDDEN_USER_SERVER),
@@ -514,7 +515,7 @@ impl<'a> JidRef<'a> {
 
     pub fn to_owned(&self) -> Jid {
         Jid {
-            user: self.user.to_string(),
+            user: CompactString::from(self.user.as_ref()),
             server: cow_server_from_str(&self.server),
             agent: self.agent,
             device: self.device,
@@ -548,7 +549,7 @@ impl FromStr for Jid {
         // Try fast path first for well-formed JIDs
         if let Some(parts) = parse_jid_fast(s) {
             return Ok(Jid {
-                user: parts.user.to_string(),
+                user: CompactString::from(parts.user),
                 server: cow_server_from_str(parts.server),
                 agent: parts.agent,
                 device: parts.device,
@@ -594,7 +595,7 @@ impl FromStr for Jid {
                 (user_part, 0)
             };
             return Ok(Jid {
-                user: user.to_string(),
+                user: CompactString::from(user),
                 server: cow_server_from_str(server),
                 device,
                 agent: 0,
@@ -639,7 +640,7 @@ impl FromStr for Jid {
         }
 
         Ok(Jid {
-            user: user.to_string(),
+            user: CompactString::from(user),
             server: cow_server_from_str(server),
             agent,
             device,
@@ -847,7 +848,7 @@ mod tests {
         // Failure Case 1: An AD-JID for s.whatsapp.net decoded with an agent.
         // The Display trait MUST NOT show the agent number.
         let jid1 = Jid {
-            user: "1234567890".to_string(),
+            user: "1234567890".into(),
             server: Cow::Borrowed("s.whatsapp.net"),
             device: 15,
             agent: 2, // This agent would be decoded from binary but should be ignored in display
@@ -860,7 +861,7 @@ mod tests {
         // Failure Case 2: A LID JID with a device, decoded with an agent.
         // The Display trait MUST NOT show the agent number.
         let jid2 = Jid {
-            user: "12345.6789".to_string(),
+            user: "12345.6789".into(),
             server: Cow::Borrowed("lid"),
             device: 25,
             agent: 1, // This agent would be decoded from binary but should be ignored in display
@@ -873,7 +874,7 @@ mod tests {
         // Failure Case 3: A JID that was decoded as "hosted" because of its agent.
         // The Display trait MUST NOT show the agent number.
         let jid3 = Jid {
-            user: "1234567890".to_string(),
+            user: "1234567890".into(),
             server: Cow::Borrowed("hosted"),
             device: 15,
             agent: 2,
@@ -885,7 +886,7 @@ mod tests {
 
         // Verification Case: A generic JID where the agent SHOULD be displayed.
         let jid4 = Jid {
-            user: "user".to_string(),
+            user: "user".into(),
             server: Cow::Owned("custom.net".to_string()),
             device: 10,
             agent: 5,

--- a/wacore/binary/src/lib.rs
+++ b/wacore/binary/src/lib.rs
@@ -13,6 +13,7 @@ pub mod token;
 pub mod util;
 
 pub use attrs::{AttrParser, AttrParserRef};
+pub use compact_str::CompactString;
 pub use error::{BinaryError, Result};
 pub use marshal::{
     marshal, marshal_auto, marshal_exact, marshal_ref, marshal_ref_auto, marshal_ref_exact,

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -267,7 +267,7 @@ mod tests {
                 Node::new(
                     "text",
                     Attrs::new(),
-                    Some(NodeContent::String("hello".repeat(40))),
+                    Some(NodeContent::String("hello".repeat(40).into())),
                 ),
             ])),
         )

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -1,6 +1,7 @@
 use crate::attrs::{AttrParser, AttrParserRef};
 use crate::jid::{Jid, JidRef};
 use crate::token;
+use compact_str::CompactString;
 use std::borrow::Cow;
 
 /// Intern a string as a `Cow::Borrowed(&'static str)` if it matches a known token,
@@ -26,13 +27,13 @@ fn intern_cow(s: &str) -> Cow<'static, str> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum NodeValue {
-    String(String),
+    String(CompactString),
     Jid(Jid),
 }
 
 impl Default for NodeValue {
     fn default() -> Self {
-        NodeValue::String(String::new())
+        NodeValue::String(CompactString::default())
     }
 }
 
@@ -123,21 +124,28 @@ impl PartialEq<String> for NodeValue {
 impl From<String> for NodeValue {
     #[inline]
     fn from(s: String) -> Self {
-        NodeValue::String(s)
+        NodeValue::String(CompactString::from(s))
     }
 }
 
 impl From<&str> for NodeValue {
     #[inline]
     fn from(s: &str) -> Self {
-        NodeValue::String(s.to_string())
+        NodeValue::String(CompactString::from(s))
     }
 }
 
 impl From<&String> for NodeValue {
     #[inline]
     fn from(s: &String) -> Self {
-        NodeValue::String(s.clone())
+        NodeValue::String(CompactString::from(s.as_str()))
+    }
+}
+
+impl From<CompactString> for NodeValue {
+    #[inline]
+    fn from(s: CompactString) -> Self {
+        NodeValue::String(s)
     }
 }
 
@@ -328,7 +336,7 @@ pub type NodeVec<'a> = Vec<NodeRef<'a>>;
 #[derive(Debug, Clone, PartialEq)]
 pub enum NodeContent {
     Bytes(Vec<u8>),
-    String(String),
+    String(CompactString),
     Nodes(Vec<Node>),
 }
 
@@ -344,7 +352,7 @@ impl NodeContent {
     pub fn as_content_ref(&self) -> NodeContentRef<'_> {
         match self {
             NodeContent::Bytes(b) => NodeContentRef::Bytes(Cow::Borrowed(b)),
-            NodeContent::String(s) => NodeContentRef::String(Cow::Borrowed(s)),
+            NodeContent::String(s) => NodeContentRef::String(Cow::Borrowed(s.as_str())),
             NodeContent::Nodes(nodes) => {
                 NodeContentRef::Nodes(Box::new(nodes.iter().map(|n| n.as_node_ref()).collect()))
             }
@@ -446,10 +454,12 @@ impl Node {
     }
 
     /// Extract text content, handling both String and Bytes (lossy UTF-8).
-    pub fn content_as_string(&self) -> Option<String> {
+    pub fn content_as_string(&self) -> Option<CompactString> {
         match &self.content {
             Some(NodeContent::String(s)) => Some(s.clone()),
-            Some(NodeContent::Bytes(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            Some(NodeContent::Bytes(b)) => {
+                Some(CompactString::from(String::from_utf8_lossy(b).as_ref()))
+            }
             _ => None,
         }
     }
@@ -526,7 +536,7 @@ impl<'a> NodeRef<'a> {
                 .iter()
                 .map(|(k, v)| {
                     let value = match v {
-                        ValueRef::String(s) => NodeValue::String(s.to_string()),
+                        ValueRef::String(s) => NodeValue::String(CompactString::from(s.as_ref())),
                         ValueRef::Jid(j) => NodeValue::Jid(j.to_owned()),
                     };
                     (intern_cow(k), value)
@@ -534,7 +544,7 @@ impl<'a> NodeRef<'a> {
                 .collect::<Attrs>(),
             content: self.content.as_deref().map(|c| match c {
                 NodeContentRef::Bytes(b) => NodeContent::Bytes(b.to_vec()),
-                NodeContentRef::String(s) => NodeContent::String(s.to_string()),
+                NodeContentRef::String(s) => NodeContent::String(CompactString::from(s.as_ref())),
                 NodeContentRef::Nodes(nodes) => {
                     NodeContent::Nodes(nodes.iter().map(|n| n.to_owned()).collect())
                 }

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -2,13 +2,14 @@ use crate::libsignal::protocol::PreKeyBundle;
 use crate::types::message::AddressingMode;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use wacore_binary::CompactString;
 use wacore_binary::jid::Jid;
 
-fn build_pn_to_lid_map(lid_to_pn_map: &HashMap<String, Jid>) -> HashMap<String, Jid> {
+fn build_pn_to_lid_map(lid_to_pn_map: &HashMap<CompactString, Jid>) -> HashMap<CompactString, Jid> {
     lid_to_pn_map
         .iter()
         .map(|(lid_user, phone_jid)| {
-            let lid_jid = Jid::lid(lid_user);
+            let lid_jid = Jid::lid(lid_user.clone());
             (phone_jid.user.clone(), lid_jid)
         })
         .collect()
@@ -21,10 +22,10 @@ pub struct GroupInfo {
     /// Maps a LID user identifier (the `user` part of the LID JID) to the
     /// corresponding phone-number JID. This is used for device queries since
     /// LID usync requests may not work reliably.
-    lid_to_pn_map: HashMap<String, Jid>,
+    lid_to_pn_map: HashMap<CompactString, Jid>,
     /// Reverse mapping: phone number (user part) to LID JID.
     /// This is used to convert device JIDs back to LID format after device resolution.
-    pn_to_lid_map: HashMap<String, Jid>,
+    pn_to_lid_map: HashMap<CompactString, Jid>,
 }
 
 impl GroupInfo {
@@ -46,7 +47,7 @@ impl GroupInfo {
     pub fn with_lid_to_pn_map(
         participants: Vec<Jid>,
         addressing_mode: AddressingMode,
-        lid_to_pn_map: HashMap<String, Jid>,
+        lid_to_pn_map: HashMap<CompactString, Jid>,
     ) -> Self {
         let pn_to_lid_map = build_pn_to_lid_map(&lid_to_pn_map);
 
@@ -59,13 +60,13 @@ impl GroupInfo {
     }
 
     /// Replace the current LID-to-phone mapping.
-    pub fn set_lid_to_pn_map(&mut self, lid_to_pn_map: HashMap<String, Jid>) {
+    pub fn set_lid_to_pn_map(&mut self, lid_to_pn_map: HashMap<CompactString, Jid>) {
         self.pn_to_lid_map = build_pn_to_lid_map(&lid_to_pn_map);
         self.lid_to_pn_map = lid_to_pn_map;
     }
 
     /// Access the LID-to-phone mapping.
-    pub fn lid_to_pn_map(&self) -> &HashMap<String, Jid> {
+    pub fn lid_to_pn_map(&self) -> &HashMap<CompactString, Jid> {
         &self.lid_to_pn_map
     }
 
@@ -94,7 +95,7 @@ impl GroupInfo {
                 && let Some(pn) = phone_number
             {
                 self.pn_to_lid_map
-                    .insert(pn.user.clone(), Jid::lid(&jid.user));
+                    .insert(pn.user.clone(), Jid::lid(jid.user.clone()));
                 self.lid_to_pn_map.insert(jid.user.clone(), pn.clone());
             }
 
@@ -128,7 +129,7 @@ impl GroupInfo {
         if phone_device_jid.is_pn()
             && let Some(lid_base) = self.lid_jid_for_phone_user(&phone_device_jid.user)
         {
-            return Jid::lid_device(&lid_base.user, phone_device_jid.device);
+            return Jid::lid_device(lid_base.user.clone(), phone_device_jid.device);
         }
         phone_device_jid.clone()
     }
@@ -221,8 +222,8 @@ mod tests {
     #[test]
     fn remove_participants_cleans_lid_maps() {
         let lid_to_pn = HashMap::from([
-            ("lid_alice".to_string(), pn("alice_pn")),
-            ("lid_bob".to_string(), pn("bob_pn")),
+            (CompactString::from("lid_alice"), pn("alice_pn")),
+            (CompactString::from("lid_bob"), pn("bob_pn")),
         ]);
         let mut info = GroupInfo::with_lid_to_pn_map(
             vec![lid("lid_alice"), lid("lid_bob")],

--- a/wacore/src/iq/business.rs
+++ b/wacore/src/iq/business.rs
@@ -54,7 +54,7 @@ impl serde::Serialize for BusinessHourMode {
 
 fn node_text(node: &Node) -> Option<String> {
     match &node.content {
-        Some(NodeContent::String(s)) => Some(s.clone()),
+        Some(NodeContent::String(s)) => Some(s.to_string()),
         Some(NodeContent::Bytes(b)) => String::from_utf8(b.clone()).ok(),
         _ => None,
     }

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -643,7 +643,8 @@ impl ProtocolNode for GroupInfoResponse {
         let description_node = node.get_optional_child_by_tag(&["description"]);
         let description = description_node
             .and_then(|n| n.get_optional_child("body"))
-            .and_then(|body| body.content_as_string());
+            .and_then(|body| body.content_as_string())
+            .map(|s| s.to_string());
         let description_id = description_node
             .and_then(|n| n.attrs().optional_string("id"))
             .map(|s| s.to_string());

--- a/wacore/src/iq/profile.rs
+++ b/wacore/src/iq/profile.rs
@@ -38,7 +38,7 @@ impl IqSpec for SetStatusTextSpec {
             Some(NodeContent::Nodes(vec![Node {
                 tag: Cow::Borrowed("status"),
                 attrs: Default::default(),
-                content: Some(NodeContent::String(self.text.clone())),
+                content: Some(NodeContent::String(self.text.as_str().into())),
             }])),
         )
     }

--- a/wacore/src/iq/spam_report.rs
+++ b/wacore/src/iq/spam_report.rs
@@ -58,7 +58,7 @@ impl IqSpec for SpamReportSpec {
         let report_id = response
             .get_optional_child_by_tag(&["report_id"])
             .and_then(|n| match &n.content {
-                Some(NodeContent::String(s)) => Some(s.clone()),
+                Some(NodeContent::String(s)) => Some(s.to_string()),
                 _ => None,
             });
 

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -100,7 +100,7 @@ fn build_user_nodes(users: &[IsOnWhatsAppUser]) -> Vec<Node> {
         .map(|user| {
             if user.jid.is_pn() {
                 let phone = if user.jid.user.starts_with('+') {
-                    user.jid.user.clone()
+                    user.jid.user.to_string()
                 } else {
                     format!("+{}", user.jid.user)
                 };
@@ -153,7 +153,7 @@ fn parse_user_common_fields(user_node: &Node) -> Option<ParsedUserFields> {
                 return None;
             }
             match &status_node.content {
-                Some(NodeContent::String(s)) if !s.is_empty() => Some(s.clone()),
+                Some(NodeContent::String(s)) if !s.is_empty() => Some(s.to_string()),
                 _ => None,
             }
         });

--- a/wacore/src/message_processing.rs
+++ b/wacore/src/message_processing.rs
@@ -277,7 +277,7 @@ mod tests {
 
     fn make_enc_node(enc_type: &str, content: &[u8]) -> Node {
         let mut attrs = Attrs::new();
-        attrs.insert("type", NodeValue::String(enc_type.to_string()));
+        attrs.insert("type", NodeValue::from(enc_type));
         Node::new("enc", attrs, Some(NodeContent::Bytes(content.to_vec())))
     }
 
@@ -289,15 +289,15 @@ mod tests {
         v: Option<u64>,
     ) -> Node {
         let mut attrs = Attrs::new();
-        attrs.insert("type", NodeValue::String(enc_type.to_string()));
+        attrs.insert("type", NodeValue::from(enc_type));
         if let Some(c) = count {
-            attrs.insert("count", NodeValue::String(c.to_string()));
+            attrs.insert("count", NodeValue::from(c.to_string()));
         }
         if let Some(df) = decrypt_fail {
-            attrs.insert("decrypt-fail", NodeValue::String(df.to_string()));
+            attrs.insert("decrypt-fail", NodeValue::from(df));
         }
         if let Some(ver) = v {
-            attrs.insert("v", NodeValue::String(ver.to_string()));
+            attrs.insert("v", NodeValue::from(ver.to_string()));
         }
         Node::new("enc", attrs, Some(NodeContent::Bytes(content.to_vec())))
     }
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn test_categorize_missing_content() {
         let mut attrs = Attrs::new();
-        attrs.insert("type", NodeValue::String("msg".to_string()));
+        attrs.insert("type", NodeValue::from("msg"));
         let node = Node::new("enc", attrs, None);
         let nodes: Vec<&Node> = vec![&node];
 

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -1,6 +1,7 @@
 use crate::libsignal::protocol::{IdentityKey, PreKeyBundle, PreKeyId, PublicKey, SignedPreKeyId};
 use crate::xml::DisplayableNode;
 use std::collections::HashMap;
+use wacore_binary::CompactString;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::jid::Jid;
 use wacore_binary::node::{Node, NodeContent};
@@ -114,7 +115,7 @@ impl PreKeyUtils {
                 && let Some((user_base, device_str)) = jid.user.split_once(':')
                 && let Ok(device) = device_str.parse::<u16>()
             {
-                jid.user = user_base.to_string();
+                jid.user = CompactString::from(user_base);
                 jid.device = device;
             }
             let bundle = match Self::node_to_pre_key_bundle(&jid, user_node) {
@@ -311,7 +312,7 @@ mod tests {
             .into_node();
 
         let raw_jid = Jid {
-            user: "100000012345678:33".to_string(),
+            user: "100000012345678:33".into(),
             server: Cow::Borrowed("lid"),
             agent: 1,
             device: 0,

--- a/wacore/src/protocol/retry.rs
+++ b/wacore/src/protocol/retry.rs
@@ -123,7 +123,7 @@ mod tests {
         let node = Node {
             tag: Cow::Borrowed("test"),
             attrs: Attrs::new(),
-            content: Some(NodeContent::String("hello".to_string())),
+            content: Some(NodeContent::String("hello".into())),
         };
         assert_eq!(get_bytes_content(&node), None);
     }

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1240,7 +1240,7 @@ pub async fn prepare_group_stanza<
         if let Some(ref dist) = distribution_list {
             for d in dist {
                 if !encrypted_set.contains(d) {
-                    user_set.insert(d.user.clone());
+                    user_set.insert(d.user.to_string());
                 }
             }
         }
@@ -1313,12 +1313,13 @@ pub fn ensure_status_participants(
         // <participants> already exists (from SKDM distribution).
         // Add bare <to> user JID entries for users whose devices are NOT
         // already represented by SKDM device-level entries.
-        let existing_users: std::collections::HashSet<String> = participants_node
-            .children()
-            .unwrap_or_default()
-            .iter()
-            .filter_map(|n| n.attrs.get("jid").and_then(|v| v.to_jid()).map(|j| j.user))
-            .collect();
+        let existing_users: std::collections::HashSet<wacore_binary::CompactString> =
+            participants_node
+                .children()
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|n| n.attrs.get("jid").and_then(|v| v.to_jid()).map(|j| j.user))
+                .collect();
 
         let new_to_nodes: Vec<Node> = bare_to_nodes
             .into_iter()
@@ -1850,7 +1851,10 @@ mod tests {
         let pn_device_jid = Jid::pn_device(phone, device_id);
 
         // Step 1: Look up LID for the phone number (using direct HashMap access)
-        let lid_user = resolver.phone_to_lid.get(&pn_device_jid.user).cloned();
+        let lid_user = resolver
+            .phone_to_lid
+            .get(pn_device_jid.user.as_str())
+            .cloned();
         assert!(lid_user.is_some(), "Should find LID for phone");
         let lid_user = lid_user.expect("phone should have LID mapping");
 
@@ -1900,7 +1904,10 @@ mod tests {
         let pn_device_jid = Jid::pn_device(phone, companion_device_id);
 
         // Look up LID using direct HashMap access
-        let lid_user = resolver.phone_to_lid.get(&pn_device_jid.user).cloned();
+        let lid_user = resolver
+            .phone_to_lid
+            .get(pn_device_jid.user.as_str())
+            .cloned();
 
         // Construct LID JID
         let lid_jid = Jid::lid_device(

--- a/wacore/src/stanza/business.rs
+++ b/wacore/src/stanza/business.rs
@@ -59,7 +59,7 @@ impl VerifiedName {
             .or_else(|| {
                 node.get_optional_child_by_tag(&["name"])
                     .and_then(|n| match &n.content {
-                        Some(NodeContent::String(s)) => Some(s.clone()),
+                        Some(NodeContent::String(s)) => Some(s.to_string()),
                         _ => None,
                     })
             });
@@ -262,7 +262,7 @@ impl BusinessNotification {
                     && let Some(id_node) = child.get_optional_child_by_tag(&["id"])
                     && let Some(NodeContent::String(id)) = &id_node.content
                 {
-                    product_ids.push(id.clone());
+                    product_ids.push(id.to_string());
                 } else if child.tag == "collection"
                     && let Some(id) = child.attrs().optional_string("id")
                 {

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -277,6 +277,7 @@ fn parse_action(node: &Node) -> Option<GroupNotificationAction> {
             } else {
                 node.get_optional_child("body")
                     .and_then(|body| body.content_as_string())
+                    .map(|s| s.to_string())
             };
             GroupNotificationAction::Description { id, description }
         }
@@ -308,7 +309,7 @@ fn parse_action(node: &Node) -> Option<GroupNotificationAction> {
         }
         "member_add_mode" => {
             let mode = match &node.content {
-                Some(NodeContent::String(s)) => s.clone(),
+                Some(NodeContent::String(s)) => s.to_string(),
                 Some(NodeContent::Bytes(b)) => String::from_utf8_lossy(b).into_owned(),
                 _ => String::new(),
             };

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -64,6 +64,16 @@ struct InMemoryState {
     device: Option<Device>,
 }
 
+/// Default TTL for sent messages (seconds). Matches the client's
+/// `sent_message_ttl_secs` default of 300s.
+const DEFAULT_SENT_MESSAGE_TTL_SECS: i64 = 300;
+
+/// Eviction runs inline when the map exceeds this many entries.
+const SENT_MESSAGE_EVICT_THRESHOLD: usize = 64;
+
+/// Minimum interval between eviction scans (seconds).
+const SENT_MESSAGE_EVICT_INTERVAL_SECS: i64 = 30;
+
 /// In-memory implementation of the full [`Backend`] trait.
 ///
 /// Thread-safe and runtime-agnostic (uses [`async_lock::Mutex`]).
@@ -71,6 +81,8 @@ struct InMemoryState {
 pub struct InMemoryBackend {
     state: Mutex<InMemoryState>,
     next_device_id: AtomicI32,
+    sent_message_ttl_secs: i64,
+    last_eviction: std::sync::atomic::AtomicI64,
 }
 
 impl InMemoryBackend {
@@ -79,7 +91,17 @@ impl InMemoryBackend {
         Self {
             state: Mutex::new(InMemoryState::default()),
             next_device_id: AtomicI32::new(1),
+            sent_message_ttl_secs: DEFAULT_SENT_MESSAGE_TTL_SECS,
+            last_eviction: std::sync::atomic::AtomicI64::new(0),
         }
+    }
+
+    /// Create with a custom sent-message TTL. Values ≤ 0 are ignored.
+    pub fn with_sent_message_ttl(mut self, ttl_secs: i64) -> Self {
+        if ttl_secs > 0 {
+            self.sent_message_ttl_secs = ttl_secs;
+        }
+        self
     }
 }
 
@@ -478,7 +500,24 @@ impl ProtocolStore for InMemoryBackend {
         payload: &[u8],
     ) -> Result<()> {
         let now = crate::time::now_secs();
-        self.state.lock().await.sent_messages.insert(
+        let mut s = self.state.lock().await;
+
+        // Amortized eviction: only scan when the map is large AND enough time
+        // has passed since the last eviction to avoid O(n) work on every insert.
+        if s.sent_messages.len() >= SENT_MESSAGE_EVICT_THRESHOLD {
+            let last = self
+                .last_eviction
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let interval = SENT_MESSAGE_EVICT_INTERVAL_SECS.min(self.sent_message_ttl_secs);
+            if now - last >= interval {
+                let cutoff = now - self.sent_message_ttl_secs;
+                s.sent_messages.retain(|_, e| e.timestamp >= cutoff);
+                self.last_eviction
+                    .store(now, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+
+        s.sent_messages.insert(
             (chat_jid.to_string(), message_id.to_string()),
             SentMessageEntry {
                 payload: payload.to_vec(),

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -7,9 +7,9 @@ use wacore_binary::node::Node;
 #[derive(Debug, Clone)]
 pub struct UsyncLidMapping {
     /// The phone number user part (e.g., "559980000001")
-    pub phone_number: String,
+    pub phone_number: wacore_binary::CompactString,
     /// The LID user part (e.g., "100000012345678")
-    pub lid: String,
+    pub lid: wacore_binary::CompactString,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- Replace `String` with `CompactString` in `NodeValue::String`, `NodeContent::String`, and `Jid.user` to eliminate heap allocations for short strings (≤ 24 bytes stored inline)
- Add inline TTL-based eviction to `InMemoryBackend::store_sent_message` to cap unbounded growth
- Switch benchmark example to `InMemoryBackend` instead of `SqliteStore`

## Profiling results

Measured with heaptrack against a real WhatsApp session (benchmark example via bartender mock server):

| Metric | Before | After | Change |
|---|---|---|---|
| Peak heap | 7.90 MB | 5.15–5.24 MB | **-34%** |
| Peak RSS | 32.57 MB | 28.28–28.57 MB | **-13%** |
| Total allocations | 6,030,336 | 5,406,579 | -10.3% |

The two largest allocation sites from the baseline — `Attrs::FromIterator` at 1.88 MB and 750 KB (cloning `(Cow<str>, NodeValue)` tuples during `NodeRef::to_owned()`) — no longer appear in the top 15 peak consumers. `to_owned()` still allocates (Vec containers, byte content, long strings > 24 chars), but it is no longer a top-tier memory problem.

## Why CompactString

`CompactString` (`compact_str` crate) has the same `size_of` as `String` (24 bytes on x86_64) but stores strings ≤ 24 bytes inline — zero heap allocation. PoC benchmarks showed:

- 90.9% of `NodeValue::String` values are ≤ 24 chars (protocol values like `"msg"`, `"pkmsg"`, `"text"`, timestamps)
- 100% of `Jid.user` values (phone numbers, 10-15 chars) fit inline
- Only message IDs (32 chars) spill to heap

Tags and attribute keys keep `Cow<'static, str>` + `intern_cow()` — already zero-alloc for tokenized strings via static references.

## Breaking changes

- `NodeValue::String` wraps `CompactString` instead of `String`
- `NodeContent::String` wraps `CompactString` instead of `String`
- `Jid.user` is `CompactString` instead of `String`
- Jid factory methods take `impl Into<CompactString>` instead of `impl Into<String>`

### Migration guide

**Construction** — all existing patterns still work:
```rust
NodeValue::from("text")           // &str → CompactString (inline)
NodeValue::from(some_string)      // String → CompactString
Jid::pn("12345")                  // same as before
"user@server".parse::<Jid>()?     // same as before
```

**Pattern matching** — `CompactString` derefs to `&str`:
```rust
match value {
    NodeValue::String(s) => {
        // s: CompactString, but all &str methods work via Deref
        s.starts_with("pkmsg")  // works
        s == "text"             // works
    }
}
```

**When you need `String`**:
```rust
jid.user.to_string()              // CompactString → String
map.get(jid.user.as_str())        // for HashMap<String, _> lookups
```

`CompactString` is re-exported from both `wacore_binary::CompactString` and `whatsapp_rust::CompactString`.

## Test plan

- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo test -p wacore-binary -p wacore -p whatsapp-rust` — all passing
- [x] `cargo check -p wacore-binary --all-features` — serde feature verified
- [x] heaptrack profiling (3 runs) confirms consistent ~34% peak heap reduction
- [ ] CI / e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-memory message store gains configurable sent-message TTL with automatic time-based eviction.

* **Chores**
  * Example benchmark switched to the in-memory backend.
  * Workspace adopts a compact string type across crates; several public APIs now expose or return this compact string form (may affect downstream integrations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->