### PR TITLE
feat(api): #[non_exhaustive] on public value enums + drop dead privacy enums

### DIFF
--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -198,6 +198,7 @@ impl Serialize for LazyHistorySync {
 /// be at most 64 kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum EventKind {
     Connected,
     Disconnected,
@@ -247,7 +248,20 @@ pub enum EventKind {
     NewsletterLiveUpdate,
     RawNode,
     MexNotification,
+    // When adding a variant, mind the 64-kind ceiling below (EventInterest packs
+    // each discriminant as a bit in a u64) and keep the guard pointing at the
+    // last variant.
 }
+
+impl EventKind {
+    /// Bit-index ceiling: [`EventInterest`] packs each kind's discriminant into a
+    /// `u64`, so there can be at most 64 kinds.
+    pub const CAPACITY: u8 = 64;
+}
+
+// Build-time tripwire: a new variant that would overflow EventInterest's bitmask
+// fails compilation instead of silently corrupting the mask at runtime.
+const _: () = assert!((EventKind::MexNotification as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. The event bus skips
 /// materializing and dispatching events whose kind no handler wants, so a

--- a/wacore/src/types/presence.rs
+++ b/wacore/src/types/presence.rs
@@ -25,6 +25,7 @@ pub enum ChatPresenceMedia {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(from = "String")]
+#[non_exhaustive]
 pub enum ReceiptType {
     Delivered,
     /// Sent but NOT delivered: WA Web downgrades a delivery ack to this when the

--- a/wacore/src/types/user.rs
+++ b/wacore/src/types/user.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use waproto::whatsapp as wa;
 
 #[derive(Debug, Clone)]
@@ -14,47 +13,4 @@ pub struct LocalChatSettings {
     pub muted_until: Option<DateTime<Utc>>,
     pub pinned: bool,
     pub archived: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PrivacySetting {
-    All,
-    Contacts,
-    ContactBlacklist,
-    MatchLastSeen,
-    Known,
-    None,
-    #[serde(other)]
-    Undefined,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PrivacySettingType {
-    GroupAdd,
-    Last,
-    Status,
-    Profile,
-    ReadReceipts,
-    Online,
-    CallAdd,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct PrivacySettings {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub group_add: Option<PrivacySetting>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_seen: Option<PrivacySetting>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<PrivacySetting>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub profile: Option<PrivacySetting>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub read_receipts: Option<PrivacySetting>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub call_add: Option<PrivacySetting>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub online: Option<PrivacySetting>,
 }


### PR DESCRIPTION
## What

Continues the 1.0 forward-compat freeze started for error enums in #735, now on the public **value** enums, plus removes a dead duplicate type cluster.

## Changes

- `EventKind` and `ReceiptType` get `#[non_exhaustive]`. Both are server-driven sets that already grew over time (ReceiptType added `EncRekeyRetry`, `ReadSelf`, `PlayedSelf`, `PeerMsg`, `HistorySync`); without the attribute, a downstream exhaustive `match` breaks the moment a variant is added. The sibling `Event` enum already carried it, so this closes the asymmetry. Same-crate matches are unaffected.
- `EventKind` gains a documented `CAPACITY = 64` and a build-time `assert!`. It is used as a bit index into `EventInterest`'s `u64` mask, so a future variant that would overflow the mask now fails compilation instead of silently corrupting it at runtime.
- Removes the dead `PrivacySetting` / `PrivacySettingType` / `PrivacySettings` types from `wacore/src/types/user.rs`. They have zero references anywhere in the workspace, superseded by the WireEnum-based `wacore::iq::privacy::{PrivacyCategory, PrivacyValue, PrivacySetting}` (the live privacy feature). They were also a confusing second public `PrivacySetting` on the surface and violated the repo's WireEnum convention. The now-orphaned `serde` import goes with them.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude e2e-tests` green

Resolves gap-analysis api-07, api-16, api-17. Breaking change, acceptable pre-1.0.
