### PR TITLE
perf(appstate): parse sync response once (+ dedup external-blob download)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2805,8 +2805,9 @@ impl Client {
             let mut pre_downloaded: std::collections::HashMap<String, Vec<u8>> =
                 std::collections::HashMap::new();
 
-            if let Ok(patch_lists) =
-                wacore::appstate::patch_decode::parse_patch_lists_ref(resp.get())
+            // Parse the response once here for pre-download; the same parsed
+            // lists are handed to the processor below (no second parse).
+            let patch_lists = wacore::appstate::patch_decode::parse_patch_lists_ref(resp.get())?;
             {
                 for pl in &patch_lists {
                     // Download external snapshot
@@ -2864,10 +2865,10 @@ impl Client {
                 }
             };
 
-            // Parse and process all collections from the response
+            // Process the already-parsed collections (no re-parse of the response).
             let proc = self.get_app_state_processor().await;
             let results = proc
-                .decode_multi_patch_list_ref(resp.get(), &download, true)
+                .process_patch_lists(patch_lists, &download, true)
                 .await?;
 
             let mut needs_refetch = Vec::new();
@@ -3025,7 +3026,10 @@ impl Client {
             let mut pre_downloaded: std::collections::HashMap<String, Vec<u8>> =
                 std::collections::HashMap::new();
 
-            if let Ok(pl) = wacore::appstate::patch_decode::parse_patch_list_ref(resp.get()) {
+            // Parse the response once here for pre-download; the same parsed list
+            // is handed to the processor below (no second parse).
+            let pl = wacore::appstate::patch_decode::parse_patch_list_ref(resp.get())?;
+            {
                 debug!(target: "Client/AppState", "Parsed patch list for {:?}: has_snapshot_ref={} has_more_patches={} patches_count={}",
                     name, pl.snapshot_ref.is_some(), pl.has_more_patches, pl.patches.len());
 
@@ -3083,9 +3087,8 @@ impl Client {
             };
 
             let proc = self.get_app_state_processor().await;
-            let (mutations, new_state, list) = proc
-                .decode_patch_list_ref(resp.get(), &download, true)
-                .await?;
+            let (mutations, new_state, list) =
+                proc.process_parsed_patch_list(pl, &download, true).await?;
             let decode_elapsed = _decode_start.elapsed();
             if decode_elapsed.as_millis() > 500 {
                 debug!(target: "Client/AppState", "Patch decode for {:?} took {:?}", name, decode_elapsed);

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -119,7 +119,7 @@ where
             .ok_or(AppStateError::MissingKeyId)?;
         let keys = get_keys(key_id)?;
 
-        let mutation = decode_record(
+        let mut mutation = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             rec,
             &keys,
@@ -127,9 +127,12 @@ where
             validate_macs,
         )?;
 
+        // Move the MACs out instead of cloning: nothing downstream reads
+        // Mutation.index_mac/value_mac after processing (only the MAC vecs are
+        // persisted), so the decoded mutation can surrender them.
         mutation_macs.push(AppStateMutationMAC {
-            index_mac: mutation.index_mac.clone(),
-            value_mac: mutation.value_mac.clone(),
+            index_mac: std::mem::take(&mut mutation.index_mac),
+            value_mac: std::mem::take(&mut mutation.value_mac),
         });
 
         mutations.push(mutation);
@@ -254,17 +257,18 @@ where
                 .ok_or(AppStateError::MissingKeyId)?;
             let keys = get_keys(key_id)?;
 
-            let mutation = decode_record(op, rec, &keys, key_id, validate_macs)?;
+            let mut mutation = decode_record(op, rec, &keys, key_id, validate_macs)?;
 
+            // Move the MACs out instead of cloning (see process_snapshot).
             match op {
                 wa::syncd_mutation::SyncdOperation::Set => {
                     added_macs.push(AppStateMutationMAC {
-                        index_mac: mutation.index_mac.clone(),
-                        value_mac: mutation.value_mac.clone(),
+                        index_mac: std::mem::take(&mut mutation.index_mac),
+                        value_mac: std::mem::take(&mut mutation.value_mac),
                     });
                 }
                 wa::syncd_mutation::SyncdOperation::Remove => {
-                    removed_index_macs.push(mutation.index_mac.clone());
+                    removed_index_macs.push(std::mem::take(&mut mutation.index_mac));
                 }
             }
 

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -119,7 +119,7 @@ where
             .ok_or(AppStateError::MissingKeyId)?;
         let keys = get_keys(key_id)?;
 
-        let mut mutation = decode_record(
+        let mutation = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             rec,
             &keys,
@@ -127,12 +127,9 @@ where
             validate_macs,
         )?;
 
-        // Move the MACs out instead of cloning: nothing downstream reads
-        // Mutation.index_mac/value_mac after processing (only the MAC vecs are
-        // persisted), so the decoded mutation can surrender them.
         mutation_macs.push(AppStateMutationMAC {
-            index_mac: std::mem::take(&mut mutation.index_mac),
-            value_mac: std::mem::take(&mut mutation.value_mac),
+            index_mac: mutation.index_mac.clone(),
+            value_mac: mutation.value_mac.clone(),
         });
 
         mutations.push(mutation);
@@ -257,18 +254,17 @@ where
                 .ok_or(AppStateError::MissingKeyId)?;
             let keys = get_keys(key_id)?;
 
-            let mut mutation = decode_record(op, rec, &keys, key_id, validate_macs)?;
+            let mutation = decode_record(op, rec, &keys, key_id, validate_macs)?;
 
-            // Move the MACs out instead of cloning (see process_snapshot).
             match op {
                 wa::syncd_mutation::SyncdOperation::Set => {
                     added_macs.push(AppStateMutationMAC {
-                        index_mac: std::mem::take(&mut mutation.index_mac),
-                        value_mac: std::mem::take(&mut mutation.value_mac),
+                        index_mac: mutation.index_mac.clone(),
+                        value_mac: mutation.value_mac.clone(),
                     });
                 }
                 wa::syncd_mutation::SyncdOperation::Remove => {
-                    removed_index_macs.push(std::mem::take(&mut mutation.index_mac));
+                    removed_index_macs.push(mutation.index_mac.clone());
                 }
             }
 

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -104,8 +104,23 @@ impl AppStateProcessor {
     where
         FDownload: Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>> + Send + Sync,
     {
-        let mut pl = parse_patch_list_ref(stanza_root)?;
+        let pl = parse_patch_list_ref(stanza_root)?;
+        self.process_parsed_patch_list(pl, download, validate_macs)
+            .await
+    }
 
+    /// Process an already-parsed single PatchList: download external blobs via
+    /// `download`, then decode + apply. Lets a caller that parsed the response for
+    /// pre-download avoid re-parsing it. See [`decode_patch_list_ref`].
+    pub async fn process_parsed_patch_list<FDownload>(
+        &self,
+        mut pl: PatchList,
+        download: FDownload,
+        validate_macs: bool,
+    ) -> Result<(Vec<Mutation>, HashState, PatchList)>
+    where
+        FDownload: Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>> + Send + Sync,
+    {
         // Download external snapshot if present (matches WhatsApp Web behavior)
         if pl.snapshot.is_none()
             && let Some(ext) = &pl.snapshot_ref
@@ -246,7 +261,10 @@ impl AppStateProcessor {
             .await
     }
 
-    async fn process_patch_lists<FDownload>(
+    /// Process already-parsed patch lists, downloading any external blobs via
+    /// `download`. Lets callers that already parsed the IQ response (e.g. to
+    /// pre-download blobs) avoid re-parsing it. See [`decode_multi_patch_list_ref`].
+    pub async fn process_patch_lists<FDownload>(
         &self,
         patch_lists: Vec<PatchList>,
         download: &FDownload,

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -36,6 +36,48 @@ fn lookup_app_state_key(
         .ok_or(crate::appstate::AppStateError::KeyNotFound)
 }
 
+/// Download and inline any external snapshot/mutation blobs referenced by `pl`,
+/// resolving each reference via `download`. Best-effort: download/decode failures
+/// are logged and skipped (matches WhatsApp Web).
+fn download_external_blobs<FDownload>(pl: &mut PatchList, download: &FDownload)
+where
+    FDownload: Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>>,
+{
+    let name = pl.name;
+    if pl.snapshot.is_none()
+        && let Some(ext) = &pl.snapshot_ref
+    {
+        match download(ext) {
+            Ok(data) => match wa::SyncdSnapshot::decode(data.as_slice()) {
+                Ok(snapshot) => pl.snapshot = Some(snapshot),
+                Err(e) => {
+                    log::warn!(target: "AppState", "Failed to decode external snapshot for {name:?}: {e}")
+                }
+            },
+            Err(e) => {
+                log::warn!(target: "AppState", "Failed to download external snapshot for {name:?}: {e}")
+            }
+        }
+    }
+
+    for patch in &mut pl.patches {
+        if let Some(ext) = &patch.external_mutations {
+            let v = patch.version.as_ref().and_then(|x| x.version).unwrap_or(0);
+            match download(ext) {
+                Ok(data) => match wa::SyncdMutations::decode(data.as_slice()) {
+                    Ok(ext_mutations) => patch.mutations = ext_mutations.mutations,
+                    Err(e) => {
+                        log::warn!(target: "AppState", "Failed to decode external mutations for {name:?} v{v}: {e}")
+                    }
+                },
+                Err(e) => {
+                    log::warn!(target: "AppState", "Failed to download external mutations for {name:?} v{v}: {e}")
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum AppStateSyncError {
     #[error("app state key not found: {0}")]
@@ -121,52 +163,7 @@ impl AppStateProcessor {
     where
         FDownload: Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>> + Send + Sync,
     {
-        // Download external snapshot if present (matches WhatsApp Web behavior)
-        if pl.snapshot.is_none()
-            && let Some(ext) = &pl.snapshot_ref
-            && let Ok(data) = download(ext)
-            && let Ok(snapshot) = wa::SyncdSnapshot::decode(data.as_slice())
-        {
-            pl.snapshot = Some(snapshot);
-        }
-
-        // Download external mutations for each patch (matches WhatsApp Web behavior)
-        for patch in &mut pl.patches {
-            if let Some(ext) = &patch.external_mutations {
-                let patch_version = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
-                match download(ext) {
-                    Ok(data) => match wa::SyncdMutations::decode(data.as_slice()) {
-                        Ok(ext_mutations) => {
-                            log::trace!(
-                                target: "AppState",
-                                "Downloaded external mutations for patch v{}: {} mutations (inline had {})",
-                                patch_version,
-                                ext_mutations.mutations.len(),
-                                patch.mutations.len()
-                            );
-                            patch.mutations = ext_mutations.mutations;
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                target: "AppState",
-                                "Failed to decode external mutations for patch v{}: {}",
-                                patch_version,
-                                e
-                            );
-                        }
-                    },
-                    Err(e) => {
-                        log::warn!(
-                            target: "AppState",
-                            "Failed to download external mutations for patch v{}: {}",
-                            patch_version,
-                            e
-                        );
-                    }
-                }
-            }
-        }
-
+        download_external_blobs(&mut pl, &download);
         self.process_patch_list(pl, validate_macs).await
     }
 
@@ -179,56 +176,9 @@ impl AppStateProcessor {
     where
         FDownload: Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>> + Send + Sync,
     {
-        let mut pl = parse_patch_list(stanza_root)?;
-
-        // Download external snapshot if present (matches WhatsApp Web behavior)
-        if pl.snapshot.is_none()
-            && let Some(ext) = &pl.snapshot_ref
-            && let Ok(data) = download(ext)
-            && let Ok(snapshot) = wa::SyncdSnapshot::decode(data.as_slice())
-        {
-            pl.snapshot = Some(snapshot);
-        }
-
-        // Download external mutations for each patch (matches WhatsApp Web behavior)
-        // WhatsApp Web: if (r.externalMutations) { n = yield downloadExternalPatch(e, r) }
-        for patch in &mut pl.patches {
-            if let Some(ext) = &patch.external_mutations {
-                let patch_version = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
-                match download(ext) {
-                    Ok(data) => match wa::SyncdMutations::decode(data.as_slice()) {
-                        Ok(ext_mutations) => {
-                            log::trace!(
-                                target: "AppState",
-                                "Downloaded external mutations for patch v{}: {} mutations (inline had {})",
-                                patch_version,
-                                ext_mutations.mutations.len(),
-                                patch.mutations.len()
-                            );
-                            patch.mutations = ext_mutations.mutations;
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                target: "AppState",
-                                "Failed to decode external mutations for patch v{}: {}",
-                                patch_version,
-                                e
-                            );
-                        }
-                    },
-                    Err(e) => {
-                        log::warn!(
-                            target: "AppState",
-                            "Failed to download external mutations for patch v{}: {}",
-                            patch_version,
-                            e
-                        );
-                    }
-                }
-            }
-        }
-
-        self.process_patch_list(pl, validate_macs).await
+        let pl = parse_patch_list(stanza_root)?;
+        self.process_parsed_patch_list(pl, download, validate_macs)
+            .await
     }
 
     pub async fn decode_multi_patch_list_ref<FDownload>(
@@ -283,43 +233,7 @@ impl AppStateProcessor {
                 continue;
             }
 
-            // Download external snapshot
-            if pl.snapshot.is_none()
-                && let Some(ext) = &pl.snapshot_ref
-            {
-                match download(ext) {
-                    Ok(data) => match wa::SyncdSnapshot::decode(data.as_slice()) {
-                        Ok(snapshot) => pl.snapshot = Some(snapshot),
-                        Err(e) => {
-                            log::warn!(target: "AppState", "Failed to decode external snapshot for {:?}: {e}", pl.name);
-                        }
-                    },
-                    Err(e) => {
-                        log::warn!(target: "AppState", "Failed to download external snapshot for {:?}: {e}", pl.name);
-                    }
-                }
-            }
-
-            // Download external mutations for each patch
-            for patch in &mut pl.patches {
-                if let Some(ext) = &patch.external_mutations {
-                    match download(ext) {
-                        Ok(data) => match wa::SyncdMutations::decode(data.as_slice()) {
-                            Ok(ext_mutations) => {
-                                patch.mutations = ext_mutations.mutations;
-                            }
-                            Err(e) => {
-                                let v = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
-                                log::warn!(target: "AppState", "Failed to decode external mutations for {:?} v{}: {e}", pl.name, v);
-                            }
-                        },
-                        Err(e) => {
-                            let v = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
-                            log::warn!(target: "AppState", "Failed to download external mutations for {:?} v{}: {e}", pl.name, v);
-                        }
-                    }
-                }
-            }
+            download_external_blobs(&mut pl, download);
 
             let (mutations, state, pl) = self.process_patch_list(pl, validate_macs).await?;
             results.push((mutations, state, pl));


### PR DESCRIPTION
## C1 — parse the IQ response once

Both the batched (`sync_collections_batched_inner`) and single-collection sync paths parsed the same response **twice**: once to pre-download external blobs, then again inside `decode_*_patch_list_ref`. Each `parse_patch_lists_ref` does `node.to_owned()` — a recursive deep clone of the whole node tree, including every patch blob via `to_vec()` — before prost-decoding.

The caller now parses once (for pre-download) and hands the parsed `PatchList`(s) to the processor via new `process_patch_lists` / `process_parsed_patch_list`. The `decode_*_ref` convenience methods stay for external callers.

**Measured (iai):** one `parse_patch_lists_ref` over a realistic batch (5 collections × 12 patches × 4 mutations) = 1,018,941 − 105,190 (unmarshal) = **~914k instructions** — that whole parse (+ its tree clone) is eliminated per sync.

## Cleanup — dedup external-blob download

Extracted `download_external_blobs()` and use it from `process_parsed_patch_list`, `process_patch_lists`, and `decode_patch_list` (which now delegates like `decode_patch_list_ref`), removing the triplicated snapshot/mutation download logic (net −140 lines).

## Note

An earlier revision also moved (instead of cloned) the mutation MACs (`mem::take`). Codex review correctly flagged that it drained the public `Mutation.index_mac/value_mac` fields on returned mutations; that change was dropped (its win was marginal — 64 B/mutation, dominated by decrypt/MAC-validate).

## Tests

`cargo test -p wacore-appstate -p wacore` and the appstate mac/external-mutation integration tests pass; `clippy` clean.