### PR TITLE
perf: pre-encode acks, Bytes for sessions, [u8;32] for identities

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -41,13 +41,13 @@ mod tests {
         async fn put_identity(&self, _: &str, _: [u8; 32]) -> StoreResult<()> {
             Ok(())
         }
-        async fn load_identity(&self, _: &str) -> StoreResult<Option<Vec<u8>>> {
+        async fn load_identity(&self, _: &str) -> StoreResult<Option<[u8; 32]>> {
             Ok(None)
         }
         async fn delete_identity(&self, _: &str) -> StoreResult<()> {
             Ok(())
         }
-        async fn get_session(&self, _: &str) -> StoreResult<Option<Vec<u8>>> {
+        async fn get_session(&self, _: &str) -> StoreResult<Option<bytes::Bytes>> {
             Ok(None)
         }
         async fn put_session(&self, _: &str, _: &[u8]) -> StoreResult<()> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,13 +11,16 @@ use crate::lid_pn_cache::LidPnCache;
 use crate::pair;
 use anyhow::{Result, anyhow};
 use futures::FutureExt;
+#[cfg(test)]
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use wacore::xml::{DisplayableNode, DisplayableNodeRef};
 use wacore_binary::JidExt;
+use wacore_binary::Node;
 use wacore_binary::builder::NodeBuilder;
-use wacore_binary::{Attrs, Node, NodeValue};
+#[cfg(test)]
+use wacore_binary::{Attrs, NodeValue};
 
 use crate::appstate_sync::AppStateProcessor;
 use crate::handlers::chatstate::ChatStateEvent;
@@ -1729,11 +1732,11 @@ impl Client {
             return Err(ClientError::NotConnected);
         }
         let own_pn = self.get_pn().await;
-        let ack = match build_ack_node(node, own_pn.as_ref()) {
-            Some(ack) => ack,
+        let buf = match encode_ack_bytes(node, own_pn.as_ref()) {
+            Some(buf) => buf,
             None => return Ok(()),
         };
-        self.send_node(ack).await
+        self.send_raw_bytes(buf).await
     }
 
     pub(crate) async fn handle_unimplemented(&self, tag: &str) {
@@ -3662,26 +3665,117 @@ fn build_pong(to: String, id: Option<&str>) -> wacore_binary::Node {
 /// `ackString = maybeAttrString("type")` — so `type` is only included when
 /// explicitly present on the incoming receipt (delivery receipts normally
 /// have no type attribute, meaning the ack also has no type).
+/// Encode an ack stanza directly to bytes, bypassing Node + marshal_auto.
+/// Acks are the most frequent outbound stanza (~1 per inbound message).
+fn encode_ack_bytes(
+    node: &wacore_binary::NodeRef<'_>,
+    own_device_pn: Option<&Jid>,
+) -> Option<Vec<u8>> {
+    use wacore_binary::encoder::{ByteWriter, EncodeNode, Encoder};
+
+    let id_val = node.get_attr("id")?;
+    let from_val = node.get_attr("from")?;
+    let participant_val = node.get_attr("participant");
+    let tag = node.tag.as_ref();
+
+    let typ_val = if tag != "message" && !is_encrypt_identity_notification(node) {
+        node.get_attr("type")
+    } else {
+        None
+    };
+
+    let include_from = tag == "message" && own_device_pn.is_some();
+
+    // Count attrs: class + id + to + optional(from, participant, type)
+    let attr_count = 3
+        + usize::from(include_from)
+        + usize::from(participant_val.is_some())
+        + usize::from(typ_val.is_some());
+
+    struct AckNode<'a> {
+        id: &'a wacore_binary::node::ValueRef<'a>,
+        from: &'a wacore_binary::node::ValueRef<'a>,
+        participant: Option<&'a wacore_binary::node::ValueRef<'a>>,
+        typ: Option<&'a wacore_binary::node::ValueRef<'a>>,
+        own_pn: Option<&'a Jid>,
+        tag_str: &'a str,
+        attr_count: usize,
+    }
+
+    impl EncodeNode for AckNode<'_> {
+        fn tag(&self) -> &str {
+            "ack"
+        }
+        fn attrs_len(&self) -> usize {
+            self.attr_count
+        }
+        fn has_content(&self) -> bool {
+            false
+        }
+        fn encode_attrs<'a, W: ByteWriter>(
+            &self,
+            enc: &mut Encoder<'a, W>,
+        ) -> wacore_binary::Result<()> {
+            enc.write_string("class")?;
+            enc.write_string(self.tag_str)?;
+            enc.write_string("id")?;
+            self.id.encode_value(enc)?;
+            enc.write_string("to")?;
+            self.from.encode_value(enc)?;
+            if let Some(pn) = self.own_pn {
+                enc.write_string("from")?;
+                enc.write_jid_owned(pn)?;
+            }
+            if let Some(p) = self.participant {
+                enc.write_string("participant")?;
+                p.encode_value(enc)?;
+            }
+            if let Some(t) = self.typ {
+                enc.write_string("type")?;
+                t.encode_value(enc)?;
+            }
+            Ok(())
+        }
+        fn encode_content<'a, W: ByteWriter>(
+            &self,
+            _enc: &mut Encoder<'a, W>,
+        ) -> wacore_binary::Result<()> {
+            Ok(())
+        }
+    }
+
+    let ack = AckNode {
+        id: id_val,
+        from: from_val,
+        participant: participant_val,
+        typ: typ_val,
+        own_pn: if include_from { own_device_pn } else { None },
+        tag_str: tag,
+        attr_count,
+    };
+
+    let mut buf = Vec::with_capacity(64);
+    let mut encoder = Encoder::new_vec(&mut buf).ok()?;
+    encoder.write_node(&ack).ok()?;
+    Some(buf)
+}
+
+/// Build an ack Node (used in tests for structure verification).
+#[cfg(test)]
 fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>) -> Option<Node> {
     let id = node.get_attr("id")?.to_node_value();
     let from = node.get_attr("from")?.to_node_value();
     let participant = node.get_attr("participant").map(|v| v.to_node_value());
-
     let tag = node.tag.as_ref();
-
-    // Whatsmeow: echo type for all stanza tags EXCEPT "message".
-    // WA Web additionally omits type for notification type="encrypt" with <identity/> child.
     let typ = if tag != "message" && !is_encrypt_identity_notification(node) {
         node.get_attr("type").map(|v| v.to_node_value())
     } else {
         None
     };
-
     let mut attrs = Attrs::with_capacity(6);
     attrs.insert("class", NodeValue::from(tag));
     attrs.insert("id", id);
     attrs.insert("to", from);
-
     if tag == "message"
         && let Some(own_device_pn) = own_device_pn
     {
@@ -3693,7 +3787,6 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
     if let Some(t) = typ {
         attrs.insert("type", t);
     }
-
     Some(Node {
         tag: Cow::Borrowed("ack"),
         attrs,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1733,8 +1733,12 @@ impl Client {
         }
         let own_pn = self.get_pn().await;
         let buf = match encode_ack_bytes(node, own_pn.as_ref()) {
-            Some(buf) => buf,
-            None => return Ok(()),
+            Ok(Some(buf)) => buf,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                log::warn!("Failed to encode ack: {e}");
+                return Ok(());
+            }
         };
         self.send_raw_bytes(buf).await
     }
@@ -3670,11 +3674,15 @@ fn build_pong(to: String, id: Option<&str>) -> wacore_binary::Node {
 fn encode_ack_bytes(
     node: &wacore_binary::NodeRef<'_>,
     own_device_pn: Option<&Jid>,
-) -> Option<Vec<u8>> {
+) -> Result<Option<Vec<u8>>, wacore_binary::error::BinaryError> {
     use wacore_binary::encoder::{ByteWriter, EncodeNode, Encoder};
 
-    let id_val = node.get_attr("id")?;
-    let from_val = node.get_attr("from")?;
+    let Some(id_val) = node.get_attr("id") else {
+        return Ok(None);
+    };
+    let Some(from_val) = node.get_attr("from") else {
+        return Ok(None);
+    };
     let participant_val = node.get_attr("participant");
     let tag = node.tag.as_ref();
 
@@ -3755,9 +3763,9 @@ fn encode_ack_bytes(
     };
 
     let mut buf = Vec::with_capacity(64);
-    let mut encoder = Encoder::new_vec(&mut buf).ok()?;
-    encoder.write_node(&ack).ok()?;
-    Some(buf)
+    let mut encoder = Encoder::new_vec(&mut buf)?;
+    encoder.write_node(&ack)?;
+    Ok(Some(buf))
 }
 
 /// Build an ack Node (used in tests for structure verification).

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1176,8 +1176,11 @@ impl SignalStore for SqliteStore {
             .await
     }
 
-    async fn load_identity(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        self.load_identity_for_device(address, self.device_id).await
+    async fn load_identity(&self, address: &str) -> Result<Option<[u8; 32]>> {
+        let blob = self
+            .load_identity_for_device(address, self.device_id)
+            .await?;
+        Ok(blob.and_then(|v| v.try_into().ok()))
     }
 
     async fn delete_identity(&self, address: &str) -> Result<()> {
@@ -1185,8 +1188,11 @@ impl SignalStore for SqliteStore {
             .await
     }
 
-    async fn get_session(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        self.get_session_for_device(address, self.device_id).await
+    async fn get_session(&self, address: &str) -> Result<Option<bytes::Bytes>> {
+        Ok(self
+            .get_session_for_device(address, self.device_id)
+            .await?
+            .map(bytes::Bytes::from))
     }
 
     async fn has_session(&self, address: &str) -> Result<bool> {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1183,7 +1183,7 @@ impl SignalStore for SqliteStore {
         match blob {
             None => Ok(None),
             Some(v) => Ok(Some(v.try_into().map_err(|v: Vec<u8>| {
-                StoreError::Database(format!(
+                StoreError::Serialization(format!(
                     "identity key for '{}' has invalid length {} (expected 32)",
                     address,
                     v.len()

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1180,7 +1180,16 @@ impl SignalStore for SqliteStore {
         let blob = self
             .load_identity_for_device(address, self.device_id)
             .await?;
-        Ok(blob.and_then(|v| v.try_into().ok()))
+        match blob {
+            None => Ok(None),
+            Some(v) => Ok(Some(v.try_into().map_err(|v: Vec<u8>| {
+                StoreError::Database(format!(
+                    "identity key for '{}' has invalid length {} (expected 32)",
+                    address,
+                    v.len()
+                ))
+            })?)),
+        }
     }
 
     async fn delete_identity(&self, address: &str) -> Result<()> {

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -758,7 +758,7 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
 
     /// Write a JidRef directly without converting to string first.
     /// This avoids the allocation that would occur with `jid.to_string()`.
-    fn write_jid_ref(&mut self, jid: &JidRef<'_>) -> Result<()> {
+    pub fn write_jid_ref(&mut self, jid: &JidRef<'_>) -> Result<()> {
         if jid.device > 0 {
             // AD_JID format: domain_type, device, user
             let device = u8::try_from(jid.device).map_err(|_| {

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -502,6 +502,17 @@ impl serde::Serialize for ValueRef<'_> {
 }
 
 impl<'a> ValueRef<'a> {
+    /// Encode this value directly to the binary encoder.
+    pub fn encode_value<W: crate::encoder::ByteWriter>(
+        &self,
+        encoder: &mut crate::encoder::Encoder<'_, W>,
+    ) -> crate::error::Result<()> {
+        match self {
+            ValueRef::String(s) => encoder.write_string(s),
+            ValueRef::Jid(jid) => encoder.write_jid_ref(jid),
+        }
+    }
+
     /// String view of the value. Borrows from `self`.
     /// - String variant: borrows the inner str — zero copy
     /// - Jid variant: Cow::Owned — allocates only when needed

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -38,7 +38,7 @@ type BaseKeyKey = (String, String);
 struct InMemoryState {
     // --- Signal ---
     identities: HashMap<String, [u8; 32]>,
-    sessions: HashMap<String, Vec<u8>>,
+    sessions: HashMap<String, Bytes>,
     prekeys: HashMap<u32, PreKeyEntry>,
     signed_prekeys: HashMap<u32, Vec<u8>>,
     sender_keys: HashMap<String, Vec<u8>>,
@@ -128,14 +128,8 @@ impl SignalStore for InMemoryBackend {
         Ok(())
     }
 
-    async fn load_identity(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        Ok(self
-            .state
-            .lock()
-            .await
-            .identities
-            .get(address)
-            .map(|k| k.to_vec()))
+    async fn load_identity(&self, address: &str) -> Result<Option<[u8; 32]>> {
+        Ok(self.state.lock().await.identities.get(address).copied())
     }
 
     async fn delete_identity(&self, address: &str) -> Result<()> {
@@ -143,7 +137,7 @@ impl SignalStore for InMemoryBackend {
         Ok(())
     }
 
-    async fn get_session(&self, address: &str) -> Result<Option<Vec<u8>>> {
+    async fn get_session(&self, address: &str) -> Result<Option<Bytes>> {
         Ok(self.state.lock().await.sessions.get(address).cloned())
     }
 
@@ -152,7 +146,7 @@ impl SignalStore for InMemoryBackend {
             .lock()
             .await
             .sessions
-            .insert(address.to_string(), session.to_vec());
+            .insert(address.to_string(), Bytes::copy_from_slice(session));
         Ok(())
     }
 

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -88,8 +88,8 @@ pub trait SignalStore: Send + Sync {
     /// Store an identity key for a remote address.
     async fn put_identity(&self, address: &str, key: [u8; 32]) -> Result<()>;
 
-    /// Load an identity key for a remote address.
-    async fn load_identity(&self, address: &str) -> Result<Option<Vec<u8>>>;
+    /// Load an identity key for a remote address (always 32 bytes).
+    async fn load_identity(&self, address: &str) -> Result<Option<[u8; 32]>>;
 
     /// Delete an identity key.
     async fn delete_identity(&self, address: &str) -> Result<()>;
@@ -97,7 +97,7 @@ pub trait SignalStore: Send + Sync {
     // --- Session Operations ---
 
     /// Get an encrypted session for an address.
-    async fn get_session(&self, address: &str) -> Result<Option<Vec<u8>>>;
+    async fn get_session(&self, address: &str) -> Result<Option<Bytes>>;
 
     /// Store an encrypted session.
     async fn put_session(&self, address: &str, session: &[u8]) -> Result<()>;


### PR DESCRIPTION
## Summary

Two optimizations targeting the per-message send/receive hot path.

**Per-message impact (this branch vs main):**

| Metric | Before | After | Delta |
|---|---|---|---|
| send+receive x20 bytes | 108,689 | 103,576 | **-5.1 KB (-4.7%)** |
| send+receive x20 allocs | 436 | 429 | **-7 (-1.6%)** |
| DHAT total bytes | 26.3 MB | 25.9 MB | **-427 KB (-1.6%)** |

**Full journey (all PRs, original baseline -> now):**

| Metric | Original | Now | Delta |
|---|---|---|---|
| send_message allocs | 258 | 225 | **-33 (-12.8%)** |
| connect allocs | 21,420 | 9,523 | **-11,897 (-55.5%)** |
| connect bytes | 5.19 MB | 3.24 MB | **-1.95 MB (-37.5%)** |

## Changes

### 1. Pre-encode ack stanzas directly (-427 KB)
- Ack stanzas (~1 per inbound message) encoded directly via Encoder
- Bypasses Node construction + Attrs allocation + marshal_auto
- New `ValueRef::encode_value()` and public `write_jid_ref()` for custom EncodeNode impls
- Pre-sized buffer (64 bytes) for typical ack size

### 2. Bytes for session store, [u8;32] for identity keys
- `SignalStore::get_session` returns `Bytes` (O(1) clone on cache miss)
- `SignalStore::load_identity` returns `[u8; 32]` (stack copy, zero heap alloc)
- InMemoryBackend stores sessions as `Bytes` internally
- Structural improvement for SQLite backend (Bytes::from(vec) is zero-copy)

### Note on dispatch_parsed_message (#3)
Investigation showed the 442KB allocation is from `Box::new(msg)` when dispatching the decoded protobuf Message to event handlers -- this is inherent (the message must be heap-allocated for dispatch) and not optimizable without changing the event API.

## Test plan
- [x] cargo test --all (874 tests pass)
- [x] cargo clippy --all --tests clean
- [x] DHAT profiling: -427 KB from ack pre-encoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved ACK encoding and delivery for more reliable and efficient message acknowledgements.
  * Reduced memory usage for stored cryptographic material by using fixed-size identity records and shared session buffers.
  * Enhanced binary encoding utilities to allow more direct and consistent serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->