### PR TITLE
fix(offline): transport-ack stanzas with only unrecognized enc types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1987,6 +1987,32 @@ impl Client {
         });
     }
 
+    /// Tracked ack encoded from the original node. Use when the stanza carries
+    /// `recipient` (LID-routed/hosted-companion/peer) since `MessageInfo`
+    /// drops it on non-self branches and the server needs it for routing.
+    pub(crate) async fn spawn_node_transport_ack(
+        self: &Arc<Self>,
+        node: &wacore_binary::NodeRef<'_>,
+    ) {
+        let own_pn = self.get_pn().await;
+        let buf = match encode_ack_bytes(node, own_pn.as_ref()) {
+            Ok(Some(b)) => b,
+            Ok(None) => return,
+            Err(e) => {
+                log::warn!("Failed to encode node transport ack: {e}");
+                return;
+            }
+        };
+        let client = Arc::clone(self);
+        self.outbound_flush.spawn(&*self.runtime, async move {
+            if let Err(e) = client.send_raw_bytes(buf).await
+                && !e.is_transport_unavailable()
+            {
+                log::warn!("Failed to send node transport ack: {e:?}");
+            }
+        });
+    }
+
     pub async fn set_passive(&self, passive: bool) -> Result<(), crate::request::IqError> {
         use wacore::iq::passive::PassiveModeSpec;
         self.execute(PassiveModeSpec::new(passive)).await

--- a/src/message.rs
+++ b/src/message.rs
@@ -566,8 +566,9 @@ impl Client {
                 continue;
             }
 
-            // Distinguish unknown type (msmsg etc., needs fallback ack) from
-            // known-but-empty (malformed; existing flow handles it).
+            // `had_unknown_enc` means "produced no usable payload": either the
+            // type is unrecognized (msmsg) or it's known but the body is empty.
+            // Either way the stanza needs the fallback ack or the server replays.
             if EncType::from_wire(enc_type.as_ref()).is_none() {
                 log::warn!("Enc node has unknown type: {enc_type}");
                 had_unknown_enc = true;
@@ -578,6 +579,7 @@ impl Client {
                 Some(p) => p,
                 None => {
                     log::warn!("Enc node {enc_type} has no content");
+                    had_unknown_enc = true;
                     continue;
                 }
             };
@@ -7351,9 +7353,9 @@ mod tests {
         );
     }
 
-    /// Known type with empty content is malformed; not our fallback's job.
+    /// Known type with empty content still has no usable payload; ack it.
     #[tokio::test]
-    async fn known_enc_type_with_empty_content_skips_fallback_ack() {
+    async fn known_enc_type_with_empty_content_is_transport_acked() {
         let (client, transport) = capturing_client("known_empty").await;
         let node = NodeBuilder::new("message")
             .attr("from", "5511777776666@s.whatsapp.net")
@@ -7362,18 +7364,19 @@ mod tests {
             .children([NodeBuilder::new("enc").attr("type", "pkmsg").build()])
             .build();
         let owned = node_to_arc(node);
-        let _ = client.classify_incoming_message(&owned).await;
+        let classified = client.classify_incoming_message(&owned).await;
+        assert!(classified.is_none());
 
-        for _ in 0..16 {
-            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-            if find_message_ack(&transport.sent()).is_some() {
+        let mut found = None;
+        for _ in 0..80 {
+            if let Some(a) = find_message_ack(&transport.sent()) {
+                found = Some(a);
                 break;
             }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
-        assert!(
-            find_message_ack(&transport.sent()).is_none(),
-            "known-but-empty enc must not trigger the unknown-enc fallback ack"
-        );
+        let (to, _) = found.expect("known-but-empty enc must emit a transport ack");
+        assert_eq!(to, "5511777776666@s.whatsapp.net");
     }
 
     /// status is covered by should_ack; the fallback must not double-ack it.

--- a/src/message.rs
+++ b/src/message.rs
@@ -504,6 +504,8 @@ impl Client {
         let mut group_payloads = Vec::with_capacity(all_enc_nodes.len());
         let mut max_sender_retry_count: u8 = 0;
         let mut has_hide_fail = false;
+        let mut had_unknown_enc = false;
+        let mut had_custom_handler = false;
 
         for enc_node in &all_enc_nodes {
             // Parse sender retry count (WA Web: e.maybeAttrInt("count") ?? 0)
@@ -528,6 +530,7 @@ impl Client {
                 Some(t) => t,
                 None => {
                     log::warn!("Enc node missing 'type' attribute, skipping");
+                    had_unknown_enc = true;
                     continue;
                 }
             };
@@ -559,6 +562,7 @@ impl Client {
                         }
                     }))
                     .detach();
+                had_custom_handler = true;
                 continue;
             }
 
@@ -569,6 +573,7 @@ impl Client {
                 Some(p) => p,
                 None => {
                     log::warn!("Enc node has no content or unknown type: {enc_type}");
+                    had_unknown_enc = true;
                     continue;
                 }
             };
@@ -595,6 +600,25 @@ impl Client {
                 info.id,
                 info.source.sender
             );
+        }
+
+        // Stanzas whose enc nodes are all unrecognized (e.g. msmsg from the Meta
+        // AI bot) would otherwise leave the offline queue without any ack,
+        // causing the server to replay them until <stream:error>. Custom
+        // handlers ack on their own; status is acked by the should_ack gate.
+        if session_payloads.is_empty()
+            && group_payloads.is_empty()
+            && had_unknown_enc
+            && !had_custom_handler
+        {
+            log::info!(
+                "[msg:{}] All enc payloads unrecognized; transport-acking to drop from offline queue",
+                info.id
+            );
+            if !info.source.chat.is_status_broadcast() {
+                self.spawn_message_ack(&info);
+            }
+            return None;
         }
 
         Some(ClassifiedMessage {
@@ -7254,6 +7278,166 @@ mod tests {
         }
         let (to, _) = found.expect("unavailable message must get a transport ack");
         assert_eq!(to, "5511777776666@s.whatsapp.net");
+    }
+
+    /// Stanzas with only unrecognized enc types (e.g. msmsg from the Meta AI
+    /// bot) used to silently fall through with no ack, so the server replayed
+    /// them on every reconnect until <stream:error>. Classify must now emit a
+    /// transport ack to drop the stanza from the offline queue.
+    #[tokio::test]
+    async fn unknown_only_enc_is_transport_acked() {
+        let (client, transport) = capturing_client("msmsg_ack").await;
+        let node = NodeBuilder::new("message")
+            .attr("from", "5511777776666@s.whatsapp.net")
+            .attr("id", "MSMSG1")
+            .attr("type", "text")
+            .children([NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .bytes(vec![0u8; 8])
+                .build()])
+            .build();
+        let owned = node_to_arc(node);
+        let classified = client.classify_incoming_message(&owned).await;
+        assert!(
+            classified.is_none(),
+            "unknown-only enc must short-circuit before the process phase"
+        );
+
+        let mut found = None;
+        for _ in 0..80 {
+            if let Some(a) = find_message_ack(&transport.sent()) {
+                found = Some(a);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let (to, _) = found.expect("unknown-only enc must emit a transport ack");
+        assert_eq!(to, "5511777776666@s.whatsapp.net");
+    }
+
+    /// status@broadcast is already acked by the `should_ack` gate; the fallback
+    /// path must skip it to avoid a duplicate transport ack.
+    #[tokio::test]
+    async fn unknown_only_enc_on_status_skips_fallback_ack() {
+        let (client, transport) = capturing_client("msmsg_status_skip").await;
+        let node = NodeBuilder::new("message")
+            .attr("from", "status@broadcast")
+            .attr("id", "MSMSG_STATUS")
+            .attr("type", "text")
+            .attr("participant", "5511777776666@s.whatsapp.net")
+            .children([NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .bytes(vec![0u8; 8])
+                .build()])
+            .build();
+        let owned = node_to_arc(node);
+        let classified = client.classify_incoming_message(&owned).await;
+        assert!(classified.is_none());
+
+        // Give any rogue spawned task time to land on the wire.
+        for _ in 0..16 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            if find_message_ack(&transport.sent()).is_some() {
+                break;
+            }
+        }
+        assert!(
+            find_message_ack(&transport.sent()).is_none(),
+            "status@broadcast must not get a fallback transport ack from classify"
+        );
+    }
+
+    /// A recognized enc alongside an unknown one must still flow through the
+    /// normal process path; the fallback must not short-circuit and prevent
+    /// decryption of the recognized payload.
+    #[tokio::test]
+    async fn mixed_recognized_and_unknown_enc_still_classifies() {
+        let (client, _transport) = capturing_client("msmsg_mixed").await;
+        let node = NodeBuilder::new("message")
+            .attr("from", "5511777776666@s.whatsapp.net")
+            .attr("id", "MIXED1")
+            .attr("type", "text")
+            .children([
+                NodeBuilder::new("enc")
+                    .attr("type", "pkmsg")
+                    .bytes(vec![0u8; 8])
+                    .build(),
+                NodeBuilder::new("enc")
+                    .attr("type", "msmsg")
+                    .bytes(vec![0u8; 8])
+                    .build(),
+            ])
+            .build();
+        let owned = node_to_arc(node);
+        let classified = client
+            .classify_incoming_message(&owned)
+            .await
+            .expect("mixed enc must produce a ClassifiedMessage");
+        assert_eq!(classified.session_payloads.len(), 1);
+        assert!(classified.group_payloads.is_empty());
+    }
+
+    /// When a custom handler claims the unknown enc type, the fallback must NOT
+    /// fire (the handler is responsible for its own ack; firing both could send
+    /// two acks for the same stanza).
+    #[tokio::test]
+    async fn custom_handler_only_skips_fallback_ack() {
+        use crate::types::enc_handler::EncHandler;
+        use async_lock::Mutex as AsyncMutex;
+
+        #[derive(Default)]
+        struct NoopHandler {
+            calls: Arc<AsyncMutex<usize>>,
+        }
+        #[async_trait::async_trait]
+        impl EncHandler for NoopHandler {
+            async fn handle(
+                &self,
+                _client: Arc<Client>,
+                _enc_node: &wacore_binary::Node,
+                _info: &crate::types::message::MessageInfo,
+            ) -> anyhow::Result<()> {
+                *self.calls.lock().await += 1;
+                Ok(())
+            }
+        }
+
+        let (client, transport) = capturing_client("msmsg_custom").await;
+        let calls = Arc::new(AsyncMutex::new(0usize));
+        let handler = Arc::new(NoopHandler {
+            calls: Arc::clone(&calls),
+        });
+        client
+            .custom_enc_handlers
+            .write()
+            .await
+            .insert("msmsg".to_string(), handler as Arc<dyn EncHandler>);
+
+        let node = NodeBuilder::new("message")
+            .attr("from", "5511777776666@s.whatsapp.net")
+            .attr("id", "CUSTOM1")
+            .attr("type", "text")
+            .children([NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .bytes(vec![0u8; 8])
+                .build()])
+            .build();
+        let owned = node_to_arc(node);
+        let classified = client.classify_incoming_message(&owned).await;
+        assert!(
+            classified.is_some(),
+            "custom-handled enc must not be short-circuited by the fallback guard"
+        );
+
+        // Let the detached handler + any rogue spawned task run.
+        for _ in 0..16 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            find_message_ack(&transport.sent()).is_none(),
+            "custom-handled enc must not get a fallback transport ack from classify"
+        );
+        assert_eq!(*calls.lock().await, 1, "custom handler must be invoked");
     }
 
     /// Security regression: a self-only `app_state_sync_key_share` protocol

--- a/src/message.rs
+++ b/src/message.rs
@@ -566,14 +566,18 @@ impl Client {
                 continue;
             }
 
-            // Zero-copy: slice_bytes returns a Bytes sub-view into the
-            // node's backing buffer without memcpy.
-            // from_owned_node returns None for unknown enc types or missing content.
+            // Distinguish unknown type (msmsg etc., needs fallback ack) from
+            // known-but-empty (malformed; existing flow handles it).
+            if EncType::from_wire(enc_type.as_ref()).is_none() {
+                log::warn!("Enc node has unknown type: {enc_type}");
+                had_unknown_enc = true;
+                continue;
+            }
+
             let payload = match EncPayload::from_owned_node(node, enc_node) {
                 Some(p) => p,
                 None => {
-                    log::warn!("Enc node has no content or unknown type: {enc_type}");
-                    had_unknown_enc = true;
+                    log::warn!("Enc node {enc_type} has no content");
                     continue;
                 }
             };
@@ -602,10 +606,10 @@ impl Client {
             );
         }
 
-        // Stanzas whose enc nodes are all unrecognized (e.g. msmsg from the Meta
-        // AI bot) would otherwise leave the offline queue without any ack,
-        // causing the server to replay them until <stream:error>. Custom
-        // handlers ack on their own; status is acked by the should_ack gate.
+        // Unknown-only stanzas (e.g. msmsg from the Meta AI bot) would loop in
+        // the offline queue until <stream:error>. Custom handlers ack on their
+        // own; status is covered by should_ack. Ack from `nr` so `recipient`
+        // survives (parse_message_info drops it on non-self branches).
         if session_payloads.is_empty()
             && group_payloads.is_empty()
             && had_unknown_enc
@@ -616,7 +620,7 @@ impl Client {
                 info.id
             );
             if !info.source.chat.is_status_broadcast() {
-                self.spawn_message_ack(&info);
+                self.spawn_node_transport_ack(nr).await;
             }
             return None;
         }
@@ -7280,10 +7284,7 @@ mod tests {
         assert_eq!(to, "5511777776666@s.whatsapp.net");
     }
 
-    /// Stanzas with only unrecognized enc types (e.g. msmsg from the Meta AI
-    /// bot) used to silently fall through with no ack, so the server replayed
-    /// them on every reconnect until <stream:error>. Classify must now emit a
-    /// transport ack to drop the stanza from the offline queue.
+    /// Unknown-only stanzas (e.g. msmsg) must be acked or they loop the queue.
     #[tokio::test]
     async fn unknown_only_enc_is_transport_acked() {
         let (client, transport) = capturing_client("msmsg_ack").await;
@@ -7315,8 +7316,67 @@ mod tests {
         assert_eq!(to, "5511777776666@s.whatsapp.net");
     }
 
-    /// status@broadcast is already acked by the `should_ack` gate; the fallback
-    /// path must skip it to avoid a duplicate transport ack.
+    /// `recipient` must be echoed verbatim or the server replies <stream:error>.
+    #[tokio::test]
+    async fn unknown_only_enc_ack_preserves_recipient() {
+        let (client, transport) = capturing_client("msmsg_recipient").await;
+        let node = NodeBuilder::new("message")
+            .attr("from", "236395184570386@lid")
+            .attr("recipient", "156535032389744@lid")
+            .attr("id", "MSMSG_LID")
+            .attr("type", "text")
+            .children([NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .bytes(vec![0u8; 8])
+                .build()])
+            .build();
+        let owned = node_to_arc(node);
+        let classified = client.classify_incoming_message(&owned).await;
+        assert!(classified.is_none());
+
+        let mut found = None;
+        for _ in 0..80 {
+            if let Some(a) = find_message_ack(&transport.sent()) {
+                found = Some(a);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let (to, recipient) = found.expect("unknown-only enc must emit a transport ack");
+        assert_eq!(to, "236395184570386@lid");
+        assert_eq!(
+            recipient.as_deref(),
+            Some("156535032389744@lid"),
+            "ack must echo the incoming `recipient` attr or the server replies with <stream:error><ack/>"
+        );
+    }
+
+    /// Known type with empty content is malformed; not our fallback's job.
+    #[tokio::test]
+    async fn known_enc_type_with_empty_content_skips_fallback_ack() {
+        let (client, transport) = capturing_client("known_empty").await;
+        let node = NodeBuilder::new("message")
+            .attr("from", "5511777776666@s.whatsapp.net")
+            .attr("id", "EMPTY1")
+            .attr("type", "text")
+            .children([NodeBuilder::new("enc").attr("type", "pkmsg").build()])
+            .build();
+        let owned = node_to_arc(node);
+        let _ = client.classify_incoming_message(&owned).await;
+
+        for _ in 0..16 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            if find_message_ack(&transport.sent()).is_some() {
+                break;
+            }
+        }
+        assert!(
+            find_message_ack(&transport.sent()).is_none(),
+            "known-but-empty enc must not trigger the unknown-enc fallback ack"
+        );
+    }
+
+    /// status is covered by should_ack; the fallback must not double-ack it.
     #[tokio::test]
     async fn unknown_only_enc_on_status_skips_fallback_ack() {
         let (client, transport) = capturing_client("msmsg_status_skip").await;
@@ -7347,9 +7407,7 @@ mod tests {
         );
     }
 
-    /// A recognized enc alongside an unknown one must still flow through the
-    /// normal process path; the fallback must not short-circuit and prevent
-    /// decryption of the recognized payload.
+    /// One recognized enc + one unknown must still go through the normal path.
     #[tokio::test]
     async fn mixed_recognized_and_unknown_enc_still_classifies() {
         let (client, _transport) = capturing_client("msmsg_mixed").await;
@@ -7377,9 +7435,7 @@ mod tests {
         assert!(classified.group_payloads.is_empty());
     }
 
-    /// When a custom handler claims the unknown enc type, the fallback must NOT
-    /// fire (the handler is responsible for its own ack; firing both could send
-    /// two acks for the same stanza).
+    /// A custom handler owns its ack; the fallback must not double-ack.
     #[tokio::test]
     async fn custom_handler_only_skips_fallback_ack() {
         use crate::types::enc_handler::EncHandler;

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -137,6 +137,10 @@ impl TestClient {
         let mut bot = builder.build().await?;
 
         let client = bot.client();
+        // with_push_name pre-seeds the name in DB, so the setting_pushName
+        // mutation arrives with `old == new` and skips the auto set_available.
+        // Force active so delivery receipts don't go out as type="inactive".
+        client.set_force_active_delivery_receipts(true);
         client.register_handler(event_handler);
 
         // The mock server no longer auto-pairs (legacy timer is off by

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -130,6 +130,7 @@ impl TestClient {
             .with_runtime(whatsapp_rust::TokioRuntime)
             .with_version((2, 3000, 0));
 
+        let push_name_pre_seeded = push_name.is_some();
         if let Some(name) = push_name {
             builder = builder.with_push_name(name);
         }
@@ -137,10 +138,10 @@ impl TestClient {
         let mut bot = builder.build().await?;
 
         let client = bot.client();
-        // with_push_name pre-seeds the name in DB, so the setting_pushName
-        // mutation arrives with `old == new` and skips the auto set_available.
-        // Force active so delivery receipts don't go out as type="inactive".
-        client.set_force_active_delivery_receipts(true);
+        // with_push_name pre-seeds the name so the setting_pushName mutation has old==new (skipping auto set_available), so force active to keep delivery receipts from being type="inactive".
+        if push_name_pre_seeded {
+            client.set_force_active_delivery_receipts(true);
+        }
         client.register_handler(event_handler);
 
         // The mock server no longer auto-pairs (legacy timer is off by


### PR DESCRIPTION
## Summary

- After PR #647 the dominant remaining cause of reconnects in prod is stanzas whose enc nodes are all unknown to the client (e.g. `msmsg` from the Meta AI bot). Classify silently dropped them, so the server replayed them every reconnect until `<stream:error>` closed the stream.
- This PR adds a fallback in `classify_incoming_message`: when both `session_payloads` and `group_payloads` end up empty AND at least one enc was unknown AND no custom handler claimed any enc, spawn a transport `<ack>` to drop the stanza from the offline queue. `status@broadcast` is left alone (the `should_ack` gate already covers it).
- Decryption of `msmsg` itself is intentionally out of scope; a follow-up PR will implement it. This change just stops the offline queue from looping on stanzas we cannot decrypt yet.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all --tests` (clean)
- [x] `cargo test -p whatsapp-rust -p wacore -p waproto` (all green)
- [x] New tests: unknown-only enc gets a transport ack; status@broadcast skips it; recognized + unknown still classifies normally; custom-handler-only does not double-ack.