### PR TITLE
fix(send): don't hide decrypt-fail on SenderRevoke

### DIFF
--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -209,15 +209,17 @@ pub fn media_type_from_message(msg: &wa::Message) -> Option<&'static str> {
 
 /// Canonical rule for `decrypt-fail="hide"` on outgoing `<enc>` nodes.
 /// Shared by DM fanout, group SKDM and group SKMSG so the three paths can't drift.
-/// `AdminRevoke` is excluded because the server drops revoke stanzas carrying the
-/// hide attribute.
+/// Both revoke kinds are excluded: WA Web never hides REVOKE, and the server
+/// drops revoke stanzas carrying the hide attribute.
 pub fn should_hide_decrypt_fail_for_send(
     edit: Option<&crate::types::message::EditAttribute>,
     msg: &wa::Message,
 ) -> bool {
+    use crate::types::message::EditAttribute;
     edit.is_some_and(|e| {
-        *e != crate::types::message::EditAttribute::Empty
-            && *e != crate::types::message::EditAttribute::AdminRevoke
+        *e != EditAttribute::Empty
+            && *e != EditAttribute::AdminRevoke
+            && *e != EditAttribute::SenderRevoke
     }) || should_hide_decrypt_fail(msg)
 }
 
@@ -3761,6 +3763,55 @@ mod tests {
                 ..Default::default()
             };
             assert!(should_hide_decrypt_fail(&msg));
+        }
+    }
+
+    mod decrypt_fail_for_send {
+        use super::*;
+        use crate::types::message::EditAttribute;
+
+        fn plain() -> wa::Message {
+            wa::Message {
+                conversation: Some("hi".into()),
+                ..Default::default()
+            }
+        }
+
+        #[test]
+        fn sender_revoke_is_not_hidden() {
+            assert!(!should_hide_decrypt_fail_for_send(
+                Some(&EditAttribute::SenderRevoke),
+                &plain()
+            ));
+        }
+
+        #[test]
+        fn admin_revoke_is_not_hidden() {
+            assert!(!should_hide_decrypt_fail_for_send(
+                Some(&EditAttribute::AdminRevoke),
+                &plain()
+            ));
+        }
+
+        #[test]
+        fn message_edit_is_hidden() {
+            assert!(should_hide_decrypt_fail_for_send(
+                Some(&EditAttribute::MessageEdit),
+                &plain()
+            ));
+        }
+
+        #[test]
+        fn revoke_does_not_block_content_based_hide() {
+            // A reaction still hides on its own merits even under a revoke edit.
+            let msg = wa::Message {
+                reaction_message: Some(Default::default()),
+                ..Default::default()
+            };
+            assert!(should_hide_decrypt_fail_for_send(
+                Some(&EditAttribute::SenderRevoke),
+                &msg
+            ));
         }
     }
 

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -298,24 +298,22 @@ mod tests {
 
     #[test]
     fn test_decrypt_fail_hide_logic_for_edits() {
-        // Documents the logic used in prepare_group_stanza (wacore/src/send.rs).
-        // The decrypt-fail="hide" attribute is added for edited messages to hide
-        // failed decryption attempts. However, admin revokes should NOT have it
-        // because WhatsApp Web doesn't include it, and the server rejects it.
+        // Exercise the real rule; both revoke kinds are excluded (WA Web never
+        // hides REVOKE and the server drops revokes carrying the attribute).
+        let plain = waproto::whatsapp::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+        let hide =
+            |e: EditAttribute| crate::send::should_hide_decrypt_fail_for_send(Some(&e), &plain);
 
-        fn should_add_decrypt_fail_hide(edit: &EditAttribute) -> bool {
-            *edit != EditAttribute::Empty && *edit != EditAttribute::AdminRevoke
-        }
+        assert!(hide(EditAttribute::MessageEdit));
+        assert!(hide(EditAttribute::PinInChat));
+        assert!(hide(EditAttribute::AdminEdit));
 
-        // Should add decrypt-fail="hide"
-        assert!(should_add_decrypt_fail_hide(&EditAttribute::MessageEdit));
-        assert!(should_add_decrypt_fail_hide(&EditAttribute::PinInChat));
-        assert!(should_add_decrypt_fail_hide(&EditAttribute::AdminEdit));
-        assert!(should_add_decrypt_fail_hide(&EditAttribute::SenderRevoke));
-
-        // Should NOT add decrypt-fail="hide"
-        assert!(!should_add_decrypt_fail_hide(&EditAttribute::Empty));
-        assert!(!should_add_decrypt_fail_hide(&EditAttribute::AdminRevoke));
+        assert!(!hide(EditAttribute::SenderRevoke));
+        assert!(!hide(EditAttribute::Empty));
+        assert!(!hide(EditAttribute::AdminRevoke));
     }
 
     #[test]


### PR DESCRIPTION
## Finding (WA Web parity audit, area: send/encrypt)

`should_hide_decrypt_fail_for_send` (wacore/src/send.rs) set `decrypt-fail="hide"` whenever the edit attribute was non-empty and not `AdminRevoke`. A from_me protocol `REVOKE` is inferred as `EditAttribute::SenderRevoke` (wacore/src/types/message.rs), so sender revokes shipped with the hide attribute.

WA Web `WAWebE2EProtoUtils.decryptFailAttributeFromProtobuf` never returns `Hide` for `REVOKE`. The server is also reported to drop revoke stanzas carrying the hide attribute, which is exactly why `AdminRevoke` is already excluded; `SenderRevoke` is the same protocol REVOKE and should be treated identically.

## Change

Exclude `SenderRevoke` alongside `AdminRevoke` in the edit-derived hide rule. Content-based hiding (reaction/pin/etc. via `should_hide_decrypt_fail`) is unaffected.

## Testing

Added `mod decrypt_fail_for_send`: sender-revoke and admin-revoke are not hidden, a normal message edit still hides, and a reaction under a revoke edit still hides on its own merits. `cargo fmt`, `cargo clippy -p wacore --tests`, `cargo test -p wacore` pass.

Draft — one of several from a WA Web parity audit; review independently.