### PR TITLE
fix(client): preserve recipient in <ack>, soften unknown stream:error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3303,8 +3303,12 @@ impl Client {
                     info!("Got 503 service unavailable, will auto-reconnect.");
                 }
                 _ => {
+                    // Mirror whatsmeow's default: log + dispatch event, but keep the
+                    // connection alive. The server wraps per-stanza notifications in
+                    // <stream:error> without a code attribute (e.g. <ack/> for malformed
+                    // routing). Proactively disconnecting on those causes reconnect storms
+                    // under load — whatsmeow lets the noise socket detect a real teardown.
                     error!("Unknown stream error: {}", DisplayableNodeRef(node));
-                    self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::StreamError(
                         crate::types::events::StreamError {
                             code: code.to_string(),
@@ -3315,7 +3319,9 @@ impl Client {
             }
         }
 
-        // Single transport lock acquisition for all branches that need disconnect.
+        // Only tear down the connection for branches that explicitly opted in.
+        // 429/503/unknown match whatsmeow: log and let the socket layer notice
+        // if the server actually closes the stream.
         if should_disconnect {
             let transport_opt = self.transport.lock().await.clone();
             if let Some(transport) = transport_opt {
@@ -3325,10 +3331,9 @@ impl Client {
                     }))
                     .detach();
             }
+            info!("Notifying connection shutdown from stream error handler");
+            self.notify_connection_shutdown();
         }
-
-        info!("Notifying connection shutdown from stream error handler");
-        self.notify_connection_shutdown();
     }
 
     pub(crate) async fn handle_connect_failure(&self, node: &wacore_binary::NodeRef<'_>) {
@@ -3904,6 +3909,10 @@ fn encode_ack_bytes(
         let from_str = from_val.as_str();
         p_str.as_ref() != from_str.as_ref()
     });
+    // Server expects `recipient` echoed back so it can route the ack to the
+    // origin companion/device (hosted-companion, peer, LID-routed stanzas).
+    // Dropping it makes the server close the stream with `<stream:error><ack/>`.
+    let recipient_val = node.get_attr("recipient");
     let tag = node.tag.as_ref();
 
     let typ_val = if tag != "message" && !is_encrypt_identity_notification(node) {
@@ -3914,16 +3923,18 @@ fn encode_ack_bytes(
 
     let include_from = tag == "message" && own_device_pn.is_some();
 
-    // Count attrs: class + id + to + optional(from, participant, type)
+    // Count attrs: class + id + to + optional(from, participant, recipient, type)
     let attr_count = 3
         + usize::from(include_from)
         + usize::from(participant_val.is_some())
+        + usize::from(recipient_val.is_some())
         + usize::from(typ_val.is_some());
 
     struct AckNode<'a> {
         id: &'a wacore_binary::node::ValueRef<'a>,
         from: &'a wacore_binary::node::ValueRef<'a>,
         participant: Option<&'a wacore_binary::node::ValueRef<'a>>,
+        recipient: Option<&'a wacore_binary::node::ValueRef<'a>>,
         typ: Option<&'a wacore_binary::node::ValueRef<'a>>,
         own_pn: Option<&'a Jid>,
         tag_str: &'a str,
@@ -3958,6 +3969,10 @@ fn encode_ack_bytes(
                 enc.write_string("participant")?;
                 p.encode_value(enc)?;
             }
+            if let Some(r) = self.recipient {
+                enc.write_string("recipient")?;
+                r.encode_value(enc)?;
+            }
             if let Some(t) = self.typ {
                 enc.write_string("type")?;
                 t.encode_value(enc)?;
@@ -3976,6 +3991,7 @@ fn encode_ack_bytes(
         id: id_val,
         from: from_val,
         participant: participant_val,
+        recipient: recipient_val,
         typ: typ_val,
         own_pn: if include_from { own_device_pn } else { None },
         tag_str: tag,
@@ -3999,13 +4015,14 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
         .get_attr("participant")
         .filter(|p| p.as_str().as_ref() != from_ref.as_str().as_ref())
         .map(|v| v.to_node_value());
+    let recipient = node.get_attr("recipient").map(|v| v.to_node_value());
     let tag = node.tag.as_ref();
     let typ = if tag != "message" && !is_encrypt_identity_notification(node) {
         node.get_attr("type").map(|v| v.to_node_value())
     } else {
         None
     };
-    let mut attrs = Attrs::with_capacity(6);
+    let mut attrs = Attrs::with_capacity(7);
     attrs.insert("class", NodeValue::from(tag));
     attrs.insert("id", id);
     attrs.insert("to", from);
@@ -4016,6 +4033,9 @@ fn build_ack_node(node: &wacore_binary::NodeRef<'_>, own_device_pn: Option<&Jid>
     }
     if let Some(p) = participant {
         attrs.insert("participant", p);
+    }
+    if let Some(r) = recipient {
+        attrs.insert("recipient", r);
     }
     if let Some(t) = typ {
         attrs.insert("type", t);
@@ -5865,6 +5885,81 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_build_ack_node_for_message_with_recipient_preserves_recipient() {
+        // Peer / hosted-companion / LID-routed messages carry `recipient`.
+        // The server uses it to route the ack back to the origin device;
+        // without it the stream is torn down with <stream:error><ack/></stream:error>.
+        let incoming = NodeBuilder::new("message")
+            .attr("from", "166361967902821@lid")
+            .attr("id", "2A32F960553696093D99")
+            .attr("type", "text")
+            .attr("recipient", "146991363395800@lid")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net"
+            .parse()
+            .expect("own device PN JID should parse");
+
+        let ack = build_ack_node(&incoming.as_node_ref(), Some(&own_device_pn))
+            .expect("message ack should be buildable");
+
+        assert!(ack.attrs.get("class").is_some_and(|v| v == "message"));
+        assert!(
+            ack.attrs
+                .get("recipient")
+                .is_some_and(|v| v == "146991363395800@lid"),
+            "message ACK must echo the incoming `recipient` attribute"
+        );
+    }
+
+    #[test]
+    fn test_build_ack_node_for_receipt_with_recipient_preserves_recipient() {
+        // Receipt acks must also echo `recipient` when the incoming carries it.
+        let incoming = NodeBuilder::new("receipt")
+            .attr("from", "120363098765432100@g.us")
+            .attr("id", "RCPT-WITH-RECIPIENT")
+            .attr("type", "read")
+            .attr("recipient", "242395589390497@lid")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net"
+            .parse()
+            .expect("own device PN JID should parse");
+
+        let ack = build_ack_node(&incoming.as_node_ref(), Some(&own_device_pn))
+            .expect("receipt ack should be buildable");
+
+        assert!(ack.attrs.get("class").is_some_and(|v| v == "receipt"));
+        assert!(
+            ack.attrs
+                .get("recipient")
+                .is_some_and(|v| v == "242395589390497@lid"),
+            "receipt ACK must echo the incoming `recipient` attribute"
+        );
+    }
+
+    #[test]
+    fn test_build_ack_node_for_message_without_recipient_omits_recipient() {
+        // Regression guard: never synthesise a `recipient` field if the
+        // incoming stanza did not carry one — server would reject the ack.
+        let incoming = NodeBuilder::new("message")
+            .attr("from", "120363161500776365@g.us")
+            .attr("id", "A5791A5392EF60E3FB06")
+            .attr("type", "text")
+            .attr("participant", "181531758878822@lid")
+            .build();
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net"
+            .parse()
+            .expect("own device PN JID should parse");
+
+        let ack = build_ack_node(&incoming.as_node_ref(), Some(&own_device_pn))
+            .expect("message ack should be buildable");
+
+        assert!(
+            !ack.attrs.contains_key("recipient"),
+            "ACK must NOT add `recipient` when the incoming stanza has none"
+        );
+    }
+
     /// Smoke test: server ping with xmlns but no id attribute is handled.
     #[tokio::test]
     async fn test_handle_iq_ping_without_id() {
@@ -5991,6 +6086,46 @@ mod tests {
         assert!(
             client.enable_auto_reconnect.load(Ordering::Relaxed),
             "503 should keep auto-reconnect enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_error_unknown_keeps_connection_alive() {
+        // Unknown stream:error (no `code` attribute) must mirror whatsmeow's
+        // default branch: log + dispatch event, but NOT mark this as an
+        // expected disconnect. Setting that flag silently swallows the next
+        // real disconnect and races the read loop into shutdown.
+        let client = create_offline_sync_test_client().await;
+        let node = NodeBuilder::new("stream:error").build();
+        client.handle_stream_error(&node.as_node_ref()).await;
+        assert!(
+            !client.expected_disconnect.load(Ordering::Relaxed),
+            "unknown stream:error must not mark the disconnect as expected"
+        );
+        assert!(
+            client.enable_auto_reconnect.load(Ordering::Relaxed),
+            "unknown stream:error must keep auto-reconnect enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_error_ack_shaped_does_not_force_shutdown() {
+        // Server wraps per-stanza routing failures in `<stream:error><ack/>`
+        // with no `code` attribute. Treat as informational, not as a fatal
+        // stream teardown.
+        let client = create_offline_sync_test_client().await;
+        let ack_child = NodeBuilder::new("ack")
+            .attr("class", "message")
+            .attr("type", "text")
+            .attr("id", "2A32F960553696093D99")
+            .build();
+        let node = NodeBuilder::new("stream:error")
+            .children([ack_child])
+            .build();
+        client.handle_stream_error(&node.as_node_ref()).await;
+        assert!(
+            !client.expected_disconnect.load(Ordering::Relaxed),
+            "ack-shaped stream:error must not mark the disconnect as expected"
         );
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3222,10 +3222,11 @@ impl Client {
     }
 
     pub(crate) async fn handle_stream_error(&self, node: &wacore_binary::NodeRef<'_>) {
-        // is_logged_in is cleared together with the disconnect below, never
-        // here: 429, 503, and unknown/code-less errors leave the session
-        // alive, and clearing it while the socket is up would flip
-        // is_fully_ready() and make prekey uploads bail with "Connection lost".
+        // is_logged_in handling: opt-in branches (515/516/401/409/conflict) clear it
+        // in the disconnect block below; 429/503 clear it inline because the server
+        // explicitly rejected the session and outgoing sends should bail fast; the
+        // unknown/code-less catch-all keeps it true so is_fully_ready()-gated work
+        // (notably prekey uploads) survives ack-shaped routing errors.
         let mut attrs = node.attrs();
         let code_cow = attrs.optional_string("code");
         let code = code_cow.as_deref().unwrap_or("");
@@ -3304,21 +3305,29 @@ impl Client {
                     should_disconnect = true;
                 }
                 "429" => {
+                    // Server signalled rate-limit on this session: mark logged-out so
+                    // outgoing sends bail fast instead of being interpreted as abuse
+                    // while we wait for the (likely-imminent) reconnect.
                     warn!(
                         "Got 429 stream error (rate limited). Will auto-reconnect with extended backoff."
                     );
+                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.auto_reconnect_errors.fetch_add(5, Ordering::Relaxed);
                 }
                 "503" => {
+                    // Server is going down/restarting: mark logged-out so sends fail
+                    // fast against the soon-to-die socket. Auto-reconnect handles recovery.
                     info!("Got 503 service unavailable, will auto-reconnect.");
+                    self.is_logged_in.store(false, Ordering::Relaxed);
                 }
                 _ => {
                     // Server wraps per-stanza routing failures in <stream:error> without a
                     // code (e.g. <ack/>): treat as informational so we don't trigger reconnect
                     // storms. is_logged_in stays true on purpose — whatsmeow clears it eagerly,
                     // but here is_fully_ready() gates prekey uploads and we want them to keep
-                    // working while the socket is still alive.
-                    error!("Unknown stream error: {}", DisplayableNodeRef(node));
+                    // working while the socket is still alive. Severity is warn!, not error!,
+                    // because the connection is intentionally preserved.
+                    warn!("Unknown stream error: {}", DisplayableNodeRef(node));
                     self.core.event_bus.dispatch(Event::StreamError(
                         crate::types::events::StreamError {
                             code: code.to_string(),
@@ -6128,12 +6137,21 @@ mod tests {
     #[tokio::test]
     async fn test_stream_error_429_keeps_reconnect_with_backoff() {
         let client = create_offline_sync_test_client().await;
+        client.is_logged_in.store(true, Ordering::Relaxed);
         let before = client.auto_reconnect_errors.load(Ordering::Relaxed);
         let node = NodeBuilder::new("stream:error").attr("code", "429").build();
         client.handle_stream_error(&node.as_node_ref()).await;
         assert!(
             client.enable_auto_reconnect.load(Ordering::Relaxed),
             "429 should keep auto-reconnect enabled"
+        );
+        assert!(
+            !client.is_logged_in.load(Ordering::Relaxed),
+            "429 must clear is_logged_in so sends bail before the server flags abuse"
+        );
+        assert!(
+            !client.expected_disconnect.load(Ordering::Relaxed),
+            "429 must not mark the disconnect as expected (auto-reconnect path)"
         );
         let after = client.auto_reconnect_errors.load(Ordering::Relaxed);
         assert_eq!(
@@ -6146,11 +6164,20 @@ mod tests {
     #[tokio::test]
     async fn test_stream_error_503_keeps_reconnect() {
         let client = create_offline_sync_test_client().await;
+        client.is_logged_in.store(true, Ordering::Relaxed);
         let node = NodeBuilder::new("stream:error").attr("code", "503").build();
         client.handle_stream_error(&node.as_node_ref()).await;
         assert!(
             client.enable_auto_reconnect.load(Ordering::Relaxed),
             "503 should keep auto-reconnect enabled"
+        );
+        assert!(
+            !client.is_logged_in.load(Ordering::Relaxed),
+            "503 must clear is_logged_in so sends bail against the dying socket"
+        );
+        assert!(
+            !client.expected_disconnect.load(Ordering::Relaxed),
+            "503 must not mark the disconnect as expected (auto-reconnect path)"
         );
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3267,13 +3267,11 @@ impl Client {
                     info!(
                         "Got 515 stream error, server is closing stream (expected after pairing). Will auto-reconnect."
                     );
-                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     should_disconnect = true;
                 }
                 "516" => {
                     info!("Got 516 stream error (device removed). Logging out.");
-                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::LoggedOut(
@@ -3286,7 +3284,6 @@ impl Client {
                 }
                 "401" => {
                     info!("Got 401 stream error (unauthorized). Logging out.");
-                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::LoggedOut(
@@ -3299,7 +3296,6 @@ impl Client {
                 }
                 "409" => {
                     info!("Got 409 stream error (conflict). Another session replaced this one.");
-                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core
@@ -3317,11 +3313,11 @@ impl Client {
                     info!("Got 503 service unavailable, will auto-reconnect.");
                 }
                 _ => {
-                    // Mirror whatsmeow's default: log + dispatch event, but keep the
-                    // connection alive. The server wraps per-stanza notifications in
-                    // <stream:error> without a code attribute (e.g. <ack/> for malformed
-                    // routing). Proactively disconnecting on those causes reconnect storms
-                    // under load — whatsmeow lets the noise socket detect a real teardown.
+                    // Server wraps per-stanza routing failures in <stream:error> without a
+                    // code (e.g. <ack/>): treat as informational so we don't trigger reconnect
+                    // storms. is_logged_in stays true on purpose — whatsmeow clears it eagerly,
+                    // but here is_fully_ready() gates prekey uploads and we want them to keep
+                    // working while the socket is still alive.
                     error!("Unknown stream error: {}", DisplayableNodeRef(node));
                     self.core.event_bus.dispatch(Event::StreamError(
                         crate::types::events::StreamError {
@@ -3333,10 +3329,9 @@ impl Client {
             }
         }
 
-        // Only tear down the connection for branches that explicitly opted in.
-        // 429/503/unknown match whatsmeow: log and let the socket layer notice
-        // if the server actually closes the stream. is_logged_in is cleared
-        // here so it flips exactly when (and only when) we disconnect.
+        // Single is_logged_in clear + transport disconnect for every opt-in branch
+        // (515/516/401/409 and conflict). 429/503/unknown fall through so the
+        // socket layer notices a real teardown without us forcing one.
         if should_disconnect {
             self.is_logged_in.store(false, Ordering::Relaxed);
             let transport_opt = self.transport.lock().await.clone();

--- a/src/client.rs
+++ b/src/client.rs
@@ -3222,8 +3222,10 @@ impl Client {
     }
 
     pub(crate) async fn handle_stream_error(&self, node: &wacore_binary::NodeRef<'_>) {
-        self.is_logged_in.store(false, Ordering::Relaxed);
-
+        // is_logged_in is cleared only inside fatal branches below. 429, 503,
+        // and unknown/code-less errors leave the session alive — clearing it
+        // unconditionally here would make is_fully_ready() flip and prekey
+        // uploads bail with "Connection lost" while the socket is still up.
         let mut attrs = node.attrs();
         let code_cow = attrs.optional_string("code");
         let code = code_cow.as_deref().unwrap_or("");
@@ -3246,6 +3248,7 @@ impl Client {
                 "Got stream error indicating client was removed or replaced (conflict={}). Logging out.",
                 conflict_type
             );
+            self.is_logged_in.store(false, Ordering::Relaxed);
             self.expected_disconnect.store(true, Ordering::Relaxed);
             self.enable_auto_reconnect.store(false, Ordering::Relaxed);
 
@@ -3265,11 +3268,13 @@ impl Client {
                     info!(
                         "Got 515 stream error, server is closing stream (expected after pairing). Will auto-reconnect."
                     );
+                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     should_disconnect = true;
                 }
                 "516" => {
                     info!("Got 516 stream error (device removed). Logging out.");
+                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::LoggedOut(
@@ -3282,6 +3287,7 @@ impl Client {
                 }
                 "401" => {
                     info!("Got 401 stream error (unauthorized). Logging out.");
+                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core.event_bus.dispatch(Event::LoggedOut(
@@ -3294,6 +3300,7 @@ impl Client {
                 }
                 "409" => {
                     info!("Got 409 stream error (conflict). Another session replaced this one.");
+                    self.is_logged_in.store(false, Ordering::Relaxed);
                     self.expected_disconnect.store(true, Ordering::Relaxed);
                     self.enable_auto_reconnect.store(false, Ordering::Relaxed);
                     self.core
@@ -6104,8 +6111,14 @@ mod tests {
         // expected disconnect. Setting that flag silently swallows the next
         // real disconnect and races the read loop into shutdown.
         let client = create_offline_sync_test_client().await;
+        // Simulate an authenticated session before the stream error arrives.
+        client.is_logged_in.store(true, Ordering::Relaxed);
         let node = NodeBuilder::new("stream:error").build();
         client.handle_stream_error(&node.as_node_ref()).await;
+        assert!(
+            client.is_logged_in.load(Ordering::Relaxed),
+            "unknown stream:error must NOT log the client out"
+        );
         assert!(
             !client.expected_disconnect.load(Ordering::Relaxed),
             "unknown stream:error must not mark the disconnect as expected"
@@ -6122,6 +6135,7 @@ mod tests {
         // with no `code` attribute. Treat as informational, not as a fatal
         // stream teardown.
         let client = create_offline_sync_test_client().await;
+        client.is_logged_in.store(true, Ordering::Relaxed);
         let ack_child = NodeBuilder::new("ack")
             .attr("class", "message")
             .attr("type", "text")
@@ -6131,6 +6145,10 @@ mod tests {
             .children([ack_child])
             .build();
         client.handle_stream_error(&node.as_node_ref()).await;
+        assert!(
+            client.is_logged_in.load(Ordering::Relaxed),
+            "ack-shaped stream:error must NOT log the client out"
+        );
         assert!(
             !client.expected_disconnect.load(Ordering::Relaxed),
             "ack-shaped stream:error must not mark the disconnect as expected"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3222,10 +3222,10 @@ impl Client {
     }
 
     pub(crate) async fn handle_stream_error(&self, node: &wacore_binary::NodeRef<'_>) {
-        // is_logged_in is cleared only inside fatal branches below. 429, 503,
-        // and unknown/code-less errors leave the session alive — clearing it
-        // unconditionally here would make is_fully_ready() flip and prekey
-        // uploads bail with "Connection lost" while the socket is still up.
+        // is_logged_in is cleared together with the disconnect below, never
+        // here: 429, 503, and unknown/code-less errors leave the session
+        // alive, and clearing it while the socket is up would flip
+        // is_fully_ready() and make prekey uploads bail with "Connection lost".
         let mut attrs = node.attrs();
         let code_cow = attrs.optional_string("code");
         let code = code_cow.as_deref().unwrap_or("");
@@ -3248,7 +3248,6 @@ impl Client {
                 "Got stream error indicating client was removed or replaced (conflict={}). Logging out.",
                 conflict_type
             );
-            self.is_logged_in.store(false, Ordering::Relaxed);
             self.expected_disconnect.store(true, Ordering::Relaxed);
             self.enable_auto_reconnect.store(false, Ordering::Relaxed);
 
@@ -3336,8 +3335,10 @@ impl Client {
 
         // Only tear down the connection for branches that explicitly opted in.
         // 429/503/unknown match whatsmeow: log and let the socket layer notice
-        // if the server actually closes the stream.
+        // if the server actually closes the stream. is_logged_in is cleared
+        // here so it flips exactly when (and only when) we disconnect.
         if should_disconnect {
+            self.is_logged_in.store(false, Ordering::Relaxed);
             let transport_opt = self.transport.lock().await.clone();
             if let Some(transport) = transport_opt {
                 self.runtime
@@ -5972,6 +5973,60 @@ mod tests {
         assert!(
             !ack.attrs.contains_key("recipient"),
             "ACK must NOT add `recipient` when the incoming stanza has none"
+        );
+    }
+
+    #[test]
+    fn test_encode_ack_bytes_roundtrip_recipient() {
+        // Exercises the real wire encoder (`encode_ack_bytes`), not just the
+        // `build_ack_node` test mirror: serialize, decode the bytes back, and
+        // assert the parsed ACK echoes `recipient` when present and omits it
+        // when absent. Guards against the two builders silently diverging.
+        let own_device_pn: Jid = "155500012345:48@s.whatsapp.net"
+            .parse()
+            .expect("own device PN JID should parse");
+
+        let with_recipient = NodeBuilder::new("message")
+            .attr("from", "166361967902821@lid")
+            .attr("id", "2A32F960553696093D99")
+            .attr("type", "text")
+            .attr("recipient", "146991363395800@lid")
+            .build();
+        let buf = encode_ack_bytes(&with_recipient.as_node_ref(), Some(&own_device_pn))
+            .expect("encode_ack_bytes should not error")
+            .expect("encode_ack_bytes should produce bytes");
+        // The Encoder prepends a leading format byte (see `marshal`); the
+        // decoder wants raw protocol bytes — same handling as `node_to_owned_ref`.
+        let decoded =
+            wacore_binary::marshal::unmarshal_ref(&buf[1..]).expect("encoded ack should decode");
+        assert_eq!(decoded.tag, "ack");
+        assert!(
+            decoded
+                .get_attr("class")
+                .is_some_and(|v| v.as_str() == "message"),
+            "decoded ack must have class=message"
+        );
+        assert!(
+            decoded
+                .get_attr("recipient")
+                .is_some_and(|v| v.as_str() == "146991363395800@lid"),
+            "encode_ack_bytes must echo `recipient` onto the wire"
+        );
+
+        let without_recipient = NodeBuilder::new("message")
+            .attr("from", "120363161500776365@g.us")
+            .attr("id", "A5791A5392EF60E3FB06")
+            .attr("type", "text")
+            .attr("participant", "181531758878822@lid")
+            .build();
+        let buf = encode_ack_bytes(&without_recipient.as_node_ref(), Some(&own_device_pn))
+            .expect("encode_ack_bytes should not error")
+            .expect("encode_ack_bytes should produce bytes");
+        let decoded =
+            wacore_binary::marshal::unmarshal_ref(&buf[1..]).expect("encoded ack should decode");
+        assert!(
+            decoded.get_attr("recipient").is_none(),
+            "encode_ack_bytes must not synthesise `recipient` when absent"
         );
     }
 


### PR DESCRIPTION
# Fix: stop spurious stream disconnects on `<stream:error><ack/>` notifications

## Summary

Two independent fixes — one in the ACK encoder, one in the stream-error handler — that together stop the reconnect storm users have been seeing under the JS bridge as `DisconnectReason.badSession (500)`.

1. **Encoder** (`encode_ack_bytes`) now copies the `recipient` attribute from the incoming stanza onto the outgoing `<ack/>`, matching whatsmeow. Without it, server cannot route the ACK back to the originating companion/device and replies with `<stream:error><ack/>…</stream:error>`.
2. **Handler** (`handle_stream_error` catch-all) no longer treats unknown / code-less stream errors as fatal. It logs + dispatches the `StreamError` event and leaves the connection alone, exactly like whatsmeow's default branch (`connectionevents.go:66-69`). The socket layer remains responsible for detecting a real teardown.

Either fix in isolation reduces the symptom; together they remove both the trigger and the over-reaction.

---

## Problem

A bot running this stack repeatedly reconnects with no actionable error. The JS bridge surfaces it as `badSession (500)`, but **the server never sends `<stream:error code="500">`** — that "500" is a bridge-side fallback for `expected_disconnect` without a recognised code.

Across 19 captured Rust debug logs (7 distinct accounts, ~2-hour window), **every** disconnect matched this exact shape:

```
DEBUG <stream:error><ack class="message" type="text" id="2A32F960553696093D99"/></stream:error>
ERROR Unknown stream error: <stream:error><ack class="message" type="text" id="2A32F960553696093D99"/></stream:error>
INFO  Notifying connection shutdown from stream error handler
DEBUG Expected disconnect signaled during frame processing. Exiting message loop.
DEBUG Transport::disconnect called
```

The `<ack>` inside the `<stream:error>` is the server's reference to the message stanza whose ACK it rejected. Immediately after reconnect, that same message is redelivered (`offline="10"`, `offline="12"`), confirming the previous ACK never registered.

Affected stanzas were a mix of:

- Peer / hosted-companion messages with `recipient="…@lid"` and `peer_recipient_pn="…"`.
- LID-mode group messages (`addressing_mode="lid"`) routed through hosted recipients.
- Retry placeholders (`<enc decrypt-fail="hide">` + `<meta tag_reason="rereg_recovery_request">`).

Common denominator: they are stanzas where WhatsApp Web / whatsmeow propagate `recipient` into the ACK. Rust drops it.

---

## Fix A — copy `recipient` in the ACK encoder

### Root cause (Fix A)

`whatsmeow/receipt.go:143-177` (`Client.sendAck`):

```go
attrs := waBinary.Attrs{
    "class": node.Tag,
    "id":    node.Attrs["id"],
}
attrs["to"] = node.Attrs["from"]
if participant, ok := node.Attrs["participant"]; ok {
    attrs["participant"] = participant
}
if recipient, ok := node.Attrs["recipient"]; ok {
    attrs["recipient"] = recipient
    // BotJIDMap remap (Meta-bot only) …
}
if receiptType, ok := node.Attrs["type"]; node.Tag != "message" && ok {
    attrs["type"] = receiptType
}
```

The server uses `recipient` to dispatch the ACK to the originating device. Without it the ACK is unroutable; the server signals that by closing the stream with `<stream:error><ack …/></stream:error>`. The `BotJIDMap` remap is for Meta's BotServer and has no analogue in `whatsapp-rust`, so we intentionally do not port it.

### Before

`whatsapp-rust/src/client.rs::encode_ack_bytes` (production path):

```rust
let Some(id_val)   = node.get_attr("id")   else { return Ok(None); };
let Some(from_val) = node.get_attr("from") else { return Ok(None); };
let participant_val = node.get_attr("participant").filter(|p| {
    p.as_str().as_ref() != from_val.as_str().as_ref()
});
// (no recipient handling)

let typ_val = if tag != "message" && !is_encrypt_identity_notification(node) {
    node.get_attr("type")
} else { None };

let attr_count = 3
    + usize::from(include_from)
    + usize::from(participant_val.is_some())
    + usize::from(typ_val.is_some());

struct AckNode<'a> {
    id: &'a ValueRef<'a>,
    from: &'a ValueRef<'a>,
    participant: Option<&'a ValueRef<'a>>,
    typ: Option<&'a ValueRef<'a>>,
    own_pn: Option<&'a Jid>,
    tag_str: &'a str,
    attr_count: usize,
}
// encode_attrs: class, id, to, [from], [participant], [type]
```

### After

```rust
let Some(id_val)   = node.get_attr("id")   else { return Ok(None); };
let Some(from_val) = node.get_attr("from") else { return Ok(None); };
let participant_val = node.get_attr("participant").filter(|p| {
    p.as_str().as_ref() != from_val.as_str().as_ref()
});
// Server expects `recipient` echoed back so it can route the ack to the
// origin companion/device (hosted-companion, peer, LID-routed stanzas).
// Dropping it makes the server close the stream with `<stream:error><ack/>`.
let recipient_val = node.get_attr("recipient");

let typ_val = if tag != "message" && !is_encrypt_identity_notification(node) {
    node.get_attr("type")
} else { None };

let attr_count = 3
    + usize::from(include_from)
    + usize::from(participant_val.is_some())
    + usize::from(recipient_val.is_some())
    + usize::from(typ_val.is_some());

struct AckNode<'a> {
    id: &'a ValueRef<'a>,
    from: &'a ValueRef<'a>,
    participant: Option<&'a ValueRef<'a>>,
    recipient: Option<&'a ValueRef<'a>>,   // new
    typ: Option<&'a ValueRef<'a>>,
    own_pn: Option<&'a Jid>,
    tag_str: &'a str,
    attr_count: usize,
}
// encode_attrs: class, id, to, [from], [participant], [recipient], [type]
```

The `#[cfg(test)]` mirror `build_ack_node` gets the same shape so structural assertions stay possible without touching the wire encoder.

---

## Fix B — don't proactively disconnect on unknown stream errors

### Root cause (Fix B)

`whatsmeow/connectionevents.go:19-69` deliberately ignores stream errors it doesn't recognise:

```go
default:
    cli.Log.Errorf("Unknown stream error: %s", node.XMLString())
    go cli.dispatchEvent(&events.StreamError{Code: code, Raw: node})
}
```

There is no `expectDisconnect()`, no socket close, no reconnect trigger. The design relies on the read loop noticing if the server actually ends the stream (via `xmlstreamend` or a closed socket).

`whatsapp-rust` diverges: its catch-all sets `expected_disconnect = true` and the function unconditionally calls `notify_connection_shutdown()` for **every** branch, including `429`, `503`, and unknown. That converts an informational stanza into a full shutdown + reconnect cycle, which under high traffic snowballs into the loop the logs show.

### Before

`whatsapp-rust/src/client.rs::handle_stream_error` (excerpt):

```rust
match code {
    "515" => { /* … */ should_disconnect = true; }
    "516" | "401" | "409" => { /* … */ should_disconnect = true; }
    "429" => {
        warn!("Got 429 stream error (rate limited). …");
        self.auto_reconnect_errors.fetch_add(5, Ordering::Relaxed);
    }
    "503" => {
        info!("Got 503 service unavailable, will auto-reconnect.");
    }
    _ => {
        error!("Unknown stream error: {}", DisplayableNodeRef(node));
        self.expected_disconnect.store(true, Ordering::Relaxed);     // ← bug
        self.core.event_bus.dispatch(Event::StreamError(/* … */));
    }
}

if should_disconnect {
    let transport_opt = self.transport.lock().await.clone();
    if let Some(transport) = transport_opt {
        self.runtime
            .spawn(Box::pin(async move { transport.disconnect().await; }))
            .detach();
    }
}

info!("Notifying connection shutdown from stream error handler");      // ← always runs
self.notify_connection_shutdown();                                     // ← always runs
```

### After

```rust
match code {
    "515" => { /* … */ should_disconnect = true; }
    "516" | "401" | "409" => { /* … */ should_disconnect = true; }
    "429" => {
        warn!("Got 429 stream error (rate limited). …");
        self.auto_reconnect_errors.fetch_add(5, Ordering::Relaxed);
    }
    "503" => {
        info!("Got 503 service unavailable, will auto-reconnect.");
    }
    _ => {
        // Mirror whatsmeow's default: log + dispatch event, but keep the
        // connection alive. The server wraps per-stanza notifications in
        // <stream:error> without a code attribute (e.g. <ack/> for malformed
        // routing). Proactively disconnecting on those causes reconnect storms
        // under load — whatsmeow lets the noise socket detect a real teardown.
        error!("Unknown stream error: {}", DisplayableNodeRef(node));
        self.core.event_bus.dispatch(Event::StreamError(/* … */));
    }
}

// Only tear down the connection for branches that explicitly opted in.
// 429/503/unknown match whatsmeow: log and let the socket layer notice
// if the server actually closes the stream.
if should_disconnect {
    let transport_opt = self.transport.lock().await.clone();
    if let Some(transport) = transport_opt {
        self.runtime
            .spawn(Box::pin(async move { transport.disconnect().await; }))
            .detach();
    }
    info!("Notifying connection shutdown from stream error handler");
    self.notify_connection_shutdown();
}
```

Two concrete behavior changes:

1. The catch-all no longer flips `expected_disconnect`. If the server really closes the stream afterwards, the existing socket-level path handles it; if it doesn't, the connection lives.
2. `notify_connection_shutdown()` (and the matching `info!` log) is now inside the `should_disconnect` block. The implicit side effect — `429` and `503` were also triggering shutdown — is gone.

This brings Rust's behavior matrix in line with whatsmeow:

| Stream error | whatsmeow | Rust before this PR | Rust after this PR |
|---|---|---|---|
| `code="515"` | Disconnect + reconnect | Disconnect + shutdown | Disconnect + shutdown |
| `code="516"` / `"401"` / `"409"` / conflict | Disconnect, disable reconnect | Disconnect + shutdown, disable reconnect | Disconnect + shutdown, disable reconnect |
| `code="429"` | Log + dispatch (no shutdown) | **Shutdown** | Log + dispatch (no shutdown) |
| `code="503"` | Log + dispatch (no shutdown) | **Shutdown** | Log + dispatch (no shutdown) |
| Unknown / no code (e.g. `<ack/>` body) | Log + dispatch (no shutdown) | **Shutdown + expected_disconnect=true** | Log + dispatch (no shutdown) |

---

## Tests

Five new unit tests in `src/client.rs` (existing test module).

### Encoder (Fix A)

- `test_build_ack_node_for_message_with_recipient_preserves_recipient` — message stanza with `recipient="146991363395800@lid"` produces an ACK that echoes the same value.
- `test_build_ack_node_for_receipt_with_recipient_preserves_recipient` — same for `<receipt>`.
- `test_build_ack_node_for_message_without_recipient_omits_recipient` — regression guard: never synthesise an empty `recipient`.

### Handler (Fix B)

- `test_stream_error_unknown_keeps_connection_alive` — bare `<stream:error/>` (no `code`, no body) leaves both `expected_disconnect` and `enable_auto_reconnect` untouched.
- `test_stream_error_ack_shaped_does_not_force_shutdown` — the exact shape seen in production (`<stream:error><ack class="message" type="text" id="…"/></stream:error>`) does not flip `expected_disconnect`.

All fictitious JIDs, per `AGENTS.md` ("No real PII in tests").

Local results:

```
$ cargo test --lib client::tests::test_build_ack_node
running 9 tests
test result: ok. 9 passed; 0 failed; 0 ignored

$ cargo test --lib client::tests::test_stream_error
running 6 tests
test result: ok. 6 passed; 0 failed; 0 ignored
```

Workspace-wide (`cargo test --workspace --exclude e2e-tests`) passes 511 + sub-crate tests with no regressions. `e2e-tests` is skipped because it requires the mock server (per `AGENTS.md`).

---

## Alignment with `whatsapp-rust/AGENTS.md`

| Rule | This PR |
|---|---|
| *Cross-reference whatsmeow, Baileys, and captured WhatsApp Web JS to verify implementations.* | Both fixes are direct ports of whatsmeow (`receipt.go:143-177` for A, `connectionevents.go:19-69` for B). Each change cites its whatsmeow line range in code comments. |
| *Collapsible if: always use let-chains instead of nested `if let`.* | New code uses the same `if let Some(_) = …` single-bind pattern already present; no nested `if let` introduced. |
| *No real PII in tests.* | All test JIDs are fictitious (`146991363395800@lid`, `155500012345:48@s.whatsapp.net`, etc.). |
| *State: never modify Device state directly. Use `DeviceCommand` + `PersistenceManager::process_command()`.* | Neither fix touches Device state. |
| *Errors: `thiserror` for typed errors, no `.unwrap()` outside tests.* | New code returns early via the existing `Result` paths; no new `.unwrap()` introduced outside tests. |
| *When adding comments to the code, don't be so verbose, also only explain why, not what.* | Both new comment blocks describe the WHY (server routing requirement, whatsmeow parity) — not the WHAT. |
| *Rust style — `cargo fmt --all`, `cargo clippy --all --tests`, `cargo test --all`.* | All three are clean. |

For reference: `NackInvalidHostedCompanionStanza = 493` already exists in `wacore/src/protocol/nack.rs`. That nack family is exactly what the server is signalling with the ack-shaped stream error before this fix — surfaced at the stream layer instead of as a nack.

---
