### PR TITLE
perf(device-registry): build lookup keys with CompactString (inline, no heap)

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -15,13 +15,19 @@ use super::Client;
 enum UserLookupKeys {
     /// User is a LID with known phone number mapping.
     /// Keys: [LID, PN]
-    LidWithPn { lid: String, pn: String },
+    LidWithPn {
+        lid: wacore_binary::CompactString,
+        pn: wacore_binary::CompactString,
+    },
     /// User is a phone number with known LID mapping.
     /// Keys: [LID, PN]
-    PnWithLid { lid: String, pn: String },
+    PnWithLid {
+        lid: wacore_binary::CompactString,
+        pn: wacore_binary::CompactString,
+    },
     /// Unknown user - no LID-PN mapping exists.
     /// Could be either a LID or PN, we don't know.
-    Unknown { user: String },
+    Unknown { user: wacore_binary::CompactString },
 }
 
 impl UserLookupKeys {
@@ -61,26 +67,26 @@ impl Client {
     /// - `PnWithLid`: User is a phone number with known LID mapping
     /// - `Unknown`: No LID-PN mapping exists (could be either type)
     async fn resolve_lookup_keys(&self, user: &str) -> UserLookupKeys {
-        // Check if user is a LID (has a phone number mapping)
+        // Check if user is a LID (has a phone number mapping). The `user`-derived
+        // key is built inline via CompactString (LID/PN are short), avoiding a
+        // heap String per member on every group send.
         if let Some(pn) = self.lid_pn_cache.get_phone_number(user).await {
             return UserLookupKeys::LidWithPn {
-                lid: user.to_string(),
-                pn,
+                lid: user.into(),
+                pn: pn.into(),
             };
         }
 
         // Check if user is a PN (has a LID mapping)
         if let Some(lid) = self.lid_pn_cache.get_current_lid(user).await {
             return UserLookupKeys::PnWithLid {
-                lid,
-                pn: user.to_string(),
+                lid: lid.into(),
+                pn: user.into(),
             };
         }
 
         // Unknown user - no mapping exists
-        UserLookupKeys::Unknown {
-            user: user.to_string(),
-        }
+        UserLookupKeys::Unknown { user: user.into() }
     }
 
     /// Get all possible lookup keys for a user (for bidirectional lookup).


### PR DESCRIPTION
## Context
Continuing the large-group send profiling (after #677/#680/#681). With the redundant key re-clone gone (#681), the next dhat hotspot in `get_user_devices` (per-member device resolution, run on every group send) was `resolve_lookup_keys` building `UserLookupKeys` from `std::String`.

## Finding
`resolve_lookup_keys` did `user.to_string()` for the user-derived lookup key — a heap allocation per member per send, even though LID/PN user parts are short (≤~18 chars). `UserLookupKeys` used `String` fields throughout.

## Change
Switch `UserLookupKeys` to `wacore_binary::CompactString` (already the type of `Jid.user`). Short strings live inline, so the user-derived key no longer heap-allocates; the cache-derived key moves in via the same type. `all_keys()` still returns `Vec<&str>` (CompactString derefs to `str`), so every consumer is unchanged.

## Measurement (dhat A/B, group-send, 800 members, 12 msgs)
| metric | #681 | this PR | Δ |
|---|---|---|---|
| `get_user_devices` allocs | 22996 | 12538 | **−45%** |
| `get_user_devices` bytes | 2.44 MB | 2.11 MB | −0.33 MB |
| total run blocks | 117245 | 105762 | −10% |
| total run bytes | 16.08 MB | 15.91 MB | −0.17 MB |

Combined with #681, per-member device resolution went from **50915 → 12538 allocs (−75%)**.

Behavior is identical (same keys, same lookup order, same results) — allocation/CPU-churn only, on the per-member-per-send path that scales with group size × message rate.

## Note on diminishing returns
This path is now close to its floor: the remaining churn is largely inherent (the actual `Vec<Jid>` device data returned per member, and moka cache machinery for the device-registry and LID-PN caches). The bigger structural lever — caching a group's fully-resolved device set to make warm sends O(1) instead of O(members) — is not pursued: per-send client CPU is already low (~0.15 s for 40 sends to 800 members), the latency is server/network fanout-bound, and it matches WA Web's per-send O(N) iteration.

Tests: clippy `--all-targets -D warnings` clean; whatsapp-rust lib suite (660) + device_registry (36) green.