### PR TITLE
fix(send): set peer PDO push priority attrs

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -3446,6 +3446,134 @@ mod tests {
             .await;
     }
 
+    fn peer_test_account_proto() -> wa::AdvSignedDeviceIdentity {
+        wa::AdvSignedDeviceIdentity {
+            details: Some(vec![0u8; 32]),
+            account_signature_key: Some(vec![0u8; 32]),
+            account_signature: Some(vec![0u8; 64]),
+            device_signature: Some(vec![0u8; 64]),
+        }
+    }
+
+    async fn seed_peer_send_state(client: &Arc<Client>, peer: &Jid) {
+        use wacore::libsignal::protocol::{
+            IdentityKeyPair, KeyPair, PreKeyBundle, SignalProtocolError, UsePQRatchet,
+            process_prekey_bundle,
+        };
+
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetAccount(Some(peer_test_account_proto())))
+            .await;
+
+        let bundle =
+            tokio::task::spawn_blocking(|| -> Result<PreKeyBundle, SignalProtocolError> {
+                let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+                let receiver = IdentityKeyPair::generate(&mut rng);
+                let spk = KeyPair::generate(&mut rng);
+                let opk = KeyPair::generate(&mut rng);
+                let sig = receiver
+                    .private_key()
+                    .calculate_signature(&spk.public_key.serialize(), &mut rng)?;
+
+                PreKeyBundle::new(
+                    1,
+                    1u32.into(),
+                    Some((1u32.into(), opk.public_key)),
+                    1u32.into(),
+                    spk.public_key,
+                    sig.to_vec(),
+                    *receiver.identity_key(),
+                )
+            })
+            .await
+            .expect("prekey bundle task")
+            .expect("prekey bundle");
+
+        let mut adapter = client.signal_adapter().await;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        process_prekey_bundle(
+            &peer.to_protocol_address(),
+            &mut adapter.session_store,
+            &mut adapter.identity_store,
+            &bundle,
+            &mut rng,
+            UsePQRatchet::No,
+        )
+        .await
+        .expect("peer session");
+    }
+
+    fn pdo_request_message(request_type: wa::message::PeerDataOperationRequestType) -> wa::Message {
+        wa::Message {
+            protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+                r#type: Some(
+                    wa::message::protocol_message::Type::PeerDataOperationRequestMessage as i32,
+                ),
+                peer_data_operation_request_message: Some(
+                    wa::message::PeerDataOperationRequestMessage {
+                        peer_data_operation_request_type: Some(request_type as i32),
+                        ..Default::default()
+                    },
+                ),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_pdo_send_path_stamps_history_sync_options() {
+        let client = crate::test_utils::create_test_client_with_name("peer_pdo_attrs").await;
+        let peer: Jid = "100000000000001@s.whatsapp.net".parse().unwrap();
+        seed_peer_send_state(&client, &peer).await;
+
+        let request_id = "PDO_PEER_ATTRS_1";
+        let waiter = client
+            .wait_for_sent_node(crate::client::NodeFilter::tag("message").attr("id", request_id));
+        let msg =
+            pdo_request_message(wa::message::PeerDataOperationRequestType::HistorySyncOnDemand);
+
+        let result = client
+            .send_message_impl(
+                peer,
+                &msg,
+                Some(request_id.to_string()),
+                true,
+                false,
+                None,
+                vec![],
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "test client has no socket; send should fail after stanza capture"
+        );
+
+        let node = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("sent node should be captured")
+            .expect("sent node waiter should resolve");
+        assert_eq!(
+            node.attrs().optional_string("category").unwrap().as_ref(),
+            "peer"
+        );
+        assert_eq!(
+            node.attrs()
+                .optional_string("push_priority")
+                .unwrap()
+                .as_ref(),
+            "high_force"
+        );
+        assert_eq!(
+            node.attrs()
+                .optional_string("privacy_sensitive")
+                .unwrap()
+                .as_ref(),
+            "1"
+        );
+    }
+
     #[tokio::test]
     async fn persist_outbound_msg_secret_writes_under_chat_sender_id() {
         let client = crate::test_utils::create_test_client_with_name("secret_chat_id").await;

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -11,6 +11,7 @@ use crate::reporting_token::{
 use crate::runtime::{AbortHandle, Runtime};
 use crate::types::jid::JidExt;
 use crate::types::jid::make_sender_key_name;
+use crate::types::message::PeerMessageOptions;
 use anyhow::{Result, anyhow, bail};
 use futures::stream::{FuturesUnordered, StreamExt};
 use prost::Message as ProtoMessage;
@@ -145,6 +146,29 @@ pub fn stanza_type_from_message(msg: &wa::Message) -> &'static str {
         return stanza::MSG_TYPE_TEXT;
     }
     stanza::MSG_TYPE_MEDIA
+}
+
+pub fn peer_message_options_from_message(msg: &wa::Message) -> PeerMessageOptions {
+    use wa::message::PeerDataOperationRequestType as PdoType;
+
+    // WAWebSendNonMessageDataRequest's A/F helpers gate rollout flags we do
+    // not model; use the default-on wire shape for supported peer PDO flows.
+    let request_type = unwrap_message(msg)
+        .protocol_message
+        .as_deref()
+        .and_then(|pm| pm.peer_data_operation_request_message.as_ref())
+        .and_then(|pdo| pdo.peer_data_operation_request_type)
+        .and_then(|raw| PdoType::try_from(raw).ok());
+
+    match request_type {
+        Some(PdoType::HistorySyncOnDemand) => PeerMessageOptions::high_force_on_demand(),
+        Some(
+            PdoType::GenerateLinkPreview
+            | PdoType::PlaceholderMessageResend
+            | PdoType::CompanionCanonicalUserNonceFetch,
+        ) => PeerMessageOptions::high_force(),
+        _ => PeerMessageOptions::default(),
+    }
 }
 
 /// Matches WAWebBackendJobsCommon.mediaTypeFromProtobuf + encodeMaybeMediaType.
@@ -1025,6 +1049,7 @@ where
     Ok(needs_pkmsg)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn prepare_peer_stanza<S, I>(
     session_store: &mut S,
     identity_store: &mut I,
@@ -1033,6 +1058,35 @@ pub async fn prepare_peer_stanza<S, I>(
     message: &wa::Message,
     request_id: String,
     account: Option<&wa::AdvSignedDeviceIdentity>,
+) -> Result<Node>
+where
+    S: crate::libsignal::protocol::SessionStore,
+    I: crate::libsignal::protocol::IdentityKeyStore,
+{
+    let options = peer_message_options_from_message(message);
+    prepare_peer_stanza_with_options(
+        session_store,
+        identity_store,
+        transport_jid,
+        signal_address,
+        message,
+        request_id,
+        account,
+        options,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn prepare_peer_stanza_with_options<S, I>(
+    session_store: &mut S,
+    identity_store: &mut I,
+    transport_jid: Jid,
+    signal_address: &ProtocolAddress,
+    message: &wa::Message,
+    request_id: String,
+    account: Option<&wa::AdvSignedDeviceIdentity>,
+    options: PeerMessageOptions,
 ) -> Result<Node>
 where
     S: crate::libsignal::protocol::SessionStore,
@@ -1074,15 +1128,17 @@ where
         );
     }
 
-    let stanza = NodeBuilder::new("message")
+    let mut stanza_builder = NodeBuilder::new("message")
         .attr("to", transport_jid)
         .attr("id", request_id)
         .attr("type", stanza::MSG_TYPE_TEXT)
         .attr("category", "peer")
-        .children(children)
-        .build();
+        .attr("push_priority", options.push_priority().as_str());
+    if let Some(privacy_sensitive) = options.privacy_sensitive() {
+        stanza_builder = stanza_builder.attr("privacy_sensitive", privacy_sensitive.as_str());
+    }
 
-    Ok(stanza)
+    Ok(stanza_builder.children(children).build())
 }
 
 /// Mirrors `WAWebSendMsgCreateDeviceStanza.createUserDeviceMsgStanza`.
@@ -1892,6 +1948,112 @@ mod tests {
                 .find(|j| j.user.as_str() == "me")
                 .expect("own LID should be present");
             assert_eq!(me.device, 0, "own LID should be non-ad (device=0)");
+        }
+    }
+
+    mod peer_message_options {
+        use super::*;
+        use crate::types::message::{PrivacySensitiveType, PushPriority};
+
+        fn pdo_message_raw(request_type: i32) -> wa::Message {
+            wa::Message {
+                protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+                    r#type: Some(
+                        wa::message::protocol_message::Type::PeerDataOperationRequestMessage as i32,
+                    ),
+                    peer_data_operation_request_message: Some(
+                        wa::message::PeerDataOperationRequestMessage {
+                            peer_data_operation_request_type: Some(request_type),
+                            ..Default::default()
+                        },
+                    ),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+        }
+
+        fn pdo_message(request_type: wa::message::PeerDataOperationRequestType) -> wa::Message {
+            pdo_message_raw(request_type as i32)
+        }
+
+        #[test]
+        fn pdo_priority_map_matches_wa_web_non_message_requests() {
+            use wa::message::PeerDataOperationRequestType as PdoType;
+
+            let high_force_cases = [
+                (PdoType::GenerateLinkPreview, PushPriority::HighForce, None),
+                (
+                    PdoType::PlaceholderMessageResend,
+                    PushPriority::HighForce,
+                    None,
+                ),
+                (
+                    PdoType::HistorySyncOnDemand,
+                    PushPriority::HighForce,
+                    Some(PrivacySensitiveType::OnDemand),
+                ),
+                (
+                    PdoType::CompanionCanonicalUserNonceFetch,
+                    PushPriority::HighForce,
+                    None,
+                ),
+            ];
+
+            for (request_type, push_priority, privacy_sensitive) in high_force_cases {
+                let options = peer_message_options_from_message(&pdo_message(request_type));
+                assert_eq!(options.push_priority(), push_priority, "{request_type:?}");
+                assert_eq!(
+                    options.privacy_sensitive(),
+                    privacy_sensitive,
+                    "{request_type:?}"
+                );
+            }
+
+            let default_cases = [
+                PdoType::UploadSticker,
+                PdoType::SendRecentStickerBootstrap,
+                PdoType::WaffleLinkingNonceFetch,
+                PdoType::FullHistorySyncOnDemand,
+                PdoType::CompanionMetaNonceFetch,
+                PdoType::CompanionSyncdSnapshotFatalRecovery,
+                PdoType::HistorySyncChunkRetry,
+                PdoType::GalaxyFlowAction,
+                PdoType::BusinessBroadcastInsightsDeliveredTo,
+                PdoType::BusinessBroadcastInsightsRefresh,
+            ];
+
+            for request_type in default_cases {
+                let options = peer_message_options_from_message(&pdo_message(request_type));
+                assert_eq!(
+                    options.push_priority(),
+                    PushPriority::High,
+                    "{request_type:?}"
+                );
+                assert_eq!(options.privacy_sensitive(), None, "{request_type:?}");
+            }
+        }
+
+        #[test]
+        fn non_pdo_and_unknown_pdo_keep_peer_defaults() {
+            let app_state_key_request = wa::Message {
+                protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+                    r#type: Some(
+                        wa::message::protocol_message::Type::AppStateSyncKeyRequest as i32,
+                    ),
+                    app_state_sync_key_request: Some(wa::message::AppStateSyncKeyRequest {
+                        key_ids: Vec::new(),
+                    }),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+
+            for msg in [app_state_key_request, pdo_message_raw(99)] {
+                let options = peer_message_options_from_message(&msg);
+                assert_eq!(options.push_priority(), PushPriority::High);
+                assert_eq!(options.privacy_sensitive(), None);
+            }
         }
     }
 
@@ -3396,9 +3558,16 @@ mod tests {
         async fn build_peer_stanza(
             account: Option<&wa::AdvSignedDeviceIdentity>,
         ) -> wacore_binary::Node {
+            build_peer_stanza_with_options(account, PeerMessageOptions::default()).await
+        }
+
+        async fn build_peer_stanza_with_options(
+            account: Option<&wa::AdvSignedDeviceIdentity>,
+            options: PeerMessageOptions,
+        ) -> wacore_binary::Node {
             let (mut ss, mut is, jid) = setup_session().await;
             let addr = jid.to_protocol_address();
-            prepare_peer_stanza(
+            prepare_peer_stanza_with_options(
                 &mut ss,
                 &mut is,
                 jid.clone(),
@@ -3406,6 +3575,7 @@ mod tests {
                 &wa::Message::default(),
                 "peer-test-1".into(),
                 account,
+                options,
             )
             .await
             .expect("peer stanza builds")
@@ -3421,6 +3591,11 @@ mod tests {
                 n.attrs().optional_string("category").unwrap().as_ref(),
                 "peer"
             );
+            assert_eq!(
+                n.attrs().optional_string("push_priority").unwrap().as_ref(),
+                "high"
+            );
+            assert!(n.attrs().optional_string("privacy_sensitive").is_none());
 
             let children = n.children().expect("peer message has children");
             let tags: Vec<&str> = children.iter().map(|c| c.tag.as_ref()).collect();
@@ -3457,6 +3632,28 @@ mod tests {
                 ),
                 other => panic!("device-identity must carry bytes, got {other:?}"),
             }
+        }
+
+        #[tokio::test]
+        async fn peer_stanza_carries_high_force_and_privacy_attrs() {
+            let account = pkmsg_account_proto();
+            let n = build_peer_stanza_with_options(
+                Some(&account),
+                PeerMessageOptions::high_force_on_demand(),
+            )
+            .await;
+
+            assert_eq!(
+                n.attrs().optional_string("push_priority").unwrap().as_ref(),
+                "high_force"
+            );
+            assert_eq!(
+                n.attrs()
+                    .optional_string("privacy_sensitive")
+                    .unwrap()
+                    .as_ref(),
+                "1"
+            );
         }
 
         #[tokio::test]

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -39,6 +39,67 @@ pub enum MessageCategory {
     Other(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
+pub enum PushPriority {
+    #[wire = "high"]
+    High,
+    #[wire = "high_force"]
+    HighForce,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
+pub enum PrivacySensitiveType {
+    #[wire = "1"]
+    OnDemand,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerMessageOptions {
+    push_priority: PushPriority,
+    privacy_sensitive: Option<PrivacySensitiveType>,
+}
+
+impl Default for PeerMessageOptions {
+    fn default() -> Self {
+        Self::high()
+    }
+}
+
+impl PeerMessageOptions {
+    const fn new(
+        push_priority: PushPriority,
+        privacy_sensitive: Option<PrivacySensitiveType>,
+    ) -> Self {
+        Self {
+            push_priority,
+            privacy_sensitive,
+        }
+    }
+
+    pub const fn high() -> Self {
+        Self::new(PushPriority::High, None)
+    }
+
+    pub const fn high_force() -> Self {
+        Self::new(PushPriority::HighForce, None)
+    }
+
+    pub const fn high_force_on_demand() -> Self {
+        Self::new(
+            PushPriority::HighForce,
+            Some(PrivacySensitiveType::OnDemand),
+        )
+    }
+
+    pub const fn push_priority(self) -> PushPriority {
+        self.push_priority
+    }
+
+    pub const fn privacy_sensitive(self) -> Option<PrivacySensitiveType> {
+        self.privacy_sensitive
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct MessageSource {
     pub chat: Jid,
@@ -367,6 +428,31 @@ mod tests {
         assert_eq!(
             EditAttribute::Unknown("anything".to_string()).to_string_val(),
             "anything"
+        );
+    }
+
+    #[test]
+    fn peer_message_options_wire_values_match_stanza_attrs() {
+        // These literals are owned by the WireEnum attributes above; stanza
+        // builders consume the generated as_str() values directly.
+        assert_eq!(PushPriority::High.as_str(), "high");
+        assert_eq!(PushPriority::HighForce.as_str(), "high_force");
+        assert_eq!(PrivacySensitiveType::OnDemand.as_str(), "1");
+
+        let default = PeerMessageOptions::high();
+        assert_eq!(default, PeerMessageOptions::default());
+        assert_eq!(default.push_priority(), PushPriority::High);
+        assert_eq!(default.privacy_sensitive(), None);
+
+        let high_force = PeerMessageOptions::high_force();
+        assert_eq!(high_force.push_priority(), PushPriority::HighForce);
+        assert_eq!(high_force.privacy_sensitive(), None);
+
+        let on_demand = PeerMessageOptions::high_force_on_demand();
+        assert_eq!(on_demand.push_priority(), PushPriority::HighForce);
+        assert_eq!(
+            on_demand.privacy_sensitive(),
+            Some(PrivacySensitiveType::OnDemand)
         );
     }
 


### PR DESCRIPTION
## What

Peer-device message stanzas now carry explicit WA Web-style priority metadata instead of always relying on the generic peer default:

- add typed `PushPriority`, `PrivacySensitiveType`, and `PeerMessageOptions` wire helpers
- infer peer message options from `PeerDataOperationRequestMessage` before building the peer stanza
- stamp `push_priority="high_force"` for link-preview generation, placeholder resend, history sync on demand, and companion canonical-user nonce fetch requests
- stamp `privacy_sensitive="1"` for history sync on demand requests
- keep non-PDO peer messages and unknown/new PDO request types on the existing `push_priority="high"` default

## Why

Captured WA Web send code threads peer-request `pushPriority` and `privacySensitive` through non-message data request send, then serializes those values as message stanza attrs. Our peer stanza path always emitted `category="peer"` with no priority/privacy specialization, so urgent PDO flows did not match the browser wire shape.

Centralizing the mapping in `wacore::send::peer_message_options_from_message` keeps call sites from having to remember per-PDO stanza knobs and preserves a conservative default for unknown request types.

## Tests

- `cargo fmt --all`
- `cargo clippy --all --tests`
- `cargo test --workspace --exclude e2e-tests`

Coverage added for:

- PDO request type to `push_priority` / `privacy_sensitive` mapping
- unknown PDO and non-PDO peer defaults
- default peer stanza attrs
- high-force plus on-demand privacy stanza attrs
- typed wire values for the new peer message option enums
