### PR TITLE
perf: cut copies in PBKDF2, noise large-frame send, history-sync secret records

### DIFF
--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -87,7 +87,7 @@ impl NoiseSocket {
                 &transport,
                 &write_key,
                 &mut write_counter,
-                &job.plaintext,
+                job.plaintext,
                 &mut enc_buf,
                 &mut out_buf,
             )
@@ -103,7 +103,7 @@ impl NoiseSocket {
         transport: &Arc<dyn Transport>,
         write_key: &Arc<NoiseCipher>,
         write_counter: &mut u32,
-        plaintext: &[u8],
+        plaintext: bytes::Bytes,
         enc_buf: &mut Vec<u8>,
         out_buf: &mut BytesMut,
     ) -> SendResult {
@@ -111,7 +111,7 @@ impl NoiseSocket {
 
         if plaintext.len() <= INLINE_ENCRYPT_THRESHOLD {
             enc_buf.clear();
-            enc_buf.extend_from_slice(plaintext);
+            enc_buf.extend_from_slice(&plaintext);
             if let Err(e) = write_key.encrypt_in_place_with_counter(counter, enc_buf) {
                 return Err(EncryptSendError::crypto(anyhow::anyhow!(e.to_string())));
             }
@@ -121,10 +121,10 @@ impl NoiseSocket {
             }
         } else {
             let write_key = write_key.clone();
-            let plaintext_owned = plaintext.to_vec();
-
+            // `Bytes` is Send + 'static: move it into the blocking task (a refcount
+            // bump) instead of copying the whole >16KB plaintext with `to_vec()`.
             let encrypt_result = wacore::runtime::blocking(&**runtime, move || {
-                write_key.encrypt_with_counter(counter, &plaintext_owned)
+                write_key.encrypt_with_counter(counter, &plaintext)
             })
             .await;
 
@@ -209,6 +209,76 @@ mod tests {
 
         let result = socket.encrypt_and_send(bytes::Bytes::new()).await;
         assert!(result.is_ok(), "encrypt_and_send should succeed");
+    }
+
+    /// Frames above INLINE_ENCRYPT_THRESHOLD take the blocking path that now moves
+    /// the `Bytes` plaintext (refcount) instead of `to_vec()`-copying it. Verify
+    /// both a small (inline) and a large (>16KB) frame still encrypt to ciphertext
+    /// that decrypts back to the exact original.
+    #[tokio::test]
+    async fn test_large_frame_round_trips_via_bytes_path() {
+        use async_lock::Mutex;
+        use async_trait::async_trait;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        struct CapturingTransport {
+            captured: Arc<Mutex<Vec<Vec<u8>>>>,
+            read_key: NoiseCipher,
+            counter: AtomicU32,
+        }
+
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        impl crate::transport::Transport for CapturingTransport {
+            async fn send(&self, data: bytes::Bytes) -> std::result::Result<(), anyhow::Error> {
+                let mut data = data.to_vec();
+                data.drain(..3); // strip the 3-byte frame length prefix
+                let counter = self.counter.fetch_add(1, Ordering::SeqCst);
+                self.read_key
+                    .decrypt_in_place_with_counter(counter, &mut data)
+                    .expect("frame should decrypt");
+                self.captured.lock().await.push(data);
+                Ok(())
+            }
+            async fn disconnect(&self) {}
+        }
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let key = [7u8; 32];
+        let transport = Arc::new(CapturingTransport {
+            captured: captured.clone(),
+            read_key: NoiseCipher::new(&key).expect("32-byte key"),
+            counter: AtomicU32::new(0),
+        });
+        let socket = NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            transport,
+            NoiseCipher::new(&key).expect("32-byte key"),
+            NoiseCipher::new(&key).expect("32-byte key"),
+        );
+
+        let small: Vec<u8> = (0..1_000u32).map(|i| i as u8).collect();
+        let large: Vec<u8> = (0..40_000u32).map(|i| (i % 251) as u8).collect();
+        assert!(small.len() <= INLINE_ENCRYPT_THRESHOLD);
+        assert!(large.len() > INLINE_ENCRYPT_THRESHOLD);
+
+        socket
+            .encrypt_and_send(bytes::Bytes::from(small.clone()))
+            .await
+            .expect("small frame send");
+        socket
+            .encrypt_and_send(bytes::Bytes::from(large.clone()))
+            .await
+            .expect("large frame send");
+
+        let got = captured.lock().await;
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0], small, "inline (<=16KB) frame must round-trip");
+        assert_eq!(
+            got[1], large,
+            "large (>16KB) frame must round-trip via the moved-Bytes path"
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -759,7 +759,7 @@ fn extract_conversation_fields(
                     break;
                 };
                 if let Ok(msg) = HistorySyncMsgInternalFields::decode(&data[pos..end]) {
-                    push_secret_record(chat_id, &msg, secrets_out);
+                    push_secret_record(chat_id, msg, secrets_out);
                 }
                 pos = end;
             }
@@ -816,33 +816,30 @@ fn extract_conversation_fields(
 /// forwarded/poll/bot detection stays in prost via the typed fields/methods.
 fn push_secret_record(
     chat_id: &str,
-    history_msg: &HistorySyncMsgInternalFields,
+    mut history_msg: HistorySyncMsgInternalFields,
     out: &mut Vec<HistoryMsgSecretRecord>,
 ) {
-    let Some(web_msg) = history_msg.message.as_ref() else {
+    // Takes `history_msg` by value: the message is decoded fresh per record and
+    // dropped right after, so the owned fields are moved into the record instead
+    // of cloned.
+    let Some(web_msg) = history_msg.message.as_mut() else {
         return;
     };
     let Some(key) = web_msg.key.as_ref() else {
         return;
     };
-    let Some(msg_id) = key.id.as_ref() else {
+    if key.id.is_none() {
         return;
-    };
+    }
+    let from_me = key.from_me == Some(true);
+
     if let Some(message) = web_msg.message.as_ref()
         && message.is_forwarded()
     {
         return;
     }
-    let Some(secret) = web_msg.message_secret.as_ref().or_else(|| {
-        web_msg
-            .message
-            .as_ref()
-            .and_then(|m| m.message_context_info.as_ref())
-            .and_then(|mci| mci.message_secret.as_ref())
-    }) else {
-        return;
-    };
 
+    // Read the Copy-flag fields by borrow before moving any owned field out.
     let is_poll_or_event = web_msg
         .message
         .as_ref()
@@ -853,15 +850,36 @@ fn push_secret_record(
         .as_ref()
         .map(|m| m.invokes_bot())
         .unwrap_or(false);
+    let timestamp = web_msg.message_timestamp;
+
+    // Top-level message_secret takes priority over the context-info one (same
+    // order as the previous `or_else`); take it rather than clone.
+    let secret = if web_msg.message_secret.is_some() {
+        web_msg.message_secret.take()
+    } else {
+        web_msg
+            .message
+            .as_mut()
+            .and_then(|m| m.message_context_info.as_mut())
+            .and_then(|mci| mci.message_secret.take())
+    };
+    let Some(secret) = secret else {
+        return;
+    };
+
+    let key = web_msg.key.as_mut().expect("key presence checked above");
+    let msg_id = key.id.take().expect("id presence checked above");
+    let key_participant = key.participant.take();
+    let web_msg_participant = web_msg.participant.take();
 
     out.push(HistoryMsgSecretRecord {
         chat_id: chat_id.to_string(),
-        from_me: key.from_me == Some(true),
-        key_participant: key.participant.clone(),
-        web_msg_participant: web_msg.participant.clone(),
-        msg_id: msg_id.clone(),
-        secret: secret.clone(),
-        timestamp: web_msg.message_timestamp,
+        from_me,
+        key_participant,
+        web_msg_participant,
+        msg_id,
+        secret,
+        timestamp,
         is_poll_or_event,
         is_bot_invocation,
     });
@@ -1004,6 +1022,58 @@ mod tests {
         assert_eq!(result.msg_secret_records[1].msg_id, "HIST_CONTEXT");
         assert!(result.msg_secret_records[1].from_me);
         assert_eq!(result.msg_secret_records[1].secret, context_secret);
+    }
+
+    #[test]
+    fn test_top_level_message_secret_takes_priority_over_context() {
+        // A message carrying BOTH the top-level WebMessageInfo.message_secret and a
+        // nested message_context_info.message_secret must extract the top-level one
+        // (the move-based push_secret_record must `.take()` the right source).
+        let chat = "5511777776666@s.whatsapp.net";
+        let top_level_secret = vec![0xAAu8; 32];
+        let context_secret = vec![0xBBu8; 32];
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::InitialBootstrap as i32,
+            conversations: vec![wa::Conversation {
+                id: chat.to_string(),
+                messages: vec![wa::HistorySyncMsg {
+                    message: Some(wa::WebMessageInfo {
+                        key: wa::MessageKey {
+                            remote_jid: Some(chat.to_string()),
+                            from_me: Some(false),
+                            id: Some("HIST_BOTH".to_string()),
+                            participant: Some("5511888889999@s.whatsapp.net".to_string()),
+                        },
+                        message_secret: Some(top_level_secret.clone()),
+                        message: Some(wa::Message {
+                            message_context_info: Some(wa::MessageContextInfo {
+                                message_secret: Some(context_secret.clone()),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let compressed = encode_and_compress(&hs);
+        let result = process_history_sync(compressed, None, false, None).unwrap();
+
+        assert_eq!(result.msg_secret_records.len(), 1);
+        assert_eq!(result.msg_secret_records[0].msg_id, "HIST_BOTH");
+        assert_eq!(
+            result.msg_secret_records[0].secret, top_level_secret,
+            "top-level message_secret must win over the context-info one"
+        );
+        assert_eq!(
+            result.msg_secret_records[0].key_participant.as_deref(),
+            Some("5511888889999@s.whatsapp.net")
+        );
     }
 
     #[test]

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -56,10 +56,13 @@ const CROCKFORD_ALPHABET: &[u8; 32] = b"123456789ABCDEFGHJKLMNPQRSTVWXYZ";
 /// which hasn't released a digest 0.11-compatible stable version yet.
 fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u8]) {
     use hmac::KeyInit as _;
+    // Derive the HMAC key schedule (ipad/opad) once and clone that keyed state
+    // per use. `new_from_slice` re-absorbs the padded key (2 SHA-256 blocks)
+    // on every call, which is wasted work repeated across all PBKDF2 rounds.
+    let keyed = Hmac::<Sha256>::new_from_slice(password).expect("HMAC accepts any key length");
     for (i, chunk) in output.chunks_mut(32).enumerate() {
         let mut u = {
-            let mut mac =
-                Hmac::<Sha256>::new_from_slice(password).expect("HMAC accepts any key length");
+            let mut mac = keyed.clone();
             mac.update(salt);
             mac.update(&((i as u32) + 1).to_be_bytes());
             let result: [u8; 32] = mac.finalize().into_bytes().into();
@@ -67,8 +70,7 @@ fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u
         };
         chunk.copy_from_slice(&u[..chunk.len()]);
         for _ in 1..rounds {
-            let mut mac =
-                Hmac::<Sha256>::new_from_slice(password).expect("HMAC accepts any key length");
+            let mut mac = keyed.clone();
             mac.update(&u);
             u = mac.finalize().into_bytes().into();
             for (a, b) in chunk.iter_mut().zip(u.iter()) {
@@ -539,6 +541,50 @@ pub enum PairCodeError {
 mod tests {
     use super::*;
     use wacore_binary::NodeContent;
+
+    /// The keyed-clone PBKDF2 must produce byte-identical output to the original
+    /// form that re-ran `new_from_slice` every round.
+    #[test]
+    fn test_pbkdf2_matches_per_iteration_reference() {
+        use hmac::{KeyInit as _, Mac as _};
+
+        fn reference(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u8]) {
+            for (i, chunk) in output.chunks_mut(32).enumerate() {
+                let mut u = {
+                    let mut mac = Hmac::<Sha256>::new_from_slice(password).unwrap();
+                    mac.update(salt);
+                    mac.update(&((i as u32) + 1).to_be_bytes());
+                    let r: [u8; 32] = mac.finalize().into_bytes().into();
+                    r
+                };
+                chunk.copy_from_slice(&u[..chunk.len()]);
+                for _ in 1..rounds {
+                    let mut mac = Hmac::<Sha256>::new_from_slice(password).unwrap();
+                    mac.update(&u);
+                    u = mac.finalize().into_bytes().into();
+                    for (a, b) in chunk.iter_mut().zip(u.iter()) {
+                        *a ^= b;
+                    }
+                }
+            }
+        }
+
+        let cases: &[(&[u8], &[u8], u32, usize)] = &[
+            (b"password", b"salt", 1, 32),
+            (b"password", b"salt", 7, 32),
+            (b"pw", b"NaCl", 100, 64),              // multi-block output
+            (b"", b"", 50, 16),                     // empty pw/salt, partial chunk
+            (&[0xffu8; 40], &[0x01u8; 13], 33, 48), // long key, odd lengths
+        ];
+        for &(pw, salt, rounds, len) in cases {
+            let mut got = vec![0u8; len];
+            let mut want = vec![0u8; len];
+            pbkdf2_hmac_sha256(pw, salt, rounds, &mut got);
+            reference(pw, salt, rounds, &mut want);
+            assert_eq!(got, want, "pbkdf2 mismatch for rounds={rounds} len={len}");
+            assert_ne!(got, vec![0u8; len], "output must not be all zeros");
+        }
+    }
 
     #[test]
     fn test_generate_code() {


### PR DESCRIPTION
Three independent copy/allocation cleanups, each with a test that pins the behavior.

## M2 — PBKDF2 keys the HMAC once

`pbkdf2_hmac_sha256` called `Hmac::<Sha256>::new_from_slice(password)` inside the round loop, re-absorbing the padded key (2 SHA-256 compressions) on every one of the ~131k rounds. Derive the keyed state once and `clone()` it per round (clone copies the precomputed ipad/opad, no re-derivation). Output is bit-identical.
*Test:* `test_pbkdf2_matches_per_iteration_reference` compares the optimized output against a per-round-rekeying reference across several inputs/lengths.
*(Measured earlier at ~45% on the function; cold path — device pairing.)*

## M4 — noise large frames move `Bytes` instead of copying

Frames above the 16 KB inline threshold took the blocking encrypt path via `plaintext.to_vec()`, copying 16–256 KB. `SendJob.plaintext` is already `bytes::Bytes` (Send + 'static), so it's now moved (a refcount bump) into the blocking task. Hits large group SKDM fan-out, history-sync, and app-state patch sends.
*Test:* `test_large_frame_round_trips_via_bytes_path` sends a small (inline) and a >16 KB frame and asserts both decrypt back to the exact original.

## M5 — history-sync secret records move, not clone

`push_secret_record` cloned 4 owned prost fields per message (participant ×2, msg_id, 32 B secret) from a value decoded fresh and dropped immediately after. It now takes the message by value and moves them, `.take()`-ing the secret from the correct source.
*Test:* `test_top_level_message_secret_takes_priority_over_context` pins the priority (top-level `message_secret` wins over the nested `message_context_info` one); existing extract/forwarded tests still pass.

## Tests
`cargo test -p wacore -p whatsapp-rust` — 852 + 663 pass (incl. the 3 new tests); `clippy --all-targets` clean.