### PR TITLE
fix(prekeys): force the upload on prekey-low instead of re-querying the server count

### DIFF
--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -252,7 +252,11 @@ async fn handle_prekey_low(client: &Arc<Client>) {
                 return;
             }
 
-            if let Err(e) = client_clone.upload_pre_keys_with_retry(false).await {
+            // WA Web's handlePreKeyLow uploads unconditionally (no server-count query).
+            // Force past the count guard: the server only emits prekey-low after crossing
+            // its own (higher) threshold, so re-querying and skipping when count >= 5 lets
+            // the pool keep draining.
+            if let Err(e) = client_clone.upload_pre_keys_with_retry(true).await {
                 warn!(
                     "Failed to upload pre-keys after prekey_low notification: {:?}",
                     e

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -108,17 +108,24 @@ impl Client {
     /// Ensure the server has enough pre-keys, uploading if below threshold.
     /// When `force` is true, skips the count guard (used by digest key repair).
     pub(crate) async fn upload_pre_keys(&self, force: bool) -> Result<(), anyhow::Error> {
-        let server_count = self
-            .get_server_pre_key_count()
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?;
+        // Decision is should_upload_pre_keys(force, count), but a forced upload short-circuits
+        // and skips the server-count IQ entirely: WA Web's handlePreKeyLow uploads
+        // unconditionally, so a stale or transiently-failing count must never block or delay
+        // the replenish. Only a non-forced caller queries the count and applies the guard.
+        if !force {
+            let server_count = self
+                .get_server_pre_key_count()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
 
-        if !should_upload_pre_keys(force, server_count) {
-            log::debug!("Server has {server_count} pre-keys, no upload needed.");
-            return Ok(());
+            if !should_upload_pre_keys(force, server_count) {
+                log::debug!("Server has {server_count} pre-keys, no upload needed.");
+                return Ok(());
+            }
+
+            log::debug!("Server has {server_count} pre-keys, uploading.");
         }
 
-        log::debug!("Server has {server_count} pre-keys, uploading.");
         self.upload_pre_keys_inner().await
     }
 

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -25,6 +25,13 @@ pub(crate) const DEFAULT_WANTED_PRE_KEY_COUNT: usize = 812;
 
 const MIN_PRE_KEY_COUNT: usize = 5;
 
+/// Whether `upload_pre_keys` should upload, given the `force` flag and the server's
+/// reported pre-key count. The prekey-low path forces, matching WA Web's
+/// `handlePreKeyLow` which uploads unconditionally, so `force` bypasses the count guard.
+fn should_upload_pre_keys(force: bool, server_count: usize) -> bool {
+    force || server_count < MIN_PRE_KEY_COUNT
+}
+
 /// WA Web uses 24-bit PreKey IDs (max 2^24 - 1); IDs wrap modulo this.
 const MAX_PREKEY_ID: u32 = 16_777_215;
 
@@ -106,7 +113,7 @@ impl Client {
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
 
-        if !force && server_count >= MIN_PRE_KEY_COUNT {
+        if !should_upload_pre_keys(force, server_count) {
             log::debug!("Server has {server_count} pre-keys, no upload needed.");
             return Ok(());
         }
@@ -432,7 +439,7 @@ impl Client {
 mod tests {
     use super::{
         DEFAULT_WANTED_PRE_KEY_COUNT, MAX_PRE_KEY_UPLOAD_BATCH, MIN_PRE_KEY_COUNT,
-        clamp_wanted_pre_key_count,
+        clamp_wanted_pre_key_count, should_upload_pre_keys,
     };
 
     #[test]
@@ -462,6 +469,21 @@ mod tests {
         assert_eq!(
             clamp_wanted_pre_key_count(usize::MAX),
             MAX_PRE_KEY_UPLOAD_BATCH
+        );
+    }
+
+    #[test]
+    fn force_upload_bypasses_count_guard() {
+        // WA Web's handlePreKeyLow uploads unconditionally, so the prekey-low path forces
+        // and the count guard must not apply.
+        assert!(should_upload_pre_keys(true, 1000), "force always uploads");
+        assert!(
+            !should_upload_pre_keys(false, MIN_PRE_KEY_COUNT),
+            "count guard skips when not forced and at/above threshold"
+        );
+        assert!(
+            should_upload_pre_keys(false, MIN_PRE_KEY_COUNT - 1),
+            "below threshold uploads even without force"
         );
     }
 }


### PR DESCRIPTION
## Problem

When the server sends a `<notification type=encrypt><count value=N/>` (prekey-low) stanza, `handle_prekey_low` calls `upload_pre_keys_with_retry(false)`, which first issues a separate `get_server_pre_key_count` IQ and returns early without uploading whenever the server still reports `>= MIN_PRE_KEY_COUNT` (5).

But the server only emits prekey-low after ITS pool drops below ITS own (much higher) replenish threshold. Our re-query routinely observes, say, 6-50 keys still present and decides to do nothing, so the replenish signal is repeatedly ignored and the pool keeps draining. Each peer that fetches a bundle consumes a one-time prekey, so under sustained fanout this reaches the prekey-exhaustion regime this notification exists to prevent (new contacts fall back to signed-prekey-only sessions or fail to establish).

WA Web's `handlePreKeyLow` (`PreKeyLow.js`) calls `uploadPreKeys()` unconditionally: it parses `numRemaining` but never uses it to gate, and `WAWebUploadPreKeysJob` has no server-count query at all.

## Fix

Force the upload on the prekey-low path so it bypasses the count guard, matching WA Web:

- `handle_prekey_low` now calls `upload_pre_keys_with_retry(true)` (the force path already exists and is used by the digest-key repair). This also drops the extra `get_server_pre_key_count` IQ on every prekey-low.
- The count guard in `upload_pre_keys` is extracted into a named `should_upload_pre_keys(force, server_count)` so the "force bypasses the guard" contract is explicit and tested.

The login path (`upload_pre_keys_at_login`) already mirrors WA Web by gating on the persisted `server_has_prekeys` flag, so it is unchanged. The `MIN_PRE_KEY_COUNT` guard stays for any non-forced caller.

## Tests

New `force_upload_bypasses_count_guard`: `force=true` always uploads; `force=false` skips at/above the threshold and uploads below it.

```
cargo fmt --all
cargo clippy -p whatsapp-rust --all-targets -- -D warnings   # clean
cargo test -p whatsapp-rust --lib   # 670 pass (incl. 1 new)
```

## Breaking

None. The only behavior change is that a prekey-low notification now always tops up and uploads (and skips a redundant server-count IQ), matching WA Web.
