### PR TITLE
feat(prekeys): expose public refresh_prekeys() for device migration

### DIFF
--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -248,6 +248,23 @@ impl Client {
         }
     }
 
+    /// Force-refresh the server's one-time pre-key pool with a fresh batch.
+    ///
+    /// Intended for callers that just restored a device from an external source
+    /// (e.g., migrating a Baileys session into an `InMemoryBackend`). The server
+    /// may still hold pre-key IDs whose private key material the caller cannot
+    /// reconstruct; any `pkmsg` referencing those IDs will fail forever with
+    /// `InvalidPreKeyId`. Uploading a fresh batch gives the server new IDs the
+    /// caller *does* have locally, and old unmatched IDs drain as peers consume
+    /// them.
+    ///
+    /// Acquires `prekey_upload_lock` for the duration so this force-upload
+    /// cannot race on `start_id` with the count-based and digest-repair paths.
+    pub async fn refresh_pre_keys(&self) -> Result<(), anyhow::Error> {
+        let _guard = self.prekey_upload_lock.lock().await;
+        self.upload_pre_keys_with_retry(true).await
+    }
+
     /// Validate server key bundle digest, re-uploading only when the server has no record.
     ///
     /// Matches WA Web's `WAWebDigestKeyJob.digestKey()`:


### PR DESCRIPTION
## Motivation

The existing `upload_pre_keys*` family is `pub(crate)`, and the only force-upload path (`force=true`) is triggered internally from `validate_digest_key` when the server returns 404 for the digest key bundle. That's correct for the steady state, but leaves external crates no recovery path for a legitimate operational case: **migrating a device from an external Signal store** (e.g., importing a Baileys session into an `InMemoryBackend`, or any other backend that restores historic state without the pre-key private key material).

In that scenario the WhatsApp server still holds pre-key IDs the caller's local store cannot reproduce — any `pkmsg` that references those IDs fails with `InvalidPreKeyId` permanently because the private key material is unrecoverable. Today the caller has no supported way to push a fresh batch so the server hands out IDs the client *does* have locally.

## Change

Adds a thin public wrapper:

```rust
pub async fn refresh_prekeys(&self) -> Result<(), anyhow::Error> {
    self.upload_pre_keys_with_retry(true).await
}
```

No behavioural change on the normal startup path. Callers that never call `refresh_prekeys()` see the exact same flow as before. The retry/backoff semantics (Fibonacci, MAX 610s, disconnect bail) are inherited from `upload_pre_keys_with_retry`.

## Expected usage

After importing an external Signal session, call `refresh_prekeys()` on the first `Event::Connected` of the first process lifetime. Server appends the fresh `WANTED_PRE_KEY_COUNT` IDs (which the caller has locally); old unmatched IDs drain naturally as peers consume them.

## Why not expose `upload_pre_keys_with_retry` directly

Thought about it — the `force: bool` argument is an internal implementation detail (today it's only ever `true` from the digest repair path). Giving it a purpose-named public method keeps the meaning explicit at the call site and leaves room to tighten semantics later (e.g., only firing once per session).

## Context

Being exercised in production against `whatsapp-rust v0.5.0` to complete a Baileys → native migration that currently has 0 successfully decrypted inbound messages despite 530 imported sessions. Patched via `[patch.crates-io]` meanwhile.

Happy to adjust — name, docs, visibility boundary, wherever you'd prefer this to live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to manually trigger a pre-key refresh operation on demand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->