### PR TITLE
perf(device-registry): borrow lookup keys in get_devices_from_registry (hot group-send path)

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -557,10 +557,14 @@ impl Client {
     /// This follows the same 2-tier pattern as [`has_device`]: registry cache first,
     /// then the backend database.
     pub(crate) async fn get_devices_from_registry(&self, jid: &Jid) -> Option<Vec<Jid>> {
-        let lookup_keys = self.get_lookup_keys(&jid.user).await;
+        // Use the borrowed `&str` keys directly: both the moka cache and the
+        // backend take `&str`, so going through `get_lookup_keys` (which re-owns
+        // the already-cloned keys into a `Vec<String>`) just churns per member on
+        // every group send. `lookup` owns the key Strings for the duration here.
+        let lookup = self.resolve_lookup_keys(&jid.user).await;
 
         // L1: device_registry_cache (moka, fast)
-        for key in &lookup_keys {
+        for key in lookup.all_keys() {
             if let Some(record) = self.device_registry_cache.get(key).await {
                 return Some(Self::reconstruct_device_jids(jid, &record));
             }
@@ -568,7 +572,7 @@ impl Client {
 
         // L2: backend DB
         let backend = self.persistence_manager.backend();
-        for key in &lookup_keys {
+        for key in lookup.all_keys() {
             match backend.get_devices(key).await {
                 Ok(Some(record)) => {
                     let devices = Self::reconstruct_device_jids(jid, &record);


### PR DESCRIPTION
## Context
Continuing the large-group send profiling (follow-up to #680). With the migration overhead gone (#677) and the LID re-learn off the critical path (#680), the next dhat hotspot on an 800-member send was `get_user_devices` — the per-member device resolution that `resolve_skdm_targets` runs **on every group send**.

## Finding
`get_devices_from_registry` resolved keys via `get_lookup_keys`, which does:
```rust
self.resolve_lookup_keys(user).await   // already builds owned Strings
    .all_keys().into_iter().map(String::from).collect()  // ...then re-clones them
```
So the lookup keys were cloned **twice**: once into `UserLookupKeys` (owned `String`s from the LID↔PN cache), then again into a `Vec<String>`. But both consumers — the moka `device_registry_cache` and `backend.get_devices` — take `&str`, so the second clone is pure churn. dhat leaf view showed it as `Vec<String> from_iter` + `<&str as String>::from` (~0.7 MB / ~29k allocs) for 800 members across 12 sends.

## Change
Call `resolve_lookup_keys(...).all_keys()` (returns `Vec<&str>` borrowing the owned keys) directly in `get_devices_from_registry`. `get_lookup_keys` stays for `has_device` (colder path), so no dead code.

## Measurement (dhat A/B, group-send, 800 members, 12 msgs)
| metric | baseline (#680) | this PR | Δ |
|---|---|---|---|
| `get_user_devices` allocs | 51046 | 22996 | **−55%** |
| `get_user_devices` bytes | 3.12 MB | 2.44 MB | −22% |
| total run blocks | 144934 | 117245 | **−19%** |
| total run bytes | 16.70 MB | 16.08 MB | −3.7% |

No behavior change: same keys, same lookup order (L1 cache → L2 backend), same results. Allocation/CPU-churn only, concentrated on the per-member-per-send path that scales with group size × message rate.

Tests: clippy `--all-targets -D warnings` clean; whatsapp-rust lib suite (660) green; `device_registry` (36) + `usync` (6) suites pass.