### PR TITLE
perf: 11 allocation trims from hot-path audit

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3581,8 +3581,13 @@ impl Client {
     }
 
     pub async fn get_push_name(&self) -> String {
-        let device_snapshot = self.persistence_manager.get_device_snapshot().await;
-        device_snapshot.push_name.clone()
+        self.persistence_manager
+            .get_device_arc()
+            .await
+            .read()
+            .await
+            .push_name
+            .clone()
     }
 
     pub async fn get_pn(&self) -> Option<Jid> {
@@ -3596,8 +3601,13 @@ impl Client {
     }
 
     pub async fn get_lid(&self) -> Option<Jid> {
-        let snapshot = self.persistence_manager.get_device_snapshot().await;
-        snapshot.lid.clone()
+        self.persistence_manager
+            .get_device_arc()
+            .await
+            .read()
+            .await
+            .lid
+            .clone()
     }
 
     pub(crate) async fn require_pn(&self) -> Result<Jid> {

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -15,22 +15,26 @@ impl Client {
         has_key: bool,
         exclude_own_devices: bool,
     ) -> Result<()> {
-        let (own_lid_user, own_pn_user) = if exclude_own_devices {
-            let snapshot = self.persistence_manager.get_device_snapshot().await;
-            (
-                snapshot.lid.as_ref().map(|j| j.user.clone()),
-                snapshot.pn.as_ref().map(|j| j.user.clone()),
-            )
+        let snapshot = if exclude_own_devices {
+            Some(self.persistence_manager.get_device_snapshot().await)
         } else {
-            (None, None)
+            None
         };
+        let own_lid_user = snapshot
+            .as_ref()
+            .and_then(|s| s.lid.as_ref())
+            .map(|j| j.user.as_str());
+        let own_pn_user = snapshot
+            .as_ref()
+            .and_then(|s| s.pn.as_ref())
+            .map(|j| j.user.as_str());
 
         let device_ids: Vec<String> = device_jids
             .iter()
             .filter(|jid| {
                 !exclude_own_devices
-                    || !(own_lid_user.as_deref().is_some_and(|u| u == jid.user)
-                        || own_pn_user.as_deref().is_some_and(|u| u == jid.user))
+                    || !(own_lid_user.is_some_and(|u| u == jid.user)
+                        || own_pn_user.is_some_and(|u| u == jid.user))
             })
             .map(ToString::to_string)
             .collect();

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -193,22 +193,21 @@ impl<'a> Groups<'a> {
 
         let group = self.client.execute(GroupQueryIq::new(jid)).await?;
 
-        let participants: Vec<Jid> = group.participants.iter().map(|p| p.jid.clone()).collect();
-
-        let lid_to_pn_map: HashMap<wacore_binary::CompactString, Jid> =
-            if group.addressing_mode == AddressingMode::Lid {
-                group
-                    .participants
-                    .iter()
-                    .filter_map(|p| {
-                        p.phone_number
-                            .as_ref()
-                            .map(|pn| (p.jid.user.clone(), pn.clone()))
-                    })
-                    .collect()
-            } else {
-                HashMap::new()
-            };
+        // Single pass: move participants out and build lid_to_pn_map alongside.
+        let n = group.participants.len();
+        let is_lid = group.addressing_mode == AddressingMode::Lid;
+        let mut participants: Vec<Jid> = Vec::with_capacity(n);
+        let mut lid_to_pn_map: HashMap<wacore_binary::CompactString, Jid> = if is_lid {
+            HashMap::with_capacity(n)
+        } else {
+            HashMap::new()
+        };
+        for p in group.participants {
+            if is_lid && let Some(pn) = p.phone_number {
+                lid_to_pn_map.insert(p.jid.user.clone(), pn);
+            }
+            participants.push(p.jid);
+        }
 
         let mut info = GroupInfo::new(participants, group.addressing_mode);
         if !lid_to_pn_map.is_empty() {

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -118,7 +118,8 @@ impl<'a> Polls<'a> {
             .get_pn()
             .await
             .ok_or_else(|| anyhow!("Not logged in — cannot determine own JID"))?;
-        let voter_jid_str = my_jid.to_non_ad().to_string();
+        let my_base = my_jid.to_non_ad();
+        let voter_jid_str = my_base.to_string();
         let creator_jid_str = poll_creator_jid.to_non_ad().to_string();
 
         let selected_hashes: Vec<Vec<u8>> = option_names
@@ -136,7 +137,7 @@ impl<'a> Polls<'a> {
         let (enc_payload, iv) =
             poll::encrypt_poll_vote(&selected_hashes, &key, poll_msg_id, &voter_jid_str)?;
 
-        let from_me = my_jid.to_non_ad() == poll_creator_jid.to_non_ad();
+        let from_me = my_base.is_same_user_as(poll_creator_jid);
 
         let poll_update = wa::message::PollUpdateMessage {
             poll_creation_message_key: Some(wa::MessageKey {
@@ -196,24 +197,33 @@ impl<'a> Polls<'a> {
             .map(|name| (poll::compute_option_hash(name), name.as_str()))
             .collect();
 
+        // `creator_str` is invariant across voters; `decrypt_vote` used to
+        // recompute it per voter via `poll_creator_jid.to_non_ad().to_string()`.
+        let creator_str = poll_creator_jid.to_non_ad().to_string();
+
         // Last-vote-wins: each new vote from the same voter replaces the previous
-        let mut latest_votes: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+        let mut latest_votes: HashMap<String, Vec<Vec<u8>>> = HashMap::with_capacity(votes.len());
         for (voter_jid, enc_payload, enc_iv) in votes {
-            let voter_key = voter_jid.to_non_ad().to_string();
-            match Self::decrypt_vote(
-                enc_payload,
-                enc_iv,
+            let voter_str = voter_jid.to_non_ad().to_string();
+            let key = match poll::derive_vote_encryption_key(
                 message_secret,
                 poll_msg_id,
-                poll_creator_jid,
-                voter_jid,
+                &creator_str,
+                &voter_str,
             ) {
+                Ok(k) => k,
+                Err(e) => {
+                    log::warn!("Failed to derive vote key for {voter_jid}: {e}");
+                    continue;
+                }
+            };
+            match poll::decrypt_poll_vote(enc_payload, enc_iv, &key, poll_msg_id, &voter_str) {
                 Ok(selected_hashes) => {
                     if selected_hashes.is_empty() {
                         // Empty selection = voter cleared their vote
-                        latest_votes.remove(&voter_key);
+                        latest_votes.remove(&voter_str);
                     } else {
-                        latest_votes.insert(voter_key, selected_hashes);
+                        latest_votes.insert(voter_str, selected_hashes);
                     }
                 }
                 Err(e) => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1098,16 +1098,17 @@ impl Client {
         }
         let mut adapter = self.signal_adapter().await;
 
+        // Always use bare sender for sender key operations. Real WA delivers
+        // skmsg with bare participant but pkmsg (SKDM) with device-qualified
+        // participant — normalizing to bare ensures consistent lookup.
+        // Hoisted out of the payload loop: all three are loop-invariant.
+        let sender_for_sk = info.source.sender.to_non_ad();
+        let sender_address = sender_for_sk.to_protocol_address();
+        let sender_key_name = make_sender_key_name(&info.source.chat, &sender_address);
+
         for payload in payloads {
             let ciphertext = &payload.ciphertext[..];
             let padding_version = payload.padding_version;
-
-            // Always use bare sender for sender key operations. Real WA delivers
-            // skmsg with bare participant but pkmsg (SKDM) with device-qualified
-            // participant — normalizing to bare ensures consistent lookup.
-            let sender_for_sk = info.source.sender.to_non_ad();
-            let sender_address = sender_for_sk.to_protocol_address();
-            let sender_key_name = make_sender_key_name(&info.source.chat, &sender_address);
 
             log::debug!(
                 "Looking up sender key for group {} with sender address {} (from sender JID: {})",
@@ -1434,10 +1435,14 @@ impl Client {
         &self,
         node: &wacore_binary::NodeRef<'_>,
     ) -> Result<MessageInfo, anyhow::Error> {
-        let device_snapshot = self.persistence_manager.get_device_snapshot().await;
+        let (own_pn, own_lid) = {
+            let arc = self.persistence_manager.get_device_arc().await;
+            let guard = arc.read().await;
+            (guard.pn.clone(), guard.lid.clone())
+        };
         let default_jid = Jid::default();
-        let own_jid = device_snapshot.pn.as_ref().unwrap_or(&default_jid);
-        wacore::messages::parse_message_info(node, own_jid, device_snapshot.lid.as_ref())
+        let own_jid = own_pn.as_ref().unwrap_or(&default_jid);
+        wacore::messages::parse_message_info(node, own_jid, own_lid.as_ref())
     }
 
     pub(crate) async fn handle_app_state_sync_key_share(

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -133,10 +133,10 @@ fn resolve_retry_chat_info(
         let is_peer = own_pn.is_some_and(|pn| from.is_same_user_as(pn))
             || own_lid.is_some_and(|lid| from.is_same_user_as(lid));
 
-        let chat = if is_bot && recipient.is_some() {
-            recipient.clone().unwrap().to_non_ad()
+        let chat = if is_bot && let Some(r) = recipient.as_ref() {
+            r.to_non_ad()
         } else if is_peer {
-            match &recipient {
+            match recipient.as_ref() {
                 Some(r) => r.to_non_ad(),
                 // No recipient on peer retry — chat will be our own JID,
                 // message lookup will likely fail. WA Web returns null here.
@@ -233,13 +233,14 @@ impl Client {
             log::debug!("Ignoring retry for {processing_key}: a retry is already in progress.");
             return Ok(());
         }
+        // processing_key isn't needed by name after this point — move it into
+        // the scopeguard instead of cloning again.
         let pending = Arc::clone(&self.pending_retries);
-        let guard_key = processing_key.clone();
         let _guard = scopeguard::guard((), move |()| {
             pending
                 .lock()
                 .unwrap_or_else(|p| p.into_inner())
-                .remove(&guard_key);
+                .remove(&processing_key);
         });
 
         let (original_msg, alt_chat) = match self.take_recent_message(&info.chat, &message_id).await
@@ -282,11 +283,13 @@ impl Client {
         };
 
         let sender_device_id = info.requester.device() as u32;
-        let sender_user = info.requester.user.clone();
-        if !self.has_device(&sender_user, sender_device_id).await {
+        if !self
+            .has_device(&info.requester.user, sender_device_id)
+            .await
+        {
             warn!(
                 "handle_retry_receipt: device not found for device={}, user={}",
-                sender_device_id, sender_user
+                sender_device_id, info.requester.user
             );
             return Ok(());
         }

--- a/src/send.rs
+++ b/src/send.rs
@@ -1154,12 +1154,10 @@ impl Client {
                 !is_sender
             });
 
-            // Dedup for self-DMs: recipient and own device lists overlap
-            // when sending to own account (WA Web uses Map keyed by toString)
-            {
-                let mut seen = std::collections::HashSet::with_capacity(all_dm_jids.len());
-                all_dm_jids.retain(|j| seen.insert(j.clone()));
-            }
+            // Dedup for self-DMs: recipient and own device lists overlap when
+            // sending to own account. `participant_list_hash` sorts internally,
+            // so reordering here is safe.
+            wacore::types::jid::sort_dedup_by_device(&mut all_dm_jids);
 
             self.ensure_e2e_sessions(&all_dm_jids).await?;
 

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -19,8 +19,8 @@ pub(crate) struct SenderKeyDeviceMap {
 
 impl SenderKeyDeviceMap {
     pub fn from_db_rows(rows: &[(String, bool)]) -> Self {
-        let mut devices: HashMap<Arc<str>, HashMap<u16, bool>> = HashMap::new();
-        let mut forgotten_users = HashSet::new();
+        let mut devices: HashMap<Arc<str>, HashMap<u16, bool>> = HashMap::with_capacity(rows.len());
+        let mut forgotten_users = HashSet::with_capacity(rows.len() / 4);
 
         for (jid_str, has_key) in rows {
             match jid_str.parse::<Jid>() {

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -165,8 +165,9 @@ impl PreKeyUtils {
             .get_optional_child("list")
             .ok_or_else(|| anyhow::anyhow!("<list> not found in pre-key response"))?;
 
-        let mut bundles = HashMap::new();
-        for user_node_ref in list_node.children().unwrap_or_default() {
+        let children = list_node.children().unwrap_or_default();
+        let mut bundles = HashMap::with_capacity(children.len());
+        for user_node_ref in children {
             if user_node_ref.tag != "user" {
                 continue;
             }

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1090,21 +1090,23 @@ pub async fn prepare_group_stanza<
             })
             .collect();
 
-        // Determine what JID to check for - use phone number if we're in LID mode and have a mapping
-        let own_jid_to_check = if own_base_jid.is_lid() {
-            group_info
-                .phone_jid_for_lid_user(&own_base_jid.user)
-                .map(|pn| pn.to_non_ad())
-                .unwrap_or_else(|| own_base_jid.clone())
+        // Determine what user to check for — use the PN user when own is LID
+        // and we have a mapping. Keeping this as a borrow avoids allocating a
+        // throwaway Jid when own is already in the list.
+        let own_pn_mapping = if own_base_jid.is_lid() {
+            group_info.phone_jid_for_lid_user(&own_base_jid.user)
         } else {
-            own_base_jid.clone()
+            None
         };
+        let own_check_user = own_pn_mapping
+            .map(|pn| pn.user.as_str())
+            .unwrap_or(own_base_jid.user.as_str());
 
-        if !jids_to_resolve
-            .iter()
-            .any(|participant| participant.is_same_user_as(&own_jid_to_check))
-        {
-            jids_to_resolve.push(own_jid_to_check);
+        if !jids_to_resolve.iter().any(|p| p.user == own_check_user) {
+            jids_to_resolve.push(match own_pn_mapping {
+                Some(pn) => pn.to_non_ad(),
+                None => own_base_jid.clone(),
+            });
         }
 
         crate::types::jid::sort_dedup_by_user(&mut jids_to_resolve);


### PR DESCRIPTION
## Motivation

Follow-up audit sweep after PR #569 surfaced two reference wins (`assemble_status_participants` + `resolve_skdm_targets`). A background agent mapped the same class of patterns across the rest of the workspace; 11 of those hits landed here. Every finding is one of:

- Eager `.to_non_ad()` / `.clone()` followed by a branch that discards it.
- Clone for a consumer that only needs a borrow.
- `HashMap::new()` where capacity is knowable.
- Loop-invariant allocation inside a tight loop.

No behavior change. All wins are mechanical.

## Findings, by hot-path frequency

### Per inbound message

| Where | Fix |
|---|---|
| `src/message.rs::parse_message_info` | Stop cloning the entire `Device` to read `pn` + `lid`; read via the RwLock guard, mirroring `get_pn()`. Saves a full `Device` clone (`CompactString`s + `Jid`s + keys + `AdvSignedDeviceIdentity`) per stanza. |
| `src/message.rs` (batch `skmsg` decrypt loop) | Hoist `sender_for_sk` / `sender_address` / `sender_key_name` out of `for payload in payloads` — all three are loop-invariant. Saves 3 allocations per extra payload in a batch (common for group / status fanouts). |

### Per send

| Where | Fix |
|---|---|
| `src/send.rs` (DM fanout dedup) | Replace `HashSet::insert(j.clone())` retain with `sort_dedup_by_device`. `participant_list_hash` sorts internally, so reordering is safe — zero allocations now. |
| `wacore/src/send.rs` (force-SKDM distribution) | Don't pre-allocate `own_jid_to_check` before the presence check; compare by `&str` user, allocate only on the push branch. Saves one `Jid` on the common "own already in list" path. |

### Per retry

| Where | Fix |
|---|---|
| `src/retry.rs` (processing key) | Drop the second `processing_key.clone()` — move it into the scopeguard closure instead. |
| `src/retry.rs` (sender_user) | Replace `info.requester.user.clone()` with a direct borrow; the only consumer is `has_device(&str)`. |
| `src/retry.rs` (recipient chat) | Replace `recipient.clone().unwrap().to_non_ad()` with an `.as_ref()` pattern match. |

### Public getters

| Where | Fix |
|---|---|
| `src/client.rs::get_push_name` / `get_lid` | Were cloning the entire device snapshot to return one field; now read via `persistence_manager.get_device_arc().read().await.<field>.clone()` like `get_pn()` already does. |
| `src/client/sender_keys.rs::set_sender_key_status_for_devices` | Borrow `own_lid_user` / `own_pn_user` as `&str` into the filter closure; snapshot stays alive via a binding for the duration of `.collect()`. |

### Group / poll paths

| Where | Fix |
|---|---|
| `src/features/groups.rs::query_info` | Collapse two iterations over `group.participants` into a single move-based loop. Saves one `Jid` clone per participant plus one `CompactString` per LID entry with a PN mapping. |
| `src/features/polls.rs::vote` | Replace `my_jid.to_non_ad() == poll_creator_jid.to_non_ad()` with `is_same_user_as` (the reference-PR shape). Cache `my_base = my_jid.to_non_ad()` to share one allocation between the voter string and the equality check. |
| `src/features/polls.rs::aggregate_votes` | Inline the decryption helper so `creator_str = poll_creator_jid.to_non_ad().to_string()` is computed once instead of per voter. Pre-allocate `latest_votes` with `votes.len()` capacity. |

### Map capacity

| Where | Fix |
|---|---|
| `wacore/src/prekeys.rs::parse_prekeys_response` | `HashMap::with_capacity(children.len())`. Rehash was possible up to N users per prekey fetch. |
| `src/sender_key_device_cache.rs::from_db_rows` | `HashMap::with_capacity(rows.len())` + `HashSet::with_capacity(rows.len() / 4)`. |

## Verification

- `cargo fmt --all`
- `cargo clippy --all --tests --exclude e2e-tests` — clean
- `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — 552 wacore lib tests + all per-crate suites green

## Not included

Flagged by the audit but left alone pending human review or verified load-bearing:
- `wacore/src/store/signal_cache.rs` flush uses `.iter().cloned().collect()` three times per flush; `drain()` would avoid the Arc bumps but changes failure semantics (current code clears only successful writes) — needs intent confirmation.
- `wacore/src/iq/usync.rs:429` (`fields.jid.clone()`), `src/portable_cache.rs:139` (`(k, _)|k.clone()`), `wacore/src/appstate_sync.rs:35` (`(**arc).clone()`) — verified necessary and/or cold paths.