### PR TITLE
fix: encrypt DMs for all recipient devices, not just bare JID

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -1056,19 +1056,30 @@ impl Client {
                 }
             }
 
-            // DM fanout: bare recipient (device 0) + own companion devices.
-            // WA Web (MsgCreateFanoutStanza.js): for CHAT fanout with a single
-            // primary device, encrypts directly for that device only. Own devices
-            // get per-device enc for multi-device self-sync. The server routes
-            // the bare enc to the correct recipient device.
+            // DM fanout: encrypt for ALL recipient devices + own companion devices.
+            //
+            // The original WA Web approach (MsgCreateFanoutStanza.js) encrypts
+            // only for the bare recipient JID (device 0) and relies on server-side
+            // fanout to deliver to companion devices. However, companion devices
+            // often receive <unavailable> instead of the encrypted payload, causing
+            // "Waiting for this message" on WhatsApp Web/Desktop clients.
+            //
+            // Fix: fetch all recipient devices and encrypt for each one
+            // individually, same as mobile clients do. This ensures companion
+            // devices get a directly-encrypted payload they can decrypt without
+            // needing a retry receipt + PDO relay from the primary phone.
             let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
 
-            // Populate device registry for retry handling
-            let _ = self.get_user_devices(std::slice::from_ref(&to)).await;
+            let recipient_devices = self.get_user_devices(std::slice::from_ref(&to)).await?;
             let own_devices = self.get_user_devices(std::slice::from_ref(own_jid)).await?;
 
-            let mut all_dm_jids = Vec::with_capacity(1 + own_devices.len());
-            all_dm_jids.push(recipient_bare);
+            let mut all_dm_jids = Vec::with_capacity(recipient_devices.len().max(1) + own_devices.len());
+            if recipient_devices.is_empty() {
+                // Fallback: no known devices, use bare JID (server fanout)
+                all_dm_jids.push(recipient_bare);
+            } else {
+                all_dm_jids.extend(recipient_devices);
+            }
             all_dm_jids.extend(own_devices);
 
             self.ensure_e2e_sessions(&all_dm_jids).await?;


### PR DESCRIPTION
## Problem

DM send path encrypts only for the recipient's bare JID (device 0) and relies on server-side fanout to deliver to companion devices. However, companion devices (WhatsApp Web, Desktop) often receive `<unavailable>` instead of the encrypted payload, causing **"Waiting for this message"** on the recipient's linked devices.

This is the send-side counterpart to #506 (which fixed the receive side).

## Root cause

```rust
// src/send.rs line 1049
let mut all_dm_jids = Vec::with_capacity(1 + own_devices.len());
all_dm_jids.push(recipient_bare);  // ← only device 0
all_dm_jids.extend(own_devices);
```

The code already fetches all recipient devices (`get_user_devices`) on the line above, but only uses it for retry handling — not for encryption.

## Fix

Use `get_user_devices` result for encryption, falling back to bare JID if no devices are known:

```rust
let recipient_devices = self.get_user_devices(std::slice::from_ref(&to)).await?;
if recipient_devices.is_empty() {
    all_dm_jids.push(recipient_bare); // fallback
} else {
    all_dm_jids.extend(recipient_devices);
}
```

## Testing

Tested with a linked device (wa-rs bot) sending DMs to a user with WhatsApp Web active:
- **Before**: WhatsApp Web shows "Waiting for this message" indefinitely
- **After**: Messages appear instantly on all devices (phone + Web + Desktop)

Combined with #506, this completes bidirectional linked device support:
- Receive: #506 — bot gets `<unavailable>` → retry receipt → PDO relay ✓
- Send: this PR — bot encrypts for all devices → direct delivery ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Direct messages now encrypt and deliver to all recipient devices in 1:1 chats, improving multi-device delivery reliability and ensuring each device receives an encrypted copy.
  * Device resolution errors are now handled reliably with a safe fallback to server-side delivery when recipient device details are unavailable, reducing message loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->