### PR TITLE
fix(message): decrypt incoming peer message edits

### DIFF
--- a/src/features/message_edit.rs
+++ b/src/features/message_edit.rs
@@ -247,6 +247,32 @@ impl<'a> SecretEncrypted<'a> {
     pub fn original_sender_jid(&self, my_jid: &Jid) -> Result<Jid> {
         resolve_target_sender(self.target_message_key, my_jid)
     }
+
+    /// Resolve the parent message's author for the secret lookup + HKDF info,
+    /// using the dispatch-time envelope frame.
+    ///
+    /// For `MESSAGE_EDIT` the editor is always the author (you can only edit
+    /// your own message) and `target_message_key` is written in the editor's
+    /// frame — its `from_me` is `true` even for an incoming peer edit, so it is
+    /// not a reliable receiver-side signal. Take the author from the envelope
+    /// instead: ourselves for a self-synced edit, else the envelope sender.
+    /// Other kinds (poll/event) can be modified by a non-author, so for those
+    /// `target_message_key` stays authoritative.
+    pub fn original_sender_for_dispatch(
+        &self,
+        is_from_me: bool,
+        envelope_sender: &Jid,
+        my_jid: &Jid,
+    ) -> Result<Jid> {
+        match self.kind {
+            SecretEncKind::MessageEdit => Ok(if is_from_me {
+                my_jid.to_non_ad()
+            } else {
+                envelope_sender.to_non_ad()
+            }),
+            _ => resolve_target_sender(self.target_message_key, my_jid),
+        }
+    }
 }
 
 /// Extract any supported `secret_encrypted_message` envelope (EVENT_EDIT,
@@ -485,6 +511,110 @@ mod tests {
         assert_eq!(
             env.original_sender_jid(&my_jid).unwrap().to_string(),
             "5510000@s.whatsapp.net"
+        );
+    }
+
+    #[test]
+    fn message_edit_original_sender_uses_envelope_sender_for_incoming_peer_edit() {
+        // Captured wire data: when a peer edits THEIR OWN message, the target
+        // key is written in the EDITOR's frame — from_me=true, no participant,
+        // even in groups. Trusting target_key.from_me resolves the original
+        // sender to *us*, so the parent messageSecret lookup misses. The editor
+        // is always the author (you can only edit your own message), so the
+        // sender must come from the envelope frame.
+        let msg = wa::Message {
+            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                target_message_key: Some(wa::MessageKey {
+                    remote_jid: Some("100000000000001@lid".to_string()), // our LID (editor's frame)
+                    from_me: Some(true),
+                    id: Some("AC1".to_string()),
+                    participant: None,
+                }),
+                enc_payload: Some(vec![0u8; 32]),
+                enc_iv: Some(vec![0u8; 12]),
+                secret_enc_type: Some(
+                    wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
+                ),
+                remote_key_id: None,
+            }),
+            ..Default::default()
+        };
+        let env = extract_secret_encrypted(&msg).expect("recognised");
+        let my_jid = "100000000000001@lid".parse::<Jid>().unwrap();
+        let editor = "200000000000002@lid".parse::<Jid>().unwrap();
+        // Incoming peer edit: envelope is NOT from me → sender is the editor.
+        assert_eq!(
+            env.original_sender_for_dispatch(false, &editor, &my_jid)
+                .unwrap()
+                .to_string(),
+            "200000000000002@lid"
+        );
+    }
+
+    #[test]
+    fn message_edit_original_sender_uses_my_jid_for_self_synced_edit() {
+        // Our own edit, synced from another linked device: the envelope IS from
+        // me, so the original sender is us — device suffix stripped.
+        let msg = wa::Message {
+            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                target_message_key: Some(wa::MessageKey {
+                    remote_jid: Some("200000000000002@lid".to_string()),
+                    from_me: Some(true),
+                    id: Some("AC1".to_string()),
+                    participant: None,
+                }),
+                enc_payload: Some(vec![0u8; 32]),
+                enc_iv: Some(vec![0u8; 12]),
+                secret_enc_type: Some(
+                    wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
+                ),
+                remote_key_id: None,
+            }),
+            ..Default::default()
+        };
+        let env = extract_secret_encrypted(&msg).expect("recognised");
+        let my_jid = "100000000000001:3@lid".parse::<Jid>().unwrap();
+        let editor = "100000000000001@lid".parse::<Jid>().unwrap();
+        assert_eq!(
+            env.original_sender_for_dispatch(true, &editor, &my_jid)
+                .unwrap()
+                .to_string(),
+            "100000000000001@lid"
+        );
+    }
+
+    #[test]
+    fn poll_edit_original_sender_still_uses_target_key() {
+        // Regression guard: poll/event modifications can be authored by someone
+        // other than the target's author (e.g. a peer votes on our poll), so the
+        // target key stays authoritative for non-edit kinds.
+        let msg = wa::Message {
+            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                target_message_key: Some(wa::MessageKey {
+                    remote_jid: Some("g@g.us".to_string()),
+                    from_me: Some(false),
+                    id: Some("AC1".to_string()),
+                    participant: Some("creator@s.whatsapp.net".to_string()),
+                }),
+                enc_payload: Some(vec![0u8; 32]),
+                enc_iv: Some(vec![0u8; 12]),
+                secret_enc_type: Some(
+                    wa::message::secret_encrypted_message::SecretEncType::PollEdit as i32,
+                ),
+                remote_key_id: None,
+            }),
+            ..Default::default()
+        };
+        let env = extract_secret_encrypted(&msg).expect("recognised");
+        let my_jid = "999@s.whatsapp.net".parse::<Jid>().unwrap();
+        let voter = "voter@s.whatsapp.net".parse::<Jid>().unwrap();
+        // Envelope sender (voter) differs, but the target's participant (poll
+        // creator) wins for poll kinds.
+        assert_eq!(
+            env.original_sender_for_dispatch(false, &voter, &my_jid)
+                .unwrap()
+                .to_string(),
+            "creator@s.whatsapp.net"
         );
     }
 

--- a/src/features/message_edit.rs
+++ b/src/features/message_edit.rs
@@ -151,23 +151,51 @@ impl<'a> EncryptedEdit<'a> {
         self.target_message_key.id.as_deref()
     }
 
-    /// Resolve the original sender JID from the target message key.
+    /// Resolve the original sender JID from the target message key alone.
     ///
-    /// `my_jid` is the receiver's own JID in the addressing mode of the
-    /// chat (PN or LID). It is needed because for self-sent edits — e.g.
-    /// edits to our own messages that arrive via device sync —
-    /// `target_message_key` has `from_me = true` and its `remote_jid`
-    /// points to the *other* party, not us. WA Web's
-    /// `MsgGetters.getOriginalSender` reads `originalSelfAuthor || sender`
-    /// from its materialised msg-row store; we have no row here, so we
-    /// reconstruct the same fact from `from_me` + own jid.
+    /// CAUTION: `target_message_key` is written in the *editor's* frame, so its
+    /// `from_me` is `true` for any edit the editor authored, including an
+    /// incoming peer edit, where it then resolves to `my_jid` (the receiver)
+    /// rather than the peer. On the receive path use
+    /// [`Self::original_sender_for_dispatch`], which takes the author from the
+    /// envelope frame. This target-key-only resolver is kept for callers that
+    /// have no envelope frame.
     ///
-    /// Resolution order:
+    /// `my_jid` is the receiver's own JID in the addressing mode of the chat
+    /// (PN or LID). Resolution order:
     /// 1. `participant` if present (always set in groups).
-    /// 2. `my_jid` if `from_me == Some(true)` (self-sent edit sync).
-    /// 3. `remote_jid` (1:1 incoming edit; the chat is the other party).
+    /// 2. `my_jid` if `from_me == Some(true)`.
+    /// 3. `remote_jid` otherwise.
     pub fn original_sender_jid(&self, my_jid: &Jid) -> Result<Jid> {
         resolve_target_sender(self.target_message_key, my_jid)
+    }
+
+    /// Resolve the edit's parent author from the dispatch-time envelope frame.
+    ///
+    /// A message can only be edited by its author, so the parent author of a
+    /// MESSAGE_EDIT is always the editor: ourselves for a self-synced edit
+    /// (`is_from_me`), else the envelope sender. Mirrors WA Web's
+    /// `MsgGetters.getOriginalSender = originalSelfAuthor || sender` and is the
+    /// correct resolver for the receive path, where the target key's `from_me`
+    /// reflects the editor, not the receiver.
+    pub fn original_sender_for_dispatch(
+        &self,
+        is_from_me: bool,
+        envelope_sender: &Jid,
+        my_jid: &Jid,
+    ) -> Jid {
+        edit_author_from_envelope(is_from_me, envelope_sender, my_jid)
+    }
+}
+
+/// Resolve a MESSAGE_EDIT's parent author from the dispatch-time envelope
+/// frame: us for a self-synced edit (`is_from_me`), else the envelope sender.
+/// The editor is always the author, so this is the parent author too.
+fn edit_author_from_envelope(is_from_me: bool, envelope_sender: &Jid, my_jid: &Jid) -> Jid {
+    if is_from_me {
+        my_jid.to_non_ad()
+    } else {
+        envelope_sender.to_non_ad()
     }
 }
 
@@ -244,6 +272,12 @@ impl<'a> SecretEncrypted<'a> {
         self.target_message_key.id.as_deref()
     }
 
+    /// Resolve the targeted message's author from the target key alone.
+    ///
+    /// See the caution on [`EncryptedEdit::original_sender_jid`]: for
+    /// MESSAGE_EDIT prefer [`Self::original_sender_for_dispatch`] on the receive
+    /// path. Authoritative for poll/event kinds (whose target key carries the
+    /// real author).
     pub fn original_sender_jid(&self, my_jid: &Jid) -> Result<Jid> {
         resolve_target_sender(self.target_message_key, my_jid)
     }
@@ -265,11 +299,11 @@ impl<'a> SecretEncrypted<'a> {
         my_jid: &Jid,
     ) -> Result<Jid> {
         match self.kind {
-            SecretEncKind::MessageEdit => Ok(if is_from_me {
-                my_jid.to_non_ad()
-            } else {
-                envelope_sender.to_non_ad()
-            }),
+            SecretEncKind::MessageEdit => Ok(edit_author_from_envelope(
+                is_from_me,
+                envelope_sender,
+                my_jid,
+            )),
             _ => resolve_target_sender(self.target_message_key, my_jid),
         }
     }
@@ -488,7 +522,11 @@ mod tests {
     }
 
     #[test]
-    fn original_sender_jid_falls_back_to_remote_jid_for_incoming_one_to_one_edit() {
+    fn original_sender_jid_uses_remote_jid_when_target_not_from_me() {
+        // Unit-tests the `resolve_target_sender` remote_jid branch, not a real
+        // edit frame: an actual incoming peer edit writes the target key in the
+        // editor's frame (from_me=true), so the receive path uses the envelope
+        // sender via `original_sender_for_dispatch`, not this resolver.
         let msg = wa::Message {
             secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
@@ -511,6 +549,44 @@ mod tests {
         assert_eq!(
             env.original_sender_jid(&my_jid).unwrap().to_string(),
             "5510000@s.whatsapp.net"
+        );
+    }
+
+    #[test]
+    fn encrypted_edit_dispatch_resolver_uses_envelope_frame() {
+        // The MESSAGE_EDIT-specific consumer API resolves from the envelope
+        // frame, ignoring the editor-framed target key (here from_me=true).
+        let msg = wa::Message {
+            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                target_message_key: Some(wa::MessageKey {
+                    remote_jid: Some("100000000000001@lid".to_string()),
+                    from_me: Some(true),
+                    id: Some("AC1".to_string()),
+                    participant: None,
+                }),
+                enc_payload: Some(vec![0u8; 32]),
+                enc_iv: Some(vec![0u8; 12]),
+                secret_enc_type: Some(
+                    wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
+                ),
+                remote_key_id: None,
+            }),
+            ..Default::default()
+        };
+        let env = extract_envelope(&msg).expect("recognised");
+        let my_jid = "100000000000001:3@lid".parse::<Jid>().unwrap();
+        let editor = "200000000000002@lid".parse::<Jid>().unwrap();
+        // Incoming peer edit → envelope sender (editor); device suffix stripped.
+        assert_eq!(
+            env.original_sender_for_dispatch(false, &editor, &my_jid)
+                .to_string(),
+            "200000000000002@lid"
+        );
+        // Self-synced edit → us, device suffix stripped.
+        assert_eq!(
+            env.original_sender_for_dispatch(true, &editor, &my_jid)
+                .to_string(),
+            "100000000000001@lid"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -298,7 +298,11 @@ impl Client {
         let target_id = env.target_id()?;
 
         let my_jid = self.own_jid_for_secret_encrypted(info).await?;
-        let original_sender = match env.original_sender_jid(&my_jid) {
+        let original_sender = match env.original_sender_for_dispatch(
+            info.source.is_from_me,
+            &info.source.sender,
+            &my_jid,
+        ) {
             Ok(jid) => jid,
             Err(_) => return None,
         };

--- a/src/message.rs
+++ b/src/message.rs
@@ -9933,6 +9933,71 @@ mod tests {
         assert!(got.is_some(), "encrypted edit must dispatch as legacy edit");
     }
 
+    /// Regression for #667: an incoming peer edit writes `target_message_key`
+    /// in the editor's frame (`from_me = true`, no `participant`, even in a
+    /// group), so the target-key resolver maps the parent author to *us* and
+    /// misses the secret stored under the real author. The dispatch path must
+    /// take the author from the envelope sender instead. Fails on the pre-fix
+    /// code (envelope stays encrypted), passes after it.
+    #[tokio::test]
+    async fn secret_encrypted_peer_edit_resolves_sender_from_envelope() {
+        let (client, _transport) = capturing_client("secret_peer_edit_dispatch").await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let group = "123456789012345678@g.us";
+        let peer = "5511777776666@s.whatsapp.net";
+        let parent_id = "PEER_PARENT";
+        let edit_id = "PEER_EDIT";
+        let secret = [0x42u8; 32];
+        // The parent (peer's own message) was stored under the real author.
+        client
+            .persistence_manager
+            .backend()
+            .put_msg_secret(group, peer, parent_id, &secret)
+            .await
+            .unwrap();
+
+        let info = Arc::new(MessageInfo {
+            id: edit_id.into(),
+            source: crate::types::message::MessageSource {
+                chat: group.parse().unwrap(),
+                sender: peer.parse().unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        // Editor's frame: from_me = true, no participant, even in a group.
+        let target_key = wa::MessageKey {
+            remote_jid: Some(group.to_string()),
+            from_me: Some(true),
+            id: Some(parent_id.to_string()),
+            participant: None,
+        };
+        // HKDF binds the real author (peer) as both original sender and editor.
+        let msg =
+            encrypted_message_edit(target_key, peer, peer, parent_id, &secret, "edited", None);
+
+        client.dispatch_parsed_message(msg, &info).await;
+
+        let got = collect_event(
+            &client,
+            collector,
+            |e| {
+                matches!(e, wacore::types::events::Event::Message(msg, info)
+                    if info.id == edit_id
+                        && legacy_edit_text(msg.as_ref()) == Some("edited")
+                        && msg.secret_encrypted_message.is_none())
+            },
+            500,
+        )
+        .await;
+        assert!(
+            got.is_some(),
+            "incoming peer edit must resolve the author from the envelope and dispatch as legacy edit"
+        );
+    }
+
     #[tokio::test]
     async fn decrypted_message_edit_recaptures_secret_for_next_edit() {
         let (client, _transport) = capturing_client("secret_edit_chain").await;


### PR DESCRIPTION
## Summary

Incoming **peer** message edits — an edit to a message authored by *another* user — never decrypted. They arrived as a `secret_encrypted_message` envelope and were never rewrapped into the legacy `protocol_message.edited_message`, so `Event::Message` consumers that detect edits never observed them. Edits to **our own** messages worked.

Follow-up to #665, which introduced the secret-encrypted edit decrypt path.

## Root cause

`maybe_decrypt_secret_encrypted_message` resolves the parent message's author (to look up its `messageSecret`) via `resolve_target_sender(target_message_key, my_jid)`:

```rust
if let Some(p) = target.participant { return p }
if target.from_me == Some(true)    { return my_jid }   // <-- here
return target.remote_jid
```

For an incoming peer edit, `target_message_key` is written in the **editor's** frame: `from_me = true`, `remote_jid` points to *us*, and there is **no `participant`** (even in groups). So the resolver returns `my_jid`. But the parent `messageSecret` was stored under the real author, so:

- the `(chat, my_jid, target_id)` secret lookup misses,
- `maybe_decrypt_secret_encrypted_message` returns `None`,
- `unwrap_or(msg)` dispatches the still-encrypted envelope unchanged.

Edits to our own messages worked only because there the editor *is* us, so `from_me = true → my_jid` is correct by coincidence.

## Fix

A message can only be edited by its author, so the parent author of a `MESSAGE_EDIT` is always the editor — i.e. the envelope sender (or us, for a self-synced edit). The new `SecretEncrypted::original_sender_for_dispatch(is_from_me, envelope_sender, my_jid)` resolves the sender from the **envelope frame** for `MESSAGE_EDIT`, and keeps the existing target-key resolution for `POLL_*` / `EVENT_EDIT` (which can be modified by a non-author). This mirrors WA Web's `MsgGetters.getOriginalSender = originalSelfAuthor || sender`.

`original_sender_jid` is retained for the manual `extract_envelope` consumer API and the poll path.

## Tests

- `message_edit_original_sender_uses_envelope_sender_for_incoming_peer_edit` — peer edit (target `from_me=true`, no `participant`) → resolves to the envelope sender.
- `message_edit_original_sender_uses_my_jid_for_self_synced_edit` → resolves to `my_jid` (device suffix stripped).
- `poll_edit_original_sender_still_uses_target_key` — regression guard: poll kinds still resolve via the target key.

`cargo test -p whatsapp-rust --lib` green (636 passed), `cargo clippy --tests` clean, `cargo fmt` applied.

Also verified end-to-end against a live client: a group peer edit now decrypts to `protocol_message.edited_message` and surfaces normally, where it previously stayed encrypted.
