### PR TITLE
fix(offline): clear self-fanout with sender receipt, not a bare ack

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -125,7 +125,7 @@ impl Client {
         // `<receipt>`. A 1:1 bot chat keeps the normal receipt (chat.isBot() →
         // the branch's `v` is false). Our transport ack is that bare
         // `<ack class="message">` (group form carries `participant`).
-        if info.source.chat.server != wacore_binary::Server::Bot && info.source.sender.is_bot() {
+        if info.source.is_bot_authored_non_bot_chat() {
             self.spawn_message_ack(info);
             return;
         }
@@ -586,9 +586,14 @@ impl Client {
             // A self-fanout is our own message; retrying it to ourselves is
             // futile and the server's offline queue ignores a bare transport
             // ack, so it would replay forever. Clear it with the sender receipt
-            // instead (same stanza the success/duplicate paths now emit). Gate
-            // on the same delivery-receipt eligibility as the normal ack path.
-            if info.source.is_self_fanout() && Self::should_send_delivery_receipt(&info) {
+            // instead (same stanza the success/duplicate paths now emit). Mirror
+            // ack_received_message: a bot-authored message in a non-bot chat
+            // takes the bot-invoke-response bare ack (the retry path below), not
+            // the sender receipt. Gate on the same eligibility as the ack path.
+            if info.source.is_self_fanout()
+                && !info.source.is_bot_authored_non_bot_chat()
+                && Self::should_send_delivery_receipt(&info)
+            {
                 client.send_delivery_receipt(&info).await;
                 return;
             }
@@ -7453,6 +7458,47 @@ mod tests {
             !saw_retry,
             "must not retry our own undecryptable fanout to ourselves"
         );
+    }
+
+    /// Consistency with the success/duplicate path: a bot-authored own DM in a
+    /// non-bot chat (sender on `@bot`, user chat) must NOT take the sender
+    /// receipt on the decrypt-failure path either; it stays on the
+    /// bot-invoke-response bare-ack path (WA Web `!chat.isBot() &&
+    /// author.isBot()`), matching ack_received_message and the locked
+    /// own_bot_author_dm_acks_not_sender_receipt test.
+    #[tokio::test]
+    async fn bot_author_self_fanout_decrypt_failure_not_sender_receipt() {
+        let (client, transport) = capturing_client("bot_author_badmac").await;
+        let info = Arc::new(MessageInfo {
+            id: "OWNBOTFAIL1".to_string(),
+            source: crate::types::message::MessageSource {
+                sender: "100000000000002@bot".parse().expect("sender"),
+                chat: "300000000000003@lid".parse().expect("chat"),
+                recipient: Some("300000000000003@lid".parse().expect("recipient")),
+                is_from_me: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        client
+            .handle_decrypt_failure(
+                &info,
+                RetryReason::BadMac,
+                crate::types::events::DecryptFailMode::Hide,
+            )
+            .await;
+
+        // Settle: a bot-authored message must never produce a sender receipt on
+        // the failure path (it would diverge from WA Web's bot-invoke ack and
+        // contradict the success-path ordering).
+        for _ in 0..5 {
+            assert!(
+                find_receipt(&transport.sent(), "OWNBOTFAIL1").is_none(),
+                "bot-authored own DM must not be cleared with a sender <receipt> on decrypt failure"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
     }
 
     /// If the resend request fails to send, the stanza must NOT be acked, so the

--- a/src/message.rs
+++ b/src/message.rs
@@ -7278,6 +7278,30 @@ mod tests {
         None
     }
 
+    /// First `<receipt>` on the wire for `id` as `(to, type, recipient)`.
+    fn find_receipt(
+        frames: &[bytes::Bytes],
+        id: &str,
+    ) -> Option<(String, Option<String>, Option<String>)> {
+        for (i, frame) in frames.iter().enumerate() {
+            let Some(buf) = decode_frame(i, frame) else {
+                continue;
+            };
+            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+                continue;
+            };
+            if node.tag.as_ref() == "receipt"
+                && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+                && let Some(to) = node.get_attr("to")
+            {
+                let typ = node.get_attr("type").map(|v| v.as_str().to_string());
+                let recipient = node.get_attr("recipient").map(|v| v.as_str().to_string());
+                return Some((to.as_str().to_string(), typ, recipient));
+            }
+        }
+        None
+    }
+
     /// Count delivery `<receipt>` (anything but type="retry") on the wire for `id`.
     fn delivery_receipts_for(frames: &[bytes::Bytes], id: &str) -> usize {
         let mut count = 0;
@@ -7578,18 +7602,21 @@ mod tests {
         );
     }
 
-    /// Own-account fan-out (is_from_me, non-peer) has its delivery receipt
-    /// suppressed by `should_send_delivery_receipt`, so it must instead get a
-    /// transport ack (to = own LID) or the server replays it forever.
+    /// Own-account self-fanout (is_from_me, non-peer, carries a `recipient`):
+    /// our own outgoing message echoed back to this device. WA Web
+    /// (`isMeAccount(author) => SENDER`) and whatsmeow (`IsFromMe => "sender"`)
+    /// clear it with a `<receipt type="sender" recipient=...>`, NOT a bare
+    /// transport `<ack>`. The server's offline queue ignores the bare ack and
+    /// replays the stanza forever (the ~50min disconnect loop).
     #[tokio::test]
-    async fn own_account_message_acked_via_transport_ack() {
+    async fn own_self_fanout_acked_via_sender_receipt() {
         let (client, transport) = capturing_client("own_ack").await;
         let own = Arc::new(MessageInfo {
             id: "OWN1".to_string(),
             source: crate::types::message::MessageSource {
-                sender: "236395184570386@lid".parse().expect("sender"),
-                chat: "156535032389744@lid".parse().expect("chat"),
-                recipient: Some("156535032389744@lid".parse().expect("recipient")),
+                sender: "100000000000001@lid".parse().expect("sender"),
+                chat: "300000000000003@lid".parse().expect("chat"),
+                recipient: Some("300000000000003@lid".parse().expect("recipient")),
                 is_from_me: true,
                 ..Default::default()
             },
@@ -7599,21 +7626,77 @@ mod tests {
 
         let mut found = None;
         for _ in 0..80 {
-            if let Some(a) = find_message_ack(&transport.sent()) {
-                found = Some(a);
+            if let Some(r) = find_receipt(&transport.sent(), "OWN1") {
+                found = Some(r);
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
-        let (to, _) = found.expect("own-account message must get a transport ack");
+        let (to, typ, recipient) = found.expect("own self-fanout must get a sender <receipt>");
         assert_eq!(
-            to, "236395184570386@lid",
-            "ack must be addressed to the own LID"
+            to, "100000000000001@lid",
+            "receipt `to` must echo the own LID with its device"
         );
         assert_eq!(
-            delivery_receipts_for(&transport.sent(), "OWN1"),
-            0,
-            "own non-peer must NOT get a delivery receipt (it's suppressed)"
+            typ.as_deref(),
+            Some("sender"),
+            "own self-fanout receipt must be type=sender"
+        );
+        assert_eq!(
+            recipient.as_deref(),
+            Some("300000000000003@lid"),
+            "receipt must echo the fanout recipient"
+        );
+        assert!(
+            find_message_ack(&transport.sent()).is_none(),
+            "self-fanout must NOT also emit a bare transport <ack> (the server rejects it)"
+        );
+    }
+
+    /// Regression for the bot self-fanout disconnect loop: our own message to a
+    /// `@bot` recipient, echoed back as a duplicate/undecryptable stanza, must
+    /// be cleared with a `<receipt type="sender" recipient=@bot>`. Pre-fix it
+    /// got a bare `<ack class="message">` which the server ignored, replaying
+    /// the stanza every reconnect until a ~50min `<stream:error><ack/>` GC
+    /// force-closed the connection (the exact production symptom).
+    #[tokio::test]
+    async fn bot_self_fanout_acked_via_sender_receipt() {
+        let (client, transport) = capturing_client("bot_self_fanout").await;
+        let own = Arc::new(MessageInfo {
+            id: "AC00000000000000000000000000BEEF".to_string(),
+            source: crate::types::message::MessageSource {
+                // from = our own LID (the server fans our outgoing bot prompt
+                // back to this device); chat = the bot (recipient.to_non_ad).
+                sender: "100000000000001@lid".parse().expect("sender"),
+                chat: "200000000000002@bot".parse().expect("chat"),
+                recipient: Some("200000000000002@bot".parse().expect("recipient")),
+                is_from_me: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        client.ack_received_message(&own);
+
+        let mut found = None;
+        for _ in 0..80 {
+            if let Some(r) = find_receipt(&transport.sent(), "AC00000000000000000000000000BEEF") {
+                found = Some(r);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let (to, typ, recipient) =
+            found.expect("bot self-fanout must get a sender <receipt> to drain the offline queue");
+        assert_eq!(to, "100000000000001@lid", "receipt `to` is the own LID");
+        assert_eq!(typ.as_deref(), Some("sender"));
+        assert_eq!(
+            recipient.as_deref(),
+            Some("200000000000002@bot"),
+            "receipt must route to the bot recipient"
+        );
+        assert!(
+            find_message_ack(&transport.sent()).is_none(),
+            "the bare <ack> that triggered <stream:error><ack/> must no longer be emitted"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -7489,9 +7489,25 @@ mod tests {
             )
             .await;
 
-        // Settle: a bot-authored message must never produce a sender receipt on
-        // the failure path (it would diverge from WA Web's bot-invoke ack and
-        // contradict the success-path ordering).
+        // Positive: the message IS cleared, via the bot-invoke-response bare
+        // <ack class="message"> (the retry-to-self is bot-skipped, so the
+        // transport ack follows), proving we took the ack path, not a no-op.
+        let mut found_ack = false;
+        for _ in 0..80 {
+            if find_message_ack(&transport.sent()).is_some() {
+                found_ack = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            found_ack,
+            "bot-authored own DM must still be transport-acked with a bare <ack class=message>"
+        );
+
+        // Negative settle: it must NEVER produce a sender receipt on the failure
+        // path (that would diverge from WA Web's bot-invoke ack and contradict
+        // the success-path ordering).
         for _ in 0..5 {
             assert!(
                 find_receipt(&transport.sent(), "OWNBOTFAIL1").is_none(),

--- a/src/message.rs
+++ b/src/message.rs
@@ -586,8 +586,9 @@ impl Client {
             // A self-fanout is our own message; retrying it to ourselves is
             // futile and the server's offline queue ignores a bare transport
             // ack, so it would replay forever. Clear it with the sender receipt
-            // instead (same stanza the success/duplicate paths now emit).
-            if info.source.is_self_fanout() {
+            // instead (same stanza the success/duplicate paths now emit). Gate
+            // on the same delivery-receipt eligibility as the normal ack path.
+            if info.source.is_self_fanout() && Self::should_send_delivery_receipt(&info) {
                 client.send_delivery_receipt(&info).await;
                 return;
             }
@@ -7738,9 +7739,11 @@ mod tests {
         let own = Arc::new(MessageInfo {
             id: "AC00000000000000000000000000BEEF".to_string(),
             source: crate::types::message::MessageSource {
-                // from = our own LID (the server fans our outgoing bot prompt
-                // back to this device); chat = the bot (recipient.to_non_ad).
-                sender: "100000000000001@lid".parse().expect("sender"),
+                // from = our own LID with its device (the server fans our
+                // outgoing bot prompt back to this device); chat = the bot
+                // (recipient.to_non_ad). The device on the sender must survive
+                // into the receipt `to`, or the LID server rejects it (#649).
+                sender: "100000000000001:11@lid".parse().expect("sender"),
                 chat: "200000000000002@bot".parse().expect("chat"),
                 recipient: Some("200000000000002@bot".parse().expect("recipient")),
                 is_from_me: true,
@@ -7760,7 +7763,10 @@ mod tests {
         }
         let (to, typ, recipient) =
             found.expect("bot self-fanout must get a sender <receipt> to drain the offline queue");
-        assert_eq!(to, "100000000000001@lid", "receipt `to` is the own LID");
+        assert_eq!(
+            to, "100000000000001:11@lid",
+            "receipt `to` must preserve the own LID device"
+        );
         assert_eq!(typ.as_deref(), Some("sender"));
         assert_eq!(
             recipient.as_deref(),
@@ -7807,10 +7813,17 @@ mod tests {
             found.is_some(),
             "own bot-author DM must emit a bare <ack class=message> (WA Web bot-invoke-response ack), not a receipt"
         );
-        assert!(
-            find_receipt(&transport.sent(), "OWNBOT1").is_none(),
-            "must NOT route to a sender <receipt> (would diverge from WA Web's bot-invoke-response ack path)"
-        );
+        // No current race (ack_received_message is synchronous and the
+        // bot-author branch returns before the receipt branch), but settle
+        // briefly so a future regression that spawned a receipt on a later tick
+        // can't slip past this negative assertion.
+        for _ in 0..5 {
+            assert!(
+                find_receipt(&transport.sent(), "OWNBOT1").is_none(),
+                "must NOT route to a sender <receipt> (would diverge from WA Web's bot-invoke-response ack path)"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
     }
 
     /// An `<unavailable>` message (no `<enc>`) must be transport-acked so the

--- a/src/message.rs
+++ b/src/message.rs
@@ -112,10 +112,9 @@ impl Client {
     }
 
     /// Acknowledge a received message so the server drops it from the offline
-    /// queue: a delivery receipt when applicable, else a transport ack for
-    /// own-account fan-out (its receipt is suppressed but the stanza still needs
-    /// clearing; the ack carries the correct to=from). status is acked by the
-    /// `should_ack` gate, newsletters/empty ids need nothing here.
+    /// queue: a delivery receipt when applicable (incl. the `type="sender"`
+    /// receipt for own-account self-fanouts), else a transport ack. status is
+    /// acked by the `should_ack` gate, newsletters/empty ids need nothing here.
     fn ack_received_message(self: &Arc<Self>, info: &Arc<MessageInfo>) {
         if info.id.is_empty() || info.source.chat.is_newsletter() {
             return;
@@ -584,6 +583,14 @@ impl Client {
         let client = Arc::clone(self);
         let info = Arc::clone(info);
         self.outbound_flush.spawn(&*self.runtime, async move {
+            // A self-fanout is our own message; retrying it to ourselves is
+            // futile and the server's offline queue ignores a bare transport
+            // ack, so it would replay forever. Clear it with the sender receipt
+            // instead (same stanza the success/duplicate paths now emit).
+            if info.source.is_self_fanout() {
+                client.send_delivery_receipt(&info).await;
+                return;
+            }
             // Only ack once the resend request is actually out; otherwise leave
             // the stanza queued so the server redelivers and we retry.
             let resend_sent = client.run_retry_receipt(&info, reason).await;
@@ -7381,6 +7388,72 @@ mod tests {
         );
     }
 
+    /// Regression for the bot self-fanout loop on the DECRYPT-FAILURE path
+    /// (BadMac/NoSession): a self-fanout we cannot decrypt must be cleared with
+    /// a `<receipt type="sender">`, NOT a bare transport `<ack>` (ignored by the
+    /// server) nor a retry-to-self (futile). Once stuck in the loop the local
+    /// counter advances past the duplicate state, so this BadMac path is what
+    /// actually fires for an already-affected account.
+    #[tokio::test]
+    async fn self_fanout_decrypt_failure_acked_via_sender_receipt() {
+        let (client, transport) = capturing_client("self_fanout_badmac").await;
+        let info = Arc::new(MessageInfo {
+            id: "AC00000000000000000000000000BEEF".to_string(),
+            source: crate::types::message::MessageSource {
+                sender: "100000000000001@lid".parse().expect("sender"),
+                chat: "200000000000002@bot".parse().expect("chat"),
+                recipient: Some("200000000000002@bot".parse().expect("recipient")),
+                is_from_me: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        client
+            .handle_decrypt_failure(
+                &info,
+                RetryReason::BadMac,
+                crate::types::events::DecryptFailMode::Hide,
+            )
+            .await;
+
+        let mut found = None;
+        for _ in 0..80 {
+            if let Some(r) = find_receipt(&transport.sent(), "AC00000000000000000000000000BEEF") {
+                found = Some(r);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        let (to, typ, recipient) = found
+            .expect("self-fanout decrypt failure must emit a sender <receipt> to drain the queue");
+        assert_eq!(to, "100000000000001@lid");
+        assert_eq!(typ.as_deref(), Some("sender"));
+        assert_eq!(recipient.as_deref(), Some("200000000000002@bot"));
+
+        let sent = transport.sent();
+        assert!(
+            find_message_ack(&sent).is_none(),
+            "must not emit the bare <ack> the server ignores"
+        );
+        let mut saw_retry = false;
+        for (i, frame) in sent.iter().enumerate() {
+            if let Some(buf) = decode_frame(i, frame)
+                && let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..])
+                && node.tag.as_ref() == "receipt"
+                && node.get_attr("type").is_some_and(|v| {
+                    v.as_str() == crate::types::presence::ReceiptType::Retry.as_wire_str()
+                })
+            {
+                saw_retry = true;
+            }
+        }
+        assert!(
+            !saw_retry,
+            "must not retry our own undecryptable fanout to ourselves"
+        );
+    }
+
     /// If the resend request fails to send, the stanza must NOT be acked, so the
     /// server keeps it queued for another try. Here NoSession needs keys, which
     /// need a device account this harness lacks, so send_retry_receipt errors.
@@ -7635,7 +7708,7 @@ mod tests {
         let (to, typ, recipient) = found.expect("own self-fanout must get a sender <receipt>");
         assert_eq!(
             to, "100000000000001@lid",
-            "receipt `to` must echo the own LID with its device"
+            "receipt `to` must echo the own LID (the fanout sender)"
         );
         assert_eq!(
             typ.as_deref(),

--- a/src/message.rs
+++ b/src/message.rs
@@ -7773,6 +7773,46 @@ mod tests {
         );
     }
 
+    /// When WE are the bot author (own DM, sender on the `@bot` server, to a
+    /// user), WA Web's `MsgSendReceipt` takes the `!chat.isBot() &&
+    /// author.isBot()` branch and emits a bot-invoke-response `<ack>`, NOT a
+    /// sender `<receipt>`. So the bot-author branch in ack_received_message must
+    /// keep running before the self-fanout receipt: this locks that ordering
+    /// against a regression that would wrongly route it to a sender receipt.
+    #[tokio::test]
+    async fn own_bot_author_dm_acks_not_sender_receipt() {
+        let (client, transport) = capturing_client("own_bot_author").await;
+        let own = Arc::new(MessageInfo {
+            id: "OWNBOT1".to_string(),
+            source: crate::types::message::MessageSource {
+                sender: "100000000000002@bot".parse().expect("sender"),
+                chat: "300000000000003@lid".parse().expect("chat"),
+                recipient: Some("300000000000003@lid".parse().expect("recipient")),
+                is_from_me: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        client.ack_received_message(&own);
+
+        let mut found = None;
+        for _ in 0..80 {
+            if let Some(a) = find_message_ack(&transport.sent()) {
+                found = Some(a);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            found.is_some(),
+            "own bot-author DM must emit a bare <ack class=message> (WA Web bot-invoke-response ack), not a receipt"
+        );
+        assert!(
+            find_receipt(&transport.sent(), "OWNBOT1").is_none(),
+            "must NOT route to a sender <receipt> (would diverge from WA Web's bot-invoke-response ack path)"
+        );
+    }
+
     /// An `<unavailable>` message (no `<enc>`) must be transport-acked so the
     /// server stops replaying it (DM/group aren't covered by the should_ack gate).
     #[tokio::test]

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -30,11 +30,10 @@ fn build_delivery_receipt_node(
     active: bool,
 ) -> wacore_binary::Node {
     let is_status = info.source.chat.is_status_broadcast();
-    let is_self_fanout = info.source.is_from_me
-        && info.source.recipient.is_some()
-        && !info.source.is_group
-        && !is_status
-        && !info.source.chat.is_newsletter();
+    // A peer-synced message takes `type="peer_msg"` and carries NO recipient
+    // (WA Web `!l` guard), so the sender-receipt shape applies only off the
+    // peer path.
+    let sender_receipt = info.source.is_self_fanout() && info.category != MessageCategory::Peer;
     // Mirror whatsmeow `buildBaseReceipt` / WA Web `JID(extractJidFromJidWithType)`:
     // echo `from` verbatim so the device survives. `chat` strips it via to_non_ad,
     // which the LID server rejects for multi-device DMs.
@@ -48,15 +47,15 @@ fn build_delivery_receipt_node(
         .attr("to", to);
 
     if info.category == MessageCategory::Peer {
-        builder = builder.attr("type", "peer_msg");
-    } else if is_self_fanout {
-        builder = builder.attr("type", "sender");
+        builder = builder.attr("type", ReceiptType::PeerMsg.as_wire_str());
+    } else if sender_receipt {
+        builder = builder.attr("type", ReceiptType::Sender.as_wire_str());
     } else if !active && !is_status {
-        builder = builder.attr("type", "inactive");
+        builder = builder.attr("type", ReceiptType::Inactive.as_wire_str());
     }
 
     // Device-stripped recipient (WA Web `USER_JID`) so the server can route it.
-    if is_self_fanout && let Some(recipient) = &info.source.recipient {
+    if sender_receipt && let Some(recipient) = &info.source.recipient {
         builder = builder.attr("recipient", recipient.to_non_ad());
     }
 
@@ -128,11 +127,9 @@ impl Client {
         // sender receipt to drain the offline queue; without it the server
         // replays it until a ~50min GC closes the stream. A recipient-less own
         // message (self-note) stays skipped. See `build_delivery_receipt_node`.
-        let is_self_fanout = info.source.is_from_me
-            && info.source.recipient.is_some()
-            && !info.source.is_group
-            && !info.source.chat.is_status_broadcast();
-        info.category == MessageCategory::Peer || !info.source.is_from_me || is_self_fanout
+        info.category == MessageCategory::Peer
+            || !info.source.is_from_me
+            || info.source.is_self_fanout()
     }
 
     pub(crate) async fn handle_receipt(self: &Arc<Self>, node: Arc<OwnedNodeRef>) {
@@ -301,9 +298,15 @@ impl Client {
 
         let receipt_node = build_delivery_receipt_node(info, self.receipts_are_active());
 
+        let receipt_kind = if info.category == MessageCategory::Peer {
+            ReceiptType::PeerMsg
+        } else if info.source.is_self_fanout() {
+            ReceiptType::Sender
+        } else {
+            ReceiptType::Delivered
+        };
         debug!(target: "Client/Receipt", "Sending {} receipt for message {} to {}",
-            if info.category == MessageCategory::Peer { "peer_msg" } else { "delivery" },
-            info.id, info.source.sender);
+            receipt_kind.as_wire_str(), info.id, info.source.sender);
 
         if let Err(e) = self.send_node(receipt_node).await
             && !matches!(e, crate::client::ClientError::NotConnected)
@@ -517,6 +520,63 @@ mod tests {
             node.attrs.get("recipient").map(|v| v.as_str()).as_deref(),
             Some("300000000000003@lid"),
             "recipient device must be stripped (USER_JID semantics)"
+        );
+    }
+
+    #[test]
+    fn peer_self_fanout_is_peer_msg_without_recipient() {
+        // A peer-synced message that also looks like a self-fanout (is_from_me +
+        // recipient) must keep `type="peer_msg"` and carry NO recipient (WA Web
+        // `!l` guard), never `type="sender"`.
+        let info = MessageInfo {
+            id: "PEER_FANOUT".to_string(),
+            source: MessageSource {
+                sender: "100000000000001@lid".parse().expect("sender"),
+                chat: "300000000000003@lid".parse().expect("chat"),
+                recipient: Some("300000000000003@lid".parse().expect("recipient")),
+                is_from_me: true,
+                is_group: false,
+                ..Default::default()
+            },
+            category: MessageCategory::Peer,
+            ..Default::default()
+        };
+        let node = build_delivery_receipt_node(&info, true);
+        assert_eq!(
+            node.attrs.get("type").map(|v| v.as_str()).as_deref(),
+            Some("peer_msg")
+        );
+        assert!(
+            node.attrs.get("recipient").is_none(),
+            "a peer_msg receipt must not carry a recipient"
+        );
+    }
+
+    #[test]
+    fn self_fanout_is_sender_even_when_inactive() {
+        // type=sender takes precedence over the inactive (passive companion)
+        // branch: a self-fanout is always acknowledged as sender.
+        let info = MessageInfo {
+            id: "FANOUT_INACTIVE".to_string(),
+            source: MessageSource {
+                sender: "100000000000001@lid".parse().expect("sender"),
+                chat: "200000000000002@bot".parse().expect("chat"),
+                recipient: Some("200000000000002@bot".parse().expect("recipient")),
+                is_from_me: true,
+                is_group: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let node = build_delivery_receipt_node(&info, false);
+        assert_eq!(
+            node.attrs.get("type").map(|v| v.as_str()).as_deref(),
+            Some("sender"),
+            "self-fanout must stay type=sender, not become inactive"
+        );
+        assert_eq!(
+            node.attrs.get("recipient").map(|v| v.as_str()).as_deref(),
+            Some("200000000000002@bot")
         );
     }
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -298,10 +298,14 @@ impl Client {
 
         let receipt_node = build_delivery_receipt_node(info, self.receipts_are_active());
 
+        // Mirror build_delivery_receipt_node's type selection so the log is
+        // accurate (a passive companion emits `inactive`, not `delivery`).
         let receipt_kind = if info.category == MessageCategory::Peer {
             ReceiptType::PeerMsg
         } else if info.source.is_self_fanout() {
             ReceiptType::Sender
+        } else if !self.receipts_are_active() && !info.source.chat.is_status_broadcast() {
+            ReceiptType::Inactive
         } else {
             ReceiptType::Delivered
         };

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -19,11 +19,22 @@ use wacore_binary::OwnedNodeRef;
 /// JID. Without it the server can't map the ack back to the status owner.
 /// `active=false` sends `type="inactive"` (not rendered as ticks), matching
 /// whatsmeow's background companion. Peer/status keep their own type/context.
+///
+/// Self-fanout (`is_from_me` + a `recipient`) gets `type="sender"` + the
+/// `recipient`, matching WA Web (`isMeAccount` author => SENDER) and whatsmeow.
+/// The server's offline queue only drops a self-fanout on this sender receipt;
+/// a bare transport `<ack>` is ignored and the stanza is replayed until a
+/// ~50min GC closes the stream.
 fn build_delivery_receipt_node(
     info: &crate::types::message::MessageInfo,
     active: bool,
 ) -> wacore_binary::Node {
     let is_status = info.source.chat.is_status_broadcast();
+    let is_self_fanout = info.source.is_from_me
+        && info.source.recipient.is_some()
+        && !info.source.is_group
+        && !is_status
+        && !info.source.chat.is_newsletter();
     // Mirror whatsmeow `buildBaseReceipt` / WA Web `JID(extractJidFromJidWithType)`:
     // echo `from` verbatim so the device survives. `chat` strips it via to_non_ad,
     // which the LID server rejects for multi-device DMs.
@@ -38,8 +49,15 @@ fn build_delivery_receipt_node(
 
     if info.category == MessageCategory::Peer {
         builder = builder.attr("type", "peer_msg");
+    } else if is_self_fanout {
+        builder = builder.attr("type", "sender");
     } else if !active && !is_status {
         builder = builder.attr("type", "inactive");
+    }
+
+    // Device-stripped recipient (WA Web `USER_JID`) so the server can route it.
+    if is_self_fanout && let Some(recipient) = &info.source.recipient {
+        builder = builder.attr("recipient", recipient.to_non_ad());
     }
 
     if info.source.is_group || is_status {
@@ -105,7 +123,16 @@ impl Client {
         // (`Send/DeliveryReceiptJob.js` + `Handle/MsgSendReceipt.js` —
         // `C = y && isStatusStanzaReceiveEnabled() ? "status" : void 0`).
         // The context attribute is added in send_delivery_receipt below.
-        info.category == MessageCategory::Peer || !info.source.is_from_me
+        //
+        // Self-fanout (own message echoed back, carrying a `recipient`) needs a
+        // sender receipt to drain the offline queue; without it the server
+        // replays it until a ~50min GC closes the stream. A recipient-less own
+        // message (self-note) stays skipped. See `build_delivery_receipt_node`.
+        let is_self_fanout = info.source.is_from_me
+            && info.source.recipient.is_some()
+            && !info.source.is_group
+            && !info.source.chat.is_status_broadcast();
+        info.category == MessageCategory::Peer || !info.source.is_from_me || is_self_fanout
     }
 
     pub(crate) async fn handle_receipt(self: &Arc<Self>, node: Arc<OwnedNodeRef>) {
@@ -431,6 +458,66 @@ mod tests {
         assert!(node.attrs.get("context").is_none());
         assert!(node.attrs.get("participant").is_none());
         assert!(node.attrs.get("type").is_none());
+    }
+
+    #[test]
+    fn delivery_receipt_for_self_fanout_to_bot_is_sender_with_recipient() {
+        // Own prompt to a @bot, echoed back: <receipt type="sender" to=ourLID
+        // recipient=@bot>, `to` preserving the sender's device. Mirrors WA Web
+        // DeliveryReceiptJob (SENDER + USER_JID(recipient)) and whatsmeow.
+        let info = MessageInfo {
+            id: "FANOUT_BOT".to_string(),
+            source: MessageSource {
+                sender: "100000000000001:11@lid".parse().expect("sender"),
+                chat: "200000000000002@bot".parse().expect("chat"),
+                recipient: Some("200000000000002@bot".parse().expect("recipient")),
+                is_from_me: true,
+                is_group: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let node = build_delivery_receipt_node(&info, true);
+        assert_eq!(node.tag, "receipt");
+        assert_eq!(
+            node.attrs.get("type").map(|v| v.as_str()).as_deref(),
+            Some("sender")
+        );
+        assert_eq!(
+            node.attrs.get("to").map(|v| v.as_str()).as_deref(),
+            Some("100000000000001:11@lid"),
+            "`to` must preserve the own device or the LID server rejects it"
+        );
+        assert_eq!(
+            node.attrs.get("recipient").map(|v| v.as_str()).as_deref(),
+            Some("200000000000002@bot")
+        );
+        assert!(node.attrs.get("participant").is_none());
+        assert!(node.attrs.get("context").is_none());
+    }
+
+    #[test]
+    fn delivery_receipt_for_self_fanout_strips_recipient_device() {
+        // WA Web's `USER_JID` strips the device from `recipient`; a fanout to a
+        // multi-device user echoes the non-AD recipient.
+        let info = MessageInfo {
+            id: "FANOUT_DEV".to_string(),
+            source: MessageSource {
+                sender: "100000000000001:5@lid".parse().expect("sender"),
+                chat: "300000000000003@lid".parse().expect("chat"),
+                recipient: Some("300000000000003:7@lid".parse().expect("recipient")),
+                is_from_me: true,
+                is_group: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let node = build_delivery_receipt_node(&info, true);
+        assert_eq!(
+            node.attrs.get("recipient").map(|v| v.as_str()).as_deref(),
+            Some("300000000000003@lid"),
+            "recipient device must be stripped (USER_JID semantics)"
+        );
     }
 
     #[test]
@@ -785,11 +872,49 @@ mod tests {
 
     #[test]
     fn should_send_delivery_receipt_skips_own_dm() {
-        // Self-sent DM with category=Regular: no receipt (we don't ack our own
-        // messages). Peer-category self-sync messages are handled below.
+        // Self-sent message with NO `recipient` (a self-note where from==to):
+        // not a fanout, so no receipt. Peer-category self-sync and self-fanouts
+        // (which carry a `recipient`) are handled by the cases below.
         let mut info = info_with("12345@s.whatsapp.net", "12345@s.whatsapp.net", false);
         info.source.is_from_me = true;
+        assert!(info.source.recipient.is_none());
         assert!(!Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_allows_self_fanout_to_user() {
+        // Own outgoing DM to another user, echoed back to this device
+        // (is_from_me + recipient). WA Web emits a `<receipt type="sender">`.
+        let mut info = info_with("300000000000003@lid", "100000000000001@lid", false);
+        info.source.is_from_me = true;
+        info.source.recipient = Some("300000000000003@lid".parse().expect("recipient"));
+        assert!(Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_allows_self_fanout_to_bot() {
+        // The reported disconnect-loop case: our own prompt to a @bot, echoed
+        // back. Must get a sender receipt or the server replays it forever.
+        let mut info = info_with("200000000000002@bot", "100000000000001@lid", false);
+        info.source.is_from_me = true;
+        info.source.recipient = Some("200000000000002@bot".parse().expect("recipient"));
+        assert!(Client::should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn should_send_delivery_receipt_skips_own_status_and_group_fanout() {
+        // Regression guard: the self-fanout allowance must NOT leak into our own
+        // status broadcasts or group messages (WA Web does not send a DM-style
+        // sender receipt there).
+        let mut own_status = info_with("status@broadcast", "100000000000001@lid", false);
+        own_status.source.is_from_me = true;
+        own_status.source.recipient = Some("100000000000001@lid".parse().expect("recipient"));
+        assert!(!Client::should_send_delivery_receipt(&own_status));
+
+        let mut own_group = info_with("120363021033254949@g.us", "100000000000001@lid", true);
+        own_group.source.is_from_me = true;
+        own_group.source.recipient = Some("100000000000001@lid".parse().expect("recipient"));
+        assert!(!Client::should_send_delivery_receipt(&own_group));
     }
 
     #[test]

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -109,9 +109,12 @@ pub fn collect_simple_message_ids(
 /// own-account fanouts (`isMeAccount(author)`). For all other own messages,
 /// receipts are skipped.
 ///
-/// NOTE: the authoritative copy used by the message-dispatch hot path is
+/// NOTE: the message-dispatch hot path uses
 /// `crate::client::Client::should_send_delivery_receipt` (in the
-/// `whatsapp-rust` crate). Keep the two in sync.
+/// `whatsapp-rust` crate), which is authoritative and intentionally diverges
+/// here (it also sends `<receipt context="status">` for status broadcasts,
+/// which this copy still skips). The self-fanout rule is shared via
+/// [`MessageSource::is_self_fanout`].
 pub fn should_send_delivery_receipt(info: &MessageInfo) -> bool {
     if info.id.is_empty()
         || info.source.chat.user == STATUS_BROADCAST_USER
@@ -120,14 +123,11 @@ pub fn should_send_delivery_receipt(info: &MessageInfo) -> bool {
         return false;
     }
 
-    // status & newsletter already returned false above, so a self-fanout here
-    // is necessarily a non-group DM to a user/bot.
-    let is_self_fanout =
-        info.source.is_from_me && info.source.recipient.is_some() && !info.source.is_group;
-
     // WA Web sends type="peer_msg" for self-synced (category="peer") and
     // type="sender" for own-account fanouts. Other own messages are skipped.
-    info.category == MessageCategory::Peer || !info.source.is_from_me || is_self_fanout
+    info.category == MessageCategory::Peer
+        || !info.source.is_from_me
+        || info.source.is_self_fanout()
 }
 
 #[cfg(test)]

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -232,6 +232,39 @@ mod tests {
     }
 
     #[test]
+    fn skip_own_status_and_group_even_with_recipient() {
+        // Negative parity with Client::should_send_delivery_receipt: the
+        // self-fanout allowance must NOT leak into own status broadcasts or
+        // group messages, even when a recipient is present.
+        let own_status = MessageInfo {
+            id: "OWN_STATUS".to_string(),
+            source: MessageSource {
+                chat: "status@broadcast".parse().unwrap(),
+                sender: "100000000000001@lid".parse().unwrap(),
+                recipient: Some("100000000000001@lid".parse().unwrap()),
+                is_from_me: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(!should_send_delivery_receipt(&own_status));
+
+        let own_group = MessageInfo {
+            id: "OWN_GROUP".to_string(),
+            source: MessageSource {
+                chat: "120363021033254949@g.us".parse().unwrap(),
+                sender: "100000000000001@lid".parse().unwrap(),
+                recipient: Some("100000000000001@lid".parse().unwrap()),
+                is_from_me: true,
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(!should_send_delivery_receipt(&own_group));
+    }
+
+    #[test]
     fn allow_incoming_dm() {
         let info = MessageInfo {
             id: "DM1".to_string(),

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -101,10 +101,17 @@ pub fn collect_simple_message_ids(
 /// - Messages with an empty ID
 /// - Status broadcasts (`status@broadcast`)
 /// - Newsletter messages
-/// - Own outgoing messages (unless category is `"peer"`, i.e., self-synced)
+/// - Own outgoing messages, EXCEPT category `"peer"` (self-synced) and
+///   self-fanouts (`is_from_me` with a `recipient`), which need a
+///   `<receipt type="sender">`.
 ///
-/// WA Web sends `type="peer_msg"` delivery receipts for self-synced messages
-/// (category="peer"). For all other messages, receipts are skipped for our own.
+/// WA Web sends `type="peer_msg"` for self-synced and `type="sender"` for
+/// own-account fanouts (`isMeAccount(author)`). For all other own messages,
+/// receipts are skipped.
+///
+/// NOTE: the authoritative copy used by the message-dispatch hot path is
+/// `crate::client::Client::should_send_delivery_receipt` (in the
+/// `whatsapp-rust` crate). Keep the two in sync.
 pub fn should_send_delivery_receipt(info: &MessageInfo) -> bool {
     if info.id.is_empty()
         || info.source.chat.user == STATUS_BROADCAST_USER
@@ -113,11 +120,14 @@ pub fn should_send_delivery_receipt(info: &MessageInfo) -> bool {
         return false;
     }
 
-    // WA Web sends type="peer_msg" delivery receipts for self-synced
-    // messages (category="peer").  These tell the primary phone that
-    // this companion device received the message.
-    // For all other messages, skip receipts for our own messages.
-    info.category == MessageCategory::Peer || !info.source.is_from_me
+    // status & newsletter already returned false above, so a self-fanout here
+    // is necessarily a non-group DM to a user/bot.
+    let is_self_fanout =
+        info.source.is_from_me && info.source.recipient.is_some() && !info.source.is_group;
+
+    // WA Web sends type="peer_msg" for self-synced (category="peer") and
+    // type="sender" for own-account fanouts. Other own messages are skipped.
+    info.category == MessageCategory::Peer || !info.source.is_from_me || is_self_fanout
 }
 
 #[cfg(test)]
@@ -197,6 +207,25 @@ mod tests {
                 ..Default::default()
             },
             category: MessageCategory::Peer,
+            ..Default::default()
+        };
+        assert!(should_send_delivery_receipt(&info));
+    }
+
+    #[test]
+    fn allow_self_fanout_with_recipient() {
+        // Own outgoing message echoed back (is_from_me + recipient): needs a
+        // sender receipt. A recipient-less own message (skip_own_non_peer_*)
+        // stays skipped. Mirrors the hot-path copy in the whatsapp-rust crate.
+        let info = MessageInfo {
+            id: "FANOUT1".to_string(),
+            source: MessageSource {
+                chat: "200000000000002@bot".parse().unwrap(),
+                sender: "100000000000001@lid".parse().unwrap(),
+                recipient: Some("200000000000002@bot".parse().unwrap()),
+                is_from_me: true,
+                ..Default::default()
+            },
             ..Default::default()
         };
         assert!(should_send_delivery_receipt(&info));

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -283,6 +283,55 @@ mod tests {
     use super::*;
 
     #[test]
+    fn is_self_fanout_matches_only_own_dm_with_recipient() {
+        let bot = MessageSource {
+            chat: "200000000000002@bot".parse().unwrap(),
+            sender: "100000000000001@lid".parse().unwrap(),
+            recipient: Some("200000000000002@bot".parse().unwrap()),
+            is_from_me: true,
+            ..Default::default()
+        };
+        assert!(bot.is_self_fanout(), "own prompt to a @bot");
+
+        let mut user = bot.clone();
+        user.chat = "300000000000003@lid".parse().unwrap();
+        user.recipient = Some("300000000000003@lid".parse().unwrap());
+        assert!(user.is_self_fanout(), "own DM to a user");
+
+        let mut incoming = bot.clone();
+        incoming.is_from_me = false;
+        assert!(!incoming.is_self_fanout(), "incoming is not a self-fanout");
+
+        let mut note = bot.clone();
+        note.recipient = None;
+        assert!(!note.is_self_fanout(), "recipient-less self-note");
+
+        // Load-bearing guard: the own-from parser leaves is_group=false and
+        // derives chat from recipient, so a group/status/newsletter self-echo
+        // must be excluded by the chat-based checks alone.
+        let mut group_chat = bot.clone();
+        group_chat.chat = "120363021033254949@g.us".parse().unwrap();
+        group_chat.recipient = Some("120363021033254949@g.us".parse().unwrap());
+        assert!(!group_chat.is_group);
+        assert!(
+            !group_chat.is_self_fanout(),
+            "group chat excluded by chat.is_group() even with is_group=false"
+        );
+
+        let mut group_flag = bot.clone();
+        group_flag.is_group = true;
+        assert!(!group_flag.is_self_fanout(), "is_group flag excludes");
+
+        let mut status = bot.clone();
+        status.chat = "status@broadcast".parse().unwrap();
+        assert!(!status.is_self_fanout(), "status broadcast excluded");
+
+        let mut newsletter = bot.clone();
+        newsletter.chat = "120363298765432100@newsletter".parse().unwrap();
+        assert!(!newsletter.is_self_fanout(), "newsletter excluded");
+    }
+
+    #[test]
     fn test_edit_attribute_parsing_and_serialization() {
         // Test all known edit attribute values
         let attrs = vec![

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use wacore_binary::{Jid, JidExt, MessageId, MessageServerId, Server};
+use wacore_binary::{Jid, JidExt, MessageId, MessageServerId};
 use waproto::whatsapp as wa;
 
 use crate::WireEnum;
@@ -79,7 +79,7 @@ impl MessageSource {
     /// decrypt-failure path must route them to the bare ack, not the sender
     /// receipt, even though such an own message is also an [`Self::is_self_fanout`].
     pub fn is_bot_authored_non_bot_chat(&self) -> bool {
-        self.chat.server != Server::Bot && self.sender.is_bot()
+        !self.chat.is_bot() && self.sender.is_bot()
     }
 }
 

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -56,6 +56,21 @@ impl MessageSource {
     pub fn is_incoming_broadcast(&self) -> bool {
         (!self.is_from_me || self.broadcast_list_owner.is_some()) && self.chat.is_broadcast_list()
     }
+
+    /// Our own outgoing DM to a user or bot, echoed back to this device
+    /// (`is_from_me` with a `recipient`). The server's offline queue only
+    /// releases these on a `<receipt type="sender">`, so they must not be
+    /// cleared with a bare transport ack. Group/status/newsletter threads are
+    /// excluded (`chat` is checked too, since the own-from parser derives
+    /// `chat` from `recipient` and leaves `is_group` defaulted).
+    pub fn is_self_fanout(&self) -> bool {
+        self.is_from_me
+            && self.recipient.is_some()
+            && !self.is_group
+            && !self.chat.is_group()
+            && !self.chat.is_status_broadcast()
+            && !self.chat.is_newsletter()
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use wacore_binary::{Jid, JidExt, MessageId, MessageServerId};
+use wacore_binary::{Jid, JidExt, MessageId, MessageServerId, Server};
 use waproto::whatsapp as wa;
 
 use crate::WireEnum;
@@ -70,6 +70,16 @@ impl MessageSource {
             && !self.chat.is_group()
             && !self.chat.is_status_broadcast()
             && !self.chat.is_newsletter()
+    }
+
+    /// The author is a bot but the chat is not a bot chat (WA Web's
+    /// `h = !chat.isBot() && author.isBot()`). WA Web clears these with a
+    /// bot-invoke-response `<ack>` (`sendBotInvokeResponseAcks`), NOT a
+    /// `<receipt>`, so both the success/duplicate ack path and the
+    /// decrypt-failure path must route them to the bare ack, not the sender
+    /// receipt, even though such an own message is also an [`Self::is_self_fanout`].
+    pub fn is_bot_authored_non_bot_chat(&self) -> bool {
+        self.chat.server != Server::Bot && self.sender.is_bot()
     }
 }
 

--- a/wacore/src/types/presence.rs
+++ b/wacore/src/types/presence.rs
@@ -128,4 +128,34 @@ mod tests {
             ReceiptType::EncRekeyRetry
         );
     }
+
+    #[test]
+    fn as_wire_str_round_trips_through_parse() {
+        // as_wire_str is the hand-maintained inverse of parse(); guard the
+        // hyphen/underscore variants against drift.
+        let variants = [
+            ReceiptType::Delivered,
+            ReceiptType::Sender,
+            ReceiptType::Retry,
+            ReceiptType::EncRekeyRetry,
+            ReceiptType::Read,
+            ReceiptType::ReadSelf,
+            ReceiptType::Played,
+            ReceiptType::PlayedSelf,
+            ReceiptType::ServerError,
+            ReceiptType::Inactive,
+            ReceiptType::PeerMsg,
+            ReceiptType::HistorySync,
+        ];
+        for v in variants {
+            assert_eq!(
+                ReceiptType::parse(v.as_wire_str()),
+                v,
+                "round-trip failed for {v:?} (wire={:?})",
+                v.as_wire_str()
+            );
+        }
+        let other = ReceiptType::Other("custom-type".to_string());
+        assert_eq!(other.as_wire_str(), "custom-type");
+    }
 }

--- a/wacore/src/types/presence.rs
+++ b/wacore/src/types/presence.rs
@@ -48,8 +48,12 @@ pub enum ReceiptType {
 }
 
 impl ReceiptType {
-    pub fn parse(s: &str) -> Self {
-        match s {
+    /// Single source of truth for the wire-string -> known-variant mapping
+    /// (the inverse of [`Self::as_wire_str`]). Returns `None` for an
+    /// unrecognized value so callers can decide how to build `Other` (clone vs
+    /// move) without duplicating the match.
+    fn from_known(s: &str) -> Option<Self> {
+        Some(match s {
             "" | "delivery" => Self::Delivered,
             "sender" => Self::Sender,
             "retry" => Self::Retry,
@@ -62,8 +66,12 @@ impl ReceiptType {
             "inactive" => Self::Inactive,
             "peer_msg" => Self::PeerMsg,
             "hist_sync" => Self::HistorySync,
-            other => Self::Other(other.to_string()),
-        }
+            _ => return None,
+        })
+    }
+
+    pub fn parse(s: &str) -> Self {
+        Self::from_known(s).unwrap_or_else(|| Self::Other(s.to_string()))
     }
 
     /// Canonical wire `type` value. Inverse of [`Self::parse`] (`Delivered`
@@ -89,20 +97,10 @@ impl ReceiptType {
 
 impl From<String> for ReceiptType {
     fn from(s: String) -> Self {
-        match s.as_str() {
-            "" | "delivery" => Self::Delivered,
-            "sender" => Self::Sender,
-            "retry" => Self::Retry,
-            "enc_rekey_retry" => Self::EncRekeyRetry,
-            "read" => Self::Read,
-            "read-self" => Self::ReadSelf,
-            "played" => Self::Played,
-            "played-self" => Self::PlayedSelf,
-            "server-error" => Self::ServerError,
-            "inactive" => Self::Inactive,
-            "peer_msg" => Self::PeerMsg,
-            "hist_sync" => Self::HistorySync,
-            _ => Self::Other(s),
+        // Reuse the owned `s` for the `Other` fallback (no extra allocation).
+        match Self::from_known(&s) {
+            Some(known) => known,
+            None => Self::Other(s),
         }
     }
 }

--- a/wacore/src/types/presence.rs
+++ b/wacore/src/types/presence.rs
@@ -65,6 +65,26 @@ impl ReceiptType {
             other => Self::Other(other.to_string()),
         }
     }
+
+    /// Canonical wire `type` value. Inverse of [`Self::parse`] (`Delivered`
+    /// maps to `"delivery"`, though it is sent as a dropped attr in practice).
+    pub fn as_wire_str(&self) -> &str {
+        match self {
+            Self::Delivered => "delivery",
+            Self::Sender => "sender",
+            Self::Retry => "retry",
+            Self::EncRekeyRetry => "enc_rekey_retry",
+            Self::Read => "read",
+            Self::ReadSelf => "read-self",
+            Self::Played => "played",
+            Self::PlayedSelf => "played-self",
+            Self::ServerError => "server-error",
+            Self::Inactive => "inactive",
+            Self::PeerMsg => "peer_msg",
+            Self::HistorySync => "hist_sync",
+            Self::Other(s) => s,
+        }
+    }
 }
 
 impl From<String> for ReceiptType {


### PR DESCRIPTION
## Problem

An account in production disconnects every ~50 minutes in a tight loop. The server closes the stream with:

```
<stream:error><ack class="message" type="text" id="AC…"/></stream:error>
<xmlstreamend/>
```

Keepalive ping/pong works fine (~150ms RTT) between the drops, so this is **not** a connection-health issue — it is a server-side offline-queue GC firing on a message that never gets cleared. The same message (and its sibling) is redelivered on every reconnect (once per ~50min connection: `offline="0|1|2…"`, 100+ times across 12h).

## Root cause

The stuck stanza is a **self-fanout to a bot**: our own outgoing prompt to a `@bot`, fanned out by the server back to this companion device. So `from` is our own LID, `recipient` is the bot, and `is_from_me = true`.

The dispatch path (`ack_received_message`) hit `should_send_delivery_receipt`, which returned `false` for `is_from_me`, and fell through to a bare `<ack class="message">` transport ack. The decrypt-failure path (`handle_decrypt_failure`) likewise sent only a retry + bare transport ack.

WhatsApp Web (`Send/DeliveryReceiptJob.js`: `isMeAccount(author) => RECEIPT_TYPE.SENDER`) and whatsmeow (`sendMessageReceipt`: `IsFromMe => "sender"`) instead clear an own message with a `<receipt type="sender" recipient=...>`. **The server's offline queue only releases a self-fanout when it sees that sender receipt; a bare transport `<ack>` is ignored.** The message stays pending, gets replayed every reconnect, and the ~50min GC resets the stream. This is acute for bot self-fanouts, which never decrypt locally (a duplicate on the first cycle, then BadMac once the local Signal counter advances), so they loop forever.

Verified against `docs/captured-js/` (`Handle/MsgSendReceipt.js`, `Send/DeliveryReceiptJob.js`, `Send/OfflineDeliveryReceiptJob.js`, `Send/ReceiptJobCommon.js`) and whatsmeow, with an adversarial pass over the production wire log.

### Why #647/#648 helped but did not fix it

Those PRs made duplicate/undecryptable messages get acked **at all** (previously they were silently dropped, which also stalled the queue). But they emit the *wrong stanza kind* for a self-fanout — a bare `<ack>` rather than the sender `<receipt>` the server expects. So the disconnects became less frequent but never stopped.

### Hypotheses ruled out

- **`from=PN` namespace mismatch** — refuted: WA Web (`MsgSendAck.js`) and whatsmeow both set `from = own device PN`. Log counter-example: self-fanouts with a `@lid` recipient clear fine with the same ack shape; only `@bot` recipients stick.
- **Dropping `recipient` from the ack** — refuted and dangerous: PR #633 added `recipient` *because* dropping it produced this exact `<stream:error><ack/>`. `encode_ack_bytes` is left untouched.

## Fix

- **`MessageSource::is_self_fanout()`** (shared helper): `is_from_me && recipient.is_some() && !is_group && !chat.is_group() && !chat.is_status_broadcast() && !chat.is_newsletter()`. The own-from parser leaves `is_group` defaulted and derives `chat` from `recipient`, so the `chat`-based guards are load-bearing (they keep a group/status/newsletter self-echo from being mis-classified).
- **`should_send_delivery_receipt`** (both the hot-path `Client` copy and the `wacore` copy) now allows a self-fanout. A recipient-less own message (a self-note) stays skipped.
- **`build_delivery_receipt_node`** emits `type="sender"` plus the **device-stripped** `recipient` (matching WA Web `USER_JID`), keeping `to` device-preserving (per #649). A peer-synced message keeps `type="peer_msg"` and carries **no** recipient (WA Web `!l` guard): the sender shape is gated on `category != Peer`.
- **`handle_decrypt_failure`** — the path that actually fires for an account already stuck in the loop (its counter has advanced past the duplicate into BadMac): for a self-fanout it now clears the queue with the sender receipt and **skips the retry-to-self**, instead of the bare transport ack. Gated on `is_self_fanout() && should_send_delivery_receipt()` (same eligibility as the ack path).
- **`ReceiptType::as_wire_str()`** added and used for the `sender`/`peer_msg`/`inactive` type attrs (no magic strings); also fixes the `send_delivery_receipt` debug label (it logged `delivery` for a passive companion's `inactive` receipt).
- `encode_ack_bytes` is unchanged (the `recipient` on the transport ack stays, per #633).

### Why skip the retry for a self-fanout decrypt failure

WA Web's `MsgSendReceipt` RETRY branch sends a retry receipt, but it **never hits that branch for an own fanout** (it has the keys, so it never BadMacs its own message) — there is no canonical WA Web behavior to mirror here. Retrying our own already-sent content recovers nothing, and because the stuck stanza is redelivered only **once per ~50min connection**, retrying to the cap (5×) would prolong the disconnect loop ~4h. An immediate sender receipt clears it on the first cycle, and a `type="sender"` receipt for our own message is semantically truthful (we are the sender).

### Deliberate non-changes (verified against WA Web)

- **Own `@bot`-author DM to a user** keeps the bare bot-invoke-response `<ack>`, **not** a sender receipt. `MsgSendReceipt.js` checks `h = !chat.isBot() && author.isBot()` first and returns `sendBotInvokeResponseAcks` (a bare ack); only the `else` reaches the SENDER receipt. The real bug case (own prompt to `@bot`, `chat.server == Bot`) makes `h` false and correctly falls through to the sender receipt. Locked by `own_bot_author_dm_acks_not_sender_receipt`. (Pre-existing nuance, out of scope: that bare ack omits the `type="text"` WA Web emits, because `encode_ack_bytes` drops `type` for `tag=="message"`; the `@bot`-server-author scenario is not real for normal accounts.)

## Tests

Happy + bad paths (all fictitious JIDs, no real PII):

- `bot_self_fanout_acked_via_sender_receipt` — the exact symptom: own message to a `@bot` → `<receipt type="sender" recipient=@bot>`, device preserved in `to`, and **no** bare `<ack>`.
- `self_fanout_decrypt_failure_acked_via_sender_receipt` — the BadMac/NoSession path (the one that fires for already-stuck accounts): sender receipt, no bare ack, no retry-to-self.
- `own_self_fanout_acked_via_sender_receipt` — user-recipient fanout (replaces the old test that asserted the buggy bare-ack behavior).
- `own_bot_author_dm_acks_not_sender_receipt` — locks the bot-author bare-ack ordering (codex P2 rejection) with a settle window.
- `delivery_receipt_for_self_fanout_to_bot_is_sender_with_recipient` / `…_strips_recipient_device`, `peer_self_fanout_is_peer_msg_without_recipient`, `self_fanout_is_sender_even_when_inactive` — `build_delivery_receipt_node` wire shape + branch precedence.
- `should_send_delivery_receipt_allows_self_fanout_to_{user,bot}` / `…_skips_own_status_and_group_fanout` (+ `wacore` `skip_own_status_and_group_even_with_recipient` parity) — gate boundaries; `…_skips_own_dm` still skips the recipient-less self-note.
- `is_self_fanout_matches_only_own_dm_with_recipient` (isolated guards incl. `chat.is_group()` with `is_group=false`) and `as_wire_str_round_trips_through_parse`.

`cargo test --workspace --exclude e2e-tests`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --all` all pass.

## Verification still needed (live)

The one premise that cannot be verified in-repo: that the server's offline GC drains on a `type="sender"` receipt but ignores a bare ack. On a real account with a stuck bot self-fanout, confirm the `offline` count drops to 0 on the next reconnect and the ~50min loop stops.

The `recipient` value uses whatsmeow's per-stanza single-receipt form (`recipient = the bot`), which also matches WA Web's **online** `DeliveryReceiptJob.js`. WA Web's **offline-aggregate** job (`OfflineDeliveryReceiptJob.js`) instead groups by `from` and emits `recipient = self`. Since this bug is an offline-redelivery loop, the offline-aggregate form is the most directly-relevant WA Web path — so **the recipient form is the primary thing live testing must validate**; switching to `recipient = self` if required is a one-line change.
