### PR TITLE
feat(upload): constant-memory streaming upload + media streaming sidecar

### DIFF
--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use wacore::net::{HttpClient, HttpRequest, HttpResponse, StreamingHttpResponse};
+use wacore::net::{HttpClient, HttpRequest, HttpResponse, StreamingHttpResponse, UploadBody};
 
 /// Matches `MAX_FILE_SIZE_BYTES` in `WAWebServerPropConstants` (2 GiB).
 /// Overrides ureq's 10 MiB default on `read_to_vec()`.
@@ -154,6 +154,49 @@ impl HttpClient for UreqHttpClient {
             body: Box::new(reader),
         })
     }
+
+    fn supports_upload_streaming(&self) -> bool {
+        true
+    }
+
+    fn execute_upload(
+        &self,
+        request: HttpRequest,
+        body: UploadBody,
+        content_length: u64,
+    ) -> Result<HttpResponse> {
+        // No spawn_blocking — like execute_streaming, this is driven from within
+        // a blocking context, and the reader is read on this thread.
+        if request.method != "POST" {
+            return Err(anyhow::anyhow!(
+                "Upload streaming only supports POST, got: {}",
+                request.method
+            ));
+        }
+
+        let mut req = self.agent.post(&request.url);
+        for (key, value) in &request.headers {
+            req = req.header(key, value);
+        }
+        // Explicit Content-Length keeps ureq length-delimited instead of chunked
+        // (which WhatsApp's CDN rejects) for an arbitrary reader body.
+        let content_length = content_length.to_string();
+        req = req.header("content-length", content_length.as_str());
+
+        let response = req.send(ureq::SendBody::from_owned_reader(body))?;
+
+        let status_code = response.status().as_u16();
+        let body_bytes = response
+            .into_body()
+            .into_with_config()
+            .limit(self.max_body_bytes)
+            .read_to_vec()?;
+
+        Ok(HttpResponse {
+            status_code,
+            body: body_bytes,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -228,5 +271,142 @@ mod tests {
             })
             .await
             .expect_err("1 KiB cap must reject a 4 MiB body");
+    }
+
+    /// Captures the raw request headers and body of a single POST, then replies 200.
+    fn spawn_capture_server() -> (String, std::sync::mpsc::Receiver<(String, Vec<u8>)>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            let header_end = loop {
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+                let n = stream.read(&mut tmp).unwrap_or(0);
+                if n == 0 {
+                    return;
+                }
+                buf.extend_from_slice(&tmp[..n]);
+            };
+            let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+            let content_length = headers.lines().find_map(|l| {
+                let (k, v) = l.split_once(':')?;
+                if k.trim().eq_ignore_ascii_case("content-length") {
+                    v.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            });
+            let mut body = buf[header_end..].to_vec();
+            if let Some(cl) = content_length {
+                while body.len() < cl {
+                    let n = stream.read(&mut tmp).unwrap_or(0);
+                    if n == 0 {
+                        break;
+                    }
+                    body.extend_from_slice(&tmp[..n]);
+                }
+            }
+            let _ = stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}");
+            let _ = tx.send((headers, body));
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    fn parsed_content_length(headers: &str) -> Option<usize> {
+        headers.lines().find_map(|l| {
+            let (k, v) = l.split_once(':')?;
+            k.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| v.trim().parse::<usize>().ok())
+                .flatten()
+        })
+    }
+
+    /// The key invariant: an arbitrary (non-`File`) reader body must be sent with
+    /// an explicit Content-Length and never chunked — matching WhatsApp Web.
+    #[test]
+    fn upload_streaming_sets_content_length_not_chunked() {
+        let (url, rx) = spawn_capture_server();
+        let payload: Vec<u8> = (0..5000u32).map(|i| i as u8).collect();
+        let client = UreqHttpClient::new();
+
+        let resp = client
+            .execute_upload(
+                HttpRequest {
+                    method: "POST".into(),
+                    url,
+                    headers: std::collections::HashMap::new(),
+                    body: None,
+                },
+                Box::new(std::io::Cursor::new(payload.clone())),
+                payload.len() as u64,
+            )
+            .expect("upload should succeed");
+        assert_eq!(resp.status_code, 200);
+
+        let (headers, body) = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("server should capture the request");
+        assert_eq!(
+            parsed_content_length(&headers),
+            Some(payload.len()),
+            "exact Content-Length expected, headers:\n{headers}"
+        );
+        assert!(
+            !headers.to_ascii_lowercase().contains("transfer-encoding"),
+            "body must not be chunked, headers:\n{headers}"
+        );
+        assert_eq!(body, payload, "server must receive the exact bytes");
+    }
+
+    /// A body larger than the 16 KiB output buffer exercises real chunked reads
+    /// from the reader while still arriving intact and length-delimited.
+    #[test]
+    fn upload_streaming_large_body_integrity() {
+        let (url, rx) = spawn_capture_server();
+        let payload: Vec<u8> = (0..200_000usize).map(|i| (i % 251) as u8).collect();
+        let client = UreqHttpClient::new();
+
+        let resp = client
+            .execute_upload(
+                HttpRequest {
+                    method: "POST".into(),
+                    url,
+                    headers: std::collections::HashMap::new(),
+                    body: None,
+                },
+                Box::new(std::io::Cursor::new(payload.clone())),
+                payload.len() as u64,
+            )
+            .expect("upload should succeed");
+        assert_eq!(resp.status_code, 200);
+
+        let (headers, body) = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("server should capture the request");
+        assert_eq!(parsed_content_length(&headers), Some(payload.len()));
+        assert_eq!(body, payload);
+    }
+
+    #[test]
+    fn upload_streaming_rejects_non_post() {
+        let client = UreqHttpClient::new();
+        let err = client.execute_upload(
+            HttpRequest {
+                method: "GET".into(),
+                url: "http://127.0.0.1:0/never".into(),
+                headers: std::collections::HashMap::new(),
+                body: None,
+            },
+            Box::new(std::io::Cursor::new(vec![1u8, 2, 3])),
+            3,
+        );
+        assert!(err.is_err(), "only POST is allowed for upload streaming");
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -59,12 +59,13 @@ fn parse_upload_progress(resp: &HttpResponse, total_size: u64) -> UploadExistsRe
     }
 }
 
+/// URL + headers only; the body is supplied by `send_body`, so one retry/resume
+/// loop serves both the buffered and streaming paths.
 fn build_upload_request(
     hostname: &str,
     upload_path: &str,
     auth: &str,
     token: &str,
-    body: &[u8],
     file_offset: Option<u64>,
 ) -> HttpRequest {
     let mut url = format!("https://{hostname}{upload_path}/{token}?auth={auth}&token={token}");
@@ -76,7 +77,6 @@ fn build_upload_request(
     HttpRequest::post(url)
         .with_header("Content-Type", "application/octet-stream")
         .with_header("Origin", "https://web.whatsapp.com")
-        .with_body(body.to_vec())
 }
 
 fn build_resume_check_request(
@@ -100,31 +100,63 @@ fn upload_error_from_response(response: HttpResponse) -> anyhow::Error {
     }
 }
 
-async fn upload_media_with_retry<
-    GetMediaConn,
-    GetMediaConnFut,
-    InvalidateMediaConn,
-    InvalidateMediaConnFut,
-    ExecuteRequest,
-    ExecuteRequestFut,
->(
-    enc: &wacore::upload::EncryptedMedia,
+/// Crypto metadata needed to finalize an upload, independent of how the
+/// encrypted body is transmitted (buffered or streamed).
+struct UploadCrypto {
+    media_key: [u8; 32],
+    file_sha256: [u8; 32],
+    file_enc_sha256: [u8; 32],
+    streaming_sidecar: Option<Vec<u8>>,
+}
+
+impl UploadCrypto {
+    fn response(
+        &self,
+        url: String,
+        direct_path: String,
+        file_length: u64,
+        media_key_timestamp: i64,
+    ) -> UploadResponse {
+        UploadResponse {
+            url,
+            direct_path,
+            media_key: self.media_key,
+            file_enc_sha256: self.file_enc_sha256,
+            file_sha256: self.file_sha256,
+            file_length,
+            media_key_timestamp,
+            streaming_sidecar: self.streaming_sidecar.clone(),
+        }
+    }
+}
+
+/// Drives host failover, auth refresh, and resumable upload. `file_length` is the
+/// plaintext size (for the response); `ciphertext_len` is the encrypted blob size
+/// (for the resume threshold/offsets). `send_body` transmits the body from a given
+/// offset; `execute_request` serves the body-less resume check.
+#[allow(clippy::too_many_arguments)]
+async fn upload_media_with_retry<GMC, GMCFut, IMC, IMCFut, EXR, EXRFut, SB, SBFut>(
+    crypto: UploadCrypto,
     media_type: MediaType,
     file_length: u64,
+    ciphertext_len: u64,
     media_key_timestamp: i64,
-    mut get_media_conn: GetMediaConn,
-    mut invalidate_media_conn: InvalidateMediaConn,
-    mut execute_request: ExecuteRequest,
+    mut get_media_conn: GMC,
+    mut invalidate_media_conn: IMC,
+    mut execute_request: EXR,
+    mut send_body: SB,
 ) -> Result<UploadResponse>
 where
-    GetMediaConn: FnMut(bool) -> GetMediaConnFut,
-    GetMediaConnFut: std::future::Future<Output = Result<crate::mediaconn::MediaConn>>,
-    InvalidateMediaConn: FnMut() -> InvalidateMediaConnFut,
-    InvalidateMediaConnFut: std::future::Future<Output = ()>,
-    ExecuteRequest: FnMut(HttpRequest) -> ExecuteRequestFut,
-    ExecuteRequestFut: std::future::Future<Output = Result<HttpResponse>>,
+    GMC: FnMut(bool) -> GMCFut,
+    GMCFut: std::future::Future<Output = Result<crate::mediaconn::MediaConn>>,
+    IMC: FnMut() -> IMCFut,
+    IMCFut: std::future::Future<Output = ()>,
+    EXR: FnMut(HttpRequest) -> EXRFut,
+    EXRFut: std::future::Future<Output = Result<HttpResponse>>,
+    SB: FnMut(HttpRequest, u64, u64) -> SBFut,
+    SBFut: std::future::Future<Output = Result<HttpResponse>>,
 {
-    let token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(enc.file_enc_sha256);
+    let token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(crypto.file_enc_sha256);
     let upload_path = media_type.upload_path();
     let mut force_refresh = false;
     let mut last_error: Option<anyhow::Error> = None;
@@ -138,12 +170,12 @@ where
         let mut retry_with_fresh_auth = false;
 
         for host in &media_conn.hosts {
-            // For large files, check if the upload already exists or can be resumed.
-            // Matches WA Web's _checkIfAlreadyUploaded / _getExistingOrUpload flow.
-            let mut upload_data: &[u8] = &enc.data_to_upload;
+            let mut offset: u64 = 0;
             let mut file_offset: Option<u64> = None;
 
-            if enc.data_to_upload.len() >= RESUMABLE_UPLOAD_THRESHOLD {
+            // For large files, check whether the upload already exists or can be
+            // resumed. Matches WA Web's _checkIfAlreadyUploaded flow.
+            if ciphertext_len >= RESUMABLE_UPLOAD_THRESHOLD as u64 {
                 let check_req = build_resume_check_request(
                     &host.hostname,
                     upload_path,
@@ -151,36 +183,32 @@ where
                     &token,
                 );
                 if let Ok(check_resp) = execute_request(check_req).await {
-                    let total = enc.data_to_upload.len() as u64;
-                    match parse_upload_progress(&check_resp, total) {
+                    match parse_upload_progress(&check_resp, ciphertext_len) {
                         UploadExistsResult::Complete { url, direct_path } => {
-                            return Ok(UploadResponse {
+                            return Ok(crypto.response(
                                 url,
                                 direct_path,
-                                media_key: enc.media_key,
-                                file_enc_sha256: enc.file_enc_sha256,
-                                file_sha256: enc.file_sha256,
                                 file_length,
                                 media_key_timestamp,
-                            });
+                            ));
                         }
                         UploadExistsResult::Resume { byte_offset } => {
-                            let offset = byte_offset as usize;
-                            if offset >= enc.data_to_upload.len() {
+                            if byte_offset >= ciphertext_len {
                                 log::warn!(
-                                    "Server resume offset {offset} exceeds data length {}; uploading from start",
-                                    enc.data_to_upload.len()
+                                    "Server resume offset {byte_offset} exceeds data length {ciphertext_len}; uploading from start"
                                 );
                             } else {
-                                log::info!("Resuming upload from byte {byte_offset}/{total}");
-                                upload_data = &enc.data_to_upload[offset..];
+                                log::info!(
+                                    "Resuming upload from byte {byte_offset}/{ciphertext_len}"
+                                );
+                                offset = byte_offset;
                                 file_offset = Some(byte_offset);
                             }
                         }
                         UploadExistsResult::NotFound => {}
                     }
                 }
-                // Non-fatal: if check request itself fails, proceed with full upload
+                // Non-fatal: if the check request itself fails, proceed with full upload.
             }
 
             let request = build_upload_request(
@@ -188,11 +216,10 @@ where
                 upload_path,
                 &media_conn.auth,
                 &token,
-                upload_data,
                 file_offset,
             );
 
-            let response = match execute_request(request).await {
+            let response = match send_body(request, offset, ciphertext_len - offset).await {
                 Ok(response) => response,
                 Err(err) => {
                     last_error = Some(err);
@@ -202,15 +229,12 @@ where
 
             if response.status_code < 400 {
                 let raw: RawUploadResponse = serde_json::from_slice(&response.body)?;
-                return Ok(UploadResponse {
-                    url: raw.url,
-                    direct_path: raw.direct_path,
-                    media_key: enc.media_key,
-                    file_enc_sha256: enc.file_enc_sha256,
-                    file_sha256: enc.file_sha256,
+                return Ok(crypto.response(
+                    raw.url,
+                    raw.direct_path,
                     file_length,
                     media_key_timestamp,
-                });
+                ));
             }
 
             let status_code = response.status_code;
@@ -248,6 +272,9 @@ pub struct UploadResponse {
     pub file_length: u64,
     /// Unix timestamp (seconds) when the media key was generated.
     pub media_key_timestamp: i64,
+    /// Per-64-KiB HMAC table for progressive playback/seek (audio/video only);
+    /// pass to `AudioMessage`/`VideoMessage.streaming_sidecar`.
+    pub streaming_sidecar: Option<Vec<u8>>,
 }
 
 impl From<UploadResponse> for wacore::sticker_pack::MediaUploadInfo {
@@ -287,12 +314,16 @@ struct RawUploadResponse {
 pub struct UploadOptions {
     /// Reuse an existing media key instead of generating a fresh one.
     pub media_key: Option<[u8; 32]>,
+    /// Override streaming-sidecar generation; `None` selects it by media type
+    /// (audio/video only).
+    pub streaming_sidecar: Option<bool>,
 }
 
 impl std::fmt::Debug for UploadOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UploadOptions")
             .field("media_key", &self.media_key.as_ref().map(|_| "<redacted>"))
+            .field("streaming_sidecar", &self.streaming_sidecar)
             .finish()
     }
 }
@@ -304,6 +335,11 @@ impl UploadOptions {
 
     pub fn with_media_key(mut self, key: [u8; 32]) -> Self {
         self.media_key = Some(key);
+        self
+    }
+
+    pub fn with_streaming_sidecar(mut self, enabled: bool) -> Self {
+        self.streaming_sidecar = Some(enabled);
         self
     }
 }
@@ -320,19 +356,89 @@ impl Client {
         options: UploadOptions,
     ) -> Result<UploadResponse> {
         let file_length = data.len() as u64;
+        let media_key = options.media_key;
+        let sidecar = options.streaming_sidecar;
         let enc = wacore::runtime::blocking(&*self.runtime, move || {
-            wacore::upload::encrypt_media_with_key(&data, media_type, options.media_key.as_ref())
+            wacore::upload::encrypt_media_with_key_and_sidecar(
+                &data,
+                media_type,
+                media_key.as_ref(),
+                sidecar,
+            )
         })
         .await?;
 
+        let ciphertext_len = enc.data_to_upload.len() as u64;
+        let crypto = UploadCrypto {
+            media_key: enc.media_key,
+            file_sha256: enc.file_sha256,
+            file_enc_sha256: enc.file_enc_sha256,
+            streaming_sidecar: enc.streaming_sidecar,
+        };
+        let ciphertext = enc.data_to_upload;
+
         upload_media_with_retry(
-            &enc,
+            crypto,
             media_type,
             file_length,
+            ciphertext_len,
             wacore::time::now_secs(),
             |force| async move { self.refresh_media_conn(force).await.map_err(Into::into) },
             || async { self.invalidate_media_conn().await },
             |request| async move { self.http_client.execute(request).await },
+            |request, offset, _remaining| {
+                let body = ciphertext[offset as usize..].to_vec();
+                async move { self.http_client.execute(request.with_body(body)).await }
+            },
+        )
+        .await
+    }
+
+    /// Uploads already-encrypted media streamed from `source`, keeping memory
+    /// constant regardless of file size. Encrypt the plaintext first with
+    /// [`wacore::upload::encrypt_media_streaming`] (or `..._with_key`) into the
+    /// storage of your choice, then pass that storage as `source` plus the
+    /// returned [`wacore::upload::EncryptedMediaInfo`]. The caller owns where the
+    /// ciphertext lives (temp file, memory, …); this method never touches disk.
+    pub async fn upload_stream<S>(
+        &self,
+        source: S,
+        info: wacore::upload::EncryptedMediaInfo,
+        media_type: MediaType,
+    ) -> Result<UploadResponse>
+    where
+        S: wacore::upload::UploadSource + 'static,
+    {
+        let file_length = info.file_length;
+        let ciphertext_len = source.len();
+        let crypto = UploadCrypto {
+            media_key: info.media_key,
+            file_sha256: info.file_sha256,
+            file_enc_sha256: info.file_enc_sha256,
+            streaming_sidecar: info.streaming_sidecar,
+        };
+        let source = std::sync::Arc::new(source);
+
+        upload_media_with_retry(
+            crypto,
+            media_type,
+            file_length,
+            ciphertext_len,
+            wacore::time::now_secs(),
+            |force| async move { self.refresh_media_conn(force).await.map_err(Into::into) },
+            || async { self.invalidate_media_conn().await },
+            |request| async move { self.http_client.execute(request).await },
+            |request, offset, remaining| {
+                let source = std::sync::Arc::clone(&source);
+                let http = std::sync::Arc::clone(&self.http_client);
+                async move {
+                    let reader = source.reader_from(offset)?;
+                    wacore::runtime::blocking(&*self.runtime, move || {
+                        http.execute_upload(request, reader, remaining)
+                    })
+                    .await
+                }
+            },
         )
         .await
     }
@@ -359,10 +465,33 @@ mod tests {
         }
     }
 
+    fn crypto_from(enc: &wacore::upload::EncryptedMedia) -> UploadCrypto {
+        UploadCrypto {
+            media_key: enc.media_key,
+            file_sha256: enc.file_sha256,
+            file_enc_sha256: enc.file_enc_sha256,
+            streaming_sidecar: enc.streaming_sidecar.clone(),
+        }
+    }
+
+    fn ok_json(url: &str, direct_path: &str) -> HttpResponse {
+        HttpResponse {
+            status_code: 200,
+            body: format!(r#"{{"url":"{url}","direct_path":"{direct_path}"}}"#).into_bytes(),
+        }
+    }
+
+    /// Resume check is skipped below the 5 MiB threshold, so a check call here
+    /// would be a logic error.
+    async fn unreachable_check(_req: HttpRequest) -> Result<HttpResponse> {
+        panic!("resume check must not run below the resumable threshold")
+    }
+
     #[tokio::test]
     async fn upload_retries_with_forced_media_conn_refresh_after_auth_error() {
         let enc = wacore::upload::encrypt_media(b"retry me", MediaType::Image)
             .expect("encryption should succeed");
+        let len = enc.data_to_upload.len() as u64;
         let first_conn = media_conn("stale-auth", &["cdn1.example.com"]);
         let refreshed_conn = media_conn("fresh-auth", &["cdn2.example.com"]);
         let refresh_calls = Arc::new(Mutex::new(Vec::new()));
@@ -370,9 +499,10 @@ mod tests {
         let seen_urls = Arc::new(Mutex::new(Vec::new()));
 
         let result = upload_media_with_retry(
-            &enc,
+            crypto_from(&enc),
             MediaType::Image,
             8,
+            len,
             0,
             {
                 let refresh_calls = Arc::clone(&refresh_calls);
@@ -395,9 +525,10 @@ mod tests {
                     }
                 }
             },
+            unreachable_check,
             {
                 let seen_urls = Arc::clone(&seen_urls);
-                move |request| {
+                move |request: HttpRequest, _offset, _remaining| {
                     let seen_urls = Arc::clone(&seen_urls);
                     async move {
                         seen_urls.lock().await.push(request.url.clone());
@@ -407,10 +538,10 @@ mod tests {
                                 body: b"expired".to_vec(),
                             })
                         } else {
-                            Ok(HttpResponse {
-                                status_code: 200,
-                                body: br#"{"url":"https://cdn2.example.com/file","direct_path":"/v/t62.7118-24/123"}"#.to_vec(),
-                            })
+                            Ok(ok_json(
+                                "https://cdn2.example.com/file",
+                                "/v/t62.7118-24/123",
+                            ))
                         }
                     }
                 }
@@ -437,22 +568,25 @@ mod tests {
     async fn upload_fails_over_to_next_host_after_non_auth_error() {
         let enc = wacore::upload::encrypt_media(b"retry host", MediaType::Image)
             .expect("encryption should succeed");
+        let len = enc.data_to_upload.len() as u64;
         let conn = media_conn("shared-auth", &["cdn1.example.com", "cdn2.example.com"]);
         let seen_urls = Arc::new(Mutex::new(Vec::new()));
 
         let result = upload_media_with_retry(
-            &enc,
+            crypto_from(&enc),
             MediaType::Image,
             10,
+            len,
             0,
             move |_force| {
                 let conn = conn.clone();
                 async move { Ok(conn) }
             },
             || async {},
+            unreachable_check,
             {
                 let seen_urls = Arc::clone(&seen_urls);
-                move |request| {
+                move |request: HttpRequest, _offset, _remaining| {
                     let seen_urls = Arc::clone(&seen_urls);
                     async move {
                         seen_urls.lock().await.push(request.url.clone());
@@ -462,10 +596,10 @@ mod tests {
                                 body: b"try another host".to_vec(),
                             })
                         } else {
-                            Ok(HttpResponse {
-                                status_code: 200,
-                                body: br#"{"url":"https://cdn2.example.com/file","direct_path":"/v/t62.7118-24/456"}"#.to_vec(),
-                            })
+                            Ok(ok_json(
+                                "https://cdn2.example.com/file",
+                                "/v/t62.7118-24/456",
+                            ))
                         }
                     }
                 }
@@ -480,5 +614,84 @@ mod tests {
         assert!(seen_urls[1].contains("cdn2.example.com"));
         assert_eq!(result.direct_path, "/v/t62.7118-24/456");
         assert_eq!(result.media_key_timestamp, 0);
+    }
+
+    /// Above the threshold, a server `resume=<offset>` must drive `send_body` to
+    /// upload only the tail (`file_offset` in the URL, `remaining = len - offset`).
+    #[tokio::test]
+    async fn resumable_upload_sends_tail_from_offset() {
+        let total: u64 = 6 * 1024 * 1024;
+        let offset: u64 = 1024 * 1024;
+        let conn = media_conn("auth", &["cdn1.example.com"]);
+        let captured: Arc<Mutex<Option<(String, u64, u64)>>> = Arc::new(Mutex::new(None));
+
+        let crypto = UploadCrypto {
+            media_key: [0u8; 32],
+            file_sha256: [0u8; 32],
+            file_enc_sha256: [9u8; 32],
+            streaming_sidecar: Some(vec![1, 2, 3]),
+        };
+
+        let result = upload_media_with_retry(
+            crypto,
+            MediaType::Video,
+            total,
+            total,
+            0,
+            move |_force| {
+                let conn = conn.clone();
+                async move { Ok(conn) }
+            },
+            || async {},
+            move |_req| async move {
+                Ok(HttpResponse {
+                    status_code: 200,
+                    body: format!(r#"{{"resume":"{offset}"}}"#).into_bytes(),
+                })
+            },
+            {
+                let captured = Arc::clone(&captured);
+                move |request: HttpRequest, off, remaining| {
+                    let captured = Arc::clone(&captured);
+                    async move {
+                        *captured.lock().await = Some((request.url.clone(), off, remaining));
+                        Ok(ok_json("https://cdn1.example.com/f", "/dp"))
+                    }
+                }
+            },
+        )
+        .await
+        .expect("resumable upload should succeed");
+
+        let (url, sent_offset, remaining) = captured.lock().await.clone().unwrap();
+        assert_eq!(sent_offset, offset);
+        assert_eq!(remaining, total - offset);
+        assert!(url.contains(&format!("file_offset={offset}")), "url: {url}");
+        // Sidecar must survive into the response.
+        assert_eq!(result.streaming_sidecar.as_deref(), Some(&[1u8, 2, 3][..]));
+    }
+
+    /// `UploadSource` over `Arc<[u8]>` must report the length and re-read the
+    /// tail from any offset, repeatably.
+    #[test]
+    fn arc_upload_source_reads_from_offset_repeatably() {
+        use std::io::Read;
+        use wacore::upload::UploadSource;
+
+        let bytes: Arc<[u8]> = (0u8..200).collect::<Vec<_>>().into();
+        assert_eq!(UploadSource::len(&bytes), 200);
+
+        let read_at = |offset: u64| {
+            let mut r = bytes.reader_from(offset).unwrap();
+            let mut out = Vec::new();
+            r.read_to_end(&mut out).unwrap();
+            out
+        };
+
+        assert_eq!(read_at(0), (0u8..200).collect::<Vec<_>>());
+        assert_eq!(read_at(50), (50u8..200).collect::<Vec<_>>());
+        // Independent, repeatable readers (host failover / auth refresh).
+        assert_eq!(read_at(50), read_at(50));
+        assert_eq!(read_at(200), Vec::<u8>::new());
     }
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -432,8 +432,10 @@ impl Client {
                 let source = std::sync::Arc::clone(&source);
                 let http = std::sync::Arc::clone(&self.http_client);
                 async move {
-                    let reader = source.reader_from(offset)?;
+                    // reader_from may open/seek a file, so run it in the blocking
+                    // task with execute_upload, not on the async worker.
                     wacore::runtime::blocking(&*self.runtime, move || {
+                        let reader = source.reader_from(offset)?;
                         http.execute_upload(request, reader, remaining)
                     })
                     .await

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -131,6 +131,11 @@ pub struct StreamingHttpResponse {
     pub body: Box<dyn std::io::Read + Send>,
 }
 
+/// A streaming request body: a reader whose total length is known up front, so
+/// the client can send an exact `Content-Length` (WhatsApp's CDN rejects chunked
+/// transfer-encoding on upload).
+pub type UploadBody = Box<dyn std::io::Read + Send>;
+
 /// Trait for executing HTTP requests in a runtime-agnostic way
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -148,6 +153,26 @@ pub trait HttpClient: Send + Sync {
     fn execute_streaming(&self, _request: HttpRequest) -> Result<StreamingHttpResponse> {
         Err(anyhow::anyhow!(
             "Streaming not supported by this HTTP client"
+        ))
+    }
+
+    /// Whether this client can stream a request body from a reader (upload).
+    fn supports_upload_streaming(&self) -> bool {
+        false
+    }
+
+    /// Synchronous streaming upload: send `body` (exactly `content_length` bytes)
+    /// as the request body. Implementations MUST set an explicit `Content-Length`
+    /// rather than chunked transfer-encoding. Any body set on `request` is
+    /// ignored. Must be called from a blocking context.
+    fn execute_upload(
+        &self,
+        _request: HttpRequest,
+        _body: UploadBody,
+        _content_length: u64,
+    ) -> Result<HttpResponse> {
+        Err(anyhow::anyhow!(
+            "Upload streaming not supported by this HTTP client"
         ))
     }
 }

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -9,11 +9,21 @@ use std::io::{Read, Write};
 
 const BLOCK: usize = 16;
 
+/// Streaming sidecar chunk size: one HMAC per 64 KiB of ciphertext.
+const SIDECAR_CHUNK: usize = 64 * 1024;
+/// Each sidecar entry is a 10-byte truncated HMAC-SHA256.
+const SIDECAR_MAC_LEN: usize = 10;
+/// 16-byte (one AES block) overlap between consecutive sidecar windows, needed
+/// so each 64 KiB window carries the CBC chaining context of its neighbour.
+const SIDECAR_OVERLAP: usize = 16;
+
 pub struct EncryptedMedia {
     pub data_to_upload: Vec<u8>,
     pub media_key: [u8; 32],
     pub file_sha256: [u8; 32],
     pub file_enc_sha256: [u8; 32],
+    /// Per-64-KiB HMAC table for progressive playback/seek (audio/video only).
+    pub streaming_sidecar: Option<Vec<u8>>,
 }
 
 pub struct EncryptedMediaInfo {
@@ -21,6 +31,8 @@ pub struct EncryptedMediaInfo {
     pub file_sha256: [u8; 32],
     pub file_enc_sha256: [u8; 32],
     pub file_length: u64,
+    /// Per-64-KiB HMAC table for progressive playback/seek (audio/video only).
+    pub streaming_sidecar: Option<Vec<u8>>,
 }
 
 /// Chunk-based AES-256-CBC media encryptor.
@@ -42,19 +54,36 @@ pub struct MediaEncryptor {
     remainder: Vec<u8>,
     media_key: [u8; 32],
     file_length: u64,
+    /// Present when a streaming sidecar is being accumulated over the ciphertext.
+    sidecar: Option<SidecarAccumulator>,
 }
 
 impl MediaEncryptor {
-    /// Initialize with a random media key.
+    /// Initialize with a random media key (no streaming sidecar).
     pub fn new(media_type: MediaType) -> Result<Self> {
-        let mut media_key = [0u8; 32];
-        rng().fill(&mut media_key);
-        Self::with_key(media_key, media_type)
+        Self::new_with_sidecar(media_type, false)
     }
 
-    /// Initialize with a caller-supplied key. The key must be 32
-    /// cryptographically random bytes; reusing keys breaks confidentiality.
+    /// Initialize with a random media key, optionally accumulating a streaming sidecar.
+    pub fn new_with_sidecar(media_type: MediaType, sidecar: bool) -> Result<Self> {
+        let mut media_key = [0u8; 32];
+        rng().fill(&mut media_key);
+        Self::with_key_and_sidecar(media_key, media_type, sidecar)
+    }
+
+    /// Initialize with a caller-supplied key (no streaming sidecar). The key must
+    /// be 32 cryptographically random bytes; reusing keys breaks confidentiality.
     pub fn with_key(media_key: [u8; 32], media_type: MediaType) -> Result<Self> {
+        Self::with_key_and_sidecar(media_key, media_type, false)
+    }
+
+    /// Initialize with a caller-supplied key, optionally accumulating a streaming
+    /// sidecar (one truncated HMAC per 64 KiB of ciphertext, for audio/video).
+    pub fn with_key_and_sidecar(
+        media_key: [u8; 32],
+        media_type: MediaType,
+        sidecar: bool,
+    ) -> Result<Self> {
         let (iv, cipher_key, mac_key) = DownloadUtils::get_media_keys(&media_key, media_type)?;
         let cipher =
             Aes256::new_from_slice(&cipher_key).map_err(|_| anyhow::anyhow!("Bad AES key"))?;
@@ -70,6 +99,7 @@ impl MediaEncryptor {
             remainder: Vec::with_capacity(BLOCK),
             media_key,
             file_length: 0,
+            sidecar: sidecar.then(|| SidecarAccumulator::new(mac_key)),
         })
     }
 
@@ -163,6 +193,9 @@ impl MediaEncryptor {
             emit(&self.prev_block);
             self.hmac.update(&self.prev_block);
             self.sha256_enc.update(&self.prev_block);
+            if let Some(sc) = &mut self.sidecar {
+                sc.push(&self.prev_block);
+            }
         }
     }
 
@@ -193,22 +226,182 @@ impl MediaEncryptor {
 
     fn finish_hashes(mut self, mac: &[u8; 10]) -> Result<EncryptedMediaInfo> {
         self.sha256_enc.update(mac);
+        // The sidecar covers the whole uploaded blob (ciphertext + trailing MAC),
+        // so feed the MAC before sealing it.
+        let streaming_sidecar = match self.sidecar.take() {
+            Some(mut sc) => {
+                sc.push(mac);
+                Some(sc.finish()?)
+            }
+            None => None,
+        };
         Ok(EncryptedMediaInfo {
             media_key: self.media_key,
             file_sha256: self.sha256_plain.finalize_sha256_array()?,
             file_enc_sha256: self.sha256_enc.finalize_sha256_array()?,
             file_length: self.file_length,
+            streaming_sidecar,
         })
     }
 }
 
-/// Encrypt media streaming with constant memory.
+/// Accumulates a WhatsApp streaming sidecar: one 10-byte truncated HMAC-SHA256
+/// per 64 KiB window of ciphertext, each window overlapping the next by one AES
+/// block (16 bytes) to preserve CBC chaining. Fed incrementally with the
+/// encrypted blocks (and the trailing MAC) so it never holds the whole file.
+struct SidecarAccumulator {
+    mac_key: [u8; 32],
+    /// Bytes buffered for the window currently being hashed.
+    window: Vec<u8>,
+    /// Concatenated 10-byte HMACs produced so far.
+    result: Vec<u8>,
+    /// Absolute offset where the current window logically starts.
+    next_chunk_start: u64,
+    /// Total bytes pushed so far.
+    total_pushed: u64,
+    /// First HMAC construction error, surfaced by `finish`.
+    err: Option<anyhow::Error>,
+}
+
+impl SidecarAccumulator {
+    fn new(mac_key: [u8; 32]) -> Self {
+        Self {
+            mac_key,
+            window: Vec::with_capacity(SIDECAR_OVERLAP + SIDECAR_CHUNK),
+            result: Vec::new(),
+            next_chunk_start: 0,
+            total_pushed: 0,
+            err: None,
+        }
+    }
+
+    fn push(&mut self, data: &[u8]) {
+        let mut src = 0;
+        while src < data.len() {
+            let window_end = self.next_chunk_start + (SIDECAR_OVERLAP + SIDECAR_CHUNK) as u64;
+            let remaining = (window_end - self.total_pushed) as usize;
+            let to_copy = remaining.min(data.len() - src);
+            self.window.extend_from_slice(&data[src..src + to_copy]);
+            self.total_pushed += to_copy as u64;
+            src += to_copy;
+            if self.total_pushed == window_end {
+                self.flush();
+            }
+        }
+    }
+
+    /// Emit the HMAC of the current window, then retain only the trailing
+    /// 16-byte overlap as the start of the next window.
+    fn flush(&mut self) {
+        if self.window.is_empty() {
+            return;
+        }
+        match hmac_sha256_trunc10(&self.mac_key, &self.window) {
+            Ok(mac) => self.result.extend_from_slice(&mac),
+            Err(e) => {
+                self.err.get_or_insert(e);
+            }
+        }
+        self.next_chunk_start += SIDECAR_CHUNK as u64;
+        let keep_from = self.window.len().saturating_sub(SIDECAR_OVERLAP);
+        self.window.drain(0..keep_from);
+    }
+
+    fn finish(mut self) -> Result<Vec<u8>> {
+        if !self.window.is_empty() {
+            self.flush();
+        }
+        match self.err {
+            Some(e) => Err(e),
+            None => Ok(self.result),
+        }
+    }
+}
+
+fn hmac_sha256_trunc10(mac_key: &[u8], data: &[u8]) -> Result<[u8; SIDECAR_MAC_LEN]> {
+    let mut hmac = CryptographicMac::new("HmacSha256", mac_key)?;
+    hmac.update(data);
+    let full = hmac.finalize_sha256_array()?;
+    let mut out = [0u8; SIDECAR_MAC_LEN];
+    out.copy_from_slice(&full[..SIDECAR_MAC_LEN]);
+    Ok(out)
+}
+
+/// Audio and video are the only media types that benefit from a streaming
+/// sidecar (progressive playback/seek); images/documents are fetched whole.
+fn media_type_uses_sidecar(media_type: MediaType) -> bool {
+    matches!(media_type, MediaType::Audio | MediaType::Video)
+}
+
+/// A re-readable source of already-encrypted upload bytes.
+///
+/// The upload path may read the body more than once (host failover, auth
+/// refresh) and from an arbitrary offset (server-driven resume), so a single
+/// consumable `Read` is not enough. Implementors decide where the ciphertext
+/// lives — this crate never creates temporary files.
+///
+/// An in-memory implementation is provided for `Arc<[u8]>`. For a disk-staged
+/// body, implement this over your own handle, e.g.:
+///
+/// ```ignore
+/// struct FileSource { path: PathBuf, len: u64 }
+/// impl UploadSource for FileSource {
+///     fn len(&self) -> u64 { self.len }
+///     fn reader_from(&self, offset: u64) -> std::io::Result<Box<dyn Read + Send>> {
+///         let mut f = std::fs::File::open(&self.path)?;
+///         f.seek(std::io::SeekFrom::Start(offset))?;
+///         Ok(Box::new(f))
+///     }
+/// }
+/// ```
+pub trait UploadSource: Send + Sync {
+    /// Total length of the encrypted blob in bytes.
+    fn len(&self) -> u64;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// A reader positioned at `offset`. Called once per upload attempt.
+    fn reader_from(&self, offset: u64) -> std::io::Result<Box<dyn Read + Send>>;
+}
+
+impl UploadSource for std::sync::Arc<[u8]> {
+    fn len(&self) -> u64 {
+        (**self).len() as u64
+    }
+
+    fn reader_from(&self, offset: u64) -> std::io::Result<Box<dyn Read + Send>> {
+        let mut cursor = std::io::Cursor::new(std::sync::Arc::clone(self));
+        cursor.set_position(offset.min(self.len()));
+        Ok(Box::new(cursor))
+    }
+}
+
+/// Encrypt media streaming with constant memory. A streaming sidecar is
+/// generated automatically for audio/video.
 pub fn encrypt_media_streaming<R: Read, W: Write>(
+    reader: R,
+    writer: W,
+    media_type: MediaType,
+) -> Result<EncryptedMediaInfo> {
+    encrypt_media_streaming_with_key(reader, writer, media_type, None, None)
+}
+
+/// Like [`encrypt_media_streaming`] but accepts an optional pre-existing key and
+/// an explicit sidecar override (`None` = automatic, by media type).
+pub fn encrypt_media_streaming_with_key<R: Read, W: Write>(
     mut reader: R,
     mut writer: W,
     media_type: MediaType,
+    media_key: Option<&[u8; 32]>,
+    sidecar: Option<bool>,
 ) -> Result<EncryptedMediaInfo> {
-    let mut enc = MediaEncryptor::new(media_type)?;
+    let want_sidecar = sidecar.unwrap_or_else(|| media_type_uses_sidecar(media_type));
+    let mut enc = match media_key {
+        Some(key) => MediaEncryptor::with_key_and_sidecar(*key, media_type, want_sidecar)?,
+        None => MediaEncryptor::new_with_sidecar(media_type, want_sidecar)?,
+    };
     let mut buf = [0u8; 8 * 1024];
     loop {
         let n = reader.read(&mut buf)?;
@@ -222,7 +415,8 @@ pub fn encrypt_media_streaming<R: Read, W: Write>(
     Ok(info)
 }
 
-/// Encrypt media in memory.
+/// Encrypt media in memory. A streaming sidecar is generated automatically for
+/// audio/video.
 pub fn encrypt_media(plaintext: &[u8], media_type: MediaType) -> Result<EncryptedMedia> {
     encrypt_media_with_key(plaintext, media_type, None)
 }
@@ -233,9 +427,21 @@ pub fn encrypt_media_with_key(
     media_type: MediaType,
     media_key: Option<&[u8; 32]>,
 ) -> Result<EncryptedMedia> {
+    encrypt_media_with_key_and_sidecar(plaintext, media_type, media_key, None)
+}
+
+/// Like [`encrypt_media_with_key`] but with an explicit sidecar override
+/// (`None` = automatic, by media type).
+pub fn encrypt_media_with_key_and_sidecar(
+    plaintext: &[u8],
+    media_type: MediaType,
+    media_key: Option<&[u8; 32]>,
+    sidecar: Option<bool>,
+) -> Result<EncryptedMedia> {
+    let want_sidecar = sidecar.unwrap_or_else(|| media_type_uses_sidecar(media_type));
     let mut enc = match media_key {
-        Some(key) => MediaEncryptor::with_key(*key, media_type)?,
-        None => MediaEncryptor::new(media_type)?,
+        Some(key) => MediaEncryptor::with_key_and_sidecar(*key, media_type, want_sidecar)?,
+        None => MediaEncryptor::new_with_sidecar(media_type, want_sidecar)?,
     };
     let mut data_to_upload = Vec::new();
     enc.update(plaintext, &mut data_to_upload);
@@ -245,6 +451,7 @@ pub fn encrypt_media_with_key(
         media_key: info.media_key,
         file_sha256: info.file_sha256,
         file_enc_sha256: info.file_enc_sha256,
+        streaming_sidecar: info.streaming_sidecar,
     })
 }
 
@@ -429,5 +636,197 @@ mod tests {
         )
         .expect("decrypt");
         assert_eq!(decrypted, msg);
+    }
+
+    // ---- streaming/buffer parity & sidecar ----
+
+    /// Deterministic pseudo-random payload (no `rand` needed; reproducible).
+    fn payload(len: usize, seed: u8) -> Vec<u8> {
+        let mut v = Vec::with_capacity(len);
+        let mut x = seed;
+        for i in 0..len {
+            x = x.wrapping_mul(31).wrapping_add(i as u8).wrapping_add(7);
+            v.push(x);
+        }
+        v
+    }
+
+    /// Independent ("naive") reimplementation of the sidecar straight from the
+    /// full encrypted blob, used to pin the incremental accumulator's behaviour.
+    fn naive_sidecar(enc_full: &[u8], mac_key: &[u8; 32]) -> Vec<u8> {
+        let c = SIDECAR_CHUNK;
+        let o = SIDECAR_OVERLAP;
+        let mut out = Vec::new();
+        let mut start = 0usize;
+        while start + c + o <= enc_full.len() {
+            out.extend_from_slice(
+                &hmac_sha256_trunc10(mac_key, &enc_full[start..start + c + o]).unwrap(),
+            );
+            start += c;
+        }
+        // Final flush: always runs (the blob is never empty — it carries the MAC).
+        out.extend_from_slice(&hmac_sha256_trunc10(mac_key, &enc_full[start..]).unwrap());
+        out
+    }
+
+    fn mac_key_for(media_key: &[u8; 32], media_type: MediaType) -> [u8; 32] {
+        let (_, _, mac_key) = DownloadUtils::get_media_keys(media_key, media_type).unwrap();
+        mac_key
+    }
+
+    #[test]
+    fn streaming_and_buffered_are_byte_identical() {
+        // Same key + same media type must produce identical ciphertext, hashes,
+        // and sidecar across the buffered and streaming paths.
+        let key = [7u8; 32];
+        for &len in &[0usize, 1, 15, 16, 17, 8192 * 3 + 5, 200_000] {
+            let data = payload(len, len as u8);
+            let buffered =
+                encrypt_media_with_key_and_sidecar(&data, MediaType::Video, Some(&key), None)
+                    .unwrap();
+
+            let mut streamed_blob = Vec::new();
+            let info = encrypt_media_streaming_with_key(
+                Cursor::new(data.as_slice()),
+                &mut streamed_blob,
+                MediaType::Video,
+                Some(&key),
+                None,
+            )
+            .unwrap();
+
+            assert_eq!(
+                buffered.data_to_upload, streamed_blob,
+                "ciphertext (len {len})"
+            );
+            assert_eq!(
+                buffered.file_sha256, info.file_sha256,
+                "file_sha256 (len {len})"
+            );
+            assert_eq!(
+                buffered.file_enc_sha256, info.file_enc_sha256,
+                "file_enc_sha256 (len {len})"
+            );
+            assert_eq!(
+                buffered.streaming_sidecar, info.streaming_sidecar,
+                "sidecar (len {len})"
+            );
+            assert!(buffered.streaming_sidecar.is_some(), "video has a sidecar");
+        }
+    }
+
+    #[test]
+    fn sidecar_matches_naive_reference() {
+        // Cross every 64 KiB boundary: just below, exactly at, and just above
+        // one and two windows of *ciphertext*.
+        let key = [0x33u8; 32];
+        let mac_key = mac_key_for(&key, MediaType::Audio);
+        for &len in &[
+            0usize,
+            10,
+            SIDECAR_CHUNK - 32,
+            SIDECAR_CHUNK,
+            SIDECAR_CHUNK + 16,
+            SIDECAR_CHUNK + 64,
+            2 * SIDECAR_CHUNK,
+            2 * SIDECAR_CHUNK + 100,
+            3 * SIDECAR_CHUNK + 7,
+        ] {
+            let data = payload(len, 0x5A);
+            let enc = encrypt_media_with_key_and_sidecar(&data, MediaType::Audio, Some(&key), None)
+                .unwrap();
+            let sidecar = enc.streaming_sidecar.expect("audio sidecar");
+            let expected = naive_sidecar(&enc.data_to_upload, &mac_key);
+            assert_eq!(
+                sidecar, expected,
+                "sidecar mismatch for plaintext len {len}"
+            );
+            assert_eq!(
+                sidecar.len() % SIDECAR_MAC_LEN,
+                0,
+                "sidecar must be a whole number of 10-byte entries"
+            );
+        }
+    }
+
+    #[test]
+    fn sidecar_first_entry_is_hmac_of_first_window() {
+        // Direct, hand-rolled check of the 64 KiB + 16 overlap window.
+        let key = [0x91u8; 32];
+        let mac_key = mac_key_for(&key, MediaType::Video);
+        let data = payload(3 * SIDECAR_CHUNK, 0x11);
+        let enc =
+            encrypt_media_with_key_and_sidecar(&data, MediaType::Video, Some(&key), None).unwrap();
+        let sidecar = enc.streaming_sidecar.unwrap();
+
+        let first = hmac_sha256_trunc10(
+            &mac_key,
+            &enc.data_to_upload[..SIDECAR_CHUNK + SIDECAR_OVERLAP],
+        )
+        .unwrap();
+        assert_eq!(&sidecar[..SIDECAR_MAC_LEN], &first[..]);
+    }
+
+    #[test]
+    fn sidecar_independent_of_input_chunking() {
+        // Feeding the encryptor in odd-sized pieces must not change the sidecar.
+        let key = [0x44u8; 32];
+        let data = payload(2 * SIDECAR_CHUNK + 123, 0x77);
+
+        let oneshot =
+            encrypt_media_with_key_and_sidecar(&data, MediaType::Video, Some(&key), None).unwrap();
+
+        let mut enc =
+            MediaEncryptor::with_key_and_sidecar([0x44u8; 32], MediaType::Video, true).unwrap();
+        let mut blob = Vec::new();
+        for chunk in data.chunks(7) {
+            enc.update(chunk, &mut blob);
+        }
+        let info = enc.finalize(&mut blob).unwrap();
+
+        assert_eq!(oneshot.data_to_upload, blob);
+        assert_eq!(oneshot.streaming_sidecar, info.streaming_sidecar);
+    }
+
+    #[test]
+    fn sidecar_only_for_audio_and_video_by_default() {
+        let key = [1u8; 32];
+        for mt in [MediaType::Audio, MediaType::Video] {
+            let enc = encrypt_media_with_key(&payload(1000, 1), mt, Some(&key)).unwrap();
+            assert!(
+                enc.streaming_sidecar.is_some(),
+                "{mt:?} should have a sidecar"
+            );
+        }
+        for mt in [MediaType::Image, MediaType::Document, MediaType::Sticker] {
+            let enc = encrypt_media_with_key(&payload(1000, 1), mt, Some(&key)).unwrap();
+            assert!(
+                enc.streaming_sidecar.is_none(),
+                "{mt:?} should have no sidecar"
+            );
+        }
+    }
+
+    #[test]
+    fn sidecar_override_forces_and_inhibits() {
+        let key = [2u8; 32];
+        // Force a sidecar on an image.
+        let forced = encrypt_media_with_key_and_sidecar(
+            &payload(1000, 2),
+            MediaType::Image,
+            Some(&key),
+            Some(true),
+        )
+        .unwrap();
+        assert!(forced.streaming_sidecar.is_some());
+        // Inhibit a sidecar on a video.
+        let inhibited = encrypt_media_with_key_and_sidecar(
+            &payload(1000, 2),
+            MediaType::Video,
+            Some(&key),
+            Some(false),
+        )
+        .unwrap();
+        assert!(inhibited.streaming_sidecar.is_none());
     }
 }


### PR DESCRIPTION
## What

`Client::upload` buffers the whole media file: it holds the plaintext `Vec` **and** the encrypted blob for the entire upload, so peak memory is ~2× the file. Fine for images, wasteful for large video/documents. We also never generated `streaming_sidecar`, so audio/video sent by this lib can't be progressively played/seeked by the recipient.

This adds a constant-memory streaming upload path (the caller decides where the ciphertext lives) and generates the streaming sidecar during encryption, while keeping `Client::upload` and the `HttpClient` trait backward-compatible. The "always send a `Content-Length`, never chunked" invariant matches WA Web's `Mms` upload flow.

## Change

**Encryption (`wacore/src/upload.rs`)**
- `encrypt_media_streaming_with_key(reader, writer, type, key, sidecar)` — the existing chunked `MediaEncryptor` already encrypts `Read → Write` at constant memory; this exposes the key + sidecar overrides.
- `SidecarAccumulator`: one truncated 10-byte HMAC-SHA256 per 64 KiB of ciphertext, each window overlapping the next by one AES block (16 bytes) for CBC chaining. Fed incrementally from the encrypted blocks, so it never holds the whole file. Auto-enabled for `Audio`/`Video`, overridable.
- `UploadSource` trait — a re-readable body that yields a reader from an arbitrary offset (needed for host failover / auth refresh / server-driven resume). In-memory `Arc<[u8]>` impl included; disk staging is the caller's choice — the lib never creates temp files.
- `EncryptedMedia`/`EncryptedMediaInfo` carry `streaming_sidecar`.

**Transport (`wacore/src/net.rs`, `http_clients/ureq-client`)**
- `HttpClient::execute_upload(request, body: Box<dyn Read + Send>, content_length)` + `supports_upload_streaming()`, both with default impls — non-breaking for existing/custom/WASM clients.
- The ureq impl streams the reader with an explicit `Content-Length`; otherwise ureq frames an arbitrary reader body as `Transfer-Encoding: chunked`, which the CDN rejects.

**Client (`src/upload.rs`)**
- `Client::upload_stream(source, info, media_type)` — encrypt to your own storage, then stream it up.
- `upload_media_with_retry` generalized: the body send is now a callback, so the buffered and streaming paths share one host-failover / auth-refresh / resumable-upload loop (`build_upload_request` no longer embeds the body).
- `UploadResponse` carries `streaming_sidecar` (pass to `AudioMessage`/`VideoMessage`). `UploadOptions::with_streaming_sidecar` overrides the per-type default.

No breaking changes: `Client::upload` keeps its signature, new trait methods are defaulted, and `UploadOptions` is `#[non_exhaustive]`.

## Tests

- **Encryption** (`wacore`, 6 new): streaming↔buffered byte-identical ciphertext/hashes/sidecar across sizes (0..200 KiB); sidecar vs an independent reference implementation across every 64 KiB boundary; first-entry HMAC overlap checked by hand; sidecar invariant to input chunking; per-type enable + override.
- **Transport** (`ureq-client`, 3 new): an arbitrary `Cursor` body is sent with an exact `Content-Length` and **no** `Transfer-Encoding: chunked`; 200 KB body integrity across the 16 KiB output buffer; non-POST rejected.
- **Retry/resume** (`src/upload.rs`, 2 new + 2 updated): server `resume=<offset>` uploads only the tail with `file_offset` set and `remaining = len - offset`; `UploadSource` re-reads the tail repeatably; existing auth-refresh and host-failover tests adapted to the shared path.

`cargo clippy --all-targets -- -D warnings` clean; full workspace test suite green.