### PR TITLE
perf!: replace PHF+SipHash token lookup with hashify PTHash (FNV-1a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,44 +1438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,12 +1894,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2411,10 +2379,9 @@ dependencies = [
  "bytes",
  "compact_str",
  "flate2",
+ "hashify",
  "iai-callgrind",
  "itoa",
- "phf",
- "phf_codegen",
  "serde",
  "serde_json",
  "stable_deref_trait",

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -7,9 +7,6 @@ license = "MIT"
 repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "Binary data and constants for WhatsApp protocol"
 
-[package.metadata.cargo-shear]
-ignored = ["phf"]
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -22,14 +19,13 @@ serde = ["dep:serde", "compact_str/serde"]
 bytes = { workspace = true }
 compact_str = { workspace = true }
 flate2 = { workspace = true }
+hashify = { version = "0.2.9", default-features = false }
 itoa = { workspace = true }
-phf = { version = "0.13.1", default-features = false }
 serde = { workspace = true, optional = true }
 stable_deref_trait = "1.2.0"
 yoke = { workspace = true }
 
 [build-dependencies]
-phf_codegen = "0.13.1"
 serde = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true, features = ["std"] }
 

--- a/wacore/binary/build.rs
+++ b/wacore/binary/build.rs
@@ -1,4 +1,3 @@
-use phf_codegen::Map;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
@@ -12,71 +11,73 @@ struct Tokens {
     double_byte: Vec<Vec<String>>,
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=src/tokens.json");
     println!("cargo:rerun-if-changed=build.rs");
 
-    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("token_maps.rs");
-    let mut file = BufWriter::new(File::create(&path).unwrap());
+    let path = Path::new(&env::var("OUT_DIR")?).join("token_maps.rs");
+    let mut file = BufWriter::new(File::create(&path)?);
 
-    let tokens_json = fs::read_to_string("src/tokens.json").unwrap();
-    let tokens: Tokens = serde_json::from_str(&tokens_json).unwrap();
+    let tokens_json = fs::read_to_string("src/tokens.json")?;
+    let tokens: Tokens = serde_json::from_str(&tokens_json)?;
 
-    // Unified token map: single lookup for both single-byte and double-byte tokens.
-    // TokenKind::Single(u8) for single-byte, TokenKind::Double(u8, u8) for double-byte.
-    let mut unified_map = Map::new();
-    let mut values = Vec::new();
-    let mut seen: HashMap<&str, &str> = HashMap::new();
+    let mut values: Vec<(String, String)> = Vec::new();
+    let mut seen: HashMap<String, String> = HashMap::new();
 
     for (i, token) in tokens.single_byte.iter().enumerate() {
         if !token.is_empty() {
-            values.push((token.clone(), format!("TokenKind::Single({})", i)));
+            let kind = format!("TokenKind::Single({})", i);
+            if let Some(existing) = seen.get(token) {
+                panic!("duplicate token {:?}: {} vs {}", token, existing, kind);
+            }
+            seen.insert(token.clone(), kind.clone());
+            values.push((token.clone(), kind));
         }
     }
 
     for (dict_idx, dict) in tokens.double_byte.iter().enumerate() {
         for (token_idx, token) in dict.iter().enumerate() {
             if !token.is_empty() {
-                values.push((
-                    token.clone(),
-                    format!("TokenKind::Double({}, {})", dict_idx, token_idx),
-                ));
+                let kind = format!("TokenKind::Double({}, {})", dict_idx, token_idx);
+                if let Some(existing) = seen.get(token) {
+                    panic!("duplicate token {:?}: {} vs {}", token, existing, kind);
+                }
+                seen.insert(token.clone(), kind.clone());
+                values.push((token.clone(), kind));
             }
         }
     }
 
-    for (token, value) in &values {
-        if let Some(existing) = seen.get(token.as_str()) {
-            panic!(
-                "duplicate token {:?}: already mapped as {}, conflicting with {}",
-                token, existing, value
-            );
-        }
-        seen.insert(token.as_str(), value.as_str());
-        unified_map.entry(token.as_str(), value.as_str());
-    }
-
+    // Generate hashify PTHash lookup (FNV-1a, compile-time perfect hash)
     writeln!(
-        &mut file,
-        "static TOKEN_MAP: phf::Map<&'static str, TokenKind> = \n{};",
-        unified_map.build()
-    )
-    .unwrap();
+        file,
+        "fn hashify_lookup(key: &[u8]) -> Option<&'static TokenKind> {{"
+    )?;
+    writeln!(file, "    hashify::map! {{")?;
+    writeln!(file, "        key,")?;
+    writeln!(file, "        TokenKind,")?;
+    for (token, kind) in &values {
+        writeln!(file, "        {:?} => {},", token.as_bytes(), kind)?;
+    }
+    writeln!(file, "    }}")?;
+    writeln!(file, "}}")?;
 
-    // Decode arrays: index → string (inverse of TOKEN_MAP)
-    writeln!(&mut file, "\nstatic SINGLE_BYTE_TOKENS: &[&str] = &[").unwrap();
+    // Decode arrays: index → string
+    writeln!(file, "\nstatic SINGLE_BYTE_TOKENS: &[&str] = &[")?;
     for token in &tokens.single_byte {
-        writeln!(&mut file, "    {:?},", token).unwrap();
+        writeln!(file, "    {:?},", token)?;
     }
-    writeln!(&mut file, "];").unwrap();
+    writeln!(file, "];")?;
 
-    writeln!(&mut file, "\nstatic DOUBLE_BYTE_TOKENS: &[&[&str]] = &[").unwrap();
+    writeln!(file, "\nstatic DOUBLE_BYTE_TOKENS: &[&[&str]] = &[")?;
     for dict in &tokens.double_byte {
-        writeln!(&mut file, "    &[").unwrap();
+        writeln!(file, "    &[")?;
         for token in dict {
-            writeln!(&mut file, "        {:?},", token).unwrap();
+            writeln!(file, "        {:?},", token)?;
         }
-        writeln!(&mut file, "    ],").unwrap();
+        writeln!(file, "    ],")?;
     }
-    writeln!(&mut file, "];").unwrap();
+    writeln!(file, "];")?;
+
+    Ok(())
 }

--- a/wacore/binary/src/token.rs
+++ b/wacore/binary/src/token.rs
@@ -22,19 +22,16 @@ pub const LIST_16: u8 = 249;
 pub const PACKED_MAX: u8 = 127;
 pub const SINGLE_BYTE_MAX: u16 = 256;
 
-/// Result of a unified token lookup — single hash for both token types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {
     Single(u8),
     Double(u8, u8),
 }
 
-// Include the generated maps from the build script
 include!(concat!(env!("OUT_DIR"), "/token_maps.rs"));
 
-/// Look up a string in the unified token map (single PHF lookup).
 pub fn index_of_token(token: &str) -> Option<TokenKind> {
-    TOKEN_MAP.get(token).copied()
+    hashify_lookup(token.as_bytes()).copied()
 }
 
 pub fn get_single_token(index: u8) -> Option<&'static str> {
@@ -52,7 +49,6 @@ pub fn get_double_token(dict: u8, index: u8) -> Option<&'static str> {
 mod tests {
     use super::*;
 
-    /// Test single byte token lookup round trip via unified map
     #[test]
     fn test_single_byte_token_roundtrip() {
         for i in 1u8..=235 {
@@ -68,7 +64,6 @@ mod tests {
         }
     }
 
-    /// Test double byte token lookup round trip via unified map
     #[test]
     fn test_double_byte_token_roundtrip() {
         for dict in 0..4u8 {
@@ -87,18 +82,20 @@ mod tests {
         }
     }
 
-    /// Test that unknown strings return None for token lookups
     #[test]
     fn test_unknown_string_returns_none() {
         assert!(index_of_token("xyzzy_not_a_token_12345").is_none());
     }
 
-    /// Test boundary token indices
+    #[test]
+    fn test_empty_string_returns_none() {
+        assert!(index_of_token("").is_none());
+    }
+
     #[test]
     fn test_token_boundary_indices() {
         let token_0 = get_single_token(0);
         assert_eq!(token_0, Some(""), "Index 0 should be empty string token");
-
         assert!(get_single_token(LIST_8).is_none());
         assert!(get_single_token(LIST_16).is_none());
         assert!(get_single_token(JID_PAIR).is_none());
@@ -109,22 +106,14 @@ mod tests {
         assert!(get_single_token(NIBBLE_8).is_none());
     }
 
-    /// Test strings that almost match tokens but shouldn't be encoded as such
     #[test]
     fn test_almost_matching_strings() {
-        if let Some(token) = get_single_token(1) {
-            let modified = format!("{}_modified", token);
-            assert!(index_of_token(&modified).is_none());
-
-            let prefixed = format!("prefix_{}", token);
-            assert!(index_of_token(&prefixed).is_none());
-
-            let suffixed = format!("{}!", token);
-            assert!(index_of_token(&suffixed).is_none());
-        }
+        let token = get_single_token(1).expect("single token at index 1 must exist");
+        assert!(index_of_token(&format!("{}_modified", token)).is_none());
+        assert!(index_of_token(&format!("prefix_{}", token)).is_none());
+        assert!(index_of_token(&format!("{}!", token)).is_none());
     }
 
-    /// Test out of bounds dictionary lookup
     #[test]
     fn test_out_of_bounds_dictionary() {
         assert!(get_double_token(4, 0).is_none());


### PR DESCRIPTION
## Summary
Replace `phf::Map` (SipHash-1-3 per lookup) with `hashify`'s compile-time PTHash using FNV-1a hashing. FNV-1a is much cheaper than SipHash for short strings (1-48 bytes), and the generated lookup table is smaller than the PHF displacement tables.

Drops `phf` and `phf_codegen`, adds `hashify` (no-std, no unsafe).

## Approaches evaluated

| Approach | .text size | marshal_allocating | many_children | long_string | Verdict |
|----------|-----------|-------------------|---------------|-------------|---------|
| **main** (PHF+SipHash unified) | 99 KB | 83,713 | 10,889,577 | 9,152 | baseline |
| Prefix-bucket table (hash-free) | 300 KB | 66,320 (-20.8%) | 9,123,926 (-16.2%) | 6,933 (-24.2%) | fastest on small nodes, but +201 KB binary |
| **hashify** (FNV-1a PTHash) | **97 KB** | **66,600 (-20.4%)** | **8,287,884 (-23.9%)** | **7,350 (-19.7%)** | best overall: smallest binary, fastest on large workloads |

Hashify chosen because it's the only approach that improves all three dimensions: smaller binary than main, fastest on high-volume protocol traffic (many_children -24%), and competitive on all other benchmarks.

## Benchmark results (iai-callgrind, instruction counts vs main)

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| `marshal_allocating` | 83,713 | 66,600 | **-20.4%** |
| `marshal_auto_allocating` | 83,746 | 66,633 | **-20.4%** |
| `marshal_many_children` | 10,889,577 | 8,287,884 | **-23.9%** |
| `marshal_auto_many_children` | 10,857,021 | 8,255,417 | **-24.0%** |
| `marshal_auto_long_string` | 9,152 | 7,350 | **-19.7%** |
| `roundtrip large` | 78,575 | 61,465 | **-21.8%** |
| `roundtrip small` | 6,874 | 5,215 | **-24.1%** |
| `jid_to_owned_access` | 13,115 | 11,467 | **-12.6%** |
| `.text` section | 99 KB | 97 KB | **-2 KB** |
| decode / unmarshal / unpack | — | — | unchanged |

## Test plan
- [ ] CI passes (all 76 wacore-binary tests pass locally)
- [ ] Benchmark CI confirms instruction count improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched the internal token lookup implementation to a more compact, byte-oriented hash-based approach while preserving public API behavior.

* **Chores**
  * Removed an obsolete dependency and its associated package metadata.

* **Build**
  * Improved code generation to propagate errors instead of unwrapping, making builds more robust.

* **Tests**
  * Updated tests for the new lookup, including explicit handling of empty input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->