### PR TITLE
perf(message): off-load LID-PN persist + migrations from the decrypt hot path

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -9,6 +9,8 @@
 //! - Resolving JIDs to their LID equivalents
 //! - Bidirectional lookup (LID to PN and PN to LID)
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use log::debug;
 use wacore::store::traits::LidPnMappingEntry;
@@ -46,31 +48,91 @@ impl Client {
         Ok(())
     }
 
-    /// Add a LID-PN mapping to both the in-memory cache and persistent storage.
-    /// This is called when we learn about a mapping from messages, usync, etc.
-    /// Also migrates any existing PN-keyed device registry entries to LID.
+    /// Awaits the persist + any device/session migrations. Hot paths should
+    /// prefer [`learn_lid_pn_mapping_fast`].
     pub(crate) async fn add_lid_pn_mapping(
         &self,
         lid: &str,
         phone_number: &str,
         source: LearningSource,
     ) -> Result<()> {
-        use anyhow::anyhow;
-        use wacore::store::traits::LidPnMappingEntry;
+        let (entry, is_new_mapping) = self
+            .record_lid_pn_in_memory(lid, phone_number, source)
+            .await;
+        self.persist_and_migrate_lid_pn(entry, is_new_mapping).await
+    }
 
-        // Check if this is a new mapping (not just an update)
+    /// Hot-path variant: cache is updated synchronously (so a subsequent
+    /// `resolve_encryption_jid` sees the mapping), DB write + migrations run
+    /// in a detached task. Matches WA Web's `warmUpLidPnMapping` + the
+    /// deferred `lidPnCacheDirtySet` flush in `WAWebDBCreateLidPnMappings`.
+    ///
+    /// `is_offline` mirrors WA Web's `flushImmediately = msgInfo.offline == null`:
+    /// offline replays only warm the in-memory cache, so a burst of queued
+    /// messages on reconnect doesn't fan out one persist task per message.
+    /// Offline mappings are re-learned from the next live message or usync.
+    ///
+    /// Durability: if the spawned persist task fails (DB error, shutdown
+    /// mid-write), the mapping is only in-memory and will be lost on restart.
+    /// Use [`add_lid_pn_mapping`] when the caller needs a durable guarantee.
+    ///
+    /// Concurrent calls for the same phone number may both observe
+    /// `is_new_mapping = true` and each spawn a persist task. The downstream
+    /// work tolerates this:
+    /// - `put_lid_mapping` is an upsert
+    /// - `migrate_device_registry_on_lid_discovery` no-ops after the PN-keyed
+    ///   record is gone
+    /// - `migrate_signal_sessions_on_lid_discovery` no-ops after the sessions
+    ///   are migrated
+    pub(crate) async fn learn_lid_pn_mapping_fast(
+        self: &Arc<Self>,
+        lid: &str,
+        phone_number: &str,
+        source: LearningSource,
+        is_offline: bool,
+    ) {
+        let (entry, is_new_mapping) = self
+            .record_lid_pn_in_memory(lid, phone_number, source)
+            .await;
+        if is_offline {
+            return;
+        }
+        let client = Arc::clone(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                if let Err(err) = client
+                    .persist_and_migrate_lid_pn(entry, is_new_mapping)
+                    .await
+                {
+                    log::warn!("Background LID-PN persist failed: {err}");
+                }
+            }))
+            .detach();
+    }
+
+    async fn record_lid_pn_in_memory(
+        &self,
+        lid: &str,
+        phone_number: &str,
+        source: LearningSource,
+    ) -> (LidPnEntry, bool) {
         let is_new_mapping = self
             .lid_pn_cache
             .get_current_lid(phone_number)
             .await
             .is_none();
-
-        // Add to in-memory cache
         let entry = LidPnEntry::new(lid.to_string(), phone_number.to_string(), source);
         self.lid_pn_cache.add(&entry).await;
+        (entry, is_new_mapping)
+    }
 
-        // Persist to storage
-        let backend = self.persistence_manager.backend();
+    async fn persist_and_migrate_lid_pn(
+        &self,
+        entry: LidPnEntry,
+        is_new_mapping: bool,
+    ) -> Result<()> {
+        use anyhow::anyhow;
+
         let storage_entry = LidPnMappingEntry {
             lid: entry.lid,
             phone_number: entry.phone_number,
@@ -79,17 +141,23 @@ impl Client {
             learning_source: entry.learning_source.as_str().to_string(),
         };
 
-        backend
+        self.persistence_manager
+            .backend()
             .put_lid_mapping(&storage_entry)
             .await
             .map_err(|e| anyhow!("persisting LID-PN mapping: {e}"))?;
 
-        // If this is a new LID mapping, migrate any existing PN-keyed entries to LID
         if is_new_mapping {
-            self.migrate_device_registry_on_lid_discovery(phone_number, lid)
-                .await;
-            self.migrate_signal_sessions_on_lid_discovery(phone_number, lid)
-                .await;
+            self.migrate_device_registry_on_lid_discovery(
+                &storage_entry.phone_number,
+                &storage_entry.lid,
+            )
+            .await;
+            self.migrate_signal_sessions_on_lid_discovery(
+                &storage_entry.phone_number,
+                &storage_entry.lid,
+            )
+            .await;
         }
 
         Ok(())
@@ -479,5 +547,23 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(entry.lid, lid);
+    }
+
+    /// `learn_lid_pn_mapping_fast` must leave the in-memory cache populated
+    /// by the time it returns — `resolve_encryption_jid` runs immediately
+    /// after on the decrypt hot path and needs to find the LID.
+    #[tokio::test]
+    async fn test_learn_lid_pn_mapping_fast_populates_cache_synchronously() {
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "5511999998877";
+        let lid = "200000000007788";
+
+        client
+            .learn_lid_pn_mapping_fast(lid, pn, LearningSource::PeerPnMessage, false)
+            .await;
+
+        let resolved = client.resolve_encryption_jid(&Jid::pn(pn)).await;
+        assert_eq!(resolved.user, lid, "cache must have the mapping on return");
+        assert_eq!(resolved.server, Server::Lid);
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -336,9 +336,12 @@ impl Client {
             return None;
         }
 
-        // Warm LID-PN cache before resolution so resolve_encryption_jid() finds the mapping
-        self.cache_lid_pn_from_message(&info.source.sender, info.source.sender_alt.as_ref())
-            .await;
+        self.cache_lid_pn_from_message(
+            &info.source.sender,
+            info.source.sender_alt.as_ref(),
+            info.is_offline,
+        )
+        .await;
         let sender_encryption_jid = self.resolve_encryption_jid(&info.source.sender).await;
 
         let unavailable_node = nr.get_optional_child("unavailable");
@@ -1392,8 +1395,12 @@ impl Client {
         }
     }
 
-    /// Cache LID-PN mapping from message attributes (before resolve_encryption_jid).
-    async fn cache_lid_pn_from_message(&self, sender: &Jid, alt: Option<&Jid>) {
+    async fn cache_lid_pn_from_message(
+        self: &Arc<Self>,
+        sender: &Jid,
+        alt: Option<&Jid>,
+        is_offline: bool,
+    ) {
         let (lid_user, pn_user, source) = if sender.is_lid() {
             if let Some(alt_jid) = alt
                 && alt_jid.is_pn()
@@ -1422,12 +1429,8 @@ impl Client {
             return;
         };
 
-        if let Err(err) = self.add_lid_pn_mapping(lid_user, pn_user, source).await {
-            warn!(
-                "Failed to cache LID-PN mapping {} <-> {}: {err}",
-                lid_user, pn_user
-            );
-        }
+        self.learn_lid_pn_mapping_fast(lid_user, pn_user, source, is_offline)
+            .await;
     }
 
     pub(crate) async fn parse_message_info(


### PR DESCRIPTION
## Summary
- Field report: 100-130ms pre-decrypt stalls in `classify_incoming_message` for ~3% of group messages with LID-PN migration. Root cause: the hot path awaits a SQLite `put_lid_mapping` + two Signal/device-registry migrations before `resolve_encryption_jid`, even though those only affect future messages — the in-memory cache already has what resolution needs.
- WA Web does this split (`docs/captured-js/WAWeb/DB/CreateLidPnMappings.js`): `warmUpLidPnMapping` is sync, DB write is either batched (`flushImmediately=true`) or queued in `lidPnCacheDirtySet`. For offline replays `flushImmediately=false`.

## Change
- `record_lid_pn_in_memory` (sync cache update) + `persist_and_migrate_lid_pn` (DB + migrations) extracted so `add_lid_pn_mapping` (awaited, used by usync/pair/notifications) and a new `learn_lid_pn_mapping_fast` (detached, used by message hot path) share code.
- `learn_lid_pn_mapping_fast` takes `is_offline`; offline replays only warm the cache — same shape as WA Web.
- `cache_lid_pn_from_message` threads `MessageInfo.is_offline` through.

## Properties
- **Correctness**: after `learn_lid_pn_mapping_fast` returns, `resolve_encryption_jid` finds the mapping (unit test added).
- **Allocations**: zero extra clones on the hot path. `entry` is moved into `LidPnMappingEntry`; migrations borrow from it.
- **Race**: two concurrent learns for the same PN both spawn detached persists. `put_lid_mapping` is upsert; both migrations are idempotent after the first completes. Documented in the method doc rather than adding a dedup lock.
- **Durability**: fast path is best-effort. Callers needing a durable guarantee should use `add_lid_pn_mapping` (doc explains this).

## Test plan
- [x] `cargo clippy --all --tests`
- [x] `cargo test -p whatsapp-rust --lib` (390 passed, +1 test)
- [x] `cargo test -p e2e-tests --test receipts --test offline_messages --test connection --test messaging --test concurrent_disconnect` green
- [ ] Not included: an e2e reproduction of the 100-130ms latency. Would need a 1500-member group with active LID migration — outside our mock server's scope. Field validation by the reporter on their workload is the next step.