### PR TITLE
feat(appstate): reject duplicate index within a patch (anti-tampering parity)

### DIFF
--- a/wacore/appstate/src/errors.rs
+++ b/wacore/appstate/src/errors.rs
@@ -32,6 +32,10 @@ pub enum AppStateError {
     PatchMACMismatch,
     #[error("patch version mismatch: expected {expected}, got {got}")]
     PatchVersionMismatch { expected: u64, got: u64 },
+    // WA Web (WAWebSyncdValidateMutations) reports SAME_INDEX_FOR_MULTIPLE_MUTATIONS_IN_PATCH
+    // and throws a fatal error: a repeated index within one patch is a tampering signal.
+    #[error("duplicate index within a single patch")]
+    DuplicateIndexInPatch,
 }
 
 pub type Result<T> = std::result::Result<T, AppStateError>;

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -519,7 +519,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot mac must fail when validating");
@@ -545,7 +545,7 @@ mod tests {
             mac: Some(vec![9u8; 32]),
             key_id: None,
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot key_id must fail when validating");

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -10,7 +10,7 @@ use crate::hash::{HashState, generate_patch_mac};
 use crate::keys::ExpandedAppStateKeys;
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use waproto::whatsapp as wa;
 
@@ -246,6 +246,14 @@ where
         )?;
     }
 
+    // Anti-tampering parity: a repeated index within the same operation of one patch
+    // is fatal in WA Web (validateNoSameIndexForMultipleMutations -> SyncdFatalError),
+    // and the cryptographic patch/snapshot MACs above don't catch it (a duplicate-index
+    // patch still MACs correctly). Runs only on the validated inbound path.
+    if validate_macs {
+        detect_duplicate_index_in_patch(&patch.mutations)?;
+    }
+
     // Decode all mutations and collect MACs in a single pass
     let mut mutations = Vec::with_capacity(patch.mutations.len());
     let mut added_macs = Vec::with_capacity(patch.mutations.len());
@@ -287,6 +295,34 @@ where
         added_macs,
         removed_index_macs,
     })
+}
+
+/// Reject a patch that repeats an index within the same operation.
+///
+/// Mirrors WA Web `WAWebSyncdValidateMutations.validateNoSameIndexForMultipleMutations`,
+/// which keeps one Set per operation (SET, REMOVE) and throws a fatal
+/// `SAME_INDEX_FOR_MULTIPLE_MUTATIONS_IN_PATCH` when an index reappears in the same one.
+/// WA Web keys on the decrypted index; the raw index_mac blob is a deterministic
+/// function of that index, so keying on it is equivalent for detection.
+fn detect_duplicate_index_in_patch(mutations: &[wa::SyncdMutation]) -> Result<(), AppStateError> {
+    let mut seen_set: HashSet<&[u8]> = HashSet::new();
+    let mut seen_remove: HashSet<&[u8]> = HashSet::new();
+    for m in mutations {
+        let Some(rec) = &m.record else { continue };
+        let Some(index_mac) = rec.index.as_ref().and_then(|i| i.blob.as_deref()) else {
+            continue;
+        };
+        let op = wa::syncd_mutation::SyncdOperation::try_from(m.operation.unwrap_or(0))
+            .unwrap_or(wa::syncd_mutation::SyncdOperation::Set);
+        let seen = match op {
+            wa::syncd_mutation::SyncdOperation::Set => &mut seen_set,
+            wa::syncd_mutation::SyncdOperation::Remove => &mut seen_remove,
+        };
+        if !seen.insert(index_mac) {
+            return Err(AppStateError::DuplicateIndexInPatch);
+        }
+    }
+    Ok(())
 }
 
 /// Validate the snapshot and patch MACs for a patch.
@@ -597,6 +633,121 @@ mod tests {
             result.added_macs[0].value_mac
         );
         assert!(result.removed_index_macs.is_empty());
+    }
+
+    #[test]
+    fn process_patch_rejects_duplicate_set_index() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let key_id = b"test_key_id".to_vec();
+        let index_mac = vec![1u8; 32];
+
+        // Two SET mutations colliding on the same index within one patch.
+        let mk = |ts| wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+            record: Some(create_encrypted_record(
+                wa::syncd_mutation::SyncdOperation::Set,
+                &index_mac,
+                &keys,
+                &key_id,
+                ts,
+            )),
+        };
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![mk(1), mk(2)],
+            key_id: Some(wa::KeyId {
+                id: Some(key_id.clone()),
+            }),
+            ..Default::default()
+        };
+
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
+        let get_prev = |_: &[u8]| Ok(None);
+        let mut state = HashState::default();
+        let err = process_patch(&patch, &mut state, get_keys, get_prev, true, "regular")
+            .expect_err("duplicate SET index must be rejected when validating");
+        assert!(matches!(err, AppStateError::DuplicateIndexInPatch));
+    }
+
+    #[test]
+    fn process_patch_allows_same_index_across_set_and_remove() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let key_id = b"test_key_id".to_vec();
+        let index_mac = vec![2u8; 32];
+
+        // SET and REMOVE share an index legitimately: WA Web tracks the two
+        // operations in separate sets, so this is not tampering.
+        let set = wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+            record: Some(create_encrypted_record(
+                wa::syncd_mutation::SyncdOperation::Set,
+                &index_mac,
+                &keys,
+                &key_id,
+                1,
+            )),
+        };
+        let remove = wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::Remove as i32),
+            record: Some(create_encrypted_record(
+                wa::syncd_mutation::SyncdOperation::Remove,
+                &index_mac,
+                &keys,
+                &key_id,
+                2,
+            )),
+        };
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![set, remove],
+            key_id: Some(wa::KeyId {
+                id: Some(key_id.clone()),
+            }),
+            ..Default::default()
+        };
+
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
+        let get_prev = |_: &[u8]| Ok(None);
+        let mut state = HashState::default();
+        let result = process_patch(&patch, &mut state, get_keys, get_prev, true, "regular");
+        assert!(
+            result.is_ok(),
+            "SET+REMOVE on the same index must be allowed: {result:?}"
+        );
+    }
+
+    #[test]
+    fn process_patch_allows_distinct_indices_when_validating() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let key_id = b"test_key_id".to_vec();
+
+        let mk = |index: &[u8], ts| wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+            record: Some(create_encrypted_record(
+                wa::syncd_mutation::SyncdOperation::Set,
+                index,
+                &keys,
+                &key_id,
+                ts,
+            )),
+        };
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(1) }),
+            mutations: vec![mk(&[3u8; 32], 1), mk(&[4u8; 32], 2)],
+            key_id: Some(wa::KeyId {
+                id: Some(key_id.clone()),
+            }),
+            ..Default::default()
+        };
+
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
+        let get_prev = |_: &[u8]| Ok(None);
+        let mut state = HashState::default();
+        let result = process_patch(&patch, &mut state, get_keys, get_prev, true, "regular");
+        assert!(result.is_ok(), "distinct indices must pass: {result:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes the protocol-10 gap (appstate anti-tampering).

WA Web's `WAWebSyncdValidateMutations.validateNoSameIndexForMultipleMutations` keeps one set of seen indices per operation (SET, REMOVE) and, when an index repeats within the same operation of a single patch, throws a fatal `SyncdFatalError` (`SAME_INDEX_FOR_MULTIPLE_MUTATIONS_IN_PATCH`). It treats this as a tampering signal. Our `process_patch` instead resolved a repeated index as last-write-wins and kept going, so a malformed or tampered patch that still MACs correctly was silently accepted. The cryptographic patch/snapshot MACs don't catch this case because a duplicate-index patch can still produce a valid MAC.

This adds `detect_duplicate_index_in_patch` (SET and REMOVE tracked in separate sets, keyed on the deterministic `index_mac` blob, which is equivalent to WA Web keying on the decrypted index) plus a new fatal `AppStateError::DuplicateIndexInPatch`. It runs only on the validated inbound path, after the existing patch/snapshot MAC checks, matching WA Web's ordering (validation runs after `computeLtHashAndValidatePatch`).

Scope note: the snapshot path is intentionally left unchanged here. WA Web treats a duplicate index in a *snapshot* as non-fatal (dedup-keeping-last via its function `y`), which would alter ltHash computation, so it belongs in a separate change rather than being bundled with the fatal patch case.

Tests: duplicate SET index is rejected; SET+REMOVE on the same index is allowed (separate operation sets); distinct indices pass under validation.

Verified against `docs/captured-js/WAWeb/Syncd/ValidateMutations.js` (function `h`, exported at :219; fatal throw at :116-121) and `CollectionHandler.js` (patch call site at :1656 with `SyncDataType.Patch`).

Note: this branch currently carries the 2-line main build fix from #751 so its CI is green; I'll rebase onto main once #751 lands and those lines drop out of the diff.