### PR TITLE
fix: status reactions via send_message with correct E2EE wire format

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -67,8 +67,8 @@ impl MessageContext {
         )
     }
 
-    /// [`wa::MessageKey`] referencing this message. `participant` is populated
-    /// for groups and status so reactions/revokes can identify the author.
+    /// Referential [`wa::MessageKey`] for [`wa::message::ReactionMessage::key`].
+    /// Sender-side revokes have a different shape; use [`Client::revoke_message`].
     pub fn message_key(&self) -> wa::MessageKey {
         use wacore_binary::JidExt;
         let needs_participant =

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -67,6 +67,20 @@ impl MessageContext {
         )
     }
 
+    /// [`wa::MessageKey`] referencing this message. `participant` is populated
+    /// for groups and status so reactions/revokes can identify the author.
+    pub fn message_key(&self) -> wa::MessageKey {
+        use wacore_binary::JidExt;
+        let needs_participant =
+            self.info.source.is_group || self.info.source.chat.is_status_broadcast();
+        wa::MessageKey {
+            remote_jid: Some(self.info.source.chat.to_string()),
+            from_me: Some(self.info.source.is_from_me),
+            id: Some(self.info.id.clone()),
+            participant: needs_participant.then(|| self.info.source.sender.to_string()),
+        }
+    }
+
     pub async fn edit_message(
         &self,
         original_message_id: impl Into<String>,

--- a/src/features/status.rs
+++ b/src/features/status.rs
@@ -180,22 +180,6 @@ impl<'a> Status<'a> {
             .send_status_message(revoke_message, recipients, options)
             .await
     }
-
-    /// React to someone's status update (e.g. the "like" heart in WA Web).
-    ///
-    /// `status_owner` is the JID of the person whose status you're reacting to.
-    /// `server_id` is the server-assigned ID of the status message.
-    /// `reaction` is the emoji code (e.g. "💚" for the default like). Pass empty to remove.
-    pub async fn send_reaction(
-        &self,
-        status_owner: &Jid,
-        server_id: u64,
-        reaction: &str,
-    ) -> Result<(), anyhow::Error> {
-        self.client
-            .send_server_reaction(status_owner, server_id, reaction)
-            .await
-    }
 }
 
 impl Client {

--- a/src/send.rs
+++ b/src/send.rs
@@ -851,10 +851,11 @@ impl Client {
                 .and_then(|rm| rm.key.as_ref())
                 .and_then(|k| k.participant.as_ref())
                 .and_then(|p| p.parse::<Jid>().ok())
+                .filter(|jid| jid.is_pn() || jid.is_lid())
                 .ok_or_else(|| {
                     anyhow!(
                         "send_message to status@broadcast requires \
-                         reaction_message.key.participant = status author. \
+                         reaction_message.key.participant = status author (user JID). \
                          Use client.status() for posting new statuses."
                     )
                 })?;
@@ -1694,6 +1695,36 @@ mod tests {
         assert!(
             msg.contains("reaction_message") || msg.contains("status"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_message_to_status_reaction_rejects_non_user_participant() {
+        let client = crate::test_utils::create_test_client().await;
+        let to = Jid::status_broadcast();
+        let err = client
+            .send_message(
+                to,
+                wa::Message {
+                    reaction_message: Some(wa::message::ReactionMessage {
+                        key: Some(wa::MessageKey {
+                            remote_jid: Some("status@broadcast".into()),
+                            from_me: Some(false),
+                            id: Some("ORIGID".into()),
+                            participant: Some("120363040237990503@g.us".into()),
+                        }),
+                        text: Some("❤️".into()),
+                        sender_timestamp_ms: Some(1),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("group JID as participant must error");
+        assert!(
+            format!("{err}").contains("user JID"),
+            "expected user-JID error, got: {err}"
         );
     }
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -842,12 +842,26 @@ impl Client {
         edit: Option<crate::types::message::EditAttribute>,
         extra_stanza_nodes: Vec<Node>,
     ) -> Result<(), anyhow::Error> {
-        // Status broadcasts must go through send_status_message() which provides recipients
-        if to.is_status_broadcast() {
-            return Err(anyhow!(
-                "Use send_status_message() or client.status() API for status@broadcast"
-            ));
-        }
+        // status@broadcast reactions fan out pairwise to the author's devices;
+        // status posts keep going through send_status_message (owns recipients).
+        let (to, is_status_addon) = if to.is_status_broadcast() {
+            let author = message
+                .reaction_message
+                .as_ref()
+                .and_then(|rm| rm.key.as_ref())
+                .and_then(|k| k.participant.as_ref())
+                .and_then(|p| p.parse::<Jid>().ok())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "send_message to status@broadcast requires \
+                         reaction_message.key.participant = status author. \
+                         Use client.status() for posting new statuses."
+                    )
+                })?;
+            (author, true)
+        } else {
+            (to, false)
+        };
 
         // Generate request ID early (doesn't need lock)
         let request_id = match request_id_override {
@@ -1030,7 +1044,14 @@ impl Client {
             // Per-device locking to match decrypt path (message.rs:684),
             // preventing ratchet desync on concurrent send/receive.
 
-            self.add_recent_message(&to, &request_id, message).await;
+            // Status reaction retries arrive with `from=status@broadcast`;
+            // cache under the broadcast chat so take_recent_message hits.
+            if is_status_addon {
+                self.add_recent_message(&Jid::status_broadcast(), &request_id, message)
+                    .await;
+            } else {
+                self.add_recent_message(&to, &request_id, message).await;
+            }
 
             let device_snapshot = self.persistence_manager.get_device_snapshot().await;
             let own_jid = device_snapshot
@@ -1121,7 +1142,9 @@ impl Client {
             self.ensure_e2e_sessions(&all_dm_jids).await?;
 
             let mut extra_stanza_nodes = extra_stanza_nodes;
-            if !to.is_group() && !to.is_newsletter() {
+            // tctoken applies to 1:1 chats; status reactions share the fanout
+            // path but WA Web does not attach tctokens to them.
+            if !to.is_group() && !to.is_newsletter() && !is_status_addon {
                 let (should_issue_after_send, cached_token_key) = self
                     .maybe_include_tc_token(&to, &mut extra_stanza_nodes)
                     .await;
@@ -1174,6 +1197,13 @@ impl Client {
         } else {
             None
         };
+
+        // Server expects the outer `to` as the broadcast chat even though
+        // encryption targeted the author's devices (mirrors incoming `from`).
+        let mut stanza_to_send = stanza_to_send;
+        if is_status_addon {
+            stanza_to_send.attrs.insert("to", Jid::status_broadcast());
+        }
 
         if let Err(e) = self.send_node(stanza_to_send).await {
             if let Some((_, _, ref msg_id)) = ack {
@@ -1645,6 +1675,57 @@ impl Client {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[tokio::test]
+    async fn send_message_to_status_without_reaction_errors() {
+        let client = crate::test_utils::create_test_client().await;
+        let to = Jid::status_broadcast();
+        let err = client
+            .send_message(
+                to,
+                wa::Message {
+                    conversation: Some("hi".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("status@broadcast without reaction must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("reaction_message") || msg.contains("status"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_message_to_status_reaction_without_participant_errors() {
+        let client = crate::test_utils::create_test_client().await;
+        let to = Jid::status_broadcast();
+        let err = client
+            .send_message(
+                to,
+                wa::Message {
+                    reaction_message: Some(wa::message::ReactionMessage {
+                        key: Some(wa::MessageKey {
+                            remote_jid: Some("status@broadcast".into()),
+                            from_me: Some(false),
+                            id: Some("ORIGID".into()),
+                            participant: None,
+                        }),
+                        text: Some("❤️".into()),
+                        sender_timestamp_ms: Some(1),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("reaction without key.participant must error");
+        assert!(
+            format!("{err}").contains("participant"),
+            "expected participant error, got: {err}"
+        );
+    }
 
     #[test]
     fn test_revoke_type_default_is_sender() {


### PR DESCRIPTION
## Summary

Three related fixes that together let a bot react to someone's status via the natural `client.send_message(chat, reaction)` API.

### Bug 1 — `Status::send_reaction` emitted the newsletter wire format

`Status::send_reaction(owner, server_id, emoji)` built a plaintext `<message type="reaction"><reaction code="…"/></message>` with a `server_id` attribute. That's the **newsletter** reaction format (`WASmaxOutMessagePublishNewsletterQuestionResponsePublishOrReactionOrReactionRevokeOrPollVoteMixinGroup`). For status reactions — and for every non-newsletter reaction — WA Web encrypts a `ReactionMessage` protobuf via the same path as DM/group reactions (`WAWeb/Send/ReactionMsgAction.js:13-65` + `WAWeb/Reactions/MsgActionUtils.js:85-99`). The server silently drops the wrong format, and the bot's typical `let _ = client.status().send_reaction(...).await` discards the error — so this failed as a no-op in production.

Method removed. `Newsletter::send_reaction` keeps `send_server_reaction` which is the correct format for newsletters.

### Bug 2 — `send_message_impl` blocked every send to `status@broadcast`

The early return `if to.is_status_broadcast() { return Err("Use send_status_message() …") }` was the correct guard for posting new statuses, but too wide: status **reactions** must go out as `to=status@broadcast` too (confirmed via `WAWeb/Send/MsgCreateFanoutStanza.js:436` where `to = CHAT_JID(addon.data.to)` and `addon.data.to = status@broadcast` from `msgKeyToTargetInfo`, see `WAWeb/Msg/KeyUtils.js:54-79`).

When a reaction hits this path, `send_message_impl` now:

- Extracts the status author from `reaction_message.key.participant` (required; returns a clear error if missing).
- Rebinds `to = author_jid` so the existing DM fanout path (pairwise Signal to each of the author's devices, `<enc type="msg">/<enc type="pkmsg">`) runs unchanged.
- Rewrites the outer stanza `to="status@broadcast"` just before send so the wire matches WA Web.

Two downstream gates kept the fix from working correctly by itself:

- `maybe_include_tc_token` already skips `status@broadcast` internally, but since the rebind happened upstream of the check, the skip never fired. Gated by `is_status_addon` at the call site.
- `add_recent_message` was keyed by the rebound author JID. Retry receipts for status reactions arrive with `from=status@broadcast` (same pattern as the receipts our bot already emits for inbound status at `src/receipt.rs:391`), so `take_recent_message(&info.chat, …)` would miss. Now caches under the original broadcast chat when `is_status_addon`.

### Bug 3 — `MessageContext::message_key()` helper

Bot-side mistake that the old broken API masked: constructing `wa::MessageKey` with `participant = None` for statuses (since `is_group = false` for `status@broadcast`). `MessageContext::message_key()` now returns a correctly-shaped key for reactions/revokes, populating `participant` for groups AND status.

## Consumer-visible change

Before (broken): `client.status().send_reaction(owner, server_id, "❤️").await`.

After (uniform across chat types):

```rust
let reaction = wa::Message {
    reaction_message: Some(wa::message::ReactionMessage {
        key: Some(ctx.message_key()),
        text: Some("❤️".into()),
        sender_timestamp_ms: Some(Utc::now().timestamp_millis()),
        ..Default::default()
    }),
    ..Default::default()
};
ctx.send_message(reaction).await?;
```

## Evidence sources

- `docs/captured-js/WAWeb/Send/ReactionMsgAction.js:13-65` — reaction path delegates to newsletter only when chat is newsletter; otherwise builds `ReactionMessage` via `addAndSendAddonToChat`.
- `docs/captured-js/WAWeb/Reactions/MsgActionUtils.js:85-99` — returns `{type: REACTION, to: status@broadcast, …}` for status.
- `docs/captured-js/WAWeb/Msg/KeyUtils.js:54-79` — `msgKeyToTargetInfo` produces `{from: me, to: status@broadcast, author, broadcastId}` for status reactions.
- `docs/captured-js/WAWeb/Send/MsgCreateFanoutStanza.js:25-67, 436` — pairwise Signal fanout path, `to = CHAT_JID(addon.data.to)`, `<enc type="msg"/pkmsg>`, conditional `<device-identity>`, no `<meta content_type="add_on"/>` on outgoing.
- User's real bot log: inbound status reactions decode as `<enc type="msg">` with server-added `<meta content_type="add_on"/>`; no outgoing reaction ever carries that meta.

## Non-goals / not in scope

- Newsletter reaction path (unchanged, already correct).
- Receiving status reaction events with richer metadata (current receive path already works).
- A typed `Status::react` helper — the natural `ctx.send_message(reaction)` path does the job now.

## Test plan

- [ ] `cargo test -p whatsapp-rust --lib send::tests::send_message_to_status` (2 regression cases on the validation paths)
- [ ] `cargo clippy --workspace --exclude e2e-tests --tests`
- [ ] Manual check with a live bot reacting to a posted status (outside the CI scope)