### PR TITLE
feat: add extension points for proxy and custom TLS support

### DIFF
--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -18,6 +18,14 @@ impl UreqHttpClient {
         let agent = build_agent();
         Self { agent }
     }
+
+    /// Create a client with a pre-configured [`ureq::Agent`].
+    ///
+    /// This lets you configure proxy support, custom TLS, timeouts,
+    /// or any other agent-level settings externally.
+    pub fn with_agent(agent: ureq::Agent) -> Self {
+        Self { agent }
+    }
 }
 
 impl Default for UreqHttpClient {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3,8 +3,7 @@ pub use wacore::net::{Transport, TransportEvent, TransportFactory};
 
 #[cfg(feature = "tokio-transport")]
 pub use whatsapp_rust_tokio_transport::{
-    Connector, MaybeTlsStream, TokioWebSocketTransportFactory, default_tls_connector,
-    from_websocket,
+    Connector, TokioWebSocketTransportFactory, default_tls_connector, from_websocket,
 };
 
 #[cfg(feature = "ureq-client")]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -2,7 +2,10 @@
 pub use wacore::net::{Transport, TransportEvent, TransportFactory};
 
 #[cfg(feature = "tokio-transport")]
-pub use whatsapp_rust_tokio_transport::{TokioWebSocketTransportFactory, from_websocket};
+pub use whatsapp_rust_tokio_transport::{
+    Connector, MaybeTlsStream, TokioWebSocketTransportFactory, default_tls_connector,
+    from_websocket,
+};
 
 #[cfg(feature = "ureq-client")]
 pub use whatsapp_rust_ureq_http_client::UreqHttpClient;

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -10,14 +10,20 @@ use log::{debug, error, trace, warn};
 use std::sync::{Arc, Once};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
-use tokio_websockets::{ClientBuilder, Connector, Message, WebSocketStream};
+use tokio_websockets::{ClientBuilder, Message, WebSocketStream};
 use wacore::net::{Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_WS_URL};
+
+pub use tokio_websockets::{Connector, MaybeTlsStream};
 
 const EVENT_CHANNEL_CAPACITY: usize = 10_000;
 
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
 
-fn create_tls_connector() -> Connector {
+/// Returns the default TLS connector used by [`TokioWebSocketTransportFactory`].
+///
+/// Useful as a starting point when users need to inspect or replicate the
+/// default TLS configuration before customising it via [`TokioWebSocketTransportFactory::with_connector`].
+pub fn default_tls_connector() -> Connector {
     CRYPTO_PROVIDER_INIT.call_once(|| {
         let _ = rustls::crypto::ring::default_provider().install_default();
     });
@@ -219,17 +225,34 @@ where
 /// For custom connection logic, use [`from_websocket`] directly.
 pub struct TokioWebSocketTransportFactory {
     url: String,
+    connector_factory: Option<Arc<dyn Fn() -> Connector + Send + Sync>>,
 }
 
 impl TokioWebSocketTransportFactory {
     pub fn new() -> Self {
         Self {
             url: WHATSAPP_WEB_WS_URL.to_string(),
+            connector_factory: None,
         }
     }
 
     pub fn with_url(mut self, url: impl Into<String>) -> Self {
         self.url = url.into();
+        self
+    }
+
+    /// Use a custom [`Connector`] factory instead of the built-in default.
+    ///
+    /// The closure is called on every connection attempt (including reconnects),
+    /// so it must be cheap to invoke.
+    ///
+    /// This is the primary extension point for proxy support: build a
+    /// `Connector` that tunnels through your proxy and return it here.
+    pub fn with_connector(
+        mut self,
+        factory: impl Fn() -> Connector + Send + Sync + 'static,
+    ) -> Self {
+        self.connector_factory = Some(Arc::new(factory));
         self
     }
 }
@@ -245,7 +268,10 @@ impl TransportFactory for TokioWebSocketTransportFactory {
     async fn create_transport(
         &self,
     ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error> {
-        let connector = create_tls_connector();
+        let connector = match &self.connector_factory {
+            Some(f) => f(),
+            None => default_tls_connector(),
+        };
         let uri: http::Uri = self
             .url
             .parse()

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 use tokio_websockets::{ClientBuilder, Message, WebSocketStream};
 use wacore::net::{Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_WS_URL};
 
-pub use tokio_websockets::{Connector, MaybeTlsStream};
+pub use tokio_websockets::Connector;
 
 const EVENT_CHANNEL_CAPACITY: usize = 10_000;
 
@@ -22,7 +22,10 @@ static CRYPTO_PROVIDER_INIT: Once = Once::new();
 /// Returns the default TLS connector used by [`TokioWebSocketTransportFactory`].
 ///
 /// Useful as a starting point when users need to inspect or replicate the
-/// default TLS configuration before customising it via [`TokioWebSocketTransportFactory::with_connector`].
+/// default TLS configuration before customizing it via [`TokioWebSocketTransportFactory::with_connector`].
+///
+/// On first call, installs `ring` as the global rustls crypto provider
+/// (no-op if one is already installed).
 pub fn default_tls_connector() -> Connector {
     CRYPTO_PROVIDER_INIT.call_once(|| {
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -225,14 +228,14 @@ where
 /// For custom connection logic, use [`from_websocket`] directly.
 pub struct TokioWebSocketTransportFactory {
     url: String,
-    connector_factory: Option<Arc<dyn Fn() -> Connector + Send + Sync>>,
+    connector: Option<Connector>,
 }
 
 impl TokioWebSocketTransportFactory {
     pub fn new() -> Self {
         Self {
             url: WHATSAPP_WEB_WS_URL.to_string(),
-            connector_factory: None,
+            connector: None,
         }
     }
 
@@ -241,18 +244,13 @@ impl TokioWebSocketTransportFactory {
         self
     }
 
-    /// Use a custom [`Connector`] factory instead of the built-in default.
+    /// Use a custom TLS [`Connector`] instead of the built-in default.
     ///
-    /// The closure is called on every connection attempt (including reconnects),
-    /// so it must be cheap to invoke.
-    ///
-    /// This is the primary extension point for proxy support: build a
-    /// `Connector` that tunnels through your proxy and return it here.
-    pub fn with_connector(
-        mut self,
-        factory: impl Fn() -> Connector + Send + Sync + 'static,
-    ) -> Self {
-        self.connector_factory = Some(Arc::new(factory));
+    /// This is the primary extension point for custom TLS configuration
+    /// (e.g. custom CA certificates, client certs). For full proxy support,
+    /// implement [`TransportFactory`] directly and use [`from_websocket`].
+    pub fn with_connector(mut self, connector: Connector) -> Self {
+        self.connector = Some(connector);
         self
     }
 }
@@ -268,18 +266,23 @@ impl TransportFactory for TokioWebSocketTransportFactory {
     async fn create_transport(
         &self,
     ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error> {
-        let connector = match &self.connector_factory {
-            Some(f) => f(),
-            None => default_tls_connector(),
-        };
         let uri: http::Uri = self
             .url
             .parse()
             .map_err(|e| anyhow::anyhow!("Failed to parse URL: {e}"))?;
 
+        let default_connector;
+        let connector = match &self.connector {
+            Some(c) => c,
+            None => {
+                default_connector = default_tls_connector();
+                &default_connector
+            }
+        };
+
         debug!("Dialing {}", self.url);
         let (ws, _) = ClientBuilder::from_uri(uri)
-            .connector(&connector)
+            .connector(connector)
             .connect()
             .await
             .map_err(|e| anyhow::anyhow!("WebSocket connect failed: {e}"))?;


### PR DESCRIPTION
## Summary

- `TokioWebSocketTransportFactory::with_connector()` - accepts a custom `Connector` for TLS customization (stored directly, no allocation overhead)
- `default_tls_connector()` - now public so users can inspect/replicate the default TLS config
- Re-export `Connector` from `tokio-websockets` so users don't need a direct dependency
- `UreqHttpClient::with_agent()` - accepts a pre-configured `ureq::Agent` for proxy, custom TLS, or timeout configuration

No breaking changes. All additions are purely additive.

Closes #535

---

## Usage examples

### HTTP proxy for media downloads (ureq)

```rust
use ureq::{Agent, Proxy, config::Config};
use whatsapp_rust::UreqHttpClient;

let proxy = Proxy::new("http://my-proxy:8080").expect("valid proxy URL");
let config = Config::builder()
    .proxy(Some(proxy))
    .build();
let agent: Agent = config.into();

let http_client = UreqHttpClient::with_agent(agent);

// Pass to the bot builder as usual
let bot = Bot::builder()
    .with_http_client(http_client)
    // ...
```

### SOCKS5 proxy for media downloads (ureq)

Requires adding the `socks-proxy` feature to ureq in your `Cargo.toml`:

```rust
use ureq::{Agent, Proxy, config::Config};
use whatsapp_rust::UreqHttpClient;

let proxy = Proxy::new("socks5://my-socks-proxy:1080").expect("valid proxy URL");
let config = Config::builder()
    .proxy(Some(proxy))
    .build();
let agent: Agent = config.into();

let http_client = UreqHttpClient::with_agent(agent);
```

### Custom TLS configuration for WebSocket transport

Use `with_connector()` to customize TLS (e.g., custom CA certificates):

```rust
use whatsapp_rust::transport::{TokioWebSocketTransportFactory, Connector};
use std::sync::Arc;
use tokio_rustls::TlsConnector;

let transport = TokioWebSocketTransportFactory::new()
    .with_connector({
        let mut root_store = rustls::RootCertStore::empty();
        // Add your custom CA certs here
        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());

        let config = rustls::ClientConfig::builder()
            .with_root_certificates(root_store)
            .with_no_client_auth();

        Connector::Rustls(TlsConnector::from(Arc::new(config)))
    });
```

### Full proxy for WebSocket transport (SOCKS5 example)

For proxying the WebSocket connection itself, implement a custom `TransportFactory` that tunnels through the proxy before handing off to `from_websocket()`. This example uses `tokio-socks`:

```rust
use std::sync::Arc;
use async_trait::async_trait;
use tokio_socks::tcp::Socks5Stream;
use tokio_rustls::TlsConnector;
use tokio_websockets::ClientBuilder;
use whatsapp_rust::transport::{
    Transport, TransportEvent, TransportFactory, from_websocket,
};

struct ProxiedTransportFactory {
    proxy_addr: String,
    target_host: String,
    target_port: u16,
    tls: TlsConnector,
}

#[async_trait]
impl TransportFactory for ProxiedTransportFactory {
    async fn create_transport(
        &self,
    ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error> {
        // 1. TCP connect through SOCKS5 proxy
        let tunnel = Socks5Stream::connect(
            &*self.proxy_addr,
            (self.target_host.as_str(), self.target_port),
        )
        .await?;

        // 2. Wrap in TLS
        let server_name = self.target_host.clone().try_into()?;
        let tls_stream = self.tls.connect(server_name, tunnel.into_inner()).await?;

        // 3. WebSocket upgrade over the TLS tunnel
        let uri: http::Uri = format!("wss://{}:{}/ws/chat", self.target_host, self.target_port)
            .parse()?;
        let (ws, _) = ClientBuilder::new().uri(&uri).connect_on(tls_stream).await?;

        // 4. Hand off to whatsapp-rust
        Ok(from_websocket(ws))
    }
}
```

## Test plan

- [x] `cargo clippy --all --tests` passes with zero warnings
- [x] All 1,122 unit tests pass
- [x] No breaking changes (all additions are purely additive)
- [x] No unnecessary allocations (`Connector` stored directly, borrowed on each connect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for creating HTTP clients from externally supplied pre-configured agents for easier integration.
  * WebSocket transport can accept an optional user-supplied TLS connector for customizable TLS handling.
  * Public TLS-related types and a default TLS connector are exposed to enable flexible transport-layer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->