### PR TITLE
Show QR code image on terminal along with text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1190,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1388,16 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1642,6 +1670,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+dependencies = [
+ "image",
 ]
 
 [[package]]
@@ -2677,6 +2720,7 @@ dependencies = [
  "moka",
  "portable-atomic",
  "prost",
+ "qrcode",
  "rand",
  "scopeguard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ log = { workspace = true }
 moka = { version = "0.12.12", features = ["future"], optional = true }
 portable-atomic = { workspace = true }
 prost = { workspace = true }
+qrcode = "0.14.1"
 rand = { workspace = true }
 scopeguard = "1.2"
 serde = { workspace = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,11 +265,11 @@ fn parse_arg(args: &[String], long: &str, short: &str) -> Option<String> {
 
 /// Show QR code on terminal as image.
 pub fn print_qr_to_terminal(txt: &str) {
-	let code = QrCode::new(txt).unwrap();
-
-	// Render QR code as UTF-8 characters for the terminal
-	let qr_string = code.render::<unicode::Dense1x2>().build();
-
-	// Print to terminal
-	println!("{}", qr_string);
+    if let Ok(code) = QrCode::new(txt) {
+        // Render QR code as UTF-8 characters for the terminal
+        let qr_string = code.render::<unicode::Dense1x2>().build();
+    
+        // Print to terminal
+        println!("{}", qr_string);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use chrono::{Local, Utc};
 use log::{error, info};
+use qrcode::{QrCode, render::unicode};
 use std::sync::Arc;
 use wacore::proto_helpers::MessageExt;
 use wacore::types::events::Event;
@@ -31,6 +32,7 @@ fn main() {
         eprintln!("Phone number provided: {}", phone);
         if let Some(ref code) = custom_code {
             eprintln!("Custom pair code: {}", code);
+            print_qr_to_terminal(&code);
         }
         eprintln!("Will use pair code authentication (concurrent with QR)");
     }
@@ -90,6 +92,7 @@ fn main() {
                             timeout.as_secs()
                         );
                         info!("\n{}\n", code);
+                        print_qr_to_terminal(&code);
                         info!("----------------------------------------");
                     }
                     Event::PairingCode { code, timeout } => {
@@ -100,6 +103,7 @@ fn main() {
                         info!("> Link with phone number instead");
                         info!("");
                         info!("    >>> {} <<<", code);
+                        print_qr_to_terminal(&code);
                         info!("");
                         info!("========================================");
                     }
@@ -257,4 +261,15 @@ fn parse_arg(args: &[String], long: &str, short: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Show QR code on terminal as image.
+pub fn print_qr_to_terminal(txt: &str) {
+	let code = QrCode::new(txt).unwrap();
+
+	// Render QR code as UTF-8 characters for the terminal
+	let qr_string = code.render::<unicode::Dense1x2>().build();
+
+	// Print to terminal
+	println!("{}", qr_string);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,6 @@ fn main() {
         eprintln!("Phone number provided: {}", phone);
         if let Some(ref code) = custom_code {
             eprintln!("Custom pair code: {}", code);
-            print_qr_to_terminal(&code);
         }
         eprintln!("Will use pair code authentication (concurrent with QR)");
     }


### PR DESCRIPTION
Currently, upon running the bot locally, it shows the code in text format. But it would be convenient if shown as QR like this:
<img width="2020" height="820" alt="image" src="https://github.com/user-attachments/assets/41ad0fb2-dcc6-4021-ac3d-79387acb5ff6" />

Thats' the FIX ✅.

- [ ] Update docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal now displays QR codes for pairing artifacts at startup (when a pair code is supplied) and during pairing events, enabling quick device pairing via visual scanning.
  * Textual pairing codes continue to be logged alongside QR output.
* **Reliability**
  * If QR rendering fails, pairing proceeds uninterrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->