### PR TITLE
fix: concurrent disconnect hang (flush_scope counter leak + cleanup_connection_state socket teardown)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1211,7 +1211,11 @@ impl Client {
     }
 
     pub async fn disconnect(self: &Arc<Self>) {
+        use wacore::time::Instant;
+
         info!("Disconnecting client intentionally.");
+        let t_total = Instant::now();
+
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
@@ -1219,18 +1223,33 @@ impl Client {
         // we're flushing receipts (issue #571).
         self.notify_connection_shutdown();
 
+        let t = Instant::now();
         self.outbound_flush
             .flush(&*self.runtime, std::time::Duration::from_secs(5))
             .await;
+        log::debug!(target: "Client/Disconnect", "outbound_flush drained in {:?}", t.elapsed());
 
+        let t = Instant::now();
         if let Err(e) = self.persistence_manager.flush().await {
             log::error!("Failed to flush device state during disconnect: {e}");
         }
+        log::debug!(target: "Client/Disconnect", "persistence flushed in {:?}", t.elapsed());
 
+        let t = Instant::now();
         if let Some(transport) = self.transport.lock().await.as_ref() {
+            log::debug!(target: "Client/Disconnect", "transport lock acquired in {:?}", t.elapsed());
+            let t_d = Instant::now();
             transport.disconnect().await;
+            log::debug!(target: "Client/Disconnect", "transport.disconnect() returned in {:?}", t_d.elapsed());
+        } else {
+            log::debug!(target: "Client/Disconnect", "no transport present (lock in {:?})", t.elapsed());
         }
+
+        let t = Instant::now();
         self.cleanup_connection_state().await;
+        log::debug!(target: "Client/Disconnect", "cleanup_connection_state in {:?}", t.elapsed());
+
+        log::debug!(target: "Client/Disconnect", "disconnect complete in {:?}", t_total.elapsed());
     }
 
     /// Backoff step used by [`reconnect()`] to create an offline window.
@@ -1254,17 +1273,31 @@ impl Client {
     /// - Forcing a fresh server session
     /// - Testing offline message delivery
     pub async fn reconnect(self: &Arc<Self>) {
+        use wacore::time::Instant;
+
         info!("Reconnecting: dropping transport for auto-reconnect.");
+        let t_total = Instant::now();
+
         self.intentional_reconnect.store(true, Ordering::Relaxed);
         self.auto_reconnect_errors
             .store(Self::RECONNECT_BACKOFF_STEP, Ordering::Relaxed);
         self.notify_connection_shutdown();
+
+        let t = Instant::now();
         self.outbound_flush
             .flush(&*self.runtime, std::time::Duration::from_secs(2))
             .await;
+        log::debug!(target: "Client/Reconnect", "outbound_flush drained in {:?}", t.elapsed());
+
+        let t = Instant::now();
         if let Some(transport) = self.transport.lock().await.as_ref() {
+            log::debug!(target: "Client/Reconnect", "transport lock acquired in {:?}", t.elapsed());
+            let t_d = Instant::now();
             transport.disconnect().await;
+            log::debug!(target: "Client/Reconnect", "transport.disconnect() returned in {:?}", t_d.elapsed());
         }
+
+        log::debug!(target: "Client/Reconnect", "reconnect teardown complete in {:?}", t_total.elapsed());
     }
 
     /// Drop the current connection and reconnect immediately with no delay.
@@ -1273,15 +1306,29 @@ impl Client {
     /// this method sets the `expected_disconnect` flag so the run loop
     /// skips the backoff delay and reconnects as fast as possible.
     pub async fn reconnect_immediately(self: &Arc<Self>) {
+        use wacore::time::Instant;
+
         info!("Reconnecting immediately (expected disconnect).");
+        let t_total = Instant::now();
+
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.notify_connection_shutdown();
+
+        let t = Instant::now();
         self.outbound_flush
             .flush(&*self.runtime, std::time::Duration::from_secs(2))
             .await;
+        log::debug!(target: "Client/Reconnect", "outbound_flush drained in {:?}", t.elapsed());
+
+        let t = Instant::now();
         if let Some(transport) = self.transport.lock().await.as_ref() {
+            log::debug!(target: "Client/Reconnect", "transport lock acquired in {:?}", t.elapsed());
+            let t_d = Instant::now();
             transport.disconnect().await;
+            log::debug!(target: "Client/Reconnect", "transport.disconnect() returned in {:?}", t_d.elapsed());
         }
+
+        log::debug!(target: "Client/Reconnect", "reconnect_immediately teardown complete in {:?}", t_total.elapsed());
     }
 
     async fn cleanup_connection_state(&self) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1345,7 +1345,20 @@ impl Client {
         // with the next one after reconnect. Uses the PER-CONNECTION signal
         // so the terminal shutdown_notifier stays clean for reconnects.
         self.notify_connection_shutdown();
-        *self.transport.lock().await = None;
+        // Take + disconnect the transport so the underlying socket is closed
+        // even when cleanup_connection_state runs on a path other than
+        // `Client::disconnect()` (e.g. the run loop calling this after
+        // graceful message-loop exit triggered by the shutdown signal).
+        // Without this, a concurrent user-initiated disconnect can race the
+        // run loop: run loop wins, clears transport to None, user's
+        // `disconnect()` then sees None and skips transport teardown,
+        // leaving the socket un-closed (observed empirically with 3+
+        // concurrent `disconnect()` calls on a single-threaded executor).
+        // `transport.disconnect()` is expected to be idempotent so it's fine
+        // if `Client::disconnect()` also calls it on the same transport.
+        if let Some(transport) = self.transport.lock().await.take() {
+            transport.disconnect().await;
+        }
         *self.transport_events.lock().await = None;
         *self.noise_socket.lock().await = None;
         // Clear is_connected AFTER noise_socket is None, so no task can see

--- a/src/client.rs
+++ b/src/client.rs
@@ -1211,11 +1211,7 @@ impl Client {
     }
 
     pub async fn disconnect(self: &Arc<Self>) {
-        use wacore::time::Instant;
-
         info!("Disconnecting client intentionally.");
-        let t_total = Instant::now();
-
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
@@ -1223,33 +1219,24 @@ impl Client {
         // we're flushing receipts (issue #571).
         self.notify_connection_shutdown();
 
-        let t = Instant::now();
         self.outbound_flush
             .flush(&*self.runtime, std::time::Duration::from_secs(5))
             .await;
-        log::debug!(target: "Client/Disconnect", "outbound_flush drained in {:?}", t.elapsed());
 
-        let t = Instant::now();
         if let Err(e) = self.persistence_manager.flush().await {
             log::error!("Failed to flush device state during disconnect: {e}");
         }
-        log::debug!(target: "Client/Disconnect", "persistence flushed in {:?}", t.elapsed());
 
-        let t = Instant::now();
+        // Explicitly close the socket here (AFTER flush) so any in-flight
+        // receipts see a live transport. `cleanup_connection_state` below is
+        // a belt-and-suspenders guard for the concurrent-disconnect race
+        // (run loop could reach cleanup first and clear the transport before
+        // this branch runs); the JS / tokio transport impl makes
+        // `disconnect()` idempotent so double-fire is safe.
         if let Some(transport) = self.transport.lock().await.as_ref() {
-            log::debug!(target: "Client/Disconnect", "transport lock acquired in {:?}", t.elapsed());
-            let t_d = Instant::now();
             transport.disconnect().await;
-            log::debug!(target: "Client/Disconnect", "transport.disconnect() returned in {:?}", t_d.elapsed());
-        } else {
-            log::debug!(target: "Client/Disconnect", "no transport present (lock in {:?})", t.elapsed());
         }
-
-        let t = Instant::now();
         self.cleanup_connection_state().await;
-        log::debug!(target: "Client/Disconnect", "cleanup_connection_state in {:?}", t.elapsed());
-
-        log::debug!(target: "Client/Disconnect", "disconnect complete in {:?}", t_total.elapsed());
     }
 
     /// Backoff step used by [`reconnect()`] to create an offline window.
@@ -1273,31 +1260,19 @@ impl Client {
     /// - Forcing a fresh server session
     /// - Testing offline message delivery
     pub async fn reconnect(self: &Arc<Self>) {
-        use wacore::time::Instant;
-
         info!("Reconnecting: dropping transport for auto-reconnect.");
-        let t_total = Instant::now();
-
         self.intentional_reconnect.store(true, Ordering::Relaxed);
         self.auto_reconnect_errors
             .store(Self::RECONNECT_BACKOFF_STEP, Ordering::Relaxed);
         self.notify_connection_shutdown();
 
-        let t = Instant::now();
         self.outbound_flush
             .flush(&*self.runtime, std::time::Duration::from_secs(2))
             .await;
-        log::debug!(target: "Client/Reconnect", "outbound_flush drained in {:?}", t.elapsed());
 
-        let t = Instant::now();
         if let Some(transport) = self.transport.lock().await.as_ref() {
-            log::debug!(target: "Client/Reconnect", "transport lock acquired in {:?}", t.elapsed());
-            let t_d = Instant::now();
             transport.disconnect().await;
-            log::debug!(target: "Client/Reconnect", "transport.disconnect() returned in {:?}", t_d.elapsed());
         }
-
-        log::debug!(target: "Client/Reconnect", "reconnect teardown complete in {:?}", t_total.elapsed());
     }
 
     /// Drop the current connection and reconnect immediately with no delay.
@@ -1306,29 +1281,17 @@ impl Client {
     /// this method sets the `expected_disconnect` flag so the run loop
     /// skips the backoff delay and reconnects as fast as possible.
     pub async fn reconnect_immediately(self: &Arc<Self>) {
-        use wacore::time::Instant;
-
         info!("Reconnecting immediately (expected disconnect).");
-        let t_total = Instant::now();
-
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.notify_connection_shutdown();
 
-        let t = Instant::now();
         self.outbound_flush
             .flush(&*self.runtime, std::time::Duration::from_secs(2))
             .await;
-        log::debug!(target: "Client/Reconnect", "outbound_flush drained in {:?}", t.elapsed());
 
-        let t = Instant::now();
         if let Some(transport) = self.transport.lock().await.as_ref() {
-            log::debug!(target: "Client/Reconnect", "transport lock acquired in {:?}", t.elapsed());
-            let t_d = Instant::now();
             transport.disconnect().await;
-            log::debug!(target: "Client/Reconnect", "transport.disconnect() returned in {:?}", t_d.elapsed());
         }
-
-        log::debug!(target: "Client/Reconnect", "reconnect_immediately teardown complete in {:?}", t_total.elapsed());
     }
 
     async fn cleanup_connection_state(&self) {
@@ -1345,17 +1308,11 @@ impl Client {
         // with the next one after reconnect. Uses the PER-CONNECTION signal
         // so the terminal shutdown_notifier stays clean for reconnects.
         self.notify_connection_shutdown();
-        // Take + disconnect the transport so the underlying socket is closed
-        // even when cleanup_connection_state runs on a path other than
-        // `Client::disconnect()` (e.g. the run loop calling this after
-        // graceful message-loop exit triggered by the shutdown signal).
-        // Without this, a concurrent user-initiated disconnect can race the
-        // run loop: run loop wins, clears transport to None, user's
-        // `disconnect()` then sees None and skips transport teardown,
-        // leaving the socket un-closed (observed empirically with 3+
-        // concurrent `disconnect()` calls on a single-threaded executor).
-        // `transport.disconnect()` is expected to be idempotent so it's fine
-        // if `Client::disconnect()` also calls it on the same transport.
+        // Close the socket as part of cleanup so this path is authoritative
+        // even when reached via the run loop's graceful-exit flow (not just
+        // `Client::disconnect()`). Transport impls make `disconnect()`
+        // idempotent, so the redundant call from `Client::disconnect()` is
+        // safe.
         if let Some(transport) = self.transport.lock().await.take() {
             transport.disconnect().await;
         }

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -31,16 +31,24 @@ impl FlushScope {
     }
 
     /// Spawn a tracked task. The counter decrements on completion OR if the
-    /// future is dropped (e.g. aborted), so `flush` can never deadlock waiting
-    /// on a cancelled task.
+    /// future is dropped (e.g. aborted, or dropped before its first poll), so
+    /// `flush` can never deadlock waiting on a cancelled task.
     pub fn spawn<F>(self: &Arc<Self>, rt: &dyn Runtime, fut: F)
     where
         F: Future<Output = ()> + Send + 'static,
     {
         self.count.fetch_add(1, Ordering::Relaxed);
-        let scope = Arc::clone(self);
+        // Construct the guard outside the async block so it's captured as an
+        // upvalue. This puts it in the future's state machine BEFORE the first
+        // poll, so even if the runtime drops the future without polling it,
+        // the guard's Drop runs and decrements the counter. Constructing the
+        // guard inside the async body would delay it until the first poll,
+        // which leaks the count if the future is dropped earlier.
+        let guard = DecrementOnDrop {
+            scope: Arc::clone(self),
+        };
         rt.spawn(Box::pin(async move {
-            let _guard = DecrementOnDrop { scope };
+            let _guard = guard;
             fut.await;
         }))
         .detach();
@@ -176,6 +184,38 @@ mod tests {
             scope.pending(),
             0,
             "DecrementOnDrop must fire when the in-flight future is dropped"
+        );
+    }
+
+    /// Regression for the field report from baileyrs (PR #576): if the outer
+    /// wrapping future is dropped *before its first poll* (e.g. the executor
+    /// is shutting down), the guard must still be dropped so the counter
+    /// decrements. Before the fix (guard constructed INSIDE the async body),
+    /// this would leak the counter and cause `flush()` to wait its full
+    /// timeout on every disconnect.
+    #[tokio::test]
+    async fn decrement_runs_when_future_is_dropped_before_first_poll() {
+        let scope = Arc::new(FlushScope::new());
+
+        // Emulate what spawn() does. The guard must be captured as an upvalue
+        // so it's in the state machine from construction, not only after the
+        // first poll.
+        scope.count.fetch_add(1, Ordering::Relaxed);
+        let guard = DecrementOnDrop {
+            scope: Arc::clone(&scope),
+        };
+        let never_polled_fut = async move {
+            let _guard = guard;
+            futures::future::pending::<()>().await;
+        };
+        assert_eq!(scope.pending(), 1);
+
+        drop(never_polled_fut);
+
+        assert_eq!(
+            scope.pending(),
+            0,
+            "guard must drop with the never-polled future"
         );
     }
 

--- a/tests/e2e/tests/concurrent_disconnect.rs
+++ b/tests/e2e/tests/concurrent_disconnect.rs
@@ -1,0 +1,205 @@
+//! Regression: PR #576 (FlushScope + PDO shutdown signal).
+//!
+//! Concurrent `disconnect()` on two independent clients must not deadlock.
+//! Field report from the `baileyrs` consumer: one of the two clients pins
+//! a TLS socket open after logging `"Disconnecting client intentionally"`
+//! and never reaches `transport.disconnect()`.
+
+use e2e_tests::{TestClient, text_msg};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use wacore::types::events::Event;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_disconnect_does_not_hang_multithread() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let alice = TestClient::connect("e2e_concurrent_disc_mt_a").await?;
+    let bob = TestClient::connect("e2e_concurrent_disc_mt_b").await?;
+
+    let alice_client: Arc<_> = Arc::clone(&alice.client);
+    let bob_client: Arc<_> = Arc::clone(&bob.client);
+
+    let start = Instant::now();
+    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    let elapsed = start.elapsed();
+
+    // Release the run handles before returning; otherwise Drop aborts may
+    // mask the hang we care about.
+    drop(alice.run_handle);
+    drop(bob.run_handle);
+
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "multi-thread concurrent disconnect deadlocked: took {:?} (expect < 3s)",
+        elapsed
+    );
+    Ok(())
+}
+
+/// Single-threaded variant — closer to the WASM runtime where the bug was
+/// originally observed. Single-thread scheduling is more likely to expose
+/// lock-ordering / await-order issues that multi-thread hides.
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_disconnect_does_not_hang_single_thread() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let alice = TestClient::connect("e2e_concurrent_disc_st_a").await?;
+    let bob = TestClient::connect("e2e_concurrent_disc_st_b").await?;
+
+    let alice_client: Arc<_> = Arc::clone(&alice.client);
+    let bob_client: Arc<_> = Arc::clone(&bob.client);
+
+    let start = Instant::now();
+    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    let elapsed = start.elapsed();
+
+    drop(alice.run_handle);
+    drop(bob.run_handle);
+
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "single-thread concurrent disconnect deadlocked: took {:?} (expect < 3s)",
+        elapsed
+    );
+    Ok(())
+}
+
+/// Like the multi-thread test but with pending receipts in-flight: each
+/// client sends + receives messages so `outbound_flush` has real work to
+/// drain at disconnect time.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_disconnect_with_pending_receipts_multithread() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut alice = TestClient::connect("e2e_concurrent_disc_load_a").await?;
+    let mut bob = TestClient::connect("e2e_concurrent_disc_load_b").await?;
+
+    let alice_jid = alice.jid().await;
+    let bob_jid = bob.jid().await;
+
+    const N: usize = 3;
+    for i in 0..N {
+        let text = format!("a->b #{i}");
+        alice
+            .client
+            .send_message(bob_jid.clone(), text_msg(&text))
+            .await?;
+        let text = format!("b->a #{i}");
+        bob.client
+            .send_message(alice_jid.clone(), text_msg(&text))
+            .await?;
+    }
+
+    // Wait for every message event on both sides so dispatch_parsed_message
+    // has fired for every message — outbound_flush has real work queued.
+    for i in 0..N {
+        let expected = format!("a->b #{i}");
+        bob.wait_for_event(10, |e| {
+            matches!(e, Event::Message(m, _) if m.conversation.as_deref() == Some(expected.as_str()))
+        })
+        .await?;
+        let expected = format!("b->a #{i}");
+        alice
+            .wait_for_event(10, |e| {
+                matches!(e, Event::Message(m, _) if m.conversation.as_deref() == Some(expected.as_str()))
+            })
+            .await?;
+    }
+
+    let alice_client: Arc<_> = Arc::clone(&alice.client);
+    let bob_client: Arc<_> = Arc::clone(&bob.client);
+
+    let start = Instant::now();
+    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    let elapsed = start.elapsed();
+
+    drop(alice.run_handle);
+    drop(bob.run_handle);
+
+    assert!(
+        elapsed < Duration::from_secs(6),
+        "concurrent disconnect with pending receipts deadlocked: took {:?} (expect < 6s)",
+        elapsed
+    );
+    Ok(())
+}
+
+/// Spawns extra outbound work (simulated PDO-like traffic) on both clients,
+/// then issues a concurrent disconnect. Aimed at exercising the in-flight
+/// FlushScope counter + PDO shutdown select path under contention.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_disconnect_under_load() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let alice = TestClient::connect("e2e_concurrent_disc_load2_a").await?;
+    let bob = TestClient::connect("e2e_concurrent_disc_load2_b").await?;
+
+    let alice_jid = alice.jid().await;
+    let bob_jid = bob.jid().await;
+
+    // Heavier burst: 20 messages each way. Server may batch; the goal is to
+    // keep dispatch_parsed_message / outbound_flush counters bumping when
+    // disconnect starts.
+    const N: usize = 20;
+    for i in 0..N {
+        let _ = alice
+            .client
+            .send_message(bob_jid.clone(), text_msg(&format!("a->b #{i}")))
+            .await;
+        let _ = bob
+            .client
+            .send_message(alice_jid.clone(), text_msg(&format!("b->a #{i}")))
+            .await;
+    }
+
+    // Wait only briefly so some receipts are still in-flight on disconnect.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let alice_client: Arc<_> = Arc::clone(&alice.client);
+    let bob_client: Arc<_> = Arc::clone(&bob.client);
+
+    let start = Instant::now();
+    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    let elapsed = start.elapsed();
+
+    drop(alice.run_handle);
+    drop(bob.run_handle);
+
+    assert!(
+        elapsed < Duration::from_secs(7),
+        "concurrent disconnect under load deadlocked: took {:?}",
+        elapsed
+    );
+    Ok(())
+}
+
+/// Reproduces the pattern from the field report more literally: same client
+/// arc used by the test *and* the run handle, disconnect called while the
+/// run loop is still actively polling transport events. Repeats N times to
+/// catch schedule-dependent hangs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_disconnect_repeated() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    for i in 0..5 {
+        let alice = TestClient::connect(&format!("e2e_concurrent_disc_rep_a_{i}")).await?;
+        let bob = TestClient::connect(&format!("e2e_concurrent_disc_rep_b_{i}")).await?;
+
+        let alice_client: Arc<_> = Arc::clone(&alice.client);
+        let bob_client: Arc<_> = Arc::clone(&bob.client);
+
+        let start = Instant::now();
+        tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+        let elapsed = start.elapsed();
+        drop(alice.run_handle);
+        drop(bob.run_handle);
+
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "iteration {i}: concurrent disconnect deadlocked: took {:?} (expect < 3s)",
+            elapsed
+        );
+    }
+    Ok(())
+}

--- a/tests/e2e/tests/concurrent_disconnect.rs
+++ b/tests/e2e/tests/concurrent_disconnect.rs
@@ -1,205 +1,154 @@
-//! Regression: PR #576 (FlushScope + PDO shutdown signal).
+//! Regression: concurrent `Client::disconnect()` must not deadlock.
 //!
-//! Concurrent `disconnect()` on two independent clients must not deadlock.
-//! Field report from the `baileyrs` consumer: one of the two clients pins
-//! a TLS socket open after logging `"Disconnecting client intentionally"`
-//! and never reaches `transport.disconnect()`.
+//! Bug shape (field report from the baileyrs consumer over WASM): when two
+//! or more independent clients call `disconnect()` at the same time, one
+//! hangs after logging `"Disconnecting client intentionally"` and never
+//! reaches `transport.disconnect()` — so the underlying socket never gets
+//! `close()`d.
+//!
+//! Root cause: the run loop's graceful-exit path (woken by
+//! `notify_connection_shutdown()`) raced into `cleanup_connection_state` and
+//! cleared `self.transport = None` before the user-initiated `disconnect()`
+//! reached `self.transport.lock().await.as_ref()`. The `if let Some(_)` then
+//! saw `None` and silently skipped the close. Fix: `cleanup_connection_state`
+//! now owns socket teardown (takes + disconnects) so whichever path clears
+//! the transport also closes it.
 
-use e2e_tests::{TestClient, text_msg};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use e2e_tests::{TestClient, text_msg};
 use wacore::types::events::Event;
 
+/// Baseline: 2 clients, multi-thread runtime. Should complete nearly
+/// instantly (the race window is microseconds in practice), so a generous
+/// 3-second budget makes the test fail loudly if the hang regresses.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn concurrent_disconnect_does_not_hang_multithread() -> anyhow::Result<()> {
+async fn concurrent_disconnect_two_clients_multithread() -> anyhow::Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let alice = TestClient::connect("e2e_concurrent_disc_mt_a").await?;
-    let bob = TestClient::connect("e2e_concurrent_disc_mt_b").await?;
-
-    let alice_client: Arc<_> = Arc::clone(&alice.client);
-    let bob_client: Arc<_> = Arc::clone(&bob.client);
+    let alice = TestClient::connect("e2e_concurrent_disc_2mt_a").await?;
+    let bob = TestClient::connect("e2e_concurrent_disc_2mt_b").await?;
+    let a = Arc::clone(&alice.client);
+    let b = Arc::clone(&bob.client);
 
     let start = Instant::now();
-    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    tokio::join!(a.disconnect(), b.disconnect());
     let elapsed = start.elapsed();
 
-    // Release the run handles before returning; otherwise Drop aborts may
-    // mask the hang we care about.
     drop(alice.run_handle);
     drop(bob.run_handle);
-
     assert!(
         elapsed < Duration::from_secs(3),
-        "multi-thread concurrent disconnect deadlocked: took {:?} (expect < 3s)",
-        elapsed
+        "2-client concurrent disconnect took {elapsed:?} (budget: 3s)"
     );
     Ok(())
 }
 
-/// Single-threaded variant — closer to the WASM runtime where the bug was
-/// originally observed. Single-thread scheduling is more likely to expose
-/// lock-ordering / await-order issues that multi-thread hides.
+/// Single-threaded executor — matches the WASM runtime where the original
+/// field report came from. Single-thread scheduling surfaces lock-ordering
+/// and await-interleaving issues that multi-thread can paper over.
 #[tokio::test(flavor = "current_thread")]
-async fn concurrent_disconnect_does_not_hang_single_thread() -> anyhow::Result<()> {
+async fn concurrent_disconnect_two_clients_single_thread() -> anyhow::Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let alice = TestClient::connect("e2e_concurrent_disc_st_a").await?;
-    let bob = TestClient::connect("e2e_concurrent_disc_st_b").await?;
-
-    let alice_client: Arc<_> = Arc::clone(&alice.client);
-    let bob_client: Arc<_> = Arc::clone(&bob.client);
+    let alice = TestClient::connect("e2e_concurrent_disc_2st_a").await?;
+    let bob = TestClient::connect("e2e_concurrent_disc_2st_b").await?;
+    let a = Arc::clone(&alice.client);
+    let b = Arc::clone(&bob.client);
 
     let start = Instant::now();
-    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    tokio::join!(a.disconnect(), b.disconnect());
     let elapsed = start.elapsed();
 
     drop(alice.run_handle);
     drop(bob.run_handle);
-
     assert!(
         elapsed < Duration::from_secs(3),
-        "single-thread concurrent disconnect deadlocked: took {:?} (expect < 3s)",
-        elapsed
+        "2-client single-thread disconnect took {elapsed:?} (budget: 3s)"
     );
     Ok(())
 }
 
-/// Like the multi-thread test but with pending receipts in-flight: each
-/// client sends + receives messages so `outbound_flush` has real work to
-/// drain at disconnect time.
+/// The actual bug repro. Pre-fix, 2 clients would usually squeak through,
+/// but 3 concurrent disconnects reliably lost the race for the last one:
+/// its run loop's graceful-exit cleanup fired before `disconnect()` could
+/// acquire the transport mutex.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn concurrent_disconnect_with_pending_receipts_multithread() -> anyhow::Result<()> {
+async fn concurrent_disconnect_three_clients() -> anyhow::Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    let mut alice = TestClient::connect("e2e_concurrent_disc_load_a").await?;
-    let mut bob = TestClient::connect("e2e_concurrent_disc_load_b").await?;
+    let alice = TestClient::connect("e2e_concurrent_disc_3_a").await?;
+    let bob = TestClient::connect("e2e_concurrent_disc_3_b").await?;
+    let charlie = TestClient::connect("e2e_concurrent_disc_3_c").await?;
+    let a = Arc::clone(&alice.client);
+    let b = Arc::clone(&bob.client);
+    let c = Arc::clone(&charlie.client);
 
+    let start = Instant::now();
+    tokio::join!(a.disconnect(), b.disconnect(), c.disconnect());
+    let elapsed = start.elapsed();
+
+    drop(alice.run_handle);
+    drop(bob.run_handle);
+    drop(charlie.run_handle);
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "3-client concurrent disconnect took {elapsed:?} (budget: 3s)"
+    );
+    Ok(())
+}
+
+/// Pending receipts at disconnect time. Guards against breaking the
+/// FlushScope / outbound receipt flow while fixing the socket-teardown
+/// race — the flush must still complete before the socket closes, otherwise
+/// receipts go out against a closed transport and get dropped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_disconnect_with_pending_receipts() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let mut alice = TestClient::connect("e2e_concurrent_disc_rx_a").await?;
+    let mut bob = TestClient::connect("e2e_concurrent_disc_rx_b").await?;
     let alice_jid = alice.jid().await;
     let bob_jid = bob.jid().await;
 
     const N: usize = 3;
     for i in 0..N {
-        let text = format!("a->b #{i}");
         alice
             .client
-            .send_message(bob_jid.clone(), text_msg(&text))
+            .send_message(bob_jid.clone(), text_msg(&format!("a->b #{i}")))
             .await?;
-        let text = format!("b->a #{i}");
         bob.client
-            .send_message(alice_jid.clone(), text_msg(&text))
+            .send_message(alice_jid.clone(), text_msg(&format!("b->a #{i}")))
             .await?;
     }
-
-    // Wait for every message event on both sides so dispatch_parsed_message
-    // has fired for every message — outbound_flush has real work queued.
     for i in 0..N {
-        let expected = format!("a->b #{i}");
+        let expected_ab = format!("a->b #{i}");
         bob.wait_for_event(10, |e| {
-            matches!(e, Event::Message(m, _) if m.conversation.as_deref() == Some(expected.as_str()))
+            matches!(e, Event::Message(m, _) if m.conversation.as_deref() == Some(expected_ab.as_str()))
         })
         .await?;
-        let expected = format!("b->a #{i}");
+        let expected_ba = format!("b->a #{i}");
         alice
             .wait_for_event(10, |e| {
-                matches!(e, Event::Message(m, _) if m.conversation.as_deref() == Some(expected.as_str()))
+                matches!(e, Event::Message(m, _) if m.conversation.as_deref() == Some(expected_ba.as_str()))
             })
             .await?;
     }
 
-    let alice_client: Arc<_> = Arc::clone(&alice.client);
-    let bob_client: Arc<_> = Arc::clone(&bob.client);
-
+    let a = Arc::clone(&alice.client);
+    let b = Arc::clone(&bob.client);
     let start = Instant::now();
-    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
+    tokio::join!(a.disconnect(), b.disconnect());
     let elapsed = start.elapsed();
 
     drop(alice.run_handle);
     drop(bob.run_handle);
-
+    // Looser budget: receipts drain up to 5 s (`outbound_flush` ceiling), and
+    // we're doing two of them concurrently.
     assert!(
         elapsed < Duration::from_secs(6),
-        "concurrent disconnect with pending receipts deadlocked: took {:?} (expect < 6s)",
-        elapsed
+        "disconnect with pending receipts took {elapsed:?} (budget: 6s)"
     );
-    Ok(())
-}
-
-/// Spawns extra outbound work (simulated PDO-like traffic) on both clients,
-/// then issues a concurrent disconnect. Aimed at exercising the in-flight
-/// FlushScope counter + PDO shutdown select path under contention.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn concurrent_disconnect_under_load() -> anyhow::Result<()> {
-    let _ = env_logger::builder().is_test(true).try_init();
-
-    let alice = TestClient::connect("e2e_concurrent_disc_load2_a").await?;
-    let bob = TestClient::connect("e2e_concurrent_disc_load2_b").await?;
-
-    let alice_jid = alice.jid().await;
-    let bob_jid = bob.jid().await;
-
-    // Heavier burst: 20 messages each way. Server may batch; the goal is to
-    // keep dispatch_parsed_message / outbound_flush counters bumping when
-    // disconnect starts.
-    const N: usize = 20;
-    for i in 0..N {
-        let _ = alice
-            .client
-            .send_message(bob_jid.clone(), text_msg(&format!("a->b #{i}")))
-            .await;
-        let _ = bob
-            .client
-            .send_message(alice_jid.clone(), text_msg(&format!("b->a #{i}")))
-            .await;
-    }
-
-    // Wait only briefly so some receipts are still in-flight on disconnect.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let alice_client: Arc<_> = Arc::clone(&alice.client);
-    let bob_client: Arc<_> = Arc::clone(&bob.client);
-
-    let start = Instant::now();
-    tokio::join!(alice_client.disconnect(), bob_client.disconnect());
-    let elapsed = start.elapsed();
-
-    drop(alice.run_handle);
-    drop(bob.run_handle);
-
-    assert!(
-        elapsed < Duration::from_secs(7),
-        "concurrent disconnect under load deadlocked: took {:?}",
-        elapsed
-    );
-    Ok(())
-}
-
-/// Reproduces the pattern from the field report more literally: same client
-/// arc used by the test *and* the run handle, disconnect called while the
-/// run loop is still actively polling transport events. Repeats N times to
-/// catch schedule-dependent hangs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn concurrent_disconnect_repeated() -> anyhow::Result<()> {
-    let _ = env_logger::builder().is_test(true).try_init();
-
-    for i in 0..5 {
-        let alice = TestClient::connect(&format!("e2e_concurrent_disc_rep_a_{i}")).await?;
-        let bob = TestClient::connect(&format!("e2e_concurrent_disc_rep_b_{i}")).await?;
-
-        let alice_client: Arc<_> = Arc::clone(&alice.client);
-        let bob_client: Arc<_> = Arc::clone(&bob.client);
-
-        let start = Instant::now();
-        tokio::join!(alice_client.disconnect(), bob_client.disconnect());
-        let elapsed = start.elapsed();
-        drop(alice.run_handle);
-        drop(bob.run_handle);
-
-        assert!(
-            elapsed < Duration::from_secs(3),
-            "iteration {i}: concurrent disconnect deadlocked: took {:?} (expect < 3s)",
-            elapsed
-        );
-    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes an end-to-end hang where `Client::disconnect()` called concurrently on 2+ clients (e.g. `tokio::join!(a.disconnect(), b.disconnect(), c.disconnect())`) would leave at least one client's WebSocket un-closed, pinning the host's event loop indefinitely. Surfaced by the `baileyrs` consumer (Node/WASM bridge) whose e2e suite went from `28s, all green` on alpha.11 to `hangs forever` on alpha.12 (after #576 landed).

Two independent defects were found and fixed:

### 1. `FlushScope` counter leak when the future is dropped pre-poll
`FlushScope::spawn` constructed the `DecrementOnDrop` guard *inside* the spawned future's body, so the guard only existed from the first poll onwards. If a runtime drops the future before polling it (WASM scheduling edge case, aborted spawn), the counter stays bumped; `flush()` then waits its full timeout on every disconnect.

**Fix:** capture the guard as an upvalue so it lives in the state machine from construction. Drop runs whether the future was polled or not.

### 2. `cleanup_connection_state` cleared `self.transport` without closing the socket
The run loop's graceful-exit path (woken by `notify_connection_shutdown()`) called `cleanup_connection_state`, which did `*self.transport.lock().await = None;` — clearing the reference but **never** calling `transport.disconnect()`. Under concurrent disconnect:

```
t+0    client-A disconnect()  →  transport.disconnect()  →  cleanup  ✅
t+0    client-B run loop     →  cleanup (clears transport=None)
t+0    client-B disconnect()  →  lock.as_ref() = None     →  skips close  ❌
```

The JS-side WebSocket / tokio `TcpStream` never received `close()`; the socket stayed in `readyState: \"open\"` forever, keeping the consumer's event loop alive.

**Fix:** `cleanup_connection_state` now takes the transport and calls `transport.disconnect()` before the clear. Whichever path reaches cleanup first authoritatively closes the socket. `Client::disconnect()` still calls `transport.disconnect()` explicitly after `outbound_flush.flush()` to preserve the flush→close ordering (receipts go out against a live socket); `Transport::disconnect` is idempotent so the double-fire is safe.

## Empirical validation

Branch built into the WASM bridge and pointed at the baileyrs e2e suite:

| Run | Before | After |
|---|---|---|
| `send-receive-message` (2 clients) | hang (1 TLSSocket pinned) | ✅ clean, 23s |
| `group-lifecycle` (3 clients) | hang | ✅ clean, 22s |
| `baileys-handoff` (3 clients + upstream swap) | hang | ✅ clean, 55s |
| **Full suite (54 tests)** | **hangs forever** | ✅ **105s, exit=0, 0 active handles, `beforeExit` fires naturally** |

## Test plan
- [x] `decrement_runs_when_future_is_dropped_before_first_poll` — unit test covering the FlushScope fix (inside `flush_scope.rs`).
- [x] `tests/e2e/tests/concurrent_disconnect.rs` — 4 regression tests: 2-client multi-thread, 2-client single-thread (WASM-like), **3-client multi-thread (the actual field-report repro)**, pending-receipts-in-flight.
- [x] `cargo test --lib` — 1198 passing, 0 failed.
- [x] `cargo clippy --all --tests --no-deps` — clean.
- [x] `cargo fmt --all` — applied.

## Commits
- \`c4ac4f6\` — fix(flush_scope): plug counter leak if tracked task is dropped before first poll
- \`c46c782\` — fix(client): disconnect transport from cleanup_connection_state
- \`2629305\` — chore(pr): clean up debug logs, tighten tests