### PR TITLE
fix: replace tokio timeout with runtime-agnostic timeout in phash validation

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -647,7 +647,8 @@ impl Client {
         };
         self.runtime
             .spawn(Box::pin(async move {
-                let ack = match tokio::time::timeout(
+                let ack = match wacore::runtime::timeout(
+                    &*client.runtime,
                     std::time::Duration::from_secs(10),
                     rx,
                 )


### PR DESCRIPTION
## Summary
- `spawn_phash_validation` in `src/send.rs` used `tokio::time::timeout` directly, breaking non-tokio consumers like `whatsapp-rust-bridge` (WASM target)
- Replaced with `wacore::runtime::timeout(&*client.runtime, ...)` matching the pattern used everywhere else in the crate

## Test plan
- [x] `cargo clippy --all --tests` passes clean
- [x] Verified `whatsapp-rust-bridge` build error is resolved by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated timeout handling logic to use the client runtime for improved consistency with the application's runtime management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->