### PR TITLE
perf(history-sync): single-byte fast-path for read_varint

### DIFF
--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -306,12 +306,21 @@ fn checked_end(
 /// Read a protobuf varint from `data`, returning (value, bytes_consumed).
 #[inline]
 fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
-    let mut value: u64 = 0;
-    let mut shift = 0u32;
-    for (i, &byte) in data.iter().enumerate() {
+    // Single-byte fast-path: most history-sync varints (tags, small lengths) fit in one byte.
+    let Some(&first) = data.first() else {
+        return Err(HistorySyncError::MalformedProtobuf(
+            "unexpected end of data in varint".into(),
+        ));
+    };
+    if first < 0x80 {
+        return Ok((first as u64, 1));
+    }
+    let mut value = (first & 0x7F) as u64;
+    let mut shift = 7u32;
+    for (i, &byte) in data[1..].iter().enumerate() {
         value |= ((byte & 0x7F) as u64) << shift;
         if byte & 0x80 == 0 {
-            return Ok((value, i + 1));
+            return Ok((value, i + 2));
         }
         shift += 7;
         if shift >= 64 {


### PR DESCRIPTION
## What

Most varints read while scanning a history-sync blob (field tags, small lengths) are a single byte. `read_varint` always took the general loop+shift path; this adds a single-byte fast-path.

## Measured (iai-callgrind, opt-level=3)

| | instructions |
|---|---|
| `read_varint` isolated (40k varints) | 508,156 → 436,156 (−14.2%) |
| `process_history_sync` (~20k-msg bootstrap) | 69,987,811 → 69,776,799 (−0.30%) |

`read_varint` is ~2% of the full path (rest is zlib inflate + prost decode), so the function-level win shows up as a small end-to-end gain.

## Tests

`cargo test -p wacore`: 850 pass (varint golden cases + streaming/full-path parity).