### PR TITLE
perf(message): cut per-message allocation churn on the hot path

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -97,13 +97,11 @@ impl Client {
         source: LearningSource,
         is_offline: bool,
     ) {
-        // Skip the per-message re-record/re-persist only once this exact pair is
-        // durably persisted (so an offline-only learn and a remap, including one
-        // whose write failed, still persist) and cache-resolvable (so an evicted
-        // entry re-warms). `source` drift is ignored (best-effort metadata).
-        if self.lid_pn_cache.is_persisted(phone_number, lid).await
-            && self.lid_pn_cache.current_lid_is(phone_number, lid).await
-        {
+        // Skip the per-message re-record/re-persist only when this exact pair is
+        // durably persisted and resolvable both ways in cache: an offline-only
+        // learn, a remap (even one whose write failed), or an evicted entry all
+        // fall through and re-warm/persist. `source` drift is ignored.
+        if self.lid_pn_cache.can_skip_relearn(phone_number, lid).await {
             return;
         }
         let (entry, is_new_mapping) = self
@@ -167,9 +165,11 @@ impl Client {
         let mut is_new_flags: Vec<bool> = Vec::with_capacity(deduped.len());
         for (phone_number, lid) in deduped {
             // Same fast path as the single-entry learn: an already durable and
-            // cache-resolvable pair needs no re-add, re-persist or migration.
-            if self.lid_pn_cache.is_persisted(&phone_number, &lid).await
-                && self.lid_pn_cache.current_lid_is(&phone_number, &lid).await
+            // both-ways cached pair needs no re-add, re-persist or migration.
+            if self
+                .lid_pn_cache
+                .can_skip_relearn(&phone_number, &lid)
+                .await
             {
                 continue;
             }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -97,19 +97,19 @@ impl Client {
         source: LearningSource,
         is_offline: bool,
     ) {
-        // Steady-state hot path: every incoming message re-asserts the
-        // sender's own LID↔PN pair, which never changes once learned. Skip
-        // re-allocating the entry, re-inserting both cache maps, and spawning
-        // the (no-op upsert) persist task when the mapping is already current.
-        // `add` always writes the LID→PN side too, so PN→LID == lid implies the
-        // pair is fully cached; a genuine remap (different lid) still falls
-        // through. `source` drift is intentionally ignored (best-effort metadata).
-        if self
-            .lid_pn_cache
-            .get_current_lid(phone_number)
-            .await
-            .as_deref()
-            == Some(lid)
+        // Skip the per-message re-record/re-persist only once the pair is both
+        // durably persisted and cache-resolvable. Gating on persistence (not
+        // just cache presence) is what keeps an offline replay, which warms the
+        // cache memory-only, from making this path swallow the first live
+        // message's persist. The cache check still re-runs on a remap or an
+        // evicted entry; `source` drift is ignored (best-effort metadata).
+        if self.lid_pn_cache.is_persisted(phone_number).await
+            && self
+                .lid_pn_cache
+                .get_current_lid(phone_number)
+                .await
+                .as_deref()
+                == Some(lid)
         {
             return;
         }
@@ -238,6 +238,12 @@ impl Client {
             .await
             .map_err(|e| anyhow!("persisting LID-PN mapping: {e}"))?;
 
+        // After the write, not before: a failed persist stays un-marked so the
+        // next live message retries instead of skipping.
+        self.lid_pn_cache
+            .mark_persisted(&storage_entry.phone_number)
+            .await;
+
         if is_new_mapping {
             self.migrate_device_registry_on_lid_discovery(
                 &storage_entry.phone_number,
@@ -282,6 +288,7 @@ impl Client {
             .map_err(|e| anyhow!("persisting LID-PN mapping batch: {e}"))?;
 
         for (entry, is_new) in storage.iter().zip(is_new_flags.iter()) {
+            self.lid_pn_cache.mark_persisted(&entry.phone_number).await;
             if *is_new {
                 self.migrate_device_registry_on_lid_discovery(&entry.phone_number, &entry.lid)
                     .await;
@@ -758,6 +765,40 @@ mod tests {
         let resolved = client.resolve_encryption_jid(&Jid::pn(pn)).await;
         assert_eq!(resolved.user, lid, "cache must have the mapping on return");
         assert_eq!(resolved.server, Server::Lid);
+    }
+
+    /// A mapping first warmed memory-only by an offline replay must still be
+    /// persisted on its first live message; the fast-path skip must not swallow
+    /// it just because the cache already holds it.
+    #[tokio::test]
+    async fn learn_fast_offline_then_live_persists() {
+        let client: Arc<Client> = create_test_client().await;
+        let lid = "200000000012345";
+        let pn = "5511988887777";
+        let backend = client.persistence_manager.backend();
+
+        client
+            .learn_lid_pn_mapping_fast(lid, pn, LearningSource::PeerPnMessage, true)
+            .await;
+        assert_eq!(client.resolve_encryption_jid(&Jid::pn(pn)).await.user, lid);
+        assert!(
+            backend.get_lid_mapping(lid).await.unwrap().is_none(),
+            "offline learn must not persist"
+        );
+
+        client
+            .learn_lid_pn_mapping_fast(lid, pn, LearningSource::PeerPnMessage, false)
+            .await;
+        // Poll until persisted; tolerate the transient SQLite read/write lock
+        // while the detached persist task is mid-write.
+        let start = wacore::time::Instant::now();
+        while !matches!(backend.get_lid_mapping(lid).await, Ok(Some(_))) {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(5),
+                "live learn after an offline-only learn must persist"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
     }
 
     /// Batched variant must populate the in-memory cache synchronously for

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -97,12 +97,12 @@ impl Client {
         source: LearningSource,
         is_offline: bool,
     ) {
-        // Skip the per-message re-record/re-persist only once this exact pair is
-        // durably persisted (pair-specific marker, so an offline-only learn and a
-        // remap or failed-remap write both fall through to persist) and still
-        // cache-resolvable (so an evicted entry re-warms). `source` drift is
-        // ignored (best-effort metadata).
-        if self.lid_pn_cache.is_persisted(phone_number, lid).await
+        // Skip the per-message re-record/re-persist only once the mapping is both
+        // durably persisted (so an offline-only learn still persists on its first
+        // live message, and a remap clears the marker via `add` to re-persist)
+        // and cache-resolvable to this exact lid (so a remap or an evicted entry
+        // re-warms). `source` drift is ignored (best-effort metadata).
+        if self.lid_pn_cache.is_persisted(phone_number).await
             && self
                 .lid_pn_cache
                 .get_current_lid(phone_number)
@@ -240,7 +240,7 @@ impl Client {
         // After the write, not before: a failed persist stays un-marked so the
         // next live message retries instead of skipping.
         self.lid_pn_cache
-            .mark_persisted(&storage_entry.phone_number, &storage_entry.lid)
+            .mark_persisted(&storage_entry.phone_number)
             .await;
 
         if is_new_mapping {
@@ -287,9 +287,7 @@ impl Client {
             .map_err(|e| anyhow!("persisting LID-PN mapping batch: {e}"))?;
 
         for (entry, is_new) in storage.iter().zip(is_new_flags.iter()) {
-            self.lid_pn_cache
-                .mark_persisted(&entry.phone_number, &entry.lid)
-                .await;
+            self.lid_pn_cache.mark_persisted(&entry.phone_number).await;
             if *is_new {
                 self.migrate_device_registry_on_lid_discovery(&entry.phone_number, &entry.lid)
                     .await;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -97,13 +97,12 @@ impl Client {
         source: LearningSource,
         is_offline: bool,
     ) {
-        // Skip the per-message re-record/re-persist only once the pair is both
-        // durably persisted and cache-resolvable. Gating on persistence (not
-        // just cache presence) is what keeps an offline replay, which warms the
-        // cache memory-only, from making this path swallow the first live
-        // message's persist. The cache check still re-runs on a remap or an
-        // evicted entry; `source` drift is ignored (best-effort metadata).
-        if self.lid_pn_cache.is_persisted(phone_number).await
+        // Skip the per-message re-record/re-persist only once this exact pair is
+        // durably persisted (pair-specific marker, so an offline-only learn and a
+        // remap or failed-remap write both fall through to persist) and still
+        // cache-resolvable (so an evicted entry re-warms). `source` drift is
+        // ignored (best-effort metadata).
+        if self.lid_pn_cache.is_persisted(phone_number, lid).await
             && self
                 .lid_pn_cache
                 .get_current_lid(phone_number)
@@ -241,7 +240,7 @@ impl Client {
         // After the write, not before: a failed persist stays un-marked so the
         // next live message retries instead of skipping.
         self.lid_pn_cache
-            .mark_persisted(&storage_entry.phone_number)
+            .mark_persisted(&storage_entry.phone_number, &storage_entry.lid)
             .await;
 
         if is_new_mapping {
@@ -288,7 +287,9 @@ impl Client {
             .map_err(|e| anyhow!("persisting LID-PN mapping batch: {e}"))?;
 
         for (entry, is_new) in storage.iter().zip(is_new_flags.iter()) {
-            self.lid_pn_cache.mark_persisted(&entry.phone_number).await;
+            self.lid_pn_cache
+                .mark_persisted(&entry.phone_number, &entry.lid)
+                .await;
             if *is_new {
                 self.migrate_device_registry_on_lid_discovery(&entry.phone_number, &entry.lid)
                     .await;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -103,12 +103,7 @@ impl Client {
         // and cache-resolvable to this exact lid (so a remap or an evicted entry
         // re-warms). `source` drift is ignored (best-effort metadata).
         if self.lid_pn_cache.is_persisted(phone_number).await
-            && self
-                .lid_pn_cache
-                .get_current_lid(phone_number)
-                .await
-                .as_deref()
-                == Some(lid)
+            && self.lid_pn_cache.current_lid_is(phone_number, lid).await
         {
             return;
         }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -97,6 +97,22 @@ impl Client {
         source: LearningSource,
         is_offline: bool,
     ) {
+        // Steady-state hot path: every incoming message re-asserts the
+        // sender's own LID↔PN pair, which never changes once learned. Skip
+        // re-allocating the entry, re-inserting both cache maps, and spawning
+        // the (no-op upsert) persist task when the mapping is already current.
+        // `add` always writes the LID→PN side too, so PN→LID == lid implies the
+        // pair is fully cached; a genuine remap (different lid) still falls
+        // through. `source` drift is intentionally ignored (best-effort metadata).
+        if self
+            .lid_pn_cache
+            .get_current_lid(phone_number)
+            .await
+            .as_deref()
+            == Some(lid)
+        {
+            return;
+        }
         let (entry, is_new_mapping) = self
             .record_lid_pn_in_memory(lid, phone_number, source)
             .await;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -97,12 +97,11 @@ impl Client {
         source: LearningSource,
         is_offline: bool,
     ) {
-        // Skip the per-message re-record/re-persist only once the mapping is both
-        // durably persisted (so an offline-only learn still persists on its first
-        // live message, and a remap clears the marker via `add` to re-persist)
-        // and cache-resolvable to this exact lid (so a remap or an evicted entry
-        // re-warms). `source` drift is ignored (best-effort metadata).
-        if self.lid_pn_cache.is_persisted(phone_number).await
+        // Skip the per-message re-record/re-persist only once this exact pair is
+        // durably persisted (so an offline-only learn and a remap, including one
+        // whose write failed, still persist) and cache-resolvable (so an evicted
+        // entry re-warms). `source` drift is ignored (best-effort metadata).
+        if self.lid_pn_cache.is_persisted(phone_number, lid).await
             && self.lid_pn_cache.current_lid_is(phone_number, lid).await
         {
             return;
@@ -167,6 +166,13 @@ impl Client {
         let mut entries: Vec<LidPnEntry> = Vec::with_capacity(deduped.len());
         let mut is_new_flags: Vec<bool> = Vec::with_capacity(deduped.len());
         for (phone_number, lid) in deduped {
+            // Same fast path as the single-entry learn: an already durable and
+            // cache-resolvable pair needs no re-add, re-persist or migration.
+            if self.lid_pn_cache.is_persisted(&phone_number, &lid).await
+                && self.lid_pn_cache.current_lid_is(&phone_number, &lid).await
+            {
+                continue;
+            }
             let is_new = self
                 .lid_pn_cache
                 .get_current_lid(&phone_number)
@@ -178,7 +184,8 @@ impl Client {
             is_new_flags.push(is_new);
         }
 
-        if is_offline {
+        // Every pair was already durable; nothing to persist or migrate.
+        if is_offline || entries.is_empty() {
             return;
         }
 
@@ -235,7 +242,7 @@ impl Client {
         // After the write, not before: a failed persist stays un-marked so the
         // next live message retries instead of skipping.
         self.lid_pn_cache
-            .mark_persisted(&storage_entry.phone_number)
+            .mark_persisted(&storage_entry.phone_number, &storage_entry.lid)
             .await;
 
         if is_new_mapping {
@@ -282,7 +289,9 @@ impl Client {
             .map_err(|e| anyhow!("persisting LID-PN mapping batch: {e}"))?;
 
         for (entry, is_new) in storage.iter().zip(is_new_flags.iter()) {
-            self.lid_pn_cache.mark_persisted(&entry.phone_number).await;
+            self.lid_pn_cache
+                .mark_persisted(&entry.phone_number, &entry.lid)
+                .await;
             if *is_new {
                 self.migrate_device_registry_on_lid_discovery(&entry.phone_number, &entry.lid)
                     .await;

--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -82,7 +82,10 @@ fn create_chat_lane(client: &Arc<Client>) -> ChatLane {
                 }
                 let start = wacore::time::Instant::now();
                 let client = client_for_worker.clone();
-                Box::pin(client.handle_incoming_message(msg_node)).await;
+                // Awaited inline (not boxed): the future lives in this
+                // once-per-chat worker task instead of a fresh ~31 KB heap box
+                // per message, which dominated per-message allocation churn.
+                client.handle_incoming_message(msg_node).await;
                 let elapsed = start.elapsed();
                 if elapsed.as_millis() as u64 > MAX_MESSAGE_DELAY_MS {
                     warn!(

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -41,14 +41,14 @@ pub struct LidPnCache {
     lid_to_entry: TypedCache<String, Arc<LidPnEntry>>,
     /// Phone number -> Entry mapping (stores the most recent LID for that PN)
     pn_to_entry: TypedCache<String, Arc<LidPnEntry>>,
-    /// PNs this process has durably persisted. Lets the learn hot path skip a
-    /// re-persist without swallowing the first live persist of a mapping an
-    /// offline replay only warmed in memory. `add` clears the marker when a PN
-    /// remaps to a new LID, so a failed remap write re-persists instead of
-    /// resting on a stale marker. Unit value: the hot-path check never clones a
-    /// payload. In-memory only; cold after restart just replays the idempotent
-    /// upsert.
-    persisted: TypedCache<String, ()>,
+    /// PN -> the LID this process durably persisted for it. Lets the learn hot
+    /// path skip a re-persist without swallowing the first live persist of a
+    /// mapping an offline replay only warmed in memory. Keyed by the pair so a
+    /// remap (or a stale detached write that marks late) only matches its own
+    /// LID, never a newer un-persisted one. `Arc<str>` value: the hot-path check
+    /// clones a refcount and compares in place, no payload copy. In-memory only;
+    /// cold after restart just replays the idempotent upsert.
+    persisted: TypedCache<String, Arc<str>>,
 }
 
 impl Default for LidPnCache {
@@ -145,17 +145,10 @@ impl LidPnCache {
     /// number can race. This is acceptable because the cache is best-effort
     /// and backed by persistent storage for correctness.
     pub async fn add(&self, entry: &LidPnEntry) {
-        let existing = self.pn_to_entry.get(entry.phone_number.as_str()).await;
-        let should_update_pn = match &existing {
-            Some(e) => e.created_at <= entry.created_at,
+        let should_update_pn = match self.pn_to_entry.get(entry.phone_number.as_str()).await {
+            Some(existing) => existing.created_at <= entry.created_at,
             None => true,
         };
-
-        // A PN remapping to a new LID makes the persisted marker stale; clear it
-        // so the new LID re-persists (and a failed remap write keeps retrying).
-        if should_update_pn && existing.is_some_and(|e| e.lid != entry.lid) {
-            self.persisted.invalidate(entry.phone_number.as_str()).await;
-        }
 
         // One heap copy of the entry, shared by both maps via the Arc refcount.
         let shared = Arc::new(entry.clone());
@@ -171,15 +164,20 @@ impl LidPnCache {
         }
     }
 
-    /// Whether this process has durably persisted the current mapping for
-    /// `phone`. Clones no payload; relies on `add` clearing the marker on a
-    /// remap so it never reports a not-yet-persisted LID as persisted.
-    pub(crate) async fn is_persisted(&self, phone: &str) -> bool {
-        self.persisted.get(phone).await.is_some()
+    /// Whether this process has durably persisted exactly `phone -> lid`.
+    /// Pair-keyed so a remap, or a stale detached write marking late, never
+    /// reports a newer un-persisted LID as persisted. Clones no payload.
+    pub(crate) async fn is_persisted(&self, phone: &str, lid: &str) -> bool {
+        self.persisted
+            .get(phone)
+            .await
+            .is_some_and(|stored| stored.as_ref() == lid)
     }
 
-    pub(crate) async fn mark_persisted(&self, phone: &str) {
-        self.persisted.insert(phone.to_string(), ()).await;
+    pub(crate) async fn mark_persisted(&self, phone: &str, lid: &str) {
+        self.persisted
+            .insert(phone.to_string(), Arc::from(lid))
+            .await;
     }
 
     /// Warm up the cache with entries from persistent storage.
@@ -385,32 +383,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remap_clears_persisted_marker() {
+    async fn persisted_marker_is_pair_specific() {
         let cache = LidPnCache::new();
         let pn = "559980000099";
-        cache
-            .add(&LidPnEntry::new(
-                "100000000000001".to_string(),
-                pn.to_string(),
-                LearningSource::PeerPnMessage,
-            ))
-            .await;
-        cache.mark_persisted(pn).await;
-        assert!(cache.is_persisted(pn).await);
-
-        // Remapping the PN to a new LID must clear the marker so the new mapping
-        // re-persists (and a failed remap write keeps retrying).
-        cache
-            .add(&LidPnEntry::new(
-                "100000000000002".to_string(),
-                pn.to_string(),
-                LearningSource::PeerPnMessage,
-            ))
-            .await;
-        assert!(
-            !cache.is_persisted(pn).await,
-            "remap must clear the persisted marker"
-        );
+        let (lid_a, lid_b) = ("100000000000001", "100000000000002");
+        assert!(!cache.is_persisted(pn, lid_a).await);
+        cache.mark_persisted(pn, lid_a).await;
+        assert!(cache.is_persisted(pn, lid_a).await);
+        // A remap to a new LID is not persisted (even a stale mark of the old
+        // LID never satisfies the new pair), so it re-persists.
+        assert!(!cache.is_persisted(pn, lid_b).await);
     }
 
     #[test]

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -105,6 +105,15 @@ impl LidPnCache {
         self.pn_to_entry.get(phone).await.map(|e| e.lid.clone())
     }
 
+    /// Whether the cached LID for `phone` equals `lid`, comparing in place
+    /// instead of cloning the LID out like `get_current_lid(..) == Some(lid)`.
+    pub(crate) async fn current_lid_is(&self, phone: &str, lid: &str) -> bool {
+        self.pn_to_entry
+            .get(phone)
+            .await
+            .is_some_and(|e| e.lid == lid)
+    }
+
     /// Get the phone number for a LID.
     ///
     /// Returns the phone number user part if a mapping exists, None otherwise.

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -36,15 +36,18 @@ const NS_PN: &str = "lid_pn_by_pn";
 ///
 /// The cache is thread-safe and can be shared across async tasks.
 pub struct LidPnCache {
-    /// LID -> Entry mapping
-    lid_to_entry: TypedCache<String, LidPnEntry>,
+    /// LID -> Entry mapping. `Arc` so the hot `get_*` lookups clone a refcount,
+    /// not the entry's two `String`s; only the owned-`LidPnEntry` accessors deep-clone.
+    lid_to_entry: TypedCache<String, Arc<LidPnEntry>>,
     /// Phone number -> Entry mapping (stores the most recent LID for that PN)
-    pn_to_entry: TypedCache<String, LidPnEntry>,
-    /// PNs this process has durably persisted. Lets the learn hot path skip a
-    /// re-persist without swallowing the first live persist of a mapping that an
-    /// offline replay only warmed in memory. In-memory only; cold after restart
-    /// just replays the idempotent upsert.
-    persisted: TypedCache<String, ()>,
+    pn_to_entry: TypedCache<String, Arc<LidPnEntry>>,
+    /// PN -> the LID this process has durably persisted for it. Lets the learn
+    /// hot path skip a re-persist without swallowing the first live persist of a
+    /// mapping an offline replay only warmed in memory. Keyed by the pair (not
+    /// PN-only) so a remap whose background write failed still re-persists
+    /// instead of resting on the stale marker. In-memory only; cold after
+    /// restart just replays the idempotent upsert.
+    persisted: TypedCache<String, String>,
 }
 
 impl Default for LidPnCache {
@@ -113,12 +116,12 @@ impl LidPnCache {
 
     /// Get the full entry for a LID.
     pub async fn get_entry_by_lid(&self, lid: &str) -> Option<LidPnEntry> {
-        self.lid_to_entry.get(lid).await
+        self.lid_to_entry.get(lid).await.map(|e| (*e).clone())
     }
 
     /// Get the full entry for a phone number.
     pub async fn get_entry_by_phone(&self, phone: &str) -> Option<LidPnEntry> {
-        self.pn_to_entry.get(phone).await
+        self.pn_to_entry.get(phone).await.map(|e| (*e).clone())
     }
 
     /// Add or update a mapping in the cache.
@@ -138,28 +141,30 @@ impl LidPnCache {
             None => true,
         };
 
-        // Update LID -> Entry map
+        // One heap copy of the entry, shared by both maps via the Arc refcount.
+        let shared = Arc::new(entry.clone());
         self.lid_to_entry
-            .insert(entry.lid.clone(), entry.clone())
+            .insert(entry.lid.clone(), Arc::clone(&shared))
             .await;
 
         // Update PN -> Entry map (only if newer or equal timestamp)
         if should_update_pn {
             self.pn_to_entry
-                .insert(entry.phone_number.clone(), entry.clone())
+                .insert(entry.phone_number.clone(), shared)
                 .await;
         }
     }
 
-    /// Whether this process has durably persisted a mapping for `phone`.
-    /// Presence-only; pair with [`get_current_lid`](Self::get_current_lid) so a
-    /// remap (same PN, new LID) still re-persists.
-    pub(crate) async fn is_persisted(&self, phone: &str) -> bool {
-        self.persisted.get(phone).await.is_some()
+    /// Whether this process has durably persisted exactly `phone -> lid`.
+    /// Pair-specific so a remap (or a remap whose write failed) re-persists.
+    pub(crate) async fn is_persisted(&self, phone: &str, lid: &str) -> bool {
+        self.persisted.get(phone).await.as_deref() == Some(lid)
     }
 
-    pub(crate) async fn mark_persisted(&self, phone: &str) {
-        self.persisted.insert(phone.to_string(), ()).await;
+    pub(crate) async fn mark_persisted(&self, phone: &str, lid: &str) {
+        self.persisted
+            .insert(phone.to_string(), lid.to_string())
+            .await;
     }
 
     /// Warm up the cache with entries from persistent storage.
@@ -362,6 +367,17 @@ mod tests {
         assert_eq!(cache.lid_count().await, 0);
         assert_eq!(cache.pn_count().await, 0);
         assert!(cache.get_current_lid("559980000001").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn persisted_marker_is_pair_specific() {
+        let cache = LidPnCache::new();
+        let pn = "559980000099";
+        assert!(!cache.is_persisted(pn, "100000000000001").await);
+        cache.mark_persisted(pn, "100000000000001").await;
+        assert!(cache.is_persisted(pn, "100000000000001").await);
+        // A remap to a different LID is not persisted, so it re-persists.
+        assert!(!cache.is_persisted(pn, "100000000000002").await);
     }
 
     #[test]

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -40,6 +40,11 @@ pub struct LidPnCache {
     lid_to_entry: TypedCache<String, LidPnEntry>,
     /// Phone number -> Entry mapping (stores the most recent LID for that PN)
     pn_to_entry: TypedCache<String, LidPnEntry>,
+    /// PNs this process has durably persisted. Lets the learn hot path skip a
+    /// re-persist without swallowing the first live persist of a mapping that an
+    /// offline replay only warmed in memory. In-memory only; cold after restart
+    /// just replays the idempotent upsert.
+    persisted: TypedCache<String, ()>,
 }
 
 impl Default for LidPnCache {
@@ -68,10 +73,14 @@ impl LidPnCache {
             Some(s) => Self {
                 lid_to_entry: TypedCache::from_store(s.clone(), NS_LID, config.timeout),
                 pn_to_entry: TypedCache::from_store(s, NS_PN, config.timeout),
+                // Always in-memory: tracks per-process persist state, never the
+                // mapping itself, so it must not go through the shared store.
+                persisted: TypedCache::from_moka(config.build_with_tti()),
             },
             None => Self {
                 lid_to_entry: TypedCache::from_moka(config.build_with_tti()),
                 pn_to_entry: TypedCache::from_moka(config.build_with_tti()),
+                persisted: TypedCache::from_moka(config.build_with_tti()),
             },
         }
     }
@@ -142,6 +151,17 @@ impl LidPnCache {
         }
     }
 
+    /// Whether this process has durably persisted a mapping for `phone`.
+    /// Presence-only; pair with [`get_current_lid`](Self::get_current_lid) so a
+    /// remap (same PN, new LID) still re-persists.
+    pub(crate) async fn is_persisted(&self, phone: &str) -> bool {
+        self.persisted.get(phone).await.is_some()
+    }
+
+    pub(crate) async fn mark_persisted(&self, phone: &str) {
+        self.persisted.insert(phone.to_string(), ()).await;
+    }
+
     /// Warm up the cache with entries from persistent storage.
     ///
     /// This should be called during client initialization to populate
@@ -169,6 +189,7 @@ impl LidPnCache {
     pub async fn clear(&self) {
         self.lid_to_entry.clear().await;
         self.pn_to_entry.clear().await;
+        self.persisted.clear().await;
     }
 
     /// Get the number of LID entries in the cache.

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -41,13 +41,14 @@ pub struct LidPnCache {
     lid_to_entry: TypedCache<String, Arc<LidPnEntry>>,
     /// Phone number -> Entry mapping (stores the most recent LID for that PN)
     pn_to_entry: TypedCache<String, Arc<LidPnEntry>>,
-    /// PN -> the LID this process has durably persisted for it. Lets the learn
-    /// hot path skip a re-persist without swallowing the first live persist of a
-    /// mapping an offline replay only warmed in memory. Keyed by the pair (not
-    /// PN-only) so a remap whose background write failed still re-persists
-    /// instead of resting on the stale marker. In-memory only; cold after
-    /// restart just replays the idempotent upsert.
-    persisted: TypedCache<String, String>,
+    /// PNs this process has durably persisted. Lets the learn hot path skip a
+    /// re-persist without swallowing the first live persist of a mapping an
+    /// offline replay only warmed in memory. `add` clears the marker when a PN
+    /// remaps to a new LID, so a failed remap write re-persists instead of
+    /// resting on a stale marker. Unit value: the hot-path check never clones a
+    /// payload. In-memory only; cold after restart just replays the idempotent
+    /// upsert.
+    persisted: TypedCache<String, ()>,
 }
 
 impl Default for LidPnCache {
@@ -135,11 +136,17 @@ impl LidPnCache {
     /// number can race. This is acceptable because the cache is best-effort
     /// and backed by persistent storage for correctness.
     pub async fn add(&self, entry: &LidPnEntry) {
-        // Check if PN map needs update first
-        let should_update_pn = match self.pn_to_entry.get(entry.phone_number.as_str()).await {
-            Some(existing) => existing.created_at <= entry.created_at,
+        let existing = self.pn_to_entry.get(entry.phone_number.as_str()).await;
+        let should_update_pn = match &existing {
+            Some(e) => e.created_at <= entry.created_at,
             None => true,
         };
+
+        // A PN remapping to a new LID makes the persisted marker stale; clear it
+        // so the new LID re-persists (and a failed remap write keeps retrying).
+        if should_update_pn && existing.is_some_and(|e| e.lid != entry.lid) {
+            self.persisted.invalidate(entry.phone_number.as_str()).await;
+        }
 
         // One heap copy of the entry, shared by both maps via the Arc refcount.
         let shared = Arc::new(entry.clone());
@@ -155,16 +162,15 @@ impl LidPnCache {
         }
     }
 
-    /// Whether this process has durably persisted exactly `phone -> lid`.
-    /// Pair-specific so a remap (or a remap whose write failed) re-persists.
-    pub(crate) async fn is_persisted(&self, phone: &str, lid: &str) -> bool {
-        self.persisted.get(phone).await.as_deref() == Some(lid)
+    /// Whether this process has durably persisted the current mapping for
+    /// `phone`. Clones no payload; relies on `add` clearing the marker on a
+    /// remap so it never reports a not-yet-persisted LID as persisted.
+    pub(crate) async fn is_persisted(&self, phone: &str) -> bool {
+        self.persisted.get(phone).await.is_some()
     }
 
-    pub(crate) async fn mark_persisted(&self, phone: &str, lid: &str) {
-        self.persisted
-            .insert(phone.to_string(), lid.to_string())
-            .await;
+    pub(crate) async fn mark_persisted(&self, phone: &str) {
+        self.persisted.insert(phone.to_string(), ()).await;
     }
 
     /// Warm up the cache with entries from persistent storage.
@@ -370,14 +376,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persisted_marker_is_pair_specific() {
+    async fn remap_clears_persisted_marker() {
         let cache = LidPnCache::new();
         let pn = "559980000099";
-        assert!(!cache.is_persisted(pn, "100000000000001").await);
-        cache.mark_persisted(pn, "100000000000001").await;
-        assert!(cache.is_persisted(pn, "100000000000001").await);
-        // A remap to a different LID is not persisted, so it re-persists.
-        assert!(!cache.is_persisted(pn, "100000000000002").await);
+        cache
+            .add(&LidPnEntry::new(
+                "100000000000001".to_string(),
+                pn.to_string(),
+                LearningSource::PeerPnMessage,
+            ))
+            .await;
+        cache.mark_persisted(pn).await;
+        assert!(cache.is_persisted(pn).await);
+
+        // Remapping the PN to a new LID must clear the marker so the new mapping
+        // re-persists (and a failed remap write keeps retrying).
+        cache
+            .add(&LidPnEntry::new(
+                "100000000000002".to_string(),
+                pn.to_string(),
+                LearningSource::PeerPnMessage,
+            ))
+            .await;
+        assert!(
+            !cache.is_persisted(pn).await,
+            "remap must clear the persisted marker"
+        );
     }
 
     #[test]

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -105,13 +105,25 @@ impl LidPnCache {
         self.pn_to_entry.get(phone).await.map(|e| e.lid.clone())
     }
 
-    /// Whether the cached LID for `phone` equals `lid`, comparing in place
-    /// instead of cloning the LID out like `get_current_lid(..) == Some(lid)`.
-    pub(crate) async fn current_lid_is(&self, phone: &str, lid: &str) -> bool {
-        self.pn_to_entry
-            .get(phone)
-            .await
-            .is_some_and(|e| e.lid == lid)
+    /// Whether the learn fast path can skip re-recording `phone <-> lid`: the
+    /// pair is durably persisted AND resolvable in BOTH cache directions.
+    /// Requiring both directions means skipping never leaves the reverse
+    /// (LID -> PN) lookup cold under a configured eviction; that lookup
+    /// (`get_phone_number`, e.g. in PN->LID session migration) has no backend
+    /// fallback. All checks compare in place over the Arc-shared values, no
+    /// payload clone.
+    pub(crate) async fn can_skip_relearn(&self, phone: &str, lid: &str) -> bool {
+        self.is_persisted(phone, lid).await
+            && self
+                .pn_to_entry
+                .get(phone)
+                .await
+                .is_some_and(|e| e.lid == lid)
+            && self
+                .lid_to_entry
+                .get(lid)
+                .await
+                .is_some_and(|e| e.phone_number == phone)
     }
 
     /// Get the phone number for a LID.
@@ -393,6 +405,29 @@ mod tests {
         // A remap to a new LID is not persisted (even a stale mark of the old
         // LID never satisfies the new pair), so it re-persists.
         assert!(!cache.is_persisted(pn, lid_b).await);
+    }
+
+    #[tokio::test]
+    async fn skip_requires_both_cache_directions() {
+        let cache = LidPnCache::new();
+        let (pn, lid) = ("559980000099", "100000000000001");
+        cache
+            .add(&LidPnEntry::new(
+                lid.to_string(),
+                pn.to_string(),
+                LearningSource::PeerPnMessage,
+            ))
+            .await;
+        cache.mark_persisted(pn, lid).await;
+        assert!(cache.can_skip_relearn(pn, lid).await);
+
+        // Evict the reverse (LID -> PN) entry: the fast path must stop skipping
+        // so the next live message re-warms it (get_phone_number has no fallback).
+        cache.lid_to_entry.invalidate(lid).await;
+        assert!(
+            !cache.can_skip_relearn(pn, lid).await,
+            "skip must require the reverse map, not just PN -> LID"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Two targeted reductions of per-message allocation churn on the hot message path (receive/decrypt + send), found by profiling the ping/pong scenario with `dhat`.

1. **Stop boxing the per-message handler future (`handlers::message`).** The per-chat worker awaited `handle_incoming_message` through a fresh `Box::pin` on every message. Awaiting it inline lets the future live in the once-per-chat worker task instead of allocating a ~31 KB heap box per message.

2. **Skip the redundant LID-PN re-learn on the steady-state path (`client::lid_pn`).** Every incoming message re-asserts the sender's own LID to PN mapping, which never changes once learned. `learn_lid_pn_mapping_fast` now returns early when the mapping is already current (`get_current_lid(pn) == Some(lid)`), so it no longer re-allocates the cache entry, re-inserts both cache maps, or spawns a per-message persist task (a no-op upsert). A genuine remap to a different LID still takes the full path.

## Why

These were the two largest library-attributable allocators in the ping/pong dhat profile, and both were pure overhead: the worker box was allocated only to be awaited inline, and the LID-PN re-learn re-did identical work on every message in the steady state. Neither carried any functional benefit.

## Results

Measured with `dhat` on the ping/pong scenario (10000 messages at 1000/s). The peak live heap is tiny (~10 MB), so the target is per-message allocation churn (malloc/free CPU), not retention.

| metric | before | after |
|---|---|---|
| total allocated | 1823 MB | 1435 MB (about -21%) |
| bytes per message | 203 KB | 150 KB (about -26%) |
| allocations per message | 396 | 337 (about -15%) |

Per call site: the worker box drops from 310 MB to 0; `LidPnCache::add` drops from 43 MB / 140k allocations to 0.01 MB / 68; the LID-PN learn path drops from 24.7 MB to 0.6 MB. Under dhat instrumentation the optimized client delivered all 10000 replies (0 dropped) versus 9427 on the baseline, so it allocated less while doing more work.

## Compatibility

No breaking changes and no behavior change. The worker still processes one message at a time per chat in arrival order. The LID-PN early-return only skips work when the cached mapping already equals what the message asserts; a different LID still falls through to the existing record / persist / migrate path, and `is_new_mapping` (which gates migration) is computed exactly as before. The learning-source metadata is intentionally not refreshed on an unchanged mapping.

## Tests

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p whatsapp-rust --lib` (654 passing), including `test_lid_pn_cache_handles_repeated_messages` which exercises the early-return path and `test_learn_lid_pn_mapping_fast_populates_cache_synchronously` for the first-learn path.
