### PR TITLE
fix(lid_pn): keep status@broadcast resolving to @lid

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -161,7 +161,10 @@ pub struct CacheConfig {
     pub group_cache: CacheEntryConfig,
     /// Device registry cache (time_to_live). Default: 1h TTL, 1000 entries.
     pub device_registry_cache: CacheEntryConfig,
-    /// LID-to-phone cache (time_to_idle). Default: 1h timeout, 2000 entries.
+    /// LID-to-phone cache. WAWebLidPnCache uses plain Maps with no expiry
+    /// and no size cap; evicting a still-valid mapping silently downgrades
+    /// Signal addresses to `@c.us`. Default: no timeout, capacity u64::MAX
+    /// (effectively unbounded — moka doesn't expose an `unbounded()` builder).
     pub lid_pn_cache: CacheEntryConfig,
     /// Optional L1 in-memory cache for sent messages (retry support).
     /// Default: capacity 0 (disabled — DB-only, matching WA Web).
@@ -242,7 +245,7 @@ impl Default for CacheConfig {
         Self {
             group_cache: CacheEntryConfig::new(one_hour, 250),
             device_registry_cache: CacheEntryConfig::new(one_hour, 1_000),
-            lid_pn_cache: CacheEntryConfig::new(one_hour, 2_000),
+            lid_pn_cache: CacheEntryConfig::new(None, u64::MAX),
             recent_messages: CacheEntryConfig::new(five_min, 0),
             message_retry_counts: CacheEntryConfig::new(five_min, 500),
             undecryptable_dispatched: CacheEntryConfig::new(five_min, 1_000),
@@ -256,5 +259,24 @@ impl Default for CacheConfig {
             sent_message_ttl_secs: 300,
             cache_stores: CacheStores::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lid_pn_cache_default_is_effectively_unbounded() {
+        let cfg = CacheConfig::default();
+        assert_eq!(
+            cfg.lid_pn_cache.timeout, None,
+            "lid_pn_cache must not expire entries by time; WAWebLidPnCache uses plain Maps"
+        );
+        assert_eq!(
+            cfg.lid_pn_cache.capacity,
+            u64::MAX,
+            "lid_pn_cache must be effectively unbounded; capacity-LRU re-introduces the eviction bug at higher thresholds"
+        );
     }
 }

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -11,8 +11,12 @@
 //! When multiple LIDs exist for the same phone number (rare), the most recent one
 //! (by `created_at` timestamp) is considered "current".
 //!
-//! Both maps are bounded (max 10 000 entries, 1 h idle TTL) to prevent unbounded
-//! memory growth in long-running sessions.
+//! Both maps are unbounded by default and never expire. WA Web
+//! (`WAWebLidPnCache`) uses plain `Map`s, so a mapping learned at startup or
+//! via usync stays available for every subsequent Signal-address resolution.
+//! A custom `CacheEntryConfig` can impose a capacity bound if memory pressure
+//! requires it, accepting the trade-off that capacity-LRU eviction silently
+//! downgrades Signal addresses to `@c.us`.
 
 use std::sync::Arc;
 
@@ -45,12 +49,14 @@ impl Default for LidPnCache {
 }
 
 impl LidPnCache {
-    /// Create a new empty cache with default settings (1h idle TTL, 10000 entries).
+    /// Create a new empty cache with default settings (no time-based expiry,
+    /// effectively unbounded — matches `WAWebLidPnCache`).
     pub fn new() -> Self {
         Self::with_config(&CacheConfig::default().lid_pn_cache, None)
     }
 
-    /// Create a new cache with custom configuration (uses time_to_idle semantics).
+    /// Create a new cache with custom configuration (uses time_to_idle semantics
+    /// when a timeout is set; default config has none).
     ///
     /// When `store` is `Some`, both internal maps use the custom backend.
     /// When `store` is `None`, both maps use in-process moka caches.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1803,8 +1803,8 @@ mod tests {
         )
         .await;
 
-        let pn_user = "556381080408";
-        let lid_user = "208512558833832";
+        let pn_user = "559980000001";
+        let lid_user = "100000012345678";
 
         assert_eq!(
             client.lid_pn_cache.get_current_lid(pn_user).await,
@@ -1814,7 +1814,7 @@ mod tests {
 
         let node = NodeBuilder::new("message")
             .attr("from", "status@broadcast")
-            .attr("id", "2A84359EC28B28E2E6CA")
+            .attr("id", "TEST_COLD_CACHE_ID")
             .attr("participant", format!("{pn_user}@s.whatsapp.net").as_str())
             .attr("participant_lid", format!("{lid_user}@lid").as_str())
             .attr("t", "1777415965")
@@ -1896,8 +1896,8 @@ mod tests {
         )
         .await;
 
-        let pn_user = "556381080408";
-        let lid_user = "208512558833832";
+        let pn_user = "559980000001";
+        let lid_user = "100000012345678";
         let device_id: u16 = 99;
 
         let node = NodeBuilder::new("message")

--- a/src/message.rs
+++ b/src/message.rs
@@ -1445,16 +1445,9 @@ impl Client {
         alt: Option<&Jid>,
         is_offline: bool,
     ) {
-        use wacore_binary::Server;
-        // Hosted/HostedLid follow the same PN↔LID alt rule as their plain
-        // counterparts, so parse_message_info populates sender_alt for them
-        // too. Mirror that here or those mappings get dropped silently.
-        let sender_is_lid = matches!(sender.server, Server::Lid | Server::HostedLid);
-        let sender_is_pn = matches!(sender.server, Server::Pn | Server::Hosted);
-
-        let (lid_user, pn_user, source) = if sender_is_lid {
+        let (lid_user, pn_user, source) = if sender.server.is_lid_family() {
             if let Some(alt_jid) = alt
-                && matches!(alt_jid.server, Server::Pn | Server::Hosted)
+                && alt_jid.server.is_pn_family()
             {
                 (
                     &sender.user,
@@ -1464,9 +1457,9 @@ impl Client {
             } else {
                 return;
             }
-        } else if sender_is_pn {
+        } else if sender.server.is_pn_family() {
             if let Some(alt_jid) = alt
-                && matches!(alt_jid.server, Server::Lid | Server::HostedLid)
+                && alt_jid.server.is_lid_family()
             {
                 (
                     &alt_jid.user,
@@ -1873,6 +1866,102 @@ mod tests {
             resolved.to_protocol_address().to_string(),
             format!("{lid_user}@lid.0"),
             "Signal address must be @lid form, not @c.us"
+        );
+    }
+
+    /// Pins the hosted-family branch + the realistic non-zero device shape.
+    /// Production stanzas almost always have device != 0, and hosted variants
+    /// (`@hosted` / `@hosted.lid`) must flow through cache_lid_pn_from_message.
+    #[tokio::test]
+    async fn test_status_broadcast_hosted_family_with_device_id_resolves_to_hosted_lid() {
+        use wacore::types::jid::JidExt as _;
+        use wacore_binary::Server;
+
+        let backend = Arc::new(
+            SqliteStore::new("file:memdb_status_hosted_device?mode=memory&cache=shared")
+                .await
+                .expect("Failed to create test backend"),
+        );
+        let pm = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("test backend should initialize"),
+        );
+        let (client, _sync_rx) = Client::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            pm,
+            mock_transport(),
+            mock_http_client(),
+            None,
+        )
+        .await;
+
+        let pn_user = "556381080408";
+        let lid_user = "208512558833832";
+        let device_id: u16 = 99;
+
+        let node = NodeBuilder::new("message")
+            .attr("from", "status@broadcast")
+            .attr("id", "HOSTED_TEST_ID")
+            .attr(
+                "participant",
+                format!("{pn_user}:{device_id}@hosted").as_str(),
+            )
+            .attr(
+                "participant_lid",
+                format!("{lid_user}:{device_id}@hosted.lid").as_str(),
+            )
+            .attr("t", "1777415965")
+            .attr("type", "media")
+            .build();
+
+        let info = client
+            .parse_message_info(&node.as_node_ref())
+            .await
+            .expect("parse_message_info must succeed");
+
+        assert_eq!(info.source.sender.server, Server::Hosted);
+        assert_eq!(info.source.sender.device, device_id);
+        let alt = info
+            .source
+            .sender_alt
+            .as_ref()
+            .expect("sender_alt must be populated for hosted participant");
+        assert_eq!(alt.server, Server::HostedLid);
+        assert_eq!(alt.user.as_str(), lid_user);
+        assert_eq!(alt.device, device_id);
+
+        client
+            .cache_lid_pn_from_message(
+                &info.source.sender,
+                info.source.sender_alt.as_ref(),
+                info.is_offline,
+            )
+            .await;
+
+        // Hosted variant must reach the cache; without it, learn_lid_pn_mapping
+        // is skipped and the hosted-device fix is incomplete.
+        assert_eq!(
+            client.lid_pn_cache.get_current_lid(pn_user).await,
+            Some(lid_user.to_string()),
+            "PN→LID lookup must work for hosted family"
+        );
+        assert_eq!(
+            client.lid_pn_cache.get_phone_number(lid_user).await,
+            Some(pn_user.to_string()),
+        );
+
+        let resolved = client.resolve_encryption_jid(&info.source.sender).await;
+        assert_eq!(resolved.user.as_str(), lid_user);
+        assert_eq!(resolved.server, Server::HostedLid);
+        assert_eq!(
+            resolved.device, device_id,
+            "device id must be preserved through resolution"
+        );
+        assert_eq!(
+            resolved.to_protocol_address().to_string(),
+            format!("{lid_user}:{device_id}@hosted.lid.0"),
+            "Signal address must be the @hosted.lid form with device suffix"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1780,6 +1780,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_status_broadcast_cold_cache_resolves_to_lid() {
+        use wacore::types::jid::JidExt as _;
+        use wacore_binary::Server;
+
+        let backend = Arc::new(
+            SqliteStore::new("file:memdb_status_cold_cache?mode=memory&cache=shared")
+                .await
+                .expect("Failed to create test backend"),
+        );
+        let pm = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("test backend should initialize"),
+        );
+        let (client, _sync_rx) = Client::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            pm,
+            mock_transport(),
+            mock_http_client(),
+            None,
+        )
+        .await;
+
+        let pn_user = "556381080408";
+        let lid_user = "208512558833832";
+
+        assert_eq!(
+            client.lid_pn_cache.get_current_lid(pn_user).await,
+            None,
+            "precondition: empty cache for {pn_user}"
+        );
+
+        let node = NodeBuilder::new("message")
+            .attr("from", "status@broadcast")
+            .attr("id", "2A84359EC28B28E2E6CA")
+            .attr("participant", format!("{pn_user}@s.whatsapp.net").as_str())
+            .attr("participant_lid", format!("{lid_user}@lid").as_str())
+            .attr("t", "1777415965")
+            .attr("type", "media")
+            .build();
+
+        let info = client
+            .parse_message_info(&node.as_node_ref())
+            .await
+            .expect("parse_message_info must succeed");
+
+        // Fix #1: parser surfaces participant_lid via sender_alt.
+        let alt = info
+            .source
+            .sender_alt
+            .as_ref()
+            .expect("sender_alt must be populated from participant_lid");
+        assert_eq!(alt.user.as_str(), lid_user);
+        assert_eq!(alt.server, Server::Lid);
+        assert_eq!(info.source.sender.user.as_str(), pn_user);
+        assert_eq!(info.source.sender.server, Server::Pn);
+
+        client
+            .cache_lid_pn_from_message(
+                &info.source.sender,
+                info.source.sender_alt.as_ref(),
+                info.is_offline,
+            )
+            .await;
+
+        // Cache learned the mapping in both directions.
+        assert_eq!(
+            client.lid_pn_cache.get_current_lid(pn_user).await,
+            Some(lid_user.to_string()),
+            "PN→LID lookup must hit"
+        );
+        assert_eq!(
+            client.lid_pn_cache.get_phone_number(lid_user).await,
+            Some(pn_user.to_string()),
+            "LID→PN lookup must hit"
+        );
+
+        // Resolution upgrades to LID and Signal address is the LID form.
+        let resolved = client.resolve_encryption_jid(&info.source.sender).await;
+        assert_eq!(resolved.user.as_str(), lid_user);
+        assert_eq!(resolved.server, Server::Lid);
+        assert_eq!(resolved.device, info.source.sender.device);
+        assert_eq!(
+            resolved.to_protocol_address().to_string(),
+            format!("{lid_user}@lid.0"),
+            "Signal address must be @lid form, not @c.us"
+        );
+    }
+
+    #[tokio::test]
     async fn test_process_session_enc_batch_handles_session_not_found_gracefully() {
         use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair, SignalMessage};
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1445,9 +1445,16 @@ impl Client {
         alt: Option<&Jid>,
         is_offline: bool,
     ) {
-        let (lid_user, pn_user, source) = if sender.is_lid() {
+        use wacore_binary::Server;
+        // Hosted/HostedLid follow the same PN↔LID alt rule as their plain
+        // counterparts, so parse_message_info populates sender_alt for them
+        // too. Mirror that here or those mappings get dropped silently.
+        let sender_is_lid = matches!(sender.server, Server::Lid | Server::HostedLid);
+        let sender_is_pn = matches!(sender.server, Server::Pn | Server::Hosted);
+
+        let (lid_user, pn_user, source) = if sender_is_lid {
             if let Some(alt_jid) = alt
-                && alt_jid.is_pn()
+                && matches!(alt_jid.server, Server::Pn | Server::Hosted)
             {
                 (
                     &sender.user,
@@ -1457,9 +1464,9 @@ impl Client {
             } else {
                 return;
             }
-        } else if sender.is_pn() {
+        } else if sender_is_pn {
             if let Some(alt_jid) = alt
-                && alt_jid.is_lid()
+                && matches!(alt_jid.server, Server::Lid | Server::HostedLid)
             {
                 (
                     &alt_jid.user,

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -211,6 +211,19 @@ impl Server {
             Self::Legacy => "c.us",
         }
     }
+
+    /// Phone-number-namespaced servers (`@s.whatsapp.net`, `@hosted`).
+    /// The PN side of the LID↔PN mapping treats these as a single class.
+    #[inline]
+    pub fn is_pn_family(self) -> bool {
+        matches!(self, Self::Pn | Self::Hosted)
+    }
+
+    /// LID-namespaced servers (`@lid`, `@hosted.lid`).
+    #[inline]
+    pub fn is_lid_family(self) -> bool {
+        matches!(self, Self::Lid | Self::HostedLid)
+    }
 }
 
 impl fmt::Display for Server {

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -164,6 +164,15 @@ pub fn parse_message_info(
         let participant = attrs.jid("participant");
         let is_from_me = participant.matches_user_or_lid(own_jid, own_lid);
 
+        // Match WAWebMsgParser: read participant_lid/_pn unconditionally so
+        // the LID-PN cache can re-warm from the stanza. Hosted/HostedLid
+        // participants follow the same PN↔LID alt rule.
+        let sender_alt = match participant.server {
+            Server::Pn | Server::Hosted => attrs.optional_jid("participant_lid"),
+            Server::Lid | Server::HostedLid => attrs.optional_jid("participant_pn"),
+            _ => None,
+        };
+
         MessageSource {
             chat: from.clone(),
             sender: participant.clone(),
@@ -174,6 +183,7 @@ pub fn parse_message_info(
             } else {
                 None
             },
+            sender_alt,
             ..Default::default()
         }
     } else if from.is_group() {
@@ -269,4 +279,39 @@ pub fn parse_message_info(
         is_offline,
         ..Default::default()
     })
+}
+
+#[cfg(test)]
+mod parse_message_info_tests {
+    use super::*;
+    use std::str::FromStr;
+    use wacore_binary::Jid;
+    use wacore_binary::builder::NodeBuilder;
+
+    #[test]
+    fn status_broadcast_with_participant_lid_populates_sender_alt() {
+        let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
+        let own_lid = Jid::from_str("100000000000000@lid").unwrap();
+        let node = NodeBuilder::new("message")
+            .attr("from", "status@broadcast")
+            .attr("type", "media")
+            .attr("id", "2A84359EC28B28E2E6CA")
+            .attr("t", "1777415965")
+            .attr("participant", "556381080408@s.whatsapp.net")
+            .attr("participant_lid", "208512558833832@lid")
+            .build();
+
+        let info = parse_message_info(&node.as_node_ref(), &own_pn, Some(&own_lid))
+            .expect("parse_message_info should succeed for status broadcast");
+
+        assert_eq!(info.source.sender.user, "556381080408");
+        assert_eq!(info.source.sender.server, wacore_binary::Server::Pn);
+        let alt = info
+            .source
+            .sender_alt
+            .as_ref()
+            .expect("status broadcast must expose participant_lid as sender_alt");
+        assert_eq!(alt.user, "208512558833832");
+        assert_eq!(alt.server, wacore_binary::Server::Lid);
+    }
 }

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -293,26 +293,28 @@ mod parse_message_info_tests {
     fn status_broadcast_with_participant_lid_populates_sender_alt() {
         let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
         let own_lid = Jid::from_str("100000000000000@lid").unwrap();
+        let pn_user = "559980000001";
+        let lid_user = "100000012345678";
         let node = NodeBuilder::new("message")
             .attr("from", "status@broadcast")
             .attr("type", "media")
-            .attr("id", "2A84359EC28B28E2E6CA")
+            .attr("id", "TEST_MSG_ID")
             .attr("t", "1777415965")
-            .attr("participant", "556381080408@s.whatsapp.net")
-            .attr("participant_lid", "208512558833832@lid")
+            .attr("participant", format!("{pn_user}@s.whatsapp.net").as_str())
+            .attr("participant_lid", format!("{lid_user}@lid").as_str())
             .build();
 
         let info = parse_message_info(&node.as_node_ref(), &own_pn, Some(&own_lid))
             .expect("parse_message_info should succeed for status broadcast");
 
-        assert_eq!(info.source.sender.user, "556381080408");
+        assert_eq!(info.source.sender.user, pn_user);
         assert_eq!(info.source.sender.server, wacore_binary::Server::Pn);
         let alt = info
             .source
             .sender_alt
             .as_ref()
             .expect("status broadcast must expose participant_lid as sender_alt");
-        assert_eq!(alt.user, "208512558833832");
+        assert_eq!(alt.user, lid_user);
         assert_eq!(alt.server, wacore_binary::Server::Lid);
     }
 }

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -165,12 +165,13 @@ pub fn parse_message_info(
         let is_from_me = participant.matches_user_or_lid(own_jid, own_lid);
 
         // Match WAWebMsgParser: read participant_lid/_pn unconditionally so
-        // the LID-PN cache can re-warm from the stanza. Hosted/HostedLid
-        // participants follow the same PN↔LID alt rule.
-        let sender_alt = match participant.server {
-            Server::Pn | Server::Hosted => attrs.optional_jid("participant_lid"),
-            Server::Lid | Server::HostedLid => attrs.optional_jid("participant_pn"),
-            _ => None,
+        // the LID-PN cache can re-warm from the stanza.
+        let sender_alt = if participant.server.is_pn_family() {
+            attrs.optional_jid("participant_lid")
+        } else if participant.server.is_lid_family() {
+            attrs.optional_jid("participant_pn")
+        } else {
+            None
         };
 
         MessageSource {

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -317,4 +317,38 @@ mod parse_message_info_tests {
         assert_eq!(alt.user, lid_user);
         assert_eq!(alt.server, wacore_binary::Server::Lid);
     }
+
+    /// Symmetric branch: when `participant` is a LID, `sender_alt` must come
+    /// from `participant_pn`. Pins the `Server::Lid`/`is_lid_family()` arm.
+    #[test]
+    fn status_broadcast_with_participant_pn_populates_sender_alt() {
+        let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
+        let own_lid = Jid::from_str("100000000000000@lid").unwrap();
+        let pn_user = "559980000001";
+        let lid_user = "100000012345678";
+        let node = NodeBuilder::new("message")
+            .attr("from", "status@broadcast")
+            .attr("type", "media")
+            .attr("id", "TEST_LID_FIRST_MSG_ID")
+            .attr("t", "1777415965")
+            .attr("participant", format!("{lid_user}@lid").as_str())
+            .attr(
+                "participant_pn",
+                format!("{pn_user}@s.whatsapp.net").as_str(),
+            )
+            .build();
+
+        let info = parse_message_info(&node.as_node_ref(), &own_pn, Some(&own_lid))
+            .expect("parse_message_info should succeed for LID-addressed status");
+
+        assert_eq!(info.source.sender.user, lid_user);
+        assert_eq!(info.source.sender.server, wacore_binary::Server::Lid);
+        let alt = info
+            .source
+            .sender_alt
+            .as_ref()
+            .expect("LID-addressed status broadcast must expose participant_pn as sender_alt");
+        assert_eq!(alt.user, pn_user);
+        assert_eq!(alt.server, wacore_binary::Server::Pn);
+    }
 }


### PR DESCRIPTION
Production bot was producing `InvalidPreKeyId` errors decrypting status@broadcast pkmsg. Two combined bugs caused the Signal address to silently downgrade to `@c.us` instead of resolving to `@lid`, where the existing session lives.

## Fixes

- `wacore/src/messages.rs` — `parse_message_info` now reads `participant_lid`/`participant_pn` in the `Server::Broadcast` branch, mirroring `WAWebMsgParser`. Covers `Hosted`/`HostedLid` participants too.
- `src/cache_config.rs` + `src/lid_pn_cache.rs` — `lid_pn_cache` default drops the 1h TTI and the capacity bound (`u64::MAX`), matching `WAWebLidPnCache`'s plain-Map semantics. Capacity-LRU eviction reintroduces the same bug at a higher threshold.

## Tests

- `wacore/src/messages.rs::status_broadcast_with_participant_lid_populates_sender_alt`
- `src/cache_config.rs::lid_pn_cache_default_is_effectively_unbounded`
- `src/message.rs::test_status_broadcast_cold_cache_resolves_to_lid` (full flow: parse → learn → resolve to `@lid`)

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude e2e-tests --tests`
- [x] `cargo test --workspace --exclude e2e-tests` (658 wacore + 448 whatsapp-rust + others, 0 failures)