### PR TITLE
feat(prekeys): make pre-key upload batch size configurable via the builder

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -297,6 +297,7 @@ pub struct BotBuilder<B = Missing, T = Missing, H = Missing, R = Missing> {
     skip_history_sync: bool,
     initial_push_name: Option<String>,
     cache_config: CacheConfig,
+    wanted_pre_key_count: Option<usize>,
     _marker: PhantomData<(B, T, H, R)>,
 }
 
@@ -315,6 +316,7 @@ impl BotBuilder<Missing, Missing, Missing, Missing> {
             skip_history_sync: false,
             initial_push_name: None,
             cache_config: CacheConfig::default(),
+            wanted_pre_key_count: None,
             _marker: PhantomData,
         }
     }
@@ -351,6 +353,7 @@ impl<T, H, R> BotBuilder<Missing, T, H, R> {
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
             cache_config: self.cache_config,
+            wanted_pre_key_count: self.wanted_pre_key_count,
             _marker: PhantomData,
         }
     }
@@ -390,6 +393,7 @@ impl<B, H, R> BotBuilder<B, Missing, H, R> {
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
             cache_config: self.cache_config,
+            wanted_pre_key_count: self.wanted_pre_key_count,
             _marker: PhantomData,
         }
     }
@@ -428,6 +432,7 @@ impl<B, T, R> BotBuilder<B, T, Missing, R> {
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
             cache_config: self.cache_config,
+            wanted_pre_key_count: self.wanted_pre_key_count,
             _marker: PhantomData,
         }
     }
@@ -451,6 +456,7 @@ impl<B, T, H> BotBuilder<B, T, H, Missing> {
             skip_history_sync: self.skip_history_sync,
             initial_push_name: self.initial_push_name,
             cache_config: self.cache_config,
+            wanted_pre_key_count: self.wanted_pre_key_count,
             _marker: PhantomData,
         }
     }
@@ -620,6 +626,27 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         self
     }
 
+    /// Set how many one-time pre-keys are generated and uploaded per batch.
+    ///
+    /// Defaults to WA Web's UPLOAD_KEYS_COUNT (812). The value is clamped to the
+    /// protocol-safe range at upload time. Useful for memory-constrained or
+    /// embedded consumers that want a smaller batch.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let bot = Bot::builder()
+    ///     .with_backend(backend)
+    ///     .with_transport_factory(transport)
+    ///     .with_http_client(http_client)
+    ///     .with_wanted_pre_key_count(200)
+    ///     .build()
+    ///     .await?;
+    /// ```
+    pub fn with_wanted_pre_key_count(mut self, count: usize) -> Self {
+        self.wanted_pre_key_count = Some(count);
+        self
+    }
+
     /// Set an initial push name on the device before connecting.
     ///
     /// This is included in the `ClientPayload` during registration, allowing the
@@ -728,6 +755,10 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
 
         if self.skip_history_sync {
             client.set_skip_history_sync(true);
+        }
+
+        if let Some(count) = self.wanted_pre_key_count {
+            client.set_wanted_pre_key_count(count);
         }
 
         Ok(Bot {
@@ -1113,6 +1144,46 @@ mod tests {
             .expect("Failed to build bot");
 
         assert!(!bot.client().skip_history_sync_enabled());
+    }
+
+    #[tokio::test]
+    async fn test_bot_builder_wanted_pre_key_count() {
+        let backend = create_test_sqlite_backend().await;
+        let transport = TokioWebSocketTransportFactory::new();
+        let http_client = MockHttpClient;
+
+        let bot = Bot::builder()
+            .with_backend(backend)
+            .with_transport_factory(transport)
+            .with_http_client(http_client)
+            .with_wanted_pre_key_count(200)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("Failed to build bot with custom pre-key count");
+
+        assert_eq!(bot.client().wanted_pre_key_count(), 200);
+    }
+
+    #[tokio::test]
+    async fn test_bot_builder_default_wanted_pre_key_count() {
+        let backend = create_test_sqlite_backend().await;
+        let transport = TokioWebSocketTransportFactory::new();
+        let http_client = MockHttpClient;
+
+        let bot = Bot::builder()
+            .with_backend(backend)
+            .with_transport_factory(transport)
+            .with_http_client(http_client)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("Failed to build bot");
+
+        assert_eq!(
+            bot.client().wanted_pre_key_count(),
+            crate::prekeys::DEFAULT_WANTED_PRE_KEY_COUNT
+        );
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -524,6 +524,12 @@ pub struct Client {
     /// or processed. Set via `BotBuilder::skip_history_sync()`.
     pub(crate) skip_history_sync: AtomicBool,
 
+    /// Number of one-time pre-keys generated per upload batch. Defaults to
+    /// [`crate::prekeys::DEFAULT_WANTED_PRE_KEY_COUNT`]; set via
+    /// [`BotBuilder::with_wanted_pre_key_count`] or [`Client::set_wanted_pre_key_count`].
+    /// Clamped to the protocol-safe range at upload time.
+    pub(crate) wanted_pre_key_count: AtomicUsize,
+
     /// Cache configuration for TTL and capacity of all caches.
     /// Stored for use by lazily-initialized caches (group_cache).
     pub(crate) cache_config: CacheConfig,
@@ -722,6 +728,22 @@ impl Client {
         self.skip_history_sync.load(Ordering::Relaxed)
     }
 
+    /// Set how many one-time pre-keys are generated per upload batch.
+    ///
+    /// Defaults to WA Web's UPLOAD_KEYS_COUNT (812). Call before connecting; it
+    /// takes effect on the next pre-key upload. The value is clamped to the
+    /// protocol-safe range at upload time, so out-of-range values are coerced
+    /// (and logged) rather than rejected here.
+    pub fn set_wanted_pre_key_count(&self, count: usize) {
+        self.wanted_pre_key_count.store(count, Ordering::Relaxed);
+    }
+
+    /// Returns the configured pre-key upload batch size (the raw value, before
+    /// the upload-time clamp).
+    pub fn wanted_pre_key_count(&self) -> usize {
+        self.wanted_pre_key_count.load(Ordering::Relaxed)
+    }
+
     pub(crate) fn is_shutting_down(&self) -> bool {
         self.expected_disconnect.load(Ordering::Relaxed) || !self.is_running.load(Ordering::Relaxed)
     }
@@ -881,6 +903,7 @@ impl Client {
             http_client,
             override_version,
             skip_history_sync: AtomicBool::new(false),
+            wanted_pre_key_count: AtomicUsize::new(crate::prekeys::DEFAULT_WANTED_PRE_KEY_COUNT),
             cache_config,
             self_weak: std::sync::OnceLock::new(),
             saver_handle: std::sync::OnceLock::new(),

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -19,9 +19,27 @@ use wacore_binary::Jid;
 
 pub use wacore::prekeys::PreKeyUtils;
 
-/// Matches WA Web's UPLOAD_KEYS_COUNT from WAWebSignalStoreApi.
-const WANTED_PRE_KEY_COUNT: usize = 812;
+/// Default number of one-time pre-keys generated and uploaded per batch.
+/// Mirrors WA Web's UPLOAD_KEYS_COUNT (`WAWebUploadPreKeysJob`).
+pub(crate) const DEFAULT_WANTED_PRE_KEY_COUNT: usize = 812;
+
 const MIN_PRE_KEY_COUNT: usize = 5;
+
+/// WA Web uses 24-bit PreKey IDs (max 2^24 - 1); IDs wrap modulo this.
+const MAX_PREKEY_ID: u32 = 16_777_215;
+
+/// The upload IQ encodes the pre-key `<list>` length as a u16
+/// (`Encoder::write_list_start`), so a larger batch fails to encode after the
+/// keys were already generated and stored. Well below MAX_PREKEY_ID, so a single
+/// batch never reuses an ID either.
+const MAX_PRE_KEY_UPLOAD_BATCH: usize = u16::MAX as usize;
+
+/// Below MIN_PRE_KEY_COUNT the pool ends up flagged-but-empty or loops on
+/// re-upload (the count guard never clears); above MAX_PRE_KEY_UPLOAD_BATCH the
+/// upload IQ fails to encode. Only an explicitly misconfigured count hits either.
+fn clamp_wanted_pre_key_count(n: usize) -> usize {
+    n.clamp(MIN_PRE_KEY_COUNT, MAX_PRE_KEY_UPLOAD_BATCH)
+}
 
 impl Client {
     pub(crate) async fn fetch_pre_keys(
@@ -97,9 +115,9 @@ impl Client {
         self.upload_pre_keys_inner().await
     }
 
-    /// Generate and upload WANTED_PRE_KEY_COUNT pre-keys. Shared by
-    /// `upload_pre_keys` and `upload_pre_keys_at_login` to avoid
-    /// redundant server count queries.
+    /// Generate and upload the configured number of pre-keys (see
+    /// [`Client::set_wanted_pre_key_count`]). Shared by `upload_pre_keys` and
+    /// `upload_pre_keys_at_login` to avoid redundant server count queries.
     async fn upload_pre_keys_inner(&self) -> Result<(), anyhow::Error> {
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
         let device_store = self.persistence_manager.get_device_arc().await;
@@ -123,35 +141,40 @@ impl Client {
             max_id + 1
         };
 
-        // WA Web uses 24-bit PreKey IDs (max 2^24 - 1 = 16777215).
         // Wrap into valid range so lingering high-ID rows don't pin start_id
-        // above the boundary and cause repeated overwrites of low IDs.
-        const MAX_PREKEY_ID: u32 = 16777215;
+        // above the 24-bit boundary and cause repeated overwrites of low IDs.
         let start_id = ((raw_start as u64 - 1) % MAX_PREKEY_ID as u64) as u32 + 1;
 
-        let mut keys_to_upload = Vec::with_capacity(WANTED_PRE_KEY_COUNT);
-        let mut key_pairs_to_upload = Vec::with_capacity(WANTED_PRE_KEY_COUNT);
-
-        for i in 0..WANTED_PRE_KEY_COUNT {
-            let pre_key_id =
-                (((start_id as u64 - 1) + i as u64) % (MAX_PREKEY_ID as u64)) as u32 + 1;
-
-            let key_pair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
-            let pre_key_record = new_pre_key_record(pre_key_id, &key_pair);
-
-            keys_to_upload.push((pre_key_id, pre_key_record));
-            key_pairs_to_upload.push((pre_key_id, key_pair));
+        let configured = self.wanted_pre_key_count.load(Ordering::Relaxed);
+        let wanted = clamp_wanted_pre_key_count(configured);
+        if wanted != configured {
+            log::warn!("wanted_pre_key_count {configured} out of range, clamped to {wanted}");
         }
 
-        // Encode all prekey records into a single contiguous buffer, then slice
-        // into Bytes sub-views. This replaces 812 individual encode_to_vec() allocs
-        // with one large allocation + zero-copy slicing.
-        let encoded_batch: Vec<(u32, bytes::Bytes)> = {
+        // Per-key X25519 generation and prost encoding are CPU-bound, and the
+        // batch size is caller-configurable, so offload the whole batch to keep
+        // the async executor responsive. Records are encoded into one contiguous
+        // buffer with zero-copy Bytes slices instead of an alloc per record.
+        let (encoded_batch, pre_key_pairs) = wacore::runtime::blocking(&*self.runtime, move || {
             use prost::Message;
-            let total_len: usize = keys_to_upload.iter().map(|(_, r)| r.encoded_len()).sum();
+
+            // Seed one CSPRNG and advance it per key, rather than reseeding from
+            // entropy on every iteration.
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut records = Vec::with_capacity(wanted);
+            let mut pre_key_pairs: Vec<(u32, PublicKey)> = Vec::with_capacity(wanted);
+            for i in 0..wanted {
+                let pre_key_id =
+                    (((start_id as u64 - 1) + i as u64) % (MAX_PREKEY_ID as u64)) as u32 + 1;
+                let key_pair = KeyPair::generate(&mut rng);
+                records.push((pre_key_id, new_pre_key_record(pre_key_id, &key_pair)));
+                pre_key_pairs.push((pre_key_id, key_pair.public_key));
+            }
+
+            let total_len: usize = records.iter().map(|(_, r)| r.encoded_len()).sum();
             let mut buf = Vec::with_capacity(total_len);
-            let mut offsets = Vec::with_capacity(keys_to_upload.len());
-            for (id, record) in &keys_to_upload {
+            let mut offsets = Vec::with_capacity(records.len());
+            for (id, record) in &records {
                 let start = buf.len();
                 record
                     .encode(&mut buf)
@@ -159,11 +182,14 @@ impl Client {
                 offsets.push((*id, start..buf.len()));
             }
             let shared = bytes::Bytes::from(buf);
-            offsets
+            let encoded_batch: Vec<(u32, bytes::Bytes)> = offsets
                 .into_iter()
                 .map(|(id, range)| (id, shared.slice(range)))
-                .collect()
-        };
+                .collect();
+
+            (encoded_batch, pre_key_pairs)
+        })
+        .await;
 
         // Persist the freshly generated prekeys before uploading them so they are
         // already available for local decryption if the server starts sending
@@ -171,11 +197,6 @@ impl Client {
         // Propagate errors — uploading a key we can't store locally would cause
         // decryption failures when the server hands it out.
         backend.store_prekeys_batch(&encoded_batch, false).await?;
-
-        let pre_key_pairs: Vec<(u32, PublicKey)> = key_pairs_to_upload
-            .iter()
-            .map(|(id, key_pair)| (*id, key_pair.public_key))
-            .collect();
 
         let spec = PreKeyUploadSpec::new(
             device_snapshot.registration_id,
@@ -197,9 +218,7 @@ impl Client {
         // high-ID prekeys still exist, the upsert (.on_conflict.do_update)
         // silently overwrites them. Acceptable: the server consumes keys well
         // before a full 16M cycle completes.
-        let next_id = (((start_id as u64 - 1) + key_pairs_to_upload.len() as u64)
-            % (MAX_PREKEY_ID as u64)) as u32
-            + 1;
+        let next_id = (((start_id as u64 - 1) + wanted as u64) % (MAX_PREKEY_ID as u64)) as u32 + 1;
         self.persistence_manager
             .process_command(DeviceCommand::SetNextPreKeyId(next_id))
             .await;
@@ -211,7 +230,7 @@ impl Client {
 
         log::debug!(
             "Successfully uploaded {} new pre-keys with sequential IDs starting from {}.",
-            key_pairs_to_upload.len(),
+            wanted,
             start_id
         );
 
@@ -406,5 +425,43 @@ impl Client {
 
         log::debug!("digestKey: key bundle validation successful");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_WANTED_PRE_KEY_COUNT, MAX_PRE_KEY_UPLOAD_BATCH, MIN_PRE_KEY_COUNT,
+        clamp_wanted_pre_key_count,
+    };
+
+    #[test]
+    fn default_matches_wa_web_upload_keys_count() {
+        // WAWebUploadPreKeysJob's UPLOAD_KEYS_COUNT; drift here diverges from WA Web.
+        assert_eq!(DEFAULT_WANTED_PRE_KEY_COUNT, 812);
+    }
+
+    #[test]
+    fn clamp_wanted_pre_key_count_bounds() {
+        assert_eq!(clamp_wanted_pre_key_count(0), MIN_PRE_KEY_COUNT);
+        assert_eq!(clamp_wanted_pre_key_count(2), MIN_PRE_KEY_COUNT);
+        assert_eq!(clamp_wanted_pre_key_count(4), MIN_PRE_KEY_COUNT);
+        assert_eq!(
+            clamp_wanted_pre_key_count(MIN_PRE_KEY_COUNT),
+            MIN_PRE_KEY_COUNT
+        );
+        assert_eq!(clamp_wanted_pre_key_count(812), 812);
+        assert_eq!(
+            clamp_wanted_pre_key_count(MAX_PRE_KEY_UPLOAD_BATCH),
+            MAX_PRE_KEY_UPLOAD_BATCH
+        );
+        assert_eq!(
+            clamp_wanted_pre_key_count(MAX_PRE_KEY_UPLOAD_BATCH + 1),
+            MAX_PRE_KEY_UPLOAD_BATCH
+        );
+        assert_eq!(
+            clamp_wanted_pre_key_count(usize::MAX),
+            MAX_PRE_KEY_UPLOAD_BATCH
+        );
     }
 }


### PR DESCRIPTION
## Problem

The per-batch one-time pre-key upload count was a hardcoded private const `WANTED_PRE_KEY_COUNT: usize = 812` in `src/prekeys.rs` (mirroring WhatsApp Web's `UPLOAD_KEYS_COUNT` from `WAWebUploadPreKeysJob`). There was no way to tune it without patching the library, which matters for memory-constrained or embedded consumers that want a smaller batch.

## Fix

Expose the batch size through the **builder/factory API** rather than `CacheConfig`:

- `BotBuilder::with_wanted_pre_key_count(n)` — fluent setter on the builder.
- `Client::set_wanted_pre_key_count(n)` / `Client::wanted_pre_key_count()` — for consumers that construct the `Client` directly (Veloz/esp32), settable before connect.

The value lives on `Client` as an `AtomicUsize` defaulting to `812`, wired exactly like the existing `skip_history_sync` flag (builder field → typestate copies → post-build `set_*`). Purely additive: no constructor or `CacheConfig` signature changes, so every existing caller is byte-identical.

### Validation (clamped at upload time to `5..=65_535`)

- **Floor 5** (`MIN_PRE_KEY_COUNT`) rejects `0` (an empty pool would still set `server_has_prekeys = true`, a silent permanent break) and `1..=4` (a top-up below the upload trigger loops forever, since the count guard never clears).
- **Ceiling 65_535** (`u16::MAX`): the upload IQ encodes the pre-key `<list>` length as a u16 (`Encoder::write_list_start` returns `InvalidNode` above that), so a larger batch would fail to encode **only after** the keys were already generated and stored locally. This is well below `MAX_PREKEY_ID`, so a single batch never reuses an ID either.

A `warn!` is logged only when a configured value is actually out of range.

### Offload batch keygen

Per-key X25519 generation + prost encoding for the whole batch is now offloaded via `wacore::runtime::blocking` (runtime-agnostic; runs inline on wasm) instead of on the async executor, since the batch size is now caller-controlled and could be large.

## Design note

The first revision put this on `CacheConfig`; per owner preference (and the review here) it was moved to the builder/factory API. `MIN_PRE_KEY_COUNT` stays a private const (the upload-trigger threshold) and doubles as the clamp floor.

## Breaking

None. All additions are new methods/fields; no existing signature changes.

## Tests

- `clamp_wanted_pre_key_count_bounds` — `0/2/4 -> 5`, `812 -> 812`, `65_535 -> 65_535`, `65_536 -> 65_535`, `usize::MAX -> 65_535`.
- `test_bot_builder_wanted_pre_key_count` — custom value (200) flows builder → client.
- `test_bot_builder_default_wanted_pre_key_count` — default is 812.

```
cargo fmt --all
cargo clippy --all-targets -- -D warnings   # clean
cargo test -p whatsapp-rust -- prekey wanted_pre_key skip_history   # 7 pass
```

