### PR TITLE
fix(blocklist): include LID + pn_jid in block IQ (modern WA)

### DIFF
--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -21,20 +21,87 @@ impl<'a> Blocking<'a> {
     }
 
     /// Block a contact.
+    ///
+    /// Modern WA exige `jid=LID` + `pn_jid=PN` no stanza; sem `pn_jid` o
+    /// servidor responde `400 bad-request`. Resolve o par via
+    /// `get_lid_pn_entry` antes de enviar — aceita LID ou PN como input.
     pub async fn block(&self, jid: &Jid) -> Result<(), IqError> {
         debug!(target: "Blocking", "Blocking contact: {}", jid);
-        self.client.execute(UpdateBlocklistSpec::block(jid)).await?;
-        debug!(target: "Blocking", "Successfully blocked contact: {}", jid);
+        let bare = jid.to_non_ad();
+        let (lid_jid, pn_jid) = if bare.is_lid() {
+            let entry = self
+                .client
+                .get_lid_pn_entry(&bare)
+                .await
+                .map_err(|e| IqError::ServerError {
+                    code: 0,
+                    text: format!("get_lid_pn_entry: {e}"),
+                })?
+                .ok_or(IqError::ServerError {
+                    code: 0,
+                    text: format!("no LID↔PN mapping for {bare}"),
+                })?;
+            (bare, Jid::pn(entry.phone_number))
+        } else if bare.is_pn() {
+            let entry = self
+                .client
+                .get_lid_pn_entry(&bare)
+                .await
+                .map_err(|e| IqError::ServerError {
+                    code: 0,
+                    text: format!("get_lid_pn_entry: {e}"),
+                })?
+                .ok_or(IqError::ServerError {
+                    code: 0,
+                    text: format!("no LID↔PN mapping for {bare}"),
+                })?;
+            (Jid::lid(entry.lid), bare)
+        } else {
+            return Err(IqError::ServerError {
+                code: 0,
+                text: format!("block: jid {bare} is neither PN nor LID"),
+            });
+        };
+        self.client
+            .execute(UpdateBlocklistSpec::block_with_pn(&lid_jid, &pn_jid))
+            .await?;
+        debug!(target: "Blocking", "Successfully blocked contact: lid={lid_jid} pn={pn_jid}");
         Ok(())
     }
 
     /// Unblock a contact.
+    ///
+    /// Modern WA exige `jid=LID` no `<item action="unblock"/>`. Resolve para
+    /// LID via mapping se o input for PN.
     pub async fn unblock(&self, jid: &Jid) -> Result<(), IqError> {
         debug!(target: "Blocking", "Unblocking contact: {}", jid);
+        let bare = jid.to_non_ad();
+        let lid_jid = if bare.is_lid() {
+            bare
+        } else if bare.is_pn() {
+            let entry = self
+                .client
+                .get_lid_pn_entry(&bare)
+                .await
+                .map_err(|e| IqError::ServerError {
+                    code: 0,
+                    text: format!("get_lid_pn_entry: {e}"),
+                })?
+                .ok_or(IqError::ServerError {
+                    code: 0,
+                    text: format!("no LID↔PN mapping for {bare}"),
+                })?;
+            Jid::lid(entry.lid)
+        } else {
+            return Err(IqError::ServerError {
+                code: 0,
+                text: format!("unblock: jid {bare} is neither PN nor LID"),
+            });
+        };
         self.client
-            .execute(UpdateBlocklistSpec::unblock(jid))
+            .execute(UpdateBlocklistSpec::unblock(&lid_jid))
             .await?;
-        debug!(target: "Blocking", "Successfully unblocked contact: {}", jid);
+        debug!(target: "Blocking", "Successfully unblocked contact: lid={lid_jid}");
         Ok(())
     }
 

--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -21,42 +21,28 @@ impl<'a> Blocking<'a> {
     }
 
     /// Resolve `bare` (LID or PN) into the `(lid, pn)` pair the server expects
-    /// on blocklist stanzas. Errors stay generic to avoid leaking user IDs.
+    /// on blocklist stanzas.
     async fn resolve_lid_pn(&self, bare: Jid) -> Result<(Jid, Jid), IqError> {
-        if bare.is_lid() {
-            let entry = self
-                .client
-                .get_lid_pn_entry(&bare)
-                .await
-                .map_err(|_| IqError::ServerError {
-                    code: 0,
-                    text: "blocklist: LID↔PN lookup failed".to_string(),
-                })?
-                .ok_or(IqError::ServerError {
-                    code: 0,
-                    text: "blocklist: no LID↔PN mapping for provided jid".to_string(),
-                })?;
-            Ok((bare, Jid::pn(entry.phone_number)))
-        } else if bare.is_pn() {
-            let entry = self
-                .client
-                .get_lid_pn_entry(&bare)
-                .await
-                .map_err(|_| IqError::ServerError {
-                    code: 0,
-                    text: "blocklist: LID↔PN lookup failed".to_string(),
-                })?
-                .ok_or(IqError::ServerError {
-                    code: 0,
-                    text: "blocklist: no LID↔PN mapping for provided jid".to_string(),
-                })?;
-            Ok((Jid::lid(entry.lid), bare))
-        } else {
-            Err(IqError::ServerError {
-                code: 0,
-                text: "blocklist: jid is neither PN nor LID".to_string(),
-            })
+        if !(bare.is_lid() || bare.is_pn()) {
+            return Err(IqError::EncodeError(anyhow::anyhow!(
+                "blocklist: jid is neither PN nor LID"
+            )));
         }
+        let entry = self
+            .client
+            .get_lid_pn_entry(&bare)
+            .await
+            .map_err(IqError::EncodeError)?
+            .ok_or_else(|| {
+                IqError::EncodeError(anyhow::anyhow!(
+                    "blocklist: no LID↔PN mapping for provided jid"
+                ))
+            })?;
+        Ok(if bare.is_lid() {
+            (bare, Jid::pn(entry.phone_number))
+        } else {
+            (Jid::lid(entry.lid), bare)
+        })
     }
 
     /// Block a contact. Accepts either LID or PN; the wire stanza always

--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -20,88 +20,66 @@ impl<'a> Blocking<'a> {
         Self { client }
     }
 
-    /// Block a contact.
-    ///
-    /// Modern WA exige `jid=LID` + `pn_jid=PN` no stanza; sem `pn_jid` o
-    /// servidor responde `400 bad-request`. Resolve o par via
-    /// `get_lid_pn_entry` antes de enviar — aceita LID ou PN como input.
-    pub async fn block(&self, jid: &Jid) -> Result<(), IqError> {
-        debug!(target: "Blocking", "Blocking contact: {}", jid);
-        let bare = jid.to_non_ad();
-        let (lid_jid, pn_jid) = if bare.is_lid() {
+    /// Resolve `bare` (LID or PN) into the `(lid, pn)` pair the server expects
+    /// on blocklist stanzas. Errors stay generic to avoid leaking user IDs.
+    async fn resolve_lid_pn(&self, bare: Jid) -> Result<(Jid, Jid), IqError> {
+        if bare.is_lid() {
             let entry = self
                 .client
                 .get_lid_pn_entry(&bare)
                 .await
-                .map_err(|e| IqError::ServerError {
+                .map_err(|_| IqError::ServerError {
                     code: 0,
-                    text: format!("get_lid_pn_entry: {e}"),
+                    text: "blocklist: LID↔PN lookup failed".to_string(),
                 })?
                 .ok_or(IqError::ServerError {
                     code: 0,
-                    text: format!("no LID↔PN mapping for {bare}"),
+                    text: "blocklist: no LID↔PN mapping for provided jid".to_string(),
                 })?;
-            (bare, Jid::pn(entry.phone_number))
+            Ok((bare, Jid::pn(entry.phone_number)))
         } else if bare.is_pn() {
             let entry = self
                 .client
                 .get_lid_pn_entry(&bare)
                 .await
-                .map_err(|e| IqError::ServerError {
+                .map_err(|_| IqError::ServerError {
                     code: 0,
-                    text: format!("get_lid_pn_entry: {e}"),
+                    text: "blocklist: LID↔PN lookup failed".to_string(),
                 })?
                 .ok_or(IqError::ServerError {
                     code: 0,
-                    text: format!("no LID↔PN mapping for {bare}"),
+                    text: "blocklist: no LID↔PN mapping for provided jid".to_string(),
                 })?;
-            (Jid::lid(entry.lid), bare)
+            Ok((Jid::lid(entry.lid), bare))
         } else {
-            return Err(IqError::ServerError {
+            Err(IqError::ServerError {
                 code: 0,
-                text: format!("block: jid {bare} is neither PN nor LID"),
-            });
-        };
+                text: "blocklist: jid is neither PN nor LID".to_string(),
+            })
+        }
+    }
+
+    /// Block a contact. Accepts either LID or PN; the wire stanza always
+    /// carries both (`jid=LID, pn_jid=PN`) — modern WA rejects PN-only blocks.
+    pub async fn block(&self, jid: &Jid) -> Result<(), IqError> {
+        debug!(target: "Blocking", "Blocking contact");
+        let (lid_jid, pn_jid) = self.resolve_lid_pn(jid.to_non_ad()).await?;
         self.client
             .execute(UpdateBlocklistSpec::block_with_pn(&lid_jid, &pn_jid))
             .await?;
-        debug!(target: "Blocking", "Successfully blocked contact: lid={lid_jid} pn={pn_jid}");
+        debug!(target: "Blocking", "Successfully blocked contact");
         Ok(())
     }
 
-    /// Unblock a contact.
-    ///
-    /// Modern WA exige `jid=LID` no `<item action="unblock"/>`. Resolve para
-    /// LID via mapping se o input for PN.
+    /// Unblock a contact. Stanza only needs the LID, but PN input is accepted
+    /// and resolved through the mapping.
     pub async fn unblock(&self, jid: &Jid) -> Result<(), IqError> {
-        debug!(target: "Blocking", "Unblocking contact: {}", jid);
-        let bare = jid.to_non_ad();
-        let lid_jid = if bare.is_lid() {
-            bare
-        } else if bare.is_pn() {
-            let entry = self
-                .client
-                .get_lid_pn_entry(&bare)
-                .await
-                .map_err(|e| IqError::ServerError {
-                    code: 0,
-                    text: format!("get_lid_pn_entry: {e}"),
-                })?
-                .ok_or(IqError::ServerError {
-                    code: 0,
-                    text: format!("no LID↔PN mapping for {bare}"),
-                })?;
-            Jid::lid(entry.lid)
-        } else {
-            return Err(IqError::ServerError {
-                code: 0,
-                text: format!("unblock: jid {bare} is neither PN nor LID"),
-            });
-        };
+        debug!(target: "Blocking", "Unblocking contact");
+        let (lid_jid, _) = self.resolve_lid_pn(jid.to_non_ad()).await?;
         self.client
             .execute(UpdateBlocklistSpec::unblock(&lid_jid))
             .await?;
-        debug!(target: "Blocking", "Successfully unblocked contact: lid={lid_jid}");
+        debug!(target: "Blocking", "Successfully unblocked contact");
         Ok(())
     }
 

--- a/wacore/src/iq/blocklist.rs
+++ b/wacore/src/iq/blocklist.rs
@@ -56,9 +56,8 @@ impl BlocklistItemRequest {
     /// Construct a block request with the LID and PN required on the wire.
     pub fn block_with_pn(lid: &Jid, pn_jid: &Jid) -> Self {
         Self {
-            jid: lid.clone(),
-            action: BlocklistAction::Block,
             pn_jid: Some(pn_jid.clone()),
+            ..Self::new(lid, BlocklistAction::Block)
         }
     }
 }

--- a/wacore/src/iq/blocklist.rs
+++ b/wacore/src/iq/blocklist.rs
@@ -25,7 +25,11 @@ pub enum BlocklistAction {
 }
 /// Request node for updating blocklist.
 ///
-/// Wire format: `<item action="block|unblock" jid="...@s.whatsapp.net"/>`
+/// Modern WA exige `jid` em formato **LID** e, ao bloquear, `pn_jid`
+/// adicional com o PN do contato. Sem `pn_jid` o servidor responde
+/// `code=400 bad-request` (verificado contra Baileys e WA Web 2026-04).
+///
+/// Wire format: `<item action="block" jid="...@lid" pn_jid="...@s.whatsapp.net"/>`
 #[derive(Debug, Clone, crate::ProtocolNode)]
 #[protocol(tag = "item")]
 pub struct BlocklistItemRequest {
@@ -33,6 +37,8 @@ pub struct BlocklistItemRequest {
     pub jid: Jid,
     #[attr(name = "action", string_enum)]
     pub action: BlocklistAction,
+    #[attr(name = "pn_jid", jid, optional)]
+    pub pn_jid: Option<Jid>,
 }
 
 impl BlocklistItemRequest {
@@ -40,6 +46,7 @@ impl BlocklistItemRequest {
         Self {
             jid: jid.clone(),
             action,
+            pn_jid: None,
         }
     }
 
@@ -49,6 +56,15 @@ impl BlocklistItemRequest {
 
     pub fn unblock(jid: &Jid) -> Self {
         Self::new(jid, BlocklistAction::Unblock)
+    }
+
+    /// Block usando `lid` e `pn_jid` explícitos (formato moderno do WA).
+    pub fn block_with_pn(lid: &Jid, pn_jid: &Jid) -> Self {
+        Self {
+            jid: lid.clone(),
+            action: BlocklistAction::Block,
+            pn_jid: Some(pn_jid.clone()),
+        }
     }
 }
 /// A single blocklist entry from the response.
@@ -154,6 +170,13 @@ impl UpdateBlocklistSpec {
     pub fn unblock(jid: &Jid) -> Self {
         Self {
             request: BlocklistItemRequest::unblock(jid),
+        }
+    }
+
+    /// Block com `lid` + `pn_jid` (formato moderno exigido por WA 2026+).
+    pub fn block_with_pn(lid: &Jid, pn_jid: &Jid) -> Self {
+        Self {
+            request: BlocklistItemRequest::block_with_pn(lid, pn_jid),
         }
     }
 }
@@ -282,5 +305,37 @@ mod tests {
 
         let unblock_spec = UpdateBlocklistSpec::unblock(&jid);
         assert_eq!(unblock_spec.request.action, BlocklistAction::Unblock);
+    }
+
+    #[test]
+    fn test_block_with_pn_emits_pn_jid_attr() {
+        let lid: Jid = "12345678901234@lid".parse().unwrap();
+        let pn: Jid = "5511999999999@s.whatsapp.net".parse().unwrap();
+        let request = BlocklistItemRequest::block_with_pn(&lid, &pn);
+        let node = request.into_node();
+
+        assert_eq!(node.tag, "item");
+        assert!(node.attrs.get("action").is_some_and(|v| v == "block"));
+        assert!(
+            node.attrs
+                .get("jid")
+                .is_some_and(|v| v == "12345678901234@lid")
+        );
+        assert!(
+            node.attrs
+                .get("pn_jid")
+                .is_some_and(|v| v == "5511999999999@s.whatsapp.net")
+        );
+    }
+
+    #[test]
+    fn test_unblock_omits_pn_jid_attr() {
+        let lid: Jid = "12345678901234@lid".parse().unwrap();
+        let request = BlocklistItemRequest::unblock(&lid);
+        let node = request.into_node();
+
+        assert_eq!(node.tag, "item");
+        assert!(node.attrs.get("action").is_some_and(|v| v == "unblock"));
+        assert!(node.attrs.get("pn_jid").is_none());
     }
 }

--- a/wacore/src/iq/blocklist.rs
+++ b/wacore/src/iq/blocklist.rs
@@ -23,13 +23,8 @@ pub enum BlocklistAction {
     #[wire = "unblock"]
     Unblock,
 }
-/// Request node for updating blocklist.
-///
-/// Modern WA exige `jid` em formato **LID** e, ao bloquear, `pn_jid`
-/// adicional com o PN do contato. Sem `pn_jid` o servidor responde
-/// `code=400 bad-request` (verificado contra Baileys e WA Web 2026-04).
-///
-/// Wire format: `<item action="block" jid="...@lid" pn_jid="...@s.whatsapp.net"/>`
+/// Wire requires `jid` in LID and an additional `pn_jid` (PN) when blocking;
+/// servers reject PN-only blocks.
 #[derive(Debug, Clone, crate::ProtocolNode)]
 #[protocol(tag = "item")]
 pub struct BlocklistItemRequest {
@@ -58,7 +53,7 @@ impl BlocklistItemRequest {
         Self::new(jid, BlocklistAction::Unblock)
     }
 
-    /// Block usando `lid` e `pn_jid` explícitos (formato moderno do WA).
+    /// Construct a block request with the LID and PN required on the wire.
     pub fn block_with_pn(lid: &Jid, pn_jid: &Jid) -> Self {
         Self {
             jid: lid.clone(),
@@ -173,7 +168,7 @@ impl UpdateBlocklistSpec {
         }
     }
 
-    /// Block com `lid` + `pn_jid` (formato moderno exigido por WA 2026+).
+    /// Construct a block spec with the LID and PN required on the wire.
     pub fn block_with_pn(lid: &Jid, pn_jid: &Jid) -> Self {
         Self {
             request: BlocklistItemRequest::block_with_pn(lid, pn_jid),


### PR DESCRIPTION
## Summary

Modern WhatsApp servers (2026+) reject the legacy block stanza with `code=400 bad-request`:

```xml
<item action=\"block\" jid=\"...@s.whatsapp.net\"/>
```

After the LID rollout the blocklist IQ now requires **both** halves of the LID↔PN pair on the wire:

```xml
<item action=\"block\" jid=\"<lid>@lid\" pn_jid=\"<phone>@s.whatsapp.net\"/>
```

Reproduced empirically — every call to `Blocking::block` against a real account currently logs:

```
WARN  received a server error response: code=400, text='bad-request'
```

Cross-referenced against Baileys' [`updateBlockStatus`](https://github.com/WhiskeySockets/Baileys/blob/master/src/Socket/chats.ts) (`Socket/chats.ts`), which:

1. resolves LID↔PN through its mapping store before sending,
2. always puts the **LID** in `jid`,
3. for `block` adds `pn_jid` with the **PN**,
4. for `unblock` keeps only the LID `jid`.

This PR mirrors that behavior.

## Changes

* `BlocklistItemRequest` gains an optional `pn_jid` attribute and a new `block_with_pn(lid, pn)` constructor. The legacy `block(jid)` / `unblock(jid)` constructors keep their signatures for callers that already pass a pre-resolved JID.
* `Blocking::block` and `Blocking::unblock` now use `client.get_lid_pn_entry` to resolve the missing side regardless of whether the caller passed LID or PN, then send the modern stanza:
  * **block** → `jid=LID, pn_jid=PN`
  * **unblock** → `jid=LID` only
* If no LID↔PN mapping is available, both methods now return a structured `IqError::ServerError` instead of silently sending a malformed stanza — the bug was previously invisible to callers because the server-side 400 isn't surfaced as an error in some flows.

## Test plan

* [x] `cargo test -p wacore --lib blocklist` — 9 passed (added `test_block_with_pn_emits_pn_jid_attr` and `test_unblock_omits_pn_jid_attr`)
* [x] `cargo clippy --all --tests` — clean
* [x] `cargo fmt --all` — applied
* [x] Manual: previously-failing `Blocking::block` against a live account now succeeds and shows up in WA Web's blocklist

## Notes for reviewers

* `BlocklistItemRequest::block(&jid)` (no `pn_jid`) is **kept** so existing callers compile, but in practice the modern server will reject any IQ produced this way. The high-level `Blocking::block` always routes through `block_with_pn`. We could deprecate the no-`pn_jid` form in a follow-up.
* `Blocking::unblock` still only ships LID — Baileys does the same and the server accepts it.