### PR TITLE
fix(http): raise UreqHttpClient body cap from ureq's 10 MiB default

### DIFF
--- a/http_clients/ureq-client/Cargo.toml
+++ b/http_clients/ureq-client/Cargo.toml
@@ -18,3 +18,6 @@ async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 wacore = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -6,17 +6,26 @@ use anyhow::Result;
 use async_trait::async_trait;
 use wacore::net::{HttpClient, HttpRequest, HttpResponse, StreamingHttpResponse};
 
+/// Matches `MAX_FILE_SIZE_BYTES` in `WAWebServerPropConstants` (2 GiB).
+/// Overrides ureq's 10 MiB default on `read_to_vec()`.
+pub const DEFAULT_MAX_BODY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 /// HTTP client implementation using `ureq` for synchronous HTTP requests.
 /// Since `ureq` is blocking, all requests are wrapped in `tokio::task::spawn_blocking`.
 #[derive(Debug, Clone)]
 pub struct UreqHttpClient {
     agent: ureq::Agent,
+    /// Cap for [`UreqHttpClient::execute`]. Streaming is unbounded — the
+    /// caller owns the sink.
+    max_body_bytes: u64,
 }
 
 impl UreqHttpClient {
     pub fn new() -> Self {
-        let agent = build_agent();
-        Self { agent }
+        Self {
+            agent: build_agent(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+        }
     }
 
     /// Create a client with a pre-configured [`ureq::Agent`].
@@ -24,7 +33,17 @@ impl UreqHttpClient {
     /// This lets you configure proxy support, custom TLS, timeouts,
     /// or any other agent-level settings externally.
     pub fn with_agent(agent: ureq::Agent) -> Self {
-        Self { agent }
+        Self {
+            agent,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+        }
+    }
+
+    /// Override the per-response cap for [`UreqHttpClient::execute`]. Set to
+    /// `u64::MAX` to disable; a hostile server can then exhaust memory.
+    pub fn with_max_body_bytes(mut self, max_body_bytes: u64) -> Self {
+        self.max_body_bytes = max_body_bytes;
+        self
     }
 }
 
@@ -59,6 +78,7 @@ fn build_agent() -> ureq::Agent {
 impl HttpClient for UreqHttpClient {
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse> {
         let agent = self.agent.clone();
+        let max_body_bytes = self.max_body_bytes;
         // Since ureq is blocking, we must use spawn_blocking
         tokio::task::spawn_blocking(move || {
             let response = match request.method.as_str() {
@@ -87,9 +107,12 @@ impl HttpClient for UreqHttpClient {
 
             let status_code = response.status().as_u16();
 
-            // Read the response body
-            let mut body = response.into_body();
-            let body_bytes = body.read_to_vec()?;
+            // ureq's `read_to_vec()` default cap is 10 MiB.
+            let body_bytes = response
+                .into_body()
+                .into_with_config()
+                .limit(max_body_bytes)
+                .read_to_vec()?;
 
             Ok(HttpResponse {
                 status_code,
@@ -130,5 +153,80 @@ impl HttpClient for UreqHttpClient {
             status_code,
             body: Box::new(reader),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn spawn_fixed_size_server(body_size: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 4096];
+            let mut total = Vec::new();
+            loop {
+                let n = stream.read(&mut buf).unwrap_or(0);
+                if n == 0 {
+                    return;
+                }
+                total.extend_from_slice(&buf[..n]);
+                if total.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body_size
+            );
+            stream.write_all(header.as_bytes()).unwrap();
+            let chunk = vec![0xABu8; 64 * 1024];
+            let mut sent = 0usize;
+            while sent < body_size {
+                let take = chunk.len().min(body_size - sent);
+                stream.write_all(&chunk[..take]).unwrap();
+                sent += take;
+            }
+        });
+        format!("http://{}", addr)
+    }
+
+    /// Regression: ureq 3.x caps `read_to_vec()` at 10 MiB by default.
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_accepts_body_larger_than_ureq_default_limit() {
+        const SIZE: usize = 12 * 1024 * 1024;
+        let url = spawn_fixed_size_server(SIZE);
+        let resp = UreqHttpClient::new()
+            .execute(HttpRequest {
+                method: "GET".into(),
+                url,
+                headers: std::collections::HashMap::new(),
+                body: None,
+            })
+            .await
+            .expect("body must fit under the configured cap");
+        assert_eq!(resp.status_code, 200);
+        assert_eq!(resp.body.len(), SIZE);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn with_max_body_bytes_enforces_tighter_cap() {
+        const SIZE: usize = 4 * 1024 * 1024;
+        let url = spawn_fixed_size_server(SIZE);
+        UreqHttpClient::new()
+            .with_max_body_bytes(1024)
+            .execute(HttpRequest {
+                method: "GET".into(),
+                url,
+                headers: std::collections::HashMap::new(),
+                body: None,
+            })
+            .await
+            .expect_err("1 KiB cap must reject a 4 MiB body");
     }
 }


### PR DESCRIPTION
## Problem

A user reported downloads failing above ~10 MiB. ureq 3.x hardcodes `MAX_BODY_SIZE = 10 * 1024 * 1024` (`ureq-3.3.0/src/body/mod.rs:30`) and applies it to `Body::read_to_vec()` / `read_to_string()` / `read_json()`. Our `UreqHttpClient::execute` went through `read_to_vec()`, so any non-streaming download over 10 MiB failed.

`execute_streaming` was never affected — `into_reader()` uses `BodyWithConfig::new` which initialises `limit: u64::MAX` and stays unbounded.

## Reference: WhatsApp's own ceilings

From `docs/captured-js/WAWeb/Server/PropConstants.js`:

| Constant | Value |
|---|---|
| `DEFAULT_MAX_FILE_SIZE_BYTES` | 100 MiB |
| `MAX_FILE_SIZE_BYTES` | **2 GiB** (server-side upload cap for documents) |

And per-media AB props (`PropsConfigs.js:891-898`) cap images/video/audio at 16–64 MiB — already well over the 10 MiB ureq default.

## Changes

- New `DEFAULT_MAX_BODY_BYTES = 2 GiB` constant, matching `MAX_FILE_SIZE_BYTES`.
- `UreqHttpClient::execute` routes through `into_with_config().limit(max_body_bytes).read_to_vec()`.
- Builder `UreqHttpClient::with_max_body_bytes(u64)` for callers that want a tighter or looser cap.
- `execute_streaming` left alone — the caller owns the sink.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — 565 existing + 2 new
- [x] New `execute_accepts_body_larger_than_ureq_default_limit` — loopback `TcpListener` serves 12 MiB, asserts full receipt
- [x] New `with_max_body_bytes_enforces_tighter_cap` — tightens cap to 1 KiB, asserts oversized body is rejected