### PR TITLE
fix(groups): correct change_number stanza shape

### DIFF
--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1976,6 +1976,145 @@ mod tests {
         );
     }
 
+    /// Same PN on both sides is still dispatched as a ContactNumberChanged
+    /// event (with `old_jid == new_jid`). WA Web JS has no special guard for
+    /// this case either; the LID mapping update is a no-op when LIDs are
+    /// also equal. Consumers can filter if they care.
+    #[tokio::test]
+    async fn test_contacts_modify_same_jid_still_dispatches() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "contacts")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "contacts-modify-same")
+            .children([NodeBuilder::new("modify")
+                .attr("old", "5511999999999@s.whatsapp.net")
+                .attr("new", "5511999999999@s.whatsapp.net")
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        let events = collector.events();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &*events[0],
+            Event::ContactNumberChanged(ContactNumberChanged { old_jid, new_jid, .. })
+                if old_jid == new_jid
+        ));
+    }
+
+    /// Partial LID (only `new_lid`, missing `old_lid`) must NOT create any
+    /// LID-PN mapping, since WA Web requires BOTH for createLidPnMappings.
+    #[tokio::test]
+    async fn test_contacts_modify_partial_lid_skips_mappings() {
+        let client = create_test_client().await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "contacts")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "contacts-modify-partial")
+            .children([NodeBuilder::new("modify")
+                .attr("old", "5511999999999@s.whatsapp.net")
+                .attr("new", "5511888888888@s.whatsapp.net")
+                .attr("new_lid", "100000022222222@lid")
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        assert!(
+            client
+                .lid_pn_cache
+                .get_phone_number("100000022222222")
+                .await
+                .is_none(),
+            "no mapping should be created when old_lid is missing"
+        );
+    }
+
+    /// Missing `new` attribute: the parser should warn and not dispatch
+    /// anything, mirroring WA Web's parser error path.
+    #[tokio::test]
+    async fn test_contacts_modify_missing_new_attr_drops_event() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "contacts")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "contacts-modify-bad")
+            .children([NodeBuilder::new("modify")
+                .attr("old", "5511999999999@s.whatsapp.net")
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        assert!(collector.events().is_empty());
+    }
+
+    /// Group `w:gp2` change_number: the parsed action must carry the new
+    /// owner from the child's `jid` attr and the sub_group_suggestions from
+    /// `<sub_group_suggestion jid=.../>` children. The old owner is the
+    /// notification's top-level `participant` attribute, surfaced on
+    /// `GroupUpdate.participant`.
+    #[tokio::test]
+    async fn test_group_change_number_dispatches_with_new_owner_and_suggestions() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "w:gp2")
+            .attr("from", "120363000000000000@g.us")
+            .attr("participant", "5511999999999@s.whatsapp.net")
+            .attr("id", "gp2-change-1")
+            .attr("t", "1773519041")
+            .children([NodeBuilder::new("change_number")
+                .attr("jid", "5511888888888@s.whatsapp.net")
+                .children([
+                    NodeBuilder::new("sub_group_suggestion")
+                        .attr("jid", "120363111111111111@g.us")
+                        .build(),
+                    NodeBuilder::new("sub_group_suggestion")
+                        .attr("jid", "120363222222222222@g.us")
+                        .build(),
+                ])
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        let events = collector.events();
+        let group_update = events
+            .iter()
+            .find_map(|e| match &**e {
+                Event::GroupUpdate(u) => Some(u),
+                _ => None,
+            })
+            .expect("expected GroupUpdate");
+
+        assert_eq!(
+            group_update.participant.as_ref().map(|j| j.user.as_str()),
+            Some("5511999999999"),
+            "old owner comes from notification.participant"
+        );
+        match &group_update.action {
+            GroupNotificationAction::ChangeNumber {
+                new_owner,
+                sub_group_suggestions,
+            } => {
+                assert_eq!(
+                    new_owner.as_ref().map(|j| j.user.as_str()),
+                    Some("5511888888888")
+                );
+                assert_eq!(sub_group_suggestions.len(), 2);
+            }
+            other => panic!("expected ChangeNumber, got {:?}", other),
+        }
+    }
+
     #[tokio::test]
     async fn test_contacts_update_hash_only_ignored() {
         // WA Web sends <update hash="Quvc"/> without jid when using hash-based lookup.

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -275,11 +275,14 @@ pub enum GroupNotificationAction {
         raw: Node,
     },
 
-    /// `<change_number>` — Participant changed their phone number; new
-    /// participant data is in the `<participant>` child.
+    /// `<change_number>` — Owner of subgroup suggestions migrated to a new
+    /// number. The old owner is in the parent notification's `participant`
+    /// attribute; the new owner is in the `jid` attribute on the child.
+    /// `sub_group_suggestions` lists the affected subgroup JIDs.
     #[wire = "change_number"]
     ChangeNumber {
-        participants: Vec<GroupParticipantInfo>,
+        new_owner: Option<Jid>,
+        sub_group_suggestions: Vec<Jid>,
     },
 
     // -- Catch-all --
@@ -540,7 +543,8 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             raw: node.to_owned(),
         },
         T::ChangeNumber => GroupNotificationAction::ChangeNumber {
-            participants: parse_participants(node),
+            new_owner: node.attrs().optional_jid("jid"),
+            sub_group_suggestions: parse_sub_group_suggestion_jids(node),
         },
         T::Unknown(_) => GroupNotificationAction::Unknown {
             tag: node.tag.to_string(),
@@ -577,6 +581,19 @@ fn parse_requested_users(node: &NodeRef<'_>) -> Vec<GroupParticipantInfo> {
                     let phone_number = c.attrs().optional_jid("phone_number");
                     Some(GroupParticipantInfo { jid, phone_number })
                 })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parses `<sub_group_suggestion jid="..."/>` children into subgroup JIDs.
+fn parse_sub_group_suggestion_jids(node: &NodeRef<'_>) -> Vec<Jid> {
+    node.children()
+        .map(|children| {
+            children
+                .iter()
+                .filter(|c| c.tag == "sub_group_suggestion")
+                .filter_map(|c| c.attrs().optional_jid("jid"))
                 .collect()
         })
         .unwrap_or_default()
@@ -1099,10 +1116,70 @@ mod tests {
         }
     }
 
+    /// Verifies the actual wire shape from `WAWebHandleGroupNotification`:
+    /// `<change_number jid="<new_owner>"><sub_group_suggestion jid="<sg>"/>...`.
+    /// The old owner stays in `notification.participant`.
     #[test]
-    fn test_parse_change_number_carries_participants() {
+    fn test_parse_change_number_real_shape() {
+        let new_owner_jid = "5511888888888@s.whatsapp.net";
+        let sg_a = "111111111111111@g.us";
+        let sg_b = "222222222222222@g.us";
         let node = make_notification(vec![
             NodeBuilder::new("change_number")
+                .attr("jid", new_owner_jid)
+                .children(vec![
+                    NodeBuilder::new("sub_group_suggestion")
+                        .attr("jid", sg_a)
+                        .build(),
+                    NodeBuilder::new("sub_group_suggestion")
+                        .attr("jid", sg_b)
+                        .build(),
+                ])
+                .build(),
+        ]);
+        let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::ChangeNumber {
+                new_owner,
+                sub_group_suggestions,
+            } => {
+                assert_eq!(
+                    new_owner.as_ref().map(|j| j.to_string()).as_deref(),
+                    Some(new_owner_jid)
+                );
+                assert_eq!(sub_group_suggestions.len(), 2);
+                assert_eq!(sub_group_suggestions[0].to_string(), sg_a);
+                assert_eq!(sub_group_suggestions[1].to_string(), sg_b);
+            }
+            other => panic!("expected ChangeNumber, got {:?}", other),
+        }
+    }
+
+    /// Missing `jid` attribute yields `new_owner: None` instead of dropping
+    /// the entire action.
+    #[test]
+    fn test_parse_change_number_missing_jid_is_tolerant() {
+        let node = make_notification(vec![NodeBuilder::new("change_number").build()]);
+        let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
+        match &notif.actions[0] {
+            GroupNotificationAction::ChangeNumber {
+                new_owner,
+                sub_group_suggestions,
+            } => {
+                assert!(new_owner.is_none());
+                assert!(sub_group_suggestions.is_empty());
+            }
+            other => panic!("expected ChangeNumber, got {:?}", other),
+        }
+    }
+
+    /// `<participant>` children inside `<change_number>` must NOT leak into
+    /// `sub_group_suggestions`; only `<sub_group_suggestion>` is read.
+    #[test]
+    fn test_parse_change_number_ignores_participant_children() {
+        let node = make_notification(vec![
+            NodeBuilder::new("change_number")
+                .attr("jid", "5511888888888@s.whatsapp.net")
                 .children(vec![
                     NodeBuilder::new("participant")
                         .attr("jid", user_jid())
@@ -1112,8 +1189,11 @@ mod tests {
         ]);
         let notif = GroupNotification::try_from_node_ref(&node.as_node_ref()).unwrap();
         match &notif.actions[0] {
-            GroupNotificationAction::ChangeNumber { participants } => {
-                assert_eq!(participants.len(), 1);
+            GroupNotificationAction::ChangeNumber {
+                sub_group_suggestions,
+                ..
+            } => {
+                assert!(sub_group_suggestions.is_empty());
             }
             other => panic!("expected ChangeNumber, got {:?}", other),
         }
@@ -1244,7 +1324,8 @@ mod tests {
                 raw: dummy_node.clone(),
             },
             GroupNotificationAction::ChangeNumber {
-                participants: vec![],
+                new_owner: None,
+                sub_group_suggestions: vec![],
             },
             GroupNotificationAction::Unknown {
                 tag: "future_tag".into(),

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -772,8 +772,12 @@ pub struct ContactUpdated {
 /// Emitted from `<notification type="contacts"><modify old="..." new="..."
 /// old_lid="..." new_lid="..."/>`.
 ///
-/// WA Web creates two LID-PN mappings (`old_lid→old_jid`, `new_lid→new_jid`)
-/// and generates a system notification message in both old and new chats.
+/// The library updates the global LID-PN cache when both `old_lid` and
+/// `new_lid` are present, mirroring `WAWebDBCreateLidPnMappings`. No Signal
+/// session is wiped (WA Web `WAWebHandleContactNotification` also leaves
+/// sessions intact). Group participant updates arrive via separate
+/// `w:gp2` notifications, so per-group caches are not touched here.
+/// Consumers can subscribe and refresh their own caches if needed.
 #[derive(Debug, Clone, Serialize)]
 pub struct ContactNumberChanged {
     /// Old phone number JID.


### PR DESCRIPTION
## Summary

The `change_number` action under `<notification type="w:gp2">` was modeled as
`{ participants: Vec<GroupParticipantInfo> }`, expecting `<participant>` children
that don't exist on the real wire. The actual shape, per
`WAWebHandleGroupNotification`, is:

```xml
<notification type="w:gp2" from=<parent> participant=<old_owner> t=...>
  <change_number jid=<new_owner>>
    <sub_group_suggestion jid=<subgroup>/>*
  </change_number>
</notification>
```

The previous parser silently returned `participants: []` for every real-world
stanza, dropping the new owner and the migrated subgroup IDs.

## Changes

- Refactor `GroupNotificationAction::ChangeNumber` to
  `{ new_owner: Option<Jid>, sub_group_suggestions: Vec<Jid> }`; the old owner
  stays on `GroupUpdate.participant` (the parent notification's `participant`
  attribute), matching the JS dispatch.
- Add `parse_sub_group_suggestion_jids` helper for the child list.
- Tolerate missing `jid` by yielding `new_owner: None` instead of dropping the
  action.
- Clarify `ContactNumberChanged` event docs: Signal sessions and per-group
  caches are intentionally not touched, mirroring WA Web's
  `WAWebHandleContactNotification`. The global LID-PN cache update remains the
  only side-effect.

## Tests

Seven new tests covering empirical wire formats and edge cases:

- `wacore/src/stanza/groups.rs`
  - `test_parse_change_number_real_shape`
  - `test_parse_change_number_missing_jid_is_tolerant`
  - `test_parse_change_number_ignores_participant_children` (regression for the
    old shape)
- `src/handlers/notification.rs`
  - `test_contacts_modify_same_jid_still_dispatches`
  - `test_contacts_modify_partial_lid_skips_mappings`
  - `test_contacts_modify_missing_new_attr_drops_event`
  - `test_group_change_number_dispatches_with_new_owner_and_suggestions`

## Cache audit

Reviewed every client-level cache and intentionally left untouched:

- `signal_cache` (sessions/identities): WA Web does not wipe. Old sessions
  remain dormant.
- `group_cache` (participants per group): DM change_number does not migrate
  group membership; a separate `<add>`/`<remove>` notification handles that.
- `device_registry_cache`, `sender_key_device_cache`: stale entries get refreshed
  on the next group notification.
- `lid_pn_cache`: already updated bidirectionally when both `old_lid` and
  `new_lid` are present (`learn_contact_modify_mappings`).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests`
- [x] `cargo test --workspace --exclude e2e-tests --exclude bench-integration`