### PR TITLE
fix(retry): match WA Web's bot gate so bot DM retry receipts aren't dropped

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -965,21 +965,16 @@ impl Client {
     ) -> Result<(), anyhow::Error> {
         let device_snapshot = self.persistence_manager.get_device_snapshot().await;
 
-        // Bot message filtering (matches WhatsApp Web behavior):
-        // Don't send retry receipts to bot accounts from non-bot accounts.
-        // This prevents unnecessary retry traffic to automated systems.
-        let we_are_bot = device_snapshot
-            .pn
-            .as_ref()
-            .map(|our_pn| our_pn.is_bot())
-            .unwrap_or(false);
-        let sender_is_bot = info.source.sender.is_bot();
-
-        if !we_are_bot && sender_is_bot {
+        // WA Web's sendRetryReceipt aborts only when `!to.isBot() && participant.isBot()`,
+        // with participant null for DMs. A bot DM is chat == sender == bot, so it is NOT
+        // suppressed and the retry is sent; only a bot reply in a non-bot group is dropped.
+        // Same helper the ack and self-fanout paths already use.
+        if info.source.is_bot_authored_non_bot_chat() {
             log::debug!(
-                "Skipping retry receipt for message {} from bot {}: bots don't process retries",
+                "Skipping retry receipt for message {} from bot {} in non-bot chat {}",
                 info.id,
-                info.source.sender
+                info.source.sender,
+                info.source.chat
             );
             return Ok(());
         }

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -409,6 +409,43 @@ mod tests {
     }
 
     #[test]
+    fn is_bot_authored_non_bot_chat_matches_wa_web() {
+        // WA Web aborts the retry receipt only when `!to.isBot() && participant.isBot()`,
+        // with participant == null for DMs. A bot DM (chat == sender == bot) must therefore
+        // NOT be suppressed; only a bot reply inside a non-bot group is.
+        let bot_dm = MessageSource {
+            chat: "200000000000002@bot".parse().unwrap(),
+            sender: "200000000000002@bot".parse().unwrap(),
+            ..Default::default()
+        };
+        assert!(
+            !bot_dm.is_bot_authored_non_bot_chat(),
+            "bot DM must not be suppressed (WA Web sends the retry)"
+        );
+
+        let group_bot = MessageSource {
+            chat: "120363021033254949@g.us".parse().unwrap(),
+            sender: "200000000000002@bot".parse().unwrap(),
+            is_group: true,
+            ..Default::default()
+        };
+        assert!(
+            group_bot.is_bot_authored_non_bot_chat(),
+            "bot reply in a non-bot group is suppressed"
+        );
+
+        let user_dm = MessageSource {
+            chat: "300000000000003@lid".parse().unwrap(),
+            sender: "300000000000003@lid".parse().unwrap(),
+            ..Default::default()
+        };
+        assert!(
+            !user_dm.is_bot_authored_non_bot_chat(),
+            "normal user DM is never suppressed"
+        );
+    }
+
+    #[test]
     fn test_edit_attribute_parsing_and_serialization() {
         // Test all known edit attribute values
         let attrs = vec![


### PR DESCRIPTION
## Problem

`send_retry_receipt` suppressed the retry receipt whenever `!we_are_bot && sender_is_bot`, i.e. any time the message sender is a bot and our own account is not. For a 1:1 chat with a bot (Meta AI, etc.), a message we failed to decrypt is then silently never recovered: `send_retry_receipt` returns `Ok(())` early, `run_retry_receipt` treats it as sent, the transport ack clears the stanza from the server queue, and no `<receipt type="retry">` is ever emitted.

WA Web's `sendRetryReceipt` aborts on a different condition: `!to.isBot() && participant.isBot()`, where `to` is the sender (`getFrom`) and `participant` is `null` for DMs (`MsgSendReceipt` passes `participant = type === CHAT ? null : ...`). So for a bot DM `participant` is null, the abort never fires, and WA Web sends the retry. Our `we_are_bot` term has no counterpart in WA Web's condition at all.

## Fix

Replace the hand-rolled gate with the existing `MessageSource::is_bot_authored_non_bot_chat()` helper, which already encodes WA Web's `!chat.isBot() && author.isBot()` and is already used on the success/ack path (`message.rs`) and the self-fanout decrypt-failure path:

```rust
if info.source.is_bot_authored_non_bot_chat() { return Ok(()); }
```

- Bot DM: `chat == sender == bot`, so `!chat.is_bot() && sender.is_bot()` is `false`, the retry is sent (matches WA Web).
- Bot reply in a non-bot group: `chat` is the group (non-bot), `sender` is the bot, so it is suppressed (matches WA Web).
- This also drops the WA-Web-less `we_are_bot` term and makes the retry path consistent with the ack and self-fanout paths, which already route through the same helper.

## Tests

New `is_bot_authored_non_bot_chat_matches_wa_web` locks the gate semantics: bot DM not suppressed, group bot reply suppressed, normal user DM not suppressed.

```
cargo fmt --all
cargo clippy -p whatsapp-rust -p wacore --all-targets -- -D warnings   # clean
cargo test -p whatsapp-rust --lib   # 669 pass
cargo test -p wacore                # pass (incl. 1 new)
```

## Breaking

None. Internal gate change; the only behavior change is that bot DM retry receipts are now sent (and a local bot account no longer over-sends in groups).
