### PR TITLE
perf!: cut clones/allocs in LID resolution, single-device send, history-sync

### DIFF
--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -45,7 +45,7 @@ impl SendContextResolver for Client {
         self.groups().query_info(jid).await
     }
 
-    async fn get_lid_for_phone(&self, phone_user: &str) -> Option<String> {
+    async fn get_lid_for_phone(&self, phone_user: &str) -> Option<wacore_binary::CompactString> {
         self.lid_pn_cache.get_current_lid(phone_user).await
     }
 }

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -80,7 +80,7 @@ impl Client {
         // Check if user is a PN (has a LID mapping)
         if let Some(lid) = self.lid_pn_cache.get_current_lid(user).await {
             return UserLookupKeys::PnWithLid {
-                lid: lid.into(),
+                lid,
                 pn: user.into(),
             };
         }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -350,7 +350,7 @@ impl Client {
         };
         match self.lid_pn_cache.get_current_lid(&target.user).await {
             Some(lid_user) => Jid {
-                user: lid_user.into(),
+                user: lid_user,
                 server: lid_server,
                 device: target.device,
                 agent: target.agent,
@@ -375,7 +375,7 @@ impl Client {
         } else if jid.is_pn() {
             let lid_user = self.lid_pn_cache.get_current_lid(&jid.user).await?;
             Some(Jid {
-                user: lid_user.into(),
+                user: lid_user,
                 server: wacore_binary::Server::Lid,
                 device: jid.device,
                 agent: jid.agent,

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -876,15 +876,19 @@ impl<'a> Groups<'a> {
 
     /// Resolve JID to tc_token store key. When `only_lid`, PN JIDs without a
     /// LID mapping return `None` instead of falling back to the PN user.
-    async fn resolve_token_key(&self, jid: &Jid, only_lid: bool) -> Option<String> {
+    async fn resolve_token_key(
+        &self,
+        jid: &Jid,
+        only_lid: bool,
+    ) -> Option<wacore_binary::CompactString> {
         if jid.is_lid() {
-            Some(jid.user.to_string())
+            Some(jid.user.clone())
         } else {
             let lid = self.client.lid_pn_cache.get_current_lid(&jid.user).await;
             if only_lid {
                 lid
             } else {
-                Some(lid.unwrap_or_else(|| jid.user.to_string()))
+                Some(lid.unwrap_or_else(|| jid.user.clone()))
             }
         }
     }

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -653,8 +653,8 @@ async fn handle_privacy_token_notification(client: &Arc<Client>, node: &NodeRef<
         .filter(|j| !j.user.is_empty());
 
     // Resolve to a LID key. We borrow from Jid.user (CompactString) or from
-    // get_current_lid (String), then pass as &str to the storage layer.
-    let resolved_lid: Option<String>;
+    // get_current_lid (CompactString), then pass as &str to the storage layer.
+    let resolved_lid: Option<wacore_binary::CompactString>;
     let sender_lid: &str = if let Some(ref lid_jid) = sender_lid_jid {
         &lid_jid.user
     } else {

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -20,6 +20,8 @@
 
 use std::sync::Arc;
 
+use wacore_binary::CompactString;
+
 use crate::cache_config::{CacheConfig, CacheEntryConfig};
 use crate::cache_store::TypedCache;
 pub use wacore::types::{LearningSource, LidPnEntry};
@@ -101,8 +103,13 @@ impl LidPnCache {
     /// Get the current LID for a phone number.
     ///
     /// Returns the LID user part if a mapping exists, None otherwise.
-    pub async fn get_current_lid(&self, phone: &str) -> Option<String> {
-        self.pn_to_entry.get(phone).await.map(|e| e.lid.clone())
+    /// The cache holds `Arc<LidPnEntry>`; return the LID user as an (inline for
+    /// typical ~15-digit LIDs) `CompactString` instead of deep-cloning a `String`.
+    pub async fn get_current_lid(&self, phone: &str) -> Option<CompactString> {
+        self.pn_to_entry
+            .get(phone)
+            .await
+            .map(|e| e.lid.as_str().into())
     }
 
     /// Whether the learn fast path can skip re-recording `phone <-> lid`: the
@@ -257,8 +264,8 @@ mod tests {
 
         // Should be retrievable both ways
         assert_eq!(
-            cache.get_current_lid("559980000001").await,
-            Some("100000012345678".to_string())
+            cache.get_current_lid("559980000001").await.as_deref(),
+            Some("100000012345678")
         );
         assert_eq!(
             cache.get_phone_number("100000012345678").await,
@@ -280,8 +287,8 @@ mod tests {
         cache.add(&old_entry).await;
 
         assert_eq!(
-            cache.get_current_lid("559980000001").await,
-            Some("100000012345678".to_string())
+            cache.get_current_lid("559980000001").await.as_deref(),
+            Some("100000012345678")
         );
 
         // Add newer mapping for same phone (different LID)
@@ -295,8 +302,8 @@ mod tests {
 
         // Should return the newer LID for PN lookup
         assert_eq!(
-            cache.get_current_lid("559980000001").await,
-            Some("100000087654321".to_string())
+            cache.get_current_lid("559980000001").await.as_deref(),
+            Some("100000087654321")
         );
 
         // Both LIDs should still be in the LID -> Entry map
@@ -334,8 +341,8 @@ mod tests {
 
         // PN -> LID should still return the newer one
         assert_eq!(
-            cache.get_current_lid("559980000001").await,
-            Some("100000087654321".to_string())
+            cache.get_current_lid("559980000001").await.as_deref(),
+            Some("100000087654321")
         );
     }
 
@@ -369,9 +376,9 @@ mod tests {
         assert_eq!(cache.lid_count().await, 3);
         assert_eq!(cache.pn_count().await, 3);
 
-        assert_eq!(cache.get_current_lid("pn1").await, Some("lid1".to_string()));
-        assert_eq!(cache.get_current_lid("pn2").await, Some("lid2".to_string()));
-        assert_eq!(cache.get_current_lid("pn3").await, Some("lid3".to_string()));
+        assert_eq!(cache.get_current_lid("pn1").await.as_deref(), Some("lid1"));
+        assert_eq!(cache.get_current_lid("pn2").await.as_deref(), Some("lid2"));
+        assert_eq!(cache.get_current_lid("pn3").await.as_deref(), Some("lid3"));
     }
 
     #[tokio::test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -3057,8 +3057,12 @@ mod tests {
 
         // Cache learned the mapping in both directions.
         assert_eq!(
-            client.lid_pn_cache.get_current_lid(pn_user).await,
-            Some(lid_user.to_string()),
+            client
+                .lid_pn_cache
+                .get_current_lid(pn_user)
+                .await
+                .as_deref(),
+            Some(lid_user),
             "PN→LID lookup must hit"
         );
         assert_eq!(
@@ -3152,8 +3156,12 @@ mod tests {
         // Hosted variant must reach the cache; without it, learn_lid_pn_mapping
         // is skipped and the hosted-device fix is incomplete.
         assert_eq!(
-            client.lid_pn_cache.get_current_lid(pn_user).await,
-            Some(lid_user.to_string()),
+            client
+                .lid_pn_cache
+                .get_current_lid(pn_user)
+                .await
+                .as_deref(),
+            Some(lid_user),
             "PN→LID lookup must work for hosted family"
         );
         assert_eq!(
@@ -5901,8 +5909,8 @@ mod tests {
         // Verify the cache has the mapping
         let cached_lid = client.lid_pn_cache.get_current_lid(phone).await;
         assert_eq!(
-            cached_lid,
-            Some(lid.to_string()),
+            cached_lid.as_deref(),
+            Some(lid),
             "Cache should have the LID-PN mapping"
         );
 
@@ -5963,7 +5971,7 @@ mod tests {
             } else if let Some(lid_user) = client.lid_pn_cache.get_current_lid(&sender.user).await {
                 // Use the cached LID
                 Jid {
-                    user: lid_user.into(),
+                    user: lid_user,
                     server: wacore_binary::Server::Lid,
                     device: sender.device,
                     agent: sender.agent,
@@ -6078,7 +6086,7 @@ mod tests {
             } else if let Some(lid_user) = client.lid_pn_cache.get_current_lid(&sender.user).await {
                 // This is the path we're testing - fallback to cached LID
                 Jid {
-                    user: lid_user.into(),
+                    user: lid_user,
                     server: wacore_binary::Server::Lid,
                     device: sender.device,
                     agent: sender.agent,
@@ -6179,7 +6187,7 @@ mod tests {
                 }
             } else if let Some(lid_user) = client.lid_pn_cache.get_current_lid(&sender.user).await {
                 Jid {
-                    user: lid_user.into(),
+                    user: lid_user,
                     server: wacore_binary::Server::Lid,
                     device: sender.device,
                     agent: sender.agent,

--- a/src/send.rs
+++ b/src/send.rs
@@ -1962,7 +1962,7 @@ impl Client {
         }
 
         if let Some(lid_user) = self.lid_pn_cache.get_current_lid(&jid.user).await {
-            Jid::new(&lid_user, Server::Lid)
+            Jid::new(lid_user, Server::Lid)
         } else {
             jid.to_non_ad()
         }

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -160,7 +160,7 @@ pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {
     /// when sending to a phone number address.
     ///
     /// Returns None if no LID mapping is known for this phone number.
-    async fn get_lid_for_phone(&self, phone_user: &str) -> Option<String> {
+    async fn get_lid_for_phone(&self, phone_user: &str) -> Option<wacore_binary::CompactString> {
         // Default implementation returns None - subclasses can override
         let _ = phone_user;
         None

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -66,15 +66,15 @@ pub fn process_history_sync(
 
     let buf = Bytes::from(decompressed);
     let mut pos = 0;
-    // Pre-size the secret-record accumulator from a single allocation-free count
-    // pass, so it never grows by repeated doubling as conversations stream in.
-    let estimated_records = count_history_sync_messages(&buf);
     let mut result = HistorySyncResult {
         own_pushname: None,
         nct_salt: None,
         conversations_processed: 0,
         tc_token_candidates: Vec::new(),
-        msg_secret_records: Vec::with_capacity(estimated_records),
+        // Grown on demand: a full pre-count pass scanned the whole blob just to
+        // size a Vec that only holds the secret-record subset (it over-allocated
+        // and cost ~2.5% of the decode); plain growth is cheaper here.
+        msg_secret_records: Vec::new(),
         // Always retained on this path: the `!retain_blob` case returned above
         // and ran the streaming variant, so control only reaches here when the
         // caller wants the blob.
@@ -355,63 +355,6 @@ fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySy
             )))
         }
     }
-}
-
-/// Best-effort count of total `HistorySyncMsg` entries (field 2 inside each
-/// field-2 conversation) in a decompressed HistorySync blob. Allocation-free;
-/// used to pre-size the message-secret accumulator in one shot instead of letting
-/// it grow by repeated doubling. An under-count (e.g. on a malformed tail) only
-/// costs a few late re-grows, never correctness — the decode loop re-validates.
-fn count_history_sync_messages(buf: &[u8]) -> usize {
-    let mut pos = 0;
-    let mut total = 0;
-    while pos < buf.len() {
-        let Ok((tag, br)) = read_varint(&buf[pos..]) else {
-            break;
-        };
-        pos += br;
-        let field = (tag >> 3) as u32;
-        let wt = (tag & 0x7) as u32;
-        if field == 2 && wt == wire_type::LENGTH_DELIMITED {
-            let Ok((len, vl)) = read_varint(&buf[pos..]) else {
-                break;
-            };
-            pos += vl;
-            let Ok(end) = checked_end(pos, len, buf.len(), "conv-count") else {
-                break;
-            };
-            total += count_conversation_messages(&buf[pos..end]);
-            pos = end;
-        } else {
-            match skip_field(wt, buf, pos) {
-                Ok(np) => pos = np,
-                Err(_) => break,
-            }
-        }
-    }
-    total
-}
-
-/// Count field-2 (message) entries within a single conversation's bytes.
-fn count_conversation_messages(buf: &[u8]) -> usize {
-    let mut pos = 0;
-    let mut n = 0;
-    while pos < buf.len() {
-        let Ok((tag, br)) = read_varint(&buf[pos..]) else {
-            break;
-        };
-        pos += br;
-        let field = (tag >> 3) as u32;
-        let wt = (tag & 0x7) as u32;
-        if field == 2 && wt == wire_type::LENGTH_DELIMITED {
-            n += 1;
-        }
-        match skip_field(wt, buf, pos) {
-            Ok(np) => pos = np,
-            Err(_) => break,
-        }
-    }
-    n
 }
 
 /// Manual pushname parser — Pushname proto has fields: id (tag 1) and pushname (tag 2).

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -91,7 +91,7 @@ pub enum UsyncContext {
 pub struct IsOnWhatsAppUser {
     pub jid: Jid,
     /// Helps server optimize the lookup (WA Web pre-populates this from its LID cache).
-    pub known_lid: Option<String>,
+    pub known_lid: Option<wacore_binary::CompactString>,
 }
 
 fn build_user_nodes(users: &[IsOnWhatsAppUser]) -> Vec<Node> {
@@ -106,7 +106,11 @@ fn build_user_nodes(users: &[IsOnWhatsAppUser]) -> Vec<Node> {
                 };
                 let mut children = vec![NodeBuilder::new("contact").string_content(phone).build()];
                 if let Some(lid) = &user.known_lid {
-                    children.push(NodeBuilder::new("lid").attr("jid", Jid::lid(lid)).build());
+                    children.push(
+                        NodeBuilder::new("lid")
+                            .attr("jid", Jid::lid(lid.as_str()))
+                            .build(),
+                    );
                 }
                 NodeBuilder::new("user").children(children).build()
             } else {
@@ -855,7 +859,7 @@ mod tests {
         let spec = IsOnWhatsAppSpec::new(
             vec![IsOnWhatsAppUser {
                 jid: Jid::pn("1234567890"),
-                known_lid: Some("100000001".to_string()),
+                known_lid: Some("100000001".into()),
             }],
             "sid",
             IsOnWhatsAppQueryType::Pn,

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -523,7 +523,8 @@ async fn encrypt_one_device(
                 Ok(Some(EncryptOneResult {
                     enc_type,
                     is_prekey,
-                    ciphertext: serialized_bytes.to_vec(),
+                    // Box<[u8]> -> Vec<u8> reuses the allocation (no copy).
+                    ciphertext: serialized_bytes.into(),
                     hide_decrypt_fail,
                 })),
             )

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -399,7 +399,6 @@ struct EncryptOneResult {
     enc_type: &'static str,
     is_prekey: bool,
     ciphertext: Vec<u8>,
-    mediatype: Option<String>,
     hide_decrypt_fail: bool,
 }
 
@@ -510,7 +509,6 @@ async fn encrypt_one_device(
     session_store: &mut dyn crate::libsignal::protocol::SessionStore,
     identity_store: &mut dyn crate::libsignal::protocol::IdentityKeyStore,
     device_jid: Jid,
-    mediatype: Option<&str>,
     hide_decrypt_fail: bool,
 ) -> (Jid, Result<Option<EncryptOneResult>, String>) {
     match message_encrypt(plaintext, addr, session_store, identity_store).await {
@@ -526,7 +524,6 @@ async fn encrypt_one_device(
                     enc_type,
                     is_prekey,
                     ciphertext: serialized_bytes.to_vec(),
-                    mediatype: mediatype.map(|s| s.to_string()),
                     hide_decrypt_fail,
                 })),
             )
@@ -539,6 +536,7 @@ async fn encrypt_one_device(
 /// success, a logged skip on failure.
 fn push_encrypt_result(
     (device_jid, res): (Jid, Result<Option<EncryptOneResult>, String>),
+    mediatype: Option<&str>,
     participant_nodes: &mut Vec<Node>,
     encrypted_devices: &mut Vec<Jid>,
     includes_prekey_message: &mut bool,
@@ -549,7 +547,9 @@ fn push_encrypt_result(
             let mut enc_builder = NodeBuilder::new("enc")
                 .attr("v", stanza::ENC_VERSION)
                 .attr("type", one.enc_type);
-            if let Some(mt) = one.mediatype.as_deref() {
+            // `mediatype` is batch-level (same for every device) and originates as
+            // a `&'static str`, so it's threaded here instead of cloned per result.
+            if let Some(mt) = mediatype {
                 enc_builder = enc_builder.attr("mediatype", mt);
             }
             if one.hide_decrypt_fail {
@@ -789,12 +789,12 @@ where
             &mut *stores.session_store,
             &mut *stores.identity_store,
             device_jid,
-            mediatype,
             hide_decrypt_fail,
         )
         .await;
         push_encrypt_result(
             res,
+            mediatype,
             &mut participant_nodes,
             &mut encrypted_devices,
             &mut includes_prekey_message,
@@ -804,7 +804,6 @@ where
         // ENCRYPT_FANOUT_CONCURRENCY; collected in completion order so the
         // fastest encrypts ship first.
         let plaintext_arc: std::sync::Arc<[u8]> = std::sync::Arc::from(plaintext_to_encrypt);
-        let mediatype_owned: Option<String> = mediatype.map(|s| s.to_string());
 
         let total = devices.len();
         let mut next_spawn = 0usize;
@@ -819,7 +818,6 @@ where
                 .unwrap_or(&devices[idx])
                 .to_protocol_address();
             let plaintext = plaintext_arc.clone();
-            let mediatype = mediatype_owned.clone();
             let mut session_store = stores.session_store.clone();
             let mut identity_store = stores.identity_store.clone();
 
@@ -830,7 +828,6 @@ where
                     &mut session_store,
                     &mut identity_store,
                     device_jid,
-                    mediatype.as_deref(),
                     hide_decrypt_fail,
                 )
                 .await
@@ -846,6 +843,7 @@ where
             match spawn_result {
                 Ok(res) => push_encrypt_result(
                     res,
+                    mediatype,
                     &mut participant_nodes,
                     &mut encrypted_devices,
                     &mut includes_prekey_message,

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -502,6 +502,73 @@ where
 
 /// Encrypt padded plaintext for each device JID, producing participant `<to>` nodes.
 ///
+/// Encrypt the plaintext for one device's Signal session. Shared by the
+/// single-device fast path and the parallel fan-out so both behave identically.
+async fn encrypt_one_device(
+    plaintext: &[u8],
+    addr: &ProtocolAddress,
+    session_store: &mut dyn crate::libsignal::protocol::SessionStore,
+    identity_store: &mut dyn crate::libsignal::protocol::IdentityKeyStore,
+    device_jid: Jid,
+    mediatype: Option<&str>,
+    hide_decrypt_fail: bool,
+) -> (Jid, Result<Option<EncryptOneResult>, String>) {
+    match message_encrypt(plaintext, addr, session_store, identity_store).await {
+        Ok(encrypted_payload) => {
+            let Some((enc_type, is_prekey, serialized_bytes)) =
+                extract_ciphertext(encrypted_payload)
+            else {
+                return (device_jid, Ok(None));
+            };
+            (
+                device_jid,
+                Ok(Some(EncryptOneResult {
+                    enc_type,
+                    is_prekey,
+                    ciphertext: serialized_bytes.to_vec(),
+                    mediatype: mediatype.map(|s| s.to_string()),
+                    hide_decrypt_fail,
+                })),
+            )
+        }
+        Err(e) => (device_jid, Err(format!("{addr}: {e}"))),
+    }
+}
+
+/// Append one encrypt result to the fan-out output: a `<to>` participant node on
+/// success, a logged skip on failure.
+fn push_encrypt_result(
+    (device_jid, res): (Jid, Result<Option<EncryptOneResult>, String>),
+    participant_nodes: &mut Vec<Node>,
+    encrypted_devices: &mut Vec<Jid>,
+    includes_prekey_message: &mut bool,
+) {
+    match res {
+        Ok(Some(one)) => {
+            *includes_prekey_message |= one.is_prekey;
+            let mut enc_builder = NodeBuilder::new("enc")
+                .attr("v", stanza::ENC_VERSION)
+                .attr("type", one.enc_type);
+            if let Some(mt) = one.mediatype.as_deref() {
+                enc_builder = enc_builder.attr("mediatype", mt);
+            }
+            if one.hide_decrypt_fail {
+                enc_builder = enc_builder.attr("decrypt-fail", "hide");
+            }
+            let enc_node = enc_builder.bytes(one.ciphertext).build();
+            participant_nodes.push(
+                NodeBuilder::new("to")
+                    .attr("jid", device_jid.clone())
+                    .children([enc_node])
+                    .build(),
+            );
+            encrypted_devices.push(device_jid);
+        }
+        Ok(None) => {}
+        Err(msg) => log::warn!("Failed to encrypt for device: {msg}. Skipping."),
+    }
+}
+
 /// Per-device Signal sessions are independent (different ratchet state per
 /// recipient), so this fans the encrypt loop out across tokio tasks bounded
 /// by [`ENCRYPT_FANOUT_CONCURRENCY`]. Each task clones the store handles
@@ -703,105 +770,95 @@ where
     let mut includes_prekey_message = false;
     let mut encrypted_devices = Vec::with_capacity(devices.len());
 
-    // Parallel encrypt fan-out. The wire-order of `<to>` participants does
-    // not need to match the input device order: WA Web's `phash` (computed
-    // both client and server side) sorts before hashing, and our
-    // `participant_list_hash` does the same. Collecting in completion order
-    // lets the fastest encrypts ship first.
-    let plaintext_arc: std::sync::Arc<[u8]> = std::sync::Arc::from(plaintext_to_encrypt);
-    let mediatype_owned: Option<String> = mediatype.map(|s| s.to_string());
-
-    let total = devices.len();
-    let mut next_spawn = 0usize;
-
-    let make_encrypt_task = |idx: usize| {
-        let device_jid = devices[idx].clone();
-        // The encryption JID is only needed to build the Signal address, so
-        // derive it here from a borrow rather than cloning the whole Jid into
-        // the task (device_jid is still cloned because it's returned).
-        let addr = encryption_overrides[idx]
+    // The wire-order of `<to>` participants does not need to match the input
+    // device order: WA Web's `phash` (computed both client and server side)
+    // sorts before hashing, as does our `participant_list_hash`.
+    if devices.len() == 1 {
+        // Single recipient device: the parallel fan-out is pure overhead here
+        // (an Arc<[u8]> copy of the plaintext, a spawned task + oneshot channel,
+        // a FuturesUnordered, and two store clones), with no parallelism to gain.
+        // Encrypt inline.
+        let device_jid = devices[0].clone();
+        let addr = encryption_overrides[0]
             .as_ref()
-            .unwrap_or(&devices[idx])
+            .unwrap_or(&devices[0])
             .to_protocol_address();
-        let plaintext = plaintext_arc.clone();
-        let mediatype = mediatype_owned.clone();
-        let mut session_store = stores.session_store.clone();
-        let mut identity_store = stores.identity_store.clone();
+        let res = encrypt_one_device(
+            plaintext_to_encrypt,
+            &addr,
+            &mut *stores.session_store,
+            &mut *stores.identity_store,
+            device_jid,
+            mediatype,
+            hide_decrypt_fail,
+        )
+        .await;
+        push_encrypt_result(
+            res,
+            &mut participant_nodes,
+            &mut encrypted_devices,
+            &mut includes_prekey_message,
+        );
+    } else {
+        // Parallel encrypt fan-out across tokio tasks bounded by
+        // ENCRYPT_FANOUT_CONCURRENCY; collected in completion order so the
+        // fastest encrypts ship first.
+        let plaintext_arc: std::sync::Arc<[u8]> = std::sync::Arc::from(plaintext_to_encrypt);
+        let mediatype_owned: Option<String> = mediatype.map(|s| s.to_string());
 
-        spawn_oneshot(runtime, async move {
-            match message_encrypt(&plaintext, &addr, &mut session_store, &mut identity_store).await
-            {
-                Ok(encrypted_payload) => {
-                    let Some((enc_type, is_prekey, serialized_bytes)) =
-                        extract_ciphertext(encrypted_payload)
-                    else {
-                        return (device_jid, Ok(None));
-                    };
-                    (
-                        device_jid,
-                        Ok(Some(EncryptOneResult {
-                            enc_type,
-                            is_prekey,
-                            ciphertext: serialized_bytes.to_vec(),
-                            mediatype,
-                            hide_decrypt_fail,
-                        })),
-                    )
-                }
-                Err(e) => {
-                    let addr_str = addr.to_string();
-                    (device_jid, Err(format!("{addr_str}: {e}")))
-                }
-            }
-        })
-    };
+        let total = devices.len();
+        let mut next_spawn = 0usize;
 
-    let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
-    while next_spawn < total && in_flight.len() < ENCRYPT_FANOUT_CONCURRENCY {
-        in_flight.push(make_encrypt_task(next_spawn));
-        next_spawn += 1;
-    }
-    while let Some(spawn_result) = in_flight.next().await {
-        match spawn_result {
-            Ok((device_jid, Ok(Some(one)))) => {
-                includes_prekey_message |= one.is_prekey;
+        let make_encrypt_task = |idx: usize| {
+            let device_jid = devices[idx].clone();
+            // The encryption JID is only needed to build the Signal address, so
+            // derive it here from a borrow rather than cloning the whole Jid into
+            // the task (device_jid is still cloned because it's returned).
+            let addr = encryption_overrides[idx]
+                .as_ref()
+                .unwrap_or(&devices[idx])
+                .to_protocol_address();
+            let plaintext = plaintext_arc.clone();
+            let mediatype = mediatype_owned.clone();
+            let mut session_store = stores.session_store.clone();
+            let mut identity_store = stores.identity_store.clone();
 
-                let mut enc_builder = NodeBuilder::new("enc")
-                    .attr("v", stanza::ENC_VERSION)
-                    .attr("type", one.enc_type);
-                if let Some(mt) = one.mediatype.as_deref() {
-                    enc_builder = enc_builder.attr("mediatype", mt);
-                }
-                if one.hide_decrypt_fail {
-                    enc_builder = enc_builder.attr("decrypt-fail", "hide");
-                }
-                let enc_node = enc_builder.bytes(one.ciphertext).build();
+            spawn_oneshot(runtime, async move {
+                encrypt_one_device(
+                    &plaintext,
+                    &addr,
+                    &mut session_store,
+                    &mut identity_store,
+                    device_jid,
+                    mediatype.as_deref(),
+                    hide_decrypt_fail,
+                )
+                .await
+            })
+        };
 
-                participant_nodes.push(
-                    NodeBuilder::new("to")
-                        .attr("jid", device_jid.clone())
-                        .children([enc_node])
-                        .build(),
-                );
-                encrypted_devices.push(device_jid);
-            }
-            Ok((_, Ok(None))) => {
-                // extract_ciphertext returned None; skip silently as the
-                // serial path did.
-            }
-            Ok((_, Err(msg))) => {
-                log::warn!("Failed to encrypt for device: {msg}. Skipping.");
-            }
-            Err(SpawnCanceled) => {
-                // Spawned task panicked or runtime tore it down. Same
-                // log+skip semantics as a regular encrypt failure.
-                log::warn!("Encrypt task did not deliver a result; skipping device.");
-            }
-        }
-
-        if next_spawn < total {
+        let mut in_flight: FuturesUnordered<_> = FuturesUnordered::new();
+        while next_spawn < total && in_flight.len() < ENCRYPT_FANOUT_CONCURRENCY {
             in_flight.push(make_encrypt_task(next_spawn));
             next_spawn += 1;
+        }
+        while let Some(spawn_result) = in_flight.next().await {
+            match spawn_result {
+                Ok(res) => push_encrypt_result(
+                    res,
+                    &mut participant_nodes,
+                    &mut encrypted_devices,
+                    &mut includes_prekey_message,
+                ),
+                Err(SpawnCanceled) => {
+                    log::warn!("Encrypt task did not deliver a result; skipping device.");
+                }
+            }
+
+            if next_spawn < total {
+                in_flight.push(make_encrypt_task(next_spawn));
+                next_spawn += 1;
+            }
         }
     }
 
@@ -2342,8 +2399,11 @@ mod tests {
             unimplemented!("resolve_group_info not needed for send.rs tests")
         }
 
-        async fn get_lid_for_phone(&self, phone_user: &str) -> Option<String> {
-            self.phone_to_lid.get(phone_user).cloned()
+        async fn get_lid_for_phone(
+            &self,
+            phone_user: &str,
+        ) -> Option<wacore_binary::CompactString> {
+            self.phone_to_lid.get(phone_user).map(|s| s.as_str().into())
         }
     }
 


### PR DESCRIPTION
Three independent allocation/clone cleanups (breaking signature changes are fine pre-1.0).

## M1 — LID lookups return `CompactString`, not a cloned `String`

The LID/PN cache stores `Arc<LidPnEntry>`, but `get_current_lid` deep-cloned the entry's `String` on every call. It (and `SendContextResolver::get_lid_for_phone` + `IsOnWhatsAppUser.known_lid`) now return `CompactString`, which is **inline** for the typical ~15-digit LID user — no heap allocation. The JID `user` field is already `CompactString`, so the common "build a LID JID from the lookup" callers no longer convert at all. This runs per-recipient during group-send fanout and per-destination on DMs.

## C3 — single-recipient send skips the parallel fan-out

`encrypt_for_devices` always built an `Arc<[u8]>` copy of the plaintext, spawned a task + oneshot channel per device, and ran a `FuturesUnordered` — even for one device, where there's no parallelism to gain. A single recipient now encrypts inline. The per-device encrypt and the result-handling are factored into shared helpers (`encrypt_one_device`, `push_encrypt_result`) used by both the fast path and the parallel path, so behavior is identical.

## C5 — drop the history-sync pre-count pass

`process_history_sync` (retain-blob path) scanned the whole decompressed blob once just to size the secret-record `Vec`. But it counted *messages* while the Vec only holds the *secret-record subset*, so it over-allocated and paid a full extra scan. Plain growth is cheaper.

**Measured (iai):** removing the count pass = **−2.5%** instructions on a 20k-message decode. M1/C3 are structural alloc/overhead removals (a heap String clone per LID lookup; an Arc copy + task spawn + 2 store clones per single-device send).

## Breaking

`get_current_lid`, `get_lid_for_phone`, and `IsOnWhatsAppUser.known_lid` change `String` → `CompactString`.

## Tests

`cargo test -p wacore -p whatsapp-rust` (1500+ tests incl. send fan-out, lid_pn_cache, usync, history_sync) pass; `clippy --all-targets` clean.