### PR TITLE
perf: skip string classification for strings longer than PACKED_MAX

### DIFF
--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -1423,4 +1423,73 @@ mod tests {
 
         Ok(())
     }
+
+    /// Regression test: strings at the PACKED_MAX boundary must be classified
+    /// normally, while strings above it must be emitted as raw bytes (skipping
+    /// SipHash/PHF classification entirely).
+    #[test]
+    fn test_long_string_skips_classification() -> TestResult {
+        use crate::decoder::Decoder;
+        use crate::marshal::marshal;
+
+        let at_boundary = "0".repeat(token::PACKED_MAX as usize); // 127 nibble chars
+        let over_boundary = "0".repeat(token::PACKED_MAX as usize + 1); // 128 chars
+
+        // 127-char all-digit string is nibble-packable
+        let node_at = Node::new(
+            "test",
+            Attrs::new(),
+            Some(NodeContent::String(at_boundary.as_str().into())),
+        );
+        let encoded_at = marshal(&node_at)?;
+
+        // 128-char string must be emitted as raw bytes (BINARY_8 + length)
+        let node_over = Node::new(
+            "test",
+            Attrs::new(),
+            Some(NodeContent::String(over_boundary.as_str().into())),
+        );
+        let encoded_over = marshal(&node_over)?;
+
+        // The 127-char string should be packed (shorter encoding than raw)
+        assert!(
+            encoded_at.len() < encoded_over.len(),
+            "127-char nibble string should pack smaller than 128-char raw: {} vs {}",
+            encoded_at.len(),
+            encoded_over.len(),
+        );
+
+        // The 128-char content must be encoded as BINARY_8 + 128 (raw bytes).
+        // Find the [BINARY_8, 128] pair — the first BINARY_8 is for the tag "test".
+        let has_raw_128 = encoded_over
+            .windows(2)
+            .any(|w| w[0] == token::BINARY_8 && w[1] == 128);
+        assert!(
+            has_raw_128,
+            "128-char string must contain BINARY_8 + length=128 sequence"
+        );
+
+        // Both must round-trip correctly (skip version byte at [0])
+        let decoded_at = Decoder::new(&encoded_at[1..]).read_node_ref()?.to_owned();
+        let decoded_over = Decoder::new(&encoded_over[1..]).read_node_ref()?.to_owned();
+
+        match &decoded_at.content {
+            Some(NodeContent::String(s)) => assert_eq!(s.as_str(), at_boundary),
+            Some(NodeContent::Bytes(b)) => {
+                assert_eq!(std::str::from_utf8(b).unwrap(), at_boundary)
+            }
+            other => panic!("Expected string/bytes content, got {:?}", other),
+        }
+        match &decoded_over.content {
+            Some(NodeContent::Bytes(b)) => {
+                assert_eq!(std::str::from_utf8(b).unwrap(), over_boundary)
+            }
+            other => panic!(
+                "Expected bytes content for 128-char string, got {:?}",
+                other
+            ),
+        }
+
+        Ok(())
+    }
 }

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -267,6 +267,9 @@ impl StringHintCache {
 
     #[inline]
     fn hint_or_insert(&mut self, s: &str) -> StringHint {
+        if s.len() > token::PACKED_MAX as usize {
+            return StringHint::RawBytes;
+        }
         let key = StrKey::from_str(s);
         if let Some(existing) = self
             .hints
@@ -701,6 +704,11 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
 
     #[inline(always)]
     fn write_string_uncached(&mut self, s: &str) -> Result<()> {
+        // Strings longer than PACKED_MAX (127) can't be protocol tokens (max 48),
+        // packed nibble/hex, or JIDs — emit as raw bytes without classification.
+        if s.len() > token::PACKED_MAX as usize {
+            return self.write_bytes_with_len(s.as_bytes());
+        }
         self.write_string_with_hint(s, classify_string_hint(s))
     }
 


### PR DESCRIPTION
## Summary
- Strings > `PACKED_MAX` (127 bytes) can never be protocol tokens (max 48), packed nibble/hex, or JIDs — yet the encoder was running two full SipHash + PHF map lookups per string that always missed
- Add a length guard in `write_string_uncached` and `hint_or_insert` to short-circuit directly to raw-bytes encoding, skipping classification entirely

## Benchmark results (iai-callgrind, instruction counts)

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| `marshal_auto_long_string` | 15,599 | 10,508 | **-32.6%** |
| `marshal_long_string` | 15,555 | 10,464 | **-32.7%** |
| `marshal_exact_long_string` | 17,335 | 12,163 | **-29.8%** |
| `marshal_allocating` | 91,389 | 91,887 | +0.54% |
| `marshal_many_children` | 13,204,384 | 13,262,569 | +0.44% |
| decode/attr/jid benchmarks | — | — | unchanged |

The +0.5% on short-string-only benchmarks is the cost of the added branch (~6 instructions per `write_string` call). For any message with content > 127 bytes the net improvement is thousands of instructions.

## Test plan
- [ ] CI passes (existing encoder tests + roundtrip tests cover correctness)
- [ ] Benchmark CI confirms instruction count improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very long strings during encoding to avoid incorrect classification and ensure stable, efficient encoding and correct decoding at length boundaries.

* **Tests**
  * Added test coverage verifying proper encoding/decoding behavior for boundary-length and over-boundary strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->