### PR TITLE
fix(message): nack unrecoverable decrypt errors instead of silent drop

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -16,6 +16,7 @@ use wacore::libsignal::protocol::{
     PublicKey as SignalPublicKey, SENDERKEY_MESSAGE_CURRENT_VERSION,
 };
 use wacore::message_processing::EncType;
+use wacore::protocol::nack::NackReason;
 use wacore::types::jid::{JidExt, make_sender_key_name};
 use wacore_binary::Jid;
 use wacore_binary::JidExt as _;
@@ -764,11 +765,30 @@ impl Client {
             let enc_type_str = enc_type.as_wire_str();
             let padding_version = payload.padding_version;
 
+            // WA Web `MsgSendReceipt.js` nacks PARSE_ERROR; without it the
+            // server retransmits the malformed stanza forever. Mirrors the
+            // `handle_decrypt_failure` shape (dispatch event + spawn wire I/O
+            // so the session lock isn't held across the send).
             let parsed_message = if enc_type == EncType::PreKeyMessage {
                 match PreKeySignalMessage::try_from(ciphertext) {
                     Ok(m) => CiphertextMessage::PreKeySignalMessage(m),
                     Err(e) => {
-                        log::error!("Failed to parse PreKeySignalMessage: {e:?}");
+                        log::error!(
+                            "[msg:{}] Failed to parse PreKeySignalMessage from {}: {e:?}. Sending nack.",
+                            info.id,
+                            info.source.sender
+                        );
+                        // |= so a later dedup'd return (false) can't clobber
+                        // a true set by a prior iteration in this batch.
+                        dispatched_undecryptable |= self
+                            .dispatch_undecryptable_event(
+                                Arc::clone(info),
+                                false,
+                                crate::types::events::UnavailableType::Unknown,
+                                decrypt_fail_mode,
+                            )
+                            .await;
+                        self.spawn_nack(info, NackReason::ParsingError, None);
                         continue;
                     }
                 }
@@ -776,7 +796,20 @@ impl Client {
                 match SignalMessage::try_from(ciphertext) {
                     Ok(m) => CiphertextMessage::SignalMessage(m),
                     Err(e) => {
-                        log::error!("Failed to parse SignalMessage: {e:?}");
+                        log::error!(
+                            "[msg:{}] Failed to parse SignalMessage from {}: {e:?}. Sending nack.",
+                            info.id,
+                            info.source.sender
+                        );
+                        dispatched_undecryptable |= self
+                            .dispatch_undecryptable_event(
+                                Arc::clone(info),
+                                false,
+                                crate::types::events::UnavailableType::Unknown,
+                                decrypt_fail_mode,
+                            )
+                            .await;
+                        self.spawn_nack(info, NackReason::ParsingError, None);
                         continue;
                     }
                 }
@@ -1116,14 +1149,23 @@ impl Client {
                             .await;
                         continue;
                     } else {
-                        // For other unexpected errors, just log them
+                        // Catch-all → WA Web's UnhandledError nack (500).
                         log::error!(
-                            "[msg:{}] Batch session decrypt failed (type: {}) from {}: {:?}",
+                            "[msg:{}] Batch session decrypt failed (type: {}) from {}: {:?}. Sending nack.",
                             info.id,
                             enc_type,
                             info.source.sender,
                             e
                         );
+                        dispatched_undecryptable |= self
+                            .dispatch_undecryptable_event(
+                                Arc::clone(info),
+                                false,
+                                crate::types::events::UnavailableType::Unknown,
+                                decrypt_fail_mode,
+                            )
+                            .await;
+                        self.spawn_nack(info, NackReason::UnhandledError, None);
                         continue;
                     }
                 }
@@ -5779,6 +5821,165 @@ mod tests {
             &event.is_unavailable,
             &event.unavailable_type,
             &event.decrypt_fail_mode,
+        );
+    }
+
+    /// Seed `device.pn` so `send_nack` clears its `get_pn()` guard.
+    async fn seed_test_pn(client: &Arc<Client>) {
+        use crate::store::commands::DeviceCommand;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(
+                "5511000000001:0@s.whatsapp.net"
+                    .parse()
+                    .expect("test PN should parse"),
+            )))
+            .await;
+    }
+
+    /// Build a Client wired to a CapturingMockTransport + a noise socket so
+    /// `send_node` reaches the wire. Returns the transport so the caller can
+    /// inspect captured frames.
+    async fn capturing_client(
+        test_id: &str,
+    ) -> (
+        Arc<Client>,
+        Arc<crate::transport::mock::CapturingMockTransport>,
+    ) {
+        use crate::socket::NoiseSocket;
+        use crate::store::SqliteStore;
+        use crate::store::persistence_manager::PersistenceManager;
+        use crate::transport::mock::CapturingMockTransportFactory;
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+        use wacore::handshake::NoiseCipher;
+
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let unique_id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let db_name = format!(
+            "file:memdb_capt_{}_{}_{}?mode=memory&cache=shared",
+            test_id,
+            unique_id,
+            std::process::id()
+        );
+
+        let backend = Arc::new(
+            SqliteStore::new(&db_name)
+                .await
+                .expect("test backend should initialize"),
+        );
+        let pm = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("persistence manager should initialize"),
+        );
+        let factory = CapturingMockTransportFactory::new();
+        let transport = factory.transport();
+        let (client, _sync_rx) = Client::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            pm,
+            Arc::new(factory),
+            Arc::new(MockHttpClient),
+            None,
+        )
+        .await;
+
+        let key = [0u8; 32];
+        let write_key = NoiseCipher::new(&key).expect("32-byte key");
+        let read_key = NoiseCipher::new(&key).expect("32-byte key");
+        let noise_socket = NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            transport.clone() as Arc<dyn crate::transport::Transport>,
+            write_key,
+            read_key,
+        );
+        // send_node only needs noise_socket Some; is_connected is read by
+        // other layers but not on this path.
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+        seed_test_pn(&client).await;
+        (client, transport)
+    }
+
+    /// Regression: a malformed pkmsg used to fall through silently. Now
+    /// it dispatches the consumer event AND emits a nack on the wire so
+    /// the server stops retransmitting.
+    #[tokio::test]
+    async fn pkmsg_parse_error_dispatches_parsing_error_nack() {
+        use crate::types::events::DecryptFailMode;
+        use wacore::message_processing::EncType;
+
+        let (client, transport) = capturing_client("pkmsg_parse_nack").await;
+        let info = Arc::new(create_test_message_info(
+            "5511999998888@s.whatsapp.net",
+            "REGRESSION_PKMSG_PARSE",
+            "5511777776666@s.whatsapp.net",
+        ));
+        let sender_jid: Jid = info.source.sender.clone();
+
+        // 1-byte ciphertext is a guaranteed parse failure.
+        let bad_payload = EncPayload {
+            ciphertext: bytes::Bytes::from_static(&[0xFF]),
+            enc_type: EncType::PreKeyMessage,
+            padding_version: 2,
+        };
+
+        let (any_success, any_duplicate, dispatched_undecryptable) = client
+            .process_session_enc_batch(&[bad_payload], &info, &sender_jid, DecryptFailMode::Show)
+            .await;
+
+        assert!(!any_success);
+        assert!(!any_duplicate);
+        assert!(dispatched_undecryptable);
+
+        // spawn_nack is detached; give it a tick to flush through the
+        // noise_socket sender_task to our CapturingMockTransport.
+        for _ in 0..40 {
+            if !transport.sent().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let sent = transport.sent();
+        assert!(
+            !sent.is_empty(),
+            "spawn_nack must produce at least one outbound frame on the wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn signal_message_parse_error_dispatches_parsing_error_nack() {
+        use crate::types::events::DecryptFailMode;
+        use wacore::message_processing::EncType;
+
+        let (client, transport) = capturing_client("sig_parse_nack").await;
+        let info = Arc::new(create_test_message_info(
+            "5511999998888@s.whatsapp.net",
+            "REGRESSION_SIG_PARSE",
+            "5511777776666@s.whatsapp.net",
+        ));
+        let sender_jid: Jid = info.source.sender.clone();
+
+        let bad_payload = EncPayload {
+            ciphertext: bytes::Bytes::from_static(&[0xFF]),
+            enc_type: EncType::Message,
+            padding_version: 2,
+        };
+
+        let (_any_success, _any_duplicate, dispatched_undecryptable) = client
+            .process_session_enc_batch(&[bad_payload], &info, &sender_jid, DecryptFailMode::Show)
+            .await;
+
+        assert!(dispatched_undecryptable);
+
+        for _ in 0..40 {
+            if !transport.sent().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            !transport.sent().is_empty(),
+            "spawn_nack must produce at least one outbound frame on the wire"
         );
     }
 }

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1,8 +1,10 @@
 use crate::client::Client;
 use crate::types::events::{Event, Receipt};
+use crate::types::message::MessageInfo;
 use crate::types::presence::ReceiptType;
 use log::debug;
 use std::sync::Arc;
+use wacore::protocol::nack::NackReason;
 use wacore::types::message::MessageCategory;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, JidExt as _};
@@ -31,6 +33,43 @@ fn build_delivery_receipt_node(info: &crate::types::message::MessageInfo) -> wac
 
     if is_status {
         builder = builder.attr("context", "status");
+    }
+
+    builder.build()
+}
+
+/// `<ack class="message" error=N>` builder, mirrors WA Web's
+/// `Handle/MsgSendAck.js::sendNack`. `failure_reason` is only emitted
+/// for `InvalidProtobuf` (as `<meta failure_reason=N>` child).
+fn build_nack_node(
+    info: &MessageInfo,
+    own_pn: &Jid,
+    reason: NackReason,
+    failure_reason: Option<i32>,
+) -> wacore_binary::Node {
+    let mut builder = NodeBuilder::new("ack")
+        .attr("class", "message")
+        .attr("id", &info.id)
+        .attr("from", own_pn)
+        .attr("to", &info.source.chat)
+        .attr("error", reason.code().to_string());
+
+    let is_status = info.source.chat.is_status_broadcast();
+    if info.source.is_group || is_status {
+        builder = builder.attr("participant", &info.source.sender);
+    }
+
+    if !info.r#type.is_empty() {
+        builder = builder.attr("type", &info.r#type);
+    }
+
+    if reason == NackReason::InvalidProtobuf
+        && let Some(code) = failure_reason
+    {
+        let meta = NodeBuilder::new("meta")
+            .attr("failure_reason", code.to_string())
+            .build();
+        builder = builder.children(vec![meta]);
     }
 
     builder.build()
@@ -231,6 +270,57 @@ impl Client {
         }
     }
 
+    /// Spawn an async nack so the caller doesn't await network I/O while
+    /// holding a session lock. Mirrors `spawn_retry_receipt`.
+    pub(crate) fn spawn_nack(
+        self: &Arc<Self>,
+        info: &Arc<MessageInfo>,
+        reason: NackReason,
+        failure_reason: Option<i32>,
+    ) {
+        let client = Arc::clone(self);
+        let info = Arc::clone(info);
+        self.runtime
+            .spawn(Box::pin(async move {
+                client.send_nack(&info, reason, failure_reason).await;
+            }))
+            .detach();
+    }
+
+    /// Emits a nack so the server stops retransmitting an unrecoverable
+    /// failure. Prefer [`Client::send_retry_receipt`] for recoverable
+    /// errors (BadMac, NoSession, etc).
+    pub(crate) async fn send_nack(
+        &self,
+        info: &MessageInfo,
+        reason: NackReason,
+        failure_reason: Option<i32>,
+    ) {
+        if info.id.is_empty() {
+            return;
+        }
+        let Some(own_pn) = self.get_pn().await else {
+            log::debug!(
+                "[msg:{}] Skipping nack ({:?}): own PN not yet set",
+                info.id,
+                reason
+            );
+            return;
+        };
+
+        let nack = build_nack_node(info, &own_pn, reason, failure_reason);
+        debug!(target: "Client/Receipt",
+            "Sending nack (reason={:?}, code={}) for message {} from {}",
+            reason, reason.code(), info.id, info.source.sender);
+
+        if let Err(e) = self.send_node(nack).await
+            && !matches!(e, crate::client::ClientError::NotConnected)
+        {
+            log::warn!(target: "Client/Receipt",
+                "Failed to send nack for message {}: {:?}", info.id, e);
+        }
+    }
+
     /// Sends read receipts for one or more messages.
     ///
     /// For group messages, pass the message sender as `sender`.
@@ -380,6 +470,120 @@ mod tests {
             node.attrs.get("context").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
+    }
+
+    fn own_pn() -> Jid {
+        "5511000000001:0@s.whatsapp.net"
+            .parse()
+            .expect("own PN should parse")
+    }
+
+    #[test]
+    fn nack_for_dm_carries_class_message_and_error_code() {
+        let info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        let node = build_nack_node(&info, &own_pn(), NackReason::ParsingError, None);
+
+        assert_eq!(node.tag, "ack");
+        assert_eq!(
+            node.attrs.get("class").map(|v| v.as_str()).as_deref(),
+            Some("message")
+        );
+        assert_eq!(
+            node.attrs.get("error").map(|v| v.as_str()).as_deref(),
+            Some("487")
+        );
+        assert_eq!(
+            node.attrs.get("id").map(|v| v.as_str()).as_deref(),
+            Some("MID")
+        );
+        assert!(node.attrs.get("from").is_some());
+        assert!(node.attrs.get("to").is_some());
+        assert!(node.attrs.get("participant").is_none());
+    }
+
+    #[test]
+    fn nack_for_group_carries_participant() {
+        let info = info_with(
+            "120363021033254949@g.us",
+            "15551234567@s.whatsapp.net",
+            true,
+        );
+        let node = build_nack_node(&info, &own_pn(), NackReason::UnhandledError, None);
+
+        assert_eq!(
+            node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
+            Some("15551234567@s.whatsapp.net")
+        );
+        assert_eq!(
+            node.attrs.get("error").map(|v| v.as_str()).as_deref(),
+            Some("500")
+        );
+    }
+
+    #[test]
+    fn nack_for_status_broadcast_carries_participant() {
+        let info = info_with("status@broadcast", "12345@s.whatsapp.net", false);
+        let node = build_nack_node(&info, &own_pn(), NackReason::ParsingError, None);
+
+        assert_eq!(
+            node.attrs.get("participant").map(|v| v.as_str()).as_deref(),
+            Some("12345@s.whatsapp.net")
+        );
+    }
+
+    #[test]
+    fn nack_invalid_protobuf_includes_meta_failure_reason() {
+        let info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        let node = build_nack_node(&info, &own_pn(), NackReason::InvalidProtobuf, Some(42));
+
+        assert_eq!(
+            node.attrs.get("error").map(|v| v.as_str()).as_deref(),
+            Some("491")
+        );
+        let meta = node
+            .get_optional_child("meta")
+            .expect("InvalidProtobuf nack must have <meta> child");
+        assert_eq!(
+            meta.attrs
+                .get("failure_reason")
+                .map(|v| v.as_str())
+                .as_deref(),
+            Some("42")
+        );
+    }
+
+    #[test]
+    fn nack_invalid_protobuf_without_failure_reason_omits_meta() {
+        let info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        let node = build_nack_node(&info, &own_pn(), NackReason::InvalidProtobuf, None);
+        assert!(node.get_optional_child("meta").is_none());
+    }
+
+    /// failure_reason only applies to InvalidProtobuf.
+    #[test]
+    fn nack_omits_meta_for_non_invalid_protobuf_even_with_failure_reason() {
+        let info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        let node = build_nack_node(&info, &own_pn(), NackReason::ParsingError, Some(99));
+        assert!(node.get_optional_child("meta").is_none());
+    }
+
+    #[test]
+    fn nack_includes_type_when_present() {
+        let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        info.r#type = "text".to_string();
+        let node = build_nack_node(&info, &own_pn(), NackReason::ParsingError, None);
+        assert_eq!(
+            node.attrs.get("type").map(|v| v.as_str()).as_deref(),
+            Some("text")
+        );
+    }
+
+    #[test]
+    fn nack_omits_type_when_empty() {
+        let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
+        info.r#type = String::new();
+        let node = build_nack_node(&info, &own_pn(), NackReason::ParsingError, None);
+        assert!(node.attrs.get("type").is_none());
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -49,4 +49,74 @@ pub mod mock {
             Ok((Arc::new(MockTransport), rx))
         }
     }
+
+    /// Records every `send()` payload so a unit test can assert what the
+    /// client wrote to the wire.
+    pub struct CapturingMockTransport {
+        sent: std::sync::Mutex<Vec<bytes::Bytes>>,
+    }
+
+    impl CapturingMockTransport {
+        pub fn new() -> Self {
+            Self {
+                sent: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        pub fn sent(&self) -> Vec<bytes::Bytes> {
+            self.sent.lock().expect("capturing mutex").clone()
+        }
+    }
+
+    impl Default for CapturingMockTransport {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl Transport for CapturingMockTransport {
+        async fn send(&self, data: bytes::Bytes) -> Result<(), anyhow::Error> {
+            self.sent.lock().expect("capturing mutex").push(data);
+            Ok(())
+        }
+
+        async fn disconnect(&self) {}
+    }
+
+    /// Factory variant for [`CapturingMockTransport`].
+    pub struct CapturingMockTransportFactory {
+        transport: Arc<CapturingMockTransport>,
+    }
+
+    impl CapturingMockTransportFactory {
+        pub fn new() -> Self {
+            Self {
+                transport: Arc::new(CapturingMockTransport::new()),
+            }
+        }
+
+        pub fn transport(&self) -> Arc<CapturingMockTransport> {
+            self.transport.clone()
+        }
+    }
+
+    impl Default for CapturingMockTransportFactory {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl TransportFactory for CapturingMockTransportFactory {
+        async fn create_transport(
+            &self,
+        ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error>
+        {
+            let (_tx, rx) = async_channel::bounded(1);
+            Ok((self.transport.clone(), rx))
+        }
+    }
 }

--- a/wacore/src/protocol/mod.rs
+++ b/wacore/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 pub mod keepalive;
+pub mod nack;
 pub mod retry;
 
 use anyhow::Result;

--- a/wacore/src/protocol/nack.rs
+++ b/wacore/src/protocol/nack.rs
@@ -1,0 +1,69 @@
+//! Codes sent as the `error` attr on `<ack class="message">` nacks
+//! (`Handle/MsgSendAck.js` + `Create/NackFromStanza.js`). Server stops
+//! retransmitting on receipt; use vs `<receipt type="retry">` for
+//! recoverable errors.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+#[wire(kind = "int")]
+#[allow(dead_code)]
+pub enum NackReason {
+    #[wire = 421]
+    StaleGroupAddressingMode,
+    #[wire = 475]
+    NewChatMessagesCapped,
+    #[wire = 487]
+    ParsingError,
+    #[wire = 488]
+    UnrecognizedStanza,
+    #[wire = 489]
+    UnrecognizedStanzaClass,
+    #[wire = 490]
+    UnrecognizedStanzaType,
+    /// WA Web pairs with `<meta failure_reason=N>` child.
+    #[wire = 491]
+    InvalidProtobuf,
+    #[wire = 493]
+    InvalidHostedCompanionStanza,
+    #[wire = 495]
+    MissingMessageSecret,
+    #[wire = 496]
+    SignalErrorOldCounter,
+    #[wire = 499]
+    MessageDeletedOnPeer,
+    #[wire = 500]
+    UnhandledError,
+    #[wire = 550]
+    UnsupportedAdminRevoke,
+    #[wire = 551]
+    UnsupportedLIDGroup,
+    #[wire = 552]
+    DBOperationFailed,
+    #[wire_fallback]
+    Unknown(i32),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin every code against `Create/NackFromStanza.js` so a renumber
+    /// can't silently break server compatibility.
+    #[test]
+    fn nack_reason_codes_match_wa_web() {
+        assert_eq!(NackReason::StaleGroupAddressingMode.code(), 421);
+        assert_eq!(NackReason::NewChatMessagesCapped.code(), 475);
+        assert_eq!(NackReason::ParsingError.code(), 487);
+        assert_eq!(NackReason::UnrecognizedStanza.code(), 488);
+        assert_eq!(NackReason::UnrecognizedStanzaClass.code(), 489);
+        assert_eq!(NackReason::UnrecognizedStanzaType.code(), 490);
+        assert_eq!(NackReason::InvalidProtobuf.code(), 491);
+        assert_eq!(NackReason::InvalidHostedCompanionStanza.code(), 493);
+        assert_eq!(NackReason::MissingMessageSecret.code(), 495);
+        assert_eq!(NackReason::SignalErrorOldCounter.code(), 496);
+        assert_eq!(NackReason::MessageDeletedOnPeer.code(), 499);
+        assert_eq!(NackReason::UnhandledError.code(), 500);
+        assert_eq!(NackReason::UnsupportedAdminRevoke.code(), 550);
+        assert_eq!(NackReason::UnsupportedLIDGroup.code(), 551);
+        assert_eq!(NackReason::DBOperationFailed.code(), 552);
+    }
+}


### PR DESCRIPTION
## Problem

`process_session_enc_batch` has three error paths that fall through
with a silent `continue`:

- `PreKeySignalMessage::try_from` parse failure
- `SignalMessage::try_from` parse failure
- "for other unexpected errors" catch-all (anything libsignal returns
  that isn't `DuplicatedMessage`, `UntrustedIdentity`, `SessionNotFound`,
  `BadMac`, `InvalidMessage`, or `InvalidPreKeyId`)

None of them call `handle_decrypt_failure`, none flip
`dispatched_undecryptable`, and the caller's drop path emits no wire
signal either. `should_ack` returns `false` for DM/group `<message>`,
so the server gets NO acknowledgment for the failing stanza and
retransmits forever. The pre-existing comment "transport ack is
sufficient" relied on a transport `<ack>` that never actually fires
for regular chats.

## Fix

Mirror WA Web's `Handle/MsgSendReceipt.js` exactly: route parse
errors through `send_nack(NackReason::ParsingError)` (code 487) and
the catch-all through `send_nack(NackReason::UnhandledError)` (code
500). Server stops retransmitting on the nack.

`<ack class="message" error=N>` shape matches
`Handle/MsgSendAck.js::sendNack`:

  - `id` from the failing stanza
  - `from` = our own PN
  - `to` = sender JID
  - `participant` for group + status@broadcast (mirrors the
    delivery-receipt gate)
  - `type` from the stanza when present
  - `error` integer from `NackReason`
  - `<meta failure_reason=N>` child when `InvalidProtobuf` carries
    a code (currently unused; reserved for protobuf-decode failures
    we may classify later)

## Changes

1. `feat(nack)` — `NackReason` enum in `wacore::protocol::nack` with
   every code pinned against `Create/NackFromStanza.js`.
2. `feat(receipt)` — pure `build_nack_node` + `send_nack` helpers
   alongside the existing delivery-receipt path.
3. `fix(message)` — the three silent branches now nack and flip
   `dispatched_undecryptable` so the caller's drop path doesn't
   double-emit the event.
4. `chore(transport)` — `CapturingMockTransport` scaffolding for
   future wire-shape tests.

## Tests

10 new unit tests + 1 wacore test:
  - `wacore::protocol::nack::nack_reason_codes_match_wa_web`
  - `nack_for_dm_carries_class_message_and_error_code`
  - `nack_for_group_carries_participant`
  - `nack_for_status_broadcast_carries_participant`
  - `nack_invalid_protobuf_includes_meta_failure_reason`
  - `nack_invalid_protobuf_without_failure_reason_omits_meta`
  - `nack_omits_meta_for_non_invalid_protobuf_even_with_failure_reason`
  - `nack_includes_type_when_present`
  - `nack_omits_type_when_empty`
  - `pkmsg_parse_error_dispatches_parsing_error_nack`
  - `signal_message_parse_error_dispatches_parsing_error_nack`

Local: 1588 unit tests pass, `cargo fmt --all` + `cargo clippy --all
--tests` clean. E2E not run locally; CI covers.