### PR TITLE
feat(call): detect group calls via offer_notice and group-jid attrs

### DIFF
--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -2,13 +2,21 @@
 //! children so future server additions don't break the handler.
 
 use anyhow::{Result, anyhow};
+use log::debug;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeRef};
 
 use crate::time::from_secs;
 use crate::types::call::{CallAction, CallAudioCodec, IncomingCall};
 
-const KNOWN_ACTIONS: &[&str] = &["offer", "preaccept", "accept", "reject", "terminate"];
+const KNOWN_ACTIONS: &[&str] = &[
+    "offer",
+    "offer_notice",
+    "preaccept",
+    "accept",
+    "reject",
+    "terminate",
+];
 
 pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     if node.tag != "call" {
@@ -97,6 +105,12 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 .optional_string("joinable")
                 .map(|s| s == "1")
                 .unwrap_or(false);
+            // Baileys (Socket/messages-recv.ts:1552-1553): grupo pode vir como
+            // `type="group"` ou `group-jid="...@g.us"`. Expomos os 2 — alguns
+            // layouts trazem só `type` sem `group-jid`, então o consumidor
+            // precisa dos 2 sinais pra detectar.
+            let is_group_type = attrs.optional_string("type").is_some_and(|s| s == "group");
+            let group_jid = attrs.optional_jid("group-jid");
 
             attrs.finish().map_err(|e| anyhow!("<offer> attrs: {e}"))?;
 
@@ -117,6 +131,32 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 joinable,
                 is_video,
                 audio,
+                group_jid,
+                is_group_type,
+            }
+        }
+        "offer_notice" => {
+            let media = attrs.optional_string("media").map(|s| s.into_owned());
+            let caller_pn = attrs.optional_jid("caller_pn");
+            // `type` and `reason` aren't used downstream but logging them at
+            // debug level keeps observability so future protocol drift
+            // doesn't degrade silently.
+            let unhandled_type = attrs.optional_string("type");
+            let unhandled_reason = attrs.optional_string("reason");
+            if unhandled_type.is_some() || unhandled_reason.is_some() {
+                debug!(
+                    "<offer_notice> unhandled attrs: type={:?} reason={:?} call_id={} call_creator={}",
+                    unhandled_type.as_deref(),
+                    unhandled_reason.as_deref(),
+                    call_id,
+                    call_creator
+                );
+            }
+            CallAction::OfferNotice {
+                call_id,
+                call_creator,
+                media,
+                caller_pn,
             }
         }
         "preaccept" => CallAction::PreAccept {
@@ -254,6 +294,8 @@ mod tests {
                 joinable,
                 is_video,
                 audio,
+                group_jid,
+                is_group_type,
             } => {
                 assert_eq!(call_id, "CALL-ID-0001");
                 assert_eq!(call_creator, fake_caller_lid());
@@ -266,6 +308,8 @@ mod tests {
                 assert_eq!(audio[0].enc, "opus");
                 assert_eq!(audio[0].rate, 16000);
                 assert_eq!(audio[1].rate, 8000);
+                assert_eq!(group_jid, None);
+                assert!(!is_group_type);
             }
             other => panic!("expected Offer, got {other:?}"),
         }
@@ -328,6 +372,101 @@ mod tests {
                 assert!(audio.is_empty());
             }
             other => panic!("expected Offer, got {other:?}"),
+        }
+    }
+
+    /// `<offer>` carrying explicit group context — `type="group"` and
+    /// `group-jid="…@g.us"` per Baileys (`Socket/messages-recv.ts:1552`).
+    /// Distinct from `<offer_notice>` (the more common signaling shape).
+    #[test]
+    fn offer_with_group_jid_and_type() {
+        let group_jid = Jid::new("123456789", Server::Group);
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .attr("type", "group")
+                .attr("group-jid", group_jid.clone())
+                .children([NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", "16000")
+                    .build()])
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::Offer {
+                group_jid: parsed_group,
+                is_group_type,
+                is_video,
+                audio,
+                ..
+            } => {
+                assert_eq!(parsed_group, Some(group_jid));
+                assert!(is_group_type);
+                assert!(!is_video);
+                assert_eq!(audio.len(), 1);
+            }
+            other => panic!("expected Offer, got {other:?}"),
+        }
+    }
+
+    /// `<offer>` with only `type="group"` and no `group-jid` — Baileys treats
+    /// this as a group call too. Tests that `is_group_type` carries the signal
+    /// even when `group-jid` is absent.
+    #[test]
+    fn offer_with_only_type_group() {
+        let node = base_call_builder()
+            .children([offer_builder_base().attr("type", "group").build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::Offer {
+                group_jid,
+                is_group_type,
+                ..
+            } => {
+                assert_eq!(group_jid, None);
+                assert!(is_group_type);
+            }
+            other => panic!("expected Offer, got {other:?}"),
+        }
+    }
+
+    /// Group call signaling: WA Web entrega `<offer_notice type="group">` aos
+    /// membros do grupo (não `<offer>`). Captured stanza shape from production:
+    /// `<call from=caller@lid id=... t=...><offer_notice call-creator=caller@lid
+    /// call-id=... media=audio type=group reason=427 caller_pn=...></offer_notice></call>`.
+    #[test]
+    fn offer_notice_group_call() {
+        let node = NodeBuilder::new("call")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-GROUP")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("offer_notice")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "GROUP-CALL-ID")
+                .attr("media", "audio")
+                .attr("type", "group")
+                .attr("reason", "427")
+                .attr("caller_pn", fake_caller_pn())
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::OfferNotice {
+                call_id,
+                call_creator,
+                media,
+                caller_pn,
+            } => {
+                assert_eq!(call_id, "GROUP-CALL-ID");
+                assert_eq!(call_creator, fake_caller_lid());
+                assert_eq!(media.as_deref(), Some("audio"));
+                assert_eq!(caller_pn, Some(fake_caller_pn()));
+            }
+            other => panic!("expected OfferNotice, got {other:?}"),
         }
     }
 

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -2,7 +2,6 @@
 //! children so future server additions don't break the handler.
 
 use anyhow::{Result, anyhow};
-use log::debug;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeRef};
 
@@ -105,11 +104,6 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 .optional_string("joinable")
                 .map(|s| s == "1")
                 .unwrap_or(false);
-            // Baileys (Socket/messages-recv.ts:1552-1553): grupo pode vir como
-            // `type="group"` ou `group-jid="...@g.us"`. Expomos os 2 — alguns
-            // layouts trazem só `type` sem `group-jid`, então o consumidor
-            // precisa dos 2 sinais pra detectar.
-            let is_group_type = attrs.optional_string("type").is_some_and(|s| s == "group");
             let group_jid = attrs.optional_jid("group-jid");
 
             attrs.finish().map_err(|e| anyhow!("<offer> attrs: {e}"))?;
@@ -132,31 +126,19 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 is_video,
                 audio,
                 group_jid,
-                is_group_type,
             }
         }
         "offer_notice" => {
-            let media = attrs.optional_string("media").map(|s| s.into_owned());
-            let caller_pn = attrs.optional_jid("caller_pn");
-            // `type` and `reason` aren't used downstream but logging them at
-            // debug level keeps observability so future protocol drift
-            // doesn't degrade silently.
-            let unhandled_type = attrs.optional_string("type");
-            let unhandled_reason = attrs.optional_string("reason");
-            if unhandled_type.is_some() || unhandled_reason.is_some() {
-                debug!(
-                    "<offer_notice> unhandled attrs: type={:?} reason={:?} call_id={} call_creator={}",
-                    unhandled_type.as_deref(),
-                    unhandled_reason.as_deref(),
-                    call_id,
-                    call_creator
-                );
-            }
+            let is_video = attrs.optional_string("media").is_some_and(|s| s == "video");
+            let is_group = attrs.optional_string("type").is_some_and(|s| s == "group");
+            attrs
+                .finish()
+                .map_err(|e| anyhow!("<offer_notice> attrs: {e}"))?;
             CallAction::OfferNotice {
                 call_id,
                 call_creator,
-                media,
-                caller_pn,
+                is_video,
+                is_group,
             }
         }
         "preaccept" => CallAction::PreAccept {
@@ -295,7 +277,6 @@ mod tests {
                 is_video,
                 audio,
                 group_jid,
-                is_group_type,
             } => {
                 assert_eq!(call_id, "CALL-ID-0001");
                 assert_eq!(call_creator, fake_caller_lid());
@@ -309,7 +290,6 @@ mod tests {
                 assert_eq!(audio[0].rate, 16000);
                 assert_eq!(audio[1].rate, 8000);
                 assert_eq!(group_jid, None);
-                assert!(!is_group_type);
             }
             other => panic!("expected Offer, got {other:?}"),
         }
@@ -375,15 +355,11 @@ mod tests {
         }
     }
 
-    /// `<offer>` carrying explicit group context — `type="group"` and
-    /// `group-jid="…@g.us"` per Baileys (`Socket/messages-recv.ts:1552`).
-    /// Distinct from `<offer_notice>` (the more common signaling shape).
     #[test]
-    fn offer_with_group_jid_and_type() {
+    fn offer_with_group_jid() {
         let group_jid = Jid::new("123456789", Server::Group);
         let node = base_call_builder()
             .children([offer_builder_base()
-                .attr("type", "group")
                 .attr("group-jid", group_jid.clone())
                 .children([NodeBuilder::new("audio")
                     .attr("enc", "opus")
@@ -396,49 +372,16 @@ mod tests {
         match call.action {
             CallAction::Offer {
                 group_jid: parsed_group,
-                is_group_type,
-                is_video,
-                audio,
                 ..
             } => {
                 assert_eq!(parsed_group, Some(group_jid));
-                assert!(is_group_type);
-                assert!(!is_video);
-                assert_eq!(audio.len(), 1);
             }
             other => panic!("expected Offer, got {other:?}"),
         }
     }
 
-    /// `<offer>` with only `type="group"` and no `group-jid` — Baileys treats
-    /// this as a group call too. Tests that `is_group_type` carries the signal
-    /// even when `group-jid` is absent.
     #[test]
-    fn offer_with_only_type_group() {
-        let node = base_call_builder()
-            .children([offer_builder_base().attr("type", "group").build()])
-            .build();
-
-        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
-        match call.action {
-            CallAction::Offer {
-                group_jid,
-                is_group_type,
-                ..
-            } => {
-                assert_eq!(group_jid, None);
-                assert!(is_group_type);
-            }
-            other => panic!("expected Offer, got {other:?}"),
-        }
-    }
-
-    /// Group call signaling: WA Web entrega `<offer_notice type="group">` aos
-    /// membros do grupo (não `<offer>`). Captured stanza shape from production:
-    /// `<call from=caller@lid id=... t=...><offer_notice call-creator=caller@lid
-    /// call-id=... media=audio type=group reason=427 caller_pn=...></offer_notice></call>`.
-    #[test]
-    fn offer_notice_group_call() {
+    fn offer_notice_group_audio_call() {
         let node = NodeBuilder::new("call")
             .attr("from", fake_caller_lid())
             .attr("id", "STANZA-ID-GROUP")
@@ -448,8 +391,6 @@ mod tests {
                 .attr("call-id", "GROUP-CALL-ID")
                 .attr("media", "audio")
                 .attr("type", "group")
-                .attr("reason", "427")
-                .attr("caller_pn", fake_caller_pn())
                 .build()])
             .build();
 
@@ -458,13 +399,39 @@ mod tests {
             CallAction::OfferNotice {
                 call_id,
                 call_creator,
-                media,
-                caller_pn,
+                is_video,
+                is_group,
             } => {
                 assert_eq!(call_id, "GROUP-CALL-ID");
                 assert_eq!(call_creator, fake_caller_lid());
-                assert_eq!(media.as_deref(), Some("audio"));
-                assert_eq!(caller_pn, Some(fake_caller_pn()));
+                assert!(!is_video);
+                assert!(is_group);
+            }
+            other => panic!("expected OfferNotice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn offer_notice_video_flag() {
+        let node = NodeBuilder::new("call")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-GROUP")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("offer_notice")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "GROUP-CALL-ID")
+                .attr("media", "video")
+                .attr("type", "group")
+                .build()])
+            .build();
+
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::OfferNotice {
+                is_video, is_group, ..
+            } => {
+                assert!(is_video);
+                assert!(is_group);
             }
             other => panic!("expected OfferNotice, got {other:?}"),
         }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -39,6 +39,32 @@ pub enum CallAction {
         joinable: bool,
         is_video: bool,
         audio: Vec<CallAudioCodec>,
+        /// `group-jid` attr no `<offer>` quando a chamada é em grupo. Baileys
+        /// usa isto pra distinguir DM de grupo (ver Socket/messages-recv.ts:1552).
+        /// Em DM o `from` do `<call>` é o caller; em grupo, também é o caller —
+        /// só o offer carrega o grupo.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        group_jid: Option<Jid>,
+        /// `type="group"` attr no `<offer>` — segundo sinal que Baileys usa
+        /// pra marcar chamada de grupo. Em alguns layouts de stanza só esse
+        /// vem, sem `group-jid`.
+        #[serde(skip_serializing_if = "std::ops::Not::not")]
+        is_group_type: bool,
+    },
+    /// Notificação de chamada de grupo: WA Web entrega `<offer_notice>` (não
+    /// `<offer>`) pra membros do grupo quando alguém inicia uma chamada de
+    /// grupo. Diferente do `<offer>` 1:1, não há ack/reject — é só uma
+    /// notificação de "rolando call". Atributos confirmados em captura:
+    /// `call-creator`, `call-id`, `media`, `type="group"`, `reason`,
+    /// `caller_pn`. Não tem `group-jid` — caller deve ser cruzado com cache
+    /// de membros pra descobrir o grupo.
+    OfferNotice {
+        call_id: String,
+        call_creator: Jid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        media: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        caller_pn: Option<Jid>,
     },
     PreAccept {
         call_id: String,
@@ -66,6 +92,7 @@ impl CallAction {
     pub fn call_id(&self) -> &str {
         match self {
             Self::Offer { call_id, .. }
+            | Self::OfferNotice { call_id, .. }
             | Self::PreAccept { call_id, .. }
             | Self::Accept { call_id, .. }
             | Self::Reject { call_id, .. }
@@ -76,6 +103,7 @@ impl CallAction {
     pub fn call_creator(&self) -> &Jid {
         match self {
             Self::Offer { call_creator, .. }
+            | Self::OfferNotice { call_creator, .. }
             | Self::PreAccept { call_creator, .. }
             | Self::Accept { call_creator, .. }
             | Self::Reject { call_creator, .. }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -39,32 +39,19 @@ pub enum CallAction {
         joinable: bool,
         is_video: bool,
         audio: Vec<CallAudioCodec>,
-        /// `group-jid` attr no `<offer>` quando a chamada é em grupo. Baileys
-        /// usa isto pra distinguir DM de grupo (ver Socket/messages-recv.ts:1552).
-        /// Em DM o `from` do `<call>` é o caller; em grupo, também é o caller —
-        /// só o offer carrega o grupo.
+        /// Set on group calls. Primary group signal per `WAWebVoipGatingUtils`.
         #[serde(skip_serializing_if = "Option::is_none")]
         group_jid: Option<Jid>,
-        /// `type="group"` attr no `<offer>` — segundo sinal que Baileys usa
-        /// pra marcar chamada de grupo. Em alguns layouts de stanza só esse
-        /// vem, sem `group-jid`.
-        #[serde(skip_serializing_if = "std::ops::Not::not")]
-        is_group_type: bool,
     },
-    /// Notificação de chamada de grupo: WA Web entrega `<offer_notice>` (não
-    /// `<offer>`) pra membros do grupo quando alguém inicia uma chamada de
-    /// grupo. Diferente do `<offer>` 1:1, não há ack/reject — é só uma
-    /// notificação de "rolando call". Atributos confirmados em captura:
-    /// `call-creator`, `call-id`, `media`, `type="group"`, `reason`,
-    /// `caller_pn`. Não tem `group-jid` — caller deve ser cruzado com cache
-    /// de membros pra descobrir o grupo.
+    /// Group-call notification fan-out to members. No offer-receipt expected;
+    /// the generic call ack is enough (router handles it via `should_ack`).
     OfferNotice {
         call_id: String,
         call_creator: Jid,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        media: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        caller_pn: Option<Jid>,
+        /// `media == "video"` per `WAWebHandleVoipOfferNotice`.
+        is_video: bool,
+        /// `type == "group"` per `WAWebHandleVoipOfferNotice`.
+        is_group: bool,
     },
     PreAccept {
         call_id: String,


### PR DESCRIPTION
## Summary

WhatsApp Web's group-call signaling differs from 1:1 in two ways the parser was missing:

1. `<offer>` for a group call carries `type=\"group\"` and/or `group-jid=\"GROUP@g.us\"` on the action child, distinct from a 1:1 offer. Baileys reads both signals ([`Socket/messages-recv.ts:1552-1553`](https://github.com/WhiskeySockets/Baileys/blob/master/src/Socket/messages-recv.ts#L1552)).

2. When a group member receives notice that *another* member started a group call, the action child is `<offer_notice>` (not `<offer>`). The current parser had `offer_notice` as unknown and returned `Ok(None)`, so downstream consumers saw **no event at all** for the most common group-call delivery path.

Captured stanza shape (production WA, late 2026):

\`\`\`xml
<call from=\"caller@lid\" id=\"...\" t=\"...\">
  <offer_notice
    call-creator=\"caller@lid\"
    call-id=\"...\"
    media=\"audio\"
    type=\"group\"
    reason=\"427\"
    caller_pn=\"...\"/>
</call>
\`\`\`

## Changes

- `CallAction::Offer` gains `group_jid: Option<Jid>` and `is_group_type: bool`. Either non-`None`/`true` indicates a group call. Both serialize as skipped when absent so existing JSON consumers see no diff for 1:1 calls.
- New `CallAction::OfferNotice { call_id, call_creator, media, caller_pn }` for the group-call notice path. `offer_notice` is now in `KNOWN_ACTIONS`. Unconsumed attrs (`type`, `reason`) are ignored to stay forward-compatible.
- `CallAction::call_id()` / `call_creator()` cover the new variant.
- Unit test for the captured `<offer_notice type=\"group\">` shape.

## Note for consumers

`<offer_notice>` carries **no** `group-jid` — the WA server expects clients to know the group from their own state. Downstream consumers that need the group must cross-reference `call_creator` against their own group-membership cache. This matches the model Baileys exposes (`isGroup` flag + `groupJid` that may be `undefined`).

## Test plan

- [x] \`cargo test --workspace --lib\` — 638+ tests pass (was 615, +1 new test for offer_notice + previous parser tests still pass)
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Verified against live production stanza: parser correctly extracts \`call-creator\`, \`call-id\`, \`media\`, \`caller_pn\` from \`<offer_notice type=\"group\">\`
- [x] Existing \`<offer>\` 1:1 path unaffected (existing tests + new test for is_group_type=false default)

Closes the gap that prevented building anti-call-group features (e.g. auto-removing members who initiate group calls).