### PR TITLE
feat(labels): add chat label create/delete/associate API with inbound sync

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3324,6 +3324,12 @@ impl Client {
             return;
         }
 
+        // Label mutations have their own index shape (labelId, not a chat JID at
+        // index[1]), so they are dispatched separately from chat actions.
+        if crate::features::labels::dispatch_label_mutation(&self.core.event_bus, m, full_sync) {
+            return;
+        }
+
         // Handle client-internal mutations that need persistence/presence access
         if m.index[0] == "setting_pushName"
             && let Some(val) = &m.action_value

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -533,10 +533,29 @@ impl<'a> ChatActions<'a> {
         index: &[u8],
         value: &wa::SyncActionValue,
     ) -> Result<()> {
+        self.client
+            .send_app_state_mutation(collection, index, value)
+            .await
+    }
+}
+
+impl Client {
+    pub fn chat_actions(&self) -> ChatActions<'_> {
+        ChatActions::new(self)
+    }
+
+    /// Encode a single `Set` app-state mutation and send it as a patch on
+    /// `collection`. Shared by the chat-action and label features.
+    pub(crate) async fn send_app_state_mutation(
+        &self,
+        collection: WAPatchName,
+        index: &[u8],
+        value: &wa::SyncActionValue,
+    ) -> Result<()> {
         use rand::Rng;
         use wacore::appstate::encode::encode_record;
 
-        let proc = self.client.get_app_state_processor().await;
+        let proc = self.get_app_state_processor().await;
         let key_id = proc
             .backend
             .get_latest_sync_key_id()
@@ -557,14 +576,7 @@ impl<'a> ChatActions<'a> {
             &iv,
         );
 
-        self.client
-            .send_app_state_patch(collection.as_str(), vec![mutation])
+        self.send_app_state_patch(collection.as_str(), vec![mutation])
             .await
-    }
-}
-
-impl Client {
-    pub fn chat_actions(&self) -> ChatActions<'_> {
-        ChatActions::new(self)
     }
 }

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -533,8 +533,11 @@ impl<'a> ChatActions<'a> {
         index: &[u8],
         value: &wa::SyncActionValue,
     ) -> Result<()> {
+        // Chat actions still emit action version 1 (their pre-existing behavior).
+        // whatsmeow uses per-action versions (mute=2, pin=5, archive=3, ...);
+        // aligning these is tracked as a follow-up.
         self.client
-            .send_app_state_mutation(collection, index, value)
+            .send_app_state_mutation(collection, index, value, 1)
             .await
     }
 }
@@ -544,13 +547,15 @@ impl Client {
         ChatActions::new(self)
     }
 
-    /// Encode a single `Set` app-state mutation and send it as a patch on
-    /// `collection`. Shared by the chat-action and label features.
+    /// Encode a single `Set` app-state mutation (stamped with the action schema
+    /// `version`) and send it as a patch on `collection`. Shared by the
+    /// chat-action and label features.
     pub(crate) async fn send_app_state_mutation(
         &self,
         collection: WAPatchName,
         index: &[u8],
         value: &wa::SyncActionValue,
+        version: i32,
     ) -> Result<()> {
         use rand::Rng;
         use wacore::appstate::encode::encode_record;
@@ -574,6 +579,7 @@ impl Client {
             &keys,
             &key_id,
             &iv,
+            version,
         );
 
         self.send_app_state_patch(collection.as_str(), vec![mutation])

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -106,6 +106,12 @@ impl<'a> Labels<'a> {
     /// this both creates a new label and renames/recolors an existing one.
     /// `color` is a WhatsApp color index.
     pub async fn create_label(&self, label_id: &str, name: &str, color: i32) -> Result<()> {
+        if label_id.is_empty() {
+            anyhow::bail!("label_id cannot be empty");
+        }
+        if name.is_empty() {
+            anyhow::bail!("label name cannot be empty");
+        }
         debug!("Setting label {label_id} (name={name:?}, color={color})");
         let index = serde_json::to_vec(&["label_edit", label_id])?;
         let value = wa::SyncActionValue {
@@ -126,6 +132,9 @@ impl<'a> Labels<'a> {
     /// Delete a label. Chats keep their association rows; WA Web prunes them
     /// from the local DB on receipt of the delete.
     pub async fn delete_label(&self, label_id: &str) -> Result<()> {
+        if label_id.is_empty() {
+            anyhow::bail!("label_id cannot be empty");
+        }
         debug!("Deleting label {label_id}");
         let index = serde_json::to_vec(&["label_edit", label_id])?;
         let value = wa::SyncActionValue {
@@ -152,6 +161,9 @@ impl<'a> Labels<'a> {
     }
 
     async fn send_association(&self, label_id: &str, chat_jid: &Jid, labeled: bool) -> Result<()> {
+        if label_id.is_empty() {
+            anyhow::bail!("label_id cannot be empty");
+        }
         debug!(
             "{} label {label_id} {} chat {chat_jid}",
             if labeled { "Adding" } else { "Removing" },
@@ -266,6 +278,28 @@ mod tests {
             }
             other => panic!("expected LabelAssociationUpdate, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn label_methods_reject_empty_id() {
+        // Validation fires before any network/app-state work, so a key-less test
+        // client still exercises the guard.
+        let client = crate::test_utils::create_test_client().await;
+        let jid: Jid = "15551112222@s.whatsapp.net".parse().unwrap();
+
+        let err = client
+            .labels()
+            .create_label("", "Work", 0)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("label_id cannot be empty"));
+
+        let err = client.labels().create_label("5", "", 0).await.unwrap_err();
+        assert!(err.to_string().contains("label name cannot be empty"));
+
+        assert!(client.labels().delete_label("").await.is_err());
+        assert!(client.labels().add_chat_label("", &jid).await.is_err());
+        assert!(client.labels().remove_chat_label("", &jid).await.is_err());
     }
 
     #[test]

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -112,7 +112,11 @@ impl<'a> Labels<'a> {
         if name.is_empty() {
             anyhow::bail!("label name cannot be empty");
         }
-        debug!("Setting label {label_id} (name={name:?}, color={color})");
+        // Don't log the label name (user content); the id/color are enough to trace.
+        debug!(
+            "Setting label {label_id} (name_len={}, color={color})",
+            name.len()
+        );
         let index = serde_json::to_vec(&["label_edit", label_id])?;
         let value = wa::SyncActionValue {
             label_edit_action: Some(wa::sync_action_value::LabelEditAction {

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -5,9 +5,7 @@
 //! - `label_edit`  (index `["label_edit", labelId]`)        -> `LabelEditAction`
 //! - `label_jid`   (index `["label_jid", labelId, chatJid]`) -> `LabelAssociationAction`
 //!
-//! Note: WA Web stamps `label_edit` with action version 3, but the syncd
-//! `SyncActionData.version` emitted by `encode_record` is a fixed `1` for every
-//! action (same as mute/pin/archive); kept consistent with the existing path.
+//! Both are stamped with action version 3, matching WhatsApp Web and whatsmeow.
 
 use crate::appstate_sync::Mutation;
 use crate::client::Client;
@@ -17,6 +15,9 @@ use wacore::appstate::patch_decode::WAPatchName;
 use wacore::types::events::{Event, LabelAssociationUpdate, LabelEditUpdate};
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
+
+/// Action schema version for both label actions (matches WA Web / whatsmeow).
+const LABEL_ACTION_VERSION: i32 = 3;
 
 /// Dispatch inbound label mutations synced from a linked device.
 /// Returns `true` if handled, `false` if the mutation is not a label kind.
@@ -118,7 +119,7 @@ impl<'a> Labels<'a> {
             ..Default::default()
         };
         self.client
-            .send_app_state_mutation(WAPatchName::Regular, &index, &value)
+            .send_app_state_mutation(WAPatchName::Regular, &index, &value, LABEL_ACTION_VERSION)
             .await
     }
 
@@ -136,7 +137,7 @@ impl<'a> Labels<'a> {
             ..Default::default()
         };
         self.client
-            .send_app_state_mutation(WAPatchName::Regular, &index, &value)
+            .send_app_state_mutation(WAPatchName::Regular, &index, &value, LABEL_ACTION_VERSION)
             .await
     }
 
@@ -166,7 +167,7 @@ impl<'a> Labels<'a> {
             ..Default::default()
         };
         self.client
-            .send_app_state_mutation(WAPatchName::Regular, &index, &value)
+            .send_app_state_mutation(WAPatchName::Regular, &index, &value, LABEL_ACTION_VERSION)
             .await
     }
 }

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -1,0 +1,298 @@
+//! Chat labels (etiquetas) via app state sync (syncd).
+//!
+//! Mirrors WhatsApp Web's `WAWebLabel*`. Both label actions live in the
+//! `regular` collection:
+//! - `label_edit`  (index `["label_edit", labelId]`)        -> `LabelEditAction`
+//! - `label_jid`   (index `["label_jid", labelId, chatJid]`) -> `LabelAssociationAction`
+//!
+//! Note: WA Web stamps `label_edit` with action version 3, but the syncd
+//! `SyncActionData.version` emitted by `encode_record` is a fixed `1` for every
+//! action (same as mute/pin/archive); kept consistent with the existing path.
+
+use crate::appstate_sync::Mutation;
+use crate::client::Client;
+use anyhow::Result;
+use log::debug;
+use wacore::appstate::patch_decode::WAPatchName;
+use wacore::types::events::{Event, LabelAssociationUpdate, LabelEditUpdate};
+use wacore_binary::Jid;
+use waproto::whatsapp as wa;
+
+/// Dispatch inbound label mutations synced from a linked device.
+/// Returns `true` if handled, `false` if the mutation is not a label kind.
+pub(crate) fn dispatch_label_mutation(
+    event_bus: &wacore::types::events::CoreEventBus,
+    m: &Mutation,
+    full_sync: bool,
+) -> bool {
+    if m.operation != wa::syncd_mutation::SyncdOperation::Set || m.index.is_empty() {
+        return false;
+    }
+
+    let kind = m.index[0].as_str();
+    if !matches!(kind, "label_edit" | "label_jid") {
+        return false;
+    }
+
+    let ts = m
+        .action_value
+        .as_ref()
+        .and_then(|v| v.timestamp)
+        .unwrap_or(0);
+    let time = wacore::time::from_millis_or_now(ts);
+
+    let Some(label_id) = m.index.get(1).cloned() else {
+        log::warn!("Skipping label mutation '{kind}': missing label id in index");
+        return true;
+    };
+
+    match kind {
+        "label_edit" => {
+            if let Some(val) = &m.action_value
+                && let Some(act) = &val.label_edit_action
+            {
+                event_bus.dispatch(Event::LabelEditUpdate(LabelEditUpdate {
+                    label_id,
+                    timestamp: time,
+                    action: Box::new(act.clone()),
+                    from_full_sync: full_sync,
+                }));
+            }
+            true
+        }
+        "label_jid" => {
+            let chat_jid: Jid = match m.index.get(2) {
+                Some(s) => match s.parse() {
+                    Ok(j) => j,
+                    Err(_) => {
+                        log::warn!("Skipping label_jid mutation: malformed chat JID '{s}'");
+                        return true;
+                    }
+                },
+                None => {
+                    log::warn!("Skipping label_jid mutation: missing chat JID in index");
+                    return true;
+                }
+            };
+            if let Some(val) = &m.action_value
+                && let Some(act) = &val.label_association_action
+            {
+                event_bus.dispatch(Event::LabelAssociationUpdate(LabelAssociationUpdate {
+                    label_id,
+                    chat_jid,
+                    timestamp: time,
+                    action: Box::new(*act),
+                    from_full_sync: full_sync,
+                }));
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Access via `client.labels()`.
+pub struct Labels<'a> {
+    client: &'a Client,
+}
+
+impl<'a> Labels<'a> {
+    pub(crate) fn new(client: &'a Client) -> Self {
+        Self { client }
+    }
+
+    /// Create or update a label. App state is an upsert keyed by `label_id`, so
+    /// this both creates a new label and renames/recolors an existing one.
+    /// `color` is a WhatsApp color index.
+    pub async fn create_label(&self, label_id: &str, name: &str, color: i32) -> Result<()> {
+        debug!("Setting label {label_id} (name={name:?}, color={color})");
+        let index = serde_json::to_vec(&["label_edit", label_id])?;
+        let value = wa::SyncActionValue {
+            label_edit_action: Some(wa::sync_action_value::LabelEditAction {
+                name: Some(name.to_string()),
+                color: Some(color),
+                deleted: Some(false),
+                ..Default::default()
+            }),
+            timestamp: Some(wacore::time::now_millis()),
+            ..Default::default()
+        };
+        self.client
+            .send_app_state_mutation(WAPatchName::Regular, &index, &value)
+            .await
+    }
+
+    /// Delete a label. Chats keep their association rows; WA Web prunes them
+    /// from the local DB on receipt of the delete.
+    pub async fn delete_label(&self, label_id: &str) -> Result<()> {
+        debug!("Deleting label {label_id}");
+        let index = serde_json::to_vec(&["label_edit", label_id])?;
+        let value = wa::SyncActionValue {
+            label_edit_action: Some(wa::sync_action_value::LabelEditAction {
+                deleted: Some(true),
+                ..Default::default()
+            }),
+            timestamp: Some(wacore::time::now_millis()),
+            ..Default::default()
+        };
+        self.client
+            .send_app_state_mutation(WAPatchName::Regular, &index, &value)
+            .await
+    }
+
+    /// Associate a label with a chat.
+    pub async fn add_chat_label(&self, label_id: &str, chat_jid: &Jid) -> Result<()> {
+        self.send_association(label_id, chat_jid, true).await
+    }
+
+    /// Remove a label association from a chat.
+    pub async fn remove_chat_label(&self, label_id: &str, chat_jid: &Jid) -> Result<()> {
+        self.send_association(label_id, chat_jid, false).await
+    }
+
+    async fn send_association(&self, label_id: &str, chat_jid: &Jid, labeled: bool) -> Result<()> {
+        debug!(
+            "{} label {label_id} {} chat {chat_jid}",
+            if labeled { "Adding" } else { "Removing" },
+            if labeled { "to" } else { "from" },
+        );
+        let chat = chat_jid.to_string();
+        let index = serde_json::to_vec(&["label_jid", label_id, chat.as_str()])?;
+        let value = wa::SyncActionValue {
+            label_association_action: Some(wa::sync_action_value::LabelAssociationAction {
+                labeled: Some(labeled),
+            }),
+            timestamp: Some(wacore::time::now_millis()),
+            ..Default::default()
+        };
+        self.client
+            .send_app_state_mutation(WAPatchName::Regular, &index, &value)
+            .await
+    }
+}
+
+impl Client {
+    pub fn labels(&self) -> Labels<'_> {
+        Labels::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use wacore::types::events::{CoreEventBus, EventHandler, EventInterest};
+
+    #[derive(Default)]
+    struct Recorder {
+        events: Mutex<Vec<Arc<Event>>>,
+    }
+    impl EventHandler for Recorder {
+        fn handle_event(&self, event: Arc<Event>) {
+            self.events.lock().unwrap().push(event);
+        }
+        fn interest(&self) -> EventInterest {
+            EventInterest::ALL
+        }
+    }
+
+    fn set_mutation(index: Vec<&str>, value: wa::SyncActionValue) -> Mutation {
+        Mutation {
+            index: index.into_iter().map(String::from).collect(),
+            operation: wa::syncd_mutation::SyncdOperation::Set,
+            action_value: Some(value),
+        }
+    }
+
+    fn run(m: &Mutation) -> (bool, Vec<Arc<Event>>) {
+        let bus = CoreEventBus::new();
+        let rec = Arc::new(Recorder::default());
+        bus.add_handler(rec.clone());
+        let handled = dispatch_label_mutation(&bus, m, false);
+        let events = rec.events.lock().unwrap().clone();
+        (handled, events)
+    }
+
+    #[test]
+    fn label_edit_dispatches_update() {
+        let m = set_mutation(
+            vec!["label_edit", "5"],
+            wa::SyncActionValue {
+                label_edit_action: Some(wa::sync_action_value::LabelEditAction {
+                    name: Some("Work".into()),
+                    color: Some(2),
+                    deleted: Some(false),
+                    ..Default::default()
+                }),
+                timestamp: Some(1000),
+                ..Default::default()
+            },
+        );
+        let (handled, events) = run(&m);
+        assert!(handled);
+        assert_eq!(events.len(), 1);
+        match &*events[0] {
+            Event::LabelEditUpdate(u) => {
+                assert_eq!(u.label_id, "5");
+                assert_eq!(u.action.name.as_deref(), Some("Work"));
+                assert_eq!(u.action.color, Some(2));
+                assert_eq!(u.action.deleted, Some(false));
+            }
+            other => panic!("expected LabelEditUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn label_jid_dispatches_association() {
+        let m = set_mutation(
+            vec!["label_jid", "5", "15551112222@s.whatsapp.net"],
+            wa::SyncActionValue {
+                label_association_action: Some(wa::sync_action_value::LabelAssociationAction {
+                    labeled: Some(true),
+                }),
+                timestamp: Some(1000),
+                ..Default::default()
+            },
+        );
+        let (handled, events) = run(&m);
+        assert!(handled);
+        assert_eq!(events.len(), 1);
+        match &*events[0] {
+            Event::LabelAssociationUpdate(u) => {
+                assert_eq!(u.label_id, "5");
+                assert_eq!(u.chat_jid.to_string(), "15551112222@s.whatsapp.net");
+                assert_eq!(u.action.labeled, Some(true));
+            }
+            other => panic!("expected LabelAssociationUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_label_kind_is_not_claimed() {
+        // A chat-action mutation must fall through so its own handler runs.
+        let m = set_mutation(
+            vec!["mute", "15551112222@s.whatsapp.net"],
+            wa::SyncActionValue::default(),
+        );
+        let (handled, events) = run(&m);
+        assert!(!handled);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn label_jid_with_malformed_chat_is_claimed_but_not_dispatched() {
+        // Claimed (returns true) so it isn't re-tried, but no event is emitted.
+        let m = set_mutation(
+            vec!["label_jid", "5", "not a jid"],
+            wa::SyncActionValue {
+                label_association_action: Some(wa::sync_action_value::LabelAssociationAction {
+                    labeled: Some(true),
+                }),
+                ..Default::default()
+            },
+        );
+        let (handled, events) = run(&m);
+        assert!(handled);
+        assert!(events.is_empty());
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -4,6 +4,7 @@ mod chatstate;
 mod community;
 mod contacts;
 mod groups;
+pub(crate) mod labels;
 mod media_reupload;
 pub mod message_edit;
 mod mex;
@@ -35,6 +36,8 @@ pub use groups::{
     MemberShareHistoryMode, MembershipApprovalMode, MembershipRequest, ParticipantChangeResponse,
     ParticipantType, PictureType,
 };
+
+pub use labels::Labels;
 
 pub use media_reupload::{MediaRetryResult, MediaReupload, MediaReuploadRequest};
 

--- a/src/features/profile.rs
+++ b/src/features/profile.rs
@@ -153,6 +153,8 @@ impl<'a> Profile<'a> {
             &keys,
             &key_id,
             &iv,
+            // setting_pushName is action version 1 (matches whatsmeow).
+            1,
         );
 
         self.client

--- a/src/features/profile.rs
+++ b/src/features/profile.rs
@@ -118,12 +118,10 @@ impl<'a> Profile<'a> {
 
     /// Build and send the `setting_pushName` app state mutation.
     async fn send_push_name_mutation(&self, name: &str) -> Result<()> {
-        use rand::Rng;
-        use wacore::appstate::encode::encode_record;
+        use wacore::appstate::patch_decode::WAPatchName;
         use waproto::whatsapp as wa;
 
         let index = serde_json::to_vec(&["setting_pushName"])?;
-
         let value = wa::SyncActionValue {
             push_name_setting: Some(wa::sync_action_value::PushNameSetting {
                 name: Some(name.to_string()),
@@ -131,37 +129,9 @@ impl<'a> Profile<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-
-        // Get the latest sync key for encryption
-        let proc = self.client.get_app_state_processor().await;
-        let key_id = proc
-            .backend
-            .get_latest_sync_key_id()
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?
-            .ok_or_else(|| anyhow::anyhow!("No app state sync key available"))?;
-        let keys = proc.get_app_state_key(&key_id).await?;
-
-        // Generate random IV
-        let mut iv = [0u8; 16];
-        rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut iv);
-
-        let (mutation, _) = encode_record(
-            wa::syncd_mutation::SyncdOperation::Set,
-            &index,
-            &value,
-            &keys,
-            &key_id,
-            &iv,
-            // setting_pushName is action version 1 (matches whatsmeow).
-            1,
-        );
-
+        // setting_pushName is action version 1 (matches whatsmeow).
         self.client
-            .send_app_state_patch(
-                wacore::appstate::patch_decode::WAPatchName::CriticalBlock.as_str(),
-                vec![mutation],
-            )
+            .send_app_state_mutation(WAPatchName::CriticalBlock, &index, &value, 1)
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use features::{
     CommunitySubgroup, Contacts, CreateCommunityOptions, CreateCommunityResult, CreateGroupResult,
     EncryptedEdit, GroupCreateOptions, GroupDescription, GroupJoinError, GroupMetadata,
     GroupParticipant, GroupParticipantOptions, GroupProfilePicture, GroupSubject, GroupType,
-    Groups, GrowthLockInfo, InviteInfoError, IsOnWhatsAppResult, JoinGroupResult,
+    Groups, GrowthLockInfo, InviteInfoError, IsOnWhatsAppResult, JoinGroupResult, Labels,
     LinkSubgroupsResult, MediaRetryResult, MediaReupload, MediaReuploadRequest, MemberAddMode,
     MemberLinkMode, MemberShareHistoryMode, MembershipApprovalMode, MembershipRequest, Mex,
     MexError, MexErrorExtensions, MexRequest, MexResponse, Newsletter, NewsletterMessage,

--- a/wacore/appstate/src/encode.rs
+++ b/wacore/appstate/src/encode.rs
@@ -19,13 +19,17 @@ pub fn encode_record(
     keys: &ExpandedAppStateKeys,
     key_id: &[u8],
     iv: &[u8; 16],
+    // Per-action schema version, mirroring whatsmeow's per-mutation `Version`.
+    // WA Web stamps each action with its own (e.g. label_edit/label_jid = 3);
+    // callers pass the value for the action they are encoding.
+    version: i32,
 ) -> (wa::SyncdMutation, [u8; 32]) {
     // 1. Build SyncActionData
     let action_data = wa::SyncActionData {
         index: Some(index.to_vec()),
         value: Some(value.clone()),
         padding: Some(vec![]),
-        version: Some(1),
+        version: Some(version),
     };
     let plaintext = action_data.encode_to_vec();
 
@@ -104,6 +108,7 @@ mod tests {
             &keys,
             key_id,
             &iv,
+            1,
         );
 
         // Decode the encoded record

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -231,6 +231,8 @@ pub enum EventKind {
     MarkChatAsReadUpdate,
     DeleteChatUpdate,
     DeleteMessageForMeUpdate,
+    LabelEditUpdate,
+    LabelAssociationUpdate,
     HistorySync,
     OfflineSyncPreview,
     OfflineSyncCompleted,
@@ -600,6 +602,8 @@ pub enum Event {
     MarkChatAsReadUpdate(MarkChatAsReadUpdate),
     DeleteChatUpdate(DeleteChatUpdate),
     DeleteMessageForMeUpdate(DeleteMessageForMeUpdate),
+    LabelEditUpdate(LabelEditUpdate),
+    LabelAssociationUpdate(LabelAssociationUpdate),
 
     HistorySync(Box<LazyHistorySync>),
     OfflineSyncPreview(OfflineSyncPreview),
@@ -685,6 +689,8 @@ impl Event {
             Event::MarkChatAsReadUpdate(_) => EventKind::MarkChatAsReadUpdate,
             Event::DeleteChatUpdate(_) => EventKind::DeleteChatUpdate,
             Event::DeleteMessageForMeUpdate(_) => EventKind::DeleteMessageForMeUpdate,
+            Event::LabelEditUpdate(_) => EventKind::LabelEditUpdate,
+            Event::LabelAssociationUpdate(_) => EventKind::LabelAssociationUpdate,
             Event::HistorySync(_) => EventKind::HistorySync,
             Event::OfflineSyncPreview(_) => EventKind::OfflineSyncPreview,
             Event::OfflineSyncCompleted(_) => EventKind::OfflineSyncCompleted,
@@ -1129,6 +1135,30 @@ pub struct DeleteMessageForMeUpdate {
     pub from_me: bool,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::DeleteMessageForMeAction>,
+    pub from_full_sync: bool,
+}
+
+/// A label was created, renamed/recolored, or deleted on a linked device.
+/// `action.deleted == Some(true)` means the label was removed.
+#[derive(Debug, Clone, Serialize)]
+pub struct LabelEditUpdate {
+    /// The label identifier (the index key, not a JID).
+    pub label_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub action: Box<wa::sync_action_value::LabelEditAction>,
+    pub from_full_sync: bool,
+}
+
+/// A label was associated with or removed from a chat on a linked device.
+/// `action.labeled == Some(true)` means the label was added to the chat.
+#[derive(Debug, Clone, Serialize)]
+pub struct LabelAssociationUpdate {
+    /// The label identifier.
+    pub label_id: String,
+    /// The chat the label was associated with or removed from.
+    pub chat_jid: Jid,
+    pub timestamp: DateTime<Utc>,
+    pub action: Box<wa::sync_action_value::LabelAssociationAction>,
     pub from_full_sync: bool,
 }
 


### PR DESCRIPTION
## Problem

WhatsApp Web supports chat labels (etiquetas) via app state sync, with `LabelEditAction` (create/rename/recolor/delete) and `LabelAssociationAction` (attach/detach a label to a chat). The proto types already exist in the tree, but there was no API in either direction: no way to send label mutations, and inbound label mutations from linked devices were silently dropped (the app-state dispatcher only whitelisted mute/pin/archive/star/contact/markRead/deleteChat/deleteMessageForMe).

## Change

New `src/features/labels.rs`, reached via `client.labels()`:

- `create_label(label_id, name, color)` — create or update (app state is an upsert keyed by id, so this also renames/recolors).
- `delete_label(label_id)`.
- `add_chat_label(label_id, chat_jid)` / `remove_chat_label(label_id, chat_jid)`.

Both actions live in the `regular` collection and are stamped with action version 3. Send shapes match WhatsApp Web and whatsmeow:

- `label_edit`: index `["label_edit", labelId]`, value `LabelEditAction { name, color, deleted }`.
- `label_jid`: index `["label_jid", labelId, chatJid]`, value `LabelAssociationAction { labeled }`.

Inbound: `dispatch_label_mutation` handles `label_edit` / `label_jid` and emits new `LabelEditUpdate` / `LabelAssociationUpdate` events, wired into the app-state dispatcher after the chat-action dispatcher (label indices put the label id, not a chat JID, at index[1]).

The per-mutation `SyncActionValue` encoder was lifted from `ChatActions` to `Client::send_app_state_mutation`, which now takes a per-action schema `version` (threaded into `encode_record`). Labels pass version 3.

## WA Web / whatsmeow parity

- `WAWebLabelSync.getLabelMutation` builds `labelEditAction = { name, deleted, color? }`, index `["label_edit", labelId]`, collection `Regular`, version 3.
- `WAWebLabelJidSync` / whatsmeow `BuildLabelChat` use index `["label_jid", labelId, chatJid]`, `labelAssociationAction.labeled`, version 3.
- whatsmeow `appstate/encode.go` sets these to `Version: 3` (`newLabelEditMutation`, `newLabelChatMutation`); index constants `IndexLabelEdit = "label_edit"`, `IndexLabelAssociationChat = "label_jid"` match exactly.

## Version note (resolved + follow-up)

`encode_record` previously hardcoded `SyncActionData.version = 1` for every action. whatsmeow stamps each action with its own (`mute=2, pin=5, archive=3, markChatAsRead=3, star=2, label=3, setting_pushName=1`), so version 1 was wrong for most actions. This PR threads a per-action `version` and uses 3 for labels. The pre-existing chat actions keep version 1 (unchanged behavior) here; aligning them with whatsmeow's values is tracked as a separate follow-up so this feature PR doesn't change their wire behavior. `setting_pushName` stays 1, which is already correct.

## Events

`LabelEditUpdate { label_id, action, timestamp, from_full_sync }` and `LabelAssociationUpdate { label_id, chat_jid, action, timestamp, from_full_sync }`, plus matching `EventKind` discriminants (48 of the 64-bit interest ceiling).

## Tests

- `label_edit_dispatches_update`, `label_jid_dispatches_association`: inbound mutations emit the right event with the right fields.
- `non_label_kind_is_not_claimed`: a chat-action mutation falls through so its own handler still runs.
- `label_jid_with_malformed_chat_is_claimed_but_not_dispatched`: malformed chat JID is consumed (not retried) but emits nothing.

Full lib suites green; `cargo clippy --all-targets -- -D warnings` clean.

## Scope

Chat-level labels only (`label_jid`), matching current WA Web (`isWid` validation). whatsmeow also has message-level labels (`label_message`); not included here. `order_index` / `predefined_id` (ordering, predefined business labels) are not exposed in this first cut.
