### PR TITLE
fix(time): stop wall-clock default from panicking on wasm32

### DIFF
--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -27,9 +27,16 @@ pub trait TimeProvider: Send + Sync + 'static {
     fn now_millis(&self) -> i64;
 }
 
-/// Default wall-clock provider using `chrono`.
+/// Default wall-clock provider using `chrono` (native targets only).
+///
+/// cfg-gated off `wasm32` for the same reason the monotonic clock is: there is
+/// no backend for `chrono::Utc::now()` on `wasm32-unknown-unknown` (we don't pull
+/// `wasmbind`), so it falls through to `SystemTime::now()`, which panics. The
+/// wasm default is [`UnsetWasmTimeProvider`].
+#[cfg(not(target_arch = "wasm32"))]
 struct ChronoTimeProvider;
 
+#[cfg(not(target_arch = "wasm32"))]
 impl TimeProvider for ChronoTimeProvider {
     // The single legitimate call to `chrono::Utc::now()`: this IS the default
     // provider backing `wacore::time::now_utc()`. Everywhere else must go
@@ -37,6 +44,29 @@ impl TimeProvider for ChronoTimeProvider {
     #[allow(clippy::disallowed_methods)]
     fn now_millis(&self) -> i64 {
         chrono::Utc::now().timestamp_millis()
+    }
+}
+
+/// WASM default when no wall-clock provider is registered. Unlike the monotonic
+/// clock, the wall clock has no internal source on `wasm32` (and we won't panic
+/// like `chrono::Utc::now()` would), so this returns epoch (0) and warns once.
+/// Embedders MUST call [`set_time_provider`] with a real provider (e.g. backed
+/// by `Date.now()`) before the first timestamp.
+#[cfg(target_arch = "wasm32")]
+struct UnsetWasmTimeProvider;
+
+#[cfg(target_arch = "wasm32")]
+impl TimeProvider for UnsetWasmTimeProvider {
+    fn now_millis(&self) -> i64 {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        if !WARNED.swap(true, Ordering::Relaxed) {
+            log::warn!(
+                "wacore::time: no wall-clock provider set on wasm32; returning epoch. \
+                 Call set_time_provider() before the first timestamp."
+            );
+        }
+        0
     }
 }
 
@@ -54,8 +84,18 @@ pub fn set_time_provider(provider: impl TimeProvider) -> Result<(), &'static str
 #[inline]
 pub fn now_millis() -> i64 {
     TIME_PROVIDER
-        .get_or_init(|| Box::new(ChronoTimeProvider))
+        .get_or_init(default_time_provider)
         .now_millis()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn default_time_provider() -> Box<dyn TimeProvider> {
+    Box::new(ChronoTimeProvider)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn default_time_provider() -> Box<dyn TimeProvider> {
+    Box::new(UnsetWasmTimeProvider)
 }
 
 /// Current time in seconds since Unix epoch.
@@ -271,5 +311,22 @@ impl std::ops::Sub<Instant> for Instant {
     type Output = std::time::Duration;
     fn sub(self, rhs: Instant) -> std::time::Duration {
         self.saturating_duration_since(rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The native default must yield a real wall-clock time, not the wasm fallback's
+    // epoch. Guards the cfg-split refactor that keeps wasm32 from panicking.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn native_default_time_provider_returns_real_time() {
+        let ms = default_time_provider().now_millis();
+        assert!(
+            ms > 1_600_000_000_000,
+            "expected a post-2020 timestamp, got {ms}"
+        );
     }
 }

--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -81,6 +81,7 @@ pub fn set_time_provider(provider: impl TimeProvider) -> Result<(), &'static str
 }
 
 /// Current time in milliseconds since Unix epoch.
+#[cfg(not(target_arch = "wasm32"))]
 #[inline]
 pub fn now_millis() -> i64 {
     TIME_PROVIDER
@@ -88,14 +89,21 @@ pub fn now_millis() -> i64 {
         .now_millis()
 }
 
+/// On wasm32 the epoch fallback is used transiently and never stored in the
+/// `OnceLock`, so a later `set_time_provider()` always wins even if an early
+/// timestamp already ran during initialization.
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub fn now_millis() -> i64 {
+    match TIME_PROVIDER.get() {
+        Some(provider) => provider.now_millis(),
+        None => UnsetWasmTimeProvider.now_millis(),
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn default_time_provider() -> Box<dyn TimeProvider> {
     Box::new(ChronoTimeProvider)
-}
-
-#[cfg(target_arch = "wasm32")]
-fn default_time_provider() -> Box<dyn TimeProvider> {
-    Box::new(UnsetWasmTimeProvider)
 }
 
 /// Current time in seconds since Unix epoch.


### PR DESCRIPTION
## Problem

`wacore::time`'s default wall-clock provider, `ChronoTimeProvider`, calls `chrono::Utc::now()` with no cfg-gate. On `wasm32-unknown-unknown` chrono has no backend (we don't pull `wasmbind`), so `Utc::now()` falls through to `SystemTime::now()`, which panics ("time not implemented on this platform"). Nothing in the repo calls `set_time_provider`, so a wasm embedder that forgets to register one panics on the first timestamp (any stanza, app-state mutation, or log line).

This is an asymmetry with the monotonic clock, which already cfg-splits: native `StdMonotonicProvider`, wasm `WallDerivedMonotonicProvider`. Only the wall clock was left un-gated, and the wasm CI is build-only so it never caught the runtime panic.

## Fix

Mirror the monotonic clock's split:

- `ChronoTimeProvider` is now `#[cfg(not(target_arch = "wasm32"))]`.
- On wasm32 the default is `UnsetWasmTimeProvider`, which returns epoch (0) and warns once. The wall clock has no internal source on wasm32 (and 0 is safe for `now_utc()` / `now_secs_u64()`), so embedders register a real provider via `set_time_provider` (e.g. backed by `Date.now()`).
- `now_millis()` selects via a cfg-split `default_time_provider()`, exactly like `now_nanos()` / `default_monotonic_provider()`.

This keeps `wacore` dependency-free on wasm32 (no `js-sys` / `wasm-bindgen`). The alternative, enabling chrono's `wasmbind` feature only for the wasm32 target, would make `Utc::now()` work out of the box but pull in `wasm-bindgen`; happy to switch if you'd prefer zero-config over leanness.

## Tests

Native `native_default_time_provider_returns_real_time` guards that the native default still yields a real (post-2020) timestamp after the cfg-split. The wasm32 default is panic-free by construction (it no longer calls `chrono::Utc::now()`); confirmed by building `whatsapp-rust --target wasm32-unknown-unknown` locally (the wasm runtime panic itself can't be exercised in CI, which is build-only).

```
cargo fmt --all
cargo clippy -p wacore --all-targets -- -D warnings   # clean
cargo test -p wacore time::                            # pass (incl. 1 new)
RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build -p whatsapp-rust --lib \
  --release --target wasm32-unknown-unknown --no-default-features --features debug-diagnostics  # ok
```

## Breaking

None. Native behavior is unchanged. On wasm32 the default goes from "panic on first timestamp" to "epoch + warning until a provider is set", which is strictly safer.
