### PR TITLE
fix(retry): allocate retry-receipt prekey from the monotonic counter, not random

### DIFF
--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -35,6 +35,19 @@ fn should_upload_pre_keys(force: bool, server_count: usize) -> bool {
 /// WA Web uses 24-bit PreKey IDs (max 2^24 - 1); IDs wrap modulo this.
 const MAX_PREKEY_ID: u32 = 16_777_215;
 
+/// Next one-time prekey id to mint from the persistent monotonic counter, falling back to
+/// `max_store_id + 1` on migration (when the counter is unset) and wrapping into the 24-bit
+/// range. Shared by the batch upload path and the retry-receipt single-key allocation so both
+/// draw from the same `NEXT_PK_ID` namespace and never collide (matching WA Web).
+fn start_prekey_id(next_pre_key_id: u32, max_store_id: u32) -> u32 {
+    let raw = if next_pre_key_id > 0 {
+        std::cmp::max(next_pre_key_id as u64, max_store_id as u64 + 1)
+    } else {
+        max_store_id as u64 + 1
+    };
+    ((raw - 1) % MAX_PREKEY_ID as u64) as u32 + 1
+}
+
 /// The upload IQ encodes the pre-key `<list>` length as a u16
 /// (`Encoder::write_list_start`), so a larger batch fails to encode after the
 /// keys were already generated and stored. Well below MAX_PREKEY_ID, so a single
@@ -129,6 +142,30 @@ impl Client {
         self.upload_pre_keys_inner().await
     }
 
+    /// Allocate the next one-time prekey id from the persistent monotonic `NEXT_PK_ID` counter
+    /// (the same namespace as uploads) and advance it, so a retry-receipt prekey can never
+    /// collide with a live pool key. The caller must hold `prekey_upload_lock` to serialize the
+    /// allocate+bump with the upload path. Mirrors WA Web's `getOrGenSinglePreKey -> NEXT_PK_ID`.
+    pub(crate) async fn allocate_next_one_time_prekey_id(&self) -> Result<u32, anyhow::Error> {
+        let next_pre_key_id = self
+            .persistence_manager
+            .get_device_snapshot()
+            .await
+            .next_pre_key_id;
+        let backend = {
+            let device_store = self.persistence_manager.get_device_arc().await;
+            let guard = device_store.read().await;
+            guard.backend.clone()
+        };
+        let max_id = backend.get_max_prekey_id().await?;
+        let id = start_prekey_id(next_pre_key_id, max_id);
+        let next = (id as u64 % MAX_PREKEY_ID as u64) as u32 + 1;
+        self.persistence_manager
+            .process_command(DeviceCommand::SetNextPreKeyId(next))
+            .await;
+        Ok(id)
+    }
+
     /// Generate and upload the configured number of pre-keys (see
     /// [`Client::set_wanted_pre_key_count`]). Shared by `upload_pre_keys` and
     /// `upload_pre_keys_at_login` to avoid redundant server count queries.
@@ -142,22 +179,17 @@ impl Client {
         };
 
         // Use the persistent counter, falling back to max(store_id)+1 for migration.
-        // The counter is the source of truth after the first upload.
+        // The counter is the source of truth after the first upload; start_prekey_id wraps
+        // into the 24-bit range so lingering high-ID rows don't pin start_id above it.
         let max_id = backend.get_max_prekey_id().await?;
-        let raw_start = if device_snapshot.next_pre_key_id > 0 {
-            std::cmp::max(device_snapshot.next_pre_key_id, max_id + 1)
-        } else {
+        if device_snapshot.next_pre_key_id == 0 {
             log::info!(
                 "Migrating pre-key counter: MAX(key_id) in store = {}, starting from {}",
                 max_id,
                 max_id + 1
             );
-            max_id + 1
-        };
-
-        // Wrap into valid range so lingering high-ID rows don't pin start_id
-        // above the 24-bit boundary and cause repeated overwrites of low IDs.
-        let start_id = ((raw_start as u64 - 1) % MAX_PREKEY_ID as u64) as u32 + 1;
+        }
+        let start_id = start_prekey_id(device_snapshot.next_pre_key_id, max_id);
 
         let configured = self.wanted_pre_key_count.load(Ordering::Relaxed);
         let wanted = clamp_wanted_pre_key_count(configured);
@@ -445,8 +477,8 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_WANTED_PRE_KEY_COUNT, MAX_PRE_KEY_UPLOAD_BATCH, MIN_PRE_KEY_COUNT,
-        clamp_wanted_pre_key_count, should_upload_pre_keys,
+        DEFAULT_WANTED_PRE_KEY_COUNT, MAX_PRE_KEY_UPLOAD_BATCH, MAX_PREKEY_ID, MIN_PRE_KEY_COUNT,
+        clamp_wanted_pre_key_count, should_upload_pre_keys, start_prekey_id,
     };
 
     #[test]
@@ -477,6 +509,19 @@ mod tests {
             clamp_wanted_pre_key_count(usize::MAX),
             MAX_PRE_KEY_UPLOAD_BATCH
         );
+    }
+
+    #[test]
+    fn start_prekey_id_uses_counter_and_wraps() {
+        // Counter ahead of the store: use the counter (monotonic, never reuses an id).
+        assert_eq!(start_prekey_id(10, 5), 10);
+        // Store ahead of (or equal to) the counter: use max_store + 1.
+        assert_eq!(start_prekey_id(3, 100), 101);
+        // Migration (counter unset = 0): max_store + 1.
+        assert_eq!(start_prekey_id(0, 5), 6);
+        // Wraps into the 24-bit range instead of pinning above MAX_PREKEY_ID.
+        assert_eq!(start_prekey_id(MAX_PREKEY_ID + 1, 0), 1);
+        assert_eq!(start_prekey_id(MAX_PREKEY_ID, 0), MAX_PREKEY_ID);
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1005,16 +1005,19 @@ impl Client {
             .build();
 
         let keys_node = if wacore::protocol::retry::should_include_keys(retry_count, reason) {
-            let device_store = self.persistence_manager.get_device_arc().await;
-            let device_guard = device_store.read().await;
-
-            let new_prekey_id = (rand::random::<u32>() % 16777215) + 1;
+            // Allocate the one-time prekey from the same monotonic NEXT_PK_ID counter as the
+            // upload path (WA Web's getOrGenSinglePreKey) so it can never overwrite a live pool
+            // key. Hold prekey_upload_lock to serialize the allocate+bump with uploads.
+            let prekey_guard = self.prekey_upload_lock.lock().await;
+            let new_prekey_id = self.allocate_next_one_time_prekey_id().await?;
             let new_prekey_keypair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
             let new_prekey_record = wacore::libsignal::store::record_helpers::new_pre_key_record(
                 new_prekey_id,
                 &new_prekey_keypair,
             );
             // This key is not uploaded to the server pool, so mark as false
+            let device_store = self.persistence_manager.get_device_arc().await;
+            let device_guard = device_store.read().await;
             if let Err(e) = device_guard
                 .store_prekey(new_prekey_id, new_prekey_record, false)
                 .await
@@ -1022,6 +1025,7 @@ impl Client {
                 warn!("Failed to store new prekey for retry receipt: {e:?}");
             }
             drop(device_guard);
+            drop(prekey_guard);
 
             let device_identity_bytes = device_snapshot
                 .account


### PR DESCRIPTION
## Problem

`send_retry_receipt` minted the one-time prekey it announces with `(rand::random::<u32>() % 16777215) + 1` and stored it, never consulting or advancing `Device::next_pre_key_id`. The store upserts by key id, so a random collision with an id already in the pool silently replaces that prekey's stored private key while the server still hands out the OLD public key for that id; a later pkmsg consuming the colliding id then resolves to the wrong private key -> InvalidPreKeyId/BadMac (the prekey-collision failure class). The reverse also bites: because the counter isn't advanced, a later batch upload can regenerate exactly the id the retry receipt just announced.

WA Web allocates this key from the same monotonic `NEXT_PK_ID` counter as uploads (`getOrGenSinglePreKey -> getOrGenPreKeys -> savePreKeys` persists `keyId + 1`), so it never collides.

## Fix

Allocate the retry-receipt prekey from the same persistent monotonic counter as uploads instead of `rand::random`:

- New `Client::allocate_next_one_time_prekey_id()` reads `next_pre_key_id` (falling back to `get_max_prekey_id() + 1` on migration), wraps into the 24-bit range, and advances the counter via `DeviceCommand::SetNextPreKeyId`.
- The wrap/fallback computation is a pure `start_prekey_id(next_pre_key_id, max_store_id)` helper, now shared by the batch upload path and the retry allocation (single source of truth, unit-testable).
- `send_retry_receipt` holds `prekey_upload_lock` around the allocate + store so the counter can't race with `upload_pre_keys_inner` / `handle_prekey_low`.

## Tests

New `start_prekey_id_uses_counter_and_wraps`: uses the counter when it's ahead, falls back to `max_store + 1` (including the migration `next_pre_key_id == 0` case), and wraps at `MAX_PREKEY_ID`.

```
cargo fmt --all
cargo clippy -p whatsapp-rust --all-targets -- -D warnings   # clean
cargo test -p whatsapp-rust --lib   # 671 pass (incl. 1 new)
```

## Breaking

None. Internal allocation change; retry-receipt prekeys now share the upload counter and can no longer overwrite a live pool key.
