### PR TITLE
fix: @call JID decode, receipt participant_pn, profile-pic empty→remove, has_device churn

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -90,10 +90,9 @@ impl Client {
         UserLookupKeys::Unknown { user: user.into() }
     }
 
-    /// Get all possible lookup keys for a user (for bidirectional lookup).
-    /// Returns keys in order of preference: [canonical_key, fallback_key].
-    ///
-    /// Note: Prefer `resolve_lookup_keys` when you need type information.
+    /// Owned-key variant of `resolve_lookup_keys`. Test-only: production callers
+    /// use the borrowed `resolve_lookup_keys(..).all_keys()` to avoid the churn.
+    #[cfg(test)]
     pub(crate) async fn get_lookup_keys(&self, user: &str) -> Vec<String> {
         self.resolve_lookup_keys(user)
             .await
@@ -116,22 +115,24 @@ impl Client {
             return true;
         }
 
-        let lookup_keys = self.get_lookup_keys(user).await;
+        // Borrowed `&str` keys (like get_devices_from_registry), bound once so both
+        // loops share one Vec<&str>: avoids the per-message get_lookup_keys churn.
+        let lookup = self.resolve_lookup_keys(user).await;
+        let keys = lookup.all_keys();
 
-        for key in &lookup_keys {
+        for &key in &keys {
             if let Some(record) = self.device_registry_cache.get(key).await {
                 return record.devices.iter().any(|d| d.device_id == device_id);
             }
         }
 
         let backend = self.persistence_manager.backend();
-        for key in &lookup_keys {
+        for &key in &keys {
             match backend.get_devices(key).await {
                 Ok(Some(record)) => {
                     let has_device = record.devices.iter().any(|d| d.device_id == device_id);
-                    // Cache under the record's actual user key (the key it was stored under
-                    // in the backend), not lookup_keys[0] which is our guessed canonical key.
-                    // This ensures consistency between the in-memory cache and the backend.
+                    // Cache under the record's actual stored key, not our guessed one,
+                    // to keep the cache and backend consistent.
                     self.device_registry_cache
                         .insert(record.user.clone(), Arc::new(record))
                         .await;
@@ -863,6 +864,26 @@ mod tests {
         assert!(client.has_device(lid, 1).await);
         // Non-existent device should return false
         assert!(!client.has_device(lid, 99).await);
+    }
+
+    /// has_device must iterate every lookup key: a record keyed under PN is found
+    /// when queried by LID (the fallback key), and vice versa. Guards the
+    /// borrowed-`all_keys()` iteration the churn fix preserves.
+    #[tokio::test]
+    async fn test_has_device_found_via_fallback_lookup_key() {
+        let client = create_test_client().await;
+        let lid = "100000000000009";
+        let pn = "15559998888";
+
+        setup_lid_pn(&client, lid, pn).await;
+        setup_device_record(&client, pn, &[2]).await;
+
+        assert!(
+            client.has_device(lid, 2).await,
+            "device keyed under PN must be found when queried by LID"
+        );
+        assert!(client.has_device(pn, 2).await);
+        assert!(!client.has_device(lid, 77).await);
     }
 
     /// Test that invalidate_device_cache clears registry cache entries for

--- a/src/features/profile.rs
+++ b/src/features/profile.rs
@@ -90,6 +90,9 @@ impl<'a> Profile<'a> {
     /// Sends a JPEG image as the new profile picture. The image should already
     /// be properly sized/cropped by the caller (WhatsApp typically uses 640x640).
     ///
+    /// Passing empty `image_data` **removes** the picture (matching WhatsApp Web);
+    /// call [`Profile::remove_profile_picture`] when removal is the intent.
+    ///
     /// ## Wire Format
     /// ```xml
     /// <iq type="set" xmlns="w:profile:picture" to="s.whatsapp.net">
@@ -100,10 +103,11 @@ impl<'a> Profile<'a> {
         &self,
         image_data: Vec<u8>,
     ) -> Result<SetProfilePictureResponse> {
+        // for_own routes empty bytes to the remove path, matching WA Web; no panic.
         debug!("Setting profile picture (size={} bytes)", image_data.len());
         Ok(self
             .client
-            .execute(SetProfilePictureSpec::set_own(image_data))
+            .execute(SetProfilePictureSpec::for_own(image_data))
             .await?)
     }
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -146,6 +146,8 @@ impl Client {
         let receipt_type_cow = attrs.optional_string("type");
         let receipt_type_str = receipt_type_cow.as_deref().unwrap_or("delivery");
         let participant = attrs.optional_jid("participant");
+        // participant_pn -> sender_alt so the LID-PN cache warms from receipts too.
+        let participant_pn = attrs.optional_jid("participant_pn");
         let stanza_ts = attrs
             .optional_u64("t")
             .and_then(|t| i64::try_from(t).ok())
@@ -207,6 +209,7 @@ impl Client {
                     source: crate::types::message::MessageSource {
                         chat: from.clone(),
                         sender: user.jid,
+                        sender_alt: user.participant_pn,
                         ..Default::default()
                     },
                     timestamp: user_ts,
@@ -232,6 +235,7 @@ impl Client {
             source: crate::types::message::MessageSource {
                 chat: from,
                 sender: default_sender,
+                sender_alt: participant_pn,
                 ..Default::default()
             },
             timestamp: stanza_ts,
@@ -1433,6 +1437,77 @@ mod tests {
         assert_eq!(receipts[0].source.sender.user, "99000000000001");
         assert_eq!(receipts[1].r#type, ReceiptType::Read);
         assert_eq!(receipts[2].r#type, ReceiptType::Inactive);
+    }
+
+    /// participant_pn must land in the Receipt event's sender_alt on both shapes.
+    #[tokio::test]
+    async fn test_receipt_threads_participant_pn_into_sender_alt() {
+        let (client, collector) = setup_client_with_collector().await;
+
+        // Aggregated shape: per-user participant_pn.
+        client
+            .handle_receipt(node_to_arc(
+                NodeBuilder::new("receipt")
+                    .attr("from", "120363000000000001@g.us")
+                    .attr("id", "STANZA-PPN")
+                    .attr("t", "1700000000")
+                    .children([NodeBuilder::new("participants")
+                        .attr("message_id", "MSG-PPN")
+                        .children([NodeBuilder::new("user")
+                            .attr("jid", "99000000000001@lid")
+                            .attr("participant_pn", "15551234567@s.whatsapp.net")
+                            .attr("type", "read")
+                            .build()])
+                        .build()])
+                    .build(),
+            ))
+            .await;
+
+        // Simple shape: receipt-level participant_pn.
+        client
+            .handle_receipt(node_to_arc(
+                NodeBuilder::new("receipt")
+                    .attr("from", "99000000000002@lid")
+                    .attr("id", "STANZA-PPN-SIMPLE")
+                    .attr("participant_pn", "15557654321@s.whatsapp.net")
+                    .attr("t", "1700000000")
+                    .build(),
+            ))
+            .await;
+
+        let events = collector.events();
+        let receipts: Vec<_> = events
+            .iter()
+            .filter_map(|e| match &**e {
+                Event::Receipt(r) => Some(r),
+                _ => None,
+            })
+            .collect();
+
+        let agg = receipts
+            .iter()
+            .find(|r| r.message_ids.iter().any(|id| id == "MSG-PPN"))
+            .expect("aggregated receipt dispatched");
+        assert_eq!(
+            agg.source.sender_alt.as_ref().expect("sender_alt set").user,
+            "15551234567",
+            "aggregated receipt must thread per-user participant_pn into sender_alt"
+        );
+
+        let simple = receipts
+            .iter()
+            .find(|r| r.message_ids.iter().any(|id| id == "STANZA-PPN-SIMPLE"))
+            .expect("simple receipt dispatched");
+        assert_eq!(
+            simple
+                .source
+                .sender_alt
+                .as_ref()
+                .expect("sender_alt set")
+                .user,
+            "15557654321",
+            "simple receipt must thread receipt-level participant_pn into sender_alt"
+        );
     }
 
     /// Missing per-user `t`: the fan-out event's timestamp falls back to

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -1607,6 +1607,29 @@ mod tests {
         Ok(())
     }
 
+    /// `@call` must round-trip via JID_PAIR instead of failing the whole node decode.
+    #[test]
+    fn test_call_jid_round_trips_via_jid_pair() -> TestResult {
+        use crate::decoder::Decoder;
+
+        let node = NodeBuilder::new("call").attr("from", "12345@call").build();
+        let mut buffer = Vec::new();
+        let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
+        encoder.write_node(&node)?;
+        assert!(
+            !buffer.contains(&token::AD_JID),
+            "AD_JID must not be emitted for @call (would lose the server)"
+        );
+
+        let decoded = Decoder::new(&buffer[1..]).read_node_ref()?.to_owned();
+        let from = decoded
+            .attrs
+            .get("from")
+            .expect("from attr must survive the round-trip");
+        assert_eq!(from.to_string(), "12345@call");
+        Ok(())
+    }
+
     /// Same invariant as above but exercised through the typed
     /// `NodeValue::Jid` path (write_jid_owned + size estimators), which
     /// previously ignored the server check and emitted AD_JID for any

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -177,6 +177,8 @@ pub enum Server {
     Interop = 8,
     Bot = 9,
     Legacy = 10,
+    /// `@call` call-signaling JID; not an AD server, so it round-trips via JID_PAIR.
+    Call = 11,
 }
 
 #[cfg(feature = "serde")]
@@ -209,6 +211,7 @@ impl Server {
             Self::Interop => "interop",
             Self::Bot => "bot",
             Self::Legacy => "c.us",
+            Self::Call => "call",
         }
     }
 
@@ -268,6 +271,7 @@ impl TryFrom<&str> for Server {
             "interop" => Ok(Self::Interop),
             "bot" => Ok(Self::Bot),
             "c.us" => Ok(Self::Legacy),
+            "call" => Ok(Self::Call),
             other => Err(JidError::InvalidFormat(format!("unknown server: {other}"))),
         }
     }
@@ -945,6 +949,9 @@ mod tests {
         // LID JID cases (critical for the bug)
         assert_jid_roundtrip("12345.6789@lid", "12345.6789", "lid", 0, 0);
         assert_jid_roundtrip("12345.6789:25@lid", "12345.6789", "lid", 25, 0);
+
+        // @call (call-signaling server) must parse and render, not be rejected.
+        assert_jid_roundtrip("12345@call", "12345", "call", 0, 0);
     }
 
     #[test]

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -234,6 +234,16 @@ impl SetProfilePictureSpec {
         }
     }
 
+    /// Set or remove the own picture from caller-supplied bytes. Empty bytes mean
+    /// remove, matching WAWebSendProfilePictureJob (`a ? wap("picture",..) : null`).
+    pub fn for_own(image_data: Vec<u8>) -> Self {
+        if image_data.is_empty() {
+            Self::remove_own()
+        } else {
+            Self::set_own(image_data)
+        }
+    }
+
     /// Set a group's profile picture. Panics if `image_data` is empty (use `remove_group` instead).
     pub fn set_group(group_jid: &Jid, image_data: Vec<u8>) -> Self {
         assert!(
@@ -305,6 +315,20 @@ impl IqSpec for SetProfilePictureSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn for_own_routes_empty_to_remove() {
+        // WA Web treats empty bytes as a removal.
+        assert!(
+            SetProfilePictureSpec::for_own(Vec::new())
+                .image_data
+                .is_none()
+        );
+        assert_eq!(
+            SetProfilePictureSpec::for_own(vec![1, 2, 3]).image_data,
+            Some(vec![1, 2, 3])
+        );
+    }
 
     #[test]
     fn test_profile_picture_spec_preview() {


### PR DESCRIPTION
Four small, independent fixes validated against `docs/captured-js/`, one per commit, each with a test.

## `fix(binary): decode @call JIDs` (commit 1)

`read_jid_pair` returned `BinaryError::AttrParse` for any server string not in the `Server` enum, which fails the entire node decode. `@call` is a real WhatsApp Web server JID (call signaling; `WAWebWid` special-cases it and `isGroupCall` checks `server === "call"`), so a frame carrying one was dropped. Adds a `Server::Call` variant; it is not an AD server, so it round-trips through JID_PAIR like the other non-AD servers, matching WA Web's permissive JID decoding.

## `fix(receipt): thread participant_pn into sender_alt` (commit 2)

The receipt parser already extracts `participant_pn` (the LID->PN counterpart of the reader), but both `handle_receipt` paths dropped it. The inbound message path already maps `participant_pn` to `MessageSource.sender_alt` to warm the LID-PN cache; receipts now do the same on both the aggregated and simple shapes, matching `WAWebHandleMsgReceiptParser` which reads `participantPn` in every branch. No event-schema change.

## `fix(profile): route empty profile-picture bytes to removal` (commit 3)

`Profile::set_profile_picture` forwarded the caller's bytes straight into `SetProfilePictureSpec::set_own`, which asserts (panics) on empty input. `WAWebSendProfilePictureJob` treats empty bytes as a removal (`a ? wap("picture",..) : null`), so empty now routes to the remove path instead of panicking, via a new `SetProfilePictureSpec::for_own` (empty -> `remove_own`, else `set_own`).

## `perf(device-registry): avoid Vec<String> churn in has_device` (commit 4)

`has_device` went through `get_lookup_keys`, which re-owns the already-resolved keys into a `Vec<String>` (1-2 heap allocs) on every received message that hits the device check. It now iterates the borrowed `resolve_lookup_keys(..).all_keys()` (bound once and shared by both the cache and backend loops), matching `get_devices_from_registry`. `get_lookup_keys` is now test-only.

## Tests

Each commit adds a test: `@call` JID_PAIR encode/decode round-trip plus parse/display; receipt `participant_pn` to `sender_alt` on both shapes; `for_own` routes empty bytes to removal and non-empty to set; `has_device` finds a device via the fallback lookup key. `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the wacore-binary + wacore + whatsapp-rust suites are green.

## Breaking

None.
