### PR TITLE
Graceful shutdown for detached tasks (fixes WASM setTimeout leaks)

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -147,8 +147,6 @@ pub struct Bot {
     sync_task_receiver: Option<async_channel::Receiver<crate::sync_task::MajorSyncTask>>,
     event_handler: Option<EventHandlerCallback>,
     pair_code_options: Option<PairCodeOptions>,
-    /// Held for its Drop: aborts the saver task when the Bot is dropped.
-    _saver_handle: wacore::runtime::AbortHandle,
 }
 
 impl std::fmt::Debug for Bot {
@@ -692,6 +690,10 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             std::time::Duration::from_secs(30),
             client.shutdown_signal(),
         );
+        // Tie the saver task to Arc<Client> so extracting client() and outliving
+        // Bot keeps periodic persistence alive. Client::drop on the last Arc
+        // drops the AbortHandle and aborts the task.
+        let _ = client.saver_handle.set(saver_handle);
 
         // Register custom enc handlers
         for (enc_type, handler) in self.custom_enc_handlers {
@@ -711,7 +713,6 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             sync_task_receiver: Some(sync_task_receiver),
             event_handler: self.event_handler,
             pair_code_options: self.pair_code_options,
-            _saver_handle: saver_handle,
         })
     }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -147,6 +147,8 @@ pub struct Bot {
     sync_task_receiver: Option<async_channel::Receiver<crate::sync_task::MajorSyncTask>>,
     event_handler: Option<EventHandlerCallback>,
     pair_code_options: Option<PairCodeOptions>,
+    /// Held for its Drop: aborts the saver task when the Bot is dropped.
+    _saver_handle: wacore::runtime::AbortHandle,
 }
 
 impl std::fmt::Debug for Bot {
@@ -652,10 +654,6 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
                 .map_err(|e| anyhow::anyhow!("Failed to create persistence manager: {}", e))?,
         );
 
-        persistence_manager
-            .clone()
-            .run_background_saver(runtime.clone(), std::time::Duration::from_secs(30));
-
         // Apply initial push name if specified (for deterministic mock server phone assignment)
         if let Some(name) = self.initial_push_name {
             persistence_manager
@@ -680,7 +678,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
 
         info!("Creating client...");
         let (client, sync_task_receiver) = Client::new_with_cache_config(
-            runtime,
+            runtime.clone(),
             persistence_manager.clone(),
             transport_factory,
             http_client,
@@ -688,6 +686,12 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             self.cache_config,
         )
         .await;
+
+        let saver_handle = persistence_manager.run_background_saver(
+            runtime,
+            std::time::Duration::from_secs(30),
+            client.shutdown_signal(),
+        );
 
         // Register custom enc handlers
         for (enc_type, handler) in self.custom_enc_handlers {
@@ -707,6 +711,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             sync_task_receiver: Some(sync_task_receiver),
             event_handler: self.event_handler,
             pair_code_options: self.pair_code_options,
+            _saver_handle: saver_handle,
         })
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -484,9 +484,8 @@ pub struct Client {
 }
 
 impl Client {
-    /// `Weak` ref so subscribers don't extend the notifier's lifetime.
-    pub fn shutdown_signal(&self) -> std::sync::Weak<event_listener::Event> {
-        Arc::downgrade(&self.shutdown_notifier)
+    pub fn shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
+        wacore::runtime::ShutdownSignal::from_weak(Arc::downgrade(&self.shutdown_notifier))
     }
 
     /// Read the current semaphore generation and Arc atomically under the mutex.

--- a/src/client.rs
+++ b/src/client.rs
@@ -304,7 +304,16 @@ pub struct Client {
     /// Uses an AtomicBool instead of probing the noise_socket mutex to avoid
     /// TOCTOU races where `try_lock()` fails due to contention, not disconnection.
     is_connected: Arc<AtomicBool>,
+    /// Terminal shutdown (process-wide). Fired ONLY by `disconnect()`.
+    /// Long-lived subscribers that must outlive reconnect cycles (saver,
+    /// device registry cleanup) subscribe here.
     pub(crate) shutdown_notifier: wacore::runtime::ShutdownNotifier,
+
+    /// Per-connection shutdown. Replaced with a fresh notifier on every new
+    /// connection; fired on cleanup_connection_state / stream end / stream
+    /// error / connect_failure / disconnect. Per-connection subscribers
+    /// (keepalive, request waiters, read loop, offline flush) observe this.
+    pub(crate) connection_shutdown: std::sync::Mutex<wacore::runtime::ShutdownNotifier>,
     /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
     /// Updated on every `DataReceived` transport event.
     /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
@@ -494,6 +503,33 @@ impl Client {
         self.shutdown_notifier.subscribe()
     }
 
+    pub(crate) fn connection_shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
+        self.connection_shutdown
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .subscribe()
+    }
+
+    /// Fire the per-connection shutdown. Per-connection subscribers exit;
+    /// the terminal shutdown_notifier is untouched so reconnects still work.
+    pub(crate) fn notify_connection_shutdown(&self) {
+        self.connection_shutdown
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .notify();
+    }
+
+    /// Reset the per-connection notifier. Call at the start of each new
+    /// connection so subscribers registered afterwards see a fresh signal.
+    /// The previous notifier's subscribers have already been woken (either
+    /// by notify on disconnect, or by falling out of scope).
+    pub(crate) fn reset_connection_shutdown(&self) {
+        *self
+            .connection_shutdown
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = wacore::runtime::ShutdownNotifier::new();
+    }
+
     /// Read the current semaphore generation and Arc atomically under the mutex.
     pub(crate) fn read_message_semaphore(&self) -> (u64, Arc<async_lock::Semaphore>) {
         let guard = match self.message_processing_semaphore.lock() {
@@ -645,6 +681,7 @@ impl Client {
             is_running: Arc::new(AtomicBool::new(false)),
             is_connected: Arc::new(AtomicBool::new(false)),
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
+            connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
             last_data_received_ms: Arc::new(AtomicU64::new(0)),
             last_data_sent_ms: Arc::new(AtomicU64::new(0)),
 
@@ -1121,6 +1158,11 @@ impl Client {
             }
         };
 
+        // Fresh per-connection shutdown so subscribers registered during this
+        // connection see a clean signal; the previous notifier was already
+        // fired on the prior cleanup_connection_state.
+        self.reset_connection_shutdown();
+
         *self.transport.lock().await = Some(transport);
         *self.transport_events.lock().await = Some(transport_events);
         *self.noise_socket.lock().await = Some(noise_socket);
@@ -1232,10 +1274,11 @@ impl Client {
         self.clear_sent_node_waiters();
         self.is_logged_in.store(false, Ordering::Relaxed);
         self.is_ready.store(false, Ordering::Relaxed);
-        // Signal the keepalive loop (and any other tasks) to exit promptly.
-        // Without this, a stale keepalive loop can overlap with the next one
-        // after reconnect, causing duplicate pings.
-        self.shutdown_notifier.notify();
+        // Signal the keepalive loop (and any other per-connection tasks) to
+        // exit promptly. Without this, a stale keepalive loop can overlap
+        // with the next one after reconnect. Uses the PER-CONNECTION signal
+        // so the terminal shutdown_notifier stays clean for reconnects.
+        self.notify_connection_shutdown();
         *self.transport.lock().await = None;
         *self.transport_events.lock().await = None;
         *self.noise_socket.lock().await = None;
@@ -1387,10 +1430,11 @@ impl Client {
 
         // Frame decoder to parse incoming data
         let mut frame_decoder = wacore::framing::FrameDecoder::new();
+        let shutdown = self.connection_shutdown_signal();
 
         loop {
             futures::select_biased! {
-                    _ = self.shutdown_notifier.listen().fuse() => {
+                    _ = wacore::runtime::wait_for_shutdown(&shutdown).fuse() => {
                         debug!("Shutdown signaled in message loop. Exiting message loop.");
                         return Ok(());
                     },
@@ -1650,7 +1694,7 @@ impl Client {
             } else {
                 warn!("Received <xmlstreamend/>, treating as disconnect.");
             }
-            self.shutdown_notifier.notify();
+            self.notify_connection_shutdown();
             return;
         }
 
@@ -3124,13 +3168,13 @@ impl Client {
             }
         }
 
-        info!("Notifying shutdown from stream error handler");
-        self.shutdown_notifier.notify();
+        info!("Notifying connection shutdown from stream error handler");
+        self.notify_connection_shutdown();
     }
 
     pub(crate) async fn handle_connect_failure(&self, node: &wacore_binary::NodeRef<'_>) {
         self.expected_disconnect.store(true, Ordering::Relaxed);
-        self.shutdown_notifier.notify();
+        self.notify_connection_shutdown();
 
         let mut attrs = node.attrs();
         let reason_code = attrs.optional_u64("reason").unwrap_or(0) as i32;
@@ -5836,6 +5880,62 @@ mod tests {
         assert!(
             result.is_ok(),
             "send_ack_for should return Ok during expected disconnect"
+        );
+    }
+
+    // Per-connection notify must NOT set the terminal sticky flag; if it did,
+    // every reconnect would instantly abort subscribers registered on the
+    // terminal signal. Regression guard for the CI breakage observed on PR #560.
+    #[tokio::test]
+    async fn per_connection_notify_leaves_terminal_signal_untouched() {
+        let client = crate::test_utils::create_test_client().await;
+
+        client.notify_connection_shutdown();
+
+        assert!(
+            !client.shutdown_signal().is_fired(),
+            "terminal shutdown must stay clean when only per-connection fires"
+        );
+    }
+
+    // Subscribers registered AFTER a reset must not see the previous
+    // notifier's fired state. This is the core property that makes reconnect
+    // work: after cleanup_connection_state notifies the per-connection
+    // signal, the next connection replaces it with a fresh one.
+    #[tokio::test]
+    async fn reset_gives_fresh_per_connection_notifier() {
+        let client = crate::test_utils::create_test_client().await;
+
+        client.notify_connection_shutdown();
+        assert!(
+            client.connection_shutdown_signal().is_fired(),
+            "subscriber BEFORE reset sees the notify on the current notifier"
+        );
+
+        client.reset_connection_shutdown();
+
+        assert!(
+            !client.connection_shutdown_signal().is_fired(),
+            "subscribers AFTER reset must NOT see the previous notifier's state"
+        );
+    }
+
+    // Terminal disconnect() must also wake per-connection subscribers via
+    // cleanup_connection_state, so keepalive/request/read loop exit promptly.
+    #[tokio::test]
+    async fn terminal_disconnect_propagates_to_per_connection_signal() {
+        let client = crate::test_utils::create_test_client().await;
+        let conn_signal = client.connection_shutdown_signal();
+
+        client.disconnect().await;
+
+        assert!(
+            conn_signal.is_fired(),
+            "disconnect must fire per-connection via cleanup_connection_state"
+        );
+        assert!(
+            client.shutdown_signal().is_fired(),
+            "disconnect must also fire terminal"
         );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -478,6 +478,12 @@ pub struct Client {
     /// Initialized after `Arc::new(this)` in the constructor.
     pub(crate) self_weak: std::sync::OnceLock<std::sync::Weak<Client>>,
 
+    /// Holds the background saver's AbortHandle so the task lifetime follows
+    /// `Arc<Client>` ref count instead of the Bot wrapper's. Set once by
+    /// `Bot::build`; on Client drop (last Arc), the handle drops and the saver
+    /// is aborted.
+    pub(crate) saver_handle: std::sync::OnceLock<wacore::runtime::AbortHandle>,
+
     /// When true, emit `Event::RawNode` for every decoded stanza before router dispatch.
     /// Default false — only enable when external consumers need raw protocol access.
     raw_node_forwarding: AtomicBool,
@@ -736,6 +742,7 @@ impl Client {
             skip_history_sync: AtomicBool::new(false),
             cache_config,
             self_weak: std::sync::OnceLock::new(),
+            saver_handle: std::sync::OnceLock::new(),
             raw_node_forwarding: AtomicBool::new(false),
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -5920,6 +5920,26 @@ mod tests {
         );
     }
 
+    // Capture-once regression guard: a ShutdownSignal captured before a reset
+    // must keep observing the pre-reset fired state. Without this, a
+    // reconnect after the old notifier is replaced in the Mutex would
+    // strand long-lived tasks (e.g. keepalive) on a new notifier they
+    // never registered for. See keepalive_loop which captures its signal
+    // once at task startup.
+    #[tokio::test]
+    async fn captured_signal_keeps_observing_old_notifier_after_reset() {
+        let client = crate::test_utils::create_test_client().await;
+
+        let captured = client.connection_shutdown_signal();
+        client.notify_connection_shutdown();
+        client.reset_connection_shutdown();
+
+        assert!(
+            captured.is_fired(),
+            "captured signal must retain the pre-reset notifier's fired state"
+        );
+    }
+
     // Terminal disconnect() must also wake per-connection subscribers via
     // cleanup_connection_state, so keepalive/request/read loop exit promptly.
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -304,7 +304,7 @@ pub struct Client {
     /// Uses an AtomicBool instead of probing the noise_socket mutex to avoid
     /// TOCTOU races where `try_lock()` fails due to contention, not disconnection.
     is_connected: Arc<AtomicBool>,
-    pub(crate) shutdown_notifier: Arc<event_listener::Event>,
+    pub(crate) shutdown_notifier: wacore::runtime::ShutdownNotifier,
     /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
     /// Updated on every `DataReceived` transport event.
     /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
@@ -491,7 +491,7 @@ pub struct Client {
 
 impl Client {
     pub fn shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
-        wacore::runtime::ShutdownSignal::from_weak(Arc::downgrade(&self.shutdown_notifier))
+        self.shutdown_notifier.subscribe()
     }
 
     /// Read the current semaphore generation and Arc atomically under the mutex.
@@ -644,7 +644,7 @@ impl Client {
             is_connecting: Arc::new(AtomicBool::new(false)),
             is_running: Arc::new(AtomicBool::new(false)),
             is_connected: Arc::new(AtomicBool::new(false)),
-            shutdown_notifier: Arc::new(event_listener::Event::new()),
+            shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             last_data_received_ms: Arc::new(AtomicU64::new(0)),
             last_data_sent_ms: Arc::new(AtomicU64::new(0)),
 
@@ -1167,7 +1167,7 @@ impl Client {
         info!("Disconnecting client intentionally.");
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
-        self.shutdown_notifier.notify(usize::MAX);
+        self.shutdown_notifier.notify();
 
         // Flush dirty device state before tearing down the connection.
         if let Err(e) = self.persistence_manager.flush().await {
@@ -1235,7 +1235,7 @@ impl Client {
         // Signal the keepalive loop (and any other tasks) to exit promptly.
         // Without this, a stale keepalive loop can overlap with the next one
         // after reconnect, causing duplicate pings.
-        self.shutdown_notifier.notify(usize::MAX);
+        self.shutdown_notifier.notify();
         *self.transport.lock().await = None;
         *self.transport_events.lock().await = None;
         *self.noise_socket.lock().await = None;
@@ -1650,7 +1650,7 @@ impl Client {
             } else {
                 warn!("Received <xmlstreamend/>, treating as disconnect.");
             }
-            self.shutdown_notifier.notify(usize::MAX);
+            self.shutdown_notifier.notify();
             return;
         }
 
@@ -3125,12 +3125,12 @@ impl Client {
         }
 
         info!("Notifying shutdown from stream error handler");
-        self.shutdown_notifier.notify(usize::MAX);
+        self.shutdown_notifier.notify();
     }
 
     pub(crate) async fn handle_connect_failure(&self, node: &wacore_binary::NodeRef<'_>) {
         self.expected_disconnect.store(true, Ordering::Relaxed);
-        self.shutdown_notifier.notify(usize::MAX);
+        self.shutdown_notifier.notify();
 
         let mut attrs = node.attrs();
         let reason_code = attrs.optional_u64("reason").unwrap_or(0) as i32;

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -166,6 +166,8 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
 
                 let client_clone = Arc::clone(&client);
                 let shutdown = client_clone.shutdown_signal();
+                // A shutdown notify fired between spawn and wait_for_shutdown's
+                // internal listen() is missed, but the 2s sleep bounds the stall.
                 client
                     .runtime
                     .spawn(Box::pin(async move {

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -165,8 +165,9 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                 client.complete_offline_sync(count);
 
                 let client_clone = Arc::clone(&client);
-                // Per-connection: the offline flush is tied to THIS connection's
-                // sync. A reconnect starts a new flush; the old task should exit.
+                // Per-connection: the offline flush is tied to THIS connection.
+                // A reconnect fires the per-connection signal; the old task exits
+                // and the new connection spawns a fresh flush.
                 let shutdown = client_clone.connection_shutdown_signal();
                 client
                     .runtime

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -2,6 +2,7 @@ use super::traits::StanzaHandler;
 use crate::client::Client;
 use crate::types::events::{Event, OfflineSyncPreview};
 use async_trait::async_trait;
+use futures::FutureExt;
 use log::{debug, info, warn};
 use std::sync::Arc;
 use wacore::appstate::patch_decode::WAPatchName;
@@ -168,11 +169,18 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                     .runtime
                     .spawn(Box::pin(async move {
                         // WA Web: OFFLINE_DEVICE_SYNC_DELAY = 2000ms
-                        client_clone
-                            .runtime
-                            .sleep(std::time::Duration::from_secs(2))
-                            .await;
-                        client_clone.flush_pending_device_sync().await;
+                        let shutdown = client_clone.shutdown_signal().upgrade().map(|e| e.listen());
+                        futures::select! {
+                            _ = client_clone.runtime.sleep(std::time::Duration::from_secs(2)).fuse() => {
+                                client_clone.flush_pending_device_sync().await;
+                            }
+                            _ = async {
+                                match shutdown {
+                                    Some(l) => l.await,
+                                    None => std::future::pending::<()>().await,
+                                }
+                            }.fuse() => {}
+                        }
                     }))
                     .detach();
             }

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -165,9 +165,9 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                 client.complete_offline_sync(count);
 
                 let client_clone = Arc::clone(&client);
-                let shutdown = client_clone.shutdown_signal();
-                // A shutdown notify fired between spawn and wait_for_shutdown's
-                // internal listen() is missed, but the 2s sleep bounds the stall.
+                // Per-connection: the offline flush is tied to THIS connection's
+                // sync. A reconnect starts a new flush; the old task should exit.
+                let shutdown = client_clone.connection_shutdown_signal();
                 client
                     .runtime
                     .spawn(Box::pin(async move {

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -165,21 +165,16 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                 client.complete_offline_sync(count);
 
                 let client_clone = Arc::clone(&client);
+                let shutdown = client_clone.shutdown_signal();
                 client
                     .runtime
                     .spawn(Box::pin(async move {
                         // WA Web: OFFLINE_DEVICE_SYNC_DELAY = 2000ms
-                        let shutdown = client_clone.shutdown_signal().upgrade().map(|e| e.listen());
                         futures::select! {
                             _ = client_clone.runtime.sleep(std::time::Duration::from_secs(2)).fuse() => {
                                 client_clone.flush_pending_device_sync().await;
                             }
-                            _ = async {
-                                match shutdown {
-                                    Some(l) => l.await,
-                                    None => std::future::pending::<()>().await,
-                                }
-                            }.fuse() => {}
+                            _ = wacore::runtime::wait_for_shutdown(&shutdown).fuse() => {}
                         }
                     }))
                     .detach();

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -91,12 +91,15 @@ impl Client {
         let mut error_count = 0u32;
         let mut cleanup_counter = 0u32;
         let sent_msg_ttl = self.cache_config.sent_message_ttl_secs;
+        // Capture the per-connection signal once — re-subscribing each iteration
+        // would let a racing reset_connection_shutdown swap the underlying
+        // notifier mid-loop and strand this task on the next connection's signal.
+        let shutdown_signal = self.connection_shutdown_signal();
 
         loop {
-            // Register the shutdown listener BEFORE calculating the sleep
-            // duration so we never miss a notification between loop iterations.
-            // Uses per-connection shutdown so a reconnect gets a fresh keepalive.
-            let shutdown = wacore::runtime::wait_for_shutdown(&self.connection_shutdown_signal());
+            // Fresh listener each iteration (event_listener is edge-triggered);
+            // the Weak underneath stays pinned to this connection's notifier.
+            let shutdown = wacore::runtime::wait_for_shutdown(&shutdown_signal);
 
             let interval_ms = rand::make_rng::<rand::rngs::StdRng>().random_range(
                 KEEP_ALIVE_INTERVAL_MIN.as_millis()..=KEEP_ALIVE_INTERVAL_MAX.as_millis(),

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -95,7 +95,8 @@ impl Client {
         loop {
             // Register the shutdown listener BEFORE calculating the sleep
             // duration so we never miss a notification between loop iterations.
-            let shutdown = self.shutdown_notifier.listen();
+            // Uses per-connection shutdown so a reconnect gets a fresh keepalive.
+            let shutdown = wacore::runtime::wait_for_shutdown(&self.connection_shutdown_signal());
 
             let interval_ms = rand::make_rng::<rand::rngs::StdRng>().random_range(
                 KEEP_ALIVE_INTERVAL_MIN.as_millis()..=KEEP_ALIVE_INTERVAL_MAX.as_millis(),

--- a/src/request.rs
+++ b/src/request.rs
@@ -213,7 +213,9 @@ impl Client {
             .await
             .insert(req_id.clone(), tx);
 
-        let shutdown = self.shutdown_notifier.listen();
+        // Per-connection: pending IQ requests are bound to the current socket;
+        // a reconnect aborts them (sender retries on the new connection).
+        let shutdown = wacore::runtime::wait_for_shutdown(&self.connection_shutdown_signal());
 
         if !self.is_running.load(Ordering::Acquire) {
             self.response_waiters.lock().await.remove(&req_id);

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -136,12 +136,15 @@ impl PersistenceManager {
         }
     }
 
-    /// Self-terminates on `shutdown.notify(...)` after a final flush.
-    /// Caller must keep the returned `AbortHandle` — dropping it aborts the task.
+    /// Spawn the background saver. The task wakes on `save_notify`, the
+    /// interval tick, or the `shutdown` signal; runs `save_to_disk` after
+    /// each wake (no-op when the dirty flag is clear); and performs a final
+    /// flush before exiting on shutdown.
     ///
-    /// A notify that fires between `spawn` and the first `listen()` inside the
-    /// loop is missed. The worst-case recovery is one interval tick (plus the
-    /// `AbortHandle` drop path) so no state is lost.
+    /// Caller must keep the returned [`AbortHandle`] — dropping it aborts
+    /// the task. [`ShutdownSignal`] is sticky (see [`ShutdownNotifier`]):
+    /// a notify that races the task's first [`listen()`](event_listener::Event::listen)
+    /// is observed via the flag on the first iteration, so no data is stranded.
     pub fn run_background_saver(
         self: Arc<Self>,
         runtime: Arc<dyn Runtime>,
@@ -157,11 +160,10 @@ impl PersistenceManager {
         runtime.spawn(Box::pin(async move {
             let mut consecutive_failures: u32 = 0;
 
-            // Flush any state dirtied during construction before the first wait.
-            // The saver is started after Client::new_with_cache_config in bot.rs,
-            // so save_notify fires from SetDeviceProps etc. happen before the first
-            // listener is registered and would otherwise be missed until the next
-            // interval tick.
+            // Flush any state dirtied during construction. save_notify is
+            // edge-triggered and fires from SetDeviceProps etc. before Bot::build
+            // spawns this task, so the dirty flag is our sticky catch for
+            // pre-spawn writes.
             if let Some(this) = weak.upgrade()
                 && let Err(e) = this.save_to_disk().await
             {

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -336,4 +336,46 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
         drop(handle); // aborts the task
     }
+
+    // Regression guard for the Client-lifetime-tie fix: storing the saver's
+    // AbortHandle inside a struct held by Arc means the handle survives Arc
+    // clones and only runs abort when the LAST strong ref drops. If the
+    // handle were held by Bot alone, extracting Arc<Client> and dropping
+    // Bot would leave the Client without periodic persistence.
+    //
+    // Tested at the primitive level (Arc<T> + OnceLock<AbortHandle>) because
+    // Client's internal detached tasks hold their own strong refs and would
+    // keep Client alive regardless. Rust's Drop semantics guarantee the
+    // chain Arc::drop -> T::drop -> OnceLock::drop -> AbortHandle::drop.
+    #[tokio::test]
+    async fn abort_handle_in_arc_drops_only_when_last_ref_released() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct Owner(std::sync::OnceLock<AbortHandle>);
+
+        let owner = Arc::new(Owner(std::sync::OnceLock::new()));
+
+        let aborted = Arc::new(AtomicBool::new(false));
+        let aborted_clone = Arc::clone(&aborted);
+        owner
+            .0
+            .set(AbortHandle::new(move || {
+                aborted_clone.store(true, Ordering::SeqCst);
+            }))
+            .ok()
+            .expect("first set");
+
+        let owner_clone = Arc::clone(&owner);
+        drop(owner);
+        assert!(
+            !aborted.load(Ordering::SeqCst),
+            "handle must survive while another Arc ref is held"
+        );
+
+        drop(owner_clone);
+        assert!(
+            aborted.load(Ordering::SeqCst),
+            "last Arc drop must release the handle and fire abort"
+        );
+    }
 }

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -8,7 +8,7 @@ use log::{debug, error};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
-use wacore::runtime::{AbortHandle, Runtime};
+use wacore::runtime::{AbortHandle, Runtime, wait_for_shutdown};
 
 pub struct PersistenceManager {
     device: Arc<RwLock<Device>>,
@@ -167,19 +167,13 @@ impl PersistenceManager {
             loop {
                 let Some(this) = weak.upgrade() else { return };
                 let save_listener = this.save_notify.listen();
-                let shutdown_listener = shutdown.upgrade().map(|e| e.listen());
                 drop(this);
 
                 let mut should_exit = false;
                 futures::select! {
                     _ = save_listener.fuse() => {}
                     _ = rt.sleep(interval).fuse() => {}
-                    _ = async {
-                        match shutdown_listener {
-                            Some(l) => l.await,
-                            None => std::future::pending::<()>().await,
-                        }
-                    }.fuse() => {
+                    _ = wait_for_shutdown(&shutdown).fuse() => {
                         should_exit = true;
                     }
                 }

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -264,3 +264,76 @@ impl PersistenceManager {
             .map_err(db_err)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_impl::TokioRuntime;
+    use std::time::Instant;
+
+    // Saver must observe shutdown.notify, run a final flush, and exit so the
+    // AbortHandle-backed task doesn't outlive the Bot.
+    #[tokio::test]
+    async fn saver_flushes_and_exits_on_shutdown() {
+        let backend = crate::test_utils::create_test_backend().await;
+        let pm = Arc::new(
+            PersistenceManager::new(backend.clone())
+                .await
+                .expect("pm init"),
+        );
+
+        let shutdown_event = Arc::new(Event::new());
+        let shutdown_signal = ShutdownSignal::from_weak(Arc::downgrade(&shutdown_event));
+
+        let runtime: Arc<dyn Runtime> = Arc::new(TokioRuntime);
+        // Interval far in the future so only shutdown can wake the saver.
+        let handle =
+            pm.clone()
+                .run_background_saver(runtime, Duration::from_secs(3600), shutdown_signal);
+
+        // Let the task enter its select before mutating.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        pm.modify_device(|d| {
+            d.push_name = "shutdown-flush".to_string();
+        })
+        .await;
+
+        shutdown_event.notify(usize::MAX);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(Some(d)) = backend.load().await
+                && d.push_name == "shutdown-flush"
+            {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("final flush did not reach backend after shutdown");
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Dropping the handle must be a no-op when the task already exited.
+        drop(handle);
+    }
+
+    // ShutdownSignal::never() compiles into a future that never resolves; verify
+    // the saver still exits when the AbortHandle is dropped.
+    #[tokio::test]
+    async fn saver_exits_when_abort_handle_dropped_without_signal() {
+        let backend = crate::test_utils::create_test_backend().await;
+        let pm = Arc::new(PersistenceManager::new(backend).await.expect("pm init"));
+
+        let runtime: Arc<dyn Runtime> = Arc::new(TokioRuntime);
+        let handle = pm.clone().run_background_saver(
+            runtime,
+            Duration::from_secs(3600),
+            ShutdownSignal::never(),
+        );
+
+        // Let the task start.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(handle); // aborts the task
+    }
+}

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -5,10 +5,10 @@ use async_lock::RwLock;
 use event_listener::Event;
 use futures::FutureExt;
 use log::{debug, error};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
-use wacore::runtime::Runtime;
+use wacore::runtime::{AbortHandle, Runtime};
 
 pub struct PersistenceManager {
     device: Arc<RwLock<Device>>,
@@ -136,50 +136,64 @@ impl PersistenceManager {
         }
     }
 
-    pub fn run_background_saver(self: Arc<Self>, runtime: Arc<dyn Runtime>, interval: Duration) {
+    /// Self-terminates on `shutdown.notify(...)` after a final flush.
+    /// Caller must keep the returned `AbortHandle` — dropping it aborts the task.
+    pub fn run_background_saver(
+        self: Arc<Self>,
+        runtime: Arc<dyn Runtime>,
+        interval: Duration,
+        shutdown: Weak<Event>,
+    ) -> AbortHandle {
         const MAX_CONSECUTIVE_FAILURES: u32 = 10;
 
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);
         drop(self);
-        runtime
-            .spawn(Box::pin(async move {
-                let mut consecutive_failures: u32 = 0;
-                loop {
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    let listener = this.save_notify.listen();
-                    drop(this);
+        runtime.spawn(Box::pin(async move {
+            let mut consecutive_failures: u32 = 0;
+            loop {
+                let Some(this) = weak.upgrade() else { return };
+                let save_listener = this.save_notify.listen();
+                let shutdown_listener = shutdown.upgrade().map(|e| e.listen());
+                drop(this);
 
-                    futures::select! {
-                        _ = listener.fuse() => {}
-                        _ = rt.sleep(interval).fuse() => {}
-                    }
-
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    if let Err(e) = this.save_to_disk().await {
-                        consecutive_failures += 1;
-                        if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
-                            this.saver_halted.store(true, Ordering::Release);
-                            error!(
-                                "Background saver: {consecutive_failures} consecutive flush failures, \
-                                 halting to prevent silent data loss. Last error: {e}"
-                            );
-                            return;
+                let mut should_exit = false;
+                futures::select! {
+                    _ = save_listener.fuse() => {}
+                    _ = rt.sleep(interval).fuse() => {}
+                    _ = async {
+                        match shutdown_listener {
+                            Some(l) => l.await,
+                            None => std::future::pending::<()>().await,
                         }
-                        error!("Background saver flush failed ({consecutive_failures}/{MAX_CONSECUTIVE_FAILURES}): {e}");
-                    } else {
-                        consecutive_failures = 0;
+                    }.fuse() => {
+                        should_exit = true;
                     }
                 }
-            }))
-            .detach();
-        debug!("Background saver task started with interval {interval:?}");
+
+                let Some(this) = weak.upgrade() else { return };
+                if let Err(e) = this.save_to_disk().await {
+                    consecutive_failures += 1;
+                    if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+                        this.saver_halted.store(true, Ordering::Release);
+                        error!(
+                            "Background saver: {consecutive_failures} consecutive flush failures, \
+                             halting to prevent silent data loss. Last error: {e}"
+                        );
+                        return;
+                    }
+                    error!(
+                        "Background saver flush failed ({consecutive_failures}/{MAX_CONSECUTIVE_FAILURES}): {e}"
+                    );
+                } else {
+                    consecutive_failures = 0;
+                }
+
+                if should_exit {
+                    return;
+                }
+            }
+        }))
     }
 }
 

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -138,6 +138,10 @@ impl PersistenceManager {
 
     /// Self-terminates on `shutdown.notify(...)` after a final flush.
     /// Caller must keep the returned `AbortHandle` — dropping it aborts the task.
+    ///
+    /// A notify that fires between `spawn` and the first `listen()` inside the
+    /// loop is missed. The worst-case recovery is one interval tick (plus the
+    /// `AbortHandle` drop path) so no state is lost.
     pub fn run_background_saver(
         self: Arc<Self>,
         runtime: Arc<dyn Runtime>,

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -151,6 +151,19 @@ impl PersistenceManager {
         drop(self);
         runtime.spawn(Box::pin(async move {
             let mut consecutive_failures: u32 = 0;
+
+            // Flush any state dirtied during construction before the first wait.
+            // The saver is started after Client::new_with_cache_config in bot.rs,
+            // so save_notify fires from SetDeviceProps etc. happen before the first
+            // listener is registered and would otherwise be missed until the next
+            // interval tick.
+            if let Some(this) = weak.upgrade()
+                && let Err(e) = this.save_to_disk().await
+            {
+                error!("Background saver: initial flush failed: {e}");
+                consecutive_failures = 1;
+            }
+
             loop {
                 let Some(this) = weak.upgrade() else { return };
                 let save_listener = this.save_notify.listen();

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -169,14 +169,11 @@ impl PersistenceManager {
                 let save_listener = this.save_notify.listen();
                 drop(this);
 
-                let mut should_exit = false;
-                futures::select! {
-                    _ = save_listener.fuse() => {}
-                    _ = rt.sleep(interval).fuse() => {}
-                    _ = wait_for_shutdown(&shutdown).fuse() => {
-                        should_exit = true;
-                    }
-                }
+                let should_exit = futures::select! {
+                    _ = save_listener.fuse() => false,
+                    _ = rt.sleep(interval).fuse() => false,
+                    _ = wait_for_shutdown(&shutdown).fuse() => true,
+                };
 
                 let Some(this) = weak.upgrade() else { return };
                 if let Err(e) = this.save_to_disk().await {

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -282,8 +282,8 @@ mod tests {
                 .expect("pm init"),
         );
 
-        let shutdown_event = Arc::new(Event::new());
-        let shutdown_signal = ShutdownSignal::from_weak(Arc::downgrade(&shutdown_event));
+        let notifier = wacore::runtime::ShutdownNotifier::new();
+        let shutdown_signal = notifier.subscribe();
 
         let runtime: Arc<dyn Runtime> = Arc::new(TokioRuntime);
         // Interval far in the future so only shutdown can wake the saver.
@@ -299,7 +299,7 @@ mod tests {
         })
         .await;
 
-        shutdown_event.notify(usize::MAX);
+        notifier.notify();
 
         let deadline = Instant::now() + Duration::from_secs(2);
         loop {

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -5,10 +5,10 @@ use async_lock::RwLock;
 use event_listener::Event;
 use futures::FutureExt;
 use log::{debug, error};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Weak};
 use std::time::Duration;
-use wacore::runtime::{AbortHandle, Runtime, wait_for_shutdown};
+use wacore::runtime::{AbortHandle, Runtime, ShutdownSignal, wait_for_shutdown};
 
 pub struct PersistenceManager {
     device: Arc<RwLock<Device>>,
@@ -146,7 +146,7 @@ impl PersistenceManager {
         self: Arc<Self>,
         runtime: Arc<dyn Runtime>,
         interval: Duration,
-        shutdown: Weak<Event>,
+        shutdown: ShutdownSignal,
     ) -> AbortHandle {
         const MAX_CONSECUTIVE_FAILURES: u32 = 10;
 

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -149,6 +149,7 @@ impl PersistenceManager {
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);
         drop(self);
+        debug!("Background saver started (interval {interval:?})");
         runtime.spawn(Box::pin(async move {
             let mut consecutive_failures: u32 = 0;
 
@@ -165,7 +166,10 @@ impl PersistenceManager {
             }
 
             loop {
-                let Some(this) = weak.upgrade() else { return };
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
                 let save_listener = this.save_notify.listen();
                 drop(this);
 
@@ -175,14 +179,22 @@ impl PersistenceManager {
                     _ = wait_for_shutdown(&shutdown).fuse() => true,
                 };
 
-                let Some(this) = weak.upgrade() else { return };
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
                 let flush_result = this.save_to_disk().await;
 
                 // On the shutdown path the task is terminating either way; a failed
                 // final flush should not permanently flag the store as halted.
                 if should_exit {
-                    if let Err(e) = flush_result {
-                        error!("Background saver: final flush on shutdown failed: {e}");
+                    match &flush_result {
+                        Err(e) => {
+                            error!("Background saver: final flush on shutdown failed: {e}");
+                        }
+                        Ok(()) => {
+                            debug!("Background saver received shutdown; final flush complete.");
+                        }
                     }
                     return;
                 }

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -320,23 +320,44 @@ mod tests {
         drop(handle);
     }
 
-    // ShutdownSignal::never() compiles into a future that never resolves; verify
-    // the saver still exits when the AbortHandle is dropped.
+    // Drop of the AbortHandle must actually terminate the task — not merely
+    // "not panic." Use the runtime Arc's strong count as the observable:
+    // the spawned task captures one reference via `rt = runtime.clone()`,
+    // which is released when the task's state machine is dropped.
     #[tokio::test]
     async fn saver_exits_when_abort_handle_dropped_without_signal() {
         let backend = crate::test_utils::create_test_backend().await;
         let pm = Arc::new(PersistenceManager::new(backend).await.expect("pm init"));
 
         let runtime: Arc<dyn Runtime> = Arc::new(TokioRuntime);
+        let baseline = Arc::strong_count(&runtime);
+
         let handle = pm.clone().run_background_saver(
-            runtime,
+            Arc::clone(&runtime),
             Duration::from_secs(3600),
             ShutdownSignal::never(),
         );
 
-        // Let the task start.
         tokio::time::sleep(Duration::from_millis(50)).await;
-        drop(handle); // aborts the task
+        assert!(
+            Arc::strong_count(&runtime) > baseline,
+            "running saver should hold a captured runtime Arc"
+        );
+
+        drop(handle);
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Arc::strong_count(&runtime) > baseline {
+            if Instant::now() > deadline {
+                panic!(
+                    "saver task did not release the runtime Arc within 1s of AbortHandle drop \
+                     (strong_count={}, baseline={})",
+                    Arc::strong_count(&runtime),
+                    baseline
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     // Regression guard for the Client-lifetime-tie fix: storing the saver's

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -176,7 +176,18 @@ impl PersistenceManager {
                 };
 
                 let Some(this) = weak.upgrade() else { return };
-                if let Err(e) = this.save_to_disk().await {
+                let flush_result = this.save_to_disk().await;
+
+                // On the shutdown path the task is terminating either way; a failed
+                // final flush should not permanently flag the store as halted.
+                if should_exit {
+                    if let Err(e) = flush_result {
+                        error!("Background saver: final flush on shutdown failed: {e}");
+                    }
+                    return;
+                }
+
+                if let Err(e) = flush_result {
                     consecutive_failures += 1;
                     if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
                         this.saver_halted.store(true, Ordering::Release);
@@ -191,10 +202,6 @@ impl PersistenceManager {
                     );
                 } else {
                     consecutive_failures = 0;
-                }
-
-                if should_exit {
-                    return;
                 }
             }
         }))

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -112,36 +112,119 @@ impl Drop for AbortHandle {
     }
 }
 
-/// Subscribe-side handle for a shutdown notifier.
-///
-/// Wraps the notifier so the concrete `event_listener` type stays out of the
-/// public API. Clone is cheap (wraps a `Weak`); the handle does not extend
-/// the notifier's lifetime, so the task owning the notifier is free to drop it.
-#[derive(Clone)]
-pub struct ShutdownSignal(std::sync::Weak<event_listener::Event>);
+/// Publish-side owner of a shutdown notifier. Exposes `notify()` which sets
+/// a sticky flag before waking listeners so a late subscriber still observes
+/// the shutdown (event_listener notifications are edge-triggered).
+pub struct ShutdownNotifier {
+    inner: std::sync::Arc<ShutdownInner>,
+}
 
-impl ShutdownSignal {
-    /// Subscribers build a `ShutdownSignal` from a downgraded notifier.
-    pub fn from_weak(weak: std::sync::Weak<event_listener::Event>) -> Self {
-        Self(weak)
+struct ShutdownInner {
+    // SeqCst ensures publishers always set `fired` before `event.notify` and
+    // subscribers always register `listen` before loading `fired`; combined,
+    // a listener either sees the flag or is guaranteed to be woken by notify.
+    fired: std::sync::atomic::AtomicBool,
+    event: event_listener::Event,
+}
+
+impl ShutdownNotifier {
+    pub fn new() -> Self {
+        Self {
+            inner: std::sync::Arc::new(ShutdownInner {
+                fired: std::sync::atomic::AtomicBool::new(false),
+                event: event_listener::Event::new(),
+            }),
+        }
     }
 
-    /// Inert handle whose listener never fires. Useful for tests or callers
-    /// that don't wire a real notifier.
-    pub fn never() -> Self {
-        Self(std::sync::Weak::new())
+    pub fn notify(&self) {
+        self.inner
+            .fired
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.inner.event.notify(usize::MAX);
+    }
+
+    pub fn is_fired(&self) -> bool {
+        self.inner.fired.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Sticky-aware listener: registers the event listener BEFORE reading the
+    /// flag so a notify that races this call either sets the flag we observe
+    /// or wakes the listener we just registered. Returned future is 'static
+    /// so it can be stored in `let` bindings and composed in `select!`.
+    pub fn listen(&self) -> impl Future<Output = ()> + use<> {
+        let listener = self.inner.event.listen();
+        let fired = self.is_fired();
+        async move {
+            if fired {
+                return;
+            }
+            listener.await;
+        }
+    }
+
+    pub fn subscribe(&self) -> ShutdownSignal {
+        ShutdownSignal {
+            inner: std::sync::Arc::downgrade(&self.inner),
+        }
     }
 }
 
-/// Wait for shutdown, resolving when the notifier fires. If the notifier has
-/// been dropped the returned future never resolves, so it composes in
-/// `futures::select!` against other exit conditions.
+impl Default for ShutdownNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Subscribe-side handle. Clone is cheap (wraps `Weak`); does not extend the
+/// notifier's lifetime.
+#[derive(Clone)]
+pub struct ShutdownSignal {
+    inner: std::sync::Weak<ShutdownInner>,
+}
+
+impl ShutdownSignal {
+    /// Inert handle whose listener never fires. Useful for tests or callers
+    /// that don't wire a real notifier.
+    pub fn never() -> Self {
+        Self {
+            inner: std::sync::Weak::new(),
+        }
+    }
+
+    /// Cheap synchronous probe without awaiting. Returns false if the notifier
+    /// has been dropped.
+    pub fn is_fired(&self) -> bool {
+        self.inner
+            .upgrade()
+            .is_some_and(|i| i.fired.load(std::sync::atomic::Ordering::SeqCst))
+    }
+}
+
+/// Wait for shutdown, resolving when `ShutdownNotifier::notify` has been
+/// called. If the notifier has been dropped the returned future never
+/// resolves, so it composes in `futures::select!` against other exit
+/// conditions.
 ///
-/// `listen()` runs synchronously at call time so the subscription is registered
-/// before any observable notify; don't delay calling this into the select arm.
+/// The listener is registered BEFORE the sticky-flag load so a notify that
+/// races the subscription either sets the flag we then observe or wakes the
+/// listener we just registered. Don't delay calling this into the select arm.
 pub fn wait_for_shutdown(signal: &ShutdownSignal) -> impl Future<Output = ()> + use<> {
-    let listener = signal.0.upgrade().map(|e| e.listen());
+    let (fired, listener) = match signal.inner.upgrade() {
+        Some(inner) => {
+            let listener = inner.event.listen();
+            // Load AFTER listen so a notify that happens between the two
+            // paths is caught — either the listener wakes or we read the
+            // flag set by the publisher.
+            let fired = inner.fired.load(std::sync::atomic::Ordering::SeqCst);
+            (fired, Some(listener))
+        }
+        None => (false, None),
+    };
     async move {
+        if fired {
+            return;
+        }
         match listener {
             Some(l) => l.await,
             None => std::future::pending::<()>().await,
@@ -201,4 +284,56 @@ pub async fn blocking<T: Send + 'static>(
 #[cfg(target_arch = "wasm32")]
 pub async fn blocking<T: 'static>(_rt: &dyn Runtime, f: impl FnOnce() -> T + 'static) -> T {
     f()
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod shutdown_tests {
+    use super::{ShutdownNotifier, ShutdownSignal, wait_for_shutdown};
+    use futures::FutureExt;
+    use futures::executor::block_on;
+
+    // Regression guard against CodeRabbit's critical finding on PR #560:
+    // event_listener notifications are edge-triggered, so a `notify()` fired
+    // before a subscriber calls `listen()` would be lost without the sticky
+    // flag. Verify that notify -> subscribe -> wait_for_shutdown still
+    // resolves immediately.
+    #[test]
+    fn wait_for_shutdown_catches_notify_fired_before_subscribe() {
+        let notifier = ShutdownNotifier::new();
+        notifier.notify();
+
+        let signal = notifier.subscribe();
+        block_on(wait_for_shutdown(&signal));
+    }
+
+    // Same guard for the publisher-side listen() helper.
+    #[test]
+    fn notifier_listen_catches_notify_fired_before_listen() {
+        let notifier = ShutdownNotifier::new();
+        notifier.notify();
+
+        block_on(notifier.listen());
+    }
+
+    // Guard the ordered path: listener registered first, notify after.
+    // Must resolve through the normal event-listener wakeup (not the sticky
+    // flag fast-path, which only fires when the flag is set before listen).
+    #[test]
+    fn wait_for_shutdown_wakes_on_notify_after_subscribe() {
+        let notifier = ShutdownNotifier::new();
+        let signal = notifier.subscribe();
+        let fut = wait_for_shutdown(&signal);
+
+        notifier.notify();
+        block_on(fut);
+    }
+
+    // never() must never resolve. Poll once manually and assert Pending.
+    #[test]
+    fn wait_for_shutdown_never_stays_pending() {
+        let signal = ShutdownSignal::never();
+        let mut fut = Box::pin(wait_for_shutdown(&signal).fuse());
+        let mut ctx = futures::task::Context::from_waker(futures::task::noop_waker_ref());
+        assert!(fut.as_mut().poll_unpin(&mut ctx).is_pending());
+    }
 }

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -165,7 +165,7 @@ impl ShutdownNotifier {
 
     pub fn subscribe(&self) -> ShutdownSignal {
         ShutdownSignal {
-            inner: std::sync::Arc::downgrade(&self.inner),
+            inner: Some(std::sync::Arc::clone(&self.inner)),
         }
     }
 }
@@ -176,42 +176,43 @@ impl Default for ShutdownNotifier {
     }
 }
 
-/// Subscribe-side handle. Clone is cheap (wraps `Weak`); does not extend the
-/// notifier's lifetime.
+/// Subscribe-side handle. Clone is cheap (atomic ref-count). Holds a strong
+/// `Arc` to the notifier's inner so the sticky flag and event survive across
+/// a publisher-side replacement (e.g. `Mutex<ShutdownNotifier>` swapped on
+/// reconnect). Long-lived tasks must capture the signal once at startup; if
+/// they re-subscribed each loop iteration a racing swap could strand them on
+/// a fresh notifier that was never fired.
 #[derive(Clone)]
 pub struct ShutdownSignal {
-    inner: std::sync::Weak<ShutdownInner>,
+    // None for `never()` — always Pending, always not-fired.
+    inner: Option<std::sync::Arc<ShutdownInner>>,
 }
 
 impl ShutdownSignal {
     /// Inert handle whose listener never fires. Useful for tests or callers
     /// that don't wire a real notifier.
     pub fn never() -> Self {
-        Self {
-            inner: std::sync::Weak::new(),
-        }
+        Self { inner: None }
     }
 
-    /// Cheap synchronous probe without awaiting. Returns false if the notifier
-    /// has been dropped.
+    /// Cheap synchronous probe without awaiting.
     pub fn is_fired(&self) -> bool {
         self.inner
-            .upgrade()
+            .as_ref()
             .is_some_and(|i| i.fired.load(std::sync::atomic::Ordering::SeqCst))
     }
 }
 
 /// Wait for shutdown, resolving when `ShutdownNotifier::notify` has been
-/// called. Stays `Pending` if the notifier has been dropped (or if the signal
-/// was built via [`ShutdownSignal::never`]); pair with another exit condition
-/// in `futures::select!`.
+/// called. Stays `Pending` for signals built via [`ShutdownSignal::never`];
+/// pair with another exit condition in `futures::select!`.
 ///
 /// The listener is registered BEFORE the sticky-flag load so a notify that
 /// races the subscription either sets the flag we then observe or wakes the
 /// listener we just registered. Call this directly inside the select arm, not
 /// earlier in the function, to keep the race window closed.
 pub fn wait_for_shutdown(signal: &ShutdownSignal) -> impl Future<Output = ()> + use<> {
-    let (fired, listener) = match signal.inner.upgrade() {
+    let (fired, listener) = match signal.inner.as_ref() {
         Some(inner) => {
             let listener = inner.event.listen();
             // Load AFTER listen so a notify that happens between the two
@@ -336,5 +337,23 @@ mod shutdown_tests {
         let mut fut = Box::pin(wait_for_shutdown(&signal).fuse());
         let mut ctx = futures::task::Context::from_waker(futures::task::noop_waker_ref());
         assert!(fut.as_mut().poll_unpin(&mut ctx).is_pending());
+    }
+
+    // Captured signal must survive the publisher being dropped — tasks that
+    // hold the signal across a Mutex<ShutdownNotifier> swap need to still see
+    // the notify that fired before the swap. With Weak<Inner> the Arc would
+    // die on swap and subsequent wait_for_shutdown calls would pend forever.
+    #[test]
+    fn captured_signal_observes_fire_after_notifier_dropped() {
+        let notifier = ShutdownNotifier::new();
+        let signal = notifier.subscribe();
+        notifier.notify();
+        drop(notifier);
+
+        assert!(
+            signal.is_fired(),
+            "Signal must remain fired after the publisher was dropped"
+        );
+        block_on(wait_for_shutdown(&signal));
     }
 }

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -144,7 +144,7 @@ impl ShutdownNotifier {
         self.inner.event.notify(usize::MAX);
     }
 
-    pub fn is_fired(&self) -> bool {
+    fn is_fired(&self) -> bool {
         self.inner.fired.load(std::sync::atomic::Ordering::SeqCst)
     }
 
@@ -202,13 +202,14 @@ impl ShutdownSignal {
 }
 
 /// Wait for shutdown, resolving when `ShutdownNotifier::notify` has been
-/// called. If the notifier has been dropped the returned future never
-/// resolves, so it composes in `futures::select!` against other exit
-/// conditions.
+/// called. Stays `Pending` if the notifier has been dropped (or if the signal
+/// was built via [`ShutdownSignal::never`]); pair with another exit condition
+/// in `futures::select!`.
 ///
 /// The listener is registered BEFORE the sticky-flag load so a notify that
 /// races the subscription either sets the flag we then observe or wakes the
-/// listener we just registered. Don't delay calling this into the select arm.
+/// listener we just registered. Call this directly inside the select arm, not
+/// earlier in the function, to keep the race window closed.
 pub fn wait_for_shutdown(signal: &ShutdownSignal) -> impl Future<Output = ()> + use<> {
     let (fired, listener) = match signal.inner.upgrade() {
         Some(inner) => {

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -112,6 +112,28 @@ impl Drop for AbortHandle {
     }
 }
 
+/// Wait for a shutdown notification on a shared `Event`, resolving when
+/// `shutdown.notify(...)` fires.
+///
+/// If the Event has already been dropped the returned future never resolves,
+/// so it safely composes in `futures::select!` against other work that has
+/// its own exit condition (sleep, listener on another Event, etc.).
+///
+/// `listen()` must be called synchronously before any notify we want to
+/// observe, so the subscription is registered at the call site of this helper
+/// (not deferred to the returned future's first poll).
+pub fn wait_for_shutdown(
+    shutdown: &std::sync::Weak<event_listener::Event>,
+) -> impl Future<Output = ()> + use<> {
+    let listener = shutdown.upgrade().map(|e| e.listen());
+    async move {
+        match listener {
+            Some(l) => l.await,
+            None => std::future::pending::<()>().await,
+        }
+    }
+}
+
 /// Error returned when an async operation times out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("operation timed out")]

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -112,20 +112,35 @@ impl Drop for AbortHandle {
     }
 }
 
-/// Wait for a shutdown notification on a shared `Event`, resolving when
-/// `shutdown.notify(...)` fires.
+/// Subscribe-side handle for a shutdown notifier.
 ///
-/// If the Event has already been dropped the returned future never resolves,
-/// so it safely composes in `futures::select!` against other work that has
-/// its own exit condition (sleep, listener on another Event, etc.).
+/// Wraps the notifier so the concrete `event_listener` type stays out of the
+/// public API. Clone is cheap (wraps a `Weak`); the handle does not extend
+/// the notifier's lifetime, so the task owning the notifier is free to drop it.
+#[derive(Clone)]
+pub struct ShutdownSignal(std::sync::Weak<event_listener::Event>);
+
+impl ShutdownSignal {
+    /// Subscribers build a `ShutdownSignal` from a downgraded notifier.
+    pub fn from_weak(weak: std::sync::Weak<event_listener::Event>) -> Self {
+        Self(weak)
+    }
+
+    /// Inert handle whose listener never fires. Useful for tests or callers
+    /// that don't wire a real notifier.
+    pub fn never() -> Self {
+        Self(std::sync::Weak::new())
+    }
+}
+
+/// Wait for shutdown, resolving when the notifier fires. If the notifier has
+/// been dropped the returned future never resolves, so it composes in
+/// `futures::select!` against other exit conditions.
 ///
-/// `listen()` must be called synchronously before any notify we want to
-/// observe, so the subscription is registered at the call site of this helper
-/// (not deferred to the returned future's first poll).
-pub fn wait_for_shutdown(
-    shutdown: &std::sync::Weak<event_listener::Event>,
-) -> impl Future<Output = ()> + use<> {
-    let listener = shutdown.upgrade().map(|e| e.listen());
+/// `listen()` runs synchronously at call time so the subscription is registered
+/// before any observable notify; don't delay calling this into the select arm.
+pub fn wait_for_shutdown(signal: &ShutdownSignal) -> impl Future<Output = ()> + use<> {
+    let listener = signal.0.upgrade().map(|e| e.listen());
     async move {
         match listener {
             Some(l) => l.await,

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -135,6 +135,10 @@ impl PersistenceManager {
 
     /// Self-terminates on `shutdown.notify(...)` after a final flush.
     /// Caller must keep the returned `AbortHandle` — dropping it aborts the task.
+    ///
+    /// A notify that fires between `spawn` and the first `listen()` inside the
+    /// loop is missed; the interval tick (or the `AbortHandle` drop) bounds the
+    /// delay so no state is lost.
     pub fn run_background_saver(
         self: Arc<Self>,
         runtime: Arc<dyn Runtime>,

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -6,7 +6,7 @@
 //! `Backend` reference. That version should eventually be consolidated into this
 //! one once the `Device` wrapper is unified.
 
-use crate::runtime::{AbortHandle, Runtime};
+use crate::runtime::{AbortHandle, Runtime, wait_for_shutdown};
 use crate::store::commands::{DeviceCommand, apply_command_to_device};
 use crate::store::device::Device;
 use crate::store::error::{StoreError, db_err};
@@ -161,21 +161,12 @@ impl PersistenceManager {
                     return;
                 };
                 let save_listener = this.save_notify.listen();
-                let shutdown_listener = shutdown.upgrade().map(|e| e.listen());
-                drop(this); // Don't hold strong ref while sleeping
+                drop(this);
 
-                // If shutdown.notify fires between spawn and this listen(),
-                // we miss it — interval ticks eventually flush dirty state
-                // and weak.upgrade() will return None once the PM is dropped.
                 let should_exit = futures::select! {
                     _ = save_listener.fuse() => false,
                     _ = rt.sleep(interval).fuse() => false,
-                    _ = async {
-                        match shutdown_listener {
-                            Some(l) => l.await,
-                            None => std::future::pending::<()>().await,
-                        }
-                    }.fuse() => true,
+                    _ = wait_for_shutdown(&shutdown).fuse() => true,
                 };
 
                 let Some(this) = weak.upgrade() else {

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -146,6 +146,15 @@ impl PersistenceManager {
         drop(self); // Release strong ref; caller's Arc keeps it alive
         debug!("Background saver task started with interval {interval:?}");
         runtime.spawn(Box::pin(async move {
+            // Flush any state dirtied during construction before the first wait,
+            // covering the window where save_notify fires between PM creation
+            // and the first listener registration.
+            if let Some(this) = weak.upgrade()
+                && let Err(e) = this.save_to_disk().await
+            {
+                error!("Background saver: initial flush failed: {e}");
+            }
+
             loop {
                 let Some(this) = weak.upgrade() else {
                     debug!("PersistenceManager dropped, exiting background saver.");

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -133,12 +133,11 @@ impl PersistenceManager {
         }
     }
 
-    /// Self-terminates on `shutdown.notify(...)` after a final flush.
-    /// Caller must keep the returned `AbortHandle` — dropping it aborts the task.
-    ///
-    /// A notify that fires between `spawn` and the first `listen()` inside the
-    /// loop is missed; the interval tick (or the `AbortHandle` drop) bounds the
-    /// delay so no state is lost.
+    /// Spawn the background saver. Wakes on `save_notify`, the interval tick,
+    /// or the `shutdown` signal; runs a final flush before exiting on shutdown.
+    /// Caller must keep the returned [`AbortHandle`] to control the task's
+    /// lifetime (dropping it aborts). [`ShutdownSignal`] is sticky so a
+    /// notify that races the task's first listen is still observed.
     pub fn run_background_saver(
         self: Arc<Self>,
         runtime: Arc<dyn Runtime>,
@@ -150,9 +149,9 @@ impl PersistenceManager {
         drop(self); // Release strong ref; caller's Arc keeps it alive
         debug!("Background saver task started with interval {interval:?}");
         runtime.spawn(Box::pin(async move {
-            // Flush any state dirtied during construction before the first wait,
-            // covering the window where save_notify fires between PM creation
-            // and the first listener registration.
+            // Flush state dirtied during construction. save_notify is
+            // edge-triggered so pre-spawn writes rely on the dirty flag
+            // rather than a missed notification.
             if let Some(this) = weak.upgrade()
                 && let Err(e) = this.save_to_disk().await
             {

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -6,7 +6,7 @@
 //! `Backend` reference. That version should eventually be consolidated into this
 //! one once the `Device` wrapper is unified.
 
-use crate::runtime::Runtime;
+use crate::runtime::{AbortHandle, Runtime};
 use crate::store::commands::{DeviceCommand, apply_command_to_device};
 use crate::store::device::Device;
 use crate::store::error::{StoreError, db_err};
@@ -15,8 +15,8 @@ use async_lock::RwLock;
 use event_listener::Event;
 use futures::FutureExt;
 use log::{debug, error};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 /// Manages device state persistence with lazy, batched writes.
@@ -133,43 +133,56 @@ impl PersistenceManager {
         }
     }
 
-    // Known limitation: the background saver does not perform a final flush
-    // when the PersistenceManager is dropped. Any dirty state that hasn't been
-    // flushed by a periodic tick will be lost. A proper fix requires adding an
-    // explicit `shutdown()` method that callers invoke before dropping, which is
-    // a larger design change tracked separately.
-    pub fn run_background_saver(self: Arc<Self>, runtime: Arc<dyn Runtime>, interval: Duration) {
+    /// Self-terminates on `shutdown.notify(...)` after a final flush.
+    /// Caller must keep the returned `AbortHandle` — dropping it aborts the task.
+    pub fn run_background_saver(
+        self: Arc<Self>,
+        runtime: Arc<dyn Runtime>,
+        interval: Duration,
+        shutdown: Weak<Event>,
+    ) -> AbortHandle {
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);
-        drop(self); // Release the strong reference; the caller's Arc keeps it alive
-        runtime
-            .spawn(Box::pin(async move {
-                loop {
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    let listener = this.save_notify.listen();
-                    drop(this); // Don't hold strong ref while sleeping
-
-                    futures::select! {
-                        _ = listener.fuse() => {
-                            debug!("Save notification received.");
-                        }
-                        _ = rt.sleep(interval).fuse() => {}
-                    }
-
-                    let Some(this) = weak.upgrade() else {
-                        debug!("PersistenceManager dropped, exiting background saver.");
-                        return;
-                    };
-                    if let Err(e) = this.save_to_disk().await {
-                        error!("Error saving device state in background: {e}");
-                    }
-                }
-            }))
-            .detach();
+        drop(self); // Release strong ref; caller's Arc keeps it alive
         debug!("Background saver task started with interval {interval:?}");
+        runtime.spawn(Box::pin(async move {
+            loop {
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
+                let save_listener = this.save_notify.listen();
+                let shutdown_listener = shutdown.upgrade().map(|e| e.listen());
+                drop(this); // Don't hold strong ref while sleeping
+
+                // If shutdown.notify fires between spawn and this listen(),
+                // we miss it — interval ticks eventually flush dirty state
+                // and weak.upgrade() will return None once the PM is dropped.
+                let should_exit = futures::select! {
+                    _ = save_listener.fuse() => false,
+                    _ = rt.sleep(interval).fuse() => false,
+                    _ = async {
+                        match shutdown_listener {
+                            Some(l) => l.await,
+                            None => std::future::pending::<()>().await,
+                        }
+                    }.fuse() => true,
+                };
+
+                let Some(this) = weak.upgrade() else {
+                    debug!("PersistenceManager dropped, exiting background saver.");
+                    return;
+                };
+                if let Err(e) = this.save_to_disk().await {
+                    error!("Error saving device state in background: {e}");
+                }
+
+                if should_exit {
+                    debug!("Background saver received shutdown; final flush complete.");
+                    return;
+                }
+            }
+        }))
     }
 
     pub async fn process_command(&self, command: DeviceCommand) {

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -6,7 +6,7 @@
 //! `Backend` reference. That version should eventually be consolidated into this
 //! one once the `Device` wrapper is unified.
 
-use crate::runtime::{AbortHandle, Runtime, wait_for_shutdown};
+use crate::runtime::{AbortHandle, Runtime, ShutdownSignal, wait_for_shutdown};
 use crate::store::commands::{DeviceCommand, apply_command_to_device};
 use crate::store::device::Device;
 use crate::store::error::{StoreError, db_err};
@@ -15,8 +15,8 @@ use async_lock::RwLock;
 use event_listener::Event;
 use futures::FutureExt;
 use log::{debug, error};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 /// Manages device state persistence with lazy, batched writes.
@@ -143,7 +143,7 @@ impl PersistenceManager {
         self: Arc<Self>,
         runtime: Arc<dyn Runtime>,
         interval: Duration,
-        shutdown: Weak<Event>,
+        shutdown: ShutdownSignal,
     ) -> AbortHandle {
         let rt = runtime.clone();
         let weak = Arc::downgrade(&self);


### PR DESCRIPTION
## Summary

Two `.detach()`-ed background tasks held pending `sleep` calls that kept WASM event loops alive for minutes after `client.disconnect()`: the background saver (`sleep(30s)`) and the offline device-sync flush (`sleep(2s)`). Each `sleep` compiles to `setTimeout` on the Node bridge, and detached tasks are never dropped, so the timers never `clearTimeout`.

This PR adds a proper shutdown signal abstraction, ties task lifetimes to their owning `Arc<Client>`, and guarantees a final flush when the saver exits.

Benefits apply to every platform, not just WASM: Tokio servers get a final flush on disconnect (resolves a long-standing "no final flush on drop" TODO), saver tasks stop promptly on disconnect instead of lingering until natural completion, and `Bot` drop cleanly aborts the saver even if `disconnect()` was never called.

## Architecture

### `wacore::runtime::ShutdownNotifier` / `ShutdownSignal`
A publisher/subscriber pair with a **sticky flag** backed by an `AtomicBool` alongside an `event_listener::Event`:

- Publisher (`notify()`) stores the flag **before** waking listeners.
- Subscribers (`wait_for_shutdown` / `ShutdownNotifier::listen()`) register the listener **before** loading the flag.

The ordering guarantees a late subscriber still observes the shutdown — `event_listener` notifications are edge-triggered on their own, so naive `listen()`-then-check races. `ShutdownSignal::never()` is an inert handle for tests and callers that don't wire a real notifier.

### Two shutdown scopes on `Client`
- `shutdown_notifier: ShutdownNotifier` — **terminal**, fired only by `disconnect()`. Long-lived subscribers that outlive reconnects (saver, device-registry cleanup) subscribe via `shutdown_signal()`.
- `connection_shutdown: Mutex<ShutdownNotifier>` — **per-connection**, fired on `cleanup_connection_state`, `<xmlstreamend/>`, stream error, and `handle_connect_failure`. Replaced with a fresh notifier at the start of each new connection so reconnect subscribers see a clean signal. Per-connection tasks (keepalive, request waiters, `read_messages_loop`, offline flush) subscribe via `connection_shutdown_signal()`.

`disconnect()` propagates through both (terminal directly; per-connection via `cleanup_connection_state`).

### Saver lifecycle tied to `Arc<Client>`
`PersistenceManager::run_background_saver` takes `ShutdownSignal` and returns `AbortHandle`. `Bot::build` stores the handle in `Client::saver_handle: OnceLock<AbortHandle>` so the task lifetime follows the last `Arc<Client>` strong ref. The saver self-terminates on shutdown notify (after a final flush); if the last `Arc<Client>` drops without a notify, the `AbortHandle::drop` aborts the task.

### Race-mitigation details
- Saver performs an initial `save_to_disk()` before entering the `select!` loop, covering state dirtied during `Bot::build` construction.
- Saver does not flip `saver_halted` when a failing flush happens on the shutdown path — a terminating task shouldn't permanently mark the store degraded.
- Extracted `wait_for_shutdown` helper dedupes three identical patterns (saver wrapper, wacore saver, `ib.rs` offline flush).

## WASM impact

Measured: Rust-origin `setTimeout`s pending after `client.disconnect()` dropped from **~47 (worst case 180s)** to **0**. Only undici keep-alive (~4s, Node layer) remains.

## Commits

| Commit | Change |
| --- | --- |
| `d87a648` | baseline: shutdown signal + saver `AbortHandle` + `ib.rs` |
| `1d917ea` | wacore: same shutdown pattern in runtime-agnostic saver |
| `c9c9164` | saver: initial flush to close reorder race during `Bot::build` |
| `751f845` | runtime: extract `wait_for_shutdown` helper, dedupe three callsites |
| `f52b794` | saver: `should_exit` as select expression value |
| `63353aa` | saver: don't halt on shutdown-path flush failure |
| `5bf8a28` | saver: restore startup/drop/shutdown debug logs |
| `a95adbc` | shutdown: document shutdown-before-listen race (later obsoleted by sticky flag) |
| `4b35db4` | runtime: `ShutdownSignal` newtype |
| `000aef4` | saver: initial unit tests |
| `6b3246e` | **fix (Codex P2)**: tie saver handle to `Arc<Client>` via `OnceLock`, not `Bot` |
| `d131cf5` | **fix (CodeRabbit critical)**: sticky shutdown flag so notify before listen is observed |
| `5562983` | **fix (CI breakage)**: split per-connection vs terminal shutdown so reconnect works |
| `7f063df` | docs/cleanup: refresh stale race comments, trim dead code |
| `1496a1d` | test: strengthen saver exit test with observable runtime Arc count |

## Test plan
- [x] `cargo clippy --all --tests` clean on every commit
- [x] `cargo test --workspace --exclude e2e-tests` — all suites pass
- [x] `cargo test -p e2e-tests --test app_state test_push_name_survives_reconnect` — one of the eight tests broken by the pre-split sticky flag now passes
- [x] Regression tests added:
  - `wacore::runtime::shutdown_tests::*` — sticky-flag ordering (4 tests)
  - `saver_flushes_and_exits_on_shutdown` — final flush + clean exit
  - `saver_exits_when_abort_handle_dropped_without_signal` — observes runtime Arc count
  - `abort_handle_in_arc_drops_only_when_last_ref_released` — Codex-fix drop semantics
  - `per_connection_notify_leaves_terminal_signal_untouched` — CI-fix scope split
  - `reset_gives_fresh_per_connection_notifier` — reset semantics
  - `terminal_disconnect_propagates_to_per_connection_signal` — disconnect wakes both
- [ ] Full e2e suite (mock server required) — reviewer should run before merge

## Notes
- Pre-existing `AbortHandle` in `wacore::runtime` has `#[must_use]`; callers can't accidentally drop the saver handle on the floor.
- `ShutdownSignal::never()` for opt-out or tests; `wait_for_shutdown` composes in `select!` against other exit conditions.
- `event_listener` stays internal; only `ShutdownNotifier` / `ShutdownSignal` are in the public API.
- `disconnect()` still does an explicit `persistence_manager.flush()` as defense-in-depth alongside the saver's own final flush.