### PR TITLE
Unify enum wire-tag derives under #[derive(WireEnum)]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ cargo test -p e2e-tests          # requires mock server running
 - **Protocol**: Cross-reference **whatsmeow**, **Baileys**, and captured WhatsApp Web JS (`docs/captured-js/`) to verify implementations.
 - **IQ Requests**: Use `client.execute(Spec::new(&jid)).await?` pattern. IqSpec constructors take `&Jid` not `Jid`.
 - **New features**: Expose via `src/features/mod.rs`, re-export in `src/lib.rs`.
-- **Wire-string enums**: Protocol enums carry their wire string in `#[derive(StringEnum)]` + `#[str = "..."]` — do NOT also derive `serde::Serialize`/`Deserialize` (the derive emits those, delegating to `as_str()` / `TryFrom<&str>`). Single source of truth per enum. For internally-tagged enums with payload variants (e.g. `GroupNotificationAction`), hand-write `impl Serialize` so the JSON discriminator reads from the same `tag_name()` method the parser dispatches on; cover it with a `serialize_discriminator_matches_wire_tag` test.
+- **Wire-tagged enums**: Every protocol enum uses `#[derive(WireEnum)]`. The `#[wire = "..."]` (or `#[wire = NUM]` for int mode) attribute is the SINGLE source of truth for each variant's wire value. Do NOT also derive `serde::Serialize`/`Deserialize` or add `#[serde(rename_all)]` — the derive owns both. Three modes: unit-string (default), tagged-with-payload (`#[wire(tag = "type")]` on the enum, optional `#[wire_alias = "..."]` and `#[wire(skip)]` on fields, `#[wire_fallback]` for catch-all), and int (`#[wire(kind = "int")]`). In tagged mode the derive auto-generates a sibling `<Name>Tag` enum; parsers must dispatch via `<Name>Tag::try_from(node.tag.as_ref())` instead of matching string literals, so renaming a wire tag stays a single-attribute change.
 
 ## Detailed Docs
 

--- a/src/features/chatstate.rs
+++ b/src/features/chatstate.rs
@@ -2,19 +2,19 @@
 
 use crate::client::Client;
 use log::debug;
-use wacore::StringEnum;
+use wacore::WireEnum;
 use wacore_binary::Jid;
 use wacore_binary::builder::NodeBuilder;
 
 /// Chat state type for typing indicators.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 #[non_exhaustive]
 pub enum ChatStateType {
-    #[str = "composing"]
+    #[wire = "composing"]
     Composing,
-    #[str = "recording"]
+    #[wire = "recording"]
     Recording,
-    #[str = "paused"]
+    #[wire = "paused"]
     Paused,
 }
 

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -4,7 +4,7 @@
 //! Uses MEX (GraphQL) for metadata/management and standard IQ for message operations.
 //! Newsletter messages are plaintext (no Signal E2E encryption).
 
-use wacore::StringEnum;
+use wacore::WireEnum;
 
 use crate::client::Client;
 use crate::features::mex::{MexError, MexRequest};
@@ -19,24 +19,24 @@ use waproto::whatsapp as wa;
 
 // Types
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 #[non_exhaustive]
 pub enum NewsletterMessageType {
-    #[str = "text"]
+    #[wire = "text"]
     Text,
-    #[str = "media"]
+    #[wire = "media"]
     Media,
-    #[str = "reaction"]
+    #[wire = "reaction"]
     Reaction,
-    #[str = "revoke"]
+    #[wire = "revoke"]
     Revoke,
-    #[str = "poll_creation"]
+    #[wire = "poll_creation"]
     PollCreation,
-    #[str = "poll_vote"]
+    #[wire = "poll_vote"]
     PollVote,
-    #[str = "edit"]
+    #[wire = "edit"]
     Edit,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -1,7 +1,7 @@
 use crate::client::Client;
 use log::{debug, warn};
 use thiserror::Error;
-use wacore::StringEnum;
+use wacore::WireEnum;
 use wacore::iq::tctoken::build_tc_token_node;
 use wacore_binary::Jid;
 use wacore_binary::Node;
@@ -16,12 +16,12 @@ pub enum PresenceError {
 }
 
 /// Presence status for online/offline state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 #[non_exhaustive]
 pub enum PresenceStatus {
-    #[str = "available"]
+    #[wire = "available"]
     Available,
-    #[str = "unavailable"]
+    #[wire = "unavailable"]
     Unavailable,
 }
 

--- a/src/features/status.rs
+++ b/src/features/status.rs
@@ -1,4 +1,4 @@
-use wacore::StringEnum;
+use wacore::WireEnum;
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
 
@@ -8,18 +8,18 @@ use crate::upload::UploadResponse;
 
 /// Privacy setting sent in the `<meta>` node of the status stanza.
 /// Matches WhatsApp Web's `status_setting` attribute.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 #[non_exhaustive]
 pub enum StatusPrivacySetting {
     /// Send to all contacts in address book.
-    #[string_default]
-    #[str = "contacts"]
+    #[wire_default]
+    #[wire = "contacts"]
     Contacts,
     /// Send only to contacts in an allow list.
-    #[str = "allowlist"]
+    #[wire = "allowlist"]
     AllowList,
     /// Send to all contacts except those in a deny list.
-    #[str = "denylist"]
+    #[wire = "denylist"]
     DenyList,
 }
 

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -648,7 +648,7 @@ fn parse_enum_level_wire(attrs: &[syn::Attribute]) -> syn::Result<WireEnumCfg> {
 
 enum VariantWire {
     Str(String),
-    Int(i64),
+    Int(i32),
 }
 
 struct VariantInfo {
@@ -696,7 +696,22 @@ fn read_variant(v: &syn::Variant) -> syn::Result<VariantInfo> {
                     syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Int(n),
                         ..
-                    }) => wire = Some(VariantWire::Int(n.base10_parse::<i64>()?)),
+                    }) => {
+                        // Reject out-of-range literals at macro parse time rather
+                        // than silently wrapping with `as i32`.
+                        let parsed: i32 = n.base10_parse().map_err(|_| {
+                            syn::Error::new_spanned(
+                                n,
+                                format!(
+                                    "#[wire = {}] does not fit in i32 ({}..={})",
+                                    n,
+                                    i32::MIN,
+                                    i32::MAX
+                                ),
+                            )
+                        })?;
+                        wire = Some(VariantWire::Int(parsed));
+                    }
                     _ => {
                         return Err(syn::Error::new_spanned(
                             &nv.value,
@@ -812,12 +827,16 @@ fn expand_wire_enum_unit(
             }
             default_variant = Some(info);
         }
-        if !info.aliases.is_empty() {
-            return syn::Error::new_spanned(
-                &info.ident,
-                "#[wire_alias] is only valid on tagged-mode WireEnum variants",
-            )
-            .to_compile_error();
+        for alias in &info.aliases {
+            if let Some(prev) = seen.insert(alias.clone(), info.ident.clone()) {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    format!(
+                        "#[wire_alias = \"{alias}\"] collides with existing wire tag from variant {prev}"
+                    ),
+                )
+                .to_compile_error();
+            }
         }
     }
 
@@ -849,19 +868,40 @@ fn expand_wire_enum_unit(
         })
         .collect();
 
+    // `as_str()` always returns the PRIMARY tag — aliases are parser-only and
+    // must never surface in serialization.
     let as_str_arms: Vec<_> = known
         .iter()
         .map(|(id, s)| quote! { #name::#id => #s })
         .collect();
 
-    let try_from_arms: Vec<_> = known
+    // For parsing, include primary + each alias; all map to the same variant.
+    let try_from_arms: Vec<proc_macro2::TokenStream> = infos
         .iter()
-        .map(|(id, s)| quote! { #s => ::core::result::Result::Ok(#name::#id) })
+        .filter(|i| !i.is_fallback)
+        .flat_map(|i| {
+            let id = &i.ident;
+            let VariantWire::Str(primary) = i.wire.as_ref().unwrap() else {
+                unreachable!()
+            };
+            std::iter::once(primary.clone())
+                .chain(i.aliases.iter().cloned())
+                .map(move |s| quote! { #s => ::core::result::Result::Ok(#name::#id) })
+        })
         .collect();
 
-    let from_arms: Vec<_> = known
+    let from_arms: Vec<proc_macro2::TokenStream> = infos
         .iter()
-        .map(|(id, s)| quote! { #s => #name::#id })
+        .filter(|i| !i.is_fallback)
+        .flat_map(|i| {
+            let id = &i.ident;
+            let VariantWire::Str(primary) = i.wire.as_ref().unwrap() else {
+                unreachable!()
+            };
+            std::iter::once(primary.clone())
+                .chain(i.aliases.iter().cloned())
+                .map(move |s| quote! { #s => #name::#id })
+        })
         .collect();
 
     let as_str_return_ty;
@@ -996,7 +1036,7 @@ fn expand_wire_enum_int(
     }
 
     let mut fallback: Option<&VariantInfo> = None;
-    let mut seen: std::collections::HashMap<i64, syn::Ident> = Default::default();
+    let mut seen: std::collections::HashMap<i32, syn::Ident> = Default::default();
 
     for info in &infos {
         if info.is_fallback {
@@ -1057,7 +1097,7 @@ fn expand_wire_enum_int(
             let VariantWire::Int(n) = i.wire.as_ref().unwrap() else {
                 unreachable!()
             };
-            let lit = proc_macro2::Literal::i32_suffixed(*n as i32);
+            let lit = proc_macro2::Literal::i32_suffixed(*n);
             quote! { #name::#id => #lit }
         })
         .collect();
@@ -1070,7 +1110,7 @@ fn expand_wire_enum_int(
             let VariantWire::Int(n) = i.wire.as_ref().unwrap() else {
                 unreachable!()
             };
-            let lit = proc_macro2::Literal::i32_suffixed(*n as i32);
+            let lit = proc_macro2::Literal::i32_suffixed(*n);
             quote! { #lit => #name::#id }
         })
         .collect();
@@ -1301,13 +1341,17 @@ fn expand_wire_enum_tagged(
         let VariantWire::Str(primary) = info.wire.as_ref().unwrap() else {
             unreachable!()
         };
-        // The tag-enum variant gets the primary wire as #[wire = "..."].
-        // Aliases become extra unit variants named <Ident>__alias_N.
-        tag_variant_tokens.push(quote! { #[wire = #primary] #id });
-        for (idx, alias) in info.aliases.iter().enumerate() {
-            let alias_ident = quote::format_ident!("{}__Alias{}", id, idx);
-            tag_variant_tokens.push(quote! { #[wire = #alias] #alias_ident });
-        }
+        // Primary tag + aliases collapse into ONE tag variant. The unit-string
+        // WireEnum derive on the tag enum expands `#[wire_alias = "..."]` into
+        // extra `From<&str>` arms pointing at the same variant, so parsers see
+        // `Tag::Foo` regardless of whether the wire tag was the primary or an
+        // alias.
+        let alias_attrs = info.aliases.iter().map(|a| quote! { #[wire_alias = #a] });
+        tag_variant_tokens.push(quote! {
+            #[wire = #primary]
+            #(#alias_attrs)*
+            #id
+        });
     }
 
     // --- Final expansion ---
@@ -1348,11 +1392,11 @@ fn expand_wire_enum_tagged(
             }
         }
 
-        /// Sibling unit enum listing every wire tag (primary + aliases) for
-        /// parser dispatch. Parse via `TryFrom<&str>`.
+        /// Sibling unit enum listing every canonical wire tag for parser
+        /// dispatch. Primary wire tags and any `#[wire_alias]` entries all
+        /// resolve to the same variant via `From<&str>`.
         #[doc = "Auto-generated by `#[derive(WireEnum)]`."]
-        #[derive(Debug, Clone, PartialEq, Eq, ::wacore_derive::WireEnum)]
-        #[allow(non_camel_case_types)]
+        #[derive(Debug, Clone, PartialEq, Eq, ::wacore::WireEnum)]
         #[allow(clippy::enum_variant_names)]
         pub enum #tag_ident {
             #(#tag_variant_tokens,)*

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use wacore_derive::{ProtocolNode, StringEnum};
+//! use wacore_derive::{ProtocolNode, WireEnum};
 //!
 //! /// A query request node.
 //! /// Wire format: `<query request="interactive"/>`
@@ -18,11 +18,11 @@
 //! }
 //!
 //! /// An enum with string representation.
-//! #[derive(StringEnum)]
+//! #[derive(WireEnum)]
 //! pub enum MemberAddMode {
-//!     #[str = "admin_add"]
+//!     #[wire = "admin_add"]
 //!     AdminAdd,
-//!     #[str = "all_member_add"]
+//!     #[wire = "all_member_add"]
 //!     AllMemberAdd,
 //! }
 //! ```
@@ -41,7 +41,7 @@ use syn::{Data, DeriveInput, Fields, parse_macro_input};
 ///   For `Option<String>` fields, a default always yields `Some(default)`.
 /// - `#[attr(name = "attrname", jid)]` - Marks a Jid field as a JID attribute (required).
 /// - `#[attr(name = "attrname", jid, optional)]` - Marks an Option<Jid> field as optional.
-/// - `#[attr(name = "attrname", string_enum)]` - Marks a StringEnum field (uses `as_str()`/`TryFrom`).
+/// - `#[attr(name = "attrname", string_enum)]` - Marks a field whose type derives `WireEnum` in unit-string mode (uses `as_str()`/`TryFrom`).
 /// - `#[attr(name = "attrname", u64)]` - Marks a u64 numeric attribute.
 /// - `#[attr(name = "attrname", u32)]` - Marks a u32 numeric attribute.
 ///   Numeric fields can also be `Option<u64>` / `Option<u32>` for optional attributes.
@@ -529,334 +529,386 @@ fn is_option_type(ty: &syn::Type) -> bool {
     false
 }
 
-/// Derive macro for enums with string representations.
-///
-/// Automatically implements:
-/// - `as_str(&self) -> &'static str` (or `&str` with fallback)
-/// - `std::fmt::Display`
-/// - `TryFrom<&str>` (or `From<&str>` with fallback)
-/// - `Default` (first variant is default, or use `#[string_default]`)
-/// - `serde::Serialize` (delegates to `as_str()`)
-/// - `serde::Deserialize` (delegates to `TryFrom<&str>` / `From<&str>`)
-///
-/// Because `StringEnum` owns the serde representation, types that derive it
-/// MUST NOT also derive `serde::Serialize` or `serde::Deserialize` directly —
-/// doing so would produce conflicting `impl` blocks. The single source of
-/// truth for the wire string is the `#[str = "..."]` attribute per variant.
-///
-/// # Attributes
-///
-/// - `#[str = "value"]` - Required on each unit variant. The string representation.
-/// - `#[string_default]` - Optional. Marks this variant as the default.
-/// - `#[string_fallback]` - Optional. Marks a `VariantName(String)` variant as catch-all.
-///   When present, unknown strings are captured instead of returning an error.
-///   Generates `From<&str>` instead of `TryFrom<&str>`, and `as_str()` returns `&str`.
-///
-/// # Example (standard)
-///
-/// ```ignore
-/// #[derive(StringEnum)]
-/// pub enum MemberAddMode {
-///     #[str = "admin_add"]
-///     AdminAdd,
-///     #[string_default]
-///     #[str = "all_member_add"]
-///     AllMemberAdd,
-/// }
-///
-/// assert_eq!(MemberAddMode::AdminAdd.as_str(), "admin_add");
-/// assert_eq!(MemberAddMode::try_from("all_member_add").unwrap(), MemberAddMode::AllMemberAdd);
-/// ```
-///
-/// # Example (with fallback)
-///
-/// ```ignore
-/// #[derive(StringEnum)]
-/// pub enum PrivacyCategory {
-///     #[str = "last"]
-///     Last,
-///     #[str = "online"]
-///     Online,
-///     #[string_fallback]
-///     Other(String),
-/// }
-///
-/// assert_eq!(PrivacyCategory::Last.as_str(), "last");
-/// assert_eq!(PrivacyCategory::from("last"), PrivacyCategory::Last);
-/// assert_eq!(PrivacyCategory::from("unknown"), PrivacyCategory::Other("unknown".to_string()));
-/// ```
-#[proc_macro_derive(StringEnum, attributes(str, string_default, string_fallback))]
-pub fn derive_string_enum(input: TokenStream) -> TokenStream {
+// =====================================================================
+// WireEnum — the unified replacement for StringEnum + manual impl Serialize
+// for tagged-with-payload and int-discriminated enums.
+//
+// Modes, inferred from attributes:
+//
+//   1. unit-string  (default when no #[wire(tag=...)] and no #[wire(kind="int")])
+//      Every variant is a unit (or a single #[wire_fallback] tuple with String).
+//      Emits: as_str, TryFrom<&str>/From<&str>, Default, Display, Serialize,
+//             Deserialize, ParseStringEnum. Drop-in replacement for StringEnum.
+//
+//   2. tagged       (enum has #[wire(tag = "type")])
+//      Variants carry payload (named fields or unit). One #[wire = "..."] per
+//      variant; optional #[wire_alias = "..."] adds parser-side aliases;
+//      #[wire(skip)] on a field excludes it from JSON; #[wire_fallback] with
+//      { tag: String } catches unknown tags.
+//      Emits: wire_tag(), impl Serialize (SerializeMap), and a sibling
+//             <Name>Tag unit enum (unit-string WireEnum) for parser dispatch.
+//      No Deserialize — follow-up work; not needed by current consumers.
+//
+//   3. int          (enum has #[wire(kind = "int")])
+//      Unit variants + optional #[wire_fallback] tuple with i32. Each variant
+//      has #[wire = NUM].
+//      Emits: code(), From<i32>, Serialize (as i32), Deserialize (from i32).
+//
+// The wire string/number lives exactly once per variant, in the #[wire = ...]
+// attribute. Everything else is derived.
+// =====================================================================
+
+#[proc_macro_derive(WireEnum, attributes(wire, wire_alias, wire_default, wire_fallback))]
+pub fn derive_wire_enum(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let name = &input.ident;
-
     let variants = match &input.data {
-        Data::Enum(data) => &data.variants,
+        Data::Enum(e) => e.variants.clone(),
         _ => {
-            return syn::Error::new_spanned(
-                &input.ident,
-                "StringEnum can only be derived for enums",
-            )
-            .to_compile_error()
-            .into();
+            return syn::Error::new_spanned(&input.ident, "WireEnum can only be derived for enums")
+                .to_compile_error()
+                .into();
         }
     };
 
-    let mut variant_infos = Vec::with_capacity(variants.len());
-    let mut default_variant = None;
-    let mut fallback_variant: Option<syn::Ident> = None;
-    let mut seen_str_values: std::collections::HashMap<String, syn::Ident> =
-        std::collections::HashMap::new();
+    let cfg = match parse_enum_level_wire(&input.attrs) {
+        Ok(c) => c,
+        Err(e) => return e.to_compile_error().into(),
+    };
 
-    for variant in variants {
-        let variant_ident = &variant.ident;
-
-        let mut is_default = false;
-        let mut is_fallback = false;
-        let mut str_value = None;
-
-        for attr in &variant.attrs {
-            if attr.path().is_ident("str") {
-                if let syn::Meta::NameValue(nv) = &attr.meta
-                    && let syn::Expr::Lit(expr_lit) = &nv.value
-                    && let syn::Lit::Str(lit_str) = &expr_lit.lit
-                {
-                    str_value = Some(lit_str.value());
-                }
-            } else if attr.path().is_ident("string_default") {
-                is_default = true;
-            } else if attr.path().is_ident("string_fallback") {
-                is_fallback = true;
-            }
+    match cfg.kind {
+        WireKind::IntTagged => expand_wire_enum_int(&input.ident, &variants).into(),
+        WireKind::StringTagged(discriminator) => {
+            expand_wire_enum_tagged(&input.ident, &variants, &discriminator).into()
         }
+        WireKind::UnitString => expand_wire_enum_unit(&input.ident, &variants).into(),
+    }
+}
 
-        if is_fallback {
-            // Validate: fallback variant must have exactly one unnamed String field
-            match &variant.fields {
-                syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {}
-                _ => {
-                    return syn::Error::new_spanned(
-                        variant_ident,
-                        "string_fallback variant must have exactly one unnamed field: VariantName(String)",
-                    )
-                    .to_compile_error()
-                    .into();
-                }
-            }
-            if fallback_variant.is_some() {
-                return syn::Error::new_spanned(
-                    variant_ident,
-                    "Multiple #[string_fallback] attributes found; only one variant may be the fallback",
-                )
-                .to_compile_error()
-                .into();
-            }
-            if str_value.is_some() {
-                return syn::Error::new_spanned(
-                    variant_ident,
-                    "string_fallback variant should not have a #[str = \"...\"] attribute",
-                )
-                .to_compile_error()
-                .into();
-            }
-            fallback_variant = Some(variant_ident.clone());
+// ----- enum-level config -----
 
-            if is_default {
-                if default_variant.is_some() {
-                    return syn::Error::new_spanned(
-                        variant_ident,
-                        "Multiple #[string_default] attributes found; only one variant may be the default",
-                    )
-                    .to_compile_error()
-                    .into();
-                }
-                default_variant = Some(variant_ident.clone());
-            }
+enum WireKind {
+    UnitString,
+    StringTagged(String),
+    IntTagged,
+}
+
+struct WireEnumCfg {
+    kind: WireKind,
+}
+
+fn parse_enum_level_wire(attrs: &[syn::Attribute]) -> syn::Result<WireEnumCfg> {
+    let mut tag_field: Option<String> = None;
+    let mut kind_is_int = false;
+
+    for attr in attrs {
+        if !attr.path().is_ident("wire") {
             continue;
         }
-
-        // Non-fallback variant must be a unit variant
-        if !matches!(variant.fields, syn::Fields::Unit) {
-            return syn::Error::new_spanned(
-                variant_ident,
-                "StringEnum only supports unit variants (except the #[string_fallback] variant)",
-            )
-            .to_compile_error()
-            .into();
-        }
-
-        let str_val = match str_value {
-            Some(v) => v,
-            None => {
-                return syn::Error::new_spanned(
-                    variant_ident,
-                    format!(
-                        "StringEnum variant {} requires #[str = \"...\"] attribute",
-                        variant_ident
-                    ),
-                )
-                .to_compile_error()
-                .into();
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("tag") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                tag_field = Some(lit.value());
+            } else if meta.path.is_ident("kind") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                match lit.value().as_str() {
+                    "int" => kind_is_int = true,
+                    "string" => kind_is_int = false,
+                    other => {
+                        return Err(meta.error(format!(
+                            "unknown wire kind {other:?}; expected \"string\" or \"int\""
+                        )));
+                    }
+                }
+            } else {
+                return Err(meta.error("unknown attribute inside #[wire(...)]"));
             }
-        };
-
-        if let Some(prev_variant) = seen_str_values.get(&str_val) {
-            return syn::Error::new_spanned(
-                variant_ident,
-                format!(
-                    "duplicate #[str = \"{}\"] value; already used by variant `{}`",
-                    str_val, prev_variant
-                ),
-            )
-            .to_compile_error()
-            .into();
-        }
-        seen_str_values.insert(str_val.clone(), variant_ident.clone());
-
-        if is_default {
-            if default_variant.is_some() {
-                return syn::Error::new_spanned(
-                    variant_ident,
-                    "Multiple #[string_default] attributes found; only one variant may be the default",
-                )
-                .to_compile_error()
-                .into();
-            }
-            default_variant = Some(variant_ident.clone());
-        }
-
-        variant_infos.push((variant_ident.clone(), str_val));
+            Ok(())
+        })?;
     }
 
-    // Check for empty enums (must have at least one known variant or a fallback)
-    if variant_infos.is_empty() && fallback_variant.is_none() {
-        return syn::Error::new_spanned(
-            &input.ident,
-            "StringEnum cannot be derived for empty enums",
-        )
-        .to_compile_error()
-        .into();
-    }
+    let kind = if kind_is_int {
+        if tag_field.is_some() {
+            return Err(syn::Error::new_spanned(
+                &attrs[0],
+                "#[wire(kind = \"int\")] is incompatible with #[wire(tag = \"...\")]",
+            ));
+        }
+        WireKind::IntTagged
+    } else if let Some(t) = tag_field {
+        WireKind::StringTagged(t)
+    } else {
+        WireKind::UnitString
+    };
 
-    // If no explicit default, use first variant
-    let default_variant = default_variant.unwrap_or_else(|| variant_infos[0].0.clone());
+    Ok(WireEnumCfg { kind })
+}
 
-    if let Some(ref fallback_ident) = fallback_variant {
-        // === Fallback mode: as_str() returns &str, From<&str> instead of TryFrom ===
+// ----- variant-level helpers -----
 
-        let as_str_arms: Vec<_> = variant_infos
-            .iter()
-            .map(|(ident, str_val)| {
-                quote! { #name::#ident => #str_val }
-            })
-            .collect();
+enum VariantWire {
+    Str(String),
+    Int(i64),
+}
 
-        let from_arms: Vec<_> = variant_infos
-            .iter()
-            .map(|(ident, str_val)| {
-                quote! { #str_val => #name::#ident }
-            })
-            .collect();
+struct VariantInfo {
+    ident: syn::Ident,
+    fields: syn::Fields,
+    wire: Option<VariantWire>,
+    aliases: Vec<String>,
+    is_default: bool,
+    is_fallback: bool,
+}
 
-        let expanded = quote! {
-            impl #name {
-                /// Returns the string representation of this enum variant.
-                pub fn as_str(&self) -> &str {
-                    match self {
-                        #(#as_str_arms,)*
-                        #name::#fallback_ident(s) => s.as_str(),
+fn read_variant(v: &syn::Variant) -> syn::Result<VariantInfo> {
+    let mut wire: Option<VariantWire> = None;
+    let mut aliases: Vec<String> = Vec::new();
+    let mut is_default = false;
+    let mut is_fallback = false;
+
+    for attr in &v.attrs {
+        if attr.path().is_ident("wire_default") {
+            is_default = true;
+        } else if attr.path().is_ident("wire_fallback") {
+            is_fallback = true;
+        } else if attr.path().is_ident("wire_alias") {
+            if let syn::Meta::NameValue(nv) = &attr.meta
+                && let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(s),
+                    ..
+                }) = &nv.value
+            {
+                aliases.push(s.value());
+            } else {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "expected #[wire_alias = \"...\"] with a string literal",
+                ));
+            }
+        } else if attr.path().is_ident("wire") {
+            // Variant-level #[wire = "..."] or #[wire = 101]
+            if let syn::Meta::NameValue(nv) = &attr.meta {
+                match &nv.value {
+                    syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(s),
+                        ..
+                    }) => wire = Some(VariantWire::Str(s.value())),
+                    syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Int(n),
+                        ..
+                    }) => wire = Some(VariantWire::Int(n.base10_parse::<i64>()?)),
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            &nv.value,
+                            "#[wire = ...] expects a string or integer literal",
+                        ));
                     }
                 }
             }
+        }
+    }
 
-            impl ::core::fmt::Display for #name {
-                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.write_str(self.as_str())
+    Ok(VariantInfo {
+        ident: v.ident.clone(),
+        fields: v.fields.clone(),
+        wire,
+        aliases,
+        is_default,
+        is_fallback,
+    })
+}
+
+fn field_has_wire_skip(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("wire") {
+            continue;
+        }
+        let mut found_skip = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("skip") {
+                found_skip = true;
+            }
+            Ok(())
+        });
+        if found_skip {
+            return true;
+        }
+    }
+    false
+}
+
+// ================== unit-string mode ==================
+
+fn expand_wire_enum_unit(
+    name: &syn::Ident,
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::Token![,]>,
+) -> proc_macro2::TokenStream {
+    let mut infos = Vec::with_capacity(variants.len());
+    for v in variants {
+        match read_variant(v) {
+            Ok(info) => infos.push(info),
+            Err(e) => return e.to_compile_error(),
+        }
+    }
+
+    let mut seen: std::collections::HashMap<String, syn::Ident> = Default::default();
+    let mut fallback: Option<&VariantInfo> = None;
+    let mut default_variant: Option<&VariantInfo> = None;
+
+    for info in &infos {
+        if info.is_fallback {
+            if fallback.is_some() {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    "only one #[wire_fallback] variant is allowed",
+                )
+                .to_compile_error();
+            }
+            match &info.fields {
+                syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {}
+                _ => {
+                    return syn::Error::new_spanned(
+                        &info.ident,
+                        "#[wire_fallback] on a unit-string enum requires VariantName(String)",
+                    )
+                    .to_compile_error();
                 }
             }
+            if info.wire.is_some() {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    "#[wire_fallback] variant must not carry #[wire = \"...\"]",
+                )
+                .to_compile_error();
+            }
+            fallback = Some(info);
+            if info.is_default {
+                default_variant = Some(info);
+            }
+            continue;
+        }
+        if !matches!(info.fields, syn::Fields::Unit) {
+            return syn::Error::new_spanned(
+                &info.ident,
+                "unit-string WireEnum only supports unit variants (use #[wire_fallback] for a catch-all)",
+            )
+            .to_compile_error();
+        }
+        let Some(VariantWire::Str(s)) = &info.wire else {
+            return syn::Error::new_spanned(&info.ident, "variant needs #[wire = \"...\"]")
+                .to_compile_error();
+        };
+        if let Some(prev) = seen.insert(s.clone(), info.ident.clone()) {
+            return syn::Error::new_spanned(
+                &info.ident,
+                format!("duplicate #[wire = \"{s}\"]; already used by {prev}"),
+            )
+            .to_compile_error();
+        }
+        if info.is_default {
+            if default_variant.is_some() {
+                return syn::Error::new_spanned(&info.ident, "only one #[wire_default] is allowed")
+                    .to_compile_error();
+            }
+            default_variant = Some(info);
+        }
+        if !info.aliases.is_empty() {
+            return syn::Error::new_spanned(
+                &info.ident,
+                "#[wire_alias] is only valid on tagged-mode WireEnum variants",
+            )
+            .to_compile_error();
+        }
+    }
 
+    let first_known: Option<&VariantInfo> = infos.iter().find(|i| !i.is_fallback);
+    let default_info = match (default_variant, first_known, fallback) {
+        (Some(d), _, _) => d,
+        (None, Some(f), _) => f,
+        (None, None, Some(fb)) => fb,
+        (None, None, None) => {
+            return syn::Error::new_spanned(name, "WireEnum cannot be derived for empty enums")
+                .to_compile_error();
+        }
+    };
+    let default_ident = &default_info.ident;
+    let default_ctor = if default_info.is_fallback {
+        quote! { #name::#default_ident(::std::string::String::new()) }
+    } else {
+        quote! { #name::#default_ident }
+    };
+
+    let known: Vec<(&syn::Ident, &String)> = infos
+        .iter()
+        .filter(|i| !i.is_fallback)
+        .map(|i| {
+            let VariantWire::Str(s) = i.wire.as_ref().unwrap() else {
+                unreachable!()
+            };
+            (&i.ident, s)
+        })
+        .collect();
+
+    let as_str_arms: Vec<_> = known
+        .iter()
+        .map(|(id, s)| quote! { #name::#id => #s })
+        .collect();
+
+    let try_from_arms: Vec<_> = known
+        .iter()
+        .map(|(id, s)| quote! { #s => ::core::result::Result::Ok(#name::#id) })
+        .collect();
+
+    let from_arms: Vec<_> = known
+        .iter()
+        .map(|(id, s)| quote! { #s => #name::#id })
+        .collect();
+
+    let as_str_return_ty;
+    let as_str_block;
+    let conversion_impls;
+
+    if let Some(fb) = fallback {
+        let fb_ident = &fb.ident;
+        as_str_return_ty = quote! { &str };
+        as_str_block = quote! {
+            match self {
+                #(#as_str_arms,)*
+                #name::#fb_ident(s) => s.as_str(),
+            }
+        };
+        conversion_impls = quote! {
             impl ::core::convert::From<&str> for #name {
                 fn from(value: &str) -> Self {
                     match value {
                         #(#from_arms,)*
-                        other => #name::#fallback_ident(other.to_string()),
+                        other => #name::#fb_ident(other.to_string()),
                     }
                 }
             }
 
             impl ::wacore::protocol::ParseStringEnum for #name {
                 fn parse_from_str(s: &str) -> ::anyhow::Result<Self> {
-                    Ok(::core::convert::From::from(s))
-                }
-            }
-
-            impl ::core::default::Default for #name {
-                fn default() -> Self {
-                    #name::#default_variant
-                }
-            }
-
-            impl ::serde::Serialize for #name {
-                fn serialize<S: ::serde::Serializer>(
-                    &self,
-                    serializer: S,
-                ) -> ::core::result::Result<S::Ok, S::Error> {
-                    serializer.serialize_str(self.as_str())
-                }
-            }
-
-            impl<'de> ::serde::Deserialize<'de> for #name {
-                fn deserialize<D: ::serde::Deserializer<'de>>(
-                    deserializer: D,
-                ) -> ::core::result::Result<Self, D::Error> {
-                    let s = <::std::string::String as ::serde::Deserialize>::deserialize(deserializer)?;
-                    ::core::result::Result::Ok(<Self as ::core::convert::From<&str>>::from(s.as_str()))
+                    ::core::result::Result::Ok(::core::convert::From::from(s))
                 }
             }
         };
-
-        expanded.into()
     } else {
-        // === Standard mode: as_str() returns &'static str, TryFrom<&str> ===
-
-        let as_str_arms: Vec<_> = variant_infos
-            .iter()
-            .map(|(ident, str_val)| {
-                quote! { #name::#ident => #str_val }
-            })
-            .collect();
-
-        let try_from_arms: Vec<_> = variant_infos
-            .iter()
-            .map(|(ident, str_val)| {
-                quote! { #str_val => Ok(#name::#ident) }
-            })
-            .collect();
-
-        let expanded = quote! {
-            impl #name {
-                /// Returns the string representation of this enum variant.
-                pub fn as_str(&self) -> &'static str {
-                    match self {
-                        #(#as_str_arms),*
-                    }
-                }
+        as_str_return_ty = quote! { &'static str };
+        as_str_block = quote! {
+            match self {
+                #(#as_str_arms),*
             }
-
-            impl ::core::fmt::Display for #name {
-                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.write_str(self.as_str())
-                }
-            }
-
+        };
+        conversion_impls = quote! {
             impl ::core::convert::TryFrom<&str> for #name {
                 type Error = ::anyhow::Error;
-
                 fn try_from(value: &str) -> ::core::result::Result<Self, Self::Error> {
                     match value {
                         #(#try_from_arms),*,
-                        _ => Err(::anyhow::anyhow!("unknown {}: {}", stringify!(#name), value)),
+                        _ => ::core::result::Result::Err(
+                            ::anyhow::anyhow!("unknown {}: {}", stringify!(#name), value)
+                        ),
                     }
                 }
             }
@@ -866,22 +918,22 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
                     ::core::convert::TryFrom::try_from(s)
                 }
             }
+        };
+    }
 
-            impl ::core::default::Default for #name {
-                fn default() -> Self {
-                    #name::#default_variant
+    let deserialize_impl = if fallback.is_some() {
+        quote! {
+            impl<'de> ::serde::Deserialize<'de> for #name {
+                fn deserialize<D: ::serde::Deserializer<'de>>(
+                    deserializer: D,
+                ) -> ::core::result::Result<Self, D::Error> {
+                    let s = <::std::string::String as ::serde::Deserialize>::deserialize(deserializer)?;
+                    ::core::result::Result::Ok(<Self as ::core::convert::From<&str>>::from(s.as_str()))
                 }
             }
-
-            impl ::serde::Serialize for #name {
-                fn serialize<S: ::serde::Serializer>(
-                    &self,
-                    serializer: S,
-                ) -> ::core::result::Result<S::Ok, S::Error> {
-                    serializer.serialize_str(self.as_str())
-                }
-            }
-
+        }
+    } else {
+        quote! {
             impl<'de> ::serde::Deserialize<'de> for #name {
                 fn deserialize<D: ::serde::Deserializer<'de>>(
                     deserializer: D,
@@ -891,8 +943,419 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
                         .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
                 }
             }
-        };
+        }
+    };
 
-        expanded.into()
+    quote! {
+        impl #name {
+            /// Wire string for this variant (single source of truth).
+            pub fn as_str(&self) -> #as_str_return_ty {
+                #as_str_block
+            }
+        }
+
+        impl ::core::fmt::Display for #name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        #conversion_impls
+
+        impl ::core::default::Default for #name {
+            fn default() -> Self {
+                #default_ctor
+            }
+        }
+
+        impl ::serde::Serialize for #name {
+            fn serialize<S: ::serde::Serializer>(
+                &self,
+                serializer: S,
+            ) -> ::core::result::Result<S::Ok, S::Error> {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        #deserialize_impl
+    }
+}
+
+// ================== int mode ==================
+
+fn expand_wire_enum_int(
+    name: &syn::Ident,
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::Token![,]>,
+) -> proc_macro2::TokenStream {
+    let mut infos = Vec::with_capacity(variants.len());
+    for v in variants {
+        match read_variant(v) {
+            Ok(info) => infos.push(info),
+            Err(e) => return e.to_compile_error(),
+        }
+    }
+
+    let mut fallback: Option<&VariantInfo> = None;
+    let mut seen: std::collections::HashMap<i64, syn::Ident> = Default::default();
+
+    for info in &infos {
+        if info.is_fallback {
+            if fallback.is_some() {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    "only one #[wire_fallback] is allowed",
+                )
+                .to_compile_error();
+            }
+            match &info.fields {
+                syn::Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {}
+                _ => {
+                    return syn::Error::new_spanned(
+                        &info.ident,
+                        "#[wire_fallback] in int mode requires VariantName(i32)",
+                    )
+                    .to_compile_error();
+                }
+            }
+            fallback = Some(info);
+            continue;
+        }
+        if !matches!(info.fields, syn::Fields::Unit) {
+            return syn::Error::new_spanned(
+                &info.ident,
+                "int-mode WireEnum variants must be unit variants (except the #[wire_fallback])",
+            )
+            .to_compile_error();
+        }
+        let Some(VariantWire::Int(n)) = &info.wire else {
+            return syn::Error::new_spanned(&info.ident, "variant needs #[wire = NUMBER]")
+                .to_compile_error();
+        };
+        if let Some(prev) = seen.insert(*n, info.ident.clone()) {
+            return syn::Error::new_spanned(
+                &info.ident,
+                format!("duplicate #[wire = {n}]; already used by {prev}"),
+            )
+            .to_compile_error();
+        }
+    }
+
+    let Some(fb) = fallback else {
+        return syn::Error::new_spanned(
+            name,
+            "int-mode WireEnum requires a #[wire_fallback] variant like Unknown(i32)",
+        )
+        .to_compile_error();
+    };
+    let fb_ident = &fb.ident;
+
+    let code_arms: Vec<_> = infos
+        .iter()
+        .filter(|i| !i.is_fallback)
+        .map(|i| {
+            let id = &i.ident;
+            let VariantWire::Int(n) = i.wire.as_ref().unwrap() else {
+                unreachable!()
+            };
+            let lit = proc_macro2::Literal::i32_suffixed(*n as i32);
+            quote! { #name::#id => #lit }
+        })
+        .collect();
+
+    let from_arms: Vec<_> = infos
+        .iter()
+        .filter(|i| !i.is_fallback)
+        .map(|i| {
+            let id = &i.ident;
+            let VariantWire::Int(n) = i.wire.as_ref().unwrap() else {
+                unreachable!()
+            };
+            let lit = proc_macro2::Literal::i32_suffixed(*n as i32);
+            quote! { #lit => #name::#id }
+        })
+        .collect();
+
+    quote! {
+        impl #name {
+            /// Numeric wire code for this variant (single source of truth).
+            pub fn code(&self) -> i32 {
+                match self {
+                    #(#code_arms,)*
+                    #name::#fb_ident(n) => *n,
+                }
+            }
+        }
+
+        impl ::core::convert::From<i32> for #name {
+            fn from(code: i32) -> Self {
+                match code {
+                    #(#from_arms,)*
+                    other => #name::#fb_ident(other),
+                }
+            }
+        }
+
+        impl ::serde::Serialize for #name {
+            fn serialize<S: ::serde::Serializer>(
+                &self,
+                serializer: S,
+            ) -> ::core::result::Result<S::Ok, S::Error> {
+                serializer.serialize_i32(self.code())
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for #name {
+            fn deserialize<D: ::serde::Deserializer<'de>>(
+                deserializer: D,
+            ) -> ::core::result::Result<Self, D::Error> {
+                let n = <i32 as ::serde::Deserialize>::deserialize(deserializer)?;
+                ::core::result::Result::Ok(<Self as ::core::convert::From<i32>>::from(n))
+            }
+        }
+    }
+}
+
+// ================== tagged mode ==================
+
+fn expand_wire_enum_tagged(
+    name: &syn::Ident,
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::Token![,]>,
+    discriminator: &str,
+) -> proc_macro2::TokenStream {
+    let mut infos = Vec::with_capacity(variants.len());
+    for v in variants {
+        match read_variant(v) {
+            Ok(info) => infos.push(info),
+            Err(e) => return e.to_compile_error(),
+        }
+    }
+
+    let mut seen: std::collections::HashMap<String, syn::Ident> = Default::default();
+    let mut fallback: Option<&VariantInfo> = None;
+
+    for info in &infos {
+        if info.is_fallback {
+            if fallback.is_some() {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    "only one #[wire_fallback] is allowed",
+                )
+                .to_compile_error();
+            }
+            // Must be { tag: String }
+            let ok = matches!(
+                &info.fields,
+                syn::Fields::Named(n)
+                    if n.named.len() == 1
+                        && n.named
+                            .first()
+                            .unwrap()
+                            .ident
+                            .as_ref()
+                            .map(|i| i == "tag")
+                            .unwrap_or(false)
+            );
+            if !ok {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    "tagged #[wire_fallback] must have exactly { tag: String }",
+                )
+                .to_compile_error();
+            }
+            if info.wire.is_some() {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    "#[wire_fallback] variant must not have #[wire = \"...\"]",
+                )
+                .to_compile_error();
+            }
+            fallback = Some(info);
+            continue;
+        }
+        let Some(VariantWire::Str(s)) = &info.wire else {
+            return syn::Error::new_spanned(&info.ident, "variant needs #[wire = \"...\"]")
+                .to_compile_error();
+        };
+        if let Some(prev) = seen.insert(s.clone(), info.ident.clone()) {
+            return syn::Error::new_spanned(
+                &info.ident,
+                format!("duplicate #[wire = \"{s}\"]; already used by {prev}"),
+            )
+            .to_compile_error();
+        }
+        for alias in &info.aliases {
+            if let Some(prev) = seen.insert(alias.clone(), info.ident.clone()) {
+                return syn::Error::new_spanned(
+                    &info.ident,
+                    format!(
+                        "#[wire_alias = \"{alias}\"] collides with wire tag from variant {prev}"
+                    ),
+                )
+                .to_compile_error();
+            }
+        }
+    }
+
+    // --- wire_tag(&self) -> &str ---
+
+    let wire_tag_arms: Vec<_> = infos
+        .iter()
+        .map(|info| {
+            let id = &info.ident;
+            if info.is_fallback {
+                // { tag: String } — return borrowed from the field
+                quote! { #name::#id { tag } => tag.as_str() }
+            } else {
+                let VariantWire::Str(s) = info.wire.as_ref().unwrap() else {
+                    unreachable!()
+                };
+                match &info.fields {
+                    syn::Fields::Unit => quote! { #name::#id => #s },
+                    syn::Fields::Named(_) => quote! { #name::#id { .. } => #s },
+                    syn::Fields::Unnamed(_) => quote! { #name::#id(..) => #s },
+                }
+            }
+        })
+        .collect();
+
+    // --- Serialize arms ---
+
+    let serialize_arms: Vec<_> = infos
+        .iter()
+        .map(|info| {
+            let id = &info.ident;
+            if info.is_fallback {
+                // Only the discriminator is written (already done before match).
+                quote! { #name::#id { tag: _ } => {} }
+            } else {
+                match &info.fields {
+                    syn::Fields::Unit => quote! { #name::#id => {} },
+                    syn::Fields::Named(named) => {
+                        let bindings: Vec<proc_macro2::TokenStream> = named
+                            .named
+                            .iter()
+                            .map(|f| {
+                                let id = f.ident.as_ref().unwrap();
+                                if field_has_wire_skip(&f.attrs) {
+                                    quote! { #id: _ }
+                                } else {
+                                    quote! { #id }
+                                }
+                            })
+                            .collect();
+                        let entries: Vec<proc_macro2::TokenStream> = named
+                            .named
+                            .iter()
+                            .filter(|f| !field_has_wire_skip(&f.attrs))
+                            .map(|f| {
+                                let id = f.ident.as_ref().unwrap();
+                                let key = id.to_string();
+                                if is_option_type(&f.ty) {
+                                    quote! {
+                                        if let ::core::option::Option::Some(__v) = #id {
+                                            ::serde::ser::SerializeMap::serialize_entry(
+                                                &mut map, #key, __v
+                                            )?;
+                                        }
+                                    }
+                                } else {
+                                    quote! {
+                                        ::serde::ser::SerializeMap::serialize_entry(
+                                            &mut map, #key, #id
+                                        )?;
+                                    }
+                                }
+                            })
+                            .collect();
+                        quote! {
+                            #name::#id { #(#bindings),* } => {
+                                #(#entries)*
+                            }
+                        }
+                    }
+                    syn::Fields::Unnamed(_) => {
+                        quote! {
+                            compile_error!("tagged WireEnum tuple variants are not supported — use named fields or unit");
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // --- Sibling <Name>Tag unit enum (unit-string WireEnum) ---
+
+    let tag_ident = quote::format_ident!("{}Tag", name);
+
+    let mut tag_variant_tokens: Vec<proc_macro2::TokenStream> = Vec::new();
+    for info in &infos {
+        let id = &info.ident;
+        if info.is_fallback {
+            tag_variant_tokens.push(quote! {
+                #[doc = "Unknown wire tag — captured for forward compatibility."]
+                #[wire_fallback]
+                Unknown(::std::string::String)
+            });
+            continue;
+        }
+        let VariantWire::Str(primary) = info.wire.as_ref().unwrap() else {
+            unreachable!()
+        };
+        // The tag-enum variant gets the primary wire as #[wire = "..."].
+        // Aliases become extra unit variants named <Ident>__alias_N.
+        tag_variant_tokens.push(quote! { #[wire = #primary] #id });
+        for (idx, alias) in info.aliases.iter().enumerate() {
+            let alias_ident = quote::format_ident!("{}__Alias{}", id, idx);
+            tag_variant_tokens.push(quote! { #[wire = #alias] #alias_ident });
+        }
+    }
+
+    // --- Final expansion ---
+
+    let discriminator_lit = discriminator;
+
+    quote! {
+        impl #name {
+            /// The wire tag this variant serializes as — the JSON discriminator
+            /// and the exact tag the parser dispatches on.
+            pub fn wire_tag(&self) -> &str {
+                match self {
+                    #(#wire_tag_arms,)*
+                }
+            }
+
+            /// Back-compat alias of [`Self::wire_tag`].
+            #[inline]
+            pub fn tag_name(&self) -> &str {
+                self.wire_tag()
+            }
+        }
+
+        impl ::serde::Serialize for #name {
+            fn serialize<S: ::serde::Serializer>(
+                &self,
+                serializer: S,
+            ) -> ::core::result::Result<S::Ok, S::Error> {
+                use ::serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(None)?;
+                ::serde::ser::SerializeMap::serialize_entry(
+                    &mut map, #discriminator_lit, self.wire_tag()
+                )?;
+                match self {
+                    #(#serialize_arms,)*
+                }
+                ::serde::ser::SerializeMap::end(map)
+            }
+        }
+
+        /// Sibling unit enum listing every wire tag (primary + aliases) for
+        /// parser dispatch. Parse via `TryFrom<&str>`.
+        #[doc = "Auto-generated by `#[derive(WireEnum)]`."]
+        #[derive(Debug, Clone, PartialEq, Eq, ::wacore_derive::WireEnum)]
+        #[allow(non_camel_case_types)]
+        #[allow(clippy::enum_variant_names)]
+        pub enum #tag_ident {
+            #(#tag_variant_tokens,)*
+        }
     }
 }

--- a/wacore/src/iq/blocklist.rs
+++ b/wacore/src/iq/blocklist.rs
@@ -3,7 +3,7 @@
 //! This module provides type-safe structures for blocklist operations following
 //! the `ProtocolNode` pattern defined in `wacore/src/protocol.rs`.
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::node::optional_child;
 use crate::iq::spec::IqSpec;
 use crate::protocol::ProtocolNode;
@@ -16,11 +16,11 @@ use wacore_binary::{Node, NodeContent, NodeRef};
 /// IQ namespace for blocklist operations.
 pub const BLOCKLIST_IQ_NAMESPACE: &str = "blocklist";
 /// Action to perform on a blocklist entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum BlocklistAction {
-    #[str = "block"]
+    #[wire = "block"]
     Block,
-    #[str = "unblock"]
+    #[wire = "unblock"]
     Unblock,
 }
 /// Request node for updating blocklist.

--- a/wacore/src/iq/business.rs
+++ b/wacore/src/iq/business.rs
@@ -1,6 +1,6 @@
 //! Business profile IQ specification (namespace `w:biz`).
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::node::optional_attr;
 use crate::iq::spec::IqSpec;
 use crate::request::InfoQuery;
@@ -8,35 +8,35 @@ use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Server};
 use wacore_binary::{NodeContent, NodeContentRef, NodeRef};
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum DayOfWeek {
-    #[str = "sun"]
+    #[wire = "sun"]
     Sunday,
-    #[str = "mon"]
+    #[wire = "mon"]
     Monday,
-    #[str = "tue"]
+    #[wire = "tue"]
     Tuesday,
-    #[str = "wed"]
+    #[wire = "wed"]
     Wednesday,
-    #[str = "thu"]
+    #[wire = "thu"]
     Thursday,
-    #[str = "fri"]
+    #[wire = "fri"]
     Friday,
-    #[str = "sat"]
+    #[wire = "sat"]
     Saturday,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum BusinessHourMode {
-    #[str = "open_24h"]
+    #[wire = "open_24h"]
     Open24H,
-    #[str = "specific_hours"]
+    #[wire = "specific_hours"]
     SpecificHours,
-    #[str = "appointment_only"]
+    #[wire = "appointment_only"]
     AppointmentOnly,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 

--- a/wacore/src/iq/chatstate.rs
+++ b/wacore/src/iq/chatstate.rs
@@ -19,7 +19,7 @@
 //! </chatstate>
 //! ```
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::protocol::ProtocolNode;
 use anyhow::Result;
 use thiserror::Error;
@@ -54,17 +54,17 @@ pub enum ChatstateParseError {
 /// - `typing` = ACTIVE_CHAT_STATE_TYPE.TYPING
 /// - `recording_audio` = ACTIVE_CHAT_STATE_TYPE.RECORDING_AUDIO
 /// - `idle` = IDLE_CHAT_STATE_TYPE.IDLE
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum ReceivedChatState {
     /// User is typing text
-    #[str = "typing"]
+    #[wire = "typing"]
     Typing,
     /// User is recording a voice message
-    #[str = "recording_audio"]
+    #[wire = "recording_audio"]
     RecordingAudio,
     /// User stopped typing/recording
-    #[str = "idle"]
-    #[string_default]
+    #[wire = "idle"]
+    #[wire_default]
     Idle,
 }
 

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -41,11 +41,11 @@ pub struct ProfilePicture {
 }
 
 /// Profile picture type (preview thumbnail or full-size).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum ProfilePictureType {
-    #[str = "preview"]
+    #[wire = "preview"]
     Preview,
-    #[str = "image"]
+    #[wire = "image"]
     Full,
 }
 

--- a/wacore/src/iq/dirty.rs
+++ b/wacore/src/iq/dirty.rs
@@ -1,4 +1,4 @@
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::spec::IqSpec;
 use crate::request::InfoQuery;
 use wacore_binary::builder::NodeBuilder;
@@ -7,17 +7,17 @@ use wacore_binary::{Node, NodeContent, NodeRef};
 
 pub const DIRTY_NAMESPACE: &str = "urn:xmpp:whatsapp:dirty";
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum DirtyType {
-    #[str = "account_sync"]
+    #[wire = "account_sync"]
     AccountSync,
-    #[str = "groups"]
+    #[wire = "groups"]
     Groups,
-    #[str = "syncd_app_state"]
+    #[wire = "syncd_app_state"]
     SyncdAppState,
-    #[str = "newsletter_metadata"]
+    #[wire = "newsletter_metadata"]
     NewsletterMetadata,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1,4 +1,4 @@
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::node::{collect_children, required_attr, required_child};
 use crate::iq::spec::IqSpec;
 use crate::protocol::ProtocolNode;
@@ -38,40 +38,40 @@ pub const BATCH_GROUP_INFO_LIMIT: usize = 10_000;
 pub const BATCH_PROFILE_PICTURES_LIMIT: usize = 1_000;
 
 /// Member link mode for group invite links.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum MemberLinkMode {
-    #[str = "admin_link"]
+    #[wire = "admin_link"]
     AdminLink,
-    #[str = "all_member_link"]
+    #[wire = "all_member_link"]
     AllMemberLink,
 }
 
 /// Member add mode for who can add participants.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum MemberAddMode {
-    #[str = "admin_add"]
+    #[wire = "admin_add"]
     AdminAdd,
-    #[str = "all_member_add"]
+    #[wire = "all_member_add"]
     AllMemberAdd,
 }
 
 /// Membership approval mode for join requests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum MembershipApprovalMode {
-    #[string_default]
-    #[str = "off"]
+    #[wire_default]
+    #[wire = "off"]
     Off,
-    #[str = "on"]
+    #[wire = "on"]
     On,
 }
 
 /// Who can share message history with new members.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum MemberShareHistoryMode {
-    #[string_default]
-    #[str = "admin_share"]
+    #[wire_default]
+    #[wire = "admin_share"]
     AdminShare,
-    #[str = "all_member_share"]
+    #[wire = "all_member_share"]
     AllMemberShare,
 }
 
@@ -153,22 +153,22 @@ define_error_code_enum! {
 }
 
 /// Query request type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum GroupQueryRequestType {
-    #[string_default]
-    #[str = "interactive"]
+    #[wire_default]
+    #[wire = "interactive"]
     Interactive,
 }
 
 /// Participant type (admin level).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum ParticipantType {
-    #[string_default]
-    #[str = "member"]
+    #[wire_default]
+    #[wire = "member"]
     Member,
-    #[str = "admin"]
+    #[wire = "admin"]
     Admin,
-    #[str = "superadmin"]
+    #[wire = "superadmin"]
     SuperAdmin,
 }
 

--- a/wacore/src/iq/mediaconn.rs
+++ b/wacore/src/iq/mediaconn.rs
@@ -16,7 +16,7 @@
 //! </iq>
 //! ```
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::spec::IqSpec;
 use crate::protocol::ProtocolNode;
 use crate::request::InfoQuery;
@@ -25,14 +25,14 @@ use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Server};
 use wacore_binary::{Node, NodeContent, NodeRef};
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum HostType {
-    #[str = "primary"]
-    #[string_default]
+    #[wire = "primary"]
+    #[wire_default]
     Primary,
-    #[str = "fallback"]
+    #[wire = "fallback"]
     Fallback,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 

--- a/wacore/src/iq/prekeys.rs
+++ b/wacore/src/iq/prekeys.rs
@@ -118,13 +118,13 @@ impl IqSpec for PreKeyCountSpec {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
 pub enum PreKeyFetchReason {
-    #[str = "identity"]
+    #[wire = "identity"]
     Identity,
-    #[str = "retry"]
+    #[wire = "retry"]
     Retry,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 

--- a/wacore/src/iq/privacy.rs
+++ b/wacore/src/iq/privacy.rs
@@ -49,7 +49,7 @@
 //! - `WAWebPrivacySettings` (value enums)
 //! - `WAWebSchemaPrivacyDisallowedList` (disallowed list types)
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::spec::IqSpec;
 use crate::request::InfoQuery;
 use crate::types::message::AddressingMode;
@@ -60,36 +60,36 @@ use wacore_binary::{Node, NodeContent, NodeRef};
 /// IQ namespace for privacy settings.
 pub const PRIVACY_NAMESPACE: &str = "privacy";
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum PrivacyCategory {
     /// Last seen visibility (`all | contacts | contact_blacklist | none`)
-    #[str = "last"]
+    #[wire = "last"]
     Last,
     /// Online status visibility (`all | match_last_seen`)
-    #[str = "online"]
+    #[wire = "online"]
     Online,
     /// Profile photo visibility (`all | contacts | contact_blacklist | none`)
-    #[str = "profile"]
+    #[wire = "profile"]
     Profile,
     /// About/status text visibility (`all | contacts | contact_blacklist | none`)
-    #[str = "status"]
+    #[wire = "status"]
     Status,
     /// Group add permissions (`all | contacts | contact_blacklist | none`)
-    #[str = "groupadd"]
+    #[wire = "groupadd"]
     GroupAdd,
     /// Read receipts (`all | none`)
-    #[str = "readreceipts"]
+    #[wire = "readreceipts"]
     ReadReceipts,
     /// Call add permissions (`all | known | contacts`)
-    #[str = "calladd"]
+    #[wire = "calladd"]
     CallAdd,
     /// Message permissions / anti-brigading (`all | contacts`)
-    #[str = "messages"]
+    #[wire = "messages"]
     Messages,
     /// Defense mode (`off | on_standard`)
-    #[str = "defense"]
+    #[wire = "defense"]
     DefenseMode,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 
@@ -126,28 +126,28 @@ impl PrivacyCategory {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum PrivacyValue {
-    #[str = "all"]
+    #[wire = "all"]
     All,
-    #[str = "contacts"]
+    #[wire = "contacts"]
     Contacts,
-    #[str = "none"]
+    #[wire = "none"]
     None,
-    #[str = "contact_blacklist"]
+    #[wire = "contact_blacklist"]
     ContactBlacklist,
-    #[str = "match_last_seen"]
+    #[wire = "match_last_seen"]
     MatchLastSeen,
     /// `calladd` only
-    #[str = "known"]
+    #[wire = "known"]
     Known,
     /// `defense` only
-    #[str = "off"]
+    #[wire = "off"]
     Off,
     /// `defense` only
-    #[str = "on_standard"]
+    #[wire = "on_standard"]
     OnStandard,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 
@@ -220,12 +220,12 @@ impl IqSpec for PrivacySettingsSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum DisallowedListAction {
-    #[string_default]
-    #[str = "add"]
+    #[wire_default]
+    #[wire = "add"]
     Add,
-    #[str = "remove"]
+    #[wire = "remove"]
     Remove,
 }
 
@@ -546,7 +546,7 @@ mod tests {
         assert_eq!(response.get_value(&PrivacyCategory::Online), None);
     }
 
-    // --- StringEnum conversion tests ---
+    // --- WireEnum conversion tests ---
 
     #[test]
     fn test_privacy_category_from_str() {

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -50,7 +50,7 @@
 //! </iq>
 //! ```
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::spec::IqSpec;
 use crate::request::InfoQuery;
 use anyhow::anyhow;
@@ -61,29 +61,29 @@ use wacore_binary::{Jid, Server};
 use wacore_binary::{Node, NodeContent, NodeContentRef, NodeRef};
 
 /// Usync mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum UsyncMode {
     /// Query mode - used for contact lookups.
-    #[string_default]
-    #[str = "query"]
+    #[wire_default]
+    #[wire = "query"]
     Query,
     /// Full mode - used for user info with more details.
-    #[str = "full"]
+    #[wire = "full"]
     Full,
 }
 
 /// Usync context.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum UsyncContext {
     /// Interactive context - for user-initiated operations.
-    #[string_default]
-    #[str = "interactive"]
+    #[wire_default]
+    #[wire = "interactive"]
     Interactive,
     /// Background context - for background sync operations.
-    #[str = "background"]
+    #[wire = "background"]
     Background,
     /// Message context - for message-related operations.
-    #[str = "message"]
+    #[wire = "message"]
     Message,
 }
 

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -4,7 +4,7 @@ pub use wacore_appstate as appstate;
 pub use wacore_noise as noise;
 
 // Re-export derive macros
-pub use wacore_derive::{EmptyNode, ProtocolNode, StringEnum};
+pub use wacore_derive::{EmptyNode, ProtocolNode, WireEnum};
 
 pub mod adv;
 pub mod appstate_sync;

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -19,7 +19,7 @@
 //! - Ephemeral encryption: AES-256-CTR
 //! - Bundle encryption: AES-256-GCM after HKDF key derivation
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::libsignal::crypto::aes_256_gcm_encrypt;
 use crate::libsignal::protocol::{KeyPair, PublicKey};
 use aes::cipher::{KeyIvInit, StreamCipher};
@@ -80,29 +80,29 @@ const PAIR_CODE_VALIDITY_SECS: u64 = 180;
 
 /// Platform identifiers for companion devices.
 /// These match the DeviceProps.PlatformType protobuf enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 #[repr(u8)]
 pub enum PlatformId {
-    #[str = "0"]
+    #[wire = "0"]
     Unknown = 0,
-    #[string_default]
-    #[str = "1"]
+    #[wire_default]
+    #[wire = "1"]
     Chrome = 1,
-    #[str = "2"]
+    #[wire = "2"]
     Firefox = 2,
-    #[str = "3"]
+    #[wire = "3"]
     InternetExplorer = 3,
-    #[str = "4"]
+    #[wire = "4"]
     Opera = 4,
-    #[str = "5"]
+    #[wire = "5"]
     Safari = 5,
-    #[str = "6"]
+    #[wire = "6"]
     Edge = 6,
-    #[str = "7"]
+    #[wire = "7"]
     Electron = 7,
-    #[str = "8"]
+    #[wire = "8"]
     Uwp = 8,
-    #[str = "9"]
+    #[wire = "9"]
     OtherWebClient = 9,
 }
 
@@ -616,7 +616,7 @@ mod tests {
 
     #[test]
     fn test_platform_id_string_enum() {
-        // StringEnum derive works correctly
+        // WireEnum derive works correctly
         assert_eq!(PlatformId::Chrome.as_str(), "1");
         assert_eq!(PlatformId::Firefox.to_string(), "2");
         assert_eq!(PlatformId::default(), PlatformId::Chrome);

--- a/wacore/src/protocol/mod.rs
+++ b/wacore/src/protocol/mod.rs
@@ -25,7 +25,7 @@ pub trait ProtocolNode: Sized {
 
 /// Trait for parsing a string enum from a `&str`.
 ///
-/// Automatically implemented by the `StringEnum` derive macro for both
+/// Automatically implemented by the `WireEnum` derive macro for both
 /// standard enums (fails on unknown) and fallback enums (captures unknown).
 pub trait ParseStringEnum: Sized {
     fn parse_from_str(s: &str) -> Result<Self>;

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -1,4 +1,4 @@
-use crate::StringEnum;
+use crate::WireEnum;
 use rand::Rng;
 use sha2::{Digest, Sha256};
 use std::time::Duration;
@@ -8,11 +8,11 @@ use wacore_binary::{Jid, JidExt, LEGACY_USER_SERVER};
 use wacore_binary::{Node, NodeContent, NodeRef};
 
 /// IQ request type for WhatsApp protocol queries.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum InfoQueryType {
-    #[str = "set"]
+    #[wire = "set"]
     Set,
-    #[str = "get"]
+    #[wire = "get"]
     Get,
 }
 

--- a/wacore/src/stanza/business.rs
+++ b/wacore/src/stanza/business.rs
@@ -8,28 +8,28 @@ use wacore_binary::Jid;
 use wacore_binary::NodeRef;
 
 /// Business notification type based on child element.
-#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
 pub enum BusinessNotificationType {
-    #[str = "remove_jid"]
+    #[wire = "remove_jid"]
     RemoveJid,
-    #[str = "remove_hash"]
+    #[wire = "remove_hash"]
     RemoveHash,
-    #[str = "verified_name_jid"]
+    #[wire = "verified_name_jid"]
     VerifiedNameJid,
-    #[str = "verified_name_hash"]
+    #[wire = "verified_name_hash"]
     VerifiedNameHash,
-    #[str = "profile"]
+    #[wire = "profile"]
     Profile,
-    #[str = "profile_hash"]
+    #[wire = "profile_hash"]
     ProfileHash,
-    #[str = "product"]
+    #[wire = "product"]
     Product,
-    #[str = "collection"]
+    #[wire = "collection"]
     Collection,
-    #[str = "subscriptions"]
+    #[wire = "subscriptions"]
     Subscriptions,
-    #[string_default]
-    #[str = "unknown"]
+    #[wire_default]
+    #[wire = "unknown"]
     Unknown,
 }
 

--- a/wacore/src/stanza/devices.rs
+++ b/wacore/src/stanza/devices.rs
@@ -10,7 +10,7 @@
 //! - Timestamp is REQUIRED (non-zero) for remove
 //! - `hash` attribute is REQUIRED for update
 
-use crate::StringEnum;
+use crate::WireEnum;
 use crate::iq::node::{required_attr, required_child};
 use crate::protocol::ProtocolNode;
 use anyhow::{Result, anyhow};
@@ -25,13 +25,13 @@ use wacore_binary::{Node, NodeRef};
 /// - `<add>` - Device was added
 /// - `<remove>` - Device was removed
 /// - `<update>` - Device info updated (hash-based lookup)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum DeviceNotificationType {
-    #[str = "add"]
+    #[wire = "add"]
     Add,
-    #[str = "remove"]
+    #[wire = "remove"]
     Remove,
-    #[str = "update"]
+    #[wire = "update"]
     Update,
 }
 

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -18,11 +18,14 @@ use wacore_binary::{Node, NodeRef};
 /// How a membership request was initiated.
 ///
 /// Maps to `WAWebRequestMethodType` in WhatsApp Web JS.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum MembershipRequestMethod {
+    #[wire_default]
+    #[wire = "invite_link"]
     InviteLink,
+    #[wire = "linked_group_join"]
     LinkedGroupJoin,
+    #[wire = "non_admin_add"]
     NonAdminAdd,
 }
 
@@ -326,15 +329,13 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
         T::Unlocked => GroupNotificationAction::Unlocked,
         T::Announce => GroupNotificationAction::Announce,
         T::NotAnnounce => GroupNotificationAction::NotAnnounce,
+        // Both `<ephemeral .../>` and the alias `<not_ephemeral/>` land here —
+        // the alias carries no `expiration`/`trigger` attrs, so the fallbacks
+        // below produce `Ephemeral { expiration: 0, trigger: None }`, matching
+        // WA Web's collapse of the two wire tags into one action.
         T::Ephemeral => GroupNotificationAction::Ephemeral {
             expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
             trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
-        },
-        // Alias auto-generated from #[wire_alias = "not_ephemeral"]. WA Web
-        // collapses it into Ephemeral with duration=0.
-        T::Ephemeral__Alias0 => GroupNotificationAction::Ephemeral {
-            expiration: 0,
-            trigger: None,
         },
         T::MembershipApprovalMode => {
             let enabled = node
@@ -480,12 +481,14 @@ fn parse_participant_jids(node: &NodeRef<'_>) -> Vec<Jid> {
 
 /// Maps the `request_method` attribute to [`MembershipRequestMethod`].
 /// Defaults to `InviteLink` when absent or unknown — matches WA Web's fallback.
+/// Wire strings come from the derived `TryFrom<&str>` impl; this function has
+/// no hard-coded tags of its own.
 fn parse_request_method(node: &NodeRef<'_>) -> MembershipRequestMethod {
-    match node.attrs().optional_string("request_method").as_deref() {
-        Some("linked_group_join") => MembershipRequestMethod::LinkedGroupJoin,
-        Some("non_admin_add") => MembershipRequestMethod::NonAdminAdd,
-        _ => MembershipRequestMethod::InviteLink,
-    }
+    node.attrs()
+        .optional_string("request_method")
+        .as_deref()
+        .and_then(|s| MembershipRequestMethod::try_from(s).ok())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -10,6 +10,7 @@
 //! - Root `participant` attribute identifies the admin/author who triggered the change
 //! - Participant lists are nested `<participant jid="..." />` children
 
+use crate::WireEnum;
 use serde::Serialize;
 use wacore_binary::Jid;
 use wacore_binary::{Node, NodeRef};
@@ -59,45 +60,53 @@ pub struct GroupParticipantInfo {
 ///
 /// Maps 1:1 to `GROUP_NOTIFICATION_TAG` child element tags from WhatsApp Web.
 ///
-/// Serialization: the JSON discriminator `"type"` is always driven by
-/// [`Self::tag_name`] — the same string the wire parser dispatches on. The
-/// `impl Serialize` below is hand-written (instead of `#[derive(Serialize)]`
-/// with serde attribute overrides) to keep that mapping as the single source
-/// of truth.
-#[derive(Debug, Clone)]
+/// The `#[wire = "..."]` attribute is the SINGLE source of truth for each
+/// variant's wire tag: the JSON discriminator (via the auto-derived
+/// `Serialize`), the parser dispatch (via the auto-generated sibling
+/// `GroupNotificationActionTag` enum), and `wire_tag()` / `tag_name()` all
+/// read from the same table.
+#[derive(Debug, Clone, WireEnum)]
+#[wire(tag = "type")]
 pub enum GroupNotificationAction {
     // -- Participant management --
     /// `<add>` — Members added to group
+    #[wire = "add"]
     Add {
         participants: Vec<GroupParticipantInfo>,
         reason: Option<String>,
     },
     /// `<remove>` — Members removed from group
+    #[wire = "remove"]
     Remove {
         participants: Vec<GroupParticipantInfo>,
         reason: Option<String>,
     },
     /// `<promote>` — Members promoted to admin
+    #[wire = "promote"]
     Promote {
         participants: Vec<GroupParticipantInfo>,
     },
     /// `<demote>` — Members demoted from admin
+    #[wire = "demote"]
     Demote {
         participants: Vec<GroupParticipantInfo>,
     },
     /// `<modify>` — Member changed phone number
+    #[wire = "modify"]
     Modify {
         participants: Vec<GroupParticipantInfo>,
     },
 
     // -- Metadata --
     /// `<subject subject="..." s_o="..." s_t="..."/>` — Group name changed
+    #[wire = "subject"]
     Subject {
         subject: String,
         subject_owner: Option<Jid>,
         subject_time: Option<u64>,
     },
     /// `<description id="..."><body>text</body></description>` or `<description id="..."><delete/></description>`
+    #[wire = "description"]
     Description {
         id: String,
         /// `Some(text)` = added/updated, `None` = deleted
@@ -106,28 +115,39 @@ pub enum GroupNotificationAction {
 
     // -- Settings --
     /// `<locked threshold="..."/>` — Only admins can edit group info
+    #[wire = "locked"]
     Locked { threshold: Option<String> },
     /// `<unlocked/>` — All members can edit group info
+    #[wire = "unlocked"]
     Unlocked,
     /// `<announcement/>` — Only admins can send messages
+    #[wire = "announcement"]
     Announce,
     /// `<not_announcement/>` — All members can send messages
+    #[wire = "not_announcement"]
     NotAnnounce,
-    /// `<ephemeral expiration="..." trigger="..."/>` or `<not_ephemeral/>` (expiration=0)
+    /// `<ephemeral expiration="..." trigger="..."/>` — and the alias
+    /// `<not_ephemeral/>` which parses into `Ephemeral { expiration: 0 }`,
+    /// matching WA Web's collapsing of the two tags into one action type.
+    #[wire = "ephemeral"]
+    #[wire_alias = "not_ephemeral"]
     Ephemeral {
         expiration: u32,
         trigger: Option<u32>,
     },
     /// `<membership_approval_mode><group_join state="on|off"/></membership_approval_mode>`
+    #[wire = "membership_approval_mode"]
     MembershipApprovalMode { enabled: bool },
     /// `<membership_approval_request request_method="..." parent_group_jid="..."/>`
     /// A user requested to join. Requester is on parent [`GroupNotification::participant`].
+    #[wire = "membership_approval_request"]
     MembershipApprovalRequest {
         request_method: MembershipRequestMethod,
         parent_group_jid: Option<Jid>,
     },
     /// `<created_membership_requests request_method="..." parent_group_jid="...">` —
     /// admin-side notification: new join requests appeared.
+    #[wire = "created_membership_requests"]
     CreatedMembershipRequests {
         request_method: MembershipRequestMethod,
         parent_group_jid: Option<Jid>,
@@ -135,211 +155,65 @@ pub enum GroupNotificationAction {
         requests: Vec<GroupParticipantInfo>,
     },
     /// `<revoked_membership_requests>` — requests rejected by admin or cancelled by requester.
+    #[wire = "revoked_membership_requests"]
     RevokedMembershipRequests { participants: Vec<Jid> },
     /// `<member_add_mode>admin_add|all_member_add</member_add_mode>`
+    #[wire = "member_add_mode"]
     MemberAddMode { mode: String },
     /// `<no_frequently_forwarded/>` — Forwarding restricted
+    #[wire = "no_frequently_forwarded"]
     NoFrequentlyForwarded,
     /// `<frequently_forwarded_ok/>` — Forwarding allowed
+    #[wire = "frequently_forwarded_ok"]
     FrequentlyForwardedOk,
 
     // -- Invites --
     /// `<invite code="..."/>` — Joined via invite link
+    #[wire = "invite"]
     Invite { code: String },
     /// `<revoke>` — Invite link revoked
+    #[wire = "revoke"]
     RevokeInvite,
     /// `<growth_locked expiration="..." type="..."/>` — Invite links unavailable
+    #[wire = "growth_locked"]
     GrowthLocked { expiration: u32, lock_type: String },
     /// `<growth_unlocked/>` — Invite links available again
+    #[wire = "growth_unlocked"]
     GrowthUnlocked,
 
     // -- Group lifecycle --
     /// `<create>` — Group created (complex structure, raw node preserved)
-    Create { raw: Node },
+    #[wire = "create"]
+    Create {
+        #[wire(skip)]
+        raw: Node,
+    },
     /// `<delete>` — Group deleted
+    #[wire = "delete"]
     Delete { reason: Option<String> },
 
     // -- Community linking --
     /// `<link link_type="...">` — Subgroup linked
-    Link { link_type: String, raw: Node },
+    #[wire = "link"]
+    Link {
+        link_type: String,
+        #[wire(skip)]
+        raw: Node,
+    },
     /// `<unlink unlink_type="..." unlink_reason="...">` — Subgroup unlinked
+    #[wire = "unlink"]
     Unlink {
         unlink_type: String,
         unlink_reason: Option<String>,
+        #[wire(skip)]
         raw: Node,
     },
 
     // -- Catch-all --
-    /// Unknown child tag — preserved for forward compatibility
+    /// Unknown child tag — preserved for forward compatibility. The `tag`
+    /// field is what `wire_tag()` returns, so roundtrips stay intact.
+    #[wire_fallback]
     Unknown { tag: String },
-}
-
-impl Serialize for GroupNotificationAction {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeMap;
-
-        // Single-source-of-truth: the JSON discriminator is the wire tag.
-        let type_str = self.tag_name();
-
-        macro_rules! entry {
-            ($map:ident, $key:literal, $val:expr) => {
-                $map.serialize_entry($key, $val)?
-            };
-        }
-        macro_rules! entry_opt {
-            ($map:ident, $key:literal, $val:expr) => {
-                if let Some(v) = $val {
-                    $map.serialize_entry($key, v)?;
-                }
-            };
-        }
-
-        let mut map = serializer.serialize_map(None)?;
-        entry!(map, "type", type_str);
-
-        match self {
-            Self::Add {
-                participants,
-                reason,
-            } => {
-                entry!(map, "participants", participants);
-                entry_opt!(map, "reason", reason);
-            }
-            Self::Remove {
-                participants,
-                reason,
-            } => {
-                entry!(map, "participants", participants);
-                entry_opt!(map, "reason", reason);
-            }
-            Self::Promote { participants }
-            | Self::Demote { participants }
-            | Self::Modify { participants } => {
-                entry!(map, "participants", participants);
-            }
-            Self::Subject {
-                subject,
-                subject_owner,
-                subject_time,
-            } => {
-                entry!(map, "subject", subject);
-                entry_opt!(map, "subject_owner", subject_owner);
-                entry_opt!(map, "subject_time", subject_time);
-            }
-            Self::Description { id, description } => {
-                entry!(map, "id", id);
-                entry_opt!(map, "description", description);
-            }
-            Self::Locked { threshold } => {
-                entry_opt!(map, "threshold", threshold);
-            }
-            Self::Unlocked
-            | Self::Announce
-            | Self::NotAnnounce
-            | Self::NoFrequentlyForwarded
-            | Self::FrequentlyForwardedOk
-            | Self::RevokeInvite
-            | Self::GrowthUnlocked => {}
-            Self::Ephemeral {
-                expiration,
-                trigger,
-            } => {
-                entry!(map, "expiration", expiration);
-                entry_opt!(map, "trigger", trigger);
-            }
-            Self::MembershipApprovalMode { enabled } => {
-                entry!(map, "enabled", enabled);
-            }
-            Self::MembershipApprovalRequest {
-                request_method,
-                parent_group_jid,
-            } => {
-                entry!(map, "request_method", request_method);
-                entry_opt!(map, "parent_group_jid", parent_group_jid);
-            }
-            Self::CreatedMembershipRequests {
-                request_method,
-                parent_group_jid,
-                requests,
-            } => {
-                entry!(map, "request_method", request_method);
-                entry_opt!(map, "parent_group_jid", parent_group_jid);
-                entry!(map, "requests", requests);
-            }
-            Self::RevokedMembershipRequests { participants } => {
-                entry!(map, "participants", participants);
-            }
-            Self::MemberAddMode { mode } => {
-                entry!(map, "mode", mode);
-            }
-            Self::Invite { code } => {
-                entry!(map, "code", code);
-            }
-            Self::GrowthLocked {
-                expiration,
-                lock_type,
-            } => {
-                entry!(map, "expiration", expiration);
-                entry!(map, "lock_type", lock_type);
-            }
-            Self::Create { .. } => {}
-            Self::Delete { reason } => {
-                entry_opt!(map, "reason", reason);
-            }
-            Self::Link { link_type, .. } => {
-                entry!(map, "link_type", link_type);
-            }
-            Self::Unlink {
-                unlink_type,
-                unlink_reason,
-                ..
-            } => {
-                entry!(map, "unlink_type", unlink_type);
-                entry_opt!(map, "unlink_reason", unlink_reason);
-            }
-            Self::Unknown { tag } => {
-                entry!(map, "tag", tag);
-            }
-        }
-
-        map.end()
-    }
-}
-
-impl GroupNotificationAction {
-    /// Returns the wire tag name for this action, matching `GROUP_NOTIFICATION_TAG` values.
-    pub fn tag_name(&self) -> &str {
-        match self {
-            Self::Add { .. } => "add",
-            Self::Remove { .. } => "remove",
-            Self::Promote { .. } => "promote",
-            Self::Demote { .. } => "demote",
-            Self::Modify { .. } => "modify",
-            Self::Subject { .. } => "subject",
-            Self::Description { .. } => "description",
-            Self::Locked { .. } => "locked",
-            Self::Unlocked => "unlocked",
-            Self::Announce => "announcement",
-            Self::NotAnnounce => "not_announcement",
-            Self::Ephemeral { .. } => "ephemeral",
-            Self::MembershipApprovalMode { .. } => "membership_approval_mode",
-            Self::MembershipApprovalRequest { .. } => "membership_approval_request",
-            Self::CreatedMembershipRequests { .. } => "created_membership_requests",
-            Self::RevokedMembershipRequests { .. } => "revoked_membership_requests",
-            Self::MemberAddMode { .. } => "member_add_mode",
-            Self::NoFrequentlyForwarded => "no_frequently_forwarded",
-            Self::FrequentlyForwardedOk => "frequently_forwarded_ok",
-            Self::Invite { .. } => "invite",
-            Self::RevokeInvite => "revoke",
-            Self::GrowthLocked { .. } => "growth_locked",
-            Self::GrowthUnlocked => "growth_unlocked",
-            Self::Create { .. } => "create",
-            Self::Delete { .. } => "delete",
-            Self::Link { .. } => "link",
-            Self::Unlink { .. } => "unlink",
-            Self::Unknown { tag } => tag.as_str(),
-        }
-    }
 }
 
 impl GroupNotification {
@@ -376,34 +250,48 @@ impl GroupNotification {
 
 /// Parse a single child element into a GroupNotificationAction.
 ///
+/// Dispatches via [`GroupNotificationActionTag`] (auto-generated by
+/// `#[derive(WireEnum)]`) — no wire-tag string literal appears in this
+/// function. If the `#[wire = "..."]` attribute on a variant changes, both
+/// the serializer and this dispatcher track it automatically.
+///
 /// Only `Create`/`Link`/`Unlink` call `.to_owned()` because those variants store `raw: Node`.
 fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
+    use GroupNotificationActionTag as T;
     use wacore_binary::NodeContentRef;
-    let action = match node.tag.as_ref() {
-        "add" => GroupNotificationAction::Add {
+
+    // WA Web drops this child entirely; mirror that behavior.
+    if node.tag.as_ref() == "missing_participant_identification" {
+        return None;
+    }
+
+    let tag = T::from(node.tag.as_ref());
+
+    let action = match tag {
+        T::Add => GroupNotificationAction::Add {
             participants: parse_participants(node),
             reason: node
                 .attrs()
                 .optional_string("reason")
                 .map(|s| s.into_owned()),
         },
-        "remove" => GroupNotificationAction::Remove {
+        T::Remove => GroupNotificationAction::Remove {
             participants: parse_participants(node),
             reason: node
                 .attrs()
                 .optional_string("reason")
                 .map(|s| s.into_owned()),
         },
-        "promote" => GroupNotificationAction::Promote {
+        T::Promote => GroupNotificationAction::Promote {
             participants: parse_participants(node),
         },
-        "demote" => GroupNotificationAction::Demote {
+        T::Demote => GroupNotificationAction::Demote {
             participants: parse_participants(node),
         },
-        "modify" => GroupNotificationAction::Modify {
+        T::Modify => GroupNotificationAction::Modify {
             participants: parse_participants(node),
         },
-        "subject" => GroupNotificationAction::Subject {
+        T::Subject => GroupNotificationAction::Subject {
             subject: node
                 .attrs()
                 .optional_string("subject")
@@ -413,7 +301,7 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             subject_owner: node.attrs().optional_jid("s_o"),
             subject_time: node.attrs().optional_u64("s_t"),
         },
-        "description" => {
+        T::Description => {
             let id = node
                 .attrs()
                 .optional_string("id")
@@ -429,31 +317,33 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             };
             GroupNotificationAction::Description { id, description }
         }
-        "locked" => GroupNotificationAction::Locked {
+        T::Locked => GroupNotificationAction::Locked {
             threshold: node
                 .attrs()
                 .optional_string("threshold")
                 .map(|s| s.into_owned()),
         },
-        "unlocked" => GroupNotificationAction::Unlocked,
-        "announcement" => GroupNotificationAction::Announce,
-        "not_announcement" => GroupNotificationAction::NotAnnounce,
-        "ephemeral" => GroupNotificationAction::Ephemeral {
+        T::Unlocked => GroupNotificationAction::Unlocked,
+        T::Announce => GroupNotificationAction::Announce,
+        T::NotAnnounce => GroupNotificationAction::NotAnnounce,
+        T::Ephemeral => GroupNotificationAction::Ephemeral {
             expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
             trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
         },
-        "not_ephemeral" => GroupNotificationAction::Ephemeral {
+        // Alias auto-generated from #[wire_alias = "not_ephemeral"]. WA Web
+        // collapses it into Ephemeral with duration=0.
+        T::Ephemeral__Alias0 => GroupNotificationAction::Ephemeral {
             expiration: 0,
             trigger: None,
         },
-        "membership_approval_mode" => {
+        T::MembershipApprovalMode => {
             let enabled = node
                 .get_optional_child("group_join")
                 .and_then(|gj| gj.attrs().optional_string("state"))
                 .is_some_and(|s| s == "on");
             GroupNotificationAction::MembershipApprovalMode { enabled }
         }
-        "membership_approval_request" => {
+        T::MembershipApprovalRequest => {
             let request_method = parse_request_method(node);
             let parent_group_jid = node.attrs().optional_jid("parent_group_jid");
             GroupNotificationAction::MembershipApprovalRequest {
@@ -461,7 +351,7 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 parent_group_jid,
             }
         }
-        "created_membership_requests" => {
+        T::CreatedMembershipRequests => {
             let request_method = parse_request_method(node);
             let parent_group_jid = node.attrs().optional_jid("parent_group_jid");
             let requests = parse_requested_users(node);
@@ -471,11 +361,11 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 requests,
             }
         }
-        "revoked_membership_requests" => {
+        T::RevokedMembershipRequests => {
             let participants = parse_participant_jids(node);
             GroupNotificationAction::RevokedMembershipRequests { participants }
         }
-        "member_add_mode" => {
+        T::MemberAddMode => {
             let mode = match node.content.as_deref() {
                 Some(NodeContentRef::String(s)) => s.to_string(),
                 Some(NodeContentRef::Bytes(b)) => String::from_utf8_lossy(b.as_ref()).into_owned(),
@@ -483,9 +373,9 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             };
             GroupNotificationAction::MemberAddMode { mode }
         }
-        "no_frequently_forwarded" => GroupNotificationAction::NoFrequentlyForwarded,
-        "frequently_forwarded_ok" => GroupNotificationAction::FrequentlyForwardedOk,
-        "invite" => GroupNotificationAction::Invite {
+        T::NoFrequentlyForwarded => GroupNotificationAction::NoFrequentlyForwarded,
+        T::FrequentlyForwardedOk => GroupNotificationAction::FrequentlyForwardedOk,
+        T::Invite => GroupNotificationAction::Invite {
             code: node
                 .attrs()
                 .optional_string("code")
@@ -493,8 +383,8 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 .unwrap_or_default()
                 .to_string(),
         },
-        "revoke" => GroupNotificationAction::RevokeInvite,
-        "growth_locked" => GroupNotificationAction::GrowthLocked {
+        T::RevokeInvite => GroupNotificationAction::RevokeInvite,
+        T::GrowthLocked => GroupNotificationAction::GrowthLocked {
             expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
             lock_type: node
                 .attrs()
@@ -503,18 +393,17 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 .unwrap_or_default()
                 .to_string(),
         },
-        "growth_unlocked" => GroupNotificationAction::GrowthUnlocked,
-        // These three variants store owned Node — only convert what's needed.
-        "create" => GroupNotificationAction::Create {
+        T::GrowthUnlocked => GroupNotificationAction::GrowthUnlocked,
+        T::Create => GroupNotificationAction::Create {
             raw: node.to_owned(),
         },
-        "delete" => GroupNotificationAction::Delete {
+        T::Delete => GroupNotificationAction::Delete {
             reason: node
                 .attrs()
                 .optional_string("reason")
                 .map(|s| s.into_owned()),
         },
-        "link" => GroupNotificationAction::Link {
+        T::Link => GroupNotificationAction::Link {
             link_type: node
                 .attrs()
                 .optional_string("link_type")
@@ -523,7 +412,7 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 .to_string(),
             raw: node.to_owned(),
         },
-        "unlink" => GroupNotificationAction::Unlink {
+        T::Unlink => GroupNotificationAction::Unlink {
             unlink_type: node
                 .attrs()
                 .optional_string("unlink_type")
@@ -536,8 +425,7 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 .map(|s| s.into_owned()),
             raw: node.to_owned(),
         },
-        "missing_participant_identification" => return None,
-        _ => GroupNotificationAction::Unknown {
+        T::Unknown(_) => GroupNotificationAction::Unknown {
             tag: node.tag.to_string(),
         },
     };

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -212,16 +212,16 @@ pub struct SelfPushNameUpdated {
 
 /// Type of device list update notification.
 /// Matches WhatsApp Web's device notification types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum DeviceListUpdateType {
     /// A device was added to the user's account
-    #[str = "add"]
+    #[wire = "add"]
     Add,
     /// A device was removed from the user's account
-    #[str = "remove"]
+    #[wire = "remove"]
     Remove,
     /// Device information was updated
-    #[str = "update"]
+    #[wire = "update"]
     Update,
 }
 
@@ -278,22 +278,22 @@ pub struct IdentityChange {
 }
 
 /// Type of business status update.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum BusinessUpdateType {
-    #[str = "removed_as_business"]
+    #[wire = "removed_as_business"]
     RemovedAsBusiness,
-    #[str = "verified_name_changed"]
+    #[wire = "verified_name_changed"]
     VerifiedNameChanged,
-    #[str = "profile_updated"]
+    #[wire = "profile_updated"]
     ProfileUpdated,
-    #[str = "products_updated"]
+    #[wire = "products_updated"]
     ProductsUpdated,
-    #[str = "collections_updated"]
+    #[wire = "collections_updated"]
     CollectionsUpdated,
-    #[str = "subscriptions_updated"]
+    #[wire = "subscriptions_updated"]
     SubscriptionsUpdated,
-    #[string_default]
-    #[str = "unknown"]
+    #[wire_default]
+    #[wire = "unknown"]
     Unknown,
 }
 
@@ -522,46 +522,21 @@ pub struct LoggedOut {
 #[derive(Debug, Clone, Serialize)]
 pub struct StreamReplaced;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
+#[wire(kind = "int")]
 pub enum TempBanReason {
+    #[wire = 101]
     SentToTooManyPeople,
+    #[wire = 102]
     BlockedByUsers,
+    #[wire = 103]
     CreatedTooManyGroups,
+    #[wire = 104]
     SentTooManySameMessage,
+    #[wire = 106]
     BroadcastList,
+    #[wire_fallback]
     Unknown(i32),
-}
-
-impl Serialize for TempBanReason {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_i32(self.code())
-    }
-}
-
-impl From<i32> for TempBanReason {
-    fn from(code: i32) -> Self {
-        match code {
-            101 => Self::SentToTooManyPeople,
-            102 => Self::BlockedByUsers,
-            103 => Self::CreatedTooManyGroups,
-            104 => Self::SentTooManySameMessage,
-            106 => Self::BroadcastList,
-            _ => Self::Unknown(code),
-        }
-    }
-}
-
-impl TempBanReason {
-    pub fn code(&self) -> i32 {
-        match self {
-            Self::SentToTooManyPeople => 101,
-            Self::BlockedByUsers => 102,
-            Self::CreatedTooManyGroups => 103,
-            Self::SentTooManySameMessage => 104,
-            Self::BroadcastList => 106,
-            Self::Unknown(code) => *code,
-        }
-    }
 }
 
 impl fmt::Display for TempBanReason {
@@ -588,68 +563,42 @@ pub struct TemporaryBan {
     pub expire: Duration,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+#[wire(kind = "int")]
 pub enum ConnectFailureReason {
+    #[wire = 400]
     Generic,
+    #[wire = 401]
     LoggedOut,
+    #[wire = 402]
     TempBanned,
+    #[wire = 403]
     MainDeviceGone,
+    #[wire = 406]
     UnknownLogout,
+    #[wire = 405]
     ClientOutdated,
+    #[wire = 409]
     BadUserAgent,
+    #[wire = 413]
     CatExpired,
+    #[wire = 414]
     CatInvalid,
+    #[wire = 415]
     NotFound,
+    #[wire = 418]
     ClientUnknown,
+    #[wire = 500]
     InternalServerError,
+    #[wire = 501]
     Experimental,
+    #[wire = 503]
     ServiceUnavailable,
+    #[wire_fallback]
     Unknown(i32),
 }
 
-impl From<i32> for ConnectFailureReason {
-    fn from(code: i32) -> Self {
-        match code {
-            400 => Self::Generic,
-            401 => Self::LoggedOut,
-            402 => Self::TempBanned,
-            403 => Self::MainDeviceGone,
-            406 => Self::UnknownLogout,
-            405 => Self::ClientOutdated,
-            409 => Self::BadUserAgent,
-            413 => Self::CatExpired,
-            414 => Self::CatInvalid,
-            415 => Self::NotFound,
-            418 => Self::ClientUnknown,
-            500 => Self::InternalServerError,
-            501 => Self::Experimental,
-            503 => Self::ServiceUnavailable,
-            _ => Self::Unknown(code),
-        }
-    }
-}
-
 impl ConnectFailureReason {
-    pub fn code(&self) -> i32 {
-        match self {
-            Self::Generic => 400,
-            Self::LoggedOut => 401,
-            Self::TempBanned => 402,
-            Self::MainDeviceGone => 403,
-            Self::UnknownLogout => 406,
-            Self::ClientOutdated => 405,
-            Self::BadUserAgent => 409,
-            Self::CatExpired => 413,
-            Self::CatInvalid => 414,
-            Self::NotFound => 415,
-            Self::ClientUnknown => 418,
-            Self::InternalServerError => 500,
-            Self::Experimental => 501,
-            Self::ServiceUnavailable => 503,
-            Self::Unknown(code) => *code,
-        }
-    }
-
     pub fn is_logged_out(&self) -> bool {
         matches!(
             self,
@@ -659,12 +608,6 @@ impl ConnectFailureReason {
 
     pub fn should_reconnect(&self) -> bool {
         matches!(self, Self::ServiceUnavailable | Self::InternalServerError)
-    }
-}
-
-impl Serialize for ConnectFailureReason {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_i32(self.code())
     }
 }
 
@@ -698,20 +641,20 @@ pub struct OfflineSyncCompleted {
     pub count: i32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum DecryptFailMode {
-    #[str = "show"]
+    #[wire = "show"]
     Show,
-    #[str = "hide"]
+    #[wire = "hide"]
     Hide,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
 pub enum UnavailableType {
-    #[string_default]
-    #[str = "unknown"]
+    #[wire_default]
+    #[wire = "unknown"]
     Unknown,
-    #[str = "view_once"]
+    #[wire = "view_once"]
     ViewOnce,
 }
 

--- a/wacore/src/types/lid_pn.rs
+++ b/wacore/src/types/lid_pn.rs
@@ -13,41 +13,41 @@
 
 /// The source from which a LID-PN mapping was learned.
 /// Different sources have different trust levels and handling for identity changes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum LearningSource {
     /// Mapping learned from usync (device sync) query response
-    #[str = "usync"]
+    #[wire = "usync"]
     Usync,
     /// Mapping learned from incoming message with sender_lid attribute (sender is PN)
-    #[str = "peer_pn_message"]
+    #[wire = "peer_pn_message"]
     PeerPnMessage,
     /// Mapping learned from incoming message with sender_pn attribute (sender is LID)
-    #[str = "peer_lid_message"]
+    #[wire = "peer_lid_message"]
     PeerLidMessage,
     /// Mapping learned when looking up recipient's latest LID
-    #[str = "recipient_latest_lid"]
+    #[wire = "recipient_latest_lid"]
     RecipientLatestLid,
     /// Mapping learned from latest history sync migration
-    #[str = "migration_sync_latest"]
+    #[wire = "migration_sync_latest"]
     MigrationSyncLatest,
     /// Mapping learned from old history sync records
-    #[str = "migration_sync_old"]
+    #[wire = "migration_sync_old"]
     MigrationSyncOld,
     /// Mapping learned from active blocklist entry
-    #[str = "blocklist_active"]
+    #[wire = "blocklist_active"]
     BlocklistActive,
     /// Mapping learned from inactive blocklist entry
-    #[str = "blocklist_inactive"]
+    #[wire = "blocklist_inactive"]
     BlocklistInactive,
     /// Mapping learned from device pairing (own JID <-> LID)
-    #[str = "pairing"]
+    #[wire = "pairing"]
     Pairing,
     /// Mapping learned from device notification (when `lid` attribute present)
-    #[str = "device_notification"]
+    #[wire = "device_notification"]
     DeviceNotification,
     /// Mapping learned from other/unknown source
-    #[string_default]
-    #[str = "other"]
+    #[wire_default]
+    #[wire = "other"]
     Other,
 }
 

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use wacore_binary::{Jid, JidExt, MessageId, MessageServerId};
 use waproto::whatsapp as wa;
 
-use crate::StringEnum;
+use crate::WireEnum;
 
 /// Identifies a specific message within a chat.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -19,23 +19,23 @@ impl ChatMessageId {
 }
 
 /// Addressing mode for a group (phone number vs LID).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum AddressingMode {
-    #[string_default]
-    #[str = "pn"]
+    #[wire_default]
+    #[wire = "pn"]
     Pn,
-    #[str = "lid"]
+    #[wire = "lid"]
     Lid,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 pub enum MessageCategory {
-    #[string_default]
-    #[str = ""]
+    #[wire_default]
+    #[wire = ""]
     Empty,
-    #[str = "peer"]
+    #[wire = "peer"]
     Peer,
-    #[string_fallback]
+    #[wire_fallback]
     Other(String),
 }
 
@@ -64,22 +64,22 @@ pub struct DeviceSentMeta {
     pub phash: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, crate::StringEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
 pub enum EditAttribute {
-    #[string_default]
-    #[str = ""]
+    #[wire_default]
+    #[wire = ""]
     Empty,
-    #[str = "1"]
+    #[wire = "1"]
     MessageEdit,
-    #[str = "2"]
+    #[wire = "2"]
     PinInChat,
-    #[str = "3"]
+    #[wire = "3"]
     AdminEdit,
-    #[str = "7"]
+    #[wire = "7"]
     SenderRevoke,
-    #[str = "8"]
+    #[wire = "8"]
     AdminRevoke,
-    #[string_fallback]
+    #[wire_fallback]
     Unknown(String),
 }
 

--- a/wacore/src/types/spam_report.rs
+++ b/wacore/src/types/spam_report.rs
@@ -1,28 +1,28 @@
 //! Spam report types and node building.
 
-use crate::StringEnum;
+use crate::WireEnum;
 use wacore_binary::Jid;
 use wacore_binary::Node;
 use wacore_binary::builder::NodeBuilder;
 
 /// The type of spam flow indicating the source of the report.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum SpamFlow {
     /// Report triggered from group spam banner
-    #[str = "GroupSpamBannerReport"]
+    #[wire = "GroupSpamBannerReport"]
     GroupSpamBannerReport,
     /// Report triggered from group info screen
-    #[str = "GroupInfoReport"]
+    #[wire = "GroupInfoReport"]
     GroupInfoReport,
     /// Report triggered from message context menu
-    #[string_default]
-    #[str = "MessageMenu"]
+    #[wire_default]
+    #[wire = "MessageMenu"]
     MessageMenu,
     /// Report triggered from contact info screen
-    #[str = "ContactInfo"]
+    #[wire = "ContactInfo"]
     ContactInfo,
     /// Report triggered from status view
-    #[str = "StatusReport"]
+    #[wire = "StatusReport"]
     StatusReport,
 }
 

--- a/wacore/tests/wire_enum_serde_test.rs
+++ b/wacore/tests/wire_enum_serde_test.rs
@@ -1,18 +1,21 @@
-//! Wire-tag invariant tests for enums that derive `StringEnum`.
+//! Wire-tag invariant tests for enums that derive `WireEnum`.
 //!
-//! These enums own the wire string per variant via `#[str = "..."]`. Since
-//! the `StringEnum` derive emits `Serialize`/`Deserialize` that delegate to
-//! `as_str()` / `TryFrom<&str>`, the JSON representation MUST be that exact
-//! string — no PascalCase discriminator, no `rename_all` override.
+//! The derive owns `Serialize`/`Deserialize`, which delegate to `as_str()` /
+//! `TryFrom<&str>` — so the JSON representation MUST be exactly what the
+//! `#[wire = "..."]` attribute declares. No PascalCase discriminator, no
+//! serde `rename_all`, no hand-written impls.
 //!
-//! The cases below cover every enum that used to derive `Serialize` directly
-//! alongside `StringEnum` (and silently produced PascalCase JSON for variants
-//! whose `#[str = "..."]` did not match the variant name).
+//! Cases cover unit-string mode (with and without `#[wire_fallback]`),
+//! int mode (see `TempBanReason` / `ConnectFailureReason` serialization as
+//! i32), and the sanity check on `EditAttribute` whose wire strings diverge
+//! from variant names. Tagged mode is covered end-to-end inside
+//! `stanza::groups::tests`.
 
 use wacore::stanza::business::BusinessNotificationType;
 use wacore::stanza::devices::DeviceNotificationType;
 use wacore::types::events::{
-    BusinessUpdateType, DecryptFailMode, DeviceListUpdateType, UnavailableType,
+    BusinessUpdateType, ConnectFailureReason, DecryptFailMode, DeviceListUpdateType, TempBanReason,
+    UnavailableType,
 };
 use wacore::types::lid_pn::LearningSource;
 use wacore::types::message::{AddressingMode, EditAttribute, MessageCategory};
@@ -161,4 +164,37 @@ fn message_category_fallback_serializes_literal() {
         serde_json::to_value(MessageCategory::Other("custom".into())).unwrap(),
         "custom"
     );
+}
+
+#[test]
+fn temp_ban_reason_serializes_as_int_and_roundtrips() {
+    for (value, expected) in [
+        (TempBanReason::SentToTooManyPeople, 101),
+        (TempBanReason::BlockedByUsers, 102),
+        (TempBanReason::CreatedTooManyGroups, 103),
+        (TempBanReason::SentTooManySameMessage, 104),
+        (TempBanReason::BroadcastList, 106),
+        (TempBanReason::Unknown(999), 999),
+    ] {
+        let json = serde_json::to_value(&value).unwrap();
+        assert_eq!(json, expected);
+        let back: TempBanReason = serde_json::from_value(json).unwrap();
+        assert_eq!(back, value);
+    }
+}
+
+#[test]
+fn connect_failure_reason_serializes_as_int_and_roundtrips() {
+    for (value, expected) in [
+        (ConnectFailureReason::Generic, 400),
+        (ConnectFailureReason::LoggedOut, 401),
+        (ConnectFailureReason::TempBanned, 402),
+        (ConnectFailureReason::ServiceUnavailable, 503),
+        (ConnectFailureReason::Unknown(999), 999),
+    ] {
+        let json = serde_json::to_value(value).unwrap();
+        assert_eq!(json, expected);
+        let back: ConnectFailureReason = serde_json::from_value(json).unwrap();
+        assert_eq!(back, value);
+    }
 }


### PR DESCRIPTION
## Motivation

After PR #566 aligned JSON discriminators with WhatsApp's wire tags, the codebase still had **three hand-written `impl Serialize` blocks** (`GroupNotificationAction`, `TempBanReason`, `ConnectFailureReason`) plus a separate `StringEnum` derive for unit-only protocol enums. For each tagged-with-payload enum the wire string lived in two places (the parser's match arms and the `tag_name()` method) — drift was bounded only by compiler exhaustiveness and a passing test, not by structure.

This PR collapses every wire-tag declaration into a single attribute per variant.

## Design

One derive — `#[derive(WireEnum)]` — covering three modes inferred from attributes:

| Mode | Trigger | Example |
|---|---|---|
| unit-string (drop-in replacement for `StringEnum`) | default | `#[wire = "add"] Add` |
| tagged with payload | `#[wire(tag = "type")]` on the enum | `#[wire = "demote"] Demote { participants: Vec<..> }` |
| int discriminator | `#[wire(kind = "int")]` on the enum | `#[wire = 101] SentToTooManyPeople` |

Each mode emits the full serde surface derived from the same `#[wire = "..."]` (or `#[wire = NUM]`) table — `Serialize`, `Deserialize`, `Default`, `Display`, `as_str()` / `code()`, and the relevant `From`/`TryFrom` conversions.

For tagged mode the derive additionally generates a sibling `<Name>Tag` unit enum with every primary wire tag **plus** aliases declared via `#[wire_alias = "..."]`. Parsers dispatch via `<Name>Tag::from(node.tag.as_ref())` instead of matching string literals — so a renamed wire tag is a single-attribute change that propagates automatically to the serializer, the parser, and any external codegen that reads the attribute via `syn`.

Payload fields can opt out of JSON with `#[wire(skip)]` (used for `raw: Node` on `Create`/`Link`/`Unlink`). Unknown tags are captured via `#[wire_fallback]` on a `{ tag: String }` variant, preserving the original string for round-trip.

## What's agnostic

`wacore` has no knowledge of TypeScript, bridges, or any downstream consumer. The `#[wire = "..."]` attribute is a declarative artifact any tool can read via `syn`. This PR does not touch any bridge or codegen in-tree — consumers keep reading the attributes from the same files they already parse.

## Drift analysis (before → after)

| Location where a wire string appeared | Before PR | After this PR |
|---|---|---|
| `#[derive]` attribute on variant | 1× (`#[str = "..."]` or none) | 1× (`#[wire = "..."]`) |
| Parser `match` arm | 1× per variant | 0 (parser uses `Tag::from`) |
| `tag_name()` method | 1× per variant in tagged enums | 0 (derived) |
| `impl Serialize` hand-written | 1× per variant in 3 enums | 0 |
| `impl From<i32>` / `code()` | 1× per variant in 2 enums | 0 |

Net: the `#[wire = ...]` attribute is the only place a wire value appears. Compiler errors on missing attribute, duplicate wire, duplicate alias.

## Migrations in this PR

- **~15 unit enums** across `wacore/src/**` and `src/features/**`: `#[derive(StringEnum)]` → `#[derive(WireEnum)]`, `#[str = "..."]` → `#[wire = "..."]`, `#[string_default]` → `#[wire_default]`, `#[string_fallback]` → `#[wire_fallback]`. Mechanical.
- **`GroupNotificationAction`**: drops 131 lines of hand-written `impl Serialize` + 32 lines of `tag_name()`. `parse_action()` rewritten to dispatch via `GroupNotificationActionTag::from`. `<not_ephemeral/>` expressed as `#[wire_alias = "not_ephemeral"]` on `Ephemeral` (matches WA Web's collapse into `Ephemeral { expiration: 0 }`).
- **`TempBanReason`**, **`ConnectFailureReason`**: drop hand-written `From<i32>`, `code()`, and `impl Serialize`. Now all derived from `#[wire = NUM]`.
- **`StringEnum` derive deleted** from `wacore_derive`. `ParseStringEnum` trait retained as internal plumbing for `ProtocolNode`'s `string_enum` field attribute (unchanged).

## Breaking changes

Pre-1.0, per project convention. Anyone using `#[derive(StringEnum)]` or matching PascalCase JSON discriminators must update. The JSON wire shape is **identical** to what post-#566 produces — this PR is a pure architectural cleanup, not a protocol change.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests --exclude e2e-tests` — no warnings from touched code
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — all green
  - 538 wacore lib tests
  - 12 `wire_enum_serde_test` tests (renamed from `string_enum_serde_test`, extended with int-mode roundtrips)
  - 16 `stanza::groups` tests including the 27-variant `serialize_discriminator_matches_wire_tag` and 7-tag `wire_tags_round_trip_through_parser`
- [x] `AGENTS.md` updated with the new convention