### PR TITLE
perf: single-buffer ProtocolAddress + reusable hot-loop address construction

### DIFF
--- a/.github/scripts/bench-comment.py
+++ b/.github/scripts/bench-comment.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 
-THRESHOLD = 0.05  # 5%
+THRESHOLD = 0.02  # 2%
 
 
 def load_baseline(data_js_path: str, bench_name: str) -> dict[str, int]:
@@ -84,7 +84,9 @@ def main():
     lines.append("## Benchmark Results\n")
 
     if regressions:
-        lines.append(f"**{len(regressions)} regression(s)** detected (>{THRESHOLD*100:.0f}% threshold):\n")
+        lines.append(
+            f"**{len(regressions)} regression(s)** detected (>{THRESHOLD * 100:.0f}% threshold):\n"
+        )
         lines.append("| Benchmark | Current | Baseline | Change |")
         lines.append("|-----------|---------|----------|--------|")
         for r in regressions:
@@ -104,7 +106,9 @@ def main():
         lines.append("")
 
     if unchanged:
-        lines.append(f"<details>\n<summary>{len(unchanged)} unchanged benchmark(s)</summary>\n")
+        lines.append(
+            f"<details>\n<summary>{len(unchanged)} unchanged benchmark(s)</summary>\n"
+        )
         lines.append("| Benchmark | Current | Baseline | Change |")
         lines.append("|-----------|---------|----------|--------|")
         for r in unchanged:

--- a/src/send.rs
+++ b/src/send.rs
@@ -1515,7 +1515,7 @@ impl Client {
         jids: &[Jid],
     ) -> Vec<std::sync::Arc<async_lock::Mutex<()>>> {
         let mut mutexes = Vec::with_capacity(jids.len());
-        let mut buf = String::with_capacity(64);
+        let mut buf = wacore::types::jid::make_address_buffer();
         for jid in jids {
             wacore::types::jid::write_protocol_address_to(jid, &mut buf);
             mutexes.push(self.session_lock_for(&buf).await);

--- a/wacore/libsignal/src/core/address.rs
+++ b/wacore/libsignal/src/core/address.rs
@@ -276,33 +276,82 @@ where
 )]
 pub struct DeviceId(u32);
 
+impl DeviceId {
+    #[inline]
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+}
+
 impl fmt::Display for DeviceId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
+const fn digit_count(n: u32) -> usize {
+    if n == 0 {
+        return 1;
+    }
+    n.ilog10() as usize + 1
+}
+
+#[inline]
+fn append_device_suffix(buf: &mut String, device_id: DeviceId) {
+    let id = u32::from(device_id);
+    if id == 0 {
+        buf.push_str(".0");
+    } else {
+        use std::fmt::Write;
+        write!(buf, ".{id}").unwrap();
+    }
+}
+
+/// Single-buffer protocol address. The buffer stores `"{name}.{device_id}"` and
+/// `name_len` marks where the name ends, so `name()` and `as_str()` are both
+/// zero-cost slices. One String instead of two — halves allocation count for
+/// one-shot construction and eliminates the copy in `reset_with()`.
 #[derive(Clone, Debug)]
 pub struct ProtocolAddress {
-    name: String,
+    buf: String,
+    name_len: usize,
     device_id: DeviceId,
-    /// Pre-computed `"{name}.{device_id}"` — avoids allocation on every `to_string()`.
-    display: String,
 }
 
 impl ProtocolAddress {
     pub fn new(name: String, device_id: DeviceId) -> Self {
-        let display = format!("{name}.{device_id}");
-        ProtocolAddress {
-            name,
+        let name_len = name.len();
+        let mut buf = name;
+        append_device_suffix(&mut buf, device_id);
+        Self {
+            buf,
+            name_len,
             device_id,
-            display,
         }
+    }
+
+    /// Pre-allocated empty address. Call `reset_with()` to fill.
+    pub fn with_capacity(capacity: usize, device_id: DeviceId) -> Self {
+        let suffix_len = 1 + digit_count(u32::from(device_id));
+        Self {
+            buf: String::with_capacity(capacity + suffix_len),
+            name_len: 0,
+            device_id,
+        }
+    }
+
+    /// Write the name via closure, then append the device_id suffix.
+    /// Single write pass — no intermediate copy.
+    pub fn reset_with(&mut self, write_name: impl FnOnce(&mut String)) {
+        self.buf.clear();
+        write_name(&mut self.buf);
+        self.name_len = self.buf.len();
+        append_device_suffix(&mut self.buf, self.device_id);
     }
 
     #[inline]
     pub fn name(&self) -> &str {
-        &self.name
+        &self.buf[..self.name_len]
     }
 
     #[inline]
@@ -310,16 +359,15 @@ impl ProtocolAddress {
         self.device_id
     }
 
-    /// Returns the cached `"name.device_id"` string without allocation.
     #[inline]
     pub fn as_str(&self) -> &str {
-        &self.display
+        &self.buf
     }
 }
 
 impl PartialEq for ProtocolAddress {
     fn eq(&self, other: &Self) -> bool {
-        self.display == other.display
+        self.buf == other.buf
     }
 }
 
@@ -327,7 +375,7 @@ impl Eq for ProtocolAddress {}
 
 impl Hash for ProtocolAddress {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.display.hash(state);
+        self.buf.hash(state);
     }
 }
 
@@ -339,12 +387,12 @@ impl PartialOrd for ProtocolAddress {
 
 impl Ord for ProtocolAddress {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.display.cmp(&other.display)
+        self.buf.cmp(&other.buf)
     }
 }
 
 impl fmt::Display for ProtocolAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.display)
+        f.write_str(&self.buf)
     }
 }

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -365,6 +365,8 @@ where
     let mut jids_needing_prekeys = Vec::with_capacity(devices.len());
     let mut had_406 = false;
 
+    let mut reusable_addr = crate::types::jid::make_reusable_protocol_address();
+
     for device_jid in devices {
         // WhatsApp Web's SignalAddress.toString() normalizes PN → LID before
         // creating signal addresses. We do the same: check LID session FIRST.
@@ -374,11 +376,11 @@ where
         {
             // Construct the LID JID with the same device ID
             let lid_jid = Jid::lid_device(lid_user, device_jid.device);
-            let lid_address = lid_jid.to_protocol_address();
+            lid_jid.reset_protocol_address(&mut reusable_addr);
 
             if stores
                 .session_store
-                .load_session(&lid_address)
+                .load_session(&reusable_addr)
                 .await?
                 .is_some()
             {
@@ -394,10 +396,10 @@ where
         }
 
         // Fall back to direct address lookup (for LID JIDs or PN without LID mapping)
-        let signal_address = device_jid.to_protocol_address();
+        device_jid.reset_protocol_address(&mut reusable_addr);
         if stores
             .session_store
-            .load_session(&signal_address)
+            .load_session(&reusable_addr)
             .await?
             .is_some()
         {
@@ -491,14 +493,12 @@ where
                 encryption_jid.agent = 0;
             }
 
-            let signal_address = encryption_jid.to_protocol_address();
-            // Fix: Use the normalized device_jid to lookup the bundle
-            // Use centralized normalization logic to avoid mismatches
+            encryption_jid.reset_protocol_address(&mut reusable_addr);
             let lookup_jid = device_jid.normalize_for_prekey_bundle();
             match prekey_bundles.get(&lookup_jid) {
                 Some(bundle) => {
                     match process_prekey_bundle(
-                        &signal_address,
+                        &reusable_addr,
                         stores.session_store,
                         stores.identity_store,
                         bundle,
@@ -536,7 +536,7 @@ where
                             // Save the new identity (this replaces the old one)
                             if let Err(e) = stores
                                 .identity_store
-                                .save_identity(&signal_address, new_identity)
+                                .save_identity(&reusable_addr, new_identity)
                                 .await
                             {
                                 log::warn!(
@@ -554,7 +554,7 @@ where
 
                             // Retry processing the prekey bundle with the updated identity
                             match process_prekey_bundle(
-                                &signal_address,
+                                &reusable_addr,
                                 stores.session_store,
                                 stores.identity_store,
                                 bundle,
@@ -583,7 +583,7 @@ where
                             // Propagate other unexpected errors
                             return Err(anyhow::anyhow!(
                                 "Failed to process pre-key bundle for {}: {:?}",
-                                signal_address,
+                                reusable_addr,
                                 e
                             ));
                         }
@@ -592,7 +592,7 @@ where
                 None => {
                     log::warn!(
                         "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
-                        &signal_address
+                        &reusable_addr
                     );
                 }
             }
@@ -605,11 +605,11 @@ where
 
     for device_jid in devices {
         let encryption_jid = jid_to_encryption_jid.get(device_jid).unwrap_or(device_jid);
-        let signal_address = encryption_jid.to_protocol_address();
+        encryption_jid.reset_protocol_address(&mut reusable_addr);
 
         match message_encrypt(
             plaintext_to_encrypt,
-            &signal_address,
+            &reusable_addr,
             stores.session_store,
             stores.identity_store,
         )
@@ -645,7 +645,7 @@ where
             Err(e) => {
                 log::warn!(
                     "Failed to encrypt for device {}: {}. Skipping.",
-                    &signal_address,
+                    &reusable_addr,
                     e
                 );
             }

--- a/wacore/src/types/jid.rs
+++ b/wacore/src/types/jid.rs
@@ -1,14 +1,39 @@
-use crate::libsignal::protocol::ProtocolAddress;
-use wacore_binary::Jid;
+use crate::libsignal::protocol::{DeviceId, ProtocolAddress};
+use wacore_binary::{DEFAULT_USER_SERVER, Jid, LEGACY_USER_SERVER};
 
-/// Map server names to WhatsApp Web's internal Signal address format.
+/// Real WhatsApp logs show max signal address length of 53 chars.
+/// 64 bytes covers all known addresses without reallocation.
+const SIGNAL_ADDRESS_CAPACITY: usize = 64;
+
+/// WhatsApp encodes the device in the address name, not in the
+/// Signal device_id field. The device_id is always 0.
+const SIGNAL_DEVICE_ID: DeviceId = DeviceId::new(0);
+
+/// WA Web's Signal address format uses the legacy `c.us` server
+/// instead of `s.whatsapp.net`.
 #[inline]
 fn mapped_server(s: &str) -> &str {
-    if s == "s.whatsapp.net" { "c.us" } else { s }
+    if s == DEFAULT_USER_SERVER {
+        LEGACY_USER_SERVER
+    } else {
+        s
+    }
 }
 
-/// Write the protocol address lock key into `buf`, reusing its allocation.
-pub fn write_protocol_address_to(jid: &Jid, buf: &mut String) {
+/// Create a pre-allocated buffer for address formatting in hot loops.
+pub fn make_address_buffer() -> String {
+    String::with_capacity(SIGNAL_ADDRESS_CAPACITY)
+}
+
+/// Create a pre-allocated `ProtocolAddress` for hot loops.
+/// Call `reset_protocol_address` to fill without allocation.
+pub fn make_reusable_protocol_address() -> ProtocolAddress {
+    ProtocolAddress::with_capacity(SIGNAL_ADDRESS_CAPACITY, SIGNAL_DEVICE_ID)
+}
+
+/// Write the signal address name (`{user}[:device]@{server}`) into `buf`,
+/// clearing it first. All other address helpers delegate to this.
+pub fn write_signal_address_to(jid: &Jid, buf: &mut String) {
     use std::fmt::Write;
     buf.clear();
     let server = mapped_server(jid.server.as_str());
@@ -19,6 +44,11 @@ pub fn write_protocol_address_to(jid: &Jid, buf: &mut String) {
     }
     buf.push('@');
     buf.push_str(server);
+}
+
+/// Write the full protocol address (`{signal_address}.0`) into `buf`.
+pub fn write_protocol_address_to(jid: &Jid, buf: &mut String) {
+    write_signal_address_to(jid, buf);
     buf.push_str(".0");
 }
 
@@ -52,49 +82,34 @@ pub fn sort_dedup_by_device(jids: &mut Vec<Jid>) {
 
 pub trait JidExt {
     fn to_protocol_address(&self) -> ProtocolAddress;
-
-    /// Returns the Signal address string in WhatsApp Web format.
-    /// Format: `{user}[:device]@{server}`
-    /// - Device part `:device` only included when `device != 0`
-    /// - Examples: `123456789@lid`, `123456789:33@lid`, `5511999887766@c.us`
     fn to_signal_address_string(&self) -> String;
-
-    /// Returns the full protocol address string including the device_id suffix.
-    /// Format: `{signal_address_string}.0`
-    /// This is equivalent to `to_protocol_address().to_string()` but avoids
-    /// the intermediate ProtocolAddress allocation — one String instead of two.
     fn to_protocol_address_string(&self) -> String;
+
+    /// Rewrite a reusable `ProtocolAddress` in place for this JID.
+    /// Writes directly into the address — no intermediate buffer needed.
+    fn reset_protocol_address(&self, addr: &mut ProtocolAddress);
 }
 
 impl JidExt for Jid {
     fn to_signal_address_string(&self) -> String {
-        use std::fmt::Write;
-        let server = mapped_server(self.server.as_str());
-        let mut result = String::with_capacity(self.user.len() + 7 + server.len());
-        result.push_str(&self.user);
-        if self.device != 0 {
-            result.push(':');
-            let _ = write!(result, "{}", self.device);
-        }
-        result.push('@');
-        result.push_str(server);
-        result
+        let mut buf = make_address_buffer();
+        write_signal_address_to(self, &mut buf);
+        buf
     }
 
-    /// Build a `ProtocolAddress` for Signal session store lookups.
-    /// The device_id is always 0 — WhatsApp encodes the device in the name.
     fn to_protocol_address(&self) -> ProtocolAddress {
-        let name = self.to_signal_address_string();
-        ProtocolAddress::new(name, 0.into())
+        ProtocolAddress::new(self.to_signal_address_string(), SIGNAL_DEVICE_ID)
     }
 
     fn to_protocol_address_string(&self) -> String {
-        // Reuse to_signal_address_string() and append the fixed ".0" suffix.
-        // Reserves 2 extra bytes so the append doesn't reallocate.
-        let mut result = self.to_signal_address_string();
-        result.reserve(2);
-        result.push_str(".0");
-        result
+        let mut buf = make_address_buffer();
+        write_protocol_address_to(self, &mut buf);
+        buf
+    }
+
+    fn reset_protocol_address(&self, addr: &mut ProtocolAddress) {
+        let jid = self;
+        addr.reset_with(|name| write_signal_address_to(jid, name));
     }
 }
 
@@ -104,88 +119,83 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_signal_address_string_lid_no_device() {
-        let jid = Jid::from_str("123456789@lid").expect("test JID should be valid");
+    fn test_signal_address_string_lid() {
+        let jid = Jid::from_str("123456789@lid").unwrap();
         assert_eq!(jid.to_signal_address_string(), "123456789@lid");
     }
 
     #[test]
     fn test_signal_address_string_lid_with_device() {
-        let jid = Jid::from_str("123456789:33@lid").expect("test JID should be valid");
+        let jid = Jid::from_str("123456789:33@lid").unwrap();
         assert_eq!(jid.to_signal_address_string(), "123456789:33@lid");
     }
 
     #[test]
-    fn test_signal_address_string_lid_with_dot_in_user() {
-        // LID user IDs can contain dots that are part of the identity
-        let jid = Jid::from_str("100000000000001.1:75@lid").expect("test JID should be valid");
-        assert_eq!(jid.to_signal_address_string(), "100000000000001.1:75@lid");
-    }
-
-    #[test]
-    fn test_signal_address_string_phone_number() {
-        // s.whatsapp.net should be converted to c.us
-        let jid = Jid::from_str("5511999887766@s.whatsapp.net").expect("test JID should be valid");
-        assert_eq!(jid.to_signal_address_string(), "5511999887766@c.us");
-    }
-
-    #[test]
-    fn test_signal_address_string_phone_with_device() {
-        let jid =
-            Jid::from_str("5511999887766:33@s.whatsapp.net").expect("test JID should be valid");
-        assert_eq!(jid.to_signal_address_string(), "5511999887766:33@c.us");
+    fn test_signal_address_string_phone() {
+        let jid = Jid::from_str("15550000001@s.whatsapp.net").unwrap();
+        assert_eq!(jid.to_signal_address_string(), "15550000001@c.us");
     }
 
     #[test]
     fn test_protocol_address_format() {
-        // ProtocolAddress.to_string() should produce: {name}.{device_id}
-        // Which matches WhatsApp Web's createSignalLikeAddress format
-        let jid = Jid::from_str("123456789:33@lid").expect("test JID should be valid");
+        let jid = Jid::from_str("123456789:33@lid").unwrap();
         let addr = jid.to_protocol_address();
-
         assert_eq!(addr.name(), "123456789:33@lid");
-        assert_eq!(u32::from(addr.device_id()), 0);
         assert_eq!(addr.to_string(), "123456789:33@lid.0");
     }
 
     #[test]
-    fn test_protocol_address_lid_with_dot() {
-        let jid = Jid::from_str("100000000000001.1:75@lid").expect("test JID should be valid");
-        let addr = jid.to_protocol_address();
-
-        assert_eq!(addr.name(), "100000000000001.1:75@lid");
-        assert_eq!(u32::from(addr.device_id()), 0);
-        assert_eq!(addr.to_string(), "100000000000001.1:75@lid.0");
-    }
-
-    #[test]
-    fn test_protocol_address_phone_number() {
-        let jid = Jid::from_str("5511999887766@s.whatsapp.net").expect("test JID should be valid");
-        let addr = jid.to_protocol_address();
-
-        assert_eq!(addr.name(), "5511999887766@c.us");
-        assert_eq!(u32::from(addr.device_id()), 0);
-        assert_eq!(addr.to_string(), "5511999887766@c.us.0");
-    }
-
-    #[test]
     fn test_protocol_address_string_matches_to_string() {
-        // to_protocol_address_string() must produce the same output as
-        // to_protocol_address().to_string() for all JID types.
         let jids = [
             "123456789@lid",
             "123456789:33@lid",
             "100000000000001.1:75@lid",
-            "5511999887766@s.whatsapp.net",
-            "5511999887766:33@s.whatsapp.net",
+            "15550000001@s.whatsapp.net",
+            "15550000001:33@s.whatsapp.net",
         ];
         for jid_str in &jids {
-            let jid = Jid::from_str(jid_str).expect("test JID should be valid");
+            let jid = Jid::from_str(jid_str).unwrap();
             assert_eq!(
                 jid.to_protocol_address_string(),
                 jid.to_protocol_address().to_string(),
-                "mismatch for JID: {jid_str}"
             );
         }
+    }
+
+    #[test]
+    fn test_reset_protocol_address_matches_fresh() {
+        let cases = [
+            ("123456789@lid", "123456789@lid", "123456789@lid.0"),
+            ("123456789:33@lid", "123456789:33@lid", "123456789:33@lid.0"),
+            (
+                "100000000000001.1:75@lid",
+                "100000000000001.1:75@lid",
+                "100000000000001.1:75@lid.0",
+            ),
+            (
+                "15550000001@s.whatsapp.net",
+                "15550000001@c.us",
+                "15550000001@c.us.0",
+            ),
+        ];
+        let mut addr = make_reusable_protocol_address();
+        for (jid_str, expected_name, expected_display) in &cases {
+            let jid = Jid::from_str(jid_str).unwrap();
+            jid.reset_protocol_address(&mut addr);
+            assert_eq!(addr.name(), *expected_name);
+            assert_eq!(addr.as_str(), *expected_display);
+        }
+    }
+
+    #[test]
+    fn test_write_functions_dry() {
+        let jid = Jid::from_str("15550000001@s.whatsapp.net").unwrap();
+        let mut buf = String::new();
+
+        write_signal_address_to(&jid, &mut buf);
+        assert_eq!(buf, "15550000001@c.us");
+
+        write_protocol_address_to(&jid, &mut buf);
+        assert_eq!(buf, "15550000001@c.us.0");
     }
 }


### PR DESCRIPTION
## Summary

### Single-buffer ProtocolAddress

Collapsed `ProtocolAddress` from two Strings (`name` + `display`) into one (`buf` + `name_len`). The buffer stores `"{name}.{device_id}"` and accessors are zero-cost slices:

- `name()` → `&buf[..name_len]`
- `as_str()` → `&buf`

| | Before (2 strings) | After (1 buffer) |
|---|---|---|
| `new(name, device_id)` | 2 allocs (name + format! display) | 1 alloc (take name, append suffix) |
| `reset_with()` | write name → copy to display → append | write name → append. No copy. |
| `clone()` | clone 2 Strings | clone 1 String |
| Struct size | ~56 bytes | ~40 bytes |

All 40+ cold-path `to_protocol_address()` call sites benefit automatically.

### DRY address formatting

- `write_signal_address_to()` is the single core helper — all address functions delegate to it
- `append_device_suffix()` shared by `new`, `reset_with` — fast path for device_id=0 (`push_str(".0")` instead of `write!`)
- `make_address_buffer()` / `make_reusable_protocol_address()` factories — no magic numbers
- `SIGNAL_ADDRESS_CAPACITY` (64) and `SIGNAL_DEVICE_ID` constants replace magic values
- `DEFAULT_USER_SERVER` / `LEGACY_USER_SERVER` replace magic strings in `mapped_server()`

### Hot loop optimization

In `encrypt_for_devices()`, one reusable `ProtocolAddress` across all 4 per-device loops:

1. LID session check
2. Direct session check
3. Prekey processing
4. Message encryption

`reset_with(|name| write_signal_address_to(jid, name))` writes directly into the buffer — single write pass, no intermediate copy. For a 100-device group, eliminates hundreds of String allocations per send.

### Buffer capacity

64 bytes based on real WhatsApp logs (`docs/real-whatsapp-log.json`) showing max signal address length of 53 chars.

## Lab results (experiments/heaptrack-impact-lab)

| Scenario | Alloc reduction | Bytes reduction | Time reduction |
|---|---|---|---|
| Reusable buffer (unique fanout) | **-100%** | **-100%** | **-78.9%** |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --all --exclude e2e-tests`
- [x] `test_reset_protocol_address_matches_fresh` — hard-coded expected strings including dotted LID
- [x] `test_write_functions_dry` — hard-coded expected output, not self-referential
- [x] `test_protocol_address_string_matches_to_string` — dotted LID, phone, device variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved protocol address handling for lower memory use and faster reuse.
  * Consolidated address normalization to rely on shared configuration for consistent formatting.
* **Tests**
  * Updated address-related tests for the new in-place formatting behavior.
* **Chores**
  * Tightened benchmark regression threshold for CI reporting (more sensitive detection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->