### PR TITLE
perf(appstate): return Arc from key-lookup callback (no per-mutation 160B clone)

### DIFF
--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -11,6 +11,7 @@ use crate::keys::ExpandedAppStateKeys;
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use waproto::whatsapp as wa;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,7 +66,7 @@ pub fn process_snapshot<F>(
     collection_name: &str,
 ) -> Result<ProcessedSnapshot, AppStateError>
 where
-    F: FnMut(&[u8]) -> Result<ExpandedAppStateKeys, AppStateError>,
+    F: FnMut(&[u8]) -> Result<Arc<ExpandedAppStateKeys>, AppStateError>,
 {
     let version = snapshot
         .version
@@ -167,7 +168,7 @@ pub fn process_patch<F, G>(
     collection_name: &str,
 ) -> Result<PatchProcessingResult, AppStateError>
 where
-    F: FnMut(&[u8]) -> Result<ExpandedAppStateKeys, AppStateError>,
+    F: FnMut(&[u8]) -> Result<Arc<ExpandedAppStateKeys>, AppStateError>,
     G: FnMut(&[u8]) -> Result<Option<Vec<u8>>, AppStateError>,
 {
     // Capture original state before modification - needed for MAC validation logic
@@ -465,7 +466,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
 
         let mut state = HashState::default();
         let result = process_snapshot(&snapshot, &mut state, get_keys, false, "regular")
@@ -517,7 +518,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| Ok(None);
 
         let mut state = HashState::default();
@@ -571,7 +572,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut snapshot_state = HashState::default();
         let snapshot_result =
             process_snapshot(&snapshot, &mut snapshot_state, get_keys, false, "regular")
@@ -598,7 +599,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         // Return the previous value MAC when asked
         let get_prev = |idx: &[u8]| {
             if idx == index_mac.as_slice() {
@@ -702,7 +703,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| Ok(None);
 
         // Fresh state -> had_no_prior_state skips version/MAC checks.
@@ -786,7 +787,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| Ok(None);
 
         let mut state = HashState::default();
@@ -848,7 +849,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| -> Result<Option<Vec<u8>>, AppStateError> { Ok(None) };
 
         let err = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
@@ -902,7 +903,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| -> Result<Option<Vec<u8>>, AppStateError> { Ok(None) };
 
         let err = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
@@ -955,7 +956,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| -> Result<Option<Vec<u8>>, AppStateError> { Ok(None) };
 
         let result = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
@@ -997,7 +998,7 @@ mod tests {
             ..Default::default()
         };
 
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let get_prev = |_: &[u8]| -> Result<Option<Vec<u8>>, AppStateError> { Ok(None) };
 
         let result = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -26,13 +26,15 @@ pub use crate::appstate::Mutation;
 fn lookup_app_state_key(
     keys_map: &HashMap<String, Arc<ExpandedAppStateKeys>>,
     key_id: &[u8],
-) -> Result<ExpandedAppStateKeys, crate::appstate::AppStateError> {
+) -> Result<Arc<ExpandedAppStateKeys>, crate::appstate::AppStateError> {
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD_NO_PAD;
     let id_b64 = STANDARD_NO_PAD.encode(key_id);
+    // Return the Arc (refcount bump) instead of deep-cloning the 160-byte
+    // ExpandedAppStateKeys; the callback runs once per mutation (up to ~1000/patch).
     keys_map
         .get(&id_b64)
-        .map(|arc| (**arc).clone())
+        .map(Arc::clone)
         .ok_or(crate::appstate::AppStateError::KeyNotFound)
 }
 


### PR DESCRIPTION
## What

The app-state `get_keys` callback returned `ExpandedAppStateKeys` by value, so `lookup_app_state_key` deep-cloned the 160-byte struct (5× `[u8; 32]`) out of its `Arc` on every call. `process_snapshot`/`process_patch` invoke the callback once per mutation, and a resume/bootstrap patch can carry up to ~1000 mutations, so that's ~1000 redundant 160-byte memcpys per patch where one refcount bump would do.

## Change

- Callback signature: `FnMut(&[u8]) -> Result<ExpandedAppStateKeys>` → `Result<Arc<ExpandedAppStateKeys>>`.
- `lookup_app_state_key` returns `Arc::clone` instead of `(**arc).clone()` (the `key_cache` already stores `Arc<ExpandedAppStateKeys>`).
- Downstream consumers (`decode_record`, `validate_patch_macs`, `generate_snapshot_mac`) take keys by `&ExpandedAppStateKeys`, so deref coercion handles the `Arc` with no call-site changes.

Cold-ish path (inbound app-state sync) but scales to ~1000 iterations per patch.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p wacore -p wacore-appstate -p whatsapp-rust` green

Resolves the per-mutation key-clone half of gap-analysis performance-06. The base64 re-encode per mutation (the other half) is a follow-up.
