### PR TITLE
feat(transport): surface the disconnect reason in logs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1646,12 +1646,21 @@ impl Client {
                                     );
                                 }
                             },
-                            Ok(crate::transport::TransportEvent::Disconnected) | Err(_) => {
+                            Ok(crate::transport::TransportEvent::Disconnected(reason)) => {
                                 if !self.expected_disconnect.load(Ordering::Relaxed) {
-                                    debug!("Transport disconnected unexpectedly.");
-                                    return Err(anyhow::anyhow!("Transport disconnected unexpectedly"));
+                                    debug!("Transport disconnected unexpectedly: {reason}");
+                                    return Err(anyhow::anyhow!("Transport disconnected: {reason}"));
                                 } else {
-                                    debug!("Transport disconnected as expected.");
+                                    debug!("Transport disconnected as expected: {reason}");
+                                    return Ok(());
+                                }
+                            }
+                            // Event channel closed (no DisconnectReason available).
+                            Err(_) => {
+                                if !self.expected_disconnect.load(Ordering::Relaxed) {
+                                    debug!("Transport event channel closed unexpectedly.");
+                                    return Err(anyhow::anyhow!("Transport event channel closed"));
+                                } else {
                                     return Ok(());
                                 }
                             }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -365,7 +365,10 @@ async fn recv_frame(
                 continue;
             }
             Ok(Ok(TransportEvent::Connected)) => continue,
-            Ok(Ok(TransportEvent::Disconnected)) => return Err(HandshakeError::Disconnected),
+            Ok(Ok(TransportEvent::Disconnected(reason))) => {
+                debug!("Transport disconnected during handshake: {reason}");
+                return Err(HandshakeError::Disconnected);
+            }
             // Channel closed (no more producers) — distinct from a real timeout.
             Ok(Err(_)) => return Err(HandshakeError::StreamClosed),
             Err(_) => return Err(HandshakeError::Timeout),

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -6,12 +6,14 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
-use log::{debug, error, trace, warn};
+use log::{debug, warn};
 use std::sync::{Arc, Once};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
 use tokio_websockets::{ClientBuilder, Message, WebSocketStream};
-use wacore::net::{Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_WS_URL};
+use wacore::net::{
+    DisconnectReason, Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_WS_URL,
+};
 
 pub use tokio_websockets::Connector;
 
@@ -161,6 +163,11 @@ async fn read_pump<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     tx: async_channel::Sender<TransportEvent>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) {
+    // Default covers the shutdown-initiated breaks (our own disconnect, where
+    // the client already knows the cause); the receive arms overwrite it with
+    // the real reason so a clean server recycle is distinguishable from an
+    // abrupt EOF or a read error in the logs.
+    let mut reason = DisconnectReason::Unknown;
     loop {
         tokio::select! {
             biased;
@@ -181,23 +188,35 @@ async fn read_pump<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
                     }
                 }
                 Some(Ok(msg)) if msg.is_close() => {
-                    trace!("Received close frame");
+                    reason = match msg.as_close() {
+                        Some((code, text)) => DisconnectReason::ServerClose {
+                            code: Some(u16::from(code)),
+                            reason: text.to_owned(),
+                        },
+                        None => DisconnectReason::ServerClose {
+                            code: None,
+                            reason: String::new(),
+                        },
+                    };
+                    debug!("Received close frame: {reason}");
                     break;
                 }
                 Some(Ok(_)) => {} // ping/pong/text handled by tokio-websockets
                 Some(Err(e)) => {
-                    error!("WebSocket read error: {e}");
+                    reason = DisconnectReason::ReadError(e.to_string());
+                    warn!("WebSocket read error: {e}");
                     break;
                 }
                 None => {
-                    trace!("WebSocket stream ended");
+                    reason = DisconnectReason::StreamEnded;
+                    debug!("WebSocket stream ended");
                     break;
                 }
             },
         }
     }
 
-    let _ = tx.send(TransportEvent::Disconnected).await;
+    let _ = tx.send(TransportEvent::Disconnected(reason)).await;
 }
 
 /// Wraps an already-upgraded [`WebSocketStream`] into a [`Transport`] + event channel.

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -7,6 +7,38 @@ use std::sync::Arc;
 /// Default WhatsApp Web websocket endpoint.
 pub const WHATSAPP_WEB_WS_URL: &str = "wss://web.whatsapp.com/ws/chat";
 
+/// Why the transport connection ended. Lets a benign server-initiated stream
+/// recycle (a clean Close frame) be told apart from an abrupt EOF or a real
+/// read error when diagnosing reconnect behavior.
+#[derive(Debug, Clone)]
+pub enum DisconnectReason {
+    /// The peer sent a WebSocket Close frame. `code` is the RFC 6455 close
+    /// code (1000 = normal closure); `reason` is the optional UTF-8 text.
+    ServerClose { code: Option<u16>, reason: String },
+    /// The stream ended (EOF) without a Close frame.
+    StreamEnded,
+    /// A transport-level read/IO error ended the connection.
+    ReadError(String),
+    /// The reason was not reported by this transport (e.g. local shutdown).
+    Unknown,
+}
+
+impl std::fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ServerClose { code, reason } => match (code, reason.is_empty()) {
+                (Some(c), false) => write!(f, "server close frame (code {c}: {reason})"),
+                (Some(c), true) => write!(f, "server close frame (code {c})"),
+                (None, false) => write!(f, "server close frame ({reason})"),
+                (None, true) => write!(f, "server close frame (no code)"),
+            },
+            Self::StreamEnded => write!(f, "stream ended (EOF)"),
+            Self::ReadError(e) => write!(f, "read error: {e}"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
 /// An event produced by the transport layer.
 #[derive(Debug, Clone)]
 pub enum TransportEvent {
@@ -14,8 +46,8 @@ pub enum TransportEvent {
     Connected,
     /// Raw data has been received from the server.
     DataReceived(Bytes),
-    /// The connection was lost.
-    Disconnected,
+    /// The connection was lost, with the reason if the transport reported one.
+    Disconnected(DisconnectReason),
 }
 
 /// Represents an active network connection.


### PR DESCRIPTION
## What

The transport layer collapsed every way a connection can end — a clean server-initiated Close frame, an EOF, a read error, or our own shutdown — into a single opaque `TransportEvent::Disconnected`, surfaced as `Transport disconnected unexpectedly`. That makes it impossible, from logs, to tell a **benign server stream recycle** apart from a **real fault** when diagnosing reconnects.

This adds a `DisconnectReason` carried by `TransportEvent::Disconnected`:

- `ServerClose { code: Option<u16>, reason: String }` — RFC 6455 close code (1000 = normal) + text, read from the WebSocket close frame via `msg.as_close()`
- `StreamEnded` — EOF without a close frame
- `ReadError(String)` — transport-level read/IO error
- `Unknown` — not reported (e.g. our own shutdown-initiated break)

The tokio transport fills the reason in `read_pump`; `src/transport.rs` now logs `Transport disconnected: <reason>` at **debug** level (e.g. `server close frame (code 1000)` vs `read error: ...`).

## Why

This is a **permanent** visibility improvement, not throwaway instrumentation. A 3h18min production log showed 3 reconnects with the cause completely hidden (the close code was discarded), which blocked diagnosing whether they were normal companion recycles or something provoking the server. With this, the next log says exactly why each disconnect happened.

No wire or behavior change — only the event payload and a log string. `DisconnectReason::Display` formats the human-readable message.

## Tests

- `cargo build` / `cargo clippy --all-targets -- -D warnings` clean on `wacore`, `whatsapp-rust-tokio-transport`, `whatsapp-rust`
- `cargo test`: 614 (whatsapp-rust lib) + 803 (wacore lib) passing
- `cargo fmt --all`