### PR TITLE
fix(send): admin revoke not applied on recipient devices

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -434,6 +434,8 @@ impl Client {
             let _session_guard = session_mutex.lock().await;
             let mut store_adapter = self.signal_adapter().await;
 
+            let edit_attr =
+                wacore::types::message::EditAttribute::infer_from_message(&original_msg);
             let stanza = wacore::send::prepare_group_retry_stanza(
                 &mut store_adapter.session_store,
                 &mut store_adapter.identity_store,
@@ -445,6 +447,7 @@ impl Client {
                 retry_count,
                 device_snapshot.account.as_ref(),
                 addressing_mode,
+                edit_attr,
             )
             .await?;
 
@@ -464,6 +467,8 @@ impl Client {
             let _session_guard = session_mutex.lock().await;
             let mut store_adapter = self.signal_adapter().await;
 
+            let edit_attr =
+                wacore::types::message::EditAttribute::infer_from_message(&original_msg);
             let stanza = wacore::send::prepare_dm_retry_stanza(
                 &mut store_adapter.session_store,
                 &mut store_adapter.identity_store,
@@ -474,6 +479,7 @@ impl Client {
                 message_id,
                 retry_count,
                 device_snapshot.account.as_ref(),
+                edit_attr,
             )
             .await?;
 

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -51,7 +51,12 @@ pub fn extract_ciphertext(msg: CiphertextMessage) -> Option<(&'static str, bool,
 
 /// Unwrap wrapper message types to reach the inner message.
 /// Matches WA Web's getUnwrappedProtobufMessage (EProtoUtils.js:19-35).
-fn unwrap_message(msg: &wa::Message) -> &wa::Message {
+///
+/// Public so the retry-edit-inference path can descend through neutral
+/// wrappers (ephemeral / view_once / device_sent) before checking for
+/// pin/edit/revoke fields. Does **not** unwrap `edited_message` — that field
+/// is itself the signal we're trying to detect.
+pub fn unwrap_message(msg: &wa::Message) -> &wa::Message {
     macro_rules! try_unwrap {
         ($($field:ident),+ $(,)?) => {
             $(
@@ -204,6 +209,28 @@ pub fn media_type_from_message(msg: &wa::Message) -> Option<&'static str> {
         return Some("url");
     }
     None
+}
+
+/// Canonical rule for the `decrypt-fail="hide"` attribute on outgoing `<enc>`
+/// nodes. Centralizes the predicate used across DM peer fanout, group SKDM
+/// distribution and group SKMSG to avoid drift — that drift was the root
+/// cause of admin revokes silently failing for the SKDM path.
+///
+/// `true` means: emit `decrypt-fail="hide"`. Returns:
+/// * `true` for any non-`Empty` edit *except* `AdminRevoke` — the server
+///   rejects revoke stanzas carrying the hide attribute (per the
+///   `test_decrypt_fail_hide_logic_for_edits` test in `types::message`).
+/// * `true` for infrastructure messages that match `should_hide_decrypt_fail`
+///   (reactions, pin changes, poll updates, etc.).
+/// * `false` otherwise.
+pub fn should_hide_decrypt_fail_for_send(
+    edit: Option<&crate::types::message::EditAttribute>,
+    msg: &wa::Message,
+) -> bool {
+    edit.is_some_and(|e| {
+        *e != crate::types::message::EditAttribute::Empty
+            && *e != crate::types::message::EditAttribute::AdminRevoke
+    }) || should_hide_decrypt_fail(msg)
 }
 
 /// Infrastructure messages get decrypt-fail="hide" so recipients don't see
@@ -859,10 +886,7 @@ pub async fn prepare_dm_stanza<
     let mut participant_nodes = Vec::with_capacity(total_devices);
     let mut includes_prekey_message = false;
 
-    let hide_decrypt_fail = edit
-        .as_ref()
-        .is_some_and(|e| *e != crate::types::message::EditAttribute::Empty)
-        || should_hide_decrypt_fail(message);
+    let hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit.as_ref(), message);
 
     let mediatype = media_type_from_message(message);
 
@@ -995,6 +1019,7 @@ pub async fn prepare_dm_retry_stanza<S, I>(
     message_id: String,
     retry_count: u8,
     account: Option<&wa::AdvSignedDeviceIdentity>,
+    edit: Option<crate::types::message::EditAttribute>,
 ) -> Result<Node>
 where
     S: crate::libsignal::protocol::SessionStore,
@@ -1037,12 +1062,19 @@ where
         );
     }
 
-    Ok(NodeBuilder::new("message")
+    let mut stanza_builder = NodeBuilder::new("message")
         .attr("to", to_jid)
         .attr("id", message_id)
-        .attr("type", stanza_type_from_message(message))
-        .children(children)
-        .build())
+        .attr("type", stanza_type_from_message(message));
+
+    // Preserve edit attribute on retry — same reason as the group path.
+    if let Some(e) = edit
+        && e != crate::types::message::EditAttribute::Empty
+    {
+        stanza_builder = stanza_builder.attr("edit", e.to_string_val());
+    }
+
+    Ok(stanza_builder.children(children).build())
 }
 
 /// Pairwise-encrypted retry stanza for a single group participant.
@@ -1060,6 +1092,7 @@ pub async fn prepare_group_retry_stanza<S, I>(
     retry_count: u8,
     account: Option<&wa::AdvSignedDeviceIdentity>,
     addressing_mode: crate::types::message::AddressingMode,
+    edit: Option<crate::types::message::EditAttribute>,
 ) -> Result<Node>
 where
     S: crate::libsignal::protocol::SessionStore,
@@ -1103,6 +1136,17 @@ where
 
     // WA Web always sets addressing_mode for groups (MsgCreateDeviceStanza.js:131-135)
     stanza_builder = stanza_builder.attr("addressing_mode", addressing_mode.as_str());
+
+    // Preserve the edit attribute on retry — without it the client receives the
+    // resend as a normal message and never applies the revoke/edit. Symptom:
+    // admin revoke worked for devices that decrypted on first try, but devices
+    // that sent a retry receipt got the resend without `edit="8"` and the
+    // image/message stayed visible for them.
+    if let Some(e) = edit
+        && e != crate::types::message::EditAttribute::Empty
+    {
+        stanza_builder = stanza_builder.attr("edit", e.to_string_val());
+    }
 
     Ok(stanza_builder.children(children).build())
 }
@@ -1323,13 +1367,19 @@ pub async fn prepare_group_stanza<
         // WA Web's GroupSkmsgJob wraps ensureE2ESessions in try/catch — logs error
         // but does NOT rethrow. SKDM distribution failure must not prevent the group
         // message from being sent. Only successfully encrypted devices are tracked.
+        //
+        // hide_decrypt_fail: matches the main skmsg payload — `false` for AdminRevoke
+        // (server rejects revoke when SKDM has `decrypt-fail="hide"`; some clients
+        // never decrypt the skmsg principal and never apply the revoke), `true` for
+        // other edits and infrastructure messages.
+        let skdm_hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit.as_ref(), message);
         match encrypt_for_devices(
             runtime,
             stores,
             resolver,
             distribution_list,
             &skdm_plaintext_to_encrypt,
-            true,
+            skdm_hide_decrypt_fail,
             None,
         )
         .await
@@ -1381,10 +1431,7 @@ pub async fn prepare_group_stanza<
     let skmsg_ciphertext = skmsg.into_serialized();
 
     let mediatype = media_type_from_message(message);
-    let hide_decrypt_fail = (edit.as_ref().is_some_and(|e| {
-        *e != crate::types::message::EditAttribute::Empty
-            && *e != crate::types::message::EditAttribute::AdminRevoke
-    })) || should_hide_decrypt_fail(message);
+    let hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit.as_ref(), message);
 
     let mut enc_builder = NodeBuilder::new("enc")
         .attr("v", stanza::ENC_VERSION)
@@ -2842,6 +2889,7 @@ mod tests {
                 1,
                 None,
                 AddressingMode::Pn,
+                None,
             )
             .await
             .unwrap();
@@ -2891,6 +2939,7 @@ mod tests {
                 &wa::Message::default(),
                 "dm-retry-1".into(),
                 1,
+                None,
                 None,
             )
             .await
@@ -2948,6 +2997,7 @@ mod tests {
                 "dm-retry-2".into(),
                 2,
                 Some(&acc),
+                None,
             )
             .await
             .unwrap();
@@ -2984,6 +3034,7 @@ mod tests {
                 2,
                 Some(&acc),
                 AddressingMode::Pn,
+                None,
             )
             .await
             .unwrap();
@@ -3023,6 +3074,7 @@ mod tests {
                 3,
                 Some(&wa::AdvSignedDeviceIdentity::default()),
                 AddressingMode::Lid,
+                None,
             )
             .await
             .unwrap();
@@ -3035,6 +3087,77 @@ mod tests {
                     .as_ref(),
                 "lid"
             );
+        }
+
+        // Regression: retry resends must preserve the original `edit` wire
+        // attribute. Without it, admin revokes were re-sent as plain messages
+        // on retry and the client never applied the revoke for that device.
+        #[tokio::test]
+        async fn group_retry_preserves_edit_attribute() {
+            let (mut ss, mut is, jid) = setup_session().await;
+            let group: Jid = "120363098765432100@g.us".parse().unwrap();
+            let p: Jid = jid.to_string().parse().unwrap();
+            let n = prepare_group_retry_stanza(
+                &mut ss,
+                &mut is,
+                group,
+                p.clone(),
+                p,
+                &wa::Message::default(),
+                "revoke-1".into(),
+                1,
+                None,
+                AddressingMode::Lid,
+                Some(crate::types::message::EditAttribute::AdminRevoke),
+            )
+            .await
+            .unwrap();
+            assert_eq!(n.attrs().optional_string("edit").unwrap().as_ref(), "8");
+        }
+
+        #[tokio::test]
+        async fn dm_retry_preserves_edit_attribute() {
+            let (mut ss, mut is, jid) = setup_session().await;
+            let to: Jid = "559922223333@s.whatsapp.net".parse().unwrap();
+            let requester: Jid = jid.to_string().parse().unwrap();
+            let n = prepare_dm_retry_stanza(
+                &mut ss,
+                &mut is,
+                to,
+                requester.clone(),
+                requester,
+                &wa::Message::default(),
+                "edit-1".into(),
+                1,
+                None,
+                Some(crate::types::message::EditAttribute::MessageEdit),
+            )
+            .await
+            .unwrap();
+            assert_eq!(n.attrs().optional_string("edit").unwrap().as_ref(), "1");
+        }
+
+        #[tokio::test]
+        async fn retry_without_edit_omits_attribute() {
+            let (mut ss, mut is, jid) = setup_session().await;
+            let group: Jid = "120363098765432100@g.us".parse().unwrap();
+            let p: Jid = jid.to_string().parse().unwrap();
+            let n = prepare_group_retry_stanza(
+                &mut ss,
+                &mut is,
+                group,
+                p.clone(),
+                p,
+                &wa::Message::default(),
+                "plain-1".into(),
+                1,
+                None,
+                AddressingMode::Lid,
+                None,
+            )
+            .await
+            .unwrap();
+            assert!(n.attrs().optional_string("edit").is_none());
         }
     }
 

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -50,13 +50,9 @@ pub fn extract_ciphertext(msg: CiphertextMessage) -> Option<(&'static str, bool,
 }
 
 /// Unwrap wrapper message types to reach the inner message.
-/// Matches WA Web's getUnwrappedProtobufMessage (EProtoUtils.js:19-35).
-///
-/// Public so the retry-edit-inference path can descend through neutral
-/// wrappers (ephemeral / view_once / device_sent) before checking for
-/// pin/edit/revoke fields. Does **not** unwrap `edited_message` — that field
-/// is itself the signal we're trying to detect.
-pub fn unwrap_message(msg: &wa::Message) -> &wa::Message {
+/// Matches WA Web's getUnwrappedProtobufMessage. Does not unwrap
+/// `edited_message`; that field is itself a signal callers may need.
+pub(crate) fn unwrap_message(msg: &wa::Message) -> &wa::Message {
     macro_rules! try_unwrap {
         ($($field:ident),+ $(,)?) => {
             $(
@@ -211,18 +207,10 @@ pub fn media_type_from_message(msg: &wa::Message) -> Option<&'static str> {
     None
 }
 
-/// Canonical rule for the `decrypt-fail="hide"` attribute on outgoing `<enc>`
-/// nodes. Centralizes the predicate used across DM peer fanout, group SKDM
-/// distribution and group SKMSG to avoid drift — that drift was the root
-/// cause of admin revokes silently failing for the SKDM path.
-///
-/// `true` means: emit `decrypt-fail="hide"`. Returns:
-/// * `true` for any non-`Empty` edit *except* `AdminRevoke` — the server
-///   rejects revoke stanzas carrying the hide attribute (per the
-///   `test_decrypt_fail_hide_logic_for_edits` test in `types::message`).
-/// * `true` for infrastructure messages that match `should_hide_decrypt_fail`
-///   (reactions, pin changes, poll updates, etc.).
-/// * `false` otherwise.
+/// Canonical rule for `decrypt-fail="hide"` on outgoing `<enc>` nodes.
+/// Shared by DM fanout, group SKDM and group SKMSG so the three paths can't drift.
+/// `AdminRevoke` is excluded because the server drops revoke stanzas carrying the
+/// hide attribute.
 pub fn should_hide_decrypt_fail_for_send(
     edit: Option<&crate::types::message::EditAttribute>,
     msg: &wa::Message,
@@ -1067,7 +1055,8 @@ where
         .attr("id", message_id)
         .attr("type", stanza_type_from_message(message));
 
-    // Preserve edit attribute on retry — same reason as the group path.
+    // Without `edit`, the resend looks like a normal message and the client never
+    // applies the revoke/edit.
     if let Some(e) = edit
         && e != crate::types::message::EditAttribute::Empty
     {
@@ -1137,11 +1126,8 @@ where
     // WA Web always sets addressing_mode for groups (MsgCreateDeviceStanza.js:131-135)
     stanza_builder = stanza_builder.attr("addressing_mode", addressing_mode.as_str());
 
-    // Preserve the edit attribute on retry — without it the client receives the
-    // resend as a normal message and never applies the revoke/edit. Symptom:
-    // admin revoke worked for devices that decrypted on first try, but devices
-    // that sent a retry receipt got the resend without `edit="8"` and the
-    // image/message stayed visible for them.
+    // Without `edit`, the resend looks like a normal message and the client never
+    // applies the revoke/edit.
     if let Some(e) = edit
         && e != crate::types::message::EditAttribute::Empty
     {
@@ -1367,11 +1353,9 @@ pub async fn prepare_group_stanza<
         // WA Web's GroupSkmsgJob wraps ensureE2ESessions in try/catch — logs error
         // but does NOT rethrow. SKDM distribution failure must not prevent the group
         // message from being sent. Only successfully encrypted devices are tracked.
-        //
-        // hide_decrypt_fail: matches the main skmsg payload — `false` for AdminRevoke
-        // (server rejects revoke when SKDM has `decrypt-fail="hide"`; some clients
-        // never decrypt the skmsg principal and never apply the revoke), `true` for
-        // other edits and infrastructure messages.
+        // Must match the rule applied to the main skmsg payload below: if SKDM carries
+        // `decrypt-fail="hide"` but the payload does not (e.g. AdminRevoke), recipients
+        // without a sender key never decrypt the skmsg and the revoke is silently dropped.
         let skdm_hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit.as_ref(), message);
         match encrypt_for_devices(
             runtime,
@@ -3089,9 +3073,6 @@ mod tests {
             );
         }
 
-        // Regression: retry resends must preserve the original `edit` wire
-        // attribute. Without it, admin revokes were re-sent as plain messages
-        // on retry and the client never applied the revoke for that device.
         #[tokio::test]
         async fn group_retry_preserves_edit_attribute() {
             let (mut ss, mut is, jid) = setup_session().await;

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -95,6 +95,62 @@ impl EditAttribute {
     pub fn to_string_val(&self) -> &str {
         self.as_str()
     }
+
+    /// Infer the wire `edit` attribute from a fully-constructed message body.
+    /// Used by the retry path to preserve the original `edit="N"` when
+    /// resending — without it, the client receives the resend as a plain
+    /// message and never applies the revoke/edit/pin operation.
+    ///
+    /// Recognizes (in order):
+    /// * `pin_in_chat_message` → `PinInChat`
+    /// * top-level `edited_message` (FutureProofMessage edit envelope, current
+    ///   WA Web format) → `MessageEdit`
+    /// * `protocol_message.r#type == Revoke` with `key.from_me` →
+    ///   `SenderRevoke` (true) / `AdminRevoke` (false)
+    /// * `protocol_message.r#type == MessageEdit` with `key.from_me` →
+    ///   `MessageEdit` (true) / `AdminEdit` (false)
+    /// * legacy `protocol_message.edited_message` (no explicit type) → `MessageEdit`
+    pub fn infer_from_message(msg: &waproto::whatsapp::Message) -> Option<Self> {
+        use waproto::whatsapp::message::protocol_message::Type as ProtocolType;
+
+        // Descend through neutral wrappers (ephemeral / view_once / device_sent /
+        // doc_with_caption / etc.) before inspecting semantic fields — the
+        // operation signal can be nested under any of them and we'd otherwise
+        // silently drop the `edit` attribute on retry.
+        let msg = crate::send::unwrap_message(msg);
+
+        if msg.pin_in_chat_message.is_some() {
+            return Some(Self::PinInChat);
+        }
+        // Top-level `edited_message` envelope (current WA Web format) doesn't
+        // carry a from_me flag — default to `MessageEdit`. The Admin variant
+        // is only distinguishable when the operation is wrapped in a
+        // `protocol_message` with `key.from_me` set explicitly.
+        if msg.edited_message.is_some() {
+            return Some(Self::MessageEdit);
+        }
+        if let Some(pm) = msg.protocol_message.as_deref() {
+            let from_me = pm.key.as_ref().and_then(|k| k.from_me).unwrap_or(false);
+            if pm.r#type == Some(ProtocolType::Revoke as i32) {
+                return Some(if from_me {
+                    Self::SenderRevoke
+                } else {
+                    Self::AdminRevoke
+                });
+            }
+            if pm.r#type == Some(ProtocolType::MessageEdit as i32) {
+                return Some(if from_me {
+                    Self::MessageEdit
+                } else {
+                    Self::AdminEdit
+                });
+            }
+            if pm.edited_message.is_some() {
+                return Some(Self::MessageEdit);
+            }
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -207,5 +263,182 @@ mod tests {
         // Should NOT add decrypt-fail="hide"
         assert!(!should_add_decrypt_fail_hide(&EditAttribute::Empty));
         assert!(!should_add_decrypt_fail_hide(&EditAttribute::AdminRevoke));
+    }
+
+    #[test]
+    fn infer_from_message_admin_revoke() {
+        let msg = waproto::whatsapp::Message {
+            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    from_me: Some(false),
+                    ..Default::default()
+                }),
+                r#type: Some(waproto::whatsapp::message::protocol_message::Type::Revoke as i32),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&msg),
+            Some(EditAttribute::AdminRevoke)
+        );
+    }
+
+    #[test]
+    fn infer_from_message_sender_revoke() {
+        let msg = waproto::whatsapp::Message {
+            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    from_me: Some(true),
+                    ..Default::default()
+                }),
+                r#type: Some(waproto::whatsapp::message::protocol_message::Type::Revoke as i32),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&msg),
+            Some(EditAttribute::SenderRevoke)
+        );
+    }
+
+    #[test]
+    fn infer_from_message_top_level_edit() {
+        // FutureProofMessage edit envelope — current WA Web format. Without
+        // this branch in `infer_from_message`, edits get resent on retry as
+        // plain messages and never apply.
+        let msg = waproto::whatsapp::Message {
+            edited_message: Some(Box::new(waproto::whatsapp::message::FutureProofMessage {
+                message: Some(Box::new(waproto::whatsapp::Message::default())),
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&msg),
+            Some(EditAttribute::MessageEdit)
+        );
+    }
+
+    #[test]
+    fn infer_from_message_legacy_edit() {
+        let msg = waproto::whatsapp::Message {
+            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
+                edited_message: Some(Box::new(waproto::whatsapp::Message::default())),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&msg),
+            Some(EditAttribute::MessageEdit)
+        );
+    }
+
+    #[test]
+    fn infer_from_message_message_edit_sender() {
+        let msg = waproto::whatsapp::Message {
+            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    from_me: Some(true),
+                    ..Default::default()
+                }),
+                r#type: Some(
+                    waproto::whatsapp::message::protocol_message::Type::MessageEdit as i32,
+                ),
+                edited_message: Some(Box::new(waproto::whatsapp::Message::default())),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&msg),
+            Some(EditAttribute::MessageEdit)
+        );
+    }
+
+    #[test]
+    fn infer_from_message_admin_edit() {
+        // Admin editing someone else's message: protocol_message wraps the
+        // edit with `key.from_me = false`, mirroring the AdminRevoke convention.
+        let msg = waproto::whatsapp::Message {
+            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    from_me: Some(false),
+                    ..Default::default()
+                }),
+                r#type: Some(
+                    waproto::whatsapp::message::protocol_message::Type::MessageEdit as i32,
+                ),
+                edited_message: Some(Box::new(waproto::whatsapp::Message::default())),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&msg),
+            Some(EditAttribute::AdminEdit)
+        );
+    }
+
+    #[test]
+    fn infer_from_message_plain_returns_none() {
+        let msg = waproto::whatsapp::Message {
+            conversation: Some("plain".into()),
+            ..Default::default()
+        };
+        assert_eq!(EditAttribute::infer_from_message(&msg), None);
+    }
+
+    #[test]
+    fn infer_from_message_unwraps_neutral_wrappers() {
+        // Admin revoke wrapped in ephemeral_message — retry path must still
+        // recover the `edit="8"` attribute.
+        let inner_revoke = waproto::whatsapp::Message {
+            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
+                key: Some(waproto::whatsapp::MessageKey {
+                    from_me: Some(false),
+                    ..Default::default()
+                }),
+                r#type: Some(waproto::whatsapp::message::protocol_message::Type::Revoke as i32),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let wrapped = waproto::whatsapp::Message {
+            ephemeral_message: Some(Box::new(waproto::whatsapp::message::FutureProofMessage {
+                message: Some(Box::new(inner_revoke)),
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&wrapped),
+            Some(EditAttribute::AdminRevoke)
+        );
+
+        // Same for pin wrapped in view_once and device_sent (double nesting).
+        let inner_pin = waproto::whatsapp::Message {
+            pin_in_chat_message: Some(waproto::whatsapp::message::PinInChatMessage::default()),
+            ..Default::default()
+        };
+        let wrapped_pin = waproto::whatsapp::Message {
+            device_sent_message: Some(Box::new(waproto::whatsapp::message::DeviceSentMessage {
+                destination_jid: Some(String::new()),
+                message: Some(Box::new(waproto::whatsapp::Message {
+                    view_once_message: Some(Box::new(
+                        waproto::whatsapp::message::FutureProofMessage {
+                            message: Some(Box::new(inner_pin)),
+                        },
+                    )),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!(
+            EditAttribute::infer_from_message(&wrapped_pin),
+            Some(EditAttribute::PinInChat)
+        );
     }
 }

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -96,56 +96,33 @@ impl EditAttribute {
         self.as_str()
     }
 
-    /// Infer the wire `edit` attribute from a fully-constructed message body.
-    /// Used by the retry path to preserve the original `edit="N"` when
-    /// resending — without it, the client receives the resend as a plain
-    /// message and never applies the revoke/edit/pin operation.
-    ///
-    /// Recognizes (in order):
-    /// * `pin_in_chat_message` → `PinInChat`
-    /// * top-level `edited_message` (FutureProofMessage edit envelope, current
-    ///   WA Web format) → `MessageEdit`
-    /// * `protocol_message.r#type == Revoke` with `key.from_me` →
-    ///   `SenderRevoke` (true) / `AdminRevoke` (false)
-    /// * `protocol_message.r#type == MessageEdit` with `key.from_me` →
-    ///   `MessageEdit` (true) / `AdminEdit` (false)
-    /// * legacy `protocol_message.edited_message` (no explicit type) → `MessageEdit`
+    /// Recover the wire `edit` value from a cached protobuf so the retry path can
+    /// re-emit `edit="N"` on resends. The original `subtype` (used by WA Web's
+    /// `editAttribute`) isn't persisted, so `key.from_me` is used as a proxy to
+    /// distinguish admin-vs-sender revoke: WA Web sets `from_me=false` on the
+    /// revoke proto's `MessageKey` when an admin revokes someone else's message.
     pub fn infer_from_message(msg: &waproto::whatsapp::Message) -> Option<Self> {
         use waproto::whatsapp::message::protocol_message::Type as ProtocolType;
 
-        // Descend through neutral wrappers (ephemeral / view_once / device_sent /
-        // doc_with_caption / etc.) before inspecting semantic fields — the
-        // operation signal can be nested under any of them and we'd otherwise
-        // silently drop the `edit` attribute on retry.
+        // The operation signal can be nested under any neutral wrapper.
         let msg = crate::send::unwrap_message(msg);
 
         if msg.pin_in_chat_message.is_some() {
             return Some(Self::PinInChat);
         }
-        // Top-level `edited_message` envelope (current WA Web format) doesn't
-        // carry a from_me flag — default to `MessageEdit`. The Admin variant
-        // is only distinguishable when the operation is wrapped in a
-        // `protocol_message` with `key.from_me` set explicitly.
         if msg.edited_message.is_some() {
             return Some(Self::MessageEdit);
         }
         if let Some(pm) = msg.protocol_message.as_deref() {
-            let from_me = pm.key.as_ref().and_then(|k| k.from_me).unwrap_or(false);
             if pm.r#type == Some(ProtocolType::Revoke as i32) {
+                let from_me = pm.key.as_ref().and_then(|k| k.from_me).unwrap_or(false);
                 return Some(if from_me {
                     Self::SenderRevoke
                 } else {
                     Self::AdminRevoke
                 });
             }
-            if pm.r#type == Some(ProtocolType::MessageEdit as i32) {
-                return Some(if from_me {
-                    Self::MessageEdit
-                } else {
-                    Self::AdminEdit
-                });
-            }
-            if pm.edited_message.is_some() {
+            if pm.r#type == Some(ProtocolType::MessageEdit as i32) || pm.edited_message.is_some() {
                 return Some(Self::MessageEdit);
             }
         }
@@ -305,9 +282,6 @@ mod tests {
 
     #[test]
     fn infer_from_message_top_level_edit() {
-        // FutureProofMessage edit envelope — current WA Web format. Without
-        // this branch in `infer_from_message`, edits get resent on retry as
-        // plain messages and never apply.
         let msg = waproto::whatsapp::Message {
             edited_message: Some(Box::new(waproto::whatsapp::message::FutureProofMessage {
                 message: Some(Box::new(waproto::whatsapp::Message::default())),
@@ -358,30 +332,6 @@ mod tests {
     }
 
     #[test]
-    fn infer_from_message_admin_edit() {
-        // Admin editing someone else's message: protocol_message wraps the
-        // edit with `key.from_me = false`, mirroring the AdminRevoke convention.
-        let msg = waproto::whatsapp::Message {
-            protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
-                key: Some(waproto::whatsapp::MessageKey {
-                    from_me: Some(false),
-                    ..Default::default()
-                }),
-                r#type: Some(
-                    waproto::whatsapp::message::protocol_message::Type::MessageEdit as i32,
-                ),
-                edited_message: Some(Box::new(waproto::whatsapp::Message::default())),
-                ..Default::default()
-            })),
-            ..Default::default()
-        };
-        assert_eq!(
-            EditAttribute::infer_from_message(&msg),
-            Some(EditAttribute::AdminEdit)
-        );
-    }
-
-    #[test]
     fn infer_from_message_plain_returns_none() {
         let msg = waproto::whatsapp::Message {
             conversation: Some("plain".into()),
@@ -392,8 +342,6 @@ mod tests {
 
     #[test]
     fn infer_from_message_unwraps_neutral_wrappers() {
-        // Admin revoke wrapped in ephemeral_message — retry path must still
-        // recover the `edit="8"` attribute.
         let inner_revoke = waproto::whatsapp::Message {
             protocol_message: Some(Box::new(waproto::whatsapp::message::ProtocolMessage {
                 key: Some(waproto::whatsapp::MessageKey {


### PR DESCRIPTION
## Summary

Admin revoke (`edit=\"8\"`) had **three independent bugs** that combined to leave the revoked message visible on a subset of recipients — most commonly the group admins/creator and any device that triggered a retry receipt.

Issue surfaced while writing an anti-content bot: revoke admin call returned `Ok(_)` and some clients saw the message disappear, but the bot operator's own device (which routinely retries on first contact) kept the message visible. The existing test in `wacore/src/types/message.rs` already documents the expected behavior for `AdminRevoke`.

## Root causes & fix

### 1. `prepare_dm_stanza` (peer fanout) sent `decrypt-fail=\"hide\"` for admin revokes

The SKMSG path in `prepare_group_stanza` (l. 1384) already excluded `AdminRevoke` from `hide_decrypt_fail`. The peer-fanout path in `prepare_dm_stanza` (l. 862) didn't — every `<enc>` went out with the attribute, and the server dropped the revoke for those recipients.

**Fix:** mirror the same exclusion: `*e != Empty && *e != AdminRevoke`.

### 2. SKDM distribution hardcoded `hide_decrypt_fail = true`

`prepare_group_stanza` l. 1326 sent the sender-key distribution with `hide_decrypt_fail: true` always. For admin revoke this dropped the SKDM, so any device that didn't already have the group sender key never decrypted the main `<enc type=\"skmsg\">` carrying the REVOKE protocol message — even though the main payload itself was correctly attribute-clean.

**Fix:** compute `skdm_hide_decrypt_fail` with the same rule used for the main payload. Reactions, edits, pins keep the `hide` behavior; only `AdminRevoke` flips to `false`.

### 3. `prepare_{group,dm}_retry_stanza` lost the `edit` attribute

When a recipient device replies with `<receipt type=\"retry\">`, the bot rebuilds the stanza via the retry builders and resends. Those builders never accepted or emitted an `edit` attribute, so the retry resend went out as a plain `<message>`. Client received it but had no signal that this was a revoke. Symptom: the group creator's device (which always retries because its session needs a prekey bundle on first contact) kept showing the revoked image.

**Fix:**
- Both retry builders now accept `edit: Option<EditAttribute>` and emit `attr(\"edit\", ...)` when present.
- New `EditAttribute::infer_from_message(&wa::Message)` helper recovers the wire `edit` value from the cached protobuf (`add_recent_message` only persists the protobuf body, not the original stanza's wire attributes):
  - `protocol_message.r#type == Revoke` + `key.from_me` → `SenderRevoke` / `AdminRevoke`
  - `pin_in_chat_message.is_some()` → `PinInChat`
  - `protocol_message.edited_message.is_some()` → `MessageEdit`
- `retry.rs` infers `edit_attr` from `original_msg` and forwards it to both retry paths.

## Test plan

- [x] `cargo build --release --target x86_64-unknown-linux-musl` (the consumer profile) builds clean.
- [x] End-to-end test in a live LID-addressed group with multiple device types (primary phone + companion device that triggers retry receipt): admin revoke applied uniformly across recipients.
- [x] Existing test `test_decrypt_fail_hide_logic_for_edits` in `wacore/src/types/message.rs` documents the expected rule and matches the new implementation.

Happy to split into three smaller commits if reviewers prefer one fix per commit — kept consolidated here because the three bugs only become observably correct together for the admin-revoke flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)