### PR TITLE
fix(send): hoist messageContextInfo to outer in DeviceSentMessage (WA Web parity)

### DIFF
--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -97,6 +97,22 @@ pub fn decode_plaintext(padded_plaintext: &[u8], padding_version: u8) -> Result<
         .map_err(|e| anyhow::anyhow!("Failed to decode decrypted plaintext: {e}"))
 }
 
+/// Wrap a message into a DeviceSentMessage for own-device sync, hoisting
+/// `message_context_info` onto the outer message (matching WA Web). Inverse of
+/// [`unwrap_device_sent`].
+pub fn wrap_device_sent(mut message: wa::Message, destination_jid: String) -> wa::Message {
+    let context = message.message_context_info.take();
+    wa::Message {
+        message_context_info: context,
+        device_sent_message: Some(Box::new(wa::message::DeviceSentMessage {
+            destination_jid: Some(destination_jid),
+            message: Some(Box::new(message)),
+            phash: None,
+        })),
+        ..Default::default()
+    }
+}
+
 /// Unwrap a DeviceSentMessage wrapper, returning the inner message.
 ///
 /// When a message is sent from our own device, the actual content is nested
@@ -738,6 +754,72 @@ mod parse_message_info_tests {
         assert!(
             info.bcl_participants.is_empty(),
             "group fanout participants are not a bcl"
+        );
+    }
+}
+
+#[cfg(test)]
+mod device_sent_tests {
+    use super::*;
+
+    fn msg_with_secret(secret: &[u8]) -> wa::Message {
+        wa::Message {
+            conversation: Some("hi".into()),
+            message_context_info: Some(wa::MessageContextInfo {
+                message_secret: Some(secret.to_vec()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn wrap_hoists_context_to_outer_on_wire() {
+        let secret = [7u8; 32];
+        let wrapped = wrap_device_sent(msg_with_secret(&secret), "1@s.whatsapp.net".into());
+
+        let bytes = wrapped.encode_to_vec();
+        let decoded = wa::Message::decode(bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            decoded
+                .message_context_info
+                .and_then(|c| c.message_secret)
+                .as_deref(),
+            Some(secret.as_slice())
+        );
+        let inner = decoded.device_sent_message.unwrap().message.unwrap();
+        assert!(inner.message_context_info.is_none());
+        assert_eq!(inner.conversation.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn wrap_without_context_leaves_outer_empty() {
+        let inner = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+        let wrapped = wrap_device_sent(inner, "1@s.whatsapp.net".into());
+
+        assert!(wrapped.message_context_info.is_none());
+        let dsm = wrapped.device_sent_message.unwrap();
+        assert_eq!(dsm.destination_jid.as_deref(), Some("1@s.whatsapp.net"));
+        assert!(dsm.message.unwrap().message_context_info.is_none());
+    }
+
+    #[test]
+    fn wrap_then_unwrap_round_trips_secret() {
+        let secret = [9u8; 32];
+        let wrapped = wrap_device_sent(msg_with_secret(&secret), "1@s.whatsapp.net".into());
+        let unwrapped = unwrap_device_sent(wrapped);
+
+        assert_eq!(unwrapped.conversation.as_deref(), Some("hi"));
+        assert_eq!(
+            unwrapped
+                .message_context_info
+                .and_then(|c| c.message_secret)
+                .as_deref(),
+            Some(secret.as_slice())
         );
     }
 }

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -808,6 +808,24 @@ mod device_sent_tests {
     }
 
     #[test]
+    fn wrap_then_unwrap_preserves_non_secret_context_fields() {
+        let inner = wa::Message {
+            message_context_info: Some(wa::MessageContextInfo {
+                message_add_on_duration_in_secs: Some(604800),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let unwrapped = unwrap_device_sent(wrap_device_sent(inner, "1@s.whatsapp.net".into()));
+        assert_eq!(
+            unwrapped
+                .message_context_info
+                .and_then(|c| c.message_add_on_duration_in_secs),
+            Some(604800)
+        );
+    }
+
+    #[test]
     fn wrap_then_unwrap_round_trips_secret() {
         let secret = [9u8; 32];
         let wrapped = wrap_device_sent(msg_with_secret(&secret), "1@s.whatsapp.net".into());

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -511,14 +511,9 @@ pub fn merge_dsm_context(
             inner.limit_sharing_v2 = None;
             Some(inner)
         }
-        (None, Some(outer)) => Some(wa::MessageContextInfo {
-            message_secret: outer.message_secret.clone(),
-            message_association: outer.message_association.clone(),
-            limit_sharing_v2: outer.limit_sharing_v2,
-            thread_id: outer.thread_id.clone(),
-            bot_metadata: outer.bot_metadata.clone(),
-            ..Default::default()
-        }),
+        // Inner was cleared by a WA-Web-style hoist; restore the full context the
+        // sender moved to the outer message, not just the merge subset.
+        (None, Some(outer)) => Some(outer.clone()),
         (Some(mut inner), Some(outer)) => {
             if inner.message_secret.is_none() {
                 inner.message_secret = outer.message_secret.clone();
@@ -1547,6 +1542,20 @@ mod tests {
         assert!(
             result.limit_sharing_v2.is_some(),
             "limit_sharing_v2 should come from outer"
+        );
+    }
+
+    #[test]
+    fn test_merge_dsm_context_outer_only_preserves_non_subset_fields() {
+        let outer = wa::MessageContextInfo {
+            message_add_on_duration_in_secs: Some(86400),
+            ..Default::default()
+        };
+        let result = merge_dsm_context(None, Some(&outer)).unwrap();
+        assert_eq!(
+            result.message_add_on_duration_in_secs,
+            Some(86400),
+            "hoisted fields outside the merge subset must survive unwrap"
         );
     }
 

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -23,7 +23,6 @@ use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, JidExt as _};
 use wacore_libsignal::crypto::aes_256_cbc_encrypt_into;
 use waproto::whatsapp as wa;
-use waproto::whatsapp::message::DeviceSentMessage;
 
 /// Wire-format constants (MsgCreateDeviceStanza.js).
 pub(crate) mod stanza {
@@ -1004,14 +1003,7 @@ pub async fn prepare_dm_stanza<
         MessageUtils::participant_list_hash(&sent).ok()
     };
 
-    let dsm = wa::Message {
-        device_sent_message: Some(Box::new(DeviceSentMessage {
-            destination_jid: Some(to_jid.to_string()),
-            message: Some(Box::new(message_for_encryption)),
-            phash: None, // WA Web only sets DSM phash for groups
-        })),
-        ..Default::default()
-    };
+    let dsm = crate::messages::wrap_device_sent(message_for_encryption, to_jid.to_string());
 
     let own_devices_plaintext = MessageUtils::encode_and_pad(&dsm);
 


### PR DESCRIPTION
## Problem

When a sent DM is synced to our own other devices, the message is wrapped in a `DeviceSentMessage`. We were placing `messageContextInfo` — which carries the `messageSecret` used to decrypt later add-ons (reactions, edits, poll votes) against the original message — on the **inner** wrapped message, leaving the **outer** message empty.

WhatsApp Web does the opposite. `WAWebDeviceSentMessageProtoUtils.wrapDeviceSentMessage` (used by `MsgCreateDeviceStanza` on the own-device path) hoists `messageContextInfo` onto the **outer** message and clears it from the inner copy:

```js
return {
  messageContextInfo: { ...rootContext },                         // outer gets the context
  deviceSentMessage: { destinationJid, message: { ...e, messageContextInfo: void 0 } } // inner cleared
};
```

Our receive path already mirrors WA Web's `unwrapDeviceSentMessage`: `unwrap_device_sent` + `merge_dsm_context` read the secret inner-first and fall back to the outer message. So our **reader** already assumed the WA Web shape, while our **writer** never produced it — an internal inconsistency, and a wire-format divergence from WA Web on the own-device sync stanza.

## Fix

Add `wrap_device_sent` (the inverse of the existing `unwrap_device_sent`) in `wacore::messages`, which hoists `message_context_info` onto the outer message and clears the inner copy, matching WA Web. `prepare_dm_stanza` now builds the own-device DSM through it.

The recipient and group paths are unchanged: the recipient message keeps its `messageContextInfo` inline, exactly as WA Web sends it. Only the own-device DSM envelope changes shape.

## Tests

New unit tests in `wacore` (`messages::device_sent_tests`):

- `wrap_hoists_context_to_outer_on_wire` — encodes then decodes the wrapped message and asserts the secret lands on the outer message and the inner copy carries no `messageContextInfo`.
- `wrap_without_context_leaves_outer_empty` — no context in, no context hoisted.
- `wrap_then_unwrap_round_trips_secret` — `wrap_device_sent` → `unwrap_device_sent` recovers the original content and the secret.

```
cargo fmt --all
cargo clippy --all-targets -- -D warnings   # clean
cargo test -p wacore                         # 861 pass (incl. 3 new)
cargo test -p whatsapp-rust --lib -- message send   # 280 pass
```

## Breaking

None. `prepare_dm_stanza`'s signature is unchanged; `wrap_device_sent` is a new additive helper. The DSM wire shape changes to match WA Web; our own reader already handled it (and still does, via the round-trip test).
