### PR TITLE
fix(send): always distribute SKDM on first group send + stop wiping tracker on identity change

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -352,17 +352,13 @@ impl Client {
         self.delete_sessions_for_devices(user, &non_primary_ids)
             .await;
 
-        // Clear persisted SKDM tracking across ALL groups so stale has_key=true
-        // rows don't survive restart. Identity changes are rare so the cost is acceptable.
-        if let Err(e) = self
-            .persistence_manager
-            .backend()
-            .clear_all_sender_key_devices()
-            .await
-        {
-            warn!("clear_device_record: failed to clear persisted sender key devices: {e}");
-        }
-        self.sender_key_device_cache.invalidate_all();
+        // SKDM tracking is left untouched on identity change to mirror WA Web's
+        // `WAWebUpdateLocalSignalSession`: it deletes the Signal session but
+        // calls `markForgetSenderKey` only on retry receipts, per-group/per-device.
+        // The previous global wipe here was over-eager — it forced the bot to
+        // re-distribute SKDM to every device of every group on every identity
+        // rotation, and worse, left `sender_key_devices` empty long enough that
+        // the next group send hit the no-distribution path (see `resolve_skdm_targets`).
     }
 
     /// Remove a device from the registry after a device remove notification.

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -352,13 +352,9 @@ impl Client {
         self.delete_sessions_for_devices(user, &non_primary_ids)
             .await;
 
-        // SKDM tracking is left untouched on identity change to mirror WA Web's
-        // `WAWebUpdateLocalSignalSession`: it deletes the Signal session but
-        // calls `markForgetSenderKey` only on retry receipts, per-group/per-device.
-        // The previous global wipe here was over-eager — it forced the bot to
-        // re-distribute SKDM to every device of every group on every identity
-        // rotation, and worse, left `sender_key_devices` empty long enough that
-        // the next group send hit the no-distribution path (see `resolve_skdm_targets`).
+        // WA Web's `WAWebUpdateLocalSignalSession` only calls `markForgetSenderKey`
+        // on retry receipts, per-group/per-device. A global SKDM wipe here would
+        // empty the tracker often enough to feed the no-distribution path.
     }
 
     /// Remove a device from the registry after a device remove notification.

--- a/src/send.rs
+++ b/src/send.rs
@@ -2119,44 +2119,75 @@ mod tests {
         );
     }
 
-    /// Regression: `resolve_skdm_targets` must NOT short-circuit when the
-    /// `sender_key_devices` table is empty. The previous early-exit
-    /// (`if cached_map.is_empty() return None`) caused the caller in
-    /// `send_message_impl` to skip SKDM distribution on the first send to
-    /// any group with empty cache — a state that occurred routinely after
-    /// `clear_all_sender_key_devices` wipes triggered by identity changes.
+    /// Regression: with `sender_key_devices` empty for the group AND
+    /// participant devices known to the registry, `resolve_skdm_targets` must
+    /// return `Some(needs_skdm)` listing every participant device — proving
+    /// that the empty-cache short-circuit is gone.
     ///
-    /// Post-fix, the function falls through to `resolve_devices`. In this
-    /// test environment that resolver has no transport → returns Err →
-    /// function returns None. We can't observe the success path here, but
-    /// we can assert that the empty-cache fast path is gone by verifying
-    /// `SenderKeyDeviceMap` no longer exposes `is_empty`.
+    /// Pre-populates `device_registry_cache` so `resolve_devices` (called by
+    /// `resolve_skdm_targets`) succeeds without network. With the legacy
+    /// `if cached_map.is_empty() return None`, this test fails because the
+    /// function returns `None` before ever calling `resolve_devices`.
     #[tokio::test]
-    async fn resolve_skdm_targets_does_not_short_circuit_on_empty_cache() {
+    async fn resolve_skdm_targets_distributes_when_cache_empty_but_devices_known() {
         use wacore::client::context::GroupInfo;
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
         use wacore::types::message::AddressingMode;
 
         let client = crate::test_utils::create_test_client().await;
         let group_jid = "120363161500776365@g.us";
         let own_lid = Jid::from_str("193832511623409:13@lid").unwrap();
 
-        let participants: Vec<Jid> = [
-            "271060335329480@lid",
-            "77610646245392@lid",
-            "276661023027320@lid",
-        ]
-        .into_iter()
-        .map(|s| Jid::from_str(s).unwrap())
-        .collect();
+        let participant_users = ["271060335329480", "77610646245392", "276661023027320"];
 
-        let group_info = GroupInfo::new(participants, AddressingMode::Lid);
+        // Pre-populate device registry so `resolve_devices` returns Ok in
+        // tests (no network). One device per participant — single-device
+        // entry is enough for the filter assertion.
+        for user in &participant_users {
+            let record = DeviceListRecord {
+                user: (*user).into(),
+                devices: vec![DeviceInfo {
+                    device_id: 0,
+                    key_index: None,
+                }],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            };
+            client
+                .device_registry_cache
+                .insert((*user).into(), record)
+                .await;
+        }
 
-        // Without a real transport this returns None via the resolver-Err branch.
-        // The point of the test is that it CALLS resolve_devices instead of
-        // shortcutting on `cached_map.is_empty()`.
-        let _ = client
+        let participants: Vec<Jid> = participant_users
+            .iter()
+            .map(|u| Jid::from_str(&format!("{u}@lid")).unwrap())
+            .collect();
+
+        let group_info = GroupInfo::new(participants.clone(), AddressingMode::Lid);
+
+        let result = client
             .resolve_skdm_targets(group_jid, &group_info, &own_lid)
-            .await;
+            .await
+            .expect(
+                "empty sender_key_devices + known participant devices must resolve to \
+                 Some(needs_skdm). If this is None, the early-exit short-circuit was \
+                 reintroduced — the bug that ships bare skmsg without SKDM bundles is back.",
+            );
+
+        // Every participant device must be flagged as needing SKDM.
+        assert_eq!(
+            result.len(),
+            participants.len(),
+            "expected one needs_skdm entry per participant device, got {result:?}"
+        );
+        for user in &participant_users {
+            assert!(
+                result.iter().any(|j| j.user == *user),
+                "participant {user} missing from needs_skdm: {result:?}"
+            );
+        }
     }
 
     /// Regression: a single retry-receipt-inserted `has_key=false` row must

--- a/src/send.rs
+++ b/src/send.rs
@@ -554,10 +554,10 @@ impl Client {
             })
             .await;
 
-        if cached_map.is_empty() {
-            return None;
-        }
-
+        // Empty cache means "first send to this group OR table just wiped".
+        // Don't short-circuit: let the natural filter (`device_has_key().unwrap_or(false)`)
+        // mark every device as needing SKDM. Mirrors WA Web, where an empty
+        // `senderKey` Map is iterated as `false` for every participant.
         let is_lid_mode = group_info.addressing_mode == wacore::types::message::AddressingMode::Lid;
         let jids_to_resolve: Vec<Jid> = group_info
             .participants
@@ -2070,6 +2070,132 @@ mod tests {
                 jid2_str
             );
         }
+    }
+
+    /// Regression for the empty-cache SKDM bug. When `sender_key_devices` is empty
+    /// for a group (fresh DB, post-restart, or after the legacy
+    /// `clear_all_sender_key_devices` wipe), the natural filter must mark every
+    /// resolved device as needing SKDM. Mirrors WA Web, where an empty
+    /// `senderKey` Map is iterated as `false` for every participant.
+    #[test]
+    fn empty_sender_key_device_map_marks_all_devices_for_skdm() {
+        use crate::sender_key_device_cache::SenderKeyDeviceMap;
+
+        let map = SenderKeyDeviceMap::from_db_rows(&[]);
+        assert_eq!(
+            map.device_has_key("271060335329480", 0),
+            None,
+            "unknown device → device_has_key returns None"
+        );
+        assert!(
+            !map.is_user_forgotten("271060335329480"),
+            "unknown user is not forgotten"
+        );
+
+        // Simulate the downstream filter that would run if the early-exit were removed.
+        let all_resolved_devices: Vec<Jid> = [
+            "271060335329480@lid",
+            "77610646245392@lid",
+            "276661023027320:5@lid",
+        ]
+        .into_iter()
+        .map(|s| Jid::from_str(s).unwrap())
+        .collect();
+
+        let needs_skdm: Vec<&Jid> = all_resolved_devices
+            .iter()
+            .filter(|device| {
+                !map.device_has_key(&device.user, device.device)
+                    .unwrap_or(false)
+                    || map.is_user_forgotten(&device.user)
+            })
+            .collect();
+
+        assert_eq!(
+            needs_skdm.len(),
+            all_resolved_devices.len(),
+            "with empty cache, EVERY resolved device should need SKDM — \
+             so the early-exit at src/send.rs:557 is incorrect"
+        );
+    }
+
+    /// Regression: `resolve_skdm_targets` must NOT short-circuit when the
+    /// `sender_key_devices` table is empty. The previous early-exit
+    /// (`if cached_map.is_empty() return None`) caused the caller in
+    /// `send_message_impl` to skip SKDM distribution on the first send to
+    /// any group with empty cache — a state that occurred routinely after
+    /// `clear_all_sender_key_devices` wipes triggered by identity changes.
+    ///
+    /// Post-fix, the function falls through to `resolve_devices`. In this
+    /// test environment that resolver has no transport → returns Err →
+    /// function returns None. We can't observe the success path here, but
+    /// we can assert that the empty-cache fast path is gone by verifying
+    /// `SenderKeyDeviceMap` no longer exposes `is_empty`.
+    #[tokio::test]
+    async fn resolve_skdm_targets_does_not_short_circuit_on_empty_cache() {
+        use wacore::client::context::GroupInfo;
+        use wacore::types::message::AddressingMode;
+
+        let client = crate::test_utils::create_test_client().await;
+        let group_jid = "120363161500776365@g.us";
+        let own_lid = Jid::from_str("193832511623409:13@lid").unwrap();
+
+        let participants: Vec<Jid> = [
+            "271060335329480@lid",
+            "77610646245392@lid",
+            "276661023027320@lid",
+        ]
+        .into_iter()
+        .map(|s| Jid::from_str(s).unwrap())
+        .collect();
+
+        let group_info = GroupInfo::new(participants, AddressingMode::Lid);
+
+        // Without a real transport this returns None via the resolver-Err branch.
+        // The point of the test is that it CALLS resolve_devices instead of
+        // shortcutting on `cached_map.is_empty()`.
+        let _ = client
+            .resolve_skdm_targets(group_jid, &group_info, &own_lid)
+            .await;
+    }
+
+    /// Regression: a single retry-receipt-inserted `has_key=false` row must
+    /// flag every other resolved device as needing SKDM (via the `is_user_forgotten`
+    /// branch of the filter, conservatively triggering full redistribution).
+    /// Mirrors the production behavior observed in the log: after one retry
+    /// receipt arrived, the next group send distributed SKDM to all 89 devices.
+    #[test]
+    fn single_forgotten_row_keeps_full_distribution() {
+        use crate::sender_key_device_cache::SenderKeyDeviceMap;
+
+        let map = SenderKeyDeviceMap::from_db_rows(&[("271060335329480@lid".to_string(), false)]);
+        assert_eq!(map.device_has_key("271060335329480", 0), Some(false));
+        assert!(map.is_user_forgotten("271060335329480"));
+
+        let all_resolved_devices: Vec<Jid> = [
+            "271060335329480@lid",
+            "77610646245392@lid",
+            "276661023027320:5@lid",
+        ]
+        .into_iter()
+        .map(|s| Jid::from_str(s).unwrap())
+        .collect();
+
+        let needs_skdm: Vec<&Jid> = all_resolved_devices
+            .iter()
+            .filter(|device| {
+                !map.device_has_key(&device.user, device.device)
+                    .unwrap_or(false)
+                    || map.is_user_forgotten(&device.user)
+            })
+            .collect();
+
+        assert_eq!(
+            needs_skdm.len(),
+            3,
+            "after retry inserts one row, ALL devices correctly flagged for SKDM \
+             (this is what unblocks redistribution on the SECOND message)"
+        );
     }
 
     #[test]

--- a/src/send.rs
+++ b/src/send.rs
@@ -554,10 +554,8 @@ impl Client {
             })
             .await;
 
-        // Empty cache means "first send to this group OR table just wiped".
-        // Don't short-circuit: let the natural filter (`device_has_key().unwrap_or(false)`)
-        // mark every device as needing SKDM. Mirrors WA Web, where an empty
-        // `senderKey` Map is iterated as `false` for every participant.
+        // No empty-cache early-exit: WA Web iterates an empty `senderKey` Map
+        // as `false` per participant, so the filter below must run unconditionally.
         let is_lid_mode = group_info.addressing_mode == wacore::types::message::AddressingMode::Lid;
         let jids_to_resolve: Vec<Jid> = group_info
             .participants
@@ -2072,27 +2070,14 @@ mod tests {
         }
     }
 
-    /// Regression for the empty-cache SKDM bug. When `sender_key_devices` is empty
-    /// for a group (fresh DB, post-restart, or after the legacy
-    /// `clear_all_sender_key_devices` wipe), the natural filter must mark every
-    /// resolved device as needing SKDM. Mirrors WA Web, where an empty
-    /// `senderKey` Map is iterated as `false` for every participant.
     #[test]
     fn empty_sender_key_device_map_marks_all_devices_for_skdm() {
         use crate::sender_key_device_cache::SenderKeyDeviceMap;
 
         let map = SenderKeyDeviceMap::from_db_rows(&[]);
-        assert_eq!(
-            map.device_has_key("271060335329480", 0),
-            None,
-            "unknown device → device_has_key returns None"
-        );
-        assert!(
-            !map.is_user_forgotten("271060335329480"),
-            "unknown user is not forgotten"
-        );
+        assert_eq!(map.device_has_key("271060335329480", 0), None);
+        assert!(!map.is_user_forgotten("271060335329480"));
 
-        // Simulate the downstream filter that would run if the early-exit were removed.
         let all_resolved_devices: Vec<Jid> = [
             "271060335329480@lid",
             "77610646245392@lid",
@@ -2111,23 +2096,10 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(
-            needs_skdm.len(),
-            all_resolved_devices.len(),
-            "with empty cache, EVERY resolved device should need SKDM — \
-             so the early-exit at src/send.rs:557 is incorrect"
-        );
+        assert_eq!(needs_skdm.len(), all_resolved_devices.len());
     }
 
-    /// Regression: with `sender_key_devices` empty for the group AND
-    /// participant devices known to the registry, `resolve_skdm_targets` must
-    /// return `Some(needs_skdm)` listing every participant device — proving
-    /// that the empty-cache short-circuit is gone.
-    ///
-    /// Pre-populates `device_registry_cache` so `resolve_devices` (called by
-    /// `resolve_skdm_targets`) succeeds without network. With the legacy
-    /// `if cached_map.is_empty() return None`, this test fails because the
-    /// function returns `None` before ever calling `resolve_devices`.
+    /// Fails if the empty-cache early-exit is reintroduced.
     #[tokio::test]
     async fn resolve_skdm_targets_distributes_when_cache_empty_but_devices_known() {
         use wacore::client::context::GroupInfo;
@@ -2140,9 +2112,7 @@ mod tests {
 
         let participant_users = ["271060335329480", "77610646245392", "276661023027320"];
 
-        // Pre-populate device registry so `resolve_devices` returns Ok in
-        // tests (no network). One device per participant — single-device
-        // entry is enough for the filter assertion.
+        // Pre-populate so `resolve_devices` succeeds without a transport.
         for user in &participant_users {
             let record = DeviceListRecord {
                 user: (*user).into(),
@@ -2170,31 +2140,14 @@ mod tests {
         let result = client
             .resolve_skdm_targets(group_jid, &group_info, &own_lid)
             .await
-            .expect(
-                "empty sender_key_devices + known participant devices must resolve to \
-                 Some(needs_skdm). If this is None, the early-exit short-circuit was \
-                 reintroduced — the bug that ships bare skmsg without SKDM bundles is back.",
-            );
+            .expect("None means the empty-cache early-exit is back");
 
-        // Every participant device must be flagged as needing SKDM.
-        assert_eq!(
-            result.len(),
-            participants.len(),
-            "expected one needs_skdm entry per participant device, got {result:?}"
-        );
+        assert_eq!(result.len(), participants.len());
         for user in &participant_users {
-            assert!(
-                result.iter().any(|j| j.user == *user),
-                "participant {user} missing from needs_skdm: {result:?}"
-            );
+            assert!(result.iter().any(|j| j.user == *user));
         }
     }
 
-    /// Regression: a single retry-receipt-inserted `has_key=false` row must
-    /// flag every other resolved device as needing SKDM (via the `is_user_forgotten`
-    /// branch of the filter, conservatively triggering full redistribution).
-    /// Mirrors the production behavior observed in the log: after one retry
-    /// receipt arrived, the next group send distributed SKDM to all 89 devices.
     #[test]
     fn single_forgotten_row_keeps_full_distribution() {
         use crate::sender_key_device_cache::SenderKeyDeviceMap;

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -46,6 +46,9 @@ impl SenderKeyDeviceMap {
         }
     }
 
+    /// Test-only — production code reads via `device_has_key` / `is_user_forgotten`.
+    /// Used by cache-invalidation regression tests in `device_registry`.
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.devices.is_empty()
     }

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -46,8 +46,6 @@ impl SenderKeyDeviceMap {
         }
     }
 
-    /// Test-only — production code reads via `device_has_key` / `is_user_forgotten`.
-    /// Used by cache-invalidation regression tests in `device_registry`.
     #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.devices.is_empty()


### PR DESCRIPTION
## Summary

Production logs showed every group reply going through the retry path: the bot would send `<enc type=\"skmsg\">` with no SKDM bundle, online recipients couldn't decrypt (\"aguardando por mensagem\"), and only after their retry receipt arrived would the next send correctly distribute SKDM to all 89 devices. Investigation found **two cascading bugs** that fed each other.

### Bug 1 — `resolve_skdm_targets` short-circuited on empty cache

`src/send.rs:557` returned `None` when `sender_key_devices` had no rows for a group. The caller in `send_message_impl` interprets `None` as \"no SKDM target list — and `force_skdm=false` because the bot already has its own sender key — so don't distribute\". Result: bare skmsg stanza, recipients can't decrypt, retry round-trip required before every group send.

The downstream filter (`!device_has_key().unwrap_or(false) || is_user_forgotten()`) already handles the empty case correctly: an unknown device returns `None` from `device_has_key`, falls through `unwrap_or(false)`, lands in `needs_skdm`. Mirrors WA Web, where an empty `senderKey` Map is iterated as `false` for every participant.

**Fix:** remove the early-exit. `SenderKeyDeviceMap::is_empty` becomes test-only (kept for cache-invalidation regression tests in `device_registry`).

### Bug 2 — `clear_device_record` wiped the tracker globally on identity change

`src/client/device_registry.rs:357-365` called `clear_all_sender_key_devices()` plus `sender_key_device_cache.invalidate_all()` whenever a single user's raw_id rotated or identity changed. WA Web's `WAWebUpdateLocalSignalSession.js` only deletes the Signal session and lets `markForgetSenderKey(group_id, [participant])` propagate per-group/per-device from the next retry receipt — it never preemptively touches the senderKey tracker.

Production DB inspection confirmed the impact: 10× wipes observed in an 8h window, leaving `sender_key_devices` at **0 rows with `has_key=1`** despite 9 own sender keys and 781 active sessions. This empty state fed straight back into bug 1 on the next send.

**Fix:** drop the global wipe. The session deletion (`delete_sessions_for_devices`) stays — that part matches WA Web.

### Empirical validation

- Three unit tests added in `send.rs` covering empty-cache filter semantics, single-forgotten-row invariant, and the regression that `resolve_skdm_targets` no longer short-circuits.
- Full workspace test suite (1362 tests) passes; `cargo clippy --all --tests` clean.
- Existing `test_patch_device_*_invalidates_sender_key_cache` regressions in `device_registry` still pass — the `#[cfg(test)] is_empty()` helper preserves their assertion shape.

## Test plan

- [x] `cargo test --workspace --lib` — 1362 passed
- [x] `cargo clippy --all --tests` — clean
- [x] `cargo fmt --all`
- [ ] Manual: deploy on the production bot, send `!ping2` from a previously-affected number, confirm the reply lands without the \"aguardando por mensagem\" stage and without a retry receipt in logs.