### PR TITLE
fix(receipt): flush in-flight delivery receipts on disconnect

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -426,6 +426,10 @@ pub struct Client {
     pub(crate) history_sync_tasks_in_flight: Arc<AtomicUsize>,
     /// Notifier triggered when history sync work becomes idle.
     pub(crate) history_sync_idle_notifier: Arc<event_listener::Event>,
+    /// Drained by `disconnect()` before tearing down the transport so in-flight
+    /// delivery receipts aren't dropped with `NotConnected` (issue #571).
+    pub(crate) pending_receipt_tasks: AtomicUsize,
+    pub(crate) pending_receipt_tasks_idle: event_listener::Event,
     /// Contacts with active presence subscriptions that must be re-subscribed on reconnect.
     pub(crate) presence_subscriptions: Arc<async_lock::Mutex<HashSet<Jid>>>,
     /// Metrics for granular offline sync logging
@@ -758,6 +762,8 @@ impl Client {
             offline_sync_completed: Arc::new(AtomicBool::new(false)),
             history_sync_tasks_in_flight: Arc::new(AtomicUsize::new(0)),
             history_sync_idle_notifier: Arc::new(event_listener::Event::new()),
+            pending_receipt_tasks: AtomicUsize::new(0),
+            pending_receipt_tasks_idle: event_listener::Event::new(),
             presence_subscriptions: Arc::new(async_lock::Mutex::new(HashSet::new())),
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),
@@ -1210,8 +1216,13 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        // Stop the read loop first so no new stanzas enter the pipeline while
+        // we're flushing receipts (issue #571).
+        self.notify_connection_shutdown();
 
-        // Flush dirty device state before tearing down the connection.
+        self.wait_for_pending_receipts(std::time::Duration::from_secs(5))
+            .await;
+
         if let Err(e) = self.persistence_manager.flush().await {
             log::error!("Failed to flush device state during disconnect: {e}");
         }
@@ -1220,6 +1231,38 @@ impl Client {
             transport.disconnect().await;
         }
         self.cleanup_connection_state().await;
+    }
+
+    async fn wait_for_pending_receipts(self: &Arc<Self>, timeout: std::time::Duration) {
+        use wacore::time::Instant;
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            let listener = self.pending_receipt_tasks_idle.listen();
+            if self.pending_receipt_tasks.load(Ordering::Acquire) == 0 {
+                return;
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                log::warn!(
+                    "Timed out flushing {} in-flight delivery receipt task(s) during disconnect",
+                    self.pending_receipt_tasks.load(Ordering::Relaxed)
+                );
+                return;
+            }
+
+            if wacore::runtime::timeout(&*self.runtime, remaining, listener)
+                .await
+                .is_err()
+            {
+                log::warn!(
+                    "Timed out flushing {} in-flight delivery receipt task(s) during disconnect",
+                    self.pending_receipt_tasks.load(Ordering::Relaxed)
+                );
+                return;
+            }
+        }
     }
 
     /// Backoff step used by [`reconnect()`] to create an offline window.
@@ -1247,6 +1290,9 @@ impl Client {
         self.intentional_reconnect.store(true, Ordering::Relaxed);
         self.auto_reconnect_errors
             .store(Self::RECONNECT_BACKOFF_STEP, Ordering::Relaxed);
+        self.notify_connection_shutdown();
+        self.wait_for_pending_receipts(std::time::Duration::from_secs(2))
+            .await;
         if let Some(transport) = self.transport.lock().await.as_ref() {
             transport.disconnect().await;
         }
@@ -1260,6 +1306,9 @@ impl Client {
     pub async fn reconnect_immediately(self: &Arc<Self>) {
         info!("Reconnecting immediately (expected disconnect).");
         self.expected_disconnect.store(true, Ordering::Relaxed);
+        self.notify_connection_shutdown();
+        self.wait_for_pending_receipts(std::time::Duration::from_secs(2))
+            .await;
         if let Some(transport) = self.transport.lock().await.as_ref() {
             transport.disconnect().await;
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -87,11 +87,26 @@ impl Client {
                 msg.get_base_message().get_ephemeral_expiration();
         }
 
+        // Tracked so `disconnect()` can flush in-flight receipts (issue #571).
         let client_clone = self.clone();
         let info_for_receipt = Arc::clone(&info);
+        self.pending_receipt_tasks
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
         self.runtime
             .spawn(Box::pin(async move {
                 client_clone.send_delivery_receipt(&info_for_receipt).await;
+                if client_clone
+                    .pending_receipt_tasks
+                    .fetch_sub(1, std::sync::atomic::Ordering::Release)
+                    <= 1
+                {
+                    // Clamp to 0 so an accidental extra decrement can't wrap the
+                    // counter around and mask future bumps.
+                    client_clone
+                        .pending_receipt_tasks
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
+                    client_clone.pending_receipt_tasks_idle.notify(usize::MAX);
+                }
             }))
             .detach();
 

--- a/tests/e2e/tests/receipts.rs
+++ b/tests/e2e/tests/receipts.rs
@@ -353,3 +353,89 @@ async fn test_group_delivery_receipt() -> anyhow::Result<()> {
     client_b.disconnect().await;
     Ok(())
 }
+
+/// Regression test for issue #571: disconnect must flush in-flight delivery
+/// receipts so they don't race the transport tear-down. Burst of N messages
+/// reliably hits the race window for at least one receipt.
+#[tokio::test]
+async fn test_delivery_receipts_flushed_on_disconnect() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut client_a = TestClient::connect("e2e_rcpt_flush_a").await?;
+    let mut client_b = TestClient::connect("e2e_rcpt_flush_b").await?;
+
+    let jid_b = client_b.jid().await;
+
+    const N: usize = 5;
+    let mut msg_ids: Vec<String> = Vec::with_capacity(N);
+    for i in 0..N {
+        let text = format!("flush burst {i}");
+        let id = client_a
+            .client
+            .send_message(jid_b.clone(), text_msg(&text))
+            .await?
+            .message_id;
+        msg_ids.push(id);
+    }
+    info!("A sent {N} messages: {msg_ids:?}");
+
+    // Wait for every message event so later-arriving ones can't slip past the
+    // disconnect. Event::Message dispatches right after the receipt task is
+    // spawned, so by then the receipt may still be queued on the runtime.
+    let mut seen = std::collections::HashSet::<usize>::new();
+    while seen.len() < N {
+        let event = client_b
+            .wait_for_event(15, |e| {
+                matches!(e, Event::Message(m, _) if m
+                    .conversation
+                    .as_deref()
+                    .and_then(|c| c.strip_prefix("flush burst "))
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .is_some_and(|i| i < N))
+            })
+            .await?;
+        if let Event::Message(m, _) = &*event
+            && let Some(i) = m
+                .conversation
+                .as_deref()
+                .and_then(|c| c.strip_prefix("flush burst "))
+                .and_then(|s| s.parse::<usize>().ok())
+        {
+            seen.insert(i);
+        }
+    }
+    info!("B saw all {N} message events");
+
+    client_b.disconnect().await;
+    info!("B disconnected");
+
+    // Dedupe by message_id — server may coalesce or split receipt stanzas.
+    let mut pending: std::collections::HashSet<String> = msg_ids.iter().cloned().collect();
+    while !pending.is_empty() {
+        let event = client_a
+            .wait_for_event(15, |e| {
+                matches!(
+                    e,
+                    Event::Receipt(r)
+                    if r.r#type == ReceiptType::Delivered
+                        && r.message_ids.iter().any(|id| pending.contains(id))
+                )
+            })
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Timed out waiting for delivery receipts, still pending: {:?} ({e})",
+                    pending
+                )
+            })?;
+        if let Event::Receipt(r) = &*event {
+            for id in &r.message_ids {
+                pending.remove(id);
+            }
+        }
+    }
+    info!("A received all {N} delivery receipts");
+
+    client_a.disconnect().await;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- `dispatch_parsed_message` spawns `send_delivery_receipt` as a detached task; `disconnect()` tears down the transport without waiting, so queued receipts hit `NotConnected` and are silently dropped. The server then re-delivers the messages on reconnect, and the next client sees stale prekey/sender-key state.
- Track the spawned tasks via `AtomicUsize` + `event_listener::Event` on `Client`, and drain them (5s bound) before `transport.disconnect()`.

## Test plan
- [x] New e2e regression: `test_delivery_receipts_flushed_on_disconnect` sends a 5-message burst then disconnects B immediately after receiving the last event. Without the fix, ~3/5 receipts are dropped; with the fix, all 5 arrive on A.
- [x] Existing 8 receipt e2e tests still green.
- [x] `cargo clippy --all --tests` clean.
- [x] `cargo test -p whatsapp-rust --lib` (383 passed).

Closes #571