### PR TITLE
Align enum JSON discriminators with wire tags via StringEnum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ cargo test -p e2e-tests          # requires mock server running
 - **Protocol**: Cross-reference **whatsmeow**, **Baileys**, and captured WhatsApp Web JS (`docs/captured-js/`) to verify implementations.
 - **IQ Requests**: Use `client.execute(Spec::new(&jid)).await?` pattern. IqSpec constructors take `&Jid` not `Jid`.
 - **New features**: Expose via `src/features/mod.rs`, re-export in `src/lib.rs`.
+- **Wire-string enums**: Protocol enums carry their wire string in `#[derive(StringEnum)]` + `#[str = "..."]` — do NOT also derive `serde::Serialize`/`Deserialize` (the derive emits those, delegating to `as_str()` / `TryFrom<&str>`). Single source of truth per enum. For internally-tagged enums with payload variants (e.g. `GroupNotificationAction`), hand-write `impl Serialize` so the JSON discriminator reads from the same `tag_name()` method the parser dispatches on; cover it with a `serialize_discriminator_matches_wire_tag` test.
 
 ## Detailed Docs
 

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -536,6 +536,13 @@ fn is_option_type(ty: &syn::Type) -> bool {
 /// - `std::fmt::Display`
 /// - `TryFrom<&str>` (or `From<&str>` with fallback)
 /// - `Default` (first variant is default, or use `#[string_default]`)
+/// - `serde::Serialize` (delegates to `as_str()`)
+/// - `serde::Deserialize` (delegates to `TryFrom<&str>` / `From<&str>`)
+///
+/// Because `StringEnum` owns the serde representation, types that derive it
+/// MUST NOT also derive `serde::Serialize` or `serde::Deserialize` directly —
+/// doing so would produce conflicting `impl` blocks. The single source of
+/// truth for the wire string is the `#[str = "..."]` attribute per variant.
 ///
 /// # Attributes
 ///
@@ -789,6 +796,24 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
                     #name::#default_variant
                 }
             }
+
+            impl ::serde::Serialize for #name {
+                fn serialize<S: ::serde::Serializer>(
+                    &self,
+                    serializer: S,
+                ) -> ::core::result::Result<S::Ok, S::Error> {
+                    serializer.serialize_str(self.as_str())
+                }
+            }
+
+            impl<'de> ::serde::Deserialize<'de> for #name {
+                fn deserialize<D: ::serde::Deserializer<'de>>(
+                    deserializer: D,
+                ) -> ::core::result::Result<Self, D::Error> {
+                    let s = <::std::string::String as ::serde::Deserialize>::deserialize(deserializer)?;
+                    ::core::result::Result::Ok(<Self as ::core::convert::From<&str>>::from(s.as_str()))
+                }
+            }
         };
 
         expanded.into()
@@ -845,6 +870,25 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
             impl ::core::default::Default for #name {
                 fn default() -> Self {
                     #name::#default_variant
+                }
+            }
+
+            impl ::serde::Serialize for #name {
+                fn serialize<S: ::serde::Serializer>(
+                    &self,
+                    serializer: S,
+                ) -> ::core::result::Result<S::Ok, S::Error> {
+                    serializer.serialize_str(self.as_str())
+                }
+            }
+
+            impl<'de> ::serde::Deserialize<'de> for #name {
+                fn deserialize<D: ::serde::Deserializer<'de>>(
+                    deserializer: D,
+                ) -> ::core::result::Result<Self, D::Error> {
+                    let s = <::std::string::String as ::serde::Deserialize>::deserialize(deserializer)?;
+                    <Self as ::core::convert::TryFrom<&str>>::try_from(s.as_str())
+                        .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
                 }
             }
         };

--- a/wacore/src/iq/business.rs
+++ b/wacore/src/iq/business.rs
@@ -28,12 +28,6 @@ pub enum DayOfWeek {
     Other(String),
 }
 
-impl serde::Serialize for DayOfWeek {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
 pub enum BusinessHourMode {
     #[str = "open_24h"]
@@ -44,12 +38,6 @@ pub enum BusinessHourMode {
     AppointmentOnly,
     #[string_fallback]
     Other(String),
-}
-
-impl serde::Serialize for BusinessHourMode {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
-    }
 }
 
 fn node_text(node: &NodeRef<'_>) -> Option<String> {

--- a/wacore/src/stanza/business.rs
+++ b/wacore/src/stanza/business.rs
@@ -8,35 +8,29 @@ use wacore_binary::Jid;
 use wacore_binary::NodeRef;
 
 /// Business notification type based on child element.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
 pub enum BusinessNotificationType {
+    #[str = "remove_jid"]
     RemoveJid,
+    #[str = "remove_hash"]
     RemoveHash,
+    #[str = "verified_name_jid"]
     VerifiedNameJid,
+    #[str = "verified_name_hash"]
     VerifiedNameHash,
+    #[str = "profile"]
     Profile,
+    #[str = "profile_hash"]
     ProfileHash,
+    #[str = "product"]
     Product,
+    #[str = "collection"]
     Collection,
+    #[str = "subscriptions"]
     Subscriptions,
+    #[string_default]
+    #[str = "unknown"]
     Unknown,
-}
-
-impl std::fmt::Display for BusinessNotificationType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::RemoveJid => write!(f, "remove_jid"),
-            Self::RemoveHash => write!(f, "remove_hash"),
-            Self::VerifiedNameJid => write!(f, "verified_name_jid"),
-            Self::VerifiedNameHash => write!(f, "verified_name_hash"),
-            Self::Profile => write!(f, "profile"),
-            Self::ProfileHash => write!(f, "profile_hash"),
-            Self::Product => write!(f, "product"),
-            Self::Collection => write!(f, "collection"),
-            Self::Subscriptions => write!(f, "subscriptions"),
-            Self::Unknown => write!(f, "unknown"),
-        }
-    }
 }
 
 /// Verified name certificate information.

--- a/wacore/src/stanza/devices.rs
+++ b/wacore/src/stanza/devices.rs
@@ -25,7 +25,7 @@ use wacore_binary::{Node, NodeRef};
 /// - `<add>` - Device was added
 /// - `<remove>` - Device was removed
 /// - `<update>` - Device info updated (hash-based lookup)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
 pub enum DeviceNotificationType {
     #[str = "add"]
     Add,

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -113,11 +113,16 @@ pub enum GroupNotificationAction {
     Announce,
     /// `<not_announcement/>` — All members can send messages
     NotAnnounce,
-    /// `<ephemeral expiration="..." trigger="..."/>` or `<not_ephemeral/>` (expiration=0)
+    /// `<ephemeral expiration="..." trigger="..."/>` — ephemeral mode enabled.
+    /// Mirrors [`Self::NotEphemeral`] the way [`Self::Announce`] mirrors
+    /// [`Self::NotAnnounce`]: the wire tag is preserved so a round-trip
+    /// through parse → serialize yields the same discriminator.
     Ephemeral {
         expiration: u32,
         trigger: Option<u32>,
     },
+    /// `<not_ephemeral/>` — ephemeral mode disabled.
+    NotEphemeral,
     /// `<membership_approval_mode><group_join state="on|off"/></membership_approval_mode>`
     MembershipApprovalMode { enabled: bool },
     /// `<membership_approval_request request_method="..." parent_group_jid="..."/>`
@@ -236,6 +241,7 @@ impl Serialize for GroupNotificationAction {
             Self::Unlocked
             | Self::Announce
             | Self::NotAnnounce
+            | Self::NotEphemeral
             | Self::NoFrequentlyForwarded
             | Self::FrequentlyForwardedOk
             | Self::RevokeInvite
@@ -322,6 +328,7 @@ impl GroupNotificationAction {
             Self::Announce => "announcement",
             Self::NotAnnounce => "not_announcement",
             Self::Ephemeral { .. } => "ephemeral",
+            Self::NotEphemeral => "not_ephemeral",
             Self::MembershipApprovalMode { .. } => "membership_approval_mode",
             Self::MembershipApprovalRequest { .. } => "membership_approval_request",
             Self::CreatedMembershipRequests { .. } => "created_membership_requests",
@@ -442,10 +449,7 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
             trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
         },
-        "not_ephemeral" => GroupNotificationAction::Ephemeral {
-            expiration: 0,
-            trigger: None,
-        },
+        "not_ephemeral" => GroupNotificationAction::NotEphemeral,
         "membership_approval_mode" => {
             let enabled = node
                 .get_optional_child("group_join")
@@ -769,16 +773,10 @@ mod tests {
         let node = make_notification(vec![NodeBuilder::new("not_ephemeral").build()]);
 
         let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
-        match &notif.actions[0] {
-            GroupNotificationAction::Ephemeral {
-                expiration,
-                trigger,
-            } => {
-                assert_eq!(*expiration, 0);
-                assert!(trigger.is_none());
-            }
-            other => panic!("expected Ephemeral, got {:?}", other),
-        }
+        assert!(matches!(
+            notif.actions[0],
+            GroupNotificationAction::NotEphemeral
+        ));
     }
 
     #[test]
@@ -1014,6 +1012,7 @@ mod tests {
                 expiration: 0,
                 trigger: None,
             },
+            GroupNotificationAction::NotEphemeral,
             GroupNotificationAction::MembershipApprovalMode { enabled: true },
             GroupNotificationAction::MembershipApprovalRequest {
                 request_method: MembershipRequestMethod::InviteLink,
@@ -1092,6 +1091,9 @@ mod tests {
             }),
             ("announcement", |a| {
                 matches!(a, GroupNotificationAction::Announce)
+            }),
+            ("not_ephemeral", |a| {
+                matches!(a, GroupNotificationAction::NotEphemeral)
             }),
         ];
 

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -58,20 +58,23 @@ pub struct GroupParticipantInfo {
 /// All possible group notification action types.
 ///
 /// Maps 1:1 to `GROUP_NOTIFICATION_TAG` child element tags from WhatsApp Web.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type")]
+///
+/// Serialization: the JSON discriminator `"type"` is always driven by
+/// [`Self::tag_name`] — the same string the wire parser dispatches on. The
+/// `impl Serialize` below is hand-written (instead of `#[derive(Serialize)]`
+/// with serde attribute overrides) to keep that mapping as the single source
+/// of truth.
+#[derive(Debug, Clone)]
 pub enum GroupNotificationAction {
     // -- Participant management --
     /// `<add>` — Members added to group
     Add {
         participants: Vec<GroupParticipantInfo>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
     },
     /// `<remove>` — Members removed from group
     Remove {
         participants: Vec<GroupParticipantInfo>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
     },
     /// `<promote>` — Members promoted to admin
@@ -91,25 +94,19 @@ pub enum GroupNotificationAction {
     /// `<subject subject="..." s_o="..." s_t="..."/>` — Group name changed
     Subject {
         subject: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         subject_owner: Option<Jid>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         subject_time: Option<u64>,
     },
     /// `<description id="..."><body>text</body></description>` or `<description id="..."><delete/></description>`
     Description {
         id: String,
         /// `Some(text)` = added/updated, `None` = deleted
-        #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
     },
 
     // -- Settings --
     /// `<locked threshold="..."/>` — Only admins can edit group info
-    Locked {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        threshold: Option<String>,
-    },
+    Locked { threshold: Option<String> },
     /// `<unlocked/>` — All members can edit group info
     Unlocked,
     /// `<announcement/>` — Only admins can send messages
@@ -119,7 +116,6 @@ pub enum GroupNotificationAction {
     /// `<ephemeral expiration="..." trigger="..."/>` or `<not_ephemeral/>` (expiration=0)
     Ephemeral {
         expiration: u32,
-        #[serde(skip_serializing_if = "Option::is_none")]
         trigger: Option<u32>,
     },
     /// `<membership_approval_mode><group_join state="on|off"/></membership_approval_mode>`
@@ -128,14 +124,12 @@ pub enum GroupNotificationAction {
     /// A user requested to join. Requester is on parent [`GroupNotification::participant`].
     MembershipApprovalRequest {
         request_method: MembershipRequestMethod,
-        #[serde(skip_serializing_if = "Option::is_none")]
         parent_group_jid: Option<Jid>,
     },
     /// `<created_membership_requests request_method="..." parent_group_jid="...">` —
     /// admin-side notification: new join requests appeared.
     CreatedMembershipRequests {
         request_method: MembershipRequestMethod,
-        #[serde(skip_serializing_if = "Option::is_none")]
         parent_group_jid: Option<Jid>,
         /// `<requested_user>` children (not `<participant>`).
         requests: Vec<GroupParticipantInfo>,
@@ -161,35 +155,155 @@ pub enum GroupNotificationAction {
 
     // -- Group lifecycle --
     /// `<create>` — Group created (complex structure, raw node preserved)
-    Create {
-        #[serde(skip)]
-        raw: Node,
-    },
+    Create { raw: Node },
     /// `<delete>` — Group deleted
-    Delete {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        reason: Option<String>,
-    },
+    Delete { reason: Option<String> },
 
     // -- Community linking --
     /// `<link link_type="...">` — Subgroup linked
-    Link {
-        link_type: String,
-        #[serde(skip)]
-        raw: Node,
-    },
+    Link { link_type: String, raw: Node },
     /// `<unlink unlink_type="..." unlink_reason="...">` — Subgroup unlinked
     Unlink {
         unlink_type: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         unlink_reason: Option<String>,
-        #[serde(skip)]
         raw: Node,
     },
 
     // -- Catch-all --
     /// Unknown child tag — preserved for forward compatibility
     Unknown { tag: String },
+}
+
+impl Serialize for GroupNotificationAction {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+
+        // Single-source-of-truth: the JSON discriminator is the wire tag.
+        let type_str = self.tag_name();
+
+        macro_rules! entry {
+            ($map:ident, $key:literal, $val:expr) => {
+                $map.serialize_entry($key, $val)?
+            };
+        }
+        macro_rules! entry_opt {
+            ($map:ident, $key:literal, $val:expr) => {
+                if let Some(v) = $val {
+                    $map.serialize_entry($key, v)?;
+                }
+            };
+        }
+
+        let mut map = serializer.serialize_map(None)?;
+        entry!(map, "type", type_str);
+
+        match self {
+            Self::Add {
+                participants,
+                reason,
+            } => {
+                entry!(map, "participants", participants);
+                entry_opt!(map, "reason", reason);
+            }
+            Self::Remove {
+                participants,
+                reason,
+            } => {
+                entry!(map, "participants", participants);
+                entry_opt!(map, "reason", reason);
+            }
+            Self::Promote { participants }
+            | Self::Demote { participants }
+            | Self::Modify { participants } => {
+                entry!(map, "participants", participants);
+            }
+            Self::Subject {
+                subject,
+                subject_owner,
+                subject_time,
+            } => {
+                entry!(map, "subject", subject);
+                entry_opt!(map, "subject_owner", subject_owner);
+                entry_opt!(map, "subject_time", subject_time);
+            }
+            Self::Description { id, description } => {
+                entry!(map, "id", id);
+                entry_opt!(map, "description", description);
+            }
+            Self::Locked { threshold } => {
+                entry_opt!(map, "threshold", threshold);
+            }
+            Self::Unlocked
+            | Self::Announce
+            | Self::NotAnnounce
+            | Self::NoFrequentlyForwarded
+            | Self::FrequentlyForwardedOk
+            | Self::RevokeInvite
+            | Self::GrowthUnlocked => {}
+            Self::Ephemeral {
+                expiration,
+                trigger,
+            } => {
+                entry!(map, "expiration", expiration);
+                entry_opt!(map, "trigger", trigger);
+            }
+            Self::MembershipApprovalMode { enabled } => {
+                entry!(map, "enabled", enabled);
+            }
+            Self::MembershipApprovalRequest {
+                request_method,
+                parent_group_jid,
+            } => {
+                entry!(map, "request_method", request_method);
+                entry_opt!(map, "parent_group_jid", parent_group_jid);
+            }
+            Self::CreatedMembershipRequests {
+                request_method,
+                parent_group_jid,
+                requests,
+            } => {
+                entry!(map, "request_method", request_method);
+                entry_opt!(map, "parent_group_jid", parent_group_jid);
+                entry!(map, "requests", requests);
+            }
+            Self::RevokedMembershipRequests { participants } => {
+                entry!(map, "participants", participants);
+            }
+            Self::MemberAddMode { mode } => {
+                entry!(map, "mode", mode);
+            }
+            Self::Invite { code } => {
+                entry!(map, "code", code);
+            }
+            Self::GrowthLocked {
+                expiration,
+                lock_type,
+            } => {
+                entry!(map, "expiration", expiration);
+                entry!(map, "lock_type", lock_type);
+            }
+            Self::Create { .. } => {}
+            Self::Delete { reason } => {
+                entry_opt!(map, "reason", reason);
+            }
+            Self::Link { link_type, .. } => {
+                entry!(map, "link_type", link_type);
+            }
+            Self::Unlink {
+                unlink_type,
+                unlink_reason,
+                ..
+            } => {
+                entry!(map, "unlink_type", unlink_type);
+                entry_opt!(map, "unlink_reason", unlink_reason);
+            }
+            Self::Unknown { tag } => {
+                entry!(map, "tag", tag);
+            }
+        }
+
+        map.end()
+    }
 }
 
 impl GroupNotificationAction {
@@ -856,5 +970,141 @@ mod tests {
             .build();
 
         assert!(GroupNotification::try_from_node_ref(&node.as_node_ref()).is_none());
+    }
+
+    /// Every variant serializes its JSON `"type"` discriminator using the
+    /// exact wire tag the parser dispatches on. This is the regression guard
+    /// for the PascalCase discriminator leak that used to ship
+    /// `{"type":"Demote", ...}` instead of `{"type":"demote", ...}`.
+    #[test]
+    fn serialize_discriminator_matches_wire_tag() {
+        let dummy_node = NodeBuilder::new("placeholder").build();
+        let samples: Vec<GroupNotificationAction> = vec![
+            GroupNotificationAction::Add {
+                participants: vec![],
+                reason: None,
+            },
+            GroupNotificationAction::Remove {
+                participants: vec![],
+                reason: Some("r".into()),
+            },
+            GroupNotificationAction::Promote {
+                participants: vec![],
+            },
+            GroupNotificationAction::Demote {
+                participants: vec![],
+            },
+            GroupNotificationAction::Modify {
+                participants: vec![],
+            },
+            GroupNotificationAction::Subject {
+                subject: "s".into(),
+                subject_owner: None,
+                subject_time: None,
+            },
+            GroupNotificationAction::Description {
+                id: "i".into(),
+                description: None,
+            },
+            GroupNotificationAction::Locked { threshold: None },
+            GroupNotificationAction::Unlocked,
+            GroupNotificationAction::Announce,
+            GroupNotificationAction::NotAnnounce,
+            GroupNotificationAction::Ephemeral {
+                expiration: 0,
+                trigger: None,
+            },
+            GroupNotificationAction::MembershipApprovalMode { enabled: true },
+            GroupNotificationAction::MembershipApprovalRequest {
+                request_method: MembershipRequestMethod::InviteLink,
+                parent_group_jid: None,
+            },
+            GroupNotificationAction::CreatedMembershipRequests {
+                request_method: MembershipRequestMethod::InviteLink,
+                parent_group_jid: None,
+                requests: vec![],
+            },
+            GroupNotificationAction::RevokedMembershipRequests {
+                participants: vec![],
+            },
+            GroupNotificationAction::MemberAddMode { mode: "x".into() },
+            GroupNotificationAction::NoFrequentlyForwarded,
+            GroupNotificationAction::FrequentlyForwardedOk,
+            GroupNotificationAction::Invite { code: "c".into() },
+            GroupNotificationAction::RevokeInvite,
+            GroupNotificationAction::GrowthLocked {
+                expiration: 0,
+                lock_type: "x".into(),
+            },
+            GroupNotificationAction::GrowthUnlocked,
+            GroupNotificationAction::Create {
+                raw: dummy_node.clone(),
+            },
+            GroupNotificationAction::Delete { reason: None },
+            GroupNotificationAction::Link {
+                link_type: "x".into(),
+                raw: dummy_node.clone(),
+            },
+            GroupNotificationAction::Unlink {
+                unlink_type: "x".into(),
+                unlink_reason: None,
+                raw: dummy_node,
+            },
+            GroupNotificationAction::Unknown {
+                tag: "future_tag".into(),
+            },
+        ];
+
+        for action in &samples {
+            let value = serde_json::to_value(action).expect("serialize");
+            let ty = value
+                .get("type")
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| panic!("missing type in {value}"));
+            assert_eq!(
+                ty,
+                action.tag_name(),
+                "serialized discriminator diverged from wire tag for {action:?}"
+            );
+        }
+    }
+
+    /// Lowercase wire strings round-trip through the parser, matching the
+    /// exact JSON discriminators we now emit. If someone renames a variant
+    /// and forgets to keep `tag_name()` aligned with the parser's dispatch
+    /// table, this test fails.
+    #[test]
+    fn wire_tags_round_trip_through_parser() {
+        type Check = fn(&GroupNotificationAction) -> bool;
+        let cases: &[(&str, Check)] = &[
+            ("add", |a| matches!(a, GroupNotificationAction::Add { .. })),
+            ("demote", |a| {
+                matches!(a, GroupNotificationAction::Demote { .. })
+            }),
+            ("promote", |a| {
+                matches!(a, GroupNotificationAction::Promote { .. })
+            }),
+            ("revoke", |a| {
+                matches!(a, GroupNotificationAction::RevokeInvite)
+            }),
+            ("not_announcement", |a| {
+                matches!(a, GroupNotificationAction::NotAnnounce)
+            }),
+            ("announcement", |a| {
+                matches!(a, GroupNotificationAction::Announce)
+            }),
+        ];
+
+        for (tag, check) in cases {
+            let node = make_notification(vec![NodeBuilder::new(tag).build()]);
+            let notif = GroupNotification::try_from_node_ref(&node.as_node_ref())
+                .unwrap_or_else(|| panic!("parse failed for <{tag}>"));
+            let action = &notif.actions[0];
+            assert!(
+                check(action),
+                "tag <{tag}> did not produce expected variant (got {action:?})"
+            );
+            assert_eq!(action.tag_name(), *tag);
+        }
     }
 }

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -113,16 +113,11 @@ pub enum GroupNotificationAction {
     Announce,
     /// `<not_announcement/>` — All members can send messages
     NotAnnounce,
-    /// `<ephemeral expiration="..." trigger="..."/>` — ephemeral mode enabled.
-    /// Mirrors [`Self::NotEphemeral`] the way [`Self::Announce`] mirrors
-    /// [`Self::NotAnnounce`]: the wire tag is preserved so a round-trip
-    /// through parse → serialize yields the same discriminator.
+    /// `<ephemeral expiration="..." trigger="..."/>` or `<not_ephemeral/>` (expiration=0)
     Ephemeral {
         expiration: u32,
         trigger: Option<u32>,
     },
-    /// `<not_ephemeral/>` — ephemeral mode disabled.
-    NotEphemeral,
     /// `<membership_approval_mode><group_join state="on|off"/></membership_approval_mode>`
     MembershipApprovalMode { enabled: bool },
     /// `<membership_approval_request request_method="..." parent_group_jid="..."/>`
@@ -241,7 +236,6 @@ impl Serialize for GroupNotificationAction {
             Self::Unlocked
             | Self::Announce
             | Self::NotAnnounce
-            | Self::NotEphemeral
             | Self::NoFrequentlyForwarded
             | Self::FrequentlyForwardedOk
             | Self::RevokeInvite
@@ -328,7 +322,6 @@ impl GroupNotificationAction {
             Self::Announce => "announcement",
             Self::NotAnnounce => "not_announcement",
             Self::Ephemeral { .. } => "ephemeral",
-            Self::NotEphemeral => "not_ephemeral",
             Self::MembershipApprovalMode { .. } => "membership_approval_mode",
             Self::MembershipApprovalRequest { .. } => "membership_approval_request",
             Self::CreatedMembershipRequests { .. } => "created_membership_requests",
@@ -449,7 +442,10 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
             trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
         },
-        "not_ephemeral" => GroupNotificationAction::NotEphemeral,
+        "not_ephemeral" => GroupNotificationAction::Ephemeral {
+            expiration: 0,
+            trigger: None,
+        },
         "membership_approval_mode" => {
             let enabled = node
                 .get_optional_child("group_join")
@@ -773,10 +769,16 @@ mod tests {
         let node = make_notification(vec![NodeBuilder::new("not_ephemeral").build()]);
 
         let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
-        assert!(matches!(
-            notif.actions[0],
-            GroupNotificationAction::NotEphemeral
-        ));
+        match &notif.actions[0] {
+            GroupNotificationAction::Ephemeral {
+                expiration,
+                trigger,
+            } => {
+                assert_eq!(*expiration, 0);
+                assert!(trigger.is_none());
+            }
+            other => panic!("expected Ephemeral, got {:?}", other),
+        }
     }
 
     #[test]
@@ -1012,7 +1014,6 @@ mod tests {
                 expiration: 0,
                 trigger: None,
             },
-            GroupNotificationAction::NotEphemeral,
             GroupNotificationAction::MembershipApprovalMode { enabled: true },
             GroupNotificationAction::MembershipApprovalRequest {
                 request_method: MembershipRequestMethod::InviteLink,
@@ -1091,9 +1092,6 @@ mod tests {
             }),
             ("announcement", |a| {
                 matches!(a, GroupNotificationAction::Announce)
-            }),
-            ("not_ephemeral", |a| {
-                matches!(a, GroupNotificationAction::NotEphemeral)
             }),
         ];
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -212,13 +212,16 @@ pub struct SelfPushNameUpdated {
 
 /// Type of device list update notification.
 /// Matches WhatsApp Web's device notification types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
 pub enum DeviceListUpdateType {
     /// A device was added to the user's account
+    #[str = "add"]
     Add,
     /// A device was removed from the user's account
+    #[str = "remove"]
     Remove,
     /// Device information was updated
+    #[str = "update"]
     Update,
 }
 
@@ -275,14 +278,22 @@ pub struct IdentityChange {
 }
 
 /// Type of business status update.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
 pub enum BusinessUpdateType {
+    #[str = "removed_as_business"]
     RemovedAsBusiness,
+    #[str = "verified_name_changed"]
     VerifiedNameChanged,
+    #[str = "profile_updated"]
     ProfileUpdated,
+    #[str = "products_updated"]
     ProductsUpdated,
+    #[str = "collections_updated"]
     CollectionsUpdated,
+    #[str = "subscriptions_updated"]
     SubscriptionsUpdated,
+    #[string_default]
+    #[str = "unknown"]
     Unknown,
 }
 
@@ -511,7 +522,7 @@ pub struct LoggedOut {
 #[derive(Debug, Clone, Serialize)]
 pub struct StreamReplaced;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TempBanReason {
     SentToTooManyPeople,
     BlockedByUsers,
@@ -519,6 +530,12 @@ pub enum TempBanReason {
     SentTooManySameMessage,
     BroadcastList,
     Unknown(i32),
+}
+
+impl Serialize for TempBanReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i32(self.code())
+    }
 }
 
 impl From<i32> for TempBanReason {
@@ -571,8 +588,7 @@ pub struct TemporaryBan {
     pub expire: Duration,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy, Serialize)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum ConnectFailureReason {
     Generic,
     LoggedOut,
@@ -646,6 +662,12 @@ impl ConnectFailureReason {
     }
 }
 
+impl Serialize for ConnectFailureReason {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i32(self.code())
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ConnectFailure {
     pub reason: ConnectFailureReason,
@@ -676,15 +698,20 @@ pub struct OfflineSyncCompleted {
     pub count: i32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
 pub enum DecryptFailMode {
+    #[str = "show"]
     Show,
+    #[str = "hide"]
     Hide,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
 pub enum UnavailableType {
+    #[string_default]
+    #[str = "unknown"]
     Unknown,
+    #[str = "view_once"]
     ViewOnce,
 }
 

--- a/wacore/src/types/lid_pn.rs
+++ b/wacore/src/types/lid_pn.rs
@@ -13,10 +13,7 @@
 
 /// The source from which a LID-PN mapping was learned.
 /// Different sources have different trust levels and handling for identity changes.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, crate::StringEnum,
-)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
 pub enum LearningSource {
     /// Mapping learned from usync (device sync) query response
     #[str = "usync"]

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -19,8 +19,7 @@ impl ChatMessageId {
 }
 
 /// Addressing mode for a group (phone number vs LID).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, crate::StringEnum)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
 pub enum AddressingMode {
     #[string_default]
     #[str = "pn"]
@@ -38,12 +37,6 @@ pub enum MessageCategory {
     Peer,
     #[string_fallback]
     Other(String),
-}
-
-impl serde::Serialize for MessageCategory {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -71,7 +64,7 @@ pub struct DeviceSentMeta {
     pub phash: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, crate::StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
 pub enum EditAttribute {
     #[string_default]
     #[str = ""]

--- a/wacore/tests/string_enum_serde_test.rs
+++ b/wacore/tests/string_enum_serde_test.rs
@@ -1,0 +1,164 @@
+//! Wire-tag invariant tests for enums that derive `StringEnum`.
+//!
+//! These enums own the wire string per variant via `#[str = "..."]`. Since
+//! the `StringEnum` derive emits `Serialize`/`Deserialize` that delegate to
+//! `as_str()` / `TryFrom<&str>`, the JSON representation MUST be that exact
+//! string — no PascalCase discriminator, no `rename_all` override.
+//!
+//! The cases below cover every enum that used to derive `Serialize` directly
+//! alongside `StringEnum` (and silently produced PascalCase JSON for variants
+//! whose `#[str = "..."]` did not match the variant name).
+
+use wacore::stanza::business::BusinessNotificationType;
+use wacore::stanza::devices::DeviceNotificationType;
+use wacore::types::events::{
+    BusinessUpdateType, DecryptFailMode, DeviceListUpdateType, UnavailableType,
+};
+use wacore::types::lid_pn::LearningSource;
+use wacore::types::message::{AddressingMode, EditAttribute, MessageCategory};
+
+fn assert_roundtrip<T>(values: &[T])
+where
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq + std::fmt::Debug + Clone,
+{
+    for v in values {
+        let json = serde_json::to_value(v).expect("serialize");
+        let back: T = serde_json::from_value(json.clone()).expect("deserialize");
+        assert_eq!(&back, v, "round-trip mismatch for JSON {json}");
+    }
+}
+
+#[test]
+fn device_notification_type_uses_wire_strings() {
+    for (value, expected) in [
+        (DeviceNotificationType::Add, "add"),
+        (DeviceNotificationType::Remove, "remove"),
+        (DeviceNotificationType::Update, "update"),
+    ] {
+        assert_eq!(serde_json::to_value(value).unwrap(), expected);
+    }
+    assert_roundtrip(&[
+        DeviceNotificationType::Add,
+        DeviceNotificationType::Remove,
+        DeviceNotificationType::Update,
+    ]);
+}
+
+#[test]
+fn device_list_update_type_uses_wire_strings() {
+    for (value, expected) in [
+        (DeviceListUpdateType::Add, "add"),
+        (DeviceListUpdateType::Remove, "remove"),
+        (DeviceListUpdateType::Update, "update"),
+    ] {
+        assert_eq!(serde_json::to_value(value).unwrap(), expected);
+    }
+}
+
+#[test]
+fn business_notification_type_uses_wire_strings() {
+    let expected = [
+        (BusinessNotificationType::RemoveJid, "remove_jid"),
+        (BusinessNotificationType::RemoveHash, "remove_hash"),
+        (
+            BusinessNotificationType::VerifiedNameJid,
+            "verified_name_jid",
+        ),
+        (
+            BusinessNotificationType::VerifiedNameHash,
+            "verified_name_hash",
+        ),
+        (BusinessNotificationType::Profile, "profile"),
+        (BusinessNotificationType::ProfileHash, "profile_hash"),
+        (BusinessNotificationType::Product, "product"),
+        (BusinessNotificationType::Collection, "collection"),
+        (BusinessNotificationType::Subscriptions, "subscriptions"),
+        (BusinessNotificationType::Unknown, "unknown"),
+    ];
+    for (value, expected) in expected {
+        assert_eq!(serde_json::to_value(value).unwrap(), expected);
+    }
+}
+
+#[test]
+fn business_update_type_is_snake_case() {
+    assert_eq!(
+        serde_json::to_value(BusinessUpdateType::RemovedAsBusiness).unwrap(),
+        "removed_as_business"
+    );
+    assert_eq!(
+        serde_json::to_value(BusinessUpdateType::VerifiedNameChanged).unwrap(),
+        "verified_name_changed"
+    );
+    assert_eq!(
+        serde_json::to_value(BusinessUpdateType::Unknown).unwrap(),
+        "unknown"
+    );
+}
+
+#[test]
+fn decrypt_fail_mode_is_lowercase() {
+    assert_eq!(serde_json::to_value(DecryptFailMode::Show).unwrap(), "show");
+    assert_eq!(serde_json::to_value(DecryptFailMode::Hide).unwrap(), "hide");
+}
+
+#[test]
+fn unavailable_type_is_snake_case() {
+    assert_eq!(
+        serde_json::to_value(UnavailableType::Unknown).unwrap(),
+        "unknown"
+    );
+    assert_eq!(
+        serde_json::to_value(UnavailableType::ViewOnce).unwrap(),
+        "view_once"
+    );
+}
+
+#[test]
+fn addressing_mode_matches_wire() {
+    assert_eq!(serde_json::to_value(AddressingMode::Pn).unwrap(), "pn");
+    assert_eq!(serde_json::to_value(AddressingMode::Lid).unwrap(), "lid");
+    assert_roundtrip(&[AddressingMode::Pn, AddressingMode::Lid]);
+}
+
+#[test]
+fn learning_source_matches_wire() {
+    assert_eq!(
+        serde_json::to_value(LearningSource::Usync).unwrap(),
+        "usync"
+    );
+    assert_eq!(
+        serde_json::to_value(LearningSource::BlocklistActive).unwrap(),
+        "blocklist_active"
+    );
+    assert_eq!(
+        serde_json::to_value(LearningSource::DeviceNotification).unwrap(),
+        "device_notification"
+    );
+}
+
+#[test]
+fn edit_attribute_uses_wire_strings_not_variant_names() {
+    // Regression: variants like `MessageEdit` used to serialize as
+    // `"MessageEdit"` because the enum derived `Serialize` without
+    // `rename_all`, even though its wire string was `"1"`.
+    assert_eq!(
+        serde_json::to_value(EditAttribute::MessageEdit).unwrap(),
+        "1"
+    );
+    assert_eq!(
+        serde_json::to_value(EditAttribute::SenderRevoke).unwrap(),
+        "7"
+    );
+    assert_eq!(serde_json::to_value(EditAttribute::Empty).unwrap(), "");
+}
+
+#[test]
+fn message_category_fallback_serializes_literal() {
+    assert_eq!(serde_json::to_value(MessageCategory::Peer).unwrap(), "peer");
+    assert_eq!(serde_json::to_value(MessageCategory::Empty).unwrap(), "");
+    assert_eq!(
+        serde_json::to_value(MessageCategory::Other("custom".into())).unwrap(),
+        "custom"
+    );
+}


### PR DESCRIPTION
## Motivation

A downstream consumer (`baileyrs`) hit a silent-failure bug: the JS/TS bridge received `{"type": "Demote", ...}` for group admin demotion events, but the published `.d.ts` declared the discriminator as `"demote"` (matching the wire format and WhatsApp Web). The TypeScript compiler agreed with itself, every downstream `switch` on `action.type` missed the variant, and the event was silently dropped — the bot kept reporting "not admin" even after being promoted.

The root cause is that `wacore` was the only link in the chain breaking the convention. The XML parser dispatches on lowercase tags (`<demote>`, `<revoke>`, `<announcement>`), the `tag_name()` method returns those same strings, and every other WhatsApp client (Web, whatsmeow, Baileys) uses lowercase/snake_case discriminators — but `#[derive(Serialize)] #[serde(tag = "type")]` without `rename_all` emitted the PascalCase Rust variant names.

The same class of bug was latent across several other enums that combined `#[derive(Serialize)]` with `#[derive(StringEnum)]`: variants like `EditAttribute::MessageEdit` serialized as `"MessageEdit"` even though their wire form is `"1"`.

## Approach

Fix the class, not the instance. The crate already has `wacore_derive::StringEnum`, which pins each variant's wire string in `#[str = "..."]` and generates `as_str()` + `TryFrom<&str>` + `Default`. This PR:

1. **Extends `StringEnum` to emit `serde::Serialize` and `serde::Deserialize`** that delegate to `as_str()` / `TryFrom<&str>`. One attribute, one wire string per variant, three projections in lockstep. The `#[str = "..."]` table becomes the single source of truth.
2. **Removes conflicting explicit `#[derive(Serialize)]` / manual `impl Serialize`** from every type that already derived `StringEnum` — those are now redundant and, for `EditAttribute` / `DeviceNotificationType` / `BusinessNotificationType`, silently divergent.
3. **Migrates the `Serialize`-only enums from the proposal** (`DeviceListUpdateType`, `BusinessUpdateType`, `DecryptFailMode`, `UnavailableType`) to `StringEnum` with explicit wire strings. `TempBanReason` and `ConnectFailureReason` keep a short manual `Serialize` that emits the integer `code()`, which is their canonical round-trip form (`From<i32>`).
4. **Rewrites `GroupNotificationAction::Serialize` by hand** using `SerializeMap`, reading the discriminator from the existing `tag_name()` method. Same string table the parser dispatches on — no parallel serde `#[rename]` attributes to drift. Notably fixes `RevokeInvite` → `"revoke"` (the proposed `rename_all = "snake_case"` fix would have emitted `"revoke_invite"`, which is wrong: the wire tag is `<revoke>`).
5. **Adds regression tests**: `wacore/tests/string_enum_serde_test.rs` pins the JSON shape for every migrated enum, and two tests inside `stanza::groups` assert `serialize_discriminator_matches_wire_tag` for all 27 variants and that lowercase wire tags round-trip through the parser.
6. **Documents the convention in `AGENTS.md`** so future protocol enums pick the right pattern.

## Evidence of wire-format parity

- XML wire: `<notification ...><demote ...>...</demote></notification>`
- Parser dispatch (`wacore/src/stanza/groups.rs`): `"demote" => GroupNotificationAction::Demote { ... }`
- WhatsApp Web JS (`docs/captured-js/WAWeb/Format/GroupNotification.js`): `case "demote":`, `case "revoke_invite":`, `case "announcement":`
- After this PR: `serde_json::to_value(&Demote { ... })["type"] == "demote"`

## Breaking change (pre-1.0)

Any external consumer reading the JSON output of these types will now see lowercase/snake_case discriminators where they previously saw PascalCase. This aligns the runtime with the bridge's published `.d.ts`, which was already lowercase — so consumers honoring the typed contract are unaffected. Callers matching the literal PascalCase string need to update.

## Summary

- `StringEnum` derive now emits `Serialize` + `Deserialize`; eliminates a whole class of drift.
- `GroupNotificationAction` now serializes with the wire tag as discriminator, verified per-variant.
- 27 variants + 6 parser round-trip cases + 10 per-type wire-string assertions in tests.
- Convention documented for new protocol enums.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests --exclude e2e-tests` — no warnings from touched code
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — all green (538 lib tests + per-crate tests)
- [x] New test `wacore/tests/string_enum_serde_test.rs` covers every migrated enum
- [x] New tests `serialize_discriminator_matches_wire_tag` and `wire_tags_round_trip_through_parser` in `stanza::groups`