### PR TITLE
fix(send): close LID↔PN zombie path for group prekey 406 latency spikes

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -1234,4 +1234,207 @@ mod tests {
             "sender key cache should have been invalidated after device removal"
         );
     }
+
+    // ── LID↔PN zombie-path regression tests (PR #579) ───────────────────
+
+    /// U1 — `update_device_list` deletes the stale DB row when the canonical
+    /// key flips (e.g. the LID↔PN mapping is learned between two writes).
+    /// Without this, the old PN-keyed row lingers and re-surfaces as a zombie
+    /// through alias lookup, causing 406s on group sends.
+    #[tokio::test]
+    async fn test_update_device_list_canonical_flip_deletes_old_db_row() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        let client = create_test_client().await;
+        let pn = "15550000011";
+        let lid = "100000000000011";
+        let backend = client.persistence_manager.backend();
+
+        // Legacy state: DB row stored under PN (mapping wasn't known yet).
+        backend
+            .update_device_list(DeviceListRecord {
+                user: pn.to_string(),
+                devices: vec![DeviceInfo {
+                    device_id: 5,
+                    key_index: None,
+                }],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        setup_lid_pn(&client, lid, pn).await;
+
+        // New write: `update_device_list` with original_user = PN, canonical
+        // now resolves to LID because the mapping is known.
+        client
+            .update_device_list(DeviceListRecord {
+                user: pn.to_string(),
+                devices: vec![DeviceInfo {
+                    device_id: 7,
+                    key_index: None,
+                }],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            backend.get_devices(pn).await.unwrap().is_none(),
+            "old PN-keyed DB row must be deleted after canonical flip"
+        );
+        let lid_row = backend.get_devices(lid).await.unwrap();
+        assert!(lid_row.is_some(), "new LID-keyed DB row must exist");
+        assert_eq!(lid_row.unwrap().devices[0].device_id, 7);
+    }
+
+    /// U2 — `migrate_device_registry_on_lid_discovery` deletes the PN-keyed DB
+    /// row, not just the cache entry. Without this the PN row stayed around
+    /// as a zombie that surfaced via alias lookup on future sends.
+    #[tokio::test]
+    async fn test_migrate_device_registry_deletes_pn_db_row() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        let client = create_test_client().await;
+        let pn = "15550000022";
+        let lid = "100000000000022";
+        let backend = client.persistence_manager.backend();
+
+        backend
+            .update_device_list(DeviceListRecord {
+                user: pn.to_string(),
+                devices: vec![DeviceInfo {
+                    device_id: 0,
+                    key_index: None,
+                }],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        setup_lid_pn(&client, lid, pn).await;
+
+        client
+            .migrate_device_registry_on_lid_discovery(pn, lid)
+            .await;
+
+        assert!(
+            backend.get_devices(pn).await.unwrap().is_none(),
+            "PN-keyed DB row must be gone after migration"
+        );
+        assert!(
+            backend.get_devices(lid).await.unwrap().is_some(),
+            "LID-keyed DB row must exist after migration"
+        );
+    }
+
+    /// U3 — `invalidate_device_cache` with a known LID↔PN mapping clears both
+    /// aliases from the DB (not only the cache). This is the primary fix for
+    /// the 23-batches-in-3h45m zombie loop from the field report.
+    #[tokio::test]
+    async fn test_invalidate_device_cache_clears_both_aliases_from_db() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        let client = create_test_client().await;
+        let pn = "15550000033";
+        let lid = "100000000000033";
+        let backend = client.persistence_manager.backend();
+
+        // Seed DB under BOTH aliases (simulating split-brain legacy state).
+        for user in [pn, lid] {
+            backend
+                .update_device_list(DeviceListRecord {
+                    user: user.to_string(),
+                    devices: vec![DeviceInfo {
+                        device_id: 1,
+                        key_index: None,
+                    }],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                })
+                .await
+                .unwrap();
+        }
+        setup_lid_pn(&client, lid, pn).await;
+
+        client.invalidate_device_cache(lid).await;
+
+        assert!(
+            backend.get_devices(pn).await.unwrap().is_none(),
+            "PN DB row must be deleted via alias resolution"
+        );
+        assert!(
+            backend.get_devices(lid).await.unwrap().is_none(),
+            "LID DB row must be deleted"
+        );
+        assert!(
+            client.device_registry_cache.get(pn).await.is_none(),
+            "PN cache entry must be gone"
+        );
+        assert!(
+            client.device_registry_cache.get(lid).await.is_none(),
+            "LID cache entry must be gone"
+        );
+    }
+
+    /// U4 — TOCTOU regression: even if the cache got repopulated between the
+    /// pre-delete `invalidate` and the DB `delete_devices`, the post-delete
+    /// `invalidate` wipes it out. Simulated by pre-seeding both cache and DB
+    /// under PN, then running the canonical-flip write.
+    #[tokio::test]
+    async fn test_update_device_list_toctou_second_invalidate_clears_resurrected_cache() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        let client = create_test_client().await;
+        let pn = "15550000044";
+        let lid = "100000000000044";
+        let backend = client.persistence_manager.backend();
+
+        let legacy = DeviceListRecord {
+            user: pn.to_string(),
+            devices: vec![DeviceInfo {
+                device_id: 9,
+                key_index: None,
+            }],
+            timestamp: wacore::time::now_secs(),
+            phash: None,
+            raw_id: None,
+        };
+        backend.update_device_list(legacy.clone()).await.unwrap();
+        // Pre-populate cache[PN] directly to emulate a concurrent reader that
+        // loaded from the DB row between the two invalidate calls.
+        client.device_registry_cache.insert(pn.into(), legacy).await;
+
+        setup_lid_pn(&client, lid, pn).await;
+
+        client
+            .update_device_list(DeviceListRecord {
+                user: pn.to_string(),
+                devices: vec![DeviceInfo {
+                    device_id: 10,
+                    key_index: None,
+                }],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            client.device_registry_cache.get(pn).await.is_none(),
+            "second invalidate must clear the pre-populated cache entry"
+        );
+        assert!(
+            backend.get_devices(pn).await.unwrap().is_none(),
+            "PN DB row must still be gone"
+        );
+    }
 }

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -168,6 +168,18 @@ impl Client {
             .context("Failed to update device list in backend")?;
 
         if canonical_key != original_user {
+            // Invalidate before + after delete so a concurrent reader that
+            // resurrects the cache from the about-to-be-deleted DB row still
+            // gets cleared. Run the second invalidate unconditionally: even
+            // if delete fails, the cache may have been repopulated with data
+            // that no longer reflects our intent.
+            self.device_registry_cache.invalidate(&original_user).await;
+            if let Err(e) = backend.delete_devices(&original_user).await {
+                warn!(
+                    "Failed to delete stale device row under {} after canonical flip: {e}",
+                    original_user
+                );
+            }
             self.device_registry_cache.invalidate(&original_user).await;
             debug!(
                 "Device registry: stored under LID {} (resolved from {})",
@@ -528,7 +540,15 @@ impl Client {
                     .insert(lid.to_string(), record)
                     .await;
 
-                // Clean up stale PN-keyed entry without touching the fresh LID entry.
+                // Drop the PN-keyed row in both cache and DB. Invalidate
+                // twice (before + after delete) so a concurrent reader can't
+                // resurrect the cache from the DB row between the two calls.
+                // Always run the second invalidate; even if delete fails, the
+                // cache may carry resurrected data that shouldn't stick.
+                self.device_registry_cache.invalidate(pn).await;
+                if let Err(e) = backend.delete_devices(pn).await {
+                    warn!("Failed to delete PN-keyed device row during LID migration: {e}");
+                }
                 self.device_registry_cache.invalidate(pn).await;
             }
             Ok(None) => {}

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -1384,12 +1384,22 @@ mod tests {
         );
     }
 
-    /// U4 — TOCTOU regression: even if the cache got repopulated between the
-    /// pre-delete `invalidate` and the DB `delete_devices`, the post-delete
-    /// `invalidate` wipes it out. Simulated by pre-seeding both cache and DB
-    /// under PN, then running the canonical-flip write.
+    /// U4 — canonical-flip path with a warm cache: no zombie entry survives.
+    ///
+    /// This does *not* deterministically exercise the TOCTOU window between
+    /// invalidate1 and delete — the first invalidate clears the pre-seeded
+    /// cache, so the test would pass even without the post-delete second
+    /// invalidate. Reaching that window requires interleaving a concurrent
+    /// reader between those two calls, which would need a backend-level
+    /// latch (i.e., wrapping `Backend` to run a hook before `delete_devices`).
+    /// The full trait has ~50 methods via blanket impl, so that machinery is
+    /// out of scope for this PR; the double-invalidate lives on as
+    /// defense-in-depth validated by code review rather than this test.
+    ///
+    /// What this still guards: the first invalidate + DB delete end-to-end
+    /// (removing either one would fail this test).
     #[tokio::test]
-    async fn test_update_device_list_toctou_second_invalidate_clears_resurrected_cache() {
+    async fn test_update_device_list_canonical_flip_clears_warm_cache() {
         use wacore::store::traits::{DeviceInfo, DeviceListRecord};
 
         let client = create_test_client().await;
@@ -1408,8 +1418,8 @@ mod tests {
             raw_id: None,
         };
         backend.update_device_list(legacy.clone()).await.unwrap();
-        // Pre-populate cache[PN] directly to emulate a concurrent reader that
-        // loaded from the DB row between the two invalidate calls.
+        // Warm cache under PN to simulate a reader that populated it before
+        // the mapping was learned.
         client.device_registry_cache.insert(pn.into(), legacy).await;
 
         setup_lid_pn(&client, lid, pn).await;
@@ -1430,11 +1440,11 @@ mod tests {
 
         assert!(
             client.device_registry_cache.get(pn).await.is_none(),
-            "second invalidate must clear the pre-populated cache entry"
+            "cache[pn] must be cleared after canonical flip"
         );
         assert!(
             backend.get_devices(pn).await.unwrap().is_none(),
-            "PN DB row must still be gone"
+            "DB[pn] must be deleted after canonical flip"
         );
     }
 }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -110,6 +110,64 @@ impl Client {
             .detach();
     }
 
+    /// Batched variant of [`learn_lid_pn_mapping_fast`]. Updates the in-memory
+    /// cache synchronously for every entry, then fires one detached task that
+    /// persists the whole batch in a single backend transaction and runs the
+    /// device/session migrations for newly discovered PN↔LID pairs.
+    ///
+    /// Mirrors WA Web's `createLidPnMappings({ mappings, flushImmediately, learningSource })`
+    /// call shape: one backend write for N participants instead of N detached
+    /// tasks racing each other. The savings are linear in batch size and
+    /// matter most on first `query_info` of large groups.
+    ///
+    /// `is_offline` mirrors the single-entry path: skip the persist task for
+    /// offline replays; mappings are re-learned from the next live event.
+    ///
+    /// Takes owned `(lid, phone_number)` pairs; each `String` moves directly
+    /// into the `LidPnEntry` stored in the cache, then (via `into_iter`) into
+    /// the `LidPnMappingEntry` that's persisted — no clones on either step.
+    /// The `Vec` itself is consumed, so no copy of the outer container either.
+    pub(crate) async fn learn_lid_pn_mappings_batch(
+        self: &Arc<Self>,
+        mappings: Vec<(String, String)>,
+        source: LearningSource,
+        is_offline: bool,
+    ) {
+        if mappings.is_empty() {
+            return;
+        }
+        let cap = mappings.len();
+        let mut entries: Vec<LidPnEntry> = Vec::with_capacity(cap);
+        let mut is_new_flags: Vec<bool> = Vec::with_capacity(cap);
+        for (lid, phone_number) in mappings {
+            let is_new = self
+                .lid_pn_cache
+                .get_current_lid(&phone_number)
+                .await
+                .is_none();
+            let entry = LidPnEntry::new(lid, phone_number, source);
+            self.lid_pn_cache.add(&entry).await;
+            entries.push(entry);
+            is_new_flags.push(is_new);
+        }
+
+        if is_offline {
+            return;
+        }
+
+        let client = Arc::clone(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                if let Err(err) = client
+                    .persist_and_migrate_lid_pn_batch(entries, is_new_flags)
+                    .await
+                {
+                    log::warn!("Background LID-PN batch persist failed: {err}");
+                }
+            }))
+            .detach();
+    }
+
     async fn record_lid_pn_in_memory(
         &self,
         lid: &str,
@@ -158,6 +216,45 @@ impl Client {
                 &storage_entry.lid,
             )
             .await;
+        }
+
+        Ok(())
+    }
+
+    async fn persist_and_migrate_lid_pn_batch(
+        &self,
+        entries: Vec<LidPnEntry>,
+        is_new_flags: Vec<bool>,
+    ) -> Result<()> {
+        use anyhow::anyhow;
+
+        // Consume entries so `lid`/`phone_number` move into storage rather
+        // than being cloned. Only `learning_source` is allocated, and only
+        // because `LidPnMappingEntry.learning_source` is a `String` field.
+        let storage: Vec<LidPnMappingEntry> = entries
+            .into_iter()
+            .map(|entry| LidPnMappingEntry {
+                lid: entry.lid,
+                phone_number: entry.phone_number,
+                created_at: entry.created_at,
+                updated_at: entry.created_at,
+                learning_source: entry.learning_source.as_str().to_string(),
+            })
+            .collect();
+
+        self.persistence_manager
+            .backend()
+            .put_lid_mappings(&storage)
+            .await
+            .map_err(|e| anyhow!("persisting LID-PN mapping batch: {e}"))?;
+
+        for (entry, is_new) in storage.iter().zip(is_new_flags.iter()) {
+            if *is_new {
+                self.migrate_device_registry_on_lid_discovery(&entry.phone_number, &entry.lid)
+                    .await;
+                self.migrate_signal_sessions_on_lid_discovery(&entry.phone_number, &entry.lid)
+                    .await;
+            }
         }
 
         Ok(())
@@ -565,5 +662,74 @@ mod tests {
         let resolved = client.resolve_encryption_jid(&Jid::pn(pn)).await;
         assert_eq!(resolved.user, lid, "cache must have the mapping on return");
         assert_eq!(resolved.server, Server::Lid);
+    }
+
+    /// Batched variant must populate the in-memory cache synchronously for
+    /// every entry before returning; WA Web parity for `createLidPnMappings`.
+    #[tokio::test]
+    async fn test_learn_lid_pn_mappings_batch_populates_cache_synchronously() {
+        let client: Arc<Client> = create_test_client().await;
+        let pairs = [
+            ("200000000000001", "5511911111111"),
+            ("200000000000002", "5511922222222"),
+            ("200000000000003", "5511933333333"),
+        ];
+
+        let batch: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(lid, pn)| ((*lid).to_string(), (*pn).to_string()))
+            .collect();
+        client
+            .learn_lid_pn_mappings_batch(batch, LearningSource::Other, false)
+            .await;
+
+        for (lid, pn) in &pairs {
+            let resolved = client.resolve_encryption_jid(&Jid::pn(*pn)).await;
+            assert_eq!(resolved.user, *lid, "batch entry {pn} missing from cache");
+            assert_eq!(resolved.server, Server::Lid);
+        }
+    }
+
+    /// Empty batch is a no-op (no detached task, no panic).
+    #[tokio::test]
+    async fn test_learn_lid_pn_mappings_batch_empty_is_noop() {
+        let client: Arc<Client> = create_test_client().await;
+        client
+            .learn_lid_pn_mappings_batch(Vec::new(), LearningSource::Other, false)
+            .await;
+        assert_eq!(client.lid_pn_cache.lid_count().await, 0);
+    }
+
+    /// Offline batch only warms the in-memory cache; the persist task never
+    /// fires. Mirrors WA Web's `flushImmediately = false` semantics.
+    #[tokio::test]
+    async fn test_learn_lid_pn_mappings_batch_offline_skips_persist() {
+        use wacore_binary::Jid;
+
+        let client: Arc<Client> = create_test_client().await;
+        let lid = "200000000009999";
+        let pn = "5511900009999";
+
+        client
+            .learn_lid_pn_mappings_batch(
+                vec![(lid.to_string(), pn.to_string())],
+                LearningSource::Other,
+                true,
+            )
+            .await;
+
+        let resolved = client.resolve_encryption_jid(&Jid::pn(pn)).await;
+        assert_eq!(resolved.user, lid);
+
+        assert!(
+            client
+                .persistence_manager
+                .backend()
+                .get_lid_mapping(lid)
+                .await
+                .unwrap()
+                .is_none(),
+            "offline batch must not persist to DB"
+        );
     }
 }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -700,6 +700,84 @@ mod tests {
         assert_eq!(client.lid_pn_cache.lid_count().await, 0);
     }
 
+    /// Online (`is_offline = false`) batch must persist the mapping to the
+    /// backend AND run `migrate_device_registry_on_lid_discovery` for each
+    /// newly learned PN. Polls until the detached task completes.
+    #[tokio::test]
+    async fn test_learn_lid_pn_mappings_batch_online_persists_and_migrates() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+        use wacore_binary::Jid;
+
+        let client: Arc<Client> = create_test_client().await;
+        let lid = "200000000077777";
+        let pn = "5511955550000";
+        let backend = client.persistence_manager.backend();
+
+        // Seed a PN-keyed device registry row so the migration has something
+        // to move when the mapping is learned. Without this, the migration
+        // helper is a no-op and the test can't distinguish "migration ran"
+        // from "migration never called".
+        backend
+            .update_device_list(DeviceListRecord {
+                user: pn.to_string(),
+                devices: vec![DeviceInfo {
+                    device_id: 3,
+                    key_index: None,
+                }],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        client
+            .learn_lid_pn_mappings_batch(
+                vec![(lid.to_string(), pn.to_string())],
+                LearningSource::Other,
+                false,
+            )
+            .await;
+
+        // Poll for the end-of-chain migration effect (device row moved to
+        // LID key). That strictly happens after both `put_lid_mappings` and
+        // `migrate_device_registry_on_lid_discovery`, so observing it
+        // guarantees both steps ran.
+        let start = std::time::Instant::now();
+        let deadline = std::time::Duration::from_secs(5);
+        loop {
+            if backend.get_devices(lid).await.unwrap().is_some() {
+                break;
+            }
+            assert!(
+                start.elapsed() < deadline,
+                "timed out waiting for batch persist + migration"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        assert!(
+            backend.get_lid_mapping(lid).await.unwrap().is_some(),
+            "mapping must be persisted"
+        );
+        assert!(
+            backend.get_devices(pn).await.unwrap().is_none(),
+            "migration must delete the old PN-keyed device row"
+        );
+        let lid_row = backend.get_devices(lid).await.unwrap().unwrap();
+        assert_eq!(lid_row.devices[0].device_id, 3);
+        // And the mapping resolves from both directions.
+        assert_eq!(
+            client
+                .get_lid_pn_entry(&Jid::pn(pn))
+                .await
+                .unwrap()
+                .unwrap()
+                .lid,
+            lid
+        );
+    }
+
     /// Offline batch only warms the in-memory cache; the persist task never
     /// fires. Mirrors WA Web's `flushImmediately = false` semantics.
     #[tokio::test]

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -212,22 +212,25 @@ impl<'a> Groups<'a> {
         // Populate lid_pn_cache so silent-observer participants (no messages
         // from them) get their mapping; otherwise `invalidate_device_cache`
         // can't resolve the PN alias and leaves zombie registry entries.
+        // One batched call mirrors WA Web's single `createLidPnMappings`
+        // invocation from `QueryGroupJob`, so N participants = 1 persist
+        // task + 1 DB transaction instead of N detached tasks.
         if !lid_to_pn_map.is_empty()
             && let Some(client_arc) = self.client.self_weak.get().and_then(|w| w.upgrade())
         {
+            let mut batch: Vec<(String, String)> = Vec::with_capacity(lid_to_pn_map.len());
             for (lid_user, pn_jid) in &lid_to_pn_map {
-                if !pn_jid.is_pn() {
-                    continue;
+                if pn_jid.is_pn() {
+                    batch.push((lid_user.as_str().to_string(), pn_jid.user.to_string()));
                 }
-                client_arc
-                    .learn_lid_pn_mapping_fast(
-                        lid_user.as_str(),
-                        &pn_jid.user,
-                        crate::lid_pn_cache::LearningSource::Other,
-                        false,
-                    )
-                    .await;
             }
+            client_arc
+                .learn_lid_pn_mappings_batch(
+                    batch,
+                    crate::lid_pn_cache::LearningSource::Other,
+                    false,
+                )
+                .await;
         }
 
         let mut info = GroupInfo::new(participants, group.addressing_mode);

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -209,6 +209,27 @@ impl<'a> Groups<'a> {
             participants.push(p.jid);
         }
 
+        // Populate lid_pn_cache so silent-observer participants (no messages
+        // from them) get their mapping; otherwise `invalidate_device_cache`
+        // can't resolve the PN alias and leaves zombie registry entries.
+        if !lid_to_pn_map.is_empty()
+            && let Some(client_arc) = self.client.self_weak.get().and_then(|w| w.upgrade())
+        {
+            for (lid_user, pn_jid) in &lid_to_pn_map {
+                if !pn_jid.is_pn() {
+                    continue;
+                }
+                client_arc
+                    .learn_lid_pn_mapping_fast(
+                        lid_user.as_str(),
+                        &pn_jid.user,
+                        crate::lid_pn_cache::LearningSource::Other,
+                        false,
+                    )
+                    .await;
+            }
+        }
+
         let mut info = GroupInfo::new(participants, group.addressing_mode);
         if !lid_to_pn_map.is_empty() {
             info.set_lid_to_pn_map(lid_to_pn_map);

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1894,41 +1894,39 @@ impl ProtocolStore for SqliteStore {
         if entries.is_empty() {
             return Ok(());
         }
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        let entries: Vec<LidPnMappingEntry> = entries.to_vec();
-        tokio::task::spawn_blocking(move || -> Result<()> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
-            conn.transaction::<_, diesel::result::Error, _>(|conn| {
-                for entry in &entries {
-                    diesel::insert_into(lid_pn_mapping::table)
-                        .values((
-                            lid_pn_mapping::lid.eq(&entry.lid),
-                            lid_pn_mapping::phone_number.eq(&entry.phone_number),
-                            lid_pn_mapping::created_at.eq(entry.created_at),
-                            lid_pn_mapping::learning_source.eq(&entry.learning_source),
-                            lid_pn_mapping::updated_at.eq(entry.updated_at),
-                            lid_pn_mapping::device_id.eq(device_id),
-                        ))
-                        .on_conflict((lid_pn_mapping::lid, lid_pn_mapping::device_id))
-                        .do_update()
-                        .set((
-                            lid_pn_mapping::phone_number.eq(&entry.phone_number),
-                            lid_pn_mapping::learning_source.eq(&entry.learning_source),
-                            lid_pn_mapping::updated_at.eq(entry.updated_at),
-                        ))
-                        .execute(conn)?;
-                }
-                Ok(())
+        // Share the batch across retry attempts via Arc so no retry re-clones
+        // the Vec. `with_retry` invokes `make_op` once per attempt; we only
+        // bump the Arc refcount.
+        let entries: std::sync::Arc<Vec<LidPnMappingEntry>> = std::sync::Arc::new(entries.to_vec());
+        self.with_retry("put_lid_mappings", move || {
+            let entries = std::sync::Arc::clone(&entries);
+            Box::new(move |conn: &mut SqliteConnection| {
+                conn.transaction::<_, DieselError, _>(|conn| {
+                    for entry in entries.iter() {
+                        diesel::insert_into(lid_pn_mapping::table)
+                            .values((
+                                lid_pn_mapping::lid.eq(&entry.lid),
+                                lid_pn_mapping::phone_number.eq(&entry.phone_number),
+                                lid_pn_mapping::created_at.eq(entry.created_at),
+                                lid_pn_mapping::learning_source.eq(&entry.learning_source),
+                                lid_pn_mapping::updated_at.eq(entry.updated_at),
+                                lid_pn_mapping::device_id.eq(device_id),
+                            ))
+                            .on_conflict((lid_pn_mapping::lid, lid_pn_mapping::device_id))
+                            .do_update()
+                            .set((
+                                lid_pn_mapping::phone_number.eq(&entry.phone_number),
+                                lid_pn_mapping::learning_source.eq(&entry.learning_source),
+                                lid_pn_mapping::updated_at.eq(entry.updated_at),
+                            ))
+                            .execute(conn)?;
+                    }
+                    Ok(())
+                })
             })
-            .map_err(|e| StoreError::Database(e.to_string()))?;
-            Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
-        Ok(())
     }
 
     async fn get_all_lid_mappings(&self) -> Result<Vec<LidPnMappingEntry>> {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1887,31 +1887,43 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn put_lid_mapping(&self, entry: &LidPnMappingEntry) -> Result<()> {
+        self.put_lid_mappings(std::slice::from_ref(entry)).await
+    }
+
+    async fn put_lid_mappings(&self, entries: &[LidPnMappingEntry]) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
         let pool = self.pool.clone();
         let device_id = self.device_id;
-        let entry = entry.clone();
+        let entries: Vec<LidPnMappingEntry> = entries.to_vec();
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(e.to_string()))?;
-            diesel::insert_into(lid_pn_mapping::table)
-                .values((
-                    lid_pn_mapping::lid.eq(&entry.lid),
-                    lid_pn_mapping::phone_number.eq(&entry.phone_number),
-                    lid_pn_mapping::created_at.eq(entry.created_at),
-                    lid_pn_mapping::learning_source.eq(&entry.learning_source),
-                    lid_pn_mapping::updated_at.eq(entry.updated_at),
-                    lid_pn_mapping::device_id.eq(device_id),
-                ))
-                .on_conflict((lid_pn_mapping::lid, lid_pn_mapping::device_id))
-                .do_update()
-                .set((
-                    lid_pn_mapping::phone_number.eq(&entry.phone_number),
-                    lid_pn_mapping::learning_source.eq(&entry.learning_source),
-                    lid_pn_mapping::updated_at.eq(entry.updated_at),
-                ))
-                .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+            conn.transaction::<_, diesel::result::Error, _>(|conn| {
+                for entry in &entries {
+                    diesel::insert_into(lid_pn_mapping::table)
+                        .values((
+                            lid_pn_mapping::lid.eq(&entry.lid),
+                            lid_pn_mapping::phone_number.eq(&entry.phone_number),
+                            lid_pn_mapping::created_at.eq(entry.created_at),
+                            lid_pn_mapping::learning_source.eq(&entry.learning_source),
+                            lid_pn_mapping::updated_at.eq(entry.updated_at),
+                            lid_pn_mapping::device_id.eq(device_id),
+                        ))
+                        .on_conflict((lid_pn_mapping::lid, lid_pn_mapping::device_id))
+                        .do_update()
+                        .set((
+                            lid_pn_mapping::phone_number.eq(&entry.phone_number),
+                            lid_pn_mapping::learning_source.eq(&entry.learning_source),
+                            lid_pn_mapping::updated_at.eq(entry.updated_at),
+                        ))
+                        .execute(conn)?;
+                }
+                Ok(())
+            })
+            .map_err(|e| StoreError::Database(e.to_string()))?;
             Ok(())
         })
         .await

--- a/tests/e2e/tests/groups.rs
+++ b/tests/e2e/tests/groups.rs
@@ -713,3 +713,52 @@ async fn test_per_device_sender_key_tracking() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// E1 — regression test for PR #579 Fix 1: after `query_info` on an LID-mode
+/// group, each LID participant's PN must be present in `lid_pn_cache`.
+/// This closes the silent-observer zombie loop where `invalidate_device_cache`
+/// couldn't resolve a participant's PN alias because the mapping was never
+/// learned from a message (matches WA Web's `CreateOrReplaceDisplayNamesAndLidPnMappings`).
+#[tokio::test]
+async fn test_query_info_populates_lid_pn_cache_for_participants() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let client_a = TestClient::connect("e2e_grp_lidpn_a").await?;
+    let client_b = TestClient::connect("e2e_grp_lidpn_b").await?;
+
+    let jid_b_pn = client_b.jid().await;
+    let jid_b_lid = client_b
+        .client
+        .get_lid()
+        .await
+        .expect("B must have a LID after pairing")
+        .to_non_ad();
+    info!("B pn={jid_b_pn} lid={jid_b_lid}");
+
+    let group_jid = client_a
+        .client
+        .groups()
+        .create_group(GroupCreateOptions {
+            subject: "LID-PN mapping test".to_string(),
+            participants: vec![GroupParticipantOptions::new(jid_b_pn.clone())],
+            ..Default::default()
+        })
+        .await?
+        .gid;
+
+    // create_group doesn't populate the group cache, so the first query_info
+    // hits the network and runs the lid_pn_cache populate loop.
+    let _info = client_a.client.groups().query_info(&group_jid).await?;
+
+    let entry = client_a
+        .client
+        .get_lid_pn_entry(&jid_b_lid)
+        .await?
+        .expect("lid_pn_cache must have B's mapping after query_info");
+    assert_eq!(entry.lid, jid_b_lid.user);
+    assert_eq!(entry.phone_number, jid_b_pn.user);
+
+    client_a.disconnect().await;
+    client_b.disconnect().await;
+    Ok(())
+}

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1285,29 +1285,12 @@ pub async fn prepare_group_stanza<
 
     let stanza = stanza_builder.children(message_children).build();
 
-    // Emit both LID and PN aliases when the group knows them: registry
-    // entries can be stored under either key depending on when/how usync
-    // was called, and `invalidate_device_cache` needs both to clean up
-    // zombie records without relying on `lid_pn_cache` being populated.
     let stale_users = if had_unregistered_devices {
-        let is_lid_mode = group_info.addressing_mode == crate::types::message::AddressingMode::Lid;
-        let encrypted_set: HashSet<&Jid> = skdm_encrypted_devices.iter().collect();
-        let mut user_set = HashSet::new();
-        if let Some(ref dist) = distribution_list {
-            for d in dist {
-                if !encrypted_set.contains(d) {
-                    user_set.insert(d.user.to_string());
-                    if is_lid_mode
-                        && d.is_lid()
-                        && let Some(pn_jid) = group_info.phone_jid_for_lid_user(&d.user)
-                        && pn_jid.is_pn()
-                    {
-                        user_set.insert(pn_jid.user.to_string());
-                    }
-                }
-            }
-        }
-        user_set.into_iter().collect()
+        collect_stale_device_users(
+            distribution_list.as_deref(),
+            &skdm_encrypted_devices,
+            group_info,
+        )
     } else {
         Vec::new()
     };
@@ -1317,6 +1300,38 @@ pub async fn prepare_group_stanza<
         skdm_devices: skdm_encrypted_devices,
         stale_device_users: stale_users,
     })
+}
+
+/// Collect users whose devices failed SKDM so the caller can invalidate their
+/// registry entries. In LID-mode groups, both the LID and PN aliases are
+/// emitted when the group knows the mapping — `invalidate_device_cache` needs
+/// both to clean up zombie records that were stored under whichever alias
+/// `update_device_list` canonicalised to at the time of the write.
+pub(crate) fn collect_stale_device_users(
+    distribution_list: Option<&[Jid]>,
+    skdm_encrypted_devices: &[Jid],
+    group_info: &GroupInfo,
+) -> Vec<String> {
+    let Some(dist) = distribution_list else {
+        return Vec::new();
+    };
+    let is_lid_mode = group_info.addressing_mode == crate::types::message::AddressingMode::Lid;
+    let encrypted_set: HashSet<&Jid> = skdm_encrypted_devices.iter().collect();
+    let mut user_set: HashSet<String> = HashSet::new();
+    for d in dist {
+        if encrypted_set.contains(d) {
+            continue;
+        }
+        user_set.insert(d.user.to_string());
+        if is_lid_mode
+            && d.is_lid()
+            && let Some(pn_jid) = group_info.phone_jid_for_lid_user(&d.user)
+            && pn_jid.is_pn()
+        {
+            user_set.insert(pn_jid.user.to_string());
+        }
+    }
+    user_set.into_iter().collect()
 }
 
 pub async fn create_sender_key_distribution_message_for_group(
@@ -2983,6 +2998,119 @@ mod tests {
             // This would only match if we also checked IqError (we don't — we use ServerErrorCode)
             // The SendContextResolver impl is responsible for wrapping in ServerErrorCode
             assert!(!is_device_unregistered_error(&err));
+        }
+    }
+
+    mod collect_stale_device_users {
+        use super::super::collect_stale_device_users;
+        use crate::client::context::GroupInfo;
+        use crate::types::message::AddressingMode;
+        use std::collections::{HashMap, HashSet};
+        use wacore_binary::{CompactString, Jid};
+
+        fn lid_device(user: &str, dev: u16) -> Jid {
+            Jid::lid_device(user.to_string(), dev)
+        }
+
+        fn pn_user(user: &str) -> Jid {
+            Jid::pn(user)
+        }
+
+        fn group_info_lid(mapping: &[(&str, &str)]) -> GroupInfo {
+            let mut info = GroupInfo::new(Vec::new(), AddressingMode::Lid);
+            if !mapping.is_empty() {
+                let mut map: HashMap<CompactString, Jid> = HashMap::new();
+                for (lid_user, pn) in mapping {
+                    map.insert(CompactString::from(*lid_user), pn_user(pn));
+                }
+                info.set_lid_to_pn_map(map);
+            }
+            info
+        }
+
+        #[test]
+        fn emits_lid_and_pn_alias_when_mapping_known() {
+            let info = group_info_lid(&[("100000000000001", "15550000001")]);
+            let dist = vec![lid_device("100000000000001", 5)];
+            let out = collect_stale_device_users(Some(&dist), &[], &info);
+            let set: HashSet<String> = out.into_iter().collect();
+            assert!(set.contains("100000000000001"));
+            assert!(set.contains("15550000001"));
+            assert_eq!(set.len(), 2);
+        }
+
+        #[test]
+        fn emits_only_lid_when_mapping_unknown() {
+            let info = group_info_lid(&[]);
+            let dist = vec![lid_device("100000000000002", 7)];
+            let out = collect_stale_device_users(Some(&dist), &[], &info);
+            assert_eq!(out, vec!["100000000000002".to_string()]);
+        }
+
+        #[test]
+        fn dedups_multiple_devices_of_same_user() {
+            let info = group_info_lid(&[("100000000000003", "15550000003")]);
+            let dist = vec![
+                lid_device("100000000000003", 1),
+                lid_device("100000000000003", 2),
+                lid_device("100000000000003", 3),
+            ];
+            let out = collect_stale_device_users(Some(&dist), &[], &info);
+            let set: HashSet<String> = out.into_iter().collect();
+            assert_eq!(set.len(), 2);
+            assert!(set.contains("100000000000003"));
+            assert!(set.contains("15550000003"));
+        }
+
+        #[test]
+        fn skips_successfully_encrypted_devices() {
+            let info = group_info_lid(&[]);
+            let encrypted = lid_device("100000000000004", 5);
+            let dist = vec![encrypted.clone(), lid_device("100000000000005", 5)];
+            let encrypted_set = vec![encrypted];
+            let out = collect_stale_device_users(Some(&dist), &encrypted_set, &info);
+            assert_eq!(out, vec!["100000000000005".to_string()]);
+        }
+
+        #[test]
+        fn pn_mode_group_does_not_emit_alias() {
+            // In PN-mode groups the distribution list is already PN-form, so
+            // there's no LID↔PN duality to emit.
+            let mut info = GroupInfo::new(Vec::new(), AddressingMode::Pn);
+            let mut map: HashMap<CompactString, Jid> = HashMap::new();
+            map.insert(
+                CompactString::from("100000000000006"),
+                pn_user("15550000006"),
+            );
+            info.set_lid_to_pn_map(map);
+            let dist = vec![Jid::pn_device("15550000006", 3)];
+            let out = collect_stale_device_users(Some(&dist), &[], &info);
+            assert_eq!(out, vec!["15550000006".to_string()]);
+        }
+
+        #[test]
+        fn skips_non_pn_alias() {
+            // If phone_jid_for_lid_user returns a JID whose server isn't PN
+            // (malformed/adversarial server response), do not emit it.
+            let mut info = GroupInfo::new(Vec::new(), AddressingMode::Lid);
+            let mut map: HashMap<CompactString, Jid> = HashMap::new();
+            map.insert(
+                CompactString::from("100000000000007"),
+                Jid::lid("100000000000099"),
+            );
+            info.set_lid_to_pn_map(map);
+            let dist = vec![lid_device("100000000000007", 5)];
+            let out = collect_stale_device_users(Some(&dist), &[], &info);
+            assert_eq!(out, vec!["100000000000007".to_string()]);
+        }
+
+        #[test]
+        fn empty_distribution_list_yields_empty() {
+            let info = group_info_lid(&[]);
+            let out = collect_stale_device_users(None, &[], &info);
+            assert!(out.is_empty());
+            let out = collect_stale_device_users(Some(&[]), &[], &info);
+            assert!(out.is_empty());
         }
     }
 }

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -421,46 +421,22 @@ where
             "Fetching prekeys for {} devices without sessions",
             jids_needing_prekeys.len()
         );
-        // WA Web's fetchPrekeys() collects per-device errors separately and returns
-        // successful bundles. On batch 406, retry per-device so one stale device
-        // doesn't blank valid companions in the same batch.
+        // 406 on this batch is all-or-nothing — per-device retries just wasted
+        // N·RTT with the same failure. Mark `had_406` so the caller invalidates
+        // the users and the next send re-fetches. Matches WA Web's
+        // `GroupSkmsgJob`: log, continue without those devices.
         let prekey_bundles = match resolver
             .fetch_prekeys_for_identity_check(&jids_needing_prekeys)
             .await
         {
             Ok(bundles) => bundles,
             Err(e) if is_device_unregistered_error(&e) => {
-                if jids_needing_prekeys.len() == 1 {
-                    log::warn!(
-                        "Prekey fetch returned 406 (device unregistered): {}",
-                        jids_needing_prekeys[0]
-                    );
-                    had_406 = true;
-                    std::collections::HashMap::new()
-                } else {
-                    // Batch failed: retry per-device to salvage valid ones
-                    log::warn!(
-                        "Batch prekey fetch returned 406 for {} devices, retrying individually",
-                        jids_needing_prekeys.len()
-                    );
-                    let mut bundles = std::collections::HashMap::new();
-                    for jid in &jids_needing_prekeys {
-                        match resolver
-                            .fetch_prekeys_for_identity_check(std::slice::from_ref(jid))
-                            .await
-                        {
-                            Ok(single) => bundles.extend(single),
-                            Err(e) if is_device_unregistered_error(&e) => {
-                                log::warn!("Device {jid} returned 406, skipping");
-                                had_406 = true;
-                            }
-                            Err(e) => {
-                                log::warn!("Prekey fetch for {jid} failed: {e}, skipping");
-                            }
-                        }
-                    }
-                    bundles
-                }
+                log::warn!(
+                    "Prekey fetch returned 406 for {} device(s); skipping them this round",
+                    jids_needing_prekeys.len()
+                );
+                had_406 = true;
+                std::collections::HashMap::new()
             }
             Err(e) => return Err(e),
         };
@@ -1309,15 +1285,25 @@ pub async fn prepare_group_stanza<
 
     let stanza = stanza_builder.children(message_children).build();
 
-    // Collect deduplicated users whose devices failed SKDM (were in
-    // distribution_list but not in skdm_encrypted_devices)
+    // Emit both LID and PN aliases when the group knows them: registry
+    // entries can be stored under either key depending on when/how usync
+    // was called, and `invalidate_device_cache` needs both to clean up
+    // zombie records without relying on `lid_pn_cache` being populated.
     let stale_users = if had_unregistered_devices {
+        let is_lid_mode = group_info.addressing_mode == crate::types::message::AddressingMode::Lid;
         let encrypted_set: HashSet<&Jid> = skdm_encrypted_devices.iter().collect();
         let mut user_set = HashSet::new();
         if let Some(ref dist) = distribution_list {
             for d in dist {
                 if !encrypted_set.contains(d) {
                     user_set.insert(d.user.to_string());
+                    if is_lid_mode
+                        && d.is_lid()
+                        && let Some(pn_jid) = group_info.phone_jid_for_lid_user(&d.user)
+                        && pn_jid.is_pn()
+                    {
+                        user_set.insert(pn_jid.user.to_string());
+                    }
                 }
             }
         }

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -245,6 +245,16 @@ pub trait ProtocolStore: Send + Sync {
     /// Store or update a LID-PN mapping.
     async fn put_lid_mapping(&self, entry: &LidPnMappingEntry) -> Result<()>;
 
+    /// Batched variant of `put_lid_mapping`. Backends should override with a
+    /// single transaction; the default loops for correctness. Mirrors WA Web's
+    /// `WAWebDBCreateLidPnMappings.createLidPnMappings({ mappings, … })`.
+    async fn put_lid_mappings(&self, entries: &[LidPnMappingEntry]) -> Result<()> {
+        for entry in entries {
+            self.put_lid_mapping(entry).await?;
+        }
+        Ok(())
+    }
+
     /// Get all LID-PN mappings (for cache warm-up).
     async fn get_all_lid_mappings(&self) -> Result<Vec<LidPnMappingEntry>>;
 


### PR DESCRIPTION
## Summary
Field report against alpha.12: 23 batch 406s on the same group in 3h45m, same stale devices across batches, producing 12-41s latency spikes per group send. This PR closes the zombie-formation loop end-to-end.

## Root cause
Asymmetric key-storage in the device registry:
- `maybe_compute_skdm_devices` resolves LID participants to **PN form** before usync; usync responses are persisted under the PN key.
- On 406, `stale_device_users` is **LID form** (from `distribution_list` in LID-mode groups).
- `invalidate_device_cache(lid)` resolves aliases via `lid_pn_cache`; with no mapping it only invalidates the LID key, leaving the PN-keyed row as a zombie → every subsequent send refetches the same stale devices.

The LID↔PN mapping was never learned for silent-observer participants because `query_info` built `lid_to_pn_map` only inside `GroupInfo` — never fed the global `lid_pn_cache`. WA Web's `Create/OrReplaceDisplayNamesAndLidPnMappingsJob` populates the cache from group data with `learningSource: "other"`.

## Changes
1. **`groups.rs::query_info`**: push each `lid→pn` pair into `lid_pn_cache` via `learn_lid_pn_mapping_fast` (synchronous cache update + detached persist), guarded by `pn_jid.is_pn()`. Closes the silent-observer gap. WA Web parity.
2. **`wacore::send.rs::encrypt_for_devices`**: drop the O(N·RTT) per-device retry on batch 406. The server returns all-or-nothing here; the field log shows every individual retry also returned 406. Match WA Web `GroupSkmsgJob`: log, mark `had_406`, continue without those devices.
3. **`wacore::send.rs::prepare_group_stanza`**: emit both LID and PN aliases in `stale_device_users` when `GroupInfo` knows the mapping (guarded with `pn_jid.is_pn()`). Defensive against `lid_pn_cache` not being populated yet.
4. **`device_registry.rs::update_device_list`**: delete the stale DB row when the canonical key flips, not just the cache. Closes a zombie-creation path.
5. **`device_registry.rs::migrate_device_registry_on_lid_discovery`**: delete the PN-keyed DB row during LID migration, not just the cache.
6. **Race closure (applies to #4 and #5)**: invalidate cache → delete DB → invalidate cache again. Without the second invalidate, a concurrent reader between the invalidate and the delete can re-populate the cache from the about-to-be-deleted DB row, resurrecting the zombie.

## Review notes
Codex reviewed twice and all flags were addressed:
- Round 1: confirmed `self_weak.upgrade()` safe, Fix 2 doesn't lose salvageable bundles, no races in Fix 1.
- Round 1 flag: `pn_jid.is_pn()` guard missing in Fix 3 → added.
- Round 1 flag: pre-existing migration leak (PN-keyed DB row not deleted) → plugged via Fixes 4/5.
- Round 2 flag: `pn_jid.is_pn()` guard missing in Fix 1 too → added.
- Round 2 flag: TOCTOU window between invalidate and delete in Fixes 4/5 → closed via invalidate-delete-invalidate.

WA Web compliance:
- Fix 1 matches `Create/OrReplaceDisplayNamesAndLidPnMappingsJob.js:54` (`learningSource: "other"`).
- Fix 2 matches `Send/GroupSkmsgJob.js:18-43` (try/catch + continue).
- Fixes 3-6 address architecture specific to our dual-key storage; WA Web uses LID-primary IndexedDB so doesn't hit this.

## Test plan
- [x] `cargo clippy --all --tests` clean
- [x] `cargo test -p whatsapp-rust --lib` (390 passed)
- [x] `cargo test -p e2e-tests --test groups --test messaging --test offline_messages --test concurrent_disconnect` all green
- [ ] Field validation by the reporter on the affected bot — the 23 batches/3h45m metric is the success criterion
- [ ] Not included: a synthetic e2e reproducing the zombie state (would require seeding the registry with a stale PN-keyed LID entry; doable but outside this PR's scope)