### PR TITLE
fix(send): hide decrypt-fail for conditional-reveal and poll-add-option

### DIFF
--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -240,10 +240,13 @@ pub fn should_hide_decrypt_fail(msg: &wa::Message) -> bool {
             .as_ref()
             .is_some_and(|p| p.vote.is_some())
         || msg.message_history_notice.is_some()
+        || msg.conditional_reveal_message.is_some()
         || msg.secret_encrypted_message.as_ref().is_some_and(|s| {
             matches!(
                 SecretEncType::try_from(s.secret_enc_type.unwrap_or(0)),
-                Ok(SecretEncType::EventEdit | SecretEncType::PollEdit)
+                Ok(SecretEncType::EventEdit
+                    | SecretEncType::PollEdit
+                    | SecretEncType::PollAddOption)
             )
         })
         || msg
@@ -3758,6 +3761,28 @@ mod tests {
                         ..Default::default()
                     })),
                 })),
+                ..Default::default()
+            };
+            assert!(should_hide_decrypt_fail(&msg));
+        }
+
+        #[test]
+        fn conditional_reveal() {
+            let msg = wa::Message {
+                conditional_reveal_message: Some(Default::default()),
+                ..Default::default()
+            };
+            assert!(should_hide_decrypt_fail(&msg));
+        }
+
+        #[test]
+        fn poll_add_option_edit() {
+            use wa::message::secret_encrypted_message::SecretEncType;
+            let msg = wa::Message {
+                secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                    secret_enc_type: Some(SecretEncType::PollAddOption as i32),
+                    ..Default::default()
+                }),
                 ..Default::default()
             };
             assert!(should_hide_decrypt_fail(&msg));


### PR DESCRIPTION
## Finding (WA Web parity audit, area: send/encrypt)

`should_hide_decrypt_fail` (wacore/src/send.rs) builds the set of message kinds that ship with `decrypt-fail="hide"`. It omitted `conditional_reveal_message` and the `PollAddOption` secret-enc type. Those messages went out without the hide attribute, so a recipient who can't decrypt them gets a visible "waiting for this message" placeholder instead of a silent drop.

WA Web `WAWebE2EProtoUtils.decryptFailAttributeFromProtobuf` returns `Hide` for `conditionalRevealMessage` and for `secretEncType === POLL_ADD_OPTION` (alongside `EVENT_EDIT`/`POLL_EDIT`).

## Change

Add `conditional_reveal_message` and `SecretEncType::PollAddOption` to the hide set.

## Testing

Added `conditional_reveal` and `poll_add_option_edit` to `mod decrypt_fail`. `cargo fmt`, `cargo clippy -p wacore --tests`, `cargo test -p wacore` pass.

Draft — one of several from a WA Web parity audit; review independently.