### PR TITLE
fix(wasm): make cache backend target-aware so moka-cache defaults don't break wasm32

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,3 +42,15 @@ jobs:
           cargo build -p whatsapp-rust --lib --release
           --target wasm32-unknown-unknown
           --no-default-features --features debug-diagnostics
+      # moka-cache is in the default feature set and is thread-based (can't build
+      # on wasm32), so a defaults-based consumer that forgets --no-default-features
+      # would hit it. The target gate in src/cache.rs must fall back to
+      # PortableCache instead of pulling moka; this step exercises that path so it
+      # can't silently regress.
+      - name: Build whatsapp-rust lib for wasm32 with moka-cache (release)
+        env:
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+        run: >
+          cargo build -p whatsapp-rust --lib --release
+          --target wasm32-unknown-unknown
+          --no-default-features --features debug-diagnostics,moka-cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,6 @@ futures = { workspace = true, features = ["std"] }
 hex = { workspace = true }
 itoa = { workspace = true }
 log = { workspace = true }
-moka = { version = "0.12.12", features = ["future"], optional = true }
 portable-atomic = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
@@ -169,6 +168,13 @@ whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version 
 # selected via `--cfg getrandom_backend="wasm_js"` in RUSTFLAGS; no native effect.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
+
+# moka is thread-based (crossbeam/uuid) and does not build on wasm32, so it is
+# scoped to non-wasm targets. The `moka-cache` feature can still be enabled on
+# wasm32 (it stays in `default`); `dep:moka` is simply inert there and the cache
+# falls back to PortableCache via the target gate in src/cache.rs.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+moka = { version = "0.12.12", features = ["future"], optional = true }
 
 [dev-dependencies]
 aes = { workspace = true }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,15 +1,18 @@
-//! Unified cache type that dispatches to moka or the portable implementation
-//! depending on the `moka-cache` feature flag.
+//! Unified cache type that dispatches to moka or the portable implementation.
 //!
-//! When `moka-cache` is enabled (default), [`Cache`] is `moka::future::Cache`.
-//! When disabled, [`Cache`] is [`PortableCache`](crate::portable_cache::PortableCache).
+//! Selection is both feature- and target-aware: [`Cache`] is `moka::future::Cache`
+//! only when the `moka-cache` feature is on AND the target is not wasm32. On wasm32
+//! (or with `moka-cache` off) it is [`PortableCache`](crate::portable_cache::PortableCache).
+//! moka is thread-based (it pulls crossbeam/uuid) and does not compile on
+//! wasm32-unknown-unknown, so a defaults-based wasm32 build falls back here rather than
+//! failing deep inside moka's dependency tree.
 
-#[cfg(feature = "moka-cache")]
+#[cfg(all(feature = "moka-cache", not(target_arch = "wasm32")))]
 mod inner {
     pub type Cache<K, V> = moka::future::Cache<K, V>;
 }
 
-#[cfg(not(feature = "moka-cache"))]
+#[cfg(any(not(feature = "moka-cache"), target_arch = "wasm32"))]
 mod inner {
     pub type Cache<K, V> = crate::portable_cache::PortableCache<K, V>;
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,11 +1,8 @@
-//! Unified cache type that dispatches to moka or the portable implementation.
+//! Unified cache type backed by moka or [`PortableCache`](crate::portable_cache::PortableCache).
 //!
-//! Selection is both feature- and target-aware: [`Cache`] is `moka::future::Cache`
-//! only when the `moka-cache` feature is on AND the target is not wasm32. On wasm32
-//! (or with `moka-cache` off) it is [`PortableCache`](crate::portable_cache::PortableCache).
-//! moka is thread-based (it pulls crossbeam/uuid) and does not compile on
-//! wasm32-unknown-unknown, so a defaults-based wasm32 build falls back here rather than
-//! failing deep inside moka's dependency tree.
+//! The selection below is target-gated, not just feature-gated, because moka is
+//! thread-based (crossbeam/uuid) and can't build on wasm32: a defaults-based wasm32
+//! build must fall back to PortableCache instead of failing deep inside moka's deps.
 
 #[cfg(all(feature = "moka-cache", not(target_arch = "wasm32")))]
 mod inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ pub use wacore_binary::{Jid, Server};
 pub use waproto;
 
 pub mod cache;
-#[cfg(not(feature = "moka-cache"))]
+// Available whenever the cache falls back to PortableCache: moka off, or wasm32
+// (where moka can't build) even if `moka-cache` is enabled. Mirrors src/cache.rs.
+#[cfg(any(not(feature = "moka-cache"), target_arch = "wasm32"))]
 pub mod portable_cache;
 
 pub mod cache_config;

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -519,7 +519,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot mac must fail when validating");
@@ -545,7 +545,7 @@ mod tests {
             mac: Some(vec![9u8; 32]),
             key_id: None,
         };
-        let get_keys = |_: &[u8]| Ok(keys.clone());
+        let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
         let mut state = HashState::default();
         let err = process_snapshot(&snapshot, &mut state, get_keys, true, "regular")
             .expect_err("missing snapshot key_id must fail when validating");


### PR DESCRIPTION
Closes the portability-14 gap.

The cache backend was selected purely by the `moka-cache` feature, with no target gate (`src/cache.rs`). `moka` is thread-based and pulls `crossbeam` plus `uuid`'s v4 RNG, which `compile_error!`s on wasm32-unknown-unknown. Since `moka-cache` is in the `default` feature set, a consumer (or a fresh bridge build) that targets wasm32 without remembering `--no-default-features` hit an obscure failure deep inside moka/uuid instead of falling back to the `PortableCache` that already exists for exactly this purpose.

The fix makes selection target-aware:
- `src/cache.rs`: the moka alias is gated `all(feature = "moka-cache", not(target_arch = "wasm32"))`; the `PortableCache` fallback is `any(not(feature = "moka-cache"), target_arch = "wasm32")`.
- `src/lib.rs`: the `portable_cache` module gate is widened to match, so it is compiled whenever the fallback is used.
- `Cargo.toml`: `moka` is moved to `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` so it is never even resolved on wasm32. `dep:moka` stays inert there, so `moka-cache` can remain in `default`.

Public API is unchanged (`crate::cache::Cache` path stays); native behavior is unchanged (default still uses moka).

I also added a CI step that builds the wasm32 lib **with** `moka-cache` enabled, since the existing guard only ever exercised `--no-default-features` (which is exactly why this regressed silently).

Verified locally:
- before: `--target wasm32 ... --features moka-cache` fails with uuid's randomness `compile_error!`
- after: the same build succeeds, and `cargo tree -i moka` on wasm32 shows moka absent from the tree
- native default build still uses moka (clippy `--all-targets -D warnings` clean); native `--no-default-features` still uses PortableCache

Note: this branch currently carries the 2-line main build fix from #751 so its CI is green; I'll rebase onto main once #751 lands and those lines drop out of the diff.