### PR TITLE
feat: incoming call events + member label update

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -847,7 +847,6 @@ impl Client {
             notification::NotificationHandler,
             receipt::ReceiptHandler,
             router::StanzaRouter,
-            unimplemented::UnimplementedHandler,
         };
 
         let mut router = StanzaRouter::new();
@@ -864,8 +863,9 @@ impl Client {
         router.register(Arc::new(AckHandler));
         router.register(Arc::new(ChatstateHandler));
 
+        router.register(Arc::new(crate::handlers::call::CallHandler));
+
         // Register unimplemented handlers
-        router.register(Arc::new(UnimplementedHandler::for_call()));
         router.register(Arc::new(crate::handlers::presence::PresenceHandler));
 
         router

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -13,7 +13,7 @@ use wacore::iq::groups::{
     SetMemberAddModeIq, SetNoFrequentlyForwardedIq, normalize_participants,
 };
 use wacore::types::message::AddressingMode;
-use wacore_binary::Jid;
+use wacore_binary::{Jid, JidExt as _};
 
 use wacore::iq::groups::BatchGroupInfoResult as RawBatchResult;
 pub use wacore::iq::groups::{
@@ -723,6 +723,26 @@ impl<'a> Groups<'a> {
         }
 
         Ok(())
+    }
+
+    /// Set or clear the bot's per-group member label. Empty clears.
+    ///
+    /// WA Web sends this as a `ProtocolMessage` over the normal message path,
+    /// not as an IQ.
+    pub async fn update_member_label(
+        &self,
+        group_jid: &Jid,
+        label: impl Into<String>,
+    ) -> Result<(), anyhow::Error> {
+        if !group_jid.is_group() {
+            return Err(anyhow::anyhow!(
+                "update_member_label requires a group JID, got {group_jid}"
+            ));
+        }
+        let msg = wacore::send::build_member_label_message(label.into(), wacore::time::now_secs());
+        self.client
+            .send_message_impl(group_jid.clone(), &msg, None, false, false, None, vec![])
+            .await
     }
 
     async fn resolve_participant_tokens(&self, jids: &[Jid]) -> Vec<GroupParticipantOptions> {

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -2,10 +2,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, warn};
-use wacore::stanza::call::parse_call_stanza;
+use wacore::stanza::call::{build_offer_ack_receipt, parse_call_stanza};
 use wacore::types::call::{CallAction, IncomingCall};
 use wacore::types::events::Event;
-use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{OwnedNodeRef, Server};
 
 use crate::client::Client;
@@ -53,36 +52,16 @@ impl StanzaHandler for CallHandler {
 }
 
 async fn send_offer_ack_receipt(client: &Client, call: &IncomingCall) -> anyhow::Result<()> {
-    let CallAction::Offer {
-        call_id,
-        call_creator,
-        ..
-    } = &call.action
-    else {
-        return Ok(());
-    };
-
     let own_from = match call.from.server {
         Server::Lid => client.get_lid().await,
         _ => client.get_pn().await,
     };
 
-    let mut receipt = NodeBuilder::new("receipt")
-        .attr("to", &call.from)
-        .attr("id", call.stanza_id.as_str());
-    if let Some(jid) = own_from {
-        receipt = receipt.attr("from", jid);
-    }
+    let Some(receipt) = build_offer_ack_receipt(call, own_from.as_ref()) else {
+        return Ok(());
+    };
 
-    let offer = NodeBuilder::new("offer")
-        .attr("call-id", call_id.as_str())
-        .attr("call-creator", call_creator)
-        .build();
-
-    client
-        .send_node(receipt.children([offer]).build())
-        .await
-        .map_err(anyhow::Error::from)
+    client.send_node(receipt).await.map_err(anyhow::Error::from)
 }
 
 #[cfg(test)]
@@ -91,20 +70,21 @@ mod tests {
     use crate::test_utils::{MockHttpClient, create_test_backend, node_to_owned_ref};
     use std::sync::Arc;
     use wacore::types::events::{ChannelEventHandler, Event};
+    use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
-    fn caller_lid() -> Jid {
-        Jid::new("271240153559280", Server::Lid)
+    fn fake_caller_lid() -> Jid {
+        Jid::new("111111111111111", Server::Lid)
     }
 
     fn offer_stanza() -> wacore_binary::Node {
         NodeBuilder::new("call")
-            .attr("from", caller_lid())
-            .attr("id", "STANZA1")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-0001")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("offer")
-                .attr("call-creator", caller_lid())
-                .attr("call-id", "CALLID")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CALL-ID-0001")
                 .children([NodeBuilder::new("audio")
                     .attr("enc", "opus")
                     .attr("rate", "16000")
@@ -144,7 +124,8 @@ mod tests {
 
         let mut seen = false;
         while let Ok(ev) = rx.try_recv() {
-            if matches!(&*ev, Event::IncomingCall(call) if call.action.call_id() == "CALLID") {
+            if matches!(&*ev, Event::IncomingCall(call) if call.action.call_id() == "CALL-ID-0001")
+            {
                 seen = true;
                 break;
             }
@@ -160,7 +141,7 @@ mod tests {
 
         let node = node_to_owned_ref(
             &NodeBuilder::new("call")
-                .attr("from", caller_lid())
+                .attr("from", fake_caller_lid())
                 .attr("id", "S")
                 .attr("t", "1766847151")
                 .children([NodeBuilder::new("surprise").build()])
@@ -185,10 +166,10 @@ mod tests {
 
         let node = node_to_owned_ref(
             &NodeBuilder::new("call")
-                .attr("from", caller_lid())
+                .attr("from", fake_caller_lid())
                 .attr("id", "S")
                 .children([NodeBuilder::new("offer")
-                    .attr("call-creator", caller_lid())
+                    .attr("call-creator", fake_caller_lid())
                     .attr("call-id", "X")
                     .build()])
                 .build(),

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -1,0 +1,202 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use log::{debug, warn};
+use wacore::stanza::call::parse_call_stanza;
+use wacore::types::call::{CallAction, IncomingCall};
+use wacore::types::events::Event;
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::{OwnedNodeRef, Server};
+
+use crate::client::Client;
+
+use super::traits::StanzaHandler;
+
+/// Router sends the generic `<ack>` via `should_ack`, so this handler only
+/// parses and dispatches. On `Offer` it also emits the `<receipt><offer/></receipt>`
+/// ack-of-offer so the caller's signaling layer knows the device received the ring.
+#[derive(Default)]
+pub struct CallHandler;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl StanzaHandler for CallHandler {
+    fn tag(&self) -> &'static str {
+        "call"
+    }
+
+    async fn handle(
+        &self,
+        client: Arc<Client>,
+        node: Arc<OwnedNodeRef>,
+        _cancelled: &mut bool,
+    ) -> bool {
+        let nr = node.get();
+        match parse_call_stanza(nr) {
+            Ok(Some(call)) => {
+                if matches!(call.action, CallAction::Offer { .. })
+                    && let Err(e) = send_offer_ack_receipt(&client, &call).await
+                {
+                    warn!("call: failed to send offer ack receipt: {e}");
+                }
+                client.core.event_bus.dispatch(Event::IncomingCall(call));
+            }
+            Ok(None) => {
+                debug!("call: ignoring unrecognized action (forward-compat)");
+            }
+            Err(e) => {
+                warn!("call: failed to parse stanza: {e}");
+            }
+        }
+        true
+    }
+}
+
+async fn send_offer_ack_receipt(client: &Client, call: &IncomingCall) -> anyhow::Result<()> {
+    let CallAction::Offer {
+        call_id,
+        call_creator,
+        ..
+    } = &call.action
+    else {
+        return Ok(());
+    };
+
+    let own_from = match call.from.server {
+        Server::Lid => client.get_lid().await,
+        _ => client.get_pn().await,
+    };
+
+    let mut receipt = NodeBuilder::new("receipt")
+        .attr("to", &call.from)
+        .attr("id", call.stanza_id.as_str());
+    if let Some(jid) = own_from {
+        receipt = receipt.attr("from", jid);
+    }
+
+    let offer = NodeBuilder::new("offer")
+        .attr("call-id", call_id.as_str())
+        .attr("call-creator", call_creator)
+        .build();
+
+    client
+        .send_node(receipt.children([offer]).build())
+        .await
+        .map_err(anyhow::Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{MockHttpClient, create_test_backend, node_to_owned_ref};
+    use std::sync::Arc;
+    use wacore::types::events::{ChannelEventHandler, Event};
+    use wacore_binary::{Jid, Server};
+
+    fn caller_lid() -> Jid {
+        Jid::new("271240153559280", Server::Lid)
+    }
+
+    fn offer_stanza() -> wacore_binary::Node {
+        NodeBuilder::new("call")
+            .attr("from", caller_lid())
+            .attr("id", "STANZA1")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("offer")
+                .attr("call-creator", caller_lid())
+                .attr("call-id", "CALLID")
+                .children([NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", "16000")
+                    .build()])
+                .build()])
+            .build()
+    }
+
+    async fn make_client() -> Arc<Client> {
+        use crate::store::persistence_manager::PersistenceManager;
+        let backend = create_test_backend().await;
+        let pm = PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager should initialize");
+        let transport = Arc::new(crate::transport::mock::MockTransportFactory::new());
+        let http_client = Arc::new(MockHttpClient);
+        let (client, _rx) = Client::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(pm),
+            transport,
+            http_client,
+            None,
+        )
+        .await;
+        client
+    }
+
+    #[tokio::test]
+    async fn offer_dispatches_event() {
+        let client = make_client().await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.register_handler(handler);
+
+        let node = node_to_owned_ref(&offer_stanza());
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+
+        let mut seen = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(&*ev, Event::IncomingCall(call) if call.action.call_id() == "CALLID") {
+                seen = true;
+                break;
+            }
+        }
+        assert!(seen, "IncomingCall event must be dispatched");
+    }
+
+    #[tokio::test]
+    async fn unrecognized_action_does_not_dispatch() {
+        let client = make_client().await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.register_handler(handler);
+
+        let node = node_to_owned_ref(
+            &NodeBuilder::new("call")
+                .attr("from", caller_lid())
+                .attr("id", "S")
+                .attr("t", "1766847151")
+                .children([NodeBuilder::new("surprise").build()])
+                .build(),
+        );
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+
+        while let Ok(ev) = rx.try_recv() {
+            assert!(
+                !matches!(&*ev, Event::IncomingCall(_)),
+                "must not dispatch IncomingCall for unknown action"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_stanza_does_not_error_or_dispatch() {
+        let client = make_client().await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.register_handler(handler);
+
+        let node = node_to_owned_ref(
+            &NodeBuilder::new("call")
+                .attr("from", caller_lid())
+                .attr("id", "S")
+                .children([NodeBuilder::new("offer")
+                    .attr("call-creator", caller_lid())
+                    .attr("call-id", "X")
+                    .build()])
+                .build(),
+        );
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+        while let Ok(ev) = rx.try_recv() {
+            assert!(!matches!(&*ev, Event::IncomingCall(_)));
+        }
+    }
+}

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -158,6 +158,55 @@ mod tests {
         }
     }
 
+    /// Drives the handler end-to-end with a real `NoiseSocket` wired to a
+    /// counting transport so the offer-ack send path is exercised. Without
+    /// this, a regression that removes `send_offer_ack_receipt` from the
+    /// handler would go unnoticed by the event-dispatch test alone.
+    #[tokio::test]
+    async fn offer_triggers_outbound_send() {
+        use async_trait::async_trait;
+        use bytes::Bytes;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wacore::handshake::NoiseCipher;
+
+        struct CountingTransport {
+            count: Arc<AtomicUsize>,
+        }
+
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        impl crate::transport::Transport for CountingTransport {
+            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+                self.count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+            async fn disconnect(&self) {}
+        }
+
+        let client = make_client().await;
+        let count = Arc::new(AtomicUsize::new(0));
+        let transport: Arc<dyn crate::transport::Transport> = Arc::new(CountingTransport {
+            count: count.clone(),
+        });
+        let key = [0u8; 32];
+        let noise_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            transport,
+            NoiseCipher::new(&key).expect("valid key"),
+            NoiseCipher::new(&key).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+
+        let node = node_to_owned_ref(&offer_stanza());
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+
+        assert!(
+            count.load(Ordering::SeqCst) >= 1,
+            "handler must invoke the outbound send path for offer ack receipts"
+        );
+    }
+
     #[tokio::test]
     async fn malformed_stanza_does_not_error_or_dispatch() {
         let client = make_client().await;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod basic;
+pub mod call;
 pub mod chatstate;
 pub mod ib;
 pub mod iq;

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1424,6 +1424,24 @@ pub fn ensure_status_participants(
     stanza
 }
 
+/// Build a `Message.ProtocolMessage` for `GROUP_MEMBER_LABEL_CHANGE`.
+///
+/// Sent via the standard E2EE fanout, not an IQ. Empty `label` clears.
+/// `ts_secs` is unix seconds, matching WA Web's `unixTime()`.
+pub fn build_member_label_message(label: String, ts_secs: i64) -> wa::Message {
+    wa::Message {
+        protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+            r#type: Some(wa::message::protocol_message::Type::GroupMemberLabelChange as i32),
+            member_label: Some(wa::MemberLabel {
+                label: Some(label),
+                label_timestamp: Some(ts_secs),
+            }),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1431,6 +1449,49 @@ mod tests {
     use crate::libsignal::protocol::{IdentityKeyPair, KeyPair, PreKeyBundle};
     use std::collections::HashMap;
     use wacore_binary::Jid;
+
+    #[test]
+    fn build_member_label_message_sets_fields() {
+        let msg = build_member_label_message("VIP".to_string(), 1_766_847_151);
+        let pm = msg.protocol_message.as_ref().expect("protocol_message set");
+        assert_eq!(
+            pm.r#type,
+            Some(wa::message::protocol_message::Type::GroupMemberLabelChange as i32)
+        );
+        let ml = pm.member_label.as_ref().expect("member_label set");
+        assert_eq!(ml.label.as_deref(), Some("VIP"));
+        assert_eq!(ml.label_timestamp, Some(1_766_847_151));
+        assert!(
+            pm.key.is_none(),
+            "MessageKey must NOT be set (WA Web parity)"
+        );
+    }
+
+    #[test]
+    fn build_member_label_message_clear_uses_empty_string() {
+        let msg = build_member_label_message(String::new(), 1);
+        let ml = msg
+            .protocol_message
+            .as_ref()
+            .unwrap()
+            .member_label
+            .as_ref()
+            .unwrap();
+        assert_eq!(ml.label.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn build_member_label_message_preserves_unicode() {
+        let msg = build_member_label_message("🚀 BOT".to_string(), 2);
+        let ml = msg
+            .protocol_message
+            .as_ref()
+            .unwrap()
+            .member_label
+            .as_ref()
+            .unwrap();
+        assert_eq!(ml.label.as_deref(), Some("🚀 BOT"));
+    }
 
     /// Mock implementation of SendContextResolver for testing
     struct MockSendContextResolver {

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -59,6 +59,21 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     }))
 }
 
+fn parse_audio_codec(node: &NodeRef<'_>) -> Result<CallAudioCodec> {
+    let mut a = node.attrs();
+    let enc = a
+        .required_string("enc")
+        .map_err(|e| anyhow!("<audio> missing 'enc': {e}"))?
+        .into_owned();
+    let rate_raw = a
+        .optional_u64("rate")
+        .ok_or_else(|| anyhow!("<audio enc={enc}> missing or invalid 'rate'"))?;
+    let rate = u32::try_from(rate_raw)
+        .map_err(|_| anyhow!("<audio enc={enc}> 'rate'={rate_raw} overflows u32"))?;
+    a.finish().map_err(|e| anyhow!("<audio> attrs: {e}"))?;
+    Ok(CallAudioCodec { enc, rate })
+}
+
 fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
     let mut attrs = node.attrs();
     let call_id = attrs
@@ -87,19 +102,11 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
 
             let children = node.children().unwrap_or_default();
             let is_video = children.iter().any(|c| c.tag == "video");
-            let audio: Vec<CallAudioCodec> = children
+            let audio = children
                 .iter()
                 .filter(|c| c.tag == "audio")
-                .filter_map(|c| {
-                    let mut a = c.attrs();
-                    let enc = a.optional_string("enc")?.into_owned();
-                    let rate = a
-                        .optional_u64("rate")
-                        .and_then(|r| u32::try_from(r).ok())
-                        .unwrap_or(0);
-                    Some(CallAudioCodec { enc, rate })
-                })
-                .collect();
+                .map(parse_audio_codec)
+                .collect::<Result<Vec<_>>>()?;
 
             CallAction::Offer {
                 call_id,
@@ -392,6 +399,42 @@ mod tests {
             .children([NodeBuilder::new("surprise").build()])
             .build();
         assert!(parse_call_stanza(&as_ref(&node)).unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_audio_missing_enc_errors() {
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .children([NodeBuilder::new("audio").attr("rate", "16000").build()])
+                .build()])
+            .build();
+
+        assert!(parse_call_stanza(&as_ref(&node)).is_err());
+    }
+
+    #[test]
+    fn malformed_audio_missing_rate_errors() {
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .children([NodeBuilder::new("audio").attr("enc", "opus").build()])
+                .build()])
+            .build();
+
+        assert!(parse_call_stanza(&as_ref(&node)).is_err());
+    }
+
+    #[test]
+    fn malformed_audio_rate_overflow_errors() {
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .children([NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", "4294967296") // u32::MAX + 1
+                    .build()])
+                .build()])
+            .build();
+
+        assert!(parse_call_stanza(&as_ref(&node)).is_err());
     }
 
     #[test]

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -2,17 +2,27 @@
 //! children so future server additions don't break the handler.
 
 use anyhow::{Result, anyhow};
-use wacore_binary::NodeRef;
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::{Jid, Node, NodeRef};
 
 use crate::time::from_secs;
 use crate::types::call::{CallAction, CallAudioCodec, IncomingCall};
 
-const KNOWN_ACTIONS: &[&str] = &["offer", "pre-accept", "accept", "reject", "terminate"];
+const KNOWN_ACTIONS: &[&str] = &["offer", "preaccept", "accept", "reject", "terminate"];
 
 pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     if node.tag != "call" {
         return Err(anyhow!("expected <call>, got <{}>", node.tag));
     }
+
+    // Find a known action child first so unknown/future actions short-circuit
+    // before attr validation (forward-compat, even if stanza attrs also shift).
+    let Some(child) = node
+        .children()
+        .and_then(|cs| cs.iter().find(|c| KNOWN_ACTIONS.contains(&c.tag.as_ref())))
+    else {
+        return Ok(None);
+    };
 
     let mut attrs = node.attrs();
     let from = attrs
@@ -34,13 +44,6 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     let offline = attrs.optional_string("e").is_some_and(|s| s == "1");
 
     attrs.finish().map_err(|e| anyhow!("<call> attrs: {e}"))?;
-
-    let Some(child) = node
-        .children()
-        .and_then(|cs| cs.iter().find(|c| KNOWN_ACTIONS.contains(&c.tag.as_ref())))
-    else {
-        return Ok(None);
-    };
 
     let action = parse_action(child)?;
 
@@ -109,7 +112,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 audio,
             }
         }
-        "pre-accept" => CallAction::PreAccept {
+        "preaccept" => CallAction::PreAccept {
             call_id,
             call_creator,
         },
@@ -139,35 +142,63 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
     })
 }
 
+/// Build `<receipt to=caller id=stanza_id [from=own_ad]><offer call-id call-creator/></receipt>`
+/// for acknowledging an incoming `<offer>`. Pure so it can be unit-tested
+/// without a live socket.
+pub fn build_offer_ack_receipt(call: &IncomingCall, own_ad: Option<&Jid>) -> Option<Node> {
+    let CallAction::Offer {
+        call_id,
+        call_creator,
+        ..
+    } = &call.action
+    else {
+        return None;
+    };
+
+    let mut receipt = NodeBuilder::new("receipt")
+        .attr("to", &call.from)
+        .attr("id", call.stanza_id.as_str());
+    if let Some(jid) = own_ad {
+        receipt = receipt.attr("from", jid);
+    }
+
+    let offer = NodeBuilder::new("offer")
+        .attr("call-id", call_id.as_str())
+        .attr("call-creator", call_creator)
+        .build();
+
+    Some(receipt.children([offer]).build())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
-    fn caller_lid() -> Jid {
-        Jid::new("271240153559280", Server::Lid)
+    fn fake_caller_lid() -> Jid {
+        Jid::new("111111111111111", Server::Lid)
     }
 
-    fn caller_pn_jid() -> Jid {
-        Jid::new("559984726682", Server::Pn)
+    fn fake_caller_pn() -> Jid {
+        Jid::new("15555550100", Server::Pn)
     }
 
     fn base_call_builder() -> NodeBuilder {
         NodeBuilder::new("call")
-            .attr("from", caller_lid())
-            .attr("id", "749D3EE94DC6B008974C36460DA2D9BC")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-0001")
             .attr("version", "2.25.37.76")
             .attr("platform", "android")
-            .attr("notify", "Elis")
+            .attr("notify", "Test Caller")
             .attr("t", "1766847151")
             .attr("e", "0")
     }
 
     fn offer_builder_base() -> NodeBuilder {
         NodeBuilder::new("offer")
-            .attr("call-creator", caller_lid())
-            .attr("call-id", "AC589ABE46B3770DC5B7A143D007DC3E")
+            .attr("call-creator", fake_caller_lid())
+            .attr("call-id", "CALL-ID-0001")
     }
 
     fn as_ref<'a>(n: &'a wacore_binary::Node) -> NodeRef<'a> {
@@ -178,7 +209,7 @@ mod tests {
     fn offer_audio_only() {
         let node = base_call_builder()
             .children([offer_builder_base()
-                .attr("caller_pn", caller_pn_jid())
+                .attr("caller_pn", fake_caller_pn())
                 .attr("device_class", "2016")
                 .attr("joinable", "1")
                 .attr("caller_country_code", "BR")
@@ -196,11 +227,11 @@ mod tests {
             .build();
 
         let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
-        assert_eq!(call.stanza_id, "749D3EE94DC6B008974C36460DA2D9BC");
-        assert_eq!(call.from, caller_lid());
+        assert_eq!(call.stanza_id, "STANZA-ID-0001");
+        assert_eq!(call.from, fake_caller_lid());
         assert_eq!(call.timestamp.timestamp(), 1766847151);
         assert!(!call.offline);
-        assert_eq!(call.notify.as_deref(), Some("Elis"));
+        assert_eq!(call.notify.as_deref(), Some("Test Caller"));
         assert_eq!(call.platform.as_deref(), Some("android"));
 
         match call.action {
@@ -214,9 +245,9 @@ mod tests {
                 is_video,
                 audio,
             } => {
-                assert_eq!(call_id, "AC589ABE46B3770DC5B7A143D007DC3E");
-                assert_eq!(call_creator, caller_lid());
-                assert_eq!(caller_pn, Some(caller_pn_jid()));
+                assert_eq!(call_id, "CALL-ID-0001");
+                assert_eq!(call_creator, fake_caller_lid());
+                assert_eq!(caller_pn, Some(fake_caller_pn()));
                 assert_eq!(caller_country_code.as_deref(), Some("BR"));
                 assert_eq!(device_class.as_deref(), Some("2016"));
                 assert!(joinable);
@@ -259,8 +290,8 @@ mod tests {
     #[test]
     fn offer_minimum_attrs() {
         let node = NodeBuilder::new("call")
-            .attr("from", caller_lid())
-            .attr("id", "STANZA1")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-0001")
             .attr("t", "1766847151")
             .children([offer_builder_base().build()])
             .build();
@@ -291,15 +322,15 @@ mod tests {
     }
 
     #[test]
-    fn pre_accept_accept_reject_variants() {
+    fn preaccept_accept_reject_variants() {
         for (tag, expected_variant) in [
-            ("pre-accept", "pre_accept"),
+            ("preaccept", "pre_accept"),
             ("accept", "accept"),
             ("reject", "reject"),
         ] {
             let node = base_call_builder()
                 .children([NodeBuilder::new(tag)
-                    .attr("call-creator", caller_lid())
+                    .attr("call-creator", fake_caller_lid())
                     .attr("call-id", "CID")
                     .build()])
                 .build();
@@ -320,7 +351,7 @@ mod tests {
     fn terminate_with_duration() {
         let node = base_call_builder()
             .children([NodeBuilder::new("terminate")
-                .attr("call-creator", caller_lid())
+                .attr("call-creator", fake_caller_lid())
                 .attr("call-id", "CID")
                 .attr("duration", "3670")
                 .attr("audio_duration", "3670")
@@ -350,10 +381,21 @@ mod tests {
     }
 
     #[test]
+    fn unknown_action_short_circuits_before_attr_validation() {
+        // No `t` attr, but unknown action means we never validate it.
+        let node = NodeBuilder::new("call")
+            .attr("from", fake_caller_lid())
+            .attr("id", "S")
+            .children([NodeBuilder::new("surprise").build()])
+            .build();
+        assert!(parse_call_stanza(&as_ref(&node)).unwrap().is_none());
+    }
+
+    #[test]
     fn malformed_missing_t_errors() {
         let node = NodeBuilder::new("call")
-            .attr("from", caller_lid())
-            .attr("id", "STANZA1")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-0001")
             .children([offer_builder_base().build()])
             .build();
 
@@ -363,7 +405,7 @@ mod tests {
     #[test]
     fn offline_delivery_flag() {
         let offline_node = NodeBuilder::new("call")
-            .attr("from", caller_lid())
+            .attr("from", fake_caller_lid())
             .attr("id", "S")
             .attr("t", "1766847151")
             .attr("e", "1")
@@ -377,7 +419,7 @@ mod tests {
         );
 
         let online_node = NodeBuilder::new("call")
-            .attr("from", caller_lid())
+            .attr("from", fake_caller_lid())
             .attr("id", "S")
             .attr("t", "1766847151")
             .children([offer_builder_base().build()])
@@ -388,5 +430,56 @@ mod tests {
                 .unwrap()
                 .offline
         );
+    }
+
+    #[test]
+    fn build_offer_ack_receipt_matches_wa_web_shape() {
+        let node = base_call_builder()
+            .children([offer_builder_base().build()])
+            .build();
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        let own = Jid::new("222222222222222", Server::Lid).with_device(42);
+
+        let receipt = build_offer_ack_receipt(&call, Some(&own)).unwrap();
+        assert_eq!(receipt.tag.as_ref(), "receipt");
+
+        let mut a = receipt.attrs();
+        assert_eq!(
+            a.required_string("to").unwrap(),
+            fake_caller_lid().to_string()
+        );
+        assert_eq!(a.required_string("id").unwrap(), "STANZA-ID-0001");
+        assert_eq!(a.required_string("from").unwrap(), own.to_string());
+
+        let offer = receipt.get_optional_child("offer").unwrap();
+        let mut oa = offer.attrs();
+        assert_eq!(oa.required_string("call-id").unwrap(), "CALL-ID-0001");
+        assert_eq!(
+            oa.required_string("call-creator").unwrap(),
+            fake_caller_lid().to_string()
+        );
+    }
+
+    #[test]
+    fn build_offer_ack_receipt_returns_none_for_non_offer() {
+        let node = base_call_builder()
+            .children([NodeBuilder::new("reject")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "X")
+                .build()])
+            .build();
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        assert!(build_offer_ack_receipt(&call, None).is_none());
+    }
+
+    #[test]
+    fn build_offer_ack_receipt_omits_from_when_own_ad_missing() {
+        let node = base_call_builder()
+            .children([offer_builder_base().build()])
+            .build();
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        let receipt = build_offer_ack_receipt(&call, None).unwrap();
+        let mut a = receipt.attrs();
+        assert!(a.optional_string("from").is_none());
     }
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -131,6 +131,9 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
             let audio_duration = attrs
                 .optional_u64("audio_duration")
                 .and_then(|v| u32::try_from(v).ok());
+            attrs
+                .finish()
+                .map_err(|e| anyhow!("<terminate> attrs: {e}"))?;
             CallAction::Terminate {
                 call_id,
                 call_creator,

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -1,0 +1,392 @@
+//! Parser for inbound `<call>` stanzas. Returns `Ok(None)` on unknown action
+//! children so future server additions don't break the handler.
+
+use anyhow::{Result, anyhow};
+use wacore_binary::NodeRef;
+
+use crate::time::from_secs;
+use crate::types::call::{CallAction, CallAudioCodec, IncomingCall};
+
+const KNOWN_ACTIONS: &[&str] = &["offer", "pre-accept", "accept", "reject", "terminate"];
+
+pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
+    if node.tag != "call" {
+        return Err(anyhow!("expected <call>, got <{}>", node.tag));
+    }
+
+    let mut attrs = node.attrs();
+    let from = attrs
+        .optional_jid("from")
+        .ok_or_else(|| anyhow!("<call> missing 'from' attribute"))?;
+    let stanza_id = attrs
+        .required_string("id")
+        .map_err(|e| anyhow!("<call> missing 'id': {e}"))?
+        .into_owned();
+    let notify = attrs
+        .optional_string("notify")
+        .and_then(|s| (!s.is_empty()).then(|| s.into_owned()));
+    let platform = attrs.optional_string("platform").map(|s| s.into_owned());
+    let version = attrs.optional_string("version").map(|s| s.into_owned());
+    let ts = attrs
+        .optional_unix_time("t")
+        .ok_or_else(|| anyhow!("<call> missing or invalid 't' attribute"))?;
+    let timestamp = from_secs(ts).ok_or_else(|| anyhow!("<call> 't'={ts} out of range"))?;
+    let offline = attrs.optional_string("e").is_some_and(|s| s == "1");
+
+    attrs.finish().map_err(|e| anyhow!("<call> attrs: {e}"))?;
+
+    let Some(child) = node
+        .children()
+        .and_then(|cs| cs.iter().find(|c| KNOWN_ACTIONS.contains(&c.tag.as_ref())))
+    else {
+        return Ok(None);
+    };
+
+    let action = parse_action(child)?;
+
+    Ok(Some(IncomingCall {
+        from,
+        stanza_id,
+        notify,
+        platform,
+        version,
+        timestamp,
+        offline,
+        action,
+    }))
+}
+
+fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
+    let mut attrs = node.attrs();
+    let call_id = attrs
+        .required_string("call-id")
+        .map_err(|e| anyhow!("<{}> missing 'call-id': {e}", node.tag))?
+        .into_owned();
+    let call_creator = attrs
+        .optional_jid("call-creator")
+        .ok_or_else(|| anyhow!("<{}> missing 'call-creator'", node.tag))?;
+
+    Ok(match node.tag.as_ref() {
+        "offer" => {
+            let caller_pn = attrs.optional_jid("caller_pn");
+            let caller_country_code = attrs
+                .optional_string("caller_country_code")
+                .map(|s| s.into_owned());
+            let device_class = attrs
+                .optional_string("device_class")
+                .map(|s| s.into_owned());
+            let joinable = attrs
+                .optional_string("joinable")
+                .map(|s| s == "1")
+                .unwrap_or(false);
+
+            attrs.finish().map_err(|e| anyhow!("<offer> attrs: {e}"))?;
+
+            let children = node.children().unwrap_or_default();
+            let is_video = children.iter().any(|c| c.tag == "video");
+            let audio: Vec<CallAudioCodec> = children
+                .iter()
+                .filter(|c| c.tag == "audio")
+                .filter_map(|c| {
+                    let mut a = c.attrs();
+                    let enc = a.optional_string("enc")?.into_owned();
+                    let rate = a
+                        .optional_u64("rate")
+                        .and_then(|r| u32::try_from(r).ok())
+                        .unwrap_or(0);
+                    Some(CallAudioCodec { enc, rate })
+                })
+                .collect();
+
+            CallAction::Offer {
+                call_id,
+                call_creator,
+                caller_pn,
+                caller_country_code,
+                device_class,
+                joinable,
+                is_video,
+                audio,
+            }
+        }
+        "pre-accept" => CallAction::PreAccept {
+            call_id,
+            call_creator,
+        },
+        "accept" => CallAction::Accept {
+            call_id,
+            call_creator,
+        },
+        "reject" => CallAction::Reject {
+            call_id,
+            call_creator,
+        },
+        "terminate" => {
+            let duration = attrs
+                .optional_u64("duration")
+                .and_then(|v| u32::try_from(v).ok());
+            let audio_duration = attrs
+                .optional_u64("audio_duration")
+                .and_then(|v| u32::try_from(v).ok());
+            CallAction::Terminate {
+                call_id,
+                call_creator,
+                duration,
+                audio_duration,
+            }
+        }
+        other => return Err(anyhow!("unreachable: unknown action <{other}>")),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wacore_binary::builder::NodeBuilder;
+    use wacore_binary::{Jid, Server};
+
+    fn caller_lid() -> Jid {
+        Jid::new("271240153559280", Server::Lid)
+    }
+
+    fn caller_pn_jid() -> Jid {
+        Jid::new("559984726682", Server::Pn)
+    }
+
+    fn base_call_builder() -> NodeBuilder {
+        NodeBuilder::new("call")
+            .attr("from", caller_lid())
+            .attr("id", "749D3EE94DC6B008974C36460DA2D9BC")
+            .attr("version", "2.25.37.76")
+            .attr("platform", "android")
+            .attr("notify", "Elis")
+            .attr("t", "1766847151")
+            .attr("e", "0")
+    }
+
+    fn offer_builder_base() -> NodeBuilder {
+        NodeBuilder::new("offer")
+            .attr("call-creator", caller_lid())
+            .attr("call-id", "AC589ABE46B3770DC5B7A143D007DC3E")
+    }
+
+    fn as_ref<'a>(n: &'a wacore_binary::Node) -> NodeRef<'a> {
+        n.as_node_ref()
+    }
+
+    #[test]
+    fn offer_audio_only() {
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .attr("caller_pn", caller_pn_jid())
+                .attr("device_class", "2016")
+                .attr("joinable", "1")
+                .attr("caller_country_code", "BR")
+                .children([
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", "16000")
+                        .build(),
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", "8000")
+                        .build(),
+                ])
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        assert_eq!(call.stanza_id, "749D3EE94DC6B008974C36460DA2D9BC");
+        assert_eq!(call.from, caller_lid());
+        assert_eq!(call.timestamp.timestamp(), 1766847151);
+        assert!(!call.offline);
+        assert_eq!(call.notify.as_deref(), Some("Elis"));
+        assert_eq!(call.platform.as_deref(), Some("android"));
+
+        match call.action {
+            CallAction::Offer {
+                call_id,
+                call_creator,
+                caller_pn,
+                caller_country_code,
+                device_class,
+                joinable,
+                is_video,
+                audio,
+            } => {
+                assert_eq!(call_id, "AC589ABE46B3770DC5B7A143D007DC3E");
+                assert_eq!(call_creator, caller_lid());
+                assert_eq!(caller_pn, Some(caller_pn_jid()));
+                assert_eq!(caller_country_code.as_deref(), Some("BR"));
+                assert_eq!(device_class.as_deref(), Some("2016"));
+                assert!(joinable);
+                assert!(!is_video);
+                assert_eq!(audio.len(), 2);
+                assert_eq!(audio[0].enc, "opus");
+                assert_eq!(audio[0].rate, 16000);
+                assert_eq!(audio[1].rate, 8000);
+            }
+            other => panic!("expected Offer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offer_video() {
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .children([
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", "16000")
+                        .build(),
+                    NodeBuilder::new("video").build(),
+                ])
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::Offer {
+                is_video, audio, ..
+            } => {
+                assert!(is_video);
+                assert_eq!(audio.len(), 1);
+            }
+            other => panic!("expected Offer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offer_minimum_attrs() {
+        let node = NodeBuilder::new("call")
+            .attr("from", caller_lid())
+            .attr("id", "STANZA1")
+            .attr("t", "1766847151")
+            .children([offer_builder_base().build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        assert_eq!(call.notify, None);
+        assert_eq!(call.platform, None);
+        assert_eq!(call.version, None);
+        match call.action {
+            CallAction::Offer {
+                caller_pn,
+                caller_country_code,
+                device_class,
+                joinable,
+                is_video,
+                audio,
+                ..
+            } => {
+                assert_eq!(caller_pn, None);
+                assert_eq!(caller_country_code, None);
+                assert_eq!(device_class, None);
+                assert!(!joinable);
+                assert!(!is_video);
+                assert!(audio.is_empty());
+            }
+            other => panic!("expected Offer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pre_accept_accept_reject_variants() {
+        for (tag, expected_variant) in [
+            ("pre-accept", "pre_accept"),
+            ("accept", "accept"),
+            ("reject", "reject"),
+        ] {
+            let node = base_call_builder()
+                .children([NodeBuilder::new(tag)
+                    .attr("call-creator", caller_lid())
+                    .attr("call-id", "CID")
+                    .build()])
+                .build();
+
+            let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+            assert_eq!(call.action.call_id(), "CID");
+            let name = match call.action {
+                CallAction::PreAccept { .. } => "pre_accept",
+                CallAction::Accept { .. } => "accept",
+                CallAction::Reject { .. } => "reject",
+                _ => "other",
+            };
+            assert_eq!(name, expected_variant);
+        }
+    }
+
+    #[test]
+    fn terminate_with_duration() {
+        let node = base_call_builder()
+            .children([NodeBuilder::new("terminate")
+                .attr("call-creator", caller_lid())
+                .attr("call-id", "CID")
+                .attr("duration", "3670")
+                .attr("audio_duration", "3670")
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::Terminate {
+                duration,
+                audio_duration,
+                ..
+            } => {
+                assert_eq!(duration, Some(3670));
+                assert_eq!(audio_duration, Some(3670));
+            }
+            other => panic!("expected Terminate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_action_returns_none() {
+        let node = base_call_builder()
+            .children([NodeBuilder::new("surprise").build()])
+            .build();
+        assert!(parse_call_stanza(&as_ref(&node)).unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_missing_t_errors() {
+        let node = NodeBuilder::new("call")
+            .attr("from", caller_lid())
+            .attr("id", "STANZA1")
+            .children([offer_builder_base().build()])
+            .build();
+
+        assert!(parse_call_stanza(&as_ref(&node)).is_err());
+    }
+
+    #[test]
+    fn offline_delivery_flag() {
+        let offline_node = NodeBuilder::new("call")
+            .attr("from", caller_lid())
+            .attr("id", "S")
+            .attr("t", "1766847151")
+            .attr("e", "1")
+            .children([offer_builder_base().build()])
+            .build();
+        assert!(
+            parse_call_stanza(&as_ref(&offline_node))
+                .unwrap()
+                .unwrap()
+                .offline
+        );
+
+        let online_node = NodeBuilder::new("call")
+            .attr("from", caller_lid())
+            .attr("id", "S")
+            .attr("t", "1766847151")
+            .children([offer_builder_base().build()])
+            .build();
+        assert!(
+            !parse_call_stanza(&as_ref(&online_node))
+                .unwrap()
+                .unwrap()
+                .offline
+        );
+    }
+}

--- a/wacore/src/stanza/mod.rs
+++ b/wacore/src/stanza/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains type-safe parsers for incoming notification stanzas.
 
 pub mod business;
+pub mod call;
 pub mod devices;
 pub mod groups;
 pub mod message;

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use serde::Serialize;
 use wacore_binary::Jid;
 
 #[derive(Debug, Clone)]
@@ -13,4 +14,89 @@ pub struct BasicCallMeta {
 pub struct CallRemoteMeta {
     pub remote_platform: String,
     pub remote_version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CallAudioCodec {
+    pub enc: String,
+    pub rate: u32,
+}
+
+/// Fields kept per-variant (not a shared `BasicCallMeta`) so the `serde` shape
+/// mirrors the stanza 1:1 for downstream JS consumers.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CallAction {
+    Offer {
+        call_id: String,
+        call_creator: Jid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        caller_pn: Option<Jid>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        caller_country_code: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        device_class: Option<String>,
+        joinable: bool,
+        is_video: bool,
+        audio: Vec<CallAudioCodec>,
+    },
+    PreAccept {
+        call_id: String,
+        call_creator: Jid,
+    },
+    Accept {
+        call_id: String,
+        call_creator: Jid,
+    },
+    Reject {
+        call_id: String,
+        call_creator: Jid,
+    },
+    Terminate {
+        call_id: String,
+        call_creator: Jid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        audio_duration: Option<u32>,
+    },
+}
+
+impl CallAction {
+    pub fn call_id(&self) -> &str {
+        match self {
+            Self::Offer { call_id, .. }
+            | Self::PreAccept { call_id, .. }
+            | Self::Accept { call_id, .. }
+            | Self::Reject { call_id, .. }
+            | Self::Terminate { call_id, .. } => call_id,
+        }
+    }
+
+    pub fn call_creator(&self) -> &Jid {
+        match self {
+            Self::Offer { call_creator, .. }
+            | Self::PreAccept { call_creator, .. }
+            | Self::Accept { call_creator, .. }
+            | Self::Reject { call_creator, .. }
+            | Self::Terminate { call_creator, .. } => call_creator,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IncomingCall {
+    pub from: Jid,
+    /// Stanza id; distinct from `CallAction::call_id`.
+    pub stanza_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notify: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub timestamp: DateTime<Utc>,
+    pub offline: bool,
+    pub action: CallAction,
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1,4 +1,5 @@
 use crate::stanza::BusinessSubscription;
+use crate::types::call::IncomingCall;
 use crate::types::message::MessageInfo;
 use crate::types::presence::{ChatPresence, ChatPresenceMedia, ReceiptType};
 use bytes::Bytes;
@@ -391,6 +392,10 @@ pub enum Event {
     /// Group metadata/settings/participant change from w:gp2 notification.
     GroupUpdate(GroupUpdate),
     ContactUpdate(ContactUpdate),
+
+    /// Incoming `<call>` stanza from the server (offer, pre-accept, accept,
+    /// reject, terminate). Mirror of WA Web's inbound call signaling.
+    IncomingCall(IncomingCall),
 
     PushNameUpdate(PushNameUpdate),
     SelfPushNameUpdated(SelfPushNameUpdated),

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -393,7 +393,7 @@ pub enum Event {
     GroupUpdate(GroupUpdate),
     ContactUpdate(ContactUpdate),
 
-    /// Incoming `<call>` stanza from the server (offer, pre-accept, accept,
+    /// Incoming `<call>` stanza from the server (offer, preaccept, accept,
     /// reject, terminate). Mirror of WA Web's inbound call signaling.
     IncomingCall(IncomingCall),
 


### PR DESCRIPTION
## Summary

Two features unblocking Baileys-style bot migration on top of this crate:

### 1. `Event::IncomingCall`

Inbound `<call>` stanzas (offer / pre-accept / accept / reject / terminate) were being dropped by `UnimplementedHandler::for_call()`. Consumers had no way to react to ring events, which made the existing `reject_call` API effectively unusable.

- New `IncomingCall` / `CallAction` / `CallAudioCodec` types in `wacore/src/types/call.rs`, re-exported through `Event::IncomingCall(IncomingCall)` in `wacore/src/types/events.rs`.
- Pure parser `wacore::stanza::call::parse_call_stanza` (returns `Ok(None)` on unknown action children for forward-compat).
- New `CallHandler` in `src/handlers/call.rs`, registered in place of the old placeholder. Parses, dispatches, and for `Offer` actions emits the `<receipt><offer call-id=.../></receipt>` ack-of-offer observed in captured WA Web traffic (see `docs/real-log-whatsapp-web-accepting-call.json`).
- Router already ACKs `<call>` via `should_ack`, so the handler does not send a duplicate `<ack>`.

### 2. `Groups::update_member_label`

Sets (or clears, with an empty string) the bot's per-group member label. Investigation of `docs/captured-js/WAWeb/Send/MemberLabelAction.js` + `Generate/ProtocolMemberLabelMessageProto.js` confirmed this is **not** an IQ: WA Web sends it as a `ProtocolMessage` (`type = GROUP_MEMBER_LABEL_CHANGE`) over the normal E2EE fanout path.

- New `wacore::send::build_member_label_message(label, ts_secs)` helper. Takes `String` (not `&str`) so callers can move without double-allocating.
- `Groups::update_member_label(&self, group_jid, label)` consumes the label once, delegates to `send_message_impl`.
- `labelTimestamp` is unix seconds, confirmed via `docs/captured-js/WA/Time/Utils.js:88` (`unixTime()` returns `Date.now() / 1e3 - skew`).

## Wire format sources of truth

- Feature 1 offer stanza: `docs/real-log-whatsapp-web-accepting-call.json` (captured 2025-12-27). Confirms the stanza `id` vs `<offer call-id>` split and shows the `<receipt><offer/></receipt>` ack-of-offer shape.
- Feature 2: `WAWeb/Send/MemberLabelAction.js`, `WAWeb/Generate/ProtocolMemberLabelMessageProto.js`, `WAWeb/Parse/ProtocolMemberLabelMessageProto.js`, `WAWeb/Handle/MemberLabelChange.js`, and proto definitions at `waproto/src/whatsapp.proto:2179` (`MemberLabel`), `:3572` (`GROUP_MEMBER_LABEL_CHANGE = 30`).

## Non-goals

- Outgoing `accept` / `pre-accept` / `terminate` call signaling.
- Synthesizing a `timeout` call event.
- JS bridge mapping (follow-up in `whatsapp-rust-bridge`).

## Test plan

- [ ] `cargo test -p wacore --lib stanza::call` (8 parser cases)
- [ ] `cargo test -p wacore --lib send::tests::build_member_label` (3 proto builder cases)
- [ ] `cargo test --lib handlers::call` (3 handler dispatch cases)
- [ ] `cargo clippy --all --tests`
- [ ] `cargo fmt --all --check`