### PR TITLE
perf(retry): replace session-recreate Mutex with a TTL cache, atomic per-peer check+stamp

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -182,6 +182,9 @@ pub struct CacheConfig {
     /// Sender key device tracking cache (time_to_idle). Default: 1h TTI, 500 entries.
     /// Caches per-group SKDM distribution state to avoid DB reads on every group send.
     pub sender_key_devices_cache: CacheEntryConfig,
+    /// Session-recreate throttle history (time_to_live). Default: 1h TTL, 256
+    /// entries. Replaces a global `Mutex<HashMap>` scanned O(n) per retry receipt.
+    pub session_recreate_history: CacheEntryConfig,
 
     // --- Coordination caches (capacity-only, no TTL) ---
     /// Per-device Signal session lock capacity. Default: 10000.
@@ -226,6 +229,7 @@ impl std::fmt::Debug for CacheConfig {
             .field("undecryptable_dispatched", &self.undecryptable_dispatched)
             .field("pdo_pending_requests", &self.pdo_pending_requests)
             .field("sender_key_devices_cache", &self.sender_key_devices_cache)
+            .field("session_recreate_history", &self.session_recreate_history)
             .field("session_locks_capacity", &self.session_locks_capacity)
             .field("chat_lanes_capacity", &self.chat_lanes_capacity)
             .field("sent_message_ttl_secs", &self.sent_message_ttl_secs)
@@ -262,6 +266,7 @@ impl Default for CacheConfig {
             undecryptable_dispatched: CacheEntryConfig::new(five_min, 1_000),
             pdo_pending_requests: CacheEntryConfig::new(Some(Duration::from_secs(30)), 200),
             sender_key_devices_cache: CacheEntryConfig::new(one_hour, 500),
+            session_recreate_history: CacheEntryConfig::new(one_hour, 256),
             // Coordination caches hold live mutexes/senders; capacity eviction
             // while a reference is held creates a second lock for the same key,
             // breaking serialization. Size generously to avoid eviction pressure.

--- a/src/client.rs
+++ b/src/client.rs
@@ -433,8 +433,7 @@ pub struct Client {
     /// base-key collision — sessions that diverged without either trigger
     /// stay stuck. This map throttles the fallback so a noisy peer can't
     /// loop us through prekey fetches.
-    pub(crate) session_recreate_history:
-        Arc<std::sync::Mutex<HashMap<wacore_binary::jid::Jid, wacore::time::Instant>>>,
+    pub(crate) session_recreate_history: Cache<wacore_binary::jid::Jid, wacore::time::Instant>,
 
     /// Dispatch-once gate for `UndecryptableMessage`: a server resend of a
     /// failed id re-enters the failure path and would otherwise fire a
@@ -835,7 +834,7 @@ impl Client {
 
             recent_retry_reasons: cache_config.message_retry_counts.build_with_ttl(),
 
-            session_recreate_history: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            session_recreate_history: cache_config.session_recreate_history.build_with_ttl(),
 
             undecryptable_dispatched: cache_config.undecryptable_dispatched.build_with_ttl(),
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -410,19 +410,29 @@ impl Client {
 
         // Whatsmeow parity (`retry.go:284`). WA Web's regId/base-key check
         // doesn't catch silently-diverged sessions; this fallback does.
-        if nr.get_optional_child("keys").is_none()
-            && let Some(reason) = self
-                .should_recreate_session(retry_count, &resolved_jid)
-                .await
-        {
-            info!("Recreating session with {resolved_jid} for retry of {message_id}: {reason}");
+        if nr.get_optional_child("keys").is_none() {
+            // Hold the per-peer session lock across the throttle check+stamp AND
+            // the delete so the recreate decision is atomic per peer. The moka
+            // `session_recreate_history` get+insert is not atomic on its own,
+            // and retry receipts for different message_ids from the same peer
+            // dispatch concurrently (detached spawn in `handle_receipt`), so
+            // without this lock two of them could both pass the throttle and
+            // recreate. Mirrors whatsmeow holding `sessionRecreateHistoryLock`
+            // across its check+stamp (`retry.go:160`). This is the same per-peer
+            // lock the delete already used, so it adds no new lock.
             let signal_address = resolved_jid.to_protocol_address();
             let lock = self.session_lock_for(signal_address.as_str()).await;
-            let _guard = lock.lock().await;
-            self.signal_cache.delete_session(&signal_address).await;
-            drop(_guard);
-            self.flush_signal_cache_logged("should_recreate_session", Some(&message_id))
-                .await;
+            let guard = lock.lock().await;
+            if let Some(reason) = self
+                .should_recreate_session(retry_count, &resolved_jid)
+                .await
+            {
+                info!("Recreating session with {resolved_jid} for retry of {message_id}: {reason}");
+                self.signal_cache.delete_session(&signal_address).await;
+                drop(guard);
+                self.flush_signal_cache_logged("should_recreate_session", Some(&message_id))
+                    .await;
+            }
         }
 
         // Status broadcasts can't resend (requires explicit recipient list).
@@ -774,7 +784,12 @@ impl Client {
             return None;
         }
 
-        // Throttle: skip if this peer was recreated within the timeout.
+        // Throttle: skip if this peer was recreated within the timeout. This
+        // explicit age check against the injectable `now` is the authoritative,
+        // deterministic gate. moka's 1h TTL on `session_recreate_history` is
+        // only a real-wall-clock memory backstop (it evicts on moka's own clock,
+        // which tests don't advance and which the stored `now` doesn't drive).
+        // Do NOT drop this check as "redundant with the TTL".
         if let Some(prev) = history.get(jid).await
             && now.saturating_duration_since(prev) < RECREATE_SESSION_TIMEOUT
         {
@@ -2034,6 +2049,83 @@ mod tests {
                 .await
                 .is_some_and(|r| r.contains("don't have a Signal session")),
             "missing session should recreate"
+        );
+    }
+
+    /// The moka `session_recreate_history` is capacity-bounded (256), unlike the
+    /// old age-only prune which never evicted a still-recent entry. Under more
+    /// than that many distinct peers retrying within the window, moka can evict
+    /// a recent entry, costing at most one extra recreate for that peer
+    /// (bounded and self-healing: re-stamped on the next receipt), never the
+    /// unbounded prekey loop the throttle prevents. Documents that trade-off.
+    #[tokio::test]
+    async fn session_recreate_history_is_capacity_bounded() {
+        let client =
+            crate::test_utils::create_test_client_with_failing_http("session_recreate_history_cap")
+                .await;
+        let now = wacore::time::Instant::now();
+        let cap: u64 = 256;
+
+        // Insert well over the cap of distinct, all-recent peers.
+        for i in 0..(cap * 2) {
+            let jid = Jid::lid_device(format!("{}", 900_000_000_000_000u64 + i), 3);
+            client.session_recreate_history.insert(jid, now).await;
+        }
+        client.session_recreate_history.run_pending_tasks().await;
+
+        let count = client.session_recreate_history.entry_count();
+        assert!(
+            count <= cap,
+            "capacity must bound the throttle history (got {count}, cap {cap}); \
+             a still-recent entry can be evicted under heavy peer load"
+        );
+    }
+
+    /// Atomicity guard for the per-peer session lock the retry caller wraps
+    /// around the recreate check+stamp. moka's get+insert is not atomic, and
+    /// same-peer retries for different message_ids dispatch concurrently, so
+    /// without the lock both could observe a cold history and recreate. Holding
+    /// `session_lock_for` serializes the decision: exactly one recreate fires.
+    /// (Mirrors the caller's lock; the matrix test covers the sequential logic.)
+    #[tokio::test]
+    async fn concurrent_same_peer_recreate_check_is_serialized() {
+        let client =
+            crate::test_utils::create_test_client_with_failing_http("concurrent_recreate").await;
+        let jid = Jid::lid_device("999999999999993".to_string(), 3);
+
+        // Seed a session so the retry>=2 throttle branch is exercised (the
+        // no-session branch always stamps and would not show serialization).
+        let session_bytes = valid_serialized_session(8888, vec![0xCC; 32]);
+        client
+            .persistence_manager
+            .backend()
+            .put_session(jid.to_protocol_address().as_str(), &session_bytes)
+            .await
+            .unwrap();
+
+        let c1 = client.clone();
+        let j1 = jid.clone();
+        let task1 = async move {
+            let addr = j1.to_protocol_address();
+            let lock = c1.session_lock_for(addr.as_str()).await;
+            let _g = lock.lock().await;
+            c1.should_recreate_session(2, &j1).await.is_some()
+        };
+        let c2 = client.clone();
+        let j2 = jid.clone();
+        let task2 = async move {
+            let addr = j2.to_protocol_address();
+            let lock = c2.session_lock_for(addr.as_str()).await;
+            let _g = lock.lock().await;
+            c2.should_recreate_session(2, &j2).await.is_some()
+        };
+        let (a, b) = tokio::join!(task1, task2);
+
+        assert_eq!(
+            usize::from(a) + usize::from(b),
+            1,
+            "exactly one of two concurrent same-peer recreate checks may fire; \
+             the per-peer session lock serializes the non-atomic get+insert"
         );
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -86,10 +86,6 @@ const MIN_RETRY_FOR_BASE_KEY_CHECK: u8 = 2;
 /// whatsmeow's `recreateSessionTimeout` (`retry.go:156`).
 const RECREATE_SESSION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3600);
 
-/// Prune `session_recreate_history` only when it crosses this size, to avoid
-/// paying O(n) under a global Mutex on every retry receipt.
-const SESSION_RECREATE_HISTORY_PRUNE_THRESHOLD: usize = 256;
-
 /// Separated chat and requester JIDs for retry receipt handling.
 /// Mirrors WAWebHandleRetryRequest `getActualChatInfo` + `getTargetChat`.
 struct RetryChatInfo {
@@ -767,21 +763,10 @@ impl Client {
         };
         drop(device_guard);
 
-        let mut history = self
-            .session_recreate_history
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-
-        // Prune lazily — every call under a global Mutex is O(n) and serializes
-        // retry receipts across sessions. Threshold tuned so the map can't grow
-        // unbounded but the common case skips the scan.
-        if history.len() > SESSION_RECREATE_HISTORY_PRUNE_THRESHOLD {
-            history
-                .retain(|_, prev| now.saturating_duration_since(*prev) < RECREATE_SESSION_TIMEOUT);
-        }
+        let history = &self.session_recreate_history;
 
         if !has_session {
-            history.insert(jid.clone(), now);
+            history.insert(jid.clone(), now).await;
             return Some("we don't have a Signal session with them");
         }
 
@@ -789,16 +774,14 @@ impl Client {
             return None;
         }
 
-        // Check age explicitly — lazy pruning may leave an expired entry in
-        // the map. Without this check a peer would stay pinned to its first
-        // recreate forever in low-traffic deployments.
-        if let Some(prev) = history.get(jid)
-            && now.saturating_duration_since(*prev) < RECREATE_SESSION_TIMEOUT
+        // Throttle: skip if this peer was recreated within the timeout.
+        if let Some(prev) = history.get(jid).await
+            && now.saturating_duration_since(prev) < RECREATE_SESSION_TIMEOUT
         {
             return None;
         }
 
-        history.insert(jid.clone(), now);
+        history.insert(jid.clone(), now).await;
         Some("retry count > 1 and over an hour since last recreation")
     }
 
@@ -2003,9 +1986,8 @@ mod tests {
         assert!(
             client
                 .session_recreate_history
-                .lock()
-                .unwrap()
                 .get(&jid_with)
+                .await
                 .is_none(),
             "no-op path must not stamp the history"
         );
@@ -2018,12 +2000,7 @@ mod tests {
                 .is_some_and(|r| r.contains("retry count > 1")),
             "retry≥2 with cold history should recreate"
         );
-        let after_first = client
-            .session_recreate_history
-            .lock()
-            .unwrap()
-            .get(&jid_with)
-            .copied();
+        let after_first = client.session_recreate_history.get(&jid_with).await;
         assert!(after_first.is_some(), "first recreate must stamp history");
 
         // 3) session present + retry≥2 + recent history → throttled.
@@ -2032,24 +2009,14 @@ mod tests {
             "retry≥2 within {}s should be throttled",
             RECREATE_SESSION_TIMEOUT.as_secs()
         );
-        let after_second = client
-            .session_recreate_history
-            .lock()
-            .unwrap()
-            .get(&jid_with)
-            .copied();
+        let after_second = client.session_recreate_history.get(&jid_with).await;
         assert_eq!(
             after_first, after_second,
             "throttled path must not re-stamp the history"
         );
 
-        // 4) Throttle entry past the window must allow a fresh recreate.
-        // Lazy pruning (size threshold) leaves expired entries in the map for
-        // small deployments, so the age check at the decision site is
-        // load-bearing. Pass a future `now` via the injectable-clock variant
-        // because subtracting a Duration from a young test runtime's Instant
-        // would saturate to zero (still "recent" relative to that runtime's
-        // own now), exercising the wrong branch.
+        // 4) Past the throttle window → fresh recreate. Use a future `now`
+        // (subtracting from a young runtime's Instant would saturate to zero).
         let stamp_then = after_first.expect("first recreate stamped history");
         let well_past = stamp_then + RECREATE_SESSION_TIMEOUT + std::time::Duration::from_secs(1);
         assert!(


### PR DESCRIPTION
Replaces a global `Mutex<HashMap<Jid, Instant>>` (the session-recreate throttle) with a moka TTL cache, removing cross-peer lock contention and an O(n) prune, and makes the throttle check+stamp atomic per peer.

## Change

`should_recreate_session` held a global `Mutex<HashMap<Jid, Instant>>` on every retry receipt and ran an O(n) `retain()` prune once the map passed 256 entries, serializing recreate checks across all unrelated peers.

Replaced with a moka `Cache<Jid, Instant>` (1h TTL, 256 cap) via the existing `CacheEntryConfig`/`build_with_ttl` pattern: capacity + TTL bound growth (no manual prune) and moka is internally lock-striped, so different peers no longer contend. The explicit age check against the injectable `now` is the authoritative, deterministic throttle gate; moka's 1h TTL is only a real-wall-clock memory backstop (it evicts on moka's own clock, which tests don't advance).

### Atomicity

A bare moka `get`+`insert` is not atomic, and retry receipts for different `message_id`s from the same peer dispatch concurrently (detached spawn in `handle_receipt`), so two of them could both observe a cold history and recreate. The check+stamp is therefore done inside the per-peer `session_lock_for` lock that the recreate branch already acquired for `delete_session`: no new lock, just acquired before the check instead of only around the delete. This restores whatsmeow's atomic check+stamp (it holds `sessionRecreateHistoryLock` across the whole decision, `retry.go:160`), so exactly one recreate fires per peer.

### Trade-off

The 256-entry cap uses moka LRU/TinyLFU eviction, so under more than 256 distinct peers retrying within the 1h window a still-recent throttle entry can be evicted, costing at most one extra session recreate for that peer (bounded and self-healing, since the next receipt re-stamps it), never the unbounded prekey loop the throttle exists to prevent. This is strictly bounded but slightly weaker than the old age-only prune, which never evicted a still-recent entry (it grew unbounded instead). moka also adds ~400-600B idle overhead per instance vs a bare `HashMap`, traded for the removed lock contention and prune.

If a hard memory bound is not required, the cap can be raised substantially (each entry is just a `Jid` + an 8-byte `Instant`) to make recent-entry eviction effectively impossible, matching the deliberately-unbounded sibling `lid_pn_cache`. Left at 256 here; tunable via `CacheConfig::session_recreate_history`.

## Testing

`cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace --exclude e2e-tests` all pass. Tests:

- `should_recreate_session_matrix` — cold / throttled-no-restamp / past-window / no-session / no-op-no-stamp (updated to the cache API).
- `concurrent_same_peer_recreate_check_is_serialized` — two concurrent same-peer checks under the session lock yield exactly one recreate (atomicity guard).
- `session_recreate_history_is_capacity_bounded` — documents that the 256 cap can evict a still-recent entry under heavy peer load (the bounded weakening above).

## Scope note

This PR originally also included a `signal_cache::flush` change (release the store lock during backend I/O). Adversarial review (reviewer + a deep pass + Codex) found multiple concurrency holes in that approach: eviction of in-flight entries, infinite re-dirty loops on corrupt entries, asymmetric delete re-marking, and a production-reachable overlapping-flush stale-write. The original lock-held flush is correct, so the flush change was dropped from this PR; it needs a ground-up correct design (serialized flushes + in-flight eviction protection + write ordering) as a separate effort. This PR keeps only the clean, self-contained retry-throttle change.
