### PR TITLE
fix(client): use portable_atomic::AtomicU64 in offline_resume

### DIFF
--- a/src/client/offline_resume.rs
+++ b/src/client/offline_resume.rs
@@ -14,8 +14,9 @@
 //! continuation per cycle, just as WA Web's `$6` timer coalesces
 //! synchronously-arriving stanzas into one `$13` call.
 
+use portable_atomic::AtomicU64;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use log::{debug, warn};


### PR DESCRIPTION
## Problem

`src/client/offline_resume.rs` imports `std::sync::atomic::AtomicU64`. `std` omits that type on targets without native 64-bit atomics, so a `default-features = false` build for `xtensa-esp32s3-espidf` (ESP32) fails to compile:

```
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
  --> src/client/offline_resume.rs:18:37
   |
18 | use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
   |                                     ^^^^^^^^^ no `AtomicU64` in `sync::atomic`
```

## Fix

Use `portable_atomic::AtomicU64` instead. The crate already depends on `portable-atomic` and uses it for exactly this reason elsewhere (`src/client.rs`, `src/unified_session.rs`, `wacore/src/request.rs`), so this just aligns `offline_resume` with the existing pattern. No behavioral change on native targets.

## Validation

With this change, `whatsapp-rust` with `default-features = false` compiles cleanly for `xtensa-esp32s3-espidf` (verified by building an ESP32-S3 firmware that depends on it from `main`). Before the change the build stopped at the import above; after it, the whole `whatsapp-rust` lib compiles for the target.