### PR TITLE
fix: centralize timestamp handling via wacore::time and fix signed parsing

### DIFF
--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -7,7 +7,6 @@
 use crate::appstate_sync::Mutation;
 use crate::client::Client;
 use anyhow::Result;
-use chrono::DateTime;
 use log::debug;
 use wacore::appstate::patch_decode::WAPatchName;
 use wacore::types::events::{
@@ -89,7 +88,7 @@ pub(crate) fn dispatch_chat_mutation(
         .as_ref()
         .and_then(|v| v.timestamp)
         .unwrap_or(0);
-    let time = DateTime::from_timestamp_millis(ts).unwrap_or_else(wacore::time::now_utc);
+    let time = wacore::time::from_millis_or_now(ts);
     let jid: Jid = if m.index.len() > 1 {
         match m.index[1].parse() {
             Ok(j) => j,

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -849,7 +849,8 @@ async fn handle_business_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
     let event = Event::BusinessStatusUpdate(BusinessStatusUpdate {
         jid: notification.from.clone(),
         update_type,
-        timestamp: chrono::DateTime::from_timestamp(notification.timestamp, 0).unwrap_or_default(),
+        timestamp: chrono::DateTime::from_timestamp(notification.timestamp, 0)
+            .unwrap_or_else(chrono::Utc::now),
         target_jid: notification.jid.clone(),
         hash: notification.hash.clone(),
         verified_name,
@@ -1699,7 +1700,7 @@ mod tests {
     /// Helper: parse a disappearing_mode notification node the same way
     /// the handler does, returning `(duration, setting_timestamp)` or `None`
     /// on validation failure.
-    fn parse_disappearing_mode(node: &Node) -> Option<(u32, u64)> {
+    fn parse_disappearing_mode(node: &Node) -> Option<(u32, i64)> {
         let dm_node = node.get_optional_child("disappearing_mode")?;
         let mut dm_attrs = dm_node.attrs();
         let duration = dm_attrs
@@ -1708,7 +1709,7 @@ mod tests {
             .unwrap_or(0);
         let setting_timestamp = dm_attrs
             .optional_string("t")
-            .and_then(|s| s.parse::<u64>().ok())?;
+            .and_then(|s| s.parse::<i64>().ok())?;
         Some((duration, setting_timestamp))
     }
 

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -849,7 +849,7 @@ async fn handle_business_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
     let event = Event::BusinessStatusUpdate(BusinessStatusUpdate {
         jid: notification.from.clone(),
         update_type,
-        timestamp: notification.timestamp,
+        timestamp: chrono::DateTime::from_timestamp(notification.timestamp, 0).unwrap_or_default(),
         target_jid: notification.jid.clone(),
         hash: notification.hash.clone(),
         verified_name,
@@ -1396,7 +1396,8 @@ fn handle_disappearing_mode_notification(client: &Arc<Client>, node: &NodeRef<'_
     // WA Web: `t.attrTime("t")` — required, no default.
     let Some(setting_timestamp) = dm_attrs
         .optional_string("t")
-        .and_then(|s| s.parse::<u64>().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+        .and_then(|t| chrono::DateTime::from_timestamp(t, 0))
     else {
         warn!(
             "disappearing_mode notification missing or invalid 't' attribute: {}",

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1708,7 +1708,8 @@ mod tests {
             .unwrap_or(0);
         let setting_timestamp = dm_attrs
             .optional_string("t")
-            .and_then(|s| s.parse::<i64>().ok())?;
+            .and_then(|s| s.parse::<i64>().ok())
+            .filter(|&t| wacore::time::from_secs(t).is_some())?;
         Some((duration, setting_timestamp))
     }
 

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -849,8 +849,7 @@ async fn handle_business_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
     let event = Event::BusinessStatusUpdate(BusinessStatusUpdate {
         jid: notification.from.clone(),
         update_type,
-        timestamp: chrono::DateTime::from_timestamp(notification.timestamp, 0)
-            .unwrap_or_else(wacore::time::now_utc),
+        timestamp: wacore::time::from_secs_or_now(notification.timestamp),
         target_jid: notification.jid.clone(),
         hash: notification.hash.clone(),
         verified_name,
@@ -1046,7 +1045,7 @@ fn notification_timestamp(node: &NodeRef<'_>) -> chrono::DateTime<chrono::Utc> {
     node.attrs()
         .optional_u64("t")
         .and_then(|t| i64::try_from(t).ok())
-        .and_then(|t| chrono::DateTime::from_timestamp(t, 0))
+        .and_then(wacore::time::from_secs)
         .unwrap_or_else(wacore::time::now_utc)
 }
 
@@ -1172,7 +1171,7 @@ async fn handle_contacts_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
             let after = child
                 .attrs()
                 .optional_u64("after")
-                .and_then(|after| chrono::DateTime::from_timestamp(after as i64, 0));
+                .and_then(|after| wacore::time::from_secs(after as i64));
 
             debug!(
                 target: "Client/Contacts",
@@ -1221,7 +1220,7 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
 
     let timestamp = i64::try_from(notification.timestamp)
         .ok()
-        .and_then(|t| chrono::DateTime::from_timestamp(t, 0))
+        .and_then(wacore::time::from_secs)
         .unwrap_or_else(wacore::time::now_utc);
 
     for action in notification.actions {
@@ -1398,7 +1397,7 @@ fn handle_disappearing_mode_notification(client: &Arc<Client>, node: &NodeRef<'_
     let Some(setting_timestamp) = dm_attrs
         .optional_string("t")
         .and_then(|s| s.parse::<i64>().ok())
-        .and_then(|t| chrono::DateTime::from_timestamp(t, 0))
+        .and_then(wacore::time::from_secs)
     else {
         warn!(
             "disappearing_mode notification missing or invalid 't' attribute: {}",

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -850,7 +850,7 @@ async fn handle_business_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
         jid: notification.from.clone(),
         update_type,
         timestamp: chrono::DateTime::from_timestamp(notification.timestamp, 0)
-            .unwrap_or_else(chrono::Utc::now),
+            .unwrap_or_else(wacore::time::now_utc),
         target_jid: notification.jid.clone(),
         hash: notification.hash.clone(),
         verified_name,
@@ -1047,7 +1047,7 @@ fn notification_timestamp(node: &NodeRef<'_>) -> chrono::DateTime<chrono::Utc> {
         .optional_u64("t")
         .and_then(|t| i64::try_from(t).ok())
         .and_then(|t| chrono::DateTime::from_timestamp(t, 0))
-        .unwrap_or_else(chrono::Utc::now)
+        .unwrap_or_else(wacore::time::now_utc)
 }
 
 /// Learn LID-PN mappings from a contacts modify notification.
@@ -1222,7 +1222,7 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
     let timestamp = i64::try_from(notification.timestamp)
         .ok()
         .and_then(|t| chrono::DateTime::from_timestamp(t, 0))
-        .unwrap_or_else(chrono::Utc::now);
+        .unwrap_or_else(wacore::time::now_utc);
 
     for action in notification.actions {
         // Granularly patch group cache instead of invalidating — matches WA Web's

--- a/src/handlers/presence.rs
+++ b/src/handlers/presence.rs
@@ -44,7 +44,7 @@ impl StanzaHandler for PresenceHandler {
             .get_attr("last")
             .map(|v| v.as_str())
             .and_then(|s| s.parse::<i64>().ok())
-            .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0));
+            .and_then(wacore::time::from_secs);
 
         debug!(
             target: "PresenceHandler",

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -219,15 +219,10 @@ impl Client {
                 self.store_tc_token_from_conversation_bytes(&raw_bytes)
                     .await;
 
+                // Wrap Bytes in LazyConversation using from_bytes (true zero-copy)
+                // Parsing only happens if the event handler calls .conversation() or .get()
                 let lazy_conv = LazyConversation::from_bytes(raw_bytes);
-                if let Some(conv) = lazy_conv.get()
-                    && let Ok(group_jid) = conv.id.parse()
-                {
-                    self.core.event_bus.dispatch(Event::JoinedGroup {
-                        group_jid,
-                        conversation: lazy_conv,
-                    });
-                }
+                self.core.event_bus.dispatch(Event::JoinedGroup(lazy_conv));
             }
 
             // Drop receiver before awaiting the blocking task. If we broke out

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -219,10 +219,15 @@ impl Client {
                 self.store_tc_token_from_conversation_bytes(&raw_bytes)
                     .await;
 
-                // Wrap Bytes in LazyConversation using from_bytes (true zero-copy)
-                // Parsing only happens if the event handler calls .conversation() or .get()
                 let lazy_conv = LazyConversation::from_bytes(raw_bytes);
-                self.core.event_bus.dispatch(Event::JoinedGroup(lazy_conv));
+                if let Some(conv) = lazy_conv.get()
+                    && let Ok(group_jid) = conv.id.parse()
+                {
+                    self.core.event_bus.dispatch(Event::JoinedGroup {
+                        group_jid,
+                        conversation: lazy_conv,
+                    });
+                }
             }
 
             // Drop receiver before awaiting the blocking task. If we broke out

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -414,9 +414,9 @@ impl Client {
         let timestamp = web_msg
             .message_timestamp
             .map(|ts| {
-                chrono::DateTime::from_timestamp(ts as i64, 0).unwrap_or_else(chrono::Utc::now)
+                chrono::DateTime::from_timestamp(ts as i64, 0).unwrap_or_else(wacore::time::now_utc)
             })
-            .unwrap_or_else(chrono::Utc::now);
+            .unwrap_or_else(wacore::time::now_utc);
 
         Ok(MessageInfo {
             id: key.id.clone().unwrap_or_default(),

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -413,9 +413,7 @@ impl Client {
 
         let timestamp = web_msg
             .message_timestamp
-            .map(|ts| {
-                chrono::DateTime::from_timestamp(ts as i64, 0).unwrap_or_else(wacore::time::now_utc)
-            })
+            .map(|ts| wacore::time::from_secs_or_now(ts as i64))
             .unwrap_or_else(wacore::time::now_utc);
 
         Ok(MessageInfo {

--- a/src/version.rs
+++ b/src/version.rs
@@ -49,7 +49,7 @@ pub async fn resolve_and_update_version(
     let needs_fetch = if last_fetched_ms == 0 {
         true
     } else {
-        match chrono::DateTime::from_timestamp_millis(last_fetched_ms) {
+        match wacore::time::from_millis(last_fetched_ms) {
             Some(last_fetched_dt) => {
                 wacore::time::now_utc().signed_duration_since(last_fetched_dt)
                     > chrono::Duration::hours(24)

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -260,8 +260,7 @@ pub fn parse_message_info(
             .optional_string("notify")
             .map(|s| s.to_string())
             .unwrap_or_default(),
-        timestamp: chrono::DateTime::from_timestamp(attrs.unix_time("t"), 0)
-            .unwrap_or_else(crate::time::now_utc),
+        timestamp: crate::time::from_secs_or_now(attrs.unix_time("t")),
         category,
         edit: attrs
             .optional_string("edit")

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -261,7 +261,7 @@ pub fn parse_message_info(
             .map(|s| s.to_string())
             .unwrap_or_default(),
         timestamp: chrono::DateTime::from_timestamp(attrs.unix_time("t"), 0)
-            .unwrap_or_else(chrono::Utc::now),
+            .unwrap_or_else(crate::time::now_utc),
         category,
         edit: attrs
             .optional_string("edit")

--- a/wacore/src/stanza/notification.rs
+++ b/wacore/src/stanza/notification.rs
@@ -20,7 +20,7 @@ use wacore_binary::Node;
 pub fn notification_timestamp(node: &Node) -> chrono::DateTime<chrono::Utc> {
     node.attrs()
         .optional_u64("t")
-        .and_then(|t| chrono::DateTime::from_timestamp(t as i64, 0))
+        .and_then(|t| crate::time::from_secs(t as i64))
         .unwrap_or_else(crate::time::now_utc)
 }
 

--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -52,6 +52,34 @@ pub fn now_utc() -> chrono::DateTime<chrono::Utc> {
         .expect("time provider returned out-of-range millisecond timestamp")
 }
 
+/// Convert a Unix timestamp (seconds) to `DateTime<Utc>`.
+/// Returns `None` for out-of-range values.
+#[inline]
+pub fn from_secs(ts: i64) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::from_timestamp(ts, 0)
+}
+
+/// Convert a Unix timestamp (seconds) to `DateTime<Utc>`,
+/// falling back to `now_utc()` for out-of-range values.
+#[inline]
+pub fn from_secs_or_now(ts: i64) -> chrono::DateTime<chrono::Utc> {
+    from_secs(ts).unwrap_or_else(now_utc)
+}
+
+/// Convert a Unix timestamp (milliseconds) to `DateTime<Utc>`.
+/// Returns `None` for out-of-range values.
+#[inline]
+pub fn from_millis(ts: i64) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::from_timestamp_millis(ts)
+}
+
+/// Convert a Unix timestamp (milliseconds) to `DateTime<Utc>`,
+/// falling back to `now_utc()` for out-of-range values.
+#[inline]
+pub fn from_millis_or_now(ts: i64) -> chrono::DateTime<chrono::Utc> {
+    from_millis(ts).unwrap_or_else(now_utc)
+}
+
 /// Portable monotonic instant, replacing `std::time::Instant` which is
 /// unavailable on `wasm32-unknown-unknown`.
 ///

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -454,9 +454,9 @@ impl Event {
 
     /// Returns the primary JID associated with this event, if any.
     ///
-    /// Useful for routing events to the right chat without exhaustively matching every variant.
-    /// Returns `None` for connection-lifecycle and sync events that have no associated chat.
-    pub fn chat_jid(&self) -> Option<&Jid> {
+    /// Useful for routing or filtering events without exhaustively matching every variant.
+    /// Returns `None` for connection-lifecycle and sync events that have no associated JID.
+    pub fn primary_jid(&self) -> Option<&Jid> {
         match self {
             Event::Message(_, info) => Some(&info.source.chat),
             Event::Receipt(r) => Some(&r.source.chat),

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -316,6 +316,7 @@ impl From<crate::stanza::business::BusinessNotificationType> for BusinessUpdateT
 /// Business status update notification.
 #[derive(Debug, Clone, Serialize)]
 pub struct BusinessStatusUpdate {
+    /// The business account whose status changed.
     pub jid: Jid,
     pub update_type: BusinessUpdateType,
     pub timestamp: DateTime<Utc>,
@@ -445,12 +446,67 @@ impl Event {
         let (msg, _) = self.as_message()?;
         msg.conversation.as_deref()
     }
+
+    /// Returns the primary JID associated with this event, if any.
+    ///
+    /// Useful for routing events to the right chat without exhaustively matching every variant.
+    /// Returns `None` for connection-lifecycle and sync events that have no associated chat.
+    pub fn chat_jid(&self) -> Option<&Jid> {
+        match self {
+            Event::Message(_, info) => Some(&info.source.chat),
+            Event::Receipt(r) => Some(&r.source.chat),
+            Event::UndecryptableMessage(u) => Some(&u.info.source.chat),
+            Event::ChatPresence(c) => Some(&c.source.chat),
+            Event::Presence(p) => Some(&p.from),
+            Event::PictureUpdate(p) => Some(&p.jid),
+            Event::UserAboutUpdate(u) => Some(&u.jid),
+            Event::ContactUpdated(c) => Some(&c.jid),
+            Event::ContactNumberChanged(c) => Some(&c.new_jid),
+            Event::GroupUpdate(g) => Some(&g.group_jid),
+            Event::JoinedGroup(_) => None,
+            Event::ContactUpdate(c) => Some(&c.jid),
+            Event::PushNameUpdate(p) => Some(&p.jid),
+            Event::PinUpdate(p) => Some(&p.jid),
+            Event::MuteUpdate(m) => Some(&m.jid),
+            Event::ArchiveUpdate(a) => Some(&a.jid),
+            Event::StarUpdate(s) => Some(&s.chat_jid),
+            Event::MarkChatAsReadUpdate(m) => Some(&m.jid),
+            Event::DeleteChatUpdate(d) => Some(&d.jid),
+            Event::DeleteMessageForMeUpdate(d) => Some(&d.chat_jid),
+            Event::BusinessStatusUpdate(b) => Some(&b.jid),
+            Event::DisappearingModeChanged(d) => Some(&d.from),
+            Event::NewsletterLiveUpdate(n) => Some(&n.newsletter_jid),
+            Event::DeviceListUpdate(d) => Some(&d.user),
+            Event::IdentityChange(i) => Some(&i.user),
+            Event::Connected(_)
+            | Event::Disconnected(_)
+            | Event::PairSuccess(_)
+            | Event::PairError(_)
+            | Event::LoggedOut(_)
+            | Event::PairingQrCode { .. }
+            | Event::PairingCode { .. }
+            | Event::QrScannedWithoutMultidevice(_)
+            | Event::ClientOutdated(_)
+            | Event::SelfPushNameUpdated(_)
+            | Event::HistorySync(_)
+            | Event::OfflineSyncPreview(_)
+            | Event::OfflineSyncCompleted(_)
+            | Event::StreamReplaced(_)
+            | Event::TemporaryBan(_)
+            | Event::ConnectFailure(_)
+            | Event::StreamError(_)
+            | Event::ContactSyncRequested(_)
+            | Event::Notification(_)
+            | Event::RawNode(_) => None,
+        }
+    }
 }
 
 /// A newsletter live update notification, typically containing updated
 /// reaction counts for one or more messages.
 #[derive(Debug, Clone, Serialize)]
 pub struct NewsletterLiveUpdate {
+    /// The newsletter channel this update belongs to.
     pub newsletter_jid: Jid,
     pub messages: Vec<NewsletterLiveUpdateMessage>,
 }
@@ -706,6 +762,7 @@ pub struct ChatPresenceUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PresenceUpdate {
+    /// The contact whose presence changed.
     pub from: Jid,
     pub unavailable: bool,
     pub last_seen: Option<DateTime<Utc>>,
@@ -729,6 +786,7 @@ pub struct PictureUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct UserAboutUpdate {
+    /// The contact whose about text changed.
     pub jid: Jid,
     pub status: String,
     pub timestamp: DateTime<Utc>,
@@ -744,6 +802,7 @@ pub struct UserAboutUpdate {
 /// sync mutations (different source, different payload).
 #[derive(Debug, Clone, Serialize)]
 pub struct ContactUpdated {
+    /// The contact whose profile was updated.
     pub jid: Jid,
     pub timestamp: DateTime<Utc>,
 }
@@ -804,6 +863,7 @@ pub struct GroupUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ContactUpdate {
+    /// The chat/contact this sync action applies to.
     pub jid: Jid,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::ContactAction>,
@@ -812,6 +872,7 @@ pub struct ContactUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PushNameUpdate {
+    /// The contact who changed their push name.
     pub jid: Jid,
     pub message: Arc<MessageInfo>,
     pub old_push_name: String,
@@ -821,6 +882,7 @@ pub struct PushNameUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct PinUpdate {
+    /// The chat being pinned or unpinned.
     pub jid: Jid,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::PinAction>,
@@ -829,6 +891,7 @@ pub struct PinUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MuteUpdate {
+    /// The chat being muted or unmuted.
     pub jid: Jid,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::MuteAction>,
@@ -837,6 +900,7 @@ pub struct MuteUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ArchiveUpdate {
+    /// The chat being archived or unarchived.
     pub jid: Jid,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::ArchiveChatAction>,
@@ -845,6 +909,7 @@ pub struct ArchiveUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct StarUpdate {
+    /// The chat containing the starred or unstarred message.
     pub chat_jid: Jid,
     /// The participant who sent the message. `Some` for group messages from
     /// others, `None` for self-authored or 1-on-1 messages (wire value `"0"`).
@@ -858,6 +923,7 @@ pub struct StarUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MarkChatAsReadUpdate {
+    /// The chat being marked as read or unread.
     pub jid: Jid,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::MarkChatAsReadAction>,
@@ -866,6 +932,7 @@ pub struct MarkChatAsReadUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DeleteChatUpdate {
+    /// The chat being deleted.
     pub jid: Jid,
     /// From the index, not the proto — DeleteChatAction only has messageRange.
     pub delete_media: bool,
@@ -876,6 +943,7 @@ pub struct DeleteChatUpdate {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DeleteMessageForMeUpdate {
+    /// The chat containing the deleted message.
     pub chat_jid: Jid,
     pub participant_jid: Option<Jid>,
     pub message_id: String,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -389,7 +389,10 @@ pub enum Event {
     ContactNumberChanged(ContactNumberChanged),
     ContactSyncRequested(ContactSyncRequested),
 
-    JoinedGroup(LazyConversation),
+    JoinedGroup {
+        group_jid: Jid,
+        conversation: LazyConversation,
+    },
     /// Group metadata/settings/participant change from w:gp2 notification.
     GroupUpdate(GroupUpdate),
     ContactUpdate(ContactUpdate),
@@ -452,9 +455,7 @@ impl Event {
     /// Returns the primary JID associated with this event, if any.
     ///
     /// Useful for routing events to the right chat without exhaustively matching every variant.
-    /// Returns `None` for connection-lifecycle and sync events that have no associated chat,
-    /// and for `JoinedGroup` (the JID is embedded inside the serialized `LazyConversation`
-    /// bytes and would require proto decoding to extract).
+    /// Returns `None` for connection-lifecycle and sync events that have no associated chat.
     pub fn chat_jid(&self) -> Option<&Jid> {
         match self {
             Event::Message(_, info) => Some(&info.source.chat),
@@ -467,7 +468,7 @@ impl Event {
             Event::ContactUpdated(c) => Some(&c.jid),
             Event::ContactNumberChanged(c) => Some(&c.new_jid),
             Event::GroupUpdate(g) => Some(&g.group_jid),
-            Event::JoinedGroup(_) => None,
+            Event::JoinedGroup { group_jid, .. } => Some(group_jid),
             Event::ContactUpdate(c) => Some(&c.jid),
             Event::PushNameUpdate(p) => Some(&p.jid),
             Event::PinUpdate(p) => Some(&p.jid),

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -318,7 +318,7 @@ impl From<crate::stanza::business::BusinessNotificationType> for BusinessUpdateT
 pub struct BusinessStatusUpdate {
     pub jid: Jid,
     pub update_type: BusinessUpdateType,
-    pub timestamp: i64,
+    pub timestamp: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_jid: Option<Jid>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -344,9 +344,9 @@ pub struct DisappearingModeChanged {
     pub from: Jid,
     /// New duration in seconds (0 = disabled, 86400 = 24h, etc.).
     pub duration: u32,
-    /// Unix timestamp (seconds) when the setting was changed.
-    /// Consumers should only apply this if it's newer than their stored timestamp.
-    pub setting_timestamp: u64,
+    /// When the setting was changed.
+    /// Consumers should only apply this if it's newer than their stored value.
+    pub setting_timestamp: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -813,9 +813,10 @@ pub struct ContactUpdate {
 #[derive(Debug, Clone, Serialize)]
 pub struct PushNameUpdate {
     pub jid: Jid,
-    pub message: Box<MessageInfo>,
+    pub message: Arc<MessageInfo>,
     pub old_push_name: String,
     pub new_push_name: String,
+    pub from_full_sync: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -389,10 +389,7 @@ pub enum Event {
     ContactNumberChanged(ContactNumberChanged),
     ContactSyncRequested(ContactSyncRequested),
 
-    JoinedGroup {
-        group_jid: Jid,
-        conversation: LazyConversation,
-    },
+    JoinedGroup(LazyConversation),
     /// Group metadata/settings/participant change from w:gp2 notification.
     GroupUpdate(GroupUpdate),
     ContactUpdate(ContactUpdate),
@@ -450,60 +447,6 @@ impl Event {
     pub fn message_text(&self) -> Option<&str> {
         let (msg, _) = self.as_message()?;
         msg.conversation.as_deref()
-    }
-
-    /// Returns the primary JID associated with this event, if any.
-    ///
-    /// Useful for routing or filtering events without exhaustively matching every variant.
-    /// Returns `None` for connection-lifecycle and sync events that have no associated JID.
-    pub fn primary_jid(&self) -> Option<&Jid> {
-        match self {
-            Event::Message(_, info) => Some(&info.source.chat),
-            Event::Receipt(r) => Some(&r.source.chat),
-            Event::UndecryptableMessage(u) => Some(&u.info.source.chat),
-            Event::ChatPresence(c) => Some(&c.source.chat),
-            Event::Presence(p) => Some(&p.from),
-            Event::PictureUpdate(p) => Some(&p.jid),
-            Event::UserAboutUpdate(u) => Some(&u.jid),
-            Event::ContactUpdated(c) => Some(&c.jid),
-            Event::ContactNumberChanged(c) => Some(&c.new_jid),
-            Event::GroupUpdate(g) => Some(&g.group_jid),
-            Event::JoinedGroup { group_jid, .. } => Some(group_jid),
-            Event::ContactUpdate(c) => Some(&c.jid),
-            Event::PushNameUpdate(p) => Some(&p.jid),
-            Event::PinUpdate(p) => Some(&p.jid),
-            Event::MuteUpdate(m) => Some(&m.jid),
-            Event::ArchiveUpdate(a) => Some(&a.jid),
-            Event::StarUpdate(s) => Some(&s.chat_jid),
-            Event::MarkChatAsReadUpdate(m) => Some(&m.jid),
-            Event::DeleteChatUpdate(d) => Some(&d.jid),
-            Event::DeleteMessageForMeUpdate(d) => Some(&d.chat_jid),
-            Event::BusinessStatusUpdate(b) => Some(&b.jid),
-            Event::DisappearingModeChanged(d) => Some(&d.from),
-            Event::NewsletterLiveUpdate(n) => Some(&n.newsletter_jid),
-            Event::DeviceListUpdate(d) => Some(&d.user),
-            Event::IdentityChange(i) => Some(&i.user),
-            Event::Connected(_)
-            | Event::Disconnected(_)
-            | Event::PairSuccess(_)
-            | Event::PairError(_)
-            | Event::LoggedOut(_)
-            | Event::PairingQrCode { .. }
-            | Event::PairingCode { .. }
-            | Event::QrScannedWithoutMultidevice(_)
-            | Event::ClientOutdated(_)
-            | Event::SelfPushNameUpdated(_)
-            | Event::HistorySync(_)
-            | Event::OfflineSyncPreview(_)
-            | Event::OfflineSyncCompleted(_)
-            | Event::StreamReplaced(_)
-            | Event::TemporaryBan(_)
-            | Event::ConnectFailure(_)
-            | Event::StreamError(_)
-            | Event::ContactSyncRequested(_)
-            | Event::Notification(_)
-            | Event::RawNode(_) => None,
-        }
     }
 }
 
@@ -879,10 +822,9 @@ pub struct ContactUpdate {
 pub struct PushNameUpdate {
     /// The contact who changed their push name.
     pub jid: Jid,
-    pub message: Arc<MessageInfo>,
+    pub message: Box<MessageInfo>,
     pub old_push_name: String,
     pub new_push_name: String,
-    pub from_full_sync: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -319,6 +319,7 @@ pub struct BusinessStatusUpdate {
     /// The business account whose status changed.
     pub jid: Jid,
     pub update_type: BusinessUpdateType,
+    #[serde(with = "chrono::serde::ts_seconds")]
     pub timestamp: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_jid: Option<Jid>,
@@ -347,6 +348,7 @@ pub struct DisappearingModeChanged {
     pub duration: u32,
     /// When the setting was changed.
     /// Consumers should only apply this if it's newer than their stored value.
+    #[serde(with = "chrono::serde::ts_seconds")]
     pub setting_timestamp: DateTime<Utc>,
 }
 
@@ -450,7 +452,9 @@ impl Event {
     /// Returns the primary JID associated with this event, if any.
     ///
     /// Useful for routing events to the right chat without exhaustively matching every variant.
-    /// Returns `None` for connection-lifecycle and sync events that have no associated chat.
+    /// Returns `None` for connection-lifecycle and sync events that have no associated chat,
+    /// and for `JoinedGroup` (the JID is embedded inside the serialized `LazyConversation`
+    /// bytes and would require proto decoding to extract).
     pub fn chat_jid(&self) -> Option<&Jid> {
         match self {
             Event::Message(_, info) => Some(&info.source.chat),


### PR DESCRIPTION
## Summary

### Centralized time helpers (`wacore::time`)
- Added `from_secs`, `from_secs_or_now`, `from_millis`, `from_millis_or_now` helpers
- Replaced **all** direct `chrono::DateTime::from_timestamp*` and `chrono::Utc::now` calls with `wacore::time` helpers — ensures WASM compatibility via the pluggable `TimeProvider`
- Fixed call sites: `notification.rs`, `presence.rs`, `pdo.rs`, `version.rs`, `chat_actions.rs`, `wacore/messages.rs`, `wacore/stanza/notification.rs`

### Type fixes
- `BusinessStatusUpdate.timestamp`: `i64` → `DateTime<Utc>` with `#[serde(with = "chrono::serde::ts_seconds")]` — consistent with every other timestamped event, preserves integer serialization
- `DisappearingModeChanged.setting_timestamp`: `u64` → `DateTime<Utc>` with `ts_seconds` — fixes sign (parsed as `i64` to match WA Web's `attrTime` / `castToUnixTime` semantics)

### Test alignment
- Updated `parse_disappearing_mode` test helper to validate timestamp range via `wacore::time::from_secs`, mirroring the production handler

### Documentation
- Added doc comments to the primary JID field in event structs to clarify what each JID represents

### Breaking changes
- `BusinessStatusUpdate.timestamp`: `i64` → `DateTime<Utc>` (serde output preserved as integer via `ts_seconds`)
- `DisappearingModeChanged.setting_timestamp`: `u64` → `DateTime<Utc>` (serde output preserved as integer via `ts_seconds`)

`cargo clippy --all --tests` and `cargo fmt --all` pass clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Consolidated timestamp handling throughout the application with centralized conversion utilities
  * Improved timestamp parsing with proper fallback mechanisms for invalid or missing timestamps
  * Enhanced type safety for time-related data structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->