### PR TITLE
perf(identity): gate identity-change reset behind had-prior-identity, like WA Web

### DIFF
--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -349,19 +349,28 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
     // path would otherwise eagerly fetch prekeys + X3DH to build a session we may
     // never use.
     //
-    // Check BOTH the resolved (preferred LID-or-PN) address and the original PN
-    // address. They diverge when a PN->LID mapping was learned from offline replay
-    // but the Signal-state migration hasn't run yet: the identity is still under the
-    // PN address while resolve_encryption_jid already points at the LID one. Reading
-    // only the resolved address would then false-negative and skip a real reset.
+    // Check every address the identity could be stored under, because PN/LID
+    // resolution can diverge from where the state actually lives:
+    //   - the resolved (preferred LID-or-PN) address from resolve_encryption_jid;
+    //   - the original PN address (state can still be under PN when a PN->LID
+    //     mapping was learned from offline replay but the migration hasn't run yet);
+    //   - the LID carried by the stanza itself (the local cache may be cold/evicted
+    //     so resolve falls back to PN, yet the state lives under the stanza LID).
+    // Reading only the resolved address would false-negative and skip a real reset.
     let resolved = client.resolve_encryption_jid(&from_jid).await;
-    let addr = resolved.to_protocol_address();
-    let original_addr = from_jid.to_protocol_address();
-    let mut reset_addrs = vec![addr.clone()];
-    if original_addr != addr {
-        reset_addrs.push(original_addr);
-    }
+    let stanza_lid = node.attrs().optional_jid("lid");
     let backend = client.persistence_manager.backend();
+
+    let mut reset_addrs = vec![resolved.to_protocol_address()];
+    for candidate in [Some(from_jid.clone()), stanza_lid.clone()]
+        .into_iter()
+        .flatten()
+    {
+        let cand_addr = candidate.to_protocol_address();
+        if !reset_addrs.contains(&cand_addr) {
+            reset_addrs.push(cand_addr);
+        }
+    }
 
     // Treat a backend read error as had-prior (fail-safe): run the reset rather
     // than silently skip it, matching the old always-reset behavior. Collapsing
@@ -452,7 +461,7 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
     client.core.event_bus.dispatch(Event::IdentityChange(
         crate::types::events::IdentityChange {
             user: from_jid.clone(),
-            lid_user: node.attrs().optional_jid("lid"),
+            lid_user: stanza_lid,
             implicit: false,
         },
     ));
@@ -2755,6 +2764,61 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "the stale PN identity must be deleted by the reset"
+        );
+    }
+
+    /// Regression: a stanza can carry a `lid` attr while the local PN->LID cache is
+    /// cold, so resolve_encryption_jid falls back to PN. If the identity lives under
+    /// the stanza LID, the gate must still find it (via the stanza-LID candidate) and
+    /// run the reset rather than skip it.
+    #[tokio::test]
+    async fn test_identity_change_resets_identity_under_stanza_lid_with_cold_cache() {
+        use wacore::types::jid::JidExt;
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        // Cold cache: no PN->LID mapping, so resolve_encryption_jid(PN) returns PN.
+        let pn_jid: Jid = "5511444444444@s.whatsapp.net".parse().unwrap();
+        let resolved = client.resolve_encryption_jid(&pn_jid).await;
+        assert!(
+            !resolved.is_lid(),
+            "test setup: cache must be cold (resolve -> PN), got {resolved}"
+        );
+
+        // The identity lives under the LID carried by the stanza, not the PN.
+        let lid_jid: Jid = "100000000000066@lid".parse().unwrap();
+        let lid_addr = lid_jid.to_protocol_address();
+        client
+            .signal_cache
+            .put_identity(&lid_addr, &[7u8; 32])
+            .await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "encrypt")
+            .attr("from", "5511444444444@s.whatsapp.net")
+            .attr("lid", "100000000000066@lid")
+            .attr("id", "identity-change-stanzalid")
+            .children([NodeBuilder::new("identity").build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        assert!(
+            collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::IdentityChange(_))),
+            "must dispatch IdentityChange when the identity is under the stanza LID"
+        );
+        let backend = client.persistence_manager.backend();
+        assert!(
+            client
+                .signal_cache
+                .get_identity(&lid_addr, backend.as_ref())
+                .await
+                .unwrap()
+                .is_none(),
+            "the stale stanza-LID identity must be deleted by the reset"
         );
     }
 }

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -347,28 +347,47 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
     // group-only peer we never had a session with), skip the session delete/rebuild,
     // status sender-key rotation, tcToken reissue and the change notification — that
     // path would otherwise eagerly fetch prekeys + X3DH to build a session we may
-    // never use. Use the same `addr` the delete uses so read and delete agree.
+    // never use.
+    //
+    // Check BOTH the resolved (preferred LID-or-PN) address and the original PN
+    // address. They diverge when a PN->LID mapping was learned from offline replay
+    // but the Signal-state migration hasn't run yet: the identity is still under the
+    // PN address while resolve_encryption_jid already points at the LID one. Reading
+    // only the resolved address would then false-negative and skip a real reset.
     let resolved = client.resolve_encryption_jid(&from_jid).await;
     let addr = resolved.to_protocol_address();
+    let original_addr = from_jid.to_protocol_address();
+    let mut reset_addrs = vec![addr.clone()];
+    if original_addr != addr {
+        reset_addrs.push(original_addr);
+    }
     let backend = client.persistence_manager.backend();
+
     // Treat a backend read error as had-prior (fail-safe): run the reset rather
     // than silently skip it, matching the old always-reset behavior. Collapsing
     // an Err into "no prior identity" would be a fail-open regression on a
     // session-deletion path (see the same explicit-match rule in lid_pn.rs).
-    let had_prior_identity = match client
-        .signal_cache
-        .get_identity(&addr, backend.as_ref())
-        .await
-    {
-        Ok(identity) => identity.is_some(),
-        Err(e) => {
-            warn!(
-                "Identity change: failed reading stored identity for {}: {e}; proceeding with reset",
-                from_jid.user
-            );
-            true
+    let mut had_prior_identity = false;
+    for cand in &reset_addrs {
+        match client
+            .signal_cache
+            .get_identity(cand, backend.as_ref())
+            .await
+        {
+            Ok(Some(_)) => {
+                had_prior_identity = true;
+                break;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!(
+                    "Identity change: failed reading stored identity for {cand}: {e}; proceeding with reset"
+                );
+                had_prior_identity = true;
+                break;
+            }
         }
-    };
+    }
 
     if !had_prior_identity {
         info!(
@@ -383,16 +402,19 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
         from_jid.user
     );
 
-    // Delete primary session + identity so a fresh session can be established,
-    // and rotate status sender key for forward secrecy. Single flush covers both.
+    // Delete the session + identity at every candidate address (resolved + the
+    // pre-migration PN one) so a fresh session can be established, and rotate the
+    // status sender key for forward secrecy. Single flush covers all of it.
     {
-        // Hold session lock while deleting to prevent concurrent encrypt/decrypt
-        // from recreating the stale session (mirrors Signal::delete_sessions)
-        let lock = client.session_lock_for(addr.as_str()).await;
-        let _guard = lock.lock().await;
-        client.signal_cache.delete_session(&addr).await;
-        client.signal_cache.delete_identity(&addr).await;
-        drop(_guard);
+        for cand in &reset_addrs {
+            // Hold the per-address session lock while deleting to prevent concurrent
+            // encrypt/decrypt from recreating the stale session (mirrors
+            // Signal::delete_sessions). One lock at a time, so no lock-ordering risk.
+            let lock = client.session_lock_for(cand.as_str()).await;
+            let _guard = lock.lock().await;
+            client.signal_cache.delete_session(cand).await;
+            client.signal_cache.delete_identity(cand).await;
+        }
 
         let status_group = "status@broadcast";
         for own_jid in device_snapshot.pn.iter().chain(device_snapshot.lid.iter()) {
@@ -2675,6 +2697,64 @@ mod tests {
                 .await
                 .unwrap(),
             "companion-device session must be cleared even on the no-prior path"
+        );
+    }
+
+    /// Regression: when a PN->LID mapping was learned offline (migration deferred),
+    /// the identity is still under the PN address while resolve_encryption_jid points
+    /// at the LID. The gate must check the original PN address too and still run the
+    /// reset (delete the stale PN identity + dispatch the event), not false-negative.
+    #[tokio::test]
+    async fn test_identity_change_resets_unmigrated_pn_identity_under_lid_resolve() {
+        use wacore::types::jid::JidExt;
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let pn = "5511555555555";
+        let lid = "100000000000055";
+        // Offline learn: records the PN->LID mapping in cache but skips the Signal
+        // migration, so resolve points at the LID while state stays under the PN.
+        client
+            .learn_lid_pn_mapping_fast(lid, pn, LearningSource::Other, true)
+            .await;
+
+        let pn_jid: Jid = "5511555555555@s.whatsapp.net".parse().unwrap();
+        // Confirm the setup actually diverges (resolve -> LID), else the test is moot.
+        let resolved = client.resolve_encryption_jid(&pn_jid).await;
+        assert!(
+            resolved.is_lid(),
+            "test setup: resolve_encryption_jid should return the LID, got {resolved}"
+        );
+
+        // Seed the identity under the PN address (not the LID).
+        let pn_addr = pn_jid.to_protocol_address();
+        client.signal_cache.put_identity(&pn_addr, &[7u8; 32]).await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "encrypt")
+            .attr("from", "5511555555555@s.whatsapp.net")
+            .attr("id", "identity-change-pnlid")
+            .children([NodeBuilder::new("identity").build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        assert!(
+            collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::IdentityChange(_))),
+            "must dispatch IdentityChange when the identity is under the unmigrated PN address"
+        );
+        let backend = client.persistence_manager.backend();
+        assert!(
+            client
+                .signal_cache
+                .get_identity(&pn_addr, backend.as_ref())
+                .await
+                .unwrap()
+                .is_none(),
+            "the stale PN identity must be deleted by the reset"
         );
     }
 }

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -327,28 +327,65 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
         return;
     }
 
-    info!(
-        "Identity change for user {}: clearing device record",
-        from_jid.user
-    );
+    use wacore::libsignal::store::sender_key_name::SenderKeyName;
+    use wacore::types::jid::JidExt;
 
-    // Deletes non-primary sessions + all sender key device tracking
+    // Always run the device-list cleanup, matching WA Web's
+    // clearDeviceRecordForIdentityChange (which runs BEFORE the had-prior-identity
+    // gate): drop companion device sessions + force a fresh usync of the peer's
+    // device list on the next send.
     if let Some(record) = client.load_device_record(&from_jid.user).await {
         client
             .clear_device_record(&from_jid.user, from_jid.server.as_str(), &record)
             .await;
     }
+    client.invalidate_device_cache(&from_jid.user).await;
+
+    // WA Web gates the heavy reset behind loadIdentityKey(addr) != null
+    // (WAWebHandleIdentityChange: `if (!isStringNullOrEmpty(t))`). Read the stored
+    // identity non-destructively BEFORE deleting it. With no prior identity (e.g. a
+    // group-only peer we never had a session with), skip the session delete/rebuild,
+    // status sender-key rotation, tcToken reissue and the change notification — that
+    // path would otherwise eagerly fetch prekeys + X3DH to build a session we may
+    // never use. Use the same `addr` the delete uses so read and delete agree.
+    let resolved = client.resolve_encryption_jid(&from_jid).await;
+    let addr = resolved.to_protocol_address();
+    let backend = client.persistence_manager.backend();
+    // Treat a backend read error as had-prior (fail-safe): run the reset rather
+    // than silently skip it, matching the old always-reset behavior. Collapsing
+    // an Err into "no prior identity" would be a fail-open regression on a
+    // session-deletion path (see the same explicit-match rule in lid_pn.rs).
+    let had_prior_identity = match client
+        .signal_cache
+        .get_identity(&addr, backend.as_ref())
+        .await
+    {
+        Ok(identity) => identity.is_some(),
+        Err(e) => {
+            warn!(
+                "Identity change: failed reading stored identity for {}: {e}; proceeding with reset",
+                from_jid.user
+            );
+            true
+        }
+    };
+
+    if !had_prior_identity {
+        info!(
+            "Identity change for {} (had_prior_identity=false): device record cleared, skipping session reset",
+            from_jid.user
+        );
+        return;
+    }
+
+    info!(
+        "Identity change for {} (had_prior_identity=true): resetting session",
+        from_jid.user
+    );
 
     // Delete primary session + identity so a fresh session can be established,
-    // and rotate status sender key for forward secrecy (clear_device_record only
-    // cleared device tracking, not the key itself). Single flush covers both.
+    // and rotate status sender key for forward secrecy. Single flush covers both.
     {
-        use wacore::libsignal::store::sender_key_name::SenderKeyName;
-        use wacore::types::jid::JidExt;
-
-        let resolved = client.resolve_encryption_jid(&from_jid).await;
-        let addr = resolved.to_protocol_address();
-
         // Hold session lock while deleting to prevent concurrent encrypt/decrypt
         // from recreating the stale session (mirrors Signal::delete_sessions)
         let lock = client.session_lock_for(addr.as_str()).await;
@@ -372,14 +409,10 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
             .await;
     }
 
-    // Force fresh usync on next send
-    client.invalidate_device_cache(&from_jid.user).await;
-
     // Re-issue an active trusted-contact token, matching WA Web
     // handleE2eIdentityChange -> sendTcTokenWhenDeviceIdentityChange. Spawned so
     // the notification handler doesn't block on an IQ; it no-ops unless a
-    // non-expired sender token already exists (so it only fires for a prior
-    // relationship, mirroring WA Web's "had old identity" guard).
+    // non-expired sender token already exists.
     if !from_jid.is_bot() && !from_jid.is_status_broadcast() {
         let tc_client = client.clone();
         let tc_jid = from_jid.clone();
@@ -393,25 +426,43 @@ async fn handle_identity_change(client: &Arc<Client>, node: &NodeRef<'_>) {
             .detach();
     }
 
-    let session_jid = from_jid.clone();
+    // = addSecurityCodeChangedNotifications, which WA Web fires inside the gate.
     client.core.event_bus.dispatch(Event::IdentityChange(
         crate::types::events::IdentityChange {
-            user: from_jid,
+            user: from_jid.clone(),
             lid_user: node.attrs().optional_jid("lid"),
             implicit: false,
         },
     ));
 
-    // Re-establish session in background (self-defers when offline)
-    let client_clone = client.clone();
-    client
-        .runtime
-        .spawn(Box::pin(async move {
-            if let Err(e) = client_clone.ensure_e2e_sessions(&[session_jid]).await {
-                warn!("Identity change: failed to re-establish session: {e}");
-            }
-        }))
-        .detach();
+    // Re-establish the session eagerly so the next send is fast (WA Web does this
+    // inside the gate too). Skip only while the offline backlog is still draining,
+    // matching WA Web's `C = !isEmpty(offline) && !isResumeFromRestartComplete()`:
+    // deferring every offline-tagged push would otherwise pile up a prekey-fetch
+    // burst when the resume completes. Deferral is safe because every send path
+    // re-establishes before encrypting (ensure_e2e_sessions in the DM/group send
+    // paths, plus encrypt_for_devices' own has_session->prekey-fetch fallback).
+    let arrived_during_resume = node.attrs().optional_string("offline").is_some()
+        && !client
+            .offline_sync_completed
+            .load(std::sync::atomic::Ordering::Relaxed);
+    if arrived_during_resume {
+        debug!(
+            "Identity change for {} arrived during offline resume; deferring session re-establishment to next send",
+            from_jid.user
+        );
+    } else {
+        let client_clone = client.clone();
+        let session_jid = from_jid;
+        client
+            .runtime
+            .spawn(Box::pin(async move {
+                if let Err(e) = client_clone.ensure_e2e_sessions(&[session_jid]).await {
+                    warn!("Identity change: failed to re-establish session: {e}");
+                }
+            }))
+            .detach();
+    }
 }
 
 /// React to a locally-detected identity change.
@@ -2253,6 +2304,17 @@ mod tests {
             .insert("5511999999999".into(), Arc::new(record))
             .await;
 
+        // Seed a stored identity so the had-prior-identity gate runs the full reset
+        // (delete + notify), matching WA Web's `if (!isEmpty(loadIdentityKey(addr)))`.
+        {
+            use wacore::types::jid::JidExt;
+            let target: Jid = "5511999999999@s.whatsapp.net".parse().unwrap();
+            client
+                .signal_cache
+                .put_identity(&target.to_protocol_address(), &[7u8; 32])
+                .await;
+        }
+
         // Simulate identity change notification: type="encrypt" with <identity/> child
         let node = NodeBuilder::new("notification")
             .attr("type", "encrypt")
@@ -2462,6 +2524,14 @@ mod tests {
             .put_sender_key(&sk_name, sk_record)
             .await;
 
+        // Seed a stored identity for the changed user so the had-prior-identity gate
+        // runs the reset (which rotates the status sender key).
+        let changed: Jid = "5511888888888@s.whatsapp.net".parse().unwrap();
+        client
+            .signal_cache
+            .put_identity(&changed.to_protocol_address(), &[7u8; 32])
+            .await;
+
         // Fire identity change for a different user
         let node = NodeBuilder::new("notification")
             .attr("type", "encrypt")
@@ -2485,9 +2555,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_identity_change_with_offline_attribute() {
+        use wacore::types::jid::JidExt;
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
         client.register_handler(collector.clone());
+
+        // Prior identity present so the gate runs (the offline attr only defers the
+        // eager session re-establishment, not the change notification).
+        let changed: Jid = "5511888888888@s.whatsapp.net".parse().unwrap();
+        client
+            .signal_cache
+            .put_identity(&changed.to_protocol_address(), &[7u8; 32])
+            .await;
 
         // Notification with offline attribute should still be processed
         let node = NodeBuilder::new("notification")
@@ -2505,6 +2584,97 @@ mod tests {
                 .iter()
                 .any(|e| matches!(&**e, Event::IdentityChange(_))),
             "offline identity change should still dispatch event"
+        );
+    }
+
+    /// With no prior identity for the peer (e.g. a group-only member we never had a
+    /// session with), the had-prior-identity gate skips the heavy reset: no change
+    /// notification and no session/identity deletion. Only the device-list cleanup
+    /// runs. Mirrors WA Web `if (!isEmpty(loadIdentityKey(addr)))`.
+    #[tokio::test]
+    async fn test_identity_change_no_prior_identity_skips_reset() {
+        use wacore::types::jid::JidExt;
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let target: Jid = "5511666666666@s.whatsapp.net".parse().unwrap();
+        let addr = target.to_protocol_address();
+        // Seed a device-registry entry (with a companion device) so the always-on
+        // cleanup has something to do, but deliberately do NOT seed an identity.
+        client
+            .device_registry_cache
+            .insert(
+                "5511666666666".into(),
+                Arc::new(wacore::store::traits::DeviceListRecord {
+                    user: "5511666666666".into(),
+                    devices: vec![wacore::store::traits::DeviceInfo {
+                        device_id: 1,
+                        key_index: None,
+                    }],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: Some(1),
+                }),
+            )
+            .await;
+
+        // Seed a companion-device (device 1) Signal session: clear_device_record
+        // runs even on the no-prior path, so this must be deleted afterward. Keyed
+        // the same way delete_sessions_for_devices builds the address.
+        let mut companion = wacore_binary::Jid::new("5511666666666", wacore_binary::Server::Pn);
+        companion.device = 1;
+        let companion_addr = companion.to_protocol_address();
+        client
+            .signal_cache
+            .put_session(
+                &companion_addr,
+                wacore::libsignal::protocol::SessionRecord::new_fresh(),
+            )
+            .await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "encrypt")
+            .attr("from", "5511666666666@s.whatsapp.net")
+            .attr("id", "identity-change-noprior")
+            .children([NodeBuilder::new("identity").build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        // No change notification for a peer we had no prior identity with.
+        assert!(
+            collector.events().is_empty(),
+            "no-prior-identity push must not dispatch IdentityChange, got: {:?}",
+            collector.events()
+        );
+        // But the always-on device-list cleanup still ran.
+        assert!(
+            client
+                .device_registry_cache
+                .get("5511666666666")
+                .await
+                .is_none(),
+            "device registry cache should still be invalidated on the no-prior path"
+        );
+        // And no identity was created by an (skipped) eager re-establishment.
+        let backend = client.persistence_manager.backend();
+        assert!(
+            client
+                .signal_cache
+                .get_identity(&addr, backend.as_ref())
+                .await
+                .unwrap()
+                .is_none(),
+            "no-prior path must not establish an identity"
+        );
+        // The always-on clear_device_record must still delete companion sessions.
+        assert!(
+            !client
+                .signal_cache
+                .has_session(&companion_addr, backend.as_ref())
+                .await
+                .unwrap(),
+            "companion-device session must be cleared even on the no-prior path"
         );
     }
 }


### PR DESCRIPTION
## Problem

`handle_identity_change` (the handler for the server's `<notification type="encrypt"><identity/></notification>` push, fired when a peer reinstalls / rotates their identity key) ran the full heavy reset unconditionally for every non-self primary-device push: clear device record, delete the primary session + identity under a lock, rotate the status sender key, flush, invalidate the device cache, re-issue a tcToken, dispatch an event, and eagerly re-establish the session.

The dominant cost is self-inflicted: the handler deletes the primary session and then spawns `ensure_e2e_sessions`, which sees the just-deleted session missing and therefore always does a `fetch_pre_keys` IQ + X3DH to rebuild it. So every push paid a network round-trip + a key agreement, including for peers we have no prior relationship with (for example a group-only member we have never had a session with), where the rebuild creates a session we may never use.

WA Web (`WAWebHandleIdentityChange.handleE2eIdentityChange`) gates everything after `clearDeviceRecordForIdentityChange` behind `loadIdentityKey(addr) != null` (only react to a real prior relationship), and only re-establishes when not still draining the offline backlog (`C = !isEmpty(offline) && !isResumeFromRestartComplete()` -> `C || ensureE2ESessions`). We had neither gate.

## Change

Mirror WA Web. Keep the eager re-establishment for the cases that benefit from it (so the next send stays fast), but gate it.

- The device-list cleanup (`clear_device_record` for companion sessions + `invalidate_device_cache`) still runs always, matching `clearDeviceRecordForIdentityChange`, which WA Web runs before the gate.
- Read the stored identity non-destructively (`get_identity`) before deleting it, using the same resolved address the delete uses. With no prior identity, skip the whole reset (session/identity delete, status sender-key rotation, tcToken reissue, the change event, and the eager re-establishment) and return. A backend read error is treated as had-prior (fail-safe: run the reset rather than silently skip it).
- For a prior identity, do the reset as before, then re-establish eagerly unless the push arrived while the offline backlog is still draining (`offline` attr present and `offline_sync_completed == false`), matching WA Web's `C || ensureE2ESessions`. After resume completes, offline-tagged pushes re-establish eagerly again.
- Log `had_prior_identity` per push so the skip rate is measurable.

The deferral is safe because every send path re-establishes before encrypting: `ensure_e2e_sessions` in the DM (`send.rs`) and group (`features/signal.rs`) paths, plus `encrypt_for_devices`'s own `has_session` -> `process_prekey_bundle` fallback. A reinstalled peer's first inbound message is a pkmsg, which establishes the session on decrypt.

## Behavior change

`Event::IdentityChange` (the analog of WA Web's `addSecurityCodeChangedNotifications`, which is inside the gate) now fires only for contacts we had a prior identity with. Consumers no longer get it for a no-prior peer (for example a group-only member), where there was no prior security code to "change."

## Tests

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` (clean)
- `cargo test --all --exclude e2e-tests` (all green)

Existing identity-change tests were updated to seed a stored identity so they exercise the prior-identity path. New `test_identity_change_no_prior_identity_skips_reset`: a push for a peer with no stored identity dispatches no event, still invalidates the device cache, still deletes a seeded companion-device session (the always-on cleanup), and establishes no identity.

## Performance

Removes the per-push `fetch_pre_keys` IQ + X3DH for the no-prior subset (and the eager re-establish burst after a reconnect). For the prior-identity online case the eager re-establish is kept, so next-send latency is unchanged. The gate adds one non-destructive identity read (already cached on the hot path); the redundant `has_session` read that earlier only fed a log line was removed.

## Breaking

None (signatures unchanged). The `Event::IdentityChange` gating above is a behavior change, not an API break.
