### PR TITLE
fix(lid_pn): WA Web compliant signal address for Hosted JIDs

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -549,6 +549,8 @@ mod tests {
         for device in [99u16, 7] {
             let mut hosted = Jid::new(user, Server::Hosted);
             hosted.device = device;
+            hosted.agent = 0xAB;
+            hosted.integrator = 0xBEEF;
             let resolved = client.resolve_encryption_jid(&hosted).await;
 
             assert_eq!(resolved.user, lid);
@@ -557,6 +559,8 @@ mod tests {
                 resolved.device, device,
                 "device must round-trip, not be coerced to 99"
             );
+            assert_eq!(resolved.agent, hosted.agent);
+            assert_eq!(resolved.integrator, hosted.integrator);
         }
     }
 

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -295,40 +295,51 @@ impl Client {
         resolved
     }
 
-    /// Resolve the encryption JID for a given target JID.
-    /// This uses the same logic as the receiving path to ensure consistent
-    /// lock keys between sending and receiving.
+    /// Resolve a JID into the canonical form used for Signal session and
+    /// sender-key lookups. Mirrors WA Web's `SignalAddress.toString()`
+    /// (`WAWeb/Signal/Address.js`):
     ///
-    /// For PN JIDs, this checks if a LID mapping exists and returns the LID.
-    /// This ensures that sending and receiving use the same session lock.
+    /// - LID / HostedLid: already in canonical form, returned as-is.
+    /// - PN: upgraded to `{lid_user}@lid` when a mapping is known, kept as
+    ///   `{user}@s.whatsapp.net` (mapped to `@c.us` at format time) otherwise.
+    /// - Hosted: upgraded to `{lid_user}@hosted.lid` when a mapping is known,
+    ///   kept as `{user}@hosted` otherwise. WA Web hardcodes device=99 for
+    ///   hosted; we preserve whatever device the input carries so a
+    ///   misformed JID is still routable rather than silently dropped.
     pub(crate) async fn resolve_encryption_jid(&self, target: &Jid) -> Jid {
-        if target.is_lid() {
-            // Already a LID - use it directly
-            target.clone()
-        } else if target.is_pn() {
-            // PN JID - check if we have a LID mapping
-            if let Some(lid_user) = self.lid_pn_cache.get_current_lid(&target.user).await {
-                let lid_jid = Jid {
-                    user: lid_user.into(),
-                    server: wacore_binary::Server::Lid,
-                    device: target.device,
-                    agent: target.agent,
-                    integrator: target.integrator,
-                };
-                debug!(
-                    "[SEND-LOCK] Resolved {} to LID {} for session lock",
-                    target, lid_jid
-                );
-                lid_jid
-            } else {
-                // No LID mapping - use PN as-is
-                debug!("[SEND-LOCK] No LID mapping for {}, using PN", target);
-                target.clone()
-            }
-        } else {
-            // Other server type - use as-is
-            target.clone()
+        use wacore_binary::Server;
+        match target.server {
+            Server::Lid | Server::HostedLid => target.clone(),
+            Server::Pn => self
+                .upgrade_to_lid_namespace(target, Server::Lid)
+                .await
+                .unwrap_or_else(|| {
+                    debug!("[SEND-LOCK] No LID mapping for {target}, using PN");
+                    target.clone()
+                }),
+            Server::Hosted => self
+                .upgrade_to_lid_namespace(target, Server::HostedLid)
+                .await
+                .unwrap_or_else(|| target.clone()),
+            _ => target.clone(),
         }
+    }
+
+    async fn upgrade_to_lid_namespace(
+        &self,
+        target: &Jid,
+        lid_server: wacore_binary::Server,
+    ) -> Option<Jid> {
+        let lid_user = self.lid_pn_cache.get_current_lid(&target.user).await?;
+        let upgraded = Jid {
+            user: lid_user.into(),
+            server: lid_server,
+            device: target.device,
+            agent: target.agent,
+            integrator: target.integrator,
+        };
+        debug!("[SEND-LOCK] Resolved {target} to {upgraded} for session lock");
+        Some(upgraded)
     }
 
     /// Swap a JID's namespace between PN and LID, preserving device/agent/integrator.
@@ -547,6 +558,54 @@ mod tests {
         let resolved = client.resolve_encryption_jid(&pn_jid).await;
 
         assert_eq!(resolved, pn_jid);
+    }
+
+    /// WA Web `SignalAddress.toString()` for Hosted with known LID:
+    /// `[lid_user, ":99", "@hosted.lid"]`.
+    #[tokio::test]
+    async fn test_resolve_encryption_jid_hosted_with_lid_upgrades_to_hosted_lid() {
+        let client: Arc<Client> = create_test_client().await;
+        let user = "55999999999";
+        let lid = "100000012345678";
+
+        client
+            .add_lid_pn_mapping(lid, user, LearningSource::PeerPnMessage)
+            .await
+            .unwrap();
+
+        let mut hosted = Jid::new(user, Server::Hosted);
+        hosted.device = 99;
+        let resolved = client.resolve_encryption_jid(&hosted).await;
+
+        assert_eq!(resolved.user, lid);
+        assert_eq!(resolved.server, Server::HostedLid);
+        assert_eq!(resolved.device, 99);
+    }
+
+    /// WA Web `SignalAddress.toString()` for Hosted without a known LID:
+    /// `[user, ":99", "@hosted"]` (no upgrade).
+    #[tokio::test]
+    async fn test_resolve_encryption_jid_hosted_no_mapping_keeps_hosted() {
+        let client: Arc<Client> = create_test_client().await;
+        let mut hosted = Jid::new("55999999999", Server::Hosted);
+        hosted.device = 99;
+
+        let resolved = client.resolve_encryption_jid(&hosted).await;
+
+        assert_eq!(resolved, hosted);
+    }
+
+    /// HostedLid is already in the canonical (LID-keyed) form WA Web
+    /// uses internally, so resolution is a no-op.
+    #[tokio::test]
+    async fn test_resolve_encryption_jid_preserves_hosted_lid() {
+        let client: Arc<Client> = create_test_client().await;
+        let mut hosted_lid = Jid::new("100000012345678", Server::HostedLid);
+        hosted_lid.device = 99;
+
+        let resolved = client.resolve_encryption_jid(&hosted_lid).await;
+
+        assert_eq!(resolved, hosted_lid);
     }
 
     #[tokio::test]

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -295,51 +295,26 @@ impl Client {
         resolved
     }
 
-    /// Resolve a JID into the canonical form used for Signal session and
-    /// sender-key lookups. Mirrors WA Web's `SignalAddress.toString()`
-    /// (`WAWeb/Signal/Address.js`):
-    ///
-    /// - LID / HostedLid: already in canonical form, returned as-is.
-    /// - PN: upgraded to `{lid_user}@lid` when a mapping is known, kept as
-    ///   `{user}@s.whatsapp.net` (mapped to `@c.us` at format time) otherwise.
-    /// - Hosted: upgraded to `{lid_user}@hosted.lid` when a mapping is known,
-    ///   kept as `{user}@hosted` otherwise. WA Web hardcodes device=99 for
-    ///   hosted; we preserve whatever device the input carries so a
-    ///   misformed JID is still routable rather than silently dropped.
+    /// Mirrors WA Web `SignalAddress.toString()` (`WAWeb/Signal/Address.js`):
+    /// upgrade Pn → Lid and Hosted → HostedLid when a mapping is known, else
+    /// preserve the input.
     pub(crate) async fn resolve_encryption_jid(&self, target: &Jid) -> Jid {
         use wacore_binary::Server;
-        match target.server {
-            Server::Lid | Server::HostedLid => target.clone(),
-            Server::Pn => self
-                .upgrade_to_lid_namespace(target, Server::Lid)
-                .await
-                .unwrap_or_else(|| {
-                    debug!("[SEND-LOCK] No LID mapping for {target}, using PN");
-                    target.clone()
-                }),
-            Server::Hosted => self
-                .upgrade_to_lid_namespace(target, Server::HostedLid)
-                .await
-                .unwrap_or_else(|| target.clone()),
-            _ => target.clone(),
-        }
-    }
-
-    async fn upgrade_to_lid_namespace(
-        &self,
-        target: &Jid,
-        lid_server: wacore_binary::Server,
-    ) -> Option<Jid> {
-        let lid_user = self.lid_pn_cache.get_current_lid(&target.user).await?;
-        let upgraded = Jid {
-            user: lid_user.into(),
-            server: lid_server,
-            device: target.device,
-            agent: target.agent,
-            integrator: target.integrator,
+        let lid_server = match target.server {
+            Server::Pn => Server::Lid,
+            Server::Hosted => Server::HostedLid,
+            _ => return target.clone(),
         };
-        debug!("[SEND-LOCK] Resolved {target} to {upgraded} for session lock");
-        Some(upgraded)
+        match self.lid_pn_cache.get_current_lid(&target.user).await {
+            Some(lid_user) => Jid {
+                user: lid_user.into(),
+                server: lid_server,
+                device: target.device,
+                agent: target.agent,
+                integrator: target.integrator,
+            },
+            None => target.clone(),
+        }
     }
 
     /// Swap a JID's namespace between PN and LID, preserving device/agent/integrator.
@@ -560,8 +535,6 @@ mod tests {
         assert_eq!(resolved, pn_jid);
     }
 
-    /// WA Web `SignalAddress.toString()` for Hosted with known LID:
-    /// `[lid_user, ":99", "@hosted.lid"]`.
     #[tokio::test]
     async fn test_resolve_encryption_jid_hosted_with_lid_upgrades_to_hosted_lid() {
         let client: Arc<Client> = create_test_client().await;
@@ -582,8 +555,6 @@ mod tests {
         assert_eq!(resolved.device, 99);
     }
 
-    /// WA Web `SignalAddress.toString()` for Hosted without a known LID:
-    /// `[user, ":99", "@hosted"]` (no upgrade).
     #[tokio::test]
     async fn test_resolve_encryption_jid_hosted_no_mapping_keeps_hosted() {
         let client: Arc<Client> = create_test_client().await;
@@ -595,8 +566,6 @@ mod tests {
         assert_eq!(resolved, hosted);
     }
 
-    /// HostedLid is already in the canonical (LID-keyed) form WA Web
-    /// uses internally, so resolution is a no-op.
     #[tokio::test]
     async fn test_resolve_encryption_jid_preserves_hosted_lid() {
         let client: Arc<Client> = create_test_client().await;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -546,13 +546,18 @@ mod tests {
             .await
             .unwrap();
 
-        let mut hosted = Jid::new(user, Server::Hosted);
-        hosted.device = 99;
-        let resolved = client.resolve_encryption_jid(&hosted).await;
+        for device in [99u16, 7] {
+            let mut hosted = Jid::new(user, Server::Hosted);
+            hosted.device = device;
+            let resolved = client.resolve_encryption_jid(&hosted).await;
 
-        assert_eq!(resolved.user, lid);
-        assert_eq!(resolved.server, Server::HostedLid);
-        assert_eq!(resolved.device, 99);
+            assert_eq!(resolved.user, lid);
+            assert_eq!(resolved.server, Server::HostedLid);
+            assert_eq!(
+                resolved.device, device,
+                "device must round-trip, not be coerced to 99"
+            );
+        }
     }
 
     #[tokio::test]

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -1430,11 +1430,8 @@ mod tests {
         Ok(())
     }
 
-    /// Pre-#391, the encoder wrote `jid.agent` instead of the
-    /// server-derived `domain_type`. For directly constructed JIDs the
-    /// `agent` field defaults to 0, so any server other than `Pn` would
-    /// encode wrong. This test pins down the practical impact for Hosted
-    /// and HostedLid when they're built without going through the parser.
+    /// Pin domain_type for direct-constructed Hosted/HostedLid JIDs (default
+    /// `agent=0`); pre-#391 these encoded as `0` instead of `128`/`129`.
     #[test]
     fn test_direct_constructed_hosted_encodes_correct_domain_type() -> TestResult {
         let mut hosted = Jid::new("100000000000001", jid::Server::Hosted);

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -1430,6 +1430,43 @@ mod tests {
         Ok(())
     }
 
+    /// Pre-#391, the encoder wrote `jid.agent` instead of the
+    /// server-derived `domain_type`. For directly constructed JIDs the
+    /// `agent` field defaults to 0, so any server other than `Pn` would
+    /// encode wrong. This test pins down the practical impact for Hosted
+    /// and HostedLid when they're built without going through the parser.
+    #[test]
+    fn test_direct_constructed_hosted_encodes_correct_domain_type() -> TestResult {
+        let mut hosted = Jid::new("100000000000001", jid::Server::Hosted);
+        hosted.device = 99;
+        assert_eq!(
+            hosted.agent, 0,
+            "default agent for direct construction is 0"
+        );
+
+        let mut hosted_lid = Jid::new("100000000000002", jid::Server::HostedLid);
+        hosted_lid.device = 99;
+        assert_eq!(hosted_lid.agent, 0);
+
+        for (jid, expected) in [(&hosted, 128u8), (&hosted_lid, 129u8)] {
+            let node = NodeBuilder::new("to").attr("jid", jid.clone()).build();
+            let mut buf = Vec::new();
+            Encoder::new(Cursor::new(&mut buf))?.write_node(&node)?;
+
+            let pos = buf
+                .iter()
+                .position(|&b| b == token::AD_JID)
+                .expect("AD_JID marker present");
+            assert_eq!(
+                buf[pos + 1],
+                expected,
+                "direct-constructed {jid} must emit domain_type {expected} \
+                 (pre-#391 would have emitted agent=0)"
+            );
+        }
+        Ok(())
+    }
+
     /// Regression test: strings at the PACKED_MAX boundary must be classified
     /// normally, while strings above it must be emitted as raw bytes (skipping
     /// SipHash/PHF classification entirely).


### PR DESCRIPTION
## Background

Audit of the Hosted/HostedLid path triggered by a question on the encoder \`domain_type\` bug (#391) surfaced a deeper Signal-address divergence. WA Web's \`SignalAddress.toString()\` in \`WAWeb/Signal/Address.js\`:

\`\`\`js
if (this.wid.isHosted()) {
    if (bizHostedDevicesEnabled()) {
        if (t !== ":99") throw "Hosted jid with wrong device id";
        var n = asUserWidOrThrow(this.wid),
            a = !n.isLid() && !n.isHostedLid() && n.isUser(),
            i = a ? getCurrentLid(n) : n;
        return i == null
            ? [this.wid.user, t, "@hosted"].join("")
            : [i.user, t, "@hosted.lid"].join("");
    }
    throw "Unexpected hosted jid";
}
\`\`\`

Same pattern for non-hosted JIDs lower in the function: prefer LID-keyed addresses, fall back to the original namespace if no LID mapping is known.

## What was wrong

\`resolve_encryption_jid\` only handled the PN → LID upgrade. Hosted JIDs fell through the catch-all \`_ => target.clone()\`, so a hosted device whose LID was known was keyed locally at \`{user}@hosted\` while WA Web would key it at \`{lid_user}@hosted.lid\`.

Practical impact today: nil — current send paths filter \`is_hosted()\` before reaching the resolver, so the divergent key was never built or looked up. The gap was dormant but real, and any future hosted support would have inherited an incompatible keyspace.

## Fix

\`resolve_encryption_jid\` mirrors WA Web in a single match:

\`\`\`rust
let lid_server = match target.server {
    Server::Pn => Server::Lid,
    Server::Hosted => Server::HostedLid,
    _ => return target.clone(),
};
match self.lid_pn_cache.get_current_lid(&target.user).await {
    Some(lid_user) => Jid { user: lid_user.into(), server: lid_server, .. },
    None => target.clone(),
}
\`\`\`

| Input | Output | Source |
|---|---|---|
| Lid / HostedLid | unchanged | already canonical |
| Pn | Lid when mapping known, else Pn | matches existing behavior |
| Hosted | **HostedLid when mapping known, else Hosted** | new |
| anything else | unchanged | matches existing behavior |

The Hosted upgrade reuses the same \`lid_pn_cache.get_current_lid()\` lookup as the PN upgrade. PN/LID dispatch cost is unchanged.

### Allocation profile

| Branch | Heap allocs |
|---|---|
| Lid / HostedLid / other | 0 (CompactString user inline ≤24 bytes — always for phone/lid lengths) |
| Pn / Hosted with mapping | 1 wasted (String temp from \`lid_pn_cache\`, dropped after \`.into()\` to inline CompactString) |
| Pn / Hosted no mapping | 0 (cache miss + inline clone) |

The wasted \`String\` is a property of \`lid_pn_cache.get_current_lid() -> Option<String>\`. Eliminating it requires changing \`LidPnEntry.lid: String → CompactString\` cross-crate; out of scope here, dormant in hot paths today (LID groups don't go through the upgrade — devices already are LID).

## Tests

- \`test_resolve_encryption_jid_hosted_with_lid_upgrades_to_hosted_lid\` — loops over \`[99, 7]\` device ids to prove the input device round-trips and is **not** coerced to 99.
- \`test_resolve_encryption_jid_hosted_no_mapping_keeps_hosted\`
- \`test_resolve_encryption_jid_preserves_hosted_lid\`

Plus a wire-encoding regression in \`wacore/binary/src/encoder.rs\`: direct-constructed Hosted JIDs (\`Jid::new(_, Server::Hosted)\` defaults \`agent=0\`) now emit the correct \`domain_type\` byte (128 / 129) because the encoder derives it from the server enum, not from \`agent\`. Pre-#391 the same input would have written \`0\`.

## What's not in this PR

- Hosted send-path activation. Group SKDM still filters hosted (matches WA Web's \`!t.includes("hosted")\` filter in \`getGroupSenderKeyListFromParticipantRecord\`). DM hosted filters remain in place. Activating hosted as an active recipient is a feature, not part of address compliance.
- Device=99 enforcement at the JID boundary. WA Web throws on hosted JIDs with other device ids; we preserve the input and let the wire layer route it. Soft-reject is a separate hardening.
- Hosted ↔ HostedLid swap in \`swap_pn_lid_namespace\`. That helper handles cross-alias message lookup which is dormant for hosted (no stored messages keyed under hosted today).
- \`LidPnEntry.lid\` switch from \`String\` to \`CompactString\` to drop the wasted String alloc on the upgrade path.

## Test plan

- [x] \`cargo test --workspace --lib\` — 1370+ tests pass
- [x] \`cargo clippy --all --tests\` — clean
- [x] \`cargo fmt --all\`