### PR TITLE
audit (round 2): more WA Web protocol compliance fixes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3858,7 +3858,13 @@ fn encode_ack_bytes(
     let Some(from_val) = node.get_attr("from") else {
         return Ok(None);
     };
-    let participant_val = node.get_attr("participant");
+    // WAWebReceiptAck: `participant: r && r !== e ? DEVICE_JID(r) : DROP_ATTR`.
+    // Drop the attribute when it would duplicate `to` (which is the flipped `from`).
+    let participant_val = node.get_attr("participant").filter(|p| {
+        let p_str = p.as_str();
+        let from_str = from_val.as_str();
+        p_str.as_ref() != from_str.as_ref()
+    });
     let tag = node.tag.as_ref();
 
     let typ_val = if tag != "message" && !is_encrypt_identity_notification(node) {
@@ -3947,8 +3953,13 @@ fn encode_ack_bytes(
 #[cfg(test)]
 fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>) -> Option<Node> {
     let id = node.get_attr("id")?.to_node_value();
-    let from = node.get_attr("from")?.to_node_value();
-    let participant = node.get_attr("participant").map(|v| v.to_node_value());
+    let from_ref = node.get_attr("from")?;
+    let from = from_ref.to_node_value();
+    // Drop participant when it duplicates `to` (the flipped `from`).
+    let participant = node
+        .get_attr("participant")
+        .filter(|p| p.as_str().as_ref() != from_ref.as_str().as_ref())
+        .map(|v| v.to_node_value());
     let tag = node.tag.as_ref();
     let typ = if tag != "message" && !is_encrypt_identity_notification(node) {
         node.get_attr("type").map(|v| v.to_node_value())
@@ -5731,6 +5742,47 @@ mod tests {
         assert!(
             !ack.attrs.contains_key("from"),
             "receipt ACKs should not include our device PN"
+        );
+    }
+
+    #[test]
+    fn test_build_ack_node_drops_participant_when_equal_to_from() {
+        // WAWebReceiptAck: `participant: r && r !== e ? DEVICE_JID(r) : DROP_ATTR`.
+        // When the incoming stanza carries participant == from (redundant),
+        // the ack must not echo it.
+        let incoming = NodeBuilder::new("receipt")
+            .attr("from", "156535032389744@lid")
+            .attr("participant", "156535032389744@lid")
+            .attr("id", "RCPT-PARTICIPANT-EQ-FROM")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net".parse().unwrap();
+
+        let ack = build_ack_node(&incoming.as_node_ref(), Some(&own_device_pn))
+            .expect("ack should build");
+        assert!(
+            !ack.attrs.contains_key("participant"),
+            "ack must drop participant when it duplicates `to` (the flipped from); got {:?}",
+            ack.attrs.get("participant")
+        );
+    }
+
+    #[test]
+    fn test_build_ack_node_keeps_participant_when_distinct_from_from() {
+        // Group receipt: participant = sender (user), from = group jid; must be kept.
+        let incoming = NodeBuilder::new("receipt")
+            .attr("from", "120363098765432100@g.us")
+            .attr("participant", "5511999999999@s.whatsapp.net")
+            .attr("id", "RCPT-GROUP")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net".parse().unwrap();
+
+        let ack = build_ack_node(&incoming.as_node_ref(), Some(&own_device_pn))
+            .expect("ack should build");
+        assert!(
+            ack.attrs
+                .get("participant")
+                .is_some_and(|v| v == "5511999999999@s.whatsapp.net"),
+            "ack must keep participant when it differs from `to`"
         );
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1829,12 +1829,24 @@ impl Client {
     }
 
     /// Determine if a node should be acknowledged with <ack/>.
+    ///
+    /// WA Web only emits `<ack class="message">` for newsletter deliveries
+    /// (`OutMessageDeliverCommonAckMixin`). Regular DMs / groups / status
+    /// rely on the `<receipt>` (delivery / read / played) for ack semantics
+    /// — sending both would be redundant.
     fn should_ack(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
-        matches!(
-            node.tag.as_ref(),
-            "message" | "receipt" | "notification" | "call"
-        ) && node.get_attr("id").is_some()
-            && node.get_attr("from").is_some()
+        let tag = node.tag.as_ref();
+        if node.get_attr("id").is_none() {
+            return false;
+        }
+        let Some(from) = node.get_attr("from") else {
+            return false;
+        };
+        match tag {
+            "receipt" | "notification" | "call" => true,
+            "message" => from.to_jid().is_some_and(|j| j.is_newsletter()),
+            _ => false,
+        }
     }
 
     /// Possibly send a deferred ack: either immediately or via spawned task.
@@ -4045,6 +4057,42 @@ mod tests {
         assert!(
             client.should_ack(&notification_node.as_node_ref()),
             "should_ack must still return TRUE for <notification> stanzas."
+        );
+
+        // Regular <message> stanzas (DM / group) are acked via the delivery
+        // <receipt>, not a bare <ack class="message">. WA Web only emits
+        // <ack class="message"> for newsletter deliveries.
+        let mut dm_attrs = Attrs::new();
+        dm_attrs.insert(
+            "from".to_string(),
+            "5511999999999@s.whatsapp.net".to_string(),
+        );
+        dm_attrs.insert("id".to_string(), "MSG-DM-1".to_string());
+        let dm_message = Node::new("message", dm_attrs, None);
+        assert!(
+            !client.should_ack(&dm_message.as_node_ref()),
+            "should_ack must return FALSE for regular DM <message> (delivery receipt covers it)."
+        );
+
+        let mut group_attrs = Attrs::new();
+        group_attrs.insert("from".to_string(), "120363098765432100@g.us".to_string());
+        group_attrs.insert("id".to_string(), "MSG-GROUP-1".to_string());
+        let group_message = Node::new("message", group_attrs, None);
+        assert!(
+            !client.should_ack(&group_message.as_node_ref()),
+            "should_ack must return FALSE for group <message>."
+        );
+
+        let mut newsletter_attrs = Attrs::new();
+        newsletter_attrs.insert(
+            "from".to_string(),
+            "120363298765432100@newsletter".to_string(),
+        );
+        newsletter_attrs.insert("id".to_string(), "MSG-NL-1".to_string());
+        let newsletter_message = Node::new("message", newsletter_attrs, None);
+        assert!(
+            client.should_ack(&newsletter_message.as_node_ref()),
+            "should_ack must return TRUE for newsletter <message>."
         );
 
         info!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -527,6 +527,19 @@ impl Client {
         self.shutdown_notifier.subscribe()
     }
 
+    /// Synchronous flag-only equivalent of the first lines of `disconnect()`.
+    /// Spawned tasks watching `is_shutting_down()` / `shutdown_notifier` exit
+    /// on their next poll. Does NOT flush, close the transport, or touch
+    /// persistence — prefer `disconnect()` whenever you can `await`. Exists
+    /// for `Drop` impls on FFI wrappers (e.g. `WasmWhatsAppClient`) that
+    /// can't run async cleanup synchronously.
+    pub fn signal_shutdown_sync(&self) {
+        self.expected_disconnect.store(true, Ordering::Relaxed);
+        self.is_running.store(false, Ordering::Relaxed);
+        self.shutdown_notifier.notify();
+        self.notify_connection_shutdown();
+    }
+
     pub(crate) fn connection_shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
         self.connection_shutdown
             .lock()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1844,9 +1844,11 @@ impl Client {
     /// Determine if a node should be acknowledged with <ack/>.
     ///
     /// WA Web only emits `<ack class="message">` for newsletter deliveries
-    /// (`OutMessageDeliverCommonAckMixin`). Regular DMs / groups / status
-    /// rely on the `<receipt>` (delivery / read / played) for ack semantics
-    /// — sending both would be redundant.
+    /// (`OutMessageDeliverCommonAckMixin`); regular DMs / groups send a
+    /// `<receipt>` instead. Status broadcasts also get a `<receipt
+    /// context="status">` in WA Web, but the receipt path here currently
+    /// skips them — so we keep the ack as a server-level acknowledgement
+    /// safety-net until the status-receipt path is fixed.
     fn should_ack(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
         let tag = node.tag.as_ref();
         if node.get_attr("id").is_none() {
@@ -1857,7 +1859,9 @@ impl Client {
         };
         match tag {
             "receipt" | "notification" | "call" => true,
-            "message" => from.to_jid().is_some_and(|j| j.is_newsletter()),
+            "message" => from
+                .to_jid()
+                .is_some_and(|j| j.is_newsletter() || j.is_status_broadcast()),
             _ => false,
         }
     }
@@ -4117,6 +4121,17 @@ mod tests {
         assert!(
             client.should_ack(&newsletter_message.as_node_ref()),
             "should_ack must return TRUE for newsletter <message>."
+        );
+
+        // Status broadcasts: send_delivery_receipt currently skips them, so the
+        // <ack> stays in place as a server-level acknowledgement safety net.
+        let mut status_attrs = Attrs::new();
+        status_attrs.insert("from".to_string(), "status@broadcast".to_string());
+        status_attrs.insert("id".to_string(), "MSG-STATUS-1".to_string());
+        let status_message = Node::new("message", status_attrs, None);
+        assert!(
+            client.should_ack(&status_message.as_node_ref()),
+            "should_ack must return TRUE for status@broadcast <message> until receipts cover it."
         );
 
         info!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1843,12 +1843,10 @@ impl Client {
 
     /// Determine if a node should be acknowledged with <ack/>.
     ///
-    /// WA Web only emits `<ack class="message">` for newsletter deliveries
-    /// (`OutMessageDeliverCommonAckMixin`); regular DMs / groups send a
-    /// `<receipt>` instead. Status broadcasts also get a `<receipt
-    /// context="status">` in WA Web, but the receipt path here currently
-    /// skips them — so we keep the ack as a server-level acknowledgement
-    /// safety-net until the status-receipt path is fixed.
+    /// Newsletter messages need `<ack class="message">` (per
+    /// `OutMessageDeliverCommonAckMixin`); regular DM/group send a
+    /// `<receipt>` instead. Status broadcasts also need the ack until
+    /// `send_delivery_receipt` stops skipping them.
     fn should_ack(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
         let tag = node.tag.as_ref();
         if node.get_attr("id").is_none() {
@@ -4123,8 +4121,8 @@ mod tests {
             "should_ack must return TRUE for newsletter <message>."
         );
 
-        // Status broadcasts: send_delivery_receipt currently skips them, so the
-        // <ack> stays in place as a server-level acknowledgement safety net.
+        // send_delivery_receipt skips status@broadcast, so the ack stays
+        // as the server-level acknowledgement until receipts cover it.
         let mut status_attrs = Attrs::new();
         status_attrs.insert("from".to_string(), "status@broadcast".to_string());
         status_attrs.insert("id".to_string(), "MSG-STATUS-1".to_string());

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -260,17 +260,18 @@ impl IqSpec for SetProfilePictureSpec {
     type Response = SetProfilePictureResponse;
 
     fn build_iq(&self) -> InfoQuery<'static> {
-        let mut picture_builder = NodeBuilder::new("picture").attr("type", "image");
+        // WAWebSendProfilePictureJob: emits `<picture type="image">{bytes}</picture>`
+        // on set, NO `<picture>` child on remove.
+        let content = self.image_data.as_ref().map(|data| {
+            NodeContent::Nodes(vec![
+                NodeBuilder::new("picture")
+                    .attr("type", "image")
+                    .bytes(data.clone())
+                    .build(),
+            ])
+        });
 
-        if let Some(data) = &self.image_data {
-            picture_builder = picture_builder.bytes(data.clone());
-        }
-
-        let mut iq = InfoQuery::set(
-            "w:profile:picture",
-            Jid::new("", Server::Pn),
-            Some(NodeContent::Nodes(vec![picture_builder.build()])),
-        );
+        let mut iq = InfoQuery::set("w:profile:picture", Jid::new("", Server::Pn), content);
 
         if let Some(target) = &self.target {
             iq = iq.with_target_ref(target);
@@ -466,20 +467,24 @@ mod tests {
     }
 
     #[test]
-    fn test_set_profile_picture_spec_remove_own() {
+    fn test_set_profile_picture_spec_remove_own_emits_no_picture_child() {
+        // WAWebSendProfilePictureJob: removal IQ has no `<picture>` child at all.
         let spec = SetProfilePictureSpec::remove_own();
         let iq = spec.build_iq();
+        assert!(
+            iq.content.is_none(),
+            "Remove must emit an empty <iq> with no <picture> child; got {:?}",
+            iq.content
+        );
+    }
 
-        if let Some(NodeContent::Nodes(nodes)) = &iq.content {
-            let picture = &nodes[0];
-            // Remove: picture node with no content
-            assert!(
-                picture.content.is_none(),
-                "Remove should have no picture content"
-            );
-        } else {
-            panic!("Expected NodeContent::Nodes");
-        }
+    #[test]
+    fn test_set_profile_picture_spec_remove_group_emits_no_picture_child() {
+        let group_jid: Jid = "123456789@g.us".parse().unwrap();
+        let spec = SetProfilePictureSpec::remove_group(&group_jid);
+        let iq = spec.build_iq();
+        assert!(iq.content.is_none(), "Remove group: no <picture> child");
+        assert_eq!(iq.target, Some(group_jid));
     }
 
     #[test]

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -195,10 +195,9 @@ pub struct SetProfilePictureResponse {
 ///
 /// ## Wire Format (Remove)
 /// ```xml
-/// <iq xmlns="w:profile:picture" type="set" to="s.whatsapp.net" id="...">
-///   <picture type="image"/>
-/// </iq>
+/// <iq xmlns="w:profile:picture" type="set" to="s.whatsapp.net" id="..."/>
 /// ```
+/// No `<picture>` child — `WAWebSendProfilePictureJob` emits an empty IQ.
 ///
 /// ## Response
 /// ```xml

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -197,7 +197,7 @@ pub struct SetProfilePictureResponse {
 /// ```xml
 /// <iq xmlns="w:profile:picture" type="set" to="s.whatsapp.net" id="..."/>
 /// ```
-/// No `<picture>` child — `WAWebSendProfilePictureJob` emits an empty IQ.
+/// No `<picture>` child: `WAWebSendProfilePictureJob` emits an empty IQ.
 ///
 /// ## Response
 /// ```xml

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -267,14 +267,12 @@ pub struct GroupCreateOptions {
     /// Only used when `is_parent` is true.
     #[builder(default)]
     pub create_general_chat: bool,
-    /// JID of an existing community parent to link this subgroup to. Emits
-    /// `<linked_parent jid="..."/>` so a subgroup can be created atomically
-    /// (matches `OutGroupsCreateRequest`).
+    /// Parent community to link this subgroup to. Atomic alternative to
+    /// creating then linking; mutually exclusive with `is_parent`.
     #[builder(default, setter(strip_option, into))]
     pub linked_parent: Option<Jid>,
-    /// Optional `<description id="<token>"><body>{text}</body></description>`
-    /// child on the create stanza. WA Web supports inline description on
-    /// create so callers can avoid a follow-up set-description IQ.
+    /// Inline description carried on the create stanza; avoids a follow-up
+    /// SetGroupDescription IQ.
     #[builder(default, setter(strip_option, into))]
     pub description: Option<String>,
 }
@@ -339,10 +337,9 @@ impl Default for GroupCreateOptions {
 }
 
 /// Normalize participants: drop phone_number for non-LID JIDs.
-/// Random 8-char hex token for a `<description id="...">` attribute. WA Web
-/// uses an opaque server-echoed id; the format only needs to be unique. Both
-/// `GroupCreateIq` (inline description) and `SetGroupDescriptionIq` (update)
-/// route through this so the seeding strategy stays centralized.
+/// Random 8-char hex token for a `<description id="...">` attribute. Shared
+/// between create-with-inline-description and SetGroupDescriptionIq so the
+/// RNG seeding stays in one place.
 fn generate_description_id() -> String {
     use rand::RngExt as _;
     format!(
@@ -430,10 +427,9 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
         );
     }
 
-    // `<parent>` ("this group IS a community") and `<linked_parent jid=...>`
-    // ("this group is a subgroup of X") are semantically exclusive — a group
-    // can't be both a community and a child of one. When both are requested,
-    // `linked_parent` wins since it carries an explicit target.
+    // `<parent>` (this group IS a community) and `<linked_parent>` (this
+    // group is a subgroup of X) are mutually exclusive. When both are
+    // requested, `linked_parent` wins; it carries an explicit target.
     if let Some(parent_jid) = &options.linked_parent {
         children.push(
             NodeBuilder::new("linked_parent")
@@ -1090,14 +1086,13 @@ impl IqSpec for GroupCreateIq {
         let group_node = required_child(response, "group")?;
         let mut info = GroupInfoResponse::try_from_node_ref(group_node)?;
 
-        // The server may omit `<parent>` / `<allow_non_admin_sub_group_creation>`
-        // from the create reply (WA Web's CreateJob never reads them either),
-        // so propagate the request flags so a freshly created community classifies
-        // correctly via `group_type()` without a follow-up metadata query.
-        // `allow_non_admin_sub_group_creation` is one-directional (request only
-        // fills when server omitted) so a server-set `true` is never clobbered
-        // by a `false` request flag.
-        if self.options.is_parent {
+        // Server may omit `<parent>` from a community-create reply; overlay
+        // request flags so `group_type()` classifies without a follow-up query.
+        // A `linked_parent` (in request or response) means this is a subgroup,
+        // so don't promote it to parent even if `is_parent` was requested.
+        let is_linked_subgroup =
+            info.parent_group_jid.is_some() || self.options.linked_parent.is_some();
+        if self.options.is_parent && !is_linked_subgroup {
             info.is_parent_group = true;
             info.allow_non_admin_sub_group_creation |=
                 self.options.allow_non_admin_sub_group_creation;
@@ -1111,22 +1106,18 @@ impl IqSpec for GroupCreateIq {
 // Group Management IQ Specs
 // ---------------------------------------------------------------------------
 
-/// V4 invite-token returned on `<participant error="403">` when the target's
-/// privacy settings block a direct add. The app can fall back to sending a
-/// `GroupInviteMessage` carrying these fields.
-///
-/// Wire shape: `<add_request code="..." expiration="N"/>`.
+/// V4 invite token returned in `<participant error="403">` when privacy
+/// blocks a direct add; lets callers fall back to a `GroupInviteMessage`.
+/// Wire: `<add_request code="..." expiration="N"/>`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddRequestInfo {
     pub code: String,
     pub expiration: u64,
 }
 
-/// Response for participant change operations.
-///
-/// Success is signaled by absent `error`; `type` is often omitted by the server.
-/// When `error == "403"` an `<add_request>` child may be present carrying the
-/// V4 invite fallback token (see `add_request`).
+/// Response for participant change operations. Success: `error` is None;
+/// `type` is often omitted by the server. On `error == "403"` the
+/// `<add_request>` child (`add_request` field) carries the V4 invite token.
 #[derive(Debug, Clone)]
 pub struct ParticipantChangeResponse {
     pub jid: Jid,
@@ -1188,10 +1179,8 @@ impl crate::protocol::ProtocolNode for ParticipantChangeResponse {
         let phone_number = attrs.optional_jid("phone_number");
         let username = attrs.optional_string("username").map(|c| c.into_owned());
 
-        // <add_request code="..." expiration="N"/> appears on error="403"
-        // (WAWebInGroupsParticipantRequestCodeCanBeSentMixin). Absent → None;
-        // present but malformed → hard error, since a 403 response that drops
-        // the V4 invite token is a server bug we want to surface.
+        // Absent → None. Present but malformed → hard error so a server-side
+        // drop of the V4 invite token doesn't silently disappear.
         let add_request = node
             .get_optional_child("add_request")
             .map(|n| -> ::anyhow::Result<AddRequestInfo> {
@@ -1746,8 +1735,7 @@ impl IqSpec for SetGroupAnnouncementIq {
     }
 }
 
-/// Max value for the `<ephemeral trigger>` attribute, per
-/// `WASmaxInGroupsGroupInfoMixin` (range 0..=20).
+/// Max for `<ephemeral trigger>`, per `WASmaxInGroupsGroupInfoMixin`.
 pub const EPHEMERAL_TRIGGER_MAX: u32 = 20;
 
 /// IQ specification for setting ephemeral (disappearing) messages on a group.
@@ -1772,10 +1760,8 @@ pub struct SetGroupEphemeralIq {
     pub group_jid: Jid,
     /// Expiration in seconds. `None` means disable.
     pub expiration: Option<NonZeroU32>,
-    /// Optional `trigger` attribute on `<ephemeral>` (WA Web range
-    /// 0..=[`EPHEMERAL_TRIGGER_MAX`]). Identifies the disappearing-mode
-    /// source (e.g. per-chat setting vs device-wide default). `None` omits
-    /// the attribute.
+    /// `trigger` attr on `<ephemeral>` (0..=[`EPHEMERAL_TRIGGER_MAX`]);
+    /// identifies the disappearing-mode source. `None` omits the attr.
     pub trigger: Option<u32>,
 }
 
@@ -1789,11 +1775,10 @@ impl SetGroupEphemeralIq {
         }
     }
 
-    /// Enable ephemeral messages with both expiration and explicit `trigger`.
+    /// Enable ephemeral messages with an explicit `trigger`.
     ///
     /// # Panics
-    /// If `trigger > [EPHEMERAL_TRIGGER_MAX]` (WA Web's `attrIntRange(0,20)`
-    /// constraint). Out-of-range values would be rejected by the server.
+    /// If `trigger > EPHEMERAL_TRIGGER_MAX`.
     pub fn enable_with_trigger(group_jid: &Jid, expiration: NonZeroU32, trigger: u32) -> Self {
         assert!(
             trigger <= EPHEMERAL_TRIGGER_MAX,
@@ -3933,6 +3918,34 @@ mod tests {
             nodes[0].get_optional_child("create_general_chat").is_none(),
             "community-only children must also be omitted"
         );
+    }
+
+    #[test]
+    fn test_group_create_iq_parse_response_does_not_promote_subgroup_to_parent() {
+        let parent: Jid = "120363000000000001@g.us".parse().unwrap();
+        let options = GroupCreateOptions {
+            subject: "Subgroup".into(),
+            is_parent: true,
+            allow_non_admin_sub_group_creation: true,
+            linked_parent: Some(parent.clone()),
+            ..Default::default()
+        };
+        let spec = GroupCreateIq::new(options);
+
+        let iq = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("group")
+                .attr("id", "120363999999999999")
+                .attr("subject", "Subgroup")
+                .children([NodeBuilder::new("linked_parent")
+                    .attr("jid", &parent)
+                    .build()])
+                .build()])
+            .build();
+        let response = spec.parse_response(&iq.as_node_ref()).unwrap();
+
+        assert!(!response.is_parent_group);
+        assert_eq!(response.parent_group_jid, Some(parent));
+        assert!(!response.allow_non_admin_sub_group_creation);
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1637,6 +1637,10 @@ pub struct SetGroupEphemeralIq {
     pub group_jid: Jid,
     /// Expiration in seconds. `None` means disable.
     pub expiration: Option<NonZeroU32>,
+    /// Optional `trigger` attribute on `<ephemeral>` (WA Web range 0..20).
+    /// Identifies the disappearing-mode source (e.g. per-chat setting vs
+    /// device-wide default). `None` omits the attribute.
+    pub trigger: Option<u32>,
 }
 
 impl SetGroupEphemeralIq {
@@ -1645,6 +1649,16 @@ impl SetGroupEphemeralIq {
         Self {
             group_jid: group_jid.clone(),
             expiration: Some(expiration),
+            trigger: None,
+        }
+    }
+
+    /// Enable ephemeral messages with both expiration and explicit `trigger`.
+    pub fn enable_with_trigger(group_jid: &Jid, expiration: NonZeroU32, trigger: u32) -> Self {
+        Self {
+            group_jid: group_jid.clone(),
+            expiration: Some(expiration),
+            trigger: Some(trigger),
         }
     }
 
@@ -1653,6 +1667,7 @@ impl SetGroupEphemeralIq {
         Self {
             group_jid: group_jid.clone(),
             expiration: None,
+            trigger: None,
         }
     }
 }
@@ -1662,9 +1677,13 @@ impl IqSpec for SetGroupEphemeralIq {
 
     fn build_iq(&self) -> InfoQuery<'static> {
         let node = match self.expiration {
-            Some(exp) => NodeBuilder::new("ephemeral")
-                .attr("expiration", exp.get())
-                .build(),
+            Some(exp) => {
+                let mut b = NodeBuilder::new("ephemeral").attr("expiration", exp.get());
+                if let Some(trigger) = self.trigger {
+                    b = b.attr("trigger", trigger);
+                }
+                b.build()
+            }
             None => NodeBuilder::new("not_ephemeral").build(),
         };
         InfoQuery::set_ref(
@@ -3210,6 +3229,36 @@ mod tests {
         } else {
             panic!("expected nodes content");
         }
+    }
+
+    #[test]
+    fn test_set_group_ephemeral_iq_with_trigger() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        let with_trigger =
+            SetGroupEphemeralIq::enable_with_trigger(&group, NonZeroU32::new(604800).unwrap(), 7);
+        let iq = with_trigger.build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected nodes content");
+        };
+        let mut attrs = nodes[0].attrs();
+        assert_eq!(
+            attrs.optional_string("expiration").as_deref(),
+            Some("604800")
+        );
+        assert_eq!(attrs.optional_string("trigger").as_deref(), Some("7"));
+    }
+
+    #[test]
+    fn test_set_group_ephemeral_iq_without_trigger_omits_attr() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        let iq = SetGroupEphemeralIq::enable(&group, NonZeroU32::new(86400).unwrap()).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected nodes content");
+        };
+        assert!(
+            nodes[0].attrs().optional_string("trigger").is_none(),
+            "default enable() must not emit a trigger attribute"
+        );
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -445,18 +445,13 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
     }
 
     // Inline description: WA Web emits `<description id="<token>"><body>{text}</body></description>`.
+    // Matches SetGroupDescriptionIq's 8-char hex id format for consistency.
     if let Some(desc) = &options.description {
-        use rand::Rng as _;
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let mut id_bytes = [0u8; 8];
-        rng.fill_bytes(&mut id_bytes);
-        let id = id_bytes
-            .iter()
-            .fold(String::with_capacity(16), |mut acc, b| {
-                use std::fmt::Write as _;
-                let _ = write!(acc, "{b:02X}");
-                acc
-            });
+        use rand::RngExt as _;
+        let id = format!(
+            "{:08X}",
+            rand::make_rng::<rand::rngs::StdRng>().random::<u32>()
+        );
         children.push(
             NodeBuilder::new("description")
                 .attr("id", id)

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -339,6 +339,18 @@ impl Default for GroupCreateOptions {
 }
 
 /// Normalize participants: drop phone_number for non-LID JIDs.
+/// Random 8-char hex token for a `<description id="...">` attribute. WA Web
+/// uses an opaque server-echoed id; the format only needs to be unique. Both
+/// `GroupCreateIq` (inline description) and `SetGroupDescriptionIq` (update)
+/// route through this so the seeding strategy stays centralized.
+fn generate_description_id() -> String {
+    use rand::RngExt as _;
+    format!(
+        "{:08X}",
+        rand::make_rng::<rand::rngs::StdRng>().random::<u32>()
+    )
+}
+
 pub fn normalize_participants(
     participants: &[GroupParticipantOptions],
 ) -> Vec<GroupParticipantOptions> {
@@ -418,8 +430,17 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
         );
     }
 
-    // Community (parent group) fields
-    if options.is_parent {
+    // `<parent>` ("this group IS a community") and `<linked_parent jid=...>`
+    // ("this group is a subgroup of X") are semantically exclusive — a group
+    // can't be both a community and a child of one. When both are requested,
+    // `linked_parent` wins since it carries an explicit target.
+    if let Some(parent_jid) = &options.linked_parent {
+        children.push(
+            NodeBuilder::new("linked_parent")
+                .attr("jid", parent_jid)
+                .build(),
+        );
+    } else if options.is_parent {
         let mut parent_builder = NodeBuilder::new("parent");
         if options.closed {
             parent_builder =
@@ -435,26 +456,11 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
         }
     }
 
-    // Link this subgroup to an existing community parent atomically.
-    if let Some(parent_jid) = &options.linked_parent {
-        children.push(
-            NodeBuilder::new("linked_parent")
-                .attr("jid", parent_jid)
-                .build(),
-        );
-    }
-
     // Inline description: WA Web emits `<description id="<token>"><body>{text}</body></description>`.
-    // Matches SetGroupDescriptionIq's 8-char hex id format for consistency.
     if let Some(desc) = &options.description {
-        use rand::RngExt as _;
-        let id = format!(
-            "{:08X}",
-            rand::make_rng::<rand::rngs::StdRng>().random::<u32>()
-        );
         children.push(
             NodeBuilder::new("description")
-                .attr("id", id)
+                .attr("id", generate_description_id())
                 .children([NodeBuilder::new("body").string_content(desc).build()])
                 .build(),
         );
@@ -1174,24 +1180,40 @@ impl crate::protocol::ProtocolNode for ParticipantChangeResponse {
             ));
         }
         let mut attrs = node.attrs();
-        let jid = attrs.jid("jid");
+        let jid = attrs
+            .optional_jid("jid")
+            .ok_or_else(|| ::anyhow::anyhow!("participant missing required 'jid' attribute"))?;
         let status = attrs.optional_string("type").map(|c| c.into_owned());
         let error = attrs.optional_string("error").map(|c| c.into_owned());
         let phone_number = attrs.optional_jid("phone_number");
         let username = attrs.optional_string("username").map(|c| c.into_owned());
 
         // <add_request code="..." expiration="N"/> appears on error="403"
-        // (WAWebInGroupsParticipantRequestCodeCanBeSentMixin). Only attempt
-        // to parse it when the child is actually present so non-403 entries
-        // keep returning None.
-        let add_request = node.get_optional_child("add_request").and_then(|n| {
-            let mut a = n.attrs();
-            let code = a.optional_string("code")?.into_owned();
-            let expiration = a
-                .optional_string("expiration")
-                .and_then(|s| s.parse::<u64>().ok())?;
-            Some(AddRequestInfo { code, expiration })
-        });
+        // (WAWebInGroupsParticipantRequestCodeCanBeSentMixin). Absent → None;
+        // present but malformed → hard error, since a 403 response that drops
+        // the V4 invite token is a server bug we want to surface.
+        let add_request = node
+            .get_optional_child("add_request")
+            .map(|n| -> ::anyhow::Result<AddRequestInfo> {
+                let mut a = n.attrs();
+                let code = a
+                    .optional_string("code")
+                    .ok_or_else(|| {
+                        ::anyhow::anyhow!("<add_request> missing required 'code' attribute")
+                    })?
+                    .into_owned();
+                let expiration = a
+                    .optional_string("expiration")
+                    .ok_or_else(|| {
+                        ::anyhow::anyhow!("<add_request> missing required 'expiration' attribute")
+                    })?
+                    .parse::<u64>()
+                    .map_err(|e| {
+                        ::anyhow::anyhow!("<add_request> 'expiration' is not a u64: {e}")
+                    })?;
+                Ok(AddRequestInfo { code, expiration })
+            })
+            .transpose()?;
 
         Ok(Self {
             jid,
@@ -1275,11 +1297,7 @@ impl SetGroupDescriptionIq {
         description: Option<GroupDescription>,
         prev: Option<String>,
     ) -> Self {
-        use rand::RngExt;
-        let id = format!(
-            "{:08X}",
-            rand::make_rng::<rand::rngs::StdRng>().random::<u32>()
-        );
+        let id = generate_description_id();
         Self {
             group_jid: group_jid.clone(),
             description,
@@ -1728,6 +1746,10 @@ impl IqSpec for SetGroupAnnouncementIq {
     }
 }
 
+/// Max value for the `<ephemeral trigger>` attribute, per
+/// `WASmaxInGroupsGroupInfoMixin` (range 0..=20).
+pub const EPHEMERAL_TRIGGER_MAX: u32 = 20;
+
 /// IQ specification for setting ephemeral (disappearing) messages on a group.
 ///
 /// Wire format:
@@ -1740,6 +1762,7 @@ impl IqSpec for SetGroupAnnouncementIq {
 /// ```
 ///
 /// Common expiration values (seconds):
+///
 /// - 86400 (24 hours)
 /// - 604800 (7 days)
 /// - 7776000 (90 days)
@@ -1749,9 +1772,10 @@ pub struct SetGroupEphemeralIq {
     pub group_jid: Jid,
     /// Expiration in seconds. `None` means disable.
     pub expiration: Option<NonZeroU32>,
-    /// Optional `trigger` attribute on `<ephemeral>` (WA Web range 0..20).
-    /// Identifies the disappearing-mode source (e.g. per-chat setting vs
-    /// device-wide default). `None` omits the attribute.
+    /// Optional `trigger` attribute on `<ephemeral>` (WA Web range
+    /// 0..=[`EPHEMERAL_TRIGGER_MAX`]). Identifies the disappearing-mode
+    /// source (e.g. per-chat setting vs device-wide default). `None` omits
+    /// the attribute.
     pub trigger: Option<u32>,
 }
 
@@ -1766,7 +1790,15 @@ impl SetGroupEphemeralIq {
     }
 
     /// Enable ephemeral messages with both expiration and explicit `trigger`.
+    ///
+    /// # Panics
+    /// If `trigger > [EPHEMERAL_TRIGGER_MAX]` (WA Web's `attrIntRange(0,20)`
+    /// constraint). Out-of-range values would be rejected by the server.
     pub fn enable_with_trigger(group_jid: &Jid, expiration: NonZeroU32, trigger: u32) -> Self {
+        assert!(
+            trigger <= EPHEMERAL_TRIGGER_MAX,
+            "ephemeral trigger must be in 0..={EPHEMERAL_TRIGGER_MAX}, got {trigger}"
+        );
         Self {
             group_jid: group_jid.clone(),
             expiration: Some(expiration),
@@ -1792,6 +1824,10 @@ impl IqSpec for SetGroupEphemeralIq {
             Some(exp) => {
                 let mut b = NodeBuilder::new("ephemeral").attr("expiration", exp.get());
                 if let Some(trigger) = self.trigger {
+                    debug_assert!(
+                        trigger <= EPHEMERAL_TRIGGER_MAX,
+                        "ephemeral trigger out of range (0..={EPHEMERAL_TRIGGER_MAX}): {trigger}"
+                    );
                     b = b.attr("trigger", trigger);
                 }
                 b.build()
@@ -3306,6 +3342,42 @@ mod tests {
     }
 
     #[test]
+    fn test_participant_change_response_rejects_missing_jid() {
+        let node = NodeBuilder::new("participant").attr("error", "403").build();
+        let err = ParticipantChangeResponse::try_from_node(&node)
+            .expect_err("missing jid must be a hard error");
+        assert!(err.to_string().contains("missing required 'jid' attribute"));
+    }
+
+    #[test]
+    fn test_participant_change_response_rejects_malformed_add_request() {
+        // <add_request> present but no code → hard error.
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "5511999999999@s.whatsapp.net")
+            .attr("error", "403")
+            .children([NodeBuilder::new("add_request")
+                .attr("expiration", "1735689600")
+                .build()])
+            .build();
+        let err = ParticipantChangeResponse::try_from_node(&node)
+            .expect_err("missing add_request code must be a hard error");
+        assert!(err.to_string().contains("missing required 'code'"));
+
+        // <add_request> with non-numeric expiration → hard error.
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "5511999999999@s.whatsapp.net")
+            .attr("error", "403")
+            .children([NodeBuilder::new("add_request")
+                .attr("code", "ABC")
+                .attr("expiration", "not-a-number")
+                .build()])
+            .build();
+        let err = ParticipantChangeResponse::try_from_node(&node)
+            .expect_err("non-u64 expiration must be a hard error");
+        assert!(err.to_string().contains("'expiration' is not a u64"));
+    }
+
+    #[test]
     fn test_set_group_locked_iq() {
         let group: Jid = "120363000000000001@g.us".parse().unwrap();
 
@@ -3389,6 +3461,28 @@ mod tests {
             Some("604800")
         );
         assert_eq!(attrs.optional_string("trigger").as_deref(), Some("7"));
+    }
+
+    #[test]
+    fn test_set_group_ephemeral_iq_accepts_trigger_at_max() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        // Boundary: trigger == EPHEMERAL_TRIGGER_MAX must succeed.
+        let _iq = SetGroupEphemeralIq::enable_with_trigger(
+            &group,
+            NonZeroU32::new(86400).unwrap(),
+            EPHEMERAL_TRIGGER_MAX,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "ephemeral trigger must be in 0..=20")]
+    fn test_set_group_ephemeral_iq_rejects_trigger_above_max() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        let _ = SetGroupEphemeralIq::enable_with_trigger(
+            &group,
+            NonZeroU32::new(86400).unwrap(),
+            EPHEMERAL_TRIGGER_MAX + 1,
+        );
     }
 
     #[test]
@@ -3801,6 +3895,43 @@ mod tests {
             linked.attrs().jid("jid"),
             parent,
             "linked_parent jid must match the requested parent"
+        );
+    }
+
+    #[test]
+    fn test_group_create_iq_linked_parent_excludes_parent_block() {
+        // `<parent>` ("I am a community") and `<linked_parent>` ("I am a
+        // subgroup of X") are semantically exclusive. When both are set,
+        // linked_parent must win and <parent>/<allow_non_admin_sub_group_creation>
+        // /<create_general_chat> must be omitted.
+        let parent: Jid = "120363000000000001@g.us".parse().unwrap();
+        let options = GroupCreateOptions {
+            subject: "Conflicting".into(),
+            is_parent: true,
+            closed: true,
+            allow_non_admin_sub_group_creation: true,
+            create_general_chat: true,
+            linked_parent: Some(parent.clone()),
+            ..Default::default()
+        };
+        let iq = GroupCreateIq::new(options).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected <create>");
+        };
+        assert!(nodes[0].get_optional_child("linked_parent").is_some());
+        assert!(
+            nodes[0].get_optional_child("parent").is_none(),
+            "<parent> must be omitted when linked_parent is set"
+        );
+        assert!(
+            nodes[0]
+                .get_optional_child("allow_non_admin_sub_group_creation")
+                .is_none(),
+            "community-only children must also be omitted"
+        );
+        assert!(
+            nodes[0].get_optional_child("create_general_chat").is_none(),
+            "community-only children must also be omitted"
         );
     }
 

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1068,27 +1068,102 @@ impl IqSpec for GroupCreateIq {
 // Group Management IQ Specs
 // ---------------------------------------------------------------------------
 
+/// V4 invite-token returned on `<participant error="403">` when the target's
+/// privacy settings block a direct add. The app can fall back to sending a
+/// `GroupInviteMessage` carrying these fields.
+///
+/// Wire shape: `<add_request code="..." expiration="N"/>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddRequestInfo {
+    pub code: String,
+    pub expiration: u64,
+}
+
 /// Response for participant change operations.
 ///
 /// Success is signaled by absent `error`; `type` is often omitted by the server.
-#[derive(Debug, Clone, crate::ProtocolNode)]
-#[protocol(tag = "participant")]
+/// When `error == "403"` an `<add_request>` child may be present carrying the
+/// V4 invite fallback token (see `add_request`).
+#[derive(Debug, Clone)]
 pub struct ParticipantChangeResponse {
-    #[attr(name = "jid", jid)]
     pub jid: Jid,
-    #[attr(name = "type")]
     pub status: Option<String>,
-    #[attr(name = "error")]
     pub error: Option<String>,
-    #[attr(name = "phone_number", jid)]
     pub phone_number: Option<Jid>,
-    #[attr(name = "username")]
     pub username: Option<String>,
+    pub add_request: Option<AddRequestInfo>,
 }
 
 impl ParticipantChangeResponse {
     pub fn is_ok(&self) -> bool {
         self.error.is_none()
+    }
+}
+
+impl crate::protocol::ProtocolNode for ParticipantChangeResponse {
+    fn tag(&self) -> &'static str {
+        "participant"
+    }
+
+    fn into_node(self) -> ::wacore_binary::node::Node {
+        let mut builder =
+            ::wacore_binary::builder::NodeBuilder::new("participant").attr("jid", &self.jid);
+        if let Some(s) = self.status {
+            builder = builder.attr("type", s);
+        }
+        if let Some(e) = self.error {
+            builder = builder.attr("error", e);
+        }
+        if let Some(ref pn) = self.phone_number {
+            builder = builder.attr("phone_number", pn);
+        }
+        if let Some(u) = self.username {
+            builder = builder.attr("username", u);
+        }
+        if let Some(ar) = self.add_request {
+            builder = builder.children([::wacore_binary::builder::NodeBuilder::new("add_request")
+                .attr("code", ar.code)
+                .attr("expiration", ar.expiration)
+                .build()]);
+        }
+        builder.build()
+    }
+
+    fn try_from_node_ref(node: &::wacore_binary::node::NodeRef<'_>) -> ::anyhow::Result<Self> {
+        if node.tag != "participant" {
+            return Err(::anyhow::anyhow!(
+                "expected <participant>, got <{}>",
+                node.tag
+            ));
+        }
+        let mut attrs = node.attrs();
+        let jid = attrs.jid("jid");
+        let status = attrs.optional_string("type").map(|c| c.into_owned());
+        let error = attrs.optional_string("error").map(|c| c.into_owned());
+        let phone_number = attrs.optional_jid("phone_number");
+        let username = attrs.optional_string("username").map(|c| c.into_owned());
+
+        // <add_request code="..." expiration="N"/> appears on error="403"
+        // (WAWebInGroupsParticipantRequestCodeCanBeSentMixin). Only attempt
+        // to parse it when the child is actually present so non-403 entries
+        // keep returning None.
+        let add_request = node.get_optional_child("add_request").and_then(|n| {
+            let mut a = n.attrs();
+            let code = a.optional_string("code")?.into_owned();
+            let expiration = a
+                .optional_string("expiration")
+                .and_then(|s| s.parse::<u64>().ok())?;
+            Some(AddRequestInfo { code, expiration })
+        });
+
+        Ok(Self {
+            jid,
+            status,
+            error,
+            phone_number,
+            username,
+            add_request,
+        })
     }
 }
 
@@ -3160,6 +3235,37 @@ mod tests {
             Some("15555550100")
         );
         assert_eq!(result.username.as_deref(), Some("example_user"));
+    }
+
+    #[test]
+    fn test_participant_change_response_parses_add_request_on_403() {
+        // WAWebInGroupsParticipantRequestCodeCanBeSentMixin: on error="403"
+        // the server returns the V4 invite token in <add_request code=... expiration=N/>.
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "5511999999999@s.whatsapp.net")
+            .attr("error", "403")
+            .children([NodeBuilder::new("add_request")
+                .attr("code", "ABC123DEF")
+                .attr("expiration", "1735689600")
+                .build()])
+            .build();
+
+        let result = ParticipantChangeResponse::try_from_node(&node).unwrap();
+        assert_eq!(result.error.as_deref(), Some("403"));
+        let ar = result
+            .add_request
+            .expect("403 response must carry the add_request token");
+        assert_eq!(ar.code, "ABC123DEF");
+        assert_eq!(ar.expiration, 1735689600);
+    }
+
+    #[test]
+    fn test_participant_change_response_no_add_request_on_success() {
+        let node = NodeBuilder::new("participant")
+            .attr("jid", "5511999999999@s.whatsapp.net")
+            .build();
+        let result = ParticipantChangeResponse::try_from_node(&node).unwrap();
+        assert!(result.add_request.is_none());
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -272,9 +272,10 @@ pub struct GroupCreateOptions {
     #[builder(default, setter(strip_option, into))]
     pub linked_parent: Option<Jid>,
     /// Inline description carried on the create stanza; avoids a follow-up
-    /// SetGroupDescription IQ.
+    /// SetGroupDescription IQ. Validation (length cap) goes through
+    /// [`GroupDescription`] so both create paths share the same contract.
     #[builder(default, setter(strip_option, into))]
-    pub description: Option<String>,
+    pub description: Option<GroupDescription>,
 }
 
 impl GroupCreateOptions {
@@ -430,7 +431,21 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
     // `<parent>` (this group IS a community) and `<linked_parent>` (this
     // group is a subgroup of X) are mutually exclusive. When both are
     // requested, `linked_parent` wins; it carries an explicit target.
+    debug_assert!(
+        options.linked_parent.is_none() || !options.is_parent,
+        "GroupCreateOptions: linked_parent and is_parent are mutually exclusive"
+    );
     if let Some(parent_jid) = &options.linked_parent {
+        if options.is_parent {
+            log::warn!(
+                "GroupCreateOptions has both linked_parent={parent_jid} and is_parent=true \
+                 (closed={}, allow_non_admin_sub_group_creation={}, create_general_chat={}); \
+                 dropping parent-only flags",
+                options.closed,
+                options.allow_non_admin_sub_group_creation,
+                options.create_general_chat,
+            );
+        }
         children.push(
             NodeBuilder::new("linked_parent")
                 .attr("jid", parent_jid)
@@ -457,7 +472,9 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
         children.push(
             NodeBuilder::new("description")
                 .attr("id", generate_description_id())
-                .children([NodeBuilder::new("body").string_content(desc).build()])
+                .children([NodeBuilder::new("body")
+                    .string_content(desc.as_str())
+                    .build()])
                 .build(),
         );
     }
@@ -1808,11 +1825,12 @@ impl IqSpec for SetGroupEphemeralIq {
         let node = match self.expiration {
             Some(exp) => {
                 let mut b = NodeBuilder::new("ephemeral").attr("expiration", exp.get());
-                if let Some(trigger) = self.trigger {
-                    debug_assert!(
-                        trigger <= EPHEMERAL_TRIGGER_MAX,
-                        "ephemeral trigger out of range (0..={EPHEMERAL_TRIGGER_MAX}): {trigger}"
-                    );
+                // Skip out-of-range triggers instead of emitting them; the
+                // constructor asserts on misuse, this is the defence-in-depth
+                // path for direct field assignment.
+                if let Some(trigger) = self.trigger
+                    && trigger <= EPHEMERAL_TRIGGER_MAX
+                {
                     b = b.attr("trigger", trigger);
                 }
                 b.build()
@@ -3484,6 +3502,23 @@ mod tests {
     }
 
     #[test]
+    fn test_set_group_ephemeral_iq_skips_out_of_range_trigger_in_build_iq() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        // Bypass the constructor and write directly to mimic a caller that
+        // sets the public field to an invalid value.
+        let mut iq_spec = SetGroupEphemeralIq::enable(&group, NonZeroU32::new(86400).unwrap());
+        iq_spec.trigger = Some(EPHEMERAL_TRIGGER_MAX + 1);
+        let iq = iq_spec.build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected nodes content");
+        };
+        assert!(
+            nodes[0].attrs().optional_string("trigger").is_none(),
+            "out-of-range trigger must be dropped on the wire"
+        );
+    }
+
+    #[test]
     fn test_set_group_membership_approval_iq() {
         let group: Jid = "120363000000000001@g.us".parse().unwrap();
 
@@ -3884,11 +3919,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "mutually exclusive"))]
     fn test_group_create_iq_linked_parent_excludes_parent_block() {
-        // `<parent>` ("I am a community") and `<linked_parent>` ("I am a
-        // subgroup of X") are semantically exclusive. When both are set,
-        // linked_parent must win and <parent>/<allow_non_admin_sub_group_creation>
-        // /<create_general_chat> must be omitted.
+        // Setting both is a programmer error: debug builds panic on the
+        // debug_assert; release builds silently emit only <linked_parent>.
         let parent: Jid = "120363000000000001@g.us".parse().unwrap();
         let options = GroupCreateOptions {
             subject: "Conflicting".into(),
@@ -3904,20 +3938,13 @@ mod tests {
             panic!("expected <create>");
         };
         assert!(nodes[0].get_optional_child("linked_parent").is_some());
-        assert!(
-            nodes[0].get_optional_child("parent").is_none(),
-            "<parent> must be omitted when linked_parent is set"
-        );
+        assert!(nodes[0].get_optional_child("parent").is_none());
         assert!(
             nodes[0]
                 .get_optional_child("allow_non_admin_sub_group_creation")
-                .is_none(),
-            "community-only children must also be omitted"
+                .is_none()
         );
-        assert!(
-            nodes[0].get_optional_child("create_general_chat").is_none(),
-            "community-only children must also be omitted"
-        );
+        assert!(nodes[0].get_optional_child("create_general_chat").is_none());
     }
 
     #[test]
@@ -3952,7 +3979,7 @@ mod tests {
     fn test_group_create_iq_emits_description_with_body() {
         let options = GroupCreateOptions {
             subject: "Group with desc".into(),
-            description: Some("Hello, group".into()),
+            description: Some(GroupDescription::new("Hello, group").unwrap()),
             ..Default::default()
         };
         let iq = GroupCreateIq::new(options).build_iq();
@@ -3977,6 +4004,12 @@ mod tests {
             _ => panic!("description body must carry text"),
         };
         assert_eq!(text, "Hello, group");
+    }
+
+    #[test]
+    fn test_group_create_iq_description_rejects_over_max_length() {
+        let too_long = "x".repeat(GROUP_DESCRIPTION_MAX_LENGTH + 1);
+        assert!(GroupDescription::new(too_long).is_err());
     }
 
     #[test]

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -267,6 +267,16 @@ pub struct GroupCreateOptions {
     /// Only used when `is_parent` is true.
     #[builder(default)]
     pub create_general_chat: bool,
+    /// JID of an existing community parent to link this subgroup to. Emits
+    /// `<linked_parent jid="..."/>` so a subgroup can be created atomically
+    /// (matches `OutGroupsCreateRequest`).
+    #[builder(default, setter(strip_option, into))]
+    pub linked_parent: Option<Jid>,
+    /// Optional `<description id="<token>"><body>{text}</body></description>`
+    /// child on the create stanza. WA Web supports inline description on
+    /// create so callers can avoid a follow-up set-description IQ.
+    #[builder(default, setter(strip_option, into))]
+    pub description: Option<String>,
 }
 
 impl GroupCreateOptions {
@@ -322,6 +332,8 @@ impl Default for GroupCreateOptions {
             closed: false,
             allow_non_admin_sub_group_creation: false,
             create_general_chat: false,
+            linked_parent: None,
+            description: None,
         }
     }
 }
@@ -421,6 +433,36 @@ pub fn build_create_group_node(options: &GroupCreateOptions) -> Node {
         if options.create_general_chat {
             children.push(NodeBuilder::new("create_general_chat").build());
         }
+    }
+
+    // Link this subgroup to an existing community parent atomically.
+    if let Some(parent_jid) = &options.linked_parent {
+        children.push(
+            NodeBuilder::new("linked_parent")
+                .attr("jid", parent_jid)
+                .build(),
+        );
+    }
+
+    // Inline description: WA Web emits `<description id="<token>"><body>{text}</body></description>`.
+    if let Some(desc) = &options.description {
+        use rand::Rng as _;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut id_bytes = [0u8; 8];
+        rng.fill_bytes(&mut id_bytes);
+        let id = id_bytes
+            .iter()
+            .fold(String::with_capacity(16), |mut acc, b| {
+                use std::fmt::Write as _;
+                let _ = write!(acc, "{b:02X}");
+                acc
+            });
+        children.push(
+            NodeBuilder::new("description")
+                .attr("id", id)
+                .children([NodeBuilder::new("body").string_content(desc).build()])
+                .build(),
+        );
     }
 
     NodeBuilder::new("create")
@@ -3743,6 +3785,69 @@ mod tests {
 
         assert!(response.is_parent_group);
         assert!(response.allow_non_admin_sub_group_creation);
+    }
+
+    #[test]
+    fn test_group_create_iq_emits_linked_parent() {
+        let parent: Jid = "120363000000000001@g.us".parse().unwrap();
+        let options = GroupCreateOptions {
+            subject: "Subgroup".into(),
+            linked_parent: Some(parent.clone()),
+            ..Default::default()
+        };
+        let iq = GroupCreateIq::new(options).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected <create>");
+        };
+        let linked = nodes[0]
+            .get_optional_child("linked_parent")
+            .expect("linked_parent child must be emitted");
+        assert_eq!(
+            linked.attrs().jid("jid"),
+            parent,
+            "linked_parent jid must match the requested parent"
+        );
+    }
+
+    #[test]
+    fn test_group_create_iq_emits_description_with_body() {
+        let options = GroupCreateOptions {
+            subject: "Group with desc".into(),
+            description: Some("Hello, group".into()),
+            ..Default::default()
+        };
+        let iq = GroupCreateIq::new(options).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected <create>");
+        };
+        let desc = nodes[0]
+            .get_optional_child("description")
+            .expect("description child must be emitted");
+        assert!(
+            desc.attrs()
+                .optional_string("id")
+                .is_some_and(|id| !id.is_empty()),
+            "description must carry an opaque id token"
+        );
+        let body = desc
+            .get_optional_child("body")
+            .expect("description must have a body child");
+        let text = match &body.content {
+            Some(NodeContent::String(s)) => s.to_string(),
+            Some(NodeContent::Bytes(b)) => String::from_utf8_lossy(b).into_owned(),
+            _ => panic!("description body must carry text"),
+        };
+        assert_eq!(text, "Hello, group");
+    }
+
+    #[test]
+    fn test_group_create_iq_omits_linked_parent_and_description_by_default() {
+        let iq = GroupCreateIq::new(GroupCreateOptions::new("Plain")).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected <create>");
+        };
+        assert!(nodes[0].get_optional_child("linked_parent").is_none());
+        assert!(nodes[0].get_optional_child("description").is_none());
     }
 
     /// Plain (non-community) group create: overlay branch must not run, both

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -2,12 +2,10 @@ use std::str::FromStr;
 use wacore_binary::{Jid, JidExt};
 use waproto::whatsapp as wa;
 
-/// Invokes a callback macro with the list of all message types that have `context_info`.
-///
-/// This macro ensures both `for_each_context_info_message!` and `set_context_info_on_message!`
-/// use the same list of message types, making it easy to add new types in one place.
-///
-/// When WhatsApp adds new message types with context_info, add them here.
+/// Single source of truth for the message types that carry a `context_info`
+/// field. Consumed by `for_each_context_info_message!`, `set_context_info`
+/// (via an inlined `try_attach!`), `get_ephemeral_expiration`, and
+/// `set_ephemeral_expiration`. Add new WA message types with context_info here.
 macro_rules! with_context_info_fields {
     ($callback:ident!($($prefix:tt)*)) => {
         $callback!($($prefix)*
@@ -949,6 +947,8 @@ mod tests {
             ..Default::default()
         };
         assert!(!msg.set_context_info(context));
+        assert!(msg.conversation.is_none());
+        assert!(msg.extended_text_message.is_none());
     }
 
     /// Test: build_quote_context produces correct structure.

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -66,27 +66,6 @@ macro_rules! for_each_context_info_impl {
     };
 }
 
-/// Sets context_info on the first matching message type.
-/// Returns true if context was set, false otherwise.
-macro_rules! set_context_info_on_message {
-    ($msg:expr, $ctx:expr) => {
-        with_context_info_fields!(set_context_info_impl!($msg, $ctx,))
-    };
-}
-
-macro_rules! set_context_info_impl {
-    ($msg:expr, $ctx:expr, $($field:ident),+ $(,)?) => {{
-        let ctx = $ctx;
-        $(
-            if let Some(ref mut m) = $msg.$field {
-                m.context_info = Some(ctx);
-                return true;
-            }
-        )+
-        false
-    }};
-}
-
 /// Extension trait for wa::Message
 pub trait MessageExt {
     /// Recursively unwraps ephemeral/view-once/document_with_caption/edited wrappers to get the core message.
@@ -315,7 +294,33 @@ impl MessageExt for wa::Message {
     }
 
     fn set_context_info(&mut self, context: wa::ContextInfo) -> bool {
-        set_context_info_on_message!(self, Box::new(context))
+        // Existing fields first (image/video/extended_text/...): the macro
+        // expands to a sequence of `if let ... { ...; return true; }` blocks
+        // so a match here exits the function before the conversation fallback.
+        macro_rules! try_attach {
+            ($($field:ident),+ $(,)?) => {
+                $(
+                    if let Some(ref mut m) = self.$field {
+                        m.context_info = Some(Box::new(context));
+                        return true;
+                    }
+                )+
+            };
+        }
+        with_context_info_fields!(try_attach!());
+
+        // Bare conversation: promote to extended_text_message. Mirrors the
+        // ephemeral-expiration path; WA Web upgrades text-only bodies
+        // whenever a ContextInfo field needs to be populated.
+        if let Some(text) = self.conversation.take() {
+            self.extended_text_message = Some(Box::new(wa::message::ExtendedTextMessage {
+                text: Some(text),
+                context_info: Some(Box::new(context)),
+                ..Default::default()
+            }));
+            return true;
+        }
+        false
     }
 
     fn get_ephemeral_expiration(&self) -> Option<u32> {
@@ -915,7 +920,10 @@ mod tests {
 
     /// Test: set_context_info returns false for unsupported message types
     #[test]
-    fn test_set_context_info_unsupported() {
+    fn test_set_context_info_promotes_bare_conversation() {
+        // Mirrors WAWebMessageSendUtils: a bare `conversation` body is
+        // promoted to `extended_text_message` when a ContextInfo needs to
+        // attach (e.g. quote, mention, ephemeral timer).
         let mut msg = wa::Message {
             conversation: Some("Simple text".to_string()),
             ..Default::default()
@@ -926,6 +934,27 @@ mod tests {
             ..Default::default()
         };
 
+        assert!(msg.set_context_info(context));
+        assert!(msg.conversation.is_none(), "conversation must be moved out");
+        let ext = msg
+            .extended_text_message
+            .expect("promoted to extended_text_message");
+        assert_eq!(ext.text.as_deref(), Some("Simple text"));
+        assert_eq!(
+            ext.context_info
+                .as_ref()
+                .and_then(|c| c.stanza_id.as_deref()),
+            Some("test-id")
+        );
+    }
+
+    #[test]
+    fn test_set_context_info_returns_false_on_empty_message() {
+        let mut msg = wa::Message::default();
+        let context = wa::ContextInfo {
+            stanza_id: Some("test-id".to_string()),
+            ..Default::default()
+        };
         assert!(!msg.set_context_info(context));
     }
 

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -354,6 +354,22 @@ impl MessageExt for wa::Message {
             };
         }
         with_context_info_fields!(try_set!());
+
+        // WAWebMessageSendUtils: when a bare <conversation> body needs a
+        // ContextInfo, promote it to <extended_text_message> so the timer
+        // attaches. Without this, the lib silently drops the ephemeral flag.
+        if let Some(text) = self.conversation.take() {
+            self.extended_text_message = Some(Box::new(wa::message::ExtendedTextMessage {
+                text: Some(text),
+                context_info: Some(Box::new(wa::ContextInfo {
+                    expiration: Some(expiration),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }));
+            return true;
+        }
+
         false
     }
 }
@@ -1824,6 +1840,37 @@ mod tests {
             ..Default::default()
         };
         assert!(msg.is_view_once());
+    }
+
+    #[test]
+    fn set_ephemeral_expiration_promotes_bare_conversation_to_extended_text() {
+        // WAWebMessageSendUtils: bare conversation needs to be promoted so a
+        // ContextInfo (and thus the timer) can attach.
+        let mut msg = wa::Message {
+            conversation: Some("hello".to_string()),
+            ..Default::default()
+        };
+        assert!(msg.set_ephemeral_expiration(86400));
+        assert!(
+            msg.conversation.is_none(),
+            "conversation must be moved out, not duplicated"
+        );
+        let ext = msg
+            .extended_text_message
+            .expect("conversation must have been promoted");
+        assert_eq!(ext.text.as_deref(), Some("hello"));
+        assert_eq!(
+            ext.context_info.as_ref().and_then(|c| c.expiration),
+            Some(86400)
+        );
+    }
+
+    #[test]
+    fn set_ephemeral_expiration_returns_false_on_empty_message() {
+        let mut msg = wa::Message::default();
+        assert!(!msg.set_ephemeral_expiration(60));
+        assert!(msg.conversation.is_none());
+        assert!(msg.extended_text_message.is_none());
     }
 
     #[test]

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -132,16 +132,11 @@ pub trait MessageExt {
     /// Reads `context_info.expiration` from the first message type that has it.
     fn get_ephemeral_expiration(&self) -> Option<u32>;
 
-    /// Sets `context_info.expiration` on the first message type found.
-    /// Creates a default `context_info` if needed.
-    ///
-    /// For a bare `conversation` body, this promotes the message to
-    /// `extended_text_message { text, context_info { expiration } }` so the
-    /// timer can attach — matching `WAWebMessageSendUtils`. Returns `true`
-    /// after a successful set or promotion; `false` only when there is no
-    /// supported body to carry the timer (e.g. an empty `Message::default()`).
-    ///
-    /// See [`set_ephemeral_expiration`](Self::set_ephemeral_expiration) impl.
+    /// Sets `context_info.expiration` on the first message type found, creating
+    /// a default `context_info` if needed. A bare `conversation` body is
+    /// promoted to `extended_text_message { text, context_info { expiration } }`
+    /// (mirrors `WAWebMessageSendUtils`). Returns `true` on success or
+    /// promotion, `false` only when no body can carry the timer.
     fn set_ephemeral_expiration(&mut self, expiration: u32) -> bool;
 }
 
@@ -301,9 +296,6 @@ impl MessageExt for wa::Message {
     }
 
     fn set_context_info(&mut self, context: wa::ContextInfo) -> bool {
-        // Existing fields first (image/video/extended_text/...): the macro
-        // expands to a sequence of `if let ... { ...; return true; }` blocks
-        // so a match here exits the function before the conversation fallback.
         macro_rules! try_attach {
             ($($field:ident),+ $(,)?) => {
                 $(
@@ -316,9 +308,8 @@ impl MessageExt for wa::Message {
         }
         with_context_info_fields!(try_attach!());
 
-        // Bare conversation: promote to extended_text_message. Mirrors the
-        // ephemeral-expiration path; WA Web upgrades text-only bodies
-        // whenever a ContextInfo field needs to be populated.
+        // Promote bare conversation to extended_text_message so the context
+        // can attach; matches WAWebMessageSendUtils.
         if let Some(text) = self.conversation.take() {
             self.extended_text_message = Some(Box::new(wa::message::ExtendedTextMessage {
                 text: Some(text),
@@ -367,9 +358,8 @@ impl MessageExt for wa::Message {
         }
         with_context_info_fields!(try_set!());
 
-        // WAWebMessageSendUtils: when a bare <conversation> body needs a
-        // ContextInfo, promote it to <extended_text_message> so the timer
-        // attaches. Without this, the lib silently drops the ephemeral flag.
+        // Promote bare conversation so the timer can attach; matches
+        // WAWebMessageSendUtils.
         if let Some(text) = self.conversation.take() {
             self.extended_text_message = Some(Box::new(wa::message::ExtendedTextMessage {
                 text: Some(text),
@@ -925,12 +915,8 @@ mod tests {
         assert!(loc.context_info.is_some());
     }
 
-    /// Test: set_context_info returns false for unsupported message types
     #[test]
     fn test_set_context_info_promotes_bare_conversation() {
-        // Mirrors WAWebMessageSendUtils: a bare `conversation` body is
-        // promoted to `extended_text_message` when a ContextInfo needs to
-        // attach (e.g. quote, mention, ephemeral timer).
         let mut msg = wa::Message {
             conversation: Some("Simple text".to_string()),
             ..Default::default()
@@ -1880,20 +1866,13 @@ mod tests {
 
     #[test]
     fn set_ephemeral_expiration_promotes_bare_conversation_to_extended_text() {
-        // WAWebMessageSendUtils: bare conversation needs to be promoted so a
-        // ContextInfo (and thus the timer) can attach.
         let mut msg = wa::Message {
             conversation: Some("hello".to_string()),
             ..Default::default()
         };
         assert!(msg.set_ephemeral_expiration(86400));
-        assert!(
-            msg.conversation.is_none(),
-            "conversation must be moved out, not duplicated"
-        );
-        let ext = msg
-            .extended_text_message
-            .expect("conversation must have been promoted");
+        assert!(msg.conversation.is_none());
+        let ext = msg.extended_text_message.unwrap();
         assert_eq!(ext.text.as_deref(), Some("hello"));
         assert_eq!(
             ext.context_info.as_ref().and_then(|c| c.expiration),

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -133,8 +133,15 @@ pub trait MessageExt {
     fn get_ephemeral_expiration(&self) -> Option<u32>;
 
     /// Sets `context_info.expiration` on the first message type found.
-    /// Creates a default `context_info` if needed. Returns `false` for
-    /// bare `conversation` messages (use `ExtendedTextMessage` instead).
+    /// Creates a default `context_info` if needed.
+    ///
+    /// For a bare `conversation` body, this promotes the message to
+    /// `extended_text_message { text, context_info { expiration } }` so the
+    /// timer can attach — matching `WAWebMessageSendUtils`. Returns `true`
+    /// after a successful set or promotion; `false` only when there is no
+    /// supported body to carry the timer (e.g. an empty `Message::default()`).
+    ///
+    /// See [`set_ephemeral_expiration`](Self::set_ephemeral_expiration) impl.
     fn set_ephemeral_expiration(&mut self, expiration: u32) -> bool;
 }
 

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -404,8 +404,15 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
         // below produce `Ephemeral { expiration: 0, trigger: None }`, matching
         // WA Web's collapse of the two wire tags into one action.
         T::Ephemeral => GroupNotificationAction::Ephemeral {
-            expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
-            trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
+            expiration: node
+                .attrs()
+                .optional_u64("expiration")
+                .and_then(|t| t.try_into().ok())
+                .unwrap_or(0),
+            trigger: node
+                .attrs()
+                .optional_u64("trigger")
+                .and_then(|t| t.try_into().ok()),
         },
         T::MembershipApprovalMode => {
             let enabled = node
@@ -456,7 +463,11 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
         },
         T::RevokeInvite => GroupNotificationAction::RevokeInvite,
         T::GrowthLocked => GroupNotificationAction::GrowthLocked {
-            expiration: node.attrs().optional_u64("expiration").unwrap_or(0) as u32,
+            expiration: node
+                .attrs()
+                .optional_u64("expiration")
+                .and_then(|t| t.try_into().ok())
+                .unwrap_or(0),
             lock_type: node
                 .attrs()
                 .optional_string("type")
@@ -508,7 +519,11 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
         T::IsCapiHostedGroup => GroupNotificationAction::IsCapiHostedGroup,
         T::GroupSafetyCheck => GroupNotificationAction::GroupSafetyCheck,
         T::LimitSharingEnabled => GroupNotificationAction::LimitSharingEnabled {
-            trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
+            // try_into so >u32::MAX yields None instead of silently truncating.
+            trigger: node
+                .attrs()
+                .optional_u64("trigger")
+                .and_then(|t| t.try_into().ok()),
         },
         T::AllowAdminReports => GroupNotificationAction::AllowAdminReports,
         T::NotAllowAdminReports => GroupNotificationAction::NotAllowAdminReports,
@@ -978,32 +993,50 @@ mod tests {
 
     #[test]
     fn test_parse_suspended_toggle_variants() {
-        let table = [
-            ("suspended", "Suspended"),
-            ("unsuspended", "Unsuspended"),
-            ("auto_add_disabled", "AutoAddDisabled"),
-            ("is_capi_hosted_group", "IsCapiHostedGroup"),
-            ("group_safety_check", "GroupSafetyCheck"),
-            ("limit_sharing_enabled", "LimitSharingEnabled"),
-            ("allow_admin_reports", "AllowAdminReports"),
-            ("not_allow_admin_reports", "NotAllowAdminReports"),
-            ("reports", "Reports"),
-            (
-                "allow_non_admin_sub_group_creation",
-                "AllowNonAdminSubGroupCreation",
-            ),
-            (
-                "not_allow_non_admin_sub_group_creation",
-                "NotAllowNonAdminSubGroupCreation",
-            ),
+        // (wire_tag, matcher) pairs. Type-safe `matches!` on the parsed
+        // enum guarantees a parser regression (e.g. landing in `Unknown`)
+        // surfaces immediately, instead of relying on `Debug` string prefix.
+        type Matcher = fn(&GroupNotificationAction) -> bool;
+        let table: &[(&str, Matcher)] = &[
+            ("suspended", |a| {
+                matches!(a, GroupNotificationAction::Suspended)
+            }),
+            ("unsuspended", |a| {
+                matches!(a, GroupNotificationAction::Unsuspended)
+            }),
+            ("auto_add_disabled", |a| {
+                matches!(a, GroupNotificationAction::AutoAddDisabled)
+            }),
+            ("is_capi_hosted_group", |a| {
+                matches!(a, GroupNotificationAction::IsCapiHostedGroup)
+            }),
+            ("group_safety_check", |a| {
+                matches!(a, GroupNotificationAction::GroupSafetyCheck)
+            }),
+            ("limit_sharing_enabled", |a| {
+                matches!(a, GroupNotificationAction::LimitSharingEnabled { .. })
+            }),
+            ("allow_admin_reports", |a| {
+                matches!(a, GroupNotificationAction::AllowAdminReports)
+            }),
+            ("not_allow_admin_reports", |a| {
+                matches!(a, GroupNotificationAction::NotAllowAdminReports)
+            }),
+            ("reports", |a| matches!(a, GroupNotificationAction::Reports)),
+            ("allow_non_admin_sub_group_creation", |a| {
+                matches!(a, GroupNotificationAction::AllowNonAdminSubGroupCreation)
+            }),
+            ("not_allow_non_admin_sub_group_creation", |a| {
+                matches!(a, GroupNotificationAction::NotAllowNonAdminSubGroupCreation)
+            }),
         ];
-        for (tag, expected) in table {
+        for (tag, matcher) in table {
             let node = make_notification(vec![NodeBuilder::new(tag).build()]);
             let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
-            let action_name = format!("{:?}", notif.actions[0]);
             assert!(
-                action_name.starts_with(expected),
-                "wire tag {tag} must parse to {expected}, got {action_name}"
+                matcher(&notif.actions[0]),
+                "wire tag {tag} parsed to unexpected variant: {:?}",
+                notif.actions[0]
             );
         }
     }

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -290,10 +290,9 @@ pub enum GroupNotificationAction {
 }
 
 impl GroupNotification {
-    /// Parse from a `NodeRef`.
-    ///
-    /// Most fields are parsed zero-copy. Only `Create`/`Link`/`Unlink` actions
-    /// call `.to_owned()` on their specific child node (structurally required to store `raw: Node`).
+    /// Parse from a `NodeRef`. Most fields are zero-copy; `Create`, `Link`,
+    /// `Unlink`, `CreatedSubGroupSuggestion` and `RevokedSubGroupSuggestions`
+    /// call `.to_owned()` to store their child as `raw: Node`.
     pub fn try_from_node_ref(node: &NodeRef<'_>) -> Option<Self> {
         let mut attrs = node.attrs();
         let group_jid = attrs.optional_jid("from")?;
@@ -328,7 +327,9 @@ impl GroupNotification {
 /// function. If the `#[wire = "..."]` attribute on a variant changes, both
 /// the serializer and this dispatcher track it automatically.
 ///
-/// Only `Create`/`Link`/`Unlink` call `.to_owned()` because those variants store `raw: Node`.
+/// `Create`, `Link`, `Unlink`, `CreatedSubGroupSuggestion` and
+/// `RevokedSubGroupSuggestions` call `.to_owned()` because those variants
+/// store `raw: Node`.
 fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
     use GroupNotificationActionTag as T;
     use wacore_binary::NodeContentRef;
@@ -993,9 +994,6 @@ mod tests {
 
     #[test]
     fn test_parse_suspended_toggle_variants() {
-        // (wire_tag, matcher) pairs. Type-safe `matches!` on the parsed
-        // enum guarantees a parser regression (e.g. landing in `Unknown`)
-        // surfaces immediately, instead of relying on `Debug` string prefix.
         type Matcher = fn(&GroupNotificationAction) -> bool;
         let table: &[(&str, Matcher)] = &[
             ("suspended", |a| {
@@ -1183,12 +1181,39 @@ mod tests {
             GroupNotificationAction::Unlink {
                 unlink_type: "x".into(),
                 unlink_reason: None,
-                raw: dummy_node,
+                raw: dummy_node.clone(),
+            },
+            GroupNotificationAction::LinkedGroupPromote {
+                participants: vec![],
+            },
+            GroupNotificationAction::LinkedGroupDemote {
+                participants: vec![],
+            },
+            GroupNotificationAction::Suspended,
+            GroupNotificationAction::Unsuspended,
+            GroupNotificationAction::AutoAddDisabled,
+            GroupNotificationAction::IsCapiHostedGroup,
+            GroupNotificationAction::GroupSafetyCheck,
+            GroupNotificationAction::LimitSharingEnabled { trigger: None },
+            GroupNotificationAction::AllowAdminReports,
+            GroupNotificationAction::NotAllowAdminReports,
+            GroupNotificationAction::Reports,
+            GroupNotificationAction::AllowNonAdminSubGroupCreation,
+            GroupNotificationAction::NotAllowNonAdminSubGroupCreation,
+            GroupNotificationAction::CreatedSubGroupSuggestion {
+                raw: dummy_node.clone(),
+            },
+            GroupNotificationAction::RevokedSubGroupSuggestions {
+                raw: dummy_node.clone(),
+            },
+            GroupNotificationAction::ChangeNumber {
+                participants: vec![],
             },
             GroupNotificationAction::Unknown {
                 tag: "future_tag".into(),
             },
         ];
+        let _ = dummy_node;
 
         for action in &samples {
             let value = serde_json::to_value(action).expect("serialize");

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -238,9 +238,11 @@ pub enum GroupNotificationAction {
     /// `<group_safety_check/>` — Integrity check toggle.
     #[wire = "group_safety_check"]
     GroupSafetyCheck,
-    /// `<limit_sharing_enabled trigger="..."/>` — Limit sharing toggle.
+    /// `<limit_sharing_enabled trigger="..."/>` — Limit sharing toggle. The
+    /// optional `trigger` attribute (range 0..20 per
+    /// `WASmaxInGroupsGroupInfoMixin`) identifies the source of the change.
     #[wire = "limit_sharing_enabled"]
-    LimitSharingEnabled,
+    LimitSharingEnabled { trigger: Option<u32> },
     /// `<allow_admin_reports/>` — Admins may receive report alerts.
     #[wire = "allow_admin_reports"]
     AllowAdminReports,
@@ -505,7 +507,9 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
         T::AutoAddDisabled => GroupNotificationAction::AutoAddDisabled,
         T::IsCapiHostedGroup => GroupNotificationAction::IsCapiHostedGroup,
         T::GroupSafetyCheck => GroupNotificationAction::GroupSafetyCheck,
-        T::LimitSharingEnabled => GroupNotificationAction::LimitSharingEnabled,
+        T::LimitSharingEnabled => GroupNotificationAction::LimitSharingEnabled {
+            trigger: node.attrs().optional_u64("trigger").map(|t| t as u32),
+        },
         T::AllowAdminReports => GroupNotificationAction::AllowAdminReports,
         T::NotAllowAdminReports => GroupNotificationAction::NotAllowAdminReports,
         T::Reports => GroupNotificationAction::Reports,
@@ -1001,6 +1005,29 @@ mod tests {
                 action_name.starts_with(expected),
                 "wire tag {tag} must parse to {expected}, got {action_name}"
             );
+        }
+    }
+
+    #[test]
+    fn test_parse_limit_sharing_enabled_captures_trigger() {
+        let with_trigger = make_notification(vec![
+            NodeBuilder::new("limit_sharing_enabled")
+                .attr("trigger", "5")
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&with_trigger.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::LimitSharingEnabled { trigger } => {
+                assert_eq!(*trigger, Some(5));
+            }
+            other => panic!("expected LimitSharingEnabled, got {:?}", other),
+        }
+
+        let no_trigger = make_notification(vec![NodeBuilder::new("limit_sharing_enabled").build()]);
+        let notif = GroupNotification::try_from_node_ref(&no_trigger.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::LimitSharingEnabled { trigger } => assert!(trigger.is_none()),
+            other => panic!("expected LimitSharingEnabled, got {:?}", other),
         }
     }
 

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -211,6 +211,74 @@ pub enum GroupNotificationAction {
         #[wire(skip)]
         raw: Node,
     },
+    /// `<linked_group_promote>` — Subgroup admin elevated (community parent).
+    #[wire = "linked_group_promote"]
+    LinkedGroupPromote {
+        participants: Vec<GroupParticipantInfo>,
+    },
+    /// `<linked_group_demote>` — Subgroup admin demoted.
+    #[wire = "linked_group_demote"]
+    LinkedGroupDemote {
+        participants: Vec<GroupParticipantInfo>,
+    },
+
+    // -- State toggles --
+    /// `<suspended/>` — Group suspended by Meta moderation.
+    #[wire = "suspended"]
+    Suspended,
+    /// `<unsuspended/>` — Suspension lifted.
+    #[wire = "unsuspended"]
+    Unsuspended,
+    /// `<auto_add_disabled/>` — Community auto-add to general chat disabled.
+    #[wire = "auto_add_disabled"]
+    AutoAddDisabled,
+    /// `<is_capi_hosted_group/>` — Group routed through CAPI hosted server.
+    #[wire = "is_capi_hosted_group"]
+    IsCapiHostedGroup,
+    /// `<group_safety_check/>` — Integrity check toggle.
+    #[wire = "group_safety_check"]
+    GroupSafetyCheck,
+    /// `<limit_sharing_enabled trigger="..."/>` — Limit sharing toggle.
+    #[wire = "limit_sharing_enabled"]
+    LimitSharingEnabled,
+    /// `<allow_admin_reports/>` — Admins may receive report alerts.
+    #[wire = "allow_admin_reports"]
+    AllowAdminReports,
+    /// `<not_allow_admin_reports/>` — Admin reports disabled.
+    #[wire = "not_allow_admin_reports"]
+    NotAllowAdminReports,
+    /// `<reports/>` — Generic reports notification.
+    #[wire = "reports"]
+    Reports,
+    /// `<allow_non_admin_sub_group_creation/>` — Community permits members to
+    /// create subgroups without admin approval.
+    #[wire = "allow_non_admin_sub_group_creation"]
+    AllowNonAdminSubGroupCreation,
+    /// `<not_allow_non_admin_sub_group_creation/>` — Community restricts
+    /// subgroup creation to admins.
+    #[wire = "not_allow_non_admin_sub_group_creation"]
+    NotAllowNonAdminSubGroupCreation,
+
+    // -- Subgroup suggestions (community) --
+    /// `<created_sub_group_suggestion>` — Suggested subgroup added.
+    #[wire = "created_sub_group_suggestion"]
+    CreatedSubGroupSuggestion {
+        #[wire(skip)]
+        raw: Node,
+    },
+    /// `<revoked_sub_group_suggestions>` — Subgroup suggestion revoked.
+    #[wire = "revoked_sub_group_suggestions"]
+    RevokedSubGroupSuggestions {
+        #[wire(skip)]
+        raw: Node,
+    },
+
+    /// `<change_number>` — Participant changed their phone number; new
+    /// participant data is in the `<participant>` child.
+    #[wire = "change_number"]
+    ChangeNumber {
+        participants: Vec<GroupParticipantInfo>,
+    },
 
     // -- Catch-all --
     /// Unknown child tag — preserved for forward compatibility. The `tag`
@@ -425,6 +493,34 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
                 .optional_string("unlink_reason")
                 .map(|s| s.into_owned()),
             raw: node.to_owned(),
+        },
+        T::LinkedGroupPromote => GroupNotificationAction::LinkedGroupPromote {
+            participants: parse_participants(node),
+        },
+        T::LinkedGroupDemote => GroupNotificationAction::LinkedGroupDemote {
+            participants: parse_participants(node),
+        },
+        T::Suspended => GroupNotificationAction::Suspended,
+        T::Unsuspended => GroupNotificationAction::Unsuspended,
+        T::AutoAddDisabled => GroupNotificationAction::AutoAddDisabled,
+        T::IsCapiHostedGroup => GroupNotificationAction::IsCapiHostedGroup,
+        T::GroupSafetyCheck => GroupNotificationAction::GroupSafetyCheck,
+        T::LimitSharingEnabled => GroupNotificationAction::LimitSharingEnabled,
+        T::AllowAdminReports => GroupNotificationAction::AllowAdminReports,
+        T::NotAllowAdminReports => GroupNotificationAction::NotAllowAdminReports,
+        T::Reports => GroupNotificationAction::Reports,
+        T::AllowNonAdminSubGroupCreation => GroupNotificationAction::AllowNonAdminSubGroupCreation,
+        T::NotAllowNonAdminSubGroupCreation => {
+            GroupNotificationAction::NotAllowNonAdminSubGroupCreation
+        }
+        T::CreatedSubGroupSuggestion => GroupNotificationAction::CreatedSubGroupSuggestion {
+            raw: node.to_owned(),
+        },
+        T::RevokedSubGroupSuggestions => GroupNotificationAction::RevokedSubGroupSuggestions {
+            raw: node.to_owned(),
+        },
+        T::ChangeNumber => GroupNotificationAction::ChangeNumber {
+            participants: parse_participants(node),
         },
         T::Unknown(_) => GroupNotificationAction::Unknown {
             tag: node.tag.to_string(),
@@ -837,6 +933,94 @@ mod tests {
                 assert_eq!(requests[0].jid, user_jid());
             }
             other => panic!("expected CreatedMembershipRequests, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_linked_group_promote_demote_carry_participants() {
+        let promote_node = make_notification(vec![
+            NodeBuilder::new("linked_group_promote")
+                .children(vec![
+                    NodeBuilder::new("participant")
+                        .attr("jid", user_jid())
+                        .build(),
+                ])
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&promote_node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::LinkedGroupPromote { participants } => {
+                assert_eq!(participants.len(), 1);
+                assert_eq!(participants[0].jid, user_jid());
+            }
+            other => panic!("expected LinkedGroupPromote, got {:?}", other),
+        }
+
+        let demote_node = make_notification(vec![
+            NodeBuilder::new("linked_group_demote")
+                .children(vec![
+                    NodeBuilder::new("participant")
+                        .attr("jid", user_jid())
+                        .build(),
+                ])
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&demote_node.as_node_ref()).unwrap();
+        assert!(matches!(
+            notif.actions[0],
+            GroupNotificationAction::LinkedGroupDemote { .. }
+        ));
+    }
+
+    #[test]
+    fn test_parse_suspended_toggle_variants() {
+        let table = [
+            ("suspended", "Suspended"),
+            ("unsuspended", "Unsuspended"),
+            ("auto_add_disabled", "AutoAddDisabled"),
+            ("is_capi_hosted_group", "IsCapiHostedGroup"),
+            ("group_safety_check", "GroupSafetyCheck"),
+            ("limit_sharing_enabled", "LimitSharingEnabled"),
+            ("allow_admin_reports", "AllowAdminReports"),
+            ("not_allow_admin_reports", "NotAllowAdminReports"),
+            ("reports", "Reports"),
+            (
+                "allow_non_admin_sub_group_creation",
+                "AllowNonAdminSubGroupCreation",
+            ),
+            (
+                "not_allow_non_admin_sub_group_creation",
+                "NotAllowNonAdminSubGroupCreation",
+            ),
+        ];
+        for (tag, expected) in table {
+            let node = make_notification(vec![NodeBuilder::new(tag).build()]);
+            let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+            let action_name = format!("{:?}", notif.actions[0]);
+            assert!(
+                action_name.starts_with(expected),
+                "wire tag {tag} must parse to {expected}, got {action_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_change_number_carries_participants() {
+        let node = make_notification(vec![
+            NodeBuilder::new("change_number")
+                .children(vec![
+                    NodeBuilder::new("participant")
+                        .attr("jid", user_jid())
+                        .build(),
+                ])
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::ChangeNumber { participants } => {
+                assert_eq!(participants.len(), 1);
+            }
+            other => panic!("expected ChangeNumber, got {:?}", other),
         }
     }
 

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -1063,6 +1063,43 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_limit_sharing_enabled_overflow_yields_none() {
+        // trigger > u32::MAX must yield None instead of truncating.
+        let node = make_notification(vec![
+            NodeBuilder::new("limit_sharing_enabled")
+                .attr("trigger", "4294967296")
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::LimitSharingEnabled { trigger } => assert!(trigger.is_none()),
+            other => panic!("expected LimitSharingEnabled, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_ephemeral_overflow_yields_zero_and_none() {
+        // expiration > u32::MAX falls back to 0; trigger > u32::MAX yields None.
+        let node = make_notification(vec![
+            NodeBuilder::new("ephemeral")
+                .attr("expiration", "4294967296")
+                .attr("trigger", "4294967296")
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::Ephemeral {
+                expiration,
+                trigger,
+            } => {
+                assert_eq!(*expiration, 0);
+                assert!(trigger.is_none());
+            }
+            other => panic!("expected Ephemeral, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_parse_change_number_carries_participants() {
         let node = make_notification(vec![
             NodeBuilder::new("change_number")


### PR DESCRIPTION
## Summary

Round-2 audit against `docs/captured-js/`. Eight isolated fixes (one per fix commit) plus four review-followup commits incorporating reviewer feedback. No public API breaks: new optional fields default to existing behavior.

## Fixes

### `fix(client): stop double-acking regular messages`

`WAWebSendDeliveryReceiptJob` emits a single `<receipt>` per incoming message; `<ack class="message">` is reserved for newsletter deliveries (`OutMessageDeliverCommonAckMixin`). Rust was emitting both. `should_ack` now returns `true` for the `"message"` tag only when `from` is a newsletter or `status@broadcast` JID. The status branch stays acked because `send_delivery_receipt` still skips status; otherwise the server would get no acknowledgement at all.

### `fix(profile): omit <picture> child from profile-picture remove IQ`

`WAWebSendProfilePictureJob` builds the set IQ with `<picture type="image">{bytes}</picture>` and the remove IQ with no child at all. Rust was emitting `<picture type="image"/>` on remove. `SetProfilePictureSpec::build_iq` now produces empty content when `image_data` is `None`.

### `fix(client): drop redundant participant attr from ack when equal to from`

`WAWebReceiptAck`: `participant: r && r !== e ? DEVICE_JID(r) : DROP_ATTR`. Rust always echoed `participant` if present in the source stanza, even when it duplicated `to` (the flipped `from`). The filter now lives in both `encode_ack_bytes` (hot path) and `build_ack_node` (test helper).

### `feat(group): expose disappearing-mode trigger on SetGroupEphemeralIq`

`OutGroupsCreateRequest` documents `<ephemeral expiration trigger>` where `trigger` (0..=20) carries the disappearing-mode source. The existing builder only emitted `expiration`. New `enable_with_trigger` constructor sets it; range is asserted at construction (`EPHEMERAL_TRIGGER_MAX = 20`) and `debug_assert`ed in `build_iq` for defense.

### `feat(group): parse <add_request> child on ParticipantChangeResponse 403`

`WAWebInGroupsParticipantRequestCodeCanBeSentMixin`: on `error="403"` the server attaches a V4 invite token: `<add_request code="..." expiration="N"/>`. The app can fall back to `GroupInviteMessage` carrying those fields when privacy blocks a direct add.

`ParticipantChangeResponse` was dropping the child silently. Replaced the derive with a hand-rolled `ProtocolNode` impl that captures it into an `AddRequestInfo { code, expiration }`. Missing `jid` and malformed `<add_request>` now hard-fail (mirrors `GroupParticipantResponse`).

### `feat(groups): add 14 missing w:gp2 notification variants`

`WAWebHandleGroupNotificationConst` lists 45 tags; `GroupNotificationAction` covered 24. The rest collapsed into `Unknown`, so consumers couldn't react to community-admin churn or community-policy toggles.

New variants:

- `LinkedGroupPromote` / `LinkedGroupDemote`
- `Suspended` / `Unsuspended`
- `AutoAddDisabled`, `IsCapiHostedGroup`, `GroupSafetyCheck`
- `LimitSharingEnabled { trigger: Option<u32> }`
- `AllowAdminReports` / `NotAllowAdminReports` / `Reports`
- `AllowNonAdminSubGroupCreation` / `NotAllowNonAdminSubGroupCreation`
- `CreatedSubGroupSuggestion { raw }` / `RevokedSubGroupSuggestions { raw }`
- `ChangeNumber { participants }`

### `feat(group): support linked_parent + inline description on GroupCreateIq`

`OutGroupsCreateRequest` accepts `<linked_parent jid=...>` and `<description id=... body>...</body></description>` children on `<create>`. We only emitted a subset. Add both as optional fields:

- `linked_parent`: subgroup created atomically as a child of a community
- `description`: inline description, avoids a follow-up SetGroupDescription IQ

`<parent>` (this group IS a community) and `<linked_parent>` (this group is a subgroup of X) are mutually exclusive. When both are set, `linked_parent` wins on both the build path and the `parse_response` overlay — a linked subgroup is never promoted to `is_parent_group` even when the request flag is set.

The description-id helper is shared with `SetGroupDescriptionIq`, so RNG/seeding stays centralized.

### `fix(send): promote bare conversation to extended_text when timer needs to attach`

`WAWebMessageSendUtils` upgrades a bare `conversation` body to `extended_text_message` whenever a `ContextInfo` field needs to attach (mention, quote, expiration). The Rust `set_ephemeral_expiration` and `set_context_info` returned `false`, silently dropping the data. Both now promote the message and return `true` after promotion.

## Review-followup commits

- `60910cae`: status broadcast ack safety net, `LimitSharingEnabled.trigger` payload, `set_context_info` promotion parity, description-id format alignment with `SetGroupDescriptionIq`.
- `d87b531a`: trigger range 0..=20 validation, type-safe matches in toggle test, shared `generate_description_id` helper, hard-fail parse for missing jid / malformed add_request, `try_into` for u64→u32 (`Ephemeral`, `GrowthLocked`, `LimitSharingEnabled`).
- `b444e352`: subgroup parse precedence fix, doc lists updated for `.to_owned()` callers, samples Vec covers all 16 new variants, comment trim per project style.

## Skipped

- **inactive receipt for `decrypt-fail="hide"`**: needs threading `decrypt_fail_mode` through several `dispatch_parsed_message` callsites. Impact is server-side analytics only; deferred to a focused follow-up.

## Test plan

- `cargo test --workspace --exclude e2e-tests --exclude bench-integration` ✅
- `cargo clippy --workspace --tests --exclude e2e-tests -- -D warnings` ✅
- Every fix ships with regression tests covering its branch