### PR TITLE
fix: suppress ack errors for all transport-unavailable conditions

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -271,6 +271,16 @@ pub enum ClientError {
     NotLoggedIn,
 }
 
+impl ClientError {
+    pub fn is_transport_unavailable(&self) -> bool {
+        match self {
+            ClientError::NotConnected => true,
+            ClientError::EncryptSend(e) => e.is_transport_unavailable(),
+            _ => false,
+        }
+    }
+}
+
 use wacore::types::message::ChatMessageId;
 
 /// Metrics for tracking offline sync progress
@@ -1694,7 +1704,9 @@ impl Client {
     /// Uses Arc<OwnedNodeRef> to avoid cloning when spawning the async task.
     async fn maybe_deferred_ack(self: &Arc<Self>, node: Arc<wacore_binary::OwnedNodeRef>) {
         if self.synchronous_ack {
-            if let Err(e) = self.send_ack_for(node.get()).await {
+            if let Err(e) = self.send_ack_for(node.get()).await
+                && !e.is_transport_unavailable()
+            {
                 warn!("Failed to send ack: {e:?}");
             }
         } else {
@@ -1702,7 +1714,7 @@ impl Client {
             self.runtime
                 .spawn(Box::pin(async move {
                     if let Err(e) = this.send_ack_for(node.get()).await
-                        && !matches!(e, ClientError::NotConnected)
+                        && !e.is_transport_unavailable()
                     {
                         warn!("Failed to send ack: {e:?}");
                     }

--- a/src/socket/error.rs
+++ b/src/socket/error.rs
@@ -71,4 +71,12 @@ impl EncryptSendError {
             source: anyhow::anyhow!("sender task channel closed unexpectedly"),
         }
     }
+
+    /// The transport is gone (broken pipe, closed connection, channel dropped).
+    pub fn is_transport_unavailable(&self) -> bool {
+        matches!(
+            self.kind,
+            EncryptSendErrorKind::Transport | EncryptSendErrorKind::ChannelClosed
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Add `is_transport_unavailable()` to `ClientError` and `EncryptSendError`
- Matches `NotConnected`, `EncryptSend(Transport)`, and `EncryptSend(ChannelClosed)`
- Use in `maybe_deferred_ack` to suppress spurious "Failed to send ack" warnings during disconnects

Previously only `NotConnected` was silenced in the async ack path, and the sync path had no filter at all. Transport pipe breaks and channel drops during disconnect produced noisy warnings.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --all --exclude e2e-tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transport unavailability errors to reduce unnecessary warning logs when the network connection is temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->