### PR TITLE
feat(reaction): add Client::send_reaction and MessageContext::react for DM/group

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -118,6 +118,15 @@ impl MessageContext {
             .revoke_message(self.info.source.chat.clone(), message_id, revoke_type)
             .await
     }
+
+    /// React to the incoming message. An empty `emoji` removes a previous
+    /// reaction. The target key (including the group/status participant) is
+    /// taken from [`MessageContext::message_key`].
+    pub async fn react(&self, emoji: &str) -> Result<crate::send::SendResult, anyhow::Error> {
+        self.client
+            .send_reaction(&self.info.source.chat, self.message_key(), emoji)
+            .await
+    }
 }
 
 type EventHandlerCallback =
@@ -1212,5 +1221,92 @@ mod tests {
             MessageContext::from_arc(Arc::clone(&original), &MessageInfo::default(), bot.client());
 
         assert!(std::ptr::eq(Arc::as_ptr(&ctx.message), original_ptr));
+    }
+
+    async fn test_context_with_info(info: MessageInfo) -> MessageContext {
+        let backend = create_test_sqlite_backend().await;
+        let bot = Bot::builder()
+            .with_backend(backend)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("Failed to build bot");
+        MessageContext::from_arc(Arc::new(wa::Message::default()), &info, bot.client())
+    }
+
+    fn react_info(chat: &str, sender: &str, id: &str, is_group: bool) -> MessageInfo {
+        use crate::types::message::MessageSource;
+        MessageInfo {
+            id: id.to_string(),
+            source: MessageSource {
+                chat: chat.parse().expect("chat jid"),
+                sender: sender.parse().expect("sender jid"),
+                is_group,
+                is_from_me: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn react_target_key_carries_group_participant() {
+        let info = react_info(
+            "120363012345@g.us",
+            "15551230000@s.whatsapp.net",
+            "MSGID01",
+            true,
+        );
+        let ctx = test_context_with_info(info).await;
+        let key = ctx.message_key();
+
+        assert_eq!(key.remote_jid.as_deref(), Some("120363012345@g.us"));
+        assert_eq!(key.id.as_deref(), Some("MSGID01"));
+        assert_eq!(key.from_me, Some(false));
+        // Group reactions must attribute the original sender via participant.
+        assert_eq!(
+            key.participant.as_deref(),
+            Some("15551230000@s.whatsapp.net")
+        );
+    }
+
+    #[tokio::test]
+    async fn react_target_key_omits_participant_in_dm() {
+        let info = react_info(
+            "15559990000@s.whatsapp.net",
+            "15559990000@s.whatsapp.net",
+            "MSGID02",
+            false,
+        );
+        let ctx = test_context_with_info(info).await;
+        let key = ctx.message_key();
+
+        assert_eq!(
+            key.remote_jid.as_deref(),
+            Some("15559990000@s.whatsapp.net")
+        );
+        // DMs do not carry participant (matches WA Web message-key shape).
+        assert!(key.participant.is_none());
+    }
+
+    #[tokio::test]
+    async fn react_target_key_carries_status_author() {
+        let info = react_info(
+            "status@broadcast",
+            "15551112222@s.whatsapp.net",
+            "MSGID03",
+            false,
+        );
+        let ctx = test_context_with_info(info).await;
+        let key = ctx.message_key();
+
+        // status@broadcast reactions fan out to the author's devices, so the
+        // author must be present in participant for the send path to extract it.
+        assert_eq!(
+            key.participant.as_deref(),
+            Some("15551112222@s.whatsapp.net")
+        );
     }
 }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod newsletter;
 mod polls;
 mod presence;
 mod profile;
+mod reaction;
 mod signal;
 pub(crate) mod status;
 mod tctoken;

--- a/src/features/reaction.rs
+++ b/src/features/reaction.rs
@@ -1,0 +1,36 @@
+//! Sending reactions to DM/group/status messages.
+//!
+//! Newsletter reactions go through a different (plaintext) wire path; use
+//! [`Client::newsletter`]'s `send_reaction` for channels.
+
+use wacore_binary::Jid;
+use waproto::whatsapp as wa;
+
+use crate::client::Client;
+use crate::send::SendResult;
+
+impl Client {
+    /// React to a DM, group, or status@broadcast message.
+    ///
+    /// `target_key` references the message being reacted to. For groups and
+    /// status it must carry `participant` (the original sender) so the receipt
+    /// can be attributed; [`crate::bot::MessageContext::react`] fills this in
+    /// from the incoming message. An empty `emoji` removes a previous reaction
+    /// (WA Web's empty-text reaction == sender-revoke).
+    ///
+    /// status@broadcast reactions fan out to the status author's devices; the
+    /// author is read from `target_key.participant` by the send path.
+    pub async fn send_reaction(
+        &self,
+        chat: &Jid,
+        target_key: wa::MessageKey,
+        emoji: &str,
+    ) -> Result<SendResult, anyhow::Error> {
+        let reaction = wacore::proto_helpers::build_reaction_message(
+            target_key,
+            emoji,
+            wacore::time::now_millis(),
+        );
+        self.send_message(chat.clone(), reaction).await
+    }
+}

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -615,6 +615,28 @@ pub fn build_quote_context_with_info(
     }
 }
 
+/// Builds a `reactionMessage` matching WA Web's `WAWebReactionsGenerateReactionMessageProto`
+/// (`{ key, text, senderTimestampMs }`).
+///
+/// `key` references the message being reacted to. An empty `emoji` is the
+/// remove-reaction form: the wire stays a `reactionMessage` with empty `text`,
+/// which the edit-attr classifier treats as a sender-revoke of the prior reaction.
+pub fn build_reaction_message(
+    key: wa::MessageKey,
+    emoji: impl Into<String>,
+    sender_timestamp_ms: i64,
+) -> wa::Message {
+    wa::Message {
+        reaction_message: Some(wa::message::ReactionMessage {
+            key: Some(key),
+            text: Some(emoji.into()),
+            sender_timestamp_ms: Some(sender_timestamp_ms),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
 /// Wraps a media message as an album child (WA Web `EProtoGenerator` parity).
 /// Lifts `message_context_info` to the outer message and adds the album association.
 pub fn wrap_as_album_child(
@@ -2185,5 +2207,71 @@ mod tests {
             ..Default::default()
         };
         assert!(!not_fwd.is_forwarded());
+    }
+
+    fn group_target_key() -> wa::MessageKey {
+        wa::MessageKey {
+            remote_jid: Some("120363012345@g.us".to_string()),
+            from_me: Some(false),
+            id: Some("ABCD1234".to_string()),
+            participant: Some("15551230000@s.whatsapp.net".to_string()),
+        }
+    }
+
+    #[test]
+    fn build_reaction_populates_key_text_and_timestamp() {
+        let key = group_target_key();
+        let ts = 1_700_000_000_000;
+        let msg = build_reaction_message(key.clone(), "👍", ts);
+
+        let react = msg
+            .reaction_message
+            .as_ref()
+            .expect("reaction_message must be set");
+        assert_eq!(react.key.as_ref(), Some(&key));
+        assert_eq!(react.text.as_deref(), Some("👍"));
+        assert_eq!(react.sender_timestamp_ms, Some(ts));
+        // Only the reaction field is populated.
+        assert!(msg.conversation.is_none());
+        assert!(react.grouping_key.is_none());
+    }
+
+    #[test]
+    fn build_reaction_preserves_participant_for_group_target() {
+        let key = group_target_key();
+        let msg = build_reaction_message(key, "❤️", 1);
+        let participant = msg
+            .reaction_message
+            .and_then(|r| r.key)
+            .and_then(|k| k.participant);
+        assert_eq!(participant.as_deref(), Some("15551230000@s.whatsapp.net"));
+    }
+
+    #[test]
+    fn build_reaction_empty_emoji_is_unreact_form() {
+        // Empty text stays a reaction with present-but-empty text (not None),
+        // which the edit-attr classifier maps to a sender-revoke.
+        let msg = build_reaction_message(group_target_key(), "", 1);
+        let text = msg
+            .reaction_message
+            .as_ref()
+            .and_then(|r| r.text.as_deref());
+        assert_eq!(text, Some(""));
+    }
+
+    #[test]
+    fn build_reaction_edit_attr_classification() {
+        use crate::types::message::EditAttribute;
+
+        // A non-empty reaction is a regular send, not an edit/revoke.
+        let react = build_reaction_message(group_target_key(), "🔥", 1);
+        assert_eq!(EditAttribute::infer_from_message(&react), None);
+
+        // An empty reaction is the sender-revoke of a previous reaction.
+        let unreact = build_reaction_message(group_target_key(), "", 1);
+        assert_eq!(
+            EditAttribute::infer_from_message(&unreact),
+            Some(EditAttribute::SenderRevoke)
+        );
     }
 }


### PR DESCRIPTION
## Problem

The only public reaction sender is `Client::newsletter().send_reaction`, which is newsletter-only. To react to a DM or group message, consumers have to hand-build a `wa::Message { reaction_message: ... }` themselves (key, text, sender_timestamp_ms), which is easy to get wrong, especially the participant attribution for groups/status and the empty-text unreact form.

## Change

Adds a first-class reaction helper for DM/group/status messages:

- `wacore::proto_helpers::build_reaction_message(key, emoji, sender_timestamp_ms)` builds the reaction proto, matching WhatsApp Web's `WAWebReactionsGenerateReactionMessageProto` shape (`{ key, text, senderTimestampMs }`). The reusable protocol logic lives in wacore.
- `Client::send_reaction(chat, target_key, emoji)` (new file `src/features/reaction.rs`) routes through the existing `send_message` path. That path already handles status@broadcast author extraction (it reads the author from `reaction_message.key.participant`) and infers the `SenderRevoke` edit attribute when the reaction text is empty, so no extra wiring is needed.
- `MessageContext::react(emoji)` on the bot wrapper fills the target key from the existing `message_key()` and sits beside `edit_message`/`revoke_message`.

An empty `emoji` is the unreact form: the wire stays a `reactionMessage` with present-but-empty `text`, which WhatsApp Web treats as a sender-revoke of the prior reaction. This matches whatsmeow's `BuildReaction` as well.

## Tests

All offline, no live send:

- `build_reaction_message` populates `key`, `text`, and `sender_timestamp_ms`, and only the reaction field.
- Group target keeps the sender in `participant`.
- Empty emoji yields the unreact form (empty text, not absent text), and the edit-attribute classifier maps it to `SenderRevoke` while a non-empty reaction stays a regular send (`None`).
- `MessageContext::message_key()` (the key `react` feeds into `send_reaction`) carries `participant` for groups and status@broadcast, and omits it in DMs, matching the WhatsApp Web message-key shape.

## Breaking

None. Adds new public API only.
