### PR TITLE
perf: unify single/double-byte token maps into single PHF lookup

### DIFF
--- a/wacore/binary/build.rs
+++ b/wacore/binary/build.rs
@@ -21,45 +21,40 @@ fn main() {
     let tokens_json = fs::read_to_string("src/tokens.json").unwrap();
     let tokens: Tokens = serde_json::from_str(&tokens_json).unwrap();
 
-    let mut single_byte_map = Map::new();
-    let single_byte_values: Vec<String> = (0..tokens.single_byte.len())
-        .map(|i| i.to_string())
-        .collect();
+    // Unified token map: single lookup for both single-byte and double-byte tokens.
+    // TokenKind::Single(u8) for single-byte, TokenKind::Double(u8, u8) for double-byte.
+    let mut unified_map = Map::new();
+    let mut values = Vec::new();
+
     for (i, token) in tokens.single_byte.iter().enumerate() {
         if !token.is_empty() {
-            single_byte_map.entry(token.as_str(), &single_byte_values[i]);
+            values.push((token.clone(), format!("TokenKind::Single({})", i)));
         }
     }
-    writeln!(
-        &mut file,
-        "static SINGLE_BYTE_MAP: phf::Map<&'static str, u8> = \n{};",
-        single_byte_map.build()
-    )
-    .unwrap();
 
-    let mut double_byte_map = Map::new();
-    let mut double_byte_values = Vec::new();
     for (dict_idx, dict) in tokens.double_byte.iter().enumerate() {
-        for (token_idx, _token) in dict.iter().enumerate() {
-            let value = format!("({}, {})", dict_idx, token_idx);
-            double_byte_values.push(value);
+        for (token_idx, token) in dict.iter().enumerate() {
+            if !token.is_empty() {
+                values.push((
+                    token.clone(),
+                    format!("TokenKind::Double({}, {})", dict_idx, token_idx),
+                ));
+            }
         }
     }
 
-    let mut value_idx = 0;
-    for dict in tokens.double_byte.iter() {
-        for token in dict.iter() {
-            double_byte_map.entry(token.as_str(), &double_byte_values[value_idx]);
-            value_idx += 1;
-        }
+    for (token, value) in &values {
+        unified_map.entry(token.as_str(), value.as_str());
     }
+
     writeln!(
         &mut file,
-        "\nstatic DOUBLE_BYTE_MAP: phf::Map<&'static str, (u8, u8)> = \n{};",
-        double_byte_map.build()
+        "static TOKEN_MAP: phf::Map<&'static str, TokenKind> = \n{};",
+        unified_map.build()
     )
     .unwrap();
 
+    // Decode arrays (index → string) remain unchanged
     writeln!(&mut file, "\nstatic SINGLE_BYTE_TOKENS: &[&str] = &[").unwrap();
     for token in &tokens.single_byte {
         writeln!(&mut file, "    {:?},", token).unwrap();

--- a/wacore/binary/build.rs
+++ b/wacore/binary/build.rs
@@ -1,5 +1,6 @@
 use phf_codegen::Map;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::env;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
@@ -25,6 +26,7 @@ fn main() {
     // TokenKind::Single(u8) for single-byte, TokenKind::Double(u8, u8) for double-byte.
     let mut unified_map = Map::new();
     let mut values = Vec::new();
+    let mut seen: HashMap<&str, &str> = HashMap::new();
 
     for (i, token) in tokens.single_byte.iter().enumerate() {
         if !token.is_empty() {
@@ -44,6 +46,13 @@ fn main() {
     }
 
     for (token, value) in &values {
+        if let Some(existing) = seen.get(token.as_str()) {
+            panic!(
+                "duplicate token {:?}: already mapped as {}, conflicting with {}",
+                token, existing, value
+            );
+        }
+        seen.insert(token.as_str(), value.as_str());
         unified_map.entry(token.as_str(), value.as_str());
     }
 
@@ -54,7 +63,7 @@ fn main() {
     )
     .unwrap();
 
-    // Decode arrays (index → string) remain unchanged
+    // Decode arrays: index → string (inverse of TOKEN_MAP)
     writeln!(&mut file, "\nstatic SINGLE_BYTE_TOKENS: &[&str] = &[").unwrap();
     for token in &tokens.single_byte {
         writeln!(&mut file, "    {:?},", token).unwrap();

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -376,11 +376,16 @@ fn classify_string_hint(s: &str) -> StringHint {
 
     let is_likely_jid = s.len() <= 48;
 
-    if let Some(token) = token::index_of_single_token(s) {
-        StringHint::SingleToken(token)
-    } else if let Some((dict, token)) = token::index_of_double_byte_token(s) {
-        StringHint::DoubleToken { dict, token }
-    } else if validate_nibble(s) {
+    if let Some(kind) = token::index_of_token(s) {
+        match kind {
+            token::TokenKind::Single(token) => return StringHint::SingleToken(token),
+            token::TokenKind::Double(dict, token) => {
+                return StringHint::DoubleToken { dict, token };
+            }
+        }
+    }
+
+    if validate_nibble(s) {
         StringHint::PackedNibble
     } else if validate_hex(s) {
         StringHint::PackedHex

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -377,12 +377,10 @@ fn classify_string_hint(s: &str) -> StringHint {
     let is_likely_jid = s.len() <= 48;
 
     if let Some(kind) = token::index_of_token(s) {
-        match kind {
-            token::TokenKind::Single(token) => return StringHint::SingleToken(token),
-            token::TokenKind::Double(dict, token) => {
-                return StringHint::DoubleToken { dict, token };
-            }
-        }
+        return match kind {
+            token::TokenKind::Single(token) => StringHint::SingleToken(token),
+            token::TokenKind::Double(dict, token) => StringHint::DoubleToken { dict, token },
+        };
     }
 
     if validate_nibble(s) {

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -119,14 +119,14 @@ impl From<CompactString> for NodeStr<'_> {
 /// vast majority of tag names and attribute keys which are protocol tokens.
 #[inline]
 fn intern_cow(s: &str) -> Cow<'static, str> {
-    if let Some(idx) = token::index_of_single_token(s)
-        && let Some(token) = token::get_single_token(idx)
-    {
-        return Cow::Borrowed(token);
-    } else if let Some((dict, idx)) = token::index_of_double_byte_token(s)
-        && let Some(token) = token::get_double_token(dict, idx)
-    {
-        return Cow::Borrowed(token);
+    if let Some(kind) = token::index_of_token(s) {
+        let interned = match kind {
+            token::TokenKind::Single(idx) => token::get_single_token(idx),
+            token::TokenKind::Double(dict, idx) => token::get_double_token(dict, idx),
+        };
+        if let Some(token) = interned {
+            return Cow::Borrowed(token);
+        }
     }
     Cow::Owned(s.to_string())
 }

--- a/wacore/binary/src/token.rs
+++ b/wacore/binary/src/token.rs
@@ -22,8 +22,8 @@ pub const LIST_16: u8 = 249;
 pub const PACKED_MAX: u8 = 127;
 pub const SINGLE_BYTE_MAX: u16 = 256;
 
-/// Result of a unified token lookup — single SipHash for both token types.
-#[derive(Debug, Clone, Copy)]
+/// Result of a unified token lookup — single hash for both token types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {
     Single(u8),
     Double(u8, u8),
@@ -32,7 +32,7 @@ pub enum TokenKind {
 // Include the generated maps from the build script
 include!(concat!(env!("OUT_DIR"), "/token_maps.rs"));
 
-/// Look up a string in the unified token map (single SipHash computation).
+/// Look up a string in the unified token map (single PHF lookup).
 pub fn index_of_token(token: &str) -> Option<TokenKind> {
     TOKEN_MAP.get(token).copied()
 }

--- a/wacore/binary/src/token.rs
+++ b/wacore/binary/src/token.rs
@@ -22,16 +22,19 @@ pub const LIST_16: u8 = 249;
 pub const PACKED_MAX: u8 = 127;
 pub const SINGLE_BYTE_MAX: u16 = 256;
 
+/// Result of a unified token lookup — single SipHash for both token types.
+#[derive(Debug, Clone, Copy)]
+pub enum TokenKind {
+    Single(u8),
+    Double(u8, u8),
+}
+
 // Include the generated maps from the build script
 include!(concat!(env!("OUT_DIR"), "/token_maps.rs"));
 
-// The lookup functions now use the compile-time maps
-pub fn index_of_single_token(token: &str) -> Option<u8> {
-    SINGLE_BYTE_MAP.get(token).copied()
-}
-
-pub fn index_of_double_byte_token(token: &str) -> Option<(u8, u8)> {
-    DOUBLE_BYTE_MAP.get(token).copied()
+/// Look up a string in the unified token map (single SipHash computation).
+pub fn index_of_token(token: &str) -> Option<TokenKind> {
+    TOKEN_MAP.get(token).copied()
 }
 
 pub fn get_single_token(index: u8) -> Option<&'static str> {
@@ -49,39 +52,35 @@ pub fn get_double_token(dict: u8, index: u8) -> Option<&'static str> {
 mod tests {
     use super::*;
 
-    /// Test single byte token lookup round trip
+    /// Test single byte token lookup round trip via unified map
     #[test]
     fn test_single_byte_token_roundtrip() {
-        // Test some known tokens exist and can be retrieved
         for i in 1u8..=235 {
             if let Some(token) = get_single_token(i) {
-                let index = index_of_single_token(token);
-                assert_eq!(
-                    index,
-                    Some(i),
+                let result = index_of_token(token);
+                assert!(
+                    matches!(result, Some(TokenKind::Single(idx)) if idx == i),
                     "Token '{}' at index {} doesn't round-trip",
                     token,
-                    i
+                    i,
                 );
             }
         }
     }
 
-    /// Test double byte token lookup round trip
+    /// Test double byte token lookup round trip via unified map
     #[test]
     fn test_double_byte_token_roundtrip() {
-        // Test dictionary 0-3
         for dict in 0..4u8 {
             for idx in 0..255u8 {
                 if let Some(token) = get_double_token(dict, idx) {
-                    let lookup = index_of_double_byte_token(token);
-                    assert_eq!(
-                        lookup,
-                        Some((dict, idx)),
+                    let result = index_of_token(token);
+                    assert!(
+                        matches!(result, Some(TokenKind::Double(d, i)) if d == dict && i == idx),
                         "Token '{}' at dict {} index {} doesn't round-trip",
                         token,
                         dict,
-                        idx
+                        idx,
                     );
                 }
             }
@@ -91,54 +90,43 @@ mod tests {
     /// Test that unknown strings return None for token lookups
     #[test]
     fn test_unknown_string_returns_none() {
-        // Completely random strings shouldn't match any token
-        assert!(index_of_single_token("xyzzy_not_a_token_12345").is_none());
-        assert!(index_of_double_byte_token("xyzzy_not_a_token_12345").is_none());
+        assert!(index_of_token("xyzzy_not_a_token_12345").is_none());
     }
 
     /// Test boundary token indices
     #[test]
     fn test_token_boundary_indices() {
-        // Index 0 is an empty string token (LIST_EMPTY is a special tag, not same as token index 0)
         let token_0 = get_single_token(0);
         assert_eq!(token_0, Some(""), "Index 0 should be empty string token");
 
-        // Test known special indices return None for get_single_token
-        // These are reserved for special tags
-        assert!(get_single_token(LIST_8).is_none()); // 248
-        assert!(get_single_token(LIST_16).is_none()); // 249
-        assert!(get_single_token(JID_PAIR).is_none()); // 250
-        assert!(get_single_token(HEX_8).is_none()); // 251
-        assert!(get_single_token(BINARY_8).is_none()); // 252
-        assert!(get_single_token(BINARY_20).is_none()); // 253
-        assert!(get_single_token(BINARY_32).is_none()); // 254
-        assert!(get_single_token(NIBBLE_8).is_none()); // 255
+        assert!(get_single_token(LIST_8).is_none());
+        assert!(get_single_token(LIST_16).is_none());
+        assert!(get_single_token(JID_PAIR).is_none());
+        assert!(get_single_token(HEX_8).is_none());
+        assert!(get_single_token(BINARY_8).is_none());
+        assert!(get_single_token(BINARY_20).is_none());
+        assert!(get_single_token(BINARY_32).is_none());
+        assert!(get_single_token(NIBBLE_8).is_none());
     }
 
     /// Test strings that almost match tokens but shouldn't be encoded as such
     #[test]
     fn test_almost_matching_strings() {
-        // Get a known token
         if let Some(token) = get_single_token(1) {
-            // Slightly modify it
             let modified = format!("{}_modified", token);
-            // Should not match
-            assert!(index_of_single_token(&modified).is_none());
+            assert!(index_of_token(&modified).is_none());
 
-            // With prefix
             let prefixed = format!("prefix_{}", token);
-            assert!(index_of_single_token(&prefixed).is_none());
+            assert!(index_of_token(&prefixed).is_none());
 
-            // With suffix
             let suffixed = format!("{}!", token);
-            assert!(index_of_single_token(&suffixed).is_none());
+            assert!(index_of_token(&suffixed).is_none());
         }
     }
 
     /// Test out of bounds dictionary lookup
     #[test]
     fn test_out_of_bounds_dictionary() {
-        // Dictionary indices 4+ should return None
         assert!(get_double_token(4, 0).is_none());
         assert!(get_double_token(5, 100).is_none());
         assert!(get_double_token(255, 0).is_none());


### PR DESCRIPTION
## Summary
- The encoder was doing **two** separate SipHash + PHF lookups per string (single-byte map miss → double-byte map). Since there is zero overlap between the 235 single-byte and 1024 double-byte tokens, this merges them into a single `phf::Map<&str, TokenKind>` so every string is hashed exactly once.
- Also benefits `intern_cow` (the decode-to-owned path) which had the same two-lookup pattern.

## Benchmark results (iai-callgrind, instruction counts vs main)

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| `marshal_allocating` | 91,389 | 83,215 | **-8.9%** |
| `marshal_auto_allocating` | 91,422 | 83,248 | **-8.9%** |
| `marshal_many_children` | 13,204,384 | 10,831,392 | **-18.0%** |
| `marshal_auto_many_children` | 13,171,888 | 10,798,836 | **-18.4%** |
| `marshal_auto_long_string` | 15,599 | 11,675 | **-25.2%** |
| `roundtrip large` | 86,038 | 78,276 | **-9.0%** |
| `jid_to_owned_access` | 13,307 | 13,115 | **-1.4%** |
| decode / unmarshal / unpack | — | — | unchanged |

Stacks with #542 (PACKED_MAX fast-path) for additional gains on long strings.

## Test plan
- [ ] CI passes (all 74 wacore-binary tests pass locally, including updated token roundtrip tests)
- [ ] Benchmark CI confirms instruction count improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internally unified token handling and lookup into a single, simpler mechanism; observable behavior remains unchanged.
* **Tests**
  * Updated unit tests to exercise the unified token lookup and validate existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->