### PR TITLE
fix(message): ack SKDM-only session decrypts

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -70,6 +70,20 @@ pub(crate) struct ClassifiedMessage {
     pub decrypt_fail_mode: crate::types::events::DecryptFailMode,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct SessionBatchOutcome {
+    decrypted: bool,
+    duplicate: bool,
+    undecryptable: bool,
+    dispatched: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct MigrationDecryptOutcome {
+    decrypted: bool,
+    dispatched: bool,
+}
+
 /// Retry count threshold for logging high retry warnings.
 /// WhatsApp Web logs metrics when retry count exceeds this value.
 const HIGH_RETRY_COUNT_THRESHOLD: u8 = 3;
@@ -1072,11 +1086,7 @@ impl Client {
             || sender_encryption_jid.is_broadcast_list()
             || sender_encryption_jid.is_status_broadcast();
 
-        let (
-            session_decrypted_successfully,
-            session_had_duplicates,
-            session_dispatched_undecryptable,
-        ) = if !is_group_sender && !session_payloads.is_empty() {
+        let session_outcome = if !is_group_sender && !session_payloads.is_empty() {
             self.clone()
                 .process_session_enc_batch(
                     &session_payloads,
@@ -1093,8 +1103,12 @@ impl Client {
                     sender_encryption_jid
                 );
             }
-            (false, false, false)
+            SessionBatchOutcome::default()
         };
+        let session_decrypted_successfully = session_outcome.decrypted;
+        let session_had_duplicates = session_outcome.duplicate;
+        let session_dispatched_undecryptable = session_outcome.undecryptable;
+        let session_dispatched = session_outcome.dispatched;
 
         log::debug!(
             "Starting PASS 2: Processing {} group content messages (skmsg)",
@@ -1207,6 +1221,11 @@ impl Client {
             // (a status SKDM pkmsg can reach here), so skip it to avoid a
             // redundant receipt.
             self.ack_received_message(&info);
+        } else if session_decrypted_successfully && !session_dispatched {
+            // SKDM-only session decrypts skip dispatch, so this stanza would
+            // otherwise stay queued. WA Web and whatsmeow ack every decrypted
+            // message; the ack shape still comes from the message source.
+            self.ack_received_message(&info);
         }
 
         // Bot-secret (msmsg) payloads run inline here so they're serialised
@@ -1227,10 +1246,10 @@ impl Client {
         info: &Arc<MessageInfo>,
         sender_encryption_jid: &Jid,
         decrypt_fail_mode: crate::types::events::DecryptFailMode,
-    ) -> (bool, bool, bool) {
+    ) -> SessionBatchOutcome {
         use wacore::libsignal::protocol::CiphertextMessage;
         if payloads.is_empty() {
-            return (false, false, false);
+            return SessionBatchOutcome::default();
         }
 
         // Acquire a per-sender session lock to prevent race conditions when
@@ -1248,9 +1267,7 @@ impl Client {
 
         let mut adapter = self.signal_adapter().await;
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let mut any_success = false;
-        let mut any_duplicate = false;
-        let mut dispatched_undecryptable = false;
+        let mut outcome = SessionBatchOutcome::default();
 
         for payload in payloads {
             let ciphertext = &payload.ciphertext[..];
@@ -1273,7 +1290,7 @@ impl Client {
                         );
                         // |= so a later dedup'd return (false) can't clobber
                         // a true set by a prior iteration in this batch.
-                        dispatched_undecryptable |= self
+                        outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
                                 false,
@@ -1294,7 +1311,7 @@ impl Client {
                             info.id,
                             info.source.sender
                         );
-                        dispatched_undecryptable |= self
+                        outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
                                 false,
@@ -1354,8 +1371,8 @@ impl Client {
 
             match decrypt_res {
                 Ok(padded_plaintext) => {
-                    any_success = true;
-                    if let Err(e) = self
+                    outcome.decrypted = true;
+                    match self
                         .clone()
                         .handle_decrypted_plaintext(
                             enc_type,
@@ -1365,11 +1382,14 @@ impl Client {
                         )
                         .await
                     {
-                        log::warn!(
-                            "[msg:{}] Failed processing plaintext from {}: {e:?}",
-                            info.id,
-                            info.source.sender
-                        );
+                        Ok(dispatched) => outcome.dispatched |= dispatched,
+                        Err(e) => {
+                            log::warn!(
+                                "[msg:{}] Failed processing plaintext from {}: {e:?}",
+                                info.id,
+                                info.source.sender
+                            );
+                        }
                     }
                 }
                 Err(e) => {
@@ -1382,7 +1402,7 @@ impl Client {
                             counter
                         );
                         // Mark that we saw a duplicate so we can skip skmsg without showing error
-                        any_duplicate = true;
+                        outcome.duplicate = true;
                         continue;
                     }
                     // Handle UntrustedIdentity: This happens when a user re-installs WhatsApp or changes devices.
@@ -1440,8 +1460,8 @@ impl Client {
                                     info.id,
                                     address
                                 );
-                                any_success = true;
-                                if let Err(e) = self
+                                outcome.decrypted = true;
+                                match self
                                     .clone()
                                     .handle_decrypted_plaintext(
                                         enc_type,
@@ -1451,9 +1471,12 @@ impl Client {
                                     )
                                     .await
                                 {
-                                    log::warn!(
-                                        "Failed processing plaintext after identity retry: {e:?}"
-                                    );
+                                    Ok(dispatched) => outcome.dispatched |= dispatched,
+                                    Err(e) => {
+                                        log::warn!(
+                                            "Failed processing plaintext after identity retry: {e:?}"
+                                        );
+                                    }
                                 }
                             }
                             Err(retry_err) => {
@@ -1471,11 +1494,11 @@ impl Client {
                                         chain,
                                         counter
                                     );
-                                    any_duplicate = true;
+                                    outcome.duplicate = true;
                                 } else if matches!(retry_err, SignalProtocolError::InvalidPreKeyId)
                                 {
                                     // Session may exist under PN address after identity change
-                                    if self
+                                    let migration_outcome = self
                                         .try_pn_to_lid_migration_decrypt(
                                             sender_encryption_jid,
                                             &signal_address,
@@ -1488,9 +1511,10 @@ impl Client {
                                             &session_mutex,
                                             &mut session_guard,
                                         )
-                                        .await
-                                    {
-                                        any_success = true;
+                                        .await;
+                                    if migration_outcome.decrypted {
+                                        outcome.decrypted = true;
+                                        outcome.dispatched |= migration_outcome.dispatched;
                                     } else {
                                         log::debug!(
                                             "[msg:{}] InvalidPreKeyId after identity change for {}. \
@@ -1498,7 +1522,7 @@ impl Client {
                                             info.id,
                                             address
                                         );
-                                        dispatched_undecryptable = self
+                                        outcome.undecryptable = self
                                             .handle_decrypt_failure(
                                                 info,
                                                 RetryReason::InvalidKeyId,
@@ -1515,7 +1539,7 @@ impl Client {
                                     );
                                     // Send retry receipt so the sender resends with a PreKeySignalMessage
                                     // to establish a new session with the new identity
-                                    dispatched_undecryptable = self
+                                    outcome.undecryptable = self
                                         .handle_decrypt_failure(
                                             info,
                                             RetryReason::InvalidKey,
@@ -1543,7 +1567,7 @@ impl Client {
                     }
                     // Try PN→LID session migration before sending retry receipt
                     if let SignalProtocolError::SessionNotFound(_) = e {
-                        if self
+                        let migration_outcome = self
                             .try_pn_to_lid_migration_decrypt(
                                 sender_encryption_jid,
                                 &signal_address,
@@ -1556,9 +1580,10 @@ impl Client {
                                 &session_mutex,
                                 &mut session_guard,
                             )
-                            .await
-                        {
-                            any_success = true;
+                            .await;
+                        if migration_outcome.decrypted {
+                            outcome.decrypted = true;
+                            outcome.dispatched |= migration_outcome.dispatched;
                             continue;
                         }
 
@@ -1566,7 +1591,7 @@ impl Client {
                             "[msg:{}] No session found for {} message from {}. Sending retry receipt to request session establishment.",
                             info.id, enc_type, info.source.sender
                         );
-                        dispatched_undecryptable = self
+                        outcome.undecryptable = self
                             .handle_decrypt_failure(info, RetryReason::NoSession, decrypt_fail_mode)
                             .await;
                         continue;
@@ -1576,7 +1601,7 @@ impl Client {
                     ) {
                         // whatsmeow migrates PN sessions before decrypt; a fresh
                         // LID record can otherwise shadow the sender's PN ratchet.
-                        if self
+                        let migration_outcome = self
                             .try_pn_to_lid_migration_decrypt(
                                 sender_encryption_jid,
                                 &signal_address,
@@ -1589,9 +1614,10 @@ impl Client {
                                 &session_mutex,
                                 &mut session_guard,
                             )
-                            .await
-                        {
-                            any_success = true;
+                            .await;
+                        if migration_outcome.decrypted {
+                            outcome.decrypted = true;
+                            outcome.dispatched |= migration_outcome.dispatched;
                             continue;
                         }
 
@@ -1611,7 +1637,7 @@ impl Client {
                             info.source.sender
                         );
 
-                        dispatched_undecryptable = self
+                        outcome.undecryptable = self
                             .handle_decrypt_failure(info, reason, decrypt_fail_mode)
                             .await;
                         continue;
@@ -1620,7 +1646,7 @@ impl Client {
                         // session exists under a PN address (legacy migration).
                         // Migrating lets Signal use the existing ratchet state
                         // instead of looking up the consumed one-time prekey.
-                        if self
+                        let migration_outcome = self
                             .try_pn_to_lid_migration_decrypt(
                                 sender_encryption_jid,
                                 &signal_address,
@@ -1633,9 +1659,10 @@ impl Client {
                                 &session_mutex,
                                 &mut session_guard,
                             )
-                            .await
-                        {
-                            any_success = true;
+                            .await;
+                        if migration_outcome.decrypted {
+                            outcome.decrypted = true;
+                            outcome.dispatched |= migration_outcome.dispatched;
                             continue;
                         }
 
@@ -1649,7 +1676,7 @@ impl Client {
                         );
 
                         // Send retry receipt with fresh prekeys
-                        dispatched_undecryptable = self
+                        outcome.undecryptable = self
                             .handle_decrypt_failure(
                                 info,
                                 RetryReason::InvalidKeyId,
@@ -1666,7 +1693,7 @@ impl Client {
                             info.source.sender,
                             e
                         );
-                        dispatched_undecryptable |= self
+                        outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
                                 false,
@@ -1680,7 +1707,7 @@ impl Client {
                 }
             }
         }
-        (any_success, any_duplicate, dispatched_undecryptable)
+        outcome
     }
 
     async fn process_group_enc_batch(
@@ -1857,7 +1884,7 @@ impl Client {
         padded_plaintext: &[u8],
         padding_version: u8,
         info: &Arc<MessageInfo>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<bool, anyhow::Error> {
         let original_msg = wacore::messages::decode_plaintext(padded_plaintext, padding_version)?;
         log::debug!(
             "[msg:{}] Successfully decrypted message from {}: type={} [batch path]",
@@ -1950,14 +1977,16 @@ impl Client {
                 "[msg:{}] Skipping event dispatch for sender key distribution message",
                 info.id
             );
+            Ok(false)
         } else {
             self.dispatch_parsed_message(msg, info).await;
+            Ok(true)
         }
-        Ok(())
     }
 
     /// Attempt PN→LID session migration and retry decryption.
-    /// Returns true if decryption succeeded after migration.
+    /// Returns whether decryption succeeded after migration and whether it
+    /// reached user dispatch.
     ///
     /// Manages the per-address session lock around the migration loop:
     /// drops the caller's guard (migration re-enters that mutex and
@@ -1977,15 +2006,15 @@ impl Client {
         info: &Arc<MessageInfo>,
         session_mutex: &Arc<async_lock::Mutex<()>>,
         session_guard: &mut Option<async_lock::MutexGuardArc<()>>,
-    ) -> bool {
+    ) -> MigrationDecryptOutcome {
         use wacore::libsignal::protocol::{UsePQRatchet, message_decrypt};
 
         if !sender_jid.is_lid() {
-            return false;
+            return MigrationDecryptOutcome::default();
         }
 
         let Some(pn) = self.lid_pn_cache.get_phone_number(&sender_jid.user).await else {
-            return false;
+            return MigrationDecryptOutcome::default();
         };
 
         // Release the address lock so the migration loop can acquire it for
@@ -2015,31 +2044,41 @@ impl Client {
                     info.id,
                     info.source.sender
                 );
-                if let Err(e) = self
+                let dispatched = match self
                     .clone()
                     .handle_decrypted_plaintext(enc_type, &padded_plaintext, padding_version, info)
                     .await
                 {
-                    log::warn!(
-                        "[msg:{}] Failed processing plaintext after migration: {e:?}",
-                        info.id
-                    );
+                    Ok(dispatched) => dispatched,
+                    Err(e) => {
+                        log::warn!(
+                            "[msg:{}] Failed processing plaintext after migration: {e:?}",
+                            info.id
+                        );
+                        false
+                    }
+                };
+                MigrationDecryptOutcome {
+                    decrypted: true,
+                    dispatched,
                 }
-                true
             }
             Err(SignalProtocolError::DuplicatedMessage(chain, counter)) => {
                 log::debug!(
                     "[msg:{}] Already processed (chain {chain}, counter {counter}) after migration",
                     info.id
                 );
-                true
+                MigrationDecryptOutcome {
+                    decrypted: true,
+                    dispatched: false,
+                }
             }
             Err(retry_err) => {
                 log::warn!(
                     "[msg:{}] Decryption still failed after PN→LID migration: {retry_err:?}",
                     info.id
                 );
-                false
+                MigrationDecryptOutcome::default()
             }
         }
     }
@@ -2632,8 +2671,7 @@ mod tests {
         let enc_node_ref = enc_node.as_node_ref();
         let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref).unwrap()];
 
-        // With SessionNotFound, should return (false, false, true) - no success, no dupe, dispatched event
-        let (success, had_duplicates, dispatched) = client
+        let outcome = client
             .process_session_enc_batch(
                 &payloads,
                 &info,
@@ -2643,8 +2681,8 @@ mod tests {
             .await;
 
         assert!(
-            !success && !had_duplicates && dispatched,
-            "process_session_enc_batch should return (false, false, true) when SessionNotFound occurs and dispatches event"
+            !outcome.decrypted && !outcome.duplicate && outcome.undecryptable,
+            "process_session_enc_batch should mark SessionNotFound as undecryptable without success or duplicate"
         );
     }
 
@@ -2721,7 +2759,7 @@ mod tests {
         let enc_node_ref = enc_node.as_node_ref();
         let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref).unwrap()];
 
-        let (success, had_duplicates, dispatched) = client
+        let outcome = client
             .clone()
             .process_session_enc_batch(
                 &payloads,
@@ -2733,9 +2771,9 @@ mod tests {
 
         // Should behave identically to SessionNotFound: failure, no dupe, event dispatched.
         assert!(
-            !success && !had_duplicates && dispatched,
+            !outcome.decrypted && !outcome.duplicate && outcome.undecryptable,
             "Empty session record should be treated as SessionNotFound: \
-             expected (false, false, true), got ({success}, {had_duplicates}, {dispatched})"
+             expected undecryptable without success or duplicate, got {outcome:?}"
         );
 
         // After the WA Web compliance fix (no delete on BadMac/InvalidMessage either),
@@ -2768,9 +2806,11 @@ mod tests {
     use std::collections::HashMap;
     use wacore::libsignal::protocol::{
         CiphertextMessage, Direction, IdentityChange, IdentityKey, IdentityKeyPair, KeyPair,
-        PreKeyBundle, PreKeyRecord, PreKeyStore as SigPreKeyStore, ProtocolAddress, SessionRecord,
+        PreKeyBundle, PreKeyRecord, PreKeyStore as SigPreKeyStore, ProtocolAddress, SenderKeyName,
+        SenderKeyRecord, SenderKeyStore as SigSenderKeyStore, SessionRecord,
         SessionStore as SigSessionStore, SignedPreKeyStore as SigSignedPreKeyStore, UsePQRatchet,
-        message_encrypt, process_prekey_bundle,
+        create_sender_key_distribution_message, group_encrypt, message_encrypt,
+        process_prekey_bundle,
     };
     use wacore::libsignal::protocol::{
         IdentityKeyStore as SigIdentityKeyStore, SignalProtocolError,
@@ -2843,12 +2883,35 @@ mod tests {
         }
     }
 
+    #[derive(Default, Clone)]
+    struct MemSenderKeyStore(HashMap<SenderKeyName, SenderKeyRecord>);
+
+    #[async_trait]
+    impl SigSenderKeyStore for MemSenderKeyStore {
+        async fn store_sender_key(
+            &mut self,
+            name: &SenderKeyName,
+            record: SenderKeyRecord,
+        ) -> Result<(), SignalProtocolError> {
+            self.0.insert(name.clone(), record);
+            Ok(())
+        }
+
+        async fn load_sender_key(
+            &self,
+            name: &SenderKeyName,
+        ) -> Result<Option<SenderKeyRecord>, SignalProtocolError> {
+            Ok(self.0.get(name).cloned())
+        }
+    }
+
     #[derive(Clone)]
     struct AlicePeer {
         jid: Jid,
         address: ProtocolAddress,
         identity: MemIdentityStore,
         sessions: MemSessionStore,
+        sender_keys: MemSenderKeyStore,
     }
 
     impl AlicePeer {
@@ -2866,6 +2929,7 @@ mod tests {
                     known: HashMap::new(),
                 },
                 sessions: MemSessionStore::default(),
+                sender_keys: MemSenderKeyStore::default(),
             }
         }
 
@@ -2891,6 +2955,39 @@ mod tests {
             message_encrypt(plaintext, bob_addr, &mut self.sessions, &mut self.identity)
                 .await
                 .expect("encrypt")
+        }
+
+        async fn create_group_skdm(
+            &mut self,
+            group_jid: &Jid,
+        ) -> wa::message::SenderKeyDistributionMessage {
+            let sender = self.jid.to_non_ad();
+            let sender_key_name = make_sender_key_name(group_jid, &sender.to_protocol_address());
+            let skdm = create_sender_key_distribution_message(
+                &sender_key_name,
+                &mut self.sender_keys,
+                &mut rand::make_rng::<rand::rngs::StdRng>(),
+            )
+            .await
+            .expect("create sender key distribution");
+            wa::message::SenderKeyDistributionMessage {
+                group_id: Some(group_jid.to_string()),
+                axolotl_sender_key_distribution_message: Some(skdm.serialized().to_vec()),
+            }
+        }
+
+        async fn encrypt_group_message(&mut self, group_jid: &Jid, plaintext: &[u8]) -> Vec<u8> {
+            let sender = self.jid.to_non_ad();
+            let sender_key_name = make_sender_key_name(group_jid, &sender.to_protocol_address());
+            let sender_key_message = group_encrypt(
+                &mut self.sender_keys,
+                &sender_key_name,
+                plaintext,
+                &mut rand::make_rng::<rand::rngs::StdRng>(),
+            )
+            .await
+            .expect("encrypt sender key message");
+            sender_key_message.serialized().to_vec()
         }
     }
 
@@ -2995,7 +3092,7 @@ mod tests {
             },
             ..Default::default()
         });
-        let (success, dups, dispatched) = client
+        let outcome = client
             .clone()
             .process_session_enc_batch(
                 &payloads,
@@ -3010,7 +3107,12 @@ mod tests {
             .has_session(&peer_jid.to_protocol_address(), &*backend)
             .await
             .expect("has_session");
-        (success, dups, dispatched, still)
+        (
+            outcome.decrypted,
+            outcome.duplicate,
+            outcome.undecryptable,
+            still,
+        )
     }
 
     #[tokio::test]
@@ -3181,7 +3283,7 @@ mod tests {
             ..Default::default()
         });
 
-        let (success, _, dispatched) = client
+        let outcome = client
             .clone()
             .process_session_enc_batch(
                 &payloads,
@@ -3190,8 +3292,11 @@ mod tests {
                 crate::types::events::DecryptFailMode::Show,
             )
             .await;
-        assert!(!success, "tampered MAC must not decrypt");
-        assert!(dispatched, "undecryptable event must be dispatched");
+        assert!(!outcome.decrypted, "tampered MAC must not decrypt");
+        assert!(
+            outcome.undecryptable,
+            "undecryptable event must be dispatched"
+        );
 
         // The fix asserts the session lives on so the eventual sender pkmsg
         // can archive it into previous_sessions[0].
@@ -3350,7 +3455,7 @@ mod tests {
             },
             ..Default::default()
         });
-        let (_, _, _) = client
+        let _outcome = client
             .clone()
             .process_session_enc_batch(
                 &payloads,
@@ -4331,7 +4436,7 @@ mod tests {
 
         // Call process_session_enc_batch
         // This should handle any errors gracefully without panicking
-        let (success, _had_duplicates, _dispatched) = client
+        let outcome = client
             .process_session_enc_batch(
                 &payloads,
                 &info,
@@ -4342,7 +4447,7 @@ mod tests {
 
         log::info!(
             "Test: process_session_enc_batch completed - success: {}",
-            success
+            outcome.decrypted
         );
 
         // The key is that this didn't panic - deletion uses full protocol address
@@ -4420,7 +4525,7 @@ mod tests {
 
         // Process the batch
         // Should handle all errors gracefully without stopping at first error
-        let (success, _had_duplicates, _dispatched) = client
+        let outcome = client
             .process_session_enc_batch(
                 &payloads,
                 &info,
@@ -4429,7 +4534,10 @@ mod tests {
             )
             .await;
 
-        log::info!("Test: Batch processing completed - success: {}", success);
+        log::info!(
+            "Test: Batch processing completed - success: {}",
+            outcome.decrypted
+        );
     }
 
     /// Test case: Error handling in group chat context
@@ -4492,7 +4600,7 @@ mod tests {
 
         // Process the message
         // Should handle errors gracefully in group context
-        let (success, _had_duplicates, _dispatched) = client
+        let outcome = client
             .process_session_enc_batch(
                 &payloads,
                 &info,
@@ -4501,7 +4609,10 @@ mod tests {
             )
             .await;
 
-        log::info!("Test: Group message processed - success: {}", success);
+        log::info!(
+            "Test: Group message processed - success: {}",
+            outcome.decrypted
+        );
     }
 
     /// Test case: DM message parsing for self-sent messages via LID
@@ -7181,13 +7292,13 @@ mod tests {
             padding_version: 2,
         };
 
-        let (any_success, any_duplicate, dispatched_undecryptable) = client
+        let outcome = client
             .process_session_enc_batch(&[bad_payload], &info, &sender_jid, DecryptFailMode::Show)
             .await;
 
-        assert!(!any_success);
-        assert!(!any_duplicate);
-        assert!(dispatched_undecryptable);
+        assert!(!outcome.decrypted);
+        assert!(!outcome.duplicate);
+        assert!(outcome.undecryptable);
 
         // spawn_nack is detached; give it a tick to flush through the
         // noise_socket sender_task to our CapturingMockTransport.
@@ -7223,11 +7334,11 @@ mod tests {
             padding_version: 2,
         };
 
-        let (_any_success, _any_duplicate, dispatched_undecryptable) = client
+        let outcome = client
             .process_session_enc_batch(&[bad_payload], &info, &sender_jid, DecryptFailMode::Show)
             .await;
 
-        assert!(dispatched_undecryptable);
+        assert!(outcome.undecryptable);
 
         for _ in 0..40 {
             if !transport.sent().is_empty() {
@@ -7315,6 +7426,69 @@ mod tests {
         None
     }
 
+    #[derive(Debug)]
+    struct SentReceipt {
+        to: String,
+        typ: Option<String>,
+        recipient: Option<String>,
+        participant: Option<String>,
+    }
+
+    fn find_receipt_details(frames: &[bytes::Bytes], id: &str) -> Option<SentReceipt> {
+        for (i, frame) in frames.iter().enumerate() {
+            let Some(buf) = decode_frame(i, frame) else {
+                continue;
+            };
+            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+                continue;
+            };
+            if node.tag.as_ref() == "receipt"
+                && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+                && let Some(to) = node.get_attr("to")
+            {
+                return Some(SentReceipt {
+                    to: to.as_str().to_string(),
+                    typ: node.get_attr("type").map(|v| v.as_str().to_string()),
+                    recipient: node.get_attr("recipient").map(|v| v.as_str().to_string()),
+                    participant: node.get_attr("participant").map(|v| v.as_str().to_string()),
+                });
+            }
+        }
+        None
+    }
+
+    #[derive(Debug)]
+    struct SentMessageAck {
+        to: String,
+        participant: Option<String>,
+        recipient: Option<String>,
+    }
+
+    fn find_message_ack_for(frames: &[bytes::Bytes], id: &str) -> Option<SentMessageAck> {
+        for (i, frame) in frames.iter().enumerate() {
+            let Some(buf) = decode_frame(i, frame) else {
+                continue;
+            };
+            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+                continue;
+            };
+            if node.tag.as_ref() == "ack"
+                && node
+                    .get_attr("class")
+                    .is_some_and(|v| v.as_str() == "message")
+                && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+                && let Some(to) = node.get_attr("to")
+            {
+                return Some(SentMessageAck {
+                    to: to.as_str().to_string(),
+                    participant: node.get_attr("participant").map(|v| v.as_str().to_string()),
+                    recipient: node.get_attr("recipient").map(|v| v.as_str().to_string()),
+                });
+            }
+        }
+        None
+    }
+
     /// Count delivery `<receipt>` (anything but type="retry") on the wire for `id`.
     fn delivery_receipts_for(frames: &[bytes::Bytes], id: &str) -> usize {
         let mut count = 0;
@@ -7338,6 +7512,84 @@ mod tests {
             }
         }
         count
+    }
+
+    fn message_acks_for(frames: &[bytes::Bytes], id: &str) -> usize {
+        let mut count = 0;
+        for (i, frame) in frames.iter().enumerate() {
+            let Some(buf) = decode_frame(i, frame) else {
+                continue;
+            };
+            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+                continue;
+            };
+            if node.tag.as_ref() == "ack"
+                && node
+                    .get_attr("class")
+                    .is_some_and(|v| v.as_str() == "message")
+                && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+            {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    fn sender_receipts_for(frames: &[bytes::Bytes], id: &str) -> usize {
+        let mut count = 0;
+        for (i, frame) in frames.iter().enumerate() {
+            let Some(buf) = decode_frame(i, frame) else {
+                continue;
+            };
+            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+                continue;
+            };
+            if node.tag.as_ref() == "receipt"
+                && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+                && node
+                    .get_attr("type")
+                    .is_some_and(|v| v.as_str() == "sender")
+            {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    fn confirmations_for(frames: &[bytes::Bytes], id: &str) -> usize {
+        delivery_receipts_for(frames, id) + message_acks_for(frames, id)
+    }
+
+    async fn wait_for_confirmations(
+        transport: &crate::transport::mock::CapturingMockTransport,
+        id: &str,
+        expected: usize,
+    ) -> usize {
+        let mut count = 0;
+        for _ in 0..80 {
+            count = confirmations_for(&transport.sent(), id);
+            if count >= expected {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        count
+    }
+
+    async fn assert_exactly_one_confirmation(
+        transport: &crate::transport::mock::CapturingMockTransport,
+        id: &str,
+    ) {
+        let count = wait_for_confirmations(transport, id, 1).await;
+        assert_eq!(count, 1, "message {id} must be confirmed exactly once");
+        for _ in 0..5 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            assert_eq!(
+                confirmations_for(&transport.sent(), id),
+                1,
+                "message {id} must not get a late second confirmation"
+            );
+        }
     }
 
     /// A stanza that fails to decrypt must emit a transport `<ack class="message">`
@@ -7691,6 +7943,277 @@ mod tests {
                 decrypt_fail_mode: crate::types::events::DecryptFailMode::Show,
             })
             .await;
+    }
+
+    fn enc_payload_from_ciphertext(ct: &CiphertextMessage) -> EncPayload {
+        let (enc_type, bytes) = match ct {
+            CiphertextMessage::PreKeySignalMessage(m) => ("pkmsg", m.serialized().to_vec()),
+            CiphertextMessage::SignalMessage(m) => ("msg", m.serialized().to_vec()),
+            _ => panic!("unexpected ciphertext type"),
+        };
+        let enc = NodeBuilder::new("enc")
+            .attr("type", enc_type)
+            .bytes(bytes)
+            .build();
+        EncPayload::from_node_ref(&enc.as_node_ref()).expect("ciphertext payload")
+    }
+
+    fn skmsg_payload_from_bytes(bytes: Vec<u8>) -> EncPayload {
+        let enc = NodeBuilder::new("enc")
+            .attr("type", "skmsg")
+            .bytes(bytes)
+            .build();
+        EncPayload::from_node_ref(&enc.as_node_ref()).expect("skmsg payload")
+    }
+
+    fn group_message_info(
+        id: &str,
+        group: &Jid,
+        sender: &Jid,
+        is_from_me: bool,
+    ) -> Arc<MessageInfo> {
+        Arc::new(MessageInfo {
+            id: id.to_string(),
+            source: crate::types::message::MessageSource {
+                sender: sender.clone(),
+                chat: group.clone(),
+                is_from_me,
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    async fn process_group_classified(
+        client: &Arc<Client>,
+        info: Arc<MessageInfo>,
+        sender: &Jid,
+        session_payload: EncPayload,
+        group_payloads: Vec<EncPayload>,
+    ) {
+        client
+            .clone()
+            .process_classified_message(ClassifiedMessage {
+                info,
+                sender_encryption_jid: sender.clone(),
+                session_payloads: vec![session_payload],
+                group_payloads,
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: crate::types::events::DecryptFailMode::Show,
+            })
+            .await;
+    }
+
+    fn message_events_for_id(rx: &async_channel::Receiver<Arc<Event>>, id: &str) -> (usize, usize) {
+        let mut count = 0;
+        let mut visible_content = 0;
+        while let Ok(event) = rx.try_recv() {
+            if let Event::Message(msg, info) = event.as_ref()
+                && info.id == id
+            {
+                count += 1;
+                if msg.conversation.is_some() {
+                    visible_content += 1;
+                }
+            }
+        }
+        (count, visible_content)
+    }
+
+    fn message_texts_for_id(rx: &async_channel::Receiver<Arc<Event>>, id: &str) -> Vec<String> {
+        let mut texts = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let Event::Message(msg, info) = event.as_ref()
+                && info.id == id
+                && let Some(text) = &msg.conversation
+            {
+                texts.push(text.clone());
+            }
+        }
+        texts
+    }
+
+    #[tokio::test]
+    async fn skdm_only_group_session_acknowledged_once_without_message_event() {
+        use wacore::messages::MessageUtils;
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("skdm_only_group_ack").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450525@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575443@g.us".parse().expect("group");
+        let skdm = alice.create_group_skdm(&group).await;
+        let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let session_ct = alice.encrypt(&bob_addr, &plaintext).await;
+        let id = "SKDM_ONLY_SESSION";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified(
+            &client,
+            info,
+            &alice.jid,
+            enc_payload_from_ciphertext(&session_ct),
+            vec![],
+        )
+        .await;
+
+        assert_exactly_one_confirmation(&transport, id).await;
+        assert_eq!(
+            delivery_receipts_for(&transport.sent(), id),
+            1,
+            "incoming group SKDM-only session message should drain via delivery receipt"
+        );
+        let sent = transport.sent();
+        let receipt = find_receipt_details(&sent, id).expect("delivery receipt");
+        let sender_str = alice.jid.to_string();
+        assert_eq!(receipt.to, group.to_string());
+        assert_eq!(receipt.participant.as_deref(), Some(sender_str.as_str()));
+        assert_eq!(receipt.recipient, None);
+        assert_ne!(
+            receipt.typ.as_deref(),
+            Some("sender"),
+            "incoming group SKDM-only must not be cleared as a sender receipt"
+        );
+        assert_eq!(
+            message_acks_for(&sent, id),
+            0,
+            "incoming group SKDM-only must not also emit a transport ack"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            message_events_for_id(&rx, id),
+            (0, 0),
+            "SKDM-only messages must not surface Event::Message"
+        );
+    }
+
+    #[tokio::test]
+    async fn skdm_session_with_skmsg_sibling_acknowledged_once() {
+        use wacore::messages::MessageUtils;
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("skdm_plus_skmsg_ack").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450526@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575444@g.us".parse().expect("group");
+        let skdm = alice.create_group_skdm(&group).await;
+        let skdm_plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let session_ct = alice.encrypt(&bob_addr, &skdm_plaintext).await;
+
+        let content_plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            conversation: Some("group content".to_string()),
+            ..Default::default()
+        });
+        let skmsg = alice
+            .encrypt_group_message(&group, &content_plaintext)
+            .await;
+        let id = "SKDM_WITH_SKMSG";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified(
+            &client,
+            info,
+            &alice.jid,
+            enc_payload_from_ciphertext(&session_ct),
+            vec![skmsg_payload_from_bytes(skmsg)],
+        )
+        .await;
+
+        assert_exactly_one_confirmation(&transport, id).await;
+        assert_eq!(
+            delivery_receipts_for(&transport.sent(), id),
+            1,
+            "the skmsg content dispatch should own the only receipt"
+        );
+        let sent = transport.sent();
+        let receipt = find_receipt_details(&sent, id).expect("delivery receipt");
+        let sender_str = alice.jid.to_string();
+        assert_eq!(receipt.to, group.to_string());
+        assert_eq!(receipt.participant.as_deref(), Some(sender_str.as_str()));
+        assert_eq!(
+            message_acks_for(&sent, id),
+            0,
+            "SKDM+skmsg sibling must not get an extra transport ack"
+        );
+        assert_eq!(
+            message_texts_for_id(&rx, id),
+            vec!["group content".to_string()],
+            "only the skmsg content should dispatch a user message"
+        );
+    }
+
+    #[tokio::test]
+    async fn own_group_skdm_only_session_uses_transport_ack_once() {
+        use wacore::messages::MessageUtils;
+
+        let (client, transport) = capturing_client("own_group_skdm_ack").await;
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("999999999999999@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575445@g.us".parse().expect("group");
+        let skdm = alice.create_group_skdm(&group).await;
+        let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let session_ct = alice.encrypt(&bob_addr, &plaintext).await;
+        let id = "OWN_GROUP_SKDM_ONLY";
+        let info = group_message_info(id, &group, &alice.jid, true);
+
+        process_group_classified(
+            &client,
+            info,
+            &alice.jid,
+            enc_payload_from_ciphertext(&session_ct),
+            vec![],
+        )
+        .await;
+
+        assert_exactly_one_confirmation(&transport, id).await;
+        let sent = transport.sent();
+        assert_eq!(
+            message_acks_for(&sent, id),
+            1,
+            "own group SKDM-only session message should use transport ack"
+        );
+        let ack = find_message_ack_for(&sent, id).expect("transport ack");
+        let sender_str = alice.jid.to_string();
+        assert_eq!(ack.to, group.to_string());
+        assert_eq!(ack.participant.as_deref(), Some(sender_str.as_str()));
+        assert_eq!(ack.recipient, None);
+        assert_eq!(
+            delivery_receipts_for(&sent, id),
+            0,
+            "own group SKDM-only session message must not use a delivery receipt"
+        );
+        assert_eq!(
+            sender_receipts_for(&sent, id),
+            0,
+            "group self-fanout must not use type=sender receipt"
+        );
     }
 
     /// Regression for the offline-backlog disconnect: an already-processed

--- a/src/message.rs
+++ b/src/message.rs
@@ -77,6 +77,7 @@ struct SessionBatchOutcome {
     undecryptable: bool,
     dispatched: bool,
     skdm_only: bool,
+    plaintext_failed: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -85,6 +86,7 @@ struct MigrationDecryptOutcome {
     duplicate: bool,
     dispatched: bool,
     skdm_only: bool,
+    plaintext_failed: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -630,6 +632,23 @@ impl Client {
         true
     }
 
+    async fn handle_plaintext_failure(
+        self: &Arc<Self>,
+        info: &Arc<MessageInfo>,
+        decrypt_fail_mode: crate::types::events::DecryptFailMode,
+    ) -> bool {
+        let dispatched = self
+            .dispatch_undecryptable_event(
+                Arc::clone(info),
+                false,
+                crate::types::events::UnavailableType::Unknown,
+                decrypt_fail_mode,
+            )
+            .await;
+        self.spawn_nack(info, NackReason::InvalidProtobuf, None);
+        dispatched
+    }
+
     /// Increments the retry count for a message and returns the new count.
     /// Returns `None` if max retries have been reached.
     ///
@@ -1119,6 +1138,7 @@ impl Client {
         let session_dispatched_undecryptable = session_outcome.undecryptable;
         let session_dispatched = session_outcome.dispatched;
         let session_skdm_only = session_outcome.skdm_only;
+        let session_plaintext_failed = session_outcome.plaintext_failed;
 
         log::debug!(
             "Starting PASS 2: Processing {} group content messages (skmsg)",
@@ -1212,13 +1232,15 @@ impl Client {
             // Dispatch UndecryptableMessage event for messages that failed to decrypt
             // (This should not cause double-dispatching since process_session_enc_batch
             // already returned dispatched_undecryptable=false for this case)
-            self.dispatch_undecryptable_event(
-                Arc::clone(&info),
-                false,
-                crate::types::events::UnavailableType::Unknown,
-                decrypt_fail_mode,
-            )
-            .await;
+            if !session_dispatched_undecryptable {
+                self.dispatch_undecryptable_event(
+                    Arc::clone(&info),
+                    false,
+                    crate::types::events::UnavailableType::Unknown,
+                    decrypt_fail_mode,
+                )
+                .await;
+            }
             // Do NOT send delivery receipt - transport ack is sufficient
         } else if session_had_duplicates
             && !session_decrypted_successfully
@@ -1231,7 +1253,12 @@ impl Client {
             // (a status SKDM pkmsg can reach here), so skip it to avoid a
             // redundant receipt.
             self.ack_received_message(&info);
-        } else if session_decrypted_successfully && session_skdm_only && !session_dispatched {
+        } else if session_decrypted_successfully
+            && session_skdm_only
+            && !session_dispatched
+            && !session_plaintext_failed
+            && !session_dispatched_undecryptable
+        {
             // SKDM-only session decrypts skip dispatch, so this stanza would
             // otherwise stay queued. WA Web and whatsmeow ack every decrypted
             // message; the ack shape still comes from the message source.
@@ -1404,6 +1431,10 @@ impl Client {
                                 info.id,
                                 info.source.sender
                             );
+                            outcome.decrypted = true;
+                            outcome.plaintext_failed = true;
+                            outcome.undecryptable |=
+                                self.handle_plaintext_failure(info, decrypt_fail_mode).await;
                         }
                     }
                 }
@@ -1494,6 +1525,11 @@ impl Client {
                                         log::warn!(
                                             "Failed processing plaintext after identity retry: {e:?}"
                                         );
+                                        outcome.decrypted = true;
+                                        outcome.plaintext_failed = true;
+                                        outcome.undecryptable |= self
+                                            .handle_plaintext_failure(info, decrypt_fail_mode)
+                                            .await;
                                     }
                                 }
                             }
@@ -1530,11 +1566,21 @@ impl Client {
                                             &mut session_guard,
                                         )
                                         .await;
-                                    if migration_outcome.decrypted || migration_outcome.duplicate {
+                                    if migration_outcome.decrypted
+                                        || migration_outcome.duplicate
+                                        || migration_outcome.plaintext_failed
+                                    {
                                         outcome.decrypted |= migration_outcome.decrypted;
                                         outcome.duplicate |= migration_outcome.duplicate;
                                         outcome.dispatched |= migration_outcome.dispatched;
                                         outcome.skdm_only |= migration_outcome.skdm_only;
+                                        outcome.plaintext_failed |=
+                                            migration_outcome.plaintext_failed;
+                                        if migration_outcome.plaintext_failed {
+                                            outcome.undecryptable |= self
+                                                .handle_plaintext_failure(info, decrypt_fail_mode)
+                                                .await;
+                                        }
                                     } else {
                                         log::debug!(
                                             "[msg:{}] InvalidPreKeyId after identity change for {}. \
@@ -1601,11 +1647,19 @@ impl Client {
                                 &mut session_guard,
                             )
                             .await;
-                        if migration_outcome.decrypted || migration_outcome.duplicate {
+                        if migration_outcome.decrypted
+                            || migration_outcome.duplicate
+                            || migration_outcome.plaintext_failed
+                        {
                             outcome.decrypted |= migration_outcome.decrypted;
                             outcome.duplicate |= migration_outcome.duplicate;
                             outcome.dispatched |= migration_outcome.dispatched;
                             outcome.skdm_only |= migration_outcome.skdm_only;
+                            outcome.plaintext_failed |= migration_outcome.plaintext_failed;
+                            if migration_outcome.plaintext_failed {
+                                outcome.undecryptable |=
+                                    self.handle_plaintext_failure(info, decrypt_fail_mode).await;
+                            }
                             continue;
                         }
 
@@ -1637,11 +1691,19 @@ impl Client {
                                 &mut session_guard,
                             )
                             .await;
-                        if migration_outcome.decrypted || migration_outcome.duplicate {
+                        if migration_outcome.decrypted
+                            || migration_outcome.duplicate
+                            || migration_outcome.plaintext_failed
+                        {
                             outcome.decrypted |= migration_outcome.decrypted;
                             outcome.duplicate |= migration_outcome.duplicate;
                             outcome.dispatched |= migration_outcome.dispatched;
                             outcome.skdm_only |= migration_outcome.skdm_only;
+                            outcome.plaintext_failed |= migration_outcome.plaintext_failed;
+                            if migration_outcome.plaintext_failed {
+                                outcome.undecryptable |=
+                                    self.handle_plaintext_failure(info, decrypt_fail_mode).await;
+                            }
                             continue;
                         }
 
@@ -1684,11 +1746,19 @@ impl Client {
                                 &mut session_guard,
                             )
                             .await;
-                        if migration_outcome.decrypted || migration_outcome.duplicate {
+                        if migration_outcome.decrypted
+                            || migration_outcome.duplicate
+                            || migration_outcome.plaintext_failed
+                        {
                             outcome.decrypted |= migration_outcome.decrypted;
                             outcome.duplicate |= migration_outcome.duplicate;
                             outcome.dispatched |= migration_outcome.dispatched;
                             outcome.skdm_only |= migration_outcome.skdm_only;
+                            outcome.plaintext_failed |= migration_outcome.plaintext_failed;
+                            if migration_outcome.plaintext_failed {
+                                outcome.undecryptable |=
+                                    self.handle_plaintext_failure(info, decrypt_fail_mode).await;
+                            }
                             continue;
                         }
 
@@ -2092,7 +2162,11 @@ impl Client {
                             "[msg:{}] Failed processing plaintext after migration: {e:?}",
                             info.id
                         );
-                        MigrationDecryptOutcome::default()
+                        MigrationDecryptOutcome {
+                            decrypted: true,
+                            plaintext_failed: true,
+                            ..Default::default()
+                        }
                     }
                 }
             }
@@ -3228,6 +3302,97 @@ mod tests {
             .await
             .expect("has_session");
         assert!(!pn_after, "PN session should be consumed by migration");
+    }
+
+    #[tokio::test]
+    async fn migration_plaintext_failure_nacks_without_signal_retry() {
+        use crate::lid_pn_cache::{LearningSource, LidPnEntry};
+
+        let (client, transport) = capturing_client("migration_plaintext_nack").await;
+        let alice_pn: Jid = "15550001002@s.whatsapp.net".parse().expect("alice pn");
+        let alice_lid: Jid = "100000000000004@lid".parse().expect("alice lid");
+        let entry = LidPnEntry::new(
+            alice_lid.user.to_string(),
+            alice_pn.user.to_string(),
+            LearningSource::PeerLidMessage,
+        );
+        client.lid_pn_cache.add(&entry).await;
+
+        let (bundle_v1, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let alice_pn_str = alice_pn.to_string();
+        let mut alice_old = AlicePeer::new(&alice_pn_str).await;
+        alice_old.install_bob_session(&bob_addr, &bundle_v1).await;
+        let pkmsg_v1 = alice_old.encrypt_text(&bob_addr, "pn establish").await;
+        let (pn_success, _, _, _) = submit_and_check_session(&client, &alice_pn, &pkmsg_v1).await;
+        assert!(pn_success, "PN-keyed session should establish");
+
+        if let Some(record) = alice_old.sessions.0.get_mut(&bob_addr)
+            && let Some(state) = record.session_state_mut()
+        {
+            state.clear_unacknowledged_pre_key_message();
+        }
+
+        let mut alice_fresh = alice_old.clone();
+        alice_fresh.jid = alice_lid.clone();
+        alice_fresh.address = alice_lid.to_protocol_address();
+        alice_fresh.sessions = MemSessionStore::default();
+
+        let (bundle_v2, _) = bobs_prekey_bundle(&client).await;
+        alice_fresh.install_bob_session(&bob_addr, &bundle_v2).await;
+        let pkmsg_v2 = alice_fresh.encrypt_text(&bob_addr, "lid shadow").await;
+        let (lid_success, _, _, _) = submit_and_check_session(&client, &alice_lid, &pkmsg_v2).await;
+        assert!(lid_success, "LID-keyed shadow session should establish");
+
+        let bad_old_pn_msg = alice_old.encrypt(&bob_addr, &[0xff, 0x01]).await;
+        let payloads = vec![enc_payload_from_ciphertext(&bad_old_pn_msg)];
+        let info = Arc::new(MessageInfo {
+            id: "MIGRATION_BAD_PLAINTEXT".to_string(),
+            source: crate::types::message::MessageSource {
+                sender: alice_lid.clone(),
+                chat: alice_lid.clone(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let outcome = client
+            .clone()
+            .process_session_enc_batch(
+                &payloads,
+                &info,
+                &alice_lid,
+                crate::types::events::DecryptFailMode::Show,
+            )
+            .await;
+
+        assert!(
+            outcome.decrypted,
+            "Signal decrypt succeeded after migration"
+        );
+        assert!(outcome.plaintext_failed);
+        assert!(outcome.undecryptable);
+        assert!(!outcome.dispatched);
+        assert!(!outcome.skdm_only);
+
+        let mut nack_code = None;
+        for _ in 0..80 {
+            nack_code = find_message_nack_error(&transport.sent(), &info.id);
+            if nack_code.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(nack_code, Some(491));
+
+        let cache_key = client
+            .make_retry_cache_key(&info.source.chat, &info.id, &info.source.sender)
+            .await;
+        assert_eq!(
+            client.message_retry_counts.get(&cache_key).await,
+            None,
+            "local protobuf failure after migration must not request Signal retry"
+        );
     }
 
     /// Smoking-gun regression: a `BadMac` on the inbound path must NOT delete
@@ -8044,12 +8209,29 @@ mod tests {
         session_payload: EncPayload,
         group_payloads: Vec<EncPayload>,
     ) {
+        process_group_classified_with_sessions(
+            client,
+            info,
+            sender,
+            vec![session_payload],
+            group_payloads,
+        )
+        .await;
+    }
+
+    async fn process_group_classified_with_sessions(
+        client: &Arc<Client>,
+        info: Arc<MessageInfo>,
+        sender: &Jid,
+        session_payloads: Vec<EncPayload>,
+        group_payloads: Vec<EncPayload>,
+    ) {
         client
             .clone()
             .process_classified_message(ClassifiedMessage {
                 info,
                 sender_encryption_jid: sender.clone(),
-                session_payloads: vec![session_payload],
+                session_payloads,
                 group_payloads,
                 bot_payloads: vec![],
                 max_sender_retry_count: 0,
@@ -8197,6 +8379,84 @@ mod tests {
             message_events_for_id(&rx, id),
             (0, 0),
             "invalid plaintext must not surface Event::Message"
+        );
+        let mut nack_code = None;
+        for _ in 0..80 {
+            nack_code = find_message_nack_error(&transport.sent(), id);
+            if nack_code.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(
+            nack_code,
+            Some(491),
+            "invalid decrypted protobuf must be drained with InvalidProtobuf nack"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_skdm_and_bad_plaintext_session_is_nacked_not_positive_acked() {
+        use wacore::messages::MessageUtils;
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("mixed_skdm_bad_plaintext").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+        let recorder = Arc::new(EventRecorder::default());
+        client.register_handler(recorder.clone());
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450531@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575449@g.us".parse().expect("group");
+        let skdm = alice.create_group_skdm(&group).await;
+        let skdm_plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let skdm_ct = alice.encrypt(&bob_addr, &skdm_plaintext).await;
+        let bad_ct = alice.encrypt(&bob_addr, &[0xff, 0x01]).await;
+        let id = "SKDM_WITH_BAD_SESSION";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified_with_sessions(
+            &client,
+            info,
+            &alice.jid,
+            vec![
+                enc_payload_from_ciphertext(&skdm_ct),
+                enc_payload_from_ciphertext(&bad_ct),
+            ],
+            vec![],
+        )
+        .await;
+
+        let mut nack_code = None;
+        for _ in 0..80 {
+            nack_code = find_message_nack_error(&transport.sent(), id);
+            if nack_code.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(nack_code, Some(491));
+        assert_eq!(
+            confirmations_for(&transport.sent(), id),
+            0,
+            "SKDM-only fallback must not positive-ack a mixed malformed session batch"
+        );
+        assert_eq!(
+            recorder.undecryptable().len(),
+            1,
+            "the malformed sibling must still surface as undecryptable"
+        );
+        assert_eq!(
+            message_events_for_id(&rx, id),
+            (0, 0),
+            "mixed SKDM and bad plaintext must not dispatch user content"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -76,12 +76,21 @@ struct SessionBatchOutcome {
     duplicate: bool,
     undecryptable: bool,
     dispatched: bool,
+    skdm_only: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 struct MigrationDecryptOutcome {
     decrypted: bool,
+    duplicate: bool,
     dispatched: bool,
+    skdm_only: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PlaintextHandleOutcome {
+    dispatched: bool,
+    skdm_only: bool,
 }
 
 /// Retry count threshold for logging high retry warnings.
@@ -1109,6 +1118,7 @@ impl Client {
         let session_had_duplicates = session_outcome.duplicate;
         let session_dispatched_undecryptable = session_outcome.undecryptable;
         let session_dispatched = session_outcome.dispatched;
+        let session_skdm_only = session_outcome.skdm_only;
 
         log::debug!(
             "Starting PASS 2: Processing {} group content messages (skmsg)",
@@ -1221,10 +1231,12 @@ impl Client {
             // (a status SKDM pkmsg can reach here), so skip it to avoid a
             // redundant receipt.
             self.ack_received_message(&info);
-        } else if session_decrypted_successfully && !session_dispatched {
+        } else if session_decrypted_successfully && session_skdm_only && !session_dispatched {
             // SKDM-only session decrypts skip dispatch, so this stanza would
             // otherwise stay queued. WA Web and whatsmeow ack every decrypted
             // message; the ack shape still comes from the message source.
+            // Status is intentionally not filtered here, so its success receipt
+            // still follows the normal WA Web path.
             self.ack_received_message(&info);
         }
 
@@ -1371,7 +1383,6 @@ impl Client {
 
             match decrypt_res {
                 Ok(padded_plaintext) => {
-                    outcome.decrypted = true;
                     match self
                         .clone()
                         .handle_decrypted_plaintext(
@@ -1382,7 +1393,11 @@ impl Client {
                         )
                         .await
                     {
-                        Ok(dispatched) => outcome.dispatched |= dispatched,
+                        Ok(plaintext_outcome) => {
+                            outcome.decrypted = true;
+                            outcome.dispatched |= plaintext_outcome.dispatched;
+                            outcome.skdm_only |= plaintext_outcome.skdm_only;
+                        }
                         Err(e) => {
                             log::warn!(
                                 "[msg:{}] Failed processing plaintext from {}: {e:?}",
@@ -1460,7 +1475,6 @@ impl Client {
                                     info.id,
                                     address
                                 );
-                                outcome.decrypted = true;
                                 match self
                                     .clone()
                                     .handle_decrypted_plaintext(
@@ -1471,7 +1485,11 @@ impl Client {
                                     )
                                     .await
                                 {
-                                    Ok(dispatched) => outcome.dispatched |= dispatched,
+                                    Ok(plaintext_outcome) => {
+                                        outcome.decrypted = true;
+                                        outcome.dispatched |= plaintext_outcome.dispatched;
+                                        outcome.skdm_only |= plaintext_outcome.skdm_only;
+                                    }
                                     Err(e) => {
                                         log::warn!(
                                             "Failed processing plaintext after identity retry: {e:?}"
@@ -1512,9 +1530,11 @@ impl Client {
                                             &mut session_guard,
                                         )
                                         .await;
-                                    if migration_outcome.decrypted {
-                                        outcome.decrypted = true;
+                                    if migration_outcome.decrypted || migration_outcome.duplicate {
+                                        outcome.decrypted |= migration_outcome.decrypted;
+                                        outcome.duplicate |= migration_outcome.duplicate;
                                         outcome.dispatched |= migration_outcome.dispatched;
+                                        outcome.skdm_only |= migration_outcome.skdm_only;
                                     } else {
                                         log::debug!(
                                             "[msg:{}] InvalidPreKeyId after identity change for {}. \
@@ -1581,9 +1601,11 @@ impl Client {
                                 &mut session_guard,
                             )
                             .await;
-                        if migration_outcome.decrypted {
-                            outcome.decrypted = true;
+                        if migration_outcome.decrypted || migration_outcome.duplicate {
+                            outcome.decrypted |= migration_outcome.decrypted;
+                            outcome.duplicate |= migration_outcome.duplicate;
                             outcome.dispatched |= migration_outcome.dispatched;
+                            outcome.skdm_only |= migration_outcome.skdm_only;
                             continue;
                         }
 
@@ -1615,9 +1637,11 @@ impl Client {
                                 &mut session_guard,
                             )
                             .await;
-                        if migration_outcome.decrypted {
-                            outcome.decrypted = true;
+                        if migration_outcome.decrypted || migration_outcome.duplicate {
+                            outcome.decrypted |= migration_outcome.decrypted;
+                            outcome.duplicate |= migration_outcome.duplicate;
                             outcome.dispatched |= migration_outcome.dispatched;
+                            outcome.skdm_only |= migration_outcome.skdm_only;
                             continue;
                         }
 
@@ -1660,9 +1684,11 @@ impl Client {
                                 &mut session_guard,
                             )
                             .await;
-                        if migration_outcome.decrypted {
-                            outcome.decrypted = true;
+                        if migration_outcome.decrypted || migration_outcome.duplicate {
+                            outcome.decrypted |= migration_outcome.decrypted;
+                            outcome.duplicate |= migration_outcome.duplicate;
                             outcome.dispatched |= migration_outcome.dispatched;
+                            outcome.skdm_only |= migration_outcome.skdm_only;
                             continue;
                         }
 
@@ -1884,7 +1910,7 @@ impl Client {
         padded_plaintext: &[u8],
         padding_version: u8,
         info: &Arc<MessageInfo>,
-    ) -> Result<bool, anyhow::Error> {
+    ) -> Result<PlaintextHandleOutcome, anyhow::Error> {
         let original_msg = wacore::messages::decode_plaintext(padded_plaintext, padding_version)?;
         log::debug!(
             "[msg:{}] Successfully decrypted message from {}: type={} [batch path]",
@@ -1977,10 +2003,16 @@ impl Client {
                 "[msg:{}] Skipping event dispatch for sender key distribution message",
                 info.id
             );
-            Ok(false)
+            Ok(PlaintextHandleOutcome {
+                skdm_only: true,
+                ..Default::default()
+            })
         } else {
             self.dispatch_parsed_message(msg, info).await;
-            Ok(true)
+            Ok(PlaintextHandleOutcome {
+                dispatched: true,
+                ..Default::default()
+            })
         }
     }
 
@@ -2044,23 +2076,24 @@ impl Client {
                     info.id,
                     info.source.sender
                 );
-                let dispatched = match self
+                match self
                     .clone()
                     .handle_decrypted_plaintext(enc_type, &padded_plaintext, padding_version, info)
                     .await
                 {
-                    Ok(dispatched) => dispatched,
+                    Ok(plaintext_outcome) => MigrationDecryptOutcome {
+                        decrypted: true,
+                        dispatched: plaintext_outcome.dispatched,
+                        skdm_only: plaintext_outcome.skdm_only,
+                        ..Default::default()
+                    },
                     Err(e) => {
                         log::warn!(
                             "[msg:{}] Failed processing plaintext after migration: {e:?}",
                             info.id
                         );
-                        false
+                        MigrationDecryptOutcome::default()
                     }
-                };
-                MigrationDecryptOutcome {
-                    decrypted: true,
-                    dispatched,
                 }
             }
             Err(SignalProtocolError::DuplicatedMessage(chain, counter)) => {
@@ -2069,8 +2102,8 @@ impl Client {
                     info.id
                 );
                 MigrationDecryptOutcome {
-                    decrypted: true,
-                    dispatched: false,
+                    duplicate: true,
+                    ..Default::default()
                 }
             }
             Err(retry_err) => {
@@ -2957,6 +2990,20 @@ mod tests {
                 .expect("encrypt")
         }
 
+        async fn encrypt_text(
+            &mut self,
+            bob_addr: &ProtocolAddress,
+            text: &str,
+        ) -> CiphertextMessage {
+            use wacore::messages::MessageUtils;
+
+            let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+                conversation: Some(text.to_string()),
+                ..Default::default()
+            });
+            self.encrypt(bob_addr, &plaintext).await
+        }
+
         async fn create_group_skdm(
             &mut self,
             group_jid: &Jid,
@@ -3134,7 +3181,7 @@ mod tests {
         let alice_pn_str = alice_pn.to_string();
         let mut alice_old = AlicePeer::new(&alice_pn_str).await;
         alice_old.install_bob_session(&bob_addr, &bundle_v1).await;
-        let pkmsg_v1 = alice_old.encrypt(&bob_addr, b"pn establish").await;
+        let pkmsg_v1 = alice_old.encrypt_text(&bob_addr, "pn establish").await;
         let (pn_success, _, _, pn_still) =
             submit_and_check_session(&client, &alice_pn, &pkmsg_v1).await;
         assert!(pn_success, "PN-keyed session should establish");
@@ -3156,13 +3203,13 @@ mod tests {
 
         let (bundle_v2, _) = bobs_prekey_bundle(&client).await;
         alice_fresh.install_bob_session(&bob_addr, &bundle_v2).await;
-        let pkmsg_v2 = alice_fresh.encrypt(&bob_addr, b"lid shadow").await;
+        let pkmsg_v2 = alice_fresh.encrypt_text(&bob_addr, "lid shadow").await;
         let (lid_success, _, _, lid_still) =
             submit_and_check_session(&client, &alice_lid, &pkmsg_v2).await;
         assert!(lid_success, "LID-keyed shadow session should establish");
         assert!(lid_still, "LID-keyed shadow session should exist");
 
-        let old_pn_msg = alice_old.encrypt(&bob_addr, b"old pn ratchet").await;
+        let old_pn_msg = alice_old.encrypt_text(&bob_addr, "old pn ratchet").await;
         assert!(matches!(old_pn_msg, CiphertextMessage::SignalMessage(_)));
         let (success, duplicates, dispatched, lid_after) =
             submit_and_check_session(&client, &alice_lid, &old_pn_msg).await;
@@ -3231,7 +3278,7 @@ mod tests {
                 .clone())
             .expect("own jid")
             .to_protocol_address();
-        let pkmsg = alice.encrypt(&bob_addr, b"hello").await;
+        let pkmsg = alice.encrypt_text(&bob_addr, "hello").await;
         let (s1, _, _, still1) = submit_and_check_session(&client, &alice.jid, &pkmsg).await;
         assert!(s1, "pkmsg should establish session and decrypt");
         assert!(still1, "session must exist after first message");
@@ -3257,7 +3304,7 @@ mod tests {
         // The format is `[version][protobuf body][8-byte MAC]`, so the last byte
         // is squarely inside the MAC region — parse succeeds, MAC verification
         // fails -> libsignal returns BadMac.
-        let msg2 = alice.encrypt(&bob_addr, b"world").await;
+        let msg2 = alice.encrypt_text(&bob_addr, "world").await;
         let mut bytes = match &msg2 {
             CiphertextMessage::SignalMessage(m) => m.serialized().to_vec(),
             other => panic!(
@@ -3391,7 +3438,7 @@ mod tests {
             .expect("own jid")
             .to_protocol_address();
         alice.install_bob_session(&bob_addr, &bundle_v1).await;
-        let pkmsg_v1 = alice.encrypt(&bob_addr, b"v1").await;
+        let pkmsg_v1 = alice.encrypt_text(&bob_addr, "v1").await;
         let (s1, _, _, _) = submit_and_check_session(&client, &alice.jid, &pkmsg_v1).await;
         assert!(s1);
 
@@ -3430,7 +3477,7 @@ mod tests {
 
         // Tampered SignalMessage → BadMac branch (with the fix this no longer
         // deletes Bob's session).
-        let msg = alice.encrypt(&bob_addr, b"stale").await;
+        let msg = alice.encrypt_text(&bob_addr, "stale").await;
         let mut bytes = match &msg {
             CiphertextMessage::SignalMessage(m) => m.serialized().to_vec(),
             other => panic!(
@@ -3482,7 +3529,7 @@ mod tests {
         let (bundle_v2, _) = bobs_prekey_bundle(&client).await;
         alice.sessions = MemSessionStore::default(); // forget Alice's v1 to force a fresh X3DH
         alice.install_bob_session(&bob_addr, &bundle_v2).await;
-        let pkmsg_v2 = alice.encrypt(&bob_addr, b"v2").await;
+        let pkmsg_v2 = alice.encrypt_text(&bob_addr, "v2").await;
         let (s2, _, _, still2) = submit_and_check_session(&client, &alice.jid, &pkmsg_v2).await;
         assert!(s2, "pkmsg_v2 should decrypt");
         assert!(still2);
@@ -7393,6 +7440,7 @@ mod tests {
                 && node
                     .get_attr("class")
                     .is_some_and(|v| v.as_str() == "message")
+                && node.get_attr("error").is_none()
                 && let Some(to) = node.get_attr("to")
             {
                 let recipient = node.get_attr("recipient").map(|v| v.as_str().to_string());
@@ -7432,6 +7480,7 @@ mod tests {
         typ: Option<String>,
         recipient: Option<String>,
         participant: Option<String>,
+        context: Option<String>,
     }
 
     fn find_receipt_details(frames: &[bytes::Bytes], id: &str) -> Option<SentReceipt> {
@@ -7451,6 +7500,7 @@ mod tests {
                     typ: node.get_attr("type").map(|v| v.as_str().to_string()),
                     recipient: node.get_attr("recipient").map(|v| v.as_str().to_string()),
                     participant: node.get_attr("participant").map(|v| v.as_str().to_string()),
+                    context: node.get_attr("context").map(|v| v.as_str().to_string()),
                 });
             }
         }
@@ -7476,6 +7526,7 @@ mod tests {
                 && node
                     .get_attr("class")
                     .is_some_and(|v| v.as_str() == "message")
+                && node.get_attr("error").is_none()
                 && node.get_attr("id").is_some_and(|v| v.as_str() == id)
                 && let Some(to) = node.get_attr("to")
             {
@@ -7527,6 +7578,7 @@ mod tests {
                 && node
                     .get_attr("class")
                     .is_some_and(|v| v.as_str() == "message")
+                && node.get_attr("error").is_none()
                 && node.get_attr("id").is_some_and(|v| v.as_str() == id)
             {
                 count += 1;
@@ -8099,6 +8151,212 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_plaintext_decode_error_is_not_acked_as_skdm_only() {
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("bad_plaintext_no_skdm_ack").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+        let recorder = Arc::new(EventRecorder::default());
+        client.register_handler(recorder.clone());
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450527@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575446@g.us".parse().expect("group");
+        let invalid_padded_plaintext = vec![0xff, 0x01];
+        let session_ct = alice.encrypt(&bob_addr, &invalid_padded_plaintext).await;
+        let id = "BAD_SESSION_PLAINTEXT";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified(
+            &client,
+            info,
+            &alice.jid,
+            enc_payload_from_ciphertext(&session_ct),
+            vec![],
+        )
+        .await;
+
+        for _ in 0..5 {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            assert_eq!(
+                confirmations_for(&transport.sent(), id),
+                0,
+                "invalid plaintext must not be counted as a successful SKDM-only ack"
+            );
+        }
+        assert_eq!(
+            recorder.undecryptable().len(),
+            1,
+            "plaintext handler failures must stay on the undecryptable path"
+        );
+        assert_eq!(
+            message_events_for_id(&rx, id),
+            (0, 0),
+            "invalid plaintext must not surface Event::Message"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_content_group_message_acknowledged_once_without_fallback() {
+        use wacore::messages::MessageUtils;
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("session_content_group_ack").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450528@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575447@g.us".parse().expect("group");
+        let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            conversation: Some("session content".to_string()),
+            ..Default::default()
+        });
+        let session_ct = alice.encrypt(&bob_addr, &plaintext).await;
+        let id = "SESSION_CONTENT_GROUP";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified(
+            &client,
+            info,
+            &alice.jid,
+            enc_payload_from_ciphertext(&session_ct),
+            vec![],
+        )
+        .await;
+
+        assert_exactly_one_confirmation(&transport, id).await;
+        let sent = transport.sent();
+        assert_eq!(
+            delivery_receipts_for(&sent, id),
+            1,
+            "session content dispatch should own the only delivery receipt"
+        );
+        assert_eq!(
+            message_acks_for(&sent, id),
+            0,
+            "normal session content must not also use the SKDM-only transport ack"
+        );
+        assert_eq!(
+            message_texts_for_id(&rx, id),
+            vec!["session content".to_string()],
+            "normal session content must dispatch exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn status_skdm_only_session_uses_one_status_receipt() {
+        use wacore::messages::MessageUtils;
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("status_skdm_only_ack").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450529@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let status: Jid = "status@broadcast".parse().expect("status");
+        let skdm = alice.create_group_skdm(&status).await;
+        let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let session_ct = alice.encrypt(&bob_addr, &plaintext).await;
+        let id = "STATUS_SKDM_ONLY";
+        let info = group_message_info(id, &status, &alice.jid, false);
+
+        process_group_classified(
+            &client,
+            info,
+            &alice.jid,
+            enc_payload_from_ciphertext(&session_ct),
+            vec![],
+        )
+        .await;
+
+        assert_exactly_one_confirmation(&transport, id).await;
+        let sent = transport.sent();
+        assert_eq!(
+            delivery_receipts_for(&sent, id),
+            1,
+            "status SKDM-only success must still send the WA Web status receipt"
+        );
+        assert_eq!(
+            message_acks_for(&sent, id),
+            0,
+            "status success path should not use a transport ack"
+        );
+        let receipt = find_receipt_details(&sent, id).expect("status delivery receipt");
+        let sender_str = alice.jid.to_string();
+        assert_eq!(receipt.to, status.to_string());
+        assert_eq!(receipt.participant.as_deref(), Some(sender_str.as_str()));
+        assert_eq!(receipt.context.as_deref(), Some("status"));
+        assert_eq!(
+            message_events_for_id(&rx, id),
+            (0, 0),
+            "status SKDM-only messages must not surface Event::Message"
+        );
+    }
+
+    #[tokio::test]
+    async fn error_message_ack_is_not_counted_as_positive_confirmation() {
+        let (client, transport) = capturing_client("error_ack_not_positive").await;
+        let id = "ERROR_ACK_NOT_POSITIVE";
+        let info = Arc::new(MessageInfo {
+            id: id.to_string(),
+            source: crate::types::message::MessageSource {
+                sender: "146824178450530@lid".parse().expect("sender"),
+                chat: "120363408782575448@g.us".parse().expect("group"),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        client.spawn_nack(
+            &info,
+            wacore::protocol::nack::NackReason::ParsingError,
+            None,
+        );
+
+        let mut nack_code = None;
+        for _ in 0..80 {
+            nack_code = find_message_nack_error(&transport.sent(), id);
+            if nack_code.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(nack_code, Some(487));
+
+        let sent = transport.sent();
+        assert_eq!(
+            message_acks_for(&sent, id),
+            0,
+            "nacks carry class=message but must not count as positive transport acks"
+        );
+        assert_eq!(
+            confirmations_for(&sent, id),
+            0,
+            "nacks must not satisfy exactly-one positive confirmation assertions"
+        );
+        assert!(
+            find_message_ack_for(&sent, id).is_none(),
+            "error acks must be excluded from positive ack lookup"
+        );
+    }
+
+    #[tokio::test]
     async fn skdm_session_with_skmsg_sibling_acknowledged_once() {
         use wacore::messages::MessageUtils;
         use wacore::types::events::ChannelEventHandler;
@@ -8230,7 +8488,7 @@ mod tests {
 
         // Establish the session, then mark Alice's prekey acked so her next message
         // is a plain SignalMessage. Re-submitting it is a clean duplicate.
-        let establish = alice.encrypt(&bob_addr, b"establish").await;
+        let establish = alice.encrypt_text(&bob_addr, "establish").await;
         process_session_ct(&client, &alice.jid, "EST", &establish).await;
         if let Some(record) = alice.sessions.0.get_mut(&bob_addr)
             && let Some(state) = record.session_state_mut()

--- a/src/message.rs
+++ b/src/message.rs
@@ -78,6 +78,7 @@ struct SessionBatchOutcome {
     dispatched: bool,
     skdm_only: bool,
     plaintext_failed: bool,
+    had_failure: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -1139,6 +1140,7 @@ impl Client {
         let session_dispatched = session_outcome.dispatched;
         let session_skdm_only = session_outcome.skdm_only;
         let session_plaintext_failed = session_outcome.plaintext_failed;
+        let session_had_failure = session_outcome.had_failure;
 
         log::debug!(
             "Starting PASS 2: Processing {} group content messages (skmsg)",
@@ -1156,8 +1158,8 @@ impl Client {
         // to resend the entire message including SKDM.
         if !group_payloads.is_empty() {
             let should_process_skmsg = session_payloads.is_empty()
-                || session_decrypted_successfully
-                || session_had_duplicates;
+                || (!session_had_failure
+                    && (session_decrypted_successfully || session_had_duplicates));
 
             if should_process_skmsg {
                 match self
@@ -1256,8 +1258,10 @@ impl Client {
         } else if session_decrypted_successfully
             && session_skdm_only
             && !session_dispatched
+            && !session_had_failure
             && !session_plaintext_failed
             && !session_dispatched_undecryptable
+            && bot_payloads.is_empty()
         {
             // SKDM-only session decrypts skip dispatch, so this stanza would
             // otherwise stay queued. WA Web and whatsmeow ack every decrypted
@@ -1329,6 +1333,7 @@ impl Client {
                         );
                         // |= so a later dedup'd return (false) can't clobber
                         // a true set by a prior iteration in this batch.
+                        outcome.had_failure = true;
                         outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
@@ -1350,6 +1355,7 @@ impl Client {
                             info.id,
                             info.source.sender
                         );
+                        outcome.had_failure = true;
                         outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
@@ -1433,6 +1439,7 @@ impl Client {
                             );
                             outcome.decrypted = true;
                             outcome.plaintext_failed = true;
+                            outcome.had_failure = true;
                             outcome.undecryptable |=
                                 self.handle_plaintext_failure(info, decrypt_fail_mode).await;
                         }
@@ -1527,6 +1534,7 @@ impl Client {
                                         );
                                         outcome.decrypted = true;
                                         outcome.plaintext_failed = true;
+                                        outcome.had_failure = true;
                                         outcome.undecryptable |= self
                                             .handle_plaintext_failure(info, decrypt_fail_mode)
                                             .await;
@@ -1576,6 +1584,7 @@ impl Client {
                                         outcome.skdm_only |= migration_outcome.skdm_only;
                                         outcome.plaintext_failed |=
                                             migration_outcome.plaintext_failed;
+                                        outcome.had_failure |= migration_outcome.plaintext_failed;
                                         if migration_outcome.plaintext_failed {
                                             outcome.undecryptable |= self
                                                 .handle_plaintext_failure(info, decrypt_fail_mode)
@@ -1588,6 +1597,7 @@ impl Client {
                                             info.id,
                                             address
                                         );
+                                        outcome.had_failure = true;
                                         outcome.undecryptable = self
                                             .handle_decrypt_failure(
                                                 info,
@@ -1605,6 +1615,7 @@ impl Client {
                                     );
                                     // Send retry receipt so the sender resends with a PreKeySignalMessage
                                     // to establish a new session with the new identity
+                                    outcome.had_failure = true;
                                     outcome.undecryptable = self
                                         .handle_decrypt_failure(
                                             info,
@@ -1656,6 +1667,7 @@ impl Client {
                             outcome.dispatched |= migration_outcome.dispatched;
                             outcome.skdm_only |= migration_outcome.skdm_only;
                             outcome.plaintext_failed |= migration_outcome.plaintext_failed;
+                            outcome.had_failure |= migration_outcome.plaintext_failed;
                             if migration_outcome.plaintext_failed {
                                 outcome.undecryptable |=
                                     self.handle_plaintext_failure(info, decrypt_fail_mode).await;
@@ -1667,6 +1679,7 @@ impl Client {
                             "[msg:{}] No session found for {} message from {}. Sending retry receipt to request session establishment.",
                             info.id, enc_type, info.source.sender
                         );
+                        outcome.had_failure = true;
                         outcome.undecryptable = self
                             .handle_decrypt_failure(info, RetryReason::NoSession, decrypt_fail_mode)
                             .await;
@@ -1700,6 +1713,7 @@ impl Client {
                             outcome.dispatched |= migration_outcome.dispatched;
                             outcome.skdm_only |= migration_outcome.skdm_only;
                             outcome.plaintext_failed |= migration_outcome.plaintext_failed;
+                            outcome.had_failure |= migration_outcome.plaintext_failed;
                             if migration_outcome.plaintext_failed {
                                 outcome.undecryptable |=
                                     self.handle_plaintext_failure(info, decrypt_fail_mode).await;
@@ -1723,6 +1737,7 @@ impl Client {
                             info.source.sender
                         );
 
+                        outcome.had_failure = true;
                         outcome.undecryptable = self
                             .handle_decrypt_failure(info, reason, decrypt_fail_mode)
                             .await;
@@ -1755,6 +1770,7 @@ impl Client {
                             outcome.dispatched |= migration_outcome.dispatched;
                             outcome.skdm_only |= migration_outcome.skdm_only;
                             outcome.plaintext_failed |= migration_outcome.plaintext_failed;
+                            outcome.had_failure |= migration_outcome.plaintext_failed;
                             if migration_outcome.plaintext_failed {
                                 outcome.undecryptable |=
                                     self.handle_plaintext_failure(info, decrypt_fail_mode).await;
@@ -1772,6 +1788,7 @@ impl Client {
                         );
 
                         // Send retry receipt with fresh prekeys
+                        outcome.had_failure = true;
                         outcome.undecryptable = self
                             .handle_decrypt_failure(
                                 info,
@@ -1789,6 +1806,7 @@ impl Client {
                             info.source.sender,
                             e
                         );
+                        outcome.had_failure = true;
                         outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
@@ -6262,36 +6280,56 @@ mod tests {
     /// resend the entire message including SKDM.
     #[test]
     fn test_should_process_skmsg_logic_matches_wa_web() {
-        // Test cases: (chat_jid, session_empty, session_success, session_dupe, expected)
+        // Test cases: (chat_jid, session_empty, session_success, session_dupe, session_failed, expected)
         let test_cases = [
             // Status broadcast: same rules as all other chats (WA Web: canDecryptNext is uniform)
-            ("status@broadcast", false, false, false, false), // Fail: session failed → skip skmsg
-            ("status@broadcast", false, false, true, true),   // OK: duplicate
-            ("status@broadcast", false, true, false, true),   // OK: success
-            ("status@broadcast", true, false, false, true),   // OK: no session msgs
+            ("status@broadcast", false, false, false, false, false), // Fail: session failed → skip skmsg
+            ("status@broadcast", false, false, true, false, true),   // OK: duplicate
+            ("status@broadcast", false, true, false, false, true),   // OK: success
+            ("status@broadcast", false, true, false, true, false), // Fail: mixed success + failure
+            ("status@broadcast", true, false, false, false, true), // OK: no session msgs
             // Regular group
-            ("120363021033254949@g.us", false, false, false, false),
-            ("120363021033254949@g.us", false, false, true, true),
-            ("120363021033254949@g.us", false, true, false, true),
-            ("120363021033254949@g.us", true, false, false, true),
+            ("120363021033254949@g.us", false, false, false, false, false),
+            ("120363021033254949@g.us", false, false, true, false, true),
+            ("120363021033254949@g.us", false, true, false, false, true),
+            ("120363021033254949@g.us", false, true, false, true, false),
+            ("120363021033254949@g.us", true, false, false, false, true),
             // 1:1 chat
-            ("15551234567@s.whatsapp.net", false, false, false, false),
-            ("15551234567@s.whatsapp.net", true, false, false, true),
+            (
+                "15551234567@s.whatsapp.net",
+                false,
+                false,
+                false,
+                false,
+                false,
+            ),
+            (
+                "15551234567@s.whatsapp.net",
+                true,
+                false,
+                false,
+                false,
+                true,
+            ),
         ];
 
-        for (jid_str, session_empty, session_success, session_dupe, expected) in test_cases {
+        for (jid_str, session_empty, session_success, session_dupe, session_failed, expected) in
+            test_cases
+        {
             // Recreate the should_process_skmsg logic from handle_incoming_message
-            let should_process_skmsg = session_empty || session_success || session_dupe;
+            let should_process_skmsg =
+                session_empty || (!session_failed && (session_success || session_dupe));
 
             assert_eq!(
                 should_process_skmsg,
                 expected,
-                "For chat {} with session_empty={}, session_success={}, session_dupe={}: \
+                "For chat {} with session_empty={}, session_success={}, session_dupe={}, session_failed={}: \
                  expected should_process_skmsg={}, got {}",
                 jid_str,
                 session_empty,
                 session_success,
                 session_dupe,
+                session_failed,
                 expected,
                 should_process_skmsg
             );
@@ -8183,6 +8221,14 @@ mod tests {
         EncPayload::from_node_ref(&enc.as_node_ref()).expect("skmsg payload")
     }
 
+    fn msmsg_payload_from_bytes(bytes: Vec<u8>) -> EncPayload {
+        let enc = NodeBuilder::new("enc")
+            .attr("type", "msmsg")
+            .bytes(bytes)
+            .build();
+        EncPayload::from_node_ref(&enc.as_node_ref()).expect("msmsg payload")
+    }
+
     fn group_message_info(
         id: &str,
         group: &Jid,
@@ -8226,6 +8272,25 @@ mod tests {
         session_payloads: Vec<EncPayload>,
         group_payloads: Vec<EncPayload>,
     ) {
+        process_group_classified_with_payloads(
+            client,
+            info,
+            sender,
+            session_payloads,
+            group_payloads,
+            vec![],
+        )
+        .await;
+    }
+
+    async fn process_group_classified_with_payloads(
+        client: &Arc<Client>,
+        info: Arc<MessageInfo>,
+        sender: &Jid,
+        session_payloads: Vec<EncPayload>,
+        group_payloads: Vec<EncPayload>,
+        bot_payloads: Vec<EncPayload>,
+    ) {
         client
             .clone()
             .process_classified_message(ClassifiedMessage {
@@ -8233,7 +8298,7 @@ mod tests {
                 sender_encryption_jid: sender.clone(),
                 session_payloads,
                 group_payloads,
-                bot_payloads: vec![],
+                bot_payloads,
                 max_sender_retry_count: 0,
                 decrypt_fail_mode: crate::types::events::DecryptFailMode::Show,
             })
@@ -8457,6 +8522,125 @@ mod tests {
             message_events_for_id(&rx, id),
             (0, 0),
             "mixed SKDM and bad plaintext must not dispatch user content"
+        );
+    }
+
+    #[tokio::test]
+    async fn bad_session_plaintext_skips_skmsg_sibling_after_nack() {
+        use wacore::messages::MessageUtils;
+        use wacore::types::events::ChannelEventHandler;
+
+        let (client, transport) = capturing_client("bad_session_skips_skmsg").await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.add_handler(handler);
+        let recorder = Arc::new(EventRecorder::default());
+        client.register_handler(recorder.clone());
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450532@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575450@g.us".parse().expect("group");
+        let skdm = alice.create_group_skdm(&group).await;
+        let skdm_plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let skdm_ct = alice.encrypt(&bob_addr, &skdm_plaintext).await;
+        let bad_ct = alice.encrypt(&bob_addr, &[0xff, 0x01]).await;
+        let content_plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            conversation: Some("must not dispatch".to_string()),
+            ..Default::default()
+        });
+        let skmsg = alice
+            .encrypt_group_message(&group, &content_plaintext)
+            .await;
+        let id = "BAD_SESSION_WITH_SKMSG";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified_with_sessions(
+            &client,
+            info,
+            &alice.jid,
+            vec![
+                enc_payload_from_ciphertext(&skdm_ct),
+                enc_payload_from_ciphertext(&bad_ct),
+            ],
+            vec![skmsg_payload_from_bytes(skmsg)],
+        )
+        .await;
+
+        let mut nack_code = None;
+        for _ in 0..80 {
+            nack_code = find_message_nack_error(&transport.sent(), id);
+            if nack_code.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(nack_code, Some(491));
+        assert_eq!(
+            confirmations_for(&transport.sent(), id),
+            0,
+            "skmsg must not ack after a session InvalidProtobuf nack"
+        );
+        assert_eq!(
+            recorder.undecryptable().len(),
+            1,
+            "session plaintext failure should own the only user-visible failure"
+        );
+        assert_eq!(
+            message_texts_for_id(&rx, id),
+            Vec::<String>::new(),
+            "skmsg content must be skipped after session plaintext failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn skdm_only_session_with_msmsg_waits_for_bot_payload_response() {
+        use wacore::messages::MessageUtils;
+
+        let (client, transport) = capturing_client("skdm_msmsg_no_fallback_ack").await;
+
+        let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+        let bob_addr = bob_jid.to_protocol_address();
+        let mut alice = AlicePeer::new("146824178450533@lid").await;
+        alice.install_bob_session(&bob_addr, &bundle).await;
+
+        let group: Jid = "120363408782575451@g.us".parse().expect("group");
+        let skdm = alice.create_group_skdm(&group).await;
+        let plaintext = MessageUtils::encode_and_pad(&wa::Message {
+            sender_key_distribution_message: Some(skdm),
+            ..Default::default()
+        });
+        let session_ct = alice.encrypt(&bob_addr, &plaintext).await;
+        let id = "SKDM_WITH_MSMSG";
+        let info = group_message_info(id, &group, &alice.jid, false);
+
+        process_group_classified_with_payloads(
+            &client,
+            info,
+            &alice.jid,
+            vec![enc_payload_from_ciphertext(&session_ct)],
+            vec![],
+            vec![msmsg_payload_from_bytes(vec![0xff])],
+        )
+        .await;
+
+        let mut nack_code = None;
+        for _ in 0..80 {
+            nack_code = find_message_nack_error(&transport.sent(), id);
+            if nack_code.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(nack_code, Some(487));
+        assert_eq!(
+            confirmations_for(&transport.sent(), id),
+            0,
+            "SKDM-only fallback must not pre-ack a stanza with msmsg work"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -96,6 +96,28 @@ struct PlaintextHandleOutcome {
     skdm_only: bool,
 }
 
+fn should_process_skmsg_after_session(
+    session_payloads_empty: bool,
+    session_outcome: SessionBatchOutcome,
+) -> bool {
+    session_payloads_empty
+        || (!session_outcome.had_failure
+            && (session_outcome.decrypted || session_outcome.duplicate))
+}
+
+fn should_ack_skdm_only_session_fallback(
+    session_outcome: SessionBatchOutcome,
+    bot_payloads_empty: bool,
+) -> bool {
+    session_outcome.decrypted
+        && session_outcome.skdm_only
+        && !session_outcome.dispatched
+        && !session_outcome.had_failure
+        && !session_outcome.plaintext_failed
+        && !session_outcome.undecryptable
+        && bot_payloads_empty
+}
+
 /// Retry count threshold for logging high retry warnings.
 /// WhatsApp Web logs metrics when retry count exceeds this value.
 const HIGH_RETRY_COUNT_THRESHOLD: u8 = 3;
@@ -1137,10 +1159,6 @@ impl Client {
         let session_decrypted_successfully = session_outcome.decrypted;
         let session_had_duplicates = session_outcome.duplicate;
         let session_dispatched_undecryptable = session_outcome.undecryptable;
-        let session_dispatched = session_outcome.dispatched;
-        let session_skdm_only = session_outcome.skdm_only;
-        let session_plaintext_failed = session_outcome.plaintext_failed;
-        let session_had_failure = session_outcome.had_failure;
 
         log::debug!(
             "Starting PASS 2: Processing {} group content messages (skmsg)",
@@ -1157,9 +1175,8 @@ impl Client {
         // to avoid unnecessary retry receipts. The retry for the pkmsg will cause the sender
         // to resend the entire message including SKDM.
         if !group_payloads.is_empty() {
-            let should_process_skmsg = session_payloads.is_empty()
-                || (!session_had_failure
-                    && (session_decrypted_successfully || session_had_duplicates));
+            let should_process_skmsg =
+                should_process_skmsg_after_session(session_payloads.is_empty(), session_outcome);
 
             if should_process_skmsg {
                 match self
@@ -1255,14 +1272,7 @@ impl Client {
             // (a status SKDM pkmsg can reach here), so skip it to avoid a
             // redundant receipt.
             self.ack_received_message(&info);
-        } else if session_decrypted_successfully
-            && session_skdm_only
-            && !session_dispatched
-            && !session_had_failure
-            && !session_plaintext_failed
-            && !session_dispatched_undecryptable
-            && bot_payloads.is_empty()
-        {
+        } else if should_ack_skdm_only_session_fallback(session_outcome, bot_payloads.is_empty()) {
             // SKDM-only session decrypts skip dispatch, so this stanza would
             // otherwise stay queued. WA Web and whatsmeow ack every decrypted
             // message; the ack shape still comes from the message source.
@@ -1480,6 +1490,7 @@ impl Client {
                         // Device::is_trusted_identity reads from backend, not cache.
                         if let Err(e) = self.flush_signal_cache().await {
                             log::warn!("Failed to flush identity deletion for {}: {e:?}", address);
+                            outcome.had_failure = true;
                             continue;
                         }
                         log::info!(
@@ -3390,6 +3401,7 @@ mod tests {
         );
         assert!(outcome.plaintext_failed);
         assert!(outcome.undecryptable);
+        assert!(outcome.had_failure);
         assert!(!outcome.dispatched);
         assert!(!outcome.skdm_only);
 
@@ -6316,9 +6328,15 @@ mod tests {
         for (jid_str, session_empty, session_success, session_dupe, session_failed, expected) in
             test_cases
         {
-            // Recreate the should_process_skmsg logic from handle_incoming_message
-            let should_process_skmsg =
-                session_empty || (!session_failed && (session_success || session_dupe));
+            let should_process_skmsg = should_process_skmsg_after_session(
+                session_empty,
+                SessionBatchOutcome {
+                    decrypted: session_success,
+                    duplicate: session_dupe,
+                    had_failure: session_failed,
+                    ..Default::default()
+                },
+            );
 
             assert_eq!(
                 should_process_skmsg,
@@ -6332,6 +6350,90 @@ mod tests {
                 session_failed,
                 expected,
                 should_process_skmsg
+            );
+        }
+    }
+
+    #[test]
+    fn skdm_only_fallback_ack_decision_requires_clean_session_batch() {
+        let clean_skdm = SessionBatchOutcome {
+            decrypted: true,
+            skdm_only: true,
+            ..Default::default()
+        };
+        assert!(
+            should_ack_skdm_only_session_fallback(clean_skdm, true),
+            "a clean SKDM-only session batch needs the fallback ack"
+        );
+
+        let cases = [
+            (
+                SessionBatchOutcome {
+                    dispatched: true,
+                    ..clean_skdm
+                },
+                true,
+                "content dispatch already acked",
+            ),
+            (
+                SessionBatchOutcome {
+                    had_failure: true,
+                    ..clean_skdm
+                },
+                true,
+                "local session failure must block positive ack",
+            ),
+            (
+                SessionBatchOutcome {
+                    plaintext_failed: true,
+                    had_failure: true,
+                    ..clean_skdm
+                },
+                true,
+                "plaintext handler failure is not SKDM-only success",
+            ),
+            (
+                SessionBatchOutcome {
+                    undecryptable: true,
+                    had_failure: true,
+                    ..clean_skdm
+                },
+                true,
+                "failure event must not be paired with positive ack",
+            ),
+            (
+                SessionBatchOutcome {
+                    decrypted: false,
+                    ..clean_skdm
+                },
+                true,
+                "fallback only applies after Signal decrypt success",
+            ),
+            (
+                SessionBatchOutcome {
+                    skdm_only: false,
+                    ..clean_skdm
+                },
+                true,
+                "regular content must ack via dispatch",
+            ),
+            (
+                SessionBatchOutcome {
+                    duplicate: true,
+                    decrypted: false,
+                    skdm_only: false,
+                    ..Default::default()
+                },
+                true,
+                "duplicates use the duplicate branch",
+            ),
+            (clean_skdm, false, "msmsg work must own its response"),
+        ];
+
+        for (outcome, bot_payloads_empty, reason) in cases {
+            assert!(
+                !should_ack_skdm_only_session_fallback(outcome, bot_payloads_empty),
+                "{reason}: {outcome:?}"
             );
         }
     }
@@ -7549,6 +7651,7 @@ mod tests {
         assert!(!outcome.decrypted);
         assert!(!outcome.duplicate);
         assert!(outcome.undecryptable);
+        assert!(outcome.had_failure);
 
         // spawn_nack is detached; give it a tick to flush through the
         // noise_socket sender_task to our CapturingMockTransport.
@@ -7589,6 +7692,7 @@ mod tests {
             .await;
 
         assert!(outcome.undecryptable);
+        assert!(outcome.had_failure);
 
         for _ in 0..40 {
             if !transport.sent().is_empty() {


### PR DESCRIPTION
## What

Session decrypt now tracks whether a successfully decrypted plaintext actually reached `dispatch_parsed_message`. SKDM-only session plaintext still processes the sender-key distribution and skips user dispatch, but `process_decrypted_message` now emits the normal message confirmation when that skip would otherwise leave the stanza unacked.

This replaces the anonymous `(bool, bool, bool)` session result with `SessionBatchOutcome` and propagates the dispatch bit through direct decrypt, untrusted-identity retry, and PN→LID migration via `MigrationDecryptOutcome`.

The ack path itself is unchanged: `ack_received_message` still chooses delivery receipt, sender receipt, or transport ack from the message shape.

## Why

A production group stanza (`AC1F6388BDE0B721870652C378CFEDDB`) decrypted successfully as a session `msg`, carried only a Sender Key Distribution Message, and had no `skmsg` sibling. Because SKDM-only messages skipped dispatch, they also skipped the only success-path ack. The server retained the stanza until it later sent `<stream:error><ack class="message" id=...>`, re-delivered it, and the already-advanced Signal ratchet then hit BadMac.

whatsmeow and WA Web acknowledge every successfully decrypted message; the decision is based on decrypt result, not user-visible content.

## Tests

Added regression coverage with real Signal/session and sender-key ciphertexts, decoding captured outbound frames by message id:

- SKDM-only group session decrypt emits exactly one group delivery receipt and no `Event::Message`
- SKDM session + successful `skmsg` sibling emits exactly one receipt and dispatches only the `skmsg` content
- Own-device group SKDM-only session emits exactly one transport `<ack class="message">`, not a `type="sender"` receipt

Validation:

- `cargo fmt --all`
- `cargo build -p whatsapp-rust`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p whatsapp-rust` (617 lib + 18 discrepancy + 7 handshake + 5 doctests passed)
- `cargo test -p whatsapp-rust skdm -- --nocapture` (11 passed)