### PR TITLE
WA Web compliance: retry flow + group/status session rebuild

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -163,8 +163,6 @@ pub struct CacheConfig {
     pub device_registry_cache: CacheEntryConfig,
     /// LID-to-phone cache (time_to_idle). Default: 1h timeout, 10000 entries.
     pub lid_pn_cache: CacheEntryConfig,
-    /// Retried group messages tracker (time_to_live). Default: 5m TTL, 2000 entries.
-    pub retried_group_messages: CacheEntryConfig,
     /// Optional L1 in-memory cache for sent messages (retry support).
     /// Default: capacity 0 (disabled — DB-only, matching WA Web).
     /// Set capacity > 0 to enable a fast in-memory cache in front of the DB.
@@ -208,7 +206,6 @@ impl std::fmt::Debug for CacheConfig {
             .field("group_cache", &self.group_cache)
             .field("device_registry_cache", &self.device_registry_cache)
             .field("lid_pn_cache", &self.lid_pn_cache)
-            .field("retried_group_messages", &self.retried_group_messages)
             .field("recent_messages", &self.recent_messages)
             .field("message_retry_counts", &self.message_retry_counts)
             .field("pdo_pending_requests", &self.pdo_pending_requests)
@@ -241,7 +238,6 @@ impl Default for CacheConfig {
             group_cache: CacheEntryConfig::new(one_hour, 250),
             device_registry_cache: CacheEntryConfig::new(one_hour, 5_000),
             lid_pn_cache: CacheEntryConfig::new(one_hour, 10_000),
-            retried_group_messages: CacheEntryConfig::new(five_min, 2_000),
             recent_messages: CacheEntryConfig::new(five_min, 0),
             message_retry_counts: CacheEntryConfig::new(five_min, 1_000),
             pdo_pending_requests: CacheEntryConfig::new(Some(Duration::from_secs(30)), 500),

--- a/src/client.rs
+++ b/src/client.rs
@@ -171,7 +171,6 @@ pub struct MemoryDiagnostics {
     pub device_registry_cache: u64,
     pub lid_pn_lid_entries: u64,
     pub lid_pn_pn_entries: u64,
-    pub retried_group_messages: u64,
     pub recent_messages: u64,
     pub sender_key_device_cache: u64,
     pub message_retry_counts: u64,
@@ -207,11 +206,6 @@ impl std::fmt::Display for MemoryDiagnostics {
         )?;
         writeln!(f, "  lid_pn (lid):           {}", self.lid_pn_lid_entries)?;
         writeln!(f, "  lid_pn (pn):            {}", self.lid_pn_pn_entries)?;
-        writeln!(
-            f,
-            "  retried_group_messages: {}",
-            self.retried_group_messages
-        )?;
         writeln!(f, "  recent_messages:        {}", self.recent_messages)?;
         writeln!(
             f,
@@ -375,7 +369,6 @@ pub struct Client {
 
     pub group_cache: async_lock::Mutex<Option<Arc<TypedCache<Jid, GroupInfo>>>>,
 
-    pub(crate) retried_group_messages: Cache<String, ()>,
     pub(crate) expected_disconnect: Arc<AtomicBool>,
     /// Set by `reconnect()` to suppress the "Message loop exited with an error" warning.
     /// Unlike `expected_disconnect`, this does NOT skip the reconnect backoff.
@@ -491,6 +484,11 @@ pub struct Client {
 }
 
 impl Client {
+    /// `Weak` ref so subscribers don't extend the notifier's lifetime.
+    pub fn shutdown_signal(&self) -> std::sync::Weak<event_listener::Event> {
+        Arc::downgrade(&self.shutdown_notifier)
+    }
+
     /// Read the current semaphore generation and Arc atomically under the mutex.
     pub(crate) fn read_message_semaphore(&self) -> (u64, Arc<async_lock::Semaphore>) {
         let guard = match self.message_processing_semaphore.lock() {
@@ -679,7 +677,6 @@ impl Client {
             )),
             ab_props: Arc::new(wacore::store::ab_props::AbPropsCache::new()),
             group_cache: async_lock::Mutex::new(None),
-            retried_group_messages: cache_config.retried_group_messages.build_with_ttl(),
 
             expected_disconnect: Arc::new(AtomicBool::new(false)),
             intentional_reconnect: AtomicBool::new(false),
@@ -1240,7 +1237,6 @@ impl Client {
         // is_connected==true with a cleared socket. send_node() independently
         // checks the socket, but this ordering avoids a confusing state window.
         self.is_connected.store(false, Ordering::Release);
-        self.retried_group_messages.invalidate_all();
         // Drop per-chat lanes so workers exit via channel close.
         self.chat_lanes.invalidate_all();
         // Clear pending retries so stale keys from detached scopeguard
@@ -1332,7 +1328,6 @@ impl Client {
             device_registry_cache: self.device_registry_cache.entry_count(),
             lid_pn_lid_entries: lid_lid,
             lid_pn_pn_entries: lid_pn,
-            retried_group_messages: self.retried_group_messages.entry_count(),
             recent_messages: self.recent_messages.entry_count(),
             sender_key_device_cache: self.sender_key_device_cache.entry_count(),
             message_retry_counts: self.message_retry_counts.entry_count(),

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -499,6 +499,14 @@ impl Client {
         if info.chat.is_group() {
             // Group retry: pairwise encrypt to failing device only (RetryMsgJob.js:71).
             // Using sender-key broadcast would resend to ALL participants → duplicates.
+            //
+            // WA Web calls ensureE2ESessions for all chat types, not just DMs
+            // (RetryRequest.js:200). Without this, a reg-ID mismatch or unknown
+            // device whose session was deleted above would fail `prepare_group_retry_stanza`
+            // with "session not found", silencing subsequent retries via the duplicate filter.
+            self.ensure_e2e_sessions_resolved(std::slice::from_ref(&resolved_jid))
+                .await?;
+
             let device_snapshot = self.persistence_manager.get_device_snapshot().await;
 
             let addressing_mode = cached_group_info
@@ -1616,6 +1624,41 @@ mod tests {
                 .is_none(),
             "resolved session should be deleted when registry has no device list"
         );
+    }
+
+    /// WA Web calls `ensureE2ESessions([g])` before resending for all chat types
+    /// (RetryRequest.js:200). When the session already exists, this MUST be a
+    /// fast no-op — otherwise group/status retries would hit the network on
+    /// every receipt, defeating the cache. Regression guard for the group-branch
+    /// call added alongside this test.
+    #[tokio::test]
+    async fn ensure_e2e_sessions_resolved_is_noop_when_session_exists() {
+        use std::sync::atomic::Ordering;
+
+        let client = crate::test_utils::create_test_client_with_failing_http(
+            "group_retry_ensure_sessions_noop",
+        )
+        .await;
+
+        // Bypass the offline-delivery wait that ensureE2ESessions does first.
+        client.offline_sync_completed.store(true, Ordering::Relaxed);
+
+        let resolved_jid = Jid::lid_device("100000000000199".to_string(), 17);
+        let signal_address = resolved_jid.to_protocol_address();
+
+        client
+            .persistence_manager
+            .backend()
+            .put_session(signal_address.as_str(), b"fake-session-record")
+            .await
+            .unwrap();
+
+        // With a session present, no prekey fetch should happen (the test
+        // client has no wired IQ responder, so a fetch would hang/error).
+        client
+            .ensure_e2e_sessions_resolved(std::slice::from_ref(&resolved_jid))
+            .await
+            .expect("no-op when session exists");
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1848,10 +1848,11 @@ mod tests {
         let resolved_jid = Jid::lid_device("100000000000199".to_string(), 17);
         let signal_address = resolved_jid.to_protocol_address();
 
+        let session_bytes = valid_serialized_session(5555, vec![0xDD; 32]);
         client
             .persistence_manager
             .backend()
-            .put_session(signal_address.as_str(), b"fake-session-record")
+            .put_session(signal_address.as_str(), &session_bytes)
             .await
             .unwrap();
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -311,59 +311,6 @@ impl Client {
                 .as_ref()
                 .is_some_and(|our_lid| info.requester.is_same_user_as(our_lid));
 
-        // Process key bundle to establish a pairwise session for the retry.
-        // Needed for both DMs and groups (group retries use pairwise, not sender key).
-        // Status broadcasts skip this — they can't resend and only mark for next send.
-        if !info.chat.is_status_broadcast() {
-            // Try to process key bundle if present
-            let key_bundle_result = self
-                .process_retry_key_bundle(nr, &resolved_jid, is_peer)
-                .await;
-
-            if let Err(e) = &key_bundle_result {
-                warn!(
-                    "Failed to process key bundle from retry receipt: {}. Checking for reg ID mismatch.",
-                    e
-                );
-
-                // WhatsApp Web behavior: If no key bundle but registration ID differs from stored
-                // session, delete the session to force re-establishment.
-                // This handles the case where the requester reinstalled but didn't include keys.
-                if let Some(received_reg_id) = extract_registration_id_from_node_ref(nr) {
-                    let signal_address = resolved_jid.to_protocol_address();
-                    let device_store = self.persistence_manager.get_device_arc().await;
-                    let device_guard = device_store.read().await;
-
-                    // Read session through cache to get consistent state
-                    let session = self
-                        .signal_cache
-                        .peek_session(&signal_address, &*device_guard.backend)
-                        .await
-                        .ok()
-                        .flatten();
-                    drop(device_guard);
-
-                    if let Some(session) = session
-                        && let Ok(stored_reg_id) = session.remote_registration_id()
-                        && stored_reg_id != 0
-                        && stored_reg_id != received_reg_id
-                    {
-                        info!(
-                            "Registration ID mismatch for {} (stored: {}, received: {}). \
-                             Deleting session since no key bundle provided.",
-                            signal_address, stored_reg_id, received_reg_id
-                        );
-                        let lock = self.session_lock_for(signal_address.as_str()).await;
-                        let _guard = lock.lock().await;
-                        self.signal_cache.delete_session(&signal_address).await;
-                        drop(_guard);
-                        self.flush_signal_cache_logged("reg ID mismatch session deletion", None)
-                            .await;
-                    }
-                }
-            }
-        }
-
         // Fetch group info (cache-first, server on miss) — used for SKDM rotation + addressing_mode.
         // Without this, a cold cache would silently default to PN semantics for LID groups.
         let cached_group_info = if info.chat.is_group() {
@@ -382,103 +329,78 @@ impl Client {
             None
         };
 
-        if is_group_or_status {
+        // WA Web rotateKey: unknown device (not in participant list, not LID) →
+        // force full sender key rotation by clearing all sender key device tracking.
+        // This is separate from updateLocalSignalSession and specific to group retries.
+        if is_group_or_status && !info.requester.is_lid() && !info.chat.is_status_broadcast() {
             let group_jid = info.chat.to_string();
+            let is_known_participant = cached_group_info
+                .as_ref()
+                .is_some_and(|g| g.participants.iter().any(|p| p.user == info.requester.user));
 
-            // WA Web rotateKey: unknown device (not in participant list, not LID) →
-            // force full sender key rotation by clearing all sender key device tracking.
-            if !info.requester.is_lid() && !info.chat.is_status_broadcast() {
-                // If we can't verify membership (no cached group info), treat
-                // as unknown and trigger rotation (matches WA Web where the
-                // device wouldn't be in the senderKey map → rotateKey=true)
-                let is_known_participant = cached_group_info
-                    .as_ref()
-                    .is_some_and(|g| g.participants.iter().any(|p| p.user == info.requester.user));
-
-                if !is_known_participant {
-                    log::warn!(
-                        "Unknown device {} in group {} — forcing full sender key rotation \
-                         (matches WA Web's rotateKey behavior)",
-                        info.requester,
-                        group_jid
-                    );
-
-                    // WA Web: deleteGroupSenderKeyInfo(groupWid, ownWid)
-                    // Delete our own sender key for forward secrecy.
-                    // When addressing mode is known, delete only that namespace.
-                    // When unknown (group info unavailable), delete both PN and LID
-                    // to ensure the active key is removed regardless of mode.
-                    let addressing_mode = cached_group_info.as_ref().map(|g| g.addressing_mode);
-
-                    let jids_to_delete: Vec<_> = match addressing_mode {
-                        Some(wacore::types::message::AddressingMode::Lid) => {
-                            device_snapshot.lid.as_ref().into_iter().collect()
-                        }
-                        Some(wacore::types::message::AddressingMode::Pn) => {
-                            device_snapshot.pn.as_ref().into_iter().collect()
-                        }
-                        None => {
-                            // Can't determine mode — delete both namespaces
-                            device_snapshot
-                                .lid
-                                .as_ref()
-                                .into_iter()
-                                .chain(device_snapshot.pn.as_ref())
-                                .collect()
-                        }
-                    };
-
-                    for own_jid in jids_to_delete {
-                        use wacore::libsignal::store::sender_key_name::SenderKeyName;
-                        let sk_name = SenderKeyName::from_parts(
-                            &group_jid,
-                            own_jid.to_protocol_address().as_str(),
-                        );
-                        self.signal_cache
-                            .delete_sender_key(sk_name.cache_key())
-                            .await;
-                    }
-
-                    // Clear DB first, then invalidate cache. This order prevents
-                    // a concurrent resolve_skdm_targets from reading stale DB rows
-                    // and re-inserting them into cache after invalidation.
-                    if let Err(e) = self
-                        .persistence_manager
-                        .clear_sender_key_devices(&group_jid)
-                        .await
-                    {
-                        log::warn!("Failed to clear sender key devices for rotation: {}", e);
-                    }
-                    self.sender_key_device_cache.invalidate(&group_jid).await;
-                }
-            }
-
-            // Mark this device as needing fresh SKDM (filters out own devices internally)
-            if let Err(e) = self
-                .mark_forget_sender_key(&group_jid, std::slice::from_ref(&info.requester))
-                .await
-            {
+            if !is_known_participant {
                 log::warn!(
-                    "Failed to mark sender key forget for {} in {}: {}",
+                    "Unknown device {} in group {} — forcing full sender key rotation \
+                     (matches WA Web's rotateKey behavior)",
                     info.requester,
-                    group_jid,
-                    e
+                    group_jid
                 );
-            } else {
-                let chat_type = if info.chat.is_status_broadcast() {
-                    "status broadcast"
-                } else {
-                    "group"
+
+                // WA Web: deleteGroupSenderKeyInfo(groupWid, ownWid) — delete our own
+                // sender key for forward secrecy. When addressing mode is known,
+                // delete only that namespace; otherwise both.
+                let addressing_mode = cached_group_info.as_ref().map(|g| g.addressing_mode);
+                let jids_to_delete: Vec<_> = match addressing_mode {
+                    Some(wacore::types::message::AddressingMode::Lid) => {
+                        device_snapshot.lid.as_ref().into_iter().collect()
+                    }
+                    Some(wacore::types::message::AddressingMode::Pn) => {
+                        device_snapshot.pn.as_ref().into_iter().collect()
+                    }
+                    None => device_snapshot
+                        .lid
+                        .as_ref()
+                        .into_iter()
+                        .chain(device_snapshot.pn.as_ref())
+                        .collect(),
                 };
-                info!(
-                    "Marked {} for fresh SKDM in {} {} due to retry receipt",
-                    info.requester, chat_type, group_jid
-                );
+
+                for own_jid in jids_to_delete {
+                    use wacore::libsignal::store::sender_key_name::SenderKeyName;
+                    let sk_name = SenderKeyName::from_parts(
+                        &group_jid,
+                        own_jid.to_protocol_address().as_str(),
+                    );
+                    self.signal_cache
+                        .delete_sender_key(sk_name.cache_key())
+                        .await;
+                }
+
+                // DB first, then cache invalidate — prevents a concurrent
+                // resolve_skdm_targets from reviving stale cache entries.
+                if let Err(e) = self
+                    .persistence_manager
+                    .clear_sender_key_devices(&group_jid)
+                    .await
+                {
+                    log::warn!("Failed to clear sender key devices for rotation: {}", e);
+                }
+                self.sender_key_device_cache.invalidate(&group_jid).await;
             }
-        } else {
-            self.delete_dm_retry_session_target(&resolved_jid, &message_id, retry_count)
-                .await?;
         }
+
+        // Mirror WAWebUpdateLocalSignalSession for all chat types: markForgetSenderKey
+        // (group/status) + processKeyBundle + regId-mismatch delete + base-key logic.
+        // Must run before ensureE2ESessions so any session deletion here is rebuilt there.
+        self.update_local_signal_session(
+            &info,
+            &resolved_jid,
+            &message_id,
+            retry_count,
+            nr,
+            is_peer,
+        )
+        .await;
 
         // Status broadcasts can't resend (requires explicit recipient list).
         // Participant already marked for fresh SKDM above; next status send includes them.
@@ -569,91 +491,187 @@ impl Client {
         Ok(())
     }
 
-    async fn delete_dm_retry_session_target(
+    /// Mirrors WAWebUpdateLocalSignalSession (`WAWeb/Update/LocalSignalSession.js`).
+    /// Runs before ensureE2ESessions + sendRetry for all chat types (DM, group,
+    /// status). Order and semantics match the WA Web implementation:
+    ///   1. markForgetSenderKey for group/status (participant needs fresh SKDM)
+    ///   2. processKeyBundle if `<keys>` present
+    ///   3. If no bundle AND stored regId differs → delete session
+    ///   4. retry == 2 → save current base key, return (no delete)
+    ///   5. retry > 2 AND same base key → delete session (force re-establish)
+    ///
+    /// Unlike the previous DM-only path, this does NOT unconditionally delete
+    /// the session on every retry — WA Web preserves it on retry==1 and on
+    /// retry>2 when the base key already changed (session was regenerated
+    /// legitimately). The subsequent `ensure_e2e_sessions_resolved` call in
+    /// `handle_retry_receipt` rebuilds any session this function deleted.
+    async fn update_local_signal_session(
         &self,
-        device_jid: &Jid,
+        info: &RetryChatInfo,
+        resolved_jid: &Jid,
         message_id: &str,
         retry_count: u8,
-    ) -> Result<(), anyhow::Error> {
-        // Base key collision detection prevents stale-session retry loops.
-        let signal_address = device_jid.to_protocol_address();
-        let device_store = self.persistence_manager.get_device_arc().await;
-
-        // Check for base key collision before deleting the session.
-        // Read session through cache for consistent state.
-        {
-            let device_guard = device_store.read().await;
-            let session = self
-                .signal_cache
-                .peek_session(&signal_address, &*device_guard.backend)
+        node: &NodeRef<'_>,
+        is_peer: bool,
+    ) {
+        // 1. markForgetSenderKey (WA Web L33-38). Rust unifies group and status
+        //    under a single storage (chat JID as the key) — markForgetSenderKey
+        //    handles both `@g.us` and `status@broadcast` as opaque group_jid.
+        if info.chat.is_group() || info.chat.is_status_broadcast() {
+            let group_jid = info.chat.to_string();
+            match self
+                .mark_forget_sender_key(&group_jid, std::slice::from_ref(&info.requester))
                 .await
-                .ok()
-                .flatten();
-
-            if let Some(session) = session
-                && let Ok(current_base_key) = session.alice_base_key()
             {
-                let addr_str = signal_address.as_str();
-                if retry_count == MIN_RETRY_FOR_BASE_KEY_CHECK {
-                    // Save retry #2's base key so later retries can prove regeneration happened.
-                    if let Err(e) = device_guard
-                        .backend
-                        .save_base_key(addr_str, message_id, current_base_key)
-                        .await
-                    {
-                        warn!("Failed to save base key for {}: {}", signal_address, e);
+                Ok(()) => {
+                    let chat_type = if info.chat.is_status_broadcast() {
+                        "status broadcast"
                     } else {
-                        info!(
-                            "Saved base key for {} at retry #{} for collision detection",
-                            signal_address, retry_count
-                        );
-                    }
-                } else if retry_count > MIN_RETRY_FOR_BASE_KEY_CHECK {
-                    // An unchanged base key means we never rebuilt the session.
-                    match device_guard
-                        .backend
-                        .has_same_base_key(addr_str, message_id, current_base_key)
-                        .await
-                    {
-                        Ok(true) => {
-                            // Collision detected! We haven't regenerated our session.
-                            warn!(
-                                "Base key collision detected for {} at retry #{}. \
-                                 Session hasn't been regenerated. Forcing fresh session.",
-                                signal_address, retry_count
-                            );
-                            // Clean up base key entry since we're deleting the session
-                            let _ = device_guard
-                                .backend
-                                .delete_base_key(addr_str, message_id)
-                                .await;
-                        }
-                        Ok(false) => {
-                            // Base key changed, session was regenerated - good!
-                            info!(
-                                "Base key changed for {} at retry #{} - session regenerated",
-                                signal_address, retry_count
-                            );
-                            // Clean up old base key entry
-                            let _ = device_guard
-                                .backend
-                                .delete_base_key(addr_str, message_id)
-                                .await;
-                        }
-                        Err(e) => {
-                            warn!("Failed to check base key for {}: {}", signal_address, e);
-                        }
-                    }
+                        "group"
+                    };
+                    info!(
+                        "Marked {} for fresh SKDM in {} {} due to retry receipt",
+                        info.requester, chat_type, group_jid
+                    );
+                }
+                Err(e) => log::warn!(
+                    "Failed to mark sender key forget for {} in {}: {}",
+                    info.requester,
+                    group_jid,
+                    e
+                ),
+            }
+        }
+
+        // 2. processKeyBundle (WA Web L51). Previously gated behind
+        //    `!is_status_broadcast()`; WA Web runs it unconditionally.
+        let key_bundle_result = self
+            .process_retry_key_bundle(node, resolved_jid, is_peer)
+            .await;
+        let key_bundle_processed = key_bundle_result.is_ok();
+
+        // 3. No bundle + regId mismatch → delete session (WA Web L52-65).
+        if !key_bundle_processed {
+            if let Err(ref e) = key_bundle_result {
+                // Demoted to debug on the happy path (peer retry without re-key):
+                // only warn when a regId mismatch triggers a delete below.
+                log::debug!(
+                    "No key bundle in retry receipt for {}: {}. Checking for reg ID mismatch.",
+                    resolved_jid,
+                    e
+                );
+            }
+
+            if let Some(received_reg_id) = extract_registration_id_from_node_ref(node) {
+                let signal_address = resolved_jid.to_protocol_address();
+                let device_store = self.persistence_manager.get_device_arc().await;
+                let device_guard = device_store.read().await;
+                let session = self
+                    .signal_cache
+                    .peek_session(&signal_address, &*device_guard.backend)
+                    .await
+                    .ok()
+                    .flatten();
+                drop(device_guard);
+
+                if let Some(session) = session
+                    && let Ok(stored_reg_id) = session.remote_registration_id()
+                    && stored_reg_id != 0
+                    && stored_reg_id != received_reg_id
+                {
+                    info!(
+                        "Registration ID mismatch for {} (stored: {}, received: {}). \
+                         Deleting session since no key bundle provided.",
+                        signal_address, stored_reg_id, received_reg_id
+                    );
+                    let lock = self.session_lock_for(signal_address.as_str()).await;
+                    let _guard = lock.lock().await;
+                    self.signal_cache.delete_session(&signal_address).await;
+                    drop(_guard);
+                    self.flush_signal_cache_logged("reg ID mismatch session deletion", None)
+                        .await;
                 }
             }
         }
 
-        // Delete through the cache so resend can't revive a stale in-memory session.
-        // The retry path flushes once after the resend so the session transition
-        // stays visible through the cache for the whole targeted rebuild.
-        self.signal_cache.delete_session(&signal_address).await;
-        info!("Deleted session for {signal_address} due to retry receipt");
-        Ok(())
+        // 4-5. Base-key collision logic (WA Web L66-80). Applied to ALL chat
+        //      types now — previously only ran in the DM branch.
+        let signal_address = resolved_jid.to_protocol_address();
+        let device_store = self.persistence_manager.get_device_arc().await;
+        let device_guard = device_store.read().await;
+        let session = self
+            .signal_cache
+            .peek_session(&signal_address, &*device_guard.backend)
+            .await
+            .ok()
+            .flatten();
+
+        let Some(session) = session else {
+            return;
+        };
+        let Ok(current_base_key) = session.alice_base_key() else {
+            return;
+        };
+
+        let addr_str = signal_address.as_str();
+        if retry_count == MIN_RETRY_FOR_BASE_KEY_CHECK {
+            // retry == 2: save base key, do NOT delete (WA Web L66-67).
+            match device_guard
+                .backend
+                .save_base_key(addr_str, message_id, current_base_key)
+                .await
+            {
+                Ok(()) => info!(
+                    "Saved base key for {} at retry #{} for collision detection",
+                    signal_address, retry_count
+                ),
+                Err(e) => warn!("Failed to save base key for {}: {}", signal_address, e),
+            }
+            return;
+        }
+
+        if retry_count > MIN_RETRY_FOR_BASE_KEY_CHECK {
+            match device_guard
+                .backend
+                .has_same_base_key(addr_str, message_id, current_base_key)
+                .await
+            {
+                Ok(true) => {
+                    warn!(
+                        "Base key collision detected for {} at retry #{}. \
+                         Session hasn't been regenerated. Forcing fresh session.",
+                        signal_address, retry_count
+                    );
+                    let _ = device_guard
+                        .backend
+                        .delete_base_key(addr_str, message_id)
+                        .await;
+                    drop(device_guard);
+                    let lock = self.session_lock_for(signal_address.as_str()).await;
+                    let _guard = lock.lock().await;
+                    self.signal_cache.delete_session(&signal_address).await;
+                    drop(_guard);
+                    self.flush_signal_cache_logged(
+                        "base key collision — forcing fresh session",
+                        None,
+                    )
+                    .await;
+                }
+                Ok(false) => {
+                    info!(
+                        "Base key changed for {} at retry #{} - session regenerated",
+                        signal_address, retry_count
+                    );
+                    let _ = device_guard
+                        .backend
+                        .delete_base_key(addr_str, message_id)
+                        .await;
+                }
+                Err(e) => {
+                    warn!("Failed to check base key for {}: {}", signal_address, e);
+                }
+            }
+        }
     }
 
     /// Extracts and processes the key bundle from a retry receipt.
@@ -1553,10 +1571,45 @@ mod tests {
         );
     }
 
+    /// Build a minimal `<receipt>` Node representing an incoming retry receipt
+    /// without `<keys>`. Used by tests that exercise the no-bundle path of
+    /// `update_local_signal_session`.
+    fn build_retry_receipt_without_keys() -> Node {
+        use wacore_binary::builder::NodeBuilder;
+        NodeBuilder::new("receipt").build()
+    }
+
+    /// Build a `<receipt>` with a `<registration>` child carrying `reg_id` (big
+    /// endian). Used to exercise the reg-ID-mismatch branch without a full
+    /// `<keys>` bundle.
+    fn build_retry_receipt_with_registration(reg_id: u32) -> Node {
+        use wacore_binary::builder::NodeBuilder;
+        NodeBuilder::new("receipt")
+            .children([NodeBuilder::new("registration")
+                .bytes(reg_id.to_be_bytes().to_vec())
+                .build()])
+            .build()
+    }
+
+    fn dm_retry_info(resolved_jid: &Jid) -> RetryChatInfo {
+        RetryChatInfo {
+            chat: resolved_jid.to_non_ad(),
+            requester: resolved_jid.clone(),
+            original_from: resolved_jid.clone(),
+            is_bot: false,
+        }
+    }
+
+    /// WA Web compliance: at retry #1 with no `<keys>`, `updateLocalSignalSession`
+    /// does NOT delete the session. Session is preserved until either a reg-ID
+    /// mismatch or a base-key collision at retry>2. Previously the Rust DM path
+    /// unconditionally deleted on every retry — this regressed legitimate
+    /// sessions and forced unnecessary prekey bundle fetches.
+    /// Ref: `WAWeb/Update/LocalSignalSession.js` (no delete on retry==1)
     #[tokio::test]
-    async fn dm_retry_deletes_only_requested_session() {
+    async fn update_local_signal_session_preserves_dm_session_at_retry_1() {
         let client =
-            crate::test_utils::create_test_client_with_failing_http("retry_dm_devices").await;
+            crate::test_utils::create_test_client_with_failing_http("retry_preserve_retry_1").await;
         let user = "100000000000088".to_string();
         let resolved_jid = Jid::lid_device(user.clone(), 33);
 
@@ -1573,10 +1626,18 @@ mod tests {
             .await
             .unwrap();
 
+        let node = build_retry_receipt_without_keys();
+        let node_ref = node.as_node_ref();
         client
-            .delete_dm_retry_session_target(&resolved_jid, "MSG-ONE-DEVICE", 1)
-            .await
-            .unwrap();
+            .update_local_signal_session(
+                &dm_retry_info(&resolved_jid),
+                &resolved_jid,
+                "MSG-RETRY-1",
+                1,
+                &node_ref,
+                false,
+            )
+            .await;
         client.flush_signal_cache().await.unwrap();
 
         assert!(
@@ -1592,16 +1653,26 @@ mod tests {
                 .get_session(device_33.as_str())
                 .await
                 .unwrap()
-                .is_none(),
-            "requesting device session should be deleted"
+                .is_some(),
+            "requesting device session should also be preserved at retry #1 — \
+             WA Web only deletes on reg-ID mismatch or base-key collision"
         );
     }
 
+    /// Mirrors the scenario from production logs (debug-1776271138): peer
+    /// sends a retry receipt without `<keys>` but with a `<registration>` child
+    /// whose reg_id differs from our stored session. WA Web deletes the session
+    /// in this case so the next ensureE2ESessions fetches a fresh bundle.
     #[tokio::test]
-    async fn dm_retry_deletes_resolved_session_without_registry_devices() {
+    async fn update_local_signal_session_handles_regid_mismatch_gracefully() {
+        // With an invalid session record in storage, peek_session returns None
+        // (errors are swallowed via .ok().flatten()). The function should not
+        // attempt to dereference a missing session — verify it completes
+        // without panicking and leaves the invalid bytes untouched (since there
+        // is no "session" for remote_registration_id() to compare against).
         let client =
-            crate::test_utils::create_test_client_with_failing_http("retry_dm_fallback").await;
-        let resolved_jid = Jid::lid("100000000000099");
+            crate::test_utils::create_test_client_with_failing_http("retry_regid_mismatch").await;
+        let resolved_jid = Jid::lid_device("100000000000099".to_string(), 17);
         let signal_address = resolved_jid.to_protocol_address();
         let backend = client.persistence_manager.backend();
 
@@ -1610,10 +1681,84 @@ mod tests {
             .await
             .unwrap();
 
+        let node = build_retry_receipt_with_registration(0xDEAD_BEEF);
+        let node_ref = node.as_node_ref();
         client
-            .delete_dm_retry_session_target(&resolved_jid, "MSG-FALLBACK", 1)
+            .update_local_signal_session(
+                &dm_retry_info(&resolved_jid),
+                &resolved_jid,
+                "MSG-REGID",
+                1,
+                &node_ref,
+                false,
+            )
+            .await;
+        client.flush_signal_cache().await.unwrap();
+
+        // Invalid bytes remain — we didn't crash, and without a parseable
+        // session the regId comparison is a no-op.
+        assert!(
+            backend
+                .get_session(signal_address.as_str())
+                .await
+                .unwrap()
+                .is_some(),
+            "unparseable session bytes should be left alone (no panic, no delete)"
+        );
+    }
+
+    /// Verify the function is a safe no-op when there is no session at all.
+    /// This is the common case for retries from devices we haven't messaged
+    /// yet (e.g., a new companion device).
+    #[tokio::test]
+    async fn update_local_signal_session_no_session_is_noop() {
+        let client =
+            crate::test_utils::create_test_client_with_failing_http("retry_no_session").await;
+        let resolved_jid = Jid::lid_device("100000000000199".to_string(), 42);
+        let node = build_retry_receipt_without_keys();
+        let node_ref = node.as_node_ref();
+        client
+            .update_local_signal_session(
+                &dm_retry_info(&resolved_jid),
+                &resolved_jid,
+                "MSG-NOSESS",
+                1,
+                &node_ref,
+                false,
+            )
+            .await;
+    }
+
+    /// Group/status at retry #1 must not delete any session (same compliance
+    /// rule as DM). Prior to this refactor, group/status didn't invoke the
+    /// base-key path at all; now it does, but the "retry 1" short-circuit
+    /// still prevents deletion.
+    #[tokio::test]
+    async fn update_local_signal_session_preserves_group_session_at_retry_1() {
+        let client =
+            crate::test_utils::create_test_client_with_failing_http("retry_group_preserve").await;
+        let resolved_jid = Jid::lid_device("100000000000088".to_string(), 33);
+        let signal_address = resolved_jid.to_protocol_address();
+        let backend = client.persistence_manager.backend();
+
+        backend
+            .put_session(signal_address.as_str(), b"invalid-session")
             .await
             .unwrap();
+
+        let group_chat: Jid = "120363042537531116@g.us".parse().unwrap();
+        let info = RetryChatInfo {
+            chat: group_chat.clone(),
+            requester: resolved_jid.clone(),
+            original_from: group_chat,
+            is_bot: false,
+        };
+
+        let node = build_retry_receipt_without_keys();
+        let node_ref = node.as_node_ref();
+        client
+            .update_local_signal_session(&info, &resolved_jid, "MSG-GRP-1", 1, &node_ref, false)
+            .await;
         client.flush_signal_cache().await.unwrap();
 
         assert!(
@@ -1621,8 +1766,8 @@ mod tests {
                 .get_session(signal_address.as_str())
                 .await
                 .unwrap()
-                .is_none(),
-            "resolved session should be deleted when registry has no device list"
+                .is_some(),
+            "group retry at #1 should not delete the session"
         );
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1590,11 +1590,36 @@ mod tests {
         }
     }
 
+    // Produces a parseable SessionRecord so peek_session succeeds and
+    // alice_base_key/remote_registration_id return meaningful values.
+    fn valid_serialized_session(remote_regid: u32, base_key: Vec<u8>) -> Vec<u8> {
+        use wacore::libsignal::protocol::{SessionRecord, SessionState};
+        use waproto::whatsapp::SessionStructure;
+
+        let state = SessionState::from_session_structure(SessionStructure {
+            session_version: Some(3),
+            local_identity_public: None,
+            remote_identity_public: None,
+            root_key: None,
+            previous_counter: Some(0),
+            sender_chain: None,
+            receiver_chains: vec![],
+            pending_pre_key: None,
+            remote_registration_id: Some(remote_regid),
+            local_registration_id: Some(0),
+            alice_base_key: Some(base_key),
+            needs_refresh: None,
+            pending_key_exchange: None,
+        });
+        SessionRecord::new(state)
+            .serialize()
+            .expect("serialize session record")
+    }
+
     /// WA Web compliance: at retry #1 with no `<keys>`, `updateLocalSignalSession`
-    /// does NOT delete the session. Session is preserved until either a reg-ID
-    /// mismatch or a base-key collision at retry>2. Previously the Rust DM path
-    /// unconditionally deleted on every retry — this regressed legitimate
-    /// sessions and forced unnecessary prekey bundle fetches.
+    /// does NOT delete the session. Previously the Rust DM path unconditionally
+    /// deleted on every retry — this regressed legitimate sessions and forced
+    /// unnecessary prekey bundle fetches.
     /// Ref: `WAWeb/Update/LocalSignalSession.js` (no delete on retry==1)
     #[tokio::test]
     async fn update_local_signal_session_preserves_dm_session_at_retry_1() {
@@ -1607,12 +1632,17 @@ mod tests {
         let device_0 = Jid::lid_device(user.clone(), 0).to_protocol_address();
         let device_33 = Jid::lid_device(user, 33).to_protocol_address();
 
+        // Real serializable SessionRecords — peek_session must return Some(...)
+        // so the function reaches the base-key branch at retry==1 and exercises
+        // the "no delete" rule. Invalid bytes would short-circuit via .ok().flatten().
+        let session_bytes_33 = valid_serialized_session(4242, vec![0xAA; 32]);
+        let session_bytes_0 = valid_serialized_session(4243, vec![0xBB; 32]);
         backend
-            .put_session(device_0.as_str(), b"invalid-session")
+            .put_session(device_0.as_str(), &session_bytes_0)
             .await
             .unwrap();
         backend
-            .put_session(device_33.as_str(), b"invalid-session")
+            .put_session(device_33.as_str(), &session_bytes_33)
             .await
             .unwrap();
 
@@ -1636,7 +1666,7 @@ mod tests {
                 .await
                 .unwrap()
                 .is_some(),
-            "non-requesting device session should be preserved"
+            "non-requesting device session must be preserved"
         );
         assert!(
             backend
@@ -1644,24 +1674,63 @@ mod tests {
                 .await
                 .unwrap()
                 .is_some(),
-            "requesting device session should also be preserved at retry #1 — \
-             WA Web only deletes on reg-ID mismatch or base-key collision"
+            "requesting device session with valid record must be preserved at retry #1"
         );
     }
 
-    /// Mirrors the scenario from production logs (debug-1776271138): peer
-    /// sends a retry receipt without `<keys>` but with a `<registration>` child
-    /// whose reg_id differs from our stored session. WA Web deletes the session
-    /// in this case so the next ensureE2ESessions fetches a fresh bundle.
+    /// Production scenario from debug-1776271138: peer sends retry receipt
+    /// without `<keys>` but with `<registration>` whose reg_id differs from
+    /// our stored session. WA Web deletes the session (LocalSignalSession.js
+    /// L52-65) so the next ensureE2ESessions fetches a fresh bundle.
     #[tokio::test]
-    async fn update_local_signal_session_handles_regid_mismatch_gracefully() {
-        // With an invalid session record in storage, peek_session returns None
-        // (errors are swallowed via .ok().flatten()). The function should not
-        // attempt to dereference a missing session — verify it completes
-        // without panicking and leaves the invalid bytes untouched (since there
-        // is no "session" for remote_registration_id() to compare against).
+    async fn update_local_signal_session_deletes_on_regid_mismatch() {
         let client =
             crate::test_utils::create_test_client_with_failing_http("retry_regid_mismatch").await;
+        let resolved_jid = Jid::lid_device("100000000000099".to_string(), 17);
+        let signal_address = resolved_jid.to_protocol_address();
+        let backend = client.persistence_manager.backend();
+
+        let stored_regid = 4242u32;
+        let session_bytes = valid_serialized_session(stored_regid, vec![0xAA; 32]);
+        backend
+            .put_session(signal_address.as_str(), &session_bytes)
+            .await
+            .unwrap();
+
+        let received_regid = 0xDEAD_BEEFu32;
+        assert_ne!(stored_regid, received_regid);
+        let node = build_retry_receipt_with_registration(received_regid);
+        let node_ref = node.as_node_ref();
+        client
+            .update_local_signal_session(
+                &dm_retry_info(&resolved_jid),
+                &resolved_jid,
+                "MSG-REGID",
+                1,
+                &node_ref,
+                false,
+            )
+            .await;
+        client.flush_signal_cache().await.unwrap();
+
+        assert!(
+            backend
+                .get_session(signal_address.as_str())
+                .await
+                .unwrap()
+                .is_none(),
+            "session must be deleted when retry has no keys and reg IDs differ"
+        );
+    }
+
+    /// Unparseable session bytes: peek_session returns None via .ok().flatten(),
+    /// so every branch that dereferences a session is skipped. Verifies we
+    /// don't panic or re-process stale bytes when the record can't decode.
+    #[tokio::test]
+    async fn update_local_signal_session_handles_unparseable_session_gracefully() {
+        let client =
+            crate::test_utils::create_test_client_with_failing_http("retry_unparseable_session")
+                .await;
         let resolved_jid = Jid::lid_device("100000000000099".to_string(), 17);
         let signal_address = resolved_jid.to_protocol_address();
         let backend = client.persistence_manager.backend();
@@ -1685,15 +1754,13 @@ mod tests {
             .await;
         client.flush_signal_cache().await.unwrap();
 
-        // Invalid bytes remain — we didn't crash, and without a parseable
-        // session the regId comparison is a no-op.
         assert!(
             backend
                 .get_session(signal_address.as_str())
                 .await
                 .unwrap()
                 .is_some(),
-            "unparseable session bytes should be left alone (no panic, no delete)"
+            "unparseable bytes skip every branch; nothing should delete them"
         );
     }
 
@@ -1719,10 +1786,9 @@ mod tests {
             .await;
     }
 
-    /// Group/status at retry #1 must not delete any session (same compliance
-    /// rule as DM). Prior to this refactor, group/status didn't invoke the
-    /// base-key path at all; now it does, but the "retry 1" short-circuit
-    /// still prevents deletion.
+    /// Group/status at retry #1 must not delete any session. Group/status
+    /// previously skipped the base-key path entirely; now it runs but the
+    /// retry==1 short-circuit still prevents deletion.
     #[tokio::test]
     async fn update_local_signal_session_preserves_group_session_at_retry_1() {
         let client =
@@ -1731,8 +1797,9 @@ mod tests {
         let signal_address = resolved_jid.to_protocol_address();
         let backend = client.persistence_manager.backend();
 
+        let session_bytes = valid_serialized_session(9999, vec![0xCC; 32]);
         backend
-            .put_session(signal_address.as_str(), b"invalid-session")
+            .put_session(signal_address.as_str(), &session_bytes)
             .await
             .unwrap();
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -166,13 +166,20 @@ fn resolve_retry_chat_info(
     }
 }
 
-fn build_retry_dedupe_key(chat: &Jid, message_id: &str, participant_jid: &Jid) -> String {
+fn build_retry_dedupe_key(
+    chat: &Jid,
+    message_id: &str,
+    participant_jid: &Jid,
+    retry_count: u8,
+) -> String {
     let mut key = String::with_capacity(message_id.len() + 64);
     chat.push_to(&mut key);
     key.push(':');
     key.push_str(message_id);
     key.push(':');
     participant_jid.push_to(&mut key);
+    key.push(':');
+    key.push_str(itoa::Buffer::new().format(retry_count));
     key
 }
 
@@ -217,13 +224,20 @@ impl Client {
         );
         let is_group_or_status = info.chat.is_group() || info.chat.is_status_broadcast();
 
-        // Deduplicate retry receipts per requesting device.
-        // DMs can also receive retries from multiple companion devices.
-        let dedupe_key = build_retry_dedupe_key(&info.chat, &message_id, &info.requester);
+        // Deduplicate retry receipts per (participant, retry_count). The count is
+        // part of the key because WA Web's recovery for a stale session relies on
+        // driving retry_count up to 3+ so `updateLocalSignalSession`'s base-key
+        // collision branch can delete the session and force a fresh bundle fetch.
+        // A participant-only key would silence retries #2-4 and leave the sender
+        // pinned to a dead pkmsg (unacknowledged_pre_key_message referencing a
+        // prekey the peer already consumed).
+        let dedupe_key =
+            build_retry_dedupe_key(&info.chat, &message_id, &info.requester, retry_count);
 
         if self.retried_group_messages.get(&dedupe_key).await.is_some() {
             log::debug!(
-                "Ignoring duplicate retry for message {} from {}: already handled.",
+                "Ignoring duplicate retry #{} for message {} from {}: already handled.",
+                retry_count,
                 message_id,
                 info.requester
             );
@@ -2236,8 +2250,11 @@ mod tests {
         assert!(info.requester.is_status_broadcast());
     }
 
-    /// Test that retry dedupe keys are differentiated per requesting device,
-    /// including DMs where multiple companion devices can retry the same message.
+    /// Test that retry dedupe keys are differentiated per requesting device AND
+    /// per retry count. The count component is critical: WA Web-compliant recovery
+    /// from a stale session (unacknowledged pkmsg referring to a consumed prekey)
+    /// relies on driving retry_count to 3+ so the base-key collision branch can
+    /// delete the session. A participant-only key would block retries #2-4.
     #[test]
     fn retry_dedupe_key_per_participant() {
         let msg_id = "3EB06D00CAB92340790621";
@@ -2245,31 +2262,37 @@ mod tests {
         let status_chat = Jid::status_broadcast();
         let status_participant_a: Jid = "236395184570386@lid".parse().unwrap();
         let status_participant_b: Jid = "559985213786@s.whatsapp.net".parse().unwrap();
-        let status_key_a = build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a);
-        let status_key_b = build_retry_dedupe_key(&status_chat, msg_id, &status_participant_b);
+        let status_key_a = build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a, 1);
+        let status_key_b = build_retry_dedupe_key(&status_chat, msg_id, &status_participant_b, 1);
         assert_ne!(
             status_key_a, status_key_b,
             "Different status participants should have different dedupe keys"
         );
         assert_eq!(
             status_key_a,
-            build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a),
-            "Same status participant should have the same dedupe key"
+            build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a, 1),
+            "Same status participant + same retry count should have the same dedupe key"
+        );
+        assert_ne!(
+            status_key_a,
+            build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a, 2),
+            "Same participant with different retry_count must NOT dedupe — base-key \
+             collision relies on retry #2+ reaching update_local_signal_session"
         );
 
         let dm_chat = Jid::pn("559911112222");
         let dm_device_a = Jid::pn_device("559922223333", 1);
         let dm_device_b = Jid::pn_device("559922223333", 2);
-        let dm_key_a = build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_a);
-        let dm_key_b = build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_b);
+        let dm_key_a = build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_a, 1);
+        let dm_key_b = build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_b, 1);
         assert_ne!(
             dm_key_a, dm_key_b,
             "Different DM requester devices should have different dedupe keys"
         );
         assert_eq!(
             dm_key_a,
-            build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_a),
-            "Same DM requester device should have the same dedupe key"
+            build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_a, 1),
+            "Same DM requester device + same retry count should have the same dedupe key"
         );
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -166,20 +166,15 @@ fn resolve_retry_chat_info(
     }
 }
 
-fn build_retry_dedupe_key(
-    chat: &Jid,
-    message_id: &str,
-    participant_jid: &Jid,
-    retry_count: u8,
-) -> String {
+// No retry_count in the key: concurrent receipts for the same participant must
+// serialize, otherwise two update_local_signal_session calls race on session state.
+fn build_retry_processing_key(chat: &Jid, message_id: &str, participant_jid: &Jid) -> String {
     let mut key = String::with_capacity(message_id.len() + 64);
     chat.push_to(&mut key);
     key.push(':');
     key.push_str(message_id);
     key.push(':');
     participant_jid.push_to(&mut key);
-    key.push(':');
-    key.push_str(itoa::Buffer::new().format(retry_count));
     key
 }
 
@@ -224,41 +219,22 @@ impl Client {
         );
         let is_group_or_status = info.chat.is_group() || info.chat.is_status_broadcast();
 
-        // Deduplicate retry receipts per (participant, retry_count). The count is
-        // part of the key because WA Web's recovery for a stale session relies on
-        // driving retry_count up to 3+ so `updateLocalSignalSession`'s base-key
-        // collision branch can delete the session and force a fresh bundle fetch.
-        // A participant-only key would silence retries #2-4 and leave the sender
-        // pinned to a dead pkmsg (unacknowledged_pre_key_message referencing a
-        // prekey the peer already consumed).
-        let dedupe_key =
-            build_retry_dedupe_key(&info.chat, &message_id, &info.requester, retry_count);
+        // WA Web doesn't dedupe receipts (Message/Queue.js just serializes per-chat);
+        // MAX_RETRY_COUNT covers loop prevention. This lock only guards against
+        // two concurrent receipts racing on session state.
+        let processing_key = build_retry_processing_key(&info.chat, &message_id, &info.requester);
 
-        if self.retried_group_messages.get(&dedupe_key).await.is_some() {
-            log::debug!(
-                "Ignoring duplicate retry #{} for message {} from {}: already handled.",
-                retry_count,
-                message_id,
-                info.requester
-            );
-            return Ok(());
-        }
-        self.retried_group_messages
-            .insert(dedupe_key.clone(), ())
-            .await;
-
-        // Prevent concurrent retries for the same message+participant.
         if !self
             .pending_retries
             .lock()
             .unwrap_or_else(|p| p.into_inner())
-            .insert(dedupe_key.clone())
+            .insert(processing_key.clone())
         {
-            log::debug!("Ignoring retry for {dedupe_key}: a retry is already in progress.");
+            log::debug!("Ignoring retry for {processing_key}: a retry is already in progress.");
             return Ok(());
         }
         let pending = Arc::clone(&self.pending_retries);
-        let guard_key = dedupe_key.clone();
+        let guard_key = processing_key.clone();
         let _guard = scopeguard::guard((), move |()| {
             pending
                 .lock()
@@ -2250,49 +2226,41 @@ mod tests {
         assert!(info.requester.is_status_broadcast());
     }
 
-    /// Test that retry dedupe keys are differentiated per requesting device AND
-    /// per retry count. The count component is critical: WA Web-compliant recovery
-    /// from a stale session (unacknowledged pkmsg referring to a consumed prekey)
-    /// relies on driving retry_count to 3+ so the base-key collision branch can
-    /// delete the session. A participant-only key would block retries #2-4.
+    // Different participants get different keys; same participant keeps the same
+    // key across retry counts so pending_retries serializes concurrent receipts.
     #[test]
-    fn retry_dedupe_key_per_participant() {
+    fn retry_processing_key_per_participant() {
         let msg_id = "3EB06D00CAB92340790621";
 
         let status_chat = Jid::status_broadcast();
         let status_participant_a: Jid = "236395184570386@lid".parse().unwrap();
         let status_participant_b: Jid = "559985213786@s.whatsapp.net".parse().unwrap();
-        let status_key_a = build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a, 1);
-        let status_key_b = build_retry_dedupe_key(&status_chat, msg_id, &status_participant_b, 1);
+        let status_key_a = build_retry_processing_key(&status_chat, msg_id, &status_participant_a);
+        let status_key_b = build_retry_processing_key(&status_chat, msg_id, &status_participant_b);
         assert_ne!(
             status_key_a, status_key_b,
-            "Different status participants should have different dedupe keys"
+            "Different status participants must have different processing keys"
         );
         assert_eq!(
             status_key_a,
-            build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a, 1),
-            "Same status participant + same retry count should have the same dedupe key"
-        );
-        assert_ne!(
-            status_key_a,
-            build_retry_dedupe_key(&status_chat, msg_id, &status_participant_a, 2),
-            "Same participant with different retry_count must NOT dedupe — base-key \
-             collision relies on retry #2+ reaching update_local_signal_session"
+            build_retry_processing_key(&status_chat, msg_id, &status_participant_a),
+            "Same participant must produce the same key — any retry count for that \
+             participant serializes through pending_retries"
         );
 
         let dm_chat = Jid::pn("559911112222");
         let dm_device_a = Jid::pn_device("559922223333", 1);
         let dm_device_b = Jid::pn_device("559922223333", 2);
-        let dm_key_a = build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_a, 1);
-        let dm_key_b = build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_b, 1);
+        let dm_key_a = build_retry_processing_key(&dm_chat, msg_id, &dm_device_a);
+        let dm_key_b = build_retry_processing_key(&dm_chat, msg_id, &dm_device_b);
         assert_ne!(
             dm_key_a, dm_key_b,
-            "Different DM requester devices should have different dedupe keys"
+            "Different DM requester devices must have different processing keys"
         );
         assert_eq!(
             dm_key_a,
-            build_retry_dedupe_key(&dm_chat, msg_id, &dm_device_a, 1),
-            "Same DM requester device + same retry count should have the same dedupe key"
+            build_retry_processing_key(&dm_chat, msg_id, &dm_device_a),
+            "Same DM requester device must produce the same processing key"
         );
     }
 

--- a/wacore/libsignal/src/protocol/group_cipher.rs
+++ b/wacore/libsignal/src/protocol/group_cipher.rs
@@ -182,7 +182,11 @@ pub async fn group_decrypt(
     let sender_key_state = match record.sender_key_state_for_chain_id(chain_id) {
         Some(state) => state,
         None => {
-            log::error!(
+            // Expected when the sender rotated their key (WA Web: rotateKey=true),
+            // re-registered, or when we missed the SKDM for this chain. Caller
+            // handles the typed error by triggering a retry receipt; WA Web
+            // emits `SenderKeyExpired` telemetry instead of an error log.
+            log::debug!(
                 "SenderKey could not find chain ID {} (known chain IDs: {:?})",
                 chain_id,
                 record.chain_ids_for_logging().collect::<Vec<_>>(),
@@ -336,6 +340,81 @@ pub async fn create_sender_key_distribution_message<R: Rng + CryptoRng>(
                 .store_sender_key(sender_key_name, record)
                 .await?;
             Ok(skdm)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::IdentityKeyPair;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+
+    struct InMemorySenderKeyStore {
+        keys: HashMap<SenderKeyName, SenderKeyRecord>,
+    }
+
+    #[async_trait]
+    impl SenderKeyStore for InMemorySenderKeyStore {
+        async fn store_sender_key(
+            &mut self,
+            name: &SenderKeyName,
+            record: SenderKeyRecord,
+        ) -> Result<()> {
+            self.keys.insert(name.clone(), record);
+            Ok(())
+        }
+
+        async fn load_sender_key(&self, name: &SenderKeyName) -> Result<Option<SenderKeyRecord>> {
+            Ok(self.keys.get(name).cloned())
+        }
+    }
+
+    /// Unknown chain IDs must return `NoSenderKeyState` (typed error) so the
+    /// caller can trigger a retry receipt. The log at this site is `debug!` —
+    /// WA Web treats this as expected (emits `SenderKeyExpired` WAM event, not
+    /// an error).
+    #[test]
+    fn unknown_chain_id_returns_no_sender_key_state() {
+        let mut rng = rand::rng();
+        let name = SenderKeyName::new("group@g.us".to_string(), "alice.0".to_string());
+
+        let mut alice_store = InMemorySenderKeyStore {
+            keys: HashMap::new(),
+        };
+
+        let skdm = futures::executor::block_on(create_sender_key_distribution_message(
+            &name,
+            &mut alice_store,
+            &mut rng,
+        ))
+        .expect("create skdm");
+
+        // Different chain ID — not in the record.
+        let unknown_chain_id = skdm.chain_id().wrapping_add(1);
+        let signing_key = IdentityKeyPair::generate(&mut rng);
+        let skm = SenderKeyMessage::new(
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+            unknown_chain_id,
+            0,
+            vec![0u8; 32].into_boxed_slice(),
+            &mut rng,
+            signing_key.private_key(),
+        )
+        .expect("build skm");
+
+        let result =
+            futures::executor::block_on(group_decrypt(skm.serialized(), &mut alice_store, &name));
+
+        match result {
+            Err(SignalProtocolError::NoSenderKeyState(msg)) => {
+                assert!(
+                    msg.contains(&unknown_chain_id.to_string()),
+                    "error message should reference the unknown chain id: {msg}"
+                );
+            }
+            other => panic!("expected NoSenderKeyState, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Aligns the retry receipt handler with WhatsApp Web's `WAWebUpdateLocalSignalSession` + `ensureE2ESessions` flow (`docs/captured-js/WAWeb/Update/LocalSignalSession.js`, `WAWeb/Handle/RetryRequest.js:199-200`).

### 1. `libsignal: demote NoSenderKeyState log from ERROR to DEBUG`
Unknown chain IDs are normal (sender key rotation, re-registration, out-of-order SKDM). The caller already converts the typed error into a retry receipt and logs at debug level with richer context. WA Web uses the `SenderKeyExpired` WAM event instead of error-level logging. Eliminates double-logging and false alerts in production observability tools.

### 2. `retry: ensure E2E sessions before group/status resend`
Fixes a concrete bug observed in production logs (debug-1776271138): when a retry receipt triggered reg-ID-mismatch session deletion or arrived from a newly-added device, `prepare_group_retry_stanza` failed with `session not found` and the duplicate-handler filter silenced all subsequent retries, permanently losing the message for that device. WA Web calls `ensureE2ESessions([g])` for all chat types (RetryRequest.js:200); the DM branch already did, the group/status branch didn't. Now it does.

### 3. `retry: mirror updateLocalSignalSession fully for all chat types`
Replaces the DM-only `delete_dm_retry_session_target` + inline processKeyBundle with a single helper mirroring WA Web semantics for DM/group/status:
- `markForgetSenderKey` for group/status
- `processKeyBundle` for all chats (was gated behind `!is_status_broadcast()`)
- reg-ID-mismatch delete for all chats (was DM-only)
- retry==2 saves base key, does NOT delete
- retry>2 with same base key deletes
- retry==1 / retry>2 with different base key: session preserved

**Behavioral delta:** DM retry #1 no longer destroys healthy sessions unconditionally. Group/status now benefit from base-key collision detection.

### 4. `retry: remove retried_group_messages dedupe to match WA Web`
WA Web has no dedupe layer for retry receipts. `WAWeb/Message/Queue.js` (`onMessageQueue`) uses a `PromiseQueueMap` that serializes per-chat but lets every receipt through. Loop prevention is covered by `MAX_RETRY_COUNT` (== WA Web's `MAX_RETRY = 5`), and `pending_retries` guards against concurrent races on session state. The extra dedupe layer was silently dropping retries #2+, which broke the WA Web-compliant recovery path that relies on driving retry_count to 3+ to trigger base-key collision. Removed the cache field, config, and stats; replaced `build_retry_dedupe_key` with `build_retry_processing_key` used only for `pending_retries`.

### 5. `retry: harden update_local_signal_session tests with real SessionRecords`
Follow-up to review feedback. The original tests seeded backend sessions with `b"invalid-session"`, which `peek_session` swallowed via `.ok().flatten()`. Every session-touching branch was skipped, so the tests verified the function didn't panic but did NOT verify the "retry #1 preserves a valid session" rule the names promised. Added a helper that builds and serializes a real `SessionRecord` via `SessionState::from_session_structure`, so the asserted branches actually run. Renamed `handles_regid_mismatch_gracefully` to `deletes_on_regid_mismatch` and made it verify the real delete branch; added `handles_unparseable_session_gracefully` to preserve coverage of the garbage-bytes short-circuit.

## WA Web references

- `WAWeb/Update/LocalSignalSession.js` — session management flow mirrored in commit 3
- `WAWeb/Handle/RetryRequest.js:199-200` — `updateLocalSignalSession` + `ensureE2ESessions([g])` for every chat type (commit 2)
- `WAWeb/Message/Queue.js` — per-chat serialization without dedupe (commit 4)
- `WAWeb/Sender/KeyExpiredWamEvent.js` — telemetry-only path for unknown chain IDs (commit 1 rationale)

## Test plan
- [x] `cargo clippy --all --tests` clean on every commit
- [x] `cargo test --workspace --exclude e2e-tests` — all suites pass
- [x] `cargo test -p e2e-tests --test retry_dm_multidevice` — passes locally with mock server
- [x] Unit tests (per commit):
  - `unknown_chain_id_returns_no_sender_key_state` — typed error path guard
  - `ensure_e2e_sessions_resolved_is_noop_when_session_exists` — regression guard against accidental network calls
  - `update_local_signal_session_preserves_dm_session_at_retry_1` — real SessionRecord; verifies no-delete at retry #1
  - `update_local_signal_session_preserves_group_session_at_retry_1` — same rule for group/status
  - `update_local_signal_session_deletes_on_regid_mismatch` — real SessionRecord; verifies the WA Web delete branch fires
  - `update_local_signal_session_handles_unparseable_session_gracefully` — garbage-bytes short-circuit
  - `update_local_signal_session_no_session_is_noop` — fast path for never-messaged devices
  - `retry_processing_key_per_participant` — serializes same-participant retries, different participants don't block each other

## Notes
- Two previous DM tests (`dm_retry_deletes_only_requested_session`, `dm_retry_deletes_resolved_session_without_registry_devices`) validated the old unconditional-delete behavior and were replaced with compliance-preserving equivalents in commit 3.
- Status broadcast retry short-circuit (no resend) preserved — WA Web does resend status, but requires audience reconstruction the Rust client doesn't maintain yet.
- Pre-existing gaps intentionally out of scope:
  - `processKeyBundle`'s `isOffline` flag is not plumbed through the Rust side
  - Peer-device reg-ID mismatch: WA Web throws to abort `updateLocalSignalSession` entirely; Rust throws but the outer flow still runs the reg-ID-mismatch delete branch