### PR TITLE
fix(edit): send message edits as a top-level protocolMessage, matching WA Web

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3836,26 +3836,13 @@ impl Client {
             None
         };
 
-        let edit_container_message = wa::Message {
-            edited_message: Some(Box::new(wa::message::FutureProofMessage {
-                message: Some(Box::new(wa::Message {
-                    protocol_message: Some(Box::new(wa::message::ProtocolMessage {
-                        key: Some(wa::MessageKey {
-                            remote_jid: Some(to.to_string()),
-                            from_me: Some(true),
-                            id: Some(original_id.clone()),
-                            participant,
-                        }),
-                        r#type: Some(wa::message::protocol_message::Type::MessageEdit as i32),
-                        edited_message: Some(Box::new(new_content)),
-                        timestamp_ms: Some(wacore::time::now_millis()),
-                        ..Default::default()
-                    })),
-                    ..Default::default()
-                })),
-            })),
-            ..Default::default()
-        };
+        let edit_container_message = crate::send::build_edit_message(
+            &to,
+            original_id.clone(),
+            participant,
+            new_content,
+            wacore::time::now_millis(),
+        );
 
         // Use a new stanza ID instead of reusing the original message ID.
         // The original message ID is already embedded in protocolMessage.key.id

--- a/src/send.rs
+++ b/src/send.rs
@@ -302,6 +302,35 @@ fn build_revoke_message(
     }
 }
 
+/// Build a message edit in WA Web's wire shape: a top-level
+/// protocolMessage(type=MESSAGE_EDIT) carrying the new content under
+/// editedMessage, same as build_revoke_message and our own receive path. The
+/// top-level Message.editedMessage FutureProofMessage is the history/storage
+/// form, not what WA Web sends on the wire.
+pub(crate) fn build_edit_message(
+    remote_jid: &Jid,
+    message_id: String,
+    participant: Option<String>,
+    new_content: wa::Message,
+    timestamp_ms: i64,
+) -> wa::Message {
+    wa::Message {
+        protocol_message: Some(Box::new(wa::message::ProtocolMessage {
+            key: Some(wa::MessageKey {
+                remote_jid: Some(remote_jid.to_string()),
+                from_me: Some(true),
+                id: Some(message_id),
+                participant,
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MessageEdit as i32),
+            edited_message: Some(Box::new(new_content)),
+            timestamp_ms: Some(timestamp_ms),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
 impl Client {
     /// Send a message to a user, group, or newsletter.
     ///
@@ -3007,6 +3036,54 @@ mod tests {
             };
             let (edit, _) = infer_stanza_metadata(&msg);
             assert_eq!(edit, Some(EditAttribute::MessageEdit));
+        }
+
+        #[test]
+        fn build_edit_message_uses_top_level_protocol_message() {
+            use std::str::FromStr;
+            let to = Jid::from_str("5511999999999@s.whatsapp.net").unwrap();
+            let new_content = wa::Message {
+                conversation: Some("edited".to_string()),
+                ..Default::default()
+            };
+            let msg = build_edit_message(
+                &to,
+                "ORIG_ID".to_string(),
+                None,
+                new_content,
+                1_700_000_000_000,
+            );
+
+            // Canonical WA Web shape: top-level protocolMessage(type=MESSAGE_EDIT),
+            // not the Message.editedMessage FutureProofMessage history wrapper.
+            assert!(
+                msg.edited_message.is_none(),
+                "edit must not use the FutureProofMessage wrapper"
+            );
+            let pm = msg
+                .protocol_message
+                .as_deref()
+                .expect("top-level protocol_message");
+            assert_eq!(
+                pm.r#type,
+                Some(wa::message::protocol_message::Type::MessageEdit as i32)
+            );
+            assert_eq!(
+                pm.key.as_ref().and_then(|k| k.id.as_deref()),
+                Some("ORIG_ID")
+            );
+            assert_eq!(pm.key.as_ref().and_then(|k| k.from_me), Some(true));
+            assert_eq!(
+                pm.edited_message
+                    .as_ref()
+                    .and_then(|m| m.conversation.as_deref()),
+                Some("edited")
+            );
+            // The send path still derives the edit attribute from this shape.
+            assert_eq!(
+                infer_stanza_metadata(&msg).0,
+                Some(EditAttribute::MessageEdit)
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

`edit_message` builds the edit as a top-level `Message.editedMessage` (`FutureProofMessage`) wrapping an inner `Message` that carries the `protocolMessage(type=MESSAGE_EDIT)`. WhatsApp Web instead sends an edit as a **top-level `protocolMessage(type=MESSAGE_EDIT)`** with the new content under `protocolMessage.editedMessage`. The top-level `Message.editedMessage` (`FutureProofMessage`) field is the history/storage representation, not the wire-send form.

Our own `build_revoke_message` and our receive/processing path already use the top-level `protocolMessage` shape, so the edit send was the lone outlier.

## Verification against WhatsApp Web (`docs/captured-js/`)

- `Create/EncryptedMessageEditMsgData.js`: builds `protocolMessage: { key, type: MESSAGE_EDIT, timestampMs, editedMessage: <content> }`.
- `Send/MsgCommonApi.js`: derives the `edit` stanza attribute from `e.protocolMessage.type`.
- Edit detection tolerates both shapes (`e.protocolMessage.type ?? e.editedMessage.message.protocolMessage.type`), so existing edits keep working. This is a wire-parity fix, not a correctness fix.

## Change

- Extract `build_edit_message` in `src/send.rs` (mirroring `build_revoke_message`) that produces the top-level `protocolMessage` shape.
- `edit_message` now uses it (drops the extra `FutureProofMessage` + inner `Message` wrapper).

Classification is unchanged: `EditAttribute::infer_from_message` already maps `protocolMessage.type == MessageEdit` to `MessageEdit`, and `edit_message` passes the edit attribute explicitly to `send_message_impl`.

## Tests

- New `build_edit_message_uses_top_level_protocol_message` (asserts no `FutureProofMessage` wrapper, top-level `protocolMessage`, correct key/type, and that the send path still infers `EditAttribute::MessageEdit`).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the wacore + whatsapp-rust test suites are green.

## Breaking

None.
