### PR TITLE
fix(retry): send raw 32-byte prekey/signed-prekey values in retry receipts

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1028,46 +1028,21 @@ impl Client {
             }
             drop(device_guard);
 
-            let identity_key_bytes = device_snapshot
-                .identity_key
-                .public_key
-                .public_key_bytes()
-                .to_vec();
-
-            let prekey_value_bytes = new_prekey_keypair.public_key.serialize().to_vec();
-
-            let skey_id = device_snapshot.signed_pre_key_id;
-            let skey_value_bytes = device_snapshot
-                .signed_pre_key
-                .public_key
-                .serialize()
-                .to_vec();
-            let skey_sig_bytes = device_snapshot.signed_pre_key_signature.to_vec();
-
             let device_identity_bytes = device_snapshot
                 .account
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("Missing device account info for retry receipt"))?
                 .encode_to_vec();
 
-            let type_bytes = vec![5u8];
-
-            Some(
-                NodeBuilder::new("keys")
-                    .children([
-                        NodeBuilder::new("type").bytes(type_bytes).build(),
-                        NodeBuilder::new("identity")
-                            .bytes(identity_key_bytes)
-                            .build(),
-                        OneTimePreKeyNode::new(new_prekey_id, prekey_value_bytes).into_node(),
-                        SignedPreKeyNode::new(skey_id, skey_value_bytes, skey_sig_bytes)
-                            .into_node(),
-                        NodeBuilder::new("device-identity")
-                            .bytes(device_identity_bytes)
-                            .build(),
-                    ])
-                    .build(),
-            )
+            Some(wacore::protocol::retry::build_retry_keys_node(
+                &device_snapshot.identity_key.public_key,
+                new_prekey_id,
+                &new_prekey_keypair.public_key,
+                device_snapshot.signed_pre_key_id,
+                &device_snapshot.signed_pre_key.public_key,
+                device_snapshot.signed_pre_key_signature.to_vec(),
+                device_identity_bytes,
+            ))
         } else {
             None
         };

--- a/wacore/src/protocol/retry.rs
+++ b/wacore/src/protocol/retry.rs
@@ -5,6 +5,10 @@
 //! (session management, message resend, cache interaction) remains in
 //! `whatsapp-rust/src/retry.rs`.
 
+use crate::iq::prekeys::{OneTimePreKeyNode, SignedPreKeyNode};
+use crate::libsignal::protocol::PublicKey;
+use crate::protocol::ProtocolNode;
+use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Node, NodeContent};
 
 /// Maximum retry attempts we'll honor (matches WhatsApp Web's MAX_RETRY = 5).
@@ -100,6 +104,41 @@ pub fn should_include_keys(retry_count: u8, reason: RetryReason) -> bool {
     let include_keys_early =
         reason == RetryReason::NoSession || reason == RetryReason::UnknownCompanionNoPrekey;
     retry_count >= MIN_RETRY_COUNT_FOR_KEYS || include_keys_early
+}
+
+/// Builds the `<keys>` bundle embedded in a retry receipt (type, identity, one-time prekey,
+/// signed prekey, device identity) so a peer can re-establish the Signal session.
+///
+/// Every public key `<value>` is the raw 32-byte curve key (`public_key_bytes`), not the
+/// 33-byte Signal-serialized form: this matches WA Web's xmppPreKey/xmppSignedPreKey and the
+/// prekey upload path, and is what a peer's prekey parser expects.
+pub fn build_retry_keys_node(
+    identity_pub: &PublicKey,
+    prekey_id: u32,
+    prekey_pub: &PublicKey,
+    signed_prekey_id: u32,
+    signed_prekey_pub: &PublicKey,
+    signed_prekey_signature: Vec<u8>,
+    device_identity: Vec<u8>,
+) -> Node {
+    NodeBuilder::new("keys")
+        .children([
+            NodeBuilder::new("type").bytes(vec![5u8]).build(),
+            NodeBuilder::new("identity")
+                .bytes(identity_pub.public_key_bytes().to_vec())
+                .build(),
+            OneTimePreKeyNode::new(prekey_id, prekey_pub.public_key_bytes().to_vec()).into_node(),
+            SignedPreKeyNode::new(
+                signed_prekey_id,
+                signed_prekey_pub.public_key_bytes().to_vec(),
+                signed_prekey_signature,
+            )
+            .into_node(),
+            NodeBuilder::new("device-identity")
+                .bytes(device_identity)
+                .build(),
+        ])
+        .build()
 }
 
 #[cfg(test)]
@@ -236,5 +275,46 @@ mod tests {
         assert_eq!(MAX_RETRY_COUNT, 5);
         assert_eq!(MIN_RETRY_COUNT_FOR_KEYS, 2);
         assert_eq!(MIN_RETRY_FOR_BASE_KEY_CHECK, 2);
+    }
+
+    #[test]
+    fn retry_keys_bundle_emits_raw_32_byte_curve_values() {
+        // WhatsApp Web's xmppPreKey / xmppSignedPreKey carry the raw 32-byte curve public key in
+        // <value>; a peer parses the retry <keys> bundle expecting exactly that, so the prekey and
+        // signed prekey values must parse with the prekey parsers (which require 32 bytes).
+        use crate::libsignal::protocol::KeyPair;
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let identity = KeyPair::generate(&mut rng);
+        let prekey = KeyPair::generate(&mut rng);
+        let signed_prekey = KeyPair::generate(&mut rng);
+
+        let keys = build_retry_keys_node(
+            &identity.public_key,
+            201,
+            &prekey.public_key,
+            100,
+            &signed_prekey.public_key,
+            vec![7u8; 64],
+            vec![9u8; 16],
+        );
+
+        let key_node = keys.get_optional_child("key").expect("<key> child present");
+        let parsed_prekey =
+            OneTimePreKeyNode::try_from_node(key_node).expect("one-time prekey should parse");
+        assert_eq!(
+            parsed_prekey.public_bytes.as_slice(),
+            prekey.public_key.public_key_bytes()
+        );
+
+        let skey_node = keys
+            .get_optional_child("skey")
+            .expect("<skey> child present");
+        let parsed_skey =
+            SignedPreKeyNode::try_from_node(skey_node).expect("signed prekey should parse");
+        assert_eq!(
+            parsed_skey.public_bytes.as_slice(),
+            signed_prekey.public_key.public_key_bytes()
+        );
     }
 }


### PR DESCRIPTION
## Problem

A retry receipt includes a `<keys>` bundle so the requester can rebuild the Signal session (the NoSession / UnknownCompanion recovery path, reached via `should_include_keys`). `send_retry_receipt` built the one-time prekey and signed prekey `<value>` with `PublicKey::serialize()`, which is the 33-byte Signal-serialized form (a `0x05` type prefix followed by the 32-byte key).

Every other path uses the raw 32-byte key: the identity sibling in the same function, the prekey upload path (`PreKeyUploadSpec`), and WhatsApp Web's `xmppPreKey` / `xmppSignedPreKey`, which emit `keyPair.pubKey`. WA Web's Curve25519 `generateKeyPair` produces a 32-byte `pubKey`; the `0x05` prefix is a serialization detail that never goes on the wire (its `toCurveKeyPubKey` strips it). Our own prekey parsers (`OneTimePreKeyNode` / `SignedPreKeyNode`) reject anything that is not 32 bytes, so the malformed 33-byte bundle is emitted exactly when a peer needs a valid bundle to recover the session, and the requester keeps failing to decrypt.

## Fix

Extract the `<keys>` construction into `wacore::protocol::retry::build_retry_keys_node`, which takes the public keys and emits each `<value>` as the raw 32-byte `public_key_bytes()`. `send_retry_receipt` now delegates to it, so the producer matches the parser, the upload path, and WA Web.

## Tests

New `retry_keys_bundle_emits_raw_32_byte_curve_values` (written TDD): it builds the bundle via the helper and parses the `<key>` / `<skey>` children back through the prekey parsers, asserting each value is the raw 32-byte curve key. It fails on the old 33-byte output ("public key must be 32 bytes") and passes after the fix.

```
cargo fmt --all
cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings   # clean
cargo test -p wacore                       # pass (incl. 1 new)
cargo test -p whatsapp-rust --lib retry    # 64 pass
```

## Breaking

None. `send_retry_receipt`'s behavior is unchanged externally and `build_retry_keys_node` is a new additive helper. The only wire change is the prekey / signed-prekey `<value>` going from a malformed 33 bytes to the correct 32 bytes.
