### PR TITLE
feat: WA Web phash parity — usync device_hash (#3), group-metadata phash (#7), bcl hash validation (#6)

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -6,11 +6,12 @@ use wacore::iq::groups::{
     AcceptGroupInviteIq, AcceptGroupInviteV4Iq, AcknowledgeGroupIq, AddParticipantsIq,
     BatchGetGroupInfoIq, CancelMembershipRequestsIq, DemoteParticipantsIq, GetGroupInviteInfoIq,
     GetGroupInviteLinkIq, GetGroupProfilePicturesIq, GetMembershipRequestsIq, GroupCreateIq,
-    GroupInfoResponse, GroupParticipantResponse, GroupParticipatingIq, GroupQueryIq, LeaveGroupIq,
-    MembershipRequestActionIq, PromoteParticipantsIq, RemoveParticipantsIq, RevokeRequestCodeIq,
-    SetAllowAdminReportsIq, SetGroupAnnouncementIq, SetGroupDescriptionIq, SetGroupEphemeralIq,
-    SetGroupHistoryIq, SetGroupLockedIq, SetGroupMembershipApprovalIq, SetGroupSubjectIq,
-    SetMemberAddModeIq, SetNoFrequentlyForwardedIq, normalize_participants,
+    GroupInfoOutcome, GroupInfoResponse, GroupParticipantResponse, GroupParticipatingIq,
+    GroupQueryIq, LeaveGroupIq, MembershipRequestActionIq, PromoteParticipantsIq,
+    RemoveParticipantsIq, RevokeRequestCodeIq, SetAllowAdminReportsIq, SetGroupAnnouncementIq,
+    SetGroupDescriptionIq, SetGroupEphemeralIq, SetGroupHistoryIq, SetGroupLockedIq,
+    SetGroupMembershipApprovalIq, SetGroupSubjectIq, SetMemberAddModeIq,
+    SetNoFrequentlyForwardedIq, normalize_participants,
 };
 use wacore::types::message::AddressingMode;
 use wacore_binary::{Jid, JidExt as _};
@@ -191,7 +192,37 @@ impl<'a> Groups<'a> {
             return Ok(cached);
         }
 
-        let group = self.client.execute(GroupQueryIq::new(jid)).await?;
+        // Send the persisted participant phash (WA Web queryGroup phash) so the
+        // server can answer "not-modified" by omitting <group> for an unchanged
+        // group, letting us reuse the persisted metadata instead of re-parsing it.
+        let jid_str = jid.to_string();
+        let backend = self.client.persistence_manager.backend();
+        let persisted: Option<GroupInfo> = match backend.get_group_metadata(&jid_str).await {
+            Ok(Some(blob)) => serde_json::from_slice(&blob).ok(),
+            _ => None,
+        };
+        let phash = persisted.as_ref().and_then(|info| {
+            wacore::messages::MessageUtils::participant_list_hash(&info.participants).ok()
+        });
+
+        let group = match self
+            .client
+            .execute(GroupQueryIq::with_phash(jid, phash))
+            .await?
+        {
+            GroupInfoOutcome::NotModified => {
+                let info = persisted.ok_or_else(|| {
+                    anyhow::anyhow!("server returned not-modified group but nothing was cached")
+                })?;
+                self.client
+                    .get_group_cache()
+                    .await
+                    .insert(jid.clone(), info.clone())
+                    .await;
+                return Ok(info);
+            }
+            GroupInfoOutcome::Full(group) => *group,
+        };
 
         // Single pass: move participants out and build lid_to_pn_map alongside.
         let n = group.participants.len();
@@ -238,6 +269,17 @@ impl<'a> Groups<'a> {
             info.set_lid_to_pn_map(lid_to_pn_map);
         }
 
+        // Persist so the next query can send this group's participant phash and
+        // skip the full re-query when membership is unchanged.
+        match serde_json::to_vec(&info) {
+            Ok(blob) => {
+                if let Err(e) = backend.put_group_metadata(&jid_str, &blob).await {
+                    log::warn!("Failed to persist group metadata for {jid}: {e}");
+                }
+            }
+            Err(e) => log::warn!("Failed to serialize group metadata for {jid}: {e}"),
+        }
+
         self.client
             .get_group_cache()
             .await
@@ -264,8 +306,13 @@ impl<'a> Groups<'a> {
     }
 
     pub async fn get_metadata(&self, jid: &Jid) -> Result<GroupMetadata, anyhow::Error> {
-        let group = self.client.execute(GroupQueryIq::new(jid)).await?;
-        Ok(GroupMetadata::from(group))
+        // No phash is sent, so the server always returns the full group.
+        match self.client.execute(GroupQueryIq::new(jid)).await? {
+            GroupInfoOutcome::Full(group) => Ok(GroupMetadata::from(*group)),
+            GroupInfoOutcome::NotModified => Err(anyhow::anyhow!(
+                "group query returned not-modified without a phash"
+            )),
+        }
     }
 
     pub async fn create_group(

--- a/src/message.rs
+++ b/src/message.rs
@@ -2441,6 +2441,22 @@ impl Client {
             );
         }
 
+        // WA Web validateBclHash: a self-synced broadcast/status carries a
+        // phashV2 of the broadcast recipients in deviceSentMessage.phash.
+        // Recompute over our <participants> view and warn on divergence. We log
+        // only (no drop) until the participant hash form is confirmed live.
+        if let Some(dsm) = &original_msg.device_sent_message
+            && let Some(expected) = dsm.phash.as_deref()
+            && !info.bcl_participants.is_empty()
+            && !wacore::messages::MessageUtils::validate_bcl_hash(&info.bcl_participants, expected)
+        {
+            warn!(
+                "[msg:{}] bcl hash mismatch on device-sent broadcast (expected={expected}); \
+                 keeping message (validate-only)",
+                info.id,
+            );
+        }
+
         // Unwrap DeviceSentMessage wrapper (self-sent messages synced from
         // the primary device). The actual content (reactions, text, etc.)
         // is nested inside device_sent_message.message and must be
@@ -6237,6 +6253,7 @@ mod tests {
             verified_level: None,
             verified_name_serial: None,
             peer_recipient_pn: None,
+            bcl_participants: Vec::new(),
         }
     }
 

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -448,6 +448,7 @@ impl Client {
             verified_level: None,
             verified_name_serial: None,
             peer_recipient_pn: None,
+            bcl_participants: Vec::new(),
         })
     }
 

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -5,7 +5,7 @@
 use crate::client::Client;
 use log::{debug, warn};
 use std::collections::HashSet;
-use wacore::iq::usync::DeviceListSpec;
+use wacore::iq::usync::{DeviceListResponse, DeviceListSpec};
 use wacore_binary::Jid;
 
 impl Client {
@@ -34,161 +34,184 @@ impl Client {
 
             let response = self.execute(spec).await?;
 
-            // Extract and persist LID mappings from the response
-            for mapping in &response.lid_mappings {
-                if let Err(err) = self
-                    .add_lid_pn_mapping(
-                        &mapping.lid,
-                        &mapping.phone_number,
-                        crate::lid_pn_cache::LearningSource::Usync,
-                    )
-                    .await
-                {
-                    warn!(
-                        "Failed to persist LID {} -> {} from usync: {err}",
-                        mapping.lid, mapping.phone_number,
-                    );
-                    continue;
-                }
-                debug!(
-                    "Learned LID mapping from usync: {} -> {}",
-                    mapping.lid, mapping.phone_number
-                );
-            }
-
-            let mut fetched_devices = Vec::with_capacity(response.device_lists.len());
-            let mut device_records: Vec<wacore::store::traits::DeviceListRecord> =
-                Vec::with_capacity(response.device_lists.len());
-
-            for user_list in &response.device_lists {
-                // Update device registry (single source of truth for device lists).
-                // Preserve key_index values from existing records (set via account_sync)
-                // Use alias-aware lookup (resolves LID ↔ PN) to find
-                // existing record regardless of which key it was stored under
-                let existing_record = self.load_device_record(&user_list.user.user).await;
-
-                let mut existing_key_indices: std::collections::HashMap<u32, Option<u32>> =
-                    existing_record
-                        .as_ref()
-                        .map(|r| {
-                            r.devices
-                                .iter()
-                                .map(|d| (d.device_id, d.key_index))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-
-                // Decode key-index-list if present (WA Web: handleKeyIndexResult)
-                let decoded_key_index = user_list
-                    .key_index_bytes
-                    .as_deref()
-                    .and_then(wacore::adv::decode_key_index_list);
-
-                // Check raw_id mismatch for identity change detection
-                // TODO: also check advAccountType mismatch (see patch_device_add TODO)
-                let mut raw_id = decoded_key_index.as_ref().map(|d| d.raw_id);
-                if let Some(ref decoded) = decoded_key_index
-                    && let Some(ref existing) = existing_record
-                    && let Some(stored_raw_id) = existing.raw_id
-                    && stored_raw_id != decoded.raw_id
-                {
-                    log::info!(
-                        "raw_id mismatch for user {} in usync: stored={stored_raw_id}, received={}. Clearing record.",
-                        user_list.user.user,
-                        decoded.raw_id
-                    );
-                    self.clear_device_record(
-                        &user_list.user.user,
-                        user_list.user.server.as_str(),
-                        existing,
-                    )
-                    .await;
-                    // Old key indices are from the previous identity — don't reuse
-                    existing_key_indices.clear();
-                }
-
-                // Preserve raw_id from existing when usync didn't provide one
-                // (no key-index-list) and no mismatch cleared the indices.
-                // existing_key_indices is empty after a mismatch clear, so this
-                // correctly skips preservation after identity change.
-                if raw_id.is_none() && !existing_key_indices.is_empty() {
-                    raw_id = existing_record.as_ref().and_then(|r| r.raw_id);
-                }
-
-                let mut devices: Vec<wacore::store::traits::DeviceInfo> = user_list
-                    .devices
-                    .iter()
-                    .map(|d| wacore::store::traits::DeviceInfo {
-                        device_id: d.device as u32,
-                        // Server-returned key_index takes priority over cached
-                        key_index: d.key_index.or_else(|| {
-                            existing_key_indices
-                                .get(&(d.device as u32))
-                                .copied()
-                                .flatten()
-                        }),
-                    })
-                    .collect();
-
-                // Apply valid_indexes filtering if key-index-list was decoded
-                if let Some(ref decoded) = decoded_key_index {
-                    devices = wacore::adv::filter_devices_by_key_index(&devices, decoded);
-                }
-
-                // Convert filtered DeviceInfo list back to JIDs for return
-                let user_jid = &user_list.user;
-                for d in &devices {
-                    let mut jid = user_jid.clone();
-                    jid.device = d.device_id as u16;
-                    fetched_devices.push(jid);
-                }
-
-                device_records.push(wacore::store::traits::DeviceListRecord {
-                    user: user_list.user.user.to_string(),
-                    devices,
-                    timestamp: wacore::time::now_secs(),
-                    phash: user_list.phash.clone(),
-                    raw_id,
-                });
-            }
-
-            // One batched backend write for the whole usync response — for
-            // large groups this collapses N spawn_blocking SQLite hops into
-            // a single transaction, which dominated the per-send wall-clock.
-            if let Err(e) = self.update_device_lists(device_records).await {
-                warn!("Failed to update device registry batch: {e}");
-            }
-
+            let fetched_devices = self.process_device_list_response(&response).await;
             all_devices.extend(fetched_devices);
         }
 
         Ok(all_devices)
     }
 
-    /// Sync own device list from the server, bypassing cache.
-    /// Matches WA Web's `syncMyDeviceList()` called during bootstrap.
+    /// Apply a usync device-list response to the registry: persist LID mappings,
+    /// rebuild each returned user's `DeviceListRecord` (preserving key indices and
+    /// handling raw_id identity changes), and batch-write them. Returns the
+    /// resolved device JIDs for the users present in the response.
+    ///
+    /// Users the server OMITS — unchanged ones, when we sent a `device_hash` — are
+    /// simply absent here, so their cached records are left untouched (the
+    /// merge-safe behavior the `device_hash` optimization depends on).
+    async fn process_device_list_response(&self, response: &DeviceListResponse) -> Vec<Jid> {
+        // Extract and persist LID mappings from the response
+        for mapping in &response.lid_mappings {
+            if let Err(err) = self
+                .add_lid_pn_mapping(
+                    &mapping.lid,
+                    &mapping.phone_number,
+                    crate::lid_pn_cache::LearningSource::Usync,
+                )
+                .await
+            {
+                warn!(
+                    "Failed to persist LID {} -> {} from usync: {err}",
+                    mapping.lid, mapping.phone_number,
+                );
+                continue;
+            }
+            debug!(
+                "Learned LID mapping from usync: {} -> {}",
+                mapping.lid, mapping.phone_number
+            );
+        }
+
+        let mut fetched_devices = Vec::with_capacity(response.device_lists.len());
+        let mut device_records: Vec<wacore::store::traits::DeviceListRecord> =
+            Vec::with_capacity(response.device_lists.len());
+
+        for user_list in &response.device_lists {
+            // Update device registry (single source of truth for device lists).
+            // Preserve key_index values from existing records (set via account_sync)
+            // Use alias-aware lookup (resolves LID ↔ PN) to find
+            // existing record regardless of which key it was stored under
+            let existing_record = self.load_device_record(&user_list.user.user).await;
+
+            let mut existing_key_indices: std::collections::HashMap<u32, Option<u32>> =
+                existing_record
+                    .as_ref()
+                    .map(|r| {
+                        r.devices
+                            .iter()
+                            .map(|d| (d.device_id, d.key_index))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+            // Decode key-index-list if present (WA Web: handleKeyIndexResult)
+            let decoded_key_index = user_list
+                .key_index_bytes
+                .as_deref()
+                .and_then(wacore::adv::decode_key_index_list);
+
+            // Check raw_id mismatch for identity change detection
+            // TODO: also check advAccountType mismatch (see patch_device_add TODO)
+            let mut raw_id = decoded_key_index.as_ref().map(|d| d.raw_id);
+            if let Some(ref decoded) = decoded_key_index
+                && let Some(ref existing) = existing_record
+                && let Some(stored_raw_id) = existing.raw_id
+                && stored_raw_id != decoded.raw_id
+            {
+                log::info!(
+                    "raw_id mismatch for user {} in usync: stored={stored_raw_id}, received={}. Clearing record.",
+                    user_list.user.user,
+                    decoded.raw_id
+                );
+                self.clear_device_record(
+                    &user_list.user.user,
+                    user_list.user.server.as_str(),
+                    existing,
+                )
+                .await;
+                // Old key indices are from the previous identity — don't reuse
+                existing_key_indices.clear();
+            }
+
+            // Preserve raw_id from existing when usync didn't provide one
+            // (no key-index-list) and no mismatch cleared the indices.
+            // existing_key_indices is empty after a mismatch clear, so this
+            // correctly skips preservation after identity change.
+            if raw_id.is_none() && !existing_key_indices.is_empty() {
+                raw_id = existing_record.as_ref().and_then(|r| r.raw_id);
+            }
+
+            let mut devices: Vec<wacore::store::traits::DeviceInfo> = user_list
+                .devices
+                .iter()
+                .map(|d| wacore::store::traits::DeviceInfo {
+                    device_id: d.device as u32,
+                    // Server-returned key_index takes priority over cached
+                    key_index: d.key_index.or_else(|| {
+                        existing_key_indices
+                            .get(&(d.device as u32))
+                            .copied()
+                            .flatten()
+                    }),
+                })
+                .collect();
+
+            // Apply valid_indexes filtering if key-index-list was decoded
+            if let Some(ref decoded) = decoded_key_index {
+                devices = wacore::adv::filter_devices_by_key_index(&devices, decoded);
+            }
+
+            // Convert filtered DeviceInfo list back to JIDs for return
+            let user_jid = &user_list.user;
+            for d in &devices {
+                let mut jid = user_jid.clone();
+                jid.device = d.device_id as u16;
+                fetched_devices.push(jid);
+            }
+
+            device_records.push(wacore::store::traits::DeviceListRecord {
+                user: user_list.user.user.to_string(),
+                devices,
+                timestamp: wacore::time::now_secs(),
+                phash: user_list.phash.clone(),
+                raw_id,
+            });
+        }
+
+        // One batched backend write for the whole usync response — for
+        // large groups this collapses N spawn_blocking SQLite hops into
+        // a single transaction, which dominated the per-send wall-clock.
+        if let Err(e) = self.update_device_lists(device_records).await {
+            warn!("Failed to update device registry batch: {e}");
+        }
+
+        fetched_devices
+    }
+
+    /// Re-sync own device list from the server. Mirrors WA Web `syncMyDeviceList`:
+    /// sends the cached per-user `device_hash` so the server answers "unchanged"
+    /// (by omitting the user) instead of returning the full list on every reconnect.
+    /// On a changed list the server returns it and we update; omitted users keep
+    /// their cache.
     pub(crate) async fn sync_own_device_list(&self) -> Result<(), anyhow::Error> {
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
 
         let mut jids = Vec::with_capacity(2);
-        if let Some(ref pn) = device_snapshot.pn {
-            let pn_bare = pn.to_non_ad();
-            self.invalidate_device_cache(&pn_bare.user).await;
-            jids.push(pn_bare);
-        }
-        if let Some(ref lid) = device_snapshot.lid {
-            let lid_bare = lid.to_non_ad();
-            self.invalidate_device_cache(&lid_bare.user).await;
-            jids.push(lid_bare);
+        let mut hashes: std::collections::HashMap<Jid, (String, i64)> =
+            std::collections::HashMap::new();
+        for own in device_snapshot.pn.iter().chain(device_snapshot.lid.iter()) {
+            let bare = own.to_non_ad();
+            // Carry the cached device_hash so an unchanged list is skipped server-side.
+            if let Some(record) = self.load_device_record(&bare.user).await
+                && let Some(phash) = record.phash
+            {
+                hashes.insert(bare.clone(), (phash, record.timestamp));
+            }
+            jids.push(bare);
         }
 
         if jids.is_empty() {
             return Ok(());
         }
 
-        let devices = self.get_user_devices(&jids).await?;
+        let sid = self.generate_request_id();
+        let spec = DeviceListSpec::with_hashes(jids, sid, hashes);
+        let response = self.execute(spec).await?;
+        // `process_device_list_response` only touches users the server actually
+        // returned, so unchanged (omitted) own devices keep their cache.
+        let devices = self.process_device_list_response(&response).await;
         log::info!(
-            "Synced own device list from server: {} devices",
+            "Re-synced own device list: {} device(s) updated",
             devices.len()
         );
         Ok(())
@@ -345,6 +368,70 @@ mod tests {
             count <= 2,
             "Cache should have at most 2 items, has {}",
             count
+        );
+    }
+
+    /// #3 merge-safety: when the server omits an unchanged user (the `device_hash`
+    /// skip), `process_device_list_response` must update only the returned users
+    /// and leave the omitted user's cached devices untouched.
+    #[tokio::test]
+    async fn process_response_preserves_omitted_users() {
+        use wacore::iq::usync::DeviceListResponse;
+        use wacore::usync::{UserDeviceList, UsyncDevice};
+
+        let client = create_test_client().await;
+
+        // Seed user B in the registry (will be the "unchanged/omitted" one).
+        client
+            .update_device_list(DeviceListRecord {
+                user: "2222222222".into(),
+                devices: vec![
+                    DeviceInfo {
+                        device_id: 0,
+                        key_index: None,
+                    },
+                    DeviceInfo {
+                        device_id: 7,
+                        key_index: None,
+                    },
+                ],
+                timestamp: wacore::time::now_secs(),
+                phash: Some("2:oldB".to_string()),
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        // Response only contains user A — B is omitted (unchanged).
+        let response = DeviceListResponse {
+            device_lists: vec![UserDeviceList {
+                user: "1111111111@s.whatsapp.net".parse().unwrap(),
+                devices: vec![UsyncDevice {
+                    device: 0,
+                    key_index: None,
+                }],
+                phash: Some("2:a".to_string()),
+                key_index_bytes: None,
+            }],
+            lid_mappings: vec![],
+        };
+
+        let fetched = client.process_device_list_response(&response).await;
+        assert!(
+            fetched.iter().any(|j| j.user == "1111111111"),
+            "returned user A must be resolved"
+        );
+
+        // B's cache is preserved (still 2 devices) — not wiped by the omission.
+        let b_jid: Jid = "2222222222@s.whatsapp.net".parse().unwrap();
+        let b_devices = client
+            .get_devices_from_registry(&b_jid)
+            .await
+            .expect("omitted user B must keep its cached record");
+        assert_eq!(
+            b_devices.len(),
+            2,
+            "omitted user's devices must be preserved"
         );
     }
 }

--- a/storages/sqlite-storage/migrations/2026-06-01-000000_add_group_metadata/down.sql
+++ b/storages/sqlite-storage/migrations/2026-06-01-000000_add_group_metadata/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS group_metadata;

--- a/storages/sqlite-storage/migrations/2026-06-01-000000_add_group_metadata/up.sql
+++ b/storages/sqlite-storage/migrations/2026-06-01-000000_add_group_metadata/up.sql
@@ -1,0 +1,12 @@
+-- Persisted group metadata for the participant-phash re-query optimization
+-- (WA Web GroupParticipant.computeGroupParticipantsHash + queryGroup phash).
+-- `info` is an opaque, caller-serialized GroupInfo snapshot. On a cache miss we
+-- send a phash computed from it so the server can answer "not-modified" by
+-- omitting <group> instead of returning the full metadata.
+CREATE TABLE group_metadata (
+    group_jid TEXT NOT NULL,
+    info BLOB NOT NULL,
+    device_id INTEGER NOT NULL DEFAULT 1,
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    PRIMARY KEY (group_jid, device_id)
+);

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -49,6 +49,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    group_metadata (group_jid, device_id) {
+        group_jid -> Text,
+        info -> Binary,
+        device_id -> Integer,
+        updated_at -> BigInt,
+    }
+}
+
+diesel::table! {
     device (id) {
         id -> Integer,
         lid -> Text,
@@ -179,6 +188,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     base_keys,
     device,
     device_registry,
+    group_metadata,
     identities,
     lid_pn_mapping,
     msg_secrets,

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2333,6 +2333,59 @@ impl ProtocolStore for SqliteStore {
         Ok(())
     }
 
+    async fn get_group_metadata(&self, group_jid: &str) -> Result<Option<Vec<u8>>> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let group_jid = group_jid.to_string();
+        tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let row: Option<Vec<u8>> = group_metadata::table
+                .select(group_metadata::info)
+                .filter(group_metadata::group_jid.eq(&group_jid))
+                .filter(group_metadata::device_id.eq(device_id))
+                .first(&mut conn)
+                .optional()
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(row)
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))?
+    }
+
+    async fn put_group_metadata(&self, group_jid: &str, blob: &[u8]) -> Result<()> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let group_jid = group_jid.to_string();
+        let blob = blob.to_vec();
+        let now = wacore::time::now_secs();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            diesel::insert_into(group_metadata::table)
+                .values((
+                    group_metadata::group_jid.eq(&group_jid),
+                    group_metadata::info.eq(&blob),
+                    group_metadata::device_id.eq(device_id),
+                    group_metadata::updated_at.eq(now),
+                ))
+                .on_conflict((group_metadata::group_jid, group_metadata::device_id))
+                .do_update()
+                .set((
+                    group_metadata::info.eq(&blob),
+                    group_metadata::updated_at.eq(now),
+                ))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        Ok(())
+    }
+
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
         let pool = self.pool.clone();
         let device_id = self.device_id;
@@ -3286,6 +3339,28 @@ mod tests {
         assert!(
             reloaded.server_cert_chain.is_none(),
             "cleared chain must round-trip as None"
+        );
+    }
+
+    #[tokio::test]
+    async fn group_metadata_round_trip_sqlite() {
+        use wacore::store::traits::ProtocolStore;
+        let store = create_test_store().await;
+        let jid = "120363000000000001@g.us";
+
+        assert!(store.get_group_metadata(jid).await.unwrap().is_none());
+
+        store.put_group_metadata(jid, b"blob-v1").await.unwrap();
+        assert_eq!(
+            store.get_group_metadata(jid).await.unwrap().as_deref(),
+            Some(&b"blob-v1"[..])
+        );
+
+        // Upsert overwrites the prior blob.
+        store.put_group_metadata(jid, b"blob-v2").await.unwrap();
+        assert_eq!(
+            store.get_group_metadata(jid).await.unwrap().as_deref(),
+            Some(&b"blob-v2"[..])
         );
     }
 

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1010,36 +1010,66 @@ impl ProtocolNode for GroupParticipatingResponse {
         Ok(Self { groups })
     }
 }
+/// Outcome of a [`GroupQueryIq`]. `NotModified` is returned when we sent a
+/// participant `phash` that matched the server's, so it omitted `<group>` (WA Web
+/// queryGroup phash skip) — the caller should reuse its cached metadata.
+#[derive(Debug, Clone)]
+pub enum GroupInfoOutcome {
+    Full(Box<GroupInfoResponse>),
+    NotModified,
+}
+
 /// IQ specification for querying a specific group's info.
+///
+/// When `phash` is set, the query carries `<query request="interactive"
+/// phash="2:.."/>` so an unchanged group is answered with an absent `<group>`
+/// ([`GroupInfoOutcome::NotModified`]).
 #[derive(Debug, Clone)]
 pub struct GroupQueryIq {
     pub group_jid: Jid,
+    pub phash: Option<String>,
 }
 
 impl GroupQueryIq {
     pub fn new(group_jid: &Jid) -> Self {
         Self {
             group_jid: group_jid.clone(),
+            phash: None,
+        }
+    }
+
+    /// Query carrying the cached participant `phash` so the server can answer
+    /// "not-modified" by omitting `<group>`.
+    pub fn with_phash(group_jid: &Jid, phash: Option<String>) -> Self {
+        Self {
+            group_jid: group_jid.clone(),
+            phash,
         }
     }
 }
 
 impl IqSpec for GroupQueryIq {
-    type Response = GroupInfoResponse;
+    type Response = GroupInfoOutcome;
 
     fn build_iq(&self) -> InfoQuery<'static> {
+        let mut query = GroupQueryRequest::default().into_node();
+        if let Some(ref phash) = self.phash {
+            query.attrs.insert("phash", phash.clone());
+        }
         InfoQuery::get_ref(
             GROUP_IQ_NAMESPACE,
             &self.group_jid,
-            Some(NodeContent::Nodes(vec![
-                GroupQueryRequest::default().into_node(),
-            ])),
+            Some(NodeContent::Nodes(vec![query])),
         )
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response> {
-        let group_node = required_child(response, "group")?;
-        GroupInfoResponse::try_from_node_ref(group_node)
+        match response.get_optional_child("group") {
+            Some(group_node) => Ok(GroupInfoOutcome::Full(Box::new(
+                GroupInfoResponse::try_from_node_ref(group_node)?,
+            ))),
+            None => Ok(GroupInfoOutcome::NotModified),
+        }
     }
 }
 
@@ -2937,6 +2967,58 @@ impl IqSpec for GetGroupProfilePicturesIq {
 mod tests {
     use super::*;
     use crate::request::InfoQueryType;
+
+    #[test]
+    fn group_query_iq_with_phash_emits_attr() {
+        let jid: Jid = "120363000000000001@g.us".parse().unwrap();
+        let iq = GroupQueryIq::with_phash(&jid, Some("2:abc123".to_string())).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected NodeContent::Nodes");
+        };
+        let query = &nodes[0];
+        assert_eq!(query.tag, "query");
+        assert!(
+            query
+                .attrs
+                .get("request")
+                .is_some_and(|s| s == "interactive")
+        );
+        assert!(query.attrs.get("phash").is_some_and(|s| s == "2:abc123"));
+    }
+
+    #[test]
+    fn group_query_iq_without_phash_has_no_attr() {
+        let jid: Jid = "120363000000000001@g.us".parse().unwrap();
+        let iq = GroupQueryIq::new(&jid).build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected NodeContent::Nodes");
+        };
+        assert!(nodes[0].attrs.get("phash").is_none());
+    }
+
+    #[test]
+    fn group_query_parse_full_vs_not_modified() {
+        let jid: Jid = "120363000000000001@g.us".parse().unwrap();
+        let spec = GroupQueryIq::new(&jid);
+
+        // Present <group> → Full.
+        let full = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("group")
+                .attr("id", "120363000000000001@g.us")
+                .build()])
+            .build();
+        assert!(matches!(
+            spec.parse_response(&full.as_node_ref()).unwrap(),
+            GroupInfoOutcome::Full(_)
+        ));
+
+        // Absent <group> → NotModified (server confirmed the phash matched).
+        let nm = NodeBuilder::new("iq").build();
+        assert!(matches!(
+            spec.parse_response(&nm.as_node_ref()).unwrap(),
+            GroupInfoOutcome::NotModified
+        ));
+    }
 
     #[test]
     fn test_group_subject_validation() {

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -488,6 +488,12 @@ pub struct DeviceListResponse {
 pub struct DeviceListSpec {
     pub jids: Vec<Jid>,
     pub sid: String,
+    /// Optional per-user device-list hint `(device_hash, ts)`, keyed by the bare
+    /// (`to_non_ad`) jid. When present, the query emits
+    /// `<user jid="..."><devices device_hash="2:.." ts="N"/></user>` so the server
+    /// returns only CHANGED users (WA Web `syncDeviceList`). Users the server omits
+    /// from the response are UNCHANGED and their cached devices must be preserved.
+    pub hashes: std::collections::HashMap<Jid, (String, i64)>,
 }
 
 impl DeviceListSpec {
@@ -495,6 +501,21 @@ impl DeviceListSpec {
         Self {
             jids,
             sid: sid.into(),
+            hashes: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Like [`new`](Self::new) but carries per-user `device_hash`/`ts` hints so the
+    /// server can skip unchanged users. Keys are bare (`to_non_ad`) jids.
+    pub fn with_hashes(
+        jids: Vec<Jid>,
+        sid: impl Into<String>,
+        hashes: std::collections::HashMap<Jid, (String, i64)>,
+    ) -> Self {
+        Self {
+            jids,
+            sid: sid.into(),
+            hashes,
         }
     }
 }
@@ -513,9 +534,17 @@ impl IqSpec for DeviceListSpec {
             .jids
             .iter()
             .map(|jid| {
-                NodeBuilder::new("user")
-                    .attr("jid", jid.to_non_ad())
-                    .build()
+                let bare = jid.to_non_ad();
+                let mut builder = NodeBuilder::new("user").attr("jid", bare.clone());
+                // WA Web sends the cached per-user device list hash so the server
+                // can answer "unchanged" by omitting the user from the response.
+                if let Some((device_hash, ts)) = self.hashes.get(&bare) {
+                    builder = builder.children([NodeBuilder::new("devices")
+                        .attr("device_hash", device_hash.as_str())
+                        .attr("ts", ts.to_string())
+                        .build()]);
+                }
+                builder.build()
             })
             .collect();
 
@@ -1037,9 +1066,85 @@ mod tests {
             let query = usync.get_optional_child("query").unwrap();
             let devices = query.get_optional_child("devices").unwrap();
             assert!(devices.attrs.get("version").is_some_and(|s| s == "2"));
+
+            // Without a hint, the <user> node is bare (no per-user <devices>).
+            let user = usync
+                .get_optional_child("list")
+                .unwrap()
+                .get_optional_child("user")
+                .unwrap();
+            assert!(user.get_optional_child("devices").is_none());
         } else {
             panic!("Expected NodeContent::Nodes");
         }
+    }
+
+    #[test]
+    fn test_device_list_spec_build_iq_with_device_hash() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let mut hashes = std::collections::HashMap::new();
+        hashes.insert(jid.clone(), ("2:cachedhash".to_string(), 1_700_000_000i64));
+        let spec = DeviceListSpec::with_hashes(vec![jid], "sid-h", hashes);
+        let iq = spec.build_iq();
+
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("Expected NodeContent::Nodes");
+        };
+        let usync = &nodes[0];
+        // Query-level <devices version="2"> still declares the protocol.
+        let query = usync.get_optional_child("query").unwrap();
+        assert!(
+            query
+                .get_optional_child("devices")
+                .unwrap()
+                .attrs
+                .get("version")
+                .is_some_and(|s| s == "2")
+        );
+        // Per-user <devices device_hash ts> carries the cached hash.
+        let user = usync
+            .get_optional_child("list")
+            .unwrap()
+            .get_optional_child("user")
+            .unwrap();
+        let dev = user.get_optional_child("devices").unwrap();
+        assert!(
+            dev.attrs
+                .get("device_hash")
+                .is_some_and(|s| s == "2:cachedhash")
+        );
+        assert!(dev.attrs.get("ts").is_some_and(|s| s == "1700000000"));
+    }
+
+    #[test]
+    fn test_device_list_spec_parse_omits_unchanged_user() {
+        // Queried two users; the server returns only one (the other unchanged →
+        // omitted). The parser must yield only the present user so the caller
+        // keeps the omitted user's cached devices (device_hash merge-safety).
+        let a: Jid = "1111111111@s.whatsapp.net".parse().unwrap();
+        let b: Jid = "2222222222@s.whatsapp.net".parse().unwrap();
+        let spec = DeviceListSpec::new(vec![a, b], "sid-omit");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1111111111@s.whatsapp.net")
+                        .children([NodeBuilder::new("devices")
+                            .children([NodeBuilder::new("device-list")
+                                .attr("hash", "2:hashA")
+                                .children([NodeBuilder::new("device").attr("id", "0").build()])
+                                .build()])
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(result.device_lists.len(), 1, "omitted user must not appear");
+        assert_eq!(result.device_lists[0].user.user, "1111111111");
     }
 
     #[test]

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -57,8 +57,10 @@ impl MessageUtils {
     /// Validate a broadcast-contact-list hash from an incoming `deviceSentMessage`
     /// against the message's `<participants>` set. Mirrors WA Web `validateBclHash`:
     /// the sender (our own other device) hashes the broadcast recipients with
-    /// phashV2; we recompute over the same set and compare. Returns `true` when
-    /// they match (or trivially when there are no participants to hash).
+    /// phashV2; here we recompute via [`participant_list_hash`](Self::participant_list_hash)
+    /// and return `true` only when the computed hash equals `expected` (including
+    /// for an empty participant list, which hashes to its own deterministic value
+    /// — not a trivial pass).
     pub fn validate_bcl_hash(participants: &[wacore_binary::Jid], expected: &str) -> bool {
         Self::participant_list_hash(participants).is_ok_and(|computed| computed == expected)
     }

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -54,6 +54,15 @@ impl MessageUtils {
         ))
     }
 
+    /// Validate a broadcast-contact-list hash from an incoming `deviceSentMessage`
+    /// against the message's `<participants>` set. Mirrors WA Web `validateBclHash`:
+    /// the sender (our own other device) hashes the broadcast recipients with
+    /// phashV2; we recompute over the same set and compare. Returns `true` when
+    /// they match (or trivially when there are no participants to hash).
+    pub fn validate_bcl_hash(participants: &[wacore_binary::Jid], expected: &str) -> bool {
+        Self::participant_list_hash(participants).is_ok_and(|computed| computed == expected)
+    }
+
     pub fn unpad_message_ref(plaintext: &[u8], version: u8) -> Result<&[u8]> {
         if version == 3 {
             return Ok(plaintext);
@@ -249,6 +258,21 @@ pub fn parse_message_info(
 
     source.addressing_mode = addressing_mode;
 
+    // Broadcast/status only: collect <participants><to jid> so the receive path
+    // can validate a deviceSentMessage.phash (WA Web validateBclHash). Group
+    // <participants> carry the device fanout, not a bcl, so they're skipped.
+    let bcl_participants: Vec<wacore_binary::Jid> = if from.server == Server::Broadcast {
+        node.get_optional_child("participants")
+            .map(|p| {
+                p.get_children_by_tag("to")
+                    .filter_map(|to| to.attrs().optional_jid("jid"))
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
     let category = attrs
         .optional_string("category")
         .map(|s| MessageCategory::from(s.as_ref()))
@@ -351,6 +375,7 @@ pub fn parse_message_info(
         peer_recipient_pn,
         meta_info,
         bot_info,
+        bcl_participants,
         ..Default::default()
     })
 }
@@ -649,5 +674,68 @@ mod parse_message_info_tests {
         assert_eq!(h_single, "2:5s+YxCff");
         assert_eq!(h_control, "2:RJWVxcMQ");
         assert_eq!(h_multi, "2:AAv/hwhn");
+    }
+
+    // #6 — validate_bcl_hash accepts the matching phashV2 and rejects a tampered
+    // one (the WA Web validateBclHash check on device-sent broadcasts).
+    #[test]
+    fn validate_bcl_hash_matches_and_rejects() {
+        let participants = vec![
+            Jid::from_str("100000000000001@lid").unwrap(),
+            Jid::from_str("100000000000002@lid").unwrap(),
+        ];
+        let good = MessageUtils::participant_list_hash(&participants).unwrap();
+        assert!(MessageUtils::validate_bcl_hash(&participants, &good));
+        assert!(!MessageUtils::validate_bcl_hash(&participants, "2:wrongxx"));
+    }
+
+    // #6 — broadcast/status stanzas expose <participants><to jid> as
+    // `bcl_participants` (for the device-sent phash check).
+    #[test]
+    fn broadcast_populates_bcl_participants() {
+        let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
+        let node = NodeBuilder::new("message")
+            .attr("from", "status@broadcast")
+            .attr("type", "media")
+            .attr("id", "BCL-1")
+            .attr("t", "1777415965")
+            .attr("participant", "559980000001@s.whatsapp.net")
+            .children([NodeBuilder::new("participants")
+                .children([
+                    NodeBuilder::new("to")
+                        .attr("jid", "100000000000001@lid")
+                        .build(),
+                    NodeBuilder::new("to")
+                        .attr("jid", "100000000000002@lid")
+                        .build(),
+                ])
+                .build()])
+            .build();
+        let info = parse_message_info(&node.as_node_ref(), &own_pn, None).unwrap();
+        assert_eq!(info.bcl_participants.len(), 2);
+    }
+
+    // #6 — a group's <participants> is the device fanout, NOT a bcl, so it must
+    // not feed the bcl hash check.
+    #[test]
+    fn group_participants_do_not_populate_bcl() {
+        let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
+        let node = NodeBuilder::new("message")
+            .attr("from", "120363000000000001@g.us")
+            .attr("participant", "559980000001@s.whatsapp.net")
+            .attr("type", "text")
+            .attr("id", "G-1")
+            .attr("t", "1777415965")
+            .children([NodeBuilder::new("participants")
+                .children([NodeBuilder::new("to")
+                    .attr("jid", "559980000002:3@s.whatsapp.net")
+                    .build()])
+                .build()])
+            .build();
+        let info = parse_message_info(&node.as_node_ref(), &own_pn, None).unwrap();
+        assert!(
+            info.bcl_participants.is_empty(),
+            "group fanout participants are not a bcl"
+        );
     }
 }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -61,6 +61,7 @@ struct InMemoryState {
     pn_to_lid: HashMap<String, String>,
     base_keys: HashMap<BaseKeyKey, Vec<u8>>,
     device_lists: HashMap<String, DeviceListRecord>,
+    group_metadata: HashMap<String, Vec<u8>>,
     tc_tokens: HashMap<String, TcTokenEntry>,
     sent_messages: HashMap<SentMessageKey, SentMessageEntry>,
 
@@ -497,6 +498,25 @@ impl ProtocolStore for InMemoryBackend {
         Ok(())
     }
 
+    async fn get_group_metadata(&self, group_jid: &str) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .group_metadata
+            .get(group_jid)
+            .cloned())
+    }
+
+    async fn put_group_metadata(&self, group_jid: &str, blob: &[u8]) -> Result<()> {
+        self.state
+            .lock()
+            .await
+            .group_metadata
+            .insert(group_jid.to_string(), blob.to_vec());
+        Ok(())
+    }
+
     // --- TcToken Storage ---
 
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
@@ -691,6 +711,25 @@ mod tests {
     #[test]
     fn in_memory_backend_implements_backend() {
         is_backend::<InMemoryBackend>();
+    }
+
+    #[tokio::test]
+    async fn group_metadata_round_trip() {
+        use crate::store::traits::ProtocolStore;
+        let backend = InMemoryBackend::new();
+        let jid = "120363000000000001@g.us";
+
+        assert!(backend.get_group_metadata(jid).await.unwrap().is_none());
+        backend.put_group_metadata(jid, b"blob-v1").await.unwrap();
+        assert_eq!(
+            backend.get_group_metadata(jid).await.unwrap().as_deref(),
+            Some(&b"blob-v1"[..])
+        );
+        backend.put_group_metadata(jid, b"blob-v2").await.unwrap();
+        assert_eq!(
+            backend.get_group_metadata(jid).await.unwrap().as_deref(),
+            Some(&b"blob-v2"[..])
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -330,6 +330,21 @@ pub trait ProtocolStore: Send + Sync {
     /// Delete a device list record, forcing a network re-fetch on next query.
     async fn delete_devices(&self, user: &str) -> Result<()>;
 
+    // --- Group Metadata Cache (WA Web participant-phash re-query skip) ---
+
+    /// Get the persisted, opaque serialized group metadata blob for `group_jid`.
+    /// The blob is a caller-serialized GroupInfo snapshot; backends without group
+    /// persistence return `None` (the group is then re-queried in full).
+    async fn get_group_metadata(&self, _group_jid: &str) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    /// Persist (upsert) the serialized group metadata blob for `group_jid`.
+    /// No-op by default; backends override to enable the phash re-query skip.
+    async fn put_group_metadata(&self, _group_jid: &str, _blob: &[u8]) -> Result<()> {
+        Ok(())
+    }
+
     // --- TcToken Storage ---
 
     /// Get a trusted contact token for a JID (stored under LID).

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -338,6 +338,12 @@ pub struct MessageInfo {
     /// goes to the right routing target).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peer_recipient_pn: Option<Jid>,
+    /// Broadcast-contact-list recipients from `<participants><to jid>` on an
+    /// incoming broadcast/status stanza. Populated only for broadcasts; used to
+    /// validate a `deviceSentMessage.phash` (WA Web `validateBclHash`). Empty
+    /// otherwise.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub bcl_participants: Vec<Jid>,
 }
 
 impl MessageInfo {


### PR DESCRIPTION
Follow-up to #678. The phash audit found three WA Web hash mechanisms we didn't fully replicate. This implements all three, faithful to WA Web where it's safe to be. None was a one-line "add a hash attr": our architecture (query-on-cache-miss + notification-driven updates) lacks the "re-query a known entity with its cached hash" pattern WA Web's hashes rely on, so each needed a small integration addition.

Shared building block: `MessageUtils::participant_list_hash` (phashV2, fixed to standard base64 in #678).

## #3 — usync `device_hash` on own-device re-sync (`feat(usync)`)
WA Web sends a per-user `device_hash` in the usync device query so the server returns only CHANGED lists. We never sent it (we query on cache-miss, or invalidate-then-full-query). Now `sync_own_device_list` sends the cached own `device_hash` (matching `syncMyDeviceList`), so an unchanged own device list is skipped server-side on every reconnect.
- `DeviceListSpec` gains optional per-user `(device_hash, ts)` hints → `<user><devices device_hash="2:.." ts="N"/></user>`.
- Response processing factored into `process_device_list_response`, shared with `get_user_devices`; it only touches users present in the response, so omitted (unchanged) users keep their cache.

whatsmeow omits this optimization entirely; it's WA-Web-specific.

## #7 — group-metadata participant phash (`feat(group)`)
WA Web's `queryGroup` carries a phashV2 of the cached participants so the server answers "not-modified" (absent `<group>`) for an unchanged group. We always re-queried in full.
- `GroupQueryIq` gains an optional phash; `Response` becomes `GroupInfoOutcome { Full(Box<..>), NotModified }`.
- `query_info` persists the resolved `GroupInfo` (new `ProtocolStore` group-metadata blob store: sqlite table + migration, in-memory map, no-op trait defaults for other backends) and on a later cache miss sends the participant phash; on `NotModified` it reuses the persisted metadata.

## #6 — incoming bcl hash validation (`feat(recv)`)
WA Web validates a self-synced broadcast/status: the sending device puts a phashV2 of the recipients in `deviceSentMessage.phash`; the receiver recomputes and drops on mismatch.
- `validate_bcl_hash` + `MessageInfo.bcl_participants` (populated from `<participants><to>` for broadcasts only; a group's `<participants>` is the device fanout, not a bcl).
- `handle_decrypted_plaintext` **logs a warning** on divergence but does **not** drop — the exact participant hash form is verified by code-reading only, so dropping could lose legitimate messages until validated against a real DSM. Can be flipped to a drop later.

## Risk framing
- **#3 and #7 are fail-safe**: a wrong/absent hash just makes the server return the full list/group (today's behavior). #3's only real risk — wiping cache for an omitted user — is covered by a merge-safety test.
- **#6 is validate-only** (no drop), so it cannot lose messages.

## Tests
- #3: `DeviceListSpec` build with/without `device_hash`; parse omits an unchanged user; merge-safety (omitted user's cache preserved).
- #7: query build with/without phash; parse `Full` vs `NotModified`; group-metadata store round-trip (sqlite + in-memory).
- #6: `validate_bcl_hash` match/reject; broadcast populates `bcl_participants`; group fanout does not.

`cargo clippy --all-targets -- -D warnings` clean; wacore + whatsapp-rust + sqlite-storage suites green.