### PR TITLE
perf(appstate): drop per-operand allocations in LTHash fold and update_hash

### DIFF
--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -43,8 +43,7 @@ impl HashState {
     where
         F: FnMut(&[u8], usize) -> anyhow::Result<Option<Vec<u8>>>,
     {
-        // Borrow the MAC tails directly out of `mutations` instead of copying each
-        // 32-byte slice; mirrors the already-optimized `update_hash_from_records`.
+        // Borrow the MAC tails instead of copying; mirrors `update_hash_from_records`.
         let mut added: Vec<&[u8]> = Vec::with_capacity(mutations.len());
         let mut removed: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
         let mut result = HashUpdateResult::default();
@@ -81,9 +80,8 @@ impl HashState {
             }
         }
 
-        // Two uniform-typed calls: subtract the owned previous MACs, then add the
-        // borrowed tails. A single mixed `Vec<u8>` + `&[u8]` call trips up deref
-        // coercion inference. Net effect is identical (subtract removed, add added).
+        // Split into two uniform-typed calls: a single mixed `Vec<u8>`/`&[u8]`
+        // call defeats deref-coercion inference. Effect is identical.
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &removed, &[] as &[Vec<u8>]);
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &[] as &[&[u8]], &added);
         (result, Ok(()))

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -80,8 +80,6 @@ impl HashState {
             }
         }
 
-        // Split into two uniform-typed calls: a single mixed `Vec<u8>`/`&[u8]`
-        // call defeats deref-coercion inference. Effect is identical.
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &removed, &[] as &[Vec<u8>]);
         WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &[] as &[&[u8]], &added);
         (result, Ok(()))

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -43,7 +43,9 @@ impl HashState {
     where
         F: FnMut(&[u8], usize) -> anyhow::Result<Option<Vec<u8>>>,
     {
-        let mut added: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
+        // Borrow the MAC tails directly out of `mutations` instead of copying each
+        // 32-byte slice; mirrors the already-optimized `update_hash_from_records`.
+        let mut added: Vec<&[u8]> = Vec::with_capacity(mutations.len());
         let mut removed: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
         let mut result = HashUpdateResult::default();
 
@@ -55,7 +57,7 @@ impl HashState {
                 && let Some(blob) = &value.blob
                 && blob.len() >= 32
             {
-                added.push(blob[blob.len() - 32..].to_vec());
+                added.push(&blob[blob.len() - 32..]);
             }
             let index_mac_opt = mutation
                 .record
@@ -79,7 +81,11 @@ impl HashState {
             }
         }
 
-        WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &removed, &added);
+        // Two uniform-typed calls: subtract the owned previous MACs, then add the
+        // borrowed tails. A single mixed `Vec<u8>` + `&[u8]` call trips up deref
+        // coercion inference. Net effect is identical (subtract removed, add added).
+        WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &removed, &[] as &[Vec<u8>]);
+        WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &[] as &[&[u8]], &added);
         (result, Ok(()))
     }
 

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -38,9 +38,7 @@ impl LTHash {
     }
 
     fn multiple_op<T: AsRef<[u8]>>(&self, base: &mut [u8], input: &[T], subtract: bool) {
-        // One stack buffer reused across every operand: the per-operand heap `Vec`
-        // from HKDF was pure churn during app-state sync. `hkdf_size` is a u8, so
-        // 256 bytes always covers it.
+        // Reuse one stack buffer instead of a per-operand HKDF heap alloc.
         let mut derived = [0u8; u8::MAX as usize + 1];
         let derived = &mut derived[..self.hkdf_size as usize];
         for item in input {

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -38,9 +38,14 @@ impl LTHash {
     }
 
     fn multiple_op<T: AsRef<[u8]>>(&self, base: &mut [u8], input: &[T], subtract: bool) {
+        // One stack buffer reused across every operand: the per-operand heap `Vec`
+        // from HKDF was pure churn during app-state sync. `hkdf_size` is a u8, so
+        // 256 bytes always covers it.
+        let mut derived = [0u8; u8::MAX as usize + 1];
+        let derived = &mut derived[..self.hkdf_size as usize];
         for item in input {
-            let derived = hkdf_sha256(item.as_ref(), None, self.hkdf_info, self.hkdf_size);
-            perform_pointwise_with_overflow(base, &derived, subtract);
+            hkdf_sha256_into(item.as_ref(), None, self.hkdf_info, derived);
+            perform_pointwise_with_overflow(base, derived, subtract);
         }
     }
 }
@@ -116,11 +121,9 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
     }
 }
 
-fn hkdf_sha256(key: &[u8], salt: Option<&[u8]>, info: &[u8], length: u8) -> Vec<u8> {
+fn hkdf_sha256_into(key: &[u8], salt: Option<&[u8]>, info: &[u8], out: &mut [u8]) {
     let hk = Hkdf::<Sha256>::new(salt, key);
-    let mut okm = vec![0u8; length as usize];
-    hk.expand(info, &mut okm).expect("hkdf expand");
-    okm
+    hk.expand(info, out).expect("hkdf expand");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Two allocation cleanups on the app-state sync path (PR1 of the performance-audit plan — the safest, most trivial batch).

### 1. `LTHash::multiple_op` — reuse a stack buffer (`lthash.rs`)

The LTHash fold called `hkdf_sha256(...)` once per operand, and each call did `vec![0u8; length]` (a heap allocation). Replaced with `hkdf_sha256_into(..., out: &mut [u8])`, which expands into a single stack buffer allocated once per `multiple_op` and reused for every operand. `hkdf_size` is a `u8`, so `[0u8; 256]` always covers it.

### 2. `HashState::update_hash` — borrow instead of copy (`hash.rs`)

`added` was `Vec<Vec<u8>>`, copying each 32-byte MAC tail via `.to_vec()`. It is now `Vec<&[u8]>`, borrowing directly from the input — mirroring the already-optimized `update_hash_from_records`.

The final fold is split into two uniform-typed calls (subtract `removed`, then add `added`) because a single call mixing `Vec<u8>` and `&[u8]` defeats the compiler's deref-coercion inference. The net effect is identical.

## Why

This is an event-bounded path (initial sync / patch application), not per-message. It reduces allocation churn with no behavior or wire-format change. Modest impact, low risk.

Public signatures are unchanged (`update_hash`, `subtract_then_add_in_place`); `hkdf_sha256` was private.