### PR TITLE
feat(appstate): guard snapshot apply against version rollback

### DIFF
--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -519,7 +519,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot mac must fail when validating");
@@ -545,7 +545,7 @@ mod tests {
             mac: Some(vec![9u8; 32]),
             key_id: None,
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot key_id must fail when validating");

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -260,8 +260,25 @@ impl AppStateProcessor {
         let mut new_mutations: Vec<Mutation> = Vec::new();
         let collection_name = pl.name.as_str();
 
-        // Process snapshot if present
-        if let Some(snapshot) = &pl.snapshot {
+        // Process snapshot if present, unless it is stale. WA Web's
+        // WAWebSyncdCollectionHandler (ot()/CollectionVersionStore) applies a snapshot only
+        // when it is strictly newer than the persisted version; a stale or replayed snapshot
+        // (persisted >= incoming) is discarded ("skip applying syncd old version") so it can't
+        // roll the collection backward. No-op on the benign first-sync path, where snapshots
+        // are requested only at version 0.
+        let snapshot_to_apply = pl.snapshot.as_ref().filter(|snapshot| {
+            let snapshot_version = snapshot.version.as_ref().and_then(|v| v.version).unwrap_or(0);
+            if snapshot_is_stale(state.version, snapshot_version) {
+                log::warn!(
+                    target: "AppState",
+                    "Skipping stale snapshot for {collection_name}: incoming v{snapshot_version} <= persisted v{}",
+                    state.version
+                );
+                return false;
+            }
+            true
+        });
+        if let Some(snapshot) = snapshot_to_apply {
             let keys_map = self.key_cache.lock().await.clone();
             let snapshot_clone = snapshot.clone();
             let collection_name_owned = collection_name.to_string();
@@ -505,4 +522,37 @@ impl AppStateProcessor {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AppStateSyncDriver {
     async fn fetch_collection(&self, name: WAPatchName, after_version: u64) -> Result<Node>;
+}
+
+/// A snapshot is stale when the collection already holds a version at or beyond the
+/// incoming snapshot's; WA Web discards it ("skip applying syncd old version") rather
+/// than rolling the collection backward. The `persisted_version > 0` guard keeps the
+/// benign first-sync path (snapshots are requested only at version 0) unaffected.
+fn snapshot_is_stale(persisted_version: u64, snapshot_version: u64) -> bool {
+    persisted_version > 0 && snapshot_version <= persisted_version
+}
+
+#[cfg(test)]
+mod snapshot_guard_tests {
+    use super::snapshot_is_stale;
+
+    #[test]
+    fn first_sync_is_never_stale() {
+        // Benign path: nothing persisted yet (version 0), so any snapshot applies.
+        assert!(!snapshot_is_stale(0, 1));
+        assert!(!snapshot_is_stale(0, 0));
+    }
+
+    #[test]
+    fn newer_snapshot_applies() {
+        assert!(!snapshot_is_stale(5, 6));
+    }
+
+    #[test]
+    fn equal_or_older_snapshot_is_stale() {
+        // WA Web's `a.version >= t` skips equal versions too.
+        assert!(snapshot_is_stale(5, 5));
+        assert!(snapshot_is_stale(5, 3));
+        assert!(snapshot_is_stale(5, 0));
+    }
 }


### PR DESCRIPTION
Closes the protocol-40 gap (appstate anti-tampering).

`process_patch` enforces a strict monotonic version check, but `process_patch_list` applied any incoming snapshot unconditionally: it builds a fresh `HashState`, runs `process_snapshot`, then overwrites and persists state without comparing the snapshot's version to the already-persisted collection version. A stale or replayed snapshot (an unsolicited or out-of-order server resend) could therefore roll the collection backward and drop mutations the client had already applied.

WA Web's `WAWebSyncdCollectionHandler` guards this via `ot()`/`CollectionVersionStore`: it applies a snapshot only when it is strictly newer than the persisted version (`a.version >= incoming` returns 'skip applying syncd old version' and does not bulkSet/update). This mirrors that with a pure `snapshot_is_stale(persisted, incoming)` helper, filtering out a stale snapshot before the expensive decode/persist.

The guard is a no-op on the benign flow: the production fetch only requests a snapshot when local `state.version == 0`, and the `persisted_version > 0` condition means a never-synced collection always applies its first snapshot. Equal versions are treated as stale too, matching WA Web's `>=`.

Verified against `docs/captured-js/WAWeb/Syncd/CollectionHandler.js` (`ot()` at :2293-2316, snapshot apply block at :1218-1244).

Note: this branch currently carries the 2-line main build fix from #751 so its CI is green; I'll rebase onto main once #751 lands and those lines drop out of the diff.