### PR TITLE
fix(time): route all now() calls through wacore::time; enforce via clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-channel",
- "chrono",
  "dhat",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ default-members = [
     "waproto",
 ]
 
+[workspace.lints.clippy]
+# Force the wacore::time abstraction so WASM/deterministic-test builds don't
+# regress. Exceptions carry `#[allow(clippy::disallowed_methods)]` inline.
+disallowed_methods = "deny"
+
 [workspace.dependencies]
 # Shared dependencies
 aes = "0.9.0"
@@ -86,6 +91,9 @@ wacore-libsignal = { path = "./wacore/libsignal", version = "0.5.0" }
 wacore-noise = { path = "./wacore/noise", version = "0.5.0" }
 waproto = { path = "./waproto", version = "0.5.0" }
 yoke = { version = "0.8", features = ["derive"] }
+
+[lints]
+workspace = true
 
 [features]
 debug-diagnostics = ["wacore/debug-diagnostics"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+disallowed-methods = [
+    { path = "chrono::Utc::now", reason = "use wacore::time::now_utc() to respect the pluggable TimeProvider (WASM + deterministic tests)" },
+    { path = "chrono::Local::now", reason = "use wacore::time::now_utc() (Local depends on SystemTime which panics on WASM)" },
+    { path = "std::time::SystemTime::now", reason = "use wacore::time::now_millis() / now_utc()" },
+    { path = "std::time::Instant::now", reason = "use wacore::time::Instant::now()" },
+]

--- a/http_clients/ureq-client/Cargo.toml
+++ b/http_clients/ureq-client/Cargo.toml
@@ -21,3 +21,6 @@ wacore = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -4385,7 +4385,7 @@ mod tests {
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // This should return immediately (not wait 10 seconds)
-        let start = std::time::Instant::now();
+        let start = wacore::time::Instant::now();
         client.wait_for_offline_delivery_end().await;
         let elapsed = start.elapsed();
 
@@ -4426,7 +4426,7 @@ mod tests {
 
         // Flag is false by default, so use a short timeout and verify the helper
         // marks the sync complete on timeout.
-        let start = std::time::Instant::now();
+        let start = wacore::time::Instant::now();
         client
             .wait_for_offline_delivery_end_with_timeout(std::time::Duration::from_millis(50))
             .await;
@@ -4493,7 +4493,7 @@ mod tests {
             client_clone.offline_sync_notifier.notify(usize::MAX);
         });
 
-        let start = std::time::Instant::now();
+        let start = wacore::time::Instant::now();
         client.wait_for_offline_delivery_end().await;
         let elapsed = start.elapsed();
 
@@ -4702,7 +4702,7 @@ mod tests {
         let test_jid = Jid::pn("559999999999");
         let ensure_handle = tokio::spawn(async move {
             // This will wait for offline sync before proceeding
-            let start = std::time::Instant::now();
+            let start = wacore::time::Instant::now();
             let _ = client_clone.ensure_e2e_sessions(&[test_jid]).await;
             start.elapsed()
         });
@@ -4775,7 +4775,7 @@ mod tests {
 
         // Call establish_primary_phone_session_immediate
         // It should NOT wait for offline sync - it should proceed immediately
-        let start = std::time::Instant::now();
+        let start = wacore::time::Instant::now();
 
         // Note: This will fail because we can't actually fetch prekeys in tests,
         // but the important thing is that it doesn't WAIT for offline sync

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -743,7 +743,7 @@ mod tests {
         // LID key). That strictly happens after both `put_lid_mappings` and
         // `migrate_device_registry_on_lid_discovery`, so observing it
         // guarantees both steps ran.
-        let start = std::time::Instant::now();
+        let start = wacore::time::Instant::now();
         let deadline = std::time::Duration::from_secs(5);
         loop {
             if backend.get_devices(lid).await.unwrap().is_some() {

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -103,7 +103,7 @@ impl Drop for DecrementOnDrop {
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
-    use std::time::Instant;
+    use wacore::time::Instant;
 
     fn rt() -> Arc<dyn Runtime> {
         Arc::new(crate::runtime_impl::TokioRuntime)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use chrono::{Local, Utc};
 use log::{error, info};
 use std::sync::Arc;
 use wacore::proto_helpers::MessageExt;
@@ -40,7 +39,7 @@ fn main() {
             writeln!(
                 buf,
                 "{} [{:<5}] [{}] - {}",
-                Local::now().format("%H:%M:%S"),
+                wacore::time::now_utc().format("%H:%M:%S"),
                 record.level(),
                 record.target(),
                 record.args()
@@ -170,7 +169,7 @@ async fn handle_text_ping(ctx: &MessageContext) {
         reaction_message: Some(wa::message::ReactionMessage {
             key: Some(key),
             text: Some(REACTION_EMOJI.to_string()),
-            sender_timestamp_ms: Some(Utc::now().timestamp_millis()),
+            sender_timestamp_ms: Some(wacore::time::now_millis()),
             ..Default::default()
         }),
         ..Default::default()
@@ -179,7 +178,7 @@ async fn handle_text_ping(ctx: &MessageContext) {
         error!("Failed to send reaction: {}", e);
     }
 
-    let start = std::time::Instant::now();
+    let start = wacore::time::Instant::now();
     let context_info = ctx.build_quote_context();
     let reply = wa::Message {
         extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {

--- a/src/message.rs
+++ b/src/message.rs
@@ -5430,7 +5430,7 @@ mod tests {
 
         let mut info =
             create_test_message_info("85010891714716@lid", "ANCIENT_MSG_1", "85010891714716@lid");
-        info.timestamp = chrono::Utc::now() - chrono::Duration::days(30);
+        info.timestamp = wacore::time::now_utc() - chrono::Duration::days(30);
         let info = Arc::new(info);
 
         let cache_key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());
@@ -5456,7 +5456,7 @@ mod tests {
         let mut info =
             create_test_message_info("85010891714716@lid", "BOUNDARY_MSG_1", "85010891714716@lid");
         info.timestamp =
-            chrono::Utc::now() - chrono::Duration::days(14) - chrono::Duration::minutes(1);
+            wacore::time::now_utc() - chrono::Duration::days(14) - chrono::Duration::minutes(1);
         let info = Arc::new(info);
 
         let cache_key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -476,7 +476,7 @@ impl Client {
         // Compare in seconds to stay bit-for-bit with WA Web's `age_s > i`
         // check — `num_days()` truncates and would let 14d1h through.
         const PDO_MAX_AGE: chrono::Duration = chrono::Duration::days(14);
-        let age = chrono::Utc::now().signed_duration_since(info.timestamp);
+        let age = wacore::time::now_utc().signed_duration_since(info.timestamp);
         if age > PDO_MAX_AGE {
             debug!(
                 "PDO request skipped for message {} (age {}s exceeds {}s limit)",

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -271,7 +271,7 @@ impl PersistenceManager {
 mod tests {
     use super::*;
     use crate::runtime_impl::TokioRuntime;
-    use std::time::Instant;
+    use wacore::time::Instant;
 
     // Saver must observe shutdown.notify, run a final flush, and exit so the
     // AbortHandle-backed task doesn't outlive the Bot.

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -32,3 +32,6 @@ wacore = { workspace = true }
 [dev-dependencies]
 portable-atomic = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
+
+[lints]
+workspace = true

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1735,10 +1735,7 @@ impl ProtocolStore for SqliteStore {
                 .map(|(jid, has_key)| (jid.to_string(), *has_key))
                 .collect(),
         );
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
+        let now = wacore::time::now_secs();
         self.with_retry("set_sender_key_status", || {
             let group_jid = group_jid.clone();
             let owned_entries = Arc::clone(&owned_entries);
@@ -1969,10 +1966,7 @@ impl ProtocolStore for SqliteStore {
         let address = address.to_string();
         let message_id = message_id.to_string();
         let base_key = base_key.to_vec();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i32;
+        let now = wacore::time::now_secs() as i32;
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
@@ -2059,10 +2053,7 @@ impl ProtocolStore for SqliteStore {
         let device_id = self.device_id;
         let devices_json = serde_json::to_string(&record.devices)
             .map_err(|e| StoreError::Serialization(e.to_string()))?;
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i32;
+        let now = wacore::time::now_secs() as i32;
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
@@ -2195,10 +2186,7 @@ impl ProtocolStore for SqliteStore {
         let device_id = self.device_id;
         let jid = jid.to_string();
         let entry = entry.clone();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
+        let now = wacore::time::now_secs();
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
@@ -2442,10 +2430,7 @@ impl DeviceStore for SqliteStore {
                 .get()
                 .map_err(|e| StoreError::Connection(e.to_string()))?;
 
-            let timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+            let timestamp = wacore::time::now_secs();
 
             // Construct target path: db_path.snapshot-TIMESTAMP-SANITIZED_NAME
             let target_path = format!("{}.snapshot-{}-{}", db_path, timestamp, sanitized_name);

--- a/tests/bench-integration/Cargo.toml
+++ b/tests/bench-integration/Cargo.toml
@@ -33,3 +33,6 @@ whatsapp-rust = { path = "../..", default-features = false, features = [
   "tokio-native",
   "signal",
 ] }
+
+[lints]
+workspace = true

--- a/tests/bench-integration/src/main.rs
+++ b/tests/bench-integration/src/main.rs
@@ -9,7 +9,7 @@ static GLOBAL: dhat::Alloc = dhat::Alloc;
 #[global_allocator]
 static GLOBAL: counting_alloc::CountingAlloc = counting_alloc::CountingAlloc;
 
-use std::time::Instant;
+use wacore::time::Instant;
 
 use e2e_tests::{TestClient, text_msg};
 use serde::Serialize;

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -36,8 +36,10 @@ whatsapp-rust-ureq-http-client = { path = "../../http_clients/ureq-client", feat
 ] }
 
 [dev-dependencies]
-chrono = { workspace = true, features = ["now", "serde"] }
 env_logger = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }
 prost = { workspace = true }
+
+[lints]
+workspace = true

--- a/tests/e2e/tests/app_state.rs
+++ b/tests/e2e/tests/app_state.rs
@@ -280,13 +280,7 @@ async fn test_multi_device_app_state_sync() -> anyhow::Result<()> {
 
     // Use a unique push name each run so the test is idempotent even if the
     // mock server persists push_name state across sessions (like the real server).
-    let new_name = format!(
-        "MultiDev_{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis()
-    );
+    let new_name = format!("MultiDev_{}", wacore::time::now_millis());
     client_a1.client.profile().set_push_name(&new_name).await?;
     info!("A1 set push name to '{new_name}'");
 

--- a/tests/e2e/tests/chat_actions.rs
+++ b/tests/e2e/tests/chat_actions.rs
@@ -168,7 +168,7 @@ async fn test_mute_chat_with_expiry() -> anyhow::Result<()> {
     client_a.wait_for_app_state_sync().await?;
 
     // Mute for 8 hours from now
-    let mute_end = chrono::Utc::now().timestamp_millis() + (8 * 60 * 60 * 1000);
+    let mute_end = wacore::time::now_millis() + (8 * 60 * 60 * 1000);
 
     client_a
         .client

--- a/tests/e2e/tests/concurrent_disconnect.rs
+++ b/tests/e2e/tests/concurrent_disconnect.rs
@@ -15,7 +15,8 @@
 //! the transport also closes it.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use wacore::time::Instant;
 
 use e2e_tests::{TestClient, text_msg};
 use wacore::types::events::Event;

--- a/tests/e2e/tests/device_cache.rs
+++ b/tests/e2e/tests/device_cache.rs
@@ -44,7 +44,7 @@ async fn test_group_send_uses_registry_cache_after_reconnect() -> anyhow::Result
 
     // Second send — exercises registry-based device resolution
     let text_2 = "after reconnect";
-    let t = std::time::Instant::now();
+    let t = wacore::time::Instant::now();
     client_a
         .client
         .send_message(group_jid.clone(), text_msg(text_2))

--- a/tests/e2e/tests/receipts.rs
+++ b/tests/e2e/tests/receipts.rs
@@ -450,7 +450,7 @@ async fn test_disconnect_is_fast_with_no_pending_receipts() -> anyhow::Result<()
 
     let client = TestClient::connect("e2e_rcpt_cold_disconnect").await?;
 
-    let start = std::time::Instant::now();
+    let start = wacore::time::Instant::now();
     client.client.disconnect().await;
     let elapsed = start.elapsed();
 
@@ -489,7 +489,7 @@ async fn test_disconnect_is_fast_with_pending_receipts() -> anyhow::Result<()> {
         .wait_for_text(&format!("burst {}", N - 1), 15)
         .await?;
 
-    let start = std::time::Instant::now();
+    let start = wacore::time::Instant::now();
     client_b.client.disconnect().await;
     let elapsed = start.elapsed();
 

--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -31,3 +31,6 @@ tokio-websockets = { version = "0.13.0", features = [
 ] }
 wacore = { workspace = true }
 webpki-roots = "1.0.4"
+
+[lints]
+workspace = true

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -66,3 +66,6 @@ harness = false
 [[bench]]
 name = "send_receive_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -31,3 +31,6 @@ wacore-libsignal = { workspace = true }
 waproto = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -43,3 +43,6 @@ harness = false
 [[bench]]
 name = "numeric_attr_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/wacore/derive/Cargo.toml
+++ b/wacore/derive/Cargo.toml
@@ -14,3 +14,6 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[lints]
+workspace = true

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -41,3 +41,6 @@ iai-callgrind = { workspace = true }
 [[bench]]
 name = "libsignal_benchmark"
 harness = false
+
+[lints]
+workspace = true

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -152,7 +152,8 @@ mod tests {
         let key_pair = KeyPair::generate(&mut rand::rng());
         let mut signature = [0u8; 64];
         rand::rng().fill_bytes(&mut signature);
-        let timestamp = chrono::Utc::now();
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .expect("fixed timestamp is in range");
         let id = 123u32;
 
         // Create structure using new_signed_pre_key_record

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -24,3 +24,6 @@ wacore-libsignal = { workspace = true }
 waproto = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -16,6 +16,10 @@ pub trait TimeProvider: Send + Sync + 'static {
 struct ChronoTimeProvider;
 
 impl TimeProvider for ChronoTimeProvider {
+    // The single legitimate call to `chrono::Utc::now()`: this IS the default
+    // provider backing `wacore::time::now_utc()`. Everywhere else must go
+    // through the abstraction — see clippy.toml.
+    #[allow(clippy::disallowed_methods)]
     fn now_millis(&self) -> i64 {
         chrono::Utc::now().timestamp_millis()
     }

--- a/waproto/Cargo.toml
+++ b/waproto/Cargo.toml
@@ -19,3 +19,6 @@ serde = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true, optional = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Problem

CI regressed (second time) because **a single `chrono::Utc::now()`** in `src/pdo.rs:479` bypassed the pluggable `TimeProvider` abstraction in `wacore::time`. That abstraction is the only thing keeping `std::time::SystemTime` out of WASM builds — without it, the underlying call resolves to `sys/time/unsupported.rs:35` and panics with `time not implemented on this platform`.

The call lives on the PDO retry path (`spawn_pdo_request_with_options`), so any Bad-MAC / retry flow triggered it:
- panic during test Phase 3: `panicked at .../library/std/src/sys/time/unsupported.rs:35:9`
- post-test leak: `RuntimeError: unreachable` caught by the Node test runner — WASM trap from a `tokio::spawn`ed task that outlived the test

## Fix

**The regression:**
- `src/pdo.rs:479`: `chrono::Utc::now()` → `wacore::time::now_utc()`

**Consistency sweep — every remaining prod and test site also goes through the abstraction** (so nobody has to remember the rule; enforcement below catches new ones):
- `src/main.rs`, `src/message.rs` (tests), `src/flush_scope.rs`, `src/store/persistence_manager.rs`, `src/client.rs`, `src/client/lid_pn.rs`
- `storages/sqlite-storage/src/sqlite_store.rs` — 5× `SystemTime::now().duration_since(UNIX_EPOCH)...` replaced with `wacore::time::now_secs()` (also drops 4 lines per call site)
- `tests/e2e/tests/{receipts,device_cache,app_state,chat_actions,concurrent_disconnect}.rs`
- `tests/bench-integration/src/main.rs`
- `wacore/libsignal/src/store/record_helpers.rs` — fixed timestamp via `DateTime::from_timestamp`; crate is a leaf and can't depend on `wacore`. Bonus: the test is now deterministic.

**Chrono cleanup (`cargo shear`-driven):**
- `tests/e2e/Cargo.toml` — `chrono` dev-dep removed; orphaned by the sweep.

## Prevention (this is the real fix for the recurring pattern)

- New `clippy.toml` with `disallowed-methods` for `chrono::{Utc,Local}::now`, `std::time::{SystemTime,Instant}::now` — each with a `reason` pointing at the correct helper.
- `[workspace.lints.clippy] disallowed_methods = \"deny\"` in the root `Cargo.toml`; `[lints] workspace = true` wired into every crate.
- Single sanctioned exception: `ChronoTimeProvider::now_millis` in `wacore/src/time.rs` with inline `#[allow(clippy::disallowed_methods)]` — this IS the provider backing `wacore::time::now_utc()`.

A future PR that writes `chrono::Utc::now()` or `std::time::Instant::now()` anywhere in the workspace fails `cargo clippy --all --tests` with a message pointing at the correct helper.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests` — deny active, zero warnings
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — 565+ tests green
- [x] `cargo shear` — zero remaining chrono hits
- [ ] WASM CI re-run — should no longer panic on PDO retry paths