### PR TITLE
chore(release): bump workspace to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wacore"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "wacore-appstate"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2183,7 +2183,7 @@ dependencies = [
 
 [[package]]
 name = "wacore-binary"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "compact_str",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "wacore-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "wacore-libsignal"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "arrayref",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "wacore-noise"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "waproto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-sqlite-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-tokio-transport"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "whatsapp-rust"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"
@@ -83,13 +83,13 @@ tokio = { version = "1.48.0", default-features = false }
 uuid = { version = "1", default-features = false }
 
 # Internal workspace crates
-wacore = { path = "./wacore", default-features = false, version = "0.5.0" }
-wacore-appstate = { path = "./wacore/appstate", default-features = false, version = "0.5.0" }
-wacore-binary = { path = "./wacore/binary", default-features = false, version = "0.5.0" }
-wacore-derive = { path = "./wacore/derive", version = "0.5.0" }
-wacore-libsignal = { path = "./wacore/libsignal", version = "0.5.0" }
-wacore-noise = { path = "./wacore/noise", version = "0.5.0" }
-waproto = { path = "./waproto", version = "0.5.0" }
+wacore = { path = "./wacore", default-features = false, version = "0.6.0" }
+wacore-appstate = { path = "./wacore/appstate", default-features = false, version = "0.6.0" }
+wacore-binary = { path = "./wacore/binary", default-features = false, version = "0.6.0" }
+wacore-derive = { path = "./wacore/derive", version = "0.6.0" }
+wacore-libsignal = { path = "./wacore/libsignal", version = "0.6.0" }
+wacore-noise = { path = "./wacore/noise", version = "0.6.0" }
+waproto = { path = "./waproto", version = "0.6.0" }
 yoke = { version = "0.8", features = ["derive"] }
 
 [features]
@@ -141,9 +141,9 @@ tokio = { workspace = true, features = ["macros", "rt", "sync", "time"], optiona
 wacore = { workspace = true }
 wacore-binary = { workspace = true }
 waproto = { workspace = true }
-whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.5.0", optional = true }
-whatsapp-rust-tokio-transport = { path = "./transports/tokio-transport", version = "0.5.0", optional = true }
-whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version = "0.5.0", optional = true }
+whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.6.0", optional = true }
+whatsapp-rust-tokio-transport = { path = "./transports/tokio-transport", version = "0.6.0", optional = true }
+whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version = "0.6.0", optional = true }
 
 [dev-dependencies]
 uuid = { workspace = true, features = ["v4"] }

--- a/http_clients/ureq-client/Cargo.toml
+++ b/http_clients/ureq-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatsapp-rust-ureq-http-client"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatsapp-rust-sqlite-storage"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatsapp-rust-tokio-transport"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wacore"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wacore-appstate"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wacore-binary"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/wacore/derive/Cargo.toml
+++ b/wacore/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wacore-derive"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wacore-libsignal"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wacore-noise"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"

--- a/waproto/Cargo.toml
+++ b/waproto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waproto"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["João Lucas <jlucaso@hotmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump every published workspace crate from 0.5.0 to 0.6.0 ahead of the next release.

Generated by:

\`\`\`bash
cargo release version 0.6.0 --workspace --execute
\`\`\`

This matches \`cargo-release@0.25.20\` pinned in the release workflow.

## Notes

- All 10 published crates are touched: \`whatsapp-rust\`, \`wacore\`, \`wacore-binary\`, \`wacore-derive\`, \`wacore-libsignal\`, \`wacore-noise\`, \`wacore-appstate\`, \`waproto\`, \`whatsapp-rust-sqlite-storage\`, \`whatsapp-rust-tokio-transport\`, \`whatsapp-rust-ureq-http-client\`.
- The matching \`version = "..."\` pins under \`[workspace.dependencies]\` in the root \`Cargo.toml\` are bumped, and \`Cargo.lock\` is updated.
- \`e2e-tests\` and \`bench-integration\` (both \`publish = false\`) were also touched by \`cargo release version\` (from 0.0.0 to 0.6.0) and **reverted** to keep their existing 0.0.0 convention.

## After merge

Trigger the **Release** workflow via *Actions → Release → Run workflow → main*. It will:

1. Validate (fmt / clippy / tests / no-SIMD stable / e2e).
2. \`cargo release publish --workspace --execute --no-confirm\` to crates.io.
3. Tag \`v0.6.0\` and create a GitHub Release with auto-generated notes.

## Test plan

- [x] \`cargo build --workspace --exclude e2e-tests\` — succeeds.
- [ ] Release workflow validation jobs pass on this PR.