### PR TITLE
perf(appstate): replace O(n²) in-patch overwrite scan with an O(1) map

### DIFF
--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -736,6 +736,81 @@ mod tests {
         );
     }
 
+    /// REMOVE carries a value blob (decode requires >= 48 bytes) and previous-value resolution
+    /// is operation-agnostic, like the reverse scan it replaces: a SET after a REMOVE on the
+    /// same index subtracts the REMOVE's tail, not the DB value.
+    #[test]
+    fn test_process_patch_set_after_remove_uses_remove_tail() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let key_id = b"test_key_id".to_vec();
+        let index_mac = vec![3; 32];
+
+        let remove = create_encrypted_record(
+            wa::syncd_mutation::SyncdOperation::Remove,
+            &index_mac,
+            &keys,
+            &key_id,
+            1000,
+        );
+        let set = create_encrypted_record(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &index_mac,
+            &keys,
+            &key_id,
+            2000,
+        );
+
+        let tail = |rec: &wa::SyncdRecord| {
+            let blob = rec.value.as_ref().unwrap().blob.as_ref().unwrap();
+            blob[blob.len() - 32..].to_vec()
+        };
+        let remove_tail = tail(&remove);
+        let set_tail = tail(&set);
+
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![
+                wa::SyncdMutation {
+                    operation: Some(wa::syncd_mutation::SyncdOperation::Remove as i32),
+                    record: Some(remove),
+                },
+                wa::SyncdMutation {
+                    operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+                    record: Some(set),
+                },
+            ],
+            key_id: Some(wa::KeyId {
+                id: Some(key_id.clone()),
+            }),
+            ..Default::default()
+        };
+
+        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_prev = |_: &[u8]| Ok(None);
+
+        let mut state = HashState::default();
+        let result = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
+            .expect("remove-then-set should process");
+
+        // The SET's previous value is the in-patch REMOVE tail, so it gets subtracted.
+        const EMPTY: &[Vec<u8>] = &[];
+        let expected = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            std::slice::from_ref(&remove_tail),
+            std::slice::from_ref(&set_tail),
+        );
+        assert_eq!(result.state.hash.as_slice(), expected.as_slice());
+
+        // An op==Set guard would skip the REMOVE, dropping to the DB and leaving only +set_tail.
+        let if_remove_skipped = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            EMPTY,
+            std::slice::from_ref(&set_tail),
+        );
+        assert_ne!(result.state.hash.as_slice(), if_remove_skipped.as_slice());
+    }
+
     /// WA Web: validatePatchVersion checks `localVersion !== patchVersion - 1`.
     /// If the patch version is not exactly local_version + 1, it rejects with
     /// "syncd-version-check-error-local-version-{greater|less}-than-expected".

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -10,6 +10,7 @@ use crate::hash::{HashState, generate_patch_mac};
 use crate::keys::ExpandedAppStateKeys;
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use waproto::whatsapp as wa;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -194,23 +195,26 @@ where
 
     state.version = patch_version;
 
-    // Update hash state - the closure handles finding previous values
+    // index_mac -> most-recent in-patch value MAC tail, filled as we iterate. Replaces a
+    // reverse scan over patch.mutations[..idx] (O(n^2) total) with an O(1) lookup, mirroring
+    // WA Web's WAWebSyncdAntiTampering Map. Recording the current value only after the lookup
+    // keeps the old strictly-prior semantics: a mutation never matches itself, and a SET that
+    // overwrites the same index earlier in the patch takes precedence over the DB value.
+    let mut in_patch: HashMap<&[u8], &[u8]> = HashMap::with_capacity(patch.mutations.len());
     let (hash_update_result, result) = state.update_hash(&patch.mutations, |index_mac, idx| {
-        // First check previous mutations in this patch (for overwrites within same patch)
-        for prev in patch.mutations[..idx].iter().rev() {
-            if let Some(rec) = &prev.record
-                && let Some(ind) = &rec.index
-                && let Some(b) = &ind.blob
-                && b == index_mac
-                && let Some(val) = &rec.value
-                && let Some(vb) = &val.blob
-                && vb.len() >= 32
-            {
-                return Ok(Some(vb[vb.len() - 32..].to_vec()));
-            }
+        let prev = if let Some(value_mac) = in_patch.get(index_mac) {
+            Some(value_mac.to_vec())
+        } else {
+            get_prev_value_mac(index_mac).map_err(|e| anyhow::anyhow!(e))?
+        };
+        if let Some(rec) = &patch.mutations[idx].record
+            && let Some(index) = rec.index.as_ref().and_then(|i| i.blob.as_deref())
+            && let Some(value) = rec.value.as_ref().and_then(|v| v.blob.as_deref())
+            && value.len() >= 32
+        {
+            in_patch.insert(index, &value[value.len() - 32..]);
         }
-        // Then check database via callback
-        get_prev_value_mac(index_mac).map_err(|e| anyhow::anyhow!(e))
+        Ok(prev)
     });
     result.map_err(|_| AppStateError::MismatchingLTHash)?;
 
@@ -640,6 +644,96 @@ mod tests {
         );
 
         assert_eq!(result.state.hash.as_slice(), expected_hash.as_slice());
+    }
+
+    /// Two SETs of the SAME index in one patch: the second must use the first SET's value
+    /// as its "previous value" (in-patch last-write-wins), NOT the DB. Locks the O(1) map
+    /// against a regression to a global last-write map (which would remove the wrong value
+    /// at position 0) or to no in-patch lookup at all (which would leave both values in the
+    /// ltHash). DB returns None here, so a correct run must still cancel the first value.
+    #[test]
+    fn test_process_patch_in_patch_overwrite_last_write_wins() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let key_id = b"test_key_id".to_vec();
+        let index_mac = vec![1; 32];
+
+        let first = create_encrypted_record(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &index_mac,
+            &keys,
+            &key_id,
+            1000,
+        );
+        let second = create_encrypted_record(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &index_mac,
+            &keys,
+            &key_id,
+            2000,
+        );
+
+        let tail = |rec: &wa::SyncdRecord| {
+            let blob = rec.value.as_ref().unwrap().blob.as_ref().unwrap();
+            blob[blob.len() - 32..].to_vec()
+        };
+        let first_tail = tail(&first);
+        let second_tail = tail(&second);
+        assert_ne!(
+            first_tail, second_tail,
+            "distinct timestamps must yield distinct value MACs"
+        );
+
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![
+                wa::SyncdMutation {
+                    operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+                    record: Some(first),
+                },
+                wa::SyncdMutation {
+                    operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+                    record: Some(second),
+                },
+            ],
+            key_id: Some(wa::KeyId {
+                id: Some(key_id.clone()),
+            }),
+            ..Default::default()
+        };
+
+        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_prev = |_: &[u8]| Ok(None);
+
+        // Fresh state -> had_no_prior_state skips version/MAC checks.
+        let mut state = HashState::default();
+        let result = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
+            .expect("two in-patch SETs should process");
+
+        assert_eq!(result.mutations.len(), 2);
+        assert_eq!(result.added_macs.len(), 2);
+
+        // Net: first value added then removed by the overwrite -> only the second remains.
+        const EMPTY: &[Vec<u8>] = &[];
+        let expected = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0u8; 128],
+            EMPTY,
+            std::slice::from_ref(&second_tail),
+        );
+        assert_eq!(
+            result.state.hash.as_slice(),
+            expected.as_slice(),
+            "in-patch overwrite must leave only the second SET's value in the ltHash"
+        );
+
+        // Guard the exact regression: if both values stayed (no in-patch lookup), this differs.
+        let both_kept =
+            WAPATCH_INTEGRITY.subtract_then_add(&[0u8; 128], EMPTY, &[first_tail, second_tail]);
+        assert_ne!(
+            result.state.hash.as_slice(),
+            both_kept.as_slice(),
+            "both SET values must not remain: in-patch overwrite regressed"
+        );
     }
 
     /// WA Web: validatePatchVersion checks `localVersion !== patchVersion - 1`.


### PR DESCRIPTION
## Problem

When processing an app-state patch, `process_patch` resolves each mutation's previous value MAC so the LtHash can subtract the old value before adding the new one. For overwrites within the same patch (the same index SET more than once), that previous value must come from the earlier in-patch SET, not the database.

The callback did this with a reverse scan over `patch.mutations[..idx]` for every mutation carrying an index MAC. Since the callback runs once per mutation and each scan walks up to `idx` earlier mutations comparing 32-byte MACs, an N-mutation patch costs ~N²/2 comparisons. Patches carry thousands of mutations during resume/bootstrap of large collections (`regular`/`regular_high`: contact names, mute, pin, archive) — WA Web itself gates this with `web_syncd_max_mutations_to_process_during_resume` — so the scan becomes the CPU bottleneck of app-state sync. (The DB lookup was already batched in #687; this removes the remaining in-patch cost.)

## Change

Build a `HashMap<index_mac, value_mac_tail>` incrementally as `update_hash` iterates, looking it up *before* recording the current mutation's value. Exactly equivalent to the old `[..idx].iter().rev()` first-match:

- **Lookup before insert** preserves the strictly-prior `[..idx]` rule: a mutation never sees itself, and position 0 always falls through to the DB.
- **Last-write-wins** on insert mirrors the reverse scan returning the most recent earlier match.
- **Only in-patch values are cached** (never the DB result), so a repeated index with no in-patch SET between still hits the DB each time.
- Insert conditions are structural (`index.blob` present, `value.blob.len() >= 32`), matching the old scan, which also ignored operation type.

Mirrors WhatsApp Web's `WAWebSyncdAntiTampering`, which keys value MACs by `hex(indexMac)` in a Map (`computeLtHashAndValidatePatch`) rather than scanning per mutation. O(n²) → O(n).

## Benchmark

Focused micro-benchmark of the changed path: resolving each mutation's previous value while applying an N-mutation patch with distinct indices and an empty local store (worst case, a fresh resume of a large collection), driven through the real `update_hash` with the old reverse scan vs the new map. Best-of-3, release build.

| patch size | old (reverse scan) | new (map) | speedup |
|---|---|---|---|
| 250 | 0.30 ms | 0.22 ms | 1.4× |
| 500 | 0.66 ms | 0.41 ms | 1.6× |
| 1000 | 1.75 ms | 0.82 ms | 2.1× |
| 2000 | 5.49 ms | 1.68 ms | 3.3× |
| 4000 | 19.9 ms | 3.44 ms | 5.8× |
| 8000 | 76.1 ms | 7.48 ms | 10.2× |

The old column quadruples per doubling of N (O(n²)); the new doubles (O(n)). `new` still includes the O(n) LtHash work that's identical on both sides, so the speedup is conservative: the eliminated scan alone is `old − new` (~69 ms at N=8000), and the gap widens with patch size.

## Tests

New `test_process_patch_in_patch_overwrite_last_write_wins`: two SETs of the same index in one patch, DB returning `None`. Asserts the final LtHash equals "only the second value present" and explicitly not "both values present", the exact shape a regression would produce. Existing `test_process_patch_with_overwrite` and `test_update_hash_with_set_overwrite_and_remove` still pass.

```
cargo fmt --all
cargo clippy -p wacore-appstate --all-targets -- -D warnings   # clean
cargo test -p wacore-appstate   # 24 pass (incl. 1 new)
cargo test -p wacore            # pass
```

## Breaking

None. `process_patch`'s signature and observable behavior (LtHash, `has_missing_remove`, decoded mutations/MACs) are unchanged, a pure internal speedup.
