### PR TITLE
feat(groups): high-level set/remove group profile picture

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -3,7 +3,10 @@ use crate::features::mex::{MexError, mex_request};
 use std::collections::HashMap;
 use std::sync::Arc;
 use wacore::client::context::GroupInfo;
-use wacore::iq::contacts::{SetProfilePictureResponse, SetProfilePictureSpec};
+use wacore::iq::contacts::SetProfilePictureSpec;
+// Returned by set/remove_profile_picture; re-exported so callers don't reach
+// into wacore directly (consistent with GroupProfilePicture below).
+pub use wacore::iq::contacts::SetProfilePictureResponse;
 use wacore::iq::groups::{
     AcceptGroupInviteIq, AcceptGroupInviteV4Iq, AcknowledgeGroupIq, AddParticipantsIq,
     BatchGetGroupInfoIq, CancelMembershipRequestsIq, DemoteParticipantsIq, GetGroupInviteInfoIq,

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -3,6 +3,7 @@ use crate::features::mex::{MexError, mex_request};
 use std::collections::HashMap;
 use std::sync::Arc;
 use wacore::client::context::GroupInfo;
+use wacore::iq::contacts::{SetProfilePictureResponse, SetProfilePictureSpec};
 use wacore::iq::groups::{
     AcceptGroupInviteIq, AcceptGroupInviteV4Iq, AcknowledgeGroupIq, AddParticipantsIq,
     BatchGetGroupInfoIq, CancelMembershipRequestsIq, DemoteParticipantsIq, GetGroupInviteInfoIq,
@@ -784,6 +785,40 @@ impl<'a> Groups<'a> {
         Ok(self
             .client
             .execute(GetGroupProfilePicturesIq::with_type(groups))
+            .await?)
+    }
+
+    /// Set a group's profile picture (admin operation).
+    ///
+    /// Sends a JPEG; the caller should size/crop it (WhatsApp uses 640x640).
+    /// Passing empty `image_data` removes the picture, mirroring the own-picture
+    /// API; prefer [`Groups::remove_profile_picture`] when removal is the intent.
+    ///
+    /// ## Wire Format
+    /// ```xml
+    /// <iq type="set" xmlns="w:profile:picture" to="{group}@g.us">
+    ///   <picture type="image">{jpeg bytes}</picture>
+    /// </iq>
+    /// ```
+    pub async fn set_profile_picture(
+        &self,
+        group_jid: &Jid,
+        image_data: Vec<u8>,
+    ) -> Result<SetProfilePictureResponse, anyhow::Error> {
+        Ok(self
+            .client
+            .execute(SetProfilePictureSpec::for_group(group_jid, image_data))
+            .await?)
+    }
+
+    /// Remove a group's profile picture (admin operation).
+    pub async fn remove_profile_picture(
+        &self,
+        group_jid: &Jid,
+    ) -> Result<SetProfilePictureResponse, anyhow::Error> {
+        Ok(self
+            .client
+            .execute(SetProfilePictureSpec::remove_group(group_jid))
             .await?)
     }
 

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -263,6 +263,16 @@ impl SetProfilePictureSpec {
             image_data: None,
         }
     }
+
+    /// Set or remove a group's picture from caller-supplied bytes. Empty bytes
+    /// mean remove, mirroring [`Self::for_own`].
+    pub fn for_group(group_jid: &Jid, image_data: Vec<u8>) -> Self {
+        if image_data.is_empty() {
+            Self::remove_group(group_jid)
+        } else {
+            Self::set_group(group_jid, image_data)
+        }
+    }
 }
 
 impl IqSpec for SetProfilePictureSpec {
@@ -328,6 +338,18 @@ mod tests {
             SetProfilePictureSpec::for_own(vec![1, 2, 3]).image_data,
             Some(vec![1, 2, 3])
         );
+    }
+
+    #[test]
+    fn for_group_routes_empty_to_remove() {
+        let group_jid: Jid = "123456789@g.us".parse().unwrap();
+        let removed = SetProfilePictureSpec::for_group(&group_jid, Vec::new());
+        assert!(removed.image_data.is_none());
+        assert_eq!(removed.target.as_ref(), Some(&group_jid));
+
+        let set = SetProfilePictureSpec::for_group(&group_jid, vec![1, 2, 3]);
+        assert_eq!(set.image_data, Some(vec![1, 2, 3]));
+        assert_eq!(set.target.as_ref(), Some(&group_jid));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a high-level API to set or remove a group's profile picture. The protocol layer already existed and was tested in wacore (`SetProfilePictureSpec::set_group` / `remove_group`, which target the `w:profile:picture` IQ at the group JID), but nothing in the high-level crate ever constructed it — `Profile` only wires the own picture and `Groups` only had the read-side `get_profile_pictures`.

## API

- `Groups::set_profile_picture(group_jid, image_data)` — admin op; sends `<picture type="image">{jpeg}</picture>`.
- `Groups::remove_profile_picture(group_jid)`.

Mirrors the `Profile` own-picture API. Empty bytes route to removal via a new `SetProfilePictureSpec::for_group` helper (parallel to the existing `for_own`), so the public method never trips the non-empty `set_group` assert.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p wacore` green (`for_group_routes_empty_to_remove` added)

Resolves gap-analysis features-37.
