### PR TITLE
fix(status): use LID addressing, skip unresolvable recipients

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -305,6 +305,35 @@ impl Client {
         self.lid_pn_cache.add(&entry).await;
         Ok(Some(entry))
     }
+
+    /// Resolve any user JID to its bare LID form, or `None` when no LID is
+    /// available. Mirrors WA Web's `WAWebLidMigrationUtils.toUserLid`
+    /// (`docs/captured-js/WAWeb/Lid/MigrationUtils.js:17-20`): LID passes
+    /// through, PN goes through the cache-aside mapping, anything else and
+    /// any lookup failure returns `None`.
+    ///
+    /// Used by `send_status_message` to replicate WA Web's
+    /// `compactMap(list, toUserLid)` skip-on-unresolvable semantics.
+    pub(crate) async fn resolve_recipient_to_lid(&self, jid: &Jid) -> Option<Jid> {
+        if jid.is_lid() {
+            return Some(jid.to_non_ad());
+        }
+        if !jid.is_pn() {
+            return None;
+        }
+        match self.get_lid_pn_entry(jid).await {
+            Ok(Some(entry)) => Some(Jid::new(entry.lid, wacore_binary::Server::Lid)),
+            Ok(None) => None,
+            Err(e) => {
+                log::warn!(
+                    "resolve_recipient_to_lid: LID lookup for {} failed: {:?}",
+                    jid,
+                    e
+                );
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/send.rs
+++ b/src/send.rs
@@ -344,16 +344,25 @@ impl Client {
             }
         }
 
-        // Resolve every user JID to its LID form (LID passes through; PN goes
-        // through the cache-aside lookup; `None` means no mapping — dropped
-        // silently to match WA Web `compactMap(list, toUserLid)`).
+        use std::collections::HashMap;
         let mut resolved: Vec<Option<Jid>> = Vec::with_capacity(recipients.len());
+        let mut lid_to_pn_map: HashMap<wacore_binary::CompactString, Jid> =
+            HashMap::with_capacity(recipients.len() + 1);
         for jid in recipients {
-            resolved.push(self.resolve_recipient_to_lid(jid).await);
+            if let Some(lid_jid) = self.resolve_recipient_to_lid(jid).await {
+                if jid.is_pn() {
+                    lid_to_pn_map.insert(lid_jid.user.clone(), jid.to_non_ad());
+                }
+                resolved.push(Some(lid_jid));
+            } else {
+                resolved.push(None);
+            }
         }
+        lid_to_pn_map.insert(own_lid.user.clone(), own_jid.to_non_ad());
 
         let participants = wacore::send::assemble_status_participants(resolved, &own_lid)?;
-        let mut group_info = GroupInfo::new(participants, AddressingMode::Lid);
+        let mut group_info =
+            GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn_map);
 
         self.add_recent_message(&to, &request_id, &message).await;
 
@@ -386,7 +395,7 @@ impl Client {
         let skdm_target_devices: Option<Vec<Jid>> = if force_skdm {
             None
         } else {
-            self.resolve_skdm_targets(&to_str, &group_info.participants, &own_lid)
+            self.resolve_skdm_targets(&to_str, &group_info, &own_lid)
                 .await
         };
 
@@ -510,15 +519,16 @@ impl Client {
         })
     }
 
-    /// Resolve which devices need SKDM by reading the per-device sender key map.
+    /// Resolve which devices need SKDM. Returns `None` for full distribution
+    /// (no cache data), or `Some(devices)` listing devices that need fresh SKDM.
     ///
-    /// Returns `None` for full distribution (no map data or all unknown), or
-    /// `Some(devices)` listing only the devices that need fresh SKDM.
-    /// Uses `Jid::device_key()` for O(1) lookups — no string allocations in the hot path.
+    /// For LID mode, uses `group_info.phone_jid_for_lid_user` to query devices
+    /// via PN when available (LID usync is unreliable for own JID), then
+    /// converts the result back to LID. Same fallback as `prepare_group_stanza`.
     async fn resolve_skdm_targets(
         &self,
         group_jid: &str,
-        participants: &[Jid],
+        group_info: &wacore::client::context::GroupInfo,
         own_sending_jid: &Jid,
     ) -> Option<Vec<Jid>> {
         use crate::sender_key_device_cache::SenderKeyDeviceMap;
@@ -549,10 +559,33 @@ impl Client {
             return None;
         }
 
-        let jids_to_resolve: Vec<Jid> = participants.iter().map(|jid| jid.to_non_ad()).collect();
+        let is_lid_mode = group_info.addressing_mode == wacore::types::message::AddressingMode::Lid;
+        let jids_to_resolve: Vec<Jid> = group_info
+            .participants
+            .iter()
+            .map(|jid| {
+                let base = jid.to_non_ad();
+                if is_lid_mode
+                    && base.is_lid()
+                    && let Some(pn) = group_info.phone_jid_for_lid_user(&base.user)
+                {
+                    return pn.to_non_ad();
+                }
+                base
+            })
+            .collect();
 
         match SendContextResolver::resolve_devices(self, &jids_to_resolve).await {
             Ok(all_devices) => {
+                let all_devices: Vec<Jid> = if is_lid_mode {
+                    all_devices
+                        .into_iter()
+                        .map(|d| group_info.phone_device_jid_to_lid(&d))
+                        .collect()
+                } else {
+                    all_devices
+                };
+
                 let needs_skdm: Vec<Jid> = all_devices
                     .into_iter()
                     .filter(|device| {
@@ -955,7 +988,7 @@ impl Client {
             let skdm_target_devices: Option<Vec<Jid>> = if force_skdm {
                 None
             } else {
-                self.resolve_skdm_targets(&to_str, &group_info.participants, &own_sending_jid)
+                self.resolve_skdm_targets(&to_str, &group_info, &own_sending_jid)
                     .await
             };
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -292,8 +292,20 @@ impl Client {
 
     /// Send a status/story update to the given recipients using sender key encryption.
     ///
-    /// This builds a `GroupInfo` from the provided recipients (always PN addressing mode),
-    /// then reuses the group encryption pipeline with `to = status@broadcast`.
+    /// Status messages use LID addressing, matching `WAWebEncryptAndSendStatusMsg`
+    /// (`docs/captured-js/WAWeb/Encrypt/AndSendStatusMsg.js:46`), which maps the
+    /// recipient list through `WAWebLidMigrationUtils.toUserLid` and filters
+    /// unresolvable entries via `compactMap`. Concretely:
+    ///
+    /// - recipients already in LID form pass through;
+    /// - PN recipients are converted to LID via the cache-aside lookup in
+    ///   `Client::get_lid_pn_entry` (warms from the backend on a cold cache);
+    /// - recipients we cannot resolve to a LID are skipped silently, not
+    ///   errored, so a single unknown contact does not fail the whole send.
+    ///
+    /// After resolution the list feeds a `GroupInfo` with `AddressingMode::Lid`,
+    /// which drives `prepare_group_stanza` to use `own_lid` for signing and emit
+    /// `addressing_mode="lid"` on the stanza.
     pub(crate) async fn send_status_message(
         &self,
         message: wa::Message,
@@ -321,12 +333,8 @@ impl Client {
             .take()
             .unwrap_or_else(|| own_jid.clone());
 
-        // Status always uses PN addressing. Resolve any LID recipients to their
-        // phone numbers so we don't end up with duplicate PN+LID entries for the
-        // same user (which causes server error 400).
-        // Reject non-user JIDs (groups, broadcasts, etc.) to prevent invalid
-        // <participants> entries that cause server errors.
-        let mut resolved_recipients = Vec::with_capacity(recipients.len());
+        // Reject non-user JIDs up-front (cheap guard; a programming bug, not
+        // something to skip silently).
         for jid in recipients {
             if jid.is_group() || jid.is_status_broadcast() || jid.is_broadcast_list() {
                 return Err(anyhow!(
@@ -334,40 +342,18 @@ impl Client {
                     jid
                 ));
             }
-            if jid.is_lid() {
-                if let Some(pn) = self.lid_pn_cache.get_phone_number(&jid.user).await {
-                    resolved_recipients.push(Jid::new(&pn, Server::Pn));
-                } else {
-                    return Err(anyhow!(
-                        "No PN mapping for LID {}. Ensure the recipient has been \
-                         contacted previously.",
-                        jid
-                    ));
-                }
-            } else {
-                resolved_recipients.push(jid.clone());
-            }
         }
 
-        if resolved_recipients.is_empty() {
-            return Err(anyhow!("No valid PN recipients after LID resolution"));
+        // Resolve every recipient to its LID form (LID passes through; PN goes
+        // through the cache-aside lookup; everything else is skipped silently
+        // — matches WA Web `compactMap(list, toUserLid)`).
+        let mut resolved: Vec<Option<Jid>> = Vec::with_capacity(recipients.len());
+        for jid in recipients {
+            resolved.push(self.resolve_recipient_to_lid(jid).await);
         }
 
-        // Deduplicate by user (in case both LID and PN were provided for the same user)
-        let mut seen_users = std::collections::HashSet::new();
-        resolved_recipients.retain(|jid| seen_users.insert(jid.user.clone()));
-
-        let mut group_info = GroupInfo::new(resolved_recipients, AddressingMode::Pn);
-
-        // Ensure we're in the participant list
-        let own_base = own_jid.to_non_ad();
-        if !group_info
-            .participants
-            .iter()
-            .any(|p| p.is_same_user_as(&own_base))
-        {
-            group_info.participants.push(own_base);
-        }
+        let participants = wacore::send::assemble_status_participants(resolved, &own_lid)?;
+        let mut group_info = GroupInfo::new(participants, AddressingMode::Lid);
 
         self.add_recent_message(&to, &request_id, &message).await;
 
@@ -376,7 +362,11 @@ impl Client {
 
         let force_skdm = {
             use wacore::libsignal::store::sender_key_name::SenderKeyName;
-            let sender_address = own_jid.to_protocol_address();
+            // Sender key name tracks the addressing mode of the group stanza.
+            // Since status now uses LID addressing (see send_status_message
+            // header), the key is stored under own_lid, matching the address
+            // prepare_group_stanza derives internally.
+            let sender_address = own_lid.to_protocol_address();
             let sender_key_name = SenderKeyName::from_parts(&to_str, sender_address.as_str());
 
             let device_guard = device_store_arc.read().await;
@@ -396,7 +386,7 @@ impl Client {
         let skdm_target_devices: Option<Vec<Jid>> = if force_skdm {
             None
         } else {
-            self.resolve_skdm_targets(&to_str, &group_info.participants, &own_jid)
+            self.resolve_skdm_targets(&to_str, &group_info.participants, &own_lid)
                 .await
         };
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -290,22 +290,15 @@ impl Client {
         Ok(result)
     }
 
-    /// Send a status/story update to the given recipients using sender key encryption.
+    /// Send a status/story update using sender-key encryption.
     ///
-    /// Status messages use LID addressing, matching `WAWebEncryptAndSendStatusMsg`
-    /// (`docs/captured-js/WAWeb/Encrypt/AndSendStatusMsg.js:46`), which maps the
-    /// recipient list through `WAWebLidMigrationUtils.toUserLid` and filters
-    /// unresolvable entries via `compactMap`. Concretely:
-    ///
-    /// - recipients already in LID form pass through;
-    /// - PN recipients are converted to LID via the cache-aside lookup in
-    ///   `Client::get_lid_pn_entry` (warms from the backend on a cold cache);
-    /// - recipients we cannot resolve to a LID are skipped silently, not
-    ///   errored, so a single unknown contact does not fail the whole send.
-    ///
-    /// After resolution the list feeds a `GroupInfo` with `AddressingMode::Lid`,
-    /// which drives `prepare_group_stanza` to use `own_lid` for signing and emit
-    /// `addressing_mode="lid"` on the stanza.
+    /// Status uses LID addressing (matches `WAWebEncryptAndSendStatusMsg`):
+    /// LID recipients pass through, PN recipients are resolved to LID via
+    /// `Client::get_lid_pn_entry` (cache-aside), and unresolvable recipients
+    /// are skipped silently. The resulting `GroupInfo` carries
+    /// `AddressingMode::Lid`; `prepare_group_stanza` signs with `own_lid`
+    /// and emits `addressing_mode="lid"` on the stanza. Errors only if no
+    /// recipient could be resolved.
     pub(crate) async fn send_status_message(
         &self,
         message: wa::Message,

--- a/src/send.rs
+++ b/src/send.rs
@@ -328,25 +328,32 @@ impl Client {
             .pn
             .take()
             .ok_or(crate::client::ClientError::NotLoggedIn)?;
-        let own_lid = device_snapshot
-            .lid
-            .take()
-            .unwrap_or_else(|| own_jid.clone());
+        // Status is LID-addressed (matches WA Web post-LID-migration). Without
+        // a real device LID we can't sign or fan out correctly; refuse rather
+        // than silently emit `addressing_mode="lid"` with a PN sender.
+        let own_lid = device_snapshot.lid.take().ok_or_else(|| {
+            anyhow!(
+                "Cannot send status: device has no LID yet. Finish pairing / LID \
+                 migration before posting status."
+            )
+        })?;
 
-        // Reject non-user JIDs up-front (cheap guard; a programming bug, not
-        // something to skip silently).
+        // Fail fast for any JID that isn't a user (PN or LID). Mirrors WA
+        // Web's `asUserWidOrThrow` inside `toUserLid`: non-user inputs are a
+        // programming bug, not something to silently drop during resolution.
         for jid in recipients {
-            if jid.is_group() || jid.is_status_broadcast() || jid.is_broadcast_list() {
+            if !(jid.is_pn() || jid.is_lid()) {
                 return Err(anyhow!(
-                    "Invalid status recipient {}: must be a user JID, not a group/broadcast",
+                    "Invalid status recipient {}: must be a user JID (PN or LID), \
+                     not a group/broadcast/newsletter/hosted/etc.",
                     jid
                 ));
             }
         }
 
-        // Resolve every recipient to its LID form (LID passes through; PN goes
-        // through the cache-aside lookup; everything else is skipped silently
-        // — matches WA Web `compactMap(list, toUserLid)`).
+        // Resolve every user JID to its LID form (LID passes through; PN goes
+        // through the cache-aside lookup; `None` means no mapping — dropped
+        // silently to match WA Web `compactMap(list, toUserLid)`).
         let mut resolved: Vec<Option<Jid>> = Vec::with_capacity(recipients.len());
         for jid in recipients {
             resolved.push(self.resolve_recipient_to_lid(jid).await);

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1425,18 +1425,13 @@ pub fn ensure_status_participants(
 }
 
 /// Dedup a pre-resolved status recipient list by user, then anchor the sender's
-/// own LID. Returns `Err` if no resolvable recipient was provided, matching
-/// WA Web's behaviour where `compactMap(list, toUserLid)` over an empty result
-/// has nothing to send to.
+/// own LID. Errors when no recipient was resolvable (matches WA Web's
+/// `WAWebLidMigrationUtils.toUserLid` + `compactMap` dropping unresolvable
+/// entries; an empty result means "nothing to send to").
 ///
 /// Pure function: no allocations besides the returned `Vec` and (when needed)
-/// pushing the caller's own LID. Dedup is a linear Vec scan — status lists
-/// stay small enough that the HashSet overhead isn't worth it.
-///
-/// Callers (see `Client::send_status_message`) are expected to have already
-/// mapped each PN → LID via `Client::get_lid_pn_entry` (cache-aside),
-/// silently skipping unresolvable entries — that's the `Option` filter in
-/// `Iterator<Item = Option<Jid>>`.
+/// the own-LID push. Dedup is a linear Vec scan — status lists stay small
+/// enough that a HashSet is not worth its allocation.
 pub fn assemble_status_participants<I>(resolved: I, own_lid: &Jid) -> anyhow::Result<Vec<Jid>>
 where
     I: IntoIterator<Item = Option<Jid>>,

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1424,6 +1424,41 @@ pub fn ensure_status_participants(
     stanza
 }
 
+/// Dedup a pre-resolved status recipient list by user, then anchor the sender's
+/// own LID. Returns `Err` if no resolvable recipient was provided, matching
+/// WA Web's behaviour where `compactMap(list, toUserLid)` over an empty result
+/// has nothing to send to.
+///
+/// Pure function: no allocations besides the returned `Vec` and (when needed)
+/// pushing the caller's own LID. Dedup is a linear Vec scan — status lists
+/// stay small enough that the HashSet overhead isn't worth it.
+///
+/// Callers (see `Client::send_status_message`) are expected to have already
+/// mapped each PN → LID via `Client::get_lid_pn_entry` (cache-aside),
+/// silently skipping unresolvable entries — that's the `Option` filter in
+/// `Iterator<Item = Option<Jid>>`.
+pub fn assemble_status_participants<I>(resolved: I, own_lid: &Jid) -> anyhow::Result<Vec<Jid>>
+where
+    I: IntoIterator<Item = Option<Jid>>,
+{
+    let iter = resolved.into_iter();
+    let (lower, _upper) = iter.size_hint();
+    let mut out: Vec<Jid> = Vec::with_capacity(lower.saturating_add(1));
+    for jid in iter.flatten() {
+        if !out.iter().any(|r| r.user == jid.user) {
+            out.push(jid);
+        }
+    }
+    if out.is_empty() {
+        anyhow::bail!("No valid status recipients after LID resolution");
+    }
+    let own_base = own_lid.to_non_ad();
+    if !out.iter().any(|r| r.user == own_base.user) {
+        out.push(own_base);
+    }
+    Ok(out)
+}
+
 /// Build a `Message.ProtocolMessage` for `GROUP_MEMBER_LABEL_CHANGE`.
 ///
 /// Sent via the standard E2EE fanout, not an IQ. Empty `label` clears.
@@ -1449,6 +1484,91 @@ mod tests {
     use crate::libsignal::protocol::{IdentityKeyPair, KeyPair, PreKeyBundle};
     use std::collections::HashMap;
     use wacore_binary::Jid;
+
+    mod assemble_status_participants {
+        use super::*;
+
+        fn lid(u: &str) -> Jid {
+            u.parse().expect("parse LID jid")
+        }
+
+        #[test]
+        fn dedup_keeps_first_entry_per_user_and_anchors_own() {
+            let own = lid("99999999999999@lid");
+            let out = assemble_status_participants(
+                vec![
+                    Some(lid("111@lid")),
+                    Some(lid("222@lid")),
+                    Some(lid("111@lid")),
+                    Some(lid("333@lid")),
+                ],
+                &own,
+            )
+            .expect("should succeed");
+            let users: Vec<&str> = out.iter().map(|j| j.user.as_str()).collect();
+            assert_eq!(users, ["111", "222", "333", "99999999999999"]);
+        }
+
+        #[test]
+        fn skips_none_entries_matching_wa_web_compactmap() {
+            // Unresolvable recipients arrive as `None` and must be silently
+            // dropped — mirrors WA Web's `compactMap(list, toUserLid)`.
+            let own = lid("me@lid");
+            let out = assemble_status_participants(
+                vec![None, Some(lid("111@lid")), None, Some(lid("222@lid"))],
+                &own,
+            )
+            .expect("should succeed");
+            let users: Vec<&str> = out.iter().map(|j| j.user.as_str()).collect();
+            assert_eq!(users, ["111", "222", "me"]);
+        }
+
+        #[test]
+        fn does_not_duplicate_own_when_already_in_list() {
+            let own = lid("me@lid");
+            let out =
+                assemble_status_participants(vec![Some(lid("111@lid")), Some(lid("me@lid"))], &own)
+                    .expect("should succeed");
+            let users: Vec<&str> = out.iter().map(|j| j.user.as_str()).collect();
+            assert_eq!(users, ["111", "me"]);
+        }
+
+        #[test]
+        fn errors_when_every_recipient_is_unresolvable() {
+            // Regression guard for the original bug: a single LID-only
+            // contact used to hard-abort the send with
+            // `No PN mapping for LID ...`. The new contract is softer —
+            // individual unresolvable entries are dropped — but we still
+            // refuse to send when the entire list came back empty, rather
+            // than silently broadcasting to own devices only.
+            let own = lid("me@lid");
+            let err = assemble_status_participants(vec![None, None, None], &own)
+                .expect_err("all-None list must error");
+            assert!(err.to_string().contains("No valid status recipients"));
+        }
+
+        #[test]
+        fn errors_when_list_is_empty() {
+            let own = lid("me@lid");
+            let err = assemble_status_participants(Vec::<Option<Jid>>::new(), &own)
+                .expect_err("empty list must error");
+            assert!(err.to_string().contains("No valid status recipients"));
+        }
+
+        #[test]
+        fn strips_device_suffix_from_own_lid() {
+            // Snapshot lid from the device store carries a device id; the
+            // participant list uses bare USER JIDs.
+            let own: Jid = "me:5@lid".parse().unwrap();
+            let out = assemble_status_participants(vec![Some(lid("111@lid"))], &own)
+                .expect("should succeed");
+            let me = out
+                .iter()
+                .find(|j| j.user.as_str() == "me")
+                .expect("own LID should be present");
+            assert_eq!(me.device, 0, "own LID should be non-ad (device=0)");
+        }
+    }
 
     #[test]
     fn build_member_label_message_sets_fields() {


### PR DESCRIPTION
## Motivation

Reacting to a status from a LID-only contact (someone whose status the bot can decrypt but whose phone number it has never learned) used to fail permanently with:

```
No PN mapping for LID 148610331189399@lid. Ensure the recipient has been contacted previously.
```

Two compounding issues caused the break, and the fix has to touch both the addressing direction AND the device-resolution fallback that the new direction depends on:

1. **Cache-aside bypass.** `send_status_message` called `lid_pn_cache.get_phone_number` directly — in-memory only. Mappings persisted in the backend but not yet loaded were invisible. `Client::get_lid_pn_entry` has a cache-aside fallback (PR #565) but the status path was not using it.

2. **Wrong addressing direction.** The code forced every recipient to PN and aborted if any LID could not be resolved. That contradicts current WA Web behaviour. In `WAWebEncryptAndSendStatusMsg`:

   ```js
   $ = r("compactMap")(x.list, o("WAWebLidMigrationUtils").toUserLid);
   ```

   WA Web maps every recipient through `toUserLid` (returns the LID or `null`), and `compactMap` silently drops the nulls. Since the LID 1:1 migration, status is LID-addressed, not PN.

3. **Device resolution in LID mode misses own companions.** LID usync is unreliable for own JID. `prepare_group_stanza` already works around this via `GroupInfo::phone_jid_for_lid_user` + `phone_device_jid_to_lid` — but only if the `GroupInfo` has an `lid_to_pn_map` populated, and only in the full-SKDM path. `resolve_skdm_targets` had no equivalent fallback.

## What changed

### Addressing + resolution

- `send_status_message` uses LID addressing. Each recipient is resolved to its LID form: LID passes through, PN goes through the cache-aside `Client::get_lid_pn_entry`. Unresolvable recipients are skipped silently. `AddressingMode::Lid` on the `GroupInfo`, signed with `own_lid`, emits `addressing_mode="lid"`.
- `GroupInfo` is built via `with_lid_to_pn_map` seeded with own's LID↔PN plus every resolved (PN→LID) recipient pair. That's the map `prepare_group_stanza` needs for its fallback to work on first send.
- `resolve_skdm_targets` now takes `&GroupInfo`. In LID mode it queries devices via PN where the map has a mapping (same pattern as `prepare_group_stanza`), then converts the resulting device JIDs back to LID via `phone_device_jid_to_lid` so they match the cache and the stanza. Fixes the incremental-SKDM case where a new companion invalidated the device cache and the old direct-LID query missed own companions. Group sends benefit from the same fallback (bug was pre-existing there too).
- Fail-fast for any recipient that is not a user JID (PN or LID). Error upfront rather than silently dropping non-user inputs through `resolve_recipient_to_lid`. Mirrors WA Web's `asUserWidOrThrow` inside `toUserLid`.
- Refuse to send when `device_snapshot.lid` is `None`. Avoids emitting `addressing_mode="lid"` while signing with a PN sender.

### Helpers

- `wacore::send::assemble_status_participants` — pure helper, dedup + own-LID anchoring + empty-list guard. Linear `Vec` scan (no `HashSet` alloc). Six unit tests: dedup, compactMap-style skip, empty-after-skip error, ad-vs-bare own.
- `Client::resolve_recipient_to_lid` — single DRY call site for per-JID PN→LID resolution. Mirrors `WAWebLidMigrationUtils.toUserLid`.
- Sender-key derivation uses device-scoped `own_lid.to_protocol_address()` — matches `WAWebSignalAddress.toString` (device suffix included when non-zero) and stays consistent with `prepare_group_stanza`.

## Evidence of wire-format parity

| Observation | WA Web | whatsapp-rust (before) | whatsapp-rust (after) |
|---|---|---|---|
| Addressing mode | LID | PN | LID |
| Unresolvable recipient | Silently dropped (`compactMap`) | Hard abort | Silently dropped |
| Non-user recipient | Throws (`asUserWidOrThrow`) | Only group/broadcast rejected | All non-user rejected |
| PN→LID resolution | `getCurrentLid` | — (wrong direction) | `get_lid_pn_entry` cache-aside |
| Device query for LID own | PN fallback | — | PN fallback via `lid_to_pn_map` |
| Sender-key address format | `user:device@lid.0` | `user:device@pn.0` | `user:device@lid.0` |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests --exclude e2e-tests` — clean
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — 29 suites green (544 wacore lib + 12 wire_enum_serde + per-crate)
- [x] Six new unit tests in `wacore::send::assemble_status_participants`: dedup, compactMap-style skip, empty-list error, own-LID anchoring, ad-vs-bare handling
- [x] `resolve_skdm_targets` + `prepare_group_stanza` verified to share the same LID→PN fallback path
- [x] `send_status_message` seeds `lid_to_pn_map` for own + resolved recipients so the fallback has data to work with

## Breaking changes

None at the caller surface. `status().send_text(...)` etc. still take `&[Jid]` — LIDs and PNs both work, with strictly more resolving correctly now. The wire format change (`addressing_mode="lid"` on status stanzas) matches WA Web and is what the server expects post-LID-migration.

The internal `Client::resolve_skdm_targets` signature changed from `(group_jid, &[Jid], &Jid)` to `(group_jid, &GroupInfo, &Jid)`. `pub(crate)`, so no public-API impact.