### PR TITLE
fix(status): drop <meta status_setting> on reactions and revokes

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -563,14 +563,13 @@ impl Client {
             .participants
             .iter()
             .map(|jid| {
-                let base = jid.to_non_ad();
                 if is_lid_mode
-                    && base.is_lid()
-                    && let Some(pn) = group_info.phone_jid_for_lid_user(&base.user)
+                    && jid.is_lid()
+                    && let Some(pn) = group_info.phone_jid_for_lid_user(&jid.user)
                 {
                     return pn.to_non_ad();
                 }
-                base
+                jid.to_non_ad()
             })
             .collect();
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -399,19 +399,18 @@ impl Client {
                 .await
         };
 
-        // WhatsApp Web includes <meta status_setting="..."/> on non-revoke status messages.
-        // Revoke messages omit this node.
-        let is_revoke = message.protocol_message.as_ref().is_some_and(|pm| {
-            pm.r#type == Some(wa::message::protocol_message::Type::Revoke as i32)
-        });
-        let extra_stanza_nodes = if is_revoke {
-            vec![]
-        } else {
+        // `<meta status_setting>` describes the POSTER's privacy on their own
+        // status. Reactions go through WA Web's addon path and never visit
+        // `WAWebEncryptAndSendStatusMsg`; attaching the meta on a reaction
+        // gets the stanza NACK'd with 479 (SmaxInvalid). Revokes also skip it.
+        let extra_stanza_nodes = if wacore::send::status_carries_privacy_meta(&message) {
             vec![
                 NodeBuilder::new("meta")
                     .attr("status_setting", options.privacy.as_str())
                     .build(),
             ]
+        } else {
+            vec![]
         };
 
         let prepared = match wacore::send::prepare_group_stanza(

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1465,9 +1465,8 @@ where
     if out.is_empty() {
         anyhow::bail!("No valid status recipients after LID resolution");
     }
-    let own_base = own_lid.to_non_ad();
-    if !out.iter().any(|r| r.user == own_base.user) {
-        out.push(own_base);
+    if !out.iter().any(|r| r.user == own_lid.user) {
+        out.push(own_lid.to_non_ad());
     }
     Ok(out)
 }

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1428,12 +1428,17 @@ pub fn ensure_status_participants(
 /// `<meta status_setting="..."/>` child. Only applies to actual status posts:
 /// reactions (handled server-side as addons) and revokes must omit it, per
 /// `WAWebEncryptAndSendStatusMsg` vs `WAWebSendReactionMsgAction`.
+///
+/// Descends `ephemeral_message` / `device_sent_message` / view-once wrappers
+/// before classifying (same as `stanza_type_from_message`), so a reaction
+/// nested inside a wrapper cannot slip past and re-trigger 479.
 pub fn status_carries_privacy_meta(message: &wa::Message) -> bool {
-    let is_revoke = message
+    let msg = unwrap_message(message);
+    let is_revoke = msg
         .protocol_message
         .as_ref()
         .is_some_and(|pm| pm.r#type == Some(wa::message::protocol_message::Type::Revoke as i32));
-    let is_reaction = message.reaction_message.is_some() || message.enc_reaction_message.is_some();
+    let is_reaction = msg.reaction_message.is_some() || msg.enc_reaction_message.is_some();
     !is_revoke && !is_reaction
 }
 
@@ -1650,6 +1655,41 @@ mod tests {
                 ..Default::default()
             };
             assert!(status_carries_privacy_meta(&msg));
+        }
+
+        #[test]
+        fn false_for_reaction_inside_ephemeral_wrapper() {
+            let inner = wa::Message {
+                reaction_message: Some(wa::message::ReactionMessage::default()),
+                ..Default::default()
+            };
+            let msg = wa::Message {
+                ephemeral_message: Some(Box::new(wa::message::FutureProofMessage {
+                    message: Some(Box::new(inner)),
+                })),
+                ..Default::default()
+            };
+            assert!(!status_carries_privacy_meta(&msg));
+        }
+
+        #[test]
+        fn false_for_revoke_inside_device_sent_wrapper() {
+            let inner = wa::Message {
+                protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+                    r#type: Some(wa::message::protocol_message::Type::Revoke as i32),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            let msg = wa::Message {
+                device_sent_message: Some(Box::new(wa::message::DeviceSentMessage {
+                    destination_jid: Some(String::new()),
+                    message: Some(Box::new(inner)),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            assert!(!status_carries_privacy_meta(&msg));
         }
     }
 

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1424,6 +1424,19 @@ pub fn ensure_status_participants(
     stanza
 }
 
+/// True when a `status@broadcast` message should carry the
+/// `<meta status_setting="..."/>` child. Only applies to actual status posts:
+/// reactions (handled server-side as addons) and revokes must omit it, per
+/// `WAWebEncryptAndSendStatusMsg` vs `WAWebSendReactionMsgAction`.
+pub fn status_carries_privacy_meta(message: &wa::Message) -> bool {
+    let is_revoke = message
+        .protocol_message
+        .as_ref()
+        .is_some_and(|pm| pm.r#type == Some(wa::message::protocol_message::Type::Revoke as i32));
+    let is_reaction = message.reaction_message.is_some() || message.enc_reaction_message.is_some();
+    !is_revoke && !is_reaction
+}
+
 /// Dedup a pre-resolved status recipient list by user, then anchor the sender's
 /// own LID. Errors when no recipient was resolvable (matches WA Web's
 /// `WAWebLidMigrationUtils.toUserLid` + `compactMap` dropping unresolvable
@@ -1562,6 +1575,81 @@ mod tests {
                 .find(|j| j.user.as_str() == "me")
                 .expect("own LID should be present");
             assert_eq!(me.device, 0, "own LID should be non-ad (device=0)");
+        }
+    }
+
+    mod status_carries_privacy_meta {
+        use super::*;
+
+        #[test]
+        fn true_for_text_post() {
+            let msg = wa::Message {
+                extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
+                    text: Some("hi".into()),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            assert!(status_carries_privacy_meta(&msg));
+        }
+
+        #[test]
+        fn true_for_image_post() {
+            let msg = wa::Message {
+                image_message: Some(Box::new(wa::message::ImageMessage::default())),
+                ..Default::default()
+            };
+            assert!(status_carries_privacy_meta(&msg));
+        }
+
+        #[test]
+        fn false_for_reaction() {
+            let msg = wa::Message {
+                reaction_message: Some(wa::message::ReactionMessage {
+                    text: Some("💚".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            assert!(
+                !status_carries_privacy_meta(&msg),
+                "reactions must omit <meta status_setting> (479 SmaxInvalid otherwise)"
+            );
+        }
+
+        #[test]
+        fn false_for_enc_reaction() {
+            let msg = wa::Message {
+                enc_reaction_message: Some(wa::message::EncReactionMessage::default()),
+                ..Default::default()
+            };
+            assert!(!status_carries_privacy_meta(&msg));
+        }
+
+        #[test]
+        fn false_for_revoke() {
+            let msg = wa::Message {
+                protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+                    r#type: Some(wa::message::protocol_message::Type::Revoke as i32),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            assert!(!status_carries_privacy_meta(&msg));
+        }
+
+        #[test]
+        fn true_for_non_revoke_protocol_message() {
+            // Other ProtocolMessage types (e.g., EphemeralSettings) aren't
+            // reactions and aren't revokes — treat as posts for now.
+            let msg = wa::Message {
+                protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+                    r#type: Some(wa::message::protocol_message::Type::EphemeralSetting as i32),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            assert!(status_carries_privacy_meta(&msg));
         }
     }
 


### PR DESCRIPTION
## Motivation

After PR #568 fixed the client-side abort on LID-only recipients, status reactions actually reached the server — and started coming back as NACK with `error=\"479\"` (SmaxInvalid). Reactions never appeared on the poster's side.

Observed wire exchange:

```
⟶  <message addressing_mode=\"lid\" to=\"status@broadcast\" type=\"reaction\">
     <participants>
       <to jid=\"271060335329480@lid\"/>
       <to jid=\"236395184570386@lid\"/>
     </participants>
     <enc decrypt-fail=\"hide\" type=\"skmsg\" v=\"2\">...</enc>
     <meta status_setting=\"contacts\"/>      ← trigger
   </message>

⟵  <ack error=\"479\"/>                        ← 160 ms later
```

## Cause

`send_status_message` attached `<meta status_setting>` to every non-revoke send. That semantic is wrong: `status_setting` describes the poster's privacy on their own status — meaningless when reacting to someone else's content. WA Web handles the split architecturally:

- **Status post**: `WAWebEncryptAndSendStatusMsg` attaches the meta, reading `WAWebUserPrefsStatus.getStatusList().setting`.
- **Reaction**: `WAWebSendReactionMsgAction` → `WAWebSendAddonMsgChatAction` → `sendAddonRecord`. Never visits the status-post path, never attaches the meta.

Upstream Baileys doesn't emit `status_setting` on any stanza (grep `status_setting` in `WhiskeySockets/Baileys/src/Socket/messages-send.ts` returns zero).

whatsapp-rust was the lone outlier, gratuitously attaching the meta to every status-shaped send regardless of whether it was an actual post or a reaction.

## Fix

New pure helper in `wacore::send`:

```rust
pub fn status_carries_privacy_meta(message: &wa::Message) -> bool
```

Returns `true` only for actual status posts — not reactions (`reaction_message` or `enc_reaction_message`), not revokes (`protocol_message.type == Revoke`). Descends `ephemeral_message` / `device_sent_message` / view-once wrappers via `unwrap_message` (same pattern `stanza_type_from_message` uses) so a reaction nested inside a wrapper is still detected.

`send_status_message` calls this before building `extra_stanza_nodes`. Reactions and revokes ship without the meta; posts keep it.

## Tests

Eight unit tests in `wacore::send::tests::status_carries_privacy_meta`:

- `true_for_text_post` — `ExtendedTextMessage`
- `true_for_image_post` — `ImageMessage`
- `false_for_reaction` — `ReactionMessage` (primary regression guard for 479)
- `false_for_enc_reaction` — `EncReactionMessage`
- `false_for_revoke` — `ProtocolMessage { type: Revoke }`
- `true_for_non_revoke_protocol_message` — e.g. `EphemeralSetting`
- `false_for_reaction_inside_ephemeral_wrapper` — wrapped-reaction regression guard
- `false_for_revoke_inside_device_sent_wrapper` — wrapped-revoke regression guard

## Perf polish

Two small Jid-allocation wins landed alongside the fix:

- `assemble_status_participants`: compare against `own_lid.user` before calling `to_non_ad()`, so the non-ad copy only runs when the push is actually needed. Saves one Jid clone per call when own is already in the resolved list.
- `resolve_skdm_targets`: inspect `is_lid()` / `user` on the borrowed `&Jid` before picking PN vs LID, instead of pre-allocating `base = jid.to_non_ad()` and then discarding it on the PN branch. Saves one Jid clone per participant that has a phone mapping (typically own + any PN-resolved recipient).

Pure refactors, no behavior change.

## Verification

- `cargo fmt --all`
- `cargo clippy --all --tests --exclude e2e-tests` — clean
- `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — 29 suites green

## Scope note

The proposal that surfaced this bug also claimed upstream Baileys emits reactions as `type=\"text\"` rather than `\"reaction\"`. I verified against `WhiskeySockets/Baileys/master/src/Socket/messages-send.ts:1050-1051`: Baileys does emit `'reaction'` for reaction messages, same as whatsapp-rust and WA Web. Not a divergence; not addressed here.