### PR TITLE
perf(send): cut throwaway allocations in DM phash and LID conversion

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -668,7 +668,7 @@ impl Client {
                 let all_devices: Vec<Jid> = if is_lid_mode {
                     all_devices
                         .into_iter()
-                        .map(|d| group_info.phone_device_jid_to_lid(&d))
+                        .map(|d| group_info.phone_device_jid_into_lid(d))
                         .collect()
                 } else {
                     all_devices

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -126,15 +126,15 @@ impl GroupInfo {
         }
     }
 
-    /// Convert a phone-based device JID to a LID-based device JID using the mapping.
-    /// If no mapping exists, returns the original JID unchanged.
-    pub fn phone_device_jid_to_lid(&self, phone_device_jid: &Jid) -> Jid {
+    /// Convert a phone-based device JID to a LID-based device JID using the mapping,
+    /// consuming the JID. If no mapping exists, returns it unchanged.
+    pub fn phone_device_jid_into_lid(&self, phone_device_jid: Jid) -> Jid {
         if phone_device_jid.is_pn()
             && let Some(lid_base) = self.lid_jid_for_phone_user(&phone_device_jid.user)
         {
             return Jid::lid_device(lid_base.user.clone(), phone_device_jid.device);
         }
-        phone_device_jid.clone()
+        phone_device_jid
     }
 }
 

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -30,9 +30,11 @@ impl MessageUtils {
         buf
     }
 
-    pub fn participant_list_hash(devices: &[wacore_binary::Jid]) -> Result<String> {
+    pub fn participant_list_hash<'a>(
+        devices: impl IntoIterator<Item = &'a wacore_binary::Jid>,
+    ) -> Result<String> {
         // Hash sorted ad_strings incrementally (avoids join() allocation).
-        let mut jids: Vec<String> = devices.iter().map(|j| j.to_ad_string()).collect();
+        let mut jids: Vec<String> = devices.into_iter().map(|j| j.to_ad_string()).collect();
         jids.sort_unstable();
 
         let mut h = CryptographicHash::new("SHA-256")
@@ -48,10 +50,10 @@ impl MessageUtils {
         // Standard base64 ('+'/'/'), matching whatsmeow (`base64.RawStdEncoding`)
         // and WA Web (`WABase64.encodeB64`). URL-safe ('-'/'_') diverges from the
         // server on ~22% of phashes (any output hitting base64 index 62/63).
-        Ok(format!(
-            "2:{hash}",
-            hash = base64::prelude::BASE64_STANDARD_NO_PAD.encode(&full_hash[..6])
-        ))
+        let mut out = String::with_capacity(10);
+        out.push_str("2:");
+        base64::prelude::BASE64_STANDARD_NO_PAD.encode_string(&full_hash[..6], &mut out);
+        Ok(out)
     }
 
     /// Validate a broadcast-contact-list hash from an incoming `deviceSentMessage`

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -997,12 +997,10 @@ pub async fn prepare_dm_stanza<
     let (recipient_devices, own_other_devices) =
         partition_dm_devices(all_devices, own_jid, own_lid);
 
-    let phash = {
-        let mut sent = Vec::with_capacity(recipient_devices.len() + own_other_devices.len());
-        sent.extend_from_slice(&recipient_devices);
-        sent.extend_from_slice(&own_other_devices);
-        MessageUtils::participant_list_hash(&sent).ok()
-    };
+    let phash = MessageUtils::participant_list_hash(
+        recipient_devices.iter().chain(own_other_devices.iter()),
+    )
+    .ok();
 
     let dsm = wa::Message {
         device_sent_message: Some(Box::new(DeviceSentMessage {
@@ -1578,7 +1576,7 @@ pub async fn prepare_group_stanza<
         if group_info.addressing_mode == crate::types::message::AddressingMode::Lid {
             resolved_list = resolved_list
                 .into_iter()
-                .map(|device_jid| group_info.phone_device_jid_to_lid(&device_jid))
+                .map(|device_jid| group_info.phone_device_jid_into_lid(device_jid))
                 .collect();
             log::debug!(
                 "Converted {} devices to LID addressing for group {}",


### PR DESCRIPTION
Three small, behavior-identical allocation removals on the outgoing-message send path.

## Changes

**1. `participant_list_hash` takes an iterator instead of `&[Jid]`**

The DM phash built a throwaway `Vec<Jid>` per send (`Vec::with_capacity` + two `extend_from_slice`, which clone every `Jid`) only to hand a contiguous slice to `participant_list_hash`. The function now accepts `impl IntoIterator<Item = &Jid>`, so the DM path chains the two device slices by reference:

```rust
let phash =
    MessageUtils::participant_list_hash(recipient_devices.iter().chain(own_other_devices.iter()))
        .ok();
```

`participant_list_hash` sorts the ad-strings before hashing, so iteration order is irrelevant and the resulting phash is **byte-identical**. Existing callers pass `&[Jid]` / `&Vec<Jid>`, both of which satisfy the new bound and compile unchanged.

**2. phash base64 into one pre-sized `String`**

`encode()` + `format!("2:{hash}", …)` allocated two `String`s (one discarded). It now appends into a single pre-sized 10-byte buffer:

```rust
let mut out = String::with_capacity(10);
out.push_str("2:");
base64::prelude::BASE64_STANDARD_NO_PAD.encode_string(&full_hash[..6], &mut out);
Ok(out)
```

Same engine, same 6 input bytes, same `"2:"` prefix — byte-identical output.

**3. `phone_device_jid_into_lid` consumes the JID**

Renamed from `phone_device_jid_to_lid`; takes the `Jid` by value and moves it through on the no-mapping fallthrough instead of `clone()`-ing. Both call sites already own the value.

## Impact

Small but real: one throwaway `Vec` + N `Jid` clones per DM send, one discarded `String` per phash, and one clone per group device on the LID-conversion fallthrough. All local, mechanical, and behavior-preserving.

## Breaking

Pre-1.0 only: `phone_device_jid_to_lid` → `phone_device_jid_into_lid` (rename + now consumes). `participant_list_hash`'s signature changed but is source-compatible with all current call patterns (`&[Jid]` / `&Vec<Jid>`).

## Tests

No behavior change. The phash regression vectors (`phash_crosscheck_vectors`, `group_phash_golden::*`) pin the exact hash output and pass unchanged.

```
cargo fmt --all
cargo clippy --all-targets -- -D warnings   # clean
cargo test -p wacore --lib -- messages:: send::   # 98 pass
cargo test -p whatsapp-rust --lib -- send groups  # pass
```
