### PR TITLE
fix(send): emit mediatype for interactive/list/order/product/native-flow sends

### DIFF
--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -222,6 +222,13 @@ pub fn peer_message_options_from_message(msg: &wa::Message) -> PeerMessageOption
 /// Matches WAWebBackendJobsCommon.mediaTypeFromProtobuf + encodeMaybeMediaType.
 /// Returns `None` when the attribute should be omitted.
 pub fn media_type_from_message(msg: &wa::Message) -> Option<&'static str> {
+    // WA Web's mediaTypeFromProtobuf treats a top-level lottieStickerMessage as a
+    // terminal "sticker" and does NOT recurse into it (unlike typeAttributeFromProtobuf,
+    // which unwraps it via getUnwrappedProtobufMessage). Check before the shared unwrap.
+    if msg.lottie_sticker_message.is_some() {
+        return Some("sticker");
+    }
+
     let msg = unwrap_message(msg);
 
     if msg.image_message.is_some() {
@@ -279,6 +286,31 @@ pub fn media_type_from_message(msg: &wa::Message) -> Option<&'static str> {
     }
     if msg.group_invite_message.is_some() {
         return Some("url");
+    }
+    // Interactive / business message families. WA Web's mediaTypeFromProtobuf maps
+    // each to a concrete mediatype; without it the server drops the type="media"
+    // stanza. buttonsMessage is intentionally absent: WA Web maps it to
+    // EncMediaType.Button, which its string mapper drops (no attribute).
+    if msg.list_message.is_some() {
+        return Some("list");
+    }
+    if msg.list_response_message.is_some() {
+        return Some("list_response");
+    }
+    if msg.buttons_response_message.is_some() {
+        return Some("buttons_response");
+    }
+    if msg.order_message.is_some() {
+        return Some("order");
+    }
+    if msg.product_message.is_some() {
+        return Some("product");
+    }
+    if msg.interactive_response_message.is_some() {
+        return Some("native_flow_response");
+    }
+    if msg.message_history_bundle.is_some() {
+        return Some("group_history");
     }
     None
 }
@@ -4419,6 +4451,102 @@ mod tests {
                 ..Default::default()
             };
             assert_eq!(stanza_type_from_message(&url), stanza::MSG_TYPE_MEDIA);
+        }
+
+        #[test]
+        fn interactive_and_list_types_get_their_mediatype() {
+            // WA Web's mediaTypeFromProtobuf maps these to concrete mediatypes;
+            // omitting the attribute makes the server drop the type="media" stanza.
+            let list = wa::Message {
+                list_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(stanza_type_from_message(&list), stanza::MSG_TYPE_MEDIA);
+            assert_eq!(media_type_from_message(&list), Some("list"));
+
+            let list_response = wa::Message {
+                list_response_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(
+                media_type_from_message(&list_response),
+                Some("list_response")
+            );
+
+            let buttons_response = wa::Message {
+                buttons_response_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(
+                media_type_from_message(&buttons_response),
+                Some("buttons_response")
+            );
+
+            let order = wa::Message {
+                order_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(media_type_from_message(&order), Some("order"));
+
+            let product = wa::Message {
+                product_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(media_type_from_message(&product), Some("product"));
+
+            let interactive_response = wa::Message {
+                interactive_response_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(
+                media_type_from_message(&interactive_response),
+                Some("native_flow_response")
+            );
+
+            let history_bundle = wa::Message {
+                message_history_bundle: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(
+                media_type_from_message(&history_bundle),
+                Some("group_history")
+            );
+        }
+
+        #[test]
+        fn buttons_message_has_no_mediatype() {
+            // WA Web maps buttonsMessage to EncMediaType.Button, but its string
+            // mapper has no Button case (returns null/DROP_ATTR), so the attribute
+            // is omitted. Adding a "buttons" mediatype would diverge from WA Web.
+            let buttons = wa::Message {
+                buttons_message: Some(Box::default()),
+                ..Default::default()
+            };
+            assert_eq!(media_type_from_message(&buttons), None);
+        }
+
+        #[test]
+        fn ephemeral_wrapped_list_reaches_list_mediatype() {
+            let m = wa::Message {
+                ephemeral_message: Some(fpm(wa::Message {
+                    list_message: Some(Box::default()),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            };
+            assert_eq!(media_type_from_message(&m), Some("list"));
+        }
+
+        #[test]
+        fn top_level_lottie_sticker_is_terminal_sticker() {
+            // WA Web's mediaTypeFromProtobuf treats a top-level lottieStickerMessage
+            // as a terminal "sticker" and does NOT recurse into it, unlike the
+            // stanza-type path which unwraps it.
+            let lottie = wa::Message {
+                lottie_sticker_message: Some(fpm(image_inner())),
+                ..Default::default()
+            };
+            assert_eq!(media_type_from_message(&lottie), Some("sticker"));
         }
     }
 


### PR DESCRIPTION
## Problem

`media_type_from_message` (the outgoing `mediatype` attribute classifier) has no terminal cases for several interactive/business message types, so it returns `None` for them. Since these types are not in the `text` list of `stanza_type_from_message` either, they fall through to the default `type="media"`. The result is a `<message type="media">` with **no `mediatype` attribute**, which the server drops silently. Affected sends: list, list-response, buttons-response, order, product, interactive-response (native flow), and group-history.

A second, smaller divergence: WA Web's `mediaTypeFromProtobuf` treats a top-level `lottieStickerMessage` as a terminal `"sticker"` and does not recurse into it, but our shared `unwrap_message` unwraps it (the stanza-type path correctly wants that), so a top-level lottie sticker resolved to the wrong mediatype.

## Change

Add the missing terminal cases to `media_type_from_message`, matching WA Web's `mediaTypeFromProtobuf` (`f`) + its string mapper (`g`) in `WAWebBackendJobsCommon`:

- `listMessage` -> `"list"`
- `listResponseMessage` -> `"list_response"`
- `buttonsResponseMessage` -> `"buttons_response"`
- `orderMessage` -> `"order"`
- `productMessage` -> `"product"`
- `interactiveResponseMessage` -> `"native_flow_response"`
- `messageHistoryBundle` -> `"group_history"`

`buttonsMessage` is intentionally left returning `None`: WA Web maps it to `EncMediaType.Button`, but the string mapper `g` has no `Button` case and returns null (the attribute is dropped). Adding a `"buttons"` mediatype would diverge from WA Web.

Lottie stickers are handled as a terminal `"sticker"` before the shared unwrap, mirroring WA Web's `f` (which does not unwrap lottie for the media type, unlike `typeAttributeFromProtobuf`).

`stanza_type_from_message` needs no change: these types already default to `type="media"`, matching WA Web's `typeAttributeFromProtobuf`.

## WA Web parity

Verified against `docs/captured-js/WAWeb/Backend/JobsCommon.js`: `f` (lines 134-168) maps each message to an `EncMediaType`, and `g` (lines 182-228) stringifies them; `Button` has no case in `g` (falls to the `default: null`), and `lottieStickerMessage` is in `f`'s terminal block (line 137), not its unwrap chain.

## Tests

Written before the fix (red), then green:

- `interactive_and_list_types_get_their_mediatype` — each of the 7 types maps to the right string, and list still classifies as `type="media"`.
- `buttons_message_has_no_mediatype` — regression guard that buttons stays `None` (no `"buttons"` divergence).
- `ephemeral_wrapped_list_reaches_list_mediatype` — wrappers still resolve to the inner type.
- `top_level_lottie_sticker_is_terminal_sticker` — a lottie wrapping an image yields `"sticker"`, proving it is not unwrapped.

Full lib suites green; `cargo clippy --all-targets -- -D warnings` clean.

## Known edge (out of scope)

A `lottieStickerMessage` nested under another wrapper (e.g. a disappearing-message `ephemeralMessage`) still unwraps past the lottie. This is a deep edge (disappearing lottie sticker); the top-level case is the realistic send path and is fixed here.
