### PR TITLE
perf(send): build encrypt-task Signal address from a borrow, not a Jid clone

### DIFF
--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -692,18 +692,19 @@ where
 
     let make_encrypt_task = |idx: usize| {
         let device_jid = devices[idx].clone();
-        let encryption_jid = encryption_overrides[idx]
-            .clone()
-            .unwrap_or_else(|| device_jid.clone());
+        // The encryption JID is only needed to build the Signal address, so
+        // derive it here from a borrow rather than cloning the whole Jid into
+        // the task (device_jid is still cloned because it's returned).
+        let addr = encryption_overrides[idx]
+            .as_ref()
+            .unwrap_or(&devices[idx])
+            .to_protocol_address();
         let plaintext = plaintext_arc.clone();
         let mediatype = mediatype_owned.clone();
         let mut session_store = stores.session_store.clone();
         let mut identity_store = stores.identity_store.clone();
 
         spawn_oneshot(runtime, async move {
-            let mut addr = crate::types::jid::make_reusable_protocol_address();
-            encryption_jid.reset_protocol_address(&mut addr);
-
             match message_encrypt(&plaintext, &addr, &mut session_store, &mut identity_store).await
             {
                 Ok(encrypted_payload) => {


### PR DESCRIPTION
## What

In the per-device encrypt fan-out (`encrypt_for_devices`, `wacore/src/send.rs`), each task cloned `encryption_jid` — a **second** clone of `device_jid` in the common no-override case — purely to call `reset_protocol_address` inside the task.

This builds the `ProtocolAddress` once in the orchestrator from a **borrow** of the exact same JID the task would have used (`encryption_overrides[idx]` when present, otherwise `devices[idx]`) and moves the owned address into the task. The `ProtocolAddress` was already allocated inside the task before, so this is strictly fewer allocations: one `Jid` clone removed per encrypted device.

`device_jid` stays cloned — it is returned from the task and pushed into the `<to>` participant node.

## Why it's byte-identical / safe

- `to_protocol_address()` and the previous `reset_protocol_address()` both derive the address from `write_signal_address_to`, which reads only `user`, `device`, and `server` — **never** `agent`. So the LID `agent = 0` handling that exists in the *session-establishment* loop is irrelevant to the address bytes, and this change touches only the *encrypt* loop (which never zeroed the agent in the first place).
- The selected JID is exactly what the old code selected (`encryption_overrides[idx]` or `devices[idx]`), just borrowed instead of cloned.

No behavior or wire-format change.

## Tests

- `cargo test -p wacore` (405) and `cargo test -p whatsapp-rust --lib` (614) pass
- `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings` clean