### PR TITLE
feat(chat-actions): add save_contact (outgoing contact-name sync)

### DIFF
--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -509,8 +509,13 @@ impl<'a> ChatActions<'a> {
         first_name: Option<String>,
         save_on_primary_addressbook: bool,
     ) -> Result<()> {
-        if jid.is_lid() {
-            anyhow::bail!("save_contact: contact id must be a phone-number JID, not a LID");
+        // The contact index must be a bare phone-number JID. Reject LIDs (separate
+        // path in WA Web), group/status/broadcast/newsletter JIDs, and AD/device
+        // JIDs (e.g. 123:4@s.whatsapp.net) that would form an invalid contact index.
+        if !jid.is_pn() || jid.device != 0 {
+            anyhow::bail!(
+                "save_contact: contact id must be a bare phone-number JID (not a LID, group, or device-specific JID)"
+            );
         }
         debug!("Saving contact {jid}");
         let value = wa::SyncActionValue {

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -281,6 +281,13 @@ fn bool_str(b: bool) -> &'static str {
 
 /// Assemble the JSON-array mutation index for `schema` from its non-literal index
 /// args (in `schema.index_parts` order). The arg count must match.
+/// A `contact` app-state mutation is keyed by a bare phone-number JID. Reject
+/// LIDs (a separate WA Web path), group/status/broadcast/newsletter JIDs, and
+/// AD/device JIDs (e.g. `123:4@s.whatsapp.net`) that would form an invalid index.
+fn is_valid_contact_id(jid: &Jid) -> bool {
+    jid.is_pn() && jid.device == 0
+}
+
 pub(crate) fn build_action_index(schema: &Schema, args: &[&str]) -> Result<Vec<u8>> {
     let non_literal = schema
         .index_parts
@@ -509,10 +516,7 @@ impl<'a> ChatActions<'a> {
         first_name: Option<String>,
         save_on_primary_addressbook: bool,
     ) -> Result<()> {
-        // The contact index must be a bare phone-number JID. Reject LIDs (separate
-        // path in WA Web), group/status/broadcast/newsletter JIDs, and AD/device
-        // JIDs (e.g. 123:4@s.whatsapp.net) that would form an invalid contact index.
-        if !jid.is_pn() || jid.device != 0 {
+        if !is_valid_contact_id(jid) {
             anyhow::bail!(
                 "save_contact: contact id must be a bare phone-number JID (not a LID, group, or device-specific JID)"
             );
@@ -784,6 +788,7 @@ mod registry_tests {
         assert_eq!(schemas::ARCHIVE.version, 3);
         assert_eq!(schemas::MARK_CHAT_AS_READ.version, 3);
         assert_eq!(schemas::STAR.version, 2);
+        assert_eq!(schemas::CONTACT.version, 2);
         assert_eq!(schemas::DELETE_MESSAGE_FOR_ME.version, 3);
         assert_eq!(schemas::LABEL_EDIT.version, 3);
         assert_eq!(schemas::LABEL_JID.version, 3);
@@ -819,5 +824,20 @@ mod registry_tests {
             collection_patch_name(schemas::CONTACT.collection),
             WAPatchName::CriticalUnblockLow
         );
+    }
+
+    #[test]
+    fn contact_id_validation_accepts_only_bare_pn() {
+        let valid = |s: &str| is_valid_contact_id(&s.parse::<Jid>().expect("test JID"));
+        // bare PN -> accepted
+        assert!(valid("5511999@s.whatsapp.net"));
+        // AD/device-specific PN -> rejected (would form an invalid contact index)
+        assert!(!valid("5511999:4@s.whatsapp.net"));
+        // LID -> rejected (separate WA Web path)
+        assert!(!valid("100000012345678@lid"));
+        // group / newsletter / status -> rejected
+        assert!(!valid("120363012345@g.us"));
+        assert!(!valid("123@newsletter"));
+        assert!(!valid("status@broadcast"));
     }
 }

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -492,6 +492,43 @@ impl<'a> ChatActions<'a> {
             .await
     }
 
+    /// Save or rename a contact, syncing the name to the user's other linked devices.
+    ///
+    /// Writes a `contact` app-state SET mutation (WAWebContactSync.getContactSyncMutation)
+    /// to the `critical_unblock_low` collection with index `["contact", jid]`.
+    /// `full_name`/`first_name` are sent verbatim; an absent `first_name` is omitted
+    /// (WA Web derives no short-name default). `save_on_primary_addressbook` controls
+    /// whether it is saved to the phone's address book.
+    ///
+    /// The contact id must be a phone-number JID: WA Web refuses to send a contact
+    /// mutation keyed by a LID (LID contacts use a separate path), so a LID is rejected.
+    pub async fn save_contact(
+        &self,
+        jid: &Jid,
+        full_name: Option<String>,
+        first_name: Option<String>,
+        save_on_primary_addressbook: bool,
+    ) -> Result<()> {
+        if jid.is_lid() {
+            anyhow::bail!("save_contact: contact id must be a phone-number JID, not a LID");
+        }
+        debug!("Saving contact {jid}");
+        let value = wa::SyncActionValue {
+            contact_action: Some(wa::sync_action_value::ContactAction {
+                full_name,
+                first_name,
+                save_on_primary_addressbook: Some(save_on_primary_addressbook),
+                ..Default::default()
+            }),
+            timestamp: Some(wacore::time::now_millis()),
+            ..Default::default()
+        };
+        let jid_str = jid.to_string();
+        self.client
+            .send_app_state_action(&schemas::CONTACT, &[jid_str.as_str()], &value)
+            .await
+    }
+
     async fn send_archive_mutation(
         &self,
         jid: &Jid,
@@ -762,5 +799,20 @@ mod registry_tests {
             // Round-trips through the wire name.
             assert_eq!(collection_patch_name(c).as_str(), c.as_str());
         }
+    }
+
+    #[test]
+    fn contact_action_index_and_collection() {
+        // WAWebContactSync writes ["contact", jid] to critical_unblock_low.
+        let index = build_action_index(&schemas::CONTACT, &["5511999@s.whatsapp.net"]).unwrap();
+        let parts: Vec<String> = serde_json::from_slice(&index).unwrap();
+        assert_eq!(
+            parts,
+            vec!["contact".to_string(), "5511999@s.whatsapp.net".to_string()]
+        );
+        assert_eq!(
+            collection_patch_name(schemas::CONTACT.collection),
+            WAPatchName::CriticalUnblockLow
+        );
     }
 }


### PR DESCRIPTION
## What

The client handled incoming `contact` app-state mutations (dispatched as `Event::ContactUpdate`) but had no way to WRITE one, so a consumer could not save or rename a contact in a way that syncs to the user's other linked devices. WA Web exposes this via `WAWebContactEditSync` / `WAWebContactSync`.

## API

`ChatActions::save_contact(jid, full_name, first_name, save_on_primary_addressbook)`.

Builds a `contact` SET mutation through the existing `schemas::CONTACT` (collection `critical_unblock_low`, index `["contact", jid]`, version 2), matching `WAWebContactSync.getContactSyncMutation`:

- `full_name`/`first_name` are sent verbatim; an absent `first_name` is omitted (WA Web derives no short-name default).
- `save_on_primary_addressbook` is a plain bool.
- A LID contact id is rejected — WA Web refuses to send a contact mutation keyed by a LID (those go through a separate path).

## Scope

The REMOVE/delete-contact variant is left as a follow-up: the high-level app-state helper (`send_app_state_action`) only does SET today. `lid_jid`/`username` are omitted (optional metadata WA Web sets conditionally).

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p whatsapp-rust` green (index `["contact", jid]` + `critical_unblock_low` covered)

Resolves gap-analysis features-33.
