### PR TITLE
fix(send): fail DM send when every per-device encrypt fails

### DIFF
--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -918,13 +918,12 @@ pub async fn prepare_dm_stanza<
         includes_prekey_message = includes_prekey_message || result.includes_prekey_message;
     }
 
-    // If every per-device encrypt failed, shipping an empty <participants>
-    // stanza would silently drop the message. WA Web's encryptAndSendUserMsg
-    // rejects with "encryption fail for all devices"; mirror that so the
-    // caller's error path fires instead of a false success.
-    if participant_nodes.is_empty() && total_devices > 0 {
+    // All per-device encrypts failed: an empty <participants> would silently
+    // drop the message. WA Web's encryptAndSendUserMsg rejects here too.
+    let attempted_devices = recipient_devices.len() + own_other_devices.len();
+    if participant_nodes.is_empty() && attempted_devices > 0 {
         return Err(anyhow!(
-            "encryption failed for all {total_devices} recipient device(s)"
+            "encryption failed for all {attempted_devices} recipient device(s)"
         ));
     }
 

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -918,6 +918,16 @@ pub async fn prepare_dm_stanza<
         includes_prekey_message = includes_prekey_message || result.includes_prekey_message;
     }
 
+    // If every per-device encrypt failed, shipping an empty <participants>
+    // stanza would silently drop the message. WA Web's encryptAndSendUserMsg
+    // rejects with "encryption fail for all devices"; mirror that so the
+    // caller's error path fires instead of a false success.
+    if participant_nodes.is_empty() && total_devices > 0 {
+        return Err(anyhow!(
+            "encryption failed for all {total_devices} recipient device(s)"
+        ));
+    }
+
     let mut message_content_nodes = vec![
         NodeBuilder::new("participants")
             .children(participant_nodes)


### PR DESCRIPTION
## Finding (WA Web parity audit, area: send/encrypt)

`prepare_dm_stanza` (wacore/src/send.rs) extends `participant_nodes` from `encrypt_for_devices`, which logs+skips each device whose encryption fails (missing prekey bundle, etc.) and returns `Ok` with whatever succeeded. When ALL recipient devices fail, `participant_nodes` is empty, yet the code unconditionally built `<participants>` and returned `Ok` — shipping an empty stanza and reporting success. The message is silently dropped with no error and no retry trigger.

WA Web `WAWebSendMsgCreateFanoutStanza` (encryptAndSendUserMsg) rejects with `encryption fail for all devices` when the per-device encrypt set is empty.

## Change

Return `Err` when `participant_nodes.is_empty() && total_devices > 0`, mirroring WA Web. Only the all-fail case changes (previously a silent no-op); partial success is unaffected.

## Testing

`cargo build -p wacore`, `cargo clippy -p wacore --tests`, `cargo test -p wacore` (send tests pass). The all-fail path requires the full Signal store adapter (src/), so a dedicated test belongs at integration level; the guard is a minimal invariant verified by reading the fanout path.

Draft — one of several from a WA Web parity audit; review independently.