### PR TITLE
perf!: reduce hot-path allocations in receipt, send, and signal paths

### DIFF
--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -3,7 +3,6 @@
 //! Encryption, decryption, session management, and participant node creation.
 
 use anyhow::{Result, anyhow};
-use prost::Message as ProtoMessage;
 use wacore::libsignal::protocol::{
     CiphertextMessage, PreKeySignalMessage, SignalMessage, UsePQRatchet, message_decrypt,
     message_encrypt,
@@ -270,7 +269,7 @@ impl<'a> Signal<'a> {
             _session_guards.push(mutex.lock().await);
         }
 
-        let plaintext = MessageUtils::pad_message_v2(message.encode_to_vec());
+        let plaintext = MessageUtils::encode_and_pad(message);
         let mut adapter = self.client.signal_adapter().await;
         let mediatype = wacore::send::media_type_from_message(message);
         let hide_decrypt_fail = wacore::send::should_hide_decrypt_fail(message);

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -46,25 +46,25 @@ impl Client {
 
         debug!("Received receipt type '{receipt_type:?}' for message {id} from {from}");
 
-        let sender = if from.is_group() {
+        let is_group = from.is_group();
+        let sender = if is_group {
             participant.unwrap_or_else(|| from.clone())
         } else {
             from.clone()
         };
 
         let receipt = Receipt {
-            message_ids: vec![id.clone()],
+            message_ids: vec![id],
             source: crate::types::message::MessageSource {
-                chat: from.clone(),
-                sender: sender.clone(),
+                chat: from,
+                sender,
                 ..Default::default()
             },
             timestamp: wacore::time::now_utc(),
-            r#type: receipt_type.clone(),
-            message_sender: sender.clone(),
+            r#type: receipt_type,
         };
 
-        if receipt_type == ReceiptType::Retry {
+        if receipt.r#type == ReceiptType::Retry {
             let client_clone = Arc::clone(self);
             let node_clone = Arc::clone(&node);
             self.runtime
@@ -81,7 +81,7 @@ impl Client {
                     }
                 }))
                 .detach();
-        } else if receipt_type == ReceiptType::EncRekeyRetry {
+        } else if receipt.r#type == ReceiptType::EncRekeyRetry {
             // WA Web: both "retry" and "enc_rekey_retry" route through
             // handleMessageRetryRequest, but enc_rekey_retry branches to the
             // VoIP stack's resendEncRekeyRetry(peerJid, retryCount).
@@ -97,7 +97,7 @@ impl Client {
                         .optional_string("call-id")
                         .as_deref()
                         .unwrap_or_default(),
-                    from,
+                    receipt.source.chat,
                     child_attrs
                         .optional_string("call-creator")
                         .as_deref()

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -403,8 +403,6 @@ where
             .await?
             .is_some()
         {
-            // Session exists under direct address, use it
-            jid_to_encryption_jid.insert(device_jid, device_jid.clone());
             continue;
         }
 
@@ -728,7 +726,7 @@ pub async fn prepare_dm_stanza<
         ..Default::default()
     };
 
-    let own_devices_plaintext = MessageUtils::pad_message_v2(dsm.encode_to_vec());
+    let own_devices_plaintext = MessageUtils::encode_and_pad(&dsm);
 
     let total_devices = all_devices.len();
     let (recipient_devices, own_other_devices) =
@@ -1118,8 +1116,7 @@ pub async fn prepare_group_stanza<
             }),
             ..Default::default()
         };
-        let skdm_plaintext_to_encrypt =
-            MessageUtils::pad_message_v2(skdm_wrapper_msg.encode_to_vec());
+        let skdm_plaintext_to_encrypt = MessageUtils::encode_and_pad(&skdm_wrapper_msg);
 
         // WA Web's GroupSkmsgJob wraps ensureE2ESessions in try/catch — logs error
         // but does NOT rethrow. SKDM distribution failure must not prevent the group

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -695,7 +695,6 @@ pub struct Receipt {
     pub message_ids: Vec<MessageId>,
     pub timestamp: DateTime<Utc>,
     pub r#type: ReceiptType,
-    pub message_sender: Jid,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

- **Receipt construction**: move values instead of cloning — reduces from 6 clones to 1 per incoming receipt
- **Remove dead `Receipt.message_sender`**: field duplicated `source.sender` and was never read
- **`encode_and_pad()`**: replace `pad_message_v2(msg.encode_to_vec())` with single pre-sized allocation in DM, group SKDM, and signal encrypt paths
- **Remove redundant clone**: `jid_to_encryption_jid.insert(jid, jid.clone())` was unnecessary — the encrypt loop already falls back to `device_jid` when no mapping exists
- **Remove unused import**: `prost::Message` no longer needed in signal.rs

## Breaking changes

- `Receipt.message_sender` field removed (was never accessed, always duplicated `source.sender`)

## Experiment data

From `experiments/heaptrack-impact-lab` (10k node benchmark):

| Optimization | alloc delta | byte delta | time delta |
|---|---:|---:|---:|
| Receipt: move vs clone | -100% | -100% | -72.4% |
| encode_and_pad vs encode_to_vec+pad | -99.9% | -98.5% | ~neutral |
| Session map: skip self-mapping | +0% | +0% | -4.9% |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --all --exclude e2e-tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `message_sender` field from Receipt events. Code relying on this field requires updates.

* **Refactor**
  * Optimized message encryption plaintext preparation across direct and group messaging paths.
  * Enhanced Receipt handling to eliminate redundant copying and improve memory efficiency.
  * Removed unused code dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->