### PR TITLE
feat(chat): support clearChat app-state action (incoming + outgoing)

### DIFF
--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -11,8 +11,8 @@ use log::debug;
 use wacore::appstate::patch_decode::WAPatchName;
 use wacore::appstate::schemas::{self, IndexPart, Schema};
 use wacore::types::events::{
-    ArchiveUpdate, ContactUpdate, DeleteChatUpdate, DeleteMessageForMeUpdate, Event,
-    MarkChatAsReadUpdate, MuteUpdate, PinUpdate, StarUpdate,
+    ArchiveUpdate, ClearChatUpdate, ContactUpdate, DeleteChatUpdate, DeleteMessageForMeUpdate,
+    Event, MarkChatAsReadUpdate, MuteUpdate, PinUpdate, StarUpdate,
 };
 use wacore_binary::{Jid, JidExt};
 use waproto::whatsapp as wa;
@@ -79,6 +79,7 @@ pub(crate) fn dispatch_chat_mutation(
             | "mark_chat_as_read"
             | "markChatAsRead"
             | "deleteChat"
+            | "clearChat"
             | "deleteMessageForMe"
     ) {
         return false;
@@ -199,6 +200,26 @@ pub(crate) fn dispatch_chat_mutation(
                 let delete_media = m.index.get(2).is_none_or(|v| v != "0");
                 event_bus.dispatch(Event::DeleteChatUpdate(DeleteChatUpdate {
                     jid,
+                    delete_media,
+                    timestamp: time,
+                    action: Box::new(act.clone()),
+                    from_full_sync: full_sync,
+                }));
+            }
+            true
+        }
+        "clearChat" => {
+            if let Some(val) = &m.action_value
+                && let Some(act) = &val.clear_chat_action
+            {
+                // deleteStarred/deleteMedia live in the index (index[2]/index[3]),
+                // not in ClearChatAction (which only has messageRange). WA Web's send
+                // builder encodes both as "1"/"0".
+                let delete_starred = m.index.get(2).is_some_and(|v| v == "1");
+                let delete_media = m.index.get(3).is_some_and(|v| v == "1");
+                event_bus.dispatch(Event::ClearChatUpdate(ClearChatUpdate {
+                    jid,
+                    delete_starred,
                     delete_media,
                     timestamp: time,
                     action: Box::new(act.clone()),
@@ -459,6 +480,36 @@ impl<'a> ChatActions<'a> {
             .send_app_state_action(
                 &schemas::DELETE_CHAT,
                 &[jid.as_str(), delete_media_str],
+                &value,
+            )
+            .await
+    }
+
+    /// Clears a chat's messages while keeping the chat (WA Web's clearChat).
+    ///
+    /// `delete_starred` also removes starred messages; `delete_media` also removes
+    /// downloaded media. Both flags live only in the mutation index, not the proto.
+    pub async fn clear_chat(
+        &self,
+        jid: &Jid,
+        delete_starred: bool,
+        delete_media: bool,
+        message_range: Option<SyncActionMessageRange>,
+    ) -> Result<()> {
+        debug!("Clearing chat {jid}");
+        // WA Web's $ClearChatSync$p_3 encodes both flags as "1"/"0".
+        let delete_starred_str = if delete_starred { "1" } else { "0" };
+        let delete_media_str = if delete_media { "1" } else { "0" };
+        let value = wa::SyncActionValue {
+            clear_chat_action: Some(wa::sync_action_value::ClearChatAction { message_range }),
+            timestamp: Some(wacore::time::now_millis()),
+            ..Default::default()
+        };
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(
+                &schemas::CLEAR_CHAT,
+                &[jid.as_str(), delete_starred_str, delete_media_str],
                 &value,
             )
             .await
@@ -748,6 +799,11 @@ mod registry_tests {
                 &schemas::DELETE_CHAT,
                 &["123@s.whatsapp.net", "1"],
                 &["deleteChat", "123@s.whatsapp.net", "1"],
+            ),
+            (
+                &schemas::CLEAR_CHAT,
+                &["123@s.whatsapp.net", "0", "1"],
+                &["clearChat", "123@s.whatsapp.net", "0", "1"],
             ),
             (&schemas::LABEL_EDIT, &["5"], &["label_edit", "5"]),
             (

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -519,7 +519,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot mac must fail when validating");
@@ -545,7 +545,7 @@ mod tests {
             mac: Some(vec![9u8; 32]),
             key_id: None,
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot key_id must fail when validating");

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -231,6 +231,7 @@ pub enum EventKind {
     StarUpdate,
     MarkChatAsReadUpdate,
     DeleteChatUpdate,
+    ClearChatUpdate,
     DeleteMessageForMeUpdate,
     LabelEditUpdate,
     LabelAssociationUpdate,
@@ -632,6 +633,7 @@ pub enum Event {
     StarUpdate(StarUpdate),
     MarkChatAsReadUpdate(MarkChatAsReadUpdate),
     DeleteChatUpdate(DeleteChatUpdate),
+    ClearChatUpdate(ClearChatUpdate),
     DeleteMessageForMeUpdate(DeleteMessageForMeUpdate),
     LabelEditUpdate(LabelEditUpdate),
     LabelAssociationUpdate(LabelAssociationUpdate),
@@ -719,6 +721,7 @@ impl Event {
             Event::StarUpdate(_) => EventKind::StarUpdate,
             Event::MarkChatAsReadUpdate(_) => EventKind::MarkChatAsReadUpdate,
             Event::DeleteChatUpdate(_) => EventKind::DeleteChatUpdate,
+            Event::ClearChatUpdate(_) => EventKind::ClearChatUpdate,
             Event::DeleteMessageForMeUpdate(_) => EventKind::DeleteMessageForMeUpdate,
             Event::LabelEditUpdate(_) => EventKind::LabelEditUpdate,
             Event::LabelAssociationUpdate(_) => EventKind::LabelAssociationUpdate,
@@ -1154,6 +1157,20 @@ pub struct DeleteChatUpdate {
     pub delete_media: bool,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::DeleteChatAction>,
+    pub from_full_sync: bool,
+}
+
+/// A chat's messages were cleared (kept) on a linked device.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClearChatUpdate {
+    /// The chat being cleared.
+    pub jid: Jid,
+    /// From the index, not the proto — ClearChatAction only has messageRange.
+    pub delete_starred: bool,
+    /// From the index, not the proto.
+    pub delete_media: bool,
+    pub timestamp: DateTime<Utc>,
+    pub action: Box<wa::sync_action_value::ClearChatAction>,
     pub from_full_sync: bool,
 }
 


### PR DESCRIPTION
Closes the features-31 gap.

WA Web's `clearChat` action (`SyncActionValue.clear_chat_action`, collection `regular_high`, version 6) wipes a chat's messages while keeping the chat. The client handled `deleteChat` but neither received nor sent `clearChat`: an incoming `clearChat` mutation from a linked device fell through `dispatch_chat_mutation` and was silently dropped (no event), and there was no outgoing API to replicate the action across devices.

**Incoming**: `clearChat` is added to the dispatch guard and emits a new `Event::ClearChatUpdate` (mirroring `DeleteChatUpdate`). The `deleteStarred`/`deleteMedia` flags live in the index (`index[2]`/`index[3]`), not in `ClearChatAction` (which only carries `messageRange`), so the event surfaces them from the index.

**Outgoing**: `ChatActions::clear_chat(jid, delete_starred, delete_media, message_range)`, modeled on `delete_chat`. The `CLEAR_CHAT` schema already exists in the auto-generated registry with the 4-part index `["clearChat", chatJid, deleteStarred, deleteMedia]`; both flags are encoded `"1"`/`"0"` exactly as WA Web's `$ClearChatSync$p_3` builds them.

`EventKind` is `#[non_exhaustive]` with a 64-variant ceiling (now 49), and `Event` is `#[non_exhaustive]`, so adding the variant is non-breaking.

Tests: the `clearChat` index shape is added to `build_index_matches_legacy_shapes`.

Verified against `docs/captured-js/WAWeb/Clear/ChatSync.js` (send index build at :311, parse at :360-374) and the `CLEAR_CHAT` schema entry.

Note: this branch currently carries the 2-line main build fix from #751 so its CI is green; I'll rebase onto main once #751 lands and those lines drop out of the diff.