### PR TITLE
feat(status): add send_reaction for status likes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3445,6 +3445,27 @@ impl Client {
         Ok(original_id)
     }
 
+    /// Send a server-side reaction (used by both newsletter and status reactions).
+    pub(crate) async fn send_server_reaction(
+        &self,
+        to: &Jid,
+        server_id: u64,
+        reaction: &str,
+    ) -> Result<(), anyhow::Error> {
+        let request_id = self.generate_message_id().await;
+
+        let stanza = NodeBuilder::new("message")
+            .attr("to", to)
+            .attr("type", "reaction")
+            .attr("id", &request_id)
+            .attr("server_id", server_id.to_string())
+            .children([NodeBuilder::new("reaction").attr("code", reaction).build()])
+            .build();
+
+        self.send_node(stanza).await?;
+        Ok(())
+    }
+
     pub async fn send_node(&self, node: Node) -> Result<(), ClientError> {
         debug!(target: "Client/Send", "{}", DisplayableNode(&node));
         if self.sent_node_waiter_count.load(Ordering::Acquire) > 0 {

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -374,18 +374,9 @@ impl<'a> Newsletter<'a> {
         server_id: u64,
         reaction: &str,
     ) -> Result<(), anyhow::Error> {
-        let request_id = self.client.generate_message_id().await;
-
-        let stanza = NodeBuilder::new("message")
-            .attr("to", jid)
-            .attr("type", "reaction")
-            .attr("id", &request_id)
-            .attr("server_id", server_id.to_string())
-            .children([NodeBuilder::new("reaction").attr("code", reaction).build()])
-            .build();
-
-        self.client.send_node(stanza).await?;
-        Ok(())
+        self.client
+            .send_server_reaction(jid, server_id, reaction)
+            .await
     }
 
     /// Fetch message history from a newsletter.

--- a/src/features/status.rs
+++ b/src/features/status.rs
@@ -180,6 +180,22 @@ impl<'a> Status<'a> {
             .send_status_message(revoke_message, recipients, options)
             .await
     }
+
+    /// React to someone's status update (e.g. the "like" heart in WA Web).
+    ///
+    /// `status_owner` is the JID of the person whose status you're reacting to.
+    /// `server_id` is the server-assigned ID of the status message.
+    /// `reaction` is the emoji code (e.g. "💚" for the default like). Pass empty to remove.
+    pub async fn send_reaction(
+        &self,
+        status_owner: &Jid,
+        server_id: u64,
+        reaction: &str,
+    ) -> Result<(), anyhow::Error> {
+        self.client
+            .send_server_reaction(status_owner, server_id, reaction)
+            .await
+    }
 }
 
 impl Client {


### PR DESCRIPTION
## Summary

- Add `Status::send_reaction()` to react/like someone's status update (the heart button in WA Web)
- Extract shared `Client::send_server_reaction()` helper so both newsletter and status reactions share the same stanza-building code
- Refactor `Newsletter::send_reaction()` to delegate to the shared helper

Status reactions use the same server-side protocol as newsletter reactions (verified against WA Web captured JS: `WAWebSendReactionMsgAction` routes status chats through `WAWebNewsletterSendReactionAction`).

### Usage
```rust
// Like a status (💚 is WA Web's default heart)
client.status().send_reaction(&owner_jid, server_id, "💚").await?;

// Remove reaction
client.status().send_reaction(&owner_jid, server_id, "").await?;
```

## Test plan

- [ ] Clippy passes (`cargo clippy --all --tests`)
- [ ] Existing newsletter reaction behavior unchanged (shared helper is functionally identical)
- [ ] Manual test: send a status reaction and verify server accepts the stanza

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to react to status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->