### PR TITLE
refactor!: preserve typed error sources across the workspace

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3608,7 +3608,7 @@ impl Client {
 
         let plaintext_buf = wacore_binary::marshal::marshal_auto(&node).map_err(|e| {
             error!("Failed to marshal node: {e:?}");
-            SocketError::Crypto("Marshal error".to_string())
+            SocketError::Marshal(e)
         })?;
 
         self.send_raw_bytes(plaintext_buf).await

--- a/src/client.rs
+++ b/src/client.rs
@@ -2506,10 +2506,16 @@ impl Client {
                         }
                         continue;
                     }
-                    let is_db_locked = e.downcast_ref::<wacore::store::error::StoreError>()
-                        .is_some_and(|se| matches!(se, wacore::store::error::StoreError::Database(msg) if msg.contains("locked") || msg.contains("busy")))
+                    let is_db_locked = e
+                        .downcast_ref::<wacore::store::error::StoreError>()
+                        .is_some_and(|se| se.is_database_busy_or_locked())
                         || e.downcast_ref::<crate::appstate_sync::AppStateSyncError>()
-                            .is_some_and(|ase| matches!(ase, crate::appstate_sync::AppStateSyncError::Store(wacore::store::error::StoreError::Database(msg)) if msg.contains("locked") || msg.contains("busy")));
+                            .is_some_and(|ase| match ase {
+                                crate::appstate_sync::AppStateSyncError::Store(se) => {
+                                    se.is_database_busy_or_locked()
+                                }
+                                _ => false,
+                            });
                     if is_db_locked && attempt < APP_STATE_RETRY_MAX_ATTEMPTS {
                         let backoff = Duration::from_millis(200 * attempt as u64 + 150);
                         warn!(target: "Client/AppState", "Attempt {} for {:?} failed due to locked DB; backing off {:?} and retrying", attempt, name, backoff);

--- a/src/features/mex.rs
+++ b/src/features/mex.rs
@@ -7,6 +7,7 @@ use crate::request::IqError;
 use serde_json::Value;
 use thiserror::Error;
 use wacore::iq::mex::MexQuerySpec;
+use wacore_binary::jid::JidError;
 
 // Re-export types from wacore
 pub use wacore::iq::mex::{MexDoc, MexErrorExtensions, MexGraphQLError, MexResponse};
@@ -14,16 +15,21 @@ pub use wacore::iq::mex::{MexDoc, MexErrorExtensions, MexGraphQLError, MexRespon
 /// Error types for MEX operations.
 #[derive(Debug, Error)]
 pub enum MexError {
+    /// Payload missing or otherwise malformed in a way that has no underlying
+    /// typed source (descriptive message only — e.g. "missing data").
     #[error("MEX payload parsing error: {0}")]
     PayloadParsing(String),
+
+    #[error("MEX payload contained an invalid JID")]
+    InvalidJid(#[from] JidError),
 
     #[error("MEX extension error: code={code}, message='{message}'")]
     ExtensionError { code: i32, message: String },
 
-    #[error("IQ request failed: {0}")]
+    #[error("IQ request failed")]
     Request(#[from] IqError),
 
-    #[error("JSON error: {0}")]
+    #[error("JSON error")]
     Json(#[from] serde_json::Error),
 }
 
@@ -236,5 +242,29 @@ mod tests {
         assert!(ext.is_summary.is_none());
         assert!(ext.is_retryable.is_none());
         assert!(ext.severity.is_none());
+    }
+
+    #[test]
+    fn invalid_jid_preserves_jid_error_source() {
+        let raw: Result<wacore_binary::Jid, JidError> = "not-a-valid-jid".parse();
+        let jid_err = raw.unwrap_err();
+        let me: MexError = jid_err.into();
+        let src = std::error::Error::source(&me).expect("source preserved");
+        let inner = src
+            .downcast_ref::<JidError>()
+            .expect("downcasts to JidError");
+        assert!(matches!(inner, JidError::InvalidFormat(_)));
+    }
+
+    #[test]
+    fn request_preserves_iq_error_source() {
+        let iq = IqError::ServerError {
+            code: 404,
+            text: "not-found".into(),
+        };
+        let me: MexError = iq.into();
+        let src = std::error::Error::source(&me).expect("source preserved");
+        let inner = src.downcast_ref::<IqError>().expect("downcasts to IqError");
+        assert!(matches!(inner, IqError::ServerError { code: 404, .. }));
     }
 }

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -420,9 +420,7 @@ fn parse_newsletter_metadata(value: &serde_json::Value) -> Result<NewsletterMeta
     let jid_str = value["id"]
         .as_str()
         .ok_or_else(|| MexError::PayloadParsing("missing newsletter id".into()))?;
-    let jid: Jid = jid_str
-        .parse()
-        .map_err(|e| MexError::PayloadParsing(format!("invalid newsletter JID: {e}")))?;
+    let jid: Jid = jid_str.parse()?;
 
     let thread = &value["thread_metadata"];
 

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -31,6 +31,8 @@ enum KeepaliveResult {
 fn classify_keepalive_error(e: &IqError) -> KeepaliveResult {
     match e {
         IqError::Socket(_)
+        | IqError::EncryptSend(_)
+        | IqError::ClientState(_)
         | IqError::Disconnected(_)
         | IqError::NotConnected
         | IqError::InternalChannelClosed
@@ -229,7 +231,7 @@ mod tests {
     #[test]
     fn test_classify_socket_error_is_fatal() {
         assert_eq!(
-            classify_keepalive_error(&IqError::Socket(SocketError::Crypto("test".to_string()))),
+            classify_keepalive_error(&IqError::Socket(SocketError::SocketClosed)),
             KeepaliveResult::FatalFailure,
         );
     }

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -52,13 +52,25 @@ use log::{error, info, warn};
 
 use std::sync::Arc;
 use wacore::libsignal::protocol::KeyPair;
-use wacore::pair_code::{PairCodeError, PairCodeState, PairCodeUtils, resolve_companion_platform};
+use wacore::pair_code::{PairCodeState, PairCodeUtils, resolve_companion_platform};
 use wacore_binary::Jid;
 use wacore_binary::{NodeContent, NodeContentRef, NodeRef};
 
-// Re-export types for user convenience
 pub use wacore::companion_reg::CompanionWebClientType;
-pub use wacore::pair_code::PairCodeOptions;
+pub use wacore::pair_code::{PairCodeError, PairCodeOptions};
+
+/// Errors raised by the high-level pair-code flow.
+///
+/// Wraps `wacore::pair_code::PairCodeError` (validation, key derivation, bundle
+/// building) and adds the IQ transport layer via `RequestFailed`.
+#[derive(Debug, thiserror::Error)]
+pub enum PairError {
+    #[error(transparent)]
+    PairCode(#[from] PairCodeError),
+
+    #[error("pair-code IQ request failed")]
+    RequestFailed(#[from] IqError),
+}
 
 impl Client {
     /// Initiates pair code authentication as an alternative to QR code pairing.
@@ -99,7 +111,7 @@ impl Client {
     pub async fn pair_with_code(
         self: &Arc<Self>,
         options: PairCodeOptions,
-    ) -> Result<String, PairCodeError> {
+    ) -> Result<String, PairError> {
         // Strip non-digit characters from phone number (allows "+1-555-123-4567" format)
         let phone_number: String = options
             .phone_number
@@ -109,20 +121,20 @@ impl Client {
 
         // Validate phone number
         if phone_number.is_empty() {
-            return Err(PairCodeError::PhoneNumberRequired);
+            return Err(PairCodeError::PhoneNumberRequired.into());
         }
         if phone_number.len() < 7 {
-            return Err(PairCodeError::PhoneNumberTooShort);
+            return Err(PairCodeError::PhoneNumberTooShort.into());
         }
         if phone_number.starts_with('0') {
-            return Err(PairCodeError::PhoneNumberNotInternational);
+            return Err(PairCodeError::PhoneNumberNotInternational.into());
         }
 
         // Generate or validate code
         let code = match &options.custom_code {
             Some(custom) => {
                 if !PairCodeUtils::validate_code(custom) {
-                    return Err(PairCodeError::InvalidCustomCode);
+                    return Err(PairCodeError::InvalidCustomCode.into());
                 }
                 custom.to_uppercase()
             }
@@ -192,12 +204,8 @@ impl Client {
             timeout: Some(std::time::Duration::from_secs(30)),
         };
 
-        let response = self
-            .send_iq(query)
-            .await
-            .map_err(|e: IqError| PairCodeError::RequestFailed(e.to_string()))?;
+        let response = self.send_iq(query).await?;
 
-        // Extract pairing ref from response
         let pairing_ref = PairCodeUtils::parse_companion_hello_response(response.get())
             .ok_or(PairCodeError::MissingPairingRef)?;
 
@@ -372,4 +380,37 @@ pub(crate) async fn handle_pair_code_notification(
     *client.pair_code_state.lock().await = PairCodeState::Completed;
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pair_error_request_failed_preserves_iq_source() {
+        let iq = IqError::ServerError {
+            code: 400,
+            text: "bad-request".into(),
+        };
+        let pe: PairError = iq.into();
+        let src = std::error::Error::source(&pe).expect("source preserved");
+        let downcast = src.downcast_ref::<IqError>().expect("downcasts to IqError");
+        assert!(matches!(downcast, IqError::ServerError { code: 400, .. }));
+    }
+
+    #[test]
+    fn pair_error_paircode_transparent_walks_to_curve_error() {
+        use wacore::libsignal::protocol::CurveError;
+        // Wrap a wacore PairCodeError that itself carries a CurveError source.
+        // Because PairError::PairCode is `transparent`, walking source() once
+        // skips the transparent layer and lands directly on the CurveError.
+        let pe: PairError =
+            PairCodeError::EphemeralKeyAgreement(CurveError::NoKeyTypeIdentifier).into();
+        assert_eq!(pe.to_string(), "ephemeral key agreement failed");
+        let src = std::error::Error::source(&pe).expect("source preserved");
+        let curve = src
+            .downcast_ref::<CurveError>()
+            .expect("downcasts to CurveError through transparent wrapper");
+        assert!(matches!(curve, CurveError::NoKeyTypeIdentifier));
+    }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,6 @@
 use crate::client::Client;
-use crate::socket::error::SocketError;
+use crate::client::ClientError;
+use crate::socket::error::{EncryptSendError, SocketError};
 use futures::FutureExt;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -14,19 +15,23 @@ pub use wacore::request::{InfoQuery, InfoQueryType, RequestUtils};
 pub enum IqError {
     #[error("IQ request timed out")]
     Timeout,
-    #[error("Client is not connected")]
+    #[error("client is not connected")]
     NotConnected,
-    #[error("Socket error: {0}")]
+    #[error("socket error")]
     Socket(#[from] SocketError),
-    #[error("Received disconnect node during IQ wait: {0:?}")]
+    #[error("encrypted send pipeline failed")]
+    EncryptSend(#[from] EncryptSendError),
+    #[error("client state prevented send")]
+    ClientState(#[source] ClientError),
+    #[error("received disconnect node during IQ wait: {0:?}")]
     Disconnected(Node),
-    #[error("Received a server error response: code={code}, text='{text}'")]
+    #[error("received a server error response: code={code}, text='{text}'")]
     ServerError { code: u16, text: String },
-    #[error("Internal channel closed unexpectedly")]
+    #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
-    #[error("Failed to encode IQ request: {0}")]
-    EncodeError(anyhow::Error),
-    #[error("Failed to parse IQ response: {0}")]
+    #[error("failed to encode IQ request")]
+    EncodeError(#[source] anyhow::Error),
+    #[error("failed to parse IQ response")]
     ParseError(#[from] anyhow::Error),
 }
 
@@ -40,7 +45,6 @@ impl From<wacore::request::IqError> for IqError {
                 Self::ServerError { code, text }
             }
             wacore::request::IqError::InternalChannelClosed => Self::InternalChannelClosed,
-            wacore::request::IqError::Network(msg) => Self::Socket(SocketError::Crypto(msg)),
         }
     }
 }
@@ -225,9 +229,12 @@ impl Client {
         if let Err(e) = send_fn.await {
             self.response_waiters.lock().await.remove(&req_id);
             return match e {
-                crate::client::ClientError::Socket(s_err) => Err(IqError::Socket(s_err)),
-                crate::client::ClientError::NotConnected => Err(IqError::NotConnected),
-                _ => Err(IqError::Socket(SocketError::Crypto(e.to_string()))),
+                ClientError::Socket(s_err) => Err(IqError::Socket(s_err)),
+                ClientError::EncryptSend(es_err) => Err(IqError::EncryptSend(es_err)),
+                ClientError::NotConnected => Err(IqError::NotConnected),
+                other @ (ClientError::AlreadyConnected | ClientError::NotLoggedIn) => {
+                    Err(IqError::ClientState(other))
+                }
             };
         }
 

--- a/src/socket/error.rs
+++ b/src/socket/error.rs
@@ -1,15 +1,17 @@
 use thiserror::Error;
+use wacore::handshake::NoiseError;
+use wacore_binary::error::BinaryError;
 
 #[derive(Debug, Error)]
 pub enum SocketError {
-    #[error("Socket is closed")]
+    #[error("socket is closed")]
     SocketClosed,
-    #[error("Noise handshake failed: {0}")]
-    NoiseHandshake(String),
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
-    #[error("Crypto error: {0}")]
-    Crypto(String),
+    #[error("noise cipher operation failed")]
+    Cipher(#[from] NoiseError),
+    #[error("binary protocol marshalling failed")]
+    Marshal(#[source] BinaryError),
 }
 
 pub type Result<T> = std::result::Result<T, SocketError>;
@@ -78,5 +80,40 @@ impl EncryptSendError {
             self.kind,
             EncryptSendErrorKind::Transport | EncryptSendErrorKind::ChannelClosed
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wacore::libsignal::crypto::CryptoProviderError;
+
+    #[test]
+    fn cipher_preserves_noise_source_through_socket_error() {
+        let noise = NoiseError::Decrypt(CryptoProviderError::AuthFailed);
+        let se: SocketError = noise.into();
+        // First hop: SocketError → NoiseError
+        let src = std::error::Error::source(&se).expect("source preserved");
+        let ne = src
+            .downcast_ref::<NoiseError>()
+            .expect("downcasts to NoiseError");
+        assert!(matches!(ne, NoiseError::Decrypt(_)));
+        // Second hop: NoiseError → CryptoProviderError
+        let inner = std::error::Error::source(ne).expect("inner source preserved");
+        let cpe = inner
+            .downcast_ref::<CryptoProviderError>()
+            .expect("downcasts to CryptoProviderError");
+        assert!(matches!(cpe, CryptoProviderError::AuthFailed));
+    }
+
+    #[test]
+    fn marshal_preserves_binary_error_source() {
+        let be = BinaryError::InvalidNode;
+        let se = SocketError::Marshal(be);
+        let src = std::error::Error::source(&se).expect("source preserved");
+        let inner = src
+            .downcast_ref::<BinaryError>()
+            .expect("downcasts to BinaryError");
+        assert!(matches!(inner, BinaryError::InvalidNode));
     }
 }

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -180,7 +180,7 @@ impl NoiseSocket {
         let counter = self.read_counter.fetch_add(1, Ordering::SeqCst);
         self.read_key
             .decrypt_in_place_with_counter(counter, &mut ciphertext)
-            .map_err(|e| SocketError::Crypto(e.to_string()))?;
+            .map_err(SocketError::Cipher)?;
         Ok(ciphertext)
     }
 }

--- a/src/store/error.rs
+++ b/src/store/error.rs
@@ -1,2 +1,2 @@
 // Re-export error types from wacore for compatibility
-pub use wacore::store::error::{Result, StoreError, db_err};
+pub use wacore::store::error::{Result, StoreError};

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -122,9 +122,7 @@ impl PersistenceManager {
         {
             // Ensure pending changes are saved first
             self.save_to_disk().await?;
-            self.backend
-                .snapshot_db(name, extra_content)
-                .await
+            self.backend.snapshot_db(name, extra_content).await
         }
         #[cfg(not(feature = "debug-snapshots"))]
         {
@@ -241,9 +239,7 @@ impl PersistenceManager {
         &self,
         group_jid: &str,
     ) -> Result<Vec<(String, bool)>, StoreError> {
-        self.backend
-            .get_sender_key_devices(group_jid)
-            .await
+        self.backend.get_sender_key_devices(group_jid).await
     }
 
     pub async fn set_sender_key_status(
@@ -251,15 +247,11 @@ impl PersistenceManager {
         group_jid: &str,
         entries: &[(&str, bool)],
     ) -> Result<(), StoreError> {
-        self.backend
-            .set_sender_key_status(group_jid, entries)
-            .await
+        self.backend.set_sender_key_status(group_jid, entries).await
     }
 
     pub async fn clear_sender_key_devices(&self, group_jid: &str) -> Result<(), StoreError> {
-        self.backend
-            .clear_sender_key_devices(group_jid)
-            .await
+        self.backend.clear_sender_key_devices(group_jid).await
     }
 }
 

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -1,4 +1,4 @@
-use super::error::{StoreError, db_err};
+use super::error::StoreError;
 use crate::store::Device;
 use crate::store::traits::Backend;
 use async_lock::RwLock;
@@ -27,15 +27,15 @@ impl PersistenceManager {
     pub async fn new(backend: Arc<dyn Backend>) -> Result<Self, StoreError> {
         debug!("PersistenceManager: Ensuring device row exists.");
         // Ensure a device row exists for this backend's device_id; create it if not.
-        let exists = backend.exists().await.map_err(db_err)?;
+        let exists = backend.exists().await?;
         if !exists {
             debug!("PersistenceManager: No device row found. Creating new device row.");
-            let id = backend.create().await.map_err(db_err)?;
+            let id = backend.create().await?;
             debug!("PersistenceManager: Created device row with id={id}.");
         }
 
         debug!("PersistenceManager: Attempting to load device data via Backend.");
-        let device_data_opt = backend.load().await.map_err(db_err)?;
+        let device_data_opt = backend.load().await?;
 
         let device = if let Some(serializable_device) = device_data_opt {
             debug!(
@@ -104,7 +104,7 @@ impl PersistenceManager {
             if let Err(e) = self.backend.save(&serializable_device).await {
                 // Restore dirty flag so the next tick retries the save
                 self.dirty.store(true, Ordering::Release);
-                return Err(db_err(e));
+                return Err(e);
             }
             debug!("Device state saved successfully.");
         }
@@ -125,7 +125,6 @@ impl PersistenceManager {
             self.backend
                 .snapshot_db(name, extra_content)
                 .await
-                .map_err(db_err)
         }
         #[cfg(not(feature = "debug-snapshots"))]
         {
@@ -245,7 +244,6 @@ impl PersistenceManager {
         self.backend
             .get_sender_key_devices(group_jid)
             .await
-            .map_err(db_err)
     }
 
     pub async fn set_sender_key_status(
@@ -256,14 +254,12 @@ impl PersistenceManager {
         self.backend
             .set_sender_key_status(group_jid, entries)
             .await
-            .map_err(db_err)
     }
 
     pub async fn clear_sender_key_devices(&self, group_jid: &str) -> Result<(), StoreError> {
         self.backend
             .clear_sender_key_devices(group_jid)
             .await
-            .map_err(db_err)
     }
 }
 

--- a/src/store/signal.rs
+++ b/src/store/signal.rs
@@ -220,9 +220,7 @@ impl IdentityKeyStore for Device {
                 })?,
             )
             .await
-            .map_err(|e| {
-                SignalProtocolError::InvalidState("backend put_identity", e.to_string())
-            })?;
+            .map_err(|e| SignalProtocolError::BackendError("backend put_identity", Box::new(e)))?;
 
         match existing_identity_opt {
             None => Ok(IdentityChange::NewOrUnchanged),
@@ -248,9 +246,7 @@ impl IdentityKeyStore for Device {
             .backend
             .load_identity(address.as_str())
             .await
-            .map_err(|e| {
-                SignalProtocolError::InvalidState("backend get_identity", e.to_string())
-            })?;
+            .map_err(|e| SignalProtocolError::BackendError("backend get_identity", Box::new(e)))?;
 
         match identity_bytes {
             Some(bytes) if !bytes.is_empty() => {
@@ -479,7 +475,7 @@ impl SenderKeyStore for Device {
         self.backend
             .put_sender_key(sender_key_name.cache_key(), &serialized_record)
             .await
-            .map_err(|e| SignalProtocolError::InvalidState("store_sender_key", e.to_string()))
+            .map_err(|e| SignalProtocolError::BackendError("store_sender_key", Box::new(e)))
     }
 
     async fn load_sender_key(
@@ -490,7 +486,7 @@ impl SenderKeyStore for Device {
             .backend
             .get_sender_key(sender_key_name.cache_key())
             .await
-            .map_err(|e| SignalProtocolError::InvalidState("load_sender_key", e.to_string()))?
+            .map_err(|e| SignalProtocolError::BackendError("load_sender_key", Box::new(e)))?
         {
             Some(data) => {
                 let record = SenderKeyRecord::deserialize(&data)?;

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -15,10 +15,11 @@ use wacore::libsignal::store::{
     PreKeyStore as WacorePreKeyStore, SignedPreKeyStore as WacoreSignedPreKeyStore,
 };
 
-fn signal_err<E: std::fmt::Display>(
-    context: &'static str,
-) -> impl FnOnce(E) -> SignalProtocolError {
-    move |e| SignalProtocolError::InvalidState(context, e.to_string())
+fn signal_err<E>(context: &'static str) -> impl FnOnce(E) -> SignalProtocolError
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+{
+    move |e| SignalProtocolError::BackendError(context, e.into())
 }
 
 #[derive(Clone)]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -27,7 +27,7 @@ enum DieselOrStore {
 impl From<DieselOrStore> for StoreError {
     fn from(e: DieselOrStore) -> Self {
         match e {
-            DieselOrStore::Diesel(e) => StoreError::Database(e.to_string()),
+            DieselOrStore::Diesel(e) => StoreError::Database(Box::new(e)),
             DieselOrStore::Store(e) => e,
         }
     }
@@ -124,7 +124,7 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
 fn parse_database_path(database_url: &str) -> Result<String> {
     // Reject in-memory databases
     if database_url == ":memory:" {
-        return Err(StoreError::Database(
+        return Err(StoreError::InvalidConfig(
             "Snapshot not supported for in-memory databases".to_string(),
         ));
     }
@@ -140,7 +140,7 @@ fn parse_database_path(database_url: &str) -> Result<String> {
 
     // Check if the resulting path looks like an in-memory marker
     if path == ":memory:" || path.starts_with(":memory:?") {
-        return Err(StoreError::Database(
+        return Err(StoreError::InvalidConfig(
             "Snapshot not supported for in-memory databases".to_string(),
         ));
     }
@@ -158,25 +158,25 @@ impl SqliteStore {
             .max_size(pool_size)
             .connection_customizer(Box::new(ConnectionOptions))
             .build(manager)
-            .map_err(|e| StoreError::Connection(e.to_string()))?;
+            .map_err(|e| StoreError::Connection(Box::new(e)))?;
 
         let pool_clone = pool.clone();
         tokio::task::spawn_blocking(move || -> std::result::Result<(), StoreError> {
             let mut conn = pool_clone
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
 
             diesel::sql_query("PRAGMA journal_mode = WAL;")
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             conn.run_pending_migrations(MIGRATIONS)
-                .map_err(|e| StoreError::Migration(e.to_string()))?;
+                .map_err(StoreError::Migration)?;
 
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         let database_path = parse_database_path(database_url)?;
 
@@ -211,14 +211,14 @@ impl SqliteStore {
             .clone()
             .acquire_owned()
             .await
-            .map_err(|e| StoreError::Database(format!("Semaphore error: {}", e)))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
         let result = tokio::task::spawn_blocking(move || {
             let res = f();
             drop(permit);
             res
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(result)
     }
 
@@ -240,7 +240,7 @@ impl SqliteStore {
                 .clone()
                 .acquire_owned()
                 .await
-                .map_err(|e| StoreError::Database(format!("Semaphore error: {}", e)))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool = self.pool.clone();
             let op = make_op();
@@ -250,7 +250,7 @@ impl SqliteStore {
                     let _permit = permit;
                     let mut conn = pool
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     op(&mut conn).map_err(DieselOrStore::Diesel)
                 })
                 .await;
@@ -264,14 +264,13 @@ impl SqliteStore {
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(e.to_string())),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(format!(
-            "{} exhausted retries",
-            op_name
-        )))
+        Err(StoreError::RetriesExhausted {
+            op: op_name.to_string(),
+        })
     }
 
     fn serialize_keypair(&self, key_pair: &KeyPair) -> Result<Vec<u8>> {
@@ -283,16 +282,16 @@ impl SqliteStore {
 
     fn deserialize_keypair(&self, bytes: &[u8]) -> Result<KeyPair> {
         if bytes.len() != 64 {
-            return Err(StoreError::Serialization(format!(
+            return Err(StoreError::Validation(format!(
                 "Invalid KeyPair length: {}",
                 bytes.len()
             )));
         }
 
         let private_key = PrivateKey::deserialize(&bytes[0..32])
-            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            .map_err(|e| StoreError::Serialization(Box::new(e)))?;
         let public_key = PublicKey::from_djb_public_key_bytes(&bytes[32..64])
-            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            .map_err(|e| StoreError::Serialization(Box::new(e)))?;
 
         Ok(KeyPair::new(public_key, private_key))
     }
@@ -485,18 +484,18 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<bool> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
 
             let count: i64 = device::table
                 .filter(device::id.eq(device_id))
                 .count()
                 .get_result(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             Ok(count > 0)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     pub async fn load_device_data_for_device(&self, device_id: i32) -> Result<Option<CoreDevice>> {
@@ -506,16 +505,16 @@ impl SqliteStore {
         let row = tokio::task::spawn_blocking(move || -> Result<Option<DeviceRow>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let result = device::table
                 .filter(device::id.eq(device_id))
                 .first::<DeviceRow>(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(result)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         if let Some(row) = row {
             let pn = if !row.pn.is_empty() {
@@ -535,18 +534,19 @@ impl SqliteStore {
 
             let signed_pre_key_signature: [u8; 64] =
                 row.signed_pre_key_signature.try_into().map_err(|_| {
-                    StoreError::Serialization("Invalid signed_pre_key_signature length".to_string())
+                    StoreError::Validation("Invalid signed_pre_key_signature length".to_string())
                 })?;
 
-            let adv_secret_key: [u8; 32] = row.adv_secret_key.try_into().map_err(|_| {
-                StoreError::Serialization("Invalid adv_secret_key length".to_string())
-            })?;
+            let adv_secret_key: [u8; 32] = row
+                .adv_secret_key
+                .try_into()
+                .map_err(|_| StoreError::Validation("Invalid adv_secret_key length".to_string()))?;
 
             let account = row
                 .account
                 .map(|data| {
                     wacore::store::device::account_serde::from_bytes(&data)
-                        .map_err(|e| StoreError::Serialization(e.to_string()))
+                        .map_err(|e| StoreError::Serialization(Box::new(e)))
                 })
                 .transpose()?;
 
@@ -594,10 +594,11 @@ impl SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
             let address_clone = address_owned.clone();
@@ -607,7 +608,7 @@ impl SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     diesel::insert_into(identities::table)
                         .values((
                             identities::address.eq(address_clone),
@@ -640,14 +641,13 @@ impl SqliteStore {
                     continue;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(format!("Task join error: {}", e))),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(format!(
-            "Identity write failed after {} attempts",
-            MAX_RETRIES + 1
-        )))
+        Err(StoreError::RetriesExhausted {
+            op: format!("identity_write (after {} attempts)", MAX_RETRIES + 1),
+        })
     }
 
     pub async fn delete_identity_for_device(&self, address: &str, device_id: i32) -> Result<()> {
@@ -657,18 +657,18 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::delete(
                 identities::table
                     .filter(identities::address.eq(address_owned))
                     .filter(identities::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         Ok(())
     }
@@ -684,14 +684,14 @@ impl SqliteStore {
             .with_semaphore(move || -> Result<Option<Vec<u8>>> {
                 let mut conn = pool
                     .get()
-                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let res: Option<Vec<u8>> = identities::table
                     .select(identities::key)
                     .filter(identities::address.eq(address))
                     .filter(identities::device_id.eq(device_id))
                     .first(&mut conn)
                     .optional()
-                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
             })
             .await?;
@@ -710,14 +710,14 @@ impl SqliteStore {
             .with_semaphore(move || -> Result<Option<Vec<u8>>> {
                 let mut conn = pool
                     .get()
-                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let res: Option<Vec<u8>> = sessions::table
                     .select(sessions::record)
                     .filter(sessions::address.eq(address_for_query.clone()))
                     .filter(sessions::device_id.eq(device_id))
                     .first(&mut conn)
                     .optional()
-                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
 
                 Ok(res)
             })
@@ -740,10 +740,11 @@ impl SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
             let address_clone = address_owned.clone();
@@ -753,7 +754,7 @@ impl SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     diesel::insert_into(sessions::table)
                         .values((
                             sessions::address.eq(address_clone),
@@ -786,14 +787,13 @@ impl SqliteStore {
                     continue;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(format!("Task join error: {}", e))),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(format!(
-            "Session write failed after {} attempts",
-            MAX_RETRIES + 1
-        )))
+        Err(StoreError::RetriesExhausted {
+            op: format!("session_write (after {} attempts)", MAX_RETRIES + 1),
+        })
     }
 
     pub async fn delete_session_for_device(&self, address: &str, device_id: i32) -> Result<()> {
@@ -803,18 +803,18 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::delete(
                 sessions::table
                     .filter(sessions::address.eq(address_owned))
                     .filter(sessions::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         Ok(())
     }
@@ -831,7 +831,7 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::insert_into(sender_keys::table)
                 .values((
                     sender_keys::address.eq(address),
@@ -842,11 +842,11 @@ impl SqliteStore {
                 .do_update()
                 .set(sender_keys::record.eq(&record_vec))
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -860,18 +860,18 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let res: Option<Vec<u8>> = sender_keys::table
                 .select(sender_keys::record)
                 .filter(sender_keys::address.eq(address))
                 .filter(sender_keys::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     pub async fn delete_sender_key_for_device(&self, address: &str, device_id: i32) -> Result<()> {
@@ -880,18 +880,18 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::delete(
                 sender_keys::table
                     .filter(sender_keys::address.eq(address))
                     .filter(sender_keys::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -906,22 +906,22 @@ impl SqliteStore {
             tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
                 let mut conn = pool
                     .get()
-                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let res: Option<Vec<u8>> = app_state_keys::table
                     .select(app_state_keys::key_data)
                     .filter(app_state_keys::key_id.eq(&key_id))
                     .filter(app_state_keys::device_id.eq(device_id))
                     .first(&mut conn)
                     .optional()
-                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
             })
             .await
-            .map_err(|e| StoreError::Database(e.to_string()))??;
+            .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         if let Some(data) = res {
             let (key, _) = bincode::serde::decode_from_slice(&data, bincode::config::standard())
-                .map_err(|e| StoreError::Serialization(e.to_string()))?;
+                .map_err(|e| StoreError::Serialization(Box::new(e)))?;
             Ok(Some(key))
         } else {
             Ok(None)
@@ -937,11 +937,11 @@ impl SqliteStore {
         let pool = self.pool.clone();
         let key_id = key_id.to_vec();
         let data = bincode::serde::encode_to_vec(&key, bincode::config::standard())
-            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            .map_err(|e| StoreError::Serialization(Box::new(e)))?;
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::insert_into(app_state_keys::table)
                 .values((
                     app_state_keys::key_id.eq(&key_id),
@@ -952,11 +952,11 @@ impl SqliteStore {
                 .do_update()
                 .set(app_state_keys::key_data.eq(&data))
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -969,18 +969,18 @@ impl SqliteStore {
             tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
                 let mut conn = pool
                     .get()
-                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let res: Option<Vec<u8>> = app_state_keys::table
                     .select(app_state_keys::key_id)
                     .filter(app_state_keys::device_id.eq(device_id))
                     .order(app_state_keys::key_id.desc())
                     .first(&mut conn)
                     .optional()
-                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
             })
             .await
-            .map_err(|e| StoreError::Database(e.to_string()))??;
+            .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(res)
     }
 
@@ -995,22 +995,22 @@ impl SqliteStore {
             tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
                 let mut conn = pool
                     .get()
-                    .map_err(|e| StoreError::Connection(e.to_string()))?;
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let res: Option<Vec<u8>> = app_state_versions::table
                     .select(app_state_versions::state_data)
                     .filter(app_state_versions::name.eq(name))
                     .filter(app_state_versions::device_id.eq(device_id))
                     .first(&mut conn)
                     .optional()
-                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
             })
             .await
-            .map_err(|e| StoreError::Database(e.to_string()))??;
+            .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         if let Some(data) = res {
             let (state, _) = bincode::serde::decode_from_slice(&data, bincode::config::standard())
-                .map_err(|e| StoreError::Serialization(e.to_string()))?;
+                .map_err(|e| StoreError::Serialization(Box::new(e)))?;
             Ok(state)
         } else {
             Ok(HashState::default())
@@ -1025,7 +1025,7 @@ impl SqliteStore {
     ) -> Result<()> {
         let name = name.to_string();
         let data = bincode::serde::encode_to_vec(&state, bincode::config::standard())
-            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            .map_err(|e| StoreError::Serialization(Box::new(e)))?;
         self.with_retry("set_app_state_version", || {
             let name = name.clone();
             let data = data.clone();
@@ -1150,7 +1150,7 @@ impl SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let res: Option<Vec<u8>> = app_state_mutation_macs::table
                 .select(app_state_mutation_macs::value_mac)
                 .filter(app_state_mutation_macs::name.eq(&name))
@@ -1158,11 +1158,11 @@ impl SqliteStore {
                 .filter(app_state_mutation_macs::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 }
 
@@ -1181,7 +1181,7 @@ impl SignalStore for SqliteStore {
         match blob {
             None => Ok(None),
             Some(v) => Ok(Some(v.try_into().map_err(|v: Vec<u8>| {
-                StoreError::Serialization(format!(
+                StoreError::Validation(format!(
                     "identity key for '{}' has invalid length {} (expected 32)",
                     address,
                     v.len()
@@ -1209,14 +1209,14 @@ impl SignalStore for SqliteStore {
         self.with_semaphore(move || -> Result<bool> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let exists = diesel::select(diesel::dsl::exists(
                 sessions::table
                     .filter(sessions::address.eq(&address_owned))
                     .filter(sessions::device_id.eq(device_id)),
             ))
             .get_result(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(exists)
         })
         .await
@@ -1241,10 +1241,11 @@ impl SignalStore for SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
             let record_clone = record.clone();
@@ -1253,7 +1254,7 @@ impl SignalStore for SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     diesel::insert_into(prekeys::table)
                         .values((
                             prekeys::id.eq(id as i32),
@@ -1284,13 +1285,13 @@ impl SignalStore for SqliteStore {
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(e.to_string())),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(
-            "store_prekey exhausted retries".to_string(),
-        ))
+        Err(StoreError::RetriesExhausted {
+            op: "store_prekey".to_string(),
+        })
     }
 
     async fn store_prekeys_batch(&self, keys: &[(u32, Bytes)], uploaded: bool) -> Result<()> {
@@ -1306,10 +1307,11 @@ impl SignalStore for SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
             let keys_clone = keys.clone();
@@ -1318,7 +1320,7 @@ impl SignalStore for SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
 
                     conn.transaction(|conn| {
                         for (id, record) in &keys_clone {
@@ -1354,13 +1356,13 @@ impl SignalStore for SqliteStore {
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(e.to_string())),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(
-            "store_prekeys_batch exhausted retries".to_string(),
-        ))
+        Err(StoreError::RetriesExhausted {
+            op: "store_prekeys_batch".to_string(),
+        })
     }
 
     async fn load_prekey(&self, id: u32) -> Result<Option<Bytes>> {
@@ -1369,18 +1371,18 @@ impl SignalStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<Bytes>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let res: Option<Vec<u8>> = prekeys::table
                 .select(prekeys::key)
                 .filter(prekeys::id.eq(id as i32))
                 .filter(prekeys::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res.map(Bytes::from))
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn load_prekeys_batch(&self, ids: &[u32]) -> Result<Vec<(u32, Bytes)>> {
@@ -1393,13 +1395,13 @@ impl SignalStore for SqliteStore {
         self.with_semaphore(move || -> Result<Vec<(u32, Bytes)>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let rows: Vec<(i32, Vec<u8>)> = prekeys::table
                 .select((prekeys::id, prekeys::key))
                 .filter(prekeys::id.eq_any(&ids))
                 .filter(prekeys::device_id.eq(device_id))
                 .load(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
                 .map(|(id, key)| (id as u32, Bytes::from(key)))
@@ -1416,10 +1418,11 @@ impl SignalStore for SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
 
@@ -1427,7 +1430,7 @@ impl SignalStore for SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     diesel::delete(
                         prekeys::table
                             .filter(prekeys::id.eq(id as i32))
@@ -1450,13 +1453,13 @@ impl SignalStore for SqliteStore {
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(e.to_string())),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(
-            "remove_prekey exhausted retries".to_string(),
-        ))
+        Err(StoreError::RetriesExhausted {
+            op: "remove_prekey".to_string(),
+        })
     }
 
     async fn get_max_prekey_id(&self) -> Result<u32> {
@@ -1466,22 +1469,22 @@ impl SignalStore for SqliteStore {
         let _permit = db_semaphore
             .acquire()
             .await
-            .map_err(|e| StoreError::Database(format!("Failed to acquire semaphore: {}", e)))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
 
         tokio::task::spawn_blocking(move || -> Result<u32> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             use diesel::dsl::max;
             let result: Option<i32> = prekeys::table
                 .filter(prekeys::device_id.eq(device_id))
                 .select(max(prekeys::id))
                 .first(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(result.unwrap_or(0) as u32)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn store_signed_prekey(&self, id: u32, record: &[u8]) -> Result<()> {
@@ -1493,10 +1496,11 @@ impl SignalStore for SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
             let record_clone = record.clone();
@@ -1505,7 +1509,7 @@ impl SignalStore for SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     diesel::insert_into(signed_prekeys::table)
                         .values((
                             signed_prekeys::id.eq(id as i32),
@@ -1532,13 +1536,13 @@ impl SignalStore for SqliteStore {
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(e.to_string())),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(
-            "store_signed_prekey exhausted retries".to_string(),
-        ))
+        Err(StoreError::RetriesExhausted {
+            op: "store_signed_prekey".to_string(),
+        })
     }
 
     async fn load_signed_prekey(&self, id: u32) -> Result<Option<Vec<u8>>> {
@@ -1547,18 +1551,18 @@ impl SignalStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let res: Option<Vec<u8>> = signed_prekeys::table
                 .select(signed_prekeys::record)
                 .filter(signed_prekeys::id.eq(id as i32))
                 .filter(signed_prekeys::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn load_all_signed_prekeys(&self) -> Result<Vec<(u32, Vec<u8>)>> {
@@ -1567,19 +1571,19 @@ impl SignalStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Vec<(u32, Vec<u8>)>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let results: Vec<(i32, Vec<u8>)> = signed_prekeys::table
                 .select((signed_prekeys::id, signed_prekeys::record))
                 .filter(signed_prekeys::device_id.eq(device_id))
                 .load(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(results
                 .into_iter()
                 .map(|(id, record)| (id as u32, record))
                 .collect())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn remove_signed_prekey(&self, id: u32) -> Result<()> {
@@ -1590,10 +1594,11 @@ impl SignalStore for SqliteStore {
         const MAX_RETRIES: u32 = 5;
 
         for attempt in 0..=MAX_RETRIES {
-            let permit =
-                db_semaphore.clone().acquire_owned().await.map_err(|e| {
-                    StoreError::Database(format!("Failed to acquire semaphore: {}", e))
-                })?;
+            let permit = db_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             let pool_clone = pool.clone();
 
@@ -1601,7 +1606,7 @@ impl SignalStore for SqliteStore {
                 tokio::task::spawn_blocking(move || -> std::result::Result<(), DieselOrStore> {
                     let mut conn = pool_clone
                         .get()
-                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(e.to_string())))?;
+                        .map_err(|e| DieselOrStore::Store(StoreError::Connection(Box::new(e))))?;
                     diesel::delete(
                         signed_prekeys::table
                             .filter(signed_prekeys::id.eq(id as i32))
@@ -1624,13 +1629,13 @@ impl SignalStore for SqliteStore {
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }
                 Ok(Err(e)) => return Err(e.into()),
-                Err(e) => return Err(StoreError::Database(e.to_string())),
+                Err(e) => return Err(StoreError::Database(Box::new(e))),
             }
         }
 
-        Err(StoreError::Database(
-            "remove_signed_prekey exhausted retries".to_string(),
-        ))
+        Err(StoreError::RetriesExhausted {
+            op: "remove_signed_prekey".to_string(),
+        })
     }
 
     async fn put_sender_key(&self, address: &str, record: &[u8]) -> Result<()> {
@@ -1708,20 +1713,20 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Vec<(String, bool)>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let rows: Vec<(String, i32)> = sender_key_devices::table
                 .select((sender_key_devices::device_jid, sender_key_devices::has_key))
                 .filter(sender_key_devices::group_jid.eq(&group_jid))
                 .filter(sender_key_devices::device_id.eq(device_id))
                 .load(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
                 .map(|(jid, has_key)| (jid, has_key != 0))
                 .collect())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn set_sender_key_status(&self, group_jid: &str, entries: &[(&str, bool)]) -> Result<()> {
@@ -1817,7 +1822,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<LidPnMappingEntry>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -1830,7 +1835,7 @@ impl ProtocolStore for SqliteStore {
                 .filter(lid_pn_mapping::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row.map(
                 |(lid, phone_number, created_at, learning_source, updated_at)| LidPnMappingEntry {
                     lid,
@@ -1842,7 +1847,7 @@ impl ProtocolStore for SqliteStore {
             ))
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn get_pn_mapping(&self, phone: &str) -> Result<Option<LidPnMappingEntry>> {
@@ -1852,7 +1857,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<LidPnMappingEntry>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -1866,7 +1871,7 @@ impl ProtocolStore for SqliteStore {
                 .order(lid_pn_mapping::updated_at.desc())
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row.map(
                 |(lid, phone_number, created_at, learning_source, updated_at)| LidPnMappingEntry {
                     lid,
@@ -1878,7 +1883,7 @@ impl ProtocolStore for SqliteStore {
             ))
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn put_lid_mapping(&self, entry: &LidPnMappingEntry) -> Result<()> {
@@ -1930,7 +1935,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Vec<LidPnMappingEntry>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let rows: Vec<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -1941,7 +1946,7 @@ impl ProtocolStore for SqliteStore {
                 ))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
                 .load(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
                 .map(
@@ -1958,7 +1963,7 @@ impl ProtocolStore for SqliteStore {
                 .collect())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn save_base_key(&self, address: &str, message_id: &str, base_key: &[u8]) -> Result<()> {
@@ -1971,7 +1976,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::insert_into(base_keys::table)
                 .values((
                     base_keys::address.eq(&address),
@@ -1988,11 +1993,11 @@ impl ProtocolStore for SqliteStore {
                 .do_update()
                 .set(base_keys::base_key.eq(&base_key))
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -2010,7 +2015,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<bool> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let stored_key: Option<Vec<u8>> = base_keys::table
                 .select(base_keys::base_key)
                 .filter(base_keys::address.eq(&address))
@@ -2018,11 +2023,11 @@ impl ProtocolStore for SqliteStore {
                 .filter(base_keys::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(stored_key.as_ref() == Some(&current_base_key))
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_base_key(&self, address: &str, message_id: &str) -> Result<()> {
@@ -2033,7 +2038,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::delete(
                 base_keys::table
                     .filter(base_keys::address.eq(&address))
@@ -2041,11 +2046,11 @@ impl ProtocolStore for SqliteStore {
                     .filter(base_keys::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -2053,12 +2058,12 @@ impl ProtocolStore for SqliteStore {
         let pool = self.pool.clone();
         let device_id = self.device_id;
         let devices_json = serde_json::to_string(&record.devices)
-            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            .map_err(|e| StoreError::Serialization(Box::new(e)))?;
         let now = wacore::time::now_secs() as i32;
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let raw_id_i32 = record.raw_id.map(|r| r as i32);
             diesel::insert_into(device_registry::table)
                 .values((
@@ -2080,11 +2085,11 @@ impl ProtocolStore for SqliteStore {
                     device_registry::raw_id.eq(raw_id_i32),
                 ))
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -2095,7 +2100,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<DeviceListRecord>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(String, String, i32, Option<String>, Option<i32>)> =
                 device_registry::table
                     .select((
@@ -2109,11 +2114,11 @@ impl ProtocolStore for SqliteStore {
                     .filter(device_registry::device_id.eq(device_id))
                     .first(&mut conn)
                     .optional()
-                    .map_err(|e| StoreError::Database(e.to_string()))?;
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
             match row {
                 Some((user, devices_json, timestamp, phash, raw_id)) => {
                     let devices: Vec<DeviceInfo> = serde_json::from_str(&devices_json)
-                        .map_err(|e| StoreError::Serialization(e.to_string()))?;
+                        .map_err(|e| StoreError::Serialization(Box::new(e)))?;
                     Ok(Some(DeviceListRecord {
                         user,
                         devices,
@@ -2126,7 +2131,7 @@ impl ProtocolStore for SqliteStore {
             }
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_devices(&self, user: &str) -> Result<()> {
@@ -2136,18 +2141,18 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::delete(
                 device_registry::table
                     .filter(device_registry::user_id.eq(&user))
                     .filter(device_registry::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -2158,7 +2163,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Option<TcTokenEntry>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(Vec<u8>, i64, Option<i64>)> = tc_tokens::table
                 .select((
                     tc_tokens::token,
@@ -2169,7 +2174,7 @@ impl ProtocolStore for SqliteStore {
                 .filter(tc_tokens::device_id.eq(device_id))
                 .first(&mut conn)
                 .optional()
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(
                 row.map(|(token, token_timestamp, sender_timestamp)| TcTokenEntry {
                     token,
@@ -2179,7 +2184,7 @@ impl ProtocolStore for SqliteStore {
             )
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()> {
@@ -2191,7 +2196,7 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::insert_into(tc_tokens::table)
                 .values((
                     tc_tokens::jid.eq(&jid),
@@ -2210,11 +2215,11 @@ impl ProtocolStore for SqliteStore {
                     tc_tokens::updated_at.eq(now),
                 ))
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -2225,18 +2230,18 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             diesel::delete(
                 tc_tokens::table
                     .filter(tc_tokens::jid.eq(&jid))
                     .filter(tc_tokens::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
         Ok(())
     }
 
@@ -2246,16 +2251,16 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<Vec<String>> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let jids: Vec<String> = tc_tokens::table
                 .select(tc_tokens::jid)
                 .filter(tc_tokens::device_id.eq(device_id))
                 .load(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(jids)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32> {
@@ -2264,18 +2269,18 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<u32> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let deleted = diesel::delete(
                 tc_tokens::table
                     .filter(tc_tokens::token_timestamp.lt(cutoff_timestamp))
                     .filter(tc_tokens::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(deleted as u32)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn store_sent_message(
@@ -2347,18 +2352,18 @@ impl ProtocolStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<u32> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let deleted = diesel::delete(
                 sent_messages::table
                     .filter(sent_messages::created_at.lt(cutoff_timestamp))
                     .filter(sent_messages::device_id.eq(device_id)),
             )
             .execute(&mut conn)
-            .map_err(|e| StoreError::Database(e.to_string()))?;
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(deleted as u32)
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))?
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 }
 
@@ -2405,13 +2410,13 @@ impl DeviceStore for SqliteStore {
             let sanitized = sanitized.trim_matches(['/', '\\', '.']);
 
             if sanitized.is_empty() {
-                return Err(StoreError::Database(
+                return Err(StoreError::InvalidConfig(
                     "Snapshot name cannot be empty after sanitization".to_string(),
                 ));
             }
 
             if sanitized.len() > MAX_LENGTH {
-                return Err(StoreError::Database(format!(
+                return Err(StoreError::InvalidConfig(format!(
                     "Snapshot name exceeds maximum length of {} characters",
                     MAX_LENGTH
                 )));
@@ -2429,7 +2434,7 @@ impl DeviceStore for SqliteStore {
         tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = pool
                 .get()
-                .map_err(|e| StoreError::Connection(e.to_string()))?;
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
 
             let timestamp = wacore::time::now_secs();
 
@@ -2442,20 +2447,18 @@ impl DeviceStore for SqliteStore {
 
             diesel::sql_query(query)
                 .execute(&mut conn)
-                .map_err(|e| StoreError::Database(e.to_string()))?;
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             // Save extra content if provided
             if let Some(data) = extra_data {
                 let extra_path = format!("{}.json", target_path);
-                std::fs::write(&extra_path, data).map_err(|e| {
-                    StoreError::Database(format!("Failed to write snapshot extra content: {}", e))
-                })?;
+                std::fs::write(&extra_path, data)?;
             }
 
             Ok(())
         })
         .await
-        .map_err(|e| StoreError::Database(e.to_string()))??;
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         Ok(())
     }

--- a/wacore/libsignal/src/protocol/error.rs
+++ b/wacore/libsignal/src/protocol/error.rs
@@ -24,6 +24,12 @@ pub enum SignalProtocolError {
     /// invalid state for call to {0} to succeed: {1}
     InvalidState(&'static str, String),
 
+    /// backend store error in {0}
+    BackendError(
+        &'static str,
+        #[source] Box<dyn std::error::Error + Send + Sync>,
+    ),
+
     /// protobuf encoding was invalid
     InvalidProtobufEncoding,
 
@@ -114,5 +120,27 @@ impl From<CurveError> for SignalProtocolError {
             CurveError::BadKeyType(raw) => Self::BadKeyType(raw),
             CurveError::BadKeyLength(key_type, len) => Self::BadKeyLength(key_type, len),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("synthetic backend failure: {code}")]
+    struct DummyBackendError {
+        code: u32,
+    }
+
+    #[test]
+    fn backend_error_preserves_typed_source_via_downcast() {
+        let dummy = DummyBackendError { code: 42 };
+        let spe = SignalProtocolError::BackendError("test_context", Box::new(dummy));
+        let src = std::error::Error::source(&spe).expect("source preserved");
+        let inner = src
+            .downcast_ref::<DummyBackendError>()
+            .expect("downcasts to DummyBackendError");
+        assert_eq!(inner.code, 42);
     }
 }

--- a/wacore/noise/src/error.rs
+++ b/wacore/noise/src/error.rs
@@ -1,25 +1,32 @@
 use thiserror::Error;
+use wacore_libsignal::crypto::CryptoProviderError;
 
 /// Errors that can occur during Noise protocol operations.
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Error)]
 pub enum NoiseError {
-    #[error("Invalid pattern length: expected {expected}, got {got}")]
+    #[error("invalid pattern length: expected {expected}, got {got}")]
     InvalidPatternLength { expected: usize, got: usize },
 
-    #[error("Cryptographic operation failed: {0}")]
-    CryptoError(String),
+    #[error("AES-GCM encryption failed")]
+    Encrypt(#[source] CryptoProviderError),
+
+    #[error("AES-GCM decryption failed")]
+    Decrypt(#[source] CryptoProviderError),
+
+    #[error("ciphertext too short to contain authentication tag")]
+    CiphertextTooShort,
 
     #[error("HKDF expansion failed")]
     HkdfExpandFailed,
 
-    #[error("Invalid key length for {name}: expected {expected}, got {got}")]
+    #[error("invalid key length for {name}: expected {expected}, got {got}")]
     InvalidKeyLength {
         name: &'static str,
         expected: usize,
         got: usize,
     },
 
-    #[error("Counter exhausted: nonce would be reused after 2^32 messages")]
+    #[error("counter exhausted: nonce would be reused after 2^32 messages")]
     CounterExhausted,
 }
 

--- a/wacore/noise/src/state.rs
+++ b/wacore/noise/src/state.rs
@@ -40,7 +40,7 @@ impl NoiseCipher {
         let iv = generate_iv(counter);
         let mut out = Vec::with_capacity(plaintext.len() + TAG_LEN);
         aes_256_gcm_encrypt(&self.key, &iv, b"", plaintext, &mut out)
-            .map_err(|e| NoiseError::CryptoError(format!("{e}")))?;
+            .map_err(NoiseError::Encrypt)?;
         Ok(out)
     }
 
@@ -54,8 +54,7 @@ impl NoiseCipher {
         buffer: &mut B,
     ) -> Result<()> {
         let iv = generate_iv(counter);
-        aes_256_gcm_encrypt_in_place(&self.key, &iv, b"", buffer)
-            .map_err(|e| NoiseError::CryptoError(format!("{e}")))
+        aes_256_gcm_encrypt_in_place(&self.key, &iv, b"", buffer).map_err(NoiseError::Encrypt)
     }
 
     /// Decrypts ciphertext (with 16-byte tag appended) in-place within the
@@ -68,8 +67,7 @@ impl NoiseCipher {
         buffer: &mut B,
     ) -> Result<()> {
         let iv = generate_iv(counter);
-        aes_256_gcm_decrypt_in_place(&self.key, &iv, b"", buffer)
-            .map_err(|e| NoiseError::CryptoError(format!("Decrypt failed: {e}")))
+        aes_256_gcm_decrypt_in_place(&self.key, &iv, b"", buffer).map_err(NoiseError::Decrypt)
     }
 }
 
@@ -154,7 +152,7 @@ impl NoiseState {
         let iv = generate_iv(self.post_increment_counter()?);
         let mut out = Vec::with_capacity(plaintext.len() + TAG_LEN);
         aes_256_gcm_encrypt(&self.key, &iv, &self.hash, plaintext, &mut out)
-            .map_err(|e| NoiseError::CryptoError(format!("{e}")))?;
+            .map_err(NoiseError::Encrypt)?;
         self.authenticate(&out);
         Ok(out)
     }
@@ -164,8 +162,7 @@ impl NoiseState {
         let iv = generate_iv(self.post_increment_counter()?);
         let aad = self.hash;
         let start = out.len();
-        aes_256_gcm_encrypt(&self.key, &iv, &aad, plaintext, out)
-            .map_err(|e| NoiseError::CryptoError(format!("{e}")))?;
+        aes_256_gcm_encrypt(&self.key, &iv, &aad, plaintext, out).map_err(NoiseError::Encrypt)?;
         self.authenticate(&out[start..]);
         Ok(())
     }
@@ -176,7 +173,7 @@ impl NoiseState {
         let iv = generate_iv(self.post_increment_counter()?);
         let mut out = Vec::with_capacity(ciphertext.len().saturating_sub(TAG_LEN));
         aes_256_gcm_decrypt(&self.key, &iv, &aad, ciphertext, &mut out)
-            .map_err(|e| NoiseError::CryptoError(format!("Noise decrypt failed: {e}")))?;
+            .map_err(NoiseError::Decrypt)?;
         self.authenticate(ciphertext);
         Ok(out)
     }
@@ -184,14 +181,11 @@ impl NoiseState {
     /// Zero-allocation decryption that appends the plaintext to the provided buffer.
     pub fn decrypt_into(&mut self, ciphertext: &[u8], out: &mut Vec<u8>) -> Result<()> {
         if ciphertext.len() < TAG_LEN {
-            return Err(NoiseError::CryptoError(
-                "Ciphertext too short (missing tag)".into(),
-            ));
+            return Err(NoiseError::CiphertextTooShort);
         }
         let aad = self.hash;
         let iv = generate_iv(self.post_increment_counter()?);
-        aes_256_gcm_decrypt(&self.key, &iv, &aad, ciphertext, out)
-            .map_err(|e| NoiseError::CryptoError(format!("Noise decrypt failed: {e}")))?;
+        aes_256_gcm_decrypt(&self.key, &iv, &aad, ciphertext, out).map_err(NoiseError::Decrypt)?;
         self.authenticate(ciphertext);
         Ok(())
     }

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -40,7 +40,7 @@ fn lookup_app_state_key(
 pub enum AppStateSyncError {
     #[error("app state key not found: {0}")]
     KeyNotFound(String),
-    #[error("store error: {0}")]
+    #[error("store error")]
     Store(#[from] crate::store::error::StoreError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -1,4 +1,7 @@
-use crate::libsignal::crypto::{CryptographicMac, aes_256_cbc_decrypt_into};
+use crate::libsignal::crypto::{
+    CryptographicMac, DecryptionError as AesCbcDecryptionError, Error as CryptoError,
+    aes_256_cbc_decrypt_into,
+};
 use anyhow::{Result, anyhow};
 use base64::Engine as _;
 use base64::prelude::*;
@@ -17,8 +20,10 @@ pub enum MediaDecryptionError {
     PayloadTooShort,
     #[error("invalid MAC signature")]
     InvalidMac,
-    #[error("decryption error: {0}")]
-    Decryption(String),
+    #[error("AES-CBC decryption failed")]
+    Decryption(#[source] AesCbcDecryptionError),
+    #[error("HMAC initialization failed")]
+    Mac(#[source] CryptoError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -497,7 +502,7 @@ impl DownloadUtils {
     pub fn decrypt_cbc(cipher_key: &[u8], iv: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
         let mut output = Vec::new();
         aes_256_cbc_decrypt_into(ciphertext, cipher_key, iv, &mut output)
-            .map_err(|e| anyhow!(e.to_string()))?;
+            .map_err(anyhow::Error::new)?;
         Ok(output)
     }
 
@@ -517,8 +522,8 @@ impl DownloadUtils {
         let (iv, cipher_key, mac_key) = Self::get_media_keys(media_key, media_type)?;
 
         let computed_mac_full = {
-            let mut mac = CryptographicMac::new("HmacSha256", &mac_key)
-                .map_err(|e| MediaDecryptionError::Decryption(e.to_string()))?;
+            let mut mac =
+                CryptographicMac::new("HmacSha256", &mac_key).map_err(MediaDecryptionError::Mac)?;
             mac.update(&iv);
             mac.update(ciphertext);
             mac.finalize()
@@ -529,7 +534,7 @@ impl DownloadUtils {
 
         let mut output = Vec::new();
         aes_256_cbc_decrypt_into(ciphertext, &cipher_key, &iv, &mut output)
-            .map_err(|e| MediaDecryptionError::Decryption(e.to_string()))?;
+            .map_err(MediaDecryptionError::Decryption)?;
         Ok(output)
     }
 }
@@ -707,5 +712,27 @@ mod tests {
             DownloadUtils::copy_and_validate_plaintext_to_writer(reader, &wrong_hash, &mut writer)
                 .unwrap_err();
         assert!(err.to_string().contains("SHA-256 mismatch"));
+    }
+
+    #[test]
+    fn media_decryption_decryption_preserves_aes_cbc_source() {
+        let inner = AesCbcDecryptionError::BadKeyOrIv;
+        let mde = MediaDecryptionError::Decryption(inner);
+        let src = std::error::Error::source(&mde).expect("source preserved");
+        let cbc = src
+            .downcast_ref::<AesCbcDecryptionError>()
+            .expect("downcasts to AesCbcDecryptionError");
+        assert!(matches!(cbc, AesCbcDecryptionError::BadKeyOrIv));
+    }
+
+    #[test]
+    fn media_decryption_mac_preserves_crypto_error_source() {
+        let inner = CryptoError::UnknownAlgorithm("MAC", "BogusAlg".into());
+        let mde = MediaDecryptionError::Mac(inner);
+        let src = std::error::Error::source(&mde).expect("source preserved");
+        let ce = src
+            .downcast_ref::<CryptoError>()
+            .expect("downcasts to CryptoError");
+        assert!(matches!(ce, CryptoError::UnknownAlgorithm("MAC", _)));
     }
 }

--- a/wacore/src/handshake/mod.rs
+++ b/wacore/src/handshake/mod.rs
@@ -1,6 +1,6 @@
 // Re-export everything from wacore-noise
 pub use wacore_noise::{
     EdgeRoutingError, HandshakeError, HandshakeResult as Result, HandshakeState, HandshakeUtils,
-    MAX_EDGE_ROUTING_LEN, NoiseCipher, NoiseHandshake, WA_CERT_PUB_KEY,
+    MAX_EDGE_ROUTING_LEN, NoiseCipher, NoiseError, NoiseHandshake, WA_CERT_PUB_KEY,
     build_edge_routing_preintro, build_handshake_header, generate_iv,
 };

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -22,8 +22,8 @@
 use crate::companion_reg::{
     CompanionWebClientType, companion_platform_display, companion_web_client_type_for_props,
 };
-use crate::libsignal::crypto::aes_256_gcm_encrypt;
-use crate::libsignal::protocol::{KeyPair, PublicKey};
+use crate::libsignal::crypto::{CryptoProviderError, aes_256_gcm_encrypt};
+use crate::libsignal::protocol::{CurveError, KeyPair, PublicKey};
 use aes::cipher::{KeyIvInit, StreamCipher};
 use ctr::Ctr128BE;
 use hkdf::Hkdf;
@@ -412,29 +412,21 @@ impl PairCodeUtils {
         primary_identity_pub: &[u8; 32],
         identity_key: &KeyPair,
     ) -> Result<(Vec<u8>, [u8; 32]), PairCodeError> {
-        // Parse primary's ephemeral public key
-        let primary_eph_pub =
-            PublicKey::from_djb_public_key_bytes(primary_ephemeral_pub).map_err(|e| {
-                PairCodeError::CryptoError(format!("Invalid primary ephemeral key: {e}"))
-            })?;
+        let primary_eph_pub = PublicKey::from_djb_public_key_bytes(primary_ephemeral_pub)
+            .map_err(PairCodeError::InvalidPrimaryEphemeralKey)?;
 
-        // Parse primary's identity public key
-        let primary_id_pub =
-            PublicKey::from_djb_public_key_bytes(primary_identity_pub).map_err(|e| {
-                PairCodeError::CryptoError(format!("Invalid primary identity key: {e}"))
-            })?;
+        let primary_id_pub = PublicKey::from_djb_public_key_bytes(primary_identity_pub)
+            .map_err(PairCodeError::InvalidPrimaryIdentityKey)?;
 
-        // DH 1: Ephemeral key exchange
         let ephemeral_shared = ephemeral_keypair
             .private_key
             .calculate_agreement(&primary_eph_pub)
-            .map_err(|e| PairCodeError::CryptoError(format!("Ephemeral DH failed: {e}")))?;
+            .map_err(PairCodeError::EphemeralKeyAgreement)?;
 
-        // DH 2: Identity key exchange (for ADV secret derivation)
         let identity_shared = identity_key
             .private_key
             .calculate_agreement(&primary_id_pub)
-            .map_err(|e| PairCodeError::CryptoError(format!("Identity DH failed: {e}")))?;
+            .map_err(PairCodeError::IdentityKeyAgreement)?;
 
         // Generate random bytes for ADV secret derivation
         let mut random_bytes = [0u8; 32];
@@ -451,7 +443,7 @@ impl PairCodeUtils {
         let mut new_adv_secret = [0u8; 32];
         hk_adv
             .expand(b"adv_secret", &mut new_adv_secret)
-            .map_err(|_| PairCodeError::CryptoError("HKDF expand for adv_secret failed".into()))?;
+            .map_err(|_| PairCodeError::AdvSecretKeyDerivation)?;
 
         // Prepare bundle: companion_identity_pub (32) + primary_identity_pub (32) + random_bytes (32) = 96 bytes
         let mut bundle = Vec::with_capacity(96);
@@ -469,9 +461,7 @@ impl PairCodeUtils {
         let mut enc_key = [0u8; 32];
         hk_bundle
             .expand(b"link_code_pairing_key_bundle_encryption_key", &mut enc_key)
-            .map_err(|_| {
-                PairCodeError::CryptoError("HKDF expand for bundle encryption key failed".into())
-            })?;
+            .map_err(|_| PairCodeError::BundleKeyDerivation)?;
 
         // Generate random IV for AES-GCM (12 bytes)
         let mut iv = [0u8; 12];
@@ -482,7 +472,7 @@ impl PairCodeUtils {
         wrapped_bundle.extend_from_slice(&key_bundle_salt);
         wrapped_bundle.extend_from_slice(&iv);
         aes_256_gcm_encrypt(&enc_key, &iv, b"", &bundle, &mut wrapped_bundle)
-            .map_err(|e| PairCodeError::CryptoError(format!("AES-GCM encryption failed: {e}")))?;
+            .map_err(PairCodeError::BundleAead)?;
 
         Ok((wrapped_bundle, new_adv_secret))
     }
@@ -493,35 +483,53 @@ impl PairCodeUtils {
     }
 }
 
-/// Errors that can occur during pair code operations.
+/// Errors raised by wacore-side pair-code validation, key derivation, and
+/// protocol-bundle building. The high-level crate wraps this in
+/// `whatsapp_rust::pair_code::PairError` and adds an IQ-failure variant for the
+/// transport layer.
 #[derive(Debug, thiserror::Error)]
 pub enum PairCodeError {
-    #[error("Phone number is required")]
+    #[error("phone number is required")]
     PhoneNumberRequired,
 
-    #[error("Phone number is too short (must be at least 7 digits)")]
+    #[error("phone number is too short (must be at least 7 digits)")]
     PhoneNumberTooShort,
 
-    #[error("Phone number must not start with 0 (use international format)")]
+    #[error("phone number must not start with 0 (use international format)")]
     PhoneNumberNotInternational,
 
-    #[error("Invalid custom code: must be 8 characters from Crockford Base32 alphabet")]
+    #[error("invalid custom code: must be 8 characters from Crockford Base32 alphabet")]
     InvalidCustomCode,
 
-    #[error("Invalid wrapped data: expected {expected} bytes, got {got}")]
+    #[error("invalid wrapped data: expected {expected} bytes, got {got}")]
     InvalidWrappedData { expected: usize, got: usize },
 
-    #[error("Cryptographic operation failed: {0}")]
-    CryptoError(String),
+    #[error("primary device sent an invalid ephemeral public key")]
+    InvalidPrimaryEphemeralKey(#[source] CurveError),
 
-    #[error("Not in waiting state for pair code notification")]
+    #[error("primary device sent an invalid identity public key")]
+    InvalidPrimaryIdentityKey(#[source] CurveError),
+
+    #[error("ephemeral key agreement failed")]
+    EphemeralKeyAgreement(#[source] CurveError),
+
+    #[error("identity key agreement failed")]
+    IdentityKeyAgreement(#[source] CurveError),
+
+    #[error("HKDF expand failed for adv_secret")]
+    AdvSecretKeyDerivation,
+
+    #[error("HKDF expand failed for bundle encryption key")]
+    BundleKeyDerivation,
+
+    #[error("AES-GCM encryption of key bundle failed")]
+    BundleAead(#[source] CryptoProviderError),
+
+    #[error("not in waiting state for pair code notification")]
     NotWaiting,
 
-    #[error("Server response missing pairing ref")]
+    #[error("server response missing pairing ref")]
     MissingPairingRef,
-
-    #[error("Request failed: {0}")]
-    RequestFailed(String),
 }
 
 #[cfg(test)]
@@ -931,18 +939,18 @@ mod tests {
     #[test]
     fn test_pair_code_error_display() {
         let err = PairCodeError::PhoneNumberRequired;
-        assert_eq!(err.to_string(), "Phone number is required");
+        assert_eq!(err.to_string(), "phone number is required");
 
         let err = PairCodeError::PhoneNumberTooShort;
         assert_eq!(
             err.to_string(),
-            "Phone number is too short (must be at least 7 digits)"
+            "phone number is too short (must be at least 7 digits)"
         );
 
         let err = PairCodeError::InvalidCustomCode;
         assert_eq!(
             err.to_string(),
-            "Invalid custom code: must be 8 characters from Crockford Base32 alphabet"
+            "invalid custom code: must be 8 characters from Crockford Base32 alphabet"
         );
 
         let err = PairCodeError::InvalidWrappedData {
@@ -951,8 +959,28 @@ mod tests {
         };
         assert_eq!(
             err.to_string(),
-            "Invalid wrapped data: expected 80 bytes, got 50"
+            "invalid wrapped data: expected 80 bytes, got 50"
         );
+    }
+
+    #[test]
+    fn invalid_primary_ephemeral_key_preserves_curve_source() {
+        let err = PairCodeError::InvalidPrimaryEphemeralKey(CurveError::NoKeyTypeIdentifier);
+        let src = std::error::Error::source(&err).expect("source preserved");
+        let curve = src
+            .downcast_ref::<CurveError>()
+            .expect("downcasts to CurveError");
+        assert!(matches!(curve, CurveError::NoKeyTypeIdentifier));
+    }
+
+    #[test]
+    fn bundle_aead_preserves_crypto_provider_source() {
+        let err = PairCodeError::BundleAead(CryptoProviderError::BadInput);
+        let src = std::error::Error::source(&err).expect("source preserved");
+        let cpe = src
+            .downcast_ref::<CryptoProviderError>()
+            .expect("downcasts to CryptoProviderError");
+        assert!(matches!(cpe, CryptoProviderError::BadInput));
     }
 
     #[test]

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -82,16 +82,14 @@ impl<'a> InfoQuery<'a> {
 pub enum IqError {
     #[error("IQ request timed out")]
     Timeout,
-    #[error("Client is not connected")]
+    #[error("client is not connected")]
     NotConnected,
-    #[error("Received disconnect node during IQ wait: {0:?}")]
+    #[error("received disconnect node during IQ wait: {0:?}")]
     Disconnected(Node),
-    #[error("Received a server error response: code={code}, text='{text}'")]
+    #[error("received a server error response: code={code}, text='{text}'")]
     ServerError { code: u16, text: String },
-    #[error("Internal channel closed unexpectedly")]
+    #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
-    #[error("Network error: {0}")]
-    Network(String),
 }
 
 /// Lightweight server error that can be embedded in `anyhow::Error` and

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -68,6 +68,8 @@ pub mod key_pair_serde {
         if bytes.len() != 64 {
             return Err(serde::de::Error::invalid_length(bytes.len(), &"64"));
         }
+        // reason: serde::de::Error::custom flattens to a String at the boundary —
+        // serde's error model has no source-chain preservation.
         let private_key = PrivateKey::deserialize(&bytes[0..32])
             .map_err(|e| serde::de::Error::custom(e.to_string()))?;
         let public_key = PublicKey::from_djb_public_key_bytes(&bytes[32..64])

--- a/wacore/src/store/error.rs
+++ b/wacore/src/store/error.rs
@@ -45,7 +45,7 @@ impl StoreError {
     pub fn is_database_busy_or_locked(&self) -> bool {
         let mut layer: &dyn std::error::Error = self;
         loop {
-            let s = layer.to_string();
+            let s = layer.to_string().to_lowercase();
             if s.contains("locked") || s.contains("busy") {
                 return true;
             }
@@ -90,5 +90,24 @@ mod tests {
         let inner = DummyBackendError("permission denied");
         let se = StoreError::Database(Box::new(inner));
         assert!(!se.is_database_busy_or_locked());
+    }
+
+    #[test]
+    fn is_busy_or_locked_is_case_insensitive() {
+        // SQLite drivers in different ecosystems vary on casing for these
+        // diagnostic strings ("database is LOCKED", "Busy", etc.). The check
+        // must not depend on the exact casing the underlying driver chose.
+        for msg in [
+            "database is LOCKED",
+            "SQLITE_BUSY: write contention",
+            "Busy",
+            "Locked",
+        ] {
+            let se = StoreError::Database(Box::new(DummyBackendError(msg)));
+            assert!(
+                se.is_database_busy_or_locked(),
+                "expected {msg:?} to be detected"
+            );
+        }
     }
 }

--- a/wacore/src/store/error.rs
+++ b/wacore/src/store/error.rs
@@ -2,36 +2,93 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum StoreError {
-    #[error("I/O error: {0}")]
+    #[error("I/O error")]
     Io(#[from] std::io::Error),
 
-    #[error("Serialization/deserialization error: {0}")]
-    Serialization(String),
+    #[error("serialization/deserialization error")]
+    Serialization(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("Item not found: {0}")]
-    NotFound(String),
+    /// Validation failure with a descriptive message and no underlying typed
+    /// source — e.g. "Invalid foo length: 17". Prefer `Serialization` or a
+    /// dedicated typed variant if a real source exists.
+    #[error("data validation failed: {0}")]
+    Validation(String),
 
-    #[error("Database backend error: {0}")]
-    Backend(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("database connection error")]
+    Connection(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("Database connection error: {0}")]
-    Connection(String),
+    #[error("database operation error")]
+    Database(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("Database operation error: {0}")]
-    Database(String),
+    #[error("database operation '{op}' exhausted retries")]
+    RetriesExhausted { op: String },
 
-    #[error("Migration error: {0}")]
-    Migration(String),
+    #[error("migration error")]
+    Migration(#[source] Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("Device with ID {0} not found")]
+    #[error("store configuration is invalid: {0}")]
+    InvalidConfig(String),
+
+    #[error("device with ID {0} not found")]
     DeviceNotFound(i32),
+}
+
+impl StoreError {
+    /// Walks the error source chain and returns true if any layer's `Display`
+    /// indicates a SQLite busy/locked condition. Used by retry layers that
+    /// can't depend on a specific backend (Diesel, libsql, etc.) directly.
+    ///
+    /// Substring matching is necessary because SQLite reports BUSY/LOCKED
+    /// through `sqlite3_errmsg()` strings; the error code itself is mapped
+    /// to `Diesel::DatabaseError(Unknown, _)` (or similar) without further
+    /// discrimination.
+    pub fn is_database_busy_or_locked(&self) -> bool {
+        let mut layer: &dyn std::error::Error = self;
+        loop {
+            let s = layer.to_string();
+            if s.contains("locked") || s.contains("busy") {
+                return true;
+            }
+            match layer.source() {
+                Some(inner) => layer = inner,
+                None => return false,
+            }
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, StoreError>;
 
-/// Helper to convert any Display error into StoreError::Database.
-/// Use with `.map_err(db_err)?` instead of `.map_err(|e| StoreError::Database(e.to_string()))?`
-#[inline]
-pub fn db_err<E: std::fmt::Display>(e: E) -> StoreError {
-    StoreError::Database(e.to_string())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("synthetic backend error: {0}")]
+    struct DummyBackendError(&'static str);
+
+    #[test]
+    fn database_preserves_typed_source_via_downcast() {
+        let inner = DummyBackendError("bang");
+        let se = StoreError::Database(Box::new(inner));
+        let src = std::error::Error::source(&se).expect("source preserved");
+        let downcast = src
+            .downcast_ref::<DummyBackendError>()
+            .expect("downcasts to DummyBackendError");
+        assert_eq!(downcast.0, "bang");
+    }
+
+    #[test]
+    fn is_busy_or_locked_walks_chain() {
+        let inner = DummyBackendError("database is locked");
+        let se = StoreError::Database(Box::new(inner));
+        assert!(se.is_database_busy_or_locked());
+    }
+
+    #[test]
+    fn is_busy_or_locked_negative() {
+        let inner = DummyBackendError("permission denied");
+        let se = StoreError::Database(Box::new(inner));
+        assert!(!se.is_database_busy_or_locked());
+    }
 }

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -9,7 +9,7 @@
 use crate::runtime::{AbortHandle, Runtime, ShutdownSignal, wait_for_shutdown};
 use crate::store::commands::{DeviceCommand, apply_command_to_device};
 use crate::store::device::Device;
-use crate::store::error::{StoreError, db_err};
+use crate::store::error::StoreError;
 use crate::store::traits::Backend;
 use async_lock::RwLock;
 use event_listener::Event;
@@ -34,15 +34,15 @@ impl PersistenceManager {
     /// Create a PersistenceManager with a backend implementation.
     pub async fn new(backend: Arc<dyn Backend>) -> Result<Self, StoreError> {
         debug!("PersistenceManager: Ensuring device row exists.");
-        let exists = backend.exists().await.map_err(db_err)?;
+        let exists = backend.exists().await?;
         if !exists {
             debug!("PersistenceManager: No device row found. Creating new device row.");
-            let id = backend.create().await.map_err(db_err)?;
+            let id = backend.create().await?;
             debug!("PersistenceManager: Created device row with id={id}.");
         }
 
         debug!("PersistenceManager: Attempting to load device data via Backend.");
-        let device_data_opt = backend.load().await.map_err(db_err)?;
+        let device_data_opt = backend.load().await?;
 
         let device = if let Some(serializable_device) = device_data_opt {
             debug!(
@@ -103,7 +103,7 @@ impl PersistenceManager {
             if let Err(e) = self.backend.save(&serializable_device).await {
                 // Restore dirty flag so the next tick retries the save
                 self.dirty.store(true, Ordering::Release);
-                return Err(db_err(e));
+                return Err(e);
             }
             debug!("Device state saved successfully.");
         }
@@ -122,7 +122,6 @@ impl PersistenceManager {
             self.backend
                 .snapshot_db(name, extra_content)
                 .await
-                .map_err(db_err)
         }
         #[cfg(not(feature = "debug-snapshots"))]
         {
@@ -202,7 +201,6 @@ impl PersistenceManager {
         self.backend
             .get_sender_key_devices(group_jid)
             .await
-            .map_err(db_err)
     }
 
     pub async fn set_sender_key_status(
@@ -213,13 +211,11 @@ impl PersistenceManager {
         self.backend
             .set_sender_key_status(group_jid, entries)
             .await
-            .map_err(db_err)
     }
 
     pub async fn clear_sender_key_devices(&self, group_jid: &str) -> Result<(), StoreError> {
         self.backend
             .clear_sender_key_devices(group_jid)
             .await
-            .map_err(db_err)
     }
 }

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -119,9 +119,7 @@ impl PersistenceManager {
         #[cfg(feature = "debug-snapshots")]
         {
             self.save_to_disk().await?;
-            self.backend
-                .snapshot_db(name, extra_content)
-                .await
+            self.backend.snapshot_db(name, extra_content).await
         }
         #[cfg(not(feature = "debug-snapshots"))]
         {
@@ -198,9 +196,7 @@ impl PersistenceManager {
         &self,
         group_jid: &str,
     ) -> Result<Vec<(String, bool)>, StoreError> {
-        self.backend
-            .get_sender_key_devices(group_jid)
-            .await
+        self.backend.get_sender_key_devices(group_jid).await
     }
 
     pub async fn set_sender_key_status(
@@ -208,14 +204,10 @@ impl PersistenceManager {
         group_jid: &str,
         entries: &[(&str, bool)],
     ) -> Result<(), StoreError> {
-        self.backend
-            .set_sender_key_status(group_jid, entries)
-            .await
+        self.backend.set_sender_key_status(group_jid, entries).await
     }
 
     pub async fn clear_sender_key_devices(&self, group_jid: &str) -> Result<(), StoreError> {
-        self.backend
-            .clear_sender_key_devices(group_jid)
-            .await
+        self.backend.clear_sender_key_devices(group_jid).await
     }
 }


### PR DESCRIPTION
## Summary

6-commit series eliminating the `error.to_string()` / `format!("{e}")` anti-pattern across the workspace. Every typed error from one layer was being flattened into a String at the next, dropping `.source()` chains and forcing downstream consumers to parse English prose to discriminate cases (e.g. `code=400` vs timeout vs disconnect).

Principle applied: **um erro só vira `String` no momento de imprimir, nunca antes.** Breaking changes accepted because the code is pre-1.0 and the wrong thing was on the public surface.

## Series (each commit is independent and reviewable on its own)

1. **`refactor(pair-code)!`** — Split `PairCodeError`. wacore variants kept (validation, key derivation, AEAD), high-level `PairError` introduced wrapping `PairCodeError + IqError`. `CryptoError(String)` exploded into typed variants for `CurveError` (key parse, key agreement) and `CryptoProviderError` (AES-GCM).
2. **`refactor(socket,noise,iq)!`** — `NoiseError::CryptoError(String)` → `Encrypt/Decrypt(#[source] CryptoProviderError)`. `SocketError::Crypto/NoiseHandshake` removed; new `Cipher(#[from] NoiseError)` and `Marshal(#[source] BinaryError)`. `IqError` got `EncryptSend(#[from])` + `ClientState(#[source])` for the catch-all that previously flattened `ClientError`. Two dead variants (`SocketError::NoiseHandshake`, `wacore::request::IqError::Network`) deleted.
3. **`refactor(media-download)!`** — `MediaDecryptionError::Decryption(String)` → `Decryption(#[source] DecryptionError)` + new `Mac(#[source] CryptoError)`.
4. **`refactor(mex)!`** — `MexError::PayloadParsing(String)` kept for the 15+ descriptive call sites; one site that wrapped a real `JidError` got moved to a new `InvalidJid(#[from] JidError)` variant.
5. **`refactor(libsignal,store)!`** — Added `SignalProtocolError::BackendError(&'static str, #[source] Box<dyn Error+Send+Sync>)` to vendored libsignal (`ApplicationCallbackError` requires `UnwindSafe`, which `StoreError::Backend` doesn't satisfy). 4 call sites in `signal_adapter`/`signal.rs` switched. Documented divergence from upstream Signal.
6. **`refactor(store)!`** — Largest commit. `StoreError`'s 4 String variants (`Database`, `Connection`, `Migration`, `Serialization`) all gained `#[source] Box<dyn Error+Send+Sync>`. New variants: `Validation(String)` for descriptive validation, `RetriesExhausted { op }`, `InvalidConfig(String)`. Dead variants removed (`Backend`, `NotFound`, `DeviceNotFound`). 30+ call sites in `sqlite-storage` updated. New `is_database_busy_or_locked()` helper walks the source chain — replaces the substring `matches!(... msg.contains(\"locked\"))` anti-pattern in `client.rs:2510`. Retired `db_err()` helper (was wrap-already-wrapped — backend already returned `StoreError`).

## Breaking changes

Surface-level (anyone matching variants):
- `PairCodeError::CryptoError`, `PairCodeError::RequestFailed` removed; replaced by typed variants and the new `PairError` wrapper.
- `Client::pair_with_code` returns `PairError` (not `PairCodeError`).
- `SocketError::Crypto`, `SocketError::NoiseHandshake` removed.
- `NoiseError::CryptoError` removed; `NoiseError` no longer `Clone`.
- `wacore::request::IqError::Network` removed.
- `IqError` gained `EncryptSend` + `ClientState`; pattern matching needs to cover them.
- `MediaDecryptionError::Decryption(String)` now carries `DecryptionError`.
- `StoreError::{Database, Connection, Migration, Serialization}` carry typed sources, not Strings; `Backend`, `NotFound`, `DeviceNotFound` removed.
- `db_err` helper removed.
- `SignalProtocolError` got a new `BackendError` variant (vendored libsignal divergence).

Display messages on most touched variants are lowercased and dropped the `: {0}` suffix when source is preserved (avoids duplication when consumers walk the chain via `tracing::error!(error = ?e)` or anyhow).

## Source-chain tests

Each touched enum has a test verifying `error.source()` returns the expected concrete type via `downcast_ref`:

- `wacore::pair_code::tests::invalid_primary_ephemeral_key_preserves_curve_source`
- `wacore::pair_code::tests::bundle_aead_preserves_crypto_provider_source`
- `whatsapp_rust::pair_code::tests::pair_error_request_failed_preserves_iq_source`
- `whatsapp_rust::pair_code::tests::pair_error_paircode_transparent_walks_to_curve_error`
- `whatsapp_rust::socket::error::tests::cipher_preserves_noise_source_through_socket_error` (two-hop downcast)
- `whatsapp_rust::socket::error::tests::marshal_preserves_binary_error_source`
- `wacore::download::tests::media_decryption_decryption_preserves_aes_cbc_source`
- `wacore::download::tests::media_decryption_mac_preserves_crypto_error_source`
- `whatsapp_rust::features::mex::tests::invalid_jid_preserves_jid_error_source`
- `whatsapp_rust::features::mex::tests::request_preserves_iq_error_source`
- `wacore_libsignal::protocol::error::tests::backend_error_preserves_typed_source_via_downcast`
- `wacore::store::error::tests::database_preserves_typed_source_via_downcast`
- `wacore::store::error::tests::is_busy_or_locked_walks_chain` (+ negative case)

## Acceptance criteria

- `grep -rn 'map_err.*\.to_string()' src wacore/src` returns only the two annotated `// reason:` lines in `wacore/src/store/device.rs` (serde boundary, no chain support).
- `cargo test --workspace --exclude e2e-tests --exclude bench-integration` — all passing.
- `cargo clippy --workspace --exclude e2e-tests --exclude bench-integration --all-targets -- -D warnings` — clean.

## Test plan

- [x] `cargo test --workspace --exclude e2e-tests`
- [x] `cargo clippy --workspace -- -D warnings`
- [ ] `cargo test -p e2e-tests` (requires mock server — not run locally)
- [ ] Smoke-test Veloz against this branch to confirm the high-level error surface still works at the consumer side