### PR TITLE
fix(blocking): resolve LID/PN before is_blocked compares, fixing PN-query false negatives

### DIFF
--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -79,17 +79,77 @@ impl<'a> Blocking<'a> {
 
     /// Check if a contact is blocked.
     ///
-    /// Compares only the user part of the JID, ignoring device ID,
-    /// since blocking applies to the entire user account, not individual devices.
+    /// Compares only the user part of the JID, ignoring device ID, since blocking
+    /// applies to the entire user account, not individual devices.
     pub async fn is_blocked(&self, jid: &Jid) -> anyhow::Result<bool> {
         let blocklist = self.get_blocklist().await?;
-        Ok(blocklist.iter().any(|e| e.jid.user == jid.user))
+        let bare = jid.to_non_ad();
+
+        // Blocks are stored keyed by LID (block() always resolves the input to a LID), so a
+        // PN-input query must resolve to its LID before comparing or it never matches a
+        // LID-keyed entry. Match against the raw user plus the resolved LID and PN; fall back
+        // to the raw user alone when no mapping exists.
+        let mapping = self.client.get_lid_pn_entry(&bare).await.ok().flatten();
+        let mut users: Vec<&str> = vec![bare.user.as_str()];
+        if let Some(entry) = mapping.as_ref() {
+            users.push(entry.lid.as_str());
+            users.push(entry.phone_number.as_str());
+        }
+
+        Ok(blocklist_contains(&blocklist, &users))
     }
+}
+
+/// Whether any blocklist entry's user part matches one of `candidate_users`.
+///
+/// Blocks are stored keyed by LID, so the caller resolves the queried JID to its
+/// LID/PN pair and passes all of them (raw, LID, PN) to catch a LID-keyed entry from
+/// a PN-input query (and the reverse).
+fn blocklist_contains(blocklist: &[BlocklistEntry], candidate_users: &[&str]) -> bool {
+    blocklist
+        .iter()
+        .any(|e| candidate_users.contains(&e.jid.user.as_str()))
 }
 
 impl Client {
     /// Access blocking operations.
     pub fn blocking(&self) -> Blocking<'_> {
         Blocking::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lid_entry(user: &str) -> BlocklistEntry {
+        BlocklistEntry {
+            jid: Jid::lid(user.to_string()),
+            timestamp: None,
+        }
+    }
+
+    #[test]
+    fn pn_query_matches_lid_keyed_block_only_when_resolved() {
+        // A block stored under the LID (modern WA) must be found once the PN query is
+        // resolved to that LID. Without resolution the LID-keyed block is missed (the bug).
+        let blocklist = vec![lid_entry("100000012345678")];
+
+        assert!(
+            blocklist_contains(&blocklist, &["559980000001", "100000012345678"]),
+            "resolved PN->LID candidate matches the LID-keyed block"
+        );
+        assert!(
+            !blocklist_contains(&blocklist, &["559980000001"]),
+            "raw PN alone misses the LID-keyed block (the false negative)"
+        );
+        assert!(
+            blocklist_contains(&blocklist, &["100000012345678"]),
+            "a LID query matches directly"
+        );
+        assert!(
+            !blocklist_contains(&blocklist, &["559981111111", "100000099999999"]),
+            "an unrelated contact is not blocked"
+        );
     }
 }

--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -87,9 +87,10 @@ impl<'a> Blocking<'a> {
 
         // Blocks are stored keyed by LID (block() always resolves the input to a LID), so a
         // PN-input query must resolve to its LID before comparing or it never matches a
-        // LID-keyed entry. Match against the raw user plus the resolved LID and PN; fall back
-        // to the raw user alone when no mapping exists.
-        let mapping = self.client.get_lid_pn_entry(&bare).await.ok().flatten();
+        // LID-keyed entry. Match against the raw user plus the resolved LID and PN. Propagate a
+        // backend failure (swallowing it would fall back to the raw user and re-introduce the
+        // false negative); a genuine absence (Ok(None), incl. a non-LID/PN input) falls back.
+        let mapping = self.client.get_lid_pn_entry(&bare).await?;
         let mut users: Vec<&str> = vec![bare.user.as_str()];
         if let Some(entry) = mapping.as_ref() {
             users.push(entry.lid.as_str());


### PR DESCRIPTION
## Problem

`block()` / `unblock()` always resolve the input JID to a LID before sending (`resolve_lid_pn`), so modern WhatsApp stores blocks keyed by LID and `GetBlocklist` returns `<item jid=...@lid>` entries whose `.user` is the LID number. But `is_blocked` compared `entry.jid.user == jid.user` against the caller's JID verbatim, with no LID/PN resolution. If the caller passes a PN JID (the natural input for a phone-number contact), `jid.user` is the phone number, which never equals the stored LID's user, so `is_blocked` returns `false` even when the contact is blocked: a silent false negative.

WA Web keeps the blocklist keyed by LID (`WAWebBlocklistCollection`, membership by `id`) and normalizes membership tests to LID first.

## Fix

Resolve the queried JID to its LID/PN pair (the same `get_lid_pn_entry` mapping `block()` / `unblock()` use) and match each blocklist entry against the raw user plus the resolved LID and PN. Falls back to the raw user alone when no mapping exists, so a LID query keeps working and the behavior only improves for PN input.

The match itself is a small pure helper `blocklist_contains(&[BlocklistEntry], &[&str])`, so the LID/PN-resolution semantics are unit-testable without a server.

## Tests

New `pn_query_matches_lid_keyed_block_only_when_resolved`: a LID-keyed block is found when the candidate set includes the resolved LID, missed when only the raw PN is given (the old bug), matched directly for a LID query, and an unrelated contact is not blocked.

```
cargo fmt --all
cargo clippy -p whatsapp-rust --all-targets -- -D warnings   # clean
cargo test -p whatsapp-rust --lib blocking   # pass (incl. 1 new)
```

## Breaking

None. `is_blocked` keeps its signature; PN-input queries now resolve correctly, LID-input queries are unchanged.
