### PR TITLE
fix(polls): align poll vote encryption/decryption to conversation addressing

### DIFF
--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -119,7 +119,11 @@ impl<'a> Polls<'a> {
             .await
             .ok_or_else(|| anyhow!("Not logged in — cannot determine own JID"))?;
         let my_base = my_jid.to_non_ad();
-        let voter_jid_str = my_base.to_string();
+
+        let voter_jid = self
+            .resolve_voter_jid(poll_creator_jid, &my_base, poll_msg_id)
+            .await;
+        let voter_jid_str = voter_jid.to_string();
         let creator_jid_str = poll_creator_jid.to_non_ad().to_string();
 
         let selected_hashes: Vec<Vec<u8>> = option_names
@@ -164,9 +168,47 @@ impl<'a> Polls<'a> {
         self.client.send_message(chat_jid.clone(), message).await
     }
 
+    /// Pick the self JID whose addressing matches the poll creator, so the
+    /// HKDF key the host derives lines up with what we encrypt under.
+    ///
+    /// The voter (self) JID feeds the poll-vote HKDF info + AAD. WA Web
+    /// (`WAWebAddonEncryption.h`/`y`) resolves both the original sender and the
+    /// addon sender to LID in LID-addressed / pnless conversations; whatsmeow
+    /// keys this off the poll sender's server (commit 5d16908e). A vote authored
+    /// under the wrong namespace cannot be decrypted by the poll host.
+    ///
+    /// `own_pn` is the caller's already-non-AD phone-number JID, used both as
+    /// the PN-addressing answer and as the fallback when the poll is
+    /// LID-addressed but our own LID is not yet known.
+    async fn resolve_voter_jid(
+        &self,
+        poll_creator_jid: &Jid,
+        own_pn: &Jid,
+        poll_msg_id: &str,
+    ) -> Jid {
+        if !poll_creator_jid.is_lid() {
+            return own_pn.clone();
+        }
+        match self.client.get_lid().await {
+            Some(lid) => lid.to_non_ad(),
+            None => {
+                log::warn!(
+                    "Poll {poll_msg_id} is LID-addressed but own LID is unknown; \
+                     falling back to PN voter (host may fail to decrypt)"
+                );
+                own_pn.clone()
+            }
+        }
+    }
+
     /// Returns the selected option hashes (each 32 bytes).
-    /// JIDs are normalized (AD suffix stripped) to match the key derivation in `vote()`.
-    pub fn decrypt_vote(
+    ///
+    /// JIDs are normalized (AD suffix stripped) to match the key derivation in
+    /// `vote()`. Decryption retries under the opposite addressing (LID↔PN) when
+    /// a counterpart is known, mirroring WA Web's `decryptAddOn`, so votes
+    /// authored across the LID migration boundary still open.
+    pub async fn decrypt_vote(
+        &self,
         enc_payload: &[u8],
         enc_iv: &[u8],
         message_secret: &[u8],
@@ -174,22 +216,62 @@ impl<'a> Polls<'a> {
         poll_creator_jid: &Jid,
         voter_jid: &Jid,
     ) -> Result<Vec<Vec<u8>>> {
-        let creator = poll_creator_jid.to_non_ad().to_string();
-        let voter = voter_jid.to_non_ad().to_string();
-        poll::decrypt_poll_vote_with_secret(
+        let creator = poll_creator_jid.to_non_ad();
+        let voter = voter_jid.to_non_ad();
+        let creator_str = creator.to_string();
+        let voter_str = voter.to_string();
+
+        let creator_alt = self.swapped_user(&creator).await;
+        let voter_alt = self.swapped_user(&voter).await;
+        let fallback = Self::build_fallback(&creator_alt, &voter_alt);
+
+        poll::decrypt_poll_vote_with_fallback(
             enc_payload,
             enc_iv,
             message_secret,
             poll_msg_id,
-            &creator,
-            &voter,
+            poll::PollVoteAddressing {
+                poll_creator_jid: &creator_str,
+                voter_jid: &voter_str,
+            },
+            fallback,
         )
+    }
+
+    /// Bare-LID/PN counterpart of a user JID, normalized to non-AD, or `None`
+    /// when no mapping is known. Used to build the decrypt fallback pair.
+    async fn swapped_user(&self, jid: &Jid) -> Option<String> {
+        self.client
+            .swap_pn_lid_namespace(jid)
+            .await
+            .map(|j| j.to_non_ad().to_string())
+    }
+
+    /// Build the homogeneous fallback pair only when *both* the creator and the
+    /// voter have a known counterpart — WA Web's `decryptAddOn` swaps both
+    /// together (LID pair, then PN pair) and never mixes one LID with one PN.
+    fn build_fallback<'b>(
+        creator_alt: &'b Option<String>,
+        voter_alt: &'b Option<String>,
+    ) -> Option<poll::PollVoteAddressing<'b>> {
+        match (creator_alt, voter_alt) {
+            (Some(c), Some(v)) => Some(poll::PollVoteAddressing {
+                poll_creator_jid: c,
+                voter_jid: v,
+            }),
+            _ => None,
+        }
     }
 
     /// Decrypts each vote and tallies per-option results.
     /// Later votes from the same voter replace earlier ones (last-vote-wins).
     /// `votes` should be ordered oldest-first.
-    pub fn aggregate_votes(
+    ///
+    /// Each vote is decrypted with the same LID↔PN fallback as
+    /// [`Self::decrypt_vote`], so a tally mixing pre- and post-LID-migration
+    /// votes still opens every entry it has a mapping for.
+    pub async fn aggregate_votes(
+        &self,
         poll_options: &[String],
         votes: &[(&Jid, &[u8], &[u8])], // (voter_jid, enc_payload, enc_iv)
         message_secret: &[u8],
@@ -201,21 +283,29 @@ impl<'a> Polls<'a> {
             .map(|name| (poll::compute_option_hash(name), name.as_str()))
             .collect();
 
-        // `creator_str` is invariant across voters; `decrypt_vote` used to
-        // recompute it per voter via `poll_creator_jid.to_non_ad().to_string()`.
-        let creator_str = poll_creator_jid.to_non_ad().to_string();
+        // Creator addressing is invariant across voters: resolve it and its
+        // LID↔PN counterpart once.
+        let creator = poll_creator_jid.to_non_ad();
+        let creator_str = creator.to_string();
+        let creator_alt = self.swapped_user(&creator).await;
 
         // Last-vote-wins: each new vote from the same voter replaces the previous
         let mut latest_votes: HashMap<String, Vec<Vec<u8>>> = HashMap::with_capacity(votes.len());
         for (voter_jid, enc_payload, enc_iv) in votes {
-            let voter_str = voter_jid.to_non_ad().to_string();
-            match poll::decrypt_poll_vote_with_secret(
+            let voter = voter_jid.to_non_ad();
+            let voter_str = voter.to_string();
+            let voter_alt = self.swapped_user(&voter).await;
+            let fallback = Self::build_fallback(&creator_alt, &voter_alt);
+            match poll::decrypt_poll_vote_with_fallback(
                 enc_payload,
                 enc_iv,
                 message_secret,
                 poll_msg_id,
-                &creator_str,
-                &voter_str,
+                poll::PollVoteAddressing {
+                    poll_creator_jid: &creator_str,
+                    voter_jid: &voter_str,
+                },
+                fallback,
             ) {
                 Ok(selected_hashes) => {
                     if selected_hashes.is_empty() {
@@ -256,5 +346,191 @@ impl<'a> Polls<'a> {
 impl Client {
     pub fn polls(&self) -> Polls<'_> {
         Polls::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lid_pn_cache::LearningSource;
+    use crate::store::commands::DeviceCommand;
+    use crate::test_utils::create_test_client;
+    use std::sync::Arc;
+
+    // ---- encrypt-side voter selection (resolve_voter_jid) ----
+
+    #[tokio::test]
+    async fn voter_is_pn_when_poll_creator_is_pn() {
+        let client: Arc<Client> = create_test_client().await;
+        let own_pn = Jid::pn("5511999999999");
+        let creator = Jid::pn("5511777777777");
+
+        let voter = client
+            .polls()
+            .resolve_voter_jid(&creator, &own_pn, "POLLID")
+            .await;
+        assert_eq!(voter, own_pn);
+    }
+
+    #[tokio::test]
+    async fn voter_is_own_lid_when_poll_creator_is_lid() {
+        let client: Arc<Client> = create_test_client().await;
+        let own_lid: Jid = "888000888000888:3@lid".parse().unwrap();
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(Some(own_lid.clone())))
+            .await;
+
+        let own_pn = Jid::pn("5511999999999");
+        let creator = Jid::lid("111000111000111");
+
+        let voter = client
+            .polls()
+            .resolve_voter_jid(&creator, &own_pn, "POLLID")
+            .await;
+        assert!(voter.is_lid(), "voter must be LID-addressed in a LID poll");
+        assert_eq!(voter.user, own_lid.user);
+        assert_eq!(voter, own_lid.to_non_ad());
+    }
+
+    #[tokio::test]
+    async fn voter_falls_back_to_pn_when_own_lid_unknown() {
+        let client: Arc<Client> = create_test_client().await;
+        // No SetLid → get_lid() is None.
+        let own_pn = Jid::pn("5511999999999");
+        let creator = Jid::lid("111000111000111");
+
+        let voter = client
+            .polls()
+            .resolve_voter_jid(&creator, &own_pn, "POLLID")
+            .await;
+        assert_eq!(voter, own_pn);
+    }
+
+    // ---- decrypt-side LID↔PN fallback ----
+
+    /// A vote encrypted under the PN pair must still decrypt when the consumer
+    /// only knows the LID JIDs, via the namespace-swap fallback. This is the
+    /// concrete LID-migration regression the fallback exists to prevent.
+    #[tokio::test]
+    async fn decrypt_vote_recovers_when_fed_lid_but_encrypted_under_pn() {
+        let client: Arc<Client> = create_test_client().await;
+        let secret = [0x21u8; 32];
+        let stanza_id = "3EB0POLLVOTE";
+
+        let creator_pn = "5511777777777";
+        let creator_lid = "111000111000111";
+        let voter_pn = "5511888888888";
+        let voter_lid = "222000222000222";
+
+        client
+            .add_lid_pn_mapping(creator_lid, creator_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+        client
+            .add_lid_pn_mapping(voter_lid, voter_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+
+        let hashes = vec![poll::compute_option_hash("Yes").to_vec()];
+        let (enc, iv) = poll::encrypt_poll_vote_with_secret(
+            &hashes,
+            &secret,
+            stanza_id,
+            &Jid::pn(creator_pn).to_string(),
+            &Jid::pn(voter_pn).to_string(),
+        )
+        .unwrap();
+
+        // Consumer feeds LID JIDs; primary (LID) fails, fallback swaps to PN.
+        let out = client
+            .polls()
+            .decrypt_vote(
+                &enc,
+                &iv,
+                &secret,
+                stanza_id,
+                &Jid::lid(creator_lid),
+                &Jid::lid(voter_lid),
+            )
+            .await
+            .expect("fallback should rescue the PN-encrypted vote");
+        assert_eq!(out, hashes);
+    }
+
+    /// Without a known mapping there is no fallback pair, so a LID-fed decrypt
+    /// of a PN-encrypted vote must fail rather than silently mis-decrypt.
+    #[tokio::test]
+    async fn decrypt_vote_fails_without_mapping() {
+        let client: Arc<Client> = create_test_client().await;
+        let secret = [0x21u8; 32];
+        let stanza_id = "3EB0POLLVOTE";
+
+        let (enc, iv) = poll::encrypt_poll_vote_with_secret(
+            &[poll::compute_option_hash("Yes").to_vec()],
+            &secret,
+            stanza_id,
+            &Jid::pn("5511777777777").to_string(),
+            &Jid::pn("5511888888888").to_string(),
+        )
+        .unwrap();
+
+        let res = client
+            .polls()
+            .decrypt_vote(
+                &enc,
+                &iv,
+                &secret,
+                stanza_id,
+                &Jid::lid("111000111000111"),
+                &Jid::lid("222000222000222"),
+            )
+            .await;
+        assert!(res.is_err(), "no mapping → no fallback → must not decrypt");
+    }
+
+    #[tokio::test]
+    async fn aggregate_votes_recovers_across_addressing() {
+        let client: Arc<Client> = create_test_client().await;
+        let secret = [0x31u8; 32];
+        let stanza_id = "3EB0AGG";
+        let options = vec!["Yes".to_string(), "No".to_string()];
+
+        let creator_pn = "5511777777777";
+        let creator_lid = "111000111000111";
+        let voter_pn = "5511888888888";
+        let voter_lid = "222000222000222";
+
+        client
+            .add_lid_pn_mapping(creator_lid, creator_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+        client
+            .add_lid_pn_mapping(voter_lid, voter_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+
+        let (enc, iv) = poll::encrypt_poll_vote_with_secret(
+            &[poll::compute_option_hash("Yes").to_vec()],
+            &secret,
+            stanza_id,
+            &Jid::pn(creator_pn).to_string(),
+            &Jid::pn(voter_pn).to_string(),
+        )
+        .unwrap();
+
+        let voter_lid_jid = Jid::lid(voter_lid);
+        let votes: Vec<(&Jid, &[u8], &[u8])> = vec![(&voter_lid_jid, &enc, &iv)];
+
+        let results = client
+            .polls()
+            .aggregate_votes(&options, &votes, &secret, stanza_id, &Jid::lid(creator_lid))
+            .await
+            .unwrap();
+
+        let yes = results.iter().find(|r| r.name == "Yes").unwrap();
+        assert_eq!(yes.voters.len(), 1, "the LID voter's 'Yes' must be tallied");
+        let no = results.iter().find(|r| r.name == "No").unwrap();
+        assert!(no.voters.is_empty());
     }
 }

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -168,18 +168,10 @@ impl<'a> Polls<'a> {
         self.client.send_message(chat_jid.clone(), message).await
     }
 
-    /// Pick the self JID whose addressing matches the poll creator, so the
-    /// HKDF key the host derives lines up with what we encrypt under.
-    ///
-    /// The voter (self) JID feeds the poll-vote HKDF info + AAD. WA Web
-    /// (`WAWebAddonEncryption.h`/`y`) resolves both the original sender and the
-    /// addon sender to LID in LID-addressed / pnless conversations; whatsmeow
-    /// keys this off the poll sender's server (commit 5d16908e). A vote authored
-    /// under the wrong namespace cannot be decrypted by the poll host.
-    ///
-    /// `own_pn` is the caller's already-non-AD phone-number JID, used both as
-    /// the PN-addressing answer and as the fallback when the poll is
-    /// LID-addressed but our own LID is not yet known.
+    /// The voter (self) JID keys the vote's HKDF/AAD, so it must use the poll
+    /// creator's namespace, else the host derives a different key. Own LID for
+    /// LID-addressed polls, own PN otherwise, falling back to PN when our LID
+    /// isn't known yet. Matches WA Web `WAWebAddonEncryption`.
     async fn resolve_voter_jid(
         &self,
         poll_creator_jid: &Jid,
@@ -201,12 +193,9 @@ impl<'a> Polls<'a> {
         }
     }
 
-    /// Returns the selected option hashes (each 32 bytes).
-    ///
-    /// JIDs are normalized (AD suffix stripped) to match the key derivation in
-    /// `vote()`. Decryption retries under the opposite addressing (LID↔PN) when
-    /// a counterpart is known, mirroring WA Web's `decryptAddOn`, so votes
-    /// authored across the LID migration boundary still open.
+    /// Selected option hashes (32 bytes each). Retries under the opposite
+    /// namespace (LID/PN) when a counterpart is known, so votes authored across
+    /// the LID migration still open. Mirrors WA Web `WAWebAddonEncryption`.
     pub async fn decrypt_vote(
         &self,
         enc_payload: &[u8],
@@ -238,8 +227,7 @@ impl<'a> Polls<'a> {
         )
     }
 
-    /// Bare-LID/PN counterpart of a user JID, normalized to non-AD, or `None`
-    /// when no mapping is known. Used to build the decrypt fallback pair.
+    /// Non-AD LID/PN counterpart of a user JID, or `None` when unmapped.
     async fn swapped_user(&self, jid: &Jid) -> Option<String> {
         self.client
             .swap_pn_lid_namespace(jid)
@@ -247,9 +235,8 @@ impl<'a> Polls<'a> {
             .map(|j| j.to_non_ad().to_string())
     }
 
-    /// Build the homogeneous fallback pair only when *both* the creator and the
-    /// voter have a known counterpart — WA Web's `decryptAddOn` swaps both
-    /// together (LID pair, then PN pair) and never mixes one LID with one PN.
+    /// Fallback pair only when both JIDs have a counterpart, keeping it
+    /// homogeneous (LID or PN, never mixed) like WA Web's `decryptAddOn`.
     fn build_fallback<'b>(
         creator_alt: &'b Option<String>,
         voter_alt: &'b Option<String>,
@@ -267,9 +254,9 @@ impl<'a> Polls<'a> {
     /// Later votes from the same voter replace earlier ones (last-vote-wins).
     /// `votes` should be ordered oldest-first.
     ///
-    /// Each vote is decrypted with the same LID↔PN fallback as
-    /// [`Self::decrypt_vote`], so a tally mixing pre- and post-LID-migration
-    /// votes still opens every entry it has a mapping for.
+    /// Dedupes voters by their canonical (LID-preferred) identity so a voter who
+    /// re-votes under the other namespace after migrating replaces, rather than
+    /// duplicates, their earlier vote.
     pub async fn aggregate_votes(
         &self,
         poll_options: &[String],
@@ -283,19 +270,25 @@ impl<'a> Polls<'a> {
             .map(|name| (poll::compute_option_hash(name), name.as_str()))
             .collect();
 
-        // Creator addressing is invariant across voters: resolve it and its
-        // LID↔PN counterpart once.
+        // Creator addressing is constant across voters; resolve its counterpart once.
         let creator = poll_creator_jid.to_non_ad();
         let creator_str = creator.to_string();
         let creator_alt = self.swapped_user(&creator).await;
 
-        // Last-vote-wins: each new vote from the same voter replaces the previous
-        let mut latest_votes: HashMap<String, Vec<Vec<u8>>> = HashMap::with_capacity(votes.len());
+        // Keyed by canonical (LID-preferred) identity; value holds the
+        // as-received JID for the reported voters list. Last-vote-wins.
+        let mut latest_votes: HashMap<String, (String, Vec<Vec<u8>>)> =
+            HashMap::with_capacity(votes.len());
         for (voter_jid, enc_payload, enc_iv) in votes {
             let voter = voter_jid.to_non_ad();
             let voter_str = voter.to_string();
             let voter_alt = self.swapped_user(&voter).await;
             let fallback = Self::build_fallback(&creator_alt, &voter_alt);
+            let canonical_voter = if voter.is_lid() {
+                voter_str.clone()
+            } else {
+                voter_alt.clone().unwrap_or_else(|| voter_str.clone())
+            };
             match poll::decrypt_poll_vote_with_fallback(
                 enc_payload,
                 enc_iv,
@@ -309,10 +302,9 @@ impl<'a> Polls<'a> {
             ) {
                 Ok(selected_hashes) => {
                     if selected_hashes.is_empty() {
-                        // Empty selection = voter cleared their vote
-                        latest_votes.remove(&voter_str);
+                        latest_votes.remove(&canonical_voter);
                     } else {
-                        latest_votes.insert(voter_str, selected_hashes);
+                        latest_votes.insert(canonical_voter, (voter_str, selected_hashes));
                     }
                 }
                 Err(e) => {
@@ -329,12 +321,12 @@ impl<'a> Polls<'a> {
             })
             .collect();
 
-        for (voter_jid, selected_hashes) in &latest_votes {
+        for (display_jid, selected_hashes) in latest_votes.values() {
             for hash in selected_hashes {
                 if let Ok(hash_arr) = <[u8; 32]>::try_from(hash.as_slice())
                     && let Some(idx) = option_hashes.iter().position(|(h, _)| *h == hash_arr)
                 {
-                    results[idx].voters.push(voter_jid.clone());
+                    results[idx].voters.push(display_jid.clone());
                 }
             }
         }
@@ -357,7 +349,7 @@ mod tests {
     use crate::test_utils::create_test_client;
     use std::sync::Arc;
 
-    // ---- encrypt-side voter selection (resolve_voter_jid) ----
+    // encrypt-side voter selection (resolve_voter_jid)
 
     #[tokio::test]
     async fn voter_is_pn_when_poll_creator_is_pn() {
@@ -396,7 +388,7 @@ mod tests {
     #[tokio::test]
     async fn voter_falls_back_to_pn_when_own_lid_unknown() {
         let client: Arc<Client> = create_test_client().await;
-        // No SetLid → get_lid() is None.
+        // No SetLid, so get_lid() is None.
         let own_pn = Jid::pn("5511999999999");
         let creator = Jid::lid("111000111000111");
 
@@ -407,11 +399,10 @@ mod tests {
         assert_eq!(voter, own_pn);
     }
 
-    // ---- decrypt-side LID↔PN fallback ----
+    // decrypt-side LID/PN fallback
 
     /// A vote encrypted under the PN pair must still decrypt when the consumer
-    /// only knows the LID JIDs, via the namespace-swap fallback. This is the
-    /// concrete LID-migration regression the fallback exists to prevent.
+    /// only knows the LID JIDs, via the namespace-swap fallback.
     #[tokio::test]
     async fn decrypt_vote_recovers_when_fed_lid_but_encrypted_under_pn() {
         let client: Arc<Client> = create_test_client().await;
@@ -532,5 +523,124 @@ mod tests {
         assert_eq!(yes.voters.len(), 1, "the LID voter's 'Yes' must be tallied");
         let no = results.iter().find(|r| r.name == "No").unwrap();
         assert!(no.voters.is_empty());
+    }
+
+    /// Same voter votes as PN then re-votes as LID after migrating. The
+    /// canonical key must collapse them so last-vote-wins replaces, not
+    /// duplicates, the earlier namespace's entry.
+    #[tokio::test]
+    async fn aggregate_dedupes_revote_across_namespace() {
+        let client: Arc<Client> = create_test_client().await;
+        let secret = [0x41u8; 32];
+        let stanza_id = "3EB0REVOTE";
+        let options = vec!["Yes".to_string(), "No".to_string()];
+
+        let creator_pn = "5511777777777";
+        let creator_lid = "111000111000111";
+        let voter_pn = "5511888888888";
+        let voter_lid = "222000222000222";
+        client
+            .add_lid_pn_mapping(creator_lid, creator_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+        client
+            .add_lid_pn_mapping(voter_lid, voter_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+
+        // Oldest-first: PN "Yes", then LID "No".
+        let (enc_pn, iv_pn) = poll::encrypt_poll_vote_with_secret(
+            &[poll::compute_option_hash("Yes").to_vec()],
+            &secret,
+            stanza_id,
+            &Jid::pn(creator_pn).to_string(),
+            &Jid::pn(voter_pn).to_string(),
+        )
+        .unwrap();
+        let (enc_lid, iv_lid) = poll::encrypt_poll_vote_with_secret(
+            &[poll::compute_option_hash("No").to_vec()],
+            &secret,
+            stanza_id,
+            &Jid::lid(creator_lid).to_string(),
+            &Jid::lid(voter_lid).to_string(),
+        )
+        .unwrap();
+
+        let voter_pn_jid = Jid::pn(voter_pn);
+        let voter_lid_jid = Jid::lid(voter_lid);
+        let votes: Vec<(&Jid, &[u8], &[u8])> = vec![
+            (&voter_pn_jid, &enc_pn, &iv_pn),
+            (&voter_lid_jid, &enc_lid, &iv_lid),
+        ];
+
+        let results = client
+            .polls()
+            .aggregate_votes(&options, &votes, &secret, stanza_id, &Jid::lid(creator_lid))
+            .await
+            .unwrap();
+
+        let yes = results.iter().find(|r| r.name == "Yes").unwrap();
+        let no = results.iter().find(|r| r.name == "No").unwrap();
+        assert!(yes.voters.is_empty(), "the PN 'Yes' must be replaced");
+        assert_eq!(no.voters.len(), 1, "only the re-vote should count, once");
+    }
+
+    /// A clear-vote received under the other namespace must remove the prior
+    /// vote, not leave a stale entry keyed by the original namespace.
+    #[tokio::test]
+    async fn aggregate_clears_vote_across_namespace() {
+        let client: Arc<Client> = create_test_client().await;
+        let secret = [0x51u8; 32];
+        let stanza_id = "3EB0CLEAR";
+        let options = vec!["Yes".to_string(), "No".to_string()];
+
+        let creator_pn = "5511777777777";
+        let creator_lid = "111000111000111";
+        let voter_pn = "5511888888888";
+        let voter_lid = "222000222000222";
+        client
+            .add_lid_pn_mapping(creator_lid, creator_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+        client
+            .add_lid_pn_mapping(voter_lid, voter_pn, LearningSource::Usync)
+            .await
+            .unwrap();
+
+        let (enc_pn, iv_pn) = poll::encrypt_poll_vote_with_secret(
+            &[poll::compute_option_hash("Yes").to_vec()],
+            &secret,
+            stanza_id,
+            &Jid::pn(creator_pn).to_string(),
+            &Jid::pn(voter_pn).to_string(),
+        )
+        .unwrap();
+        // Empty selection = clear, authored under the LID pair after migrating.
+        let (enc_clear, iv_clear) = poll::encrypt_poll_vote_with_secret(
+            &[],
+            &secret,
+            stanza_id,
+            &Jid::lid(creator_lid).to_string(),
+            &Jid::lid(voter_lid).to_string(),
+        )
+        .unwrap();
+
+        let voter_pn_jid = Jid::pn(voter_pn);
+        let voter_lid_jid = Jid::lid(voter_lid);
+        let votes: Vec<(&Jid, &[u8], &[u8])> = vec![
+            (&voter_pn_jid, &enc_pn, &iv_pn),
+            (&voter_lid_jid, &enc_clear, &iv_clear),
+        ];
+
+        let results = client
+            .polls()
+            .aggregate_votes(&options, &votes, &secret, stanza_id, &Jid::lid(creator_lid))
+            .await
+            .unwrap();
+
+        assert!(
+            results.iter().all(|r| r.voters.is_empty()),
+            "the LID clear-vote must remove the earlier PN 'Yes'"
+        );
     }
 }

--- a/wacore/src/poll.rs
+++ b/wacore/src/poll.rs
@@ -143,28 +143,20 @@ pub fn decrypt_poll_vote(
     Ok(vote_msg.selected_options)
 }
 
-/// Addressing pair fed into the poll-vote HKDF + AAD. JIDs must be in the
-/// form they were sent/received under (AD suffix already stripped); the caller
-/// owns any LID↔PN normalisation. See [`decrypt_poll_vote_with_fallback`].
+/// Creator + voter JIDs (non-AD) that key the poll-vote HKDF and AAD.
 #[derive(Debug, Clone, Copy)]
 pub struct PollVoteAddressing<'a> {
     pub poll_creator_jid: &'a str,
     pub voter_jid: &'a str,
 }
 
-/// Decrypt a poll vote, retrying once under an alternate addressing pair.
+/// Decrypt a poll vote, retrying once under the alternate addressing.
 ///
-/// Mirrors WA Web's `WAWebAddonEncryption.decryptAddOn`, which opens the
-/// AES-GCM payload across addressing modes (LID pair, then PN pair) because
-/// both the poll creator and voter JIDs feed the HKDF info buffer and the AAD
-/// (`WAUseCaseSecret.createUseCaseSecret`): a vote authored under one namespace
-/// only decrypts with the same namespace. As WhatsApp migrates contacts to
-/// LID, a vote can be received under one addressing but the parent poll learned
-/// under the other, so a single attempt silently fails.
-///
-/// `primary` is the as-received pair; `fallback` is the swapped pair with
-/// *both* JIDs converted together, matching WA Web's homogeneous LID/PN
-/// attempts (it never mixes one LID with one PN).
+/// The creator and voter JIDs key the derivation, so a vote authored under LID
+/// only opens under LID. As contacts migrate to LID a vote can arrive in a
+/// different namespace than the parent poll was learned in, so `fallback`
+/// retries with both JIDs swapped together (never mixed), matching WA Web
+/// `WAWebAddonEncryption.decryptAddOn`.
 pub fn decrypt_poll_vote_with_fallback(
     enc_payload: &[u8],
     iv: &[u8],

--- a/wacore/src/poll.rs
+++ b/wacore/src/poll.rs
@@ -143,6 +143,62 @@ pub fn decrypt_poll_vote(
     Ok(vote_msg.selected_options)
 }
 
+/// Addressing pair fed into the poll-vote HKDF + AAD. JIDs must be in the
+/// form they were sent/received under (AD suffix already stripped); the caller
+/// owns any LID↔PN normalisation. See [`decrypt_poll_vote_with_fallback`].
+#[derive(Debug, Clone, Copy)]
+pub struct PollVoteAddressing<'a> {
+    pub poll_creator_jid: &'a str,
+    pub voter_jid: &'a str,
+}
+
+/// Decrypt a poll vote, retrying once under an alternate addressing pair.
+///
+/// Mirrors WA Web's `WAWebAddonEncryption.decryptAddOn`, which opens the
+/// AES-GCM payload across addressing modes (LID pair, then PN pair) because
+/// both the poll creator and voter JIDs feed the HKDF info buffer and the AAD
+/// (`WAUseCaseSecret.createUseCaseSecret`): a vote authored under one namespace
+/// only decrypts with the same namespace. As WhatsApp migrates contacts to
+/// LID, a vote can be received under one addressing but the parent poll learned
+/// under the other, so a single attempt silently fails.
+///
+/// `primary` is the as-received pair; `fallback` is the swapped pair with
+/// *both* JIDs converted together, matching WA Web's homogeneous LID/PN
+/// attempts (it never mixes one LID with one PN).
+pub fn decrypt_poll_vote_with_fallback(
+    enc_payload: &[u8],
+    iv: &[u8],
+    message_secret: &[u8],
+    stanza_id: &str,
+    primary: PollVoteAddressing<'_>,
+    fallback: Option<PollVoteAddressing<'_>>,
+) -> Result<Vec<Vec<u8>>> {
+    match decrypt_poll_vote_with_secret(
+        enc_payload,
+        iv,
+        message_secret,
+        stanza_id,
+        primary.poll_creator_jid,
+        primary.voter_jid,
+    ) {
+        Ok(v) => Ok(v),
+        Err(primary_err) => match fallback {
+            Some(fb) => decrypt_poll_vote_with_secret(
+                enc_payload,
+                iv,
+                message_secret,
+                stanza_id,
+                fb.poll_creator_jid,
+                fb.voter_jid,
+            )
+            .map_err(|fb_err| {
+                anyhow!("poll vote decrypt failed: primary={primary_err}; fallback={fb_err}")
+            }),
+            None => Err(primary_err),
+        },
+    }
+}
+
 /// Decrypt a poll vote given the poll's `messageSecret` directly. Preferred
 /// over the legacy two-step path that splits derive+decrypt.
 pub fn decrypt_poll_vote_with_secret(
@@ -234,6 +290,138 @@ mod tests {
                 "id",
                 "c@s.whatsapp.net",
                 "wrong@s.whatsapp.net"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn fallback_recovers_across_addressing() {
+        // Vote encrypted under the PN pair (creator + voter both PN)...
+        let secret = [0x33u8; 32];
+        let stanza_id = "3EB0FALLBACK";
+        let creator_pn = "5511999999999@s.whatsapp.net";
+        let voter_pn = "5511888888888@s.whatsapp.net";
+        let (enc, iv) = encrypt_poll_vote_with_secret(
+            &[compute_option_hash("Yes").to_vec()],
+            &secret,
+            stanza_id,
+            creator_pn,
+            voter_pn,
+        )
+        .unwrap();
+
+        // ...consumer first guesses the LID pair (primary), which fails, then
+        // recovers via the PN fallback. Mirrors WA Web's homogeneous retry.
+        let creator_lid = "111111111111111@lid";
+        let voter_lid = "222222222222222@lid";
+        let out = decrypt_poll_vote_with_fallback(
+            &enc,
+            &iv,
+            &secret,
+            stanza_id,
+            PollVoteAddressing {
+                poll_creator_jid: creator_lid,
+                voter_jid: voter_lid,
+            },
+            Some(PollVoteAddressing {
+                poll_creator_jid: creator_pn,
+                voter_jid: voter_pn,
+            }),
+        )
+        .unwrap();
+        assert_eq!(out, vec![compute_option_hash("Yes").to_vec()]);
+    }
+
+    #[test]
+    fn fallback_primary_succeeds_without_using_fallback() {
+        let secret = [0x44u8; 32];
+        let stanza_id = "id";
+        let creator = "c@s.whatsapp.net";
+        let voter = "v@s.whatsapp.net";
+        let (enc, iv) = encrypt_poll_vote_with_secret(
+            &[compute_option_hash("A").to_vec()],
+            &secret,
+            stanza_id,
+            creator,
+            voter,
+        )
+        .unwrap();
+
+        // Primary matches; a deliberately-wrong fallback must never be reached.
+        let out = decrypt_poll_vote_with_fallback(
+            &enc,
+            &iv,
+            &secret,
+            stanza_id,
+            PollVoteAddressing {
+                poll_creator_jid: creator,
+                voter_jid: voter,
+            },
+            Some(PollVoteAddressing {
+                poll_creator_jid: "wrong@lid",
+                voter_jid: "wrong@lid",
+            }),
+        )
+        .unwrap();
+        assert_eq!(out, vec![compute_option_hash("A").to_vec()]);
+    }
+
+    #[test]
+    fn fallback_combined_error_when_both_fail() {
+        let secret = [0x55u8; 32];
+        let stanza_id = "id";
+        let (enc, iv) = encrypt_poll_vote_with_secret(
+            &[compute_option_hash("A").to_vec()],
+            &secret,
+            stanza_id,
+            "c@s.whatsapp.net",
+            "v@s.whatsapp.net",
+        )
+        .unwrap();
+
+        let err = decrypt_poll_vote_with_fallback(
+            &enc,
+            &iv,
+            &secret,
+            stanza_id,
+            PollVoteAddressing {
+                poll_creator_jid: "x@lid",
+                voter_jid: "y@lid",
+            },
+            Some(PollVoteAddressing {
+                poll_creator_jid: "x@s.whatsapp.net",
+                voter_jid: "y@s.whatsapp.net",
+            }),
+        )
+        .unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("primary="), "got: {s}");
+        assert!(s.contains("fallback="), "got: {s}");
+    }
+
+    #[test]
+    fn fallback_none_propagates_primary_error() {
+        let secret = [0x66u8; 32];
+        let (enc, iv) = encrypt_poll_vote_with_secret(
+            &[compute_option_hash("A").to_vec()],
+            &secret,
+            "id",
+            "c@s.whatsapp.net",
+            "v@s.whatsapp.net",
+        )
+        .unwrap();
+        assert!(
+            decrypt_poll_vote_with_fallback(
+                &enc,
+                &iv,
+                &secret,
+                "id",
+                PollVoteAddressing {
+                    poll_creator_jid: "wrong@lid",
+                    voter_jid: "wrong@lid",
+                },
+                None,
             )
             .is_err()
         );


### PR DESCRIPTION
## Summary
Poll votes always used the own **PN** as the voter JID. But the voter feeds the poll-vote HKDF info + AAD, so it must match the addressing of the poll creator. In LID-addressed conversations the real WhatsApp Web (`WAWebAddonEncryption`) authors the vote under the **LID** — so PN-authored votes fail to decrypt on the host as contacts migrate to LID.

This brings whatsapp-rust in line with WA Web behavior (verified against `docs/captured-js/WAWeb/Addon/Encryption.js`), mirroring the concept of whatsmeow `5d16908e` (encrypt) and `e46d104e`/`1c97bf40` (decrypt fallback). The decrypt path reuses the same LID↔PN fallback pattern the message-edit path (`wacore/src/message_edit.rs`) already implements.

- **encrypt** (`Polls::vote`): pick the voter JID to match the poll creator's namespace — own LID for LID-addressed polls, own PN otherwise — falling back to PN (with a warning) when the own LID is unknown.
- **decrypt** (`Polls::decrypt_vote` / `aggregate_votes`): retry under the opposite addressing (LID↔PN) when a counterpart mapping is known, matching WA Web's `decryptAddOn` homogeneous LID/PN attempts. The fallback pair is built only when **both** the creator and the voter have a known counterpart.
- new `wacore::poll::decrypt_poll_vote_with_fallback` + `PollVoteAddressing`.

### ⚠️ Breaking change
`Polls::decrypt_vote` and `Polls::aggregate_votes` changed from sync associated functions to `&self async` methods. Call sites must use `client.polls().decrypt_vote(...).await`. No internal callers in this repo.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests` (clean)
- [x] `cargo test --workspace --exclude e2e-tests` (0 failures)
- [x] wacore unit tests: fallback recovers across addressing, primary-without-fallback, combined error, `None` propagation
- [x] client tests: voter is PN/own-LID/PN-fallback; decrypt + aggregate recover when fed LID but encrypted under PN; no-mapping must not silently decrypt