### PR TITLE
feat(history-sync): server-error receipt to request blob re-upload

### DIFF
--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -240,6 +240,36 @@ impl Client {
         }
     }
 
+    /// Ask the phone to re-upload a history-sync blob whose download failed,
+    /// by sending a `<receipt type="server-error" category="peer">` with the
+    /// blob's `media_key`.
+    ///
+    /// WA Web (`WAWebHandleHistorySyncNotification`) sends this on a non-network
+    /// download failure; the encrypted payload is the same `ServerErrorReceipt`
+    /// used for media retries. Exposed for consumers that detect an undownloadable
+    /// or unwanted history-sync chunk and want the phone to re-send it.
+    pub async fn send_history_sync_server_error_receipt(
+        &self,
+        message_id: &str,
+        media_key: &[u8],
+    ) -> Result<(), anyhow::Error> {
+        let own_jid = self
+            .get_pn()
+            .await
+            .ok_or(crate::client::ClientError::NotLoggedIn)?
+            .to_non_ad();
+        let (ciphertext, iv) =
+            wacore::media_retry::encrypt_media_retry_receipt(media_key, message_id)?;
+        let node = wacore::media_retry::build_history_sync_server_error_receipt(
+            &own_jid,
+            message_id,
+            &ciphertext,
+            &iv,
+        );
+        self.send_node(node).await?;
+        Ok(())
+    }
+
     /// Store a tctoken candidate extracted during history sync streaming.
     async fn store_tc_token_candidate(&self, candidate: TcTokenCandidate) {
         let jid: wacore_binary::Jid = match candidate.id.parse() {

--- a/wacore/src/media_retry.rs
+++ b/wacore/src/media_retry.rs
@@ -152,6 +152,34 @@ pub fn build_media_retry_receipt(
         .build()
 }
 
+/// Build the `<receipt type="server-error" category="peer">` node that asks the
+/// phone to re-upload a history-sync blob whose download failed.
+///
+/// WA Web: `WAWebSendHistSyncServerErrorReceiptJob`. Differs from the media
+/// retry receipt: it carries `category="peer"`, targets our own JID, and omits
+/// the `<rmr>` child. The encrypted payload reuses [`encrypt_media_retry_receipt`].
+pub fn build_history_sync_server_error_receipt(
+    own_jid: &Jid,
+    msg_id: &str,
+    ciphertext: &[u8],
+    iv: &[u8],
+) -> Node {
+    let encrypt_node = NodeBuilder::new("encrypt")
+        .children([
+            NodeBuilder::new("enc_p").bytes(ciphertext.to_vec()).build(),
+            NodeBuilder::new("enc_iv").bytes(iv.to_vec()).build(),
+        ])
+        .build();
+
+    NodeBuilder::new("receipt")
+        .attr("type", "server-error")
+        .attr("to", own_jid)
+        .attr("id", msg_id)
+        .attr("category", "peer")
+        .children([encrypt_node])
+        .build()
+}
+
 /// Parse a `<notification type="mediaretry">` node into a `MediaRetryResult`.
 ///
 /// The node may contain:
@@ -305,5 +333,34 @@ mod tests {
 
         let rmr = node.get_optional_child_by_tag(&["rmr"]).unwrap();
         assert!(rmr.attrs().optional_string("participant").is_some());
+    }
+
+    #[test]
+    fn build_history_sync_receipt_structure() {
+        let own_jid = Jid::pn("1234567890");
+        let (ciphertext, iv) = encrypt_media_retry_receipt(&[2u8; 32], "HS1").unwrap();
+
+        let node = build_history_sync_server_error_receipt(&own_jid, "HS1", &ciphertext, &iv);
+
+        assert_eq!(node.tag.as_ref(), "receipt");
+        assert_eq!(
+            node.attrs().optional_string("type").unwrap().as_ref(),
+            "server-error"
+        );
+        assert_eq!(
+            node.attrs().optional_string("category").unwrap().as_ref(),
+            "peer"
+        );
+        assert_eq!(node.attrs().optional_string("id").unwrap().as_ref(), "HS1");
+        assert_eq!(
+            node.attrs().optional_string("to").unwrap().as_ref(),
+            own_jid.to_string()
+        );
+
+        let encrypt = node.get_optional_child_by_tag(&["encrypt"]).unwrap();
+        assert!(encrypt.get_optional_child_by_tag(&["enc_p"]).is_some());
+        assert!(encrypt.get_optional_child_by_tag(&["enc_iv"]).is_some());
+        // The history-sync variant carries no <rmr> child.
+        assert!(node.get_optional_child_by_tag(&["rmr"]).is_none());
     }
 }


### PR DESCRIPTION
## Summary
Adds `Client::send_history_sync_server_error_receipt(message_id, media_key)`, which sends a `<receipt type="server-error" category="peer">` asking the phone to **re-upload a history-sync blob** whose download failed. The encrypted payload reuses the existing `ServerErrorReceipt` media-retry primitive (`encrypt_media_retry_receipt`).

Verified against the real WhatsApp Web module **`WAWebSendHistSyncServerErrorReceiptJob`** (`docs/captured-js/WAWeb/Send/HistSyncServerErrorReceiptJob.js`): identical stanza shape — `type="server-error"`, `category="peer"`, `to` = own JID, a single `<encrypt>`/`<enc_p>`/`<enc_iv>` child and **no `<rmr>`** — and the same `WAWebCryptoMediaRetry` encryption the media-retry path already uses. Mirrors whatsmeow's `SendHistorySyncServerErrorReceipt` (commit `60c04885`).

### Scope note
Left as a **consumer-callable** method rather than auto-wired into the download-failure path, matching whatsmeow's design. WA Web auto-triggers it on download failure but skips `HttpNetworkError`; faithfully replicating that guard requires surfacing typed download errors up from `download_to_writer` (currently flattened to `anyhow`), which is a separate change and out of scope here to avoid re-upload loops on transient network errors.

## Changes
- `wacore/src/media_retry.rs`: `build_history_sync_server_error_receipt(own_jid, msg_id, ciphertext, iv)` (the `category="peer"`, no-`rmr` variant).
- `src/history_sync.rs`: public `Client::send_history_sync_server_error_receipt`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests` (clean)
- [x] `cargo test --workspace --exclude e2e-tests` (0 failures)
- [x] Unit test `build_history_sync_receipt_structure`: asserts type/category/to/id, `enc_p`/`enc_iv` present, and `<rmr>` absent