### PR TITLE
perf: avoid unnecessary clone and pre-allocate Vecs in hot paths

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -286,7 +286,7 @@ impl Client {
 
         let unavailable_node = nr.get_optional_child("unavailable");
 
-        let mut all_enc_nodes: Vec<&NodeRef<'_>> = Vec::new();
+        let mut all_enc_nodes: Vec<&NodeRef<'_>> = Vec::with_capacity(4);
 
         let direct_enc_nodes = nr.get_children_by_tag("enc");
         all_enc_nodes.extend(direct_enc_nodes);

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1080,11 +1080,11 @@ pub async fn prepare_group_stanza<
         //   because they need the SKDM to decrypt messages we send from this device
         // - Exclude hosted/Cloud API devices (device ID 99 or @hosted server) - they don't
         //   participate in group E2EE, only in 1:1 chats
-        let own_user = own_sending_jid.user.clone();
+        let own_user = &own_sending_jid.user;
         let own_device = own_sending_jid.device;
         let before_filter = resolved_list.len();
         resolved_list.retain(|device_jid| {
-            let is_exact_sender = device_jid.user == own_user && device_jid.device == own_device;
+            let is_exact_sender = device_jid.user == *own_user && device_jid.device == own_device;
             let is_hosted = device_jid.is_hosted();
             // Exclude the exact sending device and hosted devices
             !is_exact_sender && !is_hosted

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -85,9 +85,9 @@ pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Ve
                 _ => None,
             });
 
-        let device_iter = device_list_node.get_children_by_tag("device");
-        let mut devices = Vec::with_capacity(device_iter.size_hint().1.unwrap_or(0));
-        for device_node in device_iter {
+        let capacity = device_list_node.children().map_or(0, |c| c.len());
+        let mut devices = Vec::with_capacity(capacity);
+        for device_node in device_list_node.get_children_by_tag("device") {
             let device_id_str = match device_node.attrs().optional_string("id") {
                 Some(id) => id,
                 None => {

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -85,8 +85,9 @@ pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Ve
                 _ => None,
             });
 
-        let mut devices = Vec::new();
-        for device_node in device_list_node.get_children_by_tag("device") {
+        let device_nodes: Vec<_> = device_list_node.get_children_by_tag("device").collect();
+        let mut devices = Vec::with_capacity(device_nodes.len());
+        for device_node in device_nodes {
             let device_id_str = match device_node.attrs().optional_string("id") {
                 Some(id) => id,
                 None => {

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -85,9 +85,9 @@ pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Ve
                 _ => None,
             });
 
-        let device_nodes: Vec<_> = device_list_node.get_children_by_tag("device").collect();
-        let mut devices = Vec::with_capacity(device_nodes.len());
-        for device_node in device_nodes {
+        let device_iter = device_list_node.get_children_by_tag("device");
+        let mut devices = Vec::with_capacity(device_iter.size_hint().1.unwrap_or(0));
+        for device_node in device_iter {
             let device_id_str = match device_node.attrs().optional_string("id") {
                 Some(id) => id,
                 None => {


### PR DESCRIPTION
## Summary
- **send.rs**: borrow `own_sending_jid.user` instead of cloning the `CompactString` into the retain closure
- **usync.rs**: use `size_hint()` upper bound to pre-allocate device Vec instead of growing from empty
- **message.rs**: pre-allocate enc_nodes Vec with capacity 4 in the message decrypt path

## Test plan
- [ ] CI passes
- [ ] Benchmark CI confirms no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Internal optimizations to message handling and device synchronization processes for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->