### PR TITLE
perf: signal store hot path - lightweight PN, cache-first identity, reusable flush buffer

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1728,8 +1728,8 @@ impl Client {
         if !self.is_connected() {
             return Err(ClientError::NotConnected);
         }
-        let device_snapshot = self.persistence_manager.get_device_snapshot().await;
-        let ack = match build_ack_node(node, device_snapshot.pn.as_ref()) {
+        let own_pn = self.get_pn().await;
+        let ack = match build_ack_node(node, own_pn.as_ref()) {
             Some(ack) => ack,
             None => return Ok(()),
         };
@@ -3534,8 +3534,13 @@ impl Client {
     }
 
     pub async fn get_pn(&self) -> Option<Jid> {
-        let snapshot = self.persistence_manager.get_device_snapshot().await;
-        snapshot.pn.clone()
+        self.persistence_manager
+            .get_device_arc()
+            .await
+            .read()
+            .await
+            .pn
+            .clone()
     }
 
     pub async fn get_lid(&self) -> Option<Jid> {

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -137,17 +137,10 @@ impl IdentityKeyStore for IdentityAdapter {
     ) -> Result<IdentityChange, SignalProtocolError> {
         let existing_identity = self.get_identity(address).await?;
 
-        // Update the Device's in-memory identity store first (for is_trusted_identity checks).
-        // Cache is only marked dirty after Device accepts the identity.
-        let mut device = self.0.device.write().await;
-        IdentityKeyStore::save_identity(&mut *device, address, identity)
-            .await
-            .map_err(signal_err("save_identity"))?;
-        drop(device);
-
-        // Device accepted — now write to cache (deferred flush to DB)
-        // Store raw 32-byte public key (not 33-byte serialized form with 0x05 prefix),
-        // matching what SignalStore::put_identity expects.
+        // Cache-first: write to cache only. The cache flushes to the backend
+        // during flush_signal_cache(). This avoids a synchronous backend write
+        // on every encrypt/decrypt. is_trusted_identity always returns true
+        // (matching WA Web), so the Device-level save is redundant.
         self.0
             .cache
             .put_identity(address, identity.public_key().public_key_bytes())

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -52,7 +52,7 @@ pub struct SignalStoreCache {
     sessions: Mutex<SessionStoreState>,
     identities: Mutex<ByteStoreState>,
     sender_keys: Mutex<SenderKeyStoreState>,
-    /// Reusable buffer for session serialization during flush.
+    /// Avoids per-flush Vec allocation on the hot path (called after every message).
     flush_encode_buf: Mutex<Vec<u8>>,
     max_entries: usize,
 }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -52,6 +52,8 @@ pub struct SignalStoreCache {
     sessions: Mutex<SessionStoreState>,
     identities: Mutex<ByteStoreState>,
     sender_keys: Mutex<SenderKeyStoreState>,
+    /// Reusable buffer for session serialization during flush.
+    flush_encode_buf: Mutex<Vec<u8>>,
     max_entries: usize,
 }
 
@@ -264,6 +266,7 @@ impl SignalStoreCache {
             sessions: Mutex::new(SessionStoreState::new()),
             identities: Mutex::new(ByteStoreState::new()),
             sender_keys: Mutex::new(SenderKeyStoreState::new()),
+            flush_encode_buf: Mutex::new(Vec::with_capacity(4096)),
             max_entries,
         }
     }
@@ -482,7 +485,7 @@ impl SignalStoreCache {
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
             let deleted_keys: Vec<_> = state.deleted.iter().cloned().collect();
 
-            let mut encode_buf = Vec::new();
+            let mut encode_buf = self.flush_encode_buf.lock().await;
             for address in &dirty_keys {
                 match state.cache.get(address.as_ref()) {
                     Some(SessionEntry::Present(record)) => {


### PR DESCRIPTION
## Summary

Three small-effort optimizations targeting the per-message send/receive hot path.

**Per-message impact:**

| Metric | Before | After | Delta |
|---|---|---|---|
| send_message allocs | 246 | 225 | **-21 (-8.5%)** |
| send_message bytes | 40,669 | 37,602 | **-3.1 KB (-7.5%)** |
| send+receive x20 allocs | 490 | 436 | **-54 (-11.0%)** |
| send+receive x20 bytes | 119,832 | 108,689 | **-11.1 KB (-9.3%)** |

**Session-wide impact:**

| Metric | Before | After | Delta |
|---|---|---|---|
| DHAT total bytes | 27.3 MB | 26.3 MB | **-962 KB (-3.5%)** |
| DHAT total blocks | 87,846 | 84,381 | **-3,465 (-3.9%)** |

**Full optimization journey (all PRs combined):**

| Metric | Original | Now | Delta |
|---|---|---|---|
| DHAT total bytes | 37.9 MB | 26.3 MB | **-11.5 MB (-30.5%)** |
| DHAT total blocks | 158K | 84K | **-74K (-46.6%)** |

## Changes

### 1. Lightweight PN getter for ack path
- `send_ack_for` now uses `get_pn()` instead of `get_device_snapshot()`
- Avoids cloning the entire Device struct just to read the PN JID
- `get_pn()` reads directly via the device Arc read lock

### 2. Cache-first identity saves
- `IdentityAdapter::save_identity` writes only to the signal cache
- Skips the synchronous `Device::save_identity` backend write
- Cache flushes to backend during `flush_signal_cache()`
- Safe because `is_trusted_identity` always returns true (WA Web behavior)

### 3. Reusable session encode buffer in flush
- `SignalStoreCache` owns a persistent `flush_encode_buf`
- Session serialization reuses buffer capacity across flush() calls
- Eliminates a fresh Vec allocation per flush (called after every message)

## Test plan
- [x] cargo test --all (874 tests pass)
- [x] cargo clippy --all --tests clean
- [x] DHAT profiling: -962 KB total, -11% per-message allocs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal data access for greater consistency and reliability.
  * Optimized in-memory cache writes and reduced synchronization overhead to lower runtime contention.
  * Reused serialization buffers during session flushes to reduce memory allocations and improve throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->