### PR TITLE
fix(pair)!: map Android PlatformType to Chrome, drop Unknown variant

### DIFF
--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -1,6 +1,5 @@
-//! `companion_platform_id` + `companion_platform_display` emission for
-//! pair-code and QR linking. Encoding only — the wire field is never
-//! parsed back into this enum.
+//! `companion_platform_id` + `companion_platform_display` emission.
+//! Encoding only.
 
 use waproto::whatsapp as wa;
 
@@ -8,10 +7,9 @@ use waproto::whatsapp as wa;
 /// Concatenate with `make_qr_data` output to get a scannable deep-link URL.
 pub const NATIVE_CAMERA_DEEP_LINK_PREFIX: &str = "https://wa.me/settings/linked_devices#";
 
-/// Each variant has a fixed single-byte ASCII wire form. Web codes follow
-/// `WAWebCompanionRegClientUtils.DEVICE_PLATFORM`; the Android letters
-/// come from the official Android client and require server-side
-/// attestation, so they are reachable only through explicit opt-in.
+/// Web codes follow `WAWebCompanionRegClientUtils.DEVICE_PLATFORM`.
+/// Android letters need server-side attestation, so they're reachable
+/// only through explicit opt-in.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum CompanionWebClientType {
     Chrome,
@@ -22,11 +20,9 @@ pub enum CompanionWebClientType {
     Safari,
     Electron,
     Uwp,
-    /// Catch-all WA Web emits when the browser detection returns a name
-    /// that doesn't match any known cohort. Also the safe default for
-    /// platforms with no confirmed wire byte. The proto's `UNKNOWN`
-    /// (`'0'`) is intentionally not represented: real browsers never
-    /// emit it and the server rejects it.
+    /// Default fallback. The proto's `UNKNOWN` (wire `'0'`) is absent
+    /// because WA Web never emits it from a real browser and the server
+    /// rejects it.
     #[default]
     OtherWebClient,
     AndroidTablet,
@@ -81,19 +77,12 @@ pub const fn companion_browser_name(ct: CompanionWebClientType) -> &'static str 
     }
 }
 
-/// Maps `DeviceProps::PlatformType` to a wire variant.
-///
-/// Android variants map to `Chrome`: that's what real WA Web on
-/// Chrome-Android emits (`info().name === "Chrome"`) and what the server
-/// accepts without attestation. The Android letters `'e'`/`'d'`/`'f'`
-/// stay reachable through explicit opt-in via `PairCodeOptions::platform_id`
-/// but require Android-side signing material the server validates.
-///
-/// Platforms without a confirmed wire byte (iOS, AR/VR, etc.) and the
-/// proto's `UNKNOWN` collapse to `OtherWebClient` (`'9'`). `'0'` is
-/// deliberately unreachable: WA Web only emits it when `info().name` is
-/// null, which doesn't happen in a real browser, and the server rejects
-/// it from any non-WA-Web client.
+/// Android maps to `Chrome` because that's what real WA Web on
+/// Chrome-Android emits and what the server accepts; the Android
+/// letters need attestation we can't fake from this crate, so they
+/// stay behind `PairCodeOptions::platform_id`. iOS/AR/VR and the
+/// proto's `UNKNOWN` collapse to `OtherWebClient` — `'0'` would be
+/// server-rejected.
 pub const fn companion_web_client_type_for_platform(
     pt: wa::device_props::PlatformType,
 ) -> CompanionWebClientType {
@@ -215,9 +204,6 @@ mod tests {
         }
     }
 
-    /// Android values map to `Chrome` (`'1'`) — what real WA Web on
-    /// Chrome-Android emits and what the server accepts. The Android
-    /// letters stay opt-in only.
     #[test]
     fn android_platform_types_map_to_chrome() {
         use CompanionWebClientType as C;
@@ -258,8 +244,6 @@ mod tests {
         }
     }
 
-    /// `P::Unknown` collapses to `OtherWebClient` — the server rejects
-    /// `'0'` from any non-WA-Web client.
     #[test]
     fn proto_unknown_collapses_to_other_web_client() {
         use CompanionWebClientType as C;
@@ -270,7 +254,6 @@ mod tests {
         );
     }
 
-    /// Explicit opt-in via the enum still renders the right wire byte.
     #[test]
     fn android_variants_still_emit_their_wire_bytes_when_used_directly() {
         assert_eq!(CompanionWebClientType::AndroidPhone.wire_byte(), b'e');

--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -1,11 +1,6 @@
-//! `companion_platform_id` and `companion_platform_display` emission.
-//!
-//! Server accepts 23 single-byte ids: digits `0..9` (WA Web) and letters
-//! `a..m`. Only the 13 with a confirmed platform meaning are exposed.
-//! Sources: WA Web `WAWebCompanionRegClientUtils` for the digits; the
-//! official WhatsApp Android client for the mobile letters `d`, `e`,
-//! `f`. Adding the rest without binary or wire confirmation risks
-//! mislabelling the device on the primary side.
+//! `companion_platform_id` + `companion_platform_display` emission for
+//! pair-code and QR linking. Encoding only — the wire field is never
+//! parsed back into this enum.
 
 use waproto::whatsapp as wa;
 
@@ -13,14 +8,12 @@ use waproto::whatsapp as wa;
 /// Concatenate with `make_qr_data` output to get a scannable deep-link URL.
 pub const NATIVE_CAMERA_DEEP_LINK_PREFIX: &str = "https://wa.me/settings/linked_devices#";
 
-/// Encode-only: every variant has a fixed single-byte ASCII wire form.
-/// Decoding from the wire is not modelled because this crate only emits
-/// the field, never receives it.
+/// Each variant has a fixed single-byte ASCII wire form. Web codes follow
+/// `WAWebCompanionRegClientUtils.DEVICE_PLATFORM`; the Android letters
+/// come from the official Android client and require server-side
+/// attestation, so they are reachable only through explicit opt-in.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum CompanionWebClientType {
-    // Web (digit codes from WAWebCompanionRegClientUtils.DEVICE_PLATFORM).
-    #[default]
-    Unknown,
     Chrome,
     Edge,
     Firefox,
@@ -29,8 +22,13 @@ pub enum CompanionWebClientType {
     Safari,
     Electron,
     Uwp,
+    /// Catch-all WA Web emits when the browser detection returns a name
+    /// that doesn't match any known cohort. Also the safe default for
+    /// platforms with no confirmed wire byte. The proto's `UNKNOWN`
+    /// (`'0'`) is intentionally not represented: real browsers never
+    /// emit it and the server rejects it.
+    #[default]
     OtherWebClient,
-    // Mobile (letter codes from the official WhatsApp Android client).
     AndroidTablet,
     AndroidPhone,
     AndroidAmbiguous,
@@ -40,7 +38,6 @@ impl CompanionWebClientType {
     /// Single-byte ASCII id placed in `<companion_platform_id>`.
     pub const fn wire_byte(self) -> u8 {
         match self {
-            Self::Unknown => b'0',
             Self::Chrome => b'1',
             Self::Edge => b'2',
             Self::Firefox => b'3',
@@ -75,8 +72,7 @@ pub const fn companion_browser_name(ct: CompanionWebClientType) -> &'static str 
         CompanionWebClientType::Ie => "IE",
         CompanionWebClientType::Opera => "Opera",
         CompanionWebClientType::Safari => "Safari",
-        CompanionWebClientType::Unknown
-        | CompanionWebClientType::Electron
+        CompanionWebClientType::Electron
         | CompanionWebClientType::Uwp
         | CompanionWebClientType::OtherWebClient
         | CompanionWebClientType::AndroidTablet
@@ -85,16 +81,25 @@ pub const fn companion_browser_name(ct: CompanionWebClientType) -> &'static str 
     }
 }
 
-/// Maps `DeviceProps::PlatformType` to a wire variant. Variants without
-/// a confirmed letter fall back to `OtherWebClient` ('9'), which the
-/// server still accepts.
+/// Maps `DeviceProps::PlatformType` to a wire variant.
+///
+/// Android variants map to `Chrome`: that's what real WA Web on
+/// Chrome-Android emits (`info().name === "Chrome"`) and what the server
+/// accepts without attestation. The Android letters `'e'`/`'d'`/`'f'`
+/// stay reachable through explicit opt-in via `PairCodeOptions::platform_id`
+/// but require Android-side signing material the server validates.
+///
+/// Platforms without a confirmed wire byte (iOS, AR/VR, etc.) and the
+/// proto's `UNKNOWN` collapse to `OtherWebClient` (`'9'`). `'0'` is
+/// deliberately unreachable: WA Web only emits it when `info().name` is
+/// null, which doesn't happen in a real browser, and the server rejects
+/// it from any non-WA-Web client.
 pub const fn companion_web_client_type_for_platform(
     pt: wa::device_props::PlatformType,
 ) -> CompanionWebClientType {
     use CompanionWebClientType as C;
     use wa::device_props::PlatformType as P;
     match pt {
-        P::Unknown => C::Unknown,
         P::Chrome => C::Chrome,
         P::Firefox => C::Firefox,
         P::Ie => C::Ie,
@@ -103,10 +108,9 @@ pub const fn companion_web_client_type_for_platform(
         P::Edge => C::Edge,
         P::Desktop => C::Electron,
         P::Uwp => C::Uwp,
-        P::AndroidPhone => C::AndroidPhone,
-        P::AndroidTablet => C::AndroidTablet,
-        P::AndroidAmbiguous => C::AndroidAmbiguous,
-        P::Ipad
+        P::AndroidPhone | P::AndroidTablet | P::AndroidAmbiguous => C::Chrome,
+        P::Unknown
+        | P::Ipad
         | P::Ohana
         | P::Aloha
         | P::Catalina
@@ -127,7 +131,7 @@ pub fn companion_web_client_type_for_props(props: &wa::DeviceProps) -> Companion
         .platform_type
         .and_then(|v| wa::device_props::PlatformType::try_from(v).ok())
         .map(companion_web_client_type_for_platform)
-        .unwrap_or_default()
+        .unwrap_or(CompanionWebClientType::OtherWebClient)
 }
 
 /// `companion_platform_display` body. Server validates only length
@@ -153,7 +157,6 @@ mod tests {
 
     #[test]
     fn wire_byte_matches_wa_web() {
-        assert_eq!(CompanionWebClientType::Unknown.wire_byte(), b'0');
         assert_eq!(CompanionWebClientType::Chrome.wire_byte(), b'1');
         assert_eq!(CompanionWebClientType::Edge.wire_byte(), b'2');
         assert_eq!(CompanionWebClientType::Firefox.wire_byte(), b'3');
@@ -174,7 +177,6 @@ mod tests {
 
     #[test]
     fn display_renders_wire_byte_as_char() {
-        assert_eq!(format!("{}", CompanionWebClientType::Unknown), "0");
         assert_eq!(format!("{}", CompanionWebClientType::Chrome), "1");
         assert_eq!(format!("{}", CompanionWebClientType::OtherWebClient), "9");
         assert_eq!(format!("{}", CompanionWebClientType::AndroidPhone), "e");
@@ -183,65 +185,56 @@ mod tests {
     }
 
     #[test]
-    fn default_is_unknown_zero() {
+    fn default_is_other_web_client_nine() {
         assert_eq!(
             CompanionWebClientType::default(),
-            CompanionWebClientType::Unknown,
+            CompanionWebClientType::OtherWebClient,
         );
-        assert_eq!(CompanionWebClientType::default().wire_byte(), b'0');
+        assert_eq!(CompanionWebClientType::default().wire_byte(), b'9');
     }
 
     #[test]
-    fn browser_platform_types_round_trip() {
+    fn browser_and_desktop_platform_types_map_to_their_variants() {
         use CompanionWebClientType as C;
         use wa::device_props::PlatformType as P;
-        assert_eq!(companion_web_client_type_for_platform(P::Chrome), C::Chrome);
-        assert_eq!(
-            companion_web_client_type_for_platform(P::Firefox),
-            C::Firefox
-        );
-        assert_eq!(companion_web_client_type_for_platform(P::Edge), C::Edge);
-        assert_eq!(companion_web_client_type_for_platform(P::Safari), C::Safari);
-        assert_eq!(companion_web_client_type_for_platform(P::Opera), C::Opera);
-        assert_eq!(companion_web_client_type_for_platform(P::Ie), C::Ie);
+        for (pt, expected) in [
+            (P::Chrome, C::Chrome),
+            (P::Firefox, C::Firefox),
+            (P::Edge, C::Edge),
+            (P::Safari, C::Safari),
+            (P::Opera, C::Opera),
+            (P::Ie, C::Ie),
+            (P::Desktop, C::Electron),
+            (P::Uwp, C::Uwp),
+        ] {
+            assert_eq!(
+                companion_web_client_type_for_platform(pt),
+                expected,
+                "{pt:?}"
+            );
+        }
     }
 
+    /// Android values map to `Chrome` (`'1'`) — what real WA Web on
+    /// Chrome-Android emits and what the server accepts. The Android
+    /// letters stay opt-in only.
     #[test]
-    fn desktop_maps_to_electron_and_uwp_preserved() {
+    fn android_platform_types_map_to_chrome() {
         use CompanionWebClientType as C;
         use wa::device_props::PlatformType as P;
-        assert_eq!(
-            companion_web_client_type_for_platform(P::Desktop),
-            C::Electron
-        );
-        assert_eq!(companion_web_client_type_for_platform(P::Uwp), C::Uwp);
-    }
-
-    #[test]
-    fn android_platform_types_map_to_dedicated_letters() {
-        use CompanionWebClientType as C;
-        use wa::device_props::PlatformType as P;
-        assert_eq!(
-            companion_web_client_type_for_platform(P::AndroidPhone),
-            C::AndroidPhone,
-        );
-        assert_eq!(
-            companion_web_client_type_for_platform(P::AndroidTablet),
-            C::AndroidTablet,
-        );
-        assert_eq!(
-            companion_web_client_type_for_platform(P::AndroidAmbiguous),
-            C::AndroidAmbiguous,
-        );
+        for pt in [P::AndroidPhone, P::AndroidTablet, P::AndroidAmbiguous] {
+            assert_eq!(
+                companion_web_client_type_for_platform(pt),
+                C::Chrome,
+                "{pt:?}"
+            );
+        }
     }
 
     #[test]
     fn unconfirmed_platform_types_collapse_to_other() {
         use CompanionWebClientType as C;
         use wa::device_props::PlatformType as P;
-        // No confirmed letter for these yet (would need iOS/Mac/Quest RE
-        // or live capture). Fallback to OtherWebClient ('9') stays
-        // server-valid.
         for pt in [
             P::Ipad,
             P::IosPhone,
@@ -260,9 +253,29 @@ mod tests {
             assert_eq!(
                 companion_web_client_type_for_platform(pt),
                 C::OtherWebClient,
-                "{pt:?} must fall back to OtherWebClient",
+                "{pt:?}",
             );
         }
+    }
+
+    /// `P::Unknown` collapses to `OtherWebClient` — the server rejects
+    /// `'0'` from any non-WA-Web client.
+    #[test]
+    fn proto_unknown_collapses_to_other_web_client() {
+        use CompanionWebClientType as C;
+        use wa::device_props::PlatformType as P;
+        assert_eq!(
+            companion_web_client_type_for_platform(P::Unknown),
+            C::OtherWebClient,
+        );
+    }
+
+    /// Explicit opt-in via the enum still renders the right wire byte.
+    #[test]
+    fn android_variants_still_emit_their_wire_bytes_when_used_directly() {
+        assert_eq!(CompanionWebClientType::AndroidPhone.wire_byte(), b'e');
+        assert_eq!(CompanionWebClientType::AndroidTablet.wire_byte(), b'd');
+        assert_eq!(CompanionWebClientType::AndroidAmbiguous.wire_byte(), b'f');
     }
 
     #[test]
@@ -278,52 +291,44 @@ mod tests {
     }
 
     #[test]
-    fn for_props_missing_platform_type_is_unknown() {
+    fn for_props_missing_platform_type_is_other_web_client() {
         let props = wa::DeviceProps::default();
         assert_eq!(
             companion_web_client_type_for_props(&props),
-            CompanionWebClientType::Unknown,
+            CompanionWebClientType::OtherWebClient,
         );
     }
 
     #[test]
-    fn for_props_invalid_platform_type_is_unknown() {
+    fn for_props_invalid_platform_type_is_other_web_client() {
         let props = wa::DeviceProps {
             platform_type: Some(9999),
             ..Default::default()
         };
         assert_eq!(
             companion_web_client_type_for_props(&props),
-            CompanionWebClientType::Unknown,
+            CompanionWebClientType::OtherWebClient,
         );
     }
 
     #[test]
     fn browser_name_for_six_valid_browsers() {
-        assert_eq!(
-            companion_browser_name(CompanionWebClientType::Chrome),
-            "Chrome"
-        );
-        assert_eq!(companion_browser_name(CompanionWebClientType::Edge), "Edge");
-        assert_eq!(
-            companion_browser_name(CompanionWebClientType::Firefox),
-            "Firefox"
-        );
-        assert_eq!(companion_browser_name(CompanionWebClientType::Ie), "IE");
-        assert_eq!(
-            companion_browser_name(CompanionWebClientType::Opera),
-            "Opera"
-        );
-        assert_eq!(
-            companion_browser_name(CompanionWebClientType::Safari),
-            "Safari"
-        );
+        use CompanionWebClientType as C;
+        for (ct, name) in [
+            (C::Chrome, "Chrome"),
+            (C::Edge, "Edge"),
+            (C::Firefox, "Firefox"),
+            (C::Ie, "IE"),
+            (C::Opera, "Opera"),
+            (C::Safari, "Safari"),
+        ] {
+            assert_eq!(companion_browser_name(ct), name, "{ct:?}");
+        }
     }
 
     #[test]
     fn browser_name_for_non_browser_falls_back_to_chrome() {
         for ct in [
-            CompanionWebClientType::Unknown,
             CompanionWebClientType::Electron,
             CompanionWebClientType::Uwp,
             CompanionWebClientType::OtherWebClient,

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -423,7 +423,6 @@ mod tests {
     fn make_qr_data_renders_each_client_type_wire_byte() {
         let state = dummy_device_state();
         for (ct, wire) in [
-            (CompanionWebClientType::Unknown, "0"),
             (CompanionWebClientType::Chrome, "1"),
             (CompanionWebClientType::Edge, "2"),
             (CompanionWebClientType::Firefox, "3"),
@@ -554,12 +553,14 @@ mod tests {
             (wa::device_props::PlatformType::Edge, "2"),
             (wa::device_props::PlatformType::Desktop, "7"),
             (wa::device_props::PlatformType::Uwp, "8"),
-            (wa::device_props::PlatformType::AndroidPhone, "e"),
-            (wa::device_props::PlatformType::AndroidTablet, "d"),
-            (wa::device_props::PlatformType::AndroidAmbiguous, "f"),
+            // Android* maps to Chrome ('1') — what real WA Web on
+            // Chrome-Android emits and what the server accepts.
+            (wa::device_props::PlatformType::AndroidPhone, "1"),
+            (wa::device_props::PlatformType::AndroidTablet, "1"),
+            (wa::device_props::PlatformType::AndroidAmbiguous, "1"),
             (wa::device_props::PlatformType::IosPhone, "9"),
             (wa::device_props::PlatformType::Vr, "9"),
-            (wa::device_props::PlatformType::Unknown, "0"),
+            (wa::device_props::PlatformType::Unknown, "9"),
         ];
         let state = dummy_device_state();
         for (pt, expected_wire) in cases {
@@ -574,9 +575,9 @@ mod tests {
         }
     }
 
-    /// Bare `DeviceProps` produces 5-field QR with trailing "0", no panic.
+    /// Bare `DeviceProps` produces 5-field QR with trailing "9" (catch-all).
     #[test]
-    fn auto_derive_default_device_props_yields_unknown_zero() {
+    fn auto_derive_default_device_props_yields_other_web_client_nine() {
         use crate::companion_reg::companion_web_client_type_for_props;
         use waproto::whatsapp as wa;
 
@@ -585,7 +586,7 @@ mod tests {
         let qr = PairUtils::make_qr_data(&state, "ref", ct);
         let parts: Vec<&str> = qr.split(',').collect();
         assert_eq!(parts.len(), 5);
-        assert_eq!(parts[4], "0");
+        assert_eq!(parts[4], "9");
     }
 
     /// `make_qr_data` output must always round-trip through `parse_qr_code`.
@@ -593,7 +594,6 @@ mod tests {
     fn round_trip_make_then_parse_for_every_client_type() {
         let state = dummy_device_state();
         for ct in [
-            CompanionWebClientType::Unknown,
             CompanionWebClientType::Chrome,
             CompanionWebClientType::Edge,
             CompanionWebClientType::Firefox,

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -553,8 +553,6 @@ mod tests {
             (wa::device_props::PlatformType::Edge, "2"),
             (wa::device_props::PlatformType::Desktop, "7"),
             (wa::device_props::PlatformType::Uwp, "8"),
-            // Android* maps to Chrome ('1') — what real WA Web on
-            // Chrome-Android emits and what the server accepts.
             (wa::device_props::PlatformType::AndroidPhone, "1"),
             (wa::device_props::PlatformType::AndroidTablet, "1"),
             (wa::device_props::PlatformType::AndroidAmbiguous, "1"),
@@ -575,7 +573,6 @@ mod tests {
         }
     }
 
-    /// Bare `DeviceProps` produces 5-field QR with trailing "9" (catch-all).
     #[test]
     fn auto_derive_default_device_props_yields_other_web_client_nine() {
         use crate::companion_reg::companion_web_client_type_for_props;

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -81,14 +81,22 @@ fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u
 /// Validity duration for pair codes (approximately).
 const PAIR_CODE_VALIDITY_SECS: u64 = 180;
 
+/// Pairs `id` with the display string built from `props.os`. Single
+/// source of truth for the os→display step shared by [`derive_companion_platform`]
+/// and [`resolve_companion_platform`].
+fn build_id_and_display(
+    id: CompanionWebClientType,
+    props: &wa::DeviceProps,
+) -> (CompanionWebClientType, String) {
+    let os = props.os.as_deref().unwrap_or("");
+    (id, companion_platform_display(id, os))
+}
+
 /// `(companion_platform_id, companion_platform_display)` per WA Web's
 /// `Alt/DeviceLinkingIq.js`. Display always Browser-valid (see
 /// `companion_platform_display`).
 pub fn derive_companion_platform(props: &wa::DeviceProps) -> (CompanionWebClientType, String) {
-    let id = companion_web_client_type_for_props(props);
-    let os = props.os.as_deref().unwrap_or("");
-    let display = companion_platform_display(id, os);
-    (id, display)
+    build_id_and_display(companion_web_client_type_for_props(props), props)
 }
 
 /// Honours `PairCodeOptions::platform_id` override; display is always
@@ -100,9 +108,7 @@ pub fn resolve_companion_platform(
     let id = options
         .platform_id
         .unwrap_or_else(|| companion_web_client_type_for_props(props));
-    let os = props.os.as_deref().unwrap_or("");
-    let display = companion_platform_display(id, os);
-    (id, display)
+    build_id_and_display(id, props)
 }
 
 /// Options for pair code authentication.
@@ -668,40 +674,19 @@ mod tests {
         assert_eq!(display, "Edge (Windows)");
     }
 
+    /// Android `PlatformType` values map to `Chrome` (`'1'`) — what real
+    /// WA Web on Chrome-Android emits. The Android letters `'e'`/`'d'`/`'f'`
+    /// require explicit opt-in via `PairCodeOptions::platform_id` because
+    /// the server validates them against Android-side attestation.
     #[test]
-    fn derive_android_phone_uses_dedicated_letter_and_android_label() {
-        let p = props(
-            Some("Android"),
-            Some(wa::device_props::PlatformType::AndroidPhone),
-        );
-        let (id, display) = derive_companion_platform(&p);
-        assert_eq!(id, CompanionWebClientType::AndroidPhone);
-        assert_eq!(id.wire_byte(), b'e');
-        assert_eq!(display, "Android (Android)");
-    }
-
-    #[test]
-    fn derive_android_tablet_uses_dedicated_letter() {
-        let p = props(
-            Some("Android"),
-            Some(wa::device_props::PlatformType::AndroidTablet),
-        );
-        let (id, display) = derive_companion_platform(&p);
-        assert_eq!(id, CompanionWebClientType::AndroidTablet);
-        assert_eq!(id.wire_byte(), b'd');
-        assert_eq!(display, "Android (Android)");
-    }
-
-    #[test]
-    fn derive_android_ambiguous_uses_dedicated_letter() {
-        let p = props(
-            Some("Android"),
-            Some(wa::device_props::PlatformType::AndroidAmbiguous),
-        );
-        let (id, display) = derive_companion_platform(&p);
-        assert_eq!(id, CompanionWebClientType::AndroidAmbiguous);
-        assert_eq!(id.wire_byte(), b'f');
-        assert_eq!(display, "Android (Android)");
+    fn derive_android_platform_types_map_to_chrome() {
+        use wa::device_props::PlatformType as P;
+        for pt in [P::AndroidPhone, P::AndroidTablet, P::AndroidAmbiguous] {
+            let (id, display) = derive_companion_platform(&props(Some("Android"), Some(pt)));
+            assert_eq!(id, CompanionWebClientType::Chrome, "{pt:?}");
+            assert_eq!(id.wire_byte(), b'1', "{pt:?}");
+            assert_eq!(display, "Chrome (Android)", "{pt:?}");
+        }
     }
 
     #[test]
@@ -730,21 +715,23 @@ mod tests {
         );
     }
 
+    /// Missing/invalid props collapse to `OtherWebClient` (`'9'`), the
+    /// catch-all WA Web emits when `info().name` doesn't match a known
+    /// browser.
     #[test]
-    fn derive_unknown_proto_yields_unknown_id_and_chrome_display() {
+    fn derive_unknown_proto_yields_other_web_client_id_and_chrome_display() {
         let p = props(None, None);
         assert_eq!(
             derive_companion_platform(&p),
             (
-                CompanionWebClientType::Unknown,
+                CompanionWebClientType::OtherWebClient,
                 "Chrome (Linux)".to_string()
             )
         );
     }
 
-    /// Every proto variant produces a wire byte from the server's
-    /// accept-list and a display whose label is one of the known emitter
-    /// cohorts (`Browser` for web, `Android` for Android).
+    /// Every proto variant produces a server-acceptable wire byte (`'1'..'9'`)
+    /// and a `<Browser> (<OS>)` display with a known browser label.
     #[test]
     fn derive_display_uses_known_label_for_every_proto_variant() {
         use wa::device_props::PlatformType as P;
@@ -1053,16 +1040,20 @@ mod tests {
         assert_eq!(child_bytes(reg, "link_code_pairing_nonce"), b"0");
     }
 
+    /// `build_companion_hello_iq` is byte-passthrough for the platform
+    /// id/display strings. Pins the explicit Android-letter shape so a
+    /// caller that opts in via `PairCodeOptions::platform_id =
+    /// Some(AndroidPhone)` still gets the right wire bytes.
     #[test]
-    fn companion_hello_iq_android_wire_strings() {
-        let iq = build_iq("e", "Android (Android)");
+    fn companion_hello_iq_passes_through_explicit_android_letter() {
+        let iq = build_iq("e", "Android (16)");
         let reg = iq
             .get_optional_child_by_tag(&["link_code_companion_reg"])
             .unwrap();
         assert_eq!(child_bytes(reg, "companion_platform_id"), b"e");
         assert_eq!(
             child_bytes(reg, "companion_platform_display"),
-            b"Android (Android)"
+            b"Android (16)"
         );
     }
 
@@ -1080,27 +1071,30 @@ mod tests {
         );
     }
 
-    /// E2E: mobile DeviceProps + default options emit server-valid companion_hello.
+    /// E2E regression: mobile DeviceProps + default options must emit a
+    /// server-accepted `companion_hello`. Android* derives to Chrome
+    /// (`'1'`) + `"Chrome (Android)"`, matching real WA Web on
+    /// Chrome-Android.
     #[test]
-    fn android_device_props_emit_server_valid_companion_hello() {
+    fn android_device_props_emit_server_accepted_companion_hello() {
         let props = wa::DeviceProps {
             os: Some("Android".into()),
             platform_type: Some(wa::device_props::PlatformType::AndroidPhone as i32),
             ..Default::default()
         };
         let (pid, pdisp) = resolve_companion_platform(&PairCodeOptions::default(), &props);
-        assert_eq!(pid, CompanionWebClientType::AndroidPhone);
-        assert_eq!(pid.wire_byte(), b'e');
-        assert_eq!(pdisp, "Android (Android)");
+        assert_eq!(pid, CompanionWebClientType::Chrome);
+        assert_eq!(pid.wire_byte(), b'1');
+        assert_eq!(pdisp, "Chrome (Android)");
 
         let iq = build_iq(&pid.to_string(), &pdisp);
         let reg = iq
             .get_optional_child_by_tag(&["link_code_companion_reg"])
             .unwrap();
-        assert_eq!(child_bytes(reg, "companion_platform_id"), b"e");
+        assert_eq!(child_bytes(reg, "companion_platform_id"), b"1");
         assert_eq!(
             child_bytes(reg, "companion_platform_display"),
-            b"Android (Android)"
+            b"Chrome (Android)"
         );
     }
 

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -81,9 +81,6 @@ fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u
 /// Validity duration for pair codes (approximately).
 const PAIR_CODE_VALIDITY_SECS: u64 = 180;
 
-/// Pairs `id` with the display string built from `props.os`. Single
-/// source of truth for the os→display step shared by [`derive_companion_platform`]
-/// and [`resolve_companion_platform`].
 fn build_id_and_display(
     id: CompanionWebClientType,
     props: &wa::DeviceProps,
@@ -674,10 +671,6 @@ mod tests {
         assert_eq!(display, "Edge (Windows)");
     }
 
-    /// Android `PlatformType` values map to `Chrome` (`'1'`) — what real
-    /// WA Web on Chrome-Android emits. The Android letters `'e'`/`'d'`/`'f'`
-    /// require explicit opt-in via `PairCodeOptions::platform_id` because
-    /// the server validates them against Android-side attestation.
     #[test]
     fn derive_android_platform_types_map_to_chrome() {
         use wa::device_props::PlatformType as P;
@@ -715,9 +708,6 @@ mod tests {
         );
     }
 
-    /// Missing/invalid props collapse to `OtherWebClient` (`'9'`), the
-    /// catch-all WA Web emits when `info().name` doesn't match a known
-    /// browser.
     #[test]
     fn derive_unknown_proto_yields_other_web_client_id_and_chrome_display() {
         let p = props(None, None);
@@ -730,8 +720,6 @@ mod tests {
         );
     }
 
-    /// Every proto variant produces a server-acceptable wire byte (`'1'..'9'`)
-    /// and a `<Browser> (<OS>)` display with a known browser label.
     #[test]
     fn derive_display_uses_known_label_for_every_proto_variant() {
         use wa::device_props::PlatformType as P;
@@ -1040,10 +1028,6 @@ mod tests {
         assert_eq!(child_bytes(reg, "link_code_pairing_nonce"), b"0");
     }
 
-    /// `build_companion_hello_iq` is byte-passthrough for the platform
-    /// id/display strings. Pins the explicit Android-letter shape so a
-    /// caller that opts in via `PairCodeOptions::platform_id =
-    /// Some(AndroidPhone)` still gets the right wire bytes.
     #[test]
     fn companion_hello_iq_passes_through_explicit_android_letter() {
         let iq = build_iq("e", "Android (16)");
@@ -1071,10 +1055,6 @@ mod tests {
         );
     }
 
-    /// E2E regression: mobile DeviceProps + default options must emit a
-    /// server-accepted `companion_hello`. Android* derives to Chrome
-    /// (`'1'`) + `"Chrome (Android)"`, matching real WA Web on
-    /// Chrome-Android.
     #[test]
     fn android_device_props_emit_server_accepted_companion_hello() {
         let props = wa::DeviceProps {


### PR DESCRIPTION
## Summary

- Auto-derivation of `companion_platform_id` for `PlatformType::AndroidPhone`/`Tablet`/`Ambiguous` now produces `Chrome` (`'1'`) + `"Chrome (Android)"`, matching what real WA Web on Chrome-Android emits per `WAWebCompanionRegClientUtils.DEVICE_PLATFORM`. Empirical reproduction showed the server rejects the dedicated Android letters `'e'`/`'d'`/`'f'` (introduced in #595) with `400 bad-request` from any client that lacks Android-side attestation. The letters are still reachable through explicit opt-in via `PairCodeOptions::platform_id` for callers with legitimate Android signing material.
- `CompanionWebClientType::Unknown` (wire byte `'0'`) is removed from the public enum. WA Web only emits `'0'` when `info().name` is null — unreachable in real browsers — and the server rejects it from any non-WA-Web caller. `#[default]` now points to `OtherWebClient` (`'9'`), the catch-all WA Web actually emits when browser detection returns an unknown name. **Breaking** for the pre-1.0 API.
- Refactor: `pair_code.rs` factors the shared os→display step into a private `build_id_and_display` helper, and a few table-shaped tests were merged into single parametrised loops.

## Test plan

- [x] `cargo test -p wacore --lib` — 644 pass
- [x] `cargo build --workspace`
- [x] `cargo clippy --all --tests` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] End-to-end: pair-code stage 1 against the live server with `DeviceProps { platform_type: AndroidPhone, os: "Android", .. }` returns a `link_code_pairing_ref` (no `400 bad-request`)