### PR TITLE
feat(groups): return full GroupMetadata from create_group / community.create

### DIFF
--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -60,10 +60,9 @@ impl CreateCommunityOptions {
 }
 
 /// Result of creating a community.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct CreateCommunityResult {
-    /// JID of the created community parent group.
-    pub gid: Jid,
+    pub metadata: GroupMetadata,
 }
 
 /// A subgroup within a community.
@@ -135,22 +134,23 @@ impl<'a> Community<'a> {
             ..Default::default()
         };
 
-        let gid = self
+        let group = self
             .client
             .execute(GroupCreateIq::new(create_options))
             .await?;
+        let mut metadata = GroupMetadata::from(group);
 
-        // Set description via follow-up IQ if provided
         if let Some(desc_text) = description
             && let Ok(desc) = wacore::iq::groups::GroupDescription::new(&desc_text)
         {
             self.client
                 .groups()
-                .set_description(&gid, Some(desc), None)
+                .set_description(&metadata.id, Some(desc), None)
                 .await?;
+            metadata.description = Some(desc_text);
         }
 
-        Ok(CreateCommunityResult { gid })
+        Ok(CreateCommunityResult { metadata })
     }
 
     /// Deactivate (delete) a community. Subgroups are unlinked but not deleted.

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -172,9 +172,9 @@ impl From<GroupInfoResponse> for GroupMetadata {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct CreateGroupResult {
-    pub gid: Jid,
+    pub metadata: GroupMetadata,
 }
 
 pub struct Groups<'a> {
@@ -303,9 +303,11 @@ impl<'a> Groups<'a> {
                 .await;
         }
 
-        let gid = self.client.execute(GroupCreateIq::new(options)).await?;
+        let group = self.client.execute(GroupCreateIq::new(options)).await?;
 
-        Ok(CreateGroupResult { gid })
+        Ok(CreateGroupResult {
+            metadata: GroupMetadata::from(group),
+        })
     }
 
     pub async fn set_subject(&self, jid: &Jid, subject: GroupSubject) -> Result<(), anyhow::Error> {

--- a/tests/e2e/tests/community.rs
+++ b/tests/e2e/tests/community.rs
@@ -16,15 +16,19 @@ async fn test_community_create() -> anyhow::Result<()> {
         .await?;
 
     assert!(
-        result.gid.server == "g.us",
+        result.metadata.id.server == "g.us",
         "community JID should be a group: {}",
-        result.gid
+        result.metadata.id
     );
 
-    info!("Created community: {}", result.gid);
+    info!("Created community: {}", result.metadata.id);
 
     // Query the community and verify it's a parent group
-    let metadata = client.client.groups().get_metadata(&result.gid).await?;
+    let metadata = client
+        .client
+        .groups()
+        .get_metadata(&result.metadata.id)
+        .await?;
     assert!(metadata.is_parent_group, "should be a parent group");
     assert_eq!(group_type(&metadata), GroupType::Community);
 
@@ -50,10 +54,14 @@ async fn test_community_create_with_general_chat() -> anyhow::Result<()> {
         })
         .await?;
 
-    info!("Created community: {}", result.gid);
+    info!("Created community: {}", result.metadata.id);
 
     // Fetch subgroups — should have at least a default announcement subgroup
-    let subgroups = client.client.community().get_subgroups(&result.gid).await?;
+    let subgroups = client
+        .client
+        .community()
+        .get_subgroups(&result.metadata.id)
+        .await?;
 
     assert!(
         !subgroups.is_empty(),
@@ -106,7 +114,11 @@ async fn test_community_get_subgroups() -> anyhow::Result<()> {
         .create(CreateCommunityOptions::new("Subgroups Test"))
         .await?;
 
-    let subgroups = client.client.community().get_subgroups(&result.gid).await?;
+    let subgroups = client
+        .client
+        .community()
+        .get_subgroups(&result.metadata.id)
+        .await?;
 
     // A newly created community should have an auto-created default subgroup
     assert!(
@@ -116,7 +128,7 @@ async fn test_community_get_subgroups() -> anyhow::Result<()> {
 
     info!(
         "Community {} has {} subgroup(s)",
-        result.gid,
+        result.metadata.id,
         subgroups.len()
     );
 
@@ -137,7 +149,7 @@ async fn test_community_link_subgroup() -> anyhow::Result<()> {
         .create(CreateCommunityOptions::new("Link Test Community"))
         .await?;
 
-    info!("Created community: {}", community.gid);
+    info!("Created community: {}", community.metadata.id);
 
     // Create a regular group to link as a subgroup
     let group = client
@@ -146,13 +158,16 @@ async fn test_community_link_subgroup() -> anyhow::Result<()> {
         .create_group(GroupCreateOptions::new("Sub Group"))
         .await?;
 
-    info!("Created group: {}", group.gid);
+    info!("Created group: {}", group.metadata.id);
 
     // Link the group to the community
     let link_result = client
         .client
         .community()
-        .link_subgroups(&community.gid, std::slice::from_ref(&group.gid))
+        .link_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+        )
         .await?;
 
     assert!(
@@ -161,21 +176,21 @@ async fn test_community_link_subgroup() -> anyhow::Result<()> {
         link_result.failed_groups
     );
     assert!(
-        link_result.linked_jids.contains(&group.gid),
+        link_result.linked_jids.contains(&group.metadata.id),
         "linked JIDs should contain the subgroup"
     );
 
-    info!("Linked subgroup {} to community", group.gid);
+    info!("Linked subgroup {} to community", group.metadata.id);
 
     // Verify the subgroup appears in the community's subgroup list
     let subgroups = client
         .client
         .community()
-        .get_subgroups(&community.gid)
+        .get_subgroups(&community.metadata.id)
         .await?;
 
     assert!(
-        subgroups.iter().any(|s| s.id == group.gid),
+        subgroups.iter().any(|s| s.id == group.metadata.id),
         "linked group should appear in subgroup list"
     );
 
@@ -205,19 +220,26 @@ async fn test_community_unlink_subgroup() -> anyhow::Result<()> {
     client
         .client
         .community()
-        .link_subgroups(&community.gid, std::slice::from_ref(&group.gid))
+        .link_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+        )
         .await?;
 
     info!(
         "Linked subgroup {} to community {}",
-        group.gid, community.gid
+        group.metadata.id, community.metadata.id
     );
 
     // Unlink the subgroup
     let unlink_result = client
         .client
         .community()
-        .unlink_subgroups(&community.gid, std::slice::from_ref(&group.gid), false)
+        .unlink_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+            false,
+        )
         .await?;
 
     assert!(
@@ -225,21 +247,21 @@ async fn test_community_unlink_subgroup() -> anyhow::Result<()> {
         "no groups should fail unlinking"
     );
     assert!(
-        unlink_result.unlinked_jids.contains(&group.gid),
+        unlink_result.unlinked_jids.contains(&group.metadata.id),
         "unlinked JIDs should contain the subgroup"
     );
 
-    info!("Unlinked subgroup {}", group.gid);
+    info!("Unlinked subgroup {}", group.metadata.id);
 
     // Verify it's gone from the subgroup list
     let subgroups = client
         .client
         .community()
-        .get_subgroups(&community.gid)
+        .get_subgroups(&community.metadata.id)
         .await?;
 
     assert!(
-        !subgroups.iter().any(|s| s.id == group.gid),
+        !subgroups.iter().any(|s| s.id == group.metadata.id),
         "unlinked group should not appear in subgroup list"
     );
 
@@ -259,15 +281,23 @@ async fn test_community_deactivate() -> anyhow::Result<()> {
         .create(CreateCommunityOptions::new("Deactivate Test"))
         .await?;
 
-    info!("Created community: {}", community.gid);
+    info!("Created community: {}", community.metadata.id);
 
     // Deactivate the community
-    client.client.community().deactivate(&community.gid).await?;
+    client
+        .client
+        .community()
+        .deactivate(&community.metadata.id)
+        .await?;
 
-    info!("Deactivated community: {}", community.gid);
+    info!("Deactivated community: {}", community.metadata.id);
 
     // Querying the deactivated community should fail or return non-parent
-    let metadata_result = client.client.groups().get_metadata(&community.gid).await;
+    let metadata_result = client
+        .client
+        .groups()
+        .get_metadata(&community.metadata.id)
+        .await;
     match metadata_result {
         Ok(metadata) => {
             // If the server still returns the group, it should no longer be a parent
@@ -307,17 +337,20 @@ async fn test_community_query_linked_group() -> anyhow::Result<()> {
     client
         .client
         .community()
-        .link_subgroups(&community.gid, std::slice::from_ref(&group.gid))
+        .link_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+        )
         .await?;
 
     // Query the linked group's metadata from the community
     let metadata = client
         .client
         .community()
-        .query_linked_group(&community.gid, &group.gid)
+        .query_linked_group(&community.metadata.id, &group.metadata.id)
         .await?;
 
-    assert_eq!(metadata.id, group.gid, "metadata JID should match");
+    assert_eq!(metadata.id, group.metadata.id, "metadata JID should match");
     assert_eq!(metadata.subject, "Queryable Sub");
 
     info!(
@@ -365,14 +398,17 @@ async fn test_community_join_subgroup() -> anyhow::Result<()> {
     client_a
         .client
         .community()
-        .link_subgroups(&community.gid, std::slice::from_ref(&group.gid))
+        .link_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+        )
         .await?;
 
     // Add Client B to the community parent group first
     client_a
         .client
         .groups()
-        .add_participants(&community.gid, std::slice::from_ref(&jid_b_lid))
+        .add_participants(&community.metadata.id, std::slice::from_ref(&jid_b_lid))
         .await?;
 
     info!("Added client B to community, now joining subgroup");
@@ -381,10 +417,10 @@ async fn test_community_join_subgroup() -> anyhow::Result<()> {
     let metadata = client_b
         .client
         .community()
-        .join_subgroup(&community.gid, &group.gid)
+        .join_subgroup(&community.metadata.id, &group.metadata.id)
         .await?;
 
-    assert_eq!(metadata.id, group.gid);
+    assert_eq!(metadata.id, group.metadata.id);
 
     // Verify client B is in the subgroup's participant list (may be LID or PN)
     let b_in_subgroup = metadata.participants.iter().any(|p| {
@@ -402,7 +438,7 @@ async fn test_community_join_subgroup() -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     );
 
-    info!("Client B joined subgroup {}", group.gid);
+    info!("Client B joined subgroup {}", group.metadata.id);
 
     client_a.disconnect().await;
     client_b.disconnect().await;
@@ -431,14 +467,17 @@ async fn test_community_get_linked_groups_participants() -> anyhow::Result<()> {
     client
         .client
         .community()
-        .link_subgroups(&community.gid, std::slice::from_ref(&group.gid))
+        .link_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+        )
         .await?;
 
     // Get all participants across linked groups
     let participants = client
         .client
         .community()
-        .get_linked_groups_participants(&community.gid)
+        .get_linked_groups_participants(&community.metadata.id)
         .await?;
 
     let own_pn = client
@@ -501,14 +540,17 @@ async fn test_community_subgroup_participant_counts() -> anyhow::Result<()> {
     client
         .client
         .community()
-        .link_subgroups(&community.gid, std::slice::from_ref(&group.gid))
+        .link_subgroups(
+            &community.metadata.id,
+            std::slice::from_ref(&group.metadata.id),
+        )
         .await?;
 
     // Fetch participant counts
     let counts = client
         .client
         .community()
-        .get_subgroup_participant_counts(&community.gid)
+        .get_subgroup_participant_counts(&community.metadata.id)
         .await?;
 
     info!("Subgroup participant counts: {:?}", counts);
@@ -516,7 +558,7 @@ async fn test_community_subgroup_participant_counts() -> anyhow::Result<()> {
     // The linked subgroup should appear with a count >= 1 (at least the creator)
     let subgroup_count = counts
         .iter()
-        .find(|(jid, _)| *jid == group.gid)
+        .find(|(jid, _)| *jid == group.metadata.id)
         .map(|(_, count)| *count);
 
     assert!(

--- a/tests/e2e/tests/community.rs
+++ b/tests/e2e/tests/community.rs
@@ -23,7 +23,16 @@ async fn test_community_create() -> anyhow::Result<()> {
 
     info!("Created community: {}", result.metadata.id);
 
-    // Query the community and verify it's a parent group
+    // The create response itself should classify as a community without
+    // a follow-up metadata query — overlay in `GroupCreateIq::parse_response`
+    // restores `is_parent_group` even if the server omits `<parent>`.
+    assert!(
+        result.metadata.is_parent_group,
+        "create result should classify as a parent group"
+    );
+    assert_eq!(group_type(&result.metadata), GroupType::Community);
+
+    // Cross-check against a fresh `get_metadata` query.
     let metadata = client
         .client
         .groups()

--- a/tests/e2e/tests/device_cache.rs
+++ b/tests/e2e/tests/device_cache.rs
@@ -27,7 +27,7 @@ async fn test_group_send_uses_registry_cache_after_reconnect() -> anyhow::Result
             ..Default::default()
         })
         .await?;
-    let group_jid = group.gid;
+    let group_jid = group.metadata.id;
 
     // First send — populates device registry (in-memory cache + SQLite DB)
     let text_1 = "before reconnect";

--- a/tests/e2e/tests/groups.rs
+++ b/tests/e2e/tests/groups.rs
@@ -31,7 +31,7 @@ async fn test_group_create_send_message_and_add_member() -> anyhow::Result<()> {
         })
         .await?;
 
-    let group_jid = create_result.gid;
+    let group_jid = create_result.metadata.id;
     info!("Group created: {group_jid}");
 
     let text_1 = "Hello group from A!";
@@ -120,7 +120,8 @@ async fn test_group_remove_member() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     let text_before = "Before removal";
@@ -235,7 +236,7 @@ async fn test_group_promote_and_demote_admin() -> anyhow::Result<()> {
         })
         .await?;
 
-    let group_jid = create_result.gid;
+    let group_jid = create_result.metadata.id;
     info!("Group created: {group_jid}");
 
     // Verify B is NOT an admin initially
@@ -310,7 +311,8 @@ async fn test_group_cache_invalidation_on_add() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     // B sends a message to prime its group participant cache
@@ -381,7 +383,8 @@ async fn test_group_settings() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     // Verify initial state
@@ -544,7 +547,8 @@ async fn test_group_leave() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     let text_before = "Before B leaves";
@@ -636,7 +640,8 @@ async fn test_per_device_sender_key_tracking() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     // A sends first message — triggers full SKDM distribution to B
@@ -744,7 +749,8 @@ async fn test_query_info_populates_lid_pn_cache_for_participants() -> anyhow::Re
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
 
     // create_group doesn't populate the group cache, so the first query_info
     // hits the network and runs the lid_pn_cache populate loop.

--- a/tests/e2e/tests/memory_soak.rs
+++ b/tests/e2e/tests/memory_soak.rs
@@ -390,7 +390,8 @@ async fn test_heavy_group_soak() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group 1: {g1}");
 
     // Wait for notifications
@@ -412,7 +413,8 @@ async fn test_heavy_group_soak() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group 2: {g2}");
 
     client_b
@@ -533,7 +535,8 @@ async fn test_heavy_mixed_soak() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group: {group_jid}");
 
     for client in [&mut client_b, &mut client_c] {

--- a/tests/e2e/tests/offline_groups.rs
+++ b/tests/e2e/tests/offline_groups.rs
@@ -31,7 +31,8 @@ async fn test_offline_group_notification() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     // Drain create notifications before testing offline delivery
@@ -95,7 +96,8 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     client_c.wait_for_group_notification(10).await?;
@@ -217,7 +219,8 @@ async fn test_offline_group_message_delivery() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     client_b.wait_for_group_notification(10).await?;
@@ -301,7 +304,8 @@ async fn test_offline_multi_sender_group_messages() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group 1 created: {group1_jid}");
 
     let group2_jid = client_a
@@ -317,7 +321,8 @@ async fn test_offline_multi_sender_group_messages() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group 2 created: {group2_jid}");
 
     // Drain group creation notifications for all participants

--- a/tests/e2e/tests/receipts.rs
+++ b/tests/e2e/tests/receipts.rs
@@ -321,7 +321,8 @@ async fn test_group_delivery_receipt() -> anyhow::Result<()> {
             ..Default::default()
         })
         .await?
-        .gid;
+        .metadata
+        .id;
     info!("Group created: {group_jid}");
 
     client_b.wait_for_group_notification(10).await?;

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1029,7 +1029,9 @@ impl GroupCreateIq {
 }
 
 impl IqSpec for GroupCreateIq {
-    type Response = Jid;
+    // Server's `<create>` reply carries the full `<group>` node, so callers
+    // can skip a follow-up `get_metadata` IQ. Mirrors WA Web's CreateJob.
+    type Response = GroupInfoResponse;
 
     fn build_iq(&self) -> InfoQuery<'static> {
         InfoQuery::set(
@@ -1043,13 +1045,7 @@ impl IqSpec for GroupCreateIq {
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
         let group_node = required_child(response, "group")?;
-        let group_id_str = required_attr(group_node, "id")?;
-
-        if group_id_str.contains('@') {
-            group_id_str.parse().map_err(Into::into)
-        } else {
-            Ok(Jid::group(group_id_str))
-        }
+        GroupInfoResponse::try_from_node_ref(group_node)
     }
 }
 
@@ -3498,6 +3494,67 @@ mod tests {
             Some("5511999999999@s.whatsapp.net".parse().unwrap())
         );
         assert_eq!(response.description_time, Some(1700000000));
+    }
+
+    /// Mirrors a real `<create>` IQ result captured from WA Web (LID community).
+    /// The create reply omits `<description>`, `<locked>`, `<announcement>`,
+    /// `size`, etc. — only `id` is required by `try_from_node_ref`, so this
+    /// guards against accidentally promoting any of those to required.
+    #[test]
+    fn test_group_info_response_parses_create_response() {
+        let node = NodeBuilder::new("group")
+            .attr("id", "120363424766426717")
+            .attr("addressing_mode", "lid")
+            .attr("subject", "test")
+            .attr("creator", "236395184570386@lid")
+            .attr("creation", "1769039112")
+            .attr("s_t", "1769039112")
+            .attr("s_o", "236395184570386@lid")
+            .children([
+                NodeBuilder::new("ephemeral")
+                    .attr("expiration", 0u32)
+                    .build(),
+                NodeBuilder::new("member_link_mode")
+                    .string_content("admin_link")
+                    .build(),
+                NodeBuilder::new("member_add_mode")
+                    .string_content("all_member_add")
+                    .build(),
+                NodeBuilder::new("member_share_group_history_mode")
+                    .string_content("all_member_share")
+                    .build(),
+                NodeBuilder::new("participant")
+                    .attr("jid", "236395184570386@lid")
+                    .attr("type", "superadmin")
+                    .attr("phone_number", "559984726662@s.whatsapp.net")
+                    .build(),
+                NodeBuilder::new("participant")
+                    .attr("jid", "119009819262985@lid")
+                    .attr("phone_number", "559984696848@s.whatsapp.net")
+                    .build(),
+            ])
+            .build();
+
+        let response = GroupInfoResponse::try_from_node(&node).unwrap();
+
+        assert_eq!(response.id.to_string(), "120363424766426717@g.us");
+        assert_eq!(response.subject.as_str(), "test");
+        assert_eq!(response.addressing_mode, AddressingMode::Lid);
+        assert_eq!(response.creation_time, Some(1769039112));
+        assert_eq!(response.subject_time, Some(1769039112));
+        assert_eq!(response.member_link_mode, Some(MemberLinkMode::AdminLink));
+        assert_eq!(response.member_add_mode, Some(MemberAddMode::AllMemberAdd));
+        assert_eq!(
+            response.member_share_history_mode,
+            Some(MemberShareHistoryMode::AllMemberShare)
+        );
+        assert_eq!(response.participants.len(), 2);
+        // Fields absent from the create response: should default cleanly
+        assert!(response.description.is_none());
+        assert!(!response.is_locked);
+        assert!(!response.is_announcement);
+        assert!(!response.is_parent_group);
+        assert!(response.size.is_none());
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1051,9 +1051,12 @@ impl IqSpec for GroupCreateIq {
         // from the create reply (WA Web's CreateJob never reads them either),
         // so propagate the request flags so a freshly created community classifies
         // correctly via `group_type()` without a follow-up metadata query.
+        // `allow_non_admin_sub_group_creation` is one-directional (request only
+        // fills when server omitted) so a server-set `true` is never clobbered
+        // by a `false` request flag.
         if self.options.is_parent {
             info.is_parent_group = true;
-            info.allow_non_admin_sub_group_creation =
+            info.allow_non_admin_sub_group_creation |=
                 self.options.allow_non_admin_sub_group_creation;
         }
 
@@ -3533,6 +3536,82 @@ mod tests {
 
         assert!(response.is_parent_group);
         assert!(response.allow_non_admin_sub_group_creation);
+    }
+
+    /// Overlay must not promote a `false` request flag to `true`.
+    /// With `is_parent = true` but `allow_non_admin_sub_group_creation = false`,
+    /// `is_parent_group` is restored from the request, but
+    /// `allow_non_admin_sub_group_creation` stays `false`.
+    #[test]
+    fn test_group_create_iq_overlay_does_not_elevate_false_flag() {
+        let options = GroupCreateOptions {
+            subject: "Closed Community".into(),
+            is_parent: true,
+            allow_non_admin_sub_group_creation: false,
+            ..Default::default()
+        };
+        let spec = GroupCreateIq::new(options);
+
+        let iq = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("group")
+                .attr("id", "120363000000000001")
+                .attr("subject", "Closed Community")
+                .build()])
+            .build();
+        let response = spec.parse_response(&iq.as_node_ref()).unwrap();
+
+        assert!(response.is_parent_group);
+        assert!(!response.allow_non_admin_sub_group_creation);
+    }
+
+    /// Server-set `<allow_non_admin_sub_group_creation>` must survive a
+    /// `false` request flag — overlay is one-directional (request fills only
+    /// when server omitted).
+    #[test]
+    fn test_group_create_iq_overlay_preserves_server_true() {
+        let options = GroupCreateOptions {
+            subject: "Community".into(),
+            is_parent: true,
+            allow_non_admin_sub_group_creation: false,
+            ..Default::default()
+        };
+        let spec = GroupCreateIq::new(options);
+
+        let iq = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("group")
+                .attr("id", "120363000000000001")
+                .attr("subject", "Community")
+                .children([NodeBuilder::new("allow_non_admin_sub_group_creation").build()])
+                .build()])
+            .build();
+        let response = spec.parse_response(&iq.as_node_ref()).unwrap();
+
+        assert!(response.is_parent_group);
+        assert!(response.allow_non_admin_sub_group_creation);
+    }
+
+    /// Plain (non-community) group create: overlay branch must not run, both
+    /// flags stay at the parsed defaults (`false`).
+    #[test]
+    fn test_group_create_iq_no_overlay_for_plain_group() {
+        let options = GroupCreateOptions {
+            subject: "Plain Group".into(),
+            is_parent: false,
+            allow_non_admin_sub_group_creation: false,
+            ..Default::default()
+        };
+        let spec = GroupCreateIq::new(options);
+
+        let iq = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("group")
+                .attr("id", "120363000000000001")
+                .attr("subject", "Plain Group")
+                .build()])
+            .build();
+        let response = spec.parse_response(&iq.as_node_ref()).unwrap();
+
+        assert!(!response.is_parent_group);
+        assert!(!response.allow_non_admin_sub_group_creation);
     }
 
     /// Mirrors the wire-format shape of a real `<create>` IQ result for a LID

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1045,7 +1045,19 @@ impl IqSpec for GroupCreateIq {
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
         let group_node = required_child(response, "group")?;
-        GroupInfoResponse::try_from_node_ref(group_node)
+        let mut info = GroupInfoResponse::try_from_node_ref(group_node)?;
+
+        // The server may omit `<parent>` / `<allow_non_admin_sub_group_creation>`
+        // from the create reply (WA Web's CreateJob never reads them either),
+        // so propagate the request flags so a freshly created community classifies
+        // correctly via `group_type()` without a follow-up metadata query.
+        if self.options.is_parent {
+            info.is_parent_group = true;
+            info.allow_non_admin_sub_group_creation =
+                self.options.allow_non_admin_sub_group_creation;
+        }
+
+        Ok(info)
     }
 }
 
@@ -3494,6 +3506,33 @@ mod tests {
             Some("5511999999999@s.whatsapp.net".parse().unwrap())
         );
         assert_eq!(response.description_time, Some(1700000000));
+    }
+
+    /// `parse_response` should overlay `is_parent_group` and
+    /// `allow_non_admin_sub_group_creation` from the request when the server
+    /// omits `<parent>` from a community-create reply (WA Web's CreateJob
+    /// never reads parent markers from the response either).
+    #[test]
+    fn test_group_create_iq_overlays_parent_flags() {
+        let options = GroupCreateOptions {
+            subject: "My Community".into(),
+            is_parent: true,
+            allow_non_admin_sub_group_creation: true,
+            ..Default::default()
+        };
+        let spec = GroupCreateIq::new(options);
+
+        // Server reply with no `<parent>` / `<allow_non_admin_sub_group_creation>`
+        let iq = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("group")
+                .attr("id", "120363000000000001")
+                .attr("subject", "My Community")
+                .build()])
+            .build();
+        let response = spec.parse_response(&iq.as_node_ref()).unwrap();
+
+        assert!(response.is_parent_group);
+        assert!(response.allow_non_admin_sub_group_creation);
     }
 
     /// Mirrors a real `<create>` IQ result captured from WA Web (LID community).

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -3535,20 +3535,21 @@ mod tests {
         assert!(response.allow_non_admin_sub_group_creation);
     }
 
-    /// Mirrors a real `<create>` IQ result captured from WA Web (LID community).
-    /// The create reply omits `<description>`, `<locked>`, `<announcement>`,
-    /// `size`, etc. — only `id` is required by `try_from_node_ref`, so this
-    /// guards against accidentally promoting any of those to required.
+    /// Mirrors the wire-format shape of a real `<create>` IQ result for a LID
+    /// community: only `id` is required, and the create reply omits
+    /// `<description>`, `<locked>`, `<announcement>`, `size`, etc. — guards
+    /// against accidentally promoting any of those to required.
+    /// JIDs/timestamps below are fictitious per the AGENTS.md test policy.
     #[test]
     fn test_group_info_response_parses_create_response() {
         let node = NodeBuilder::new("group")
-            .attr("id", "120363424766426717")
+            .attr("id", "120363000000000001")
             .attr("addressing_mode", "lid")
             .attr("subject", "test")
-            .attr("creator", "236395184570386@lid")
-            .attr("creation", "1769039112")
-            .attr("s_t", "1769039112")
-            .attr("s_o", "236395184570386@lid")
+            .attr("creator", "100000000000001@lid")
+            .attr("creation", "1700000000")
+            .attr("s_t", "1700000000")
+            .attr("s_o", "100000000000001@lid")
             .children([
                 NodeBuilder::new("ephemeral")
                     .attr("expiration", 0u32)
@@ -3563,24 +3564,24 @@ mod tests {
                     .string_content("all_member_share")
                     .build(),
                 NodeBuilder::new("participant")
-                    .attr("jid", "236395184570386@lid")
+                    .attr("jid", "100000000000001@lid")
                     .attr("type", "superadmin")
-                    .attr("phone_number", "559984726662@s.whatsapp.net")
+                    .attr("phone_number", "5511999999999@s.whatsapp.net")
                     .build(),
                 NodeBuilder::new("participant")
-                    .attr("jid", "119009819262985@lid")
-                    .attr("phone_number", "559984696848@s.whatsapp.net")
+                    .attr("jid", "100000000000002@lid")
+                    .attr("phone_number", "5511988888888@s.whatsapp.net")
                     .build(),
             ])
             .build();
 
         let response = GroupInfoResponse::try_from_node(&node).unwrap();
 
-        assert_eq!(response.id.to_string(), "120363424766426717@g.us");
+        assert_eq!(response.id.to_string(), "120363000000000001@g.us");
         assert_eq!(response.subject.as_str(), "test");
         assert_eq!(response.addressing_mode, AddressingMode::Lid);
-        assert_eq!(response.creation_time, Some(1769039112));
-        assert_eq!(response.subject_time, Some(1769039112));
+        assert_eq!(response.creation_time, Some(1700000000));
+        assert_eq!(response.subject_time, Some(1700000000));
         assert_eq!(response.member_link_mode, Some(MemberLinkMode::AdminLink));
         assert_eq!(response.member_add_mode, Some(MemberAddMode::AllMemberAdd));
         assert_eq!(


### PR DESCRIPTION
## Summary

The server's reply to a `<create>` IQ already carries the complete `<group>` node — identical in shape to a `<query>` response. This PR parses it as `GroupInfoResponse` so callers can skip the follow-up `get_metadata` IQ, mirroring WA Web's `CreateJob`.

- `wacore/src/iq/groups.rs`: `GroupCreateIq::Response` is now `GroupInfoResponse` (was `Jid`).
- `src/features/groups.rs`: `CreateGroupResult { gid: Jid }` → `CreateGroupResult { metadata: GroupMetadata }`.
- `src/features/community.rs`: same shape change for `CreateCommunityResult`. When a description is supplied via the follow-up `set_description` IQ, the local `metadata.description` is updated so the returned struct is consistent.
- e2e tests updated: `result.gid` → `result.metadata.id` across 6 files.

## Breaking change (pre-1.0)

`CreateGroupResult.gid` and `CreateCommunityResult.gid` are gone. Migration:

```rust
let result = client.groups().create_group(opts).await?;
- let jid = result.gid;
+ let jid = result.metadata.id;
```

`PartialEq, Eq` derives were dropped since `GroupMetadata` does not implement them.

## WA Web cross-reference

- `docs/captured-js/WAWeb/Group/CreateJob.js:131-186` — extracts `groupId`, `groupCreator`, `groupCreation`, `subject`, `groupParticipant[]` directly from the `<create>` response.
- A real captured `<create>` reply (LID community, attached to the discussion that drove this) confirms the shape: `id`, `addressing_mode`, `subject`, `creator(_pn)`, `creation`, `s_t`, `s_o(_pn)`, `<ephemeral>`, `<member_link_mode>`, `<member_add_mode>`, `<member_share_group_history_mode>`, `<participant>` — no `<description>`, `<locked>`, `<announcement>`, `<parent>`, or `size` attribute. The new test reproduces this exact shape.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests` (no warnings)
- [x] `cargo test --workspace --exclude e2e-tests` (all green)
- [x] New unit test `test_group_info_response_parses_create_response` reproducing the captured `<create>` payload (passes)
- [ ] e2e tests require the mock server to verify against live LID/PN flows