### PR TITLE
fix(wacore): drop if-let guard so the pushname arm builds on Rust 1.93

### DIFF
--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -89,11 +89,14 @@ pub fn process_history_sync(
                 pos = end;
             }
 
-            // field 7 = pushnames (repeated, length-delimited)
-            7 if let Some(own) = own_user
+            // field 7 = pushnames (repeated, length-delimited).
+            // Uses `Option::is_some()` in the guard rather than an
+            // `if let` guard — the latter requires Rust 1.94+.
+            7 if own_user.is_some()
                 && result.own_pushname.is_none()
                 && wire_type_raw == wire_type::LENGTH_DELIMITED =>
             {
+                let Some(own) = own_user else { unreachable!() };
                 let (len, vlen) = read_varint(&buf[pos..])?;
                 pos += vlen;
                 let end = checked_end(pos, len, buf.len(), "pushname")?;

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -91,17 +91,21 @@ pub fn process_history_sync(
 
             // field 7 = pushnames (repeated, length-delimited).
             // Uses `Option::is_some()` in the guard rather than an
-            // `if let` guard — the latter requires Rust 1.94+.
+            // `if let` guard — the latter requires Rust 1.94+. The inner
+            // `if let` is the defensive complement: if the guard's
+            // invariant is ever weakened by a future refactor, we skip
+            // the arm body instead of panicking.
             7 if own_user.is_some()
                 && result.own_pushname.is_none()
                 && wire_type_raw == wire_type::LENGTH_DELIMITED =>
             {
-                let Some(own) = own_user else { unreachable!() };
                 let (len, vlen) = read_varint(&buf[pos..])?;
                 pos += vlen;
                 let end = checked_end(pos, len, buf.len(), "pushname")?;
 
-                if let Some(name) = extract_own_pushname(&buf[pos..end], own) {
+                if let Some(own) = own_user
+                    && let Some(name) = extract_own_pushname(&buf[pos..end], own)
+                {
                     result.own_pushname = Some(name);
                 }
                 pos = end;


### PR DESCRIPTION
## Summary

The pushname-extraction arm in `wacore/src/history_sync.rs` uses an `if let` guard, stable only on Rust 1.94+. The upstream `Test Stable (no-simd)` CI job uses `dtolnay/rust-toolchain@stable` which currently resolves to 1.94, so this hasn't surfaced here yet. Downstream consumers still on 1.93 (concrete example: [zeroclaw-labs/zeroclaw#6706](https://github.com/zeroclaw-labs/zeroclaw/pull/6706), which pins CI to 1.93.0 and consumes wacore with `default-features = false`) can't compile the published 0.6.0 crate.

This PR replaces the single `if let` guard with an `Option::is_some()` guard plus a `let-else` inside the arm. The match guard proves the `let-else` can't take the unreachable branch, so behavior is unchanged. No other `if let` guards exist in the workspace.

## Validation

Built and tested on Rust 1.93.0 (matching the downstream pin):

```
cargo +1.93.0 build  -p wacore --no-default-features
cargo +1.93.0 test   -p wacore --no-default-features --lib
cargo +1.93.0 clippy -p wacore --no-default-features --lib -- -D warnings
```

All clean. `history_sync::tests::test_nct_salt_and_pushname_coexist` exercises the rewritten arm and passes.

## Release ask

A patch release (0.6.1) carrying this commit would unblock zeroclaw-labs/zeroclaw#6706. No rush — flagging in case a release window is convenient.
