### PR TITLE
perf(jid): add consuming into_non_ad for owned send-path JIDs

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -1256,7 +1256,7 @@ impl Client {
             // DM fanout: all known recipient devices + own companions.
             // WAWebSendUserMsgJob reads local device table only on the send
             // path; WAWebDBDeviceListFanout excludes hosted devices.
-            let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
+            let recipient_bare = self.resolve_encryption_jid(&to).await.into_non_ad();
             let recipient_is_lid = recipient_bare.is_lid();
 
             // Local registry first; network warm only on miss to avoid
@@ -1919,7 +1919,7 @@ impl Client {
             jid.to_non_ad()
         };
         // Issuance targets bare account JIDs, not device-scoped ones
-        resolved.to_non_ad()
+        resolved.into_non_ad()
     }
 }
 

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -527,6 +527,18 @@ impl Jid {
         }
     }
 
+    /// Consuming `to_non_ad`: reuses the owned `user` instead of cloning it.
+    /// Prefer this when the receiver is a throwaway owned `Jid`.
+    pub fn into_non_ad(self) -> Self {
+        Self {
+            user: self.user,
+            server: self.server,
+            integrator: self.integrator,
+            agent: 0,
+            device: 0,
+        }
+    }
+
     /// Canonical non-AD string form (`user@server`, device + agent stripped)
     /// in a single allocation. Equivalent to `to_non_ad().to_string()` but
     /// skips the throwaway intermediate `Jid` and its `CompactString` clone.
@@ -1312,6 +1324,27 @@ mod tests {
             assert_eq!(
                 jid.to_non_ad_string(),
                 jid.to_non_ad().to_string(),
+                "mismatch for {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_into_non_ad_matches_to_non_ad() {
+        // into_non_ad (consuming) must produce a JID identical to to_non_ad (cloning).
+        for s in [
+            "1234567890.2:33@s.whatsapp.net",
+            "1234567890@s.whatsapp.net",
+            "100000012345678:25@lid",
+            "user.5:10@bot",
+            "447911123456.3@interop",
+            "120363021033254949@g.us",
+            "status@broadcast",
+        ] {
+            let jid: Jid = s.parse().expect("parse");
+            assert_eq!(
+                jid.clone().into_non_ad(),
+                jid.to_non_ad(),
                 "mismatch for {s}"
             );
         }


### PR DESCRIPTION
## What

Adds a consuming `Jid::into_non_ad(self)` and uses it at the two send-path call sites where the receiver is a throwaway owned `Jid` (PR3 of the performance-audit plan).

`resolve_encryption_jid` returns an **owned** `Jid`, which the send path immediately strips to its bare form via `to_non_ad()` — cloning the `user` a second time before the original is dropped. `into_non_ad(self)` moves the `user` instead of cloning it.

Applied at:
- `send.rs` DM fanout (`self.resolve_encryption_jid(&to).await.into_non_ad()`) — per-send path
- `resolve_issuance_jid` (`resolved.into_non_ad()`) — privacy-token issuance

The six other `to_non_ad()` call sites in `send.rs` take a `&Jid` (borrowed participant/parameter) and correctly keep `to_non_ad()`.

A parity test (`test_into_non_ad_matches_to_non_ad`) pins `into_non_ad() == to_non_ad()` across PN/LID/bot/interop/group/broadcast inputs.

## Scope note

The audit's PR3 also floated turning `normalize_for_prekey_bundle` into a `Cow<'_, Jid>`. I dropped that: its two hot call sites either mutate the result (`prekeys.rs`) or move it into an `async move` closure (`send.rs`), both of which would force `.into_owned()` and still allocate. The remaining saving was a stack memcpy of an SSO string, not a heap allocation — not worth the API churn.

## Why

Removes one redundant `user` clone per DM send. The win is small (the user string is usually short-string-optimized, so this is mostly a stack memcpy rather than a heap allocation), but consuming an owned value instead of cloning it is the correct shape and the intent is clearer. No behavior or wire-format change.