### PR TITLE
feat(send): add keep_message (keep-in-chat for everyone)

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -1052,6 +1052,27 @@ impl Client {
         .await
     }
 
+    /// Keep (or un-keep) a message in a disappearing chat for everyone.
+    ///
+    /// Sends a `keepInChatMessage` add-on (WA Web `WAWebKeepInChatMsgAction`):
+    /// `keep = true` requests `KEEP_FOR_ALL`, `keep = false` requests
+    /// `UNDO_KEEP_FOR_ALL`. `key` is the target (kept) message's key; the keep
+    /// message itself is sent with a fresh id. The send path classifies this as a
+    /// text add-on and maps the undo case to a sender-revoke edit attribute.
+    pub async fn keep_message(
+        &self,
+        chat: Jid,
+        key: wa::MessageKey,
+        keep: bool,
+    ) -> Result<SendResult, anyhow::Error> {
+        let message = wacore::proto_helpers::build_keep_in_chat_message(
+            key,
+            keep,
+            wacore::time::now_millis(),
+        );
+        self.send_message(chat, message).await
+    }
+
     /// Pin a message in a chat for all participants.
     pub async fn pin_message(
         &self,

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -430,6 +430,34 @@ impl MessageExt for wa::Message {
     }
 }
 
+/// Builds a `keepInChatMessage` body that keeps (or un-keeps) a message in a
+/// disappearing chat for everyone.
+///
+/// Mirrors WA Web `WAWebGenerateKeepInChatMessageProto`: the body carries the
+/// kept message's `key`, the keep type (`keep = true` -> `KEEP_FOR_ALL`,
+/// `false` -> `UNDO_KEEP_FOR_ALL`), and `timestamp_ms` = the *send* time (not
+/// the kept message's). The keep message itself is sent with a fresh
+/// `MessageKey` by the send path, so only the target key goes in the body.
+pub fn build_keep_in_chat_message(
+    key: wa::MessageKey,
+    keep: bool,
+    timestamp_ms: i64,
+) -> wa::Message {
+    let keep_type = if keep {
+        wa::KeepType::KeepForAll
+    } else {
+        wa::KeepType::UndoKeepForAll
+    };
+    wa::Message {
+        keep_in_chat_message: Some(wa::message::KeepInChatMessage {
+            key: Some(key),
+            keep_type: Some(keep_type as i32),
+            timestamp_ms: Some(timestamp_ms),
+        }),
+        ..Default::default()
+    }
+}
+
 /// Strips nested context_info fields to match WhatsApp Web.
 ///
 /// Clears quote-chain fields plus `mentioned_jid`/`group_mentions` to avoid
@@ -2207,6 +2235,35 @@ mod tests {
             ..Default::default()
         };
         assert!(!not_fwd.is_forwarded());
+    }
+
+    #[test]
+    fn build_keep_in_chat_message_keep_for_all() {
+        let key = wa::MessageKey {
+            id: Some("MID".into()),
+            from_me: Some(false),
+            ..Default::default()
+        };
+        let msg = build_keep_in_chat_message(key, true, 12345);
+        let k = msg
+            .keep_in_chat_message
+            .as_ref()
+            .expect("keep_in_chat_message set");
+        assert_eq!(k.keep_type, Some(wa::KeepType::KeepForAll as i32));
+        assert_eq!(k.timestamp_ms, Some(12345));
+        assert_eq!(
+            k.key.as_ref().and_then(|key| key.id.as_deref()),
+            Some("MID")
+        );
+    }
+
+    #[test]
+    fn build_keep_in_chat_message_undo() {
+        let msg = build_keep_in_chat_message(wa::MessageKey::default(), false, 1);
+        assert_eq!(
+            msg.keep_in_chat_message.unwrap().keep_type,
+            Some(wa::KeepType::UndoKeepForAll as i32)
+        );
     }
 
     fn group_target_key() -> wa::MessageKey {


### PR DESCRIPTION
## What

Adds a high-level API to keep (or un-keep) a message in a disappearing chat for everyone (`KeepInChatMessage`). The wire semantics were already known to the classifier (stanza-type and edit-attribute inference both branch on `keep_in_chat_message`), but there was no way to send one — every production reference was classification-only and the only construction lived in tests.

## API

- `Client::keep_message(chat, key, keep)` — `keep = true` requests `KEEP_FOR_ALL`, `false` requests `UNDO_KEEP_FOR_ALL`.
- `wacore::proto_helpers::build_keep_in_chat_message(key, keep, timestamp_ms)` — the tested builder.

## Shape (matches WAWebGenerateKeepInChatMessageProto)

`keepInChatMessage { key = kept message's key, keep_type, timestamp_ms = send time }`. The `timestamp_ms` is the current send time (not the kept message's), per `WAWebKeepInChatMsgAction`. The keep message itself is sent with a fresh `MessageKey` — only the target key goes in the body — so it routes through `send_message`, which mints a fresh stanza id. The existing classifier resolves the stanza to text and maps the undo case to a sender-revoke edit attribute, so no extra wiring is needed.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p wacore` green (builder covered for keep + undo)

Resolves gap-analysis features-12.
