### PR TITLE
fix: participant change success check + phone/username mixins

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -332,16 +332,15 @@ impl<'a> Groups<'a> {
         };
 
         let result = self.client.execute(iq).await?;
-        // phone_number mixin backfills LID↔PN maps for LID-addressed groups.
-        let accepted: Vec<_> = result
-            .iter()
-            .filter(|r| r.is_ok())
-            .map(|r| (r.jid.clone(), r.phone_number.clone()))
-            .collect();
-        if !accepted.is_empty() {
+        if result.iter().any(|r| r.is_ok()) {
             let group_cache = self.client.get_group_cache().await;
             if let Some(mut info) = group_cache.get(jid).await {
-                info.add_participants(&accepted);
+                info.add_participants(
+                    result
+                        .iter()
+                        .filter(|r| r.is_ok())
+                        .map(|r| (&r.jid, r.phone_number.as_ref())),
+                );
                 group_cache.insert(jid.clone(), info).await;
             }
         }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -332,13 +332,9 @@ impl<'a> Groups<'a> {
         };
 
         let result = self.client.execute(iq).await?;
-        // Patch cache with only the participants the server accepted (status 200).
-        // Note: the get→mutate→insert is not atomic; a concurrent notification
-        // for the same group could race.  This is acceptable — the cache is
-        // best-effort and a full refetch on next query_info() corrects it.
         let accepted: Vec<_> = result
             .iter()
-            .filter(|r| r.status.as_deref() == Some("200"))
+            .filter(|r| r.is_ok())
             .map(|r| (r.jid.clone(), None))
             .collect();
         if !accepted.is_empty() {
@@ -360,10 +356,9 @@ impl<'a> Groups<'a> {
             .client
             .execute(RemoveParticipantsIq::new(jid, participants))
             .await?;
-        // Patch cache with only the participants the server accepted.
         let accepted: Vec<&str> = result
             .iter()
-            .filter(|r| r.status.as_deref() == Some("200"))
+            .filter(|r| r.is_ok())
             .map(|r| r.jid.user.as_str())
             .collect();
         if !accepted.is_empty() {

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -332,10 +332,11 @@ impl<'a> Groups<'a> {
         };
 
         let result = self.client.execute(iq).await?;
+        // phone_number mixin backfills LID↔PN maps for LID-addressed groups.
         let accepted: Vec<_> = result
             .iter()
             .filter(|r| r.is_ok())
-            .map(|r| (r.jid.clone(), None))
+            .map(|r| (r.jid.clone(), r.phone_number.clone()))
             .collect();
         if !accepted.is_empty() {
             let group_cache = self.client.get_group_cache().await;

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1184,11 +1184,11 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
             GroupNotificationAction::Add { participants, .. } => {
                 let group_cache = client.get_group_cache().await;
                 if let Some(mut info) = group_cache.get(&notification.group_jid).await {
-                    let new: Vec<_> = participants
-                        .iter()
-                        .map(|p| (p.jid.clone(), p.phone_number.clone()))
-                        .collect();
-                    info.add_participants(&new);
+                    info.add_participants(
+                        participants
+                            .iter()
+                            .map(|p| (&p.jid, p.phone_number.as_ref())),
+                    );
                     group_cache
                         .insert(notification.group_jid.clone(), info)
                         .await;

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -86,7 +86,10 @@ impl GroupInfo {
     /// using the `phone_number` field from each participant.  Maps are updated
     /// even for already-present participants so that a later call with
     /// `Some(phone_number)` backfills a previous `None` entry.
-    pub fn add_participants(&mut self, new: &[(Jid, Option<Jid>)]) {
+    pub fn add_participants<'a, I>(&mut self, new: I)
+    where
+        I: IntoIterator<Item = (&'a Jid, Option<&'a Jid>)>,
+    {
         for (jid, phone_number) in new {
             // Always backfill LID maps — a re-add with phone_number fills a
             // previous None (e.g., client-initiated add followed by server
@@ -178,7 +181,9 @@ mod tests {
     #[test]
     fn add_participants_pn_mode() {
         let mut info = GroupInfo::new(vec![pn("alice")], AddressingMode::Pn);
-        info.add_participants(&[(pn("bob"), None), (pn("carol"), None)]);
+        let bob = pn("bob");
+        let carol = pn("carol");
+        info.add_participants([(&bob, None), (&carol, None)]);
         assert_eq!(info.participants.len(), 3);
         assert!(info.participants.iter().any(|p| p.user == "bob"));
     }
@@ -186,14 +191,18 @@ mod tests {
     #[test]
     fn add_participants_deduplicates() {
         let mut info = GroupInfo::new(vec![pn("alice"), pn("bob")], AddressingMode::Pn);
-        info.add_participants(&[(pn("bob"), None), (pn("carol"), None)]);
+        let bob = pn("bob");
+        let carol = pn("carol");
+        info.add_participants([(&bob, None), (&carol, None)]);
         assert_eq!(info.participants.len(), 3); // bob not duplicated
     }
 
     #[test]
     fn add_participants_lid_mode_updates_maps() {
         let mut info = GroupInfo::new(vec![lid("lid_alice")], AddressingMode::Lid);
-        info.add_participants(&[(lid("lid_bob"), Some(pn("bob_pn")))]);
+        let bob_lid = lid("lid_bob");
+        let bob_pn = pn("bob_pn");
+        info.add_participants([(&bob_lid, Some(&bob_pn))]);
 
         assert_eq!(info.participants.len(), 2);
         assert_eq!(
@@ -253,11 +262,13 @@ mod tests {
     fn add_participants_backfills_lid_map_for_existing() {
         let mut info = GroupInfo::new(vec![lid("lid_bob")], AddressingMode::Lid);
         // First add without phone_number (simulates client-initiated add)
-        info.add_participants(&[(lid("lid_bob"), None)]);
+        let bob_lid = lid("lid_bob");
+        let bob_pn = pn("bob_pn");
+        info.add_participants([(&bob_lid, None)]);
         assert!(info.phone_jid_for_lid_user("lid_bob").is_none());
 
         // Second add with phone_number (simulates server notification backfill)
-        info.add_participants(&[(lid("lid_bob"), Some(pn("bob_pn")))]);
+        info.add_participants([(&bob_lid, Some(&bob_pn))]);
         assert_eq!(info.participants.len(), 1); // not duplicated
         assert_eq!(
             info.phone_jid_for_lid_user("lid_bob")

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1063,19 +1063,28 @@ impl IqSpec for GroupCreateIq {
 // Group Management IQ Specs
 // ---------------------------------------------------------------------------
 
-/// Response for participant change operations (add/remove/promote/demote).
+/// Response for participant change operations.
 ///
-/// Wire format: `<participant jid="..." type="200" error="..."/>`
+/// Success is signaled by absent `error`; `type` is often omitted by the server.
 #[derive(Debug, Clone, crate::ProtocolNode)]
 #[protocol(tag = "participant")]
 pub struct ParticipantChangeResponse {
     #[attr(name = "jid", jid)]
     pub jid: Jid,
-    /// HTTP-like status code (e.g. 200, 403, 409).
     #[attr(name = "type")]
     pub status: Option<String>,
     #[attr(name = "error")]
     pub error: Option<String>,
+    #[attr(name = "phone_number", jid)]
+    pub phone_number: Option<Jid>,
+    #[attr(name = "username")]
+    pub username: Option<String>,
+}
+
+impl ParticipantChangeResponse {
+    pub fn is_ok(&self) -> bool {
+        self.error.is_none()
+    }
 }
 
 /// IQ specification for setting a group's subject.
@@ -3076,7 +3085,7 @@ mod tests {
     }
 
     #[test]
-    fn test_participant_change_response_parse() {
+    fn test_participant_change_response_parse_with_type() {
         let node = NodeBuilder::new("participant")
             .attr("jid", "1234567890@s.whatsapp.net")
             .attr("type", "200")
@@ -3085,6 +3094,48 @@ mod tests {
         let result = ParticipantChangeResponse::try_from_node(&node).unwrap();
         assert_eq!(result.jid.user, "1234567890");
         assert_eq!(result.status, Some("200".to_string()));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_participant_change_response_parse_without_type() {
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "1234567890@s.whatsapp.net")
+            .build();
+
+        let result = ParticipantChangeResponse::try_from_node(&node).unwrap();
+        assert_eq!(result.status, None);
+        assert_eq!(result.error, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_participant_change_response_parse_error() {
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "1234567890@s.whatsapp.net")
+            .attr("error", "403")
+            .build();
+
+        let result = ParticipantChangeResponse::try_from_node(&node).unwrap();
+        assert_eq!(result.error.as_deref(), Some("403"));
+        assert!(!result.is_ok());
+    }
+
+    #[test]
+    fn test_participant_change_response_parse_mixins() {
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "100000000000001@lid")
+            .attr("phone_number", "5511999999999@s.whatsapp.net")
+            .attr("username", "example_user")
+            .build();
+
+        let result = ParticipantChangeResponse::try_from_node(&node).unwrap();
+        assert!(result.is_ok());
+        assert_eq!(
+            result.phone_number.as_ref().map(|j| j.user.as_str()),
+            Some("5511999999999")
+        );
+        assert_eq!(result.username.as_deref(), Some("example_user"));
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -3125,7 +3125,7 @@ mod tests {
     fn test_participant_change_response_parse_mixins() {
         let node = NodeBuilder::new("participant")
             .attr("jid", "100000000000001@lid")
-            .attr("phone_number", "5511999999999@s.whatsapp.net")
+            .attr("phone_number", "15555550100@s.whatsapp.net")
             .attr("username", "example_user")
             .build();
 
@@ -3133,7 +3133,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(
             result.phone_number.as_ref().map(|j| j.user.as_str()),
-            Some("5511999999999")
+            Some("15555550100")
         );
         assert_eq!(result.username.as_deref(), Some("example_user"));
     }


### PR DESCRIPTION
## Summary

`Groups::add_participants` and `Groups::remove_participants` filtered cache updates by `status.as_deref() == Some("200")`, but the server typically omits `type` on successful `<participant>` responses. In real traffic the accepted-set was empty and the cache never got patched — next `query_info()` had to refetch to notice the change.

Evidence in captured WA Web (`WAWebGroupModifyParticipantsJob.js:58`):

```js
code: a != null ? a : "200",   // "200" is synthesized client-side when error absent
```

And the success parser (`WASmaxInGroupsRemoveParticipantsResponseSuccess`) reads only `jid`, `phone_number`, `username`, and the error mixin — never `type`.

## Changes

- `ParticipantChangeResponse::is_ok()` now returns `error.is_none()`.
- Added `phone_number: Option<Jid>` and `username: Option<String>` mixin fields, matching the attributes WA Web emits on `<participant>` responses (`WASmaxInGroupsPhoneNumberMixin`, `WASmaxInGroupsUsernameAttMixin`).
- `add_participants` / `remove_participants` use `is_ok()` for the cache-update filter.

## Test plan

- [ ] `cargo test -p wacore --lib participant_change_response` — 4 cases (with `type`, without `type`, with `error`, with mixins)
- [ ] `cargo clippy --workspace --exclude e2e-tests --tests`