### PR TITLE
perf(usync): batch LID-PN re-learn from device response off the cold group-send path

### DIFF
--- a/src/usync.rs
+++ b/src/usync.rs
@@ -50,13 +50,18 @@ impl Client {
     /// simply absent here, so their cached records are left untouched (the
     /// merge-safe behavior the `device_hash` optimization depends on).
     async fn process_device_list_response(&self, response: &DeviceListResponse) -> Vec<Jid> {
-        // Learn LID↔PN mappings from the response via the batched, guarded path:
-        // one detached DB transaction for genuinely-new pairs (skipping ones
-        // already durably learned, e.g. by query_info's batch learn right before
-        // a group send). The previous per-mapping add_lid_pn_mapping awaited a DB
-        // write + migrations serially, so a large cold group send redid ~N writes
-        // on the critical path for mappings we already had. Falls back to the
-        // per-mapping path if the owning Arc<Client> isn't available.
+        // Learn LID↔PN mappings via the same batched, guarded learner query_info
+        // uses (one detached transaction, skipping already-durable pairs), so
+        // per-mapping DB writes stay off the send's critical path. Falls back to
+        // the per-mapping path if the owning Arc<Client> isn't available.
+        //
+        // Ordering: the old per-mapping path AWAITED migrate_signal_sessions_on_lid_discovery.
+        // Detaching it can let a standalone usync (sync_own_device_list /
+        // flush_pending_device_sync) that is the FIRST learner of a LID for a
+        // contact with prior PN Signal state encrypt before the PN-wins migration
+        // runs — but the per-address session_lock_for both take is the real
+        // barrier (they can't interleave). The group-send path is unchanged:
+        // query_info already learns these same pairs detached upstream.
         if !response.lid_mappings.is_empty() {
             if let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) {
                 let mappings: Vec<(String, String)> = response
@@ -450,6 +455,44 @@ mod tests {
             b_devices.len(),
             2,
             "omitted user's devices must be preserved"
+        );
+    }
+
+    /// The batched LID-PN learn path warms the in-memory cache SYNCHRONOUSLY
+    /// (the persist runs detached), so a mapping from the usync response is
+    /// resolvable the moment `process_device_list_response` returns. Locks the
+    /// contract that the new path doesn't defer the cache update.
+    #[tokio::test]
+    async fn process_response_warms_lid_pn_cache_synchronously() {
+        use wacore::usync::UsyncLidMapping;
+
+        let client = create_test_client().await;
+        let response = DeviceListResponse {
+            device_lists: vec![],
+            lid_mappings: vec![UsyncLidMapping {
+                phone_number: "559980000123".into(),
+                lid: "100000000000123".into(),
+            }],
+        };
+
+        assert!(
+            client
+                .lid_pn_cache
+                .get_current_lid("559980000123")
+                .await
+                .is_none()
+        );
+
+        let _ = client.process_device_list_response(&response).await;
+
+        assert_eq!(
+            client
+                .lid_pn_cache
+                .get_current_lid("559980000123")
+                .await
+                .as_deref(),
+            Some("100000000000123"),
+            "usync LID mapping must be in the cache synchronously after the call"
         );
     }
 }

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -50,26 +50,44 @@ impl Client {
     /// simply absent here, so their cached records are left untouched (the
     /// merge-safe behavior the `device_hash` optimization depends on).
     async fn process_device_list_response(&self, response: &DeviceListResponse) -> Vec<Jid> {
-        // Extract and persist LID mappings from the response
-        for mapping in &response.lid_mappings {
-            if let Err(err) = self
-                .add_lid_pn_mapping(
-                    &mapping.lid,
-                    &mapping.phone_number,
-                    crate::lid_pn_cache::LearningSource::Usync,
-                )
-                .await
-            {
-                warn!(
-                    "Failed to persist LID {} -> {} from usync: {err}",
-                    mapping.lid, mapping.phone_number,
-                );
-                continue;
+        // Learn LID↔PN mappings from the response via the batched, guarded path:
+        // one detached DB transaction for genuinely-new pairs (skipping ones
+        // already durably learned, e.g. by query_info's batch learn right before
+        // a group send). The previous per-mapping add_lid_pn_mapping awaited a DB
+        // write + migrations serially, so a large cold group send redid ~N writes
+        // on the critical path for mappings we already had. Falls back to the
+        // per-mapping path if the owning Arc<Client> isn't available.
+        if !response.lid_mappings.is_empty() {
+            if let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) {
+                let mappings: Vec<(String, String)> = response
+                    .lid_mappings
+                    .iter()
+                    .map(|m| (m.lid.to_string(), m.phone_number.to_string()))
+                    .collect();
+                client
+                    .learn_lid_pn_mappings_batch(
+                        mappings,
+                        crate::lid_pn_cache::LearningSource::Usync,
+                        false,
+                    )
+                    .await;
+            } else {
+                for mapping in &response.lid_mappings {
+                    if let Err(err) = self
+                        .add_lid_pn_mapping(
+                            &mapping.lid,
+                            &mapping.phone_number,
+                            crate::lid_pn_cache::LearningSource::Usync,
+                        )
+                        .await
+                    {
+                        warn!(
+                            "Failed to persist LID {} -> {} from usync: {err}",
+                            mapping.lid, mapping.phone_number,
+                        );
+                    }
+                }
             }
-            debug!(
-                "Learned LID mapping from usync: {} -> {}",
-                mapping.lid, mapping.phone_number
-            );
         }
 
         let mut fetched_devices = Vec::with_capacity(response.device_lists.len());

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -467,6 +467,17 @@ mod tests {
         use wacore::usync::UsyncLidMapping;
 
         let client = create_test_client().await;
+
+        // Pin that we exercise the BATCHED branch, not the per-mapping fallback:
+        // the branch is `if let Some(client) = self.self_weak...upgrade()`, so a
+        // live self_weak upgrade means learn_lid_pn_mappings_batch is the path
+        // taken. (Both paths warm the cache, so without this the test could pass
+        // via the fallback.)
+        assert!(
+            client.self_weak.get().and_then(|w| w.upgrade()).is_some(),
+            "fixture must populate self_weak so the batched learner is exercised"
+        );
+
         let response = DeviceListResponse {
             device_lists: vec![],
             lid_mappings: vec![UsyncLidMapping {


### PR DESCRIPTION
## Context
Continued group-send benchmark profiling against the current main (post #677/#678/#679). The big bottleneck — `migrate_signal_sessions_on_lid_discovery` (10 GB on an 800-member cold send) — is already fixed (#677): the cold send now allocates only ~16.6 MB. Profiling the remainder surfaced one clean, latency-only redundancy.

## Finding
`process_device_list_response` (the usync device-list handler inside `get_user_devices`) learned each LID↔PN mapping by **awaiting `add_lid_pn_mapping` per entry** — a serial `record + DB write + migration` per mapping. On a large **cold group send**, the device usync echoes the same mappings `query_info` already learned moments earlier (via its *batched, detached* `learn_lid_pn_mappings_batch`), so the send blocked on ~N serial awaited DB writes for pairs we already had.

CPU was never the issue (0.15 s total for 40 sends to 800 members); this was wall-clock latency from serial awaited `spawn_blocking` SQLite hops on the send's critical path.

## Change
Route the usync re-learn through `learn_lid_pn_mappings_batch` (the same path `query_info` uses): one detached transaction for genuinely-new pairs, internally guarded against re-learning already-durable ones. Falls back to the per-mapping path if the owning `Arc<Client>` isn't available. No new ordering risk — `query_info` already triggers these migrations detached before `get_user_devices` runs.

## Measurement (group-send bench, 800 members, mock server, single A/B)
| metric | baseline | this PR | Δ |
|---|---|---|---|
| ack_avg | 64.50 ms | 55.48 ms | **−14%** |
| ack_max (cold first send) | 139.33 ms | 95.68 ms | **−31%** |
| pong_avg | 80.56 ms | 73.39 ms | −9% |
| duration | 683 ms | 671 ms | −2% |
| CPU total | 0.150 s | 0.150 s | = |
| dhat total alloc | 16.61 MB | 16.70 MB | = (alloc unchanged; pure latency win) |

Multiple independent metrics moved together, consistent with removing the serial awaited writes from the cold send.

## Scope note
The remaining client-side cost for large groups (per-member device/LID resolution on every send: `get_current_lid`/`resolve_lookup_keys` String churn) is O(members × messages) but CPU-cheap (0.15 s total), so it isn't pursued here. The dominant per-send latency (pong ~73 ms) is server/network fanout + the per-(group,sender) chain-lock serializing the bench flood, not client work.

Tests: clippy `--all-targets -D warnings` clean; whatsapp-rust lib suite (659) green; existing `process_response_preserves_omitted_users` (merge-safety) unaffected.