### PR TITLE
refactor(appstate): drive syncd actions from a generated schema registry + public generic action API

### DIFF
--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -9,6 +9,7 @@ use crate::client::Client;
 use anyhow::Result;
 use log::debug;
 use wacore::appstate::patch_decode::WAPatchName;
+use wacore::appstate::schemas::{self, IndexPart, Schema};
 use wacore::types::events::{
     ArchiveUpdate, ContactUpdate, DeleteChatUpdate, DeleteMessageForMeUpdate, Event,
     MarkChatAsReadUpdate, MuteUpdate, PinUpdate, StarUpdate,
@@ -257,31 +258,66 @@ fn parse_message_key_fields(kind: &str, index: &[String]) -> Option<(String, boo
     Some((message_id, from_me, participant_jid))
 }
 
-/// Mirrors WAWebSyncdActionUtils.buildMessageKey.
-fn build_message_key_index(
-    action: &str,
+/// Validate and own only the index args that must outlive the call: the chat JID
+/// and (optional) participant JID. `messageId` and `fromMe` are passed through by
+/// the caller without copying. Mirrors WAWebSyncdActionUtils.buildMessageKey.
+fn message_key_owned(
     chat_jid: &Jid,
     participant_jid: Option<&Jid>,
-    message_id: &str,
     from_me: bool,
-) -> Result<Vec<u8>> {
+) -> Result<(String, Option<String>)> {
     // syncKeyToMsgKey rejects group non-fromMe without valid participant
     if chat_jid.is_group() && !from_me && participant_jid.is_none() {
+        anyhow::bail!("participant_jid is required for group messages not sent by us");
+    }
+    Ok((chat_jid.to_string(), participant_jid.map(|j| j.to_string())))
+}
+
+/// The `"1"`/`"0"` wire string for a `fromMe` flag (no allocation).
+#[inline]
+fn bool_str(b: bool) -> &'static str {
+    if b { "1" } else { "0" }
+}
+
+/// Assemble the JSON-array mutation index for `schema` from its non-literal index
+/// args (in `schema.index_parts` order). The arg count must match.
+pub(crate) fn build_action_index(schema: &Schema, args: &[&str]) -> Result<Vec<u8>> {
+    let non_literal = schema
+        .index_parts
+        .iter()
+        .filter(|p| !matches!(p, IndexPart::Literal { .. }))
+        .count();
+    if args.len() != non_literal {
         anyhow::bail!(
-            "participant_jid is required for group messages not sent by us (action: {action})"
+            "index args for action '{}': expected {non_literal}, got {}",
+            schema.name,
+            args.len()
         );
     }
-    let from_me_str = if from_me { "1" } else { "0" };
-    let participant = participant_jid
-        .map(|j| j.to_string())
-        .unwrap_or_else(|| "0".to_string());
-    Ok(serde_json::to_vec(&[
-        action,
-        &chat_jid.to_string(),
-        message_id,
-        from_me_str,
-        &participant,
-    ])?)
+    let mut parts: Vec<&str> = Vec::with_capacity(schema.index_parts.len());
+    let mut it = args.iter();
+    for part in schema.index_parts {
+        match part {
+            IndexPart::Literal { value } => parts.push(value),
+            _ => parts.push(it.next().expect("arg count checked above")),
+        }
+    }
+    Ok(serde_json::to_vec(&parts)?)
+}
+
+/// Map a generated `Collection` to our `WAPatchName`.
+pub(crate) fn collection_patch_name(c: schemas::Collection) -> Result<WAPatchName> {
+    use schemas::Collection;
+    Ok(match c {
+        Collection::Regular => WAPatchName::Regular,
+        Collection::RegularLow => WAPatchName::RegularLow,
+        Collection::RegularHigh => WAPatchName::RegularHigh,
+        Collection::CriticalBlock => WAPatchName::CriticalBlock,
+        // No action we send lives here (block/unblock go through the blocklist IQ).
+        Collection::CriticalUnblockLow => {
+            anyhow::bail!("critical_unblock_low collection is not supported for sending")
+        }
+    })
 }
 
 /// Access via `client.chat_actions()`.
@@ -386,7 +422,6 @@ impl<'a> ChatActions<'a> {
             "Marking chat {jid} as {}",
             if read { "read" } else { "unread" }
         );
-        let index = serde_json::to_vec(&["markChatAsRead", &jid.to_string()])?;
         let value = wa::SyncActionValue {
             mark_chat_as_read_action: Some(wa::sync_action_value::MarkChatAsReadAction {
                 read: Some(read),
@@ -395,7 +430,9 @@ impl<'a> ChatActions<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularLow, &index, &value)
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(&schemas::MARK_CHAT_AS_READ, &[jid.as_str()], &value)
             .await
     }
 
@@ -407,13 +444,18 @@ impl<'a> ChatActions<'a> {
     ) -> Result<()> {
         debug!("Deleting chat {jid}");
         let delete_media_str = if delete_media { "1" } else { "0" };
-        let index = serde_json::to_vec(&["deleteChat", &jid.to_string(), delete_media_str])?;
         let value = wa::SyncActionValue {
             delete_chat_action: Some(wa::sync_action_value::DeleteChatAction { message_range }),
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularHigh, &index, &value)
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(
+                &schemas::DELETE_CHAT,
+                &[jid.as_str(), delete_media_str],
+                &value,
+            )
             .await
     }
 
@@ -429,13 +471,7 @@ impl<'a> ChatActions<'a> {
         message_timestamp: Option<i64>,
     ) -> Result<()> {
         debug!("Deleting message {message_id} for me in {chat_jid}");
-        let index = build_message_key_index(
-            "deleteMessageForMe",
-            chat_jid,
-            participant_jid,
-            message_id,
-            from_me,
-        )?;
+        let (chat, participant) = message_key_owned(chat_jid, participant_jid, from_me)?;
         let value = wa::SyncActionValue {
             delete_message_for_me_action: Some(wa::sync_action_value::DeleteMessageForMeAction {
                 delete_media: Some(delete_media),
@@ -444,7 +480,17 @@ impl<'a> ChatActions<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularHigh, &index, &value)
+        self.client
+            .send_app_state_action(
+                &schemas::DELETE_MESSAGE_FOR_ME,
+                &[
+                    chat.as_str(),
+                    message_id,
+                    bool_str(from_me),
+                    participant.as_deref().unwrap_or("0"),
+                ],
+                &value,
+            )
             .await
     }
 
@@ -454,7 +500,6 @@ impl<'a> ChatActions<'a> {
         archived: bool,
         message_range: Option<SyncActionMessageRange>,
     ) -> Result<()> {
-        let index = serde_json::to_vec(&["archive", &jid.to_string()])?;
         let value = wa::SyncActionValue {
             archive_chat_action: Some(wa::sync_action_value::ArchiveChatAction {
                 archived: Some(archived),
@@ -463,12 +508,13 @@ impl<'a> ChatActions<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularLow, &index, &value)
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(&schemas::ARCHIVE, &[jid.as_str()], &value)
             .await
     }
 
     async fn send_pin_mutation(&self, jid: &Jid, pinned: bool) -> Result<()> {
-        let index = serde_json::to_vec(&["pin_v1", &jid.to_string()])?;
         let value = wa::SyncActionValue {
             pin_action: Some(wa::sync_action_value::PinAction {
                 pinned: Some(pinned),
@@ -476,7 +522,9 @@ impl<'a> ChatActions<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularLow, &index, &value)
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(&schemas::PIN, &[jid.as_str()], &value)
             .await
     }
 
@@ -486,7 +534,6 @@ impl<'a> ChatActions<'a> {
         muted: bool,
         mute_end_timestamp_ms: i64,
     ) -> Result<()> {
-        let index = serde_json::to_vec(&["mute", &jid.to_string()])?;
         // -1 = indefinite, 0 = unmuted, positive = expiry ms
         let mute_end = if muted {
             Some(mute_end_timestamp_ms)
@@ -502,7 +549,9 @@ impl<'a> ChatActions<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularHigh, &index, &value)
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(&schemas::MUTE, &[jid.as_str()], &value)
             .await
     }
 
@@ -514,8 +563,7 @@ impl<'a> ChatActions<'a> {
         from_me: bool,
         starred: bool,
     ) -> Result<()> {
-        let index =
-            build_message_key_index("star", chat_jid, participant_jid, message_id, from_me)?;
+        let (chat, participant) = message_key_owned(chat_jid, participant_jid, from_me)?;
         let value = wa::SyncActionValue {
             star_action: Some(wa::sync_action_value::StarAction {
                 starred: Some(starred),
@@ -523,21 +571,17 @@ impl<'a> ChatActions<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        self.send_mutation(WAPatchName::RegularHigh, &index, &value)
-            .await
-    }
-
-    async fn send_mutation(
-        &self,
-        collection: WAPatchName,
-        index: &[u8],
-        value: &wa::SyncActionValue,
-    ) -> Result<()> {
-        // Chat actions still emit action version 1 (their pre-existing behavior).
-        // whatsmeow uses per-action versions (mute=2, pin=5, archive=3, ...);
-        // aligning these is tracked as a follow-up.
         self.client
-            .send_app_state_mutation(collection, index, value, 1)
+            .send_app_state_action(
+                &schemas::STAR,
+                &[
+                    chat.as_str(),
+                    message_id,
+                    bool_str(from_me),
+                    participant.as_deref().unwrap_or("0"),
+                ],
+                &value,
+            )
             .await
     }
 }
@@ -584,5 +628,137 @@ impl Client {
 
         self.send_app_state_patch(collection.as_str(), vec![mutation])
             .await
+    }
+
+    /// Send any app-state (syncd) `Set` action, driven by a generated
+    /// [`Schema`](wacore::appstate::schemas::Schema) from
+    /// [`wacore::appstate::schemas`]. The collection, action version, and index
+    /// shape come from the registry; the caller only fills the typed
+    /// [`SyncActionValue`](wa::SyncActionValue) (its action sub-field, plus a
+    /// `timestamp`) and supplies the non-literal index args in `index_parts`
+    /// order. This is the generic escape hatch for actions without a dedicated
+    /// helper (e.g. `clear_chat`, `favorites`, `quick_reply`); the typed APIs
+    /// like [`ChatActions`] and [`Labels`](crate::Labels) wrap it.
+    ///
+    /// ```no_run
+    /// # async fn ex(client: &whatsapp_rust::Client) -> anyhow::Result<()> {
+    /// use whatsapp_rust::schemas;
+    /// use whatsapp_rust::waproto::whatsapp as wa;
+    /// let value = wa::SyncActionValue {
+    ///     clear_chat_action: Some(Default::default()),
+    ///     timestamp: Some(1_700_000_000_000), // a real epoch-ms timestamp
+    ///     ..Default::default()
+    /// };
+    /// client
+    ///     .send_app_state_action(&schemas::CLEAR_CHAT, &["123@s.whatsapp.net"], &value)
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn send_app_state_action(
+        &self,
+        schema: &Schema,
+        index_args: &[&str],
+        value: &wa::SyncActionValue,
+    ) -> Result<()> {
+        let index = build_action_index(schema, index_args)?;
+        let collection = collection_patch_name(schema.collection)?;
+        self.send_app_state_mutation(collection, &index, value, schema.version as i32)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    #[test]
+    fn build_index_matches_legacy_shapes() {
+        let cases: &[(&Schema, &[&str], &[&str])] = &[
+            (
+                &schemas::ARCHIVE,
+                &["123@s.whatsapp.net"],
+                &["archive", "123@s.whatsapp.net"],
+            ),
+            (
+                &schemas::PIN,
+                &["123@s.whatsapp.net"],
+                &["pin_v1", "123@s.whatsapp.net"],
+            ),
+            (
+                &schemas::MUTE,
+                &["123@s.whatsapp.net"],
+                &["mute", "123@s.whatsapp.net"],
+            ),
+            (
+                &schemas::MARK_CHAT_AS_READ,
+                &["123@s.whatsapp.net"],
+                &["markChatAsRead", "123@s.whatsapp.net"],
+            ),
+            (
+                &schemas::DELETE_CHAT,
+                &["123@s.whatsapp.net", "1"],
+                &["deleteChat", "123@s.whatsapp.net", "1"],
+            ),
+            (&schemas::LABEL_EDIT, &["5"], &["label_edit", "5"]),
+            (
+                &schemas::LABEL_JID,
+                &["5", "123@s.whatsapp.net"],
+                &["label_jid", "5", "123@s.whatsapp.net"],
+            ),
+            (
+                &schemas::STAR,
+                &["123@g.us", "MSGID", "1", "0"],
+                &["star", "123@g.us", "MSGID", "1", "0"],
+            ),
+            (&schemas::SETTING_PUSH_NAME, &[], &["setting_pushName"]),
+        ];
+        for (schema, args, expected) in cases {
+            assert_eq!(
+                build_action_index(schema, args).unwrap(),
+                serde_json::to_vec(expected).unwrap(),
+                "index mismatch for {}",
+                schema.name
+            );
+        }
+    }
+
+    #[test]
+    fn build_index_rejects_arg_count_mismatch() {
+        assert!(build_action_index(&schemas::ARCHIVE, &[]).is_err());
+        assert!(build_action_index(&schemas::ARCHIVE, &["a", "b"]).is_err());
+        assert!(build_action_index(&schemas::SETTING_PUSH_NAME, &["x"]).is_err());
+    }
+
+    #[test]
+    fn registry_versions_match_whatsmeow() {
+        // Locks the per-action versions the migration relies on (vs whatsmeow);
+        // a regenerated registry that changes one will trip this for review.
+        assert_eq!(schemas::MUTE.version, 2);
+        assert_eq!(schemas::PIN.version, 5);
+        assert_eq!(schemas::ARCHIVE.version, 3);
+        assert_eq!(schemas::MARK_CHAT_AS_READ.version, 3);
+        assert_eq!(schemas::STAR.version, 2);
+        assert_eq!(schemas::DELETE_MESSAGE_FOR_ME.version, 3);
+        assert_eq!(schemas::LABEL_EDIT.version, 3);
+        assert_eq!(schemas::LABEL_JID.version, 3);
+        assert_eq!(schemas::SETTING_PUSH_NAME.version, 1);
+    }
+
+    #[test]
+    fn collection_mapping() {
+        use schemas::Collection;
+        assert_eq!(
+            collection_patch_name(Collection::Regular).unwrap(),
+            WAPatchName::Regular
+        );
+        assert_eq!(
+            collection_patch_name(Collection::RegularHigh).unwrap(),
+            WAPatchName::RegularHigh
+        );
+        assert_eq!(
+            collection_patch_name(Collection::CriticalBlock).unwrap(),
+            WAPatchName::CriticalBlock
+        );
+        assert!(collection_patch_name(Collection::CriticalUnblockLow).is_err());
     }
 }

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -305,19 +305,17 @@ pub(crate) fn build_action_index(schema: &Schema, args: &[&str]) -> Result<Vec<u
     Ok(serde_json::to_vec(&parts)?)
 }
 
-/// Map a generated `Collection` to our `WAPatchName`.
-pub(crate) fn collection_patch_name(c: schemas::Collection) -> Result<WAPatchName> {
+/// Map a generated `Collection` to our `WAPatchName` (total — every generated
+/// collection has a `WAPatchName` counterpart).
+pub(crate) fn collection_patch_name(c: schemas::Collection) -> WAPatchName {
     use schemas::Collection;
-    Ok(match c {
+    match c {
         Collection::Regular => WAPatchName::Regular,
         Collection::RegularLow => WAPatchName::RegularLow,
         Collection::RegularHigh => WAPatchName::RegularHigh,
         Collection::CriticalBlock => WAPatchName::CriticalBlock,
-        // No action we send lives here (block/unblock go through the blocklist IQ).
-        Collection::CriticalUnblockLow => {
-            anyhow::bail!("critical_unblock_low collection is not supported for sending")
-        }
-    })
+        Collection::CriticalUnblockLow => WAPatchName::CriticalUnblockLow,
+    }
 }
 
 /// Access via `client.chat_actions()`.
@@ -649,8 +647,14 @@ impl Client {
     ///     timestamp: Some(1_700_000_000_000), // a real epoch-ms timestamp
     ///     ..Default::default()
     /// };
+    /// // Args are the non-literal index parts in `schema.index_parts` order;
+    /// // CLEAR_CHAT is [chatJid, deleteStarred, deleteMedia].
     /// client
-    ///     .send_app_state_action(&schemas::CLEAR_CHAT, &["123@s.whatsapp.net"], &value)
+    ///     .send_app_state_action(
+    ///         &schemas::CLEAR_CHAT,
+    ///         &["123@s.whatsapp.net", "0", "0"],
+    ///         &value,
+    ///     )
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -661,7 +665,7 @@ impl Client {
         value: &wa::SyncActionValue,
     ) -> Result<()> {
         let index = build_action_index(schema, index_args)?;
-        let collection = collection_patch_name(schema.collection)?;
+        let collection = collection_patch_name(schema.collection);
         self.send_app_state_mutation(collection, &index, value, schema.version as i32)
             .await
     }
@@ -747,18 +751,16 @@ mod registry_tests {
     #[test]
     fn collection_mapping() {
         use schemas::Collection;
-        assert_eq!(
-            collection_patch_name(Collection::Regular).unwrap(),
-            WAPatchName::Regular
-        );
-        assert_eq!(
-            collection_patch_name(Collection::RegularHigh).unwrap(),
-            WAPatchName::RegularHigh
-        );
-        assert_eq!(
-            collection_patch_name(Collection::CriticalBlock).unwrap(),
-            WAPatchName::CriticalBlock
-        );
-        assert!(collection_patch_name(Collection::CriticalUnblockLow).is_err());
+        // Every generated collection has a WAPatchName counterpart (total map).
+        for c in [
+            Collection::Regular,
+            Collection::RegularLow,
+            Collection::RegularHigh,
+            Collection::CriticalBlock,
+            Collection::CriticalUnblockLow,
+        ] {
+            // Round-trips through the wire name.
+            assert_eq!(collection_patch_name(c).as_str(), c.as_str());
+        }
     }
 }

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -5,19 +5,17 @@
 //! - `label_edit`  (index `["label_edit", labelId]`)        -> `LabelEditAction`
 //! - `label_jid`   (index `["label_jid", labelId, chatJid]`) -> `LabelAssociationAction`
 //!
-//! Both are stamped with action version 3, matching WhatsApp Web and whatsmeow.
+//! Collection, action version, and index shape all come from the generated
+//! `schemas::{LABEL_EDIT, LABEL_JID}` registry.
 
 use crate::appstate_sync::Mutation;
 use crate::client::Client;
 use anyhow::Result;
 use log::debug;
-use wacore::appstate::patch_decode::WAPatchName;
+use wacore::appstate::schemas;
 use wacore::types::events::{Event, LabelAssociationUpdate, LabelEditUpdate};
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
-
-/// Action schema version for both label actions (matches WA Web / whatsmeow).
-const LABEL_ACTION_VERSION: i32 = 3;
 
 /// Dispatch inbound label mutations synced from a linked device.
 /// Returns `true` if handled, `false` if the mutation is not a label kind.
@@ -117,7 +115,6 @@ impl<'a> Labels<'a> {
             "Setting label {label_id} (name_len={}, color={color})",
             name.len()
         );
-        let index = serde_json::to_vec(&["label_edit", label_id])?;
         let value = wa::SyncActionValue {
             label_edit_action: Some(wa::sync_action_value::LabelEditAction {
                 name: Some(name.to_string()),
@@ -129,7 +126,7 @@ impl<'a> Labels<'a> {
             ..Default::default()
         };
         self.client
-            .send_app_state_mutation(WAPatchName::Regular, &index, &value, LABEL_ACTION_VERSION)
+            .send_app_state_action(&schemas::LABEL_EDIT, &[label_id], &value)
             .await
     }
 
@@ -140,7 +137,6 @@ impl<'a> Labels<'a> {
             anyhow::bail!("label_id cannot be empty");
         }
         debug!("Deleting label {label_id}");
-        let index = serde_json::to_vec(&["label_edit", label_id])?;
         let value = wa::SyncActionValue {
             label_edit_action: Some(wa::sync_action_value::LabelEditAction {
                 deleted: Some(true),
@@ -150,7 +146,7 @@ impl<'a> Labels<'a> {
             ..Default::default()
         };
         self.client
-            .send_app_state_mutation(WAPatchName::Regular, &index, &value, LABEL_ACTION_VERSION)
+            .send_app_state_action(&schemas::LABEL_EDIT, &[label_id], &value)
             .await
     }
 
@@ -174,7 +170,6 @@ impl<'a> Labels<'a> {
             if labeled { "to" } else { "from" },
         );
         let chat = chat_jid.to_string();
-        let index = serde_json::to_vec(&["label_jid", label_id, chat.as_str()])?;
         let value = wa::SyncActionValue {
             label_association_action: Some(wa::sync_action_value::LabelAssociationAction {
                 labeled: Some(labeled),
@@ -183,7 +178,7 @@ impl<'a> Labels<'a> {
             ..Default::default()
         };
         self.client
-            .send_app_state_mutation(WAPatchName::Regular, &index, &value, LABEL_ACTION_VERSION)
+            .send_app_state_action(&schemas::LABEL_JID, &[label_id, chat.as_str()], &value)
             .await
     }
 }

--- a/src/features/profile.rs
+++ b/src/features/profile.rs
@@ -118,10 +118,9 @@ impl<'a> Profile<'a> {
 
     /// Build and send the `setting_pushName` app state mutation.
     async fn send_push_name_mutation(&self, name: &str) -> Result<()> {
-        use wacore::appstate::patch_decode::WAPatchName;
+        use wacore::appstate::schemas;
         use waproto::whatsapp as wa;
 
-        let index = serde_json::to_vec(&["setting_pushName"])?;
         let value = wa::SyncActionValue {
             push_name_setting: Some(wa::sync_action_value::PushNameSetting {
                 name: Some(name.to_string()),
@@ -129,9 +128,9 @@ impl<'a> Profile<'a> {
             timestamp: Some(wacore::time::now_millis()),
             ..Default::default()
         };
-        // setting_pushName is action version 1 (matches whatsmeow).
+        // setting_pushName's index has no args (collection/version come from the schema).
         self.client
-            .send_app_state_mutation(WAPatchName::CriticalBlock, &index, &value, 1)
+            .send_app_state_action(&schemas::SETTING_PUSH_NAME, &[], &value)
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub use wacore::appstate::schemas;
 pub use wacore::client_profile::ClientProfile;
 pub use wacore::{
     iq::privacy as privacy_settings, proto_helpers, sticker_pack, store::traits, webp,

--- a/wacore/appstate/src/lib.rs
+++ b/wacore/appstate/src/lib.rs
@@ -7,6 +7,7 @@ pub mod keys;
 pub mod lthash;
 pub mod patch_decode;
 pub mod processor;
+pub mod schemas;
 
 pub use decode::{Mutation, collect_key_ids_from_patch_list, decode_record};
 pub use encode::encode_record;

--- a/wacore/appstate/src/schemas.rs
+++ b/wacore/appstate/src/schemas.rs
@@ -1,0 +1,1439 @@
+//! Auto-generated AppState (syncd) action schemas (WhatsApp 2.3000.1040832931). DO NOT EDIT.
+//!
+//! Typed registry of syncd actions: collection, version, scope, value proto type,
+//! enum fields, and the mutation-index parts. `const`/`&'static`, no deps.
+
+#![allow(clippy::all)]
+
+/// A syncd collection (mutation bucket / priority).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Collection {
+    Regular,
+    RegularLow,
+    RegularHigh,
+    CriticalBlock,
+    CriticalUnblockLow,
+}
+
+impl Collection {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Collection::Regular => "regular",
+            Collection::RegularLow => "regular_low",
+            Collection::RegularHigh => "regular_high",
+            Collection::CriticalBlock => "critical_block",
+            Collection::CriticalUnblockLow => "critical_unblock_low",
+        }
+    }
+}
+
+/// The index scope an action applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    Account,
+    Chat,
+    ChatMessageRange,
+    ChatOrContact,
+    Message,
+}
+
+impl Scope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Scope::Account => "account",
+            Scope::Chat => "chat",
+            Scope::ChatMessageRange => "chatMessageRange",
+            Scope::ChatOrContact => "chatOrContact",
+            Scope::Message => "message",
+        }
+    }
+}
+
+/// One component of a mutation index key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexPart {
+    /// Fixed wire name at position 0.
+    Literal { value: &'static str },
+    /// A WhatsApp JID (legacy-encoded).
+    Jid { name: &'static str },
+    /// '0' or '1' bool encoding.
+    BoolString { name: &'static str },
+    /// Participant slot: a JID, or '0' when fromMe/null.
+    JidOrZero { name: &'static str },
+    /// Stringified protobuf-enum integer; `proto_enum` is the dotted enum path.
+    Enum {
+        name: &'static str,
+        proto_enum: &'static str,
+    },
+    /// Opaque identifier (msg/label/agent id, etc.).
+    StringPart { name: &'static str },
+    /// Unrecognized slot.
+    Unknown { name: &'static str },
+}
+
+/// A syncd action schema.
+#[derive(Debug, Clone, Copy)]
+pub struct Schema {
+    /// Registry key (e.g. "Agent").
+    pub key: &'static str,
+    /// On-wire action name (e.g. "deviceAgent").
+    pub name: &'static str,
+    /// Source WA Web module.
+    pub module: &'static str,
+    pub collection: Collection,
+    pub version: u32,
+    pub scope: Scope,
+    /// Field on `SyncActionValue` carrying the payload.
+    pub value_field: Option<&'static str>,
+    /// Dotted protobuf type of the value (in `waproto`).
+    pub value_proto_type: Option<&'static str>,
+    /// `(field, dotted enum path)` for enum-typed value fields.
+    pub value_enum_fields: &'static [(&'static str, &'static str)],
+    /// Index position holding the chat JID, if any.
+    pub chat_jid_index: Option<i64>,
+    pub index_parts: &'static [IndexPart],
+}
+
+/// All syncd collections, in dependency order.
+pub const COLLECTIONS: &[Collection] = &[
+    Collection::Regular,
+    Collection::RegularLow,
+    Collection::RegularHigh,
+    Collection::CriticalBlock,
+    Collection::CriticalUnblockLow,
+];
+
+/// `AdsCtwaPerCustomerDataSharing` — module `WAWebCtwaPerCustomerDataSharingSync`.
+pub const ADS_CTWA_PER_CUSTOMER_DATA_SHARING: Schema = Schema {
+    key: "AdsCtwaPerCustomerDataSharing",
+    name: "ctwaPerCustomerDataSharing",
+    module: "WAWebCtwaPerCustomerDataSharingSync",
+    collection: Collection::RegularHigh,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("ctwaPerCustomerDataSharingAction"),
+    value_proto_type: Some("SyncActionValue.CtwaPerCustomerDataSharingAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "ctwaPerCustomerDataSharing",
+        },
+        IndexPart::StringPart { name: "accountLid" },
+    ],
+};
+
+/// `Agent` — module `WAWebAgentSync`.
+pub const AGENT: Schema = Schema {
+    key: "Agent",
+    name: "deviceAgent",
+    module: "WAWebAgentSync",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("agentAction"),
+    value_proto_type: Some("SyncActionValue.AgentAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "deviceAgent",
+        },
+        IndexPart::StringPart { name: "agentId" },
+    ],
+};
+
+/// `AiThreadDelete` — module `WAWebAiThreadDeleteSync`.
+pub const AI_THREAD_DELETE: Schema = Schema {
+    key: "AiThreadDelete",
+    name: "ai_thread_delete",
+    module: "WAWebAiThreadDeleteSync",
+    collection: Collection::RegularHigh,
+    version: 7,
+    scope: Scope::Chat,
+    value_field: None,
+    value_proto_type: None,
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "ai_thread_delete",
+        },
+        IndexPart::Jid { name: "chatJid" },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `AiThreadPin` — module `WAWebAiThreadPinSync`.
+pub const AI_THREAD_PIN: Schema = Schema {
+    key: "AiThreadPin",
+    name: "thread_pin",
+    module: "WAWebAiThreadPinSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Chat,
+    value_field: Some("threadPinAction"),
+    value_proto_type: Some("SyncActionValue.ThreadPinAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "thread_pin",
+        },
+        IndexPart::Jid { name: "chatJid" },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `AiThreadRename` — module `WAWebAiThreadRenameSync`.
+pub const AI_THREAD_RENAME: Schema = Schema {
+    key: "AiThreadRename",
+    name: "ai_thread_rename",
+    module: "WAWebAiThreadRenameSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Chat,
+    value_field: Some("aiThreadRenameAction"),
+    value_proto_type: Some("SyncActionValue.AiThreadRenameAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "ai_thread_rename",
+        },
+        IndexPart::Jid { name: "chatJid" },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `AndroidUnsupportedActions` — module `WAWebAndroidUnsupportedActionsSync`.
+pub const ANDROID_UNSUPPORTED_ACTIONS: Schema = Schema {
+    key: "AndroidUnsupportedActions",
+    name: "android_unsupported_actions",
+    module: "WAWebAndroidUnsupportedActionsSync",
+    collection: Collection::RegularLow,
+    version: 4,
+    scope: Scope::Account,
+    value_field: Some("androidUnsupportedActions"),
+    value_proto_type: Some("SyncActionValue.AndroidUnsupportedActions"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "android_unsupported_actions",
+    }],
+};
+
+/// `Archive` — module `WAWebArchiveChatSync`.
+pub const ARCHIVE: Schema = Schema {
+    key: "Archive",
+    name: "archive",
+    module: "WAWebArchiveChatSync",
+    collection: Collection::RegularLow,
+    version: 3,
+    scope: Scope::ChatMessageRange,
+    value_field: Some("archiveChatAction"),
+    value_proto_type: Some("SyncActionValue.ArchiveChatAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal { value: "archive" },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `AvatarUpdated` — module `WAWebStickersAvatarUpdatedSyncAction`.
+pub const AVATAR_UPDATED: Schema = Schema {
+    key: "AvatarUpdated",
+    name: "avatar_updated_action",
+    module: "WAWebStickersAvatarUpdatedSyncAction",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("avatarUpdatedAction"),
+    value_proto_type: Some("SyncActionValue.AvatarUpdatedAction"),
+    value_enum_fields: &[("eventType", "AvatarUpdatedAction.AvatarEventType")],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "avatar_updated_action",
+    }],
+};
+
+/// `BizAiSettingsNudge` — module `WAWebBizAiSettingsNudgeSync`.
+pub const BIZ_AI_SETTINGS_NUDGE: Schema = Schema {
+    key: "BizAiSettingsNudge",
+    name: "biz_ai_settings_nudge",
+    module: "WAWebBizAiSettingsNudgeSync",
+    collection: Collection::RegularHigh,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("bizAiSettingsNudgeAction"),
+    value_proto_type: Some("SyncActionValue.BizAISettingsNudgeAction"),
+    value_enum_fields: &[("category", "BizAISettingsNudgeAction.BizAISettingsCategory")],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "biz_ai_settings_nudge",
+    }],
+};
+
+/// `BotWelcomeRequest` — module `WAWebBotWelcomeRequestSync`.
+pub const BOT_WELCOME_REQUEST: Schema = Schema {
+    key: "BotWelcomeRequest",
+    name: "bot_welcome_request",
+    module: "WAWebBotWelcomeRequestSync",
+    collection: Collection::RegularLow,
+    version: 2,
+    scope: Scope::Chat,
+    value_field: Some("botWelcomeRequestAction"),
+    value_proto_type: Some("SyncActionValue.BotWelcomeRequestAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "bot_welcome_request",
+        },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `BusinessBroadcastCampaign` — module `WAWebBroadcastCampaignSync`.
+pub const BUSINESS_BROADCAST_CAMPAIGN: Schema = Schema {
+    key: "BusinessBroadcastCampaign",
+    name: "business_broadcast_campaign",
+    module: "WAWebBroadcastCampaignSync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("businessBroadcastCampaignAction"),
+    value_proto_type: Some("SyncActionValue.BusinessBroadcastCampaignAction"),
+    value_enum_fields: &[("status", "BusinessBroadcastCampaignStatus")],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "business_broadcast_campaign",
+        },
+        IndexPart::StringPart { name: "campaign" },
+    ],
+};
+
+/// `BusinessBroadcastInsights` — module `WAWebBusinessBroadcastInsightsSync`.
+pub const BUSINESS_BROADCAST_INSIGHTS: Schema = Schema {
+    key: "BusinessBroadcastInsights",
+    name: "business_broadcast_insights_sync",
+    module: "WAWebBusinessBroadcastInsightsSync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("businessBroadcastInsightsAction"),
+    value_proto_type: Some("SyncActionValue.BusinessBroadcastInsightsAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "business_broadcast_insights_sync",
+        },
+        IndexPart::StringPart { name: "campaignId" },
+    ],
+};
+
+/// `BusinessBroadcastList` — module `WAWebBroadcastListSync`.
+pub const BUSINESS_BROADCAST_LIST: Schema = Schema {
+    key: "BusinessBroadcastList",
+    name: "business_broadcast_list",
+    module: "WAWebBroadcastListSync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("businessBroadcastListAction"),
+    value_proto_type: Some("SyncActionValue.BusinessBroadcastListAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "business_broadcast_list",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `CallLog` — module `WAWebCallLogSync`.
+pub const CALL_LOG: Schema = Schema {
+    key: "CallLog",
+    name: "call_log",
+    module: "WAWebCallLogSync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("callLogAction"),
+    value_proto_type: Some("SyncActionValue.CallLogAction"),
+    value_enum_fields: &[
+        ("callLogRecord.callResult", "CallLogRecord.CallResult"),
+        ("callLogRecord.callType", "CallLogRecord.CallType"),
+        (
+            "callLogRecord.participants.callResult",
+            "CallLogRecord.CallResult",
+        ),
+        ("callLogRecord.silenceReason", "CallLogRecord.SilenceReason"),
+    ],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal { value: "call_log" }],
+};
+
+/// `ChatAssignment` — module `WAWebChatAssignmentSync`.
+pub const CHAT_ASSIGNMENT: Schema = Schema {
+    key: "ChatAssignment",
+    name: "agentChatAssignment",
+    module: "WAWebChatAssignmentSync",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Chat,
+    value_field: Some("chatAssignment"),
+    value_proto_type: Some("SyncActionValue.ChatAssignmentAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "agentChatAssignment",
+        },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `ChatAssignmentOpenedStatus` — module `WAWebChatAssignmentOpenedStatusSync`.
+pub const CHAT_ASSIGNMENT_OPENED_STATUS: Schema = Schema {
+    key: "ChatAssignmentOpenedStatus",
+    name: "agentChatAssignmentOpenedStatus",
+    module: "WAWebChatAssignmentOpenedStatusSync",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Chat,
+    value_field: Some("chatAssignmentOpenedStatus"),
+    value_proto_type: Some("SyncActionValue.ChatAssignmentOpenedStatusAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "agentChatAssignmentOpenedStatus",
+        },
+        IndexPart::Jid { name: "chatJid" },
+        IndexPart::StringPart { name: "agentId" },
+    ],
+};
+
+/// `ChatLockSettings` — module `WAWebChatLockSettingsSync`.
+pub const CHAT_LOCK_SETTINGS: Schema = Schema {
+    key: "ChatLockSettings",
+    name: "setting_chatLock",
+    module: "WAWebChatLockSettingsSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("chatLockSettings"),
+    value_proto_type: Some("ChatLockSettings"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "setting_chatLock",
+    }],
+};
+
+/// `ClearChat` — module `WAWebClearChatSync`.
+pub const CLEAR_CHAT: Schema = Schema {
+    key: "ClearChat",
+    name: "clearChat",
+    module: "WAWebClearChatSync",
+    collection: Collection::RegularHigh,
+    version: 6,
+    scope: Scope::ChatMessageRange,
+    value_field: Some("clearChatAction"),
+    value_proto_type: Some("SyncActionValue.ClearChatAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal { value: "clearChat" },
+        IndexPart::Jid { name: "chatJid" },
+        IndexPart::StringPart {
+            name: "deleteStarred",
+        },
+        IndexPart::StringPart {
+            name: "deleteMedia",
+        },
+    ],
+};
+
+/// `Contact` — module `WAWebContactSync`.
+pub const CONTACT: Schema = Schema {
+    key: "Contact",
+    name: "contact",
+    module: "WAWebContactSync",
+    collection: Collection::CriticalUnblockLow,
+    version: 2,
+    scope: Scope::Account,
+    value_field: Some("contactAction"),
+    value_proto_type: Some("SyncActionValue.ContactAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal { value: "contact" },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `CustomPaymentMethods` — module `WAWebCustomPaymentMethodsSync`.
+pub const CUSTOM_PAYMENT_METHODS: Schema = Schema {
+    key: "CustomPaymentMethods",
+    name: "custom_payment_methods",
+    module: "WAWebCustomPaymentMethodsSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("customPaymentMethodsAction"),
+    value_proto_type: Some("SyncActionValue.CustomPaymentMethodsAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "custom_payment_methods",
+    }],
+};
+
+/// `CustomerData` — module `WAWebCustomerDataSync`.
+pub const CUSTOMER_DATA: Schema = Schema {
+    key: "CustomerData",
+    name: "customer_data",
+    module: "WAWebCustomerDataSync",
+    collection: Collection::RegularLow,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("customerDataAction"),
+    value_proto_type: Some("SyncActionValue.CustomerDataAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "customer_data",
+        },
+        IndexPart::StringPart { name: "chatJid" },
+    ],
+};
+
+/// `DeleteChat` — module `WAWebDeleteChatSync`.
+pub const DELETE_CHAT: Schema = Schema {
+    key: "DeleteChat",
+    name: "deleteChat",
+    module: "WAWebDeleteChatSync",
+    collection: Collection::RegularHigh,
+    version: 6,
+    scope: Scope::ChatMessageRange,
+    value_field: Some("deleteChatAction"),
+    value_proto_type: Some("SyncActionValue.DeleteChatAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "deleteChat",
+        },
+        IndexPart::Jid { name: "chatJid" },
+        IndexPart::StringPart {
+            name: "deleteMedia",
+        },
+    ],
+};
+
+/// `DeleteMessageForMe` — module `WAWebDeleteMessageForMeSync`.
+pub const DELETE_MESSAGE_FOR_ME: Schema = Schema {
+    key: "DeleteMessageForMe",
+    name: "deleteMessageForMe",
+    module: "WAWebDeleteMessageForMeSync",
+    collection: Collection::RegularHigh,
+    version: 3,
+    scope: Scope::Message,
+    value_field: Some("deleteMessageForMeAction"),
+    value_proto_type: Some("SyncActionValue.DeleteMessageForMeAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "deleteMessageForMe",
+        },
+        IndexPart::Jid { name: "remote" },
+        IndexPart::StringPart { name: "id" },
+        IndexPart::BoolString { name: "fromMe" },
+        IndexPart::JidOrZero {
+            name: "participant",
+        },
+    ],
+};
+
+/// `DetectedOutcomeStatus` — module `WAWebDetectedOutcomesStatusSync`.
+pub const DETECTED_OUTCOME_STATUS: Schema = Schema {
+    key: "DetectedOutcomeStatus",
+    name: "detected_outcomes_status_action",
+    module: "WAWebDetectedOutcomesStatusSync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("detectedOutcomesStatusAction"),
+    value_proto_type: Some("SyncActionValue.DetectedOutcomesStatusAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "detected_outcomes_status_action",
+    }],
+};
+
+/// `DeviceCapabilities` — module `WAWebDeviceCapabilitiesSync`.
+pub const DEVICE_CAPABILITIES: Schema = Schema {
+    key: "DeviceCapabilities",
+    name: "device_capabilities",
+    module: "WAWebDeviceCapabilitiesSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("deviceCapabilities"),
+    value_proto_type: Some("DeviceCapabilities"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "device_capabilities",
+    }],
+};
+
+/// `DisableLinkPreviews` — module `WAWebDisableLinkPreviewsSync`.
+pub const DISABLE_LINK_PREVIEWS: Schema = Schema {
+    key: "DisableLinkPreviews",
+    name: "setting_disableLinkPreviews",
+    module: "WAWebDisableLinkPreviewsSync",
+    collection: Collection::Regular,
+    version: 8,
+    scope: Scope::Account,
+    value_field: Some("privacySettingDisableLinkPreviewsAction"),
+    value_proto_type: Some("SyncActionValue.PrivacySettingDisableLinkPreviewsAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "setting_disableLinkPreviews",
+    }],
+};
+
+/// `ExternalWebBeta` — module `WAWebExternalWebBetaSync`.
+pub const EXTERNAL_WEB_BETA: Schema = Schema {
+    key: "ExternalWebBeta",
+    name: "external_web_beta",
+    module: "WAWebExternalWebBetaSync",
+    collection: Collection::Regular,
+    version: 3,
+    scope: Scope::Account,
+    value_field: Some("externalWebBetaAction"),
+    value_proto_type: Some("SyncActionValue.ExternalWebBetaAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "external_web_beta",
+    }],
+};
+
+/// `FavoriteSticker` — module `WAWebStickersFavoriteSyncAction`.
+pub const FAVORITE_STICKER: Schema = Schema {
+    key: "FavoriteSticker",
+    name: "favoriteSticker",
+    module: "WAWebStickersFavoriteSyncAction",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("stickerAction"),
+    value_proto_type: Some("SyncActionValue.StickerAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "favoriteSticker",
+        },
+        IndexPart::StringPart { name: "filehash" },
+    ],
+};
+
+/// `Favorites` — module `WAWebFavoritesSync`.
+pub const FAVORITES: Schema = Schema {
+    key: "Favorites",
+    name: "favorites",
+    module: "WAWebFavoritesSync",
+    collection: Collection::RegularHigh,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("favoritesAction"),
+    value_proto_type: Some("SyncActionValue.FavoritesAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal { value: "favorites" }],
+};
+
+/// `InteractiveMessageAction` — module `WAWebInteractiveMessageSync`.
+pub const INTERACTIVE_MESSAGE_ACTION: Schema = Schema {
+    key: "InteractiveMessageAction",
+    name: "interactive_message_action",
+    module: "WAWebInteractiveMessageSync",
+    collection: Collection::RegularLow,
+    version: 1,
+    scope: Scope::Message,
+    value_field: Some("interactiveMessageAction"),
+    value_proto_type: Some("SyncActionValue.InteractiveMessageAction"),
+    value_enum_fields: &[(
+        "type",
+        "InteractiveMessageAction.InteractiveMessageActionMode",
+    )],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "interactive_message_action",
+        },
+        IndexPart::Jid { name: "remote" },
+        IndexPart::StringPart { name: "id" },
+        IndexPart::BoolString { name: "fromMe" },
+        IndexPart::JidOrZero {
+            name: "participant",
+        },
+        IndexPart::StringPart { name: "arg5" },
+    ],
+};
+
+/// `LabelEdit` — module `WAWebLabelSync`.
+pub const LABEL_EDIT: Schema = Schema {
+    key: "LabelEdit",
+    name: "label_edit",
+    module: "WAWebLabelSync",
+    collection: Collection::Regular,
+    version: 3,
+    scope: Scope::Account,
+    value_field: Some("labelEditAction"),
+    value_proto_type: Some("SyncActionValue.LabelEditAction"),
+    value_enum_fields: &[("type", "LabelEditAction.ListType")],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "label_edit",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `LabelJid` — module `WAWebLabelJidSync`.
+pub const LABEL_JID: Schema = Schema {
+    key: "LabelJid",
+    name: "label_jid",
+    module: "WAWebLabelJidSync",
+    collection: Collection::Regular,
+    version: 3,
+    scope: Scope::ChatOrContact,
+    value_field: Some("labelAssociationAction"),
+    value_proto_type: Some("SyncActionValue.LabelAssociationAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(2),
+    index_parts: &[
+        IndexPart::Literal { value: "label_jid" },
+        IndexPart::StringPart { name: "labelId" },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `LabelReordering` — module `WAWebLabelReorderingSync`.
+pub const LABEL_REORDERING: Schema = Schema {
+    key: "LabelReordering",
+    name: "label_reordering",
+    module: "WAWebLabelReorderingSync",
+    collection: Collection::Regular,
+    version: 3,
+    scope: Scope::Account,
+    value_field: Some("labelReorderingAction"),
+    value_proto_type: Some("SyncActionValue.LabelReorderingAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "label_reordering",
+    }],
+};
+
+/// `LidContact` — module `WAWebLidContactSync`.
+pub const LID_CONTACT: Schema = Schema {
+    key: "LidContact",
+    name: "lid_contact",
+    module: "WAWebLidContactSync",
+    collection: Collection::CriticalUnblockLow,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("lidContactAction"),
+    value_proto_type: Some("SyncActionValue.LidContactAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "lid_contact",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `LocaleSetting` — module `WAWebLocaleSettingSync`.
+pub const LOCALE_SETTING: Schema = Schema {
+    key: "LocaleSetting",
+    name: "setting_locale",
+    module: "WAWebLocaleSettingSync",
+    collection: Collection::CriticalBlock,
+    version: 3,
+    scope: Scope::Account,
+    value_field: Some("localeSetting"),
+    value_proto_type: Some("SyncActionValue.LocaleSetting"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "setting_locale",
+    }],
+};
+
+/// `LockChat` — module `WAWebLockChatSync`.
+pub const LOCK_CHAT: Schema = Schema {
+    key: "LockChat",
+    name: "lock",
+    module: "WAWebLockChatSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Chat,
+    value_field: Some("lockChatAction"),
+    value_proto_type: Some("SyncActionValue.LockChatAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal { value: "lock" },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `MarkChatAsRead` — module `WAWebMarkChatAsReadSync`.
+pub const MARK_CHAT_AS_READ: Schema = Schema {
+    key: "MarkChatAsRead",
+    name: "markChatAsRead",
+    module: "WAWebMarkChatAsReadSync",
+    collection: Collection::RegularLow,
+    version: 3,
+    scope: Scope::ChatMessageRange,
+    value_field: Some("markChatAsReadAction"),
+    value_proto_type: Some("SyncActionValue.MarkChatAsReadAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "markChatAsRead",
+        },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `MarketingMessage` — module `WAWebPremiumMessageSync`.
+pub const MARKETING_MESSAGE: Schema = Schema {
+    key: "MarketingMessage",
+    name: "marketingMessage",
+    module: "WAWebPremiumMessageSync",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("marketingMessageAction"),
+    value_proto_type: Some("SyncActionValue.MarketingMessageAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "marketingMessage",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `MarketingMessageBroadcast` — module `WAWebPremiumMessageBroadcastSync`.
+pub const MARKETING_MESSAGE_BROADCAST: Schema = Schema {
+    key: "MarketingMessageBroadcast",
+    name: "marketingMessageBroadcast",
+    module: "WAWebPremiumMessageBroadcastSync",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Account,
+    value_field: None,
+    value_proto_type: None,
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "marketingMessageBroadcast",
+        },
+        IndexPart::StringPart {
+            name: "premiumMessageId",
+        },
+        IndexPart::StringPart { name: "messageId" },
+    ],
+};
+
+/// `MerchantPaymentPartner` — module `WAWebMerchantPaymentPartnerSync`.
+pub const MERCHANT_PAYMENT_PARTNER: Schema = Schema {
+    key: "MerchantPaymentPartner",
+    name: "merchant_payment_partner",
+    module: "WAWebMerchantPaymentPartnerSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: None,
+    value_proto_type: None,
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "merchant_payment_partner",
+    }],
+};
+
+/// `Mute` — module `WAWebMuteChatSync`.
+pub const MUTE: Schema = Schema {
+    key: "Mute",
+    name: "mute",
+    module: "WAWebMuteChatSync",
+    collection: Collection::RegularHigh,
+    version: 2,
+    scope: Scope::Chat,
+    value_field: Some("muteAction"),
+    value_proto_type: Some("SyncActionValue.MuteAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal { value: "mute" },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `NctSaltSync` — module `WAWebNctSaltSync`.
+pub const NCT_SALT_SYNC: Schema = Schema {
+    key: "NctSaltSync",
+    name: "nct_salt_sync",
+    module: "WAWebNctSaltSync",
+    collection: Collection::RegularHigh,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("nctSaltSyncAction"),
+    value_proto_type: Some("SyncActionValue.NctSaltSyncAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "nct_salt_sync",
+    }],
+};
+
+/// `NoteEdit` — module `WAWebNoteSync`.
+pub const NOTE_EDIT: Schema = Schema {
+    key: "NoteEdit",
+    name: "note_edit",
+    module: "WAWebNoteSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("noteEditAction"),
+    value_proto_type: Some("SyncActionValue.NoteEditAction"),
+    value_enum_fields: &[("type", "NoteEditAction.NoteType")],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal { value: "note_edit" },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `Nux` — module `WAWebNuxSync`.
+pub const NUX: Schema = Schema {
+    key: "Nux",
+    name: "nux",
+    module: "WAWebNuxSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("nuxAction"),
+    value_proto_type: Some("SyncActionValue.NuxAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal { value: "nux" },
+        IndexPart::StringPart { name: "nuxKey" },
+    ],
+};
+
+/// `OutContact` — module `WAWebOutContactSync`.
+pub const OUT_CONTACT: Schema = Schema {
+    key: "OutContact",
+    name: "out_contact",
+    module: "WAWebOutContactSync",
+    collection: Collection::RegularLow,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("outContactAction"),
+    value_proto_type: Some("SyncActionValue.OutContactAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "out_contact",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `PaymentInfo` — module `WAWebPaymentInfoSync`.
+pub const PAYMENT_INFO: Schema = Schema {
+    key: "PaymentInfo",
+    name: "payment_info",
+    module: "WAWebPaymentInfoSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("paymentInfoAction"),
+    value_proto_type: Some("SyncActionValue.PaymentInfoAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "payment_info",
+    }],
+};
+
+/// `PaymentTos` — module `WAWebPaymentTosSync`.
+pub const PAYMENT_TOS: Schema = Schema {
+    key: "PaymentTos",
+    name: "payment_tos",
+    module: "WAWebPaymentTosSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("paymentTosAction"),
+    value_proto_type: Some("SyncActionValue.PaymentTosAction"),
+    value_enum_fields: &[("paymentNotice", "PaymentTosAction.PaymentNotice")],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "payment_tos",
+    }],
+};
+
+/// `Pin` — module `WAWebPinChatSync`.
+pub const PIN: Schema = Schema {
+    key: "Pin",
+    name: "pin_v1",
+    module: "WAWebPinChatSync",
+    collection: Collection::RegularLow,
+    version: 5,
+    scope: Scope::Chat,
+    value_field: Some("pinAction"),
+    value_proto_type: Some("SyncActionValue.PinAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal { value: "pin_v1" },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `PnForLidChat` — module `WAWebPnForLidChatSync`.
+pub const PN_FOR_LID_CHAT: Schema = Schema {
+    key: "PnForLidChat",
+    name: "pnForLidChat",
+    module: "WAWebPnForLidChatSync",
+    collection: Collection::Regular,
+    version: 8,
+    scope: Scope::Account,
+    value_field: Some("pnForLidChatAction"),
+    value_proto_type: Some("SyncActionValue.PnForLidChatAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "pnForLidChat",
+        },
+        IndexPart::StringPart { name: "lid" },
+    ],
+};
+
+/// `PrimaryFeature` — module `WAWebPrimaryFeatureSync`.
+pub const PRIMARY_FEATURE: Schema = Schema {
+    key: "PrimaryFeature",
+    name: "primary_feature",
+    module: "WAWebPrimaryFeatureSync",
+    collection: Collection::Regular,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("primaryFeature"),
+    value_proto_type: Some("SyncActionValue.PrimaryFeature"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "primary_feature",
+    }],
+};
+
+/// `PrimaryVersion` — module `WAWebPrimaryVersionSync`.
+pub const PRIMARY_VERSION: Schema = Schema {
+    key: "PrimaryVersion",
+    name: "primary_version",
+    module: "WAWebPrimaryVersionSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("primaryVersionAction"),
+    value_proto_type: Some("SyncActionValue.PrimaryVersionAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "primary_version",
+        },
+        IndexPart::StringPart { name: "key1" },
+    ],
+};
+
+/// `QuickReply` — module `WAWebQuickRepliesSync`.
+pub const QUICK_REPLY: Schema = Schema {
+    key: "QuickReply",
+    name: "quick_reply",
+    module: "WAWebQuickRepliesSync",
+    collection: Collection::Regular,
+    version: 2,
+    scope: Scope::Account,
+    value_field: Some("quickReplyAction"),
+    value_proto_type: Some("SyncActionValue.QuickReplyAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "quick_reply",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `RemoveRecentSticker` — module `WAWebStickersRemoveRecentSyncAction`.
+pub const REMOVE_RECENT_STICKER: Schema = Schema {
+    key: "RemoveRecentSticker",
+    name: "removeRecentSticker",
+    module: "WAWebStickersRemoveRecentSyncAction",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("removeRecentStickerAction"),
+    value_proto_type: Some("SyncActionValue.RemoveRecentStickerAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "removeRecentSticker",
+        },
+        IndexPart::StringPart { name: "filehash" },
+    ],
+};
+
+/// `Sentinel` — module `WAWebSentinelMutationSync`.
+pub const SENTINEL: Schema = Schema {
+    key: "Sentinel",
+    name: "sentinel",
+    module: "WAWebSentinelMutationSync",
+    collection: Collection::RegularLow,
+    version: 3,
+    scope: Scope::Account,
+    value_field: Some("keyExpiration"),
+    value_proto_type: Some("SyncActionValue.KeyExpiration"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal { value: "sentinel" }],
+};
+
+/// `SettingPushName` — module `WAWebPushNameSync`.
+pub const SETTING_PUSH_NAME: Schema = Schema {
+    key: "SettingPushName",
+    name: "setting_pushName",
+    module: "WAWebPushNameSync",
+    collection: Collection::CriticalBlock,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("pushNameSetting"),
+    value_proto_type: Some("SyncActionValue.PushNameSetting"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "setting_pushName",
+    }],
+};
+
+/// `SettingsSync` — module `WAWebSettingsSync`.
+pub const SETTINGS_SYNC: Schema = Schema {
+    key: "SettingsSync",
+    name: "settings_sync",
+    module: "WAWebSettingsSync",
+    collection: Collection::RegularLow,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("settingsSyncAction"),
+    value_proto_type: Some("SyncActionValue.SettingsSyncAction"),
+    value_enum_fields: &[
+        (
+            "bannerNotificationDisplayMode",
+            "SettingsSyncAction.DisplayMode",
+        ),
+        (
+            "mediaUploadQuality",
+            "SettingsSyncAction.MediaQualitySetting",
+        ),
+        (
+            "unreadCounterBadgeDisplayMode",
+            "SettingsSyncAction.DisplayMode",
+        ),
+    ],
+    chat_jid_index: Some(3),
+    index_parts: &[
+        IndexPart::Literal {
+            value: "settings_sync",
+        },
+        IndexPart::Enum {
+            name: "settingPlatform",
+            proto_enum: "SettingsSyncAction.SettingPlatform",
+        },
+        IndexPart::Enum {
+            name: "settingKey",
+            proto_enum: "SettingsSyncAction.SettingKey",
+        },
+        IndexPart::Jid { name: "chatJid" },
+    ],
+};
+
+/// `ShareOwnPn` — module `WAWebShareOwnPnSync`.
+pub const SHARE_OWN_PN: Schema = Schema {
+    key: "ShareOwnPn",
+    name: "shareOwnPn",
+    module: "WAWebShareOwnPnSync",
+    collection: Collection::Regular,
+    version: 8,
+    scope: Scope::Account,
+    value_field: None,
+    value_proto_type: None,
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "shareOwnPn",
+        },
+        IndexPart::StringPart { name: "lid" },
+    ],
+};
+
+/// `Star` — module `WAWebStarMessageSync`.
+pub const STAR: Schema = Schema {
+    key: "Star",
+    name: "star",
+    module: "WAWebStarMessageSync",
+    collection: Collection::RegularHigh,
+    version: 2,
+    scope: Scope::Message,
+    value_field: Some("starAction"),
+    value_proto_type: Some("SyncActionValue.StarAction"),
+    value_enum_fields: &[],
+    chat_jid_index: Some(1),
+    index_parts: &[
+        IndexPart::Literal { value: "star" },
+        IndexPart::Jid { name: "remote" },
+        IndexPart::StringPart { name: "id" },
+        IndexPart::BoolString { name: "fromMe" },
+        IndexPart::JidOrZero {
+            name: "participant",
+        },
+    ],
+};
+
+/// `StatusPrivacy` — module `WAWebStatusPrivacySettingSync`.
+pub const STATUS_PRIVACY: Schema = Schema {
+    key: "StatusPrivacy",
+    name: "status_privacy",
+    module: "WAWebStatusPrivacySettingSync",
+    collection: Collection::RegularHigh,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("statusPrivacy"),
+    value_proto_type: Some("SyncActionValue.StatusPrivacyAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "status_privacy",
+    }],
+};
+
+/// `SubscriptionsSyncV2` — module `WAWebSubscriptionsSyncV2Sync`.
+pub const SUBSCRIPTIONS_SYNC_V2: Schema = Schema {
+    key: "SubscriptionsSyncV2",
+    name: "subscriptions_sync_v2",
+    module: "WAWebSubscriptionsSyncV2Sync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("subscriptionsSyncV2Action"),
+    value_proto_type: Some("SyncActionValue.SubscriptionsSyncV2Action"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "subscriptions_sync_v2",
+    }],
+};
+
+/// `TimeFormat` — module `WAWebTimeFormatSync`.
+pub const TIME_FORMAT: Schema = Schema {
+    key: "TimeFormat",
+    name: "time_format",
+    module: "WAWebTimeFormatSync",
+    collection: Collection::RegularLow,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("timeFormatAction"),
+    value_proto_type: Some("SyncActionValue.TimeFormatAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "time_format",
+    }],
+};
+
+/// `UnarchiveChatsSetting` — module `WAWebArchiveSettingSync`.
+pub const UNARCHIVE_CHATS_SETTING: Schema = Schema {
+    key: "UnarchiveChatsSetting",
+    name: "setting_unarchiveChats",
+    module: "WAWebArchiveSettingSync",
+    collection: Collection::RegularLow,
+    version: 4,
+    scope: Scope::Account,
+    value_field: Some("unarchiveChatsSetting"),
+    value_proto_type: Some("SyncActionValue.UnarchiveChatsSetting"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "setting_unarchiveChats",
+    }],
+};
+
+/// `UserStatusMute` — module `WAWebUserStatusMuteSync`.
+pub const USER_STATUS_MUTE: Schema = Schema {
+    key: "UserStatusMute",
+    name: "userStatusMute",
+    module: "WAWebUserStatusMuteSync",
+    collection: Collection::RegularHigh,
+    version: 7,
+    scope: Scope::Account,
+    value_field: Some("userStatusMuteAction"),
+    value_proto_type: Some("SyncActionValue.UserStatusMuteAction"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[
+        IndexPart::Literal {
+            value: "userStatusMute",
+        },
+        IndexPart::StringPart { name: "id" },
+    ],
+};
+
+/// `VoipRelayAllCalls` — module `WAWebVoipRelayAllCallsSettingSync`.
+pub const VOIP_RELAY_ALL_CALLS: Schema = Schema {
+    key: "VoipRelayAllCalls",
+    name: "setting_relayAllCalls",
+    module: "WAWebVoipRelayAllCallsSettingSync",
+    collection: Collection::Regular,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("privacySettingRelayAllCalls"),
+    value_proto_type: Some("SyncActionValue.PrivacySettingRelayAllCalls"),
+    value_enum_fields: &[],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "setting_relayAllCalls",
+    }],
+};
+
+/// `WaffleAccountLinkState` — module `WAWebWaffleAccountLinkStateSync`.
+pub const WAFFLE_ACCOUNT_LINK_STATE: Schema = Schema {
+    key: "WaffleAccountLinkState",
+    name: "waffle_account_link_state",
+    module: "WAWebWaffleAccountLinkStateSync",
+    collection: Collection::RegularHigh,
+    version: 1,
+    scope: Scope::Account,
+    value_field: Some("waffleAccountLinkStateAction"),
+    value_proto_type: Some("SyncActionValue.WaffleAccountLinkStateAction"),
+    value_enum_fields: &[("linkState", "WaffleAccountLinkStateAction.AccountLinkState")],
+    chat_jid_index: None,
+    index_parts: &[IndexPart::Literal {
+        value: "waffle_account_link_state",
+    }],
+};
+
+/// Every action schema, keyed-sorted.
+pub const ALL: &[Schema] = &[
+    ADS_CTWA_PER_CUSTOMER_DATA_SHARING,
+    AGENT,
+    AI_THREAD_DELETE,
+    AI_THREAD_PIN,
+    AI_THREAD_RENAME,
+    ANDROID_UNSUPPORTED_ACTIONS,
+    ARCHIVE,
+    AVATAR_UPDATED,
+    BIZ_AI_SETTINGS_NUDGE,
+    BOT_WELCOME_REQUEST,
+    BUSINESS_BROADCAST_CAMPAIGN,
+    BUSINESS_BROADCAST_INSIGHTS,
+    BUSINESS_BROADCAST_LIST,
+    CALL_LOG,
+    CHAT_ASSIGNMENT,
+    CHAT_ASSIGNMENT_OPENED_STATUS,
+    CHAT_LOCK_SETTINGS,
+    CLEAR_CHAT,
+    CONTACT,
+    CUSTOM_PAYMENT_METHODS,
+    CUSTOMER_DATA,
+    DELETE_CHAT,
+    DELETE_MESSAGE_FOR_ME,
+    DETECTED_OUTCOME_STATUS,
+    DEVICE_CAPABILITIES,
+    DISABLE_LINK_PREVIEWS,
+    EXTERNAL_WEB_BETA,
+    FAVORITE_STICKER,
+    FAVORITES,
+    INTERACTIVE_MESSAGE_ACTION,
+    LABEL_EDIT,
+    LABEL_JID,
+    LABEL_REORDERING,
+    LID_CONTACT,
+    LOCALE_SETTING,
+    LOCK_CHAT,
+    MARK_CHAT_AS_READ,
+    MARKETING_MESSAGE,
+    MARKETING_MESSAGE_BROADCAST,
+    MERCHANT_PAYMENT_PARTNER,
+    MUTE,
+    NCT_SALT_SYNC,
+    NOTE_EDIT,
+    NUX,
+    OUT_CONTACT,
+    PAYMENT_INFO,
+    PAYMENT_TOS,
+    PIN,
+    PN_FOR_LID_CHAT,
+    PRIMARY_FEATURE,
+    PRIMARY_VERSION,
+    QUICK_REPLY,
+    REMOVE_RECENT_STICKER,
+    SENTINEL,
+    SETTING_PUSH_NAME,
+    SETTINGS_SYNC,
+    SHARE_OWN_PN,
+    STAR,
+    STATUS_PRIVACY,
+    SUBSCRIPTIONS_SYNC_V2,
+    TIME_FORMAT,
+    UNARCHIVE_CHATS_SETTING,
+    USER_STATUS_MUTE,
+    VOIP_RELAY_ALL_CALLS,
+    WAFFLE_ACCOUNT_LINK_STATE,
+];
+
+/// Look up a schema by its action key (the registry key, e.g. `"Agent"`).
+pub fn by_name(key: &str) -> Option<&'static Schema> {
+    ALL.iter().find(|s| s.key == key)
+}


### PR DESCRIPTION
## Problem

App-state (syncd) actions were hand-coded one by one: each `ChatActions` / `Labels` method built its own index, picked a collection, and stamped a fixed `SyncActionData.version = 1`. But every action has its own version (whatsmeow: `mute=2, pin=5, archive=3, markChatAsRead=3, star=2, label=3, setting_pushName=1`), so version 1 was wrong for almost all of them and could be mishandled by linked clients that honor the action version. Each new action also meant re-deriving the collection and index shape by hand.

## Change

Adopt a generated, dependency-free registry of every syncd action (`wacore/appstate/src/schemas.rs`, generated from WhatsApp Web's app-state schemas). Each `Schema` carries its `collection`, `version`, `scope`, value field, and `index_parts` (the index shape), plus `ALL` and `by_name`.

A new helper drives sends from the registry:

```rust
impl Client {
    pub async fn send_app_state_action(
        &self,
        schema: &schemas::Schema,
        index_args: &[&str],
        value: &wa::SyncActionValue,
    ) -> Result<()>;
}
```

It builds the index from `schema.index_parts` + the supplied non-literal args, maps `schema.collection` to `WAPatchName`, and stamps `schema.version`. `ChatActions` (mute/pin/archive/markChatAsRead/deleteChat/deleteMessageForMe/star), `Labels`, and the push-name setting now all go through it, so every action gets its correct per-action version for free. `encode_record` already takes the version (added in #715); this wires the right value into every call site.

## Public generic API

`send_app_state_action` is public and `schemas` is re-exported, so callers can send any of the registry's actions even when there is no dedicated helper, the same way `send_message` takes an auto-generated `Message`:

```rust
use whatsapp_rust::schemas;
use whatsapp_rust::waproto::whatsapp as wa;

let value = wa::SyncActionValue {
    clear_chat_action: Some(Default::default()),
    timestamp: Some(now_ms),
    ..Default::default()
};
client.send_app_state_action(&schemas::CLEAR_CHAT, &["123@s.whatsapp.net"], &value).await?;
```

The typed APIs (`ChatActions`, `Labels`) are thin wrappers over it.

## Allocations / type-safety

- `build_action_index` assembles the index from `&str` references (no string copies); the only allocation is the JSON output.
- The message-key path (`star` / `deleteMessageForMe`) now owns only what must outlive the call (chat + participant JIDs); `messageId` is borrowed and `fromMe` is a `&'static "1"/"0"` (previously a 4-element `String` array).
- Label create/delete allocate nothing for the index (the label id is already a `&str`); single-JID actions allocate only the one unavoidable JID string.
- Index arg counts are validated against the schema at runtime.

## Versions fixed

mute 1->2, pin 1->5, archive 1->3, markChatAsRead 1->3, deleteChat 1->6, deleteMessageForMe 1->3, star 1->2. label_edit/label_jid stay 3, setting_pushName stays 1 (both already correct).

## Tests

- `build_index_matches_legacy_shapes`: the registry-driven index is byte-for-byte identical to the previous hand-coded format for every migrated action, so the migration changes only the version on the wire, not the index.
- `registry_versions_match_whatsmeow`: locks the per-action versions; a regenerated registry that changes one trips this for review.
- `collection_mapping`, arg-count mismatch, and a doctest for the public generic API.

Full lib suites green; `cargo clippy --all-targets -- -D warnings` clean.
