### PR TITLE
fix(send): classify payment-family stanzas as text + add stanza-type override

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3189,6 +3189,7 @@ impl Client {
             false,
             None,
             vec![],
+            None,
         )
         .await?;
         Ok(())
@@ -3823,6 +3824,7 @@ impl Client {
             false,
             Some(crate::types::message::EditAttribute::MessageEdit),
             vec![],
+            None,
         )
         .await?;
 

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -811,7 +811,16 @@ impl<'a> Groups<'a> {
         }
         let msg = wacore::send::build_member_label_message(label.into(), wacore::time::now_secs());
         self.client
-            .send_message_impl(group_jid.clone(), &msg, None, false, false, None, vec![])
+            .send_message_impl(
+                group_jid.clone(),
+                &msg,
+                None,
+                false,
+                false,
+                None,
+                vec![],
+                None,
+            )
             .await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub use runtime_impl::TokioRuntime;
 pub use wacore::runtime::Runtime;
 pub mod send;
 pub use send::{PinDuration, RevokeType, SendOptions, SendResult};
+pub use wacore::send::StanzaType;
 pub mod session;
 pub mod socket;
 pub mod store;

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -243,6 +243,7 @@ impl Client {
             false, // is_retry
             None,
             vec![], // No extra stanza nodes for peer messages
+            None,
         )
         .await?;
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -3666,6 +3666,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stanza_type_override_sets_wire_type_attr() {
+        let client = crate::test_utils::create_test_client_with_name("stanza_type_override").await;
+        let peer: Jid = "100000000000003@s.whatsapp.net".parse().unwrap();
+        seed_peer_send_state(&client, &peer).await;
+
+        let request_id = "STANZA_TYPE_OVERRIDE_1";
+        let waiter = client
+            .wait_for_sent_node(crate::client::NodeFilter::tag("message").attr("id", request_id));
+        let msg =
+            pdo_request_message(wa::message::PeerDataOperationRequestType::HistorySyncOnDemand);
+
+        // Poll is never the type for this message; it can only come from the override.
+        let result = client
+            .send_message_impl(
+                peer,
+                &msg,
+                Some(request_id.to_string()),
+                true,
+                false,
+                None,
+                vec![],
+                Some(wacore::send::StanzaType::Poll),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "test client has no socket; send should fail after stanza capture"
+        );
+
+        let node = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("sent node should be captured")
+            .expect("sent node waiter should resolve");
+        assert_eq!(
+            node.attrs().optional_string("type").unwrap().as_ref(),
+            wacore::send::StanzaType::Poll.as_wire()
+        );
+    }
+
+    #[tokio::test]
     async fn persist_outbound_msg_secret_writes_under_chat_sender_id() {
         let client = crate::test_utils::create_test_client_with_name("secret_chat_id").await;
         seed_pn(&client, "5511000000001:0@s.whatsapp.net").await;

--- a/src/send.rs
+++ b/src/send.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use log::debug;
 use wacore::client::context::SendContextResolver;
 use wacore::libsignal::protocol::SignalProtocolError;
+use wacore::send::StanzaType;
 use wacore::types::jid::JidExt;
 use wacore::types::message::AddressingMode;
 #[cfg(test)]
@@ -25,6 +26,9 @@ pub struct SendOptions {
     /// message (WA Web `EProtoGenerator.js:183` parity).
     /// Common values: 86400 (24h), 604800 (7d), 7776000 (90d).
     pub ephemeral_expiration: Option<u32>,
+    /// Force the `<message type="...">` attribute instead of deriving it from
+    /// content. Escape hatch for a type the classifier can't infer.
+    pub stanza_type_override: Option<StanzaType>,
 }
 
 /// Result of a successfully sent message.
@@ -309,6 +313,7 @@ impl Client {
             }
         }
 
+        let stanza_type_override = options.stanza_type_override;
         let request_id = match options.message_id {
             Some(id) => id,
             None => self.generate_message_id().await,
@@ -323,7 +328,9 @@ impl Client {
         // Matches WA Web's OutMessagePublishNewsletterRequest + ContentType mixins.
         if to.is_newsletter() {
             use prost::Message as _;
-            let stanza_type = wacore::send::stanza_type_from_message(&message);
+            let stanza_type = stanza_type_override
+                .map(StanzaType::as_wire)
+                .unwrap_or_else(|| wacore::send::stanza_type_from_message(&message));
             let (_, meta_node) = infer_stanza_metadata(&message);
             let mut plaintext_builder = NodeBuilder::new("plaintext");
             if let Some(mt) = wacore::send::media_type_from_message(&message) {
@@ -356,6 +363,7 @@ impl Client {
             false,
             edit,
             extra_nodes,
+            stanza_type_override,
         )
         .await?;
         Ok(result)
@@ -918,6 +926,7 @@ impl Client {
             force_skdm,
             Some(edit_attr),
             vec![],
+            None,
         )
         .await
     }
@@ -977,6 +986,7 @@ impl Client {
             false,
             Some(crate::types::message::EditAttribute::PinInChat),
             vec![],
+            None,
         )
         .await
     }
@@ -991,6 +1001,7 @@ impl Client {
         force_key_distribution: bool,
         edit: Option<crate::types::message::EditAttribute>,
         extra_stanza_nodes: Vec<Node>,
+        stanza_type_override: Option<StanzaType>,
     ) -> Result<(), anyhow::Error> {
         // status@broadcast reactions fan out pairwise to the author's devices;
         // status posts keep going through send_status_message (owns recipients).
@@ -1439,6 +1450,9 @@ impl Client {
         let mut stanza_to_send = stanza_to_send;
         if is_status_addon {
             stanza_to_send.attrs.insert("to", Jid::status_broadcast());
+        }
+        if let Some(t) = stanza_type_override {
+            stanza_to_send.attrs.insert("type", t.as_wire());
         }
 
         if let Err(e) = self.send_node(stanza_to_send).await {
@@ -3619,6 +3633,7 @@ mod tests {
                 false,
                 None,
                 vec![],
+                None,
             )
             .await;
         assert!(

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -36,6 +36,31 @@ pub(crate) mod stanza {
     pub const ENC_TYPE_MSG: &str = "msg";
     pub const ENC_TYPE_PKMSG: &str = "pkmsg";
     pub const ENC_TYPE_SKMSG: &str = "skmsg";
+    pub const MSG_TYPE_PAY: &str = "pay";
+}
+
+/// Type-safe `<message type="...">` value for the send-time override.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StanzaType {
+    Text,
+    Media,
+    Reaction,
+    Poll,
+    Event,
+    Pay,
+}
+
+impl StanzaType {
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Text => stanza::MSG_TYPE_TEXT,
+            Self::Media => stanza::MSG_TYPE_MEDIA,
+            Self::Reaction => stanza::MSG_TYPE_REACTION,
+            Self::Poll => stanza::MSG_TYPE_POLL,
+            Self::Event => stanza::MSG_TYPE_EVENT,
+            Self::Pay => stanza::MSG_TYPE_PAY,
+        }
+    }
 }
 
 /// Extract (enc_type, is_prekey, serialized) from a CiphertextMessage.
@@ -143,6 +168,14 @@ pub fn stanza_type_from_message(msg: &wa::Message) -> &'static str {
         || msg.newsletter_follower_invite_message_v2.is_some()
         || msg.message_history_notice.is_some()
         || msg.album_message.is_some()
+        // Payment family. WA Web's typeAttributeFromProtobuf leaves these at the media
+        // default, but media-without-mediatype is dropped by the server (so is a bare
+        // "pay" stanza); text is what delivers and renders on Android.
+        || msg.request_payment_message.is_some()
+        || msg.send_payment_message.is_some()
+        || msg.payment_invite_message.is_some()
+        || msg.decline_payment_request_message.is_some()
+        || msg.cancel_payment_request_message.is_some()
     {
         return stanza::MSG_TYPE_TEXT;
     }
@@ -4279,21 +4312,34 @@ mod tests {
         }
 
         #[test]
-        fn request_payment_carries_no_mediatype_and_is_not_text() {
-            // request_payment_message is absent from WA Web's typeAttributeFromProtobuf
-            // (it only maps to the internal MSG_TYPE.PAYMENT enum, not the wire `type`)
-            // and carries no mediatype. WA Web's classifier defaults it to "media", but
-            // a media stanza without a `mediatype` attribute is dropped by the server,
-            // so WA Web does not send request_payment_message standalone through this
-            // path. Pin the two stable facts — no mediatype, and not misclassified as
-            // text (the bug this PR removes) — rather than hardening that droppable
-            // "media" wire shape as if it were a valid send.
-            let m = wa::Message {
-                request_payment_message: Some(Box::default()),
-                ..Default::default()
-            };
-            assert_eq!(media_type_from_message(&m), None);
-            assert_ne!(stanza_type_from_message(&m), stanza::MSG_TYPE_TEXT);
+        fn payment_family_is_text() {
+            // Payment family classifies as text; the media default would be dropped.
+            let cases = [
+                wa::Message {
+                    request_payment_message: Some(Box::default()),
+                    ..Default::default()
+                },
+                wa::Message {
+                    send_payment_message: Some(Box::default()),
+                    ..Default::default()
+                },
+                wa::Message {
+                    decline_payment_request_message: Some(Default::default()),
+                    ..Default::default()
+                },
+                wa::Message {
+                    cancel_payment_request_message: Some(Default::default()),
+                    ..Default::default()
+                },
+                wa::Message {
+                    payment_invite_message: Some(Default::default()),
+                    ..Default::default()
+                },
+            ];
+            for m in cases {
+                assert_eq!(media_type_from_message(&m), None);
+                assert_eq!(stanza_type_from_message(&m), stanza::MSG_TYPE_TEXT);
+            }
         }
 
         #[test]


### PR DESCRIPTION
Two related send changes from tracking down why payment-request messages never rendered.

## Payment-family stanzas now classify as text

`requestPaymentMessage`, `sendPaymentMessage`, `paymentInviteMessage`, `declinePaymentRequestMessage` and `cancelPaymentRequestMessage` were absent from `stanza_type_from_message` and fell through to the `media` default. `media_type_from_message` returns `None` for them, so they went out as `<message type="media">` with no `mediatype` — a shape the server silently drops, so they never rendered on any recipient.

`WAWebE2EProtoUtils.typeAttributeFromProtobuf` also leaves the payment family at the media default, because WA Web doesn't send these at all (it maps them to the internal `MSG_TYPE.PAYMENT`, not a wire type). They're an Android feature. Confirmed against the live server: the same `requestPaymentMessage` is dropped both as `type="media"` and as a bare `type="pay"`, but delivers and renders on Android as `type="text"`. So the whole family is classified as text.

*Test:* `payment_family_is_text` — all five carry no `mediatype` and classify as `text`.

## `SendOptions.stanza_type_override`

Adds a type-safe `StanzaType` enum (`Text`/`Media`/`Reaction`/`Poll`/`Event`/`Pay`) and `SendOptions.stanza_type_override: Option<StanzaType>` to force the `<message type="...">` attribute when the content classifier can't infer it. Applied where the outgoing stanza is finalized and on the newsletter path; `None` everywhere else.

Non-breaking: `SendOptions` derives `Default`, the new field is `Option`. Known limitation: the override doesn't reach the retry path (resends reclassify from content) — harmless for the payment family since the classifier already returns text.
