### PR TITLE
refactor(receipt): extract FlushScope primitive; fix PDO leak via shutdown signal

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -426,10 +426,10 @@ pub struct Client {
     pub(crate) history_sync_tasks_in_flight: Arc<AtomicUsize>,
     /// Notifier triggered when history sync work becomes idle.
     pub(crate) history_sync_idle_notifier: Arc<event_listener::Event>,
-    /// Drained by `disconnect()` before tearing down the transport so in-flight
-    /// delivery receipts aren't dropped with `NotConnected` (issue #571).
-    pub(crate) pending_receipt_tasks: AtomicUsize,
-    pub(crate) pending_receipt_tasks_idle: event_listener::Event,
+    /// Flushed by `disconnect()`/`reconnect()` before tearing down the transport
+    /// so in-flight delivery receipts aren't dropped with `NotConnected`
+    /// (issue #571).
+    pub(crate) outbound_flush: Arc<crate::flush_scope::FlushScope>,
     /// Contacts with active presence subscriptions that must be re-subscribed on reconnect.
     pub(crate) presence_subscriptions: Arc<async_lock::Mutex<HashSet<Jid>>>,
     /// Metrics for granular offline sync logging
@@ -762,8 +762,7 @@ impl Client {
             offline_sync_completed: Arc::new(AtomicBool::new(false)),
             history_sync_tasks_in_flight: Arc::new(AtomicUsize::new(0)),
             history_sync_idle_notifier: Arc::new(event_listener::Event::new()),
-            pending_receipt_tasks: AtomicUsize::new(0),
-            pending_receipt_tasks_idle: event_listener::Event::new(),
+            outbound_flush: Arc::new(crate::flush_scope::FlushScope::new()),
             presence_subscriptions: Arc::new(async_lock::Mutex::new(HashSet::new())),
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),
@@ -1220,7 +1219,8 @@ impl Client {
         // we're flushing receipts (issue #571).
         self.notify_connection_shutdown();
 
-        self.wait_for_pending_receipts(std::time::Duration::from_secs(5))
+        self.outbound_flush
+            .flush(&*self.runtime, std::time::Duration::from_secs(5))
             .await;
 
         if let Err(e) = self.persistence_manager.flush().await {
@@ -1231,38 +1231,6 @@ impl Client {
             transport.disconnect().await;
         }
         self.cleanup_connection_state().await;
-    }
-
-    async fn wait_for_pending_receipts(self: &Arc<Self>, timeout: std::time::Duration) {
-        use wacore::time::Instant;
-
-        let deadline = Instant::now() + timeout;
-        loop {
-            let listener = self.pending_receipt_tasks_idle.listen();
-            if self.pending_receipt_tasks.load(Ordering::Acquire) == 0 {
-                return;
-            }
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                log::warn!(
-                    "Timed out flushing {} in-flight delivery receipt task(s) during disconnect",
-                    self.pending_receipt_tasks.load(Ordering::Relaxed)
-                );
-                return;
-            }
-
-            if wacore::runtime::timeout(&*self.runtime, remaining, listener)
-                .await
-                .is_err()
-            {
-                log::warn!(
-                    "Timed out flushing {} in-flight delivery receipt task(s) during disconnect",
-                    self.pending_receipt_tasks.load(Ordering::Relaxed)
-                );
-                return;
-            }
-        }
     }
 
     /// Backoff step used by [`reconnect()`] to create an offline window.
@@ -1291,7 +1259,8 @@ impl Client {
         self.auto_reconnect_errors
             .store(Self::RECONNECT_BACKOFF_STEP, Ordering::Relaxed);
         self.notify_connection_shutdown();
-        self.wait_for_pending_receipts(std::time::Duration::from_secs(2))
+        self.outbound_flush
+            .flush(&*self.runtime, std::time::Duration::from_secs(2))
             .await;
         if let Some(transport) = self.transport.lock().await.as_ref() {
             transport.disconnect().await;
@@ -1307,7 +1276,8 @@ impl Client {
         info!("Reconnecting immediately (expected disconnect).");
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.notify_connection_shutdown();
-        self.wait_for_pending_receipts(std::time::Duration::from_secs(2))
+        self.outbound_flush
+            .flush(&*self.runtime, std::time::Duration::from_secs(2))
             .await;
         if let Some(transport) = self.transport.lock().await.as_ref() {
             transport.disconnect().await;

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -1,0 +1,194 @@
+//! Tracks spawned tasks so a shutdown point can wait for them to complete.
+//!
+//! Used for outbound stanzas (delivery receipts, etc.) that must land before
+//! the transport is torn down (issue #571). The decrement runs via a Drop
+//! guard so the counter can't leak if the task future is cancelled mid-await.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use wacore::runtime::Runtime;
+
+pub struct FlushScope {
+    count: AtomicUsize,
+    idle: event_listener::Event,
+}
+
+impl Default for FlushScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FlushScope {
+    pub fn new() -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+            idle: event_listener::Event::new(),
+        }
+    }
+
+    /// Spawn a tracked task. The counter decrements on completion OR if the
+    /// future is dropped (e.g. aborted), so `flush` can never deadlock waiting
+    /// on a cancelled task.
+    pub fn spawn<F>(self: &Arc<Self>, rt: &dyn Runtime, fut: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        let scope = Arc::clone(self);
+        rt.spawn(Box::pin(async move {
+            let _guard = DecrementOnDrop { scope };
+            fut.await;
+        }))
+        .detach();
+    }
+
+    /// Wait until every tracked task has finished or the timeout elapses.
+    /// Emits a warn log on timeout with the number of leaked tasks.
+    pub async fn flush(&self, rt: &dyn Runtime, timeout: Duration) {
+        use wacore::time::Instant;
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            let listener = self.idle.listen();
+            if self.count.load(Ordering::Relaxed) == 0 {
+                return;
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero()
+                || wacore::runtime::timeout(rt, remaining, listener)
+                    .await
+                    .is_err()
+            {
+                log::warn!(
+                    "FlushScope timed out with {} pending task(s)",
+                    self.count.load(Ordering::Relaxed)
+                );
+                return;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn pending(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+struct DecrementOnDrop {
+    scope: Arc<FlushScope>,
+}
+
+impl Drop for DecrementOnDrop {
+    fn drop(&mut self) {
+        if self.scope.count.fetch_sub(1, Ordering::Relaxed) == 1 {
+            self.scope.idle.notify(usize::MAX);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::time::Instant;
+
+    fn rt() -> Arc<dyn Runtime> {
+        Arc::new(crate::runtime_impl::TokioRuntime)
+    }
+
+    #[tokio::test]
+    async fn flush_returns_after_tasks_complete() {
+        let scope = Arc::new(FlushScope::new());
+        let runtime = rt();
+        for _ in 0..5 {
+            let r = Arc::clone(&runtime);
+            scope.spawn(&*runtime, async move {
+                r.sleep(Duration::from_millis(20)).await;
+            });
+        }
+        assert_eq!(scope.pending(), 5);
+
+        let start = Instant::now();
+        scope.flush(&*runtime, Duration::from_secs(1)).await;
+        assert!(start.elapsed() < Duration::from_millis(500));
+        assert_eq!(scope.pending(), 0);
+    }
+
+    #[tokio::test]
+    async fn flush_returns_immediately_when_idle() {
+        let scope = Arc::new(FlushScope::new());
+        let runtime = rt();
+
+        let start = Instant::now();
+        scope.flush(&*runtime, Duration::from_secs(5)).await;
+        assert!(start.elapsed() < Duration::from_millis(10));
+    }
+
+    #[tokio::test]
+    async fn flush_honors_timeout_and_logs() {
+        let scope = Arc::new(FlushScope::new());
+        let runtime = rt();
+        let r = Arc::clone(&runtime);
+        scope.spawn(&*runtime, async move {
+            r.sleep(Duration::from_secs(10)).await;
+        });
+
+        let start = Instant::now();
+        scope.flush(&*runtime, Duration::from_millis(50)).await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(50));
+        assert!(elapsed < Duration::from_millis(500));
+        assert_eq!(scope.pending(), 1);
+    }
+
+    /// Regression: if a tracked task's future is dropped after being polled
+    /// (the normal abort path), the counter must still decrement via Drop.
+    #[tokio::test]
+    async fn decrement_runs_when_future_is_aborted_mid_flight() {
+        use std::task::{Context, Poll};
+
+        let scope = Arc::new(FlushScope::new());
+        scope.count.fetch_add(1, Ordering::Relaxed);
+
+        let scope_for_fut = Arc::clone(&scope);
+        let mut fut: std::pin::Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
+            let _guard = DecrementOnDrop {
+                scope: scope_for_fut,
+            };
+            futures::future::pending::<()>().await;
+        });
+
+        // Poll once so the guard is constructed and the future suspends on the
+        // inner pending().
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending));
+        assert_eq!(scope.pending(), 1);
+
+        // Simulate abort: drop the in-flight boxed future.
+        drop(fut);
+        assert_eq!(
+            scope.pending(),
+            0,
+            "DecrementOnDrop must fire when the in-flight future is dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn ran_bodies_observe_completion() {
+        let scope = Arc::new(FlushScope::new());
+        let runtime = rt();
+        let done = Arc::new(AtomicBool::new(false));
+        let done_clone = Arc::clone(&done);
+        scope.spawn(&*runtime, async move {
+            done_clone.store(true, Ordering::Relaxed);
+        });
+        scope.flush(&*runtime, Duration::from_secs(1)).await;
+        assert!(done.load(Ordering::Relaxed));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod http;
 pub mod types;
 
 pub mod client;
+pub(crate) mod flush_scope;
 pub use client::Client;
 #[cfg(feature = "debug-diagnostics")]
 pub use client::MemoryDiagnostics;

--- a/src/message.rs
+++ b/src/message.rs
@@ -90,25 +90,9 @@ impl Client {
         // Tracked so `disconnect()` can flush in-flight receipts (issue #571).
         let client_clone = self.clone();
         let info_for_receipt = Arc::clone(&info);
-        self.pending_receipt_tasks
-            .fetch_add(1, std::sync::atomic::Ordering::Release);
-        self.runtime
-            .spawn(Box::pin(async move {
-                client_clone.send_delivery_receipt(&info_for_receipt).await;
-                if client_clone
-                    .pending_receipt_tasks
-                    .fetch_sub(1, std::sync::atomic::Ordering::Release)
-                    <= 1
-                {
-                    // Clamp to 0 so an accidental extra decrement can't wrap the
-                    // counter around and mask future bumps.
-                    client_clone
-                        .pending_receipt_tasks
-                        .store(0, std::sync::atomic::Ordering::Relaxed);
-                    client_clone.pending_receipt_tasks_idle.notify(usize::MAX);
-                }
-            }))
-            .detach();
+        self.outbound_flush.spawn(&*self.runtime, async move {
+            client_clone.send_delivery_receipt(&info_for_receipt).await;
+        });
 
         self.core
             .event_bus

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -466,13 +466,30 @@ impl Client {
 
         let client_clone = Arc::clone(self);
         let info_clone = Arc::clone(info);
+        // Per-connection: on disconnect/reconnect the signal fires and we bail
+        // before inserting into `pdo_pending_requests`, preventing a 30s TTL
+        // strand on an entry that can no longer receive its response.
+        let shutdown = self.connection_shutdown_signal();
 
         self.runtime
             .spawn(Box::pin(async move {
+                use futures::FutureExt;
+
                 if !immediate {
-                    // Add a small delay to allow the retry receipt to be processed first
-                    // This avoids overwhelming the phone with simultaneous requests
-                    client_clone.runtime.sleep(Duration::from_millis(500)).await;
+                    // Delay lets the retry receipt land before we pile PDO on top.
+                    futures::select! {
+                        _ = client_clone
+                            .runtime
+                            .sleep(Duration::from_millis(500))
+                            .fuse() => {}
+                        _ = wacore::runtime::wait_for_shutdown(&shutdown).fuse() => {
+                            return;
+                        }
+                    }
+                }
+
+                if shutdown.is_fired() {
+                    return;
                 }
 
                 if let Err(e) = client_clone


### PR DESCRIPTION
## Summary
- Extracts the receipt-flush pattern from #573 into a reusable `FlushScope` primitive with a Drop-guard decrement (so an aborted task can't leak the counter — per Codex review finding).
- Fixes a fire-and-forget leak in `spawn_pdo_request_with_options` by racing the sleep against the per-connection shutdown signal and checking `is_fired` before the send. No new primitive needed — the existing `ShutdownSignal` pattern (already used in `keepalive`, `ib` handlers) fits.
- Call-site cleanup: receipt spawn goes from ~10 lines of counter bookkeeping to 3. `wait_for_pending_receipts` method + two `Client` fields removed in favor of one `Arc<FlushScope>` field.

## Design notes
- `FlushScope::spawn` uses `self: &Arc<Self>` so the spawned future captures an `Arc` — required because the runtime's `spawn` needs `'static`.
- Decrement runs via `DecrementOnDrop` guard inside the wrapped future, so cancellation (task aborted mid-`.await`) still drops the counter. Without the guard, a single aborted task would permanently stall any future `flush()`.
- PDO aborts BEFORE inserting into `pdo_pending_requests`, so disconnect no longer strands entries for the 30s TTL.
- `AbortScope` was considered and dropped: the CANCEL-class sites (keepalive, ib, etc.) already use `ShutdownSignal` for cooperative cancellation. Replicating that with an abort-based primitive would duplicate infra and give less cleanup control.

## Test plan
- [x] 5 unit tests on `FlushScope`: completes/idle/timeout/decrement-on-abort/body-runs (388 total, +5)
- [x] `cargo clippy --all --tests` clean
- [x] #573 regression `test_delivery_receipts_flushed_on_disconnect` still passes
- [x] Offline/connection e2e pass (exercise `reconnect()` path)
- [ ] E2E coverage for PDO shutdown path is not included (mock server doesn't have a bad-ciphertext helper; the behavior is validated via the pattern match against existing `ib` handler usage)

## Net
229 insertions, 63 deletions. Most of the 229 is the new `flush_scope.rs` (~100 code + ~80 tests).