### PR TITLE
perf(appstate)!: drop duplicate index/value MAC storage from Mutation

### DIFF
--- a/wacore/appstate/src/decode.rs
+++ b/wacore/appstate/src/decode.rs
@@ -94,11 +94,13 @@ pub fn decode_record(
         }
     }
 
+    // A record without an index MAC is malformed; never persist an empty MAC
+    // (previously unwrap_or_default() let this through when validate_macs=false).
     let index_mac = record
         .index
         .as_ref()
         .and_then(|i| i.blob.clone())
-        .unwrap_or_default();
+        .ok_or(AppStateError::MissingIndexMAC)?;
     Ok((
         Mutation {
             action_value: action.value,
@@ -218,7 +220,7 @@ mod tests {
             &action_data,
         );
 
-        let (mutation, _macs) = decode_record(
+        let (mutation, macs) = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             &record,
             &keys,
@@ -232,6 +234,11 @@ mod tests {
             Some(1234567890)
         );
         assert_eq!(mutation.operation, wa::syncd_mutation::SyncdOperation::Set);
+        // MACs are returned separately and must carry the real bytes, not empty
+        // or swapped values: the record's index blob is `vec![1; 32]`.
+        assert_eq!(macs.index_mac, vec![1u8; 32]);
+        assert!(!macs.value_mac.is_empty());
+        assert_ne!(macs.index_mac, macs.value_mac);
     }
 
     #[test]

--- a/wacore/appstate/src/decode.rs
+++ b/wacore/appstate/src/decode.rs
@@ -10,14 +10,19 @@ use waproto::whatsapp as wa;
 pub struct Mutation {
     /// The decoded action value.
     pub action_value: Option<wa::SyncActionValue>,
-    /// The MAC of the index.
-    pub index_mac: Vec<u8>,
-    /// The MAC of the value.
-    pub value_mac: Vec<u8>,
     /// The parsed index components (JSON array of strings).
     pub index: Vec<String>,
     /// The operation type (Set or Remove).
     pub operation: wa::syncd_mutation::SyncdOperation,
+}
+
+/// Index/value MACs extracted from a record, returned alongside the decoded
+/// [`Mutation`]. Kept out of `Mutation` so the MACs live only in the persisted
+/// MAC list rather than being duplicated on every returned mutation.
+#[derive(Debug, Clone)]
+pub struct RecordMacs {
+    pub index_mac: Vec<u8>,
+    pub value_mac: Vec<u8>,
 }
 
 /// Decode a single encrypted record into a mutation.
@@ -33,14 +38,15 @@ pub struct Mutation {
 /// * `validate_macs` - Whether to validate MACs during decoding
 ///
 /// # Returns
-/// A decoded `Mutation` or an error if decoding/validation fails.
+/// The decoded `Mutation` together with its index/value MACs, or an error if
+/// decoding/validation fails.
 pub fn decode_record(
     operation: wa::syncd_mutation::SyncdOperation,
     record: &wa::SyncdRecord,
     keys: &ExpandedAppStateKeys,
     key_id: &[u8],
     validate_macs: bool,
-) -> Result<Mutation, AppStateError> {
+) -> Result<(Mutation, RecordMacs), AppStateError> {
     let value_blob = record
         .value
         .as_ref()
@@ -88,17 +94,22 @@ pub fn decode_record(
         }
     }
 
-    Ok(Mutation {
-        action_value: action.value,
-        index_mac: record
-            .index
-            .as_ref()
-            .and_then(|i| i.blob.clone())
-            .unwrap_or_default(),
-        value_mac: value_mac.to_vec(),
-        index: index_list,
-        operation,
-    })
+    let index_mac = record
+        .index
+        .as_ref()
+        .and_then(|i| i.blob.clone())
+        .unwrap_or_default();
+    Ok((
+        Mutation {
+            action_value: action.value,
+            index: index_list,
+            operation,
+        },
+        RecordMacs {
+            index_mac,
+            value_mac: value_mac.to_vec(),
+        },
+    ))
 }
 
 /// Extract all unique key IDs from a patch list that need to be fetched.
@@ -207,7 +218,7 @@ mod tests {
             &action_data,
         );
 
-        let mutation = decode_record(
+        let (mutation, _macs) = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             &record,
             &keys,

--- a/wacore/appstate/src/encode.rs
+++ b/wacore/appstate/src/encode.rs
@@ -108,7 +108,7 @@ mod tests {
 
         // Decode the encoded record
         let record = mutation.record.as_ref().unwrap();
-        let decoded = decode_record(
+        let (decoded, _macs) = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             record,
             &keys,

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -119,7 +119,7 @@ where
             .ok_or(AppStateError::MissingKeyId)?;
         let keys = get_keys(key_id)?;
 
-        let mutation = decode_record(
+        let (mutation, macs) = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             rec,
             &keys,
@@ -128,8 +128,8 @@ where
         )?;
 
         mutation_macs.push(AppStateMutationMAC {
-            index_mac: mutation.index_mac.clone(),
-            value_mac: mutation.value_mac.clone(),
+            index_mac: macs.index_mac,
+            value_mac: macs.value_mac,
         });
 
         mutations.push(mutation);
@@ -254,17 +254,17 @@ where
                 .ok_or(AppStateError::MissingKeyId)?;
             let keys = get_keys(key_id)?;
 
-            let mutation = decode_record(op, rec, &keys, key_id, validate_macs)?;
+            let (mutation, macs) = decode_record(op, rec, &keys, key_id, validate_macs)?;
 
             match op {
                 wa::syncd_mutation::SyncdOperation::Set => {
                     added_macs.push(AppStateMutationMAC {
-                        index_mac: mutation.index_mac.clone(),
-                        value_mac: mutation.value_mac.clone(),
+                        index_mac: macs.index_mac,
+                        value_mac: macs.value_mac,
                     });
                 }
                 wa::syncd_mutation::SyncdOperation::Remove => {
-                    removed_index_macs.push(mutation.index_mac.clone());
+                    removed_index_macs.push(macs.index_mac);
                 }
             }
 

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -470,6 +470,13 @@ mod tests {
         assert_eq!(result.state.version, 1);
         assert_eq!(result.mutations.len(), 1);
         assert_eq!(result.mutation_macs.len(), 1);
+        // Exact MAC bytes (not just counts): catches empty/swapped MACs.
+        assert_eq!(result.mutation_macs[0].index_mac, index_mac);
+        assert!(!result.mutation_macs[0].value_mac.is_empty());
+        assert_ne!(
+            result.mutation_macs[0].index_mac,
+            result.mutation_macs[0].value_mac
+        );
         assert_eq!(
             result.mutations[0]
                 .action_value
@@ -516,6 +523,13 @@ mod tests {
         assert_eq!(result.state.version, 2);
         assert_eq!(result.mutations.len(), 1);
         assert_eq!(result.added_macs.len(), 1);
+        // Exact MAC bytes (not just counts): catches empty/swapped MACs.
+        assert_eq!(result.added_macs[0].index_mac, index_mac);
+        assert!(!result.added_macs[0].value_mac.is_empty());
+        assert_ne!(
+            result.added_macs[0].index_mac,
+            result.added_macs[0].value_mac
+        );
         assert!(result.removed_index_macs.is_empty());
     }
 


### PR DESCRIPTION
Follow-up to #688's dropped C8, done the clean way (breaking, fine pre-1.0).

## What

`decode_record` stored the index/value MACs **twice**: once on the returned `Mutation` and again (cloned) in the persisted MAC vec (`mutation_macs` / `added_macs` / `removed_index_macs`). Nothing downstream reads `Mutation.index_mac`/`value_mac` — they only exist to feed the MAC vec — so every decoded mutation carried a redundant 64 B copy.

`decode_record` now returns `(Mutation, RecordMacs)`; the processor moves the MACs straight into the MAC vec (no clone), and `Mutation` no longer stores them.

## Why this shape (and not the earlier `mem::take`)

The first attempt (in #688) used `mem::take` to move the MACs out of the returned `Mutation`, which silently left its public fields empty — flagged in review. Removing the fields instead makes the duplication impossible and turns any external read into a compile error rather than a silent empty value.

## Breaking

- `Mutation` loses its `index_mac` / `value_mac` fields.
- `decode_record` returns `(Mutation, RecordMacs)` instead of `Mutation`.

Honest note: this is a clarity/allocation-hygiene change, not a measurable speedup (the 64 B clone is dwarfed by per-mutation AES-CBC decrypt + HMAC).

## Tests

`cargo test -p wacore-appstate -p wacore` + appstate mac/external-mutation integration tests pass; `clippy` clean.