### PR TITLE
perf(events): share wa::Message via Arc end-to-end (zero deep-clone on dispatch)

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1160,13 +1160,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn into_box_reclaims_when_unique() {
-        // When the inner Arc has refcount 1, `Arc::try_unwrap` succeeds and
-        // moves the message out without cloning. The Arc's allocation is then
-        // freed — observable via a `Weak` sentinel that becomes orphan.
-        // (Box::new still allocates fresh heap for the destination, so
-        //  boxed.as_ref() addresses do not match the original Arc payload —
-        //  hence we use Weak::strong_count, not pointer identity.)
+    async fn into_box_with_unique_arc_consumes_strong_ref() {
+        // State-level test: confirms that when the inner Arc has refcount 1,
+        // `into_box` consumes it (Weak sentinel becomes orphan). This alone
+        // does NOT prove `try_unwrap` was taken — a hypothetical impl that
+        // always clones and drops the original would pass the same way.
+        // Path-level coverage lives in `into_box_skips_clone_when_unique`.
         let client = make_test_client().await;
         let arc = Arc::new(sample_message("solo"));
         let weak = Arc::downgrade(&arc);
@@ -1180,10 +1179,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn into_box_clones_when_shared() {
-        // With a second outstanding `Arc`, `try_unwrap` returns `Err` and
-        // `into_box` falls back to deep-cloning the inner message. The kept
-        // Arc survives with refcount 1 afterwards.
+    async fn into_box_with_shared_arc_preserves_other_strong_refs() {
+        // State-level: with a second outstanding `Arc`, into_box drops only
+        // its own strong ref; `kept` survives at refcount 1 and the boxed
+        // message lives in a distinct allocation. Path-level (clone happens
+        // exactly once) covered in `into_box_skips_clone_when_unique`.
         let client = make_test_client().await;
         let arc = Arc::new(sample_message("shared"));
         let kept = Arc::clone(&arc);
@@ -1192,9 +1192,85 @@ mod tests {
 
         let boxed = ctx.into_box();
         assert_eq!(boxed.conversation.as_deref(), Some("shared"));
-        // ctx's internal Arc was dropped when into_box returned; only `kept` remains.
         assert_eq!(Arc::strong_count(&kept), 1);
-        // Boxed message must be a distinct allocation from the surviving Arc.
-        assert!(!std::ptr::eq(boxed.as_ref() as *const _, Arc::as_ptr(&kept)));
+        assert!(!std::ptr::eq(
+            boxed.as_ref() as *const _,
+            Arc::as_ptr(&kept)
+        ));
+    }
+
+    // ── Path-level probe for the `into_box` algorithm ────────────────────────
+    //
+    // The state-level tests above can't distinguish `try_unwrap → Ok` from a
+    // hypothetical "always clone, then drop the Arc" impl. This block probes
+    // the algorithm directly: a payload type that increments a shared counter
+    // every time `Clone::clone` runs. We replicate the exact `match
+    // Arc::try_unwrap(...) { Ok => Box::new, Err => clone }` pattern from
+    // `into_box` and assert the counter only changes on the shared path.
+    //
+    // A regression that swaps `into_box` for `Box::new((*self.message).clone())`
+    // would be caught by these tests if the algorithm were exercised; for
+    // ironclad coverage you'd need to make `into_box` itself generic over the
+    // payload type, which is out of scope here. Until then this guarantees
+    // the pattern this PR is shipping behaves as documented.
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CloneCounter {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Clone for CloneCounter {
+        fn clone(&self) -> Self {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            Self {
+                count: Arc::clone(&self.count),
+            }
+        }
+    }
+
+    fn try_unwrap_or_clone<T: Clone>(arc: Arc<T>) -> Box<T> {
+        // Mirror of `MessageContext::into_box`. Kept here as a free function
+        // so it can be exercised against any T — the production version is
+        // monomorphized over `wa::Message` and can't be probed directly.
+        match Arc::try_unwrap(arc) {
+            Ok(v) => Box::new(v),
+            Err(arc) => Box::new((*arc).clone()),
+        }
+    }
+
+    #[test]
+    fn into_box_skips_clone_when_unique() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let payload = CloneCounter {
+            count: Arc::clone(&counter),
+        };
+        let arc = Arc::new(payload);
+
+        let _boxed = try_unwrap_or_clone(arc);
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            0,
+            "try_unwrap path must not invoke Clone"
+        );
+    }
+
+    #[test]
+    fn into_box_invokes_clone_exactly_once_when_shared() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let payload = CloneCounter {
+            count: Arc::clone(&counter),
+        };
+        let arc = Arc::new(payload);
+        let _kept = Arc::clone(&arc);
+
+        let _boxed = try_unwrap_or_clone(arc);
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "shared-arc fallback must invoke Clone exactly once"
+        );
     }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -30,6 +30,17 @@ pub enum BotBuilderError {
     Other(#[from] anyhow::Error),
 }
 
+/// Single source of truth for the `Arc::try_unwrap` → `Box` conversion.
+/// Used by [`MessageContext::into_box`] and exercised directly in tests so
+/// production and test code share one implementation — no chance for a
+/// regression in the production path to slip past tests that mirror it.
+fn arc_into_box<T: Clone>(arc: Arc<T>) -> Box<T> {
+    match Arc::try_unwrap(arc) {
+        Ok(value) => Box::new(value),
+        Err(arc) => Box::new((*arc).clone()),
+    }
+}
+
 /// `message` lives behind `Arc` so cloning the context (e.g., re-spawning into
 /// a fire-and-forget task) only bumps a refcount — deep-cloning per spawn was
 /// costly on hot paths (emoji-challenge, sticker triggers) where the message
@@ -84,10 +95,7 @@ impl MessageContext {
     /// ownership. Tries to reclaim the inner `Message` when the `Arc` is
     /// uniquely held; falls back to deep-cloning otherwise.
     pub fn into_box(self) -> Box<wa::Message> {
-        match Arc::try_unwrap(self.message) {
-            Ok(msg) => Box::new(msg),
-            Err(arc) => Box::new((*arc).clone()),
-        }
+        arc_into_box(self.message)
     }
 
     pub fn from_event(event: &Event, client: Arc<Client>) -> Option<Self> {
@@ -1183,7 +1191,7 @@ mod tests {
         // State-level: with a second outstanding `Arc`, into_box drops only
         // its own strong ref; `kept` survives at refcount 1 and the boxed
         // message lives in a distinct allocation. Path-level (clone happens
-        // exactly once) covered in `into_box_skips_clone_when_unique`.
+        // exactly once) covered in `into_box_invokes_clone_exactly_once_when_shared`.
         let client = make_test_client().await;
         let arc = Arc::new(sample_message("shared"));
         let kept = Arc::clone(&arc);
@@ -1203,16 +1211,10 @@ mod tests {
     //
     // The state-level tests above can't distinguish `try_unwrap → Ok` from a
     // hypothetical "always clone, then drop the Arc" impl. This block probes
-    // the algorithm directly: a payload type that increments a shared counter
-    // every time `Clone::clone` runs. We replicate the exact `match
-    // Arc::try_unwrap(...) { Ok => Box::new, Err => clone }` pattern from
-    // `into_box` and assert the counter only changes on the shared path.
-    //
-    // A regression that swaps `into_box` for `Box::new((*self.message).clone())`
-    // would be caught by these tests if the algorithm were exercised; for
-    // ironclad coverage you'd need to make `into_box` itself generic over the
-    // payload type, which is out of scope here. Until then this guarantees
-    // the pattern this PR is shipping behaves as documented.
+    // the algorithm directly: a payload type that bumps a shared counter on
+    // every `Clone::clone`, exercised against the SAME helper the production
+    // path uses. `MessageContext::into_box` delegates to `arc_into_box`, so a
+    // regression in the production path is forced to surface here.
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1229,16 +1231,6 @@ mod tests {
         }
     }
 
-    fn try_unwrap_or_clone<T: Clone>(arc: Arc<T>) -> Box<T> {
-        // Mirror of `MessageContext::into_box`. Kept here as a free function
-        // so it can be exercised against any T — the production version is
-        // monomorphized over `wa::Message` and can't be probed directly.
-        match Arc::try_unwrap(arc) {
-            Ok(v) => Box::new(v),
-            Err(arc) => Box::new((*arc).clone()),
-        }
-    }
-
     #[test]
     fn into_box_skips_clone_when_unique() {
         let counter = Arc::new(AtomicUsize::new(0));
@@ -1247,7 +1239,7 @@ mod tests {
         };
         let arc = Arc::new(payload);
 
-        let _boxed = try_unwrap_or_clone(arc);
+        let _boxed = arc_into_box(arc);
 
         assert_eq!(
             counter.load(Ordering::SeqCst),
@@ -1265,7 +1257,7 @@ mod tests {
         let arc = Arc::new(payload);
         let _kept = Arc::clone(&arc);
 
-        let _boxed = try_unwrap_or_clone(arc);
+        let _boxed = arc_into_box(arc);
 
         assert_eq!(
             counter.load(Ordering::SeqCst),

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -30,12 +30,18 @@ pub enum BotBuilderError {
     Other(#[from] anyhow::Error),
 }
 
-/// `Arc<wa::Message>` so cloning the context to re-spawn into a fire-and-forget
-/// task only bumps a refcount; deep-cloning per spawn was costly on hot paths
-/// (emoji-challenge, sticker triggers) where the message carries media buffers.
+/// `message` lives behind `Arc` so cloning the context (e.g., re-spawning into
+/// a fire-and-forget task) only bumps a refcount — deep-cloning per spawn was
+/// costly on hot paths (emoji-challenge, sticker triggers) where the message
+/// carries media buffers.
+///
+/// The field is private to keep the storage representation an implementation
+/// detail. Use [`Self::message`] for read-only access (95% of call sites),
+/// [`Self::message_arc`] when you need to share ownership (e.g., re-spawn),
+/// or [`Self::into_box`] for legacy code that requires `Box<wa::Message>`.
 #[derive(Clone)]
 pub struct MessageContext {
-    pub message: Arc<wa::Message>,
+    message: Arc<wa::Message>,
     pub info: MessageInfo,
     pub client: Arc<Client>,
 }
@@ -55,6 +61,32 @@ impl MessageContext {
             message,
             info: info.clone(),
             client,
+        }
+    }
+
+    /// Read-only access to the underlying message. Replaces direct
+    /// `ctx.message` field access from the previous `Box`-based API.
+    #[inline]
+    pub fn message(&self) -> &wa::Message {
+        &self.message
+    }
+
+    /// Cheap clone of the inner `Arc` for sharing ownership across tasks
+    /// without deep-copying `wa::Message` (typical for [`Self::from_arc`]
+    /// re-spawns). Calling `Arc::clone` directly via `&ctx.message` is no
+    /// longer available since the field is private.
+    #[inline]
+    pub fn message_arc(&self) -> Arc<wa::Message> {
+        Arc::clone(&self.message)
+    }
+
+    /// Compatibility helper for legacy code that needs `Box<wa::Message>`
+    /// ownership. Tries to reclaim the inner `Message` when the `Arc` is
+    /// uniquely held; falls back to deep-cloning otherwise.
+    pub fn into_box(self) -> Box<wa::Message> {
+        match Arc::try_unwrap(self.message) {
+            Ok(msg) => Box::new(msg),
+            Err(arc) => Box::new((*arc).clone()),
         }
     }
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -30,8 +30,12 @@ pub enum BotBuilderError {
     Other(#[from] anyhow::Error),
 }
 
+/// `Arc<wa::Message>` so cloning the context to re-spawn into a fire-and-forget
+/// task only bumps a refcount; deep-cloning per spawn was costly on hot paths
+/// (emoji-challenge, sticker triggers) where the message carries media buffers.
+#[derive(Clone)]
 pub struct MessageContext {
-    pub message: Box<wa::Message>,
+    pub message: Arc<wa::Message>,
     pub info: MessageInfo,
     pub client: Arc<Client>,
 }
@@ -39,7 +43,16 @@ pub struct MessageContext {
 impl MessageContext {
     pub fn from_parts(message: &wa::Message, info: &MessageInfo, client: Arc<Client>) -> Self {
         Self {
-            message: Box::new(message.clone()),
+            message: Arc::new(message.clone()),
+            info: info.clone(),
+            client,
+        }
+    }
+
+    /// Zero-clone alternative when the caller already owns an `Arc`.
+    pub fn from_arc(message: Arc<wa::Message>, info: &MessageInfo, client: Arc<Client>) -> Self {
+        Self {
+            message,
             info: info.clone(),
             client,
         }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1115,4 +1115,86 @@ mod tests {
 
         assert!(!bot.client().skip_history_sync_enabled());
     }
+
+    // ── MessageContext Arc compatibility boundary ────────────────────────────
+    //
+    // Lock down the contract introduced by switching `message` from Box to Arc.
+    // These tests guarantee:
+    //   • `from_arc` doesn't deep-clone — `message_arc()` returns the same
+    //     allocation (`Arc::ptr_eq`).
+    //   • `message()` exposes the inner message read-only.
+    //   • `into_box()` reclaims via `Arc::try_unwrap` when the Arc is unique
+    //     (no clone), and falls back to deep-clone when shared.
+    async fn make_test_client() -> Arc<crate::client::Client> {
+        let backend = create_test_sqlite_backend().await;
+        let bot = Bot::builder()
+            .with_backend(backend)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("Failed to build bot");
+        bot.client()
+    }
+
+    fn sample_message(text: &str) -> wa::Message {
+        wa::Message {
+            conversation: Some(text.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn from_arc_preserves_allocation() {
+        let client = make_test_client().await;
+        let original = Arc::new(sample_message("ping"));
+        let original_ptr = Arc::as_ptr(&original);
+
+        let ctx = MessageContext::from_arc(original, &MessageInfo::default(), client);
+
+        assert_eq!(ctx.message().conversation.as_deref(), Some("ping"));
+        let exposed = ctx.message_arc();
+        // Same allocation: the Arc round-trips without cloning the inner message.
+        assert!(std::ptr::eq(Arc::as_ptr(&exposed), original_ptr));
+    }
+
+    #[tokio::test]
+    async fn into_box_reclaims_when_unique() {
+        // When the inner Arc has refcount 1, `Arc::try_unwrap` succeeds and
+        // moves the message out without cloning. The Arc's allocation is then
+        // freed — observable via a `Weak` sentinel that becomes orphan.
+        // (Box::new still allocates fresh heap for the destination, so
+        //  boxed.as_ref() addresses do not match the original Arc payload —
+        //  hence we use Weak::strong_count, not pointer identity.)
+        let client = make_test_client().await;
+        let arc = Arc::new(sample_message("solo"));
+        let weak = Arc::downgrade(&arc);
+        let ctx = MessageContext::from_arc(arc, &MessageInfo::default(), client);
+        assert_eq!(weak.strong_count(), 1);
+
+        let boxed = ctx.into_box();
+        assert_eq!(boxed.conversation.as_deref(), Some("solo"));
+        assert_eq!(weak.strong_count(), 0);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn into_box_clones_when_shared() {
+        // With a second outstanding `Arc`, `try_unwrap` returns `Err` and
+        // `into_box` falls back to deep-cloning the inner message. The kept
+        // Arc survives with refcount 1 afterwards.
+        let client = make_test_client().await;
+        let arc = Arc::new(sample_message("shared"));
+        let kept = Arc::clone(&arc);
+        let ctx = MessageContext::from_arc(arc, &MessageInfo::default(), client);
+        assert_eq!(Arc::strong_count(&kept), 2);
+
+        let boxed = ctx.into_box();
+        assert_eq!(boxed.conversation.as_deref(), Some("shared"));
+        // ctx's internal Arc was dropped when into_box returned; only `kept` remains.
+        assert_eq!(Arc::strong_count(&kept), 1);
+        // Boxed message must be a distinct allocation from the surviving Arc.
+        assert!(!std::ptr::eq(boxed.as_ref() as *const _, Arc::as_ptr(&kept)));
+    }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -30,43 +30,21 @@ pub enum BotBuilderError {
     Other(#[from] anyhow::Error),
 }
 
-/// Single source of truth for the `Arc::try_unwrap` → `Box` conversion.
-/// Used by [`MessageContext::into_box`] and exercised directly in tests so
-/// production and test code share one implementation — no chance for a
-/// regression in the production path to slip past tests that mirror it.
-fn arc_into_box<T: Clone>(arc: Arc<T>) -> Box<T> {
-    match Arc::try_unwrap(arc) {
-        Ok(value) => Box::new(value),
-        Err(arc) => Box::new((*arc).clone()),
-    }
-}
-
-/// `message` lives behind `Arc` so cloning the context (e.g., re-spawning into
-/// a fire-and-forget task) only bumps a refcount — deep-cloning per spawn was
-/// costly on hot paths (emoji-challenge, sticker triggers) where the message
-/// carries media buffers.
-///
-/// The field is private to keep the storage representation an implementation
-/// detail. Use [`Self::message`] for read-only access (95% of call sites),
-/// [`Self::message_arc`] when you need to share ownership (e.g., re-spawn),
-/// or [`Self::into_box`] for legacy code that requires `Box<wa::Message>`.
+/// `message` is `Arc` so cloning the context across spawned tasks only bumps a
+/// refcount, matching the pattern used by serenity's `Context` and matrix-sdk's
+/// `Room`/`Client`.
 #[derive(Clone)]
 pub struct MessageContext {
-    message: Arc<wa::Message>,
+    pub message: Arc<wa::Message>,
     pub info: MessageInfo,
     pub client: Arc<Client>,
 }
 
 impl MessageContext {
     pub fn from_parts(message: &wa::Message, info: &MessageInfo, client: Arc<Client>) -> Self {
-        Self {
-            message: Arc::new(message.clone()),
-            info: info.clone(),
-            client,
-        }
+        Self::from_arc(Arc::new(message.clone()), info, client)
     }
 
-    /// Zero-clone alternative when the caller already owns an `Arc`.
     pub fn from_arc(message: Arc<wa::Message>, info: &MessageInfo, client: Arc<Client>) -> Self {
         Self {
             message,
@@ -75,32 +53,9 @@ impl MessageContext {
         }
     }
 
-    /// Read-only access to the underlying message. Replaces direct
-    /// `ctx.message` field access from the previous `Box`-based API.
-    #[inline]
-    pub fn message(&self) -> &wa::Message {
-        &self.message
-    }
-
-    /// Cheap clone of the inner `Arc` for sharing ownership across tasks
-    /// without deep-copying `wa::Message` (typical for [`Self::from_arc`]
-    /// re-spawns). Calling `Arc::clone` directly via `&ctx.message` is no
-    /// longer available since the field is private.
-    #[inline]
-    pub fn message_arc(&self) -> Arc<wa::Message> {
-        Arc::clone(&self.message)
-    }
-
-    /// Compatibility helper for legacy code that needs `Box<wa::Message>`
-    /// ownership. Tries to reclaim the inner `Message` when the `Arc` is
-    /// uniquely held; falls back to deep-cloning otherwise.
-    pub fn into_box(self) -> Box<wa::Message> {
-        arc_into_box(self.message)
-    }
-
     pub fn from_event(event: &Event, client: Arc<Client>) -> Option<Self> {
         let (msg, info) = event.as_message()?;
-        Some(Self::from_parts(msg, info, client))
+        Some(Self::from_arc(Arc::clone(msg), info, client))
     }
 
     pub async fn send_message(
@@ -1124,16 +1079,8 @@ mod tests {
         assert!(!bot.client().skip_history_sync_enabled());
     }
 
-    // ── MessageContext Arc compatibility boundary ────────────────────────────
-    //
-    // Lock down the contract introduced by switching `message` from Box to Arc.
-    // These tests guarantee:
-    //   • `from_arc` doesn't deep-clone — `message_arc()` returns the same
-    //     allocation (`Arc::ptr_eq`).
-    //   • `message()` exposes the inner message read-only.
-    //   • `into_box()` reclaims via `Arc::try_unwrap` when the Arc is unique
-    //     (no clone), and falls back to deep-clone when shared.
-    async fn make_test_client() -> Arc<crate::client::Client> {
+    #[tokio::test]
+    async fn from_arc_does_not_deep_clone() {
         let backend = create_test_sqlite_backend().await;
         let bot = Bot::builder()
             .with_backend(backend)
@@ -1143,126 +1090,16 @@ mod tests {
             .build()
             .await
             .expect("Failed to build bot");
-        bot.client()
-    }
 
-    fn sample_message(text: &str) -> wa::Message {
-        wa::Message {
-            conversation: Some(text.to_string()),
+        let original = Arc::new(wa::Message {
+            conversation: Some("ping".to_string()),
             ..Default::default()
-        }
-    }
-
-    #[tokio::test]
-    async fn from_arc_preserves_allocation() {
-        let client = make_test_client().await;
-        let original = Arc::new(sample_message("ping"));
+        });
         let original_ptr = Arc::as_ptr(&original);
 
-        let ctx = MessageContext::from_arc(original, &MessageInfo::default(), client);
+        let ctx =
+            MessageContext::from_arc(Arc::clone(&original), &MessageInfo::default(), bot.client());
 
-        assert_eq!(ctx.message().conversation.as_deref(), Some("ping"));
-        let exposed = ctx.message_arc();
-        // Same allocation: the Arc round-trips without cloning the inner message.
-        assert!(std::ptr::eq(Arc::as_ptr(&exposed), original_ptr));
-    }
-
-    #[tokio::test]
-    async fn into_box_with_unique_arc_consumes_strong_ref() {
-        // State-level test: confirms that when the inner Arc has refcount 1,
-        // `into_box` consumes it (Weak sentinel becomes orphan). This alone
-        // does NOT prove `try_unwrap` was taken — a hypothetical impl that
-        // always clones and drops the original would pass the same way.
-        // Path-level coverage lives in `into_box_skips_clone_when_unique`.
-        let client = make_test_client().await;
-        let arc = Arc::new(sample_message("solo"));
-        let weak = Arc::downgrade(&arc);
-        let ctx = MessageContext::from_arc(arc, &MessageInfo::default(), client);
-        assert_eq!(weak.strong_count(), 1);
-
-        let boxed = ctx.into_box();
-        assert_eq!(boxed.conversation.as_deref(), Some("solo"));
-        assert_eq!(weak.strong_count(), 0);
-        assert!(weak.upgrade().is_none());
-    }
-
-    #[tokio::test]
-    async fn into_box_with_shared_arc_preserves_other_strong_refs() {
-        // State-level: with a second outstanding `Arc`, into_box drops only
-        // its own strong ref; `kept` survives at refcount 1 and the boxed
-        // message lives in a distinct allocation. Path-level (clone happens
-        // exactly once) covered in `into_box_invokes_clone_exactly_once_when_shared`.
-        let client = make_test_client().await;
-        let arc = Arc::new(sample_message("shared"));
-        let kept = Arc::clone(&arc);
-        let ctx = MessageContext::from_arc(arc, &MessageInfo::default(), client);
-        assert_eq!(Arc::strong_count(&kept), 2);
-
-        let boxed = ctx.into_box();
-        assert_eq!(boxed.conversation.as_deref(), Some("shared"));
-        assert_eq!(Arc::strong_count(&kept), 1);
-        assert!(!std::ptr::eq(
-            boxed.as_ref() as *const _,
-            Arc::as_ptr(&kept)
-        ));
-    }
-
-    // ── Path-level probe for the `into_box` algorithm ────────────────────────
-    //
-    // The state-level tests above can't distinguish `try_unwrap → Ok` from a
-    // hypothetical "always clone, then drop the Arc" impl. This block probes
-    // the algorithm directly: a payload type that bumps a shared counter on
-    // every `Clone::clone`, exercised against the SAME helper the production
-    // path uses. `MessageContext::into_box` delegates to `arc_into_box`, so a
-    // regression in the production path is forced to surface here.
-
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct CloneCounter {
-        count: Arc<AtomicUsize>,
-    }
-
-    impl Clone for CloneCounter {
-        fn clone(&self) -> Self {
-            self.count.fetch_add(1, Ordering::SeqCst);
-            Self {
-                count: Arc::clone(&self.count),
-            }
-        }
-    }
-
-    #[test]
-    fn into_box_skips_clone_when_unique() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let payload = CloneCounter {
-            count: Arc::clone(&counter),
-        };
-        let arc = Arc::new(payload);
-
-        let _boxed = arc_into_box(arc);
-
-        assert_eq!(
-            counter.load(Ordering::SeqCst),
-            0,
-            "try_unwrap path must not invoke Clone"
-        );
-    }
-
-    #[test]
-    fn into_box_invokes_clone_exactly_once_when_shared() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let payload = CloneCounter {
-            count: Arc::clone(&counter),
-        };
-        let arc = Arc::new(payload);
-        let _kept = Arc::clone(&arc);
-
-        let _boxed = arc_into_box(arc);
-
-        assert_eq!(
-            counter.load(Ordering::SeqCst),
-            1,
-            "shared-arc fallback must invoke Clone exactly once"
-        );
+        assert!(std::ptr::eq(Arc::as_ptr(&ctx.message), original_ptr));
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -96,7 +96,7 @@ impl Client {
 
         self.core
             .event_bus
-            .dispatch(Event::Message(Box::new(msg), info));
+            .dispatch(Event::Message(Arc::new(msg), info));
     }
 
     /// Handles a newsletter plaintext message.

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -370,7 +370,7 @@ impl Client {
         self.core
             .event_bus
             .dispatch(wacore::types::events::Event::Message(
-                Box::new(message),
+                Arc::new(message),
                 message_info,
             ));
     }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -386,7 +386,7 @@ pub enum Event {
     QrScannedWithoutMultidevice(QrScannedWithoutMultidevice),
     ClientOutdated(ClientOutdated),
 
-    Message(Box<wa::Message>, Arc<MessageInfo>),
+    Message(Arc<wa::Message>, Arc<MessageInfo>),
     Receipt(Receipt),
     UndecryptableMessage(UndecryptableMessage),
     #[serde(skip)]
@@ -466,7 +466,7 @@ pub struct MexNotification {
 }
 
 impl Event {
-    pub fn as_message(&self) -> Option<(&wa::Message, &MessageInfo)> {
+    pub fn as_message(&self) -> Option<(&Arc<wa::Message>, &MessageInfo)> {
         if let Event::Message(msg, info) = self {
             Some((msg, &**info))
         } else {


### PR DESCRIPTION
## Summary

Make `wa::Message` shareable via `Arc` from the dispatch site all the way to user
handlers, eliminating the deep-clone that previously happened on every received
message.

## Motivation

`wa::Message` carries media buffers and extended-text payloads (often >1 KB).
On the inbound path it was deep-cloned twice:

1. `Client::dispatch_message` → `Event::Message(Box::new(msg), ...)` (owned move into Box, fine)
2. `MessageContext::from_event` → `from_parts(&msg, ...)` → `Box::new(message.clone())` ← deep clone

Downstream bots that re-spawned per message (`tokio::spawn` with a cloned context
for fire-and-forget side effects) cloned the whole message again on every spawn.

## Changes

**Core (`wacore`)**

- `Event::Message(Box<wa::Message>, Arc<MessageInfo>)` → `Event::Message(Arc<wa::Message>, Arc<MessageInfo>)`
- `Event::as_message()` now returns `Option<(&Arc<wa::Message>, &MessageInfo)>` so
  callers that need to share ownership can `Arc::clone` cheaply

**Client (`whatsapp-rust`)**

- `MessageContext::message`: `Box<wa::Message>` → `Arc<wa::Message>`
- `MessageContext` derives `Clone` (refcount bump only)
- `MessageContext::from_event` clones the `Arc` instead of deep-cloning the message
- New `MessageContext::from_arc(Arc<wa::Message>, ...)` constructor for callers
  that already own an Arc
- Dispatch sites in `src/message.rs` and `src/pdo.rs` switched from
  `Box::new(...)` to `Arc::new(...)`

## Compatibility (pre-1.0 breakage)

- `Event::Message` variant signature changed (`Box` → `Arc`). Pattern matches
  like `Event::Message(msg, info)` keep working since both `Box` and `Arc`
  deref to `&wa::Message`. Code that explicitly constructed
  `Event::Message(Box::new(m), info)` needs to switch to `Arc::new`.
- `Event::as_message()` return type changed; field access via the returned
  `&Arc<wa::Message>` keeps compiling thanks to deref coercion.
- `MessageContext.message` type changed but the field stays `pub`. Reading via
  `ctx.message.field` continues to work via `Arc` deref. Code that moved out
  of the field (`let m = *ctx.message`) needs `(*ctx.message).clone()`.

## Precedent

The pattern matches what other Rust messaging libs do for shareable per-event
context: serenity's `Context` (Arc-internal, Clone-cheap), matrix-rust-sdk's
`Room`/`Client`, teloxide's `Bot`. Message payload itself is owned/Arc-shared
rather than boxed.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --exclude e2e-tests --tests` — no new warnings
- [x] `cargo test --workspace --exclude e2e-tests --lib` — 1378 passed, 0 failed
- [x] `cargo check` covers `e2e-tests` compilation (full e2e run requires the mock server)