### PR TITLE
feat(signal): react to locally-detected peer identity changes

### DIFF
--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -49,4 +49,8 @@ impl SendContextResolver for Client {
     async fn get_lid_for_phone(&self, phone_user: &str) -> Option<wacore_binary::CompactString> {
         self.lid_pn_cache.get_current_lid(phone_user).await
     }
+
+    fn on_local_identity_change(&self, jid: &Jid) {
+        self.react_to_local_identity_change(jid);
+    }
 }

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -415,6 +415,11 @@ impl Client {
     /// Matches WA Web's `clearDeviceRecord()` in `IdentityUpdateDeviceTableApi`:
     /// - Deletes Signal sessions for non-primary devices (stale identity)
     /// - Invalidates sender key device cache so SKDM will be redistributed
+    ///
+    /// The companion-device session wipe is intentionally not per-device locked
+    /// (matches WA Web's single-threaded model). A concurrent encrypt to one of
+    /// those companions can re-store a session right after the wipe, but that is
+    /// self-healing: the next send re-establishes it via `process_prekey_bundle`.
     pub(crate) async fn clear_device_record(
         &self,
         user: &str,

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -256,6 +256,29 @@ impl Client {
         Ok(())
     }
 
+    /// Spawn the local identity-change reaction off the current path so it runs
+    /// after any held session lock is released (the reaction acquires its own
+    /// locks and must not deadlock against an in-flight decrypt/encrypt batch).
+    ///
+    /// Triggered from both the inbound decrypt path and the outbound
+    /// session-establishment paths when `save_identity` reports
+    /// [`IdentityChange::ReplacedExisting`](wacore::libsignal::protocol::IdentityChange),
+    /// mirroring WA Web `saveIdentity` -> `handleNewIdentity`. Gating
+    /// (primary-device, skip-self) lives in [`handle_local_identity_change`].
+    ///
+    /// [`handle_local_identity_change`]: crate::handlers::notification::handle_local_identity_change
+    pub(crate) fn react_to_local_identity_change(&self, sender: &Jid) {
+        let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) else {
+            return;
+        };
+        let sender = sender.clone();
+        self.runtime
+            .spawn(Box::pin(async move {
+                crate::handlers::notification::handle_local_identity_change(&client, sender).await;
+            }))
+            .detach();
+    }
+
     /// Invalidate cached device data for a specific user.
     ///
     /// Removes all device registry cache entries (all LID/PN aliases) so the

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -239,9 +239,14 @@ impl Client {
                 )
                 .await
                 {
-                    Ok(_) => {
+                    Ok(identity_change) => {
                         success_count += 1;
                         log::debug!("Successfully established session with {}", jid);
+                        if identity_change
+                            == wacore::libsignal::protocol::IdentityChange::ReplacedExisting
+                        {
+                            self.react_to_local_identity_change(jid);
+                        }
                     }
                     Err(e) => {
                         failed_count += 1;

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -100,7 +100,7 @@ impl<'a> Signal<'a> {
         let mut adapter = self.client.signal_adapter().await;
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
-        let plaintext = message_decrypt(
+        let decrypted = message_decrypt(
             &parsed,
             &signal_addr,
             &mut adapter.session_store,
@@ -115,7 +115,7 @@ impl<'a> Signal<'a> {
         drop(_guard);
         self.client.flush_signal_cache().await?;
 
-        Ok(plaintext.to_vec())
+        Ok(decrypted.plaintext)
     }
 
     /// Encrypt plaintext for a group using sender keys.

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -380,6 +380,7 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
         crate::types::events::IdentityChange {
             user: from_jid,
             lid_user: node.attrs().optional_jid("lid"),
+            implicit: false,
         },
     ));
 
@@ -393,6 +394,72 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
             }
         }))
         .detach();
+}
+
+/// React to a locally-detected identity change.
+///
+/// Fires when decrypting a peer's message saved a new identity key that replaced
+/// a different one (`IdentityChange::ReplacedExisting`). Mirrors WA Web
+/// `ProtocolStoreUnifiedApi.saveIdentity` -> `handleNewIdentity`: clear the
+/// device-list/sender-key tracking, force a fresh usync, re-issue an active tc
+/// token, and emit `Event::IdentityChange { implicit: true }`.
+///
+/// Deliberately lighter than the server `<identity/>` push handler
+/// ([`handle_identity_change`]): it does NOT delete the primary session, rotate
+/// the status sender key, or re-establish sessions. The message that triggered
+/// this is establishing the new session right now, and the heavier reset is the
+/// server push's job (which reliably follows). This matches WA Web, where the
+/// local `handleNewIdentity` omits those steps that only the server-push
+/// `handleE2eIdentityChange` performs.
+pub(crate) async fn handle_local_identity_change(client: &Arc<Client>, sender: Jid) {
+    // Only a peer's primary-device identity change matters; companion devices
+    // carry their own identities (WA Web ignores them on this path).
+    if sender.device != 0 {
+        return;
+    }
+
+    // Self-identity changes use a separate flow; clearing our own record would
+    // break our sessions.
+    let device_snapshot = client.persistence_manager.get_device_snapshot().await;
+    let is_me = device_snapshot
+        .pn
+        .as_ref()
+        .is_some_and(|pn| pn.user == sender.user)
+        || device_snapshot
+            .lid
+            .as_ref()
+            .is_some_and(|lid| lid.user == sender.user);
+    if is_me {
+        return;
+    }
+
+    info!(
+        "Local identity change detected for {}: clearing device record",
+        sender.user
+    );
+
+    // Deletes non-primary sessions + all sender key device tracking.
+    if let Some(record) = client.load_device_record(&sender.user).await {
+        client
+            .clear_device_record(&sender.user, sender.server.as_str(), &record)
+            .await;
+    }
+
+    // Force a fresh usync on next send so we re-learn the peer's device list.
+    client.invalidate_device_cache(&sender.user).await;
+
+    // Re-issue an active trusted-contact token (no-op unless one is live).
+    if !sender.is_bot() && !sender.is_status_broadcast() {
+        client.reissue_tc_token_after_identity_change(&sender).await;
+    }
+
+    client.core.event_bus.dispatch(Event::IdentityChange(
+        crate::types::events::IdentityChange {
+            user: sender,
+            lid_user: None,
+            implicit: true,
+        },
+    ));
 }
 
 /// Handle device list change notifications.
@@ -2240,6 +2307,70 @@ mod tests {
             .children([NodeBuilder::new("identity").build()])
             .build();
         handle_notification_impl(&client, node_to_arc(node)).await;
+
+        assert!(
+            collector.events().is_empty(),
+            "companion device identity change should be ignored"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_local_identity_change_dispatches_implicit_event() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let sender: Jid = "5511777777777@s.whatsapp.net".parse().unwrap();
+        handle_local_identity_change(&client, sender).await;
+
+        let events = collector.events();
+        // The event is dispatched last (after clear_device_record +
+        // invalidate_device_cache), so observing it proves the handler ran to
+        // completion. invalidate_device_cache itself is covered by
+        // test_invalidate_device_cache_uses_correct_jid_types.
+        let ic = events
+            .iter()
+            .find_map(|e| match &**e {
+                Event::IdentityChange(ic) => Some(ic.clone()),
+                _ => None,
+            })
+            .expect("local detection should dispatch IdentityChange");
+        assert!(
+            ic.implicit,
+            "locally-detected identity change must set implicit=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_local_identity_change_skips_self() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        client
+            .persistence_manager
+            .modify_device(|d| {
+                d.pn = Some("5511999999999@s.whatsapp.net".parse().unwrap());
+            })
+            .await;
+
+        let sender: Jid = "5511999999999@s.whatsapp.net".parse().unwrap();
+        handle_local_identity_change(&client, sender).await;
+
+        assert!(
+            collector.events().is_empty(),
+            "self identity change must never clear our own record"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_local_identity_change_skips_companion_device() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let sender: Jid = "5511777777777:5@s.whatsapp.net".parse().unwrap();
+        handle_local_identity_change(&client, sender).await;
 
         assert!(
             collector.events().is_empty(),

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -375,6 +375,24 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
     // Force fresh usync on next send
     client.invalidate_device_cache(&from_jid.user).await;
 
+    // Re-issue an active trusted-contact token, matching WA Web
+    // handleE2eIdentityChange -> sendTcTokenWhenDeviceIdentityChange. Spawned so
+    // the notification handler doesn't block on an IQ; it no-ops unless a
+    // non-expired sender token already exists (so it only fires for a prior
+    // relationship, mirroring WA Web's "had old identity" guard).
+    if !from_jid.is_bot() && !from_jid.is_status_broadcast() {
+        let tc_client = client.clone();
+        let tc_jid = from_jid.clone();
+        client
+            .runtime
+            .spawn(Box::pin(async move {
+                tc_client
+                    .reissue_tc_token_after_identity_change(&tc_jid)
+                    .await;
+            }))
+            .detach();
+    }
+
     let session_jid = from_jid.clone();
     client.core.event_bus.dispatch(Event::IdentityChange(
         crate::types::events::IdentityChange {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1950,6 +1950,16 @@ impl Client {
                                     info.id,
                                     address
                                 );
+                                // Normally NewOrUnchanged here (the untrusted
+                                // identity was deleted+flushed before the retry),
+                                // but mirror the main-decode gate so a concurrent
+                                // re-save can't drop the signal.
+                                if decrypted.identity_change == IdentityChange::ReplacedExisting
+                                    && !local_identity_reacted
+                                {
+                                    local_identity_reacted = true;
+                                    self.react_to_local_identity_change(sender_encryption_jid);
+                                }
                                 let padded_plaintext = decrypted.plaintext;
                                 match self
                                     .clone()

--- a/src/message.rs
+++ b/src/message.rs
@@ -10,7 +10,8 @@ use wacore::libsignal::protocol::SenderKeyDistributionMessage;
 use wacore::libsignal::protocol::group_decrypt;
 use wacore::libsignal::protocol::process_sender_key_distribution_message;
 use wacore::libsignal::protocol::{
-    PreKeySignalMessage, SignalMessage, SignalProtocolError, UsePQRatchet, message_decrypt,
+    IdentityChange, PreKeySignalMessage, SignalMessage, SignalProtocolError, UsePQRatchet,
+    message_decrypt,
 };
 use wacore::libsignal::protocol::{
     PublicKey as SignalPublicKey, SENDERKEY_MESSAGE_CURRENT_VERSION,
@@ -1736,6 +1737,9 @@ impl Client {
         let mut adapter = self.signal_adapter().await;
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let mut outcome = SessionBatchOutcome::default();
+        // Local identity-change detection fires once per batch: the first pkmsg
+        // saves the new key (ReplacedExisting); the rest are NewOrUnchanged.
+        let mut local_identity_reacted = false;
 
         for payload in payloads {
             let ciphertext = &payload.ciphertext[..];
@@ -1840,7 +1844,14 @@ impl Client {
             .await;
 
             match decrypt_res {
-                Ok(padded_plaintext) => {
+                Ok(decrypted) => {
+                    if decrypted.identity_change == IdentityChange::ReplacedExisting
+                        && !local_identity_reacted
+                    {
+                        local_identity_reacted = true;
+                        self.react_to_local_identity_change(sender_encryption_jid);
+                    }
+                    let padded_plaintext = decrypted.plaintext;
                     match self
                         .clone()
                         .handle_decrypted_plaintext(
@@ -1933,12 +1944,13 @@ impl Client {
                         .await;
 
                         match retry_decrypt_res {
-                            Ok(padded_plaintext) => {
+                            Ok(decrypted) => {
                                 log::debug!(
                                     "[msg:{}] Successfully decrypted message from {} after handling untrusted identity",
                                     info.id,
                                     address
                                 );
+                                let padded_plaintext = decrypted.plaintext;
                                 match self
                                     .clone()
                                     .handle_decrypted_plaintext(
@@ -2600,12 +2612,16 @@ impl Client {
         )
         .await
         {
-            Ok(padded_plaintext) => {
+            // PN→LID migration re-addresses an existing peer; the LID address gets
+            // the identity for the first time (NewOrUnchanged), so no local
+            // identity-change reaction is warranted here.
+            Ok(decrypted) => {
                 log::info!(
                     "[msg:{}] Decrypted after PN→LID session migration for {}",
                     info.id,
                     info.source.sender
                 );
+                let padded_plaintext = decrypted.plaintext;
                 match self
                     .clone()
                     .handle_decrypted_plaintext(enc_type, &padded_plaintext, padding_version, info)

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -928,7 +928,7 @@ impl Client {
 
         let mut adapter = self.signal_adapter().await;
 
-        process_prekey_bundle(
+        let identity_change = process_prekey_bundle(
             &signal_address,
             &mut adapter.session_store,
             &mut adapter.identity_store,
@@ -940,6 +940,10 @@ impl Client {
 
         // Flush after session establishment
         self.flush_signal_cache().await?;
+
+        if identity_change == wacore::libsignal::protocol::IdentityChange::ReplacedExisting {
+            self.react_to_local_identity_change(requester_jid);
+        }
 
         info!(
             "Processed key bundle from retry receipt for {}",

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -441,7 +441,7 @@ fn decrypt_dm(
             CiphertextMessage::SignalMessage(SignalMessage::try_from(ciphertext).unwrap())
         };
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let plaintext = message_decrypt(
+        let decrypted = message_decrypt(
             &parsed,
             sender_addr,
             &mut receiver.sessions,
@@ -454,7 +454,7 @@ fn decrypt_dm(
         .await
         .unwrap();
 
-        let unpadded = MessageUtils::unpad_message_ref(&plaintext, 2).unwrap();
+        let unpadded = MessageUtils::unpad_message_ref(&decrypted.plaintext, 2).unwrap();
         wa::Message::decode(unpadded).unwrap()
     })
 }

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -58,7 +58,8 @@ pub use ratchet::{
 pub use sender_keys::{SenderKeyRecord, SenderKeyState};
 pub use session::{process_prekey, process_prekey_bundle};
 pub use session_cipher::{
-    message_decrypt, message_decrypt_prekey, message_decrypt_signal, message_encrypt,
+    DecryptionResult, message_decrypt, message_decrypt_prekey, message_decrypt_signal,
+    message_encrypt,
 };
 pub use state::{
     GenericSignedPreKey, PreKeyBundle, PreKeyBundleContent, PreKeyId, PreKeyRecord, SessionRecord,

--- a/wacore/libsignal/src/protocol/session.rs
+++ b/wacore/libsignal/src/protocol/session.rs
@@ -46,7 +46,7 @@ pub async fn process_prekey<'a>(
     pre_key_store: &dyn PreKeyStore,
     signed_prekey_store: &dyn SignedPreKeyStore,
     use_pq_ratchet: ratchet::UsePQRatchet,
-) -> Result<(PreKeysUsed, IdentityToSave<'a>)> {
+) -> Result<(PreKeysUsed, IdentityToSave<'a>, bool)> {
     let their_identity_key = message.identity_key();
 
     if !identity_store
@@ -58,7 +58,7 @@ pub async fn process_prekey<'a>(
         ));
     }
 
-    let pre_keys_used = process_prekey_impl(
+    let (pre_keys_used, reused_existing_session) = process_prekey_impl(
         message,
         remote_address,
         session_record,
@@ -74,7 +74,7 @@ pub async fn process_prekey<'a>(
         their_identity_key,
     };
 
-    Ok((pre_keys_used, identity_to_save))
+    Ok((pre_keys_used, identity_to_save, reused_existing_session))
 }
 
 async fn process_prekey_impl(
@@ -85,13 +85,16 @@ async fn process_prekey_impl(
     pre_key_store: &dyn PreKeyStore,
     identity_store: &dyn IdentityKeyStore,
     use_pq_ratchet: ratchet::UsePQRatchet,
-) -> Result<PreKeysUsed> {
+) -> Result<(PreKeysUsed, bool)> {
     if session_record.promote_matching_session(
         message.message_version() as u32,
         &message.base_key().serialize(),
     )? {
-        // We've already set up a session for this message, we can exit early.
-        return Ok(Default::default());
+        // We've already set up a session for this message (current or a promoted
+        // archived one), so this is a duplicate/out-of-order pkmsg. The `bool`
+        // signals the caller not to treat its (possibly stale) identity as a
+        // fresh rotation.
+        return Ok((Default::default(), true));
     }
 
     let our_signed_pre_key_pair = signed_prekey_store
@@ -138,7 +141,7 @@ async fn process_prekey_impl(
     let pre_keys_used = PreKeysUsed {
         pre_key_id: message.pre_key_id(),
     };
-    Ok(pre_keys_used)
+    Ok((pre_keys_used, false))
 }
 
 pub async fn process_prekey_bundle<R: Rng + CryptoRng>(

--- a/wacore/libsignal/src/protocol/session.rs
+++ b/wacore/libsignal/src/protocol/session.rs
@@ -8,9 +8,9 @@ use rand::{CryptoRng, Rng};
 use crate::protocol::state::GenericSignedPreKey;
 use crate::protocol::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
 use crate::protocol::{
-    Direction, IdentityKey, IdentityKeyStore, KeyPair, PreKeyBundle, PreKeyId, PreKeySignalMessage,
-    PreKeyStore, ProtocolAddress, Result, SessionRecord, SessionStore, SignalProtocolError,
-    SignedPreKeyStore, ratchet,
+    Direction, IdentityChange, IdentityKey, IdentityKeyStore, KeyPair, PreKeyBundle, PreKeyId,
+    PreKeySignalMessage, PreKeyStore, ProtocolAddress, Result, SessionRecord, SessionStore,
+    SignalProtocolError, SignedPreKeyStore, ratchet,
 };
 
 #[derive(Default)]
@@ -148,7 +148,7 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
     bundle: &PreKeyBundle,
     mut csprng: &mut R,
     use_pq_ratchet: ratchet::UsePQRatchet,
-) -> Result<()> {
+) -> Result<IdentityChange> {
     let their_identity_key = bundle.identity_key()?;
 
     if !identity_store
@@ -199,7 +199,7 @@ async fn process_prekey_bundle_inner<R: Rng + CryptoRng>(
     their_identity_key: &IdentityKey,
     csprng: &mut R,
     use_pq_ratchet: ratchet::UsePQRatchet,
-) -> Result<()> {
+) -> Result<IdentityChange> {
     let our_base_key_pair = KeyPair::generate(csprng);
     let our_base_public_key = our_base_key_pair.public_key;
     let their_signed_prekey = bundle.signed_pre_key_public()?;
@@ -237,11 +237,11 @@ async fn process_prekey_bundle_inner<R: Rng + CryptoRng>(
     session.set_local_registration_id(identity_store.get_local_registration_id().await?);
     session.set_remote_registration_id(bundle.registration_id()?);
 
-    identity_store
+    let identity_change = identity_store
         .save_identity(remote_address, their_identity_key)
         .await?;
 
     session_record.promote_state(session);
 
-    Ok(())
+    Ok(identity_change)
 }

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -327,7 +327,7 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
     )
     .await;
 
-    let (pre_key_used, identity_to_save) = match process_prekey_result {
+    let (pre_key_used, identity_to_save, reused_existing_session) = match process_prekey_result {
         Ok(result) => result,
         Err(e) => {
             let errs = [e];
@@ -353,12 +353,22 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
         csprng,
     )?;
 
-    let identity_change = identity_store
+    let saved = identity_store
         .save_identity(
             identity_to_save.remote_address,
             identity_to_save.their_identity_key,
         )
         .await?;
+
+    // A duplicate/out-of-order pkmsg that matched an existing session carries the
+    // identity from when that session was built, not a fresh rotation. Reporting
+    // it as a change would fire a spurious local identity-change reaction (mirrors
+    // the previous-session SignalMessage path).
+    let identity_change = if reused_existing_session {
+        IdentityChange::NewOrUnchanged
+    } else {
+        saved
+    };
 
     Ok((
         decrypt_result.plaintext,
@@ -1461,6 +1471,68 @@ mod tests {
                 assert_eq!(res.identity_change, expected);
             });
         }
+    }
+
+    /// `process_prekey` must signal session reuse when a pkmsg matches an
+    /// already-established session. The caller relies on this to avoid treating
+    /// a duplicate/out-of-order pkmsg's (possibly stale) identity as a fresh
+    /// rotation and firing a spurious local identity-change reaction.
+    #[test]
+    fn process_prekey_signals_reuse_for_established_session() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let alice_addr = ProtocolAddress::new("alice".to_string(), 1.into());
+        let alice_id = IdentityKeyPair::generate(&mut rng);
+        let mut alice_sessions = MemSessionStore::new();
+        let mut alice_identity = MemIdentityStore::new(alice_id, 1);
+
+        let (bob_addr, _bs, bob_identity, bob_prekeys, bob_signed, bundle) = fresh_bob(&mut rng);
+
+        futures::executor::block_on(async {
+            process_prekey_bundle(
+                &bob_addr,
+                &mut alice_sessions,
+                &mut alice_identity,
+                &bundle,
+                &mut rng,
+                UsePQRatchet::No,
+            )
+            .await
+            .expect("process bundle");
+            let ct = message_encrypt(b"hi", &bob_addr, &mut alice_sessions, &mut alice_identity)
+                .await
+                .expect("encrypt");
+            let pkmsg = PreKeySignalMessage::try_from(ct.serialize()).expect("parse pkmsg");
+
+            let mut record = SessionRecord::new_fresh();
+            let (_used, _save, reused_first) = process_prekey(
+                &pkmsg,
+                &alice_addr,
+                &mut record,
+                &bob_identity,
+                &bob_prekeys,
+                &bob_signed,
+                UsePQRatchet::No,
+            )
+            .await
+            .expect("first process_prekey");
+            assert!(!reused_first, "first pkmsg establishes a new session");
+
+            let (_used2, _save2, reused_again) = process_prekey(
+                &pkmsg,
+                &alice_addr,
+                &mut record,
+                &bob_identity,
+                &bob_prekeys,
+                &bob_signed,
+                UsePQRatchet::No,
+            )
+            .await
+            .expect("second process_prekey");
+            assert!(
+                reused_again,
+                "re-processing the same pkmsg must signal session reuse"
+            );
+        });
     }
 
     /// P0: MAC verification failure must return `BadMac`, not `InvalidMessage`.

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -58,10 +58,20 @@ use crate::protocol::ratchet::{ChainKey, UsePQRatchet};
 use crate::protocol::state::PreKeyId;
 use crate::protocol::state::SessionState;
 use crate::protocol::{
-    CiphertextMessage, CiphertextMessageType, Direction, IdentityKeyStore, KeyPair,
+    CiphertextMessage, CiphertextMessageType, Direction, IdentityChange, IdentityKeyStore, KeyPair,
     PreKeySignalMessage, PreKeyStore, ProtocolAddress, PublicKey, Result, SessionRecord,
     SessionStore, SignalMessage, SignalProtocolError, SignedPreKeyStore, session,
 };
+
+/// Plaintext plus whether decrypting this message replaced a previously-stored
+/// identity key for the sender. A [`IdentityChange::ReplacedExisting`] is the
+/// local signal that the peer's identity changed (e.g. reinstall), letting the
+/// caller react without waiting for the server's `<identity/>` push.
+#[derive(Debug)]
+pub struct DecryptionResult {
+    pub plaintext: Vec<u8>,
+    pub identity_change: IdentityChange,
+}
 
 pub async fn message_encrypt(
     ptext: &[u8],
@@ -208,7 +218,7 @@ pub async fn message_decrypt<R: Rng + CryptoRng>(
     signed_pre_key_store: &dyn SignedPreKeyStore,
     csprng: &mut R,
     use_pq_ratchet: UsePQRatchet,
-) -> Result<Vec<u8>> {
+) -> Result<DecryptionResult> {
     match ciphertext {
         CiphertextMessage::SignalMessage(m) => {
             message_decrypt_signal(m, remote_address, session_store, identity_store, csprng).await
@@ -243,7 +253,7 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     signed_pre_key_store: &dyn SignedPreKeyStore,
     csprng: &mut R,
     use_pq_ratchet: UsePQRatchet,
-) -> Result<Vec<u8>> {
+) -> Result<DecryptionResult> {
     let existing = session_store.load_session(remote_address).await?;
     let had_session = existing.is_some();
     // Snapshot before process_prekey so a BadMac/InvalidMessage at the
@@ -283,13 +293,16 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
         session_store.store_session(remote_address, record).await?;
     }
 
-    let (plaintext, pre_key_used) = result?;
+    let (plaintext, pre_key_used, identity_change) = result?;
 
     if let Some(pre_key_id) = pre_key_used {
         pre_key_store.remove_pre_key(pre_key_id).await?;
     }
 
-    Ok(plaintext)
+    Ok(DecryptionResult {
+        plaintext,
+        identity_change,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -302,7 +315,7 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
     signed_pre_key_store: &dyn SignedPreKeyStore,
     csprng: &mut R,
     use_pq_ratchet: UsePQRatchet,
-) -> Result<(Vec<u8>, Option<PreKeyId>)> {
+) -> Result<(Vec<u8>, Option<PreKeyId>, IdentityChange)> {
     let process_prekey_result = session::process_prekey(
         ciphertext,
         remote_address,
@@ -340,14 +353,18 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
         csprng,
     )?;
 
-    identity_store
+    let identity_change = identity_store
         .save_identity(
             identity_to_save.remote_address,
             identity_to_save.their_identity_key,
         )
         .await?;
 
-    Ok((decrypt_result.plaintext, pre_key_used.pre_key_id))
+    Ok((
+        decrypt_result.plaintext,
+        pre_key_used.pre_key_id,
+        identity_change,
+    ))
 }
 
 pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
@@ -356,7 +373,7 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
     session_store: &mut dyn SessionStore,
     identity_store: &mut dyn IdentityKeyStore,
     csprng: &mut R,
-) -> Result<Vec<u8>> {
+) -> Result<DecryptionResult> {
     let mut session_record = session_store
         .load_session(remote_address)
         .await?
@@ -375,7 +392,11 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
         .store_session(remote_address, session_record)
         .await?;
 
-    result
+    let (plaintext, identity_change) = result?;
+    Ok(DecryptionResult {
+        plaintext,
+        identity_change,
+    })
 }
 
 async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
@@ -384,7 +405,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
     session_record: &mut SessionRecord,
     identity_store: &mut dyn IdentityKeyStore,
     csprng: &mut R,
-) -> Result<Vec<u8>> {
+) -> Result<(Vec<u8>, IdentityChange)> {
     // A record with no current state and no previous states is degenerate — treat
     // it as missing so the caller gets SessionNotFound and sends a proper retry
     // receipt (with error code 1) instead of attempting decryption that will always
@@ -424,14 +445,19 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
     // The previous session gets promoted to current via `promote_old_session`, so we need
     // to save its identity to avoid UntrustedIdentity errors on subsequent messages.
     // This handles out-of-order message delivery after an identity change gracefully.
-    if decrypt_result.used_previous_session {
+    let identity_change = if decrypt_result.used_previous_session {
         log::debug!(
             "Saving identity for {} from previous session (skipping trust check)",
             remote_address,
         );
+        // Re-saving an archived session's (older) identity for out-of-order
+        // delivery is not the peer's current identity changing, so never report
+        // it as a change. Doing so would fire a spurious local identity-change
+        // reaction and clobber the current identity.
         identity_store
             .save_identity(remote_address, &their_identity_key)
             .await?;
+        IdentityChange::NewOrUnchanged
     } else {
         if !identity_store
             .is_trusted_identity(remote_address, &their_identity_key, Direction::Receiving)
@@ -449,10 +475,10 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
 
         identity_store
             .save_identity(remote_address, &their_identity_key)
-            .await?;
-    }
+            .await?
+    };
 
-    Ok(decrypt_result.plaintext)
+    Ok((decrypt_result.plaintext, identity_change))
 }
 
 fn create_decryption_failure_log(
@@ -546,8 +572,9 @@ fn create_decryption_failure_log(
     Ok(lines.join("\n"))
 }
 
-/// Result of decrypting a message, including whether a previous session was used.
-struct DecryptionResult {
+/// Result of decrypting a message against a session record, including whether a
+/// previous session was used.
+struct RecordDecryptResult {
     plaintext: Vec<u8>,
     /// True if the message was decrypted using a previous (archived) session state
     /// rather than the current session. When true, the identity check should be
@@ -561,7 +588,7 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
     ciphertext: &SignalMessage,
     original_message_type: CiphertextMessageType,
     csprng: &mut R,
-) -> Result<DecryptionResult> {
+) -> Result<RecordDecryptResult> {
     debug_assert!(matches!(
         original_message_type,
         CiphertextMessageType::Whisper | CiphertextMessageType::PreKey
@@ -607,7 +634,7 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
                         .expect("successful decrypt always has a valid base key"),
                 );
                 record.set_session_state(current_state); // update the state
-                return Ok(DecryptionResult {
+                return Ok(RecordDecryptResult {
                     plaintext: ptext,
                     used_previous_session: false,
                 });
@@ -696,7 +723,7 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
                 );
                 // Promote this session (it's already been removed by take_previous_session)
                 record.promote_state(previous);
-                return Ok(DecryptionResult {
+                return Ok(RecordDecryptResult {
                     plaintext: ptext,
                     used_previous_session: true,
                 });
@@ -1252,6 +1279,187 @@ mod tests {
             bob_addr,
             bob_sessions,
             bob_identity,
+        }
+    }
+
+    /// Builds Bob's prekey stores plus a self-signed `PreKeyBundle`, without
+    /// establishing any session. Each call uses a fresh identity, so two bundles
+    /// for the same address model a peer reinstall.
+    #[allow(clippy::type_complexity)]
+    fn fresh_bob(
+        rng: &mut rand::rngs::StdRng,
+    ) -> (
+        ProtocolAddress,
+        MemSessionStore,
+        MemIdentityStore,
+        MemPreKeyStore,
+        MemSignedPreKeyStore,
+        PreKeyBundle,
+    ) {
+        let bob_addr = ProtocolAddress::new("bob".to_string(), 1.into());
+        let bob_id = IdentityKeyPair::generate(rng);
+        let bob_identity_key = *bob_id.identity_key();
+
+        let prekey_id: PreKeyId = 1.into();
+        let prekey_pair = KeyPair::generate(rng);
+        let signed_id: SignedPreKeyId = 1.into();
+        let signed_pair = KeyPair::generate(rng);
+        let signed_sig = bob_id
+            .private_key()
+            .calculate_signature(&signed_pair.public_key.serialize(), rng)
+            .expect("signature");
+
+        let mut bob_prekeys = MemPreKeyStore::new();
+        let mut bob_signed = MemSignedPreKeyStore::new();
+        futures::executor::block_on(async {
+            bob_prekeys
+                .save_pre_key(prekey_id, &PreKeyRecord::new(prekey_id, &prekey_pair))
+                .await
+                .expect("save prekey");
+            bob_signed
+                .save_signed_pre_key(
+                    signed_id,
+                    &SignedPreKeyRecord::new(
+                        signed_id,
+                        Timestamp::from_epoch_millis(0),
+                        &signed_pair,
+                        &signed_sig,
+                    ),
+                )
+                .await
+                .expect("save signed prekey");
+        });
+
+        let bundle = PreKeyBundle::new(
+            2,
+            1.into(),
+            Some((prekey_id, prekey_pair.public_key)),
+            signed_id,
+            signed_pair.public_key,
+            signed_sig.to_vec(),
+            bob_identity_key,
+        )
+        .expect("valid bundle");
+
+        (
+            bob_addr,
+            MemSessionStore::new(),
+            MemIdentityStore::new(bob_id, 2),
+            bob_prekeys,
+            bob_signed,
+            bundle,
+        )
+    }
+
+    /// `process_prekey_bundle` must report `NewOrUnchanged` on first contact and
+    /// `ReplacedExisting` when a later bundle carries a different identity for the
+    /// same address (peer reinstall). This is the signal the high-level client
+    /// threads up to mirror WA Web `saveIdentity` -> `handleNewIdentity`.
+    #[test]
+    fn process_prekey_bundle_reports_identity_change() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let (bob_addr, _bs, _bi, _bp, _bsp, bundle1) = fresh_bob(&mut rng);
+        let (_bob_addr2, _bs2, _bi2, _bp2, _bsp2, bundle2) = fresh_bob(&mut rng);
+
+        let alice_id = IdentityKeyPair::generate(&mut rng);
+        let mut alice_sessions = MemSessionStore::new();
+        let mut alice_identity = MemIdentityStore::new(alice_id, 1);
+
+        futures::executor::block_on(async {
+            let first = process_prekey_bundle(
+                &bob_addr,
+                &mut alice_sessions,
+                &mut alice_identity,
+                &bundle1,
+                &mut rng,
+                UsePQRatchet::No,
+            )
+            .await
+            .expect("first bundle");
+            assert_eq!(first, IdentityChange::NewOrUnchanged, "first contact");
+
+            let second = process_prekey_bundle(
+                &bob_addr,
+                &mut alice_sessions,
+                &mut alice_identity,
+                &bundle2,
+                &mut rng,
+                UsePQRatchet::No,
+            )
+            .await
+            .expect("second bundle");
+            assert_eq!(
+                second,
+                IdentityChange::ReplacedExisting,
+                "different identity for same address"
+            );
+        });
+    }
+
+    /// `message_decrypt` of a pkmsg reports `NewOrUnchanged` on first contact and
+    /// `ReplacedExisting` when the sender's stored identity differs (reinstall),
+    /// while still returning the correct plaintext.
+    #[test]
+    fn decrypt_prekey_reports_identity_change() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+        for (preseed_stale, expected) in [
+            (false, IdentityChange::NewOrUnchanged),
+            (true, IdentityChange::ReplacedExisting),
+        ] {
+            let alice_addr = ProtocolAddress::new("alice".to_string(), 1.into());
+            let alice_id = IdentityKeyPair::generate(&mut rng);
+            let mut alice_sessions = MemSessionStore::new();
+            let mut alice_identity = MemIdentityStore::new(alice_id, 1);
+
+            let (bob_addr, mut bob_sessions, mut bob_identity, mut bob_prekeys, bob_signed, bundle) =
+                fresh_bob(&mut rng);
+
+            futures::executor::block_on(async {
+                if preseed_stale {
+                    // Bob already knows a different identity for Alice → reinstall.
+                    let stale = *IdentityKeyPair::generate(&mut rng).identity_key();
+                    bob_identity
+                        .save_identity(&alice_addr, &stale)
+                        .await
+                        .expect("seed stale identity");
+                }
+
+                process_prekey_bundle(
+                    &bob_addr,
+                    &mut alice_sessions,
+                    &mut alice_identity,
+                    &bundle,
+                    &mut rng,
+                    UsePQRatchet::No,
+                )
+                .await
+                .expect("process bundle");
+
+                let ct =
+                    message_encrypt(b"hi", &bob_addr, &mut alice_sessions, &mut alice_identity)
+                        .await
+                        .expect("encrypt");
+                let pkmsg = CiphertextMessage::PreKeySignalMessage(
+                    PreKeySignalMessage::try_from(ct.serialize()).expect("parse pkmsg"),
+                );
+
+                let res = message_decrypt(
+                    &pkmsg,
+                    &alice_addr,
+                    &mut bob_sessions,
+                    &mut bob_identity,
+                    &mut bob_prekeys,
+                    &bob_signed,
+                    &mut rng,
+                    UsePQRatchet::No,
+                )
+                .await
+                .expect("decrypt pkmsg");
+
+                assert_eq!(res.plaintext, b"hi".to_vec());
+                assert_eq!(res.identity_change, expected);
+            });
         }
     }
 

--- a/wacore/libsignal/tests/session_divergence.rs
+++ b/wacore/libsignal/tests/session_divergence.rs
@@ -314,6 +314,7 @@ fn receive(
             UsePQRatchet::No,
         )
         .await
+        .map(|d| d.plaintext)
     })
 }
 

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -166,6 +166,16 @@ pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {
         let _ = phone_user;
         None
     }
+
+    /// Notify that establishing a session for `jid` replaced a previously-stored
+    /// identity key (local detection of a peer identity change on the send path).
+    ///
+    /// Default is a no-op; the high-level client reacts off-path (mirrors WA Web
+    /// `saveIdentity` -> `handleNewIdentity`). The resolver is the only handle
+    /// back to the client available inside `encrypt_for_devices`.
+    fn on_local_identity_change(&self, jid: &Jid) {
+        let _ = jid;
+    }
 }
 
 #[cfg(test)]

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -1,7 +1,8 @@
 use crate::client::context::{GroupInfo, SendContextResolver};
 use crate::libsignal::protocol::{
-    CiphertextMessage, ProtocolAddress, SENDERKEY_MESSAGE_CURRENT_VERSION, SenderKeyMessage,
-    SenderKeyStore, SignalProtocolError, UsePQRatchet, message_encrypt, process_prekey_bundle,
+    CiphertextMessage, IdentityChange, ProtocolAddress, SENDERKEY_MESSAGE_CURRENT_VERSION,
+    SenderKeyMessage, SenderKeyStore, SignalProtocolError, UsePQRatchet, message_encrypt,
+    process_prekey_bundle,
 };
 use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::messages::MessageUtils;
@@ -798,7 +799,7 @@ where
                         "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
                         addr
                     );
-                    return Ok::<(), anyhow::Error>(());
+                    return Ok::<Option<Jid>, anyhow::Error>(None);
                 };
 
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
@@ -815,7 +816,10 @@ where
                 )
                 .await
                 {
-                    Ok(_) => Ok(()),
+                    // Surface a replaced identity so the caller can react
+                    // (resolver has no 'static handle into this spawned task).
+                    Ok(IdentityChange::ReplacedExisting) => Ok(Some(encryption_jid)),
+                    Ok(IdentityChange::NewOrUnchanged) => Ok(None),
                     Err(e) => Err(anyhow::anyhow!(
                         "Failed to process pre-key bundle for {}: {:?}",
                         addr,
@@ -832,7 +836,10 @@ where
         }
         while let Some(spawn_result) = in_flight.next().await {
             match spawn_result {
-                Ok(Ok(())) => {}
+                // Some(jid) => establishing this session replaced a stored
+                // identity; notify the client so it can react off-path.
+                Ok(Ok(Some(changed_jid))) => resolver.on_local_identity_change(&changed_jid),
+                Ok(Ok(None)) => {}
                 Ok(Err(e)) => return Err(e),
                 Err(SpawnCanceled) => {
                     log::warn!(
@@ -2394,6 +2401,8 @@ mod tests {
         devices: Vec<Jid>,
         /// Phone number to LID mappings for testing LID session lookup
         phone_to_lid: HashMap<String, String>,
+        /// JIDs reported via `on_local_identity_change` (send-path detection).
+        identity_changes: std::sync::Mutex<Vec<Jid>>,
     }
 
     impl MockSendContextResolver {
@@ -2402,7 +2411,12 @@ mod tests {
                 prekey_bundles: HashMap::new(),
                 devices: Vec::new(),
                 phone_to_lid: HashMap::new(),
+                identity_changes: std::sync::Mutex::new(Vec::new()),
             }
+        }
+
+        fn captured_identity_changes(&self) -> Vec<Jid> {
+            self.identity_changes.lock().unwrap().clone()
         }
 
         fn with_missing_bundle(mut self, jid: Jid) -> Self {
@@ -2469,6 +2483,10 @@ mod tests {
             phone_user: &str,
         ) -> Option<wacore_binary::CompactString> {
             self.phone_to_lid.get(phone_user).map(|s| s.as_str().into())
+        }
+
+        fn on_local_identity_change(&self, jid: &Jid) {
+            self.identity_changes.lock().unwrap().push(jid.clone());
         }
     }
 
@@ -5069,6 +5087,233 @@ mod tests {
                 build_group_phash_set(&with_hosted, &own),
                 build_group_phash_set(&without_hosted, &own),
                 "hosted devices must not affect the phash set"
+            );
+        }
+    }
+
+    mod local_identity_change_on_send {
+        use super::*;
+        use crate::libsignal::protocol::{
+            Direction, IdentityChange, IdentityKey, IdentityKeyStore, PreKeyId, PreKeyRecord,
+            PreKeyStore, ProtocolAddress, SenderKeyRecord, SessionRecord, SessionStore,
+            SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
+        };
+        use crate::runtime::{AbortHandle, Runtime};
+        use crate::types::jid::JidExt;
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::time::Duration;
+
+        type SigResult<T> = crate::libsignal::protocol::error::Result<T>;
+
+        #[derive(Clone, Default)]
+        struct MemSessionStore(HashMap<ProtocolAddress, Vec<u8>>);
+        #[async_trait::async_trait]
+        impl SessionStore for MemSessionStore {
+            async fn load_session(&self, a: &ProtocolAddress) -> SigResult<Option<SessionRecord>> {
+                Ok(self
+                    .0
+                    .get(a)
+                    .and_then(|b| SessionRecord::deserialize(b).ok()))
+            }
+            async fn has_session(&self, a: &ProtocolAddress) -> SigResult<bool> {
+                Ok(self.0.contains_key(a))
+            }
+            async fn store_session(
+                &mut self,
+                a: &ProtocolAddress,
+                r: SessionRecord,
+            ) -> SigResult<()> {
+                self.0.insert(a.clone(), r.serialize()?);
+                Ok(())
+            }
+        }
+
+        /// Identity store that reports the real change (unlike the hardcoded
+        /// stub elsewhere), so a pre-seeded stale key surfaces as ReplacedExisting.
+        #[derive(Clone)]
+        struct MemIdentityStore {
+            pair: IdentityKeyPair,
+            known: HashMap<ProtocolAddress, IdentityKey>,
+        }
+        #[async_trait::async_trait]
+        impl IdentityKeyStore for MemIdentityStore {
+            async fn get_identity_key_pair(&self) -> SigResult<IdentityKeyPair> {
+                Ok(self.pair.clone())
+            }
+            async fn get_local_registration_id(&self) -> SigResult<u32> {
+                Ok(42)
+            }
+            async fn save_identity(
+                &mut self,
+                a: &ProtocolAddress,
+                id: &IdentityKey,
+            ) -> SigResult<IdentityChange> {
+                let changed = self.known.get(a).is_some_and(|k| k != id);
+                self.known.insert(a.clone(), *id);
+                Ok(IdentityChange::from_changed(changed))
+            }
+            async fn is_trusted_identity(
+                &self,
+                _: &ProtocolAddress,
+                _: &IdentityKey,
+                _: Direction,
+            ) -> SigResult<bool> {
+                Ok(true)
+            }
+            async fn get_identity(&self, a: &ProtocolAddress) -> SigResult<Option<IdentityKey>> {
+                Ok(self.known.get(a).copied())
+            }
+        }
+
+        struct UnusedPreKeyStore;
+        #[async_trait::async_trait]
+        impl PreKeyStore for UnusedPreKeyStore {
+            async fn get_pre_key(&self, _: PreKeyId) -> SigResult<PreKeyRecord> {
+                unreachable!()
+            }
+            async fn save_pre_key(&mut self, _: PreKeyId, _: &PreKeyRecord) -> SigResult<()> {
+                unreachable!()
+            }
+            async fn remove_pre_key(&mut self, _: PreKeyId) -> SigResult<()> {
+                unreachable!()
+            }
+        }
+        struct UnusedSignedPreKeyStore;
+        #[async_trait::async_trait]
+        impl SignedPreKeyStore for UnusedSignedPreKeyStore {
+            async fn get_signed_pre_key(&self, _: SignedPreKeyId) -> SigResult<SignedPreKeyRecord> {
+                unreachable!()
+            }
+            async fn save_signed_pre_key(
+                &mut self,
+                _: SignedPreKeyId,
+                _: &SignedPreKeyRecord,
+            ) -> SigResult<()> {
+                unreachable!()
+            }
+        }
+        #[derive(Default)]
+        struct MemSenderKeyStore(
+            HashMap<crate::libsignal::store::sender_key_name::SenderKeyName, SenderKeyRecord>,
+        );
+        #[async_trait::async_trait]
+        impl SenderKeyStore for MemSenderKeyStore {
+            async fn store_sender_key(
+                &mut self,
+                n: &crate::libsignal::store::sender_key_name::SenderKeyName,
+                r: SenderKeyRecord,
+            ) -> SigResult<()> {
+                self.0.insert(n.clone(), r);
+                Ok(())
+            }
+            async fn load_sender_key(
+                &self,
+                n: &crate::libsignal::store::sender_key_name::SenderKeyName,
+            ) -> SigResult<Option<SenderKeyRecord>> {
+                Ok(self.0.get(n).cloned())
+            }
+        }
+
+        struct TokioTestRuntime;
+        #[async_trait::async_trait]
+        impl Runtime for TokioTestRuntime {
+            fn spawn(
+                &self,
+                future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+            ) -> AbortHandle {
+                let handle = tokio::spawn(future);
+                AbortHandle::new(move || handle.abort())
+            }
+            fn sleep(&self, _d: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+                Box::pin(async {})
+            }
+            fn spawn_blocking(
+                &self,
+                f: Box<dyn FnOnce() + Send + 'static>,
+            ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+                Box::pin(async move {
+                    let _ = tokio::task::spawn_blocking(f).await;
+                })
+            }
+            fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+                None
+            }
+        }
+
+        /// The send path must report a replaced identity via the resolver when
+        /// establishing a session whose bundle carries a new identity key for an
+        /// address we already knew (peer reinstall). Mirrors WA Web saveIdentity
+        /// -> handleNewIdentity firing during outbound session setup.
+        #[tokio::test]
+        async fn encrypt_for_devices_reports_replaced_identity() {
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+            // Receiver device D with a valid signed bundle.
+            let device: Jid = "5511777777777:0@s.whatsapp.net".parse().unwrap();
+            let receiver = IdentityKeyPair::generate(&mut rng);
+            let spk = KeyPair::generate(&mut rng);
+            let opk = KeyPair::generate(&mut rng);
+            let sig = receiver
+                .private_key()
+                .calculate_signature(&spk.public_key.serialize(), &mut rng)
+                .unwrap();
+            let bundle = PreKeyBundle::new(
+                1,
+                1u32.into(),
+                Some((1u32.into(), opk.public_key)),
+                1u32.into(),
+                spk.public_key,
+                sig.to_vec(),
+                *receiver.identity_key(),
+            )
+            .unwrap();
+
+            // Local stores: no session for D + a STALE identity pre-seeded for D's
+            // address, so establishing the session reports ReplacedExisting.
+            let sender = IdentityKeyPair::generate(&mut rng);
+            let stale = *IdentityKeyPair::generate(&mut rng).identity_key();
+            let mut known = HashMap::new();
+            known.insert(device.to_protocol_address(), stale);
+
+            let mut session_store = MemSessionStore::default();
+            let mut identity_store = MemIdentityStore {
+                pair: sender,
+                known,
+            };
+            let mut prekey_store = UnusedPreKeyStore;
+            let signed_prekey_store = UnusedSignedPreKeyStore;
+            let mut sender_key_store = MemSenderKeyStore::default();
+
+            let mut stores = SignalStores {
+                sender_key_store: &mut sender_key_store,
+                session_store: &mut session_store,
+                identity_store: &mut identity_store,
+                prekey_store: &mut prekey_store,
+                signed_prekey_store: &signed_prekey_store,
+            };
+
+            let resolver = MockSendContextResolver::new()
+                .with_bundle(device.clone(), bundle)
+                .with_devices(vec![device.clone()]);
+            let rt = TokioTestRuntime;
+
+            encrypt_for_devices(
+                &rt,
+                &mut stores,
+                &resolver,
+                std::slice::from_ref(&device),
+                b"hello",
+                false,
+                None,
+            )
+            .await
+            .expect("encrypt_for_devices");
+
+            assert_eq!(
+                resolver.captured_identity_changes(),
+                vec![device],
+                "replaced identity on the send path must be reported via the resolver"
             );
         }
     }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -460,6 +460,10 @@ pub struct IdentityChange {
     /// Optional LID for the user
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lid_user: Option<Jid>,
+    /// `true` when detected locally while saving a peer's new identity during
+    /// decrypt (mirrors WA Web `saveIdentity` -> `handleNewIdentity`), `false`
+    /// when triggered by the server's `<identity/>` notification.
+    pub implicit: bool,
 }
 
 /// Type of business status update.


### PR DESCRIPTION
## Problem

When a peer reinstalls WhatsApp (or otherwise rotates their identity key), our Signal store already detects it: `save_identity` returns `IdentityChange::ReplacedExisting` when the stored identity key differs from the new one. `is_trusted_identity` intentionally returns `true` (TOFU, matching WA Web's `ProtocolStoreUnifiedApi.isTrustedIdentity`), so an identity change surfaces through `save_identity` rather than by rejecting the message.

Every caller discarded that signal. `process_prekey_bundle` and the `message_decrypt*` family called `save_identity` and threw the `IdentityChange` away, so a locally-detected identity change fired nothing: no event, no device-record cleanup, no tcToken refresh. Only the server's `<notification type="encrypt"><identity/></notification>` push (`WAWebHandleIdentityChange`) produced any reaction. A peer re-registration detected locally (a pkmsg/bundle arriving before the server push, or a bundle served with a divergent identity) was silently accepted.

Separately, our server-push handler (`handle_identity_change`) never re-issued the trusted-contact token that WA Web's `handleE2eIdentityChange` sends, so the tcToken refresh on identity change was effectively missing.

WA Web reacts in both places: `ProtocolStoreUnifiedApi.saveIdentity` calls `handleNewIdentity` when the stored key differs, and the server-push handler does the heavier `handleE2eIdentityChange`.

## Change

Thread the `IdentityChange` up from the Signal layer and react to `ReplacedExisting` on the local detection paths, mirroring WA Web's `saveIdentity -> handleNewIdentity`.

Signal layer (wacore):
- `message_decrypt` / `message_decrypt_prekey` / `message_decrypt_signal` now return `DecryptionResult { plaintext, identity_change }`.
- `process_prekey_bundle` / `process_prekey_bundle_inner` return `Result<IdentityChange>`.
- `process_prekey` additionally signals whether it reused an already-established session.
- Decrypting against a non-fresh session reports `NewOrUnchanged`, because re-saving an older identity for out-of-order delivery is not the peer's current identity changing. This covers both the previous (archived) session in the plain SignalMessage path and a duplicate/out-of-order `PreKeySignalMessage` that matched an existing session.

High-level client:
- New `handle_local_identity_change`. Gated to the peer's primary device (`device == 0`) and skip-self, it runs the lighter subset of WA Web's `handleNewIdentity`: `clear_device_record` (companion devices) + `invalidate_device_cache` + re-issue an active tcToken + dispatch `Event::IdentityChange { implicit: true }`. It deliberately does NOT delete the primary session, rotate the status sender key, or call `ensure_e2e_sessions`. Those belong to the server-push handler, and the new session is being established by the very message that triggered detection. WA Web's local `handleNewIdentity` omits them too.
- The server-push handler `handle_identity_change` now also re-issues an active tcToken, matching WA Web `handleE2eIdentityChange -> sendTcTokenWhenDeviceIdentityChange`. This is the path that fires in practice, so the tcToken refresh now actually happens. It is spawned and no-ops unless a non-expired sender token already exists (so it only fires for a prior relationship, mirroring WA Web's "had old identity" guard).
- The reaction is dispatched off-path via `Client::react_to_local_identity_change` (spawned, detached) so it never runs under the per-sender session lock, and `clear_device_record` only touches companion (non-primary) sessions.
- Triggers: the inbound decrypt batch (`process_session_enc_batch`, deduped once per batch and mirrored in the retry-after-`UntrustedIdentity` branch), outbound session establishment (`ensure_e2e_sessions`, retry-receipt bundle), and the send path (`encrypt_for_devices`) via a new defaulted `SendContextResolver::on_local_identity_change` callback. PN to LID migration decrypt does not react (re-addressing, not a reinstall).
- `Event::IdentityChange` gains an `implicit` field: `false` for the server `<identity/>` push, `true` for local detection.

No loop or self-clobber: the server-push handler deletes and flushes the identity before spawning `ensure_e2e_sessions`, so the subsequent bundle reports `NewOrUnchanged`.

## Tests

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` (clean)
- `cargo test --all --exclude e2e-tests` (all green)

New:
- libsignal threading: `process_prekey_bundle_reports_identity_change`, `decrypt_prekey_reports_identity_change` (NewOrUnchanged on first contact, ReplacedExisting on a replaced key, plaintext intact).
- reuse suppression: `process_prekey_signals_reuse_for_established_session` (first pkmsg establishes, re-processing the same pkmsg signals reuse).
- gating: `test_local_identity_change_dispatches_implicit_event`, `test_local_identity_change_skips_self`, `test_local_identity_change_skips_companion_device`.
- send path end to end: `encrypt_for_devices_reports_replaced_identity` (a bundle carrying a new identity for a known address fires the resolver callback).

## Performance

No measurable impact, so no benchmark. The decrypt return now carries a 1-byte `Copy` enum (no allocation; `save_identity` already computed it). On the send path the establishment task returns `Option<Jid>`: `None` on the common path (no clone), and only moves the already-owned `Jid` on the rare `ReplacedExisting`. The reaction (and the tcToken IQ, which is conditional on an active token) only runs on an actual identity change.

## Breaking

Yes (pre-1.0):
- `message_decrypt`, `message_decrypt_prekey`, `message_decrypt_signal` return `DecryptionResult` instead of `Vec<u8>`.
- `process_prekey_bundle` returns `Result<IdentityChange>` instead of `Result<()>`.
- `process_prekey` returns `Result<(PreKeysUsed, IdentityToSave, bool)>` (the trailing bool signals session reuse).
- `Event::IdentityChange` gained a non-optional `implicit: bool` field.
- `SendContextResolver` gained a defaulted `on_local_identity_change` method (no-op default, so external implementors are unaffected).
