### PR TITLE
perf: reduce cache and channel pre-allocations

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -159,21 +159,21 @@ impl CacheStores {
 pub struct CacheConfig {
     /// Group metadata cache (time_to_live). Default: 1h TTL, 250 entries.
     pub group_cache: CacheEntryConfig,
-    /// Device registry cache (time_to_live). Default: 1h TTL, 5000 entries.
+    /// Device registry cache (time_to_live). Default: 1h TTL, 1000 entries.
     pub device_registry_cache: CacheEntryConfig,
-    /// LID-to-phone cache (time_to_idle). Default: 1h timeout, 10000 entries.
+    /// LID-to-phone cache (time_to_idle). Default: 1h timeout, 2000 entries.
     pub lid_pn_cache: CacheEntryConfig,
     /// Optional L1 in-memory cache for sent messages (retry support).
     /// Default: capacity 0 (disabled — DB-only, matching WA Web).
     /// Set capacity > 0 to enable a fast in-memory cache in front of the DB.
     pub recent_messages: CacheEntryConfig,
-    /// Message retry counts (time_to_live). Default: 5m TTL, 1000 entries.
+    /// Message retry counts (time_to_live). Default: 5m TTL, 500 entries.
     pub message_retry_counts: CacheEntryConfig,
     /// Dedup key for `UndecryptableMessage` dispatch so a server resend of
     /// the same id does not surface a second notification. Default: 5m TTL,
     /// 1000 entries.
     pub undecryptable_dispatched: CacheEntryConfig,
-    /// PDO pending requests (time_to_live). Default: 30s TTL, 500 entries.
+    /// PDO pending requests (time_to_live). Default: 30s TTL, 200 entries.
     pub pdo_pending_requests: CacheEntryConfig,
     /// Sender key device tracking cache (time_to_idle). Default: 1h TTI, 500 entries.
     /// Caches per-group SKDM distribution state to avoid DB reads on every group send.
@@ -241,12 +241,12 @@ impl Default for CacheConfig {
 
         Self {
             group_cache: CacheEntryConfig::new(one_hour, 250),
-            device_registry_cache: CacheEntryConfig::new(one_hour, 5_000),
-            lid_pn_cache: CacheEntryConfig::new(one_hour, 10_000),
+            device_registry_cache: CacheEntryConfig::new(one_hour, 1_000),
+            lid_pn_cache: CacheEntryConfig::new(one_hour, 2_000),
             recent_messages: CacheEntryConfig::new(five_min, 0),
-            message_retry_counts: CacheEntryConfig::new(five_min, 1_000),
+            message_retry_counts: CacheEntryConfig::new(five_min, 500),
             undecryptable_dispatched: CacheEntryConfig::new(five_min, 1_000),
-            pdo_pending_requests: CacheEntryConfig::new(Some(Duration::from_secs(30)), 500),
+            pdo_pending_requests: CacheEntryConfig::new(Some(Duration::from_secs(30)), 200),
             sender_key_devices_cache: CacheEntryConfig::new(one_hour, 500),
             // Coordination caches hold live mutexes/senders; capacity eviction
             // while a reference is held creates a second lock for the same key,

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -14,7 +14,6 @@
 //! 3. The phone responds with PeerDataOperationRequestResponseMessage containing the decoded message
 //! 4. We emit the message as if we had decrypted it ourselves
 
-use crate::cache::Cache;
 use crate::client::Client;
 use crate::types::message::MessageInfo;
 use log::{debug, info, warn};
@@ -31,13 +30,6 @@ use waproto::whatsapp as wa;
 pub struct PendingPdoRequest {
     pub message_info: Arc<MessageInfo>,
     pub requested_at: wacore::time::Instant,
-}
-
-pub fn new_pdo_cache() -> Cache<ChatMessageId, PendingPdoRequest> {
-    Cache::builder()
-        .time_to_live(Duration::from_secs(30))
-        .max_capacity(500)
-        .build()
 }
 
 impl Client {

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -42,9 +42,9 @@ impl NoiseSocket {
         let write_key = Arc::new(write_key);
         let read_key = Arc::new(read_key);
 
-        // Create channel for send jobs. Buffer size of 32 allows multiple
-        // callers to enqueue work without blocking on channel capacity.
-        let (send_job_tx, send_job_rx) = async_channel::bounded::<SendJob>(32);
+        // Buffer of 8 is sufficient since the sender task processes jobs
+        // serially in <1ms each. Overflow backpressures producers.
+        let (send_job_tx, send_job_rx) = async_channel::bounded::<SendJob>(8);
 
         // Spawn the dedicated sender task
         let transport_clone = transport.clone();

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -42,8 +42,9 @@ impl NoiseSocket {
         let write_key = Arc::new(write_key);
         let read_key = Arc::new(read_key);
 
-        // Buffer of 8 is sufficient since the sender task processes jobs
-        // serially in <1ms each. Overflow backpressures producers.
+        // Small buffer matched to typical steady-state throughput; the sender
+        // task is network-bound (awaits `transport.send`), so a transient
+        // WebSocket stall will backpressure producers here rather than queue.
         let (send_job_tx, send_job_rx) = async_channel::bounded::<SendJob>(8);
 
         // Spawn the dedicated sender task

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -15,7 +15,7 @@ use wacore::net::{Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_WS_U
 
 pub use tokio_websockets::Connector;
 
-const EVENT_CHANNEL_CAPACITY: usize = 1_024;
+const EVENT_CHANNEL_CAPACITY: usize = 64;
 
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -43,7 +43,7 @@ fn evict_clean_entries<V>(
 }
 
 /// Default max entries per store before clean entry eviction triggers.
-const DEFAULT_MAX_CACHE_ENTRIES: usize = 10_000;
+const DEFAULT_MAX_CACHE_ENTRIES: usize = 2_000;
 
 /// In-memory write-back cache for Signal protocol state.
 /// Keys use `Arc<str>` for O(1) clone. Sessions cached as objects (serialized on flush).


### PR DESCRIPTION
## Summary

Trim over-provisioned default caches and the noise_socket send-job channel. All values remain tunable via `CacheConfig`.

## Changes

| Resource | Before | After |
|---|---|---|
| Signal cache (wacore) | 10 000 | 2 000 |
| `lid_pn_cache` | 10 000 | 2 000 |
| `device_registry_cache` | 5 000 | 1 000 |
| `message_retry_counts` | 1 000 | 500 |
| `pdo_pending_requests` | 500 | 200 |
| noise_socket send-job channel | 32 | 8 |
| transport event channel | 1 024 | 64 |
| `new_pdo_cache()` helper | dead code | removed |

Lossy caches fall back to DB on miss; time-bounded caches (TTL 30s-5m) tolerate pressure; channel overflow is backpressure, not corruption.

## Deliberately out of scope

- `session_locks_capacity` / `chat_lanes_capacity` — these hold live mutexes; eviction while referenced breaks serialization. Single-DM benchmark doesn't exercise distinct-chat fan-out, so the safety of reducing them is unvalidated. Left at current defaults.
- Noise `enc_buf` initial capacity — kept at 4096. The per-frame cost of the alternative pattern is indistinguishable from noise at 5K msg/s.
- Default runtime flavor change (multi-thread -> current-thread) — behavioral, belongs in its own PR with explicit breaking-change messaging.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration`
- [x] 5K msg/s single-DM benchmark sustained