### PR TITLE
perf: trim unused features, deps, and gate prost-build behind feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "castaway"
@@ -314,35 +311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -603,15 +571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,15 +726,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "futures"
@@ -1053,87 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke 0.8.1",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke 0.8.1",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,27 +1013,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -1247,18 +1095,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1465,15 +1301,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "powerfmt"
@@ -2052,16 +1879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,13 +2047,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
- "cookie_store",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",
@@ -2255,28 +2069,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -2294,12 +2090,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"
@@ -2332,7 +2122,6 @@ dependencies = [
  "itoa",
  "log",
  "md5",
- "once_cell",
  "portable-atomic",
  "prost",
  "rand",
@@ -2385,7 +2174,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stable_deref_trait",
- "yoke 0.7.5",
+ "yoke",
 ]
 
 [[package]]
@@ -2573,7 +2362,6 @@ dependencies = [
 name = "whatsapp-rust"
 version = "0.5.0"
 dependencies = [
- "aead",
  "anyhow",
  "async-channel",
  "async-lock",
@@ -2619,7 +2407,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "wacore",
- "wacore-binary",
 ]
 
 [[package]]
@@ -2894,12 +2681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,18 +2700,7 @@ checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive 0.7.5",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive 0.8.1",
+ "yoke-derive",
  "zerofrom",
 ]
 
@@ -2939,18 +2709,6 @@ name = "yoke-derive"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2993,39 +2751,6 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke 0.8.1",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke 0.8.1",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ default-members = [
 ]
 
 [workspace.dependencies]
-aead = { version = "0.6.0-rc.10", default-features = false, features = ["bytes"] }
 # Shared dependencies
 aes = "0.9.0"
 aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes", "alloc", "bytes"] }
@@ -49,10 +48,11 @@ async-lock = { version = "3", default-features = false }
 async-trait = "0.1.89"
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bytemuck = { version = "1.22", default-features = false }
-bytes = { version = "1.5", default-features = false, features = ["serde"] }
+bytes = { version = "1.5", default-features = false }
 chrono = { version = "0.4", default-features = false }
 compact_str = { version = "0.9", default-features = false }
 ctr = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 event-listener = { version = "5", default-features = false }
 flate2 = { version = "1.1.5", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
@@ -110,15 +110,14 @@ sqlite-storage = ["whatsapp-rust-sqlite-storage"]
 tokio-native = ["tokio-runtime", "tokio/rt-multi-thread"]
 
 [dependencies]
-aead = { workspace = true }
 anyhow = { workspace = true }
 async-channel = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
-chrono = { workspace = true, features = ["clock", "serde"] }
-env_logger = { version = "0.11", default-features = false }
+chrono = { workspace = true, features = ["clock"] }
+env_logger = { workspace = true }
 event-listener = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 hex = { workspace = true }

--- a/http_clients/ureq-client/Cargo.toml
+++ b/http_clients/ureq-client/Cargo.toml
@@ -16,8 +16,5 @@ danger-skip-tls-verify = []
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
-ureq = { version = "3.3.0", default-features = false, features = [
-    "rustls",
-    "json",
-] }
+ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 wacore = { workspace = true }

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -27,7 +27,6 @@ log = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
 wacore = { workspace = true }
-wacore-binary = { workspace = true }
 
 [dev-dependencies]
 portable-atomic = { workspace = true }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -30,7 +30,7 @@ whatsapp-rust-ureq-http-client = { path = "../../http_clients/ureq-client", feat
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["now", "serde"] }
-env_logger = { version = "0.11", default-features = false }
+env_logger = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
 prost = { workspace = true }

--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -17,27 +17,17 @@ anyhow = { workspace = true }
 async-channel = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
-futures-util = { version = "0.3.31", default-features = false, features = [
-    "sink",
-    "alloc",
-    "std",
-] }
+futures-util = { version = "0.3.31", default-features = false, features = ["sink", "alloc", "std"] }
 http = "1.4.0"
 log = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-tokio = { workspace = true, features = [
-    "macros",
-    "net",
-    "rt-multi-thread",
-    "sync",
-    "time",
-] }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["ring"] }
 tokio-websockets = { version = "0.13.0", features = [
-    "client",
-    "rustls-bring-your-own-connector",
-    "rand",
-    "ring",
+  "client",
+  "rustls-bring-your-own-connector",
+  "rand",
+  "ring",
 ] }
 wacore = { workspace = true }
 webpki-roots = "1.0.4"

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -37,7 +37,6 @@ hmac = { workspace = true }
 itoa = { workspace = true }
 log = { workspace = true }
 md5 = "0.8.0"
-once_cell = { version = "1.21", default-features = false, features = ["std"] }
 portable-atomic = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "Appstate for WhatsApp protocol"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [features]
 default = ["simd"]

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -7,8 +7,11 @@ license = "MIT"
 repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "Binary data and constants for WhatsApp protocol"
 
+[package.metadata.cargo-shear]
+ignored = ["hashify"]
+
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [features]
 default = ["simd"]

--- a/wacore/derive/Cargo.toml
+++ b/wacore/derive/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+syn = { version = "2.0", features = ["full"] }

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -13,7 +13,7 @@ aes-gcm = { workspace = true }
 arrayref = "0.3.9"
 async-trait = { workspace = true }
 cbc = { version = "0.2", features = ["alloc"] }
-chrono = { workspace = true, features = ["now", "serde"] }
+chrono = { workspace = true, features = ["now"] }
 ctr = { workspace = true }
 curve25519-dalek = "4.1.3"
 derive_more = { version = "2.1.0", features = ["from", "into", "try_from"] }

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "Noise Protocol implementation for WhatsApp with AES-256-GCM"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 aes-gcm = { workspace = true }

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -1,8 +1,8 @@
 use crate::libsignal::protocol::{IdentityKeyPair, KeyPair};
-use once_cell::sync::Lazy;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
+use std::sync::LazyLock;
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
 
@@ -103,7 +103,7 @@ fn build_base_client_payload(
     }
 }
 
-pub static DEVICE_PROPS: Lazy<wa::DeviceProps> = Lazy::new(|| wa::DeviceProps {
+pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::DeviceProps {
     os: Some("rust".to_string()),
     version: Some(wa::device_props::AppVersion {
         primary: Some(0),

--- a/waproto/Cargo.toml
+++ b/waproto/Cargo.toml
@@ -9,6 +9,7 @@ description = "Protocol Buffers definitions for WhatsApp"
 
 [features]
 default = []
+generate = ["dep:prost-build"]
 serde-deserialize = []
 serde-snake-case = ["serde-deserialize"]
 
@@ -17,4 +18,4 @@ prost = { workspace = true, features = ["derive"] }
 serde = { workspace = true }
 
 [build-dependencies]
-prost-build = { workspace = true }
+prost-build = { workspace = true, optional = true }

--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -9,105 +9,103 @@
 //
 // 2. Regenerate the Rust code:
 //    ```
-//    GENERATE_PROTO=1 cargo build -p waproto
+//    cargo build -p waproto --features generate
 //    ```
 //
 // 3. Fix any breaking changes in the codebase (e.g., `optional` -> `required` field changes)
 
 fn main() -> std::io::Result<()> {
-    // By default, we expect the `whatsapp.rs` file to be pre-generated.
-    // This build script will only regenerate it if the `GENERATE_PROTO`
-    // environment variable is set. This is intended for developers who modify
-    // the `.proto` file.
-    if std::env::var("GENERATE_PROTO").is_err() {
+    #[cfg(not(feature = "generate"))]
+    {
         println!("cargo:rerun-if-changed=build.rs");
-        // For a normal build, do nothing.
-        return Ok(());
+        Ok(())
     }
 
-    // This part runs only when `GENERATE_PROTO=1` is in the environment.
-    println!("cargo:rerun-if-changed=src/whatsapp.proto");
-    println!("cargo:warning=GENERATE_PROTO is set, regenerating proto definitions...");
+    #[cfg(feature = "generate")]
+    {
+        println!("cargo:rerun-if-changed=src/whatsapp.proto");
+        println!("cargo:warning=Regenerating proto definitions...");
 
-    let mut config = prost_build::Config::new();
+        let mut config = prost_build::Config::new();
 
-    // Only derive Serialize by default. Deserialize is gated behind the
-    // "serde-deserialize" feature — only needed by WASM bridge for JS interop.
-    // This eliminates ~50% of serde-generated code for non-WASM builds.
-    config.type_attribute(".", "#[derive(serde::Serialize)]");
-    config.type_attribute(
-        ".",
-        "#[cfg_attr(feature = \"serde-deserialize\", derive(serde::Deserialize))]",
-    );
-    // Make serde deserialization lenient — use defaults for missing fields.
-    // This matches protobuf semantics (missing = default value) and avoids
-    // "missing field" errors when deserializing partial JSON from JS.
-    // Uses message_attribute (not type_attribute) so it only applies to structs, not enums.
-    config.message_attribute(
-        ".",
-        "#[cfg_attr(feature = \"serde-deserialize\", serde(default))]",
-    );
+        // Only derive Serialize by default. Deserialize is gated behind the
+        // "serde-deserialize" feature — only needed by WASM bridge for JS interop.
+        // This eliminates ~50% of serde-generated code for non-WASM builds.
+        config.type_attribute(".", "#[derive(serde::Serialize)]");
+        config.type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"serde-deserialize\", derive(serde::Deserialize))]",
+        );
+        // Make serde deserialization lenient — use defaults for missing fields.
+        // This matches protobuf semantics (missing = default value) and avoids
+        // "missing field" errors when deserializing partial JSON from JS.
+        // Uses message_attribute (not type_attribute) so it only applies to structs, not enums.
+        config.message_attribute(
+            ".",
+            "#[cfg_attr(feature = \"serde-deserialize\", serde(default))]",
+        );
 
-    // Accept snake_case during deserialization. Primarily affects enum/oneof variants
-    // (prost generates PascalCase) so the bridge's to_snake_case_js works. No-op for
-    // struct fields (already snake_case). Serialize output unchanged.
-    config.type_attribute(
-        ".",
-        "#[cfg_attr(feature = \"serde-snake-case\", serde(rename_all(deserialize = \"snake_case\")))]",
-    );
+        // Accept snake_case during deserialization. Primarily affects enum/oneof variants
+        // (prost generates PascalCase) so the bridge's to_snake_case_js works. No-op for
+        // struct fields (already snake_case). Serialize output unchanged.
+        config.type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"serde-snake-case\", serde(rename_all(deserialize = \"snake_case\")))]",
+        );
 
-    // Use bytes::Bytes instead of Vec<u8> for frequently-serialized cryptographic structures.
-    // This enables O(1) cloning (reference-counted) instead of O(n) copying.
-    // See: https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.bytes
-    config.bytes([
-        // Session chain keys (called on every message encrypt/decrypt)
-        ".whatsapp.SessionStructure.Chain.ChainKey",
-        ".whatsapp.SessionStructure.Chain.MessageKey",
-        // Sender key structures (group messaging hot path)
-        ".whatsapp.SenderKeyStateStructure.SenderChainKey",
-        ".whatsapp.SenderKeyStateStructure.SenderMessageKey",
-        ".whatsapp.SenderKeyStateStructure.SenderSigningKey",
-    ]);
+        // Use bytes::Bytes instead of Vec<u8> for frequently-serialized cryptographic structures.
+        // This enables O(1) cloning (reference-counted) instead of O(n) copying.
+        // See: https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.bytes
+        config.bytes([
+            // Session chain keys (called on every message encrypt/decrypt)
+            ".whatsapp.SessionStructure.Chain.ChainKey",
+            ".whatsapp.SessionStructure.Chain.MessageKey",
+            // Sender key structures (group messaging hot path)
+            ".whatsapp.SenderKeyStateStructure.SenderChainKey",
+            ".whatsapp.SenderKeyStateStructure.SenderMessageKey",
+            ".whatsapp.SenderKeyStateStructure.SenderSigningKey",
+        ]);
 
-    // bytes::Bytes doesn't impl Serialize (prost's bytes dep lacks the serde feature).
-    // Skip serializing these fields — they're internal crypto state, not API-visible.
-    config.field_attribute(
-        ".whatsapp.SessionStructure.Chain.ChainKey.key",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SessionStructure.Chain.MessageKey.cipherKey",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SessionStructure.Chain.MessageKey.macKey",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SessionStructure.Chain.MessageKey.iv",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SenderKeyStateStructure.SenderChainKey.seed",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SenderKeyStateStructure.SenderMessageKey.seed",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SenderKeyStateStructure.SenderSigningKey.public",
-        "#[serde(skip)]",
-    );
-    config.field_attribute(
-        ".whatsapp.SenderKeyStateStructure.SenderSigningKey.private",
-        "#[serde(skip)]",
-    );
+        // bytes::Bytes doesn't impl Serialize (prost's bytes dep lacks the serde feature).
+        // Skip serializing these fields — they're internal crypto state, not API-visible.
+        config.field_attribute(
+            ".whatsapp.SessionStructure.Chain.ChainKey.key",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SessionStructure.Chain.MessageKey.cipherKey",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SessionStructure.Chain.MessageKey.macKey",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SessionStructure.Chain.MessageKey.iv",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SenderKeyStateStructure.SenderChainKey.seed",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SenderKeyStateStructure.SenderMessageKey.seed",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SenderKeyStateStructure.SenderSigningKey.public",
+            "#[serde(skip)]",
+        );
+        config.field_attribute(
+            ".whatsapp.SenderKeyStateStructure.SenderSigningKey.private",
+            "#[serde(skip)]",
+        );
 
-    // Configure prost to output the file to the `src/` directory,
-    // so it can be version-controlled.
-    config.out_dir("src/");
+        // Configure prost to output the file to the `src/` directory,
+        // so it can be version-controlled.
+        config.out_dir("src/");
 
-    config.compile_protos(&["src/whatsapp.proto"], &["src/"])?;
-    Ok(())
+        config.compile_protos(&["src/whatsapp.proto"], &["src/"])?;
+        Ok(())
+    }
 }

--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -28,46 +28,34 @@ fn main() -> std::io::Result<()> {
 
         let mut config = prost_build::Config::new();
 
-        // Only derive Serialize by default. Deserialize is gated behind the
-        // "serde-deserialize" feature — only needed by WASM bridge for JS interop.
-        // This eliminates ~50% of serde-generated code for non-WASM builds.
+        // Serialize always; Deserialize only for WASM bridge (halves serde codegen).
         config.type_attribute(".", "#[derive(serde::Serialize)]");
         config.type_attribute(
             ".",
             "#[cfg_attr(feature = \"serde-deserialize\", derive(serde::Deserialize))]",
         );
-        // Make serde deserialization lenient — use defaults for missing fields.
-        // This matches protobuf semantics (missing = default value) and avoids
-        // "missing field" errors when deserializing partial JSON from JS.
-        // Uses message_attribute (not type_attribute) so it only applies to structs, not enums.
+        // Default missing fields to match protobuf semantics (structs only).
         config.message_attribute(
             ".",
             "#[cfg_attr(feature = \"serde-deserialize\", serde(default))]",
         );
 
-        // Accept snake_case during deserialization. Primarily affects enum/oneof variants
-        // (prost generates PascalCase) so the bridge's to_snake_case_js works. No-op for
-        // struct fields (already snake_case). Serialize output unchanged.
+        // Accept snake_case on deserialization for WASM bridge enum variants.
         config.type_attribute(
             ".",
             "#[cfg_attr(feature = \"serde-snake-case\", serde(rename_all(deserialize = \"snake_case\")))]",
         );
 
-        // Use bytes::Bytes instead of Vec<u8> for frequently-serialized cryptographic structures.
-        // This enables O(1) cloning (reference-counted) instead of O(n) copying.
-        // See: https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.bytes
+        // O(1)-clone Bytes for hot-path crypto structures instead of Vec<u8>.
         config.bytes([
-            // Session chain keys (called on every message encrypt/decrypt)
             ".whatsapp.SessionStructure.Chain.ChainKey",
             ".whatsapp.SessionStructure.Chain.MessageKey",
-            // Sender key structures (group messaging hot path)
             ".whatsapp.SenderKeyStateStructure.SenderChainKey",
             ".whatsapp.SenderKeyStateStructure.SenderMessageKey",
             ".whatsapp.SenderKeyStateStructure.SenderSigningKey",
         ]);
 
-        // bytes::Bytes doesn't impl Serialize (prost's bytes dep lacks the serde feature).
-        // Skip serializing these fields — they're internal crypto state, not API-visible.
+        // Bytes fields lack serde support; skip them (internal crypto state).
         config.field_attribute(
             ".whatsapp.SessionStructure.Chain.ChainKey.key",
             "#[serde(skip)]",
@@ -101,8 +89,7 @@ fn main() -> std::io::Result<()> {
             "#[serde(skip)]",
         );
 
-        // Configure prost to output the file to the `src/` directory,
-        // so it can be version-controlled.
+        // Output to src/ so generated code is version-controlled.
         config.out_dir("src/");
 
         config.compile_protos(&["src/whatsapp.proto"], &["src/"])?;

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -1,7 +1,7 @@
 // This module contains the auto-generated protobuf definitions.
 // The code is generated from `whatsapp.proto` and checked into version control.
-// To regenerate it, run `GENERATE_PROTO=1 cargo build -p waproto`.
-// See `build.rs` for more details.
+// To regenerate, run `cargo build -p waproto --features generate`.
+// See `build.rs` for the full proto compilation config.
 
 #![allow(clippy::large_enum_variant)]
 pub mod whatsapp {


### PR DESCRIPTION
## Summary

- Audit and optimize dependency configuration across the entire workspace
- Remove unused cargo features, unused direct dependencies, and gate heavy build-only deps behind features
- Net result: **-289 lines in Cargo.lock**, **15 fewer crates** in normal builds, eliminated `hashbrown` version duplicate

### Feature trimming
- **tokio-transport**: remove unused `net`, `time`; downgrade `rt-multi-thread` → `rt`
- **ureq-client**: remove unused `json` feature (serde/serde_json not needed)
- **main crate + libsignal**: remove unused `serde` from chrono
- **wacore-derive**: remove unused `extra-traits` from syn
- **workspace bytes**: remove unused `serde` feature

### Dependency removal
- **main crate**: remove unused direct `aead` dep (only used transitively via aes-gcm)
- **wacore**: replace `once_cell::Lazy` with `std::sync::LazyLock` (eliminates dep)
- **sqlite-storage**: remove unused `wacore-binary` dep
- **workspace**: remove stale `aead` from workspace dependencies

### Build optimization
- **waproto**: gate `prost-build` behind `generate` cargo feature — eliminates 15 crates from normal builds (regex, petgraph, tempfile, rustix, hashbrown v0.15, etc.)
  - Proto regeneration is now: `cargo build -p waproto --features generate`
- Remove `cdylib` crate-type from wacore-binary, wacore-noise, wacore-appstate (only `rlib` needed)

### Housekeeping
- Centralize `env_logger` into `[workspace.dependencies]`
- Add `hashify` to cargo-shear ignore list (false positive from build-generated code)

## Test plan
- [x] `cargo check --all` passes
- [x] `cargo clippy --all --tests` passes (zero warnings)
- [x] `cargo test --all --exclude e2e-tests` passes
- [x] `cargo shear` passes (only expected optional dep warnings)
- [x] `cargo fmt --all` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined dependency feature sets and removed unused workspace dependencies.
  * Centralized logger dependency to workspace and simplified dev-dependency declarations.
* **Refactor**
  * Replaced third-party lazy-init usage with a standard-library lazy mechanism.
  * Simplified library artifact outputs to produce Rust-only rlibs.
* **New Features**
  * Added an optional, feature-gated build-time option for protocol generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->