### PR TITLE
ci(wasm): guard whatsapp-rust wasm32 build and fix two #668 regressions

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,44 @@
+permissions:
+  contents: read
+name: WASM Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  wasm:
+    name: Build whatsapp-rust (wasm32, release)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-04-05
+          targets: wasm32-unknown-unknown
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Cache Rust registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
+      # Mirrors how whatsapp-rust-bridge consumes the crate: lib only (the
+      # binary pulls tokio/sqlite), no default features. Guards against code
+      # reachable from wasm regressing on tokio/std-only APIs.
+      # getrandom needs both the wasm_js feature (declared for wasm32 in
+      # Cargo.toml) and this backend cfg.
+      - name: Build whatsapp-rust lib for wasm32 (release)
+        env:
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+        run: >
+          cargo build -p whatsapp-rust --lib --release
+          --target wasm32-unknown-unknown
+          --no-default-features --features debug-diagnostics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,6 +2398,7 @@ dependencies = [
  "event-listener",
  "flate2",
  "futures",
+ "getrandom 0.4.2",
  "hex",
  "hkdf",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,12 @@ whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "
 whatsapp-rust-tokio-transport = { path = "./transports/tokio-transport", version = "0.6.0", optional = true }
 whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version = "0.6.0", optional = true }
 
+# Select getrandom's browser backend so the crate builds for wasm32 standalone
+# (CI wasm guard + downstream consumers like whatsapp-rust-bridge). Needs
+# `--cfg getrandom_backend="wasm_js"` in RUSTFLAGS; no effect on native targets.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 aes = { workspace = true }
 cbc = { version = "0.2", features = ["alloc", "block-padding"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,10 +147,13 @@ whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "
 whatsapp-rust-tokio-transport = { path = "./transports/tokio-transport", version = "0.6.0", optional = true }
 whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version = "0.6.0", optional = true }
 
-# Select getrandom's browser backend so the crate builds for wasm32 standalone
-# (CI wasm guard + downstream consumers like whatsapp-rust-bridge). Needs
-# `--cfg getrandom_backend="wasm_js"` in RUSTFLAGS; no effect on native targets.
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+# wasm32-unknown-unknown has no default getrandom backend, so make the browser
+# one available (the only valid choice there) to build the crate standalone:
+# CI wasm guard + downstream consumers like whatsapp-rust-bridge. Gated to the
+# unknown-unknown triple per getrandom's guidance so wasm32-wasi/emscripten keep
+# their own backends and don't pull wasm-bindgen/js-sys. Backend is still
+# selected via `--cfg getrandom_backend="wasm_js"` in RUSTFLAGS; no native effect.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
 
 [dev-dependencies]

--- a/src/message.rs
+++ b/src/message.rs
@@ -918,7 +918,13 @@ impl Client {
             }
             None
         };
-        match tokio::time::timeout(self.cache_config.msg_secret_resolver_timeout, lookup).await {
+        match wacore::runtime::timeout(
+            &*self.runtime,
+            self.cache_config.msg_secret_resolver_timeout,
+            lookup,
+        )
+        .await
+        {
             Ok(Some(secret)) => Some(secret.to_vec()),
             Ok(None) => None,
             Err(_) => {

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -140,7 +140,7 @@ impl GroupInfo {
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait SendContextResolver: Send + Sync {
+pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {
     async fn resolve_devices(&self, jids: &[Jid]) -> Result<Vec<Jid>, anyhow::Error>;
 
     async fn fetch_prekeys(

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -41,6 +41,7 @@ pub mod stanza;
 pub mod sticker_pack;
 
 pub mod store;
+pub mod sync_marker;
 pub mod time;
 pub mod types;
 pub mod upload;

--- a/wacore/src/sync_marker.rs
+++ b/wacore/src/sync_marker.rs
@@ -1,0 +1,18 @@
+//! Conditional `Send + Sync` bound.
+//!
+//! Native builds drive the client across multi-threaded receive lanes, so any
+//! trait object stored on it must be `Send + Sync`. wasm32 is single-threaded
+//! and its callbacks may hold `!Send` JS handles (see
+//! [`crate::msg_secret::OriginalMessageResolver`]), so the bound is dropped
+//! there. The blanket impls keep this transparent: on native every
+//! `Send + Sync` type already satisfies it, on wasm every type does.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSendSync: Send + Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + Sync + ?Sized> MaybeSendSync for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSendSync {}
+#[cfg(target_arch = "wasm32")]
+impl<T: ?Sized> MaybeSendSync for T {}

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -192,7 +192,7 @@ impl Serialize for LazyHistorySync {
     }
 }
 
-pub trait EventHandler: Send + Sync {
+pub trait EventHandler: crate::sync_marker::MaybeSendSync {
     fn handle_event(&self, event: Arc<Event>);
 }
 


### PR DESCRIPTION
## What

Adds a CI job that builds the `whatsapp-rust` **lib** for `wasm32-unknown-unknown` in release, and fixes two regressions from #668 that broke that build (the one `whatsapp-rust-bridge` consumes).

The catch: the `tokio` unresolved-module error (`E0433`) aborts name resolution **before** type-checking, so it masked a second wasm regression sitting right behind it. The bridge build only ever surfaced the `tokio` error.

**Fix 1 — `tokio::time::timeout` in `message.rs`.** `resolve_msg_secret_via_app` called `tokio::time::timeout` directly, which doesn't exist under `--no-default-features` (no `tokio-runtime` feature → no `tokio` dep). Swapped for the runtime-agnostic `wacore::runtime::timeout(&*self.runtime, ...)`, the same helper already used by `request.rs`, `handshake.rs`, `flush_scope.rs` and `media_reupload.rs`. The `match` arms are unchanged (it returns `Result<T, Elapsed>`, same shape as `tokio`'s).

**Fix 2 — `Send + Sync` bounds vs the wasm `?Send` resolver.** #668 added `original_message_resolver: Option<Arc<dyn OriginalMessageResolver>>`. That trait is, by design, `?Send` on wasm (documented in `msg_secret.rs` — it may be backed by `!Send` JS handles), which makes `Client` `!Send`/`!Sync` on wasm. But `SendContextResolver` and `EventHandler` required `Send + Sync` unconditionally, so all 6 `impl`s (`context_impl.rs`, `send.rs`, `bot.rs`) failed to compile on wasm. Introduced `wacore::sync_marker::MaybeSendSync` — a conditional bound that is `Send + Sync` on native (via a blanket impl over every `Send + Sync` type) and empty on wasm — and switched both supertraits to it.

## Why

`whatsapp-rust-bridge` compiles `whatsapp-rust` to wasm32 with `--no-default-features --features debug-diagnostics`. Nothing in this repo's CI exercised that target, so a single accidental commit could (and did) break downstream wasm builds without turning anything red here. The new `wasm.yml` job mirrors the bridge's flags so this class of regression fails CI instead of reaching a consumer.

## Compatibility note

The `MaybeSendSync` relaxation is **transparent on native**: a transitive supertrait `Send + Sync` still propagates to `dyn SendContextResolver` / `dyn EventHandler` (verified with a standalone PoC — `Box<dyn _>: Send` still holds), so no native consumer loses a bound. It only relaxes wasm. The crate also gains a `getrandom` dependency gated to `cfg(target_arch = "wasm32")` (enables the `wasm_js` backend feature so the lib builds standalone for wasm); it is a no-op on native targets.

## Tests

- `cargo build -p whatsapp-rust --lib --release --target wasm32-unknown-unknown --no-default-features --features debug-diagnostics` (with `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`) — **clean** (was 1 error before fix 1, 6 errors after, 0 now)
- `cargo build --workspace --exclude e2e-tests` (native) — clean
- `cargo clippy -p wacore -p whatsapp-rust --all-targets` (native) — clean
- `cargo fmt --all`