### PR TITLE
fix: zombie connection after stream-error 500 (ClientPayload + receipt compliance)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "typed-builder",
- "uuid",
  "wacore-appstate",
  "wacore-binary",
  "wacore-derive",

--- a/src/client.rs
+++ b/src/client.rs
@@ -2152,13 +2152,22 @@ impl Client {
             }
 
             // WA Web bumps `lc` after each successful auth (Start/Backend.js
-            // listener on `onOpenSocketStream`, fired by Comms `onConnect`
-            // post-handshake). Server treats a flat-zero counter as an
-            // anti-abuse signal and silently invalidates the session.
-            client_clone
+            // listener on `onOpenSocketStream`). The Comms `onConnect` handler
+            // gates the trigger on `isRegistered()`, so the bump only happens
+            // for already-paired logins — never during the pairing XX
+            // handshake. We mirror that by skipping when `device.pn` is None.
+            let already_paired = client_clone
                 .persistence_manager
-                .process_command(DeviceCommand::IncrementLoginCounter)
-                .await;
+                .get_device_snapshot()
+                .await
+                .pn
+                .is_some();
+            if already_paired {
+                client_clone
+                    .persistence_manager
+                    .process_command(DeviceCommand::IncrementLoginCounter)
+                    .await;
+            }
 
             // Macro to check if this task is still valid (connection hasn't been replaced)
             macro_rules! check_generation {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1854,9 +1854,17 @@ impl Client {
     }
 
     /// Per WA Web (`Handle/MsgSendReceipt.js`), only newsletter `<message>`
-    /// gets `<ack class="message">` on the success path; DM/group/status all
-    /// use `<receipt>`. Failure paths (retry/backfill/nack) emit `<ack>` from
+    /// gets `<ack class="message">` on the success path; DM/group use
+    /// `<receipt>`. Failure paths (retry/backfill/nack) emit `<ack>` from
     /// their dedicated handlers, not via this gate.
+    ///
+    /// status@broadcast is included as a fallback: drop paths in
+    /// `process_group_enc_batch` (expired status, missing sender key, generic
+    /// decrypt error) intentionally skip the delivery receipt to avoid
+    /// inflating the server-side offline counter for messages we'll never
+    /// process. Without the transport `<ack>` from this gate, the server
+    /// would redeliver indefinitely. WA Web emits `<receipt context="status">`
+    /// in the success path on top of this; the duplicate is tolerated.
     fn should_ack(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
         let tag = node.tag.as_ref();
         if node.get_attr("id").is_none() {
@@ -1867,7 +1875,9 @@ impl Client {
         };
         match tag {
             "receipt" | "notification" | "call" => true,
-            "message" => from.to_jid().is_some_and(|j| j.is_newsletter()),
+            "message" => from
+                .to_jid()
+                .is_some_and(|j| j.is_newsletter() || j.is_status_broadcast()),
             _ => false,
         }
     }
@@ -4139,15 +4149,18 @@ mod tests {
             "should_ack must return TRUE for newsletter <message>."
         );
 
-        // WA Web sends `<receipt context="status">` for status@broadcast,
-        // not `<ack>`. send_delivery_receipt covers it.
+        // status@broadcast gets the transport <ack> as a fallback so that
+        // drop paths in process_group_enc_batch (expired status, missing
+        // sender key, decrypt error) don't leave the server retransmitting.
+        // The success path also emits <receipt context="status">; the
+        // duplicate is tolerated.
         let mut status_attrs = Attrs::new();
         status_attrs.insert("from".to_string(), "status@broadcast".to_string());
         status_attrs.insert("id".to_string(), "MSG-STATUS-1".to_string());
         let status_message = Node::new("message", status_attrs, None);
         assert!(
-            !client.should_ack(&status_message.as_node_ref()),
-            "should_ack must return FALSE for status@broadcast <message> (receipt covers it)."
+            client.should_ack(&status_message.as_node_ref()),
+            "should_ack must return TRUE for status@broadcast <message> (fallback for drop paths)."
         );
 
         info!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1853,12 +1853,10 @@ impl Client {
         }
     }
 
-    /// Determine if a node should be acknowledged with <ack/>.
-    ///
-    /// Newsletter messages need `<ack class="message">` (per
-    /// `OutMessageDeliverCommonAckMixin`); regular DM/group send a
-    /// `<receipt>` instead. Status broadcasts also need the ack until
-    /// `send_delivery_receipt` stops skipping them.
+    /// Per WA Web (`Handle/MsgSendReceipt.js`), only newsletter `<message>`
+    /// gets `<ack class="message">` on the success path; DM/group/status all
+    /// use `<receipt>`. Failure paths (retry/backfill/nack) emit `<ack>` from
+    /// their dedicated handlers, not via this gate.
     fn should_ack(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
         let tag = node.tag.as_ref();
         if node.get_attr("id").is_none() {
@@ -1869,9 +1867,7 @@ impl Client {
         };
         match tag {
             "receipt" | "notification" | "call" => true,
-            "message" => from
-                .to_jid()
-                .is_some_and(|j| j.is_newsletter() || j.is_status_broadcast()),
+            "message" => from.to_jid().is_some_and(|j| j.is_newsletter()),
             _ => false,
         }
     }
@@ -4143,15 +4139,15 @@ mod tests {
             "should_ack must return TRUE for newsletter <message>."
         );
 
-        // send_delivery_receipt skips status@broadcast, so the ack stays
-        // as the server-level acknowledgement until receipts cover it.
+        // WA Web sends `<receipt context="status">` for status@broadcast,
+        // not `<ack>`. send_delivery_receipt covers it.
         let mut status_attrs = Attrs::new();
         status_attrs.insert("from".to_string(), "status@broadcast".to_string());
         status_attrs.insert("id".to_string(), "MSG-STATUS-1".to_string());
         let status_message = Node::new("message", status_attrs, None);
         assert!(
-            client.should_ack(&status_message.as_node_ref()),
-            "should_ack must return TRUE for status@broadcast <message> until receipts cover it."
+            !client.should_ack(&status_message.as_node_ref()),
+            "should_ack must return FALSE for status@broadcast <message> (receipt covers it)."
         );
 
         info!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -2144,6 +2144,16 @@ impl Client {
                         .await;
                 }
             }
+
+            // WA Web bumps `lc` after each successful auth (Start/Backend.js
+            // listener on `onOpenSocketStream`, fired by Comms `onConnect`
+            // post-handshake). Server treats a flat-zero counter as an
+            // anti-abuse signal and silently invalidates the session.
+            client_clone
+                .persistence_manager
+                .process_command(DeviceCommand::IncrementLoginCounter)
+                .await;
+
             // Macro to check if this task is still valid (connection hasn't been replaced)
             macro_rules! check_generation {
                 () => {

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -227,12 +227,11 @@ mod tests {
         );
     }
 
-    /// Regression for the field report from baileyrs (PR #576): if the outer
-    /// wrapping future is dropped *before its first poll* (e.g. the executor
-    /// is shutting down), the guard must still be dropped so the counter
-    /// decrements. Before the fix (guard constructed INSIDE the async body),
-    /// this would leak the counter and cause `flush()` to wait its full
-    /// timeout on every disconnect.
+    /// If the outer wrapping future is dropped *before its first poll* (e.g.
+    /// the executor is shutting down), the guard must still be dropped so the
+    /// counter decrements. Before the fix (guard constructed INSIDE the async
+    /// body), this would leak the counter and cause `flush()` to wait its
+    /// full timeout on every disconnect.
     #[tokio::test]
     async fn decrement_runs_when_future_is_dropped_before_first_poll() {
         let scope = Arc::new(FlushScope::new());

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -11,7 +11,10 @@ use wacore_binary::OwnedNodeRef;
 
 /// Pure builder for the delivery `<receipt>` node. Extracted so unit tests
 /// can assert wire shape without spinning a transport. Mirrors WA Web's
-/// `Send/DeliveryReceiptJob.js` (`<receipt id to type? participant? context?>`).
+/// `Send/DeliveryReceiptJob.js` — the participant gate there is
+/// `(t.isGroup() || t.isBroadcast()) && r ? DEVICE_JID(r) : DROP_ATTR`, so
+/// status broadcasts (isBroadcast = true) also carry the original poster's
+/// JID. Without it the server can't map the ack back to the status owner.
 fn build_delivery_receipt_node(info: &crate::types::message::MessageInfo) -> wacore_binary::Node {
     let mut builder = NodeBuilder::new("receipt")
         .attr("id", &info.id)
@@ -21,11 +24,12 @@ fn build_delivery_receipt_node(info: &crate::types::message::MessageInfo) -> wac
         builder = builder.attr("type", "peer_msg");
     }
 
-    if info.source.is_group {
+    let is_status = info.source.chat.is_status_broadcast();
+    if info.source.is_group || is_status {
         builder = builder.attr("participant", &info.source.sender);
     }
 
-    if info.source.chat.is_status_broadcast() {
+    if is_status {
         builder = builder.attr("context", "status");
     }
 
@@ -297,9 +301,11 @@ mod tests {
     }
 
     #[test]
-    fn delivery_receipt_for_status_broadcast_carries_context_status() {
-        // `Send/DeliveryReceiptJob.js` emits `<receipt context="status">` for
-        // status messages; without the attr the server keeps retransmitting.
+    fn delivery_receipt_for_status_broadcast_carries_context_status_and_participant() {
+        // WA Web's gate is `(isGroup || isBroadcast) && participant` for the
+        // participant attr, and `isStatus && gating` for context — see
+        // `Send/DeliveryReceiptJob.js`. Status broadcasts must carry BOTH so
+        // the server can map the ack back to the status owner.
         let info = info_with("status@broadcast", "12345@s.whatsapp.net", false);
         let node = build_delivery_receipt_node(&info);
         assert_eq!(node.tag, "receipt");
@@ -307,7 +313,10 @@ mod tests {
             node.attrs.get("context").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
-        assert!(node.attrs.get("participant").is_none());
+        assert_eq!(
+            node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
+            Some("12345@s.whatsapp.net")
+        );
     }
 
     #[test]
@@ -341,6 +350,39 @@ mod tests {
     }
 
     #[test]
+    fn delivery_receipt_for_peer_dm_carries_type_peer_msg() {
+        // category=Peer + DM (self device sync) → type="peer_msg", no
+        // participant, no context. Matches WA Web's DROP_ATTR gating.
+        let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        info.category = MessageCategory::Peer;
+        let node = build_delivery_receipt_node(&info);
+        assert_eq!(
+            node.attrs.get("type").map(|v| v.as_str()).as_deref(),
+            Some("peer_msg")
+        );
+        assert!(node.attrs.get("participant").is_none());
+        assert!(node.attrs.get("context").is_none());
+    }
+
+    #[test]
+    fn delivery_receipt_for_status_broadcast_keeps_participant_even_with_peer_type() {
+        // Defensive: if a status broadcast ever surfaces with category=Peer,
+        // the participant attr must still be there — server identifies the
+        // status owner from it regardless of the peer_msg type.
+        let mut info = info_with("status@broadcast", "12345@s.whatsapp.net", false);
+        info.category = MessageCategory::Peer;
+        let node = build_delivery_receipt_node(&info);
+        assert_eq!(
+            node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
+            Some("12345@s.whatsapp.net")
+        );
+        assert_eq!(
+            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            Some("status")
+        );
+    }
+
+    #[test]
     fn should_send_delivery_receipt_skips_newsletter() {
         let info = info_with(
             "120363298765432100@newsletter",
@@ -348,6 +390,32 @@ mod tests {
             false,
         );
         assert!(!Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_skips_empty_id() {
+        let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        info.id = String::new();
+        assert!(!Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_skips_own_dm() {
+        // Self-sent DM with category=Regular: no receipt (we don't ack our own
+        // messages). Peer-category self-sync messages are handled below.
+        let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        info.source.is_from_me = true;
+        assert!(!Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_allows_own_peer_msg() {
+        // Self-synced messages from the primary phone (category=Peer) DO need
+        // a receipt with type="peer_msg", per the WA Web `OUR_OWN_DEVICE` ack.
+        let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        info.source.is_from_me = true;
+        info.category = MessageCategory::Peer;
+        assert!(Client::should_send_delivery_receipt(&info));
     }
 
     #[tokio::test]

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -9,14 +9,32 @@ use wacore_binary::{Jid, JidExt as _};
 
 use wacore_binary::OwnedNodeRef;
 
+/// Pure builder for the delivery `<receipt>` node. Extracted so unit tests
+/// can assert wire shape without spinning a transport. Mirrors WA Web's
+/// `Send/DeliveryReceiptJob.js` (`<receipt id to type? participant? context?>`).
+fn build_delivery_receipt_node(info: &crate::types::message::MessageInfo) -> wacore_binary::Node {
+    let mut builder = NodeBuilder::new("receipt")
+        .attr("id", &info.id)
+        .attr("to", &info.source.chat);
+
+    if info.category == MessageCategory::Peer {
+        builder = builder.attr("type", "peer_msg");
+    }
+
+    if info.source.is_group {
+        builder = builder.attr("participant", &info.source.sender);
+    }
+
+    if info.source.chat.is_status_broadcast() {
+        builder = builder.attr("context", "status");
+    }
+
+    builder.build()
+}
+
 impl Client {
     fn should_send_delivery_receipt(info: &crate::types::message::MessageInfo) -> bool {
-        use wacore_binary::STATUS_BROADCAST_USER;
-
-        if info.id.is_empty()
-            || info.source.chat.user == STATUS_BROADCAST_USER
-            || info.source.chat.is_newsletter()
-        {
+        if info.id.is_empty() || info.source.chat.is_newsletter() {
             return false;
         }
 
@@ -24,6 +42,11 @@ impl Client {
         // messages (category="peer").  These tell the primary phone that
         // this companion device received the message.
         // For all other messages, skip receipts for our own messages.
+        //
+        // status@broadcast: WA Web sends `<receipt context="status">`
+        // (`Send/DeliveryReceiptJob.js` + `Handle/MsgSendReceipt.js` —
+        // `C = y && isStatusStanzaReceiveEnabled() ? "status" : void 0`).
+        // The context attribute is added in send_delivery_receipt below.
         info.category == MessageCategory::Peer || !info.source.is_from_me
     }
 
@@ -175,34 +198,23 @@ impl Client {
 
     /// Sends a delivery receipt to the sender of a message.
     ///
-    /// This function handles:
-    /// - Direct messages (DMs) - sends receipt to the sender's JID.
-    /// - Group messages - sends receipt to the group JID with the sender as a participant.
-    /// - Peer device messages (category="peer") - sends `type="peer_msg"` receipt to
-    ///   acknowledge self-synced messages from the primary phone.
-    /// - It correctly skips sending receipts for status broadcasts, newsletters,
-    ///   or messages without an ID.
+    /// Eligibility lives in [`Self::should_send_delivery_receipt`]; the wire
+    /// shape is assembled by [`build_delivery_receipt_node`]. Coverage:
+    ///
+    /// - Direct messages (DMs) — `<receipt>` to the sender's JID.
+    /// - Group messages — `<receipt participant=...>` to the group JID.
+    /// - Peer device messages (`category="peer"`) — `<receipt type="peer_msg">`
+    ///   to acknowledge self-synced messages from the primary phone.
+    /// - Status broadcasts — `<receipt context="status">` (WA Web's
+    ///   `Send/DeliveryReceiptJob.js`); these are NOT skipped anymore.
+    /// - Newsletters and messages without an ID are skipped (newsletters are
+    ///   handled by the ack gate, not here).
     pub(crate) async fn send_delivery_receipt(&self, info: &crate::types::message::MessageInfo) {
         if !Self::should_send_delivery_receipt(info) {
             return;
         }
 
-        let mut builder = NodeBuilder::new("receipt")
-            .attr("id", &info.id)
-            .attr("to", &info.source.chat);
-
-        // WA Web: peer device messages (category="peer") use type="peer_msg".
-        // Normal delivery receipts omit the type attribute (DROP_ATTR).
-        if info.category == MessageCategory::Peer {
-            builder = builder.attr("type", "peer_msg");
-        }
-
-        // For group messages, the 'participant' attribute is required to identify the sender.
-        if info.source.is_group {
-            builder = builder.attr("participant", &info.source.sender);
-        }
-
-        let receipt_node = builder.build();
+        let receipt_node = build_delivery_receipt_node(info);
 
         debug!(target: "Client/Receipt", "Sending {} receipt for message {} to {}",
             if info.category == MessageCategory::Peer { "peer_msg" } else { "delivery" },
@@ -268,6 +280,74 @@ mod tests {
 
     fn node_to_arc(node: wacore_binary::Node) -> Arc<OwnedNodeRef> {
         crate::test_utils::node_to_owned_ref(&node)
+    }
+
+    fn info_with(chat: &str, sender: &str, is_group: bool) -> MessageInfo {
+        MessageInfo {
+            id: "MID".to_string(),
+            source: MessageSource {
+                chat: chat.parse().expect("test chat JID"),
+                sender: sender.parse().expect("test sender JID"),
+                is_from_me: false,
+                is_group,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn delivery_receipt_for_status_broadcast_carries_context_status() {
+        // `Send/DeliveryReceiptJob.js` emits `<receipt context="status">` for
+        // status messages; without the attr the server keeps retransmitting.
+        let info = info_with("status@broadcast", "12345@s.whatsapp.net", false);
+        let node = build_delivery_receipt_node(&info);
+        assert_eq!(node.tag, "receipt");
+        assert_eq!(
+            node.attrs.get("context").map(|v| v.as_str()).as_deref(),
+            Some("status")
+        );
+        assert!(node.attrs.get("participant").is_none());
+    }
+
+    #[test]
+    fn delivery_receipt_for_dm_has_no_context_no_participant() {
+        let info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        let node = build_delivery_receipt_node(&info);
+        assert!(node.attrs.get("context").is_none());
+        assert!(node.attrs.get("participant").is_none());
+        assert!(node.attrs.get("type").is_none());
+    }
+
+    #[test]
+    fn delivery_receipt_for_group_carries_participant() {
+        let info = info_with(
+            "120363021033254949@g.us",
+            "15551234567@s.whatsapp.net",
+            true,
+        );
+        let node = build_delivery_receipt_node(&info);
+        assert_eq!(
+            node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
+            Some("15551234567@s.whatsapp.net")
+        );
+        assert!(node.attrs.get("context").is_none());
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_allows_status_broadcast() {
+        let info = info_with("status@broadcast", "12345@s.whatsapp.net", false);
+        assert!(Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_skips_newsletter() {
+        let info = info_with(
+            "120363298765432100@newsletter",
+            "120363298765432100@newsletter",
+            false,
+        );
+        assert!(!Client::should_send_delivery_receipt(&info));
     }
 
     #[tokio::test]

--- a/src/send.rs
+++ b/src/send.rs
@@ -119,9 +119,8 @@ fn meta_node(key: &'static str, value: &'static str) -> Node {
 }
 
 /// Offset subtracted from the current unix timestamp to produce the
-/// `privacy_mode_ts` attr value on a `<biz>` stanza. The value is the one
-/// the upstream Baileys reproducer emits (Issue oxidezap/baileyrs#7) and is
-/// confirmed to work against the live WhatsApp servers.
+/// `privacy_mode_ts` attr value on a `<biz>` stanza. Empirically confirmed
+/// against live WhatsApp servers.
 const BIZ_PRIVACY_MODE_TS_OFFSET: u64 = 77_980_457;
 
 enum BizCategory<'a> {
@@ -233,9 +232,8 @@ fn extract_interactive_message(msg: &wa::Message) -> Option<&wa::message::Intera
 /// Assemble the `extra_stanza_nodes` vector for a non-newsletter send.
 ///
 /// Order: `inferred_meta`, optional `<bot biz_bot="1"/>` (DM only), `<biz>`,
-/// then any user-provided extra nodes. Matches the upstream Baileys
-/// reproducer (Issue oxidezap/baileyrs#7). Pure so the caller stays trivial
-/// and the assembly logic is unit-testable.
+/// then any user-provided extra nodes. Pure so the caller stays trivial and
+/// the assembly logic is unit-testable.
 fn build_extra_stanza_nodes(
     to: &Jid,
     inferred_meta: Option<Node>,

--- a/tests/discrepancy_pocs.rs
+++ b/tests/discrepancy_pocs.rs
@@ -97,17 +97,19 @@ fn regression_a4_login_payload_passive_is_configurable() {
     assert_eq!(device.get_client_payload().passive, Some(true));
 }
 
-// A5. UserAgent: phone_id is UUID v4, locale country is ISO-3166-1 alpha-2.
+// A5. UserAgent: phone_id is omitted by default (WA Web parity, see
+// Client/Payload.js), locale country is ISO-3166-1 alpha-2.
 
 #[test]
-fn regression_a5_useragent_phone_id_is_uuid_v4_by_default() {
+fn regression_a5_useragent_phone_id_is_omitted_by_default() {
     let mut device = Device::new();
     device.pn = Some("5511999999999@s.whatsapp.net".parse().unwrap());
 
     let user_agent = device.get_client_payload().user_agent.unwrap();
-    let phone_id = user_agent.phone_id.expect("phone_id must be populated");
-    let parsed = uuid::Uuid::parse_str(&phone_id).expect("phone_id must be a valid UUID");
-    assert_eq!(parsed.get_version(), Some(uuid::Version::Random));
+    assert!(
+        user_agent.phone_id.is_none(),
+        "phone_id must stay unset on the wire (WA Web never assigns UserAgent.phoneId)"
+    );
 }
 
 #[test]

--- a/tests/e2e/tests/concurrent_disconnect.rs
+++ b/tests/e2e/tests/concurrent_disconnect.rs
@@ -1,10 +1,9 @@
 //! Regression: concurrent `Client::disconnect()` must not deadlock.
 //!
-//! Bug shape (field report from the baileyrs consumer over WASM): when two
-//! or more independent clients call `disconnect()` at the same time, one
-//! hangs after logging `"Disconnecting client intentionally"` and never
-//! reaches `transport.disconnect()` — so the underlying socket never gets
-//! `close()`d.
+//! Bug shape (field report from a WASM consumer): when two or more
+//! independent clients call `disconnect()` at the same time, one hangs after
+//! logging `"Disconnecting client intentionally"` and never reaches
+//! `transport.disconnect()` — so the underlying socket never gets `close()`d.
 //!
 //! Root cause: the run loop's graceful-exit path (woken by
 //! `notify_connection_shutdown()`) raced into `cleanup_connection_state` and

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -50,7 +50,6 @@ sha2 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 typed-builder = "0.23"
-uuid = { workspace = true, features = ["v4"] }
 wacore-appstate = { workspace = true }
 wacore-binary = { workspace = true, features = ["serde"] }
 wacore-derive = { workspace = true }

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -82,10 +82,9 @@ fn build_base_client_payload(
     app_version: wa::client_payload::user_agent::AppVersion,
     profile: &ClientProfile,
 ) -> wa::ClientPayload {
-    let phone_id = profile
-        .phone_id
-        .clone()
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    // WA Web (`Client/Payload.js`) never sets `UserAgent.phoneId`; a previous
+    // audit auto-generated a UUID per build, which the server flagged as a
+    // rotating device fingerprint and silently invalidated the session.
     wa::ClientPayload {
         user_agent: Some(wa::client_payload::UserAgent {
             platform: Some(profile.user_agent_platform as i32),
@@ -99,7 +98,7 @@ fn build_base_client_payload(
             os_build_number: Some(profile.os_version.clone()),
             locale_language_iso6391: Some(profile.locale_language.clone()),
             locale_country_iso31661_alpha2: Some(profile.locale_country.clone()),
-            phone_id: Some(phone_id),
+            phone_id: profile.phone_id.clone(),
             ..Default::default()
         }),
         web_info: profile
@@ -431,9 +430,12 @@ impl Device {
         payload.username = jid.user.parse::<u64>().ok();
         payload.device = Some(jid.device as u32);
         payload.passive = Some(self.client_profile.passive_login);
+        // WA Web's `Get/ClientPayloadForLogin.js` hardcodes `pull: true` on
+        // the login wrapper; only `passive` is dynamic.
+        payload.pull = Some(true);
         payload.lc = Some(self.login_counter);
-        // Always false: the lib has no LID migration path. WA Web sends this
-        // unconditionally so the server can branch on it.
+        // Hardcoded false: no LID migration path here. WA Web sends this on
+        // every login so the server can branch on it.
         payload.lid_db_migrated = Some(false);
         payload
     }
@@ -751,6 +753,123 @@ mod tests {
                 "{platform:?} must omit web_info"
             );
         }
+    }
+
+    /// Per-connect `phone_id` UUID is flagged by the server as a rotating
+    /// fingerprint and silently kills the session. Must stay omitted.
+    #[test]
+    fn phone_id_default_is_omitted_and_payload_is_deterministic() {
+        let device = Device::new();
+        let payload_a = device.get_client_payload();
+        let payload_b = device.get_client_payload();
+        let ua_a = payload_a.user_agent.as_ref().expect("user_agent");
+        let ua_b = payload_b.user_agent.as_ref().expect("user_agent");
+        assert!(
+            ua_a.phone_id.is_none(),
+            "default ClientProfile must leave UserAgent.phoneId unset (got {:?})",
+            ua_a.phone_id
+        );
+        assert_eq!(
+            ua_a.phone_id, ua_b.phone_id,
+            "phoneId must not change between payload builds"
+        );
+        // Wire-level determinism: encoded bytes must match across builds.
+        let bytes_a = payload_a.encode_to_vec();
+        let bytes_b = payload_b.encode_to_vec();
+        assert_eq!(
+            bytes_a, bytes_b,
+            "get_client_payload() must be deterministic across calls"
+        );
+    }
+
+    #[test]
+    fn phone_id_passes_through_from_profile_when_set() {
+        let mut profile = ClientProfile::web();
+        profile.phone_id = Some("fixed-test-id".to_string());
+        let mut device = Device::new();
+        device.set_client_profile(profile);
+
+        let payload = device.get_client_payload();
+        let ua = payload.user_agent.expect("user_agent");
+        assert_eq!(ua.phone_id.as_deref(), Some("fixed-test-id"));
+    }
+
+    #[test]
+    fn login_payload_phone_id_is_omitted_by_default() {
+        let mut device = Device::new();
+        device.pn = Some("12345:0@s.whatsapp.net".parse().unwrap());
+        let payload = device.get_client_payload();
+        let ua = payload.user_agent.expect("user_agent");
+        assert!(
+            ua.phone_id.is_none(),
+            "login payload phoneId must be omitted (WA Web compliance)"
+        );
+    }
+
+    /// `lc` must be bumped per successful login, not stuck at 0.
+    #[test]
+    fn login_payload_lc_reflects_login_counter() {
+        use crate::store::commands::{DeviceCommand, apply_command_to_device};
+
+        let mut device = Device::new();
+        device.pn = Some("12345:0@s.whatsapp.net".parse().unwrap());
+
+        // Fresh device: lc = 0.
+        assert_eq!(device.get_client_payload().lc, Some(0));
+
+        // After one successful login (one IncrementLoginCounter dispatch),
+        // the NEXT payload's lc must be 1.
+        apply_command_to_device(&mut device, DeviceCommand::IncrementLoginCounter);
+        assert_eq!(device.get_client_payload().lc, Some(1));
+
+        apply_command_to_device(&mut device, DeviceCommand::IncrementLoginCounter);
+        apply_command_to_device(&mut device, DeviceCommand::IncrementLoginCounter);
+        assert_eq!(device.get_client_payload().lc, Some(3));
+    }
+
+    /// `Get/ClientPayloadForLogin.js` hardcodes `pull: true` on login wrapper.
+    #[test]
+    fn login_payload_pull_is_true() {
+        let mut device = Device::new();
+        device.pn = Some("12345:0@s.whatsapp.net".parse().unwrap());
+        let payload = device.get_client_payload();
+        assert_eq!(
+            payload.pull,
+            Some(true),
+            "login payload must send pull=true (WA Web compliance)"
+        );
+    }
+
+    #[test]
+    fn registration_payload_pull_is_false() {
+        // Fresh device without `pn` exercises the registration path.
+        let device = Device::new();
+        assert!(device.pn.is_none());
+        let payload = device.get_client_payload();
+        assert_eq!(
+            payload.pull,
+            Some(false),
+            "registration payload must send pull=false"
+        );
+    }
+
+    /// `lc` must survive process restarts (WA Web persists in IndexedDB).
+    #[test]
+    fn login_counter_survives_serde_roundtrip() {
+        use crate::store::commands::{DeviceCommand, apply_command_to_device};
+
+        let mut device = Device::new();
+        for _ in 0..5 {
+            apply_command_to_device(&mut device, DeviceCommand::IncrementLoginCounter);
+        }
+        assert_eq!(device.login_counter, 5);
+
+        let json = serde_json::to_string(&device).expect("serialize");
+        let restored: Device = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            restored.login_counter, 5,
+            "login_counter must survive Device serde roundtrip"
+        );
     }
 
     /// Backward compat: missing `account` field deserializes as `None`.

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -853,6 +853,18 @@ mod tests {
         );
     }
 
+    /// `lc` is part of the LOGIN payload only. Registration payloads use a
+    /// different protobuf path (`get_registration_payload`) that doesn't read
+    /// it; the field MUST stay None on the wire there, matching WA Web's
+    /// `getClientPayloadForRegistration` which omits the field.
+    #[test]
+    fn registration_payload_does_not_carry_lc() {
+        let device = Device::new();
+        assert!(device.pn.is_none());
+        let payload = device.get_client_payload();
+        assert!(payload.lc.is_none(), "registration payload must omit lc");
+    }
+
     /// `lc` must survive process restarts (WA Web persists in IndexedDB).
     #[test]
     fn login_counter_survives_serde_roundtrip() {


### PR DESCRIPTION
## Problem

After a `<stream:error code="500">` the client reconnects, gets a fresh
`<success>` (Noise keypair is still valid), but the server has silently
invalidated the application-layer session — every subsequent stanza is
dropped, including sends. Process restarts don't recover; only deleting
the auth state and re-pairing does.

## Root cause

Two wire-level anti-abuse signals were off vs WA Web:

1. `UserAgent.phoneId` was being auto-generated as a fresh UUID on every
   payload build. WA Web (`Client/Payload.js`) never sets the field; a
   per-connect rotating value gets flagged as a device fingerprint anomaly.

2. `ClientPayload.lc` was hardcoded to 0 because
   `DeviceCommand::IncrementLoginCounter` was defined and persisted but
   never dispatched. WA Web bumps it after every successful auth
   (`Start/Backend.js` → Comms `onConnect`).

## Changes

**Causa-raiz**
- `fix(payload)`: stop generating `phone_id`, send `pull=true` on login,
  align `lid_db_migrated` comment with WA Web's behavior.
- `fix(client)`: dispatch `IncrementLoginCounter` after `<success>`,
  gated on `device.pn.is_some()` so the XX pairing handshake doesn't
  bump it (matches WA Web's `isRegistered()` check in `Comms/Config.js`).

**Receipt compliance**
- `fix(receipt)`: ack `status@broadcast` with `<receipt context="status">`
  including the `participant` attr — WA Web's
  `Send/DeliveryReceiptJob.js` gates the participant on
  `(isGroup || isBroadcast) && participant`, not just `isGroup`.
- `fix(client)`: keep `status@broadcast` in `should_ack` as a fallback
  for `process_group_enc_batch` drop paths (expired status, missing
  sender key, generic decrypt error). Those branches deliberately skip
  the delivery receipt to avoid inflating the server offline counter;
  without a transport `<ack>`, the server retransmits forever.

## Tests

New regression coverage:
- Payload determinism — repeated `get_client_payload()` produces
  identical wire bytes, no per-build randomness.
- `lc` reflects `login_counter` and persists across serde roundtrips.
- `pull=true` on login, `pull=false` on registration, `lc` omitted
  from the registration payload.
- Receipt builder: wire shape per chat type (DM, group, status
  broadcast with participant + context=status, peer-msg DM, peer-msg
  status edge case).
- `should_send_delivery_receipt` gate: empty id, own DM, own peer-msg.
- `should_ack` gate: DM/group return false, newsletter and
  status@broadcast return true.

`cargo fmt --all`, `cargo clippy --all --tests` clean. Local test run
green: 1577 unit tests, E2E suite green in CI.