### PR TITLE
fix(appstate): repair main build broken by #748/#750 merge

### DIFF
--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -519,7 +519,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot mac must fail when validating");
@@ -545,7 +545,7 @@ mod tests {
             mac: Some(vec![9u8; 32]),
             key_id: None,
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot key_id must fail when validating");


### PR DESCRIPTION
Main's CI is red: a semantic merge conflict between #748 and #750 slipped through.

#748 added two snapshot-MAC enforcement tests (`process_snapshot_rejects_missing_mac_when_validating` and `process_snapshot_rejects_missing_key_id_when_validating`) whose `get_keys` closures returned a bare `ExpandedAppStateKeys`. #750 changed the keys callback signature to `FnMut(&[u8]) -> Result<Arc<ExpandedAppStateKeys>, AppStateError>` and updated the ten existing closures, but those two new tests merged in afterward and were never reconciled. Result: `E0271` in `wacore-appstate` (lib test), so the whole `cargo clippy --all-targets`/`cargo test` step fails on main even though both PRs were green against their own bases.

Fix is mechanical: wrap the keys in `Arc::new` in those two closures, matching what #750 already did everywhere else.

Verified locally:
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p wacore-appstate` → 27 passed, including the two previously-failing tests