### PR TITLE
feat(device)!: DevicePropsOverride builder, align DEVICE_PROPS with WA Web

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use thiserror::Error;
 use wacore::runtime::Runtime;
+use wacore::store::DevicePropsOverride;
 use waproto::whatsapp as wa;
 
 /// Typestate marker: a required builder field has not been provided yet.
@@ -268,11 +269,7 @@ pub struct BotBuilder<B = Missing, T = Missing, H = Missing, R = Missing> {
     event_handler: Option<EventHandlerCallback>,
     custom_enc_handlers: HashMap<String, Arc<dyn EncHandler>>,
     override_version: Option<(u32, u32, u32)>,
-    os_info: Option<(
-        Option<String>,
-        Option<wa::device_props::AppVersion>,
-        Option<wa::device_props::PlatformType>,
-    )>,
+    device_props_override: Option<DevicePropsOverride>,
     pair_code_options: Option<PairCodeOptions>,
     skip_history_sync: bool,
     initial_push_name: Option<String>,
@@ -290,7 +287,7 @@ impl BotBuilder<Missing, Missing, Missing, Missing> {
             event_handler: None,
             custom_enc_handlers: HashMap::new(),
             override_version: None,
-            os_info: None,
+            device_props_override: None,
             pair_code_options: None,
             skip_history_sync: false,
             initial_push_name: None,
@@ -326,7 +323,7 @@ impl<T, H, R> BotBuilder<Missing, T, H, R> {
             event_handler: self.event_handler,
             custom_enc_handlers: self.custom_enc_handlers,
             override_version: self.override_version,
-            os_info: self.os_info,
+            device_props_override: self.device_props_override,
             pair_code_options: self.pair_code_options,
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
@@ -365,7 +362,7 @@ impl<B, H, R> BotBuilder<B, Missing, H, R> {
             event_handler: self.event_handler,
             custom_enc_handlers: self.custom_enc_handlers,
             override_version: self.override_version,
-            os_info: self.os_info,
+            device_props_override: self.device_props_override,
             pair_code_options: self.pair_code_options,
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
@@ -403,7 +400,7 @@ impl<B, T, R> BotBuilder<B, T, Missing, R> {
             event_handler: self.event_handler,
             custom_enc_handlers: self.custom_enc_handlers,
             override_version: self.override_version,
-            os_info: self.os_info,
+            device_props_override: self.device_props_override,
             pair_code_options: self.pair_code_options,
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
@@ -426,7 +423,7 @@ impl<B, T, H> BotBuilder<B, T, H, Missing> {
             event_handler: self.event_handler,
             custom_enc_handlers: self.custom_enc_handlers,
             override_version: self.override_version,
-            os_info: self.os_info,
+            device_props_override: self.device_props_override,
             pair_code_options: self.pair_code_options,
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
@@ -491,52 +488,24 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Override the device properties sent to WhatsApp servers.
     /// This allows customizing how your device appears on the linked devices list.
     ///
-    /// # Arguments
-    /// * `os_name` - Optional OS name (e.g., "macOS", "Windows", "Linux")
-    /// * `version` - Optional app version as AppVersion struct
-    /// * `platform_type` - Optional platform type that determines the device name shown
-    ///   on the phone's linked devices list (e.g., Chrome, Firefox, Safari, Desktop)
-    ///
-    /// **Important**: The `platform_type` determines what device name is shown on the phone.
-    /// Common values: `Chrome`, `Firefox`, `Safari`, `Edge`, `Desktop`, `Ipad`, etc.
-    /// If not set, defaults to `Unknown` which shows as "Unknown device".
-    ///
-    /// You can pass `None` for any parameter to keep the default value.
+    /// `platform_type` controls the display name in Linked Devices; defaults
+    /// to `Unknown` ("Unknown device"). Only applied on the initial pairing.
     ///
     /// # Example
     /// ```rust,ignore
-    /// use waproto::whatsapp::device_props::{self, PlatformType};
+    /// use waproto::whatsapp::device_props::PlatformType;
+    /// use wacore::store::DevicePropsOverride;
     ///
-    /// // Show as "Chrome" on linked devices
-    /// let bot = Bot::builder()
+    /// Bot::builder()
     ///     .with_backend(backend)
     ///     .with_device_props(
-    ///         Some("macOS".to_string()),
-    ///         Some(device_props::AppVersion {
-    ///             primary: Some(2),
-    ///             secondary: Some(0),
-    ///             tertiary: Some(0),
-    ///             ..Default::default()
-    ///         }),
-    ///         Some(PlatformType::Chrome),
-    ///     )
-    ///     .build()
-    ///     .await?;
-    ///
-    /// // Show as "Desktop" on linked devices
-    /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .with_device_props(None, None, Some(PlatformType::Desktop))
-    ///     .build()
-    ///     .await?;
+    ///         DevicePropsOverride::new()
+    ///             .with_os("macOS")
+    ///             .with_platform_type(PlatformType::Chrome),
+    ///     );
     /// ```
-    pub fn with_device_props(
-        mut self,
-        os_name: Option<String>,
-        version: Option<wa::device_props::AppVersion>,
-        platform_type: Option<wa::device_props::PlatformType>,
-    ) -> Self {
-        self.os_info = Some((os_name, version, platform_type));
+    pub fn with_device_props(mut self, override_: DevicePropsOverride) -> Self {
+        self.device_props_override = Some(override_);
         self
     }
 
@@ -673,18 +642,12 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
                 .await;
         }
 
-        // Apply device props override if specified
-        if let Some((os_name, version, platform_type)) = self.os_info {
-            info!(
-                "Applying device props override: os={:?}, version={:?}, platform_type={:?}",
-                os_name, version, platform_type
-            );
+        if let Some(override_) = self.device_props_override
+            && !override_.is_empty()
+        {
+            info!("Applying device props override: {:?}", override_);
             persistence_manager
-                .process_command(DeviceCommand::SetDeviceProps(
-                    os_name,
-                    version,
-                    platform_type,
-                ))
+                .process_command(DeviceCommand::SetDeviceProps(override_))
                 .await;
         }
 
@@ -902,7 +865,11 @@ mod tests {
             .with_backend(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
-            .with_device_props(Some(custom_os.clone()), Some(custom_version), None)
+            .with_device_props(
+                DevicePropsOverride::new()
+                    .with_os(custom_os.clone())
+                    .with_version(custom_version),
+            )
             .with_runtime(TokioRuntime)
             .build()
             .await
@@ -929,7 +896,7 @@ mod tests {
             .with_backend(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
-            .with_device_props(Some(custom_os.clone()), None, None)
+            .with_device_props(DevicePropsOverride::new().with_os(custom_os.clone()))
             .with_runtime(TokioRuntime)
             .build()
             .await
@@ -965,7 +932,7 @@ mod tests {
             .with_backend(backend)
             .with_http_client(http_client)
             .with_transport_factory(transport)
-            .with_device_props(None, Some(custom_version), None)
+            .with_device_props(DevicePropsOverride::new().with_version(custom_version))
             .with_runtime(TokioRuntime)
             .build()
             .await
@@ -994,7 +961,10 @@ mod tests {
             .with_backend(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
-            .with_device_props(None, None, Some(wa::device_props::PlatformType::Chrome))
+            .with_device_props(
+                DevicePropsOverride::new()
+                    .with_platform_type(wa::device_props::PlatformType::Chrome),
+            )
             .with_runtime(TokioRuntime)
             .build()
             .await
@@ -1040,9 +1010,10 @@ mod tests {
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_device_props(
-                Some(custom_os.clone()),
-                Some(custom_version),
-                Some(custom_platform),
+                DevicePropsOverride::new()
+                    .with_os(custom_os.clone())
+                    .with_version(custom_version)
+                    .with_platform_type(custom_platform),
             )
             .with_runtime(TokioRuntime)
             .build()

--- a/src/client.rs
+++ b/src/client.rs
@@ -620,6 +620,33 @@ impl Client {
         self.skip_history_sync.store(enabled, Ordering::Relaxed);
     }
 
+    /// Override `DeviceProps` fields before the initial pairing. Only fields
+    /// with `Some` are changed. In-memory only — WA Web regenerates
+    /// `device_props` at each registration, and it has no wire effect after
+    /// pairing. Call before `connect()` on every process start that still
+    /// needs to pair.
+    pub async fn set_device_props(&self, override_: wacore::store::DevicePropsOverride) {
+        use wacore::store::commands::DeviceCommand;
+        if override_.is_empty() {
+            return;
+        }
+        if self
+            .persistence_manager
+            .get_device_snapshot()
+            .await
+            .pn
+            .is_some()
+        {
+            warn!(
+                target: "Client/DeviceProps",
+                "set_device_props called after pairing — stored but not sent on the wire"
+            );
+        }
+        self.persistence_manager
+            .process_command(DeviceCommand::SetDeviceProps(override_))
+            .await;
+    }
+
     /// Public entry point for processing [`MajorSyncTask`] from the sync channel.
     pub async fn process_sync_task(self: &Arc<Self>, task: crate::sync_task::MajorSyncTask) {
         match task {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -566,10 +566,7 @@ impl SqliteStore {
                 app_version_secondary: row.app_version_secondary as u32,
                 app_version_tertiary: row.app_version_tertiary.try_into().unwrap_or(0u32),
                 app_version_last_fetched_ms: row.app_version_last_fetched_ms,
-                device_props: {
-                    use wacore::store::device::DEVICE_PROPS;
-                    DEVICE_PROPS.clone()
-                },
+                device_props: wacore::store::device::DEVICE_PROPS.clone(),
                 edge_routing_info: row.edge_routing_info,
                 props_hash: row.props_hash,
                 next_pre_key_id: row.next_pre_key_id as u32,

--- a/wacore/src/store/commands.rs
+++ b/wacore/src/store/commands.rs
@@ -1,4 +1,5 @@
 use crate::store::Device;
+use crate::store::device::DevicePropsOverride;
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
 
@@ -9,11 +10,7 @@ pub enum DeviceCommand {
     SetPushName(String),
     SetAccount(Option<wa::AdvSignedDeviceIdentity>),
     SetAppVersion((u32, u32, u32)),
-    SetDeviceProps(
-        Option<String>,
-        Option<wa::device_props::AppVersion>,
-        Option<wa::device_props::PlatformType>,
-    ),
+    SetDeviceProps(DevicePropsOverride),
     SetPropsHash(Option<String>),
     SetNextPreKeyId(u32),
     SetAdvSecretKey([u8; 32]),
@@ -41,8 +38,8 @@ pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
             device.app_version_tertiary = t;
             device.app_version_last_fetched_ms = crate::time::now_millis();
         }
-        DeviceCommand::SetDeviceProps(os, version, platform_type) => {
-            device.set_device_props(os, version, platform_type);
+        DeviceCommand::SetDeviceProps(override_) => {
+            device.set_device_props(override_);
         }
         DeviceCommand::SetPropsHash(hash) => {
             device.props_hash = hash;

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -103,6 +103,76 @@ fn build_base_client_payload(
     }
 }
 
+/// Override for selected `DeviceProps` fields before pairing. `None` fields
+/// preserve the current value on the device.
+#[derive(Debug, Clone, Default)]
+pub struct DevicePropsOverride {
+    pub os: Option<String>,
+    pub version: Option<wa::device_props::AppVersion>,
+    pub platform_type: Option<wa::device_props::PlatformType>,
+    pub history_sync_config: Option<wa::device_props::HistorySyncConfig>,
+}
+
+impl DevicePropsOverride {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_os(mut self, os: impl Into<String>) -> Self {
+        self.os = Some(os.into());
+        self
+    }
+
+    pub fn with_version(mut self, version: wa::device_props::AppVersion) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    pub fn with_platform_type(mut self, platform_type: wa::device_props::PlatformType) -> Self {
+        self.platform_type = Some(platform_type);
+        self
+    }
+
+    /// Replaces the entire `HistorySyncConfig`. Spread [`default_history_sync_config`]
+    /// into the literal to patch only specific fields while keeping sane defaults.
+    pub fn with_history_sync_config(
+        mut self,
+        history_sync_config: wa::device_props::HistorySyncConfig,
+    ) -> Self {
+        self.history_sync_config = Some(history_sync_config);
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.os.is_none()
+            && self.version.is_none()
+            && self.platform_type.is_none()
+            && self.history_sync_config.is_none()
+    }
+}
+
+/// Default `HistorySyncConfig` aligned with WA Web's static claims
+/// (`Payload.js` in `WAWebClientPayload`). Runtime-derived fields like
+/// `storage_quota_mb`, `on_demand_ready`, and justknobx-gated flags are left
+/// unset so callers can populate them through
+/// [`DevicePropsOverride::with_history_sync_config`] without fighting stale
+/// hardcoded values.
+pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
+    wa::device_props::HistorySyncConfig {
+        full_sync_days_limit: Some(30),
+        storage_quota_mb: Some(10240),
+        inline_initial_payload_in_e2_ee_msg: Some(true),
+        support_bot_user_agent_chat_history: Some(true),
+        support_cag_reactions_and_polls: Some(true),
+        support_recent_sync_chunk_message_count_tuning: Some(true),
+        support_hosted_group_msg: Some(true),
+        support_biz_hosted_msg: Some(true),
+        support_fbid_bot_chat_history: Some(true),
+        support_message_association: Some(true),
+        ..Default::default()
+    }
+}
+
 pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::DeviceProps {
     os: Some("rust".to_string()),
     version: Some(wa::device_props::AppVersion {
@@ -113,13 +183,7 @@ pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::Device
     }),
     platform_type: Some(wa::device_props::PlatformType::Unknown as i32),
     require_full_sync: Some(true),
-    history_sync_config: Some(wa::device_props::HistorySyncConfig {
-        full_sync_days_limit: Some(30),
-        inline_initial_payload_in_e2_ee_msg: Some(true),
-        storage_quota_mb: Some(10240),
-        support_message_association: Some(true),
-        ..Default::default()
-    }),
+    history_sync_config: Some(default_history_sync_config()),
 });
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -245,20 +309,18 @@ impl Device {
         self.pn.is_some() && !self.push_name.is_empty()
     }
 
-    pub fn set_device_props(
-        &mut self,
-        os: Option<String>,
-        version: Option<wa::device_props::AppVersion>,
-        platform_type: Option<wa::device_props::PlatformType>,
-    ) {
-        if let Some(os) = os {
+    pub fn set_device_props(&mut self, o: DevicePropsOverride) {
+        if let Some(os) = o.os {
             self.device_props.os = Some(os);
         }
-        if let Some(version) = version {
+        if let Some(version) = o.version {
             self.device_props.version = Some(version);
         }
-        if let Some(platform_type) = platform_type {
+        if let Some(platform_type) = o.platform_type {
             self.device_props.platform_type = Some(platform_type as i32);
+        }
+        if let Some(history_sync_config) = o.history_sync_config {
+            self.device_props.history_sync_config = Some(history_sync_config);
         }
     }
 
@@ -392,6 +454,80 @@ mod tests {
         );
         assert_eq!(acc.account_signature.as_deref(), Some([2u8; 64].as_slice()));
         assert_eq!(acc.device_signature.as_deref(), Some([3u8; 64].as_slice()));
+    }
+
+    /// Override survives the ClientPayload → bytes → DeviceProps round-trip;
+    /// `None` fields preserve the prior value.
+    #[test]
+    fn set_device_props_override_reaches_registration_payload() {
+        let mut device = Device::new();
+        assert!(device.pn.is_none());
+
+        device.set_device_props(
+            DevicePropsOverride::new()
+                .with_os("Android 14")
+                .with_platform_type(wa::device_props::PlatformType::AndroidPhone),
+        );
+
+        let payload = device.get_client_payload();
+        let reg = payload.device_pairing_data.expect("device_pairing_data");
+        let bytes = reg.device_props.expect("device_props bytes");
+        let props = wa::DeviceProps::decode(bytes.as_slice()).expect("decode DeviceProps");
+
+        assert_eq!(props.os.as_deref(), Some("Android 14"));
+        assert_eq!(
+            props.platform_type,
+            Some(wa::device_props::PlatformType::AndroidPhone as i32)
+        );
+        // None preserves the default version.
+        assert_eq!(props.version, Some(Device::default_device_props_version()));
+    }
+
+    /// `HistorySyncConfig` override is delivered whole — users patch by
+    /// spreading [`default_history_sync_config`] into the literal.
+    #[test]
+    fn history_sync_config_override_reaches_registration_payload() {
+        let mut device = Device::new();
+        device.set_device_props(DevicePropsOverride::new().with_history_sync_config(
+            wa::device_props::HistorySyncConfig {
+                full_sync_days_limit: Some(365),
+                support_group_history: Some(true),
+                ..default_history_sync_config()
+            },
+        ));
+
+        let payload = device.get_client_payload();
+        let bytes = payload
+            .device_pairing_data
+            .expect("device_pairing_data")
+            .device_props
+            .expect("device_props bytes");
+        let props = wa::DeviceProps::decode(bytes.as_slice()).expect("decode DeviceProps");
+        let hsc = props.history_sync_config.expect("history_sync_config");
+
+        assert_eq!(hsc.full_sync_days_limit, Some(365));
+        assert_eq!(hsc.support_group_history, Some(true));
+        // Defaults spread in via default_history_sync_config() survive.
+        assert_eq!(hsc.support_message_association, Some(true));
+        assert_eq!(hsc.inline_initial_payload_in_e2_ee_msg, Some(true));
+    }
+
+    /// After pairing, `device_props` must not leak into the login payload —
+    /// WA Web only sends it during registration.
+    #[test]
+    fn login_payload_has_no_device_props() {
+        let mut device = Device::new();
+        device.pn = Some("12345@s.whatsapp.net".parse().unwrap());
+        device.set_device_props(
+            DevicePropsOverride::new()
+                .with_platform_type(wa::device_props::PlatformType::AndroidPhone),
+        );
+
+        let payload = device.get_client_payload();
+        assert!(
+            payload.device_pairing_data.is_none(),
+            "login payload must not carry device_pairing_data"
+        );
     }
 
     /// Backward compat: missing `account` field deserializes as `None`.

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -160,7 +160,6 @@ impl DevicePropsOverride {
 pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
     wa::device_props::HistorySyncConfig {
         full_sync_days_limit: Some(30),
-        storage_quota_mb: Some(10240),
         inline_initial_payload_in_e2_ee_msg: Some(true),
         support_bot_user_agent_chat_history: Some(true),
         support_cag_reactions_and_polls: Some(true),

--- a/wacore/src/store/mod.rs
+++ b/wacore/src/store/mod.rs
@@ -10,7 +10,7 @@ pub mod traits;
 
 pub use cache::CacheStore;
 pub use commands::*;
-pub use device::Device;
+pub use device::{Device, DevicePropsOverride};
 pub use in_memory::InMemoryBackend;
 pub use persistence::PersistenceManager;
 pub use signal_cache::SignalStoreCache;


### PR DESCRIPTION
## Summary

- Replace the three-positional-`Option` `DeviceCommand::SetDeviceProps` / `BotBuilder::with_device_props` signature with a typed `DevicePropsOverride` builder.
- Expose `HistorySyncConfig` as a first-class override reusing the prost-generated struct — proto additions flow through without manual syncing.
- Extract `default_history_sync_config()` as the single source for the static `support_*` flags, aligned with what `WAWebClientPayload` always advertises (`Payload.js` in `docs/captured-js/WAWeb/Client/`).
- Add `Client::set_device_props` (in-memory only — WA Web regenerates `device_props` at each registration, so persistence would be dead weight). Warns if called after pairing.

## Behavior

Before pairing:
```rust
client.set_device_props(
    DevicePropsOverride::new()
        .with_os("macOS")
        .with_platform_type(PlatformType::Chrome)
        .with_history_sync_config(wa::device_props::HistorySyncConfig {
            full_sync_days_limit: Some(365),
            ..default_history_sync_config()
        }),
).await;
```

`None` fields preserve prior values. After pairing the override is a no-op on the wire (WA Web only ships `device_props` during registration).

## Breaking changes (pre-1.0)

- `BotBuilder::with_device_props` takes `DevicePropsOverride` instead of three positional `Option`s.
- `DeviceCommand::SetDeviceProps` likewise wraps `DevicePropsOverride`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests` (clean)
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — 565 tests green
- [x] New tests: override reaches registration payload, `None` preserves defaults, `HistorySyncConfig` spread survives, login payload carries no `device_pairing_data`
- [ ] Manual pair with `PlatformType::Chrome` override visible on phone's Linked Devices