### PR TITLE
perf!: zero-copy receive pipeline and take-ownership session cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,6 @@ dependencies = [
 name = "wacore-noise"
 version = "0.5.0"
 dependencies = [
- "aead",
  "aes-gcm",
  "anyhow",
  "bytes",
@@ -2662,6 +2661,7 @@ dependencies = [
 name = "whatsapp-rust"
 version = "0.5.0"
 dependencies = [
+ "aead",
  "anyhow",
  "async-channel",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "bytes",
  "crypto-common 0.1.7",
  "generic-array",
 ]
@@ -2463,6 +2464,7 @@ dependencies = [
 name = "wacore-binary"
 version = "0.5.0"
 dependencies = [
+ "bytes",
  "compact_str",
  "flate2",
  "iai-callgrind",
@@ -2470,6 +2472,7 @@ dependencies = [
  "phf_codegen",
  "serde",
  "serde_json",
+ "stable_deref_trait",
  "yoke 0.7.5",
 ]
 
@@ -2519,6 +2522,7 @@ dependencies = [
 name = "wacore-noise"
 version = "0.5.0"
 dependencies = [
+ "aead",
  "aes-gcm",
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
+aead = { version = "0.5.2", default-features = false, features = ["bytes"] }
 # Shared dependencies
 aes = "0.8.3"
 aes-gcm = { version = "0.10.2", default-features = false, features = ["aes", "alloc", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ sqlite-storage = ["whatsapp-rust-sqlite-storage"]
 tokio-native = ["tokio-runtime", "tokio/rt-multi-thread"]
 
 [dependencies]
+aead = { workspace = true }
 anyhow = { workspace = true }
 async-channel = { workspace = true }
 async-lock = { workspace = true }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1410,7 +1410,7 @@ impl Client {
 
                                 while let Some(encrypted_frame) = frame_decoder.decode_frame() {
                                     // Decrypt the frame synchronously (required for noise counter ordering)
-                                    if let Some(node) = self.decrypt_frame(&encrypted_frame).await {
+                                    if let Some(node) = self.decrypt_frame(encrypted_frame).await {
                                         // Determine processing mode for this node:
                                         // - Critical nodes (success/failure/stream:error): inline, required for state
                                         // - Message nodes: inline, preserves arrival order for per-chat queues
@@ -1482,7 +1482,7 @@ impl Client {
     /// This must be called sequentially due to noise protocol counter requirements.
     pub(crate) async fn decrypt_frame(
         self: &Arc<Self>,
-        encrypted_frame: &bytes::Bytes,
+        encrypted_frame: bytes::BytesMut,
     ) -> Option<wacore_binary::OwnedNodeRef> {
         let noise_socket = match self.get_noise_socket().await {
             Ok(s) => s,
@@ -1500,7 +1500,7 @@ impl Client {
             }
         };
 
-        let unpacked_data_cow = match wacore_binary::util::unpack(&decrypted_payload) {
+        let buffer = match wacore_binary::util::unpack_bytes(decrypted_payload) {
             Ok(data) => data,
             Err(e) => {
                 log::warn!(target: "Client/Recv", "Failed to decompress frame: {e}");
@@ -1508,8 +1508,6 @@ impl Client {
             }
         };
 
-        // Convert Cow to owned Vec for yoke to own the buffer
-        let buffer = unpacked_data_cow.into_owned();
         match wacore_binary::OwnedNodeRef::new(buffer) {
             Ok(owned) => Some(owned),
             Err(e) => {
@@ -3638,24 +3636,21 @@ fn build_pong(to: String, id: Option<&str>) -> wacore_binary::Node {
 /// explicitly present on the incoming receipt (delivery receipts normally
 /// have no type attribute, meaning the ack also has no type).
 fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>) -> Option<Node> {
-    let id = NodeValue::from(node.get_attr("id")?.as_str().as_ref());
-    let from = NodeValue::from(node.get_attr("from")?.as_str().as_ref());
-    let participant = node
-        .get_attr("participant")
-        .map(|v| NodeValue::from(v.as_str().as_ref()));
+    let id = node.get_attr("id")?.to_node_value();
+    let from = node.get_attr("from")?.to_node_value();
+    let participant = node.get_attr("participant").map(|v| v.to_node_value());
 
     let tag = node.tag.as_ref();
 
     // Whatsmeow: echo type for all stanza tags EXCEPT "message".
     // WA Web additionally omits type for notification type="encrypt" with <identity/> child.
     let typ = if tag != "message" && !is_encrypt_identity_notification(node) {
-        node.get_attr("type")
-            .map(|v| NodeValue::from(v.as_str().as_ref()))
+        node.get_attr("type").map(|v| v.to_node_value())
     } else {
         None
     };
 
-    let mut attrs = Attrs::new();
+    let mut attrs = Attrs::with_capacity(6);
     attrs.insert("class", NodeValue::from(tag));
     attrs.insert("id", id);
     attrs.insert("to", from);

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -183,24 +183,35 @@ impl Client {
             let pn_proto = pn_jid.to_protocol_address();
             let lid_proto = lid_jid.to_protocol_address();
 
-            // Migrate session: read from cache (authoritative), write to cache
+            // Migrate session: take from cache (authoritative), write to cache
             if let Ok(Some(session)) = self
                 .signal_cache
                 .get_session(&pn_proto, backend.as_ref())
                 .await
             {
-                if self
+                match self
                     .signal_cache
                     .has_session(&lid_proto, backend.as_ref())
                     .await
-                    .unwrap_or(false)
                 {
-                    self.signal_cache.delete_session(&pn_proto).await;
-                    info!("Deleted stale PN session {} (LID exists)", pn_proto);
-                } else {
-                    self.signal_cache.put_session(&lid_proto, session).await;
-                    self.signal_cache.delete_session(&pn_proto).await;
-                    info!("Migrated session {} -> {}", pn_proto, lid_proto);
+                    Ok(true) => {
+                        self.signal_cache.delete_session(&pn_proto).await;
+                        info!("Deleted stale PN session {} (LID exists)", pn_proto);
+                    }
+                    Ok(false) => {
+                        self.signal_cache.put_session(&lid_proto, session).await;
+                        self.signal_cache.delete_session(&pn_proto).await;
+                        info!("Migrated session {} -> {}", pn_proto, lid_proto);
+                    }
+                    Err(e) => {
+                        // Restore the taken PN session to avoid losing it
+                        self.signal_cache.put_session(&pn_proto, session).await;
+                        log::warn!(
+                            "Skipping session migration {} -> {}: {e}",
+                            pn_proto,
+                            lid_proto
+                        );
+                    }
                 }
             }
 

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -191,11 +191,9 @@ impl Client {
             {
                 if self
                     .signal_cache
-                    .get_session(&lid_proto, backend.as_ref())
+                    .has_session(&lid_proto, backend.as_ref())
                     .await
-                    .ok()
-                    .flatten()
-                    .is_some()
+                    .unwrap_or(false)
                 {
                     self.signal_cache.delete_session(&pn_proto).await;
                     info!("Deleted stale PN session {} (LID exists)", pn_proto);

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -240,7 +240,7 @@ impl Client {
                     // Read session through cache to get consistent state
                     let session = self
                         .signal_cache
-                        .get_session(&signal_address, &*device_guard.backend)
+                        .peek_session(&signal_address, &*device_guard.backend)
                         .await
                         .ok()
                         .flatten();
@@ -391,7 +391,7 @@ impl Client {
                 let device_guard = device_store.read().await;
                 let session = self
                     .signal_cache
-                    .get_session(&signal_address, &*device_guard.backend)
+                    .peek_session(&signal_address, &*device_guard.backend)
                     .await
                     .ok()
                     .flatten();
@@ -573,7 +573,7 @@ impl Client {
             let device_guard = device_store.read().await;
             let session = self
                 .signal_cache
-                .get_session(&signal_address, &*device_guard.backend)
+                .peek_session(&signal_address, &*device_guard.backend)
                 .await
                 .ok()
                 .flatten();

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -1,6 +1,7 @@
 use crate::socket::error::{EncryptSendError, Result, SocketError};
 use crate::transport::Transport;
 use async_channel;
+use bytes::BytesMut;
 use futures::channel::oneshot;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -184,11 +185,12 @@ impl NoiseSocket {
         }
     }
 
-    pub fn decrypt_frame(&self, ciphertext: &[u8]) -> Result<Vec<u8>> {
+    pub fn decrypt_frame(&self, mut ciphertext: BytesMut) -> Result<BytesMut> {
         let counter = self.read_counter.fetch_add(1, Ordering::SeqCst);
         self.read_key
-            .decrypt_with_counter(counter, ciphertext)
-            .map_err(|e| SocketError::Crypto(e.to_string()))
+            .decrypt_in_place_with_counter(counter, &mut ciphertext)
+            .map_err(|e| SocketError::Crypto(e.to_string()))?;
+        Ok(ciphertext)
     }
 }
 

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -240,19 +240,21 @@ mod tests {
         #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
         #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
         impl crate::transport::Transport for RecordingTransport {
-            async fn send(&self, data: Vec<u8>) -> std::result::Result<(), anyhow::Error> {
-                // Decrypt the data to extract the index (first byte of plaintext)
+            async fn send(&self, mut data: Vec<u8>) -> std::result::Result<(), anyhow::Error> {
                 if data.len() > 16 {
-                    // Skip the noise frame header (3 bytes for length)
-                    let ciphertext = &data[3..];
+                    // Strip the 3-byte frame header, then decrypt in place
+                    data.drain(..3);
                     let counter = self
                         .counter
                         .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-                    if let Ok(plaintext) = self.read_key.decrypt_with_counter(counter, ciphertext)
-                        && !plaintext.is_empty()
+                    if self
+                        .read_key
+                        .decrypt_in_place_with_counter(counter, &mut data)
+                        .is_ok()
+                        && !data.is_empty()
                     {
-                        let index = plaintext[0];
+                        let index = data[0];
                         let mut order = self.recorded_order.lock().await;
                         order.push(index);
                     }

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -94,6 +94,15 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
+    async fn has_session(&self, address: &ProtocolAddress) -> Result<bool, SignalProtocolError> {
+        let device = self.0.device.read().await;
+        self.0
+            .cache
+            .has_session(address, &*device.backend)
+            .await
+            .map_err(signal_err("backend"))
+    }
+
     async fn store_session(
         &mut self,
         address: &ProtocolAddress,

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -121,6 +121,9 @@ impl SessionStore for MemSessionStore {
     async fn load_session(&self, a: &ProtocolAddress) -> SigResult<Option<SessionRecord>> {
         Ok(self.0.get(a).cloned())
     }
+    async fn has_session(&self, a: &ProtocolAddress) -> SigResult<bool> {
+        Ok(self.0.contains_key(a))
+    }
     async fn store_session(&mut self, a: &ProtocolAddress, r: SessionRecord) -> SigResult<()> {
         self.0.insert(a.clone(), r);
         Ok(())

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -19,10 +19,12 @@ simd = []
 serde = ["dep:serde", "compact_str/serde"]
 
 [dependencies]
+bytes = { workspace = true }
 compact_str = { workspace = true }
 flate2 = { workspace = true }
 phf = { version = "0.13.1", default-features = false }
 serde = { workspace = true, optional = true }
+stable_deref_trait = "1.2.0"
 yoke = { workspace = true }
 
 [build-dependencies]

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -693,6 +693,7 @@ impl<'a> NodeRef<'a> {
 
 use yoke::Yoke;
 
+#[derive(Clone)]
 struct BytesCart(Bytes);
 
 impl std::ops::Deref for BytesCart {

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -1,7 +1,9 @@
 use crate::attrs::{AttrParser, AttrParserRef};
 use crate::jid::{Jid, JidRef};
 use crate::token;
+use bytes::Bytes;
 use compact_str::CompactString;
+use stable_deref_trait::StableDeref;
 use std::borrow::Cow;
 
 /// Borrowed-or-inline string for decoded nodes. Short owned values (≤24 bytes)
@@ -411,6 +413,14 @@ impl<'a> ValueRef<'a> {
             ValueRef::String(s) => Jid::from_str(s.as_ref()).ok(),
         }
     }
+
+    /// Convert to an owned NodeValue, preserving the variant (JID stays JID).
+    pub fn to_node_value(&self) -> NodeValue {
+        match self {
+            ValueRef::String(s) => NodeValue::String(s.to_compact_string()),
+            ValueRef::Jid(j) => NodeValue::Jid(j.to_owned()),
+        }
+    }
 }
 
 use std::str::FromStr;
@@ -683,21 +693,37 @@ impl<'a> NodeRef<'a> {
 
 use yoke::Yoke;
 
+struct BytesCart(Bytes);
+
+impl std::ops::Deref for BytesCart {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+// Safety: `Bytes` points to immutable backing storage whose deref target
+// remains stable for the lifetime of the value, even when the wrapper moves.
+unsafe impl StableDeref for BytesCart {}
+
 /// A decoded node that owns its decompressed buffer. The inner `NodeRef`
 /// borrows string/byte payloads directly from the buffer, avoiding copies.
 /// Container allocations (attribute Vec, child Vec) still occur during decode.
 ///
 /// Wrap in `Arc<OwnedNodeRef>` for cheap sharing across handlers.
 pub struct OwnedNodeRef {
-    inner: Yoke<NodeRef<'static>, Vec<u8>>,
+    inner: Yoke<NodeRef<'static>, BytesCart>,
 }
 
 impl OwnedNodeRef {
     /// Decode a node from an owned buffer. The buffer should be the raw
     /// binary-protocol bytes (after decompression, without the leading
     /// format byte which `unpack` already strips).
-    pub fn new(buffer: Vec<u8>) -> crate::error::Result<Self> {
-        let inner = Yoke::try_attach_to_cart(buffer, |buf| crate::marshal::unmarshal_ref(buf))?;
+    pub fn new(buffer: impl Into<Bytes>) -> crate::error::Result<Self> {
+        let inner = Yoke::try_attach_to_cart(BytesCart(buffer.into()), |buf| {
+            crate::marshal::unmarshal_ref(buf)
+        })?;
         Ok(Self { inner })
     }
 

--- a/wacore/binary/src/util.rs
+++ b/wacore/binary/src/util.rs
@@ -1,4 +1,5 @@
 use crate::error::{BinaryError, Result};
+use bytes::{Buf, Bytes, BytesMut};
 use flate2::read::ZlibDecoder;
 use std::borrow::Cow;
 use std::io::Read;
@@ -22,5 +23,61 @@ pub fn unpack(data: &[u8]) -> Result<Cow<'_, [u8]>> {
         Ok(Cow::Owned(decompressed))
     } else {
         Ok(Cow::Borrowed(data))
+    }
+}
+
+/// Unpack a network payload into an owned buffer.
+///
+/// This is the hot-path variant used after frame decryption. For compressed
+/// payloads we still allocate a decompression buffer, but for uncompressed
+/// payloads we strip the leading format byte in place and reuse the existing
+/// `Vec<u8>` allocation.
+pub fn unpack_owned(mut data: Vec<u8>) -> Result<Vec<u8>> {
+    if data.is_empty() {
+        return Err(BinaryError::EmptyData);
+    }
+    let data_type = data[0];
+
+    if (data_type & 2) > 0 {
+        let mut decoder = ZlibDecoder::new(&data[1..]);
+        // Pre-allocate with estimated decompressed size (typically 4-8x compressed)
+        // Min 256 bytes for small inputs, max 64KB to limit allocation for large inputs
+        let estimated_size = ((data.len() - 1) * 4).clamp(256, 64 * 1024);
+        let mut decompressed = Vec::with_capacity(estimated_size);
+        decoder
+            .read_to_end(&mut decompressed)
+            .map_err(|e| BinaryError::Zlib(e.to_string()))?;
+        Ok(decompressed)
+    } else {
+        let unpacked_len = data.len() - 1;
+        data.copy_within(1.., 0);
+        data.truncate(unpacked_len);
+        Ok(data)
+    }
+}
+
+/// Unpack a network payload into an owned `Bytes` buffer.
+///
+/// This variant preserves ownership of the frame buffer across the receive
+/// pipeline. Uncompressed payloads reuse the existing `BytesMut` allocation
+/// and freeze it without copying. Compressed payloads still allocate a
+/// decompression buffer, which is then wrapped as `Bytes`.
+pub fn unpack_bytes(mut data: BytesMut) -> Result<Bytes> {
+    if data.is_empty() {
+        return Err(BinaryError::EmptyData);
+    }
+    let data_type = data[0];
+
+    if (data_type & 2) > 0 {
+        let mut decoder = ZlibDecoder::new(&data[1..]);
+        let estimated_size = ((data.len() - 1) * 4).clamp(256, 64 * 1024);
+        let mut decompressed = Vec::with_capacity(estimated_size);
+        decoder
+            .read_to_end(&mut decompressed)
+            .map_err(|e| BinaryError::Zlib(e.to_string()))?;
+        Ok(Bytes::from(decompressed))
+    } else {
+        data.advance(1);
+        Ok(data.freeze())
     }
 }

--- a/wacore/binary/src/util.rs
+++ b/wacore/binary/src/util.rs
@@ -4,6 +4,21 @@ use flate2::read::ZlibDecoder;
 use std::borrow::Cow;
 use std::io::Read;
 
+/// Protocol frames larger than 16 MiB after decompression are rejected.
+/// WhatsApp messages are typically small; this guards against malicious
+/// or corrupt compressed payloads that would expand into huge allocations.
+const MAX_DECOMPRESSED_SIZE: u64 = 16 * 1024 * 1024;
+
+fn decompress_zlib(compressed: &[u8]) -> Result<Vec<u8>> {
+    let estimated = (compressed.len() * 4).clamp(256, 64 * 1024);
+    let mut out = Vec::with_capacity(estimated);
+    ZlibDecoder::new(compressed)
+        .take(MAX_DECOMPRESSED_SIZE)
+        .read_to_end(&mut out)
+        .map_err(|e| BinaryError::Zlib(e.to_string()))?;
+    Ok(out)
+}
+
 pub fn unpack(data: &[u8]) -> Result<Cow<'_, [u8]>> {
     if data.is_empty() {
         return Err(BinaryError::EmptyData);
@@ -12,56 +27,17 @@ pub fn unpack(data: &[u8]) -> Result<Cow<'_, [u8]>> {
     let data = &data[1..];
 
     if (data_type & 2) > 0 {
-        let mut decoder = ZlibDecoder::new(data);
-        // Pre-allocate with estimated decompressed size (typically 4-8x compressed)
-        // Min 256 bytes for small inputs, max 64KB to limit allocation for large inputs
-        let estimated_size = (data.len() * 4).clamp(256, 64 * 1024);
-        let mut decompressed = Vec::with_capacity(estimated_size);
-        decoder
-            .read_to_end(&mut decompressed)
-            .map_err(|e| BinaryError::Zlib(e.to_string()))?;
-        Ok(Cow::Owned(decompressed))
+        Ok(Cow::Owned(decompress_zlib(data)?))
     } else {
         Ok(Cow::Borrowed(data))
     }
 }
 
-/// Unpack a network payload into an owned buffer.
-///
-/// This is the hot-path variant used after frame decryption. For compressed
-/// payloads we still allocate a decompression buffer, but for uncompressed
-/// payloads we strip the leading format byte in place and reuse the existing
-/// `Vec<u8>` allocation.
-pub fn unpack_owned(mut data: Vec<u8>) -> Result<Vec<u8>> {
-    if data.is_empty() {
-        return Err(BinaryError::EmptyData);
-    }
-    let data_type = data[0];
-
-    if (data_type & 2) > 0 {
-        let mut decoder = ZlibDecoder::new(&data[1..]);
-        // Pre-allocate with estimated decompressed size (typically 4-8x compressed)
-        // Min 256 bytes for small inputs, max 64KB to limit allocation for large inputs
-        let estimated_size = ((data.len() - 1) * 4).clamp(256, 64 * 1024);
-        let mut decompressed = Vec::with_capacity(estimated_size);
-        decoder
-            .read_to_end(&mut decompressed)
-            .map_err(|e| BinaryError::Zlib(e.to_string()))?;
-        Ok(decompressed)
-    } else {
-        let unpacked_len = data.len() - 1;
-        data.copy_within(1.., 0);
-        data.truncate(unpacked_len);
-        Ok(data)
-    }
-}
-
 /// Unpack a network payload into an owned `Bytes` buffer.
 ///
-/// This variant preserves ownership of the frame buffer across the receive
-/// pipeline. Uncompressed payloads reuse the existing `BytesMut` allocation
-/// and freeze it without copying. Compressed payloads still allocate a
-/// decompression buffer, which is then wrapped as `Bytes`.
+/// Uncompressed payloads reuse the existing `BytesMut` allocation
+/// and freeze it without copying. Compressed payloads allocate a
+/// decompression buffer which is then wrapped as `Bytes`.
 pub fn unpack_bytes(mut data: BytesMut) -> Result<Bytes> {
     if data.is_empty() {
         return Err(BinaryError::EmptyData);
@@ -69,13 +45,7 @@ pub fn unpack_bytes(mut data: BytesMut) -> Result<Bytes> {
     let data_type = data[0];
 
     if (data_type & 2) > 0 {
-        let mut decoder = ZlibDecoder::new(&data[1..]);
-        let estimated_size = ((data.len() - 1) * 4).clamp(256, 64 * 1024);
-        let mut decompressed = Vec::with_capacity(estimated_size);
-        decoder
-            .read_to_end(&mut decompressed)
-            .map_err(|e| BinaryError::Zlib(e.to_string()))?;
-        Ok(Bytes::from(decompressed))
+        Ok(Bytes::from(decompress_zlib(&data[1..])?))
     } else {
         data.advance(1);
         Ok(data.freeze())

--- a/wacore/binary/src/util.rs
+++ b/wacore/binary/src/util.rs
@@ -13,9 +13,14 @@ fn decompress_zlib(compressed: &[u8]) -> Result<Vec<u8>> {
     let estimated = (compressed.len() * 4).clamp(256, 64 * 1024);
     let mut out = Vec::with_capacity(estimated);
     ZlibDecoder::new(compressed)
-        .take(MAX_DECOMPRESSED_SIZE)
+        .take(MAX_DECOMPRESSED_SIZE + 1)
         .read_to_end(&mut out)
         .map_err(|e| BinaryError::Zlib(e.to_string()))?;
+    if out.len() as u64 > MAX_DECOMPRESSED_SIZE {
+        return Err(BinaryError::Zlib(format!(
+            "decompressed payload exceeds {MAX_DECOMPRESSED_SIZE} bytes"
+        )));
+    }
     Ok(out)
 }
 

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -176,6 +176,13 @@ impl SessionStore for InMemorySessionStore {
         Ok(self.sessions.get(address).cloned())
     }
 
+    async fn has_session(
+        &self,
+        address: &ProtocolAddress,
+    ) -> wacore_libsignal::protocol::error::Result<bool> {
+        Ok(self.sessions.contains_key(address))
+    }
+
     async fn store_session(
         &mut self,
         address: &ProtocolAddress,

--- a/wacore/libsignal/src/protocol/session.rs
+++ b/wacore/libsignal/src/protocol/session.rs
@@ -167,13 +167,41 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
         return Err(SignalProtocolError::SignatureValidationFailed);
     }
 
-    let mut session_record = session_store
-        .load_session(remote_address)
-        .await?
-        .unwrap_or_else(SessionRecord::new_fresh);
+    let existing = session_store.load_session(remote_address).await?;
+    let had_session = existing.is_some();
+    let mut session_record = existing.unwrap_or_else(SessionRecord::new_fresh);
 
-    let our_base_key_pair = KeyPair::generate(&mut csprng);
-    let our_base_public_key = our_base_key_pair.public_key; // Save before moving
+    let result = process_prekey_bundle_inner(
+        remote_address,
+        &mut session_record,
+        identity_store,
+        bundle,
+        their_identity_key,
+        &mut csprng,
+        use_pq_ratchet,
+    )
+    .await;
+
+    if had_session || result.is_ok() {
+        session_store
+            .store_session(remote_address, session_record)
+            .await?;
+    }
+
+    result
+}
+
+async fn process_prekey_bundle_inner<R: Rng + CryptoRng>(
+    remote_address: &ProtocolAddress,
+    session_record: &mut SessionRecord,
+    identity_store: &mut dyn IdentityKeyStore,
+    bundle: &PreKeyBundle,
+    their_identity_key: &IdentityKey,
+    csprng: &mut R,
+    use_pq_ratchet: ratchet::UsePQRatchet,
+) -> Result<()> {
+    let our_base_key_pair = KeyPair::generate(csprng);
+    let our_base_public_key = our_base_key_pair.public_key;
     let their_signed_prekey = bundle.signed_pre_key_public()?;
 
     let their_one_time_prekey_id = bundle.pre_key_id()?;
@@ -214,10 +242,6 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
         .await?;
 
     session_record.promote_state(session);
-
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
 
     Ok(())
 }

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -116,6 +116,21 @@ async fn message_encrypt_inner(
         )
     })?;
 
+    // Check trust before doing any crypto work
+    if !identity_store
+        .is_trusted_identity(remote_address, &their_identity_key, Direction::Sending)
+        .await?
+    {
+        log::warn!(
+            "Identity key {} is not trusted for remote address {}",
+            hex::encode(their_identity_key.public_key().public_key_bytes()),
+            remote_address,
+        );
+        return Err(SignalProtocolError::UntrustedIdentity(
+            remote_address.clone(),
+        ));
+    }
+
     let ctext = ENCRYPTION_BUFFER.with(|buffer| {
         let mut buf_wrapper = buffer.borrow_mut();
         let buf = buf_wrapper.get_buffer();
@@ -174,26 +189,10 @@ async fn message_encrypt_inner(
         )?)
     };
 
-    if !identity_store
-        .is_trusted_identity(remote_address, &their_identity_key, Direction::Sending)
-        .await?
-    {
-        log::warn!(
-            "Identity key {} is not trusted for remote address {}",
-            hex::encode(their_identity_key.public_key().public_key_bytes()),
-            remote_address,
-        );
-        return Err(SignalProtocolError::UntrustedIdentity(
-            remote_address.clone(),
-        ));
-    }
-
     identity_store
         .save_identity(remote_address, &their_identity_key)
         .await?;
 
-    // Advance chain key only after identity checks pass, so
-    // UntrustedIdentity doesn't burn a counter.
     session_state.set_sender_chain_key(&next_chain_key);
 
     Ok(message)

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -77,9 +77,8 @@ pub async fn message_encrypt(
     let result =
         message_encrypt_inner(ptext, remote_address, &mut session_record, identity_store).await;
 
-    // Always restore the session, regardless of success or failure.
-    // On error the ratchet may be partially advanced, but losing the
-    // session entirely is worse (forces a full re-establishment).
+    // Always restore — chain key is only advanced inside the inner
+    // function after identity checks pass, so no counters are burned.
     session_store
         .store_session(remote_address, session_record)
         .await?;
@@ -175,9 +174,6 @@ async fn message_encrypt_inner(
         )?)
     };
 
-    session_state.set_sender_chain_key(&next_chain_key);
-
-    // XXX why is this check after everything else?!!
     if !identity_store
         .is_trusted_identity(remote_address, &their_identity_key, Direction::Sending)
         .await?
@@ -192,10 +188,13 @@ async fn message_encrypt_inner(
         ));
     }
 
-    // XXX this could be combined with the above call to the identity store (in a new API)
     identity_store
         .save_identity(remote_address, &their_identity_key)
         .await?;
+
+    // Advance chain key only after identity checks pass, so
+    // UntrustedIdentity doesn't burn a counter.
+    session_state.set_sender_chain_key(&next_chain_key);
 
     Ok(message)
 }
@@ -262,10 +261,9 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     )
     .await;
 
-    // Only persist if we had an existing session (must return a checked-out
-    // record) or the inner call succeeded (session now has real state).
-    // Avoid storing a fresh empty record on failure.
-    if had_session || result.is_ok() {
+    // Persist if we checked out an existing session (must return it) or
+    // if process_prekey populated the record (even if a later step failed).
+    if had_session || session_record.session_state().is_some() {
         session_store
             .store_session(remote_address, session_record)
             .await?;

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -258,18 +258,30 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
                     ciphertext.message()
                 )?
             );
+            // Restore session so load_session's take-ownership doesn't lose it
+            session_store
+                .store_session(remote_address, session_record)
+                .await?;
             let [e] = errs;
             return Err(e);
         }
     };
 
-    let decrypt_result = decrypt_message_with_record(
+    let decrypt_result = match decrypt_message_with_record(
         remote_address,
         &mut session_record,
         ciphertext.message(),
         CiphertextMessageType::PreKey,
         csprng,
-    )?;
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            session_store
+                .store_session(remote_address, session_record)
+                .await?;
+            return Err(e);
+        }
+    };
 
     identity_store
         .save_identity(
@@ -311,16 +323,28 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
              Treating as SessionNotFound.",
             remote_address
         );
+        // Restore session so load_session's take-ownership doesn't lose it
+        session_store
+            .store_session(remote_address, session_record)
+            .await?;
         return Err(SignalProtocolError::SessionNotFound(remote_address.clone()));
     }
 
-    let decrypt_result = decrypt_message_with_record(
+    let decrypt_result = match decrypt_message_with_record(
         remote_address,
         &mut session_record,
         ciphertext,
         CiphertextMessageType::Whisper,
         csprng,
-    )?;
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            session_store
+                .store_session(remote_address, session_record)
+                .await?;
+            return Err(e);
+        }
+    };
 
     // Get the identity key from the (now current) session state
     let their_identity_key = session_record
@@ -358,6 +382,10 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
                 hex::encode(their_identity_key.public_key().public_key_bytes()),
                 remote_address,
             );
+            // Restore session before returning the error
+            session_store
+                .store_session(remote_address, session_record)
+                .await?;
             return Err(SignalProtocolError::UntrustedIdentity(
                 remote_address.clone(),
             ));
@@ -908,6 +936,9 @@ mod tests {
             address: &ProtocolAddress,
         ) -> error::Result<Option<SessionRecord>> {
             Ok(self.0.get(address.as_str()).cloned())
+        }
+        async fn has_session(&self, address: &ProtocolAddress) -> error::Result<bool> {
+            Ok(self.0.contains_key(address.as_str()))
         }
         async fn store_session(
             &mut self,

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -371,7 +371,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
     remote_address: &ProtocolAddress,
     session_record: &mut SessionRecord,
     identity_store: &mut dyn IdentityKeyStore,
-    _csprng: &mut R,
+    csprng: &mut R,
 ) -> Result<Vec<u8>> {
     // A record with no current state and no previous states is degenerate — treat
     // it as missing so the caller gets SessionNotFound and sends a proper retry
@@ -391,7 +391,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
         session_record,
         ciphertext,
         CiphertextMessageType::Whisper,
-        _csprng,
+        csprng,
     )?;
 
     // Get the identity key from the (now current) session state

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -246,10 +246,9 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     csprng: &mut R,
     use_pq_ratchet: UsePQRatchet,
 ) -> Result<Vec<u8>> {
-    let mut session_record = session_store
-        .load_session(remote_address)
-        .await?
-        .unwrap_or_else(SessionRecord::new_fresh);
+    let existing = session_store.load_session(remote_address).await?;
+    let had_session = existing.is_some();
+    let mut session_record = existing.unwrap_or_else(SessionRecord::new_fresh);
 
     let result = message_decrypt_prekey_inner(
         ciphertext,
@@ -263,9 +262,14 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     )
     .await;
 
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
+    // Only persist if we had an existing session (must return a checked-out
+    // record) or the inner call succeeded (session now has real state).
+    // Avoid storing a fresh empty record on failure.
+    if had_session || result.is_ok() {
+        session_store
+            .store_session(remote_address, session_record)
+            .await?;
+    }
 
     let (plaintext, pre_key_used) = result?;
 

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -55,6 +55,7 @@ impl EncryptionBuffer {
 use crate::protocol::consts::MAX_FORWARD_JUMPS;
 use crate::protocol::ratchet::keys::MessageKeyGenerator;
 use crate::protocol::ratchet::{ChainKey, UsePQRatchet};
+use crate::protocol::state::PreKeyId;
 use crate::protocol::state::SessionState;
 use crate::protocol::{
     CiphertextMessage, CiphertextMessageType, Direction, IdentityKeyStore, KeyPair,
@@ -72,6 +73,26 @@ pub async fn message_encrypt(
         .load_session(remote_address)
         .await?
         .ok_or_else(|| SignalProtocolError::SessionNotFound(remote_address.clone()))?;
+
+    let result =
+        message_encrypt_inner(ptext, remote_address, &mut session_record, identity_store).await;
+
+    // Always restore the session, regardless of success or failure.
+    // On error the ratchet may be partially advanced, but losing the
+    // session entirely is worse (forces a full re-establishment).
+    session_store
+        .store_session(remote_address, session_record)
+        .await?;
+
+    result
+}
+
+async fn message_encrypt_inner(
+    ptext: &[u8],
+    remote_address: &ProtocolAddress,
+    session_record: &mut SessionRecord,
+    identity_store: &mut dyn IdentityKeyStore,
+) -> Result<CiphertextMessage> {
     let session_state = session_record
         .session_state_mut()
         .ok_or_else(|| SignalProtocolError::SessionNotFound(remote_address.clone()))?;
@@ -176,9 +197,6 @@ pub async fn message_encrypt(
         .save_identity(remote_address, &their_identity_key)
         .await?;
 
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
     Ok(message)
 }
 
@@ -233,11 +251,46 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
         .await?
         .unwrap_or_else(SessionRecord::new_fresh);
 
-    // Make sure we log the session state if we fail to process the pre-key.
-    let process_prekey_result = session::process_prekey(
+    let result = message_decrypt_prekey_inner(
         ciphertext,
         remote_address,
         &mut session_record,
+        identity_store,
+        pre_key_store,
+        signed_pre_key_store,
+        csprng,
+        use_pq_ratchet,
+    )
+    .await;
+
+    session_store
+        .store_session(remote_address, session_record)
+        .await?;
+
+    let (plaintext, pre_key_used) = result?;
+
+    if let Some(pre_key_id) = pre_key_used {
+        pre_key_store.remove_pre_key(pre_key_id).await?;
+    }
+
+    Ok(plaintext)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
+    ciphertext: &PreKeySignalMessage,
+    remote_address: &ProtocolAddress,
+    session_record: &mut SessionRecord,
+    identity_store: &mut dyn IdentityKeyStore,
+    pre_key_store: &mut dyn PreKeyStore,
+    signed_pre_key_store: &dyn SignedPreKeyStore,
+    csprng: &mut R,
+    use_pq_ratchet: UsePQRatchet,
+) -> Result<(Vec<u8>, Option<PreKeyId>)> {
+    let process_prekey_result = session::process_prekey(
+        ciphertext,
+        remote_address,
+        session_record,
         identity_store,
         pre_key_store,
         signed_pre_key_store,
@@ -254,34 +307,22 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
                 create_decryption_failure_log(
                     remote_address,
                     &errs,
-                    &session_record,
+                    session_record,
                     ciphertext.message()
                 )?
             );
-            // Restore session so load_session's take-ownership doesn't lose it
-            session_store
-                .store_session(remote_address, session_record)
-                .await?;
             let [e] = errs;
             return Err(e);
         }
     };
 
-    let decrypt_result = match decrypt_message_with_record(
+    let decrypt_result = decrypt_message_with_record(
         remote_address,
-        &mut session_record,
+        session_record,
         ciphertext.message(),
         CiphertextMessageType::PreKey,
         csprng,
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            session_store
-                .store_session(remote_address, session_record)
-                .await?;
-            return Err(e);
-        }
-    };
+    )?;
 
     identity_store
         .save_identity(
@@ -290,15 +331,7 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
         )
         .await?;
 
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
-
-    if let Some(pre_key_id) = pre_key_used.pre_key_id {
-        pre_key_store.remove_pre_key(pre_key_id).await?;
-    }
-
-    Ok(decrypt_result.plaintext)
+    Ok((decrypt_result.plaintext, pre_key_used.pre_key_id))
 }
 
 pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
@@ -313,6 +346,29 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
         .await?
         .ok_or_else(|| SignalProtocolError::SessionNotFound(remote_address.clone()))?;
 
+    let result = message_decrypt_signal_inner(
+        ciphertext,
+        remote_address,
+        &mut session_record,
+        identity_store,
+        csprng,
+    )
+    .await;
+
+    session_store
+        .store_session(remote_address, session_record)
+        .await?;
+
+    result
+}
+
+async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
+    ciphertext: &SignalMessage,
+    remote_address: &ProtocolAddress,
+    session_record: &mut SessionRecord,
+    identity_store: &mut dyn IdentityKeyStore,
+    _csprng: &mut R,
+) -> Result<Vec<u8>> {
     // A record with no current state and no previous states is degenerate — treat
     // it as missing so the caller gets SessionNotFound and sends a proper retry
     // receipt (with error code 1) instead of attempting decryption that will always
@@ -323,28 +379,16 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
              Treating as SessionNotFound.",
             remote_address
         );
-        // Restore session so load_session's take-ownership doesn't lose it
-        session_store
-            .store_session(remote_address, session_record)
-            .await?;
         return Err(SignalProtocolError::SessionNotFound(remote_address.clone()));
     }
 
-    let decrypt_result = match decrypt_message_with_record(
+    let decrypt_result = decrypt_message_with_record(
         remote_address,
-        &mut session_record,
+        session_record,
         ciphertext,
         CiphertextMessageType::Whisper,
-        csprng,
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            session_store
-                .store_session(remote_address, session_record)
-                .await?;
-            return Err(e);
-        }
-    };
+        _csprng,
+    )?;
 
     // Get the identity key from the (now current) session state
     let their_identity_key = session_record
@@ -382,10 +426,6 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
                 hex::encode(their_identity_key.public_key().public_key_bytes()),
                 remote_address,
             );
-            // Restore session before returning the error
-            session_store
-                .store_session(remote_address, session_record)
-                .await?;
             return Err(SignalProtocolError::UntrustedIdentity(
                 remote_address.clone(),
             ));
@@ -395,10 +435,6 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
             .save_identity(remote_address, &their_identity_key)
             .await?;
     }
-
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
 
     Ok(decrypt_result.plaintext)
 }

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -577,8 +577,6 @@ impl From<&SessionState> for SessionStructure {
 #[derive(Clone)]
 pub struct SessionRecord {
     current_session: Option<SessionState>,
-    /// Wrapped in Arc so that cloning a SessionRecord is O(1) for this field.
-    /// Only mutated on rare paths (archive, promote, take/restore) via Arc::make_mut.
     previous_sessions: Arc<Vec<SessionStructure>>,
 }
 
@@ -755,9 +753,6 @@ impl SessionRecord {
         self.current_session = Some(new_state);
     }
 
-    // A non-fallible version of archive_current_state.
-    //
-    // Returns `true` if there was a session to archive, `false` if not.
     fn archive_current_state_inner(&mut self) -> bool {
         if let Some(mut current_session) = self.current_session.take() {
             let sessions = Arc::make_mut(&mut self.previous_sessions);
@@ -780,11 +775,44 @@ impl SessionRecord {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>, SignalProtocolError> {
-        let record = RecordStructure {
-            current_session: self.current_session.as_ref().map(|s| s.into()),
-            previous_sessions: (*self.previous_sessions).clone(),
-        };
-        Ok(record.encode_to_vec())
+        let mut buf = Vec::new();
+        self.serialize_into(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Encode into a caller-supplied buffer (allows reuse across flushes).
+    pub fn serialize_into(&self, buf: &mut Vec<u8>) -> Result<(), SignalProtocolError> {
+        use prost::encoding::{encoded_len_varint, message::encode as encode_msg};
+
+        let current_len = self
+            .current_session
+            .as_ref()
+            .map(|s| {
+                let msg_len = s.session.encoded_len();
+                1 + encoded_len_varint(msg_len as u64) + msg_len
+            })
+            .unwrap_or(0);
+
+        let previous_len: usize = self
+            .previous_sessions
+            .iter()
+            .map(|s| {
+                let msg_len = s.encoded_len();
+                1 + encoded_len_varint(msg_len as u64) + msg_len
+            })
+            .sum();
+
+        buf.clear();
+        buf.reserve(current_len + previous_len);
+
+        if let Some(state) = &self.current_session {
+            encode_msg(1, &state.session, buf);
+        }
+        for session in self.previous_sessions.iter() {
+            encode_msg(2, session, buf);
+        }
+
+        Ok(())
     }
 
     pub fn remote_registration_id(&self) -> Result<u32, SignalProtocolError> {

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -776,12 +776,12 @@ impl SessionRecord {
 
     pub fn serialize(&self) -> Result<Vec<u8>, SignalProtocolError> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf)?;
+        self.serialize_into(&mut buf);
         Ok(buf)
     }
 
     /// Encode into a caller-supplied buffer (allows reuse across flushes).
-    pub fn serialize_into(&self, buf: &mut Vec<u8>) -> Result<(), SignalProtocolError> {
+    pub fn serialize_into(&self, buf: &mut Vec<u8>) {
         use prost::encoding::{encoded_len_varint, message::encode as encode_msg};
 
         let current_len = self
@@ -811,8 +811,6 @@ impl SessionRecord {
         for session in self.previous_sessions.iter() {
             encode_msg(2, session, buf);
         }
-
-        Ok(())
     }
 
     pub fn remote_registration_id(&self) -> Result<u32, SignalProtocolError> {

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -131,7 +131,29 @@ pub trait SignedPreKeyStore: ThreadSafe {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait SessionStore: ThreadSafe {
     /// Look up the session corresponding to `address`.
+    ///
+    /// Although this takes `&self`, implementations are expected to use
+    /// interior mutability to hand out an exclusively owned [`SessionRecord`]
+    /// when possible.
+    ///
+    /// Hot-path caches should treat this as a logical "take": once a session
+    /// is returned, the caller owns the only mutable copy until it is written
+    /// back with [`SessionStore::store_session`]. Callers that mutate or even
+    /// inspect a session and then continue must ensure they restore it on all
+    /// paths, or they risk losing the in-memory owner and forcing a reload from
+    /// persistence on the next access.
+    ///
+    /// Recommended pattern: use a scope guard / `defer`-style helper so
+    /// [`SessionStore::store_session`] runs even when an intermediate step
+    /// returns an error.
     async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
+
+    /// Check whether a session exists without taking ownership.
+    ///
+    /// Implementations must make this a non-destructive existence check. It
+    /// must not delegate to [`SessionStore::load_session`] unless they also
+    /// restore the record before returning.
+    async fn has_session(&self, address: &ProtocolAddress) -> Result<bool>;
 
     /// Set the entry for `address` to the value of `record`.
     async fn store_session(

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -130,29 +130,12 @@ pub trait SignedPreKeyStore: ThreadSafe {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait SessionStore: ThreadSafe {
-    /// Look up the session corresponding to `address`.
-    ///
-    /// Although this takes `&self`, implementations are expected to use
-    /// interior mutability to hand out an exclusively owned [`SessionRecord`]
-    /// when possible.
-    ///
-    /// Hot-path caches should treat this as a logical "take": once a session
-    /// is returned, the caller owns the only mutable copy until it is written
-    /// back with [`SessionStore::store_session`]. Callers that mutate or even
-    /// inspect a session and then continue must ensure they restore it on all
-    /// paths, or they risk losing the in-memory owner and forcing a reload from
-    /// persistence on the next access.
-    ///
-    /// Recommended pattern: use a scope guard / `defer`-style helper so
-    /// [`SessionStore::store_session`] runs even when an intermediate step
-    /// returns an error.
+    /// Takes the session for `address`. Implementations with caches should
+    /// treat this as a logical checkout; callers must always call
+    /// [`store_session`] to return the record, even on error paths.
     async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
 
-    /// Check whether a session exists without taking ownership.
-    ///
-    /// Implementations must make this a non-destructive existence check. It
-    /// must not delegate to [`SessionStore::load_session`] unless they also
-    /// restore the record before returning.
+    /// Non-destructive existence check (must not consume the cached entry).
     async fn has_session(&self, address: &ProtocolAddress) -> Result<bool>;
 
     /// Set the entry for `address` to the value of `record`.

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -11,6 +11,7 @@ description = "Noise Protocol implementation for WhatsApp with AES-256-GCM"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+aead = { workspace = true }
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -11,7 +11,6 @@ description = "Noise Protocol implementation for WhatsApp with AES-256-GCM"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aead = { workspace = true }
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -2,7 +2,8 @@ use bytes::{Buf, BytesMut};
 use log::trace;
 
 pub const FRAME_LENGTH_SIZE: usize = 3;
-pub const FRAME_MAX_SIZE: usize = 2 << 23;
+/// WA Web: `if (t >= 1 << 24)` in WAFrameSocket.$8
+pub const FRAME_MAX_SIZE: usize = 1 << 24;
 
 /// Encodes a payload into a WhatsApp frame, writing directly into `out`.
 /// The `out` buffer is cleared before use, allowing buffer reuse.
@@ -84,7 +85,7 @@ impl FrameDecoder {
         }
 
         if self.buffer.len() >= FRAME_LENGTH_SIZE + frame_len {
-            let _ = self.buffer.split_to(FRAME_LENGTH_SIZE);
+            self.buffer.advance(FRAME_LENGTH_SIZE);
             let frame_data = self.buffer.split_to(frame_len);
             trace!("<-- Decoded frame: {} bytes", frame_data.len());
             Some(frame_data)

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, BytesMut};
 use log::trace;
 
 pub const FRAME_LENGTH_SIZE: usize = 3;
@@ -65,7 +65,7 @@ impl FrameDecoder {
         self.buffer.extend_from_slice(data);
     }
 
-    pub fn decode_frame(&mut self) -> Option<Bytes> {
+    pub fn decode_frame(&mut self) -> Option<BytesMut> {
         if self.buffer.len() < FRAME_LENGTH_SIZE {
             return None;
         }
@@ -84,8 +84,8 @@ impl FrameDecoder {
         }
 
         if self.buffer.len() >= FRAME_LENGTH_SIZE + frame_len {
-            self.buffer.advance(FRAME_LENGTH_SIZE);
-            let frame_data = self.buffer.split_to(frame_len).freeze();
+            let _ = self.buffer.split_to(FRAME_LENGTH_SIZE);
+            let frame_data = self.buffer.split_to(frame_len);
             trace!("<-- Decoded frame: {} bytes", frame_data.len());
             Some(frame_data)
         } else {

--- a/wacore/noise/src/state.rs
+++ b/wacore/noise/src/state.rs
@@ -81,7 +81,11 @@ impl NoiseCipher {
     ///
     /// The buffer should contain the ciphertext with the 16-byte authentication tag.
     /// After decryption, it will contain the plaintext (tag is removed).
-    pub fn decrypt_in_place_with_counter(&self, counter: u32, buffer: &mut Vec<u8>) -> Result<()> {
+    pub fn decrypt_in_place_with_counter<B: aes_gcm::aead::Buffer>(
+        &self,
+        counter: u32,
+        buffer: &mut B,
+    ) -> Result<()> {
         let iv = generate_iv(counter);
         self.inner
             .decrypt_in_place(iv.as_ref().into(), b"", buffer)

--- a/wacore/noise/src/state.rs
+++ b/wacore/noise/src/state.rs
@@ -31,8 +31,8 @@ pub fn generate_iv(counter: u32) -> [u8; 12] {
 /// let ciphertext = cipher.encrypt_with_counter(counter, plaintext)?;
 /// counter = counter.wrapping_add(1);
 ///
-/// // Decrypt with counter
-/// let plaintext = cipher.decrypt_with_counter(counter, ciphertext)?;
+/// // Decrypt in place with counter
+/// cipher.decrypt_in_place_with_counter(counter, &mut ciphertext_buf)?;
 /// ```
 pub struct NoiseCipher {
     inner: Aes256Gcm,
@@ -65,16 +65,6 @@ impl NoiseCipher {
         self.inner
             .encrypt_in_place(iv.as_ref().into(), b"", buffer)
             .map_err(|e| NoiseError::CryptoError(e.to_string()))
-    }
-
-    /// Decrypts ciphertext using the specified counter for IV generation.
-    ///
-    /// The ciphertext should include the 16-byte authentication tag.
-    pub fn decrypt_with_counter(&self, counter: u32, ciphertext: &[u8]) -> Result<Vec<u8>> {
-        let iv = generate_iv(counter);
-        self.inner
-            .decrypt(iv.as_ref().into(), ciphertext)
-            .map_err(|e| NoiseError::CryptoError(format!("Decrypt failed: {e}")))
     }
 
     /// Decrypts ciphertext in-place within the provided buffer.

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -168,7 +168,7 @@ impl RequestUtils {
         let hash = Sha256::digest(&data);
         let truncated = &hash[..9];
 
-        // "3EB0" prefix (4) + 9 bytes as hex (18) = 22 chars
+        // WA Web message IDs are "3EB0" + 18 hex chars (9-byte truncated hash)
         let mut id = String::with_capacity(22);
         id.push_str("3EB0");
         for &b in truncated {

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -163,13 +163,19 @@ impl RequestUtils {
         rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut random_bytes);
         data.extend_from_slice(&random_bytes);
 
-        let hash = Sha256::digest(&data);
-        let truncated_hash = &hash[..9];
+        const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
 
-        format!(
-            "3EB0{hash}",
-            hash = hex::encode(truncated_hash).to_uppercase()
-        )
+        let hash = Sha256::digest(&data);
+        let truncated = &hash[..9];
+
+        // "3EB0" prefix (4) + 9 bytes as hex (18) = 22 chars
+        let mut id = String::with_capacity(22);
+        id.push_str("3EB0");
+        for &b in truncated {
+            id.push(HEX_UPPER[(b >> 4) as usize] as char);
+            id.push(HEX_UPPER[(b & 0x0F) as usize] as char);
+        }
+        id
     }
 
     pub fn build_iq_node(&self, query: &InfoQuery<'_>, req_id: Option<String>) -> Node {

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -378,13 +378,7 @@ where
             let lid_jid = Jid::lid_device(lid_user, device_jid.device);
             lid_jid.reset_protocol_address(&mut reusable_addr);
 
-            if stores
-                .session_store
-                .load_session(&reusable_addr)
-                .await?
-                .is_some()
-            {
-                // Found existing session under LID address - use it!
+            if stores.session_store.has_session(&reusable_addr).await? {
                 log::debug!(
                     "Using LID session {} for PN {} (LID-first lookup)",
                     lid_jid,
@@ -395,14 +389,8 @@ where
             }
         }
 
-        // Fall back to direct address lookup (for LID JIDs or PN without LID mapping)
         device_jid.reset_protocol_address(&mut reusable_addr);
-        if stores
-            .session_store
-            .load_session(&reusable_addr)
-            .await?
-            .is_some()
-        {
+        if stores.session_store.has_session(&reusable_addr).await? {
             continue;
         }
 
@@ -2196,6 +2184,12 @@ mod tests {
                     .0
                     .get(a)
                     .and_then(|b| crate::libsignal::protocol::SessionRecord::deserialize(b).ok()))
+            }
+            async fn has_session(
+                &self,
+                a: &ProtocolAddress,
+            ) -> crate::libsignal::protocol::error::Result<bool> {
+                Ok(self.0.contains_key(a))
             }
             async fn store_session(
                 &mut self,

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -248,6 +248,15 @@ impl SignalStoreCache {
 
     // === Sessions (object cache — serialize only during flush) ===
 
+    /// Takes exclusive ownership of the cached [`SessionRecord`] when present.
+    ///
+    /// This removes the entry from `state.cache` so hot encrypt/decrypt paths
+    /// can mutate the owned record directly via [`SessionRecord::session_state_mut`]
+    /// without cloning the whole record first. Callers must return the record
+    /// to the cache with [`SignalStoreCache::put_session`] after use.
+    ///
+    /// Backend misses are negative-cached as `None` so repeated missing-session
+    /// checks avoid hitting persistence over and over.
     pub async fn get_session(
         &self,
         address: &ProtocolAddress,
@@ -255,16 +264,17 @@ impl SignalStoreCache {
     ) -> Result<Option<SessionRecord>> {
         let key = address.as_str();
         let mut state = self.sessions.lock().await;
-        if let Some(cached) = state.cache.get(key) {
-            return Ok(cached.clone());
+        if let Some(record) = state.cache.remove(key) {
+            return Ok(record);
         }
-        let record = match backend.get_session(key).await? {
-            Some(bytes) => Some(SessionRecord::deserialize(&bytes)?),
-            None => None,
-        };
-        state.cache.insert(Arc::from(key), record.clone());
-        state.evict_if_needed(self.max_entries);
-        Ok(record)
+        match backend.get_session(key).await? {
+            Some(bytes) => Ok(Some(SessionRecord::deserialize(&bytes)?)),
+            None => {
+                state.cache.insert(Arc::from(key), None);
+                state.evict_if_needed(self.max_entries);
+                Ok(None)
+            }
+        }
     }
 
     pub async fn put_session(&self, address: &ProtocolAddress, record: SessionRecord) {
@@ -381,12 +391,13 @@ impl SignalStoreCache {
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
             let deleted_keys: Vec<_> = state.deleted.iter().cloned().collect();
 
+            let mut encode_buf = Vec::new();
             for address in &dirty_keys {
                 if let Some(Some(record)) = state.cache.get(address.as_ref()) {
-                    let bytes = record
-                        .serialize()
+                    record
+                        .serialize_into(&mut encode_buf)
                         .map_err(|e| anyhow::anyhow!("session serialize for {address}: {e}"))?;
-                    backend.put_session(address, &bytes).await?;
+                    backend.put_session(address, &encode_buf).await?;
                 }
             }
             for address in &deleted_keys {

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -57,9 +57,17 @@ pub struct SignalStoreCache {
 
 // === Session object cache (no per-message serialize/deserialize) ===
 
+/// Cache entry tracking whether a session is present, absent, or checked out
+/// by an encrypt/decrypt operation.
+enum SessionEntry {
+    Present(Box<SessionRecord>),
+    Absent,
+    /// Taken by load_session; has_session treats as present, flush/eviction skip.
+    CheckedOut,
+}
+
 struct SessionStoreState {
-    /// Cached entries. `None` value = known-absent (negative cache).
-    cache: HashMap<Arc<str>, Option<SessionRecord>>,
+    cache: HashMap<Arc<str>, SessionEntry>,
     dirty: HashSet<Arc<str>>,
     deleted: HashSet<Arc<str>>,
 }
@@ -84,14 +92,15 @@ impl SessionStoreState {
 
     fn put(&mut self, address: &str, record: SessionRecord) {
         let addr = self.key_for(address);
-        self.cache.insert(addr.clone(), Some(record));
+        self.cache
+            .insert(addr.clone(), SessionEntry::Present(Box::new(record)));
         self.dirty.insert(addr.clone());
         self.deleted.remove(&addr);
     }
 
     fn delete(&mut self, address: &str) {
         let addr = self.key_for(address);
-        self.cache.insert(addr.clone(), None);
+        self.cache.insert(addr.clone(), SessionEntry::Absent);
         self.deleted.insert(addr.clone());
         self.dirty.remove(&addr);
     }
@@ -103,12 +112,25 @@ impl SessionStoreState {
     }
 
     fn evict_if_needed(&mut self, max_entries: usize) {
-        evict_clean_entries(
-            &mut self.cache,
-            &self.dirty,
-            Some(&self.deleted),
-            max_entries,
-        );
+        let overflow = self.cache.len().saturating_sub(max_entries);
+        if overflow == 0 {
+            return;
+        }
+        let mut negative = Vec::with_capacity(overflow);
+        let mut positive = Vec::with_capacity(overflow);
+        for (k, v) in self.cache.iter() {
+            if self.dirty.contains(k.as_ref()) || self.deleted.contains(k.as_ref()) {
+                continue;
+            }
+            match v {
+                SessionEntry::CheckedOut => continue, // never evict checked-out
+                SessionEntry::Absent => negative.push(k.clone()),
+                SessionEntry::Present(_) => positive.push(k.clone()),
+            }
+        }
+        for key in negative.into_iter().chain(positive).take(overflow) {
+            self.cache.remove(&key);
+        }
     }
 }
 
@@ -248,15 +270,8 @@ impl SignalStoreCache {
 
     // === Sessions (object cache — serialize only during flush) ===
 
-    /// Takes exclusive ownership of the cached [`SessionRecord`] when present.
-    ///
-    /// This removes the entry from `state.cache` so hot encrypt/decrypt paths
-    /// can mutate the owned record directly via [`SessionRecord::session_state_mut`]
-    /// without cloning the whole record first. Callers must return the record
-    /// to the cache with [`SignalStoreCache::put_session`] after use.
-    ///
-    /// Backend misses are negative-cached as `None` so repeated missing-session
-    /// checks avoid hitting persistence over and over.
+    /// Takes ownership of the cached session, leaving a `CheckedOut` marker.
+    /// Callers must return the record with [`put_session`] after use.
     pub async fn get_session(
         &self,
         address: &ProtocolAddress,
@@ -264,13 +279,21 @@ impl SignalStoreCache {
     ) -> Result<Option<SessionRecord>> {
         let key = address.as_str();
         let mut state = self.sessions.lock().await;
-        if let Some(record) = state.cache.remove(key) {
-            return Ok(record);
+        if let Some(entry) = state.cache.get_mut(key) {
+            if matches!(entry, SessionEntry::Present(_)) {
+                let SessionEntry::Present(record) =
+                    std::mem::replace(entry, SessionEntry::CheckedOut)
+                else {
+                    unreachable!()
+                };
+                return Ok(Some(*record));
+            }
+            return Ok(None);
         }
         match backend.get_session(key).await? {
             Some(bytes) => Ok(Some(SessionRecord::deserialize(&bytes)?)),
             None => {
-                state.cache.insert(Arc::from(key), None);
+                state.cache.insert(Arc::from(key), SessionEntry::Absent);
                 state.evict_if_needed(self.max_entries);
                 Ok(None)
             }
@@ -289,6 +312,9 @@ impl SignalStoreCache {
         state.evict_if_needed(self.max_entries);
     }
 
+    /// Non-destructive existence check (`CheckedOut` counts as present).
+    /// Backend misses are negative-cached; hits are not cached to skip
+    /// deserialization (the subsequent `get_session` will cache on demand).
     pub async fn has_session(
         &self,
         address: &ProtocolAddress,
@@ -296,16 +322,14 @@ impl SignalStoreCache {
     ) -> Result<bool> {
         let key = address.as_str();
         let mut state = self.sessions.lock().await;
-        if let Some(cached) = state.cache.get(key) {
-            return Ok(cached.is_some());
+        if let Some(entry) = state.cache.get(key) {
+            return Ok(!matches!(entry, SessionEntry::Absent));
         }
-        let record = match backend.get_session(key).await? {
-            Some(bytes) => Some(SessionRecord::deserialize(&bytes)?),
-            None => None,
-        };
-        let exists = record.is_some();
-        state.cache.insert(Arc::from(key), record);
-        state.evict_if_needed(self.max_entries);
+        let exists = backend.get_session(key).await?.is_some();
+        if !exists {
+            state.cache.insert(Arc::from(key), SessionEntry::Absent);
+            state.evict_if_needed(self.max_entries);
+        }
         Ok(exists)
     }
 
@@ -393,11 +417,13 @@ impl SignalStoreCache {
 
             let mut encode_buf = Vec::new();
             for address in &dirty_keys {
-                if let Some(Some(record)) = state.cache.get(address.as_ref()) {
-                    record
-                        .serialize_into(&mut encode_buf)
-                        .map_err(|e| anyhow::anyhow!("session serialize for {address}: {e}"))?;
-                    backend.put_session(address, &encode_buf).await?;
+                match state.cache.get(address.as_ref()) {
+                    Some(SessionEntry::Present(record)) => {
+                        record.serialize_into(&mut encode_buf);
+                        backend.put_session(address, &encode_buf).await?;
+                    }
+                    Some(SessionEntry::CheckedOut) => continue,
+                    _ => {}
                 }
             }
             for address in &deleted_keys {
@@ -405,7 +431,12 @@ impl SignalStoreCache {
             }
 
             for key in &dirty_keys {
-                state.dirty.remove(key);
+                if !matches!(
+                    state.cache.get(key.as_ref()),
+                    Some(SessionEntry::CheckedOut)
+                ) {
+                    state.dirty.remove(key);
+                }
             }
             for key in &deleted_keys {
                 state.deleted.remove(key);

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -359,14 +359,21 @@ impl SignalStoreCache {
         backend: &dyn SignalStore,
     ) -> Result<bool> {
         let key = address.as_str();
-        let mut state = self.sessions.lock().await;
-        if let Some(entry) = state.cache.get(key) {
-            return Ok(!matches!(entry, SessionEntry::Absent));
+        {
+            let state = self.sessions.lock().await;
+            if let Some(entry) = state.cache.get(key) {
+                return Ok(!matches!(entry, SessionEntry::Absent));
+            }
         }
-        let exists = backend.get_session(key).await?.is_some();
+        // Backend I/O outside the lock
+        let exists = backend.has_session(key).await?;
         if !exists {
-            state.cache.insert(Arc::from(key), SessionEntry::Absent);
-            state.evict_if_needed(self.max_entries);
+            let mut state = self.sessions.lock().await;
+            // Re-check: another task may have populated the cache
+            if !state.cache.contains_key(key) {
+                state.cache.insert(Arc::from(key), SessionEntry::Absent);
+                state.evict_if_needed(self.max_entries);
+            }
         }
         Ok(exists)
     }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -291,7 +291,12 @@ impl SignalStoreCache {
             return Ok(None);
         }
         match backend.get_session(key).await? {
-            Some(bytes) => Ok(Some(SessionRecord::deserialize(&bytes)?)),
+            Some(bytes) => {
+                let record = SessionRecord::deserialize(&bytes)?;
+                state.cache.insert(Arc::from(key), SessionEntry::CheckedOut);
+                state.evict_if_needed(self.max_entries);
+                Ok(Some(record))
+            }
             None => {
                 state.cache.insert(Arc::from(key), SessionEntry::Absent);
                 state.evict_if_needed(self.max_entries);

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -278,28 +278,41 @@ impl SignalStoreCache {
         backend: &dyn SignalStore,
     ) -> Result<Option<SessionRecord>> {
         let key = address.as_str();
-        let mut state = self.sessions.lock().await;
-        if let Some(entry) = state.cache.get_mut(key) {
-            if matches!(entry, SessionEntry::Present(_)) {
-                let SessionEntry::Present(record) =
-                    std::mem::replace(entry, SessionEntry::CheckedOut)
-                else {
-                    unreachable!()
-                };
-                return Ok(Some(*record));
+        {
+            let mut state = self.sessions.lock().await;
+            if let Some(entry) = state.cache.get_mut(key) {
+                if matches!(entry, SessionEntry::Present(_)) {
+                    let SessionEntry::Present(record) =
+                        std::mem::replace(entry, SessionEntry::CheckedOut)
+                    else {
+                        unreachable!()
+                    };
+                    return Ok(Some(*record));
+                }
+                return Ok(None);
             }
-            return Ok(None);
         }
-        match backend.get_session(key).await? {
+        // Backend I/O outside the lock
+        let backend_result = backend.get_session(key).await?;
+        let mut state = self.sessions.lock().await;
+        match backend_result {
             Some(bytes) => {
+                if state.cache.contains_key(key) {
+                    // Another task populated this slot while we were loading;
+                    // defer to whatever they wrote (Present, CheckedOut, etc).
+                    // Deserialize and return without caching to avoid conflict.
+                    return Ok(Some(SessionRecord::deserialize(&bytes)?));
+                }
                 let record = SessionRecord::deserialize(&bytes)?;
                 state.cache.insert(Arc::from(key), SessionEntry::CheckedOut);
                 state.evict_if_needed(self.max_entries);
                 Ok(Some(record))
             }
             None => {
-                state.cache.insert(Arc::from(key), SessionEntry::Absent);
-                state.evict_if_needed(self.max_entries);
+                if !state.cache.contains_key(key) {
+                    state.cache.insert(Arc::from(key), SessionEntry::Absent);
+                    state.evict_if_needed(self.max_entries);
+                }
                 Ok(None)
             }
         }
@@ -313,26 +326,35 @@ impl SignalStoreCache {
         backend: &dyn SignalStore,
     ) -> Result<Option<SessionRecord>> {
         let key = address.as_str();
-        let mut state = self.sessions.lock().await;
-        if let Some(entry) = state.cache.get(key) {
-            return match entry {
-                SessionEntry::Present(record) => Ok(Some((**record).clone())),
-                _ => Ok(None),
-            };
+        {
+            let state = self.sessions.lock().await;
+            if let Some(entry) = state.cache.get(key) {
+                return match entry {
+                    SessionEntry::Present(record) => Ok(Some((**record).clone())),
+                    _ => Ok(None),
+                };
+            }
         }
-        match backend.get_session(key).await? {
+        // Backend I/O outside the lock
+        let backend_result = backend.get_session(key).await?;
+        let mut state = self.sessions.lock().await;
+        match backend_result {
             Some(bytes) => {
                 let record = SessionRecord::deserialize(&bytes)?;
-                let cloned = record.clone();
-                state
-                    .cache
-                    .insert(Arc::from(key), SessionEntry::Present(Box::new(record)));
-                state.evict_if_needed(self.max_entries);
-                Ok(Some(cloned))
+                if !state.cache.contains_key(key) {
+                    state.cache.insert(
+                        Arc::from(key),
+                        SessionEntry::Present(Box::new(record.clone())),
+                    );
+                    state.evict_if_needed(self.max_entries);
+                }
+                Ok(Some(record))
             }
             None => {
-                state.cache.insert(Arc::from(key), SessionEntry::Absent);
-                state.evict_if_needed(self.max_entries);
+                if !state.cache.contains_key(key) {
+                    state.cache.insert(Arc::from(key), SessionEntry::Absent);
+                    state.evict_if_needed(self.max_entries);
+                }
                 Ok(None)
             }
         }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -305,6 +305,39 @@ impl SignalStoreCache {
         }
     }
 
+    /// Non-destructive read. Clones the session without removing it from
+    /// cache. Use for inspection-only paths (retry, LID migration checks).
+    pub async fn peek_session(
+        &self,
+        address: &ProtocolAddress,
+        backend: &dyn SignalStore,
+    ) -> Result<Option<SessionRecord>> {
+        let key = address.as_str();
+        let mut state = self.sessions.lock().await;
+        if let Some(entry) = state.cache.get(key) {
+            return match entry {
+                SessionEntry::Present(record) => Ok(Some((**record).clone())),
+                _ => Ok(None),
+            };
+        }
+        match backend.get_session(key).await? {
+            Some(bytes) => {
+                let record = SessionRecord::deserialize(&bytes)?;
+                let cloned = record.clone();
+                state
+                    .cache
+                    .insert(Arc::from(key), SessionEntry::Present(Box::new(record)));
+                state.evict_if_needed(self.max_entries);
+                Ok(Some(cloned))
+            }
+            None => {
+                state.cache.insert(Arc::from(key), SessionEntry::Absent);
+                state.evict_if_needed(self.max_entries);
+                Ok(None)
+            }
+        }
+    }
+
     pub async fn put_session(&self, address: &ProtocolAddress, record: SessionRecord) {
         let mut state = self.sessions.lock().await;
         state.put(address.as_str(), record);


### PR DESCRIPTION
## Summary

- **Zero-copy receive pipeline**: thread `BytesMut`/`Bytes` ownership end-to-end from frame decoding → noise decryption → unpack → node decode, eliminating intermediate `Vec<u8>` copies. Uncompressed payloads go from network buffer to parsed node with zero allocation on the main path.
- **Take-ownership session cache**: `get_session()` removes the entry from cache so encrypt/decrypt can mutate the owned `SessionRecord` directly without cloning. Added `has_session()` to `SessionStore` trait for non-destructive existence checks in the prekey fanout loop.
- **Session restore on error paths**: decrypt functions now always put the session back on failure, matching WA Web behavior (verified against `docs/captured-js/WAWeb/Signal/ProtocolStoreUnifiedApi.js`) where decrypt failures never destroy cached sessions.
- **Minor hot-path wins**: reusable serialization buffer in session flush, inline hex in `generate_message_id()`, `ValueRef::to_node_value()` for ack construction.

## Breaking changes

- `SessionStore` trait gains a required `has_session(&self, &ProtocolAddress) -> Result<bool>` method
- `FrameDecoder::decode_frame()` returns `BytesMut` instead of `Bytes`
- `NoiseSocket::decrypt_frame()` takes `BytesMut` and returns `BytesMut` (was `&[u8]` → `Vec<u8>`)
- `OwnedNodeRef::new()` takes `impl Into<Bytes>` instead of `Vec<u8>`
- `NoiseCipher::decrypt_in_place_with_counter()` is now generic over `aead::Buffer`

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --workspace --exclude e2e-tests` (1113 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Enhancements**
  * Faster crypto and parsing with fewer copies and more in-place buffer handling
  * Lower memory use via mutable frame buffers and reusable serialization buffers
  * Slightly faster message ID formatting

* **Infrastructure Improvements**
  * Improved session caching with non-destructive existence checks (has_session) and peek support
  * Refined cache checkout/eviction semantics and reduced unnecessary backend loads
  * Adjusted frame-size limit for compatibility

* **Reliability**
  * More consistent session persistence and safer migration paths to reduce stale or lost state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->