### PR TITLE
fix(pair-code): accept notification without link_code_companion_reg wrapper

### DIFF
--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -229,10 +229,14 @@ pub(crate) async fn handle_pair_code_notification(
     client: &Arc<Client>,
     node: &NodeRef<'_>,
 ) -> bool {
-    // Check if this is a link_code_companion_reg notification
-    let Some(reg_node) = node.get_optional_child_by_tag(&["link_code_companion_reg"]) else {
-        return false;
-    };
+    // The data fields may be wrapped in a child <link_code_companion_reg> node,
+    // or they may be direct children of the notification node itself (when the
+    // notification type="link_code_companion_reg"). Observed in the wild that
+    // the server sometimes omits the wrapper; without this fallback the
+    // pair-code flow silently hangs on the first attempt.
+    let reg_node = node
+        .get_optional_child_by_tag(&["link_code_companion_reg"])
+        .unwrap_or(node);
 
     // Extract primary's wrapped ephemeral public key (80 bytes: salt + iv + encrypted key)
     let primary_wrapped_ephemeral = match reg_node


### PR DESCRIPTION
## What

`handle_pair_code_notification` in `src/pair_code.rs` currently bails with `return false` when the incoming notification has no `<link_code_companion_reg>` child. In the wild, the server sometimes sends the same payload with the key fields as direct children of the `<notification>` node (no wrapper), and the current code silently drops those.

User-visible effect: the first pair-code attempt often hangs — user enters the 8-character code on their phone, sees nothing happen, retries, and sometimes the retry arrives wrapped and works.

## Fix

Fall back to the notification node itself when the wrapper child is absent:

```rust
let reg_node = node
    .get_optional_child_by_tag(&[\"link_code_companion_reg\"])
    .unwrap_or(node);
```

Backward-compatible — wrapped payloads still hit the same code path through the child lookup.

## Testing

- Observed in production that first pair-code attempts frequently fail on our deployment; retries often succeed.
- Applied this patch locally against `jlucaso1/whatsapp-rust@88a5145` (current main), ran `cargo check -p whatsapp-rust` clean.
- Ran a fresh pair-code flow end-to-end against a real WhatsApp account with the patch in place; pairing completed successfully (log output: `Successfully authenticated with WhatsApp servers! (gen=1)` followed by normal history sync).

## Context

We've been carrying this as a vendored patch for a few months. Upstreaming so we can drop it and track `main` directly. Happy to iterate on the fix shape if you'd prefer the fallback handled elsewhere (e.g. inside `get_optional_child_by_tag` or with a separate shape-detection arm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience in data parsing by gracefully handling cases where optional wrapper elements are absent from server responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->