### PR TITLE
feat(api): mark public error enums #[non_exhaustive] for 1.0 forward-compat

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -25,6 +25,7 @@ pub struct Missing;
 pub struct Provided;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum BotBuilderError {
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/src/client.rs
+++ b/src/client.rs
@@ -274,6 +274,7 @@ impl std::fmt::Display for MemoryDiagnostics {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ClientError {
     #[error("client is not connected")]
     NotConnected,

--- a/src/features/mex.rs
+++ b/src/features/mex.rs
@@ -14,6 +14,7 @@ pub use wacore::iq::mex::{MexDoc, MexErrorExtensions, MexGraphQLError, MexRespon
 
 /// Error types for MEX operations.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MexError {
     /// Payload missing or otherwise malformed in a way that has no underlying
     /// typed source (descriptive message only — e.g. "missing data").

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -8,6 +8,7 @@ use wacore_binary::Node;
 use wacore_binary::builder::NodeBuilder;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PresenceError {
     #[error("cannot send presence without a push name set")]
     PushNameEmpty,

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -22,6 +22,7 @@ const NOISE_HANDSHAKE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(20);
 const IK_FAILURE_THRESHOLD: u32 = 1;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum HandshakeError {
     #[error("Transport error: {0}")]
     Transport(#[from] anyhow::Error),

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -64,6 +64,7 @@ pub use wacore::pair_code::{PairCodeError, PairCodeOptions};
 /// Wraps `wacore::pair_code::PairCodeError` (validation, key derivation, bundle
 /// building) and adds the IQ transport layer via `RequestFailed`.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PairError {
     #[error(transparent)]
     PairCode(#[from] PairCodeError),

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,6 +12,7 @@ use wacore_binary::Node;
 pub use wacore::request::{InfoQuery, InfoQueryType, RequestUtils};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum IqError {
     #[error("IQ request timed out")]
     Timeout,
@@ -45,6 +46,9 @@ impl From<wacore::request::IqError> for IqError {
                 Self::ServerError { code, text }
             }
             wacore::request::IqError::InternalChannelClosed => Self::InternalChannelClosed,
+            // wacore::IqError is #[non_exhaustive]; a new upstream variant should
+            // get its own arm above. Until then treat it as an unexpected internal error.
+            _ => Self::InternalChannelClosed,
         }
     }
 }

--- a/src/socket/error.rs
+++ b/src/socket/error.rs
@@ -3,6 +3,7 @@ use wacore::handshake::NoiseError;
 use wacore_binary::error::BinaryError;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SocketError {
     #[error("socket is closed")]
     SocketClosed,
@@ -17,6 +18,7 @@ pub enum SocketError {
 pub type Result<T> = std::result::Result<T, SocketError>;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EncryptSendErrorKind {
     #[error("cryptography error")]
     Crypto,

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -79,6 +79,7 @@ where
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AppStateSyncError {
     #[error("app state key not found: {0}")]
     KeyNotFound(String),

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -15,6 +15,7 @@ use waproto::whatsapp::ExternalBlobReference;
 use waproto::whatsapp::message::HistorySyncNotification;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MediaDecryptionError {
     #[error("downloaded file is too short to contain MAC")]
     PayloadTooShort,

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 use wacore_binary::zlib_pool::{InflateReader, decompress_zlib_pooled};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum HistorySyncError {
     #[error("Failed to decompress history sync data: {0}")]
     DecompressionError(#[from] std::io::Error),

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -79,6 +79,7 @@ impl<'a> InfoQuery<'a> {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum IqError {
     #[error("IQ request timed out")]
     Timeout,

--- a/wacore/src/session.rs
+++ b/wacore/src/session.rs
@@ -24,6 +24,7 @@ pub type SessionResult = Result<(), SessionError>;
 
 /// Errors that can occur during session management
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SessionError {
     /// The prekey fetch operation failed
     FetchFailed(String),

--- a/wacore/src/store/error.rs
+++ b/wacore/src/store/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StoreError {
     #[error("I/O error")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
## What

Marks all 15 public **error** enums `#[non_exhaustive]` so adding a variant after 1.0 stays additive instead of forcing a major bump. Resolves the error-side of the systematic gap (value enums like `PinDuration`, `RevokeType`, `Event`, `MediaType`, `PresenceStatus` already had it).

Error enums are the ones most likely to grow over time (new server error codes, new transport failure modes, new store backends), and the attribute is itself a breaking change, so it has to land before the stable tag.

## Enums

`IqError` (high-level `src/request.rs` and `wacore::request`), `ClientError`, `SocketError`, `EncryptSendErrorKind`, `StoreError`, `SessionError`, `HandshakeError`, `HistorySyncError`, `AppStateSyncError`, `MediaDecryptionError`, `PairError`, `MexError`, `PresenceError`, `BotBuilderError`.

## Cross-crate match

Same-crate matches ignore `#[non_exhaustive]`. Six of these enums live in `wacore` and are matched cross-crate by the high-level crate; the compiler flagged exactly one exhaustive match that broke: `From<wacore::IqError> for IqError`. It keeps its five explicit arms (today's behavior is identical) plus a defensive wildcard so a future upstream variant maps to `InternalChannelClosed` until it gets its own arm.

## Scope

Structs with public fields (`EncryptSendError`, the IQ-response and event-payload structs) are deliberately left for a focused follow-up: `#[non_exhaustive]` on a struct also blocks external literal construction, so each needs a per-type constructor check before it's safe.

## Verification

- `cargo build --workspace`
- `cargo clippy --all-targets -- -D warnings` clean with and without `--features metrics,tracing`
- `cargo test --workspace --exclude e2e-tests` green

First PR of the "API toward 1.0" track. Breaking change, acceptable pre-1.0.
