### PR TITLE
ci(release): install cargo-release via taiki-e action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
           tool: protoc@${{ env.PROTOC_VERSION }}
 
       - name: Install cargo-release
-        run: cargo install cargo-release --locked --version 0.25.20
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release@0.25.20
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
## Problem

The 0.6.0 release run failed at the \`Install cargo-release\` step:

\`\`\`
error: could not execute process \`sccache /home/runner/.rustup/toolchains/.../rustc -vV\` (never executed)
Caused by:
  No such file or directory (os error 2)
Error: Process completed with exit code 101.
\`\`\`

Root cause: the workflow sets \`RUSTC_WRAPPER: sccache\` globally, but \`Setup sccache\` runs *after* \`Install cargo-release\`. The cargo install step compiles cargo-release from source, and rustc's initial \`-vV\` probe is invoked through the wrapper — which doesn't exist on disk yet.

## Fix

Swap the \`cargo install\` step for \`taiki-e/install-action@v2\`, which downloads a prebuilt cargo-release binary. No compile path → no \`RUSTC_WRAPPER\` involvement, and it's the same pattern already used to install \`protoc\` two steps above. Faster too (a couple seconds vs minutes compiling cargo-release).

## After merge

Re-trigger the **Release** workflow via *Actions → Release → Run workflow → main*.

## Test plan

- [ ] Release workflow validation jobs pass on this PR (they don't exercise this step but verify nothing else regressed).
- [ ] After merge, re-run Release on main and confirm the \`Install cargo-release\` step succeeds before \`Setup sccache\`.