### PR TITLE
feat(iq): keep server error_type + backoff on IQ error responses

### DIFF
--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -30,12 +30,18 @@ impl SendContextResolver for Client {
             .map_err(|e| {
                 // Re-wrap server errors as wacore::ServerErrorCode so
                 // encrypt_for_devices can downcast across crate boundaries
-                if let Some(crate::request::IqError::ServerError { code, text }) =
-                    e.downcast_ref::<crate::request::IqError>()
+                if let Some(crate::request::IqError::ServerError {
+                    code,
+                    text,
+                    error_type,
+                    backoff,
+                }) = e.downcast_ref::<crate::request::IqError>()
                 {
                     return anyhow::Error::new(wacore::request::ServerErrorCode {
                         code: *code,
                         text: text.clone(),
+                        error_type: error_type.clone(),
+                        backoff: *backoff,
                     });
                 }
                 e

--- a/src/features/mex.rs
+++ b/src/features/mex.rs
@@ -314,6 +314,8 @@ mod tests {
         let iq = IqError::ServerError {
             code: 404,
             text: "not-found".into(),
+            error_type: None,
+            backoff: None,
         };
         let me: MexError = iq.into();
         let src = std::error::Error::source(&me).expect("source preserved");

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -297,7 +297,9 @@ mod tests {
         assert_eq!(
             classify_keepalive_error(&IqError::ServerError {
                 code: 500,
-                text: "internal".to_string()
+                text: "internal".to_string(),
+                error_type: None,
+                backoff: None,
             }),
             KeepaliveResult::TransientFailure,
             "ServerError should be transient — server may recover"

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -400,6 +400,8 @@ mod tests {
         let iq = IqError::ServerError {
             code: 400,
             text: "bad-request".into(),
+            error_type: None,
+            backoff: None,
         };
         let pe: PairError = iq.into();
         let src = std::error::Error::source(&pe).expect("source preserved");

--- a/src/request.rs
+++ b/src/request.rs
@@ -27,7 +27,14 @@ pub enum IqError {
     #[error("received disconnect node during IQ wait: {0:?}")]
     Disconnected(Node),
     #[error("received a server error response: code={code}, text='{text}'")]
-    ServerError { code: u16, text: String },
+    ServerError {
+        code: u16,
+        text: String,
+        /// XMPP error class from the `type` attr; `None` if absent.
+        error_type: Option<String>,
+        /// Server-directed retry delay in seconds from the `backoff` attr; `None` if absent.
+        backoff: Option<u32>,
+    },
     #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
     #[error("failed to encode IQ request")]
@@ -42,9 +49,17 @@ impl From<wacore::request::IqError> for IqError {
             wacore::request::IqError::Timeout => Self::Timeout,
             wacore::request::IqError::NotConnected => Self::NotConnected,
             wacore::request::IqError::Disconnected(node) => Self::Disconnected(node),
-            wacore::request::IqError::ServerError { code, text } => {
-                Self::ServerError { code, text }
-            }
+            wacore::request::IqError::ServerError {
+                code,
+                text,
+                error_type,
+                backoff,
+            } => Self::ServerError {
+                code,
+                text,
+                error_type,
+                backoff,
+            },
             wacore::request::IqError::InternalChannelClosed => Self::InternalChannelClosed,
             // wacore::IqError is #[non_exhaustive]; a new upstream variant should
             // get its own arm above. Until then treat it as an unexpected internal error.

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -88,7 +88,15 @@ pub enum IqError {
     #[error("received disconnect node during IQ wait: {0:?}")]
     Disconnected(Node),
     #[error("received a server error response: code={code}, text='{text}'")]
-    ServerError { code: u16, text: String },
+    ServerError {
+        code: u16,
+        text: String,
+        /// XMPP error class from the `type` attr (e.g. "wait" vs "cancel"); `None` if absent.
+        error_type: Option<String>,
+        /// Server-directed retry delay in seconds from the `backoff` attr; `None` if absent.
+        /// WA Web honors this (`setProtocolBackoffMs`) before retrying throttled IQs.
+        backoff: Option<u32>,
+    },
     #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
 }
@@ -104,6 +112,10 @@ pub enum IqError {
 pub struct ServerErrorCode {
     pub code: u16,
     pub text: String,
+    /// XMPP error class from the `type` attr; `None` if absent.
+    pub error_type: Option<String>,
+    /// Server-directed retry delay in seconds from the `backoff` attr; `None` if absent.
+    pub backoff: Option<u32>,
 }
 
 impl ServerErrorCode {
@@ -212,14 +224,85 @@ impl RequestUtils {
                     .as_deref()
                     .unwrap_or("")
                     .to_string();
-                return Err(IqError::ServerError { code, text });
+                // WA Web's parseIqResponse also keeps errorType + errorBackoff; the
+                // backoff is the server's directed retry delay (seconds).
+                let error_type = parser.optional_string("type").map(|s| s.into_owned());
+                let backoff = parser.optional_u64("backoff").map(|b| b as u32);
+                return Err(IqError::ServerError {
+                    code,
+                    text,
+                    error_type,
+                    backoff,
+                });
             }
             return Err(IqError::ServerError {
                 code: 0,
                 text: "Malformed error response".to_string(),
+                error_type: None,
+                backoff: None,
             });
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod iq_error_tests {
+    use super::{IqError, RequestUtils};
+    use wacore_binary::builder::NodeBuilder;
+
+    #[test]
+    fn parse_iq_response_extracts_error_type_and_backoff() {
+        let node = NodeBuilder::new("iq")
+            .attr("type", "error")
+            .children([NodeBuilder::new("error")
+                .attr("code", "429")
+                .attr("text", "rate-overlimit")
+                .attr("type", "wait")
+                .attr("backoff", "30")
+                .build()])
+            .build();
+        let err = RequestUtils::new("t".to_string())
+            .parse_iq_response(&node.as_node_ref())
+            .unwrap_err();
+        match err {
+            IqError::ServerError {
+                code,
+                text,
+                error_type,
+                backoff,
+            } => {
+                assert_eq!(code, 429);
+                assert_eq!(text, "rate-overlimit");
+                assert_eq!(error_type.as_deref(), Some("wait"));
+                assert_eq!(backoff, Some(30));
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_iq_response_error_without_backoff_is_none() {
+        let node = NodeBuilder::new("iq")
+            .attr("type", "error")
+            .children([NodeBuilder::new("error").attr("code", "404").build()])
+            .build();
+        let err = RequestUtils::new("t".to_string())
+            .parse_iq_response(&node.as_node_ref())
+            .unwrap_err();
+        match err {
+            IqError::ServerError {
+                code,
+                error_type,
+                backoff,
+                ..
+            } => {
+                assert_eq!(code, 404);
+                assert!(error_type.is_none());
+                assert!(backoff.is_none());
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
     }
 }

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -227,7 +227,10 @@ impl RequestUtils {
                 // WA Web's parseIqResponse also keeps errorType + errorBackoff; the
                 // backoff is the server's directed retry delay (seconds).
                 let error_type = parser.optional_string("type").map(|s| s.into_owned());
-                let backoff = parser.optional_u64("backoff").map(|b| b as u32);
+                // Drop an out-of-range backoff rather than wrapping it to a wrong delay.
+                let backoff = parser
+                    .optional_u64("backoff")
+                    .and_then(|b| u32::try_from(b).ok());
                 return Err(IqError::ServerError {
                     code,
                     text,

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -2529,6 +2529,8 @@ mod device_unregistered_tests {
         let err = anyhow::Error::new(ServerErrorCode {
             code: 406,
             text: "not-acceptable".to_string(),
+            error_type: None,
+            backoff: None,
         });
         assert!(is_device_unregistered_error(&err));
     }
@@ -2538,6 +2540,8 @@ mod device_unregistered_tests {
         let err = anyhow::Error::new(ServerErrorCode {
             code: 404,
             text: "not-found".to_string(),
+            error_type: None,
+            backoff: None,
         });
         assert!(!is_device_unregistered_error(&err));
     }
@@ -2556,6 +2560,8 @@ mod device_unregistered_tests {
         let err = anyhow::Error::new(crate::request::IqError::ServerError {
             code: 406,
             text: "not-acceptable".to_string(),
+            error_type: None,
+            backoff: None,
         });
         // This would only match if we also checked IqError (we don't — we use ServerErrorCode)
         // The SendContextResolver impl is responsible for wrapping in ServerErrorCode


### PR DESCRIPTION
## What

WA Web's `parseIqResponse` extracts `errorType` and `errorBackoff` from an IQ `<error>` node; ours kept only `code`+`text`, discarding the server's directed retry delay. WA Web honors that backoff (`setProtocolBackoffMs`) before retrying throttled usync / contact-sync / app-state-sync / media-conns IQs, so dropping it means we cannot honor server-directed throttling — relevant given the repo's documented ban/retry-storm history.

## Changes

- `IqError::ServerError` (wacore and high-level) and the shared `ServerErrorCode` gain `error_type: Option<String>` and `backoff: Option<u32>`.
- `parse_iq_response` reads the `<error>` node's `type` and `backoff` attrs and populates them.
- The `From<wacore::IqError>` conversion and the `ServerErrorCode` re-wrap propagate the new fields. Matchers using `{ code, .. }` are unaffected; the two exact destructures were updated.

## Scope

This surfaces the data (the foundation). Wiring specific retry loops to prefer the server-supplied backoff over their fixed schedules is a follow-up.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude e2e-tests` green (parse extracts type+backoff; absent → None)

Resolves gap-analysis protocol-26. Breaking (adds enum-variant fields), acceptable pre-1.0.
