### PR TITLE
feat(msg-secret)!: bound messageSecret retention by policy and event-time horizon

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -233,14 +233,11 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl MsgSecretStore for MockBackend {
-        async fn put_msg_secret(
+        async fn put_msg_secrets(
             &self,
-            _chat: &str,
-            _sender: &str,
-            _msg_id: &str,
-            _secret: &[u8],
-        ) -> StoreResult<()> {
-            Ok(())
+            entries: Vec<wacore::store::traits::MsgSecretEntry>,
+        ) -> StoreResult<usize> {
+            Ok(entries.len())
         }
 
         async fn get_msg_secret(

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -210,6 +210,17 @@ pub struct CacheConfig {
     pub msg_secret_policy: MsgSecretPolicy,
     /// Per-add-on-kind retention horizons applied under `Managed`/`BotOnly`.
     pub msg_secret_retention: MsgSecretRetention,
+    /// Whether to seed `messageSecret`s from history-sync blobs. Default `true`.
+    ///
+    /// Independent of live capture (which `msg_secret_policy` governs): seeding
+    /// only matters for add-ons that arrive live after connect yet reference a
+    /// parent delivered via history sync — edits of just-pre-pairing messages,
+    /// add-options/edits on still-open polls, or replays to a reconnecting
+    /// offline device. Headless consumers that only react to new messages can
+    /// set this to `false` to skip the pairing-time seed entirely. When `true`,
+    /// the policy still filters the seed (age/type under `Managed`, bot-only
+    /// under `BotOnly`, everything under `Full`).
+    pub seed_msg_secrets_from_history: bool,
     /// Optional app-supplied fallback consulted when an add-on's parent secret
     /// is absent from the store (and its LID/PN alternates). Lets an app that
     /// keeps its own message store own secret retention; required for the
@@ -247,6 +258,10 @@ impl std::fmt::Debug for CacheConfig {
             .field("sent_message_ttl_secs", &self.sent_message_ttl_secs)
             .field("msg_secret_policy", &self.msg_secret_policy)
             .field("msg_secret_retention", &self.msg_secret_retention)
+            .field(
+                "seed_msg_secrets_from_history",
+                &self.seed_msg_secrets_from_history,
+            )
             .field(
                 "original_message_resolver",
                 &self.original_message_resolver.is_some(),
@@ -295,6 +310,7 @@ impl Default for CacheConfig {
             // longer accumulates a secret for every message forever.
             msg_secret_policy: MsgSecretPolicy::default(),
             msg_secret_retention: MsgSecretRetention::default(),
+            seed_msg_secrets_from_history: true,
             original_message_resolver: None,
             cache_stores: CacheStores::default(),
         }

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -6,6 +6,7 @@ use crate::cache::Cache;
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::cache_store::TypedCache;
+pub use wacore::msg_secret::{MsgSecretPolicy, MsgSecretRetention, OriginalMessageResolver};
 pub use wacore::store::cache::CacheStore;
 
 /// Configuration for a single cache instance.
@@ -198,11 +199,22 @@ pub struct CacheConfig {
     pub sent_message_ttl_secs: u64,
 
     // --- MsgSecret retention ---
-    /// TTL in seconds for stored `messageSecret` rows before periodic
-    /// cleanup. `0` (default) disables automatic pruning, matching
-    /// whatsmeow and WA Web. Set to a positive value (e.g. `30 * 86_400`
-    /// for 30 days) to bound DB growth on long-running deployments.
-    pub msg_secret_ttl_secs: u64,
+    /// How the per-message `messageSecret` store is managed (capture / seed /
+    /// prune). Default [`MsgSecretPolicy::Managed`] bounds DB growth: it seeds
+    /// only the still-relevant slice of history and prunes by a per-add-on-kind
+    /// event-time horizon. Set [`MsgSecretPolicy::Full`] to keep everything
+    /// forever, or [`MsgSecretPolicy::Disabled`] to persist nothing and delegate
+    /// to [`original_message_resolver`].
+    ///
+    /// [`original_message_resolver`]: CacheConfig::original_message_resolver
+    pub msg_secret_policy: MsgSecretPolicy,
+    /// Per-add-on-kind retention horizons applied under `Managed`/`BotOnly`.
+    pub msg_secret_retention: MsgSecretRetention,
+    /// Optional app-supplied fallback consulted when an add-on's parent secret
+    /// is absent from the store (and its LID/PN alternates). Lets an app that
+    /// keeps its own message store own secret retention; required for the
+    /// `Disabled` policy to decrypt anything beyond what it has seen live.
+    pub original_message_resolver: Option<Arc<dyn OriginalMessageResolver>>,
 
     // --- Custom store overrides ---
     /// Per-cache custom store overrides.
@@ -233,7 +245,12 @@ impl std::fmt::Debug for CacheConfig {
             .field("session_locks_capacity", &self.session_locks_capacity)
             .field("chat_lanes_capacity", &self.chat_lanes_capacity)
             .field("sent_message_ttl_secs", &self.sent_message_ttl_secs)
-            .field("msg_secret_ttl_secs", &self.msg_secret_ttl_secs)
+            .field("msg_secret_policy", &self.msg_secret_policy)
+            .field("msg_secret_retention", &self.msg_secret_retention)
+            .field(
+                "original_message_resolver",
+                &self.original_message_resolver.is_some(),
+            )
             .field(
                 "cache_stores.group_cache",
                 &self.cache_stores.group_cache.is_some(),
@@ -273,10 +290,12 @@ impl Default for CacheConfig {
             session_locks_capacity: 10_000,
             chat_lanes_capacity: 5_000,
             sent_message_ttl_secs: 300,
-            // Disabled by default — match whatsmeow and WA Web (neither
-            // expires stored secrets). Callers expecting long-lived bot
-            // conversations, polls, or reactions can opt in.
-            msg_secret_ttl_secs: 0,
+            // Bounded by default: seed only the still-relevant slice of history
+            // and prune by per-add-on-kind event-time horizons, so the store no
+            // longer accumulates a secret for every message forever.
+            msg_secret_policy: MsgSecretPolicy::default(),
+            msg_secret_retention: MsgSecretRetention::default(),
+            original_message_resolver: None,
             cache_stores: CacheStores::default(),
         }
     }

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -226,6 +226,12 @@ pub struct CacheConfig {
     /// keeps its own message store own secret retention; required for the
     /// `Disabled` policy to decrypt anything beyond what it has seen live.
     pub original_message_resolver: Option<Arc<dyn OriginalMessageResolver>>,
+    /// Bound on each [`original_message_resolver`] call. The resolver runs
+    /// inside the per-chat receive lane, so a slow callback would stall that
+    /// chat; on timeout the lookup degrades to a miss. Default: 5s.
+    ///
+    /// [`original_message_resolver`]: CacheConfig::original_message_resolver
+    pub msg_secret_resolver_timeout: Duration,
 
     // --- Custom store overrides ---
     /// Per-cache custom store overrides.
@@ -265,6 +271,10 @@ impl std::fmt::Debug for CacheConfig {
             .field(
                 "original_message_resolver",
                 &self.original_message_resolver.is_some(),
+            )
+            .field(
+                "msg_secret_resolver_timeout",
+                &self.msg_secret_resolver_timeout,
             )
             .field(
                 "cache_stores.group_cache",
@@ -312,6 +322,7 @@ impl Default for CacheConfig {
             msg_secret_retention: MsgSecretRetention::default(),
             seed_msg_secrets_from_history: true,
             original_message_resolver: None,
+            msg_secret_resolver_timeout: Duration::from_secs(5),
             cache_stores: CacheStores::default(),
         }
     }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -245,7 +245,16 @@ impl Client {
     }
 
     async fn store_history_sync_msg_secrets(&self, records: Vec<HistoryMsgSecretRecord>) -> usize {
+        use wacore::msg_secret::{self, RetentionClass};
         const SECRET_LEN: usize = wacore::reporting_token::MESSAGE_SECRET_SIZE;
+
+        let policy = self.cache_config.msg_secret_policy;
+        if !policy.persists() {
+            // Disabled: rely on the resolver / app store, seed nothing.
+            return 0;
+        }
+        let retention = &self.cache_config.msg_secret_retention;
+        let now = wacore::time::now_secs();
 
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         let own_pn = device_snapshot.pn.as_ref().map(|j| j.to_non_ad());
@@ -259,6 +268,28 @@ impl Client {
             let Ok(chat) = record.chat_id.parse::<Jid>() else {
                 continue;
             };
+            let class = if chat.is_bot() {
+                RetentionClass::Bot
+            } else if record.is_poll_or_event {
+                RetentionClass::PollEvent
+            } else {
+                RetentionClass::Text
+            };
+            // BotOnly restores pre-#665: seed only bot-context secrets.
+            if policy.bot_only() && !chat.is_bot() {
+                continue;
+            }
+            // Drop secrets whose parent is already past its retention horizon:
+            // no add-on can still reference them, so seeding is pure waste. Full
+            // skips the filter (prunes() is false) and seeds everything.
+            if policy.prunes()
+                && !msg_secret::within_seed_horizon(retention, class, record.timestamp, now)
+            {
+                continue;
+            }
+            let expires_at =
+                msg_secret::expires_at(policy, retention, class, record.timestamp, now);
+
             let mut senders =
                 history_msg_secret_senders(&chat, &record, own_pn.as_ref(), own_lid.as_ref());
             if chat.is_bot()
@@ -293,9 +324,7 @@ impl Client {
                     } else {
                         secret.clone()
                     },
-                    // Real deadline + age/type seed filter land in a follow-up
-                    // commit; keep prior never-expire behavior until then.
-                    expires_at: 0,
+                    expires_at,
                 });
             }
         }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -293,6 +293,9 @@ impl Client {
                     } else {
                         secret.clone()
                     },
+                    // Real deadline + age/type seed filter land in a follow-up
+                    // commit; keep prior never-expire behavior until then.
+                    expires_at: 0,
                 });
             }
         }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -248,6 +248,10 @@ impl Client {
         use wacore::msg_secret::{self, RetentionClass};
         const SECRET_LEN: usize = wacore::reporting_token::MESSAGE_SECRET_SIZE;
 
+        if !self.cache_config.seed_msg_secrets_from_history {
+            // Opt-out of the pairing-time seed; live capture still runs.
+            return 0;
+        }
         let policy = self.cache_config.msg_secret_policy;
         if !policy.persists() {
             // Disabled: rely on the resolver / app store, seed nothing.
@@ -857,6 +861,50 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "row must be pruned once its message-time deadline passes"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_seed_skipped_when_flag_disabled() {
+        use crate::cache_config::{CacheConfig, MsgSecretPolicy};
+        let cfg = CacheConfig {
+            msg_secret_policy: MsgSecretPolicy::Managed,
+            seed_msg_secrets_from_history: false,
+            ..Default::default()
+        };
+        let client = crate::test_utils::create_test_client_with_config(
+            "seed_flag_off",
+            std::sync::Arc::new(crate::test_utils::MockHttpClient),
+            cfg,
+        )
+        .await;
+        client
+            .persistence_manager
+            .process_command(wacore::store::commands::DeviceCommand::SetId(Some(
+                "5511000000001:0@s.whatsapp.net".parse().unwrap(),
+            )))
+            .await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let chat = "5511777776666@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+        let notification = history_notification(
+            chat,
+            vec![history_msg(chat, "RECENT", &[0x77u8; 32], now - 60, false)],
+        );
+        client
+            .process_history_sync_task("S6".to_string(), notification)
+            .await;
+
+        assert_eq!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(chat, chat, "RECENT")
+                .await
+                .unwrap(),
+            None,
+            "seed flag off must skip history seeding even under Managed"
         );
     }
 }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -272,15 +272,12 @@ impl Client {
             let Ok(chat) = record.chat_id.parse::<Jid>() else {
                 continue;
             };
-            let class = if chat.is_bot() {
-                RetentionClass::Bot
-            } else if record.is_poll_or_event {
-                RetentionClass::PollEvent
-            } else {
-                RetentionClass::Text
-            };
-            // BotOnly restores pre-#665: seed only bot-context secrets.
-            if policy.bot_only() && !chat.is_bot() {
+            // Same three-way rule as the live path; the seed only has flags in
+            // hand (no full message), so a group bot prompt in history can't be
+            // detected here and falls to its poll/event-or-text class.
+            let class = msg_secret::classify_from_flags(chat.is_bot(), record.is_poll_or_event);
+            // BotOnly seeds only bot-context secrets.
+            if policy.bot_only() && class != RetentionClass::Bot {
                 continue;
             }
             // Drop secrets whose parent is already past its retention horizon:

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -280,10 +280,13 @@ impl Client {
             let Ok(chat) = record.chat_id.parse::<Jid>() else {
                 continue;
             };
-            // Same three-way rule as the live path; the seed only has flags in
-            // hand (no full message), so a group bot prompt in history can't be
-            // detected here and falls to its poll/event-or-text class.
-            let class = msg_secret::classify_from_flags(chat.is_bot(), record.is_poll_or_event);
+            // Same three-way rule as the live path. A group bot prompt is a bot
+            // context via its botMetadata (record.is_bot_invocation), so BotOnly
+            // keeps it and a later bot reply can still decrypt.
+            let class = msg_secret::classify_from_flags(
+                chat.is_bot() || record.is_bot_invocation,
+                record.is_poll_or_event,
+            );
             // BotOnly seeds only bot-context secrets.
             if policy.bot_only() && class != RetentionClass::Bot {
                 continue;
@@ -915,6 +918,99 @@ mod tests {
                 .unwrap(),
             None,
             "seed flag off must skip history seeding even under Managed"
+        );
+    }
+
+    /// A group message in `chat` from `participant`, optionally carrying
+    /// botMetadata (a bot invocation), with `secret`.
+    fn group_history_msg(
+        chat: &str,
+        participant: &str,
+        msg_id: &str,
+        secret: &[u8],
+        ts_secs: u64,
+        bot_prompt: bool,
+    ) -> wa::HistorySyncMsg {
+        let message_context_info = bot_prompt.then(|| wa::MessageContextInfo {
+            bot_metadata: Some(wa::BotMetadata {
+                persona_id: Some("867051314767696".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        wa::HistorySyncMsg {
+            message: Some(wa::WebMessageInfo {
+                key: wa::MessageKey {
+                    remote_jid: Some(chat.to_string()),
+                    from_me: Some(false),
+                    id: Some(msg_id.to_string()),
+                    participant: Some(participant.to_string()),
+                },
+                message: Some(wa::Message {
+                    extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
+                        text: Some("hi".into()),
+                        ..Default::default()
+                    })),
+                    message_context_info,
+                    ..Default::default()
+                }),
+                message_secret: Some(secret.to_vec()),
+                message_timestamp: Some(ts_secs),
+                ..Default::default()
+            }),
+            msg_order_id: Some(1),
+        }
+    }
+
+    #[tokio::test]
+    async fn history_seed_botonly_keeps_group_bot_prompt_skips_plain() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_botonly_bot", MsgSecretPolicy::BotOnly).await;
+        let group = "120363021033254949@g.us";
+        let participant = "5511888887777@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+
+        let notification = history_notification(
+            group,
+            vec![
+                group_history_msg(
+                    group,
+                    participant,
+                    "BOT_PROMPT",
+                    &[0x88u8; 32],
+                    now - 60,
+                    true,
+                ),
+                group_history_msg(
+                    group,
+                    participant,
+                    "PLAIN_GRP",
+                    &[0x99u8; 32],
+                    now - 60,
+                    false,
+                ),
+            ],
+        );
+        client
+            .process_history_sync_task("SB".to_string(), notification)
+            .await;
+
+        let backend = client.persistence_manager.backend();
+        assert_eq!(
+            backend
+                .get_msg_secret(group, participant, "BOT_PROMPT")
+                .await
+                .unwrap(),
+            Some(vec![0x88u8; 32]),
+            "BotOnly must seed a group bot prompt (botMetadata = bot context)"
+        );
+        assert_eq!(
+            backend
+                .get_msg_secret(group, participant, "PLAIN_GRP")
+                .await
+                .unwrap(),
+            None,
+            "BotOnly must skip a plain group message"
         );
     }
 }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -610,4 +610,253 @@ mod tests {
         assert_eq!(primary, Some(secret.clone()));
         assert_eq!(alias, Some(secret));
     }
+
+    /// One inbound history message in `chat`, stamped at `ts_secs`, optionally a
+    /// poll-creation message, carrying `secret`.
+    fn history_msg(
+        chat: &str,
+        msg_id: &str,
+        secret: &[u8],
+        ts_secs: u64,
+        is_poll: bool,
+    ) -> wa::HistorySyncMsg {
+        let message = if is_poll {
+            wa::Message {
+                poll_creation_message: Some(Box::new(wa::message::PollCreationMessage::default())),
+                ..Default::default()
+            }
+        } else {
+            wa::Message {
+                conversation: Some("historical".to_string()),
+                ..Default::default()
+            }
+        };
+        wa::HistorySyncMsg {
+            message: Some(wa::WebMessageInfo {
+                key: wa::MessageKey {
+                    remote_jid: Some(chat.to_string()),
+                    from_me: Some(false),
+                    id: Some(msg_id.to_string()),
+                    participant: None,
+                },
+                message: Some(message),
+                message_secret: Some(secret.to_vec()),
+                message_timestamp: Some(ts_secs),
+                ..Default::default()
+            }),
+            msg_order_id: Some(1),
+        }
+    }
+
+    fn history_notification(
+        chat: &str,
+        messages: Vec<wa::HistorySyncMsg>,
+    ) -> HistorySyncNotification {
+        let history_sync = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::InitialBootstrap as i32,
+            conversations: vec![wa::Conversation {
+                id: chat.to_string(),
+                messages,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let compressed = compress_history_sync(&history_sync);
+        HistorySyncNotification {
+            file_length: Some(compressed.len() as u64),
+            sync_type: Some(wa::message::HistorySyncType::InitialBootstrap as i32),
+            initial_hist_bootstrap_inline_payload: Some(compressed),
+            ..Default::default()
+        }
+    }
+
+    async fn seeded_client(
+        name: &str,
+        policy: crate::cache_config::MsgSecretPolicy,
+    ) -> Arc<Client> {
+        let cfg = crate::cache_config::CacheConfig {
+            msg_secret_policy: policy,
+            ..Default::default()
+        };
+        let client = crate::test_utils::create_test_client_with_config(
+            name,
+            std::sync::Arc::new(crate::test_utils::MockHttpClient),
+            cfg,
+        )
+        .await;
+        client
+            .persistence_manager
+            .process_command(wacore::store::commands::DeviceCommand::SetId(Some(
+                "5511000000001:0@s.whatsapp.net".parse().unwrap(),
+            )))
+            .await;
+        client.is_running.store(true, Ordering::Relaxed);
+        client
+    }
+
+    #[tokio::test]
+    async fn history_seed_managed_drops_old_text_keeps_recent() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_managed_text", MsgSecretPolicy::Managed).await;
+        let chat = "5511777776666@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+        let old_ts = now - 60 * 86_400; // past the 30d text horizon
+        let recent_ts = now - 86_400; // within it
+
+        let notification = history_notification(
+            chat,
+            vec![
+                history_msg(chat, "OLD_TEXT", &[0x11u8; 32], old_ts, false),
+                history_msg(chat, "RECENT_TEXT", &[0x22u8; 32], recent_ts, false),
+            ],
+        );
+        client
+            .process_history_sync_task("S1".to_string(), notification)
+            .await;
+
+        let backend = client.persistence_manager.backend();
+        assert_eq!(
+            backend
+                .get_msg_secret(chat, chat, "OLD_TEXT")
+                .await
+                .unwrap(),
+            None,
+            "a text secret past its 30d horizon must not be seeded"
+        );
+        assert_eq!(
+            backend
+                .get_msg_secret(chat, chat, "RECENT_TEXT")
+                .await
+                .unwrap(),
+            Some(vec![0x22u8; 32]),
+            "a recent text secret must be seeded"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_seed_managed_keeps_old_poll_within_90d() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_managed_poll", MsgSecretPolicy::Managed).await;
+        let chat = "5511777776666@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+        let ts = now - 60 * 86_400; // past 30d text but within 90d poll/event
+
+        let notification = history_notification(
+            chat,
+            vec![history_msg(chat, "OLD_POLL", &[0x33u8; 32], ts, true)],
+        );
+        client
+            .process_history_sync_task("S2".to_string(), notification)
+            .await;
+
+        assert_eq!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(chat, chat, "OLD_POLL")
+                .await
+                .unwrap(),
+            Some(vec![0x33u8; 32]),
+            "a poll parent within the 90d horizon must be seeded even past 30d"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_seed_full_keeps_old_text() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_full", MsgSecretPolicy::Full).await;
+        let chat = "5511777776666@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+        let old_ts = now - 365 * 86_400; // a year old
+
+        let notification = history_notification(
+            chat,
+            vec![history_msg(chat, "ANCIENT", &[0x44u8; 32], old_ts, false)],
+        );
+        client
+            .process_history_sync_task("S3".to_string(), notification)
+            .await;
+
+        assert_eq!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(chat, chat, "ANCIENT")
+                .await
+                .unwrap(),
+            Some(vec![0x44u8; 32]),
+            "Full seeds everything regardless of age"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_seed_disabled_stores_nothing() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_disabled", MsgSecretPolicy::Disabled).await;
+        let chat = "5511777776666@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+
+        let notification = history_notification(
+            chat,
+            vec![history_msg(chat, "ANY", &[0x55u8; 32], now - 60, false)],
+        );
+        client
+            .process_history_sync_task("S4".to_string(), notification)
+            .await;
+
+        assert_eq!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(chat, chat, "ANY")
+                .await
+                .unwrap(),
+            None,
+            "Disabled persists nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_seed_managed_stamps_expires_at_from_message_time() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_expires", MsgSecretPolicy::Managed).await;
+        let chat = "5511777776666@s.whatsapp.net";
+        let now = wacore::time::now_secs();
+        let msg_ts = (now - 86_400) as u64; // 1 day old text → expires at msg_ts + 30d
+
+        let notification = history_notification(
+            chat,
+            vec![history_msg(chat, "RECENT", &[0x66u8; 32], msg_ts, false)],
+        );
+        client
+            .process_history_sync_task("S5".to_string(), notification)
+            .await;
+
+        let backend = client.persistence_manager.backend();
+        // Deadline is msg_ts + 30d ≈ now + 29d: a prune at "now" keeps it.
+        backend.delete_expired_msg_secrets(now).await.unwrap();
+        assert!(
+            backend
+                .get_msg_secret(chat, chat, "RECENT")
+                .await
+                .unwrap()
+                .is_some(),
+            "row must survive a prune before its deadline"
+        );
+        // A prune past msg_ts + 30d removes it, proving the deadline tracks
+        // message time, not seed time.
+        let removed = backend
+            .delete_expired_msg_secrets(now + 31 * 86_400)
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+        assert!(
+            backend
+                .get_msg_secret(chat, chat, "RECENT")
+                .await
+                .unwrap()
+                .is_none(),
+            "row must be pruned once its message-time deadline passes"
+        );
+    }
 }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -250,11 +250,19 @@ impl Client {
 
         if !self.cache_config.seed_msg_secrets_from_history {
             // Opt-out of the pairing-time seed; live capture still runs.
+            log::debug!(
+                target: "Client/MsgSecret",
+                "Skipping history-sync msg_secret seed (seed_msg_secrets_from_history = false)"
+            );
             return 0;
         }
         let policy = self.cache_config.msg_secret_policy;
         if !policy.persists() {
             // Disabled: rely on the resolver / app store, seed nothing.
+            log::debug!(
+                target: "Client/MsgSecret",
+                "Skipping history-sync msg_secret seed (policy = {policy:?})"
+            );
             return 0;
         }
         let retention = &self.cache_config.msg_secret_retention;
@@ -290,6 +298,10 @@ impl Client {
             }
             let expires_at =
                 msg_secret::expires_at(policy, retention, class, record.timestamp, now);
+            let message_ts = record
+                .timestamp
+                .and_then(|t| i64::try_from(t).ok())
+                .unwrap_or(0);
 
             let mut senders =
                 history_msg_secret_senders(&chat, &record, own_pn.as_ref(), own_lid.as_ref());
@@ -326,6 +338,7 @@ impl Client {
                         secret.clone()
                     },
                     expires_at,
+                    message_ts,
                 });
             }
         }

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -214,16 +214,21 @@ impl Client {
                 .detach();
         }
 
-        // msg_secrets retention: disabled by default (matches whatsmeow + WA
-        // Web). Caller opts in via CacheConfig.msg_secret_ttl_secs.
-        let secret_ttl = self.cache_config.msg_secret_ttl_secs;
-        if secret_ttl > 0 {
+        // msg_secrets retention: prune rows whose per-row deadline has passed.
+        // expires_at is absolute, so the cutoff is simply "now"; per-kind
+        // horizons and never-expire (0) rows are baked in at write time.
+        if self.cache_config.msg_secret_policy.prunes() {
             let backend = self.persistence_manager.backend();
-            let cutoff = cutoff_for(secret_ttl);
             self.runtime
                 .spawn(Box::pin(async move {
-                    if let Err(e) = backend.delete_expired_msg_secrets(cutoff).await {
-                        log::debug!(target: "Client/Keepalive", "msg_secrets cleanup error: {e}");
+                    match backend.delete_expired_msg_secrets(now).await {
+                        Ok(n) if n > 0 => {
+                            log::debug!(target: "Client/Keepalive", "Pruned {n} expired msg_secrets");
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            log::debug!(target: "Client/Keepalive", "msg_secrets cleanup error: {e}");
+                        }
                     }
                 }))
                 .detach();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,10 @@ pub mod cache;
 pub mod portable_cache;
 
 pub mod cache_config;
-pub use cache_config::{CacheConfig, CacheEntryConfig, CacheStores};
+pub use cache_config::{
+    CacheConfig, CacheEntryConfig, CacheStores, MsgSecretPolicy, MsgSecretRetention,
+    OriginalMessageResolver,
+};
 pub mod cache_store;
 pub(crate) mod pending_device_sync;
 pub(crate) mod sender_key_device_cache;

--- a/src/message.rs
+++ b/src/message.rs
@@ -349,11 +349,11 @@ impl Client {
             .await
             .unwrap_or_default();
 
-        let primary = backend
+        let store_secret = match backend
             .get_msg_secret(&chat_for_lookup, &original_sender_str, target_id)
-            .await;
-        let secret = match primary {
-            Ok(Some(secret)) => secret,
+            .await
+        {
+            Ok(Some(secret)) => Some(secret),
             Ok(None) => match self
                 .alternate_msg_secret_lookup(
                     &backend,
@@ -363,14 +363,13 @@ impl Client {
                 )
                 .await
             {
-                Ok(Some(secret)) => secret,
-                Ok(None) => return None,
+                Ok(found) => found,
                 Err(e) => {
                     log::warn!(
                         "[msg:{}] secret_encrypted_message alternate secret lookup failed: {e:?}",
                         info.id
                     );
-                    return None;
+                    None
                 }
             },
             Err(e) => {
@@ -378,7 +377,29 @@ impl Client {
                     "[msg:{}] backend error reading secret_encrypted_message secret: {e:?}",
                     info.id
                 );
-                return None;
+                None
+            }
+        };
+        // On a total store miss, ask the app-supplied resolver (if any) for the
+        // parent secret. This is what lets the Disabled policy still decrypt.
+        let secret = match store_secret {
+            Some(secret) => secret,
+            None => {
+                let alternate = fallback_original_sender
+                    .as_ref()
+                    .map(|j| j.to_non_ad_string());
+                match self
+                    .resolve_msg_secret_via_app(
+                        &chat_for_lookup,
+                        &original_sender_str,
+                        alternate.as_deref(),
+                        target_id,
+                    )
+                    .await
+                {
+                    Some(secret) => secret,
+                    None => return None,
+                }
             }
         };
 
@@ -610,24 +631,44 @@ impl Client {
             {
                 Ok(Some(s)) => s,
                 Ok(None) => {
-                    // For a group bot invocation initiated by our PRIMARY
-                    // device, the messageSecret lives in the bot-addressed copy
-                    // the primary sent directly to the bot — it is NOT mirrored
-                    // to companions in the group skmsg. So a companion
-                    // legitimately never holds the secret; this miss is expected
-                    // and benign (we nack 495 and the server stops replaying).
-                    // A miss in a 1:1 bot chat is unexpected and worth a warn.
-                    log::log!(
-                        if info.source.is_group {
-                            log::Level::Debug
-                        } else {
-                            log::Level::Warn
-                        },
-                        "[msg:{}] msmsg: no message_secret stored for target_id={target_id} (primary or alternate)",
-                        info.id
-                    );
-                    self.spawn_nack(info, NackReason::MissingMessageSecret, None);
-                    return;
+                    let alternate = self
+                        .alternate_msg_secret_jid(&backend, &target_sender)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|j| j.to_non_ad_string());
+                    match self
+                        .resolve_msg_secret_via_app(
+                            &chat_for_lookup,
+                            &target_sender_str,
+                            alternate.as_deref(),
+                            target_id,
+                        )
+                        .await
+                    {
+                        Some(s) => s,
+                        None => {
+                            // For a group bot invocation initiated by our PRIMARY
+                            // device, the messageSecret lives in the bot-addressed
+                            // copy the primary sent directly to the bot — it is NOT
+                            // mirrored to companions in the group skmsg. So a
+                            // companion legitimately never holds the secret; this
+                            // miss is expected and benign (we nack 495 and the
+                            // server stops replaying). A miss in a 1:1 bot chat is
+                            // unexpected and worth a warn.
+                            log::log!(
+                                if info.source.is_group {
+                                    log::Level::Debug
+                                } else {
+                                    log::Level::Warn
+                                },
+                                "[msg:{}] msmsg: no message_secret stored for target_id={target_id} (primary or alternate)",
+                                info.id
+                            );
+                            self.spawn_nack(info, NackReason::MissingMessageSecret, None);
+                            return;
+                        }
+                    }
                 }
                 Err(e) => {
                     log::warn!(
@@ -794,8 +835,47 @@ impl Client {
             .await
     }
 
+    /// On a total store miss, consult the app-supplied resolver for the parent
+    /// secret, trying the primary then the LID/PN alternate sender. Bounded by a
+    /// timeout because it runs inside the per-chat receive lane, so a slow app
+    /// callback degrades to a miss instead of stalling the chat.
+    async fn resolve_msg_secret_via_app(
+        &self,
+        chat: &str,
+        primary_sender: &str,
+        alternate_sender: Option<&str>,
+        msg_id: &str,
+    ) -> Option<Vec<u8>> {
+        let resolver = self.cache_config.original_message_resolver.as_ref()?;
+        let lookup = async {
+            if let Some(secret) = resolver
+                .resolve_msg_secret(chat, primary_sender, msg_id)
+                .await
+            {
+                return Some(secret);
+            }
+            if let Some(alt) = alternate_sender
+                && alt != primary_sender
+                && let Some(secret) = resolver.resolve_msg_secret(chat, alt, msg_id).await
+            {
+                return Some(secret);
+            }
+            None
+        };
+        match tokio::time::timeout(std::time::Duration::from_secs(5), lookup).await {
+            Ok(Some(secret)) => Some(secret.to_vec()),
+            Ok(None) => None,
+            Err(_) => {
+                log::warn!("[msg:{msg_id}] original_message_resolver timed out");
+                None
+            }
+        }
+    }
+
     /// Handles a newsletter plaintext message.
     /// Newsletters are not E2E encrypted and use the <plaintext> tag directly.
+    /// They never carry a `secret_encrypted_message`, so no messageSecret is
+    /// stored or retained for newsletter chats (no newsletter retention class).
     async fn handle_newsletter_message(
         self: &Arc<Self>,
         node: &NodeRef<'_>,

--- a/src/message.rs
+++ b/src/message.rs
@@ -10060,6 +10060,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn secret_encrypted_edit_decrypts_via_resolver_when_store_empty() {
+        use crate::cache_config::{CacheConfig, MsgSecretPolicy};
+
+        struct StaticResolver {
+            chat: String,
+            sender: String,
+            msg_id: String,
+            secret: [u8; 32],
+        }
+        #[async_trait::async_trait]
+        impl wacore::msg_secret::OriginalMessageResolver for StaticResolver {
+            async fn resolve_msg_secret(
+                &self,
+                chat: &str,
+                sender: &str,
+                msg_id: &str,
+            ) -> Option<[u8; 32]> {
+                (chat == self.chat && sender == self.sender && msg_id == self.msg_id)
+                    .then_some(self.secret)
+            }
+        }
+
+        let chat = "5511777776666@s.whatsapp.net";
+        let parent_id = "RESOLVER_PARENT";
+        let edit_id = "RESOLVER_EDIT";
+        let secret = [0x7Au8; 32];
+
+        let resolver = Arc::new(StaticResolver {
+            chat: chat.to_string(),
+            sender: chat.to_string(),
+            msg_id: parent_id.to_string(),
+            secret,
+        });
+        // Disabled persists nothing, so the only path to the secret is the resolver.
+        let cfg = CacheConfig {
+            msg_secret_policy: MsgSecretPolicy::Disabled,
+            original_message_resolver: Some(resolver),
+            ..Default::default()
+        };
+        let client = crate::test_utils::create_test_client_with_config(
+            "resolver_edit",
+            Arc::new(crate::test_utils::MockHttpClient),
+            cfg,
+        )
+        .await;
+        seed_test_pn(&client).await;
+
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        assert!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(chat, chat, parent_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "store must be empty under Disabled"
+        );
+
+        let info = Arc::new(MessageInfo {
+            id: edit_id.into(),
+            source: crate::types::message::MessageSource {
+                chat: chat.parse().unwrap(),
+                sender: chat.parse().unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let target_key = wa::MessageKey {
+            remote_jid: Some(chat.to_string()),
+            from_me: Some(false),
+            id: Some(parent_id.to_string()),
+            participant: None,
+        };
+        let msg = encrypted_message_edit(
+            target_key,
+            chat,
+            chat,
+            parent_id,
+            &secret,
+            "edited via resolver",
+            None,
+        );
+
+        client.dispatch_parsed_message(msg, &info).await;
+
+        let got = collect_event(
+            &client,
+            collector,
+            |e| {
+                matches!(e, wacore::types::events::Event::Message(msg, info)
+                    if info.id == edit_id
+                        && legacy_edit_text(msg.as_ref()) == Some("edited via resolver")
+                        && msg.secret_encrypted_message.is_none())
+            },
+            500,
+        )
+        .await;
+        assert!(
+            got.is_some(),
+            "edit must decrypt via the resolver when the store is empty"
+        );
+    }
+
+    #[tokio::test]
     async fn decrypted_message_edit_recaptures_secret_for_next_edit() {
         let (client, _transport) = capturing_client("secret_edit_chain").await;
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());

--- a/src/message.rs
+++ b/src/message.rs
@@ -212,21 +212,41 @@ impl Client {
             return;
         }
 
+        let policy = self.cache_config.msg_secret_policy;
+        if !policy.persists() {
+            return;
+        }
+        let chat_is_bot = info.source.chat.server == wacore_binary::Server::Bot;
+        // BotOnly restores pre-#665: only capture secrets in bot contexts.
+        if policy.bot_only() && !chat_is_bot {
+            return;
+        }
+        let class = wacore::msg_secret::classify(msg, chat_is_bot);
+        let message_ts = u64::try_from(info.timestamp.timestamp()).ok();
+
         self.persist_msg_secret_bytes(
             &info.source.chat,
             &info.source.sender,
             &info.id,
             secret_bytes,
+            class,
+            message_ts,
         )
         .await;
 
-        let chat_is_bot = info.source.chat.server == wacore_binary::Server::Bot;
         if chat_is_bot
             && let Some(sender) = self.dm_sender_identity_for(&info.source.chat).await
             && sender.to_non_ad() != info.source.sender.to_non_ad()
         {
-            self.persist_msg_secret_bytes(&info.source.chat, &sender, &info.id, secret_bytes)
-                .await;
+            self.persist_msg_secret_bytes(
+                &info.source.chat,
+                &sender,
+                &info.id,
+                secret_bytes,
+                class,
+                message_ts,
+            )
+            .await;
         }
     }
 
@@ -236,21 +256,39 @@ impl Client {
         sender: &Jid,
         msg_id: &str,
         secret_bytes: &[u8],
+        class: wacore::msg_secret::RetentionClass,
+        message_ts: Option<u64>,
     ) -> bool {
         const SECRET_LEN: usize = wacore::reporting_token::MESSAGE_SECRET_SIZE;
 
         let Ok(secret) = <&[u8; SECRET_LEN]>::try_from(secret_bytes) else {
             return false;
         };
-        let chat_str = chat.to_non_ad_string();
-        let sender_str = sender.to_non_ad_string();
+        let policy = self.cache_config.msg_secret_policy;
+        if !policy.persists() {
+            return false;
+        }
+        let expires_at = wacore::msg_secret::expires_at(
+            policy,
+            &self.cache_config.msg_secret_retention,
+            class,
+            message_ts,
+            wacore::time::now_secs(),
+        );
+        let entry = wacore::store::traits::MsgSecretEntry {
+            chat: chat.to_non_ad_string(),
+            sender: sender.to_non_ad_string(),
+            msg_id: msg_id.to_string(),
+            secret: secret.to_vec(),
+            expires_at,
+        };
         match self
             .persistence_manager
             .backend()
-            .put_msg_secret(&chat_str, &sender_str, msg_id, secret)
+            .put_msg_secrets(vec![entry])
             .await
         {
-            Ok(()) => true,
+            Ok(_) => true,
             Err(e) => {
                 log::warn!("[msg:{msg_id}] failed to persist messageSecret: {e:?}");
                 false
@@ -435,11 +473,21 @@ impl Client {
             .as_ref()
             .and_then(|m| m.message_secret.as_deref())
         {
+            // The re-persisted secret keys the NEXT add-on on the same parent,
+            // so its retention class follows the parent kind. The edit's arrival
+            // time is within ~20min of the parent, a bounded over-retention.
+            let class = match env.kind {
+                SecretEncKind::MessageEdit => wacore::msg_secret::RetentionClass::Text,
+                _ => wacore::msg_secret::RetentionClass::PollEvent,
+            };
+            let message_ts = u64::try_from(info.timestamp.timestamp()).ok();
             self.persist_msg_secret_bytes(
                 &info.source.chat,
                 &original_sender,
                 target_id,
                 secret_bytes,
+                class,
+                message_ts,
             )
             .await;
             if let Some(alternate_sender) = fallback_original_sender.as_ref() {
@@ -448,6 +496,8 @@ impl Client {
                     alternate_sender,
                     target_id,
                     secret_bytes,
+                    class,
+                    message_ts,
                 )
                 .await;
             }
@@ -11622,7 +11672,13 @@ mod tests {
             .await
             .expect("LID seeded");
         client
-            .persist_outbound_msg_secret(&bot_chat, &sender_identity, outbound_id, &secret)
+            .persist_outbound_msg_secret(
+                &bot_chat,
+                &sender_identity,
+                outbound_id,
+                &secret,
+                wacore::msg_secret::RetentionClass::Bot,
+            )
             .await;
 
         // Inbound msmsg payload encrypted under the same (msg_id, target, bot)

--- a/src/message.rs
+++ b/src/message.rs
@@ -887,7 +887,7 @@ impl Client {
             }
             None
         };
-        match tokio::time::timeout(std::time::Duration::from_secs(5), lookup).await {
+        match tokio::time::timeout(self.cache_config.msg_secret_resolver_timeout, lookup).await {
             Ok(Some(secret)) => Some(secret.to_vec()),
             Ok(None) => None,
             Err(_) => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -216,29 +216,29 @@ impl Client {
         if !policy.persists() {
             return;
         }
-        let chat_is_bot = info.source.chat.server == wacore_binary::Server::Bot;
-        // BotOnly restores pre-#665: only capture secrets in bot contexts.
-        if policy.bot_only() && !chat_is_bot {
-            return;
-        }
+        let chat_is_bot = info.source.chat.is_bot();
+        // BotOnly enforcement lives in build_msg_secret_entry (the chokepoint),
+        // which keys off the classified bot context including group bot prompts.
         let class = wacore::msg_secret::classify(msg, chat_is_bot);
         let message_ts = u64::try_from(info.timestamp.timestamp()).ok();
 
-        self.persist_msg_secret_bytes(
+        // Build both aliases (primary, plus the bot-DM LID key) and write them
+        // in one batch so a partial write can't leave only one stored.
+        let mut entries = Vec::with_capacity(2);
+        if let Some(entry) = self.build_msg_secret_entry(
             &info.source.chat,
             &info.source.sender,
             &info.id,
             secret_bytes,
             class,
             message_ts,
-        )
-        .await;
-
+        ) {
+            entries.push(entry);
+        }
         if chat_is_bot
             && let Some(sender) = self.dm_sender_identity_for(&info.source.chat).await
             && sender.to_non_ad() != info.source.sender.to_non_ad()
-        {
-            self.persist_msg_secret_bytes(
+            && let Some(entry) = self.build_msg_secret_entry(
                 &info.source.chat,
                 &sender,
                 &info.id,
@@ -246,11 +246,17 @@ impl Client {
                 class,
                 message_ts,
             )
-            .await;
+        {
+            entries.push(entry);
         }
+        self.persist_msg_secret_entries(entries).await;
     }
 
-    pub(crate) async fn persist_msg_secret_bytes(
+    /// Build one retention entry, applying the policy gates and computing the
+    /// per-row deadline. Returns `None` when the policy skips this write (not
+    /// persisting, or `BotOnly` and the class isn't `Bot`) or the secret isn't
+    /// 32 bytes. Pure (no I/O) so callers can batch several aliases atomically.
+    fn build_msg_secret_entry(
         &self,
         chat: &Jid,
         sender: &Jid,
@@ -258,15 +264,17 @@ impl Client {
         secret_bytes: &[u8],
         class: wacore::msg_secret::RetentionClass,
         message_ts: Option<u64>,
-    ) -> bool {
+    ) -> Option<wacore::store::traits::MsgSecretEntry> {
         const SECRET_LEN: usize = wacore::reporting_token::MESSAGE_SECRET_SIZE;
-
-        let Ok(secret) = <&[u8; SECRET_LEN]>::try_from(secret_bytes) else {
-            return false;
-        };
+        let secret = <&[u8; SECRET_LEN]>::try_from(secret_bytes).ok()?;
         let policy = self.cache_config.msg_secret_policy;
         if !policy.persists() {
-            return false;
+            return None;
+        }
+        // Single chokepoint for the BotOnly invariant: only bot-context secrets
+        // (class == Bot) are persisted, no matter which write path got here.
+        if policy.bot_only() && class != wacore::msg_secret::RetentionClass::Bot {
+            return None;
         }
         let expires_at = wacore::msg_secret::expires_at(
             policy,
@@ -275,22 +283,33 @@ impl Client {
             message_ts,
             wacore::time::now_secs(),
         );
-        let entry = wacore::store::traits::MsgSecretEntry {
+        Some(wacore::store::traits::MsgSecretEntry {
             chat: chat.to_non_ad_string(),
             sender: sender.to_non_ad_string(),
             msg_id: msg_id.to_string(),
             secret: secret.to_vec(),
             expires_at,
-        };
+        })
+    }
+
+    /// Write a batch of secret aliases in one atomic upsert, so a multi-alias
+    /// capture/re-persist never leaves only some aliases stored.
+    async fn persist_msg_secret_entries(
+        &self,
+        entries: Vec<wacore::store::traits::MsgSecretEntry>,
+    ) -> bool {
+        if entries.is_empty() {
+            return false;
+        }
         match self
             .persistence_manager
             .backend()
-            .put_msg_secrets(vec![entry])
+            .put_msg_secrets(entries)
             .await
         {
             Ok(_) => true,
             Err(e) => {
-                log::warn!("[msg:{msg_id}] failed to persist messageSecret: {e:?}");
+                log::warn!("failed to persist messageSecrets: {e:?}");
                 false
             }
         }
@@ -502,17 +521,20 @@ impl Client {
                 _ => wacore::msg_secret::RetentionClass::PollEvent,
             };
             let message_ts = u64::try_from(info.timestamp.timestamp()).ok();
-            self.persist_msg_secret_bytes(
+            // Primary + LID/PN alternate in one batch so both survive together.
+            let mut entries = Vec::with_capacity(2);
+            if let Some(entry) = self.build_msg_secret_entry(
                 &info.source.chat,
                 &original_sender,
                 target_id,
                 secret_bytes,
                 class,
                 message_ts,
-            )
-            .await;
-            if let Some(alternate_sender) = fallback_original_sender.as_ref() {
-                self.persist_msg_secret_bytes(
+            ) {
+                entries.push(entry);
+            }
+            if let Some(alternate_sender) = fallback_original_sender.as_ref()
+                && let Some(entry) = self.build_msg_secret_entry(
                     &info.source.chat,
                     alternate_sender,
                     target_id,
@@ -520,8 +542,10 @@ impl Client {
                     class,
                     message_ts,
                 )
-                .await;
+            {
+                entries.push(entry);
             }
+            self.persist_msg_secret_entries(entries).await;
         }
 
         if env.kind != SecretEncKind::MessageEdit {
@@ -620,72 +644,73 @@ impl Client {
         // target_sender_jid>` echoes the other. Covers LID migration windows
         // and asymmetric outbound/inbound identities.
         let backend = self.persistence_manager.backend();
-        let primary = backend
+        // Store lookup: primary, then the LID/PN alternate. A backend error is
+        // logged and treated as a miss (not a hard nack) so the resolver still
+        // gets a chance — mirrors the secret-encrypted edit path.
+        let store_secret = match backend
             .get_msg_secret(&chat_for_lookup, &target_sender_str, target_id)
-            .await;
-        let secret = match primary {
-            Ok(Some(s)) => s,
+            .await
+        {
+            Ok(Some(s)) => Some(s),
             Ok(None) => match self
                 .alternate_msg_secret_lookup(&backend, &chat_for_lookup, &target_sender, target_id)
                 .await
             {
-                Ok(Some(s)) => s,
-                Ok(None) => {
-                    let alternate = self
-                        .alternate_msg_secret_jid(&backend, &target_sender)
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|j| j.to_non_ad_string());
-                    match self
-                        .resolve_msg_secret_via_app(
-                            &chat_for_lookup,
-                            &target_sender_str,
-                            alternate.as_deref(),
-                            target_id,
-                        )
-                        .await
-                    {
-                        Some(s) => s,
-                        None => {
-                            // For a group bot invocation initiated by our PRIMARY
-                            // device, the messageSecret lives in the bot-addressed
-                            // copy the primary sent directly to the bot — it is NOT
-                            // mirrored to companions in the group skmsg. So a
-                            // companion legitimately never holds the secret; this
-                            // miss is expected and benign (we nack 495 and the
-                            // server stops replaying). A miss in a 1:1 bot chat is
-                            // unexpected and worth a warn.
-                            log::log!(
-                                if info.source.is_group {
-                                    log::Level::Debug
-                                } else {
-                                    log::Level::Warn
-                                },
-                                "[msg:{}] msmsg: no message_secret stored for target_id={target_id} (primary or alternate)",
-                                info.id
-                            );
-                            self.spawn_nack(info, NackReason::MissingMessageSecret, None);
-                            return;
-                        }
-                    }
-                }
+                Ok(found) => found,
                 Err(e) => {
-                    log::warn!(
-                        "[msg:{}] msmsg: alternate lookup failed: {e:?}; nack 495",
-                        info.id
-                    );
-                    self.spawn_nack(info, NackReason::MissingMessageSecret, None);
-                    return;
+                    log::warn!("[msg:{}] msmsg: alternate lookup failed: {e:?}", info.id);
+                    None
                 }
             },
             Err(e) => {
                 log::warn!(
-                    "[msg:{}] backend error reading message_secret ({e:?}); nack 495 so the server stops replaying",
+                    "[msg:{}] backend error reading message_secret: {e:?}",
                     info.id
                 );
-                self.spawn_nack(info, NackReason::MissingMessageSecret, None);
-                return;
+                None
+            }
+        };
+        let secret = match store_secret {
+            Some(s) => s,
+            None => {
+                let alternate = self
+                    .alternate_msg_secret_jid(&backend, &target_sender)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|j| j.to_non_ad_string());
+                match self
+                    .resolve_msg_secret_via_app(
+                        &chat_for_lookup,
+                        &target_sender_str,
+                        alternate.as_deref(),
+                        target_id,
+                    )
+                    .await
+                {
+                    Some(s) => s,
+                    None => {
+                        // For a group bot invocation initiated by our PRIMARY
+                        // device, the messageSecret lives in the bot-addressed
+                        // copy the primary sent directly to the bot — it is NOT
+                        // mirrored to companions in the group skmsg. So a
+                        // companion legitimately never holds the secret; this
+                        // miss is expected and benign (we nack 495 and the server
+                        // stops replaying). A miss in a 1:1 bot chat is unexpected
+                        // and worth a warn.
+                        log::log!(
+                            if info.source.is_group {
+                                log::Level::Debug
+                            } else {
+                                log::Level::Warn
+                            },
+                            "[msg:{}] msmsg: no message_secret stored for target_id={target_id} (primary or alternate)",
+                            info.id
+                        );
+                        self.spawn_nack(info, NackReason::MissingMessageSecret, None);
+                        return;
+                    }
+                }
             }
         };
 
@@ -11359,6 +11384,98 @@ mod tests {
             got.as_deref(),
             Some(&[0x7Bu8; 32][..]),
             "bot_metadata presence must let our own group prompt cache without a mention"
+        );
+    }
+
+    #[tokio::test]
+    async fn bot_only_captures_group_bot_prompt_skips_plain() {
+        use crate::cache_config::{CacheConfig, MsgSecretPolicy};
+        let cfg = CacheConfig {
+            msg_secret_policy: MsgSecretPolicy::BotOnly,
+            ..Default::default()
+        };
+        let client = crate::test_utils::create_test_client_with_config(
+            "botonly_capture",
+            Arc::new(crate::test_utils::MockHttpClient),
+            cfg,
+        )
+        .await;
+
+        let group = "120363021033254949@g.us";
+        let sender = "5511888887777@s.whatsapp.net";
+
+        // A plain group message is not a bot context → skipped under BotOnly.
+        let plain_info = Arc::new(MessageInfo {
+            id: "PLAIN".into(),
+            source: crate::types::message::MessageSource {
+                chat: group.parse().unwrap(),
+                sender: sender.parse().unwrap(),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let plain_msg = wa::Message {
+            conversation: Some("hi".into()),
+            message_context_info: Some(wa::MessageContextInfo {
+                message_secret: Some(vec![0x01; 32]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        client
+            .maybe_capture_inbound_msg_secret(&plain_msg, &plain_info)
+            .await;
+        assert!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(group, sender, "PLAIN")
+                .await
+                .unwrap()
+                .is_none(),
+            "BotOnly must skip a plain (non-bot) group message"
+        );
+
+        // A group message that invokes a bot (bot_metadata) classifies as Bot,
+        // so its secret is kept and the later bot reply can decrypt.
+        let bot_info = Arc::new(MessageInfo {
+            id: "BOTP".into(),
+            source: crate::types::message::MessageSource {
+                chat: group.parse().unwrap(),
+                sender: sender.parse().unwrap(),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let bot_msg = wa::Message {
+            extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
+                text: Some("continue".into()),
+                ..Default::default()
+            })),
+            message_context_info: Some(wa::MessageContextInfo {
+                message_secret: Some(vec![0x02; 32]),
+                bot_metadata: Some(wa::BotMetadata {
+                    persona_id: Some("867051314767696".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        client
+            .maybe_capture_inbound_msg_secret(&bot_msg, &bot_info)
+            .await;
+        assert_eq!(
+            client
+                .persistence_manager
+                .backend()
+                .get_msg_secret(group, sender, "BOTP")
+                .await
+                .unwrap(),
+            Some(vec![0x02; 32]),
+            "BotOnly must capture a group bot invocation"
         );
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -289,6 +289,7 @@ impl Client {
             msg_id: msg_id.to_string(),
             secret: secret.to_vec(),
             expires_at,
+            message_ts: message_ts.and_then(|t| i64::try_from(t).ok()).unwrap_or(0),
         })
     }
 
@@ -368,28 +369,31 @@ impl Client {
             .await
             .unwrap_or_default();
 
+        // Look up the secret AND the parent's event time (for the edit window
+        // check below): primary sender, then the LID/PN alternate.
         let store_secret = match backend
-            .get_msg_secret(&chat_for_lookup, &original_sender_str, target_id)
+            .get_msg_secret_with_ts(&chat_for_lookup, &original_sender_str, target_id)
             .await
         {
-            Ok(Some(secret)) => Some(secret),
-            Ok(None) => match self
-                .alternate_msg_secret_lookup(
-                    &backend,
-                    &chat_for_lookup,
-                    &original_sender,
-                    target_id,
-                )
-                .await
-            {
-                Ok(found) => found,
-                Err(e) => {
-                    log::warn!(
-                        "[msg:{}] secret_encrypted_message alternate secret lookup failed: {e:?}",
-                        info.id
-                    );
-                    None
+            Ok(Some(found)) => Some(found),
+            Ok(None) => match fallback_original_sender.as_ref() {
+                Some(alt) => {
+                    let alt_str = alt.to_non_ad_string();
+                    match backend
+                        .get_msg_secret_with_ts(&chat_for_lookup, &alt_str, target_id)
+                        .await
+                    {
+                        Ok(found) => found,
+                        Err(e) => {
+                            log::warn!(
+                                "[msg:{}] secret_encrypted_message alternate secret lookup failed: {e:?}",
+                                info.id
+                            );
+                            None
+                        }
+                    }
                 }
+                None => None,
             },
             Err(e) => {
                 log::warn!(
@@ -400,9 +404,10 @@ impl Client {
             }
         };
         // On a total store miss, ask the app-supplied resolver (if any) for the
-        // parent secret. This is what lets the Disabled policy still decrypt.
-        let secret = match store_secret {
-            Some(secret) => secret,
+        // parent secret. This is what lets the Disabled policy still decrypt. The
+        // resolver carries no parent timestamp, so parent_ts stays 0 (unknown).
+        let (secret, parent_ts) = match store_secret {
+            Some((secret, ts)) => (secret, ts),
             None => {
                 let alternate = fallback_original_sender
                     .as_ref()
@@ -416,7 +421,7 @@ impl Client {
                     )
                     .await
                 {
-                    Some(secret) => secret,
+                    Some(secret) => (secret, 0),
                     None => return None,
                 }
             }
@@ -508,19 +513,41 @@ impl Client {
             }
         };
 
+        // Mirror WA Web `ProcessEditProtocolMsgs`: drop a MESSAGE_EDIT authored
+        // outside the parent's edit-processing window (editTs >= parentTs + 20m).
+        // The check is on authored time, not "now", so a validly-authored edit
+        // still applies after an offline delivery gap. Only enforceable when we
+        // know the parent's event time; resolver-supplied secrets carry none
+        // (parent_ts == 0), so we stay permissive there.
+        if env.kind == SecretEncKind::MessageEdit && parent_ts > 0 {
+            let edit_ts = info.timestamp.timestamp();
+            if edit_ts >= parent_ts + wacore::msg_secret::EDIT_PROCESSING_WINDOW_SECS {
+                log::debug!(
+                    "[msg:{}] secret edit authored outside the {}s window (editTs={edit_ts}, parentTs={parent_ts}); dropping",
+                    info.id,
+                    wacore::msg_secret::EDIT_PROCESSING_WINDOW_SECS
+                );
+                return None;
+            }
+        }
+
         if let Some(secret_bytes) = inner
             .message_context_info
             .as_ref()
             .and_then(|m| m.message_secret.as_deref())
         {
             // The re-persisted secret keys the NEXT add-on on the same parent,
-            // so its retention class follows the parent kind. The edit's arrival
-            // time is within ~20min of the parent, a bounded over-retention.
+            // so its retention class follows the parent kind and the parent's own
+            // event time (when known) rather than this edit's arrival time.
             let class = match env.kind {
                 SecretEncKind::MessageEdit => wacore::msg_secret::RetentionClass::Text,
                 _ => wacore::msg_secret::RetentionClass::PollEvent,
             };
-            let message_ts = u64::try_from(info.timestamp.timestamp()).ok();
+            let message_ts = if parent_ts > 0 {
+                u64::try_from(parent_ts).ok()
+            } else {
+                u64::try_from(info.timestamp.timestamp()).ok()
+            };
             // Primary + LID/PN alternate in one batch so both survive together.
             let mut entries = Vec::with_capacity(2);
             if let Some(entry) = self.build_msg_secret_entry(
@@ -10082,6 +10109,97 @@ mod tests {
         )
         .await;
         assert!(got.is_some(), "encrypted edit must dispatch as legacy edit");
+    }
+
+    /// Store the parent secret with a known event time, then dispatch a
+    /// secret-encrypted edit authored `edit_offset` seconds after the parent.
+    /// Returns whether the decrypted legacy edit was dispatched.
+    async fn run_secret_edit_with_window(test_id: &str, parent_ts: i64, edit_offset: i64) -> bool {
+        let (client, _transport) = capturing_client(test_id).await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let chat = "5511777776666@s.whatsapp.net";
+        let parent_id = "WINDOW_PARENT";
+        let edit_id = "WINDOW_EDIT";
+        let secret = [0x42u8; 32];
+        client
+            .persistence_manager
+            .backend()
+            .put_msg_secrets(vec![wacore::store::traits::MsgSecretEntry {
+                chat: chat.to_string(),
+                sender: chat.to_string(),
+                msg_id: parent_id.to_string(),
+                secret: secret.to_vec(),
+                expires_at: 0,
+                message_ts: parent_ts,
+            }])
+            .await
+            .unwrap();
+
+        let info = Arc::new(MessageInfo {
+            id: edit_id.into(),
+            timestamp: chrono::DateTime::<chrono::Utc>::from_timestamp(parent_ts + edit_offset, 0)
+                .unwrap(),
+            source: crate::types::message::MessageSource {
+                chat: chat.parse().unwrap(),
+                sender: chat.parse().unwrap(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let target_key = wa::MessageKey {
+            remote_jid: Some(chat.to_string()),
+            from_me: Some(false),
+            id: Some(parent_id.to_string()),
+            participant: None,
+        };
+        let msg =
+            encrypted_message_edit(target_key, chat, chat, parent_id, &secret, "edited", None);
+        client.dispatch_parsed_message(msg, &info).await;
+
+        collect_event(
+            &client,
+            collector,
+            |e| {
+                matches!(e, wacore::types::events::Event::Message(msg, info)
+                    if info.id == edit_id
+                        && legacy_edit_text(msg.as_ref()) == Some("edited")
+                        && msg.secret_encrypted_message.is_none())
+            },
+            500,
+        )
+        .await
+        .is_some()
+    }
+
+    #[tokio::test]
+    async fn secret_edit_within_window_is_applied() {
+        // Authored 10 min after the parent — inside the 20 min (1200s) window.
+        assert!(
+            run_secret_edit_with_window("secret_edit_in_window", 1_700_000_000, 600).await,
+            "an in-window edit must dispatch as a legacy edit"
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_edit_outside_window_is_dropped() {
+        // Authored 30 min after the parent — past the 1200s window, like WA Web's
+        // ProcessEditProtocolMsgs, so we drop it (raw envelope surfaces instead).
+        assert!(
+            !run_secret_edit_with_window("secret_edit_out_window", 1_700_000_000, 1800).await,
+            "an out-of-window edit must not dispatch a legacy edit"
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_edit_unknown_parent_ts_is_permissive() {
+        // parent_ts = 0 (unknown, e.g. resolver-supplied): no window check, so a
+        // late edit still applies rather than being silently dropped.
+        assert!(
+            run_secret_edit_with_window("secret_edit_unknown_ts", 0, 5_000_000).await,
+            "with an unknown parent timestamp the edit must still apply"
+        );
     }
 
     #[tokio::test]

--- a/src/send.rs
+++ b/src/send.rs
@@ -1411,11 +1411,14 @@ impl Client {
                 None => self.dm_sender_identity_for(&tc_issue_target).await,
             };
             if let Some(sender) = sender {
+                let is_bot_chat = tc_issue_target.server == wacore_binary::Server::Bot;
+                let class = wacore::msg_secret::classify(message, is_bot_chat);
                 self.persist_outbound_msg_secret(
                     &tc_issue_target,
                     &sender,
                     &outbound_id_clone,
                     secret,
+                    class,
                 )
                 .await;
             }
@@ -1478,13 +1481,35 @@ impl Client {
         sender: &Jid,
         msg_id: &str,
         secret: &[u8; wacore::reporting_token::MESSAGE_SECRET_SIZE],
+        class: wacore::msg_secret::RetentionClass,
     ) {
-        let chat_str = chat.to_non_ad_string();
-        let sender_str = sender.to_non_ad_string();
+        let policy = self.cache_config.msg_secret_policy;
+        if !policy.persists() {
+            return;
+        }
+        if policy.bot_only() && chat.server != wacore_binary::Server::Bot {
+            return;
+        }
+        // Outbound secrets are minted "now", so the event time is the current
+        // clock; expires_at falls back to it when message_ts is None.
+        let expires_at = wacore::msg_secret::expires_at(
+            policy,
+            &self.cache_config.msg_secret_retention,
+            class,
+            None,
+            wacore::time::now_secs(),
+        );
+        let entry = wacore::store::traits::MsgSecretEntry {
+            chat: chat.to_non_ad_string(),
+            sender: sender.to_non_ad_string(),
+            msg_id: msg_id.to_string(),
+            secret: secret.to_vec(),
+            expires_at,
+        };
         if let Err(e) = self
             .persistence_manager
             .backend()
-            .put_msg_secret(&chat_str, &sender_str, msg_id, secret)
+            .put_msg_secrets(vec![entry])
             .await
         {
             log::warn!("Failed to persist outbound messageSecret for {msg_id}: {e:?}");
@@ -3582,7 +3607,13 @@ mod tests {
         let sender: Jid = "5511000000001:0@s.whatsapp.net".parse().unwrap();
         let secret = [0x55u8; 32];
         client
-            .persist_outbound_msg_secret(&chat, &sender, "MID_1", &secret)
+            .persist_outbound_msg_secret(
+                &chat,
+                &sender,
+                "MID_1",
+                &secret,
+                wacore::msg_secret::RetentionClass::Text,
+            )
             .await;
         let got = client
             .persistence_manager
@@ -3603,7 +3634,13 @@ mod tests {
         let chat_with_dev: Jid = "5511777776666:7@s.whatsapp.net".parse().unwrap();
         let sender_with_dev: Jid = "5511000000001:3@s.whatsapp.net".parse().unwrap();
         client
-            .persist_outbound_msg_secret(&chat_with_dev, &sender_with_dev, "MID_4", &[2u8; 32])
+            .persist_outbound_msg_secret(
+                &chat_with_dev,
+                &sender_with_dev,
+                "MID_4",
+                &[2u8; 32],
+                wacore::msg_secret::RetentionClass::Text,
+            )
             .await;
         let got = client
             .persistence_manager
@@ -3678,7 +3715,13 @@ mod tests {
         let lid_sender: Jid = "999888777666555:0@lid".parse().unwrap();
         let secret = [0x4Du8; 32];
         client
-            .persist_outbound_msg_secret(&group_chat, &lid_sender, "GROUP_MID", &secret)
+            .persist_outbound_msg_secret(
+                &group_chat,
+                &lid_sender,
+                "GROUP_MID",
+                &secret,
+                wacore::msg_secret::RetentionClass::Text,
+            )
             .await;
         let got = client
             .persistence_manager

--- a/src/send.rs
+++ b/src/send.rs
@@ -1411,7 +1411,7 @@ impl Client {
                 None => self.dm_sender_identity_for(&tc_issue_target).await,
             };
             if let Some(sender) = sender {
-                let is_bot_chat = tc_issue_target.server == wacore_binary::Server::Bot;
+                let is_bot_chat = tc_issue_target.is_bot();
                 let class = wacore::msg_secret::classify(message, is_bot_chat);
                 self.persist_outbound_msg_secret(
                     &tc_issue_target,
@@ -1487,7 +1487,9 @@ impl Client {
         if !policy.persists() {
             return;
         }
-        if policy.bot_only() && chat.server != wacore_binary::Server::Bot {
+        // BotOnly keeps only bot-context secrets; a group message that invokes a
+        // bot classifies as Bot, so its reply can still be decrypted.
+        if policy.bot_only() && class != wacore::msg_secret::RetentionClass::Bot {
             return;
         }
         // Outbound secrets are minted "now", so the event time is the current

--- a/src/send.rs
+++ b/src/send.rs
@@ -1492,14 +1492,15 @@ impl Client {
         if policy.bot_only() && class != wacore::msg_secret::RetentionClass::Bot {
             return;
         }
-        // Outbound secrets are minted "now", so the event time is the current
-        // clock; expires_at falls back to it when message_ts is None.
+        // Outbound secrets are minted "now", so the parent event time is the
+        // current clock.
+        let now = wacore::time::now_secs();
         let expires_at = wacore::msg_secret::expires_at(
             policy,
             &self.cache_config.msg_secret_retention,
             class,
-            None,
-            wacore::time::now_secs(),
+            u64::try_from(now).ok(),
+            now,
         );
         let entry = wacore::store::traits::MsgSecretEntry {
             chat: chat.to_non_ad_string(),
@@ -1507,6 +1508,7 @@ impl Client {
             msg_id: msg_id.to_string(),
             secret: secret.to_vec(),
             expires_at,
+            message_ts: now,
         };
         if let Err(e) = self
             .persistence_manager

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -60,6 +60,21 @@ pub async fn create_test_client_with_http(
     name: &str,
     http_client: Arc<dyn HttpClient>,
 ) -> Arc<Client> {
+    create_test_client_with_config(
+        name,
+        http_client,
+        crate::cache_config::CacheConfig::default(),
+    )
+    .await
+}
+
+/// Build an isolated in-memory test client with an explicit [`CacheConfig`],
+/// e.g. to exercise a non-default [`crate::cache_config::MsgSecretPolicy`].
+pub async fn create_test_client_with_config(
+    name: &str,
+    http_client: Arc<dyn HttpClient>,
+    cache_config: crate::cache_config::CacheConfig,
+) -> Arc<Client> {
     use portable_atomic::AtomicU64;
     use std::sync::atomic::Ordering;
     static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -84,12 +99,13 @@ pub async fn create_test_client_with_http(
             .expect("persistence manager should initialize"),
     );
 
-    let (client, _rx) = Client::new(
+    let (client, _rx) = Client::new_with_cache_config(
         Arc::new(TokioRuntime),
         pm,
         Arc::new(MockTransportFactory::new()),
         http_client,
         None,
+        cache_config,
     )
     .await;
 

--- a/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/down.sql
+++ b/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/down.sql
@@ -1,3 +1,4 @@
 DROP INDEX IF EXISTS idx_msg_secrets_expires;
 CREATE INDEX idx_msg_secrets_created ON msg_secrets (created_at, device_id);
+ALTER TABLE msg_secrets DROP COLUMN message_ts;
 ALTER TABLE msg_secrets DROP COLUMN expires_at;

--- a/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/down.sql
+++ b/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_msg_secrets_expires;
+CREATE INDEX idx_msg_secrets_created ON msg_secrets (created_at, device_id);
+ALTER TABLE msg_secrets DROP COLUMN expires_at;

--- a/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
+++ b/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
@@ -9,7 +9,10 @@ ALTER TABLE msg_secrets ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0;
 -- forever or being mass-deleted on the first sweep. created_at is the only
 -- timestamp legacy rows carry. Secrets for messages older than the horizon
 -- cannot unlock any add-on anyway, so reclaiming them loses nothing.
+-- 2592000 = 30 days, matching MsgSecretRetention::text's default in Rust.
 UPDATE msg_secrets SET expires_at = created_at + 2592000 WHERE expires_at = 0;
 
 DROP INDEX IF EXISTS idx_msg_secrets_created;
-CREATE INDEX idx_msg_secrets_expires ON msg_secrets (expires_at, device_id);
+-- device_id first so the prune's `device_id = ? AND expires_at <= ?` range scan
+-- stays localized to one account in a multi-account DB.
+CREATE INDEX idx_msg_secrets_expires ON msg_secrets (device_id, expires_at);

--- a/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
+++ b/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
@@ -1,0 +1,15 @@
+-- Switch msg_secret retention from insert-time created_at to a per-row
+-- absolute expires_at deadline (0 = never). created_at was overwritten on
+-- every conflict-update and edit re-persist, so no age-based TTL was sound.
+
+ALTER TABLE msg_secrets ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill the pre-existing pairing-burst seed so it ages out under the
+-- default text horizon (30d) once pruning runs, instead of either living
+-- forever or being mass-deleted on the first sweep. created_at is the only
+-- timestamp legacy rows carry. Secrets for messages older than the horizon
+-- cannot unlock any add-on anyway, so reclaiming them loses nothing.
+UPDATE msg_secrets SET expires_at = created_at + 2592000 WHERE expires_at = 0;
+
+DROP INDEX IF EXISTS idx_msg_secrets_created;
+CREATE INDEX idx_msg_secrets_expires ON msg_secrets (expires_at, device_id);

--- a/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
+++ b/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
@@ -3,6 +3,9 @@
 -- every conflict-update and edit re-persist, so no age-based TTL was sound.
 
 ALTER TABLE msg_secrets ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0;
+-- Parent message event time (0 = unknown), kept so the receive path can drop a
+-- stale edit via editTs < message_ts + window, the way WhatsApp Web does.
+ALTER TABLE msg_secrets ADD COLUMN message_ts INTEGER NOT NULL DEFAULT 0;
 
 -- Backfill the pre-existing pairing-burst seed so it ages out under the
 -- default text horizon (30d) once pruning runs, instead of either living

--- a/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
+++ b/storages/sqlite-storage/migrations/2026-05-31-000000_msg_secret_expires_at/up.sql
@@ -3,8 +3,9 @@
 -- every conflict-update and edit re-persist, so no age-based TTL was sound.
 
 ALTER TABLE msg_secrets ADD COLUMN expires_at INTEGER NOT NULL DEFAULT 0;
--- Parent message event time (0 = unknown), kept so the receive path can drop a
--- stale edit via editTs < message_ts + window, the way WhatsApp Web does.
+-- Parent message event time (0 = unknown). message_ts stores the parentTs the
+-- receive path compares against: a stale edit is dropped when
+-- editTs >= parentTs + window, the way WhatsApp Web does.
 ALTER TABLE msg_secrets ADD COLUMN message_ts INTEGER NOT NULL DEFAULT 0;
 
 -- Backfill the pre-existing pairing-burst seed so it ages out under the

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -168,6 +168,7 @@ diesel::table! {
         device_id -> Integer,
         created_at -> BigInt,
         expires_at -> BigInt,
+        message_ts -> BigInt,
     }
 }
 

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -167,6 +167,7 @@ diesel::table! {
         secret -> Binary,
         device_id -> Integer,
         created_at -> BigInt,
+        expires_at -> BigInt,
     }
 }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2506,52 +2506,6 @@ impl ProtocolStore for SqliteStore {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl MsgSecretStore for SqliteStore {
-    async fn put_msg_secret(
-        &self,
-        chat: &str,
-        sender: &str,
-        msg_id: &str,
-        secret: &[u8],
-    ) -> Result<()> {
-        let device_id = self.device_id;
-        let chat: Arc<str> = Arc::from(chat);
-        let sender: Arc<str> = Arc::from(sender);
-        let msg_id: Arc<str> = Arc::from(msg_id);
-        let secret: Arc<[u8]> = Arc::from(secret);
-        let now = wacore::time::now_secs();
-        self.with_retry("put_msg_secret", || {
-            let chat = Arc::clone(&chat);
-            let sender = Arc::clone(&sender);
-            let msg_id = Arc::clone(&msg_id);
-            let secret = Arc::clone(&secret);
-            Box::new(move |conn: &mut SqliteConnection| {
-                diesel::insert_into(msg_secrets::table)
-                    .values((
-                        msg_secrets::chat.eq(chat.as_ref()),
-                        msg_secrets::sender.eq(sender.as_ref()),
-                        msg_secrets::msg_id.eq(msg_id.as_ref()),
-                        msg_secrets::secret.eq(secret.as_ref()),
-                        msg_secrets::device_id.eq(device_id),
-                        msg_secrets::created_at.eq(now),
-                    ))
-                    .on_conflict((
-                        msg_secrets::chat,
-                        msg_secrets::sender,
-                        msg_secrets::msg_id,
-                        msg_secrets::device_id,
-                    ))
-                    .do_update()
-                    .set((
-                        msg_secrets::secret.eq(secret.as_ref()),
-                        msg_secrets::created_at.eq(now),
-                    ))
-                    .execute(conn)?;
-                Ok(())
-            })
-        })
-        .await
-    }
-
     async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize> {
         if entries.is_empty() {
             return Ok(0);
@@ -2573,6 +2527,7 @@ impl MsgSecretStore for SqliteStore {
                             msg_secrets::secret.eq(entry.secret.as_slice()),
                             msg_secrets::device_id.eq(device_id),
                             msg_secrets::created_at.eq(now),
+                            msg_secrets::expires_at.eq(entry.expires_at),
                         )
                     })
                     .collect();
@@ -2593,7 +2548,17 @@ impl MsgSecretStore for SqliteStore {
                             .do_update()
                             .set((
                                 msg_secrets::secret.eq(excluded(msg_secrets::secret)),
-                                msg_secrets::created_at.eq(excluded(msg_secrets::created_at)),
+                                msg_secrets::created_at.eq(now),
+                                // Keep the later deadline; 0 (never) wins. Mirrors
+                                // merge_msg_secret_expiry so a redelivery or edit
+                                // re-persist never shortens an existing window.
+                                msg_secrets::expires_at.eq(diesel::dsl::sql::<
+                                    diesel::sql_types::BigInt,
+                                >(
+                                    "CASE WHEN msg_secrets.expires_at = 0 \
+                                     OR excluded.expires_at = 0 THEN 0 \
+                                     ELSE MAX(msg_secrets.expires_at, excluded.expires_at) END",
+                                )),
                             ))
                             .execute(conn)?;
                     }
@@ -2638,9 +2603,11 @@ impl MsgSecretStore for SqliteStore {
         let device_id = self.device_id;
         self.with_retry("delete_expired_msg_secrets", || {
             Box::new(move |conn: &mut SqliteConnection| {
+                // Rows with expires_at = 0 never expire; only delete passed deadlines.
                 let deleted = diesel::delete(
                     msg_secrets::table
-                        .filter(msg_secrets::created_at.lt(cutoff_timestamp))
+                        .filter(msg_secrets::expires_at.ne(0))
+                        .filter(msg_secrets::expires_at.le(cutoff_timestamp))
                         .filter(msg_secrets::device_id.eq(device_id)),
                 )
                 .execute(conn)?;
@@ -3331,18 +3298,21 @@ mod tests {
                     sender: "s".into(),
                     msg_id: "M1".into(),
                     secret: vec![1u8; 32],
+                    expires_at: 0,
                 },
                 MsgSecretEntry {
                     chat: "c".into(),
                     sender: "s".into(),
                     msg_id: "M2".into(),
                     secret: vec![2u8; 32],
+                    expires_at: 0,
                 },
                 MsgSecretEntry {
                     chat: "c".into(),
                     sender: "s".into(),
                     msg_id: "M1".into(),
                     secret: vec![9u8; 32],
+                    expires_at: 0,
                 },
             ])
             .await
@@ -3360,30 +3330,110 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_expired_msg_secrets_deletes_only_below_cutoff() {
+    async fn delete_expired_msg_secrets_deletes_only_passed_deadlines() {
         let store = create_test_store().await;
-        store
-            .put_msg_secret("c", "s", "M", &[7u8; 32])
-            .await
-            .unwrap();
         let now = wacore::time::now_secs();
-        // cutoff well before insert → nothing deleted
-        let removed = store
-            .delete_expired_msg_secrets(now - 86_400)
+        store
+            .put_msg_secrets(vec![
+                MsgSecretEntry {
+                    chat: "c".into(),
+                    sender: "s".into(),
+                    msg_id: "NEVER".into(),
+                    secret: vec![1u8; 32],
+                    expires_at: 0,
+                },
+                MsgSecretEntry {
+                    chat: "c".into(),
+                    sender: "s".into(),
+                    msg_id: "FUTURE".into(),
+                    secret: vec![2u8; 32],
+                    expires_at: now + 86_400,
+                },
+                MsgSecretEntry {
+                    chat: "c".into(),
+                    sender: "s".into(),
+                    msg_id: "PAST".into(),
+                    secret: vec![3u8; 32],
+                    expires_at: now - 86_400,
+                },
+            ])
             .await
             .unwrap();
-        assert_eq!(removed, 0);
-        assert!(
-            store.get_msg_secret("c", "s", "M").await.unwrap().is_some(),
-            "row newer than cutoff must survive"
+
+        let removed = store.delete_expired_msg_secrets(now).await.unwrap();
+        assert_eq!(
+            removed, 1,
+            "only the row whose deadline has passed is deleted"
         );
-        // cutoff after insert → deleted
-        let removed = store
-            .delete_expired_msg_secrets(now + 86_400)
+        assert!(
+            store
+                .get_msg_secret("c", "s", "NEVER")
+                .await
+                .unwrap()
+                .is_some(),
+            "expires_at = 0 never expires"
+        );
+        assert!(
+            store
+                .get_msg_secret("c", "s", "FUTURE")
+                .await
+                .unwrap()
+                .is_some(),
+            "a future deadline survives"
+        );
+        assert!(
+            store
+                .get_msg_secret("c", "s", "PAST")
+                .await
+                .unwrap()
+                .is_none(),
+            "a passed deadline is pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn put_msg_secrets_keeps_later_deadline_on_conflict() {
+        let store = create_test_store().await;
+        let now = wacore::time::now_secs();
+        // First write a finite deadline, then a re-persist with an EARLIER one:
+        // the window must not shrink.
+        store
+            .put_msg_secrets(vec![MsgSecretEntry {
+                chat: "c".into(),
+                sender: "s".into(),
+                msg_id: "M".into(),
+                secret: vec![1u8; 32],
+                expires_at: now + 90 * 86_400,
+            }])
             .await
             .unwrap();
-        assert_eq!(removed, 1);
-        assert!(store.get_msg_secret("c", "s", "M").await.unwrap().is_none());
+        store
+            .put_msg_secrets(vec![MsgSecretEntry {
+                chat: "c".into(),
+                sender: "s".into(),
+                msg_id: "M".into(),
+                secret: vec![1u8; 32],
+                expires_at: now + 30 * 86_400,
+            }])
+            .await
+            .unwrap();
+        // The 90-day deadline must remain: a cutoff at now+60d deletes nothing.
+        let removed = store
+            .delete_expired_msg_secrets(now + 60 * 86_400)
+            .await
+            .unwrap();
+        assert_eq!(removed, 0, "conflict must keep the later (90d) deadline");
+
+        // A never-expire (0) write must override any finite deadline.
+        store
+            .put_msg_secret("c", "s", "M", &[1u8; 32])
+            .await
+            .unwrap();
+        let removed = store
+            .delete_expired_msg_secrets(now + 200 * 86_400)
+            .await
+            .unwrap();
+        assert_eq!(removed, 0, "a 0 (never) deadline wins over any finite one");
     }
 
     /// Multi-account isolation: same DB, different device_id rows must not

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2528,6 +2528,7 @@ impl MsgSecretStore for SqliteStore {
                             msg_secrets::device_id.eq(device_id),
                             msg_secrets::created_at.eq(now),
                             msg_secrets::expires_at.eq(entry.expires_at),
+                            msg_secrets::message_ts.eq(entry.message_ts),
                         )
                     })
                     .collect();
@@ -2559,6 +2560,13 @@ impl MsgSecretStore for SqliteStore {
                                      OR excluded.expires_at = 0 THEN 0 \
                                      ELSE MAX(msg_secrets.expires_at, excluded.expires_at) END",
                                 )),
+                                // Parent event time is immutable; keep the known
+                                // (non-zero / later) value across redeliveries.
+                                msg_secrets::message_ts.eq(diesel::dsl::sql::<
+                                    diesel::sql_types::BigInt,
+                                >(
+                                    "MAX(msg_secrets.message_ts, excluded.message_ts)",
+                                )),
                             ))
                             .execute(conn)?;
                     }
@@ -2586,6 +2594,36 @@ impl MsgSecretStore for SqliteStore {
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<Vec<u8>> = msg_secrets::table
                 .select(msg_secrets::secret)
+                .filter(msg_secrets::chat.eq(&chat))
+                .filter(msg_secrets::sender.eq(&sender))
+                .filter(msg_secrets::msg_id.eq(&msg_id))
+                .filter(msg_secrets::device_id.eq(device_id))
+                .first(&mut conn)
+                .optional()
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(row)
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))?
+    }
+
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<(Vec<u8>, i64)>> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let chat = chat.to_string();
+        let sender = sender.to_string();
+        let msg_id = msg_id.to_string();
+        tokio::task::spawn_blocking(move || -> Result<Option<(Vec<u8>, i64)>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let row: Option<(Vec<u8>, i64)> = msg_secrets::table
+                .select((msg_secrets::secret, msg_secrets::message_ts))
                 .filter(msg_secrets::chat.eq(&chat))
                 .filter(msg_secrets::sender.eq(&sender))
                 .filter(msg_secrets::msg_id.eq(&msg_id))
@@ -3299,6 +3337,7 @@ mod tests {
                     msg_id: "M1".into(),
                     secret: vec![1u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
                 MsgSecretEntry {
                     chat: "c".into(),
@@ -3306,6 +3345,7 @@ mod tests {
                     msg_id: "M2".into(),
                     secret: vec![2u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
                 MsgSecretEntry {
                     chat: "c".into(),
@@ -3313,6 +3353,7 @@ mod tests {
                     msg_id: "M1".into(),
                     secret: vec![9u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
             ])
             .await
@@ -3341,6 +3382,7 @@ mod tests {
                     msg_id: "NEVER".into(),
                     secret: vec![1u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
                 MsgSecretEntry {
                     chat: "c".into(),
@@ -3348,6 +3390,7 @@ mod tests {
                     msg_id: "FUTURE".into(),
                     secret: vec![2u8; 32],
                     expires_at: now + 86_400,
+                    message_ts: 0,
                 },
                 MsgSecretEntry {
                     chat: "c".into(),
@@ -3355,6 +3398,7 @@ mod tests {
                     msg_id: "PAST".into(),
                     secret: vec![3u8; 32],
                     expires_at: now - 86_400,
+                    message_ts: 0,
                 },
             ])
             .await
@@ -3404,6 +3448,7 @@ mod tests {
                 msg_id: "M".into(),
                 secret: vec![1u8; 32],
                 expires_at: now + 90 * 86_400,
+                message_ts: 0,
             }])
             .await
             .unwrap();
@@ -3414,6 +3459,7 @@ mod tests {
                 msg_id: "M".into(),
                 secret: vec![1u8; 32],
                 expires_at: now + 30 * 86_400,
+                message_ts: 0,
             }])
             .await
             .unwrap();
@@ -3434,6 +3480,47 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(removed, 0, "a 0 (never) deadline wins over any finite one");
+    }
+
+    #[tokio::test]
+    async fn get_msg_secret_with_ts_round_trips_and_keeps_parent_ts() {
+        let store = create_test_store().await;
+        let parent_ts = 1_700_000_000i64;
+        store
+            .put_msg_secrets(vec![MsgSecretEntry {
+                chat: "c".into(),
+                sender: "s".into(),
+                msg_id: "M".into(),
+                secret: vec![5u8; 32],
+                expires_at: 0,
+                message_ts: parent_ts,
+            }])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_msg_secret_with_ts("c", "s", "M").await.unwrap(),
+            Some((vec![5u8; 32], parent_ts))
+        );
+
+        // A later write with an unknown ts (0) must not clobber the known one.
+        store
+            .put_msg_secret("c", "s", "M", &[5u8; 32])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_msg_secret_with_ts("c", "s", "M").await.unwrap(),
+            Some((vec![5u8; 32], parent_ts)),
+            "message_ts (immutable parent time) must survive a 0-ts redelivery"
+        );
+
+        // Absent row → None.
+        assert_eq!(
+            store
+                .get_msg_secret_with_ts("c", "s", "MISSING")
+                .await
+                .unwrap(),
+            None
+        );
     }
 
     /// Multi-account isolation: same DB, different device_id rows must not

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -378,6 +378,10 @@ pub(crate) struct MessageInternalFields {
 pub(crate) struct MessageContextInfoInternalFields {
     #[prost(bytes = "vec", optional, tag = "3")]
     pub message_secret: Option<Vec<u8>>,
+    /// Raw `BotMetadata` bytes; only its presence matters (a bot invocation),
+    /// so it stays opaque to keep the partial decode cheap.
+    #[prost(bytes = "vec", optional, tag = "7")]
+    pub bot_metadata: Option<Vec<u8>>,
 }
 
 macro_rules! define_context_info_carrier {
@@ -474,6 +478,19 @@ impl MessageInternalFields {
         }
     }
 
+    /// Whether the message invokes a bot, detected via `botMetadata` presence.
+    /// botMetadata sits on the top-level `MessageContextInfo` even when wrapped,
+    /// so check both the outer message and the unwrapped base. (Mentions are not
+    /// decoded in this partial path; a mention-only prompt falls back to text.)
+    fn invokes_bot(&self) -> bool {
+        let has = |m: &Self| {
+            m.message_context_info
+                .as_ref()
+                .is_some_and(|c| c.bot_metadata.is_some())
+        };
+        has(self) || has(self.base_message())
+    }
+
     /// Whether the (unwrapped) message is a poll-creation or event message.
     /// These carry the longer poll/event retention horizon.
     fn is_poll_or_event(&self) -> bool {
@@ -545,6 +562,10 @@ pub struct HistoryMsgSecretRecord {
     /// longer poll/event retention horizon because their add-ons (poll votes,
     /// PollAddOption, EventEdit) have no sender-side time window.
     pub is_poll_or_event: bool,
+    /// Whether the parent invokes a bot (botMetadata present). Kept so the seed
+    /// classifies a group bot prompt as a bot context, matching live capture, so
+    /// `BotOnly` retains it and a later bot reply can decrypt.
+    pub is_bot_invocation: bool,
 }
 
 fn extract_conversation_fields(data: &[u8]) -> ConversationExtraction {
@@ -619,6 +640,11 @@ fn extract_msg_secret_records(conv: &ConversationInternalFields) -> Vec<HistoryM
             .as_ref()
             .map(|m| m.is_poll_or_event())
             .unwrap_or(false);
+        let is_bot_invocation = web_msg
+            .message
+            .as_ref()
+            .map(|m| m.invokes_bot())
+            .unwrap_or(false);
 
         records.push(HistoryMsgSecretRecord {
             chat_id: conv.id.clone(),
@@ -629,6 +655,7 @@ fn extract_msg_secret_records(conv: &ConversationInternalFields) -> Vec<HistoryM
             secret: secret.clone(),
             timestamp: web_msg.message_timestamp,
             is_poll_or_event,
+            is_bot_invocation,
         });
     }
 

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -282,6 +282,10 @@ pub(crate) struct WebMessageInfoInternalFields {
     pub key: Option<MessageKeyInternalFields>,
     #[prost(message, optional, tag = "2")]
     pub message: Option<MessageInternalFields>,
+    /// Parent message event time (unix seconds). Drives msg-secret retention
+    /// so a horizon expires by the message's real age, not when we seeded it.
+    #[prost(uint64, optional, tag = "3")]
+    pub message_timestamp: Option<u64>,
     #[prost(string, optional, tag = "5")]
     pub participant: Option<String>,
     #[prost(bytes = "vec", optional, tag = "49")]
@@ -470,6 +474,16 @@ impl MessageInternalFields {
         }
     }
 
+    /// Whether the (unwrapped) message is a poll-creation or event message.
+    /// These carry the longer poll/event retention horizon.
+    fn is_poll_or_event(&self) -> bool {
+        let base = self.base_message();
+        base.poll_creation_message.is_some()
+            || base.poll_creation_message_v2.is_some()
+            || base.poll_creation_message_v3.is_some()
+            || base.event_message.is_some()
+    }
+
     fn is_forwarded(&self) -> bool {
         let base = self.base_message();
         macro_rules! any_forwarded {
@@ -524,6 +538,13 @@ pub struct HistoryMsgSecretRecord {
     pub web_msg_participant: Option<String>,
     pub msg_id: String,
     pub secret: Vec<u8>,
+    /// Parent message event time (unix seconds), if present in the blob.
+    /// Used by the seed-time retention filter; `None` falls back to seed time.
+    pub timestamp: Option<u64>,
+    /// Whether the parent is a poll-creation or event message. These get the
+    /// longer poll/event retention horizon because their add-ons (poll votes,
+    /// PollAddOption, EventEdit) have no sender-side time window.
+    pub is_poll_or_event: bool,
 }
 
 fn extract_conversation_fields(data: &[u8]) -> ConversationExtraction {
@@ -593,6 +614,12 @@ fn extract_msg_secret_records(conv: &ConversationInternalFields) -> Vec<HistoryM
             continue;
         };
 
+        let is_poll_or_event = web_msg
+            .message
+            .as_ref()
+            .map(|m| m.is_poll_or_event())
+            .unwrap_or(false);
+
         records.push(HistoryMsgSecretRecord {
             chat_id: conv.id.clone(),
             from_me: key.from_me == Some(true),
@@ -600,6 +627,8 @@ fn extract_msg_secret_records(conv: &ConversationInternalFields) -> Vec<HistoryM
             web_msg_participant: web_msg.participant.clone(),
             msg_id: msg_id.clone(),
             secret: secret.clone(),
+            timestamp: web_msg.message_timestamp,
+            is_poll_or_event,
         });
     }
 

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -24,6 +24,7 @@ pub mod media_retry;
 pub mod message_edit;
 pub mod message_processing;
 pub mod messages;
+pub mod msg_secret;
 pub mod net;
 pub mod pair;
 pub mod pair_code;

--- a/wacore/src/msg_secret.rs
+++ b/wacore/src/msg_secret.rs
@@ -1,0 +1,282 @@
+//! Retention policy for the per-message `messageSecret` store.
+//!
+//! This client is headless and keeps no message store, so it must persist a
+//! standalone secret index. That index bloats: PR #665 seeds a secret for every
+//! non-forwarded history-sync message and captures one for every live message
+//! and every send. The secrets only unlock add-ons that reference a parent by
+//! id (secret-encrypted edits, msmsg bot replies, poll/event edits), all of
+//! which are bounded in time, so retaining a secret for every message forever
+//! is pure waste.
+//!
+//! This module turns the three scattered decisions (capture / seed / prune)
+//! into one [`MsgSecretPolicy`] and bounds retention by the *parent message's*
+//! event time, per add-on kind, via [`expires_at`].
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::proto_helpers::MessageExt;
+use waproto::whatsapp as wa;
+
+/// How the core manages `messageSecret` persistence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MsgSecretPolicy {
+    /// Bounded default: capture live secrets, seed only the still-relevant
+    /// slice of history, and prune by a per-kind event-time horizon.
+    #[default]
+    Managed,
+    /// Pre-#665 behavior: only capture/seed secrets in bot contexts.
+    BotOnly,
+    /// Capture and seed everything, never prune (unbounded retention).
+    Full,
+    /// Persist nothing in core. Add-on decryption relies entirely on an
+    /// app-supplied [`OriginalMessageResolver`]; without one, add-ons whose
+    /// parent secret the core never saw simply will not decrypt.
+    Disabled,
+}
+
+impl MsgSecretPolicy {
+    /// Whether this policy writes secrets to the backing store at all.
+    pub fn persists(self) -> bool {
+        !matches!(self, MsgSecretPolicy::Disabled)
+    }
+
+    /// Whether capture/seed is restricted to bot contexts.
+    pub fn bot_only(self) -> bool {
+        matches!(self, MsgSecretPolicy::BotOnly)
+    }
+
+    /// Whether the periodic prune sweep should run. `Full` keeps everything;
+    /// `Disabled` writes nothing to prune.
+    pub fn prunes(self) -> bool {
+        matches!(self, MsgSecretPolicy::Managed | MsgSecretPolicy::BotOnly)
+    }
+}
+
+/// Per-add-on-kind retention horizons applied to the parent message's event
+/// time. Defaults are derived from verified protocol limits, not guesses.
+#[derive(Debug, Clone, Copy)]
+pub struct MsgSecretRetention {
+    /// Text / `MESSAGE_EDIT` parents. An edit is sender-gated to 20 min of the
+    /// parent, but WhatsApp's offline queue can deliver that edit up to ~30
+    /// days later, so a 30-day-offline receiver still needs the secret.
+    pub text: Duration,
+    /// Poll / event parents (poll votes, `PollAddOption`, `EventEdit`,
+    /// `PollEdit`). These add-ons have no sender-side time window, so the
+    /// parent secret must outlive them generously.
+    pub poll_event: Duration,
+    /// Outbound msmsg bot context secrets.
+    pub bot: Duration,
+}
+
+impl Default for MsgSecretRetention {
+    fn default() -> Self {
+        Self {
+            text: Duration::from_secs(30 * 86_400),
+            poll_event: Duration::from_secs(90 * 86_400),
+            bot: Duration::from_secs(30 * 86_400),
+        }
+    }
+}
+
+impl MsgSecretRetention {
+    fn horizon_secs(&self, class: RetentionClass) -> u64 {
+        match class {
+            RetentionClass::Text => self.text.as_secs(),
+            RetentionClass::PollEvent => self.poll_event.as_secs(),
+            RetentionClass::Bot => self.bot.as_secs(),
+        }
+    }
+}
+
+/// Retention class of a stored secret, fixed at write time by which call site
+/// wrote it (the store cannot see the add-on kind at prune time).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetentionClass {
+    Text,
+    PollEvent,
+    Bot,
+}
+
+/// Classify a message for retention. Bot-chat secrets always take the bot
+/// horizon; otherwise poll/event parents get the longer horizon and everything
+/// else is text. Unwraps device-sent/ephemeral/etc. wrappers first.
+pub fn classify(msg: &wa::Message, is_bot_chat: bool) -> RetentionClass {
+    if is_bot_chat {
+        return RetentionClass::Bot;
+    }
+    let base = msg.get_base_message();
+    if base.poll_creation_message.is_some()
+        || base.poll_creation_message_v2.is_some()
+        || base.poll_creation_message_v3.is_some()
+        || base.event_message.is_some()
+    {
+        RetentionClass::PollEvent
+    } else {
+        RetentionClass::Text
+    }
+}
+
+/// Compute the absolute `expires_at` deadline (unix seconds, `0` = never) for a
+/// secret row.
+///
+/// `Full`/`Disabled` never set a deadline. `message_ts` is the parent's event
+/// time; when unknown it falls back to `now` so an unknown-age secret still
+/// expires a horizon from when we first saw it (bounded), rather than living
+/// forever — but it is never dropped at write for lacking a timestamp.
+pub fn expires_at(
+    policy: MsgSecretPolicy,
+    retention: &MsgSecretRetention,
+    class: RetentionClass,
+    message_ts: Option<u64>,
+    now: i64,
+) -> i64 {
+    if !policy.prunes() {
+        return 0;
+    }
+    let base = message_ts
+        .and_then(|t| i64::try_from(t).ok())
+        .unwrap_or(now);
+    let horizon = i64::try_from(retention.horizon_secs(class)).unwrap_or(i64::MAX);
+    base.saturating_add(horizon)
+}
+
+/// Whether a history-sync secret with parent event time `message_ts` is still
+/// within its retention horizon at `now` and is worth seeding. Records with no
+/// timestamp are kept (we cannot prove they are too old). Only `Managed`/
+/// `BotOnly` filter; `Full` seeds everything and `Disabled` seeds nothing
+/// (decided by the caller, not here).
+pub fn within_seed_horizon(
+    retention: &MsgSecretRetention,
+    class: RetentionClass,
+    message_ts: Option<u64>,
+    now: i64,
+) -> bool {
+    let Some(ts) = message_ts.and_then(|t| i64::try_from(t).ok()) else {
+        return true;
+    };
+    let horizon = i64::try_from(retention.horizon_secs(class)).unwrap_or(i64::MAX);
+    ts.saturating_add(horizon) > now
+}
+
+/// App-supplied fallback returning a parent message's 32-byte `messageSecret`
+/// on a store miss, keyed by the non-AD `(chat, sender, msg_id)`.
+///
+/// Lets an app that keeps its own message store own secret retention entirely
+/// (the secret rides on the stored message and is read back on demand), and is
+/// what makes the [`MsgSecretPolicy::Disabled`] tier able to decrypt add-ons
+/// whose parent the core never persisted. Consulted only after the in-core
+/// store and LID/PN alternate lookups miss.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait OriginalMessageResolver: Send + Sync {
+    async fn resolve_msg_secret(&self, chat: &str, sender: &str, msg_id: &str) -> Option<[u8; 32]>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DAY: i64 = 86_400;
+
+    #[test]
+    fn full_and_disabled_never_expire() {
+        let r = MsgSecretRetention::default();
+        for policy in [MsgSecretPolicy::Full, MsgSecretPolicy::Disabled] {
+            assert_eq!(
+                expires_at(policy, &r, RetentionClass::Text, Some(1_000), 2_000),
+                0,
+                "{policy:?} must not set a deadline"
+            );
+        }
+    }
+
+    #[test]
+    fn managed_text_expires_30d_after_message_time() {
+        let r = MsgSecretRetention::default();
+        let msg_ts = 1_000_000u64;
+        let got = expires_at(
+            MsgSecretPolicy::Managed,
+            &r,
+            RetentionClass::Text,
+            Some(msg_ts),
+            5_000_000,
+        );
+        assert_eq!(got, msg_ts as i64 + 30 * DAY);
+    }
+
+    #[test]
+    fn poll_event_horizon_is_longer_than_text() {
+        let r = MsgSecretRetention::default();
+        let now = 10_000_000i64;
+        let text = expires_at(
+            MsgSecretPolicy::Managed,
+            &r,
+            RetentionClass::Text,
+            Some(1_000),
+            now,
+        );
+        let poll = expires_at(
+            MsgSecretPolicy::Managed,
+            &r,
+            RetentionClass::PollEvent,
+            Some(1_000),
+            now,
+        );
+        assert!(poll > text, "poll/event must outlive text secrets");
+        assert_eq!(poll - text, (90 - 30) * DAY);
+    }
+
+    #[test]
+    fn unknown_timestamp_expires_a_horizon_from_now_not_forever() {
+        let r = MsgSecretRetention::default();
+        let now = 5_000_000i64;
+        let got = expires_at(
+            MsgSecretPolicy::Managed,
+            &r,
+            RetentionClass::Text,
+            None,
+            now,
+        );
+        assert_eq!(got, now + 30 * DAY, "unknown age is bounded, never 0");
+    }
+
+    #[test]
+    fn seed_horizon_drops_old_text_keeps_recent_and_unknown() {
+        let r = MsgSecretRetention::default();
+        let now = 100 * DAY;
+        // 40 days old text is past the 30-day text horizon.
+        assert!(!within_seed_horizon(
+            &r,
+            RetentionClass::Text,
+            Some((60 * DAY) as u64),
+            now
+        ));
+        // 10 days old text is still within.
+        assert!(within_seed_horizon(
+            &r,
+            RetentionClass::Text,
+            Some((90 * DAY) as u64),
+            now
+        ));
+        // 40 days old poll is still within the 90-day poll horizon.
+        assert!(within_seed_horizon(
+            &r,
+            RetentionClass::PollEvent,
+            Some((60 * DAY) as u64),
+            now
+        ));
+        // Unknown age is conservatively kept.
+        assert!(within_seed_horizon(&r, RetentionClass::Text, None, now));
+    }
+
+    #[test]
+    fn policy_predicates() {
+        assert!(MsgSecretPolicy::Managed.persists());
+        assert!(MsgSecretPolicy::Managed.prunes());
+        assert!(!MsgSecretPolicy::Full.prunes());
+        assert!(!MsgSecretPolicy::Disabled.persists());
+        assert!(MsgSecretPolicy::BotOnly.bot_only());
+    }
+}

--- a/wacore/src/msg_secret.rs
+++ b/wacore/src/msg_secret.rs
@@ -67,9 +67,12 @@ impl MsgSecretPolicy {
 /// time. Defaults are derived from verified protocol limits, not guesses.
 #[derive(Debug, Clone, Copy)]
 pub struct MsgSecretRetention {
-    /// Text / `MESSAGE_EDIT` parents. An edit is sender-gated to 20 min of the
-    /// parent, but WhatsApp's offline queue can deliver that edit up to ~30
-    /// days later, so a 30-day-offline receiver still needs the secret.
+    /// Text / `MESSAGE_EDIT` parents. An edit is only valid when authored within
+    /// 20 min of the parent — enforced on both send and receive against the
+    /// edit's own timestamp (`editTs < parentTs + window`), not "now" — so a
+    /// validly-authored edit still applies after an offline gap. WhatsApp's
+    /// offline queue can deliver it up to ~30 days later, so a 30-day-offline
+    /// receiver still needs the secret; hence a 30-day horizon for delivery.
     pub text: Duration,
     /// Poll / event parents (poll votes, `PollAddOption`, `EventEdit`,
     /// `PollEdit`). These add-ons have no sender-side time window, so the
@@ -98,6 +101,12 @@ impl MsgSecretRetention {
         }
     }
 }
+
+/// Default `message_edit_window_duration_seconds` (WA Web AB prop, 20 min). An
+/// edit is only valid when authored within this window of its parent — checked
+/// against the edit's own timestamp (`editTs < parentTs + window`), not "now" —
+/// so the receive path can drop a stale edit even after an offline delivery gap.
+pub const EDIT_PROCESSING_WINDOW_SECS: i64 = 1200;
 
 /// Retention class of a stored secret, fixed at write time by which call site
 /// wrote it (the store cannot see the add-on kind at prune time).
@@ -211,9 +220,19 @@ pub fn within_seed_horizon(
 /// The call is run under a bounded timeout (configurable, default 5s) because
 /// it executes inside the per-chat receive lane; an implementation that blocks
 /// past the bound is treated as a miss, so keep it fast or internally bounded.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+///
+/// The `Send + Sync` bound is dropped on wasm32 (single-threaded), so a
+/// resolver there may be backed by `!Send` JS handles; native builds keep it
+/// because the resolver is shared across the multi-threaded receive lanes.
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
 pub trait OriginalMessageResolver: Send + Sync {
+    async fn resolve_msg_secret(&self, chat: &str, sender: &str, msg_id: &str) -> Option<[u8; 32]>;
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+pub trait OriginalMessageResolver {
     async fn resolve_msg_secret(&self, chat: &str, sender: &str, msg_id: &str) -> Option<[u8; 32]>;
 }
 

--- a/wacore/src/msg_secret.rs
+++ b/wacore/src/msg_secret.rs
@@ -99,19 +99,49 @@ pub enum RetentionClass {
     Bot,
 }
 
-/// Classify a message for retention. Bot-chat secrets always take the bot
-/// horizon; otherwise poll/event parents get the longer horizon and everything
-/// else is text. Unwraps device-sent/ephemeral/etc. wrappers first.
-pub fn classify(msg: &wa::Message, is_bot_chat: bool) -> RetentionClass {
-    if is_bot_chat {
-        return RetentionClass::Bot;
-    }
+/// Whether `msg` belongs to a bot context for retention: the chat is a bot, or
+/// the message invokes a bot (top-level botMetadata or a bot mention). A group
+/// message that invokes a bot is a bot context even though the chat is a group,
+/// so its secret is kept under `BotOnly` and the later bot reply can decrypt.
+pub fn is_bot_context(chat_is_bot: bool, msg: &wa::Message) -> bool {
+    chat_is_bot || invokes_bot(msg)
+}
+
+fn invokes_bot(msg: &wa::Message) -> bool {
+    let has_bot_metadata = |m: &wa::Message| {
+        m.message_context_info
+            .as_ref()
+            .is_some_and(|c| c.bot_metadata.is_some())
+    };
+    // botMetadata sits on the top-level MessageContextInfo even when wrapped.
+    has_bot_metadata(msg) || has_bot_metadata(msg.get_base_message()) || msg.mentions_any_bot()
+}
+
+fn message_is_poll_or_event(msg: &wa::Message) -> bool {
     let base = msg.get_base_message();
-    if base.poll_creation_message.is_some()
+    base.poll_creation_message.is_some()
         || base.poll_creation_message_v2.is_some()
         || base.poll_creation_message_v3.is_some()
         || base.event_message.is_some()
-    {
+}
+
+/// Classify a message for retention. Bot context wins (bot horizon), then
+/// poll/event (longer horizon), else text. Unwraps device-sent/ephemeral/etc.
+/// wrappers first.
+pub fn classify(msg: &wa::Message, chat_is_bot: bool) -> RetentionClass {
+    classify_from_flags(
+        is_bot_context(chat_is_bot, msg),
+        message_is_poll_or_event(msg),
+    )
+}
+
+/// Classify from precomputed flags. Used where only flags are available — the
+/// history-sync seed has no full `wa::Message` in hand. Keeps the single
+/// three-way rule in one place so the seed and live paths cannot drift.
+pub fn classify_from_flags(bot_context: bool, poll_or_event: bool) -> RetentionClass {
+    if bot_context {
+        RetentionClass::Bot
+    } else if poll_or_event {
         RetentionClass::PollEvent
     } else {
         RetentionClass::Text
@@ -269,6 +299,35 @@ mod tests {
         ));
         // Unknown age is conservatively kept.
         assert!(within_seed_horizon(&r, RetentionClass::Text, None, now));
+    }
+
+    #[test]
+    fn classify_from_flags_precedence() {
+        assert_eq!(classify_from_flags(true, true), RetentionClass::Bot);
+        assert_eq!(classify_from_flags(true, false), RetentionClass::Bot);
+        assert_eq!(classify_from_flags(false, true), RetentionClass::PollEvent);
+        assert_eq!(classify_from_flags(false, false), RetentionClass::Text);
+    }
+
+    #[test]
+    fn is_bot_context_detects_chat_and_invocation() {
+        // Chat is a bot.
+        assert!(is_bot_context(true, &wa::Message::default()));
+        // bot_metadata on a non-bot (e.g. group) chat is still a bot context.
+        let prompt = wa::Message {
+            message_context_info: Some(wa::MessageContextInfo {
+                bot_metadata: Some(wa::BotMetadata::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(is_bot_context(false, &prompt));
+        // A plain message in a non-bot chat is not a bot context.
+        let plain = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+        assert!(!is_bot_context(false, &plain));
     }
 
     #[test]

--- a/wacore/src/msg_secret.rs
+++ b/wacore/src/msg_secret.rs
@@ -47,9 +47,18 @@ impl MsgSecretPolicy {
         matches!(self, MsgSecretPolicy::BotOnly)
     }
 
-    /// Whether the periodic prune sweep should run. `Full` keeps everything;
-    /// `Disabled` writes nothing to prune.
+    /// Whether the periodic prune sweep should run. Everything except `Full`
+    /// prunes: `Managed`/`BotOnly` reap their own expired rows, and `Disabled`
+    /// still reaps legacy rows left by a prior policy (it just writes no new
+    /// ones). Only `Full` keeps everything forever.
     pub fn prunes(self) -> bool {
+        !matches!(self, MsgSecretPolicy::Full)
+    }
+
+    /// Whether rows written under this policy get a finite deadline. Only
+    /// `Managed`/`BotOnly` do; `Full` writes never-expire rows and `Disabled`
+    /// writes none.
+    pub fn bounds_retention(self) -> bool {
         matches!(self, MsgSecretPolicy::Managed | MsgSecretPolicy::BotOnly)
     }
 }
@@ -162,7 +171,7 @@ pub fn expires_at(
     message_ts: Option<u64>,
     now: i64,
 ) -> i64 {
-    if !policy.prunes() {
+    if !policy.bounds_retention() {
         return 0;
     }
     let base = message_ts
@@ -198,6 +207,10 @@ pub fn within_seed_horizon(
 /// what makes the [`MsgSecretPolicy::Disabled`] tier able to decrypt add-ons
 /// whose parent the core never persisted. Consulted only after the in-core
 /// store and LID/PN alternate lookups miss.
+///
+/// The call is run under a bounded timeout (configurable, default 5s) because
+/// it executes inside the per-chat receive lane; an implementation that blocks
+/// past the bound is treated as a miss, so keep it fast or internally bounded.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait OriginalMessageResolver: Send + Sync {
@@ -334,7 +347,10 @@ mod tests {
     fn policy_predicates() {
         assert!(MsgSecretPolicy::Managed.persists());
         assert!(MsgSecretPolicy::Managed.prunes());
+        assert!(MsgSecretPolicy::BotOnly.prunes());
         assert!(!MsgSecretPolicy::Full.prunes());
+        // Disabled writes nothing but still reaps legacy rows.
+        assert!(MsgSecretPolicy::Disabled.prunes());
         assert!(!MsgSecretPolicy::Disabled.persists());
         assert!(MsgSecretPolicy::BotOnly.bot_only());
     }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -62,9 +62,8 @@ struct InMemoryState {
     sent_messages: HashMap<SentMessageKey, SentMessageEntry>,
 
     // --- MsgSecret ---
-    /// Value is `(secret_bytes, created_at_secs)` so the keepalive cleanup
-    /// can prune expired entries the same way `delete_expired_sent_messages`
-    /// does for the retry cache.
+    /// Value is `(secret_bytes, expires_at_secs)` where `0` means never expire.
+    /// The keepalive cleanup prunes rows whose deadline has passed.
     msg_secrets: HashMap<(String, String, String), (Vec<u8>, i64)>,
 
     // --- Device ---
@@ -594,29 +593,17 @@ impl ProtocolStore for InMemoryBackend {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl MsgSecretStore for InMemoryBackend {
-    async fn put_msg_secret(
-        &self,
-        chat: &str,
-        sender: &str,
-        msg_id: &str,
-        secret: &[u8],
-    ) -> Result<()> {
-        self.state.lock().await.msg_secrets.insert(
-            (chat.to_string(), sender.to_string(), msg_id.to_string()),
-            (secret.to_vec(), crate::time::now_secs()),
-        );
-        Ok(())
-    }
-
     async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize> {
-        let now = crate::time::now_secs();
+        use crate::store::traits::merge_msg_secret_expiry;
         let stored = entries.len();
         let mut state = self.state.lock().await;
         for entry in entries {
-            state.msg_secrets.insert(
-                (entry.chat, entry.sender, entry.msg_id),
-                (entry.secret, now),
-            );
+            let key = (entry.chat, entry.sender, entry.msg_id);
+            let expires_at = match state.msg_secrets.get(&key) {
+                Some((_, existing)) => merge_msg_secret_expiry(*existing, entry.expires_at),
+                None => entry.expires_at,
+            };
+            state.msg_secrets.insert(key, (entry.secret, expires_at));
         }
         Ok(stored)
     }
@@ -639,9 +626,10 @@ impl MsgSecretStore for InMemoryBackend {
     async fn delete_expired_msg_secrets(&self, cutoff_timestamp: i64) -> Result<u32> {
         let mut state = self.state.lock().await;
         let before = state.msg_secrets.len();
+        // Keep rows with no deadline (0 = never) or a deadline still in the future.
         state
             .msg_secrets
-            .retain(|_, (_, ts)| *ts >= cutoff_timestamp);
+            .retain(|_, (_, expires_at)| *expires_at == 0 || *expires_at > cutoff_timestamp);
         Ok((before - state.msg_secrets.len()) as u32)
     }
 }
@@ -783,18 +771,21 @@ mod tests {
                     sender: "sender".into(),
                     msg_id: "M1".into(),
                     secret: vec![1u8; 32],
+                    expires_at: 0,
                 },
                 MsgSecretEntry {
                     chat: "chat".into(),
                     sender: "sender".into(),
                     msg_id: "M2".into(),
                     secret: vec![2u8; 32],
+                    expires_at: 0,
                 },
                 MsgSecretEntry {
                     chat: "chat".into(),
                     sender: "sender".into(),
                     msg_id: "M1".into(),
                     secret: vec![9u8; 32],
+                    expires_at: 0,
                 },
             ])
             .await
@@ -826,7 +817,7 @@ mod tests {
             .put_msg_secret("c", "s", "OLD", &[1u8; 32])
             .await
             .unwrap();
-        // Mutate timestamp directly to simulate an old row.
+        // Set a deadline already in the past to simulate an expired row.
         {
             let mut state = backend.state.lock().await;
             let entry = state
@@ -835,6 +826,7 @@ mod tests {
                 .unwrap();
             entry.1 = crate::time::now_secs() - 86_400 * 30;
         }
+        // NEW keeps the default `expires_at = 0` (never), so it survives.
         backend
             .put_msg_secret("c", "s", "NEW", &[2u8; 32])
             .await

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -597,7 +597,7 @@ impl ProtocolStore for InMemoryBackend {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl MsgSecretStore for InMemoryBackend {
     async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize> {
-        use crate::store::traits::merge_msg_secret_expiry;
+        use crate::store::traits::{merge_msg_secret_expiry, merge_msg_secret_message_ts};
         let stored = entries.len();
         let mut state = self.state.lock().await;
         for entry in entries {
@@ -605,9 +605,7 @@ impl MsgSecretStore for InMemoryBackend {
             let (expires_at, message_ts) = match state.msg_secrets.get(&key) {
                 Some((_, existing_exp, existing_ts)) => (
                     merge_msg_secret_expiry(*existing_exp, entry.expires_at),
-                    // message_ts is the parent's immutable event time; keep the
-                    // known (non-zero / later) value.
-                    (*existing_ts).max(entry.message_ts),
+                    merge_msg_secret_message_ts(*existing_ts, entry.message_ts),
                 ),
                 None => (entry.expires_at, entry.message_ts),
             };
@@ -625,12 +623,9 @@ impl MsgSecretStore for InMemoryBackend {
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .state
-            .lock()
-            .await
-            .msg_secrets
-            .get(&(chat.to_string(), sender.to_string(), msg_id.to_string()))
-            .map(|(secret, _, _)| secret.clone()))
+            .get_msg_secret_with_ts(chat, sender, msg_id)
+            .await?
+            .map(|(secret, _)| secret))
     }
 
     async fn get_msg_secret_with_ts(

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -33,6 +33,9 @@ struct PreKeyEntry {
 /// Key for base-key collision detection: `(address, message_id)`.
 type BaseKeyKey = (String, String);
 
+/// Stored msg-secret value: `(secret_bytes, expires_at_secs, message_ts_secs)`.
+type MsgSecretRow = (Vec<u8>, i64, i64);
+
 /// Inner state protected by the mutex.
 #[derive(Default)]
 struct InMemoryState {
@@ -62,9 +65,9 @@ struct InMemoryState {
     sent_messages: HashMap<SentMessageKey, SentMessageEntry>,
 
     // --- MsgSecret ---
-    /// Value is `(secret_bytes, expires_at_secs)` where `0` means never expire.
-    /// The keepalive cleanup prunes rows whose deadline has passed.
-    msg_secrets: HashMap<(String, String, String), (Vec<u8>, i64)>,
+    /// `expires_at = 0` means never expire; `message_ts = 0` means the parent
+    /// event time is unknown. The keepalive cleanup prunes expired rows.
+    msg_secrets: HashMap<(String, String, String), MsgSecretRow>,
 
     // --- Device ---
     device: Option<Device>,
@@ -599,11 +602,18 @@ impl MsgSecretStore for InMemoryBackend {
         let mut state = self.state.lock().await;
         for entry in entries {
             let key = (entry.chat, entry.sender, entry.msg_id);
-            let expires_at = match state.msg_secrets.get(&key) {
-                Some((_, existing)) => merge_msg_secret_expiry(*existing, entry.expires_at),
-                None => entry.expires_at,
+            let (expires_at, message_ts) = match state.msg_secrets.get(&key) {
+                Some((_, existing_exp, existing_ts)) => (
+                    merge_msg_secret_expiry(*existing_exp, entry.expires_at),
+                    // message_ts is the parent's immutable event time; keep the
+                    // known (non-zero / later) value.
+                    (*existing_ts).max(entry.message_ts),
+                ),
+                None => (entry.expires_at, entry.message_ts),
             };
-            state.msg_secrets.insert(key, (entry.secret, expires_at));
+            state
+                .msg_secrets
+                .insert(key, (entry.secret, expires_at, message_ts));
         }
         Ok(stored)
     }
@@ -620,7 +630,22 @@ impl MsgSecretStore for InMemoryBackend {
             .await
             .msg_secrets
             .get(&(chat.to_string(), sender.to_string(), msg_id.to_string()))
-            .map(|(secret, _)| secret.clone()))
+            .map(|(secret, _, _)| secret.clone()))
+    }
+
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<(Vec<u8>, i64)>> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .msg_secrets
+            .get(&(chat.to_string(), sender.to_string(), msg_id.to_string()))
+            .map(|(secret, _, message_ts)| (secret.clone(), *message_ts)))
     }
 
     async fn delete_expired_msg_secrets(&self, cutoff_timestamp: i64) -> Result<u32> {
@@ -629,7 +654,7 @@ impl MsgSecretStore for InMemoryBackend {
         // Keep rows with no deadline (0 = never) or a deadline still in the future.
         state
             .msg_secrets
-            .retain(|_, (_, expires_at)| *expires_at == 0 || *expires_at > cutoff_timestamp);
+            .retain(|_, (_, expires_at, _)| *expires_at == 0 || *expires_at > cutoff_timestamp);
         Ok((before - state.msg_secrets.len()) as u32)
     }
 }
@@ -772,6 +797,7 @@ mod tests {
                     msg_id: "M1".into(),
                     secret: vec![1u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
                 MsgSecretEntry {
                     chat: "chat".into(),
@@ -779,6 +805,7 @@ mod tests {
                     msg_id: "M2".into(),
                     secret: vec![2u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
                 MsgSecretEntry {
                     chat: "chat".into(),
@@ -786,6 +813,7 @@ mod tests {
                     msg_id: "M1".into(),
                     secret: vec![9u8; 32],
                     expires_at: 0,
+                    message_ts: 0,
                 },
             ])
             .await

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -418,10 +418,11 @@ pub trait MsgSecretStore: Send + Sync {
         Ok(())
     }
 
-    /// Batched upsert carrying a per-row `expires_at` deadline. On key
-    /// conflict implementations keep the *later* deadline, treating `0`
-    /// ("never") as infinity, so a redelivery or edit re-persist never
-    /// shortens an existing window; `message_ts` keeps its non-zero value.
+    /// Batched upsert carrying a per-row `expires_at` deadline. On key conflict
+    /// implementations merge deterministically via [`merge_msg_secret_expiry`]
+    /// (later deadline wins, `0` = "never" = infinity) so a redelivery or edit
+    /// re-persist never shortens a window, and via [`merge_msg_secret_message_ts`]
+    /// (the later non-zero parent time wins; a `0` never clobbers a known one).
     async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize>;
 
     /// Fetch the persisted secret; returns `None` if absent.
@@ -463,6 +464,13 @@ pub fn merge_msg_secret_expiry(existing: i64, incoming: i64) -> i64 {
     } else {
         existing.max(incoming)
     }
+}
+
+/// Merge two parent `message_ts` values on key conflict: the later (larger)
+/// non-zero value wins, so a `0` ("unknown") never clobbers a known parent
+/// time. `max` already yields this because every real timestamp is `> 0`.
+pub fn merge_msg_secret_message_ts(existing: i64, incoming: i64) -> i64 {
+    existing.max(incoming)
 }
 
 /// Combined storage backend trait.

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -63,6 +63,11 @@ pub struct MsgSecretEntry {
     /// rows whose deadline has passed; it does not know the horizon itself.
     #[serde(default)]
     pub expires_at: i64,
+    /// Parent message event time (unix seconds), or `0` when unknown. Kept so
+    /// the receive path can enforce the edit-processing window
+    /// (`editTs < message_ts + window`) the same way WhatsApp Web does.
+    #[serde(default)]
+    pub message_ts: i64,
 }
 
 /// Device information for registry tracking.
@@ -407,6 +412,7 @@ pub trait MsgSecretStore: Send + Sync {
             msg_id: msg_id.to_string(),
             secret: secret.to_vec(),
             expires_at: 0,
+            message_ts: 0,
         }])
         .await?;
         Ok(())
@@ -415,7 +421,7 @@ pub trait MsgSecretStore: Send + Sync {
     /// Batched upsert carrying a per-row `expires_at` deadline. On key
     /// conflict implementations keep the *later* deadline, treating `0`
     /// ("never") as infinity, so a redelivery or edit re-persist never
-    /// shortens an existing window.
+    /// shortens an existing window; `message_ts` keeps its non-zero value.
     async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize>;
 
     /// Fetch the persisted secret; returns `None` if absent.
@@ -425,6 +431,22 @@ pub trait MsgSecretStore: Send + Sync {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>>;
+
+    /// Fetch the secret together with the parent message's event time
+    /// (`message_ts`, `0` when unknown), so the receive path can enforce the
+    /// edit-processing window. Default pairs `get_msg_secret` with `0`;
+    /// backends that store `message_ts` override this.
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<(Vec<u8>, i64)>> {
+        Ok(self
+            .get_msg_secret(chat, sender, msg_id)
+            .await?
+            .map(|secret| (secret, 0)))
+    }
 
     /// Delete rows whose non-zero `expires_at` is at or before
     /// `cutoff_timestamp` (absolute unix seconds; callers pass "now"). Rows

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -57,6 +57,12 @@ pub struct MsgSecretEntry {
     pub sender: String,
     pub msg_id: String,
     pub secret: Vec<u8>,
+    /// Absolute unix-seconds retention deadline. `0` means never expire.
+    /// Computed by the caller from the parent message's event time plus a
+    /// per-add-on-kind horizon (see `MsgSecretRetention`). The store prunes
+    /// rows whose deadline has passed; it does not know the horizon itself.
+    #[serde(default)]
+    pub expires_at: i64,
 }
 
 /// Device information for registry tracking.
@@ -378,28 +384,39 @@ pub trait DeviceStore: Send + Sync {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait MsgSecretStore: Send + Sync {
-    /// Persist `secret` (typically 32 bytes) under the composite key.
+    /// Persist `secret` (typically 32 bytes) under the composite key with NO
+    /// expiry (`expires_at = 0`). Convenience wrapper over [`put_msg_secrets`].
     /// `chat`, `sender`, and `msg_id` are JID strings / message ID strings;
     /// callers should pass non-AD (no-device) form for the JIDs so lookups
     /// match regardless of which device echo'd the stanza back.
+    ///
+    /// Real call sites that compute a retention deadline build
+    /// [`MsgSecretEntry`] directly and call [`put_msg_secrets`].
+    ///
+    /// [`put_msg_secrets`]: MsgSecretStore::put_msg_secrets
     async fn put_msg_secret(
         &self,
         chat: &str,
         sender: &str,
         msg_id: &str,
         secret: &[u8],
-    ) -> Result<()>;
-
-    /// Batched variant of `put_msg_secret`.
-    async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize> {
-        let mut stored = 0usize;
-        for entry in entries {
-            self.put_msg_secret(&entry.chat, &entry.sender, &entry.msg_id, &entry.secret)
-                .await?;
-            stored += 1;
-        }
-        Ok(stored)
+    ) -> Result<()> {
+        self.put_msg_secrets(vec![MsgSecretEntry {
+            chat: chat.to_string(),
+            sender: sender.to_string(),
+            msg_id: msg_id.to_string(),
+            secret: secret.to_vec(),
+            expires_at: 0,
+        }])
+        .await?;
+        Ok(())
     }
+
+    /// Batched upsert carrying a per-row `expires_at` deadline. On key
+    /// conflict implementations keep the *later* deadline, treating `0`
+    /// ("never") as infinity, so a redelivery or edit re-persist never
+    /// shortens an existing window.
+    async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize>;
 
     /// Fetch the persisted secret; returns `None` if absent.
     async fn get_msg_secret(
@@ -409,10 +426,21 @@ pub trait MsgSecretStore: Send + Sync {
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>>;
 
-    /// Delete rows whose `created_at` is older than `cutoff_timestamp`
-    /// (seconds since epoch). Returns the number of rows removed so the
-    /// keepalive cleanup can log/throttle.
+    /// Delete rows whose non-zero `expires_at` is at or before
+    /// `cutoff_timestamp` (absolute unix seconds; callers pass "now"). Rows
+    /// with `expires_at = 0` (never) are kept. Returns the number removed so
+    /// the keepalive cleanup can log/throttle.
     async fn delete_expired_msg_secrets(&self, cutoff_timestamp: i64) -> Result<u32>;
+}
+
+/// Merge two `expires_at` deadlines on key conflict: `0` ("never") wins,
+/// otherwise the later (larger) deadline is kept so windows never shrink.
+pub fn merge_msg_secret_expiry(existing: i64, incoming: i64) -> i64 {
+    if existing == 0 || incoming == 0 {
+        0
+    } else {
+        existing.max(incoming)
+    }
 }
 
 /// Combined storage backend trait.


### PR DESCRIPTION
## What

Bounds the per-message `messageSecret` store, which a recent change (#665) made grow without limit: it seeds a secret for every non-forwarded history-sync message and captures one for every live message and every send, and nothing ever prunes them. On a freshly paired headless account that produced ~95k rows accounting for ~99% of the SQLite file.

Retention is now one policy plus a per-row, event-time deadline, all on `CacheConfig`:

- **`msg_secret_policy: MsgSecretPolicy`** — `Managed` (default), `BotOnly`, `Full`, `Disabled` — unifies the three previously-scattered decisions (capture on live receive, seed from history, prune).
- **Per-row `expires_at`** (absolute unix seconds, `0` = never) replaces the old `created_at`-based TTL. `created_at` was insert time and was overwritten on every conflict-update and edit re-persist, so no age-based prune was ever sound. The deadline is computed from the **parent message's own event time** plus a per-add-on-kind horizon, and on conflict the later deadline wins (`0` = never wins) so a redelivery or edit re-persist never shortens a window.
- **`msg_secret_retention`** horizons: text/`MESSAGE_EDIT` 30d, poll/event 90d, bot 30d. An edit is only valid when authored within 20 min of the parent, but the offline queue can deliver that (validly-authored) edit up to ~30 days later, so 30d is the floor that keeps a 30-day-offline receiver able to decrypt. `PollAddOption`/`EventEdit` have no window and ride the parent's secret, so poll/event parents get the longer 90d horizon.
- **Edit-processing window on receive** — the parent's event time is now stored (`message_ts`) so the receive path can drop a secret-encrypted `MESSAGE_EDIT` authored outside the window (`editTs >= parentTs + 1200s`), matching WhatsApp Web's `ProcessEditProtocolMsgs`. The check is on authored time (not "now"), so a validly-authored edit still applies after an offline gap; it is permissive when the parent's time is unknown (resolver-supplied secrets carry none).
- **Age/type-filtered seed** — history secrets whose parent is already past its horizon are dropped at seed time. For a multi-month history this collapses the pairing burst to the recent, still-relevant slice.
- **`seed_msg_secrets_from_history: bool`** (default `true`) — live capture (covering everything received after connect) is independent from history seeding. Seeding only matters for the boundary case: an add-on that arrives live yet references a parent delivered via history sync. Headless consumers that only react to new messages can flip this off.
- **`original_message_resolver`** (+ `msg_secret_resolver_timeout`, default 5s) — an app-supplied fallback consulted when an add-on's parent secret is absent from the store (and its LID/PN alternates), bounded by a timeout because it runs in the per-chat receive lane. This is what lets the `Disabled` policy still decrypt: an app that keeps its own message store can own retention entirely and answer secret lookups on demand. (`Send + Sync` is dropped on wasm32 so a wasm app can supply a `!Send` resolver.)

Newsletters arrive as plaintext and never carry a `secret_encrypted_message`, so there is no newsletter retention class (documented inline to avoid a future dead branch).

## Why

The secrets only unlock add-ons that reference a parent by id — secret-encrypted edits, msmsg bot replies, and poll/event edits — all of which are bounded in time. The send path never reads the store, and poll votes/reactions take an app-supplied secret rather than reading it, so the only real consumers are five inbound add-on kinds with finite useful lifetimes. Keeping a secret for every message forever (and re-seeding the entire history on pairing) is therefore pure storage cost with no decrypt benefit beyond the horizon.

The redesign is grounded in verified behavior: the edit window is 1200s (20 min), enforced on both send and receive as an *authored-time* check (`editTs < parentTs + window`) — not relative to "now" — so an offline-delivered but validly-authored edit still applies, which is exactly why retention is sized to the ~30-day delivery window rather than the 20-minute authoring window. PollAddOption/EventEdit have no window at all, and edits by other users (newsletter admins) still key the lookup on the original author's secret, so the existing keying already covers them.

## Breaking Change

BREAKING CHANGE: `CacheConfig.msg_secret_ttl_secs: u64` is removed. Replace it with `msg_secret_policy: MsgSecretPolicy` (default `Managed`) plus the additive `msg_secret_retention`, `seed_msg_secrets_from_history` (default `true`), `original_message_resolver`, and `msg_secret_resolver_timeout`. The default behavior changes from "seed and keep everything forever" to "seed only the still-relevant slice and prune by event-time horizon".

Migration:

- To keep the previous behavior exactly, set `msg_secret_policy: MsgSecretPolicy::Full`.
- To restore pre-#665 capture (bot contexts only — including group bot invocations), use `MsgSecretPolicy::BotOnly`.
- To persist nothing and own retention in the app, use `MsgSecretPolicy::Disabled` and register an `original_message_resolver`.
- `MsgSecretStore::put_msg_secrets` is now the required method and carries `MsgSecretEntry { expires_at, message_ts }`; the scalar `put_msg_secret` is a never-expiring default wrapper, and `get_msg_secret_with_ts` has a default returning `0` for the parent time. Custom backends that implemented the scalar should move to `put_msg_secrets` and honor `expires_at` (keep the later deadline on conflict, `0` wins) and `message_ts` (keep the non-zero value).

Existing installs are not mass-deleted: the SQLite migration backfills legacy rows to `created_at + 30d`, so the prior pairing-burst seed ages out gradually once pruning runs (which now includes `Disabled`, so switching to it also reclaims legacy rows — they drain as each row hits its backfilled deadline, completing within ~30 days, not all at once on the first sweep).

## Tests

New coverage:

- seed filter: `Managed` drops text past 30d but keeps recent text and polls within 90d; `Full` seeds an ancient secret; `Disabled` seeds nothing; the opt-out flag skips seeding under `Managed`
- seeded rows carry an `expires_at` derived from the parent's `messageTimestamp` — a prune past `msg_ts + 30d` removes the row while an earlier prune keeps it
- edit-processing window: an in-window edit applies, an out-of-window edit is dropped, and an unknown parent timestamp stays permissive; `get_msg_secret_with_ts` round-trips and keeps the parent ts across a 0-ts redelivery
- `BotOnly` keeps a group bot prompt (botMetadata) but skips a plain message; unit cover for `is_bot_context` / `classify_from_flags` / policy predicates
- `OriginalMessageResolver`: a secret-encrypted edit decrypts via the resolver when the store is empty under `Disabled`
- SQLite: conflict keeps the later deadline (`0`/never wins); prune deletes only passed deadlines

Validation:

- `cargo fmt --all`
- `cargo clippy -p wacore -p whatsapp-rust -p whatsapp-rust-sqlite-storage --all-targets -- -D warnings` clean
- `cargo test -p wacore -p whatsapp-rust -p whatsapp-rust-sqlite-storage` — 819 (wacore lib) + 644 (whatsapp-rust lib) + 31 (sqlite) passing
