### PR TITLE
fix(connection)!: flush Signal cache on disconnect to stop SKDM re-fanout

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -51,7 +51,7 @@ fn main() {
         .expect("Failed to build tokio runtime");
 
     rt.block_on(async {
-        let backend = Arc::new(InMemoryBackend::new().with_sent_message_ttl(30));
+        let backend = Arc::new(InMemoryBackend::new());
 
         // Accept either WHATSAPP_WS_URL or MOCK_SERVER_URL — the latter
         // matches the convention the e2e suite uses.

--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -194,8 +194,10 @@ pub struct CacheConfig {
     pub chat_lanes_capacity: u64,
 
     // --- Sent message DB cleanup ---
-    /// TTL in seconds for sent messages in DB before periodic cleanup.
-    /// 0 = no automatic cleanup. Default: 300 (5 minutes).
+    /// TTL in seconds for sent messages in DB before periodic cleanup. Must
+    /// outlive retry receipts (which can arrive well after a send) or the retry
+    /// is dropped as "not found in cache". The periodic sweep keeps the table
+    /// bounded. 0 = no automatic cleanup. Default: 7200 (2 hours).
     pub sent_message_ttl_secs: u64,
 
     // --- MsgSecret retention ---
@@ -314,7 +316,7 @@ impl Default for CacheConfig {
             // breaking serialization. Size generously to avoid eviction pressure.
             session_locks_capacity: 10_000,
             chat_lanes_capacity: 5_000,
-            sent_message_ttl_secs: 300,
+            sent_message_ttl_secs: 7200,
             // Bounded by default: seed only the still-relevant slice of history
             // and prune by per-add-on-kind event-time horizons, so the store no
             // longer accumulates a secret for every message forever.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1432,7 +1432,12 @@ impl Client {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .clear();
-        // Clear signal cache so stale state doesn't leak across connections
+        // Flush before clear: clear() drops dirty entries, so a disconnect
+        // racing an in-flight encrypt would lose the just-advanced sender-key
+        // chain and force a full SKDM re-fanout. A disconnect is not a logout.
+        self.flush_signal_cache_logged("cleanup_connection_state", None)
+            .await;
+        // Clear signal cache so stale state doesn't leak across connections.
         self.signal_cache.clear().await;
         // Reset semaphore to 1 permit for next offline sync.
         self.swap_message_semaphore(1);
@@ -3427,7 +3432,7 @@ impl Client {
                             .map(|v| v.as_str().to_string())
                             .unwrap_or_default();
                         warn!(
-                            "Stream error: server rejected ack (class={class:?}, id={id}); reconnect will follow on stream end"
+                            "Stream error carrying <ack> (class={class:?}, id={id}): server-driven stream rotation, not an ack rejection; reconnect follows on stream end"
                         );
                     } else {
                         warn!("Unknown stream error: {}", DisplayableNodeRef(node));
@@ -3475,7 +3480,12 @@ impl Client {
         }
 
         if reason.is_logged_out() {
-            info!("Got {reason:?} connect failure, logging out.");
+            // Log the full <failure> so a server-side lock/ban is diagnosable;
+            // `location` (e.g. "rva") is a routing token, not the cause.
+            warn!(
+                "Got {reason:?} connect failure, logging out: {}",
+                DisplayableNodeRef(node)
+            );
             self.core
                 .event_bus
                 .dispatch(wacore::types::events::Event::LoggedOut(
@@ -5509,6 +5519,95 @@ mod tests {
         )
         .await;
         client
+    }
+
+    /// Regression: a transport disconnect must flush dirty Signal state before
+    /// clearing the cache, or a just-advanced sender-key chain is lost (forcing
+    /// a full SKDM re-fanout on the next send).
+    #[tokio::test]
+    async fn cleanup_connection_state_flushes_dirty_signal_state() {
+        use wacore::libsignal::protocol::ProtocolAddress;
+        let client = create_offline_sync_test_client().await;
+
+        // A dirty identity lives only in the write-back cache until flushed.
+        let addr = ProtocolAddress::new("5550001000@s.whatsapp.net".to_string(), 1u32.into());
+        client.signal_cache.put_identity(&addr, &[7u8; 32]).await;
+
+        client.cleanup_connection_state().await;
+
+        // cleanup cleared the cache, so a hit now can only come from the DB,
+        // proving the flush ran before the clear.
+        let device = client.persistence_manager.get_device_arc().await;
+        let guard = device.read().await;
+        let persisted = client
+            .signal_cache
+            .get_identity(&addr, &*guard.backend)
+            .await
+            .expect("get_identity must not error");
+        assert!(
+            persisted.is_some(),
+            "dirty Signal state must survive a transport disconnect (flush-before-clear)"
+        );
+    }
+
+    /// Same guarantee on the sender-key store, which drives SKDM fanout.
+    #[tokio::test]
+    async fn cleanup_connection_state_flushes_dirty_sender_key() {
+        use wacore::libsignal::protocol::SenderKeyRecord;
+        use wacore::libsignal::store::sender_key_name::SenderKeyName;
+        let client = create_offline_sync_test_client().await;
+
+        let name = SenderKeyName::from_parts("group@g.us", "5550001000@s.whatsapp.net:1");
+        client
+            .signal_cache
+            .put_sender_key(&name, SenderKeyRecord::new_empty())
+            .await;
+
+        client.cleanup_connection_state().await;
+
+        let device = client.persistence_manager.get_device_arc().await;
+        let guard = device.read().await;
+        let persisted = client
+            .signal_cache
+            .get_sender_key(&name, &*guard.backend)
+            .await
+            .expect("get_sender_key must not error");
+        assert!(
+            persisted.is_some(),
+            "dirty sender key must survive a transport disconnect (flush-before-clear)"
+        );
+    }
+
+    /// A 403 connect failure is WA Web's REASON_LOCKED: it must surface a logout
+    /// carrying AccountLocked and disable auto-reconnect (a lock is not transient).
+    #[tokio::test]
+    async fn connect_failure_403_dispatches_account_locked_logout() {
+        use wacore::types::events::ChannelEventHandler;
+        let client = create_offline_sync_test_client().await;
+        let (handler, events) = ChannelEventHandler::new();
+        client.register_handler(handler);
+
+        // location="rva" is a region routing token and must not change the verdict.
+        let failure = NodeBuilder::new("failure")
+            .attr("reason", "403")
+            .attr("location", "rva")
+            .build();
+        client.handle_connect_failure(&failure.as_node_ref()).await;
+
+        let evt = events
+            .try_recv()
+            .expect("403 must dispatch a LoggedOut event");
+        match &*evt {
+            Event::LoggedOut(lo) => {
+                assert!(lo.on_connect, "403 arrives as a failure-on-connect");
+                assert_eq!(lo.reason, ConnectFailureReason::AccountLocked);
+            }
+            _ => panic!("expected Event::LoggedOut for reason=403"),
+        }
+        assert!(
+            !client.enable_auto_reconnect.load(Ordering::Relaxed),
+            "a server-side lock must not auto-reconnect"
+        );
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1435,10 +1435,14 @@ impl Client {
         // Flush before clear: clear() drops dirty entries, so a disconnect
         // racing an in-flight encrypt would lose the just-advanced sender-key
         // chain and force a full SKDM re-fanout. A disconnect is not a logout.
-        self.flush_signal_cache_logged("cleanup_connection_state", None)
-            .await;
-        // Clear signal cache so stale state doesn't leak across connections.
-        self.signal_cache.clear().await;
+        // Only clear on a successful flush; on a backend error keep the cache so
+        // the dirty state isn't dropped and the next operation can persist it.
+        match self.flush_signal_cache().await {
+            Ok(()) => self.signal_cache.clear().await,
+            Err(e) => log::error!(
+                "cleanup_connection_state: signal cache flush failed, keeping cache to avoid dropping Signal state: {e:?}"
+            ),
+        }
         // Reset semaphore to 1 permit for next offline sync.
         self.swap_message_semaphore(1);
         // Reset dead-socket timestamps so stale values from the previous
@@ -5575,6 +5579,43 @@ mod tests {
         assert!(
             persisted.is_some(),
             "dirty sender key must survive a transport disconnect (flush-before-clear)"
+        );
+    }
+
+    /// When the flush itself fails, cleanup must NOT clear the cache, or it would
+    /// drop the very state the flush was meant to persist.
+    #[tokio::test]
+    async fn cleanup_connection_state_keeps_state_when_flush_fails() {
+        use wacore::libsignal::protocol::{ProtocolAddress, SenderKeyRecord};
+        use wacore::libsignal::store::sender_key_name::SenderKeyName;
+        let client = create_offline_sync_test_client().await;
+
+        // A malformed identity (not 32 bytes) makes flush() error out, standing
+        // in for a transient backend write failure during cleanup.
+        let bad = ProtocolAddress::new("5550002000@s.whatsapp.net".to_string(), 1u32.into());
+        client.signal_cache.put_identity(&bad, &[0u8; 16]).await;
+
+        // A valid dirty sender key that must not be dropped when the flush fails.
+        let name = SenderKeyName::from_parts("group@g.us", "5550001000@s.whatsapp.net:1");
+        client
+            .signal_cache
+            .put_sender_key(&name, SenderKeyRecord::new_empty())
+            .await;
+
+        client.cleanup_connection_state().await;
+
+        // flush() failed, so clear() was skipped; the unpersisted sender key
+        // survives in the write-back cache instead of being dropped.
+        let device = client.persistence_manager.get_device_arc().await;
+        let guard = device.read().await;
+        let persisted = client
+            .signal_cache
+            .get_sender_key(&name, &*guard.backend)
+            .await
+            .expect("get_sender_key must not error");
+        assert!(
+            persisted.is_some(),
+            "a flush failure must not drop dirty Signal state"
         );
     }
 

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -73,15 +73,12 @@ struct InMemoryState {
     device: Option<Device>,
 }
 
-/// Default TTL for sent messages (seconds). Matches the client's
-/// `sent_message_ttl_secs` default of 300s.
-const DEFAULT_SENT_MESSAGE_TTL_SECS: i64 = 300;
-
-/// Eviction runs inline when the map exceeds this many entries.
-const SENT_MESSAGE_EVICT_THRESHOLD: usize = 64;
-
-/// Minimum interval between eviction scans (seconds).
-const SENT_MESSAGE_EVICT_INTERVAL_SECS: i64 = 30;
+/// Hard cap on retained sent messages, bounding memory regardless of the
+/// configured retention window. Time-based pruning is the client's keepalive
+/// sweep (`delete_expired_sent_messages`, driven by
+/// `CacheConfig::sent_message_ttl_secs`, the single source of truth for the
+/// time window); this cap only guards against a burst between sweeps.
+const MAX_SENT_MESSAGES: usize = 4096;
 
 /// In-memory implementation of the full [`Backend`] trait.
 ///
@@ -90,8 +87,6 @@ const SENT_MESSAGE_EVICT_INTERVAL_SECS: i64 = 30;
 pub struct InMemoryBackend {
     state: Mutex<InMemoryState>,
     next_device_id: AtomicI32,
-    sent_message_ttl_secs: i64,
-    last_eviction: std::sync::atomic::AtomicI64,
 }
 
 impl InMemoryBackend {
@@ -100,17 +95,7 @@ impl InMemoryBackend {
         Self {
             state: Mutex::new(InMemoryState::default()),
             next_device_id: AtomicI32::new(1),
-            sent_message_ttl_secs: DEFAULT_SENT_MESSAGE_TTL_SECS,
-            last_eviction: std::sync::atomic::AtomicI64::new(0),
         }
-    }
-
-    /// Create with a custom sent-message TTL. Values ≤ 0 are ignored.
-    pub fn with_sent_message_ttl(mut self, ttl_secs: i64) -> Self {
-        if ttl_secs > 0 {
-            self.sent_message_ttl_secs = ttl_secs;
-        }
-        self
     }
 }
 
@@ -545,18 +530,20 @@ impl ProtocolStore for InMemoryBackend {
         let now = crate::time::now_secs();
         let mut s = self.state.lock().await;
 
-        // Amortized eviction: only scan when the map is large AND enough time
-        // has passed since the last eviction to avoid O(n) work on every insert.
-        if s.sent_messages.len() >= SENT_MESSAGE_EVICT_THRESHOLD {
-            let last = self
-                .last_eviction
-                .load(std::sync::atomic::Ordering::Relaxed);
-            let interval = SENT_MESSAGE_EVICT_INTERVAL_SECS.min(self.sent_message_ttl_secs);
-            if now - last >= interval {
-                let cutoff = now - self.sent_message_ttl_secs;
-                s.sent_messages.retain(|_, e| e.timestamp >= cutoff);
-                self.last_eviction
-                    .store(now, std::sync::atomic::Ordering::Relaxed);
+        // Memory bound only: when the map hits the cap, drop the oldest entries
+        // (by timestamp) down to 3/4 of it so this O(n log n) scan amortizes
+        // across many inserts. Time-based pruning is the caller's keepalive sweep.
+        if s.sent_messages.len() >= MAX_SENT_MESSAGES {
+            let target = MAX_SENT_MESSAGES * 3 / 4;
+            let drop_count = s.sent_messages.len().saturating_sub(target);
+            let mut by_age: Vec<_> = s
+                .sent_messages
+                .iter()
+                .map(|(k, e)| (e.timestamp, k.clone()))
+                .collect();
+            by_age.sort_unstable_by_key(|(ts, _)| *ts);
+            for (_, k) in by_age.into_iter().take(drop_count) {
+                s.sent_messages.remove(&k);
             }
         }
 
@@ -694,6 +681,33 @@ mod tests {
     #[test]
     fn in_memory_backend_implements_backend() {
         is_backend::<InMemoryBackend>();
+    }
+
+    #[tokio::test]
+    async fn store_sent_message_is_memory_bounded() {
+        let backend = InMemoryBackend::new();
+        for i in 0..(MAX_SENT_MESSAGES + 500) {
+            backend
+                .store_sent_message("chat@g.us", &format!("m{i}"), b"payload")
+                .await
+                .unwrap();
+        }
+        let len = backend.state.lock().await.sent_messages.len();
+        assert!(
+            len <= MAX_SENT_MESSAGES,
+            "sent_messages must stay within the hard cap, got {len}"
+        );
+        // The most recently stored message is inserted after eviction, so it
+        // always survives.
+        let last = format!("m{}", MAX_SENT_MESSAGES + 500 - 1);
+        assert!(
+            backend
+                .take_sent_message("chat@g.us", &last)
+                .await
+                .unwrap()
+                .is_some(),
+            "the newest message must survive count-cap eviction"
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -611,8 +611,11 @@ pub enum ConnectFailureReason {
     LoggedOut,
     #[wire = 402]
     TempBanned,
+    /// WA Web 403 = REASON_LOCKED: account/device locked server-side; the client
+    /// logs out as LogoutReason.AccountLocked. (A manual unlink instead arrives
+    /// as `<conflict type="device_removed">`.)
     #[wire = 403]
-    MainDeviceGone,
+    AccountLocked,
     #[wire = 406]
     UnknownLogout,
     #[wire = 405]
@@ -641,7 +644,7 @@ impl ConnectFailureReason {
     pub fn is_logged_out(&self) -> bool {
         matches!(
             self,
-            Self::LoggedOut | Self::MainDeviceGone | Self::UnknownLogout
+            Self::LoggedOut | Self::AccountLocked | Self::UnknownLogout
         )
     }
 
@@ -1046,5 +1049,36 @@ mod tests {
                 .as_deref(),
             Some("msg-0")
         );
+    }
+
+    #[test]
+    fn connect_failure_reason_403_is_account_locked() {
+        // WA Web maps reason 403 to REASON_LOCKED (account/device locked),
+        // a logout that must not auto-reconnect.
+        assert_eq!(
+            ConnectFailureReason::from(403),
+            ConnectFailureReason::AccountLocked
+        );
+        assert!(ConnectFailureReason::AccountLocked.is_logged_out());
+        assert!(!ConnectFailureReason::AccountLocked.should_reconnect());
+
+        assert!(ConnectFailureReason::LoggedOut.is_logged_out());
+        assert!(ConnectFailureReason::UnknownLogout.is_logged_out());
+
+        // Transient server errors reconnect instead of logging out.
+        assert!(ConnectFailureReason::ServiceUnavailable.should_reconnect());
+        assert!(ConnectFailureReason::InternalServerError.should_reconnect());
+        assert!(!ConnectFailureReason::ServiceUnavailable.is_logged_out());
+
+        // A temp ban is neither a logout nor a reconnect on this path.
+        assert!(!ConnectFailureReason::TempBanned.is_logged_out());
+        assert!(!ConnectFailureReason::TempBanned.should_reconnect());
+
+        // Unrecognized codes fall through to the catch-all, never a logout.
+        assert_eq!(
+            ConnectFailureReason::from(499),
+            ConnectFailureReason::Unknown(499)
+        );
+        assert!(!ConnectFailureReason::from(499).is_logged_out());
     }
 }


### PR DESCRIPTION
## What

RCA of a high-volume group bot whose ~11h session ended with a single `<failure reason="403" location="rva"/>`. The terminal event is a server-side **account lock** (WA Web `REASON_LOCKED`), and the technical engine feeding the anomaly was a client bug chain: a disconnect could drop unflushed Signal state, forcing a full SenderKey re-fanout and rewinding the skmsg counter, which generated a sustained retry storm that the short sent-message TTL could not heal. Each change below was checked against `docs/captured-js` (adversarial multi-agent pass).

1. **Flush the Signal cache before clearing it on disconnect** (`cleanup_connection_state`). The cache is write-back: encrypt advances the sender-key chain in memory and marks it dirty; only the post-send flush persists it. `clear()` drops dirty entries, so a `stream:error`/`xmlstreamend` racing an in-flight encrypt lost the just-advanced chain (or a brand-new sender key). The next group send then saw `key_exists == false` → full SKDM fanout, and the rewound counter caused recipient MAC failures → retries. We now flush and clear **only when the flush succeeds** — a transient backend error keeps the dirty state rather than dropping it.

2. **Raise `sent_message_ttl_secs` 300 → 7200.** Retry receipts arrived up to ~92 min after send but the sent copy was pruned after 5 min, so thousands of retries died as "not found in cache" and the requesters never got a decryptable copy. The periodic keepalive sweep still bounds the table. The in-memory backend no longer keeps its own retention TTL: time-based pruning is solely the keepalive sweep (the single source of truth for the window), and a count-based hard cap (`MAX_SENT_MESSAGES`) bounds its memory regardless of the window. (It previously evicted inline at a hardcoded 5 minutes, diverging from the configured value.)

3. **Rename `ConnectFailureReason::MainDeviceGone` → `AccountLocked`** to match WA Web's 403 = `REASON_LOCKED` / `LogoutReason.AccountLocked`.

4. **Failure diagnostics.** Log the full `<failure>` (location/code/expire/message) on a logout-on-connect, and reword the misleading "server rejected ack" warning.

## Why / WA Web compliance

- **Flush before clear** — WA Web persists Signal state (sessions, sender keys, the per-device `senderKey` Map) in IndexedDB and has **no** code that forgets sender keys or re-fanouts the group on a transport reconnect (only audience-change events rotate). Dropping crypto state on a transport disconnect was the divergence; a disconnect is not a logout, so the state must survive. ✅
- **TTL** — WA Web does **not** use a TTL for retry retention: it reads the message from its persisted store (`RetryKeyBundle.js` → `getMessageTable().get(...)`), gated by **delivery state** (`MessageInfoStore.isRetryEligible`) and a **5-attempt cap** (`MAX_RETRY`), and silently drops a retry whose message is gone. WA Web is therefore effectively *unbounded by time*; 5 min was far more aggressive than WA Web and 2h is a conservative step toward it (it can only honor *fewer* retries than WA Web, never more). A fully WA-Web-exact design would retain until delivered/deleted rather than by time — left as follow-up. ✅ (consistent)
- **403 = AccountLocked** — `Failure/ErrorCodes.js`: `REASON_LOCKED: 403`; `Handle/Failure.js` dispatches on `reason` only and calls `clearCredentialsAndStoredData(LogoutReason.AccountLocked)`. `location` (`rva` = region routing token, `Debug/RoutingToken.js`) is telemetry, not the cause. ✅
- **Diagnostics** — `Handle/Failure.js` parses `reason`/`location`/`code`/`expire`/`message`; `Handle/StreamError.js` treats a `<stream:error>` carrying `<ack>` as a socket close + reconnect (no logout, no "rejection", and it does not key on `class`). ✅

This addresses the root cause + the symptom + future diagnosability. The retry-storm → ban link remains a strong correlation, not a proof (one 403 in 11h, no machine-readable reason in the stanza).

## What this PR deliberately does NOT change

To keep the change surgical and avoid regressions that can't be validated against a live account, these WA-Web-aligned ideas are left as follow-ups (the flush already removes the dominant fanout driver): marking `has_key` only after the *real* server ACK (today it is after `send_node`), a per-group send lock, an in-memory incremental device-map update, and a retry-storm circuit breaker. Note: the existing count-based `SENDER_KEY_ROTATION_THRESHOLD = 1000` diverges from WA Web (which has no count rotation) but did not fire in this incident and is left as-is.

## Breaking Change

BREAKING CHANGE: two public-API changes.

- `ConnectFailureReason::MainDeviceGone` is renamed to `ConnectFailureReason::AccountLocked`. The wire value (403) and `is_logged_out()` semantics are unchanged. Migration: replace any `MainDeviceGone` match arm / reference with `AccountLocked`.
- `InMemoryBackend::with_sent_message_ttl` is removed (the backend no longer keeps a per-instance retention TTL). Migration: configure retention via `CacheConfig::sent_message_ttl_secs`, which the keepalive sweep uses for all backends.

## Tests

New coverage:

- `cleanup_connection_state_flushes_dirty_signal_state` and `..._dirty_sender_key` — a dirty identity / sender key put into the write-back cache survives `cleanup_connection_state()` (proving flush-before-clear); both fail if the flush is removed (verified).
- `cleanup_connection_state_keeps_state_when_flush_fails` — when the flush errors, `clear()` is skipped and the dirty sender key is not dropped; fails without the success-gated clear (verified).
- `store_sent_message_is_memory_bounded` — the in-memory map stays within the hard cap across a burst past it, and the newest entry survives.
- `connect_failure_403_dispatches_account_locked_logout` — a `<failure reason="403" location="rva"/>` dispatches `LoggedOut{on_connect, reason: AccountLocked}` and disables auto-reconnect.
- `connect_failure_reason_403_is_account_locked` — the `ConnectFailureReason` matrix (403 → AccountLocked + logout, 503/500 reconnect, 402 neither, unknown → catch-all).

Validation:

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p whatsapp-rust --lib` — 649 passing; `cargo test -p wacore --lib` — 821 passing
