### PR TITLE
fix(send): serialize the group sender-key chain per (group, sender)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,6 +2215,7 @@ version = "0.6.0"
 dependencies = [
  "aes",
  "arrayref",
+ "async-lock",
  "async-trait",
  "bytes",
  "cbc",

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -126,8 +126,8 @@ impl<'a> Signal<'a> {
     /// participants when present. This matches WA Web which only creates
     /// SKDM on first group encrypt or after sender key rotation.
     ///
-    /// Not safe to call concurrently with `decrypt_group_message` for the
-    /// same group — sender key state is not internally locked.
+    /// Concurrent calls for the same `(group, sender)` are serialized on the
+    /// sender-key chain, so the SKDM and the skmsg can't be split across keys.
     pub async fn encrypt_group_message(
         &self,
         group_jid: &Jid,
@@ -136,6 +136,14 @@ impl<'a> Signal<'a> {
         let own_jid = self.client.get_own_jid_for_group(group_jid).await?;
         let sender_addr = own_jid.to_protocol_address();
         let sender_key_name = make_sender_key_name(group_jid, &sender_addr);
+
+        // Serialize the key-existence check + SKDM creation + encrypt for this chain.
+        let chain_lock = self
+            .client
+            .signal_cache
+            .sender_key_lock(&sender_key_name)
+            .await;
+        let _chain_guard = chain_lock.lock().await;
 
         // Only create SKDM when no sender key exists (matches WA Web behavior)
         let device_store = self.client.persistence_manager.get_device_arc().await;
@@ -155,8 +163,7 @@ impl<'a> Signal<'a> {
             Some(
                 wacore::send::create_sender_key_distribution_message_for_group(
                     &mut adapter.sender_key_store,
-                    group_jid,
-                    &sender_addr,
+                    &sender_key_name,
                 )
                 .await?,
             )
@@ -166,8 +173,7 @@ impl<'a> Signal<'a> {
 
         let ciphertext = wacore::send::encrypt_group_message(
             &mut adapter.sender_key_store,
-            group_jid,
-            &sender_addr,
+            &sender_key_name,
             plaintext,
             &mut rng,
         )

--- a/src/send.rs
+++ b/src/send.rs
@@ -1037,10 +1037,8 @@ impl Client {
             )
             .await?
         } else if to.is_group() {
-            // Group messages: no client-level lock needed. The encrypt fan-out
-            // inside prepare_group_stanza touches a different Signal session
-            // per recipient device, so concurrent group sends to the same
-            // chat don't race on shared state.
+            // No send-level lock: encrypt_group_message serializes the
+            // sender-key chain advance per (group, sender) at the cipher.
             let mut group_info = self.groups().query_info(&to).await?;
 
             let mut device_snapshot = self.persistence_manager.get_device_snapshot().await;

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -269,4 +269,11 @@ impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
             .await
             .map_err(signal_err("backend"))
     }
+
+    async fn sender_key_lock(
+        &self,
+        sender_key_name: &SenderKeyName,
+    ) -> std::sync::Arc<async_lock::Mutex<()>> {
+        self.0.cache.sender_key_lock(sender_key_name).await
+    }
 }

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -10,6 +10,7 @@ description = "Signal Protocol implementation for the WhatsApp platform"
 [dependencies]
 aes = { workspace = true }
 arrayref = "0.3.9"
+async-lock = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 cbc = { version = "0.2", features = ["alloc"] }

--- a/wacore/libsignal/src/protocol/group_cipher.rs
+++ b/wacore/libsignal/src/protocol/group_cipher.rs
@@ -50,6 +50,9 @@ thread_local! {
     static DECRYPTION_BUFFER: RefCell<CryptoBuffer> = RefCell::new(CryptoBuffer::new());
 }
 
+/// Caller must hold `SenderKeyStore::sender_key_lock` for `sender_key_name`
+/// across this call (and any paired SKDM creation) so the load/advance/store
+/// of the chain is atomic against concurrent encrypts.
 pub async fn group_encrypt<R: Rng + CryptoRng>(
     sender_key_store: &mut dyn SenderKeyStore,
     sender_key_name: &SenderKeyName,

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -162,6 +162,16 @@ pub trait SenderKeyStore: ThreadSafe {
         &self,
         sender_key_name: &SenderKeyName,
     ) -> Result<Option<SenderKeyRecord>>;
+
+    /// Serializes the load/advance/store of one sender-key chain so concurrent
+    /// encrypts to the same `(group, sender)` can't reuse a chain iteration.
+    /// Default is uncontended; stores over shared state override it.
+    async fn sender_key_lock(
+        &self,
+        _sender_key_name: &SenderKeyName,
+    ) -> std::sync::Arc<async_lock::Mutex<()>> {
+        std::sync::Arc::new(async_lock::Mutex::new(()))
+    }
 }
 
 /// Mixes in all the store interfaces defined in this module.

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -3,6 +3,7 @@ use crate::libsignal::protocol::{
     CiphertextMessage, ProtocolAddress, SENDERKEY_MESSAGE_CURRENT_VERSION, SenderKeyMessage,
     SenderKeyStore, SignalProtocolError, UsePQRatchet, message_encrypt, process_prekey_bundle,
 };
+use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::messages::MessageUtils;
 use crate::reporting_token::{
     build_reporting_node, generate_reporting_token, prepare_message_with_context,
@@ -270,10 +271,12 @@ pub fn should_hide_decrypt_fail(msg: &wa::Message) -> bool {
         })
 }
 
+/// Caller must hold `SenderKeyStore::sender_key_lock` for `sender_key_name`
+/// across the surrounding SKDM creation + this encrypt, so a concurrent send
+/// can't split the key between the SKDM and the skmsg.
 pub async fn encrypt_group_message<S, R>(
     sender_key_store: &mut S,
-    group_jid: &Jid,
-    sender_address: &ProtocolAddress,
+    sender_key_name: &SenderKeyName,
     plaintext: &[u8],
     csprng: &mut R,
 ) -> Result<SenderKeyMessage>
@@ -281,7 +284,6 @@ where
     S: SenderKeyStore + ?Sized,
     R: Rng + CryptoRng,
 {
-    let sender_key_name = make_sender_key_name(group_jid, sender_address);
     log::debug!(
         "Attempting to load sender key for group {} sender {}",
         sender_key_name.group_id(),
@@ -289,7 +291,7 @@ where
     );
 
     let mut record = sender_key_store
-        .load_sender_key(&sender_key_name)
+        .load_sender_key(sender_key_name)
         .await?
         .ok_or_else(|| {
             SignalProtocolError::NoSenderKeyState(format!(
@@ -334,7 +336,7 @@ where
     sender_key_state.set_sender_chain_key(sender_chain_key.next()?);
 
     sender_key_store
-        .store_sender_key(&sender_key_name, record)
+        .store_sender_key(sender_key_name, record)
         .await?;
 
     Ok(skm)
@@ -1324,7 +1326,15 @@ pub async fn prepare_group_stanza<
     let mut phash_for_stanza: Option<String> = None;
     let mut skdm_encrypted_devices: Vec<Jid> = Vec::new();
 
-    let sender_address = own_sending_jid.to_protocol_address();
+    // Build the chain name once and hold its lock across SKDM creation + the
+    // skmsg encrypt, so concurrent same-(group, sender) sends can't split the
+    // key between the SKDM and the skmsg (nor reuse a chain iteration).
+    let sender_key_name = make_sender_key_name(&to_jid, &own_sending_jid.to_protocol_address());
+    let chain_lock = stores
+        .sender_key_store
+        .sender_key_lock(&sender_key_name)
+        .await;
+    let _chain_guard = chain_lock.lock().await;
 
     // Determine if we need to distribute SKDM and to which devices
     let distribution_list: Option<Vec<Jid>> = if let Some(target_devices) = skdm_target_devices {
@@ -1457,8 +1467,7 @@ pub async fn prepare_group_stanza<
         }
         let axolotl_skdm_bytes = create_sender_key_distribution_message_for_group(
             stores.sender_key_store,
-            &to_jid,
-            &sender_address,
+            &sender_key_name,
         )
         .await?;
 
@@ -1526,8 +1535,7 @@ pub async fn prepare_group_stanza<
     let plaintext = MessageUtils::encode_and_pad(&message_for_encryption);
     let skmsg = encrypt_group_message(
         stores.sender_key_store,
-        &to_jid,
-        &sender_address,
+        &sender_key_name,
         &plaintext,
         &mut rand::make_rng::<rand::rngs::StdRng>(),
     )
@@ -1635,16 +1643,16 @@ pub(crate) fn collect_stale_device_users(
     user_set.into_iter().collect()
 }
 
+/// Caller must hold `SenderKeyStore::sender_key_lock` for `sender_key_name`
+/// across this creation + the matching skmsg encrypt (see `encrypt_group_message`).
 pub async fn create_sender_key_distribution_message_for_group(
     store: &mut (dyn SenderKeyStore + Send + Sync),
-    group_jid: &Jid,
-    sender_address: &ProtocolAddress,
+    sender_key_name: &SenderKeyName,
 ) -> Result<Vec<u8>> {
-    let sender_key_name = make_sender_key_name(group_jid, sender_address);
     let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
     let skdm = crate::libsignal::protocol::create_sender_key_distribution_message(
-        &sender_key_name,
+        sender_key_name,
         store,
         &mut rng,
     )

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -54,6 +54,9 @@ pub struct SignalStoreCache {
     sender_keys: Mutex<SenderKeyStoreState>,
     /// Avoids per-flush Vec allocation on the hot path (called after every message).
     flush_encode_buf: Mutex<Vec<u8>>,
+    /// Per-(group, sender) locks serializing each sender-key chain advance.
+    /// Coordination only (like the client session locks): never time-evicted.
+    sender_key_locks: Mutex<HashMap<Arc<str>, Arc<Mutex<()>>>>,
     max_entries: usize,
 }
 
@@ -267,6 +270,7 @@ impl SignalStoreCache {
             identities: Mutex::new(ByteStoreState::new()),
             sender_keys: Mutex::new(SenderKeyStoreState::new()),
             flush_encode_buf: Mutex::new(Vec::with_capacity(4096)),
+            sender_key_locks: Mutex::new(HashMap::new()),
             max_entries,
         }
     }
@@ -471,6 +475,22 @@ impl SignalStoreCache {
         state.evict_if_needed(self.max_entries);
     }
 
+    /// Shared lock for the `name` chain. Same name returns the same lock so a
+    /// concurrent encrypt can't read a chain iteration another is advancing.
+    pub async fn sender_key_lock(&self, name: &SenderKeyName) -> Arc<Mutex<()>> {
+        let mut map = self.sender_key_locks.lock().await;
+        if let Some(lock) = map.get(name.cache_key()) {
+            return lock.clone();
+        }
+        // Drop idle locks (held only by the map) once the map grows large.
+        if map.len() >= self.max_entries {
+            map.retain(|_, lock| Arc::strong_count(lock) > 1);
+        }
+        let lock = Arc::new(Mutex::new(()));
+        map.insert(Arc::from(name.cache_key()), lock.clone());
+        lock
+    }
+
     pub async fn delete_sender_key(&self, cache_key: &str) {
         let mut state = self.sender_keys.lock().await;
         state.delete(cache_key);
@@ -598,5 +618,40 @@ impl SignalStoreCache {
         self.sessions.lock().await.clear();
         self.identities.lock().await.clear();
         self.sender_keys.lock().await.clear();
+    }
+}
+
+#[cfg(test)]
+mod sender_key_lock_tests {
+    use super::*;
+    use crate::libsignal::store::sender_key_name::SenderKeyName;
+
+    #[tokio::test]
+    async fn same_name_shares_one_lock() {
+        let cache = SignalStoreCache::new();
+        let a = SenderKeyName::from_parts("g1@g.us", "u1@s.whatsapp.net:0");
+        let b = SenderKeyName::from_parts("g2@g.us", "u1@s.whatsapp.net:0");
+
+        let l1 = cache.sender_key_lock(&a).await;
+        let l2 = cache.sender_key_lock(&a).await;
+        let l3 = cache.sender_key_lock(&b).await;
+
+        assert!(Arc::ptr_eq(&l1, &l2), "same name must share one lock");
+        assert!(!Arc::ptr_eq(&l1, &l3), "different names must not share");
+    }
+
+    #[tokio::test]
+    async fn same_name_lock_is_mutually_exclusive() {
+        let cache = SignalStoreCache::new();
+        let name = SenderKeyName::from_parts("g@g.us", "u@s.whatsapp.net:0");
+        let lock = cache.sender_key_lock(&name).await;
+
+        let guard = lock.lock().await;
+        assert!(
+            lock.try_lock().is_none(),
+            "held lock must block a second acquire"
+        );
+        drop(guard);
+        assert!(lock.try_lock().is_some(), "released lock must reacquire");
     }
 }


### PR DESCRIPTION
## Finding (WA Web parity audit, area: send/encrypt)

Concurrent `send_message()` calls to the same group raced the sender-key chain. The group send path performs **two** chain operations -- SKDM creation (`create_sender_key_distribution_message_*`, which creates the key if absent) and then the skmsg encrypt (`encrypt_group_message`, which advances the chain) -- over a store shared via `Arc<SignalStoreCache>`, with no serialization between them.

- Two concurrent **first/rotated** sends could each create a *different* sender key (A and B): one ends up distributed in the SKDM while the skmsg is encrypted under the other, so recipients install A and cannot decrypt a B-encrypted message.
- Two concurrent **steady-state** sends could read the same chain iteration and emit two skmsgs at it (one becomes undecryptable / the chain desyncs).

This is reachable on any same-group concurrency (e.g. a gateway serving two requests to one group), not just flooding.

## WA Web parity

`WAWebSendGroupMsgJob.encryptAndSendGroupMsg` runs its whole body inside `WAWebSendMsgQueueMap.sendMsgQueueMap.enqueue(groupJid, ...)` -- serialized per destination group JID -- because the sender-key ratchet is inherently sequential and the SKDM must match the skmsg.

## Change

Serialize **both** chain operations as one unit, per `(group, sender)`, with a lock owned by the cache:

- `SenderKeyStore` gains `sender_key_lock(name)` with a default uncontended impl, so the in-memory test/bench stores need no changes. `SenderKeyAdapter` delegates to `SignalStoreCache`, which hands out one shared `Arc<Mutex<()>>` per chain (keyed by the same `cache_key` as the sender keys).
- The **orchestrators** -- `prepare_group_stanza` and the `SignalApi` group-encrypt helper -- hold that lock across SKDM creation + skmsg encrypt. The cipher building blocks (`encrypt_group_message`, `create_sender_key_distribution_message_for_group`, `group_encrypt`) document the contract instead of self-locking, mirroring `encrypt_for_devices`.

The lock is held at the orchestrator (not inside each cipher) precisely so the SKDM and the skmsg can't be split across two different keys -- locking only the encrypt would leave the preceding SKDM-create unguarded.

## Performance / allocation

- The `SenderKeyName` is now built **once** per send and threaded into both the SKDM creation and the encrypt, instead of being rebuilt 2-3x -- dropping a few small-string allocations per send.
- Same-`(group, sender)` lock lookups are **allocation free** (`HashMap::get` by `&str` via `Borrow`, then `Arc` clone). Only the first send per chain allocates the lock entry. The lock map is coordination-only (never time-evicted) and prunes idle entries when it grows past the cache bound.
- The lock does **not** cover `query_info` or the per-device SKDM fanout sessions; different groups and DMs are unaffected.

## Testing

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p wacore` (799), `cargo test -p wacore-libsignal` (108) pass. Added cache tests: same name returns one shared lock (distinct names don't), and a held lock blocks a second acquire.

## Known separate follow-up (not in this PR)

The SKDM fan-out calls `encrypt_for_devices` without the per-device session locks its contract requires; two sends to *different* groups sharing a recipient device can still race that pairwise session during distribution. Pre-existing, cross-group, needs sorted per-device locks with its own deadlock analysis -- tracked separately.

Draft -- from a WA Web parity audit; review independently.