### PR TITLE
fix(message): emit quote remoteJid only for cross-chat quotes

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -68,10 +68,14 @@ impl MessageContext {
     }
 
     pub fn build_quote_context(&self) -> wa::ContextInfo {
+        // A bot reply is same-chat: quoted chat and send target are both
+        // info.source.chat, so remote_jid is omitted (WA Web parity).
+        let chat = &self.info.source.chat;
         wacore::proto_helpers::build_quote_context_with_info(
             &self.info.id,
             &self.info.source.sender,
-            &self.info.source.chat,
+            chat,
+            chat,
             &self.message,
         )
     }

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -224,6 +224,15 @@ impl Server {
     pub fn is_lid_family(self) -> bool {
         matches!(self, Self::Lid | Self::HostedLid)
     }
+
+    /// Whether the `agent` byte is part of the rendered JID for this server.
+    /// AD-capable servers (Pn/Lid/Hosted/HostedLid) carry it as a hidden domain
+    /// byte and suppress it in display; others (e.g. `@bot`/`@interop`) render it.
+    /// Single source of truth shared by the formatter and `Jid::is_same_chat_as`.
+    #[inline]
+    pub fn renders_agent(self) -> bool {
+        !matches!(self, Self::Pn | Self::Lid | Self::Hosted | Self::HostedLid)
+    }
 }
 
 impl fmt::Display for Server {
@@ -539,6 +548,20 @@ impl Jid {
         }
     }
 
+    /// Device-insensitive "same chat" check: two JIDs address the same chat when
+    /// they render to the same string ignoring the multi-device `device`. Compares
+    /// `user`, `server`, `integrator`, and `agent` only where the server renders
+    /// the agent (`@bot`/`@interop`); Pn/Lid/Hosted suppress it in display, so a
+    /// stray decoded agent byte there must not split the chat. Allocates nothing.
+    /// Stricter than `is_same_user_as`, which ignores `server`.
+    #[inline]
+    pub fn is_same_chat_as(&self, other: &Jid) -> bool {
+        self.user == other.user
+            && self.server == other.server
+            && self.integrator == other.integrator
+            && (!self.server.renders_agent() || self.agent == other.agent)
+    }
+
     /// Canonical non-AD string form (`user@server`, device + agent stripped)
     /// in a single allocation. Equivalent to `to_non_ad().to_string()` but
     /// skips the throwaway intermediate `Jid` and its `CompactString` clone.
@@ -749,12 +772,7 @@ macro_rules! write_jid {
             return;
         }
         $buf.push_str(user);
-        if agent > 0
-            && !matches!(
-                server,
-                Server::Pn | Server::Lid | Server::Hosted | Server::HostedLid
-            )
-        {
+        if agent > 0 && server.renders_agent() {
             $buf.push('.');
             $buf.push_str(itoa::Buffer::new().format(agent));
         }
@@ -772,12 +790,7 @@ macro_rules! write_jid {
             return $f.write_str(server.as_str());
         }
         $f.write_str(user)?;
-        if agent > 0
-            && !matches!(
-                server,
-                Server::Pn | Server::Lid | Server::Hosted | Server::HostedLid
-            )
-        {
+        if agent > 0 && server.renders_agent() {
             $f.write_str(".")?;
             $f.write_str(itoa::Buffer::new().format(agent))?;
         }
@@ -1145,6 +1158,55 @@ mod tests {
             !bot_jid.is_hosted(),
             "Bot JID should NOT be detected as hosted (different mechanism)"
         );
+    }
+
+    #[test]
+    fn is_same_chat_as_matches_rendered_chat_identity() {
+        let base: Jid = "5511999887766@s.whatsapp.net".parse().unwrap();
+
+        // Device is ignored.
+        assert!(base.is_same_chat_as(&base.with_device(33)));
+        assert!(base.with_device(5).is_same_chat_as(&base.with_device(0)));
+
+        // Different user or server -> different chat (server guards the
+        // is_same_user_as looseness that ignores server).
+        let other_user: Jid = "5521988776655@s.whatsapp.net".parse().unwrap();
+        assert!(!base.is_same_chat_as(&other_user));
+        let as_lid: Jid = "5511999887766@lid".parse().unwrap();
+        assert!(!base.is_same_chat_as(&as_lid));
+
+        // integrator participates in identity.
+        let other_integrator = Jid {
+            integrator: 1,
+            ..base.clone()
+        };
+        assert!(!base.is_same_chat_as(&other_integrator));
+
+        // Pn suppresses the agent in display, so a stray decoded agent byte must
+        // not split the chat: same rendered string -> same chat.
+        let pn_agent1 = Jid {
+            agent: 1,
+            ..base.clone()
+        };
+        assert_eq!(base.to_string(), pn_agent1.to_string());
+        assert!(base.is_same_chat_as(&pn_agent1));
+
+        // @bot renders the agent, so distinct agents are distinct chats; device
+        // is still ignored.
+        let bot_a = Jid {
+            user: "13136555001".into(),
+            server: Server::Bot,
+            agent: 1,
+            device: 0,
+            integrator: 0,
+        };
+        let bot_b = Jid {
+            agent: 2,
+            ..bot_a.clone()
+        };
+        assert_ne!(bot_a.to_string(), bot_b.to_string());
+        assert!(!bot_a.is_same_chat_as(&bot_b));
+        assert!(bot_a.is_same_chat_as(&bot_a.with_device(7)));
     }
 
     /// Tests that document the filtering behavior for group messages.

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -577,22 +577,31 @@ pub fn build_quote_context(
     }
 }
 
-/// Builds a quote ContextInfo matching WA Web's EProtoGenerator + getQuotedParticipantForContextInfo.
+/// Builds a quote ContextInfo matching WA Web's `msgContextInfo` + `getQuotedParticipantForContextInfo`.
 ///
-/// Sets `remote_jid` (required by iOS to scope the quote) and resolves `participant`
-/// based on chat type (newsletter → channel JID, otherwise → sender JID).
+/// `remote_jid` is emitted only for a cross-chat quote (the quoted message's
+/// chat differs from `target_chat_jid`), mirroring WA Web's quote-context getter
+/// (`remoteJid` set only when `quotedMsg.remote != targetChat`); a same-chat
+/// reply omits it. The defense against re-notifying mentions inside the quoted
+/// copy is `prepare_for_quote`, not `remote_jid`.
+/// `participant`: newsletter uses the channel JID, otherwise the sender.
 pub fn build_quote_context_with_info(
     message_id: impl Into<String>,
     sender_jid: &Jid,
-    chat_jid: &Jid,
+    quoted_chat_jid: &Jid,
+    target_chat_jid: &Jid,
     quoted_message: &wa::Message,
 ) -> wa::ContextInfo {
-    // WA Web always sets remoteJid to the chat JID (EProtoGenerator.js:108).
-    let remote_jid = chat_jid.to_string();
+    // remote_jid only for a cross-chat quote, in device-less chat form: a chat
+    // reference carries no device, and the compare above is device-insensitive.
+    // with_device(0) keeps the agent that @bot/@interop chat JIDs render (to_non_ad
+    // would wrongly drop it).
+    let remote_jid = (!quoted_chat_jid.is_same_chat_as(target_chat_jid))
+        .then(|| quoted_chat_jid.with_device(0).to_string());
 
     // Newsletter quotes use the channel JID as participant; others use the sender.
-    let participant = if chat_jid.is_newsletter() {
-        remote_jid.clone()
+    let participant = if quoted_chat_jid.is_newsletter() {
+        quoted_chat_jid.to_string()
     } else {
         sender_jid.to_string()
     };
@@ -600,7 +609,7 @@ pub fn build_quote_context_with_info(
     wa::ContextInfo {
         stanza_id: Some(message_id.into()),
         participant: Some(participant),
-        remote_jid: Some(remote_jid),
+        remote_jid,
         quoted_message: Some(quoted_message.prepare_for_quote()),
         ..Default::default()
     }
@@ -1371,7 +1380,7 @@ mod tests {
         let chat: Jid = "1234567890@newsletter".parse().unwrap();
         let msg = wa::Message::default();
 
-        let ctx = build_quote_context_with_info("msg-id", &sender, &chat, &msg);
+        let ctx = build_quote_context_with_info("msg-id", &sender, &chat, &chat, &msg);
 
         assert_eq!(
             ctx.participant.as_deref(),
@@ -1388,7 +1397,7 @@ mod tests {
         let chat: Jid = "group@g.us".parse().unwrap();
         let msg = wa::Message::default();
 
-        let ctx = build_quote_context_with_info("msg-id", &sender, &chat, &msg);
+        let ctx = build_quote_context_with_info("msg-id", &sender, &chat, &chat, &msg);
 
         assert_eq!(
             ctx.participant.as_deref(),
@@ -1404,7 +1413,7 @@ mod tests {
         let chat: Jid = "status@broadcast".parse().unwrap();
         let msg = wa::Message::default();
 
-        let ctx = build_quote_context_with_info("msg-id", &sender, &chat, &msg);
+        let ctx = build_quote_context_with_info("msg-id", &sender, &chat, &chat, &msg);
 
         assert_eq!(
             ctx.participant.as_deref(),
@@ -1659,7 +1668,7 @@ mod tests {
     }
 
     #[test]
-    fn quote_context_sets_remote_jid_for_group() {
+    fn quote_context_omits_remote_jid_same_chat_group() {
         let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
         let group: Jid = "120363098765432100@g.us".parse().unwrap();
         let msg = wa::Message {
@@ -1667,20 +1676,21 @@ mod tests {
             ..Default::default()
         };
 
-        let ctx = build_quote_context_with_info("msg-id-123", &sender, &group, &msg);
+        // Same-chat reply (quoted chat == target): WA Web omits remote_jid.
+        let ctx = build_quote_context_with_info("msg-id-123", &sender, &group, &group, &msg);
 
         assert_eq!(ctx.stanza_id.as_deref(), Some("msg-id-123"));
         assert_eq!(
             ctx.participant.as_deref(),
             Some("551199887766@s.whatsapp.net")
         );
-        assert_eq!(ctx.remote_jid.as_deref(), Some("120363098765432100@g.us"));
+        assert_eq!(ctx.remote_jid, None);
         assert!(ctx.quoted_message.is_some());
         assert!(ctx.mentioned_jid.is_empty());
     }
 
     #[test]
-    fn quote_context_sets_remote_jid_for_dm() {
+    fn quote_context_omits_remote_jid_same_chat_dm() {
         let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
         let chat: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
         let msg = wa::Message {
@@ -1688,14 +1698,73 @@ mod tests {
             ..Default::default()
         };
 
-        let ctx = build_quote_context_with_info("msg-id-456", &sender, &chat, &msg);
+        let ctx = build_quote_context_with_info("msg-id-456", &sender, &chat, &chat, &msg);
+
+        assert_eq!(ctx.remote_jid, None);
+        assert_eq!(
+            ctx.participant.as_deref(),
+            Some("551199887766@s.whatsapp.net")
+        );
+    }
+
+    #[test]
+    fn quote_context_emits_remote_jid_cross_chat() {
+        // Quoting a message from group A while sending into group B.
+        let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let quoted_chat: Jid = "120363000000000001@g.us".parse().unwrap();
+        let target_chat: Jid = "120363000000000002@g.us".parse().unwrap();
+        let msg = wa::Message {
+            conversation: Some("cross".into()),
+            ..Default::default()
+        };
+
+        let ctx =
+            build_quote_context_with_info("msg-id-x", &sender, &quoted_chat, &target_chat, &msg);
+
+        assert_eq!(ctx.remote_jid.as_deref(), Some("120363000000000001@g.us"));
+    }
+
+    #[test]
+    fn quote_context_status_reply_is_cross_chat() {
+        // Replying in a DM to a status: status@broadcast != DM target.
+        let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let status: Jid = "status@broadcast".parse().unwrap();
+        let target: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let msg = wa::Message::default();
+
+        let ctx = build_quote_context_with_info("msg-id-s", &sender, &status, &target, &msg);
+
+        assert_eq!(ctx.remote_jid.as_deref(), Some("status@broadcast"));
+    }
+
+    #[test]
+    fn quote_context_device_suffix_treated_as_same_chat() {
+        // is_same_chat_as ignores the device suffix, so this stays a same-chat reply.
+        let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let quoted_chat: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let target_chat = quoted_chat.with_device(5);
+        let msg = wa::Message::default();
+
+        let ctx =
+            build_quote_context_with_info("msg-id-d", &sender, &quoted_chat, &target_chat, &msg);
+
+        assert_eq!(ctx.remote_jid, None);
+    }
+
+    #[test]
+    fn quote_context_cross_chat_remote_jid_drops_device_suffix() {
+        // A device-scoped quoted chat must emit a device-less remote_jid: a chat
+        // reference carries no device.
+        let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let quoted_chat = sender.with_device(5);
+        let target_chat: Jid = "5521988776655@s.whatsapp.net".parse().unwrap();
+        let msg = wa::Message::default();
+
+        let ctx =
+            build_quote_context_with_info("msg-id-dev", &sender, &quoted_chat, &target_chat, &msg);
 
         assert_eq!(
             ctx.remote_jid.as_deref(),
-            Some("551199887766@s.whatsapp.net")
-        );
-        assert_eq!(
-            ctx.participant.as_deref(),
             Some("551199887766@s.whatsapp.net")
         );
     }
@@ -1706,7 +1775,27 @@ mod tests {
         let newsletter: Jid = "120363099999999999@newsletter".parse().unwrap();
         let msg = wa::Message::default();
 
-        let ctx = build_quote_context_with_info("msg-id-789", &sender, &newsletter, &msg);
+        // Same-chat newsletter reply: participant stays the channel; remote_jid omitted.
+        let ctx =
+            build_quote_context_with_info("msg-id-789", &sender, &newsletter, &newsletter, &msg);
+
+        assert_eq!(
+            ctx.participant.as_deref(),
+            Some("120363099999999999@newsletter")
+        );
+        assert_eq!(ctx.remote_jid, None);
+    }
+
+    #[test]
+    fn quote_context_newsletter_cross_chat_sets_both() {
+        // Quoting a newsletter post while sending into a different newsletter:
+        // participant stays the quoted channel AND remote_jid is emitted.
+        let sender: Jid = "551199887766@s.whatsapp.net".parse().unwrap();
+        let quoted: Jid = "120363099999999999@newsletter".parse().unwrap();
+        let target: Jid = "120363011111111111@newsletter".parse().unwrap();
+        let msg = wa::Message::default();
+
+        let ctx = build_quote_context_with_info("msg-id-nx", &sender, &quoted, &target, &msg);
 
         assert_eq!(
             ctx.participant.as_deref(),
@@ -1724,7 +1813,7 @@ mod tests {
         let group: Jid = "120363098765432100@g.us".parse().unwrap();
         let msg = create_message_with_mentions();
 
-        let ctx = build_quote_context_with_info("msg-id", &sender, &group, &msg);
+        let ctx = build_quote_context_with_info("msg-id", &sender, &group, &group, &msg);
 
         // The quoted message's nested context_info should have mentions stripped
         let quoted = ctx.quoted_message.unwrap();


### PR DESCRIPTION
## Problem

`build_quote_context_with_info` always set `ContextInfo.remoteJid` to the quoted message's chat JID. That is not what WhatsApp Web does: the message model's `msgContextInfo` getter emits `remoteJid` only when the quoted message lives in a chat other than the send target (`quotedMsg.remote != targetChat`), and a same-chat reply omits it. The serializer (`WAWebE2EProtoGenerator`) only encodes whatever `quotedRemoteJid` it receives, which is null for a same-chat quote, so the field is dropped on the wire.

Always emitting `remoteJid` on a same-chat reply diverges from WA Web and can make some clients treat a 1:1 reply as a cross-chat reference. Baileys mirrors WA Web here too (`contextInfo.remoteJid` set only when `jid !== quoted.key.remoteJid`); whatsmeow never populates `ContextInfo.RemoteJID` at all. The receive side confirms the omission is lossless: when `remoteJid` is absent, WA Web reconstructs the quoted chat from the enclosing message's `remote` (the current chat).

The old comment claimed `remoteJid` was "required by iOS to scope the quote". That was a misreading of the serializer layer. The actual defense against re-notifying mentions carried inside a quoted message is `prepare_for_quote` (it clears `mentioned_jid`/`group_mentions` from the nested copy), which is independent of `remote_jid` and predates this code.

## Fix

Thread the send target into `build_quote_context_with_info` (`quoted_chat_jid` plus a new `target_chat_jid`) and emit `remote_jid` only for a cross-chat quote:

```rust
let remote_jid = (!quoted_chat_jid.is_same_chat_as(target_chat_jid))
    .then(|| quoted_chat_jid.with_device(0).to_string());
```

The emitted `remote_jid` is the device-less chat form: a chat reference never carries a device, so `with_device(0)` strips it (and keeps the agent that `@bot`/`@interop` JIDs render, which `to_non_ad` would wrongly drop), matching the device-insensitive compare.

`Jid::is_same_chat_as` is a new device-insensitive comparator. It compares `user`/`server`/`integrator`, ignores the multi-device `device`, and compares `agent` **only for servers that render it** (`@bot`/`@interop`) via a new `Server::renders_agent` that is the single source of truth shared with the JID formatter. That keeps the comparison consistent with the JID string we actually emit: Pn/Lid/Hosted suppress the agent in display, so a stray decoded agent byte there must not split the chat, while `@bot`/`@interop` render it, so distinct agents are distinct chats. It allocates nothing, where `to_non_ad() == to_non_ad()` would build two throwaway `Jid`s.

This is equivalent to WA Web's chat comparison for every realistic input (chat JIDs are conversation addresses that carry no device), though it is not a literal port of `Wid.equals` (which is device-sensitive and has no agent concept). Newsletter participant resolution stays decoupled from `remote_jid`: a same-chat newsletter quote still sets `participant = channel`, and a cross-chat one sets both.

The bot reply path (`MessageContext::build_quote_context`) is structurally same-chat (it quotes and sends into `info.source.chat`), so it now omits `remote_jid`, matching WA Web. Cross-chat quotes stay reachable via the low-level `Client::send_message`.

## Tests

`wacore/src/proto_helpers.rs`:

- renamed `quote_context_sets_remote_jid_for_{group,dm}` to `_omits_remote_jid_same_chat_{group,dm}` (now assert `None`)
- added `_emits_remote_jid_cross_chat` (group A into group B), `_status_reply_is_cross_chat` (status@broadcast into a DM), `_device_suffix_treated_as_same_chat`, `_cross_chat_remote_jid_drops_device_suffix` (a device-scoped quoted chat emits a device-less remote_jid)
- newsletter: `_uses_channel_as_participant` (same-chat: participant kept, `remote_jid` None) and `_cross_chat_sets_both` (participant channel AND `remote_jid` emitted)
- `quote_context_strips_mentions_from_quoted_message` unchanged (the mention defense is untouched)

`wacore/binary/src/jid.rs`:

- `is_same_chat_as_matches_rendered_chat_identity`: device ignored; user/server/integrator distinguish chats; a suppressed Pn agent byte does not split the chat; distinct `@bot` agents do

```
cargo fmt --all
cargo clippy --all-targets -- -D warnings   # clean
cargo test -p wacore --lib proto_helpers     # pass (incl. new/renamed quote tests)
cargo test -p wacore-binary --lib            # 92 pass (incl. is_same_chat_as + Display)
```

## Breaking

`build_quote_context_with_info` gains a `target_chat_jid` parameter. The only in-tree caller (`MessageContext::build_quote_context`) is updated. External callers must pass the send target; pass the same JID twice for a same-chat reply.
