### PR TITLE
feat!: replace history sync events with lazy blob + perf optimizations

### DIFF
--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -1,25 +1,10 @@
 use crate::types::events::{Event, LazyHistorySync};
-use bytes::Bytes;
 use std::sync::Arc;
-use wacore::history_sync::process_history_sync;
+use wacore::history_sync::{TcTokenCandidate, process_history_sync};
 use wacore::store::traits::TcTokenEntry;
-use wacore_binary::JidExt;
 use waproto::whatsapp::message::HistorySyncNotification;
 
 use crate::client::Client;
-
-/// Partial Conversation decode — only tctoken fields, skips heavy `messages`.
-#[derive(Clone, PartialEq, prost::Message)]
-struct ConversationTcTokenFields {
-    #[prost(string, required, tag = "1")]
-    pub id: String,
-    #[prost(bytes = "vec", optional, tag = "21")]
-    pub tc_token: Option<Vec<u8>>,
-    #[prost(uint64, optional, tag = "22")]
-    pub tc_token_timestamp: Option<u64>,
-    #[prost(uint64, optional, tag = "28")]
-    pub tc_token_sender_timestamp: Option<u64>,
-}
 
 impl Client {
     pub(crate) async fn handle_history_sync(
@@ -154,59 +139,41 @@ impl Client {
             }
         };
 
-        // Get own user for pushname extraction (moved into blocking task, no clone needed)
         let own_user = {
             let device_snapshot = self.persistence_manager.get_device_snapshot().await;
             device_snapshot.pn.as_ref().map(|j| j.to_non_ad().user)
         };
 
-        // Stream conversation bytes for tctoken extraction (always needed,
-        // regardless of whether anyone listens for events).
-        let (tx, rx) = async_channel::bounded::<Bytes>(4);
+        let has_listeners = self.core.event_bus.has_handlers();
 
-        let (result_tx, result_rx) = futures::channel::oneshot::channel();
-        let blocking_fut = self.runtime.spawn_blocking(Box::new(move || {
-            let own_user_ref = own_user.as_deref();
-            let result = process_history_sync(
+        // Small blobs (PushName, Recent): decode inline to avoid spawn_blocking overhead.
+        // Large blobs: use blocking thread to avoid stalling the async runtime.
+        const INLINE_THRESHOLD: usize = 256 * 1024;
+        let parse_result = if compressed_data.len() < INLINE_THRESHOLD {
+            Some(process_history_sync(
                 compressed_data,
-                own_user_ref,
-                Some(|raw_bytes: Bytes| {
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let _ = tx.send_blocking(raw_bytes);
-                    #[cfg(target_arch = "wasm32")]
-                    let _ = tx.try_send(raw_bytes);
-                }),
+                own_user.as_deref(),
+                has_listeners,
                 compressed_size_hint,
-            );
-            // tx dropped here, closing channel
-            let _ = result_tx.send(result);
-        }));
-        self.runtime
-            .spawn(Box::pin(async move {
-                blocking_fut.await;
-            }))
-            .detach();
-
-        let mut conv_count = 0usize;
-        while let Ok(raw_bytes) = rx.recv().await {
-            if self.is_shutting_down() {
-                log::debug!(
-                    "Stopping history sync {} tctoken extraction during shutdown",
-                    message_id
+            ))
+        } else {
+            let (result_tx, result_rx) = futures::channel::oneshot::channel();
+            let blocking_fut = self.runtime.spawn_blocking(Box::new(move || {
+                let result = process_history_sync(
+                    compressed_data,
+                    own_user.as_deref(),
+                    has_listeners,
+                    compressed_size_hint,
                 );
-                break;
-            }
-            conv_count += 1;
-            if conv_count.is_multiple_of(25) {
-                log::info!("History sync progress: {conv_count} conversations processed...");
-            }
-            self.store_tc_token_from_conversation_bytes(&raw_bytes)
-                .await;
-        }
-        // Drop receiver to unblock sender if we broke out during shutdown.
-        drop(rx);
-
-        let parse_result = result_rx.await.ok();
+                let _ = result_tx.send(result);
+            }));
+            self.runtime
+                .spawn(Box::pin(async move {
+                    blocking_fut.await;
+                }))
+                .detach();
+            result_rx.await.ok()
+        };
 
         if self.is_shutting_down() {
             log::debug!(
@@ -243,10 +210,15 @@ impl Client {
                         .await;
                 }
 
+                // Store tctokens extracted during streaming
+                for candidate in &sync_result.tc_token_candidates {
+                    self.store_tc_token_candidate(candidate).await;
+                }
+
                 // Dispatch a single event with the full decompressed blob
-                if self.core.event_bus.has_handlers() {
+                if let Some(decompressed) = sync_result.decompressed_bytes {
                     let lazy_hs = LazyHistorySync::new(
-                        sync_result.decompressed_bytes,
+                        decompressed,
                         notification.sync_type().into(),
                         notification.chunk_order,
                         notification.progress,
@@ -265,35 +237,12 @@ impl Client {
         }
     }
 
-    /// Extract and store tctoken data from a raw Conversation protobuf.
-    /// Partial decode — only reads fields 1/21/22/28, skipping messages.
-    async fn store_tc_token_from_conversation_bytes(&self, raw_bytes: &[u8]) {
-        use prost::Message;
-
-        let conv = match ConversationTcTokenFields::decode(raw_bytes) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-
-        let token = match conv.tc_token {
-            Some(t) if !t.is_empty() => t,
-            _ => return,
-        };
-
-        let Some(timestamp) = conv.tc_token_timestamp else {
-            return;
-        };
-
-        // Resolve to LID for storage key consistency with notification handler
-        let jid: wacore_binary::Jid = match conv.id.parse() {
+    /// Store a tctoken candidate extracted during history sync streaming.
+    async fn store_tc_token_candidate(&self, candidate: &TcTokenCandidate) {
+        let jid: wacore_binary::Jid = match candidate.id.parse() {
             Ok(j) => j,
             Err(_) => return,
         };
-
-        // Only 1:1 conversations carry tctokens
-        if jid.is_group() || jid.is_newsletter() || jid.is_bot() {
-            return;
-        }
 
         let resolved_lid = if jid.is_lid() {
             None
@@ -305,9 +254,9 @@ impl Client {
         let backend = self.persistence_manager.backend();
 
         // Avoid clobbering a newer local sender_timestamp from post-send issuance
-        let incoming_sender_ts = conv.tc_token_sender_timestamp.map(|ts| ts as i64);
+        let incoming_sender_ts = candidate.tc_token_sender_timestamp.map(|ts| ts as i64);
         let merged_sender_ts = if let Ok(Some(existing)) = backend.get_tc_token(token_key).await {
-            if (existing.token_timestamp as u64) > timestamp {
+            if (existing.token_timestamp as u64) > candidate.tc_token_timestamp {
                 return;
             }
             match (existing.sender_timestamp, incoming_sender_ts) {
@@ -320,8 +269,8 @@ impl Client {
         };
 
         let entry = TcTokenEntry {
-            token,
-            token_timestamp: timestamp as i64,
+            token: candidate.tc_token.clone(),
+            token_timestamp: candidate.tc_token_timestamp as i64,
             sender_timestamp: merged_sender_ts,
         };
 
@@ -336,7 +285,7 @@ impl Client {
                 target: "Client/TcToken",
                 "Stored tctoken from history sync for {} (t={})",
                 token_key,
-                timestamp
+                candidate.tc_token_timestamp
             );
         }
     }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -1,4 +1,4 @@
-use crate::types::events::{Event, LazyConversation};
+use crate::types::events::{Event, LazyHistorySync};
 use bytes::Bytes;
 use std::sync::Arc;
 use wacore::history_sync::process_history_sync;
@@ -71,10 +71,9 @@ impl Client {
         }
     }
 
-    /// Process history sync with streaming and lazy parsing.
-    ///
-    /// Memory efficient: raw bytes are wrapped in LazyConversation and only
-    /// parsed if the event handler actually accesses the conversation data.
+    /// Process history sync: decompress, extract internal data (tctokens,
+    /// pushname, nct_salt), then dispatch a single `Event::HistorySync`
+    /// with the full decompressed blob for on-demand consumer decoding.
     pub(crate) async fn process_history_sync_task(
         self: &Arc<Self>,
         message_id: String,
@@ -161,118 +160,53 @@ impl Client {
             device_snapshot.pn.as_ref().map(|j| j.to_non_ad().user)
         };
 
-        // Check if anyone is listening for events
-        let has_listeners = self.core.event_bus.has_handlers();
+        // Stream conversation bytes for tctoken extraction (always needed,
+        // regardless of whether anyone listens for events).
+        let (tx, rx) = async_channel::bounded::<Bytes>(4);
 
-        let parse_result = if has_listeners {
-            // Use a bounded channel to stream raw conversation bytes as Bytes (zero-copy)
-            let (tx, rx) = async_channel::bounded::<Bytes>(4);
+        let (result_tx, result_rx) = futures::channel::oneshot::channel();
+        let blocking_fut = self.runtime.spawn_blocking(Box::new(move || {
+            let own_user_ref = own_user.as_deref();
+            let result = process_history_sync(
+                compressed_data,
+                own_user_ref,
+                Some(|raw_bytes: Bytes| {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let _ = tx.send_blocking(raw_bytes);
+                    #[cfg(target_arch = "wasm32")]
+                    let _ = tx.try_send(raw_bytes);
+                }),
+                compressed_size_hint,
+            );
+            // tx dropped here, closing channel
+            let _ = result_tx.send(result);
+        }));
+        self.runtime
+            .spawn(Box::pin(async move {
+                blocking_fut.await;
+            }))
+            .detach();
 
-            // Run streaming parsing in blocking thread
-            // own_user is moved directly, no clone needed
-            let (result_tx, result_rx) = futures::channel::oneshot::channel();
-            // Spawn the blocking work concurrently — it runs while we
-            // process channel items below.
-            let blocking_fut = self.runtime.spawn_blocking(Box::new(move || {
-                let own_user_ref = own_user.as_deref();
-
-                // Streaming: decompresses and extracts raw bytes incrementally
-                // No parsing happens here - just raw byte extraction
-                // Uses Bytes for zero-copy reference counting
-                let result = process_history_sync(
-                    compressed_data,
-                    own_user_ref,
-                    Some(|raw_bytes: Bytes| {
-                        // Send Bytes through channel (zero-copy clone)
-                        #[cfg(not(target_arch = "wasm32"))]
-                        let _ = tx.send_blocking(raw_bytes);
-                        #[cfg(target_arch = "wasm32")]
-                        let _ = tx.try_send(raw_bytes);
-                    }),
-                    compressed_size_hint,
+        let mut conv_count = 0usize;
+        while let Ok(raw_bytes) = rx.recv().await {
+            if self.is_shutting_down() {
+                log::debug!(
+                    "Stopping history sync {} tctoken extraction during shutdown",
+                    message_id
                 );
-                // tx dropped here, closing channel
-                let _ = result_tx.send(result);
-            }));
-            // Drive the blocking future to completion in the background
-            self.runtime
-                .spawn(Box::pin(async move {
-                    blocking_fut.await;
-                }))
-                .detach();
-
-            // Receive and dispatch lazy conversations as they come in
-            let mut conv_count = 0usize;
-            while let Ok(raw_bytes) = rx.recv().await {
-                if self.is_shutting_down() {
-                    log::debug!(
-                        "Stopping history sync {} event dispatch during shutdown",
-                        message_id
-                    );
-                    break;
-                }
-                conv_count += 1;
-                if conv_count.is_multiple_of(25) {
-                    log::info!("History sync progress: {conv_count} conversations processed...");
-                }
-                // Extract tctokens before dispatching to ensure backfill even if handler drops
-                self.store_tc_token_from_conversation_bytes(&raw_bytes)
-                    .await;
-
-                // Wrap Bytes in LazyConversation using from_bytes (true zero-copy)
-                // Parsing only happens if the event handler calls .conversation() or .get()
-                let lazy_conv = LazyConversation::from_bytes(raw_bytes);
-                self.core.event_bus.dispatch(Event::JoinedGroup(lazy_conv));
+                break;
             }
-
-            // Drop receiver before awaiting the blocking task. If we broke out
-            // of the loop during shutdown, the sender may be blocked on
-            // tx.send_blocking() — dropping rx causes it to return Err and
-            // unblock, preventing a deadlock.
-            drop(rx);
-
-            // Wait for parsing result
-            result_rx.await.ok()
-        } else {
-            // No event listeners, but still extract tctokens from conversations
-            // so headless/library clients have cached privacy tokens after pairing.
-            log::debug!("No event handlers registered, extracting tctokens only");
-
-            let (tx, rx) = async_channel::bounded::<Bytes>(4);
-
-            let (result_tx, result_rx) = futures::channel::oneshot::channel();
-            let blocking_fut = self.runtime.spawn_blocking(Box::new(move || {
-                let own_user_ref = own_user.as_deref();
-                let result = process_history_sync(
-                    compressed_data,
-                    own_user_ref,
-                    Some(|raw_bytes: Bytes| {
-                        #[cfg(not(target_arch = "wasm32"))]
-                        let _ = tx.send_blocking(raw_bytes);
-                        #[cfg(target_arch = "wasm32")]
-                        let _ = tx.try_send(raw_bytes);
-                    }),
-                    compressed_size_hint,
-                );
-                let _ = result_tx.send(result);
-            }));
-            self.runtime
-                .spawn(Box::pin(async move {
-                    blocking_fut.await;
-                }))
-                .detach();
-
-            while let Ok(raw_bytes) = rx.recv().await {
-                if self.is_shutting_down() {
-                    break;
-                }
-                self.store_tc_token_from_conversation_bytes(&raw_bytes)
-                    .await;
+            conv_count += 1;
+            if conv_count.is_multiple_of(25) {
+                log::info!("History sync progress: {conv_count} conversations processed...");
             }
-            drop(rx);
+            self.store_tc_token_from_conversation_bytes(&raw_bytes)
+                .await;
+        }
+        // Drop receiver to unblock sender if we broke out during shutdown.
+        drop(rx);
 
-            result_rx.await.ok()
-        };
+        let parse_result = result_rx.await.ok();
 
         if self.is_shutting_down() {
             log::debug!(
@@ -307,6 +241,19 @@ impl Client {
                             wacore::store::commands::DeviceCommand::SetNctSaltFromHistorySync(salt),
                         )
                         .await;
+                }
+
+                // Dispatch a single event with the full decompressed blob
+                if self.core.event_bus.has_handlers() {
+                    let lazy_hs = LazyHistorySync::new(
+                        sync_result.decompressed_bytes,
+                        notification.sync_type().into(),
+                        notification.chunk_order,
+                        notification.progress,
+                    );
+                    self.core
+                        .event_bus
+                        .dispatch(Event::HistorySync(Box::new(lazy_hs)));
                 }
             }
             Some(Err(e)) => {

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -210,8 +210,8 @@ impl Client {
                         .await;
                 }
 
-                // Store tctokens extracted during streaming
-                for candidate in &sync_result.tc_token_candidates {
+                // Store tctokens extracted during streaming (move to avoid cloning)
+                for candidate in sync_result.tc_token_candidates {
                     self.store_tc_token_candidate(candidate).await;
                 }
 
@@ -238,7 +238,7 @@ impl Client {
     }
 
     /// Store a tctoken candidate extracted during history sync streaming.
-    async fn store_tc_token_candidate(&self, candidate: &TcTokenCandidate) {
+    async fn store_tc_token_candidate(&self, candidate: TcTokenCandidate) {
         let jid: wacore_binary::Jid = match candidate.id.parse() {
             Ok(j) => j,
             Err(_) => return,
@@ -269,7 +269,7 @@ impl Client {
         };
 
         let entry = TcTokenEntry {
-            token: candidate.tc_token.clone(),
+            token: candidate.tc_token,
             token_timestamp: candidate.tc_token_timestamp as i64,
             sender_timestamp: merged_sender_ts,
         };

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -1,9 +1,7 @@
 use bytes::Bytes;
 use flate2::read::ZlibDecoder;
-use prost::Message;
 use std::io::Read;
 use thiserror::Error;
-use waproto::whatsapp as wa;
 
 #[derive(Debug, Error)]
 pub enum HistorySyncError {
@@ -23,12 +21,14 @@ pub struct HistorySyncResult {
     /// Source: WAWeb/History/MsgHandlerAction.js:storeNctSaltFromHistorySync
     pub nct_salt: Option<Vec<u8>>,
     pub conversations_processed: usize,
-    /// The full decompressed protobuf blob. Consumers can wrap this in
-    /// `LazyHistorySync` for on-demand decoding.
-    pub decompressed_bytes: Bytes,
+    /// Tctoken candidates extracted from 1:1 conversations during streaming.
+    pub tc_token_candidates: Vec<TcTokenCandidate>,
+    /// The full decompressed protobuf blob, only retained when event
+    /// listeners exist. Wrapped in `LazyHistorySync` for on-demand decoding.
+    pub decompressed_bytes: Option<Bytes>,
 }
 
-mod wire_type {
+pub(crate) mod wire_type {
     pub const VARINT: u32 = 0;
     pub const FIXED64: u32 = 1;
     pub const LENGTH_DELIMITED: u32 = 2;
@@ -45,40 +45,33 @@ mod wire_type {
 ///
 /// After decompression, the compressed input is dropped immediately, so peak
 /// memory = max(compressed, decompressed) + small overhead, not both.
-pub fn process_history_sync<F>(
+pub fn process_history_sync(
     compressed_data: Vec<u8>,
     own_user: Option<&str>,
-    mut on_conversation_bytes: Option<F>,
+    retain_blob: bool,
     compressed_size_hint: Option<u64>,
-) -> Result<HistorySyncResult, HistorySyncError>
-where
-    F: FnMut(Bytes),
-{
+) -> Result<HistorySyncResult, HistorySyncError> {
     // Decompress into a single contiguous buffer.
-    // If the compressed (post-decrypt) size is known from the notification's
-    // file_length, use it with the 4x multiplier for a better estimate than
-    // guessing from the encrypted input (which includes MAC/padding overhead).
     let estimated = compressed_size_hint
         .and_then(|s| usize::try_from(s).ok())
         .map(|s| s * 4)
         .unwrap_or_else(|| compressed_data.len() * 4)
-        .clamp(256, 8 * 1024 * 1024);
+        .clamp(256, 64 * 1024 * 1024);
     let mut decompressed = Vec::with_capacity(estimated);
     {
         let mut decoder = ZlibDecoder::new(compressed_data.as_slice());
         decoder.read_to_end(&mut decompressed)?;
     }
-    // Drop compressed data immediately — no longer needed.
     drop(compressed_data);
 
-    // Wrap in Bytes so we can hand out zero-copy slices.
     let buf = Bytes::from(decompressed);
     let mut pos = 0;
     let mut result = HistorySyncResult {
         own_pushname: None,
         nct_salt: None,
         conversations_processed: 0,
-        decompressed_bytes: buf.clone(), // cheap Arc refcount increment
+        tc_token_candidates: Vec::new(),
+        decompressed_bytes: if retain_blob { Some(buf.clone()) } else { None },
     };
 
     while pos < buf.len() {
@@ -95,10 +88,9 @@ where
                 pos += vlen;
                 let end = checked_end(pos, len, buf.len(), "conversation")?;
 
-                if let Some(ref mut callback) = on_conversation_bytes {
-                    // Zero-copy slice — just an Arc refcount increment.
-                    callback(buf.slice(pos..end));
-                    result.conversations_processed += 1;
+                result.conversations_processed += 1;
+                if let Some(candidate) = extract_tc_token_fields(&buf[pos..end]) {
+                    result.tc_token_candidates.push(candidate);
                 }
                 pos = end;
             }
@@ -112,11 +104,7 @@ where
                 pos += vlen;
                 let end = checked_end(pos, len, buf.len(), "pushname")?;
 
-                if let Ok(pn) = wa::Pushname::decode(&buf[pos..end])
-                    && let Some(ref id) = pn.id
-                    && Some(id.as_str()) == own_user
-                    && let Some(name) = pn.pushname
-                {
+                if let Some(name) = extract_own_pushname(&buf[pos..end], own_user.unwrap()) {
                     result.own_pushname = Some(name);
                 }
                 pos = end;
@@ -148,7 +136,7 @@ where
 
 /// Compute `pos + len` with overflow and bounds checking.
 #[inline]
-fn checked_end(
+pub(crate) fn checked_end(
     pos: usize,
     len: u64,
     buf_len: usize,
@@ -172,7 +160,7 @@ fn checked_end(
 
 /// Read a protobuf varint from `data`, returning (value, bytes_consumed).
 #[inline]
-fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
+pub(crate) fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
     let mut value: u64 = 0;
     let mut shift = 0u32;
     for (i, &byte) in data.iter().enumerate() {
@@ -194,7 +182,11 @@ fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
 
 /// Skip a protobuf field based on wire type, returning the new position.
 #[inline]
-fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySyncError> {
+pub(crate) fn skip_field(
+    wire_type: u32,
+    buf: &[u8],
+    pos: usize,
+) -> Result<usize, HistorySyncError> {
     match wire_type {
         wire_type::VARINT => {
             let (_, vlen) = read_varint(&buf[pos..])?;
@@ -215,6 +207,98 @@ fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySy
     }
 }
 
+/// Manual pushname parser — Pushname proto has fields: id (tag 1) and pushname (tag 2).
+/// Checks id first and only allocates the pushname string if id matches `own_user`.
+fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
+    let mut pos = 0;
+    let mut id_match = false;
+    let mut pushname: Option<String> = None;
+
+    while pos < data.len() {
+        let (tag, bytes_read) = read_varint(data.get(pos..)?).ok()?;
+        pos += bytes_read;
+        let field_number = (tag >> 3) as u32;
+        let wt = (tag & 0x7) as u32;
+
+        match field_number {
+            // id (tag 1, string)
+            1 if wt == wire_type::LENGTH_DELIMITED => {
+                let (len, vlen) = read_varint(data.get(pos..)?).ok()?;
+                pos += vlen;
+                let end = pos.checked_add(len as usize).filter(|&e| e <= data.len())?;
+                let id = std::str::from_utf8(data.get(pos..end)?).ok()?;
+                id_match = id == own_user;
+                if !id_match {
+                    return None; // wrong user, skip entirely
+                }
+                pos = end;
+            }
+            // pushname (tag 2, string)
+            2 if wt == wire_type::LENGTH_DELIMITED => {
+                let (len, vlen) = read_varint(data.get(pos..)?).ok()?;
+                pos += vlen;
+                let end = pos.checked_add(len as usize).filter(|&e| e <= data.len())?;
+                let name = std::str::from_utf8(data.get(pos..end)?).ok()?;
+                pushname = Some(name.to_string());
+                pos = end;
+            }
+            _ => {
+                pos = skip_field(wt, data, pos).ok()?;
+            }
+        }
+    }
+
+    if id_match { pushname } else { None }
+}
+
+/// Prost partial decode — only tctoken fields, skips heavy `messages`.
+#[derive(Clone, PartialEq, prost::Message)]
+pub(crate) struct ConversationTcTokenFields {
+    #[prost(string, required, tag = "1")]
+    pub id: String,
+    #[prost(bytes = "vec", optional, tag = "21")]
+    pub tc_token: Option<Vec<u8>>,
+    #[prost(uint64, optional, tag = "22")]
+    pub tc_token_timestamp: Option<u64>,
+    #[prost(uint64, optional, tag = "28")]
+    pub tc_token_sender_timestamp: Option<u64>,
+}
+
+/// Extract tctoken candidate from a raw Conversation proto.
+/// Uses prost partial decode (only fields 1/21/22/28, skips messages).
+/// Returns `None` for groups, newsletters, bots, or conversations without tctokens.
+pub(crate) fn extract_tc_token_fields(data: &[u8]) -> Option<TcTokenCandidate> {
+    use prost::Message;
+
+    let conv = ConversationTcTokenFields::decode(data).ok()?;
+
+    // Early-out for non-1:1 conversations
+    if let Some(parts) = wacore_binary::jid::parse_jid_fast(&conv.id)
+        && (parts.server == "g.us" || parts.server == "newsletter" || parts.server == "bot")
+    {
+        return None;
+    }
+
+    let tc_token = conv.tc_token.filter(|t| !t.is_empty())?;
+    let tc_token_timestamp = conv.tc_token_timestamp?;
+
+    Some(TcTokenCandidate {
+        id: conv.id,
+        tc_token,
+        tc_token_timestamp,
+        tc_token_sender_timestamp: conv.tc_token_sender_timestamp,
+    })
+}
+
+/// Tctoken data extracted from a conversation during streaming.
+#[derive(Debug)]
+pub struct TcTokenCandidate {
+    pub id: String,
+    pub tc_token: Vec<u8>,
+    pub tc_token_timestamp: u64,
+    pub tc_token_sender_timestamp: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -222,6 +306,7 @@ mod tests {
     use flate2::write::ZlibEncoder;
     use prost::Message;
     use std::io::Write;
+    use waproto::whatsapp as wa;
 
     /// Encode a HistorySync proto and zlib-compress it.
     fn encode_and_compress(hs: &wa::HistorySync) -> Vec<u8> {
@@ -241,7 +326,7 @@ mod tests {
         };
 
         let compressed = encode_and_compress(&hs);
-        let result = process_history_sync::<fn(Bytes)>(compressed, None, None, None).unwrap();
+        let result = process_history_sync(compressed, None, false, None).unwrap();
 
         assert_eq!(result.nct_salt, Some(salt));
     }
@@ -254,7 +339,7 @@ mod tests {
         };
 
         let compressed = encode_and_compress(&hs);
-        let result = process_history_sync::<fn(Bytes)>(compressed, None, None, None).unwrap();
+        let result = process_history_sync(compressed, None, false, None).unwrap();
 
         assert!(result.nct_salt.is_none());
     }
@@ -273,8 +358,7 @@ mod tests {
         };
 
         let compressed = encode_and_compress(&hs);
-        let result =
-            process_history_sync::<fn(Bytes)>(compressed, Some("0000000000"), None, None).unwrap();
+        let result = process_history_sync(compressed, Some("0000000000"), false, None).unwrap();
 
         assert_eq!(result.nct_salt, Some(salt));
         assert_eq!(result.own_pushname.as_deref(), Some("TestUser"));

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -28,7 +28,7 @@ pub struct HistorySyncResult {
     pub decompressed_bytes: Option<Bytes>,
 }
 
-pub(crate) mod wire_type {
+mod wire_type {
     pub const VARINT: u32 = 0;
     pub const FIXED64: u32 = 1;
     pub const LENGTH_DELIMITED: u32 = 2;
@@ -51,16 +51,20 @@ pub fn process_history_sync(
     retain_blob: bool,
     compressed_size_hint: Option<u64>,
 ) -> Result<HistorySyncResult, HistorySyncError> {
-    // Decompress into a single contiguous buffer.
+    // Hard limit to prevent OOM on malformed blobs.
+    // Typical InitialBootstrap: 5-20 MB decompressed.
+    const MAX_DECOMPRESSED: u64 = 64 * 1024 * 1024;
+
     let estimated = compressed_size_hint
         .and_then(|s| usize::try_from(s).ok())
         .map(|s| s * 4)
         .unwrap_or_else(|| compressed_data.len() * 4)
-        .clamp(256, 64 * 1024 * 1024);
+        .clamp(256, MAX_DECOMPRESSED as usize);
     let mut decompressed = Vec::with_capacity(estimated);
     {
-        let mut decoder = ZlibDecoder::new(compressed_data.as_slice());
-        decoder.read_to_end(&mut decompressed)?;
+        let decoder = ZlibDecoder::new(compressed_data.as_slice());
+        let mut limited = decoder.take(MAX_DECOMPRESSED);
+        limited.read_to_end(&mut decompressed)?;
     }
     drop(compressed_data);
 
@@ -96,7 +100,7 @@ pub fn process_history_sync(
             }
 
             // field 7 = pushnames (repeated, length-delimited)
-            7 if own_user.is_some()
+            7 if let Some(own) = own_user
                 && result.own_pushname.is_none()
                 && wire_type_raw == wire_type::LENGTH_DELIMITED =>
             {
@@ -104,7 +108,7 @@ pub fn process_history_sync(
                 pos += vlen;
                 let end = checked_end(pos, len, buf.len(), "pushname")?;
 
-                if let Some(name) = extract_own_pushname(&buf[pos..end], own_user.unwrap()) {
+                if let Some(name) = extract_own_pushname(&buf[pos..end], own) {
                     result.own_pushname = Some(name);
                 }
                 pos = end;
@@ -136,7 +140,7 @@ pub fn process_history_sync(
 
 /// Compute `pos + len` with overflow and bounds checking.
 #[inline]
-pub(crate) fn checked_end(
+fn checked_end(
     pos: usize,
     len: u64,
     buf_len: usize,
@@ -160,7 +164,7 @@ pub(crate) fn checked_end(
 
 /// Read a protobuf varint from `data`, returning (value, bytes_consumed).
 #[inline]
-pub(crate) fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
+fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
     let mut value: u64 = 0;
     let mut shift = 0u32;
     for (i, &byte) in data.iter().enumerate() {
@@ -182,11 +186,7 @@ pub(crate) fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError>
 
 /// Skip a protobuf field based on wire type, returning the new position.
 #[inline]
-pub(crate) fn skip_field(
-    wire_type: u32,
-    buf: &[u8],
-    pos: usize,
-) -> Result<usize, HistorySyncError> {
+fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySyncError> {
     match wire_type {
         wire_type::VARINT => {
             let (_, vlen) = read_varint(&buf[pos..])?;
@@ -225,7 +225,8 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
             1 if wt == wire_type::LENGTH_DELIMITED => {
                 let (len, vlen) = read_varint(data.get(pos..)?).ok()?;
                 pos += vlen;
-                let end = pos.checked_add(len as usize).filter(|&e| e <= data.len())?;
+                let len = usize::try_from(len).ok()?;
+                let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
                 let id = std::str::from_utf8(data.get(pos..end)?).ok()?;
                 id_match = id == own_user;
                 if !id_match {
@@ -237,7 +238,8 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
             2 if wt == wire_type::LENGTH_DELIMITED => {
                 let (len, vlen) = read_varint(data.get(pos..)?).ok()?;
                 pos += vlen;
-                let end = pos.checked_add(len as usize).filter(|&e| e <= data.len())?;
+                let len = usize::try_from(len).ok()?;
+                let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
                 let name = std::str::from_utf8(data.get(pos..end)?).ok()?;
                 pushname = Some(name.to_string());
                 pos = end;

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -15,7 +15,7 @@ pub enum HistorySyncError {
     MalformedProtobuf(String),
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct HistorySyncResult {
     pub own_pushname: Option<String>,
     /// NCT salt from HistorySync field 19 (nctSalt).
@@ -23,6 +23,9 @@ pub struct HistorySyncResult {
     /// Source: WAWeb/History/MsgHandlerAction.js:storeNctSaltFromHistorySync
     pub nct_salt: Option<Vec<u8>>,
     pub conversations_processed: usize,
+    /// The full decompressed protobuf blob. Consumers can wrap this in
+    /// `LazyHistorySync` for on-demand decoding.
+    pub decompressed_bytes: Bytes,
 }
 
 mod wire_type {
@@ -71,7 +74,12 @@ where
     // Wrap in Bytes so we can hand out zero-copy slices.
     let buf = Bytes::from(decompressed);
     let mut pos = 0;
-    let mut result = HistorySyncResult::default();
+    let mut result = HistorySyncResult {
+        own_pushname: None,
+        nct_salt: None,
+        conversations_processed: 0,
+        decompressed_bytes: buf.clone(), // cheap Arc refcount increment
+    };
 
     while pos < buf.len() {
         let (tag, bytes_read) = read_varint(&buf[pos..])?;

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -97,58 +97,6 @@ impl LazyHistorySync {
     pub fn raw_bytes(&self) -> &[u8] {
         &self.raw_bytes
     }
-
-    /// Consume self and return the raw decompressed bytes for zero-copy slicing.
-    pub fn into_raw_bytes(self) -> Bytes {
-        self.raw_bytes
-    }
-
-    /// Iterate over raw conversation bytes without full proto decode.
-    ///
-    /// Each yielded `Bytes` is a zero-copy slice of the decompressed buffer
-    /// containing one `Conversation` protobuf. Consumers can decode individual
-    /// conversations on demand via `wa::Conversation::decode(&bytes[..])`.
-    pub fn conversations_raw(&self) -> impl Iterator<Item = Bytes> + '_ {
-        ConversationIterator {
-            buf: &self.raw_bytes,
-            pos: 0,
-        }
-    }
-}
-
-struct ConversationIterator<'a> {
-    buf: &'a Bytes,
-    pos: usize,
-}
-
-impl Iterator for ConversationIterator<'_> {
-    type Item = Bytes;
-
-    fn next(&mut self) -> Option<Bytes> {
-        use crate::history_sync::{read_varint, skip_field, wire_type};
-
-        while self.pos < self.buf.len() {
-            let (tag, bytes_read) = read_varint(self.buf.get(self.pos..)?).ok()?;
-            self.pos += bytes_read;
-            let field_number = (tag >> 3) as u32;
-            let wt = (tag & 0x7) as u32;
-
-            if field_number == 2 && wt == wire_type::LENGTH_DELIMITED {
-                let (len, vlen) = read_varint(self.buf.get(self.pos..)?).ok()?;
-                self.pos += vlen;
-                let end = self
-                    .pos
-                    .checked_add(len as usize)
-                    .filter(|&e| e <= self.buf.len())?;
-                let slice = self.buf.slice(self.pos..end);
-                self.pos = end;
-                return Some(slice);
-            }
-
-            self.pos = skip_field(wt, self.buf, self.pos).ok()?;
-        }
-        None
-    }
 }
 
 impl fmt::Debug for LazyHistorySync {
@@ -172,11 +120,10 @@ impl Serialize for LazyHistorySync {
         S: serde::Serializer,
     {
         use serde::ser::SerializeStruct;
-        let mut s = serializer.serialize_struct("LazyHistorySync", 4)?;
+        let mut s = serializer.serialize_struct("LazyHistorySync", 3)?;
         s.serialize_field("sync_type", &self.sync_type)?;
         s.serialize_field("chunk_order", &self.chunk_order)?;
         s.serialize_field("progress", &self.progress)?;
-        s.serialize_field("data", &self.parsed.get().and_then(|o| o.as_ref()))?;
         s.end()
     }
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -99,11 +99,13 @@ impl Serialize for LazyHistorySync {
     where
         S: serde::Serializer,
     {
-        if let Some(Some(hs)) = self.parsed.get() {
-            hs.serialize(serializer)
-        } else {
-            serializer.serialize_none()
-        }
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("LazyHistorySync", 4)?;
+        s.serialize_field("sync_type", &self.sync_type)?;
+        s.serialize_field("chunk_order", &self.chunk_order)?;
+        s.serialize_field("progress", &self.progress)?;
+        s.serialize_field("data", &self.parsed.get().and_then(|o| o.as_ref()))?;
+        s.end()
     }
 }
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -67,6 +67,11 @@ impl LazyHistorySync {
 
     /// Full decode of the history sync proto, cached via OnceLock.
     /// Returns `None` if decoding fails.
+    ///
+    /// Note: decoding materializes the full proto in memory alongside the
+    /// raw bytes (~2x decompressed size). For large InitialBootstrap blobs,
+    /// prefer [`raw_bytes()`](Self::raw_bytes) with partial decoding if
+    /// you only need specific fields.
     pub fn get(&self) -> Option<&wa::HistorySync> {
         self.parsed
             .get_or_init(|| wa::HistorySync::decode(&self.raw_bytes[..]).ok())

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -24,13 +24,24 @@ use waproto::whatsapp as wa;
 /// Call [`get()`](Self::get) for full access to conversations, pushnames,
 /// global settings, past participants, call logs, and everything else in
 /// the `wa::HistorySync` proto.
-#[derive(Clone)]
 pub struct LazyHistorySync {
     raw_bytes: Bytes,
     sync_type: i32,
     chunk_order: Option<u32>,
     progress: Option<u32>,
-    parsed: OnceLock<Option<wa::HistorySync>>,
+    parsed: OnceLock<Option<Box<wa::HistorySync>>>,
+}
+
+impl Clone for LazyHistorySync {
+    fn clone(&self) -> Self {
+        Self {
+            raw_bytes: self.raw_bytes.clone(),
+            sync_type: self.sync_type,
+            chunk_order: self.chunk_order,
+            progress: self.progress,
+            parsed: OnceLock::new(), // don't deep-copy the decoded proto
+        }
+    }
 }
 
 impl LazyHistorySync {
@@ -74,13 +85,69 @@ impl LazyHistorySync {
     /// you only need specific fields.
     pub fn get(&self) -> Option<&wa::HistorySync> {
         self.parsed
-            .get_or_init(|| wa::HistorySync::decode(&self.raw_bytes[..]).ok())
-            .as_ref()
+            .get_or_init(|| {
+                wa::HistorySync::decode(&self.raw_bytes[..])
+                    .ok()
+                    .map(Box::new)
+            })
+            .as_deref()
     }
 
     /// Access the raw decompressed protobuf bytes for custom/partial decoding.
     pub fn raw_bytes(&self) -> &[u8] {
         &self.raw_bytes
+    }
+
+    /// Consume self and return the raw decompressed bytes for zero-copy slicing.
+    pub fn into_raw_bytes(self) -> Bytes {
+        self.raw_bytes
+    }
+
+    /// Iterate over raw conversation bytes without full proto decode.
+    ///
+    /// Each yielded `Bytes` is a zero-copy slice of the decompressed buffer
+    /// containing one `Conversation` protobuf. Consumers can decode individual
+    /// conversations on demand via `wa::Conversation::decode(&bytes[..])`.
+    pub fn conversations_raw(&self) -> impl Iterator<Item = Bytes> + '_ {
+        ConversationIterator {
+            buf: &self.raw_bytes,
+            pos: 0,
+        }
+    }
+}
+
+struct ConversationIterator<'a> {
+    buf: &'a Bytes,
+    pos: usize,
+}
+
+impl Iterator for ConversationIterator<'_> {
+    type Item = Bytes;
+
+    fn next(&mut self) -> Option<Bytes> {
+        use crate::history_sync::{read_varint, skip_field, wire_type};
+
+        while self.pos < self.buf.len() {
+            let (tag, bytes_read) = read_varint(self.buf.get(self.pos..)?).ok()?;
+            self.pos += bytes_read;
+            let field_number = (tag >> 3) as u32;
+            let wt = (tag & 0x7) as u32;
+
+            if field_number == 2 && wt == wire_type::LENGTH_DELIMITED {
+                let (len, vlen) = read_varint(self.buf.get(self.pos..)?).ok()?;
+                self.pos += vlen;
+                let end = self
+                    .pos
+                    .checked_add(len as usize)
+                    .filter(|&e| e <= self.buf.len())?;
+                let slice = self.buf.slice(self.pos..end);
+                self.pos = end;
+                return Some(slice);
+            }
+
+            self.pos = skip_field(wt, self.buf, self.pos).ok()?;
+        }
+        None
     }
 }
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -10,119 +10,97 @@ use std::sync::{Arc, OnceLock, RwLock};
 use wacore_binary::Node;
 use wacore_binary::OwnedNodeRef;
 use wacore_binary::{Jid, MessageId};
-use waproto::whatsapp::{self as wa, HistorySync};
+use waproto::whatsapp as wa;
 
-/// A lazily-parsed conversation from history sync.
+/// A lazily-parsed history sync blob.
 ///
-/// Raw protobuf bytes are stored and only parsed on first access.
-/// With `Arc<Event>` dispatch, all handlers share the same `LazyConversation`
+/// Wraps the decompressed protobuf bytes and only decodes on first access.
+/// With `Arc<Event>` dispatch, all handlers share the same `LazyHistorySync`
 /// so `OnceLock` gives parse-once semantics for free.
+///
+/// Cheap metadata (`sync_type`, `chunk_order`, `progress`) is available
+/// without decoding — useful for filtering events.
+///
+/// Call [`get()`](Self::get) for full access to conversations, pushnames,
+/// global settings, past participants, call logs, and everything else in
+/// the `wa::HistorySync` proto.
 #[derive(Clone)]
-pub struct LazyConversation {
-    /// Raw protobuf bytes using Bytes for zero-copy cloning.
-    /// Bytes is reference-counted internally, so clones share the same data.
+pub struct LazyHistorySync {
     raw_bytes: Bytes,
-    /// Cached parsed result, initialized on first access.
-    parsed: OnceLock<wa::Conversation>,
+    sync_type: i32,
+    chunk_order: Option<u32>,
+    progress: Option<u32>,
+    parsed: OnceLock<Option<wa::HistorySync>>,
 }
 
-impl LazyConversation {
-    /// Create a new lazy conversation from raw protobuf bytes.
-    /// The bytes are moved into Bytes for zero-copy sharing.
-    pub fn new(raw_bytes: Vec<u8>) -> Self {
-        Self {
-            raw_bytes: Bytes::from(raw_bytes),
-            parsed: OnceLock::new(),
-        }
-    }
-
-    /// Create from an existing Bytes instance (true zero-copy).
-    pub fn from_bytes(raw_bytes: Bytes) -> Self {
+impl LazyHistorySync {
+    pub fn new(
+        raw_bytes: Bytes,
+        sync_type: i32,
+        chunk_order: Option<u32>,
+        progress: Option<u32>,
+    ) -> Self {
         Self {
             raw_bytes,
+            sync_type,
+            chunk_order,
+            progress,
             parsed: OnceLock::new(),
         }
     }
 
-    /// Access the raw protobuf bytes for full decoding (including messages).
-    ///
-    /// Since [`get()`](Self::get) and [`conversation()`](Self::conversation)
-    /// strip messages to save memory, consumers that need message history
-    /// should decode from these bytes directly via
-    /// `wa::Conversation::decode(lazy_conv.raw_bytes())`.
+    /// History sync type (e.g. InitialBootstrap, Recent, PushName).
+    /// Available without decoding the proto.
+    pub fn sync_type(&self) -> i32 {
+        self.sync_type
+    }
+
+    /// Chunk ordering for multi-chunk transfers.
+    pub fn chunk_order(&self) -> Option<u32> {
+        self.chunk_order
+    }
+
+    /// Sync progress (0-100).
+    pub fn progress(&self) -> Option<u32> {
+        self.progress
+    }
+
+    /// Full decode of the history sync proto, cached via OnceLock.
+    /// Returns `None` if decoding fails.
+    pub fn get(&self) -> Option<&wa::HistorySync> {
+        self.parsed
+            .get_or_init(|| wa::HistorySync::decode(&self.raw_bytes[..]).ok())
+            .as_ref()
+    }
+
+    /// Access the raw decompressed protobuf bytes for custom/partial decoding.
     pub fn raw_bytes(&self) -> &[u8] {
         &self.raw_bytes
     }
-
-    /// Decode the full conversation including messages.
-    ///
-    /// Unlike [`get()`](Self::get) which strips messages to save memory,
-    /// this decodes a fresh copy from the raw bytes every time and keeps
-    /// the full `WebMessageInfo` array intact. Returns `None` if decoding
-    /// fails or the conversation id is empty.
-    ///
-    /// The result is not cached — call this only when you actually need
-    /// the messages, and prefer [`get()`](Self::get) for metadata-only access.
-    pub fn get_with_messages(&self) -> Option<wa::Conversation> {
-        let conv = wa::Conversation::decode(&self.raw_bytes[..]).ok()?;
-        if conv.id.is_empty() { None } else { Some(conv) }
-    }
-
-    /// Get the parsed conversation, parsing on first access.
-    /// Returns None if parsing fails (empty id indicates invalid conversation).
-    ///
-    /// Messages are always stripped on first parse to reduce memory —
-    /// history sync conversations embed full `WebMessageInfo` arrays that
-    /// can be very large. Use [`raw_bytes()`](Self::raw_bytes) if you need messages.
-    pub fn get(&self) -> Option<&wa::Conversation> {
-        let conv = self.parsed.get_or_init(|| {
-            let mut conv = wa::Conversation::decode(&self.raw_bytes[..]).unwrap_or_default();
-            conv.messages.clear();
-            conv.messages.shrink_to_fit();
-            conv
-        });
-        if conv.id.is_empty() { None } else { Some(conv) }
-    }
-
-    /// Get the parsed conversation, parsing on first access.
-    /// Panics if parsing fails (use `get()` for fallible access).
-    ///
-    /// Messages are always stripped on first parse to reduce memory.
-    pub fn conversation(&self) -> &wa::Conversation {
-        self.parsed.get_or_init(|| {
-            let mut conv = wa::Conversation::decode(&self.raw_bytes[..])
-                .expect("Failed to decode conversation");
-            conv.messages.clear();
-            conv.messages.shrink_to_fit();
-            conv
-        })
-    }
 }
 
-impl fmt::Debug for LazyConversation {
+impl fmt::Debug for LazyHistorySync {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(conv) = self.parsed.get() {
-            f.debug_struct("LazyConversation")
-                .field("id", &conv.id)
-                .field("parsed", &true)
-                .finish()
-        } else {
-            f.debug_struct("LazyConversation")
-                .field("raw_size", &self.raw_bytes.len())
-                .field("parsed", &false)
-                .finish()
-        }
+        f.debug_struct("LazyHistorySync")
+            .field("sync_type", &self.sync_type)
+            .field("chunk_order", &self.chunk_order)
+            .field("progress", &self.progress)
+            .field("raw_size", &self.raw_bytes.len())
+            .field(
+                "parsed",
+                &self.parsed.get().and_then(|o| o.as_ref()).is_some(),
+            )
+            .finish()
     }
 }
 
-impl Serialize for LazyConversation {
+impl Serialize for LazyHistorySync {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        // Only serialize if parsed, otherwise serialize as null/empty
-        if let Some(conv) = self.parsed.get() {
-            conv.serialize(serializer)
+        if let Some(Some(hs)) = self.parsed.get() {
+            hs.serialize(serializer)
         } else {
             serializer.serialize_none()
         }
@@ -389,7 +367,6 @@ pub enum Event {
     ContactNumberChanged(ContactNumberChanged),
     ContactSyncRequested(ContactSyncRequested),
 
-    JoinedGroup(LazyConversation),
     /// Group metadata/settings/participant change from w:gp2 notification.
     GroupUpdate(GroupUpdate),
     ContactUpdate(ContactUpdate),
@@ -404,7 +381,7 @@ pub enum Event {
     DeleteChatUpdate(DeleteChatUpdate),
     DeleteMessageForMeUpdate(DeleteMessageForMeUpdate),
 
-    HistorySync(HistorySync),
+    HistorySync(Box<LazyHistorySync>),
     OfflineSyncPreview(OfflineSyncPreview),
     OfflineSyncCompleted(OfflineSyncCompleted),
 
@@ -906,129 +883,113 @@ mod tests {
     use prost::Message;
     use waproto::whatsapp as wa;
 
-    /// Build a Conversation proto with an id and N dummy messages, encode it.
-    fn make_conversation_bytes(id: &str, num_messages: usize) -> Vec<u8> {
-        let messages: Vec<wa::HistorySyncMsg> = (0..num_messages)
-            .map(|i| wa::HistorySyncMsg {
-                message: Some(wa::WebMessageInfo {
-                    key: wa::MessageKey {
-                        id: Some(format!("msg-{i}")),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                msg_order_id: Some(i as u64),
-            })
-            .collect();
-
-        let conv = wa::Conversation {
-            id: id.to_string(),
-            messages,
+    /// Build a HistorySync proto with conversations and encode it.
+    fn make_history_sync_bytes(conversations: Vec<wa::Conversation>) -> Vec<u8> {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::InitialBootstrap as i32,
+            conversations,
             ..Default::default()
         };
-        conv.encode_to_vec()
+        hs.encode_to_vec()
     }
 
     #[test]
-    fn get_strips_messages() {
-        let bytes = make_conversation_bytes("chat@s.whatsapp.net", 5);
-        let lazy = LazyConversation::new(bytes);
-
-        let conv = lazy.get().expect("should parse");
-        assert_eq!(conv.id, "chat@s.whatsapp.net");
-        assert!(conv.messages.is_empty(), "get() must strip messages");
-    }
-
-    #[test]
-    fn conversation_strips_messages() {
-        let bytes = make_conversation_bytes("chat@s.whatsapp.net", 3);
-        let lazy = LazyConversation::new(bytes);
-
-        let conv = lazy.conversation();
-        assert_eq!(conv.id, "chat@s.whatsapp.net");
-        assert!(
-            conv.messages.is_empty(),
-            "conversation() must strip messages"
-        );
-    }
-
-    #[test]
-    fn raw_bytes_returns_original_proto() {
-        let bytes = make_conversation_bytes("chat@s.whatsapp.net", 4);
-        let lazy = LazyConversation::new(bytes.clone());
-
-        assert_eq!(lazy.raw_bytes(), &bytes[..]);
-
-        // Users can decode the full conversation from raw_bytes
-        let full = wa::Conversation::decode(lazy.raw_bytes()).expect("should decode");
-        assert_eq!(full.id, "chat@s.whatsapp.net");
-        assert_eq!(full.messages.len(), 4);
-    }
-
-    #[test]
-    fn get_with_messages_preserves_messages() {
-        let bytes = make_conversation_bytes("chat@s.whatsapp.net", 7);
-        let lazy = LazyConversation::new(bytes);
-
-        let full = lazy.get_with_messages().expect("should decode");
-        assert_eq!(full.id, "chat@s.whatsapp.net");
-        assert_eq!(full.messages.len(), 7);
-        assert_eq!(
-            full.messages[0].message.as_ref().unwrap().key.id.as_deref(),
-            Some("msg-0")
-        );
-    }
-
-    #[test]
-    fn get_with_messages_independent_of_cached_parse() {
-        let bytes = make_conversation_bytes("chat@s.whatsapp.net", 3);
-        let lazy = LazyConversation::new(bytes);
-
-        // Trigger the cached parse first (strips messages)
-        let stripped = lazy.get().expect("should parse");
-        assert!(stripped.messages.is_empty());
-
-        // get_with_messages should still return full messages
-        let full = lazy.get_with_messages().expect("should decode");
-        assert_eq!(full.messages.len(), 3);
-    }
-
-    #[test]
-    fn get_returns_none_for_empty_id() {
-        let conv = wa::Conversation {
-            id: String::new(),
+    fn lazy_history_sync_get_decodes() {
+        let bytes = make_history_sync_bytes(vec![wa::Conversation {
+            id: "chat@s.whatsapp.net".to_string(),
             ..Default::default()
-        };
-        let lazy = LazyConversation::new(conv.encode_to_vec());
+        }]);
+        let lazy = LazyHistorySync::new(Bytes::from(bytes), 0, None, None);
+
+        let hs = lazy.get().expect("should decode");
+        assert_eq!(hs.conversations.len(), 1);
+        assert_eq!(hs.conversations[0].id, "chat@s.whatsapp.net");
+    }
+
+    #[test]
+    fn lazy_history_sync_caches_decode() {
+        let bytes = make_history_sync_bytes(vec![wa::Conversation {
+            id: "test@g.us".to_string(),
+            ..Default::default()
+        }]);
+        let lazy = LazyHistorySync::new(Bytes::from(bytes), 0, None, None);
+
+        let first = lazy.get().expect("first decode");
+        let second = lazy.get().expect("second decode");
+        // Same reference — OnceLock cached it
+        assert!(std::ptr::eq(first, second));
+    }
+
+    #[test]
+    fn lazy_history_sync_cheap_metadata() {
+        let bytes = make_history_sync_bytes(vec![]);
+        let lazy = LazyHistorySync::new(Bytes::from(bytes), 3, Some(2), Some(50));
+
+        assert_eq!(lazy.sync_type(), 3);
+        assert_eq!(lazy.chunk_order(), Some(2));
+        assert_eq!(lazy.progress(), Some(50));
+    }
+
+    #[test]
+    fn lazy_history_sync_raw_bytes() {
+        let bytes = make_history_sync_bytes(vec![wa::Conversation {
+            id: "raw@s.whatsapp.net".to_string(),
+            ..Default::default()
+        }]);
+        let raw = bytes.clone();
+        let lazy = LazyHistorySync::new(Bytes::from(bytes), 0, None, None);
+
+        assert_eq!(lazy.raw_bytes(), &raw[..]);
+
+        // Consumer can partial-decode from raw_bytes
+        let decoded = wa::HistorySync::decode(lazy.raw_bytes()).expect("should decode");
+        assert_eq!(decoded.conversations[0].id, "raw@s.whatsapp.net");
+    }
+
+    #[test]
+    fn lazy_history_sync_empty_bytes_decodes_default() {
+        // Empty protobuf bytes are valid — decode to default HistorySync
+        let lazy = LazyHistorySync::new(Bytes::new(), 0, None, None);
+        let hs = lazy.get().expect("empty bytes decode to default");
+        assert!(hs.conversations.is_empty());
+    }
+
+    #[test]
+    fn lazy_history_sync_corrupt_bytes_returns_none() {
+        let lazy = LazyHistorySync::new(Bytes::from_static(&[0xFF, 0xFF, 0xFF]), 0, None, None);
         assert!(lazy.get().is_none());
     }
 
     #[test]
-    fn get_with_messages_returns_none_for_empty_id() {
+    fn lazy_history_sync_preserves_messages() {
         let conv = wa::Conversation {
-            id: String::new(),
+            id: "chat@s.whatsapp.net".to_string(),
+            messages: vec![wa::HistorySyncMsg {
+                message: Some(wa::WebMessageInfo {
+                    key: wa::MessageKey {
+                        id: Some("msg-0".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                msg_order_id: Some(0),
+            }],
             ..Default::default()
         };
-        let lazy = LazyConversation::new(conv.encode_to_vec());
-        assert!(lazy.get_with_messages().is_none());
-    }
+        let bytes = make_history_sync_bytes(vec![conv]);
+        let lazy = LazyHistorySync::new(Bytes::from(bytes), 0, None, None);
 
-    #[test]
-    fn get_with_messages_returns_none_for_invalid_bytes() {
-        let lazy = LazyConversation::new(vec![0xFF, 0xFF, 0xFF]);
-        assert!(lazy.get_with_messages().is_none());
-    }
-
-    #[test]
-    fn from_bytes_works_same_as_new() {
-        let bytes = make_conversation_bytes("test@s.whatsapp.net", 2);
-        let lazy = LazyConversation::from_bytes(Bytes::from(bytes));
-
-        let full = lazy.get_with_messages().expect("should decode");
-        assert_eq!(full.id, "test@s.whatsapp.net");
-        assert_eq!(full.messages.len(), 2);
-
-        let stripped = lazy.get().expect("should parse");
-        assert!(stripped.messages.is_empty());
+        let hs = lazy.get().expect("should decode");
+        assert_eq!(hs.conversations[0].messages.len(), 1);
+        assert_eq!(
+            hs.conversations[0].messages[0]
+                .message
+                .as_ref()
+                .unwrap()
+                .key
+                .id
+                .as_deref(),
+            Some("msg-0")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replaces `Event::JoinedGroup(LazyConversation)` (per-conversation, misleading name) and dead `Event::HistorySync(HistorySync)` with a single `Event::HistorySync(Box<LazyHistorySync>)` per sync blob, plus performance optimizations.

## Consumer API

```rust
Event::HistorySync(hs) => {
    // Cheap metadata — no decode
    let sync_type = hs.sync_type();
    let progress = hs.progress();

    // Full proto access on demand (lazy, cached, parse-once)
    if let Some(data) = hs.get() {
        for conv in &data.conversations { /* ... */ }
        for pn in &data.pushnames { /* ... */ }
        // global_settings, past_participants, call_log_records, etc.
    }

    // Or raw bytes for custom partial decoding
    let raw = hs.raw_bytes();
}
```

## Changes

### Event refactor
- `Event::JoinedGroup(LazyConversation)` removed — name was wrong (carried DMs, groups, newsletters)
- `Event::HistorySync(HistorySync)` removed — dead code, never dispatched
- New: `Event::HistorySync(Box<LazyHistorySync>)` — single event per sync blob with lazy decode

### Performance
- **Channel removed** — tctoken candidates collected directly in the streaming loop, no more `async_channel`/oneshot/secondary spawn
- **Conditional blob retention** — decompressed `Bytes` only kept when event listeners exist
- **Inline decode for small blobs** — PushName/Recent syncs (<256KB) skip `spawn_blocking`
- **Manual pushname parser** — checks id before allocating, skips 99% of entries without allocation
- **`parse_jid_fast` early-exit** — groups/newsletters/bots filtered without JID allocation
- **Decompression cap** — 8MB → 64MB estimate to avoid reallocs; hard 64MB limit via `Read::take()` to prevent OOM
- **`Box<wa::HistorySync>` in OnceLock** — avoids ~500 bytes inline reservation
- **Safe Clone** — shares `Bytes` cheaply, creates fresh `OnceLock` (no accidental deep copy)
- **Zero-clone tctoken storage** — candidates consumed by value, token moved directly into `TcTokenEntry`

### Safety
- Hard 64MB decompression limit via `Read::take()` prevents OOM on malformed blobs
- Safe `u64 -> usize` conversion via `try_from` (no truncation on 32-bit/WASM)
- `own_user.unwrap()` eliminated — moved into if-let chain
- Serialize is metadata-only and deterministic (no handler-order dependency)

### What's preserved
- TCToken extraction (prost partial decode of fields 1/21/22/28)
- Own pushname extraction (streaming field 7)
- NCT salt extraction (streaming field 19)
- No-listener fast path (`has_handlers()` gates blob retention and event dispatch)

## Breaking changes
- `Event::JoinedGroup` removed
- `Event::HistorySync` payload changed from `wa::HistorySync` to `Box<LazyHistorySync>`
- `LazyConversation` removed

## Test plan
- [x] `cargo clippy --all --tests` — zero warnings
- [x] `cargo fmt --all` — clean
- [x] All tests pass (7 new LazyHistorySync tests + 3 existing history sync tests)
- [x] No remaining references to `JoinedGroup`, `LazyConversation`, or old channel code