### PR TITLE
fix(prekeys): re-upload after re-pair to heal stale server bundle

### DIFF
--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -266,7 +266,7 @@ async fn handle_prekey_low(client: &Arc<Client>) {
 ///
 /// Matches WA Web's `WAWebHandleDigestKey`:
 /// Queries server for key bundle digest, validates SHA-1 hash locally,
-/// re-uploads if mismatch or missing.
+/// re-uploads only when the server has no record (404).
 ///
 /// `validate_digest_key` owns `prekey_upload_lock` acquisition internally, so
 /// any upload it triggers stays serialized with `upload_pre_keys_at_login`,

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -268,14 +268,16 @@ async fn handle_prekey_low(client: &Arc<Client>) {
 /// Queries server for key bundle digest, validates SHA-1 hash locally,
 /// re-uploads if mismatch or missing.
 ///
-/// Acquires `prekey_upload_lock` to serialize with the count-based upload path,
-/// preventing concurrent uploads that could race on prekey ID allocation.
+/// `validate_digest_key` owns `prekey_upload_lock` acquisition internally, so
+/// any upload it triggers stays serialized with `upload_pre_keys_at_login`,
+/// `handle_prekey_low`, and `refresh_pre_keys` without this caller needing to
+/// (and indeed, holding it here would deadlock — `async_lock::Mutex` is not
+/// reentrant).
 fn handle_digest_key(client: &Arc<Client>) {
     let client_clone = client.clone();
     client
         .runtime
         .spawn(Box::pin(async move {
-            let _guard = client_clone.prekey_upload_lock.lock().await;
             if let Err(e) = client_clone.validate_digest_key().await {
                 warn!("Digest key validation failed: {:?}", e);
             }

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -263,12 +263,10 @@ async fn handle_pair_success<'a>(
                 )))
                 .await;
 
-            // Force prekey re-upload on the next connect. Pairing regenerates
-            // local key material but, without this reset, `upload_pre_keys_at_login`
-            // observes `server_has_prekeys=true` (set by a previous pairing) and
-            // returns early. The server keeps the stale bundle, peers fetching it
-            // get prekeys diverged from local state, and sessions established
-            // against the old bundle BadMac forever.
+            // A prior pairing's `server_has_prekeys=true` would make
+            // `upload_pre_keys_at_login` skip and leave the server bundle stale.
+            // Reset it so the next connect re-uploads, matching WA Web where a
+            // freshly registered device always uploads its prekeys.
             client
                 .persistence_manager
                 .modify_device(|d| d.server_has_prekeys = false)

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -263,6 +263,17 @@ async fn handle_pair_success<'a>(
                 )))
                 .await;
 
+            // Force prekey re-upload on the next connect. Pairing regenerates
+            // local key material but, without this reset, `upload_pre_keys_at_login`
+            // observes `server_has_prekeys=true` (set by a previous pairing) and
+            // returns early. The server keeps the stale bundle, peers fetching it
+            // get prekeys diverged from local state, and sessions established
+            // against the old bundle BadMac forever.
+            client
+                .persistence_manager
+                .modify_device(|d| d.server_has_prekeys = false)
+                .await;
+
             // Add the own LID-PN mapping to the cache so that when sending DMs to self,
             // we can find the existing LID-based session instead of creating a new PN-based one.
             // This is critical for self-messaging to work correctly.

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -294,6 +294,13 @@ impl Client {
     /// 6. Transient/corruption signals (backend batch-load error, prekey record with
     ///    no pub key): logs and skips — re-upload won't help and next cycle will retry.
     pub(crate) async fn validate_digest_key(&self) -> Result<(), anyhow::Error> {
+        // Acquire the prekey upload lock for the entire validation pass so any
+        // upload triggered by a divergence signal can't race with
+        // `upload_pre_keys_at_login`, `handle_prekey_low`, or `refresh_pre_keys`,
+        // which all use the same lock to serialize access to `next_pre_key_id`
+        // and the storage backend.
+        let _guard = self.prekey_upload_lock.lock().await;
+
         let response = match self.execute(DigestKeyBundleSpec::new()).await {
             Ok(resp) => resp,
             Err(crate::request::IqError::ServerError { code: 404, .. }) => {

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -278,16 +278,21 @@ impl Client {
         self.upload_pre_keys_with_retry(true).await
     }
 
-    /// Validate server key bundle digest, re-uploading only when the server has no record.
+    /// Validate server key bundle digest, re-uploading on any divergence signal.
     ///
-    /// Matches WA Web's `WAWebDigestKeyJob.digestKey()`:
+    /// Mostly mirrors WA Web's `WAWebDigestKeyJob.digestKey()`:
     /// 1. Queries server for key bundle digest (identity + signed prekey + prekey IDs + SHA-1 hash)
     /// 2. If server returns 404 (no record): triggers `upload_pre_keys_with_retry()`
     /// 3. If server returns 406/503/other error: logs and does nothing
     /// 4. On success: loads local keys and computes SHA-1 over the same material
-    /// 5. If validation fails (regId mismatch, missing prekey, hash mismatch): logs warning,
-    ///    does NOT re-upload — WA Web catches all `validateLocalKeyBundle` exceptions without
-    ///    re-uploading; the normal `RotateKeyJob` will eventually refresh keys
+    /// 5. **Divergence signals (regId mismatch, missing local prekey, hash mismatch):**
+    ///    forces `upload_pre_keys_with_retry(true)`. This diverges from WA Web, which
+    ///    swallows these silently — WA Web's localStorage is stable enough to make the
+    ///    divergence rare, while Rust clients with SQLite backends hit it after restores,
+    ///    re-pairs, or partial backups, leaving peers permanently unable to establish
+    ///    sessions because the server bundle points to material the bot no longer has.
+    /// 6. Transient/corruption signals (backend batch-load error, prekey record with
+    ///    no pub key): logs and skips — re-upload won't help and next cycle will retry.
     pub(crate) async fn validate_digest_key(&self) -> Result<(), anyhow::Error> {
         let response = match self.execute(DigestKeyBundleSpec::new()).await {
             Ok(resp) => resp,
@@ -316,17 +321,25 @@ impl Client {
             }
         };
 
-        // WA Web's validateLocalKeyBundle validates but catches ALL exceptions without
-        // re-uploading. The catch block in digestKey() sets a=false for any throw from y(),
-        // meaning only 404 triggers re-upload. We match that: log warnings, return Ok(()).
+        // WA Web's validateLocalKeyBundle catches ALL exceptions without re-uploading.
+        // We diverge here: for the divergence signals (regId mismatch, hash mismatch,
+        // missing local prekey), force a fresh upload. WA Web can rely on browser
+        // localStorage stability; Rust clients hit divergence more often (SQLite
+        // restores, re-pairs, partial backups), and the "log + skip" behavior leaves
+        // peers permanently unable to establish sessions because the bundle they
+        // fetch from the server points to material the bot no longer has.
+        //
+        // Transient/corruption cases (batch-load failure, prekey record with no pub
+        // key) still log + skip — re-uploading won't help and the next digest cycle
+        // will retry.
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         if response.reg_id != device_snapshot.registration_id {
             log::warn!(
-                "digestKey: registration ID mismatch (server={}, local={}), skipping",
+                "digestKey: registration ID mismatch (server={}, local={}), forcing re-upload",
                 response.reg_id,
                 device_snapshot.registration_id
             );
-            return Ok(());
+            return self.upload_pre_keys_with_retry(true).await;
         }
 
         // Compute local SHA-1 digest over the same material as WA Web's validateLocalKeyBundle:
@@ -358,18 +371,21 @@ impl Client {
 
         if loaded_map.len() < unique_requested.len() {
             log::warn!(
-                "digestKey: missing {} local prekeys, skipping",
+                "digestKey: missing {} local prekeys, forcing re-upload",
                 unique_requested.len() - loaded_map.len()
             );
-            return Ok(());
+            return self.upload_pre_keys_with_retry(true).await;
         }
 
         // Extract public keys directly from stored protobuf bytes without full decode
         let mut prekey_pubkeys = Vec::with_capacity(response.prekey_ids.len());
         for prekey_id in &response.prekey_ids {
             let Some(record_bytes) = loaded_map.get(prekey_id) else {
-                log::warn!("digestKey: missing local prekey {}, skipping", prekey_id);
-                return Ok(());
+                log::warn!(
+                    "digestKey: missing local prekey {}, forcing re-upload",
+                    prekey_id
+                );
+                return self.upload_pre_keys_with_retry(true).await;
             };
             match wacore::prekeys::extract_prekey_public_key(record_bytes) {
                 Some(pk) => prekey_pubkeys.push(pk),
@@ -392,11 +408,11 @@ impl Client {
 
         if local_hash.as_slice() != response.hash.as_slice() {
             log::warn!(
-                "digestKey: hash mismatch (server={}, local={}), skipping",
+                "digestKey: hash mismatch (server={}, local={}), forcing re-upload",
                 hex::encode(&response.hash),
                 hex::encode(local_hash)
             );
-            return Ok(());
+            return self.upload_pre_keys_with_retry(true).await;
         }
 
         log::debug!("digestKey: key bundle validation successful");

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -278,27 +278,20 @@ impl Client {
         self.upload_pre_keys_with_retry(true).await
     }
 
-    /// Validate server key bundle digest, re-uploading on any divergence signal.
+    /// Validate server key bundle digest, re-uploading only when the server has no record.
     ///
-    /// Mostly mirrors WA Web's `WAWebDigestKeyJob.digestKey()`:
+    /// Matches WA Web's `WAWebDigestKeyJob.digestKey()`:
     /// 1. Queries server for key bundle digest (identity + signed prekey + prekey IDs + SHA-1 hash)
     /// 2. If server returns 404 (no record): triggers `upload_pre_keys_with_retry()`
     /// 3. If server returns 406/503/other error: logs and does nothing
     /// 4. On success: loads local keys and computes SHA-1 over the same material
-    /// 5. **Divergence signals (regId mismatch, missing local prekey, hash mismatch):**
-    ///    forces `upload_pre_keys_with_retry(true)`. This diverges from WA Web, which
-    ///    swallows these silently — WA Web's localStorage is stable enough to make the
-    ///    divergence rare, while Rust clients with SQLite backends hit it after restores,
-    ///    re-pairs, or partial backups, leaving peers permanently unable to establish
-    ///    sessions because the server bundle points to material the bot no longer has.
-    /// 6. Transient/corruption signals (backend batch-load error, prekey record with
-    ///    no pub key): logs and skips — re-upload won't help and next cycle will retry.
+    /// 5. If validation fails (regId mismatch, missing prekey, hash mismatch): logs warning,
+    ///    does NOT re-upload — WA Web catches all `validateLocalKeyBundle` exceptions without
+    ///    re-uploading; the normal `RotateKeyJob` will eventually refresh keys
     pub(crate) async fn validate_digest_key(&self) -> Result<(), anyhow::Error> {
-        // Acquire the prekey upload lock for the entire validation pass so any
-        // upload triggered by a divergence signal can't race with
-        // `upload_pre_keys_at_login`, `handle_prekey_low`, or `refresh_pre_keys`,
-        // which all use the same lock to serialize access to `next_pre_key_id`
-        // and the storage backend.
+        // Hold the lock across the whole pass so the 404 re-upload can't race with
+        // `upload_pre_keys_at_login`, `handle_prekey_low`, or `refresh_pre_keys` on
+        // `next_pre_key_id` allocation.
         let _guard = self.prekey_upload_lock.lock().await;
 
         let response = match self.execute(DigestKeyBundleSpec::new()).await {
@@ -328,25 +321,17 @@ impl Client {
             }
         };
 
-        // WA Web's validateLocalKeyBundle catches ALL exceptions without re-uploading.
-        // We diverge here: for the divergence signals (regId mismatch, hash mismatch,
-        // missing local prekey), force a fresh upload. WA Web can rely on browser
-        // localStorage stability; Rust clients hit divergence more often (SQLite
-        // restores, re-pairs, partial backups), and the "log + skip" behavior leaves
-        // peers permanently unable to establish sessions because the bundle they
-        // fetch from the server points to material the bot no longer has.
-        //
-        // Transient/corruption cases (batch-load failure, prekey record with no pub
-        // key) still log + skip — re-uploading won't help and the next digest cycle
-        // will retry.
+        // WA Web's validateLocalKeyBundle validates but catches ALL exceptions without
+        // re-uploading. The catch block in digestKey() sets a=false for any throw from y(),
+        // meaning only 404 triggers re-upload. We match that: log warnings, return Ok(()).
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         if response.reg_id != device_snapshot.registration_id {
             log::warn!(
-                "digestKey: registration ID mismatch (server={}, local={}), forcing re-upload",
+                "digestKey: registration ID mismatch (server={}, local={}), skipping",
                 response.reg_id,
                 device_snapshot.registration_id
             );
-            return self.upload_pre_keys_with_retry(true).await;
+            return Ok(());
         }
 
         // Compute local SHA-1 digest over the same material as WA Web's validateLocalKeyBundle:
@@ -378,21 +363,18 @@ impl Client {
 
         if loaded_map.len() < unique_requested.len() {
             log::warn!(
-                "digestKey: missing {} local prekeys, forcing re-upload",
+                "digestKey: missing {} local prekeys, skipping",
                 unique_requested.len() - loaded_map.len()
             );
-            return self.upload_pre_keys_with_retry(true).await;
+            return Ok(());
         }
 
         // Extract public keys directly from stored protobuf bytes without full decode
         let mut prekey_pubkeys = Vec::with_capacity(response.prekey_ids.len());
         for prekey_id in &response.prekey_ids {
             let Some(record_bytes) = loaded_map.get(prekey_id) else {
-                log::warn!(
-                    "digestKey: missing local prekey {}, forcing re-upload",
-                    prekey_id
-                );
-                return self.upload_pre_keys_with_retry(true).await;
+                log::warn!("digestKey: missing local prekey {}, skipping", prekey_id);
+                return Ok(());
             };
             match wacore::prekeys::extract_prekey_public_key(record_bytes) {
                 Some(pk) => prekey_pubkeys.push(pk),
@@ -415,11 +397,11 @@ impl Client {
 
         if local_hash.as_slice() != response.hash.as_slice() {
             log::warn!(
-                "digestKey: hash mismatch (server={}, local={}), forcing re-upload",
+                "digestKey: hash mismatch (server={}, local={}), skipping",
                 hex::encode(&response.hash),
                 hex::encode(local_hash)
             );
-            return self.upload_pre_keys_with_retry(true).await;
+            return Ok(());
         }
 
         log::debug!("digestKey: key bundle validation successful");


### PR DESCRIPTION
## Problem

A long-lived bot that re-pairs (or otherwise reuses a persisted store) can end up with the server holding a prekey bundle that no longer matches local key material. Peers that fetch the stale bundle then BadMac forever.

Root cause: `handle_pair_success` never resets `server_has_prekeys`. After a re-pair the persisted `server_has_prekeys=true` from the prior pairing is still there, so the next connect's `upload_pre_keys_at_login` short-circuits and skips the upload. The server keeps the old bundle.

## Fix

`src/pair.rs`: on pair-success, reset `server_has_prekeys=false` so the next connect re-uploads. This mirrors WA Web, where a freshly registered device always uploads its prekeys (its storage starts with the flag unset). It is a no-op on first pairing since the flag already defaults to false.

`src/prekeys.rs` and `src/handlers/notification.rs`: `validate_digest_key` now takes `prekey_upload_lock` internally instead of the caller holding it. This serializes the digest 404 re-upload with the login, prekey-low and refresh paths for both callers. The background-init path in `client.rs` was calling validate without the lock before, so its 404 re-upload could race on prekey id allocation. The external lock in `handle_digest_key` is removed, since holding it there plus the internal acquire would deadlock (`async_lock::Mutex` is not reentrant).

digestKey behavior stays exactly like WA Web's `WAWebDigestKeyJob.digestKey()`: re-upload only on 404, log and skip on regId / hash / missing-prekey mismatch. For the restore or partial-backup recovery case, `refresh_pre_keys()` already exists as an explicit path.

## Risk

No new IQ types and no peer-facing traffic. Worst case is one extra prekey upload on the connect right after a re-pair, which is the same upload a fresh device already does. The digest path is unchanged from main except for the added lock.

## Test plan

- cargo fmt, cargo clippy --all --tests, and the non-e2e tests are green