### PR TITLE
fix(polls): match WA Web poll wire shape (pollContentType=TEXT, no vote metadata)

### DIFF
--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -68,7 +68,10 @@ impl<'a> Polls<'a> {
             options: poll_options,
             selectable_options_count: Some(selectable_count),
             context_info: None,
-            poll_content_type: None,
+            // WA Web's GeneratePollCreationMessageProto always sets pollContentType
+            // (TEXT=1 for a normal poll); omitting it drops a field the real client
+            // always emits. poll_type=POLL is 0 (proto default) so None is wire-equal.
+            poll_content_type: Some(wa::message::PollContentType::Text as i32),
             poll_type: None,
             correct_answer: None,
             ..Default::default()
@@ -156,7 +159,9 @@ impl<'a> Polls<'a> {
                 enc_payload: Some(enc_payload),
                 enc_iv: Some(iv.to_vec()),
             }),
-            metadata: Some(wa::message::PollUpdateMessageMetadata::default()),
+            // WA Web's GeneratePollVoteMessageProto never sets metadata; a Some(empty)
+            // submessage emits a stray `1A 00` (tag 3) on the wire. Omit it.
+            metadata: None,
             sender_timestamp_ms: Some(wacore::time::now_millis()),
         };
 


### PR DESCRIPTION
## What

Two protobuf wire-parity fixes vs WA Web (`GeneratePollCreationMessageProto` / `GeneratePollVoteMessageProto`):

- **`Polls::create`** now sets `poll_content_type = PollContentType::Text` (enum value 1). WA Web always emits this field for a normal poll; leaving it `None` dropped a field the real client sends on every poll. `poll_type` stays `None` (`POLL = 0` is the proto default, wire-equivalent).
- **`Polls::vote`** no longer sets `metadata = Some(PollUpdateMessageMetadata::default())`. The metadata is an empty message, so `Some(default)` serialized a stray `1A 00` (tag 3) that WA Web never emits; `None` omits it.

Both are benign on receive (WA's parsers default/ignore these), so this is byte-for-byte wire parity, not a behavior change.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p whatsapp-rust` green

No new unit test: both are static field-value changes and the poll test harness exercises `resolve_voter_jid`, not captured send bytes. Happy to extract a builder + encode-assert test if preferred.

Resolves gap-analysis protocol-60 and protocol-61.
