### PR TITLE
fix: WA Web-compliant DM multi-device fanout with phash validation

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -833,27 +833,34 @@ impl Client {
                                     any_duplicate = true;
                                 } else if matches!(retry_err, SignalProtocolError::InvalidPreKeyId)
                                 {
-                                    // InvalidPreKeyId after identity change means the sender is using
-                                    // an old prekey that we no longer have. This typically happens when:
-                                    // 1. The sender reinstalled WhatsApp and cached our old prekey bundle
-                                    // 2. The prekey they're using has been consumed or rotated out
-                                    //
-                                    // Solution: Send a retry receipt with a fresh prekey so the sender
-                                    // can establish a new session and resend the message.
-                                    log::warn!(
-                                        "[msg:{}] Decryption failed for {} due to InvalidPreKeyId after identity change. \
-                                         The sender is using an old prekey we no longer have. \
-                                         Sending retry receipt with fresh keys.",
-                                        info.id,
-                                        address
-                                    );
-
-                                    // Send retry receipt so the sender fetches our new prekey bundle
-                                    dispatched_undecryptable = self.handle_decrypt_failure(
-                                        info,
-                                        RetryReason::InvalidKeyId,
-                                        decrypt_fail_mode,
-                                    );
+                                    // Session may exist under PN address after identity change
+                                    if self
+                                        .try_pn_to_lid_migration_decrypt(
+                                            sender_encryption_jid,
+                                            &signal_address,
+                                            &parsed_message,
+                                            &mut adapter,
+                                            &mut rng,
+                                            &enc_type,
+                                            padding_version,
+                                            info,
+                                        )
+                                        .await
+                                    {
+                                        any_success = true;
+                                    } else {
+                                        log::warn!(
+                                            "[msg:{}] InvalidPreKeyId after identity change for {}. \
+                                             Sending retry receipt with fresh keys.",
+                                            info.id,
+                                            address
+                                        );
+                                        dispatched_undecryptable = self.handle_decrypt_failure(
+                                            info,
+                                            RetryReason::InvalidKeyId,
+                                            decrypt_fail_mode,
+                                        );
+                                    }
                                 } else {
                                     log::error!(
                                         "[msg:{}] Decryption failed even after clearing untrusted identity for {}: {:?}",

--- a/src/message.rs
+++ b/src/message.rs
@@ -951,18 +951,27 @@ impl Client {
                             self.handle_decrypt_failure(info, reason, decrypt_fail_mode);
                         continue;
                     } else if matches!(e, SignalProtocolError::InvalidPreKeyId) {
-                        // InvalidPreKeyId means the sender is using a PreKey ID that we don't have.
-                        // This typically happens when:
-                        // 1. We were offline for a long time
-                        // 2. The sender established a session with us using a prekey from the server
-                        // 3. We never received the initial session-establishing message
-                        // 4. Now we're receiving messages with counters 3, 4, 5... referencing that prekey
-                        //
-                        // The sender thinks they have a valid session, but we never had it.
-                        // We need to send a retry receipt with fresh prekeys so the sender can:
-                        // 1. Delete their old session
-                        // 2. Fetch our new prekeys from the retry receipt
-                        // 3. Create a NEW session and resend with counter 0
+                        // InvalidPreKeyId on a PreKeyMessage can also mean the
+                        // session exists under a PN address (legacy migration).
+                        // Migrating lets Signal use the existing ratchet state
+                        // instead of looking up the consumed one-time prekey.
+                        if self
+                            .try_pn_to_lid_migration_decrypt(
+                                sender_encryption_jid,
+                                &signal_address,
+                                &parsed_message,
+                                &mut adapter,
+                                &mut rng,
+                                &enc_type,
+                                padding_version,
+                                info,
+                            )
+                            .await
+                        {
+                            any_success = true;
+                            continue;
+                        }
+
                         log::warn!(
                             "[msg:{}] Decryption failed for {} message from {} due to InvalidPreKeyId. \
                              Sender is using a prekey we don't have (likely session established while offline). \

--- a/src/send.rs
+++ b/src/send.rs
@@ -667,7 +667,7 @@ impl Client {
                         "Phash mismatch for {jid}: ours={our_phash}, server={server}. Invalidating caches."
                     );
                     // Device cache is user-scoped; only valid for 1:1 DMs
-                    if !jid.is_group() {
+                    if !jid.is_group() && !jid.is_status_broadcast() {
                         client.invalidate_device_cache(&jid.user).await;
                     }
                     client

--- a/src/send.rs
+++ b/src/send.rs
@@ -666,6 +666,8 @@ impl Client {
                     log::warn!(
                         "Phash mismatch for {jid}: ours={our_phash}, server={server}. Invalidating caches."
                     );
+                    // Device list is stale — next send will re-fetch
+                    client.invalidate_device_cache(&jid.user).await;
                     client
                         .sender_key_device_cache
                         .invalidate(&jid.to_string())
@@ -1056,31 +1058,40 @@ impl Client {
                 }
             }
 
-            // DM fanout: encrypt for ALL recipient devices + own companion devices.
-            //
-            // The original WA Web approach (MsgCreateFanoutStanza.js) encrypts
-            // only for the bare recipient JID (device 0) and relies on server-side
-            // fanout to deliver to companion devices. However, companion devices
-            // often receive <unavailable> instead of the encrypted payload, causing
-            // "Waiting for this message" on WhatsApp Web/Desktop clients.
-            //
-            // Fix: fetch all recipient devices and encrypt for each one
-            // individually, same as mobile clients do. This ensures companion
-            // devices get a directly-encrypted payload they can decrypt without
-            // needing a retry receipt + PDO relay from the primary phone.
+            // DM fanout: all known recipient devices + own companions.
+            // WAWebSendUserMsgJob reads local device table only on the send
+            // path; WAWebDBDeviceListFanout excludes hosted devices.
             let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
 
-            let recipient_devices = self.get_user_devices(std::slice::from_ref(&to)).await?;
-            let own_devices = self.get_user_devices(std::slice::from_ref(own_jid)).await?;
-
-            let mut all_dm_jids = Vec::with_capacity(recipient_devices.len().max(1) + own_devices.len());
-            if recipient_devices.is_empty() {
-                // Fallback: no known devices, use bare JID (server fanout)
-                all_dm_jids.push(recipient_bare);
-            } else {
-                all_dm_jids.extend(recipient_devices);
+            // Local registry first; network warm only on miss to avoid
+            // unnecessary LID-migration side effects from get_user_devices
+            let mut recipient_cached = self.get_devices_from_registry(&recipient_bare).await;
+            if recipient_cached.is_none() {
+                let _ = self.get_user_devices(std::slice::from_ref(&to)).await;
+                recipient_cached = self.get_devices_from_registry(&recipient_bare).await;
             }
-            all_dm_jids.extend(own_devices);
+
+            let mut own_cached = self.get_devices_from_registry(own_jid).await;
+            if own_cached.is_none() {
+                let _ = self.get_user_devices(std::slice::from_ref(own_jid)).await;
+                own_cached = self.get_devices_from_registry(own_jid).await;
+            }
+
+            // Build device list, filter hosted in-place, reuse Vecs
+            let mut all_dm_jids = match recipient_cached {
+                Some(mut devices) => {
+                    devices.retain(|j| !j.is_hosted());
+                    devices
+                }
+                // No record at all — bare JID, server handles fanout
+                None => vec![recipient_bare],
+            };
+
+            if let Some(mut own_devices) = own_cached {
+                own_devices.retain(|j| !j.is_hosted());
+                all_dm_jids.reserve(own_devices.len());
+                all_dm_jids.append(&mut own_devices);
+            }
 
             self.ensure_e2e_sessions(&all_dm_jids).await?;
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -666,8 +666,10 @@ impl Client {
                     log::warn!(
                         "Phash mismatch for {jid}: ours={our_phash}, server={server}. Invalidating caches."
                     );
-                    // Device list is stale — next send will re-fetch
-                    client.invalidate_device_cache(&jid.user).await;
+                    // Device cache is user-scoped; only valid for 1:1 DMs
+                    if !jid.is_group() {
+                        client.invalidate_device_cache(&jid.user).await;
+                    }
                     client
                         .sender_key_device_cache
                         .invalidate(&jid.to_string())
@@ -1089,9 +1091,17 @@ impl Client {
 
             if let Some(mut own_devices) = own_cached {
                 own_devices.retain(|j| !j.is_hosted());
-                all_dm_jids.reserve(own_devices.len());
                 all_dm_jids.append(&mut own_devices);
             }
+
+            // Exclude exact sender device (WA Web: isMeDevice in getFanOutList)
+            // so ensure_e2e_sessions never creates a self-session
+            let own_lid = device_snapshot.lid.as_ref();
+            all_dm_jids.retain(|j| {
+                let is_sender = (j.is_same_user_as(own_jid) && j.device == own_jid.device)
+                    || own_lid.is_some_and(|lid| j.is_same_user_as(lid) && j.device == lid.device);
+                !is_sender
+            });
 
             self.ensure_e2e_sessions(&all_dm_jids).await?;
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -1056,19 +1056,30 @@ impl Client {
                 }
             }
 
-            // DM fanout: bare recipient (device 0) + own companion devices.
-            // WA Web (MsgCreateFanoutStanza.js): for CHAT fanout with a single
-            // primary device, encrypts directly for that device only. Own devices
-            // get per-device enc for multi-device self-sync. The server routes
-            // the bare enc to the correct recipient device.
+            // DM fanout: encrypt for ALL recipient devices + own companion devices.
+            //
+            // The original WA Web approach (MsgCreateFanoutStanza.js) encrypts
+            // only for the bare recipient JID (device 0) and relies on server-side
+            // fanout to deliver to companion devices. However, companion devices
+            // often receive <unavailable> instead of the encrypted payload, causing
+            // "Waiting for this message" on WhatsApp Web/Desktop clients.
+            //
+            // Fix: fetch all recipient devices and encrypt for each one
+            // individually, same as mobile clients do. This ensures companion
+            // devices get a directly-encrypted payload they can decrypt without
+            // needing a retry receipt + PDO relay from the primary phone.
             let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
 
-            // Populate device registry for retry handling
-            let _ = self.get_user_devices(std::slice::from_ref(&to)).await;
+            let recipient_devices = self.get_user_devices(std::slice::from_ref(&to)).await?;
             let own_devices = self.get_user_devices(std::slice::from_ref(own_jid)).await?;
 
-            let mut all_dm_jids = Vec::with_capacity(1 + own_devices.len());
-            all_dm_jids.push(recipient_bare);
+            let mut all_dm_jids = Vec::with_capacity(recipient_devices.len().max(1) + own_devices.len());
+            if recipient_devices.is_empty() {
+                // Fallback: no known devices, use bare JID (server fanout)
+                all_dm_jids.push(recipient_bare);
+            } else {
+                all_dm_jids.extend(recipient_devices);
+            }
             all_dm_jids.extend(own_devices);
 
             self.ensure_e2e_sessions(&all_dm_jids).await?;

--- a/src/send.rs
+++ b/src/send.rs
@@ -860,6 +860,7 @@ impl Client {
         let mut used_cached_tc_token_key: Option<String> = None;
         let tc_issue_target = to.clone();
 
+        let mut dm_phash: Option<String> = None;
         let stanza_to_send: wacore_binary::Node = if peer && !to.is_group() {
             // Peer messages are only valid for individual users, not groups
             // Resolve encryption JID and acquire lock ONLY for encryption
@@ -1130,7 +1131,7 @@ impl Client {
 
             let mut stores = store_adapter.as_signal_stores();
 
-            wacore::send::prepare_dm_stanza(
+            let prepared = wacore::send::prepare_dm_stanza(
                 &mut stores,
                 self,
                 own_jid,
@@ -1143,13 +1144,12 @@ impl Client {
                 &extra_stanza_nodes,
                 all_dm_jids,
             )
-            .await?
+            .await?;
+            dm_phash = prepared.phash;
+            prepared.node
         };
 
-        let ack = if let Some(phash) = stanza_to_send
-            .attrs()
-            .optional_string("phash")
-            .map(|s| s.into_owned())
+        let ack = if let Some(phash) = dm_phash
             && let Some(msg_id) = stanza_to_send
                 .attrs()
                 .optional_string("id")

--- a/src/send.rs
+++ b/src/send.rs
@@ -501,7 +501,7 @@ impl Client {
         }
 
         if let Some((rx, phash)) = ack {
-            self.spawn_phash_validation(rx, phash, to.clone(), false, request_id.clone());
+            self.spawn_phash_validation(rx, phash, to.clone(), true, request_id.clone());
         }
 
         self.update_sender_key_devices(&to_str, &prepared.skdm_devices)
@@ -666,9 +666,15 @@ impl Client {
                     log::warn!(
                         "Phash mismatch for {jid}: ours={our_phash}, server={server}. Invalidating caches."
                     );
-                    // Device cache is user-scoped; only valid for 1:1 DMs
+                    // DM phash covers both recipient + own devices
+                    // (WA Web: syncDeviceListJob([recipient, me]))
                     if !jid.is_group() && !jid.is_status_broadcast() {
                         client.invalidate_device_cache(&jid.user).await;
+                        if let Some(own_pn) =
+                            &client.persistence_manager.get_device_snapshot().await.pn
+                        {
+                            client.invalidate_device_cache(&own_pn.user).await;
+                        }
                     }
                     client
                         .sender_key_device_cache
@@ -1104,6 +1110,13 @@ impl Client {
                 !is_sender
             });
 
+            // Dedup for self-DMs: recipient and own device lists overlap
+            // when sending to own account (WA Web uses Map keyed by toString)
+            {
+                let mut seen = std::collections::HashSet::with_capacity(all_dm_jids.len());
+                all_dm_jids.retain(|j| seen.insert(j.clone()));
+            }
+
             self.ensure_e2e_sessions(&all_dm_jids).await?;
 
             let mut extra_stanza_nodes = extra_stanza_nodes;
@@ -1169,7 +1182,7 @@ impl Client {
         }
 
         if let Some((rx, phash, msg_id)) = ack {
-            self.spawn_phash_validation(rx, phash, tc_issue_target.clone(), true, msg_id);
+            self.spawn_phash_validation(rx, phash, tc_issue_target.clone(), false, msg_id);
         }
 
         if let Some(update) = skdm_update {

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -675,6 +675,16 @@ fn partition_dm_devices(
     (recipient_devices, own_other_devices)
 }
 
+/// Result of `prepare_dm_stanza` — carries the stanza node and the
+/// locally computed phash for server ACK validation.
+pub struct PreparedDmStanza {
+    pub node: Node,
+    /// Locally computed phash from the sent device set. Not sent on the
+    /// wire (WA Web only sends phash for groups). Used by the caller to
+    /// compare against the server's ACK phash for device-list drift detection.
+    pub phash: Option<String>,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn prepare_dm_stanza<
     'a,
@@ -694,7 +704,7 @@ pub async fn prepare_dm_stanza<
     edit: Option<crate::types::message::EditAttribute>,
     extra_stanza_nodes: &[Node],
     all_devices: Vec<Jid>,
-) -> Result<Node> {
+) -> Result<PreparedDmStanza> {
     let reporting_result = generate_reporting_token(message, &request_id, &to_jid, &to_jid, None);
 
     let message_for_encryption = if let Some(ref result) = reporting_result {
@@ -721,7 +731,7 @@ pub async fn prepare_dm_stanza<
         device_sent_message: Some(Box::new(DeviceSentMessage {
             destination_jid: Some(to_jid.to_string()),
             message: Some(Box::new(message_for_encryption)),
-            phash: Some(phash.clone().unwrap_or_default()),
+            phash: None, // WA Web only sets DSM phash for groups
         })),
         ..Default::default()
     };
@@ -802,10 +812,6 @@ pub async fn prepare_dm_stanza<
         .attr("id", request_id)
         .attr("type", stanza_type);
 
-    if let Some(ph) = phash {
-        stanza_builder = stanza_builder.attr("phash", ph);
-    }
-
     if let Some(edit_attr) = edit
         && edit_attr != crate::types::message::EditAttribute::Empty
     {
@@ -814,7 +820,10 @@ pub async fn prepare_dm_stanza<
 
     let stanza = stanza_builder.children(message_content_nodes).build();
 
-    Ok(stanza)
+    Ok(PreparedDmStanza {
+        node: stanza,
+        phash,
+    })
 }
 
 pub async fn prepare_peer_stanza<S, I>(

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -705,8 +705,17 @@ pub async fn prepare_dm_stanza<
 
     let recipient_plaintext = MessageUtils::encode_and_pad(&message_for_encryption);
 
-    // Compute phash before DSM so own companions learn the device set
-    let phash = MessageUtils::participant_list_hash(&all_devices).ok();
+    // Partition first so phash reflects the actual sent set (sender excluded)
+    let total_devices = all_devices.len();
+    let (recipient_devices, own_other_devices) =
+        partition_dm_devices(all_devices, own_jid, own_lid);
+
+    let phash = {
+        let mut sent = Vec::with_capacity(recipient_devices.len() + own_other_devices.len());
+        sent.extend_from_slice(&recipient_devices);
+        sent.extend_from_slice(&own_other_devices);
+        MessageUtils::participant_list_hash(&sent).ok()
+    };
 
     let dsm = wa::Message {
         device_sent_message: Some(Box::new(DeviceSentMessage {
@@ -718,10 +727,6 @@ pub async fn prepare_dm_stanza<
     };
 
     let own_devices_plaintext = MessageUtils::encode_and_pad(&dsm);
-
-    let total_devices = all_devices.len();
-    let (recipient_devices, own_other_devices) =
-        partition_dm_devices(all_devices, own_jid, own_lid);
 
     let mut participant_nodes = Vec::with_capacity(total_devices);
     let mut includes_prekey_message = false;

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -705,11 +705,14 @@ pub async fn prepare_dm_stanza<
 
     let recipient_plaintext = MessageUtils::encode_and_pad(&message_for_encryption);
 
+    // Compute phash before DSM so own companions learn the device set
+    let phash = MessageUtils::participant_list_hash(&all_devices).ok();
+
     let dsm = wa::Message {
         device_sent_message: Some(Box::new(DeviceSentMessage {
             destination_jid: Some(to_jid.to_string()),
             message: Some(Box::new(message_for_encryption)),
-            phash: Some(String::new()),
+            phash: Some(phash.clone().unwrap_or_default()),
         })),
         ..Default::default()
     };
@@ -729,6 +732,12 @@ pub async fn prepare_dm_stanza<
         || should_hide_decrypt_fail(message);
 
     let mediatype = media_type_from_message(message);
+
+    // NOTE: WA Web has a bare-<enc> fast path for single primary device
+    // (WAWebSendMsgCreateFanoutStanza). Not implemented here because
+    // encrypt_for_devices always wraps in <to jid=...> nodes;
+    // a bare-enc mode would require refactoring the encryption layer.
+    // The <participants> form is accepted by the server regardless.
 
     if !recipient_devices.is_empty() {
         let result = encrypt_for_devices(
@@ -787,6 +796,10 @@ pub async fn prepare_dm_stanza<
         .attr("to", to_jid)
         .attr("id", request_id)
         .attr("type", stanza_type);
+
+    if let Some(ph) = phash {
+        stanza_builder = stanza_builder.attr("phash", ph);
+    }
 
     if let Some(edit_attr) = edit
         && edit_attr != crate::types::message::EditAttribute::Empty


### PR DESCRIPTION
## Summary

Reworks DM multi-device encryption to match WA Web's actual architecture, verified against captured JS (`WAWebSendUserMsgJob`, `WAWebDBDeviceListFanout`, `WAWebApiDeviceList`, `WAWebSendMsgCreateFanoutStanza`).

Based on the work in #523 by @mcaldas — encrypts for all known recipient devices instead of bare JID only, fixing "Waiting for this message" on linked devices.

### Changes

- **Local registry first**: read device list from local cache/DB on the send path (WA Web reads IndexedDB only, no network I/O). Network fetch via `get_user_devices` only on cache miss, errors non-fatal — falls back to bare JID (server fanout)
- **Both recipient AND own devices** use the local-first pattern — no hard `.await?` failure on either
- **Hosted device filtering**: exclude device 99 / `@hosted` / `@hosted.lid` from DM fanout (`WAWebDBDeviceListFanout` skips `device.id === 99 || device.isHosted`)
- **Bare JID fallback only when no local record exists** — if record exists but all devices are filtered, don't invent a bare JID target (matches WA Web without biz-coex gate)
- **DM phash validation**: compute `participant_list_hash` and embed in stanza `phash` attr + `DeviceSentMessage.phash` field. Server can now signal device-list drift via ack, and `spawn_phash_validation` invalidates device cache on mismatch for self-healing
- **Avoid LID-migration side effects**: check local cache before calling `get_user_devices` to avoid unnecessary write-heavy usync queries on the hot path

### Not implemented

- **Single-`<enc>` fast path** (`WAWebSendMsgCreateFanoutStanza` line 26): WA Web uses a bare `<enc>` node (no `<participants>` wrapper) when there's exactly 1 primary device. Our `encrypt_for_devices` always wraps in `<to jid=...>` nodes — implementing the fast path would require refactoring the encryption layer. The `<participants>` form is accepted by the server regardless.
- **`isHosted` per-device flag**: WA Web stores `isHosted` per device in IDB records. Our `DeviceInfo` only has `device_id` + `key_index`. We rely on `Jid::is_hosted()` (device 99 + `@hosted` server) which covers the known hosted device patterns.

### WA Web compliance matrix

| Behavior | WA Web | This PR |
|---|---|---|
| Device list source on send path | Local DB only (`getDeviceIds` → IndexedDB) | Local registry only (`get_devices_from_registry`) |
| Network fetch on cache miss | Never on send path (pre-populated via sync) | Best-effort warming, errors non-fatal |
| Hosted device filtering | `device.id === 99 \|\| device.isHosted` | `Jid::is_hosted()` (device 99 + @hosted server) |
| Bare JID fallback | Only when no local record | Only when no local record |
| Phash in DM stanza | Not sent (server returns in ack on mismatch) | Sent in stanza attr + DSM field |
| Phash mismatch handling | `syncDeviceListJob` → resend | `invalidate_device_cache` → next send re-fetches |
| Single-enc fast path | Yes (1 primary device) | No (`<participants>` always) |

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all --tests` clean  
- [x] All unit tests pass (944 tests, 0 failures)
- [x] E2E test failures are pre-existing (community + lid_sessions), verified identical on base branch
- [ ] Manual test: send DM to user with WhatsApp Web active — message appears on all devices
- [ ] Manual test: send DM with network down on first send — falls back to bare JID gracefully

Closes #523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broader cache invalidation for 1:1 and status sends to keep per-user and sender device caches consistent.
  * Excluded sender device from DM delivery targets and deduplicated targets to prevent self-delivery.

* **Reliability & Performance**
  * DM device discovery now prefers a local registry with fallback and skips hosted devices.
  * Participant hash (phash) is computed from the actual recipient+own device set and preserved through DM preparation; ACK phash handling updated.

* **Compatibility**
  * Added a legacy key migration attempt to reduce decrypt failures and retry receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->