### PR TITLE
feat(chat): support userStatusMute app-state action (incoming + outgoing)

### DIFF
--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -12,7 +12,7 @@ use wacore::appstate::patch_decode::WAPatchName;
 use wacore::appstate::schemas::{self, IndexPart, Schema};
 use wacore::types::events::{
     ArchiveUpdate, ClearChatUpdate, ContactUpdate, DeleteChatUpdate, DeleteMessageForMeUpdate,
-    Event, MarkChatAsReadUpdate, MuteUpdate, PinUpdate, StarUpdate,
+    Event, MarkChatAsReadUpdate, MuteUpdate, PinUpdate, StarUpdate, UserStatusMuteUpdate,
 };
 use wacore_binary::{Jid, JidExt};
 use waproto::whatsapp as wa;
@@ -80,6 +80,7 @@ pub(crate) fn dispatch_chat_mutation(
             | "markChatAsRead"
             | "deleteChat"
             | "clearChat"
+            | "userStatusMute"
             | "deleteMessageForMe"
     ) {
         return false;
@@ -223,6 +224,20 @@ pub(crate) fn dispatch_chat_mutation(
                     delete_media,
                     timestamp: time,
                     action: Box::new(act.clone()),
+                    from_full_sync: full_sync,
+                }));
+            }
+            true
+        }
+        "userStatusMute" => {
+            if let Some(val) = &m.action_value
+                && let Some(act) = &val.user_status_mute_action
+            {
+                event_bus.dispatch(Event::UserStatusMuteUpdate(UserStatusMuteUpdate {
+                    jid,
+                    muted: act.muted.unwrap_or(false),
+                    timestamp: time,
+                    action: Box::new(*act),
                     from_full_sync: full_sync,
                 }));
             }
@@ -515,6 +530,23 @@ impl<'a> ChatActions<'a> {
             .await
     }
 
+    /// Mute or unmute a contact/group/newsletter's status updates across devices
+    /// (WA Web's userStatusMute). `muted = true` hides their status.
+    pub async fn set_user_status_mute(&self, jid: &Jid, muted: bool) -> Result<()> {
+        debug!("Setting userStatusMute for {jid} -> {muted}");
+        let value = wa::SyncActionValue {
+            user_status_mute_action: Some(wa::sync_action_value::UserStatusMuteAction {
+                muted: Some(muted),
+            }),
+            timestamp: Some(wacore::time::now_millis()),
+            ..Default::default()
+        };
+        let jid = jid.to_string();
+        self.client
+            .send_app_state_action(&schemas::USER_STATUS_MUTE, &[jid.as_str()], &value)
+            .await
+    }
+
     /// Deletes locally only (not for everyone).
     /// `participant_jid`: required for group messages from others, `None` otherwise.
     pub async fn delete_message_for_me(
@@ -804,6 +836,11 @@ mod registry_tests {
                 &schemas::CLEAR_CHAT,
                 &["123@s.whatsapp.net", "0", "1"],
                 &["clearChat", "123@s.whatsapp.net", "0", "1"],
+            ),
+            (
+                &schemas::USER_STATUS_MUTE,
+                &["123@s.whatsapp.net"],
+                &["userStatusMute", "123@s.whatsapp.net"],
             ),
             (&schemas::LABEL_EDIT, &["5"], &["label_edit", "5"]),
             (

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -232,6 +232,7 @@ pub enum EventKind {
     MarkChatAsReadUpdate,
     DeleteChatUpdate,
     ClearChatUpdate,
+    UserStatusMuteUpdate,
     DeleteMessageForMeUpdate,
     LabelEditUpdate,
     LabelAssociationUpdate,
@@ -634,6 +635,7 @@ pub enum Event {
     MarkChatAsReadUpdate(MarkChatAsReadUpdate),
     DeleteChatUpdate(DeleteChatUpdate),
     ClearChatUpdate(ClearChatUpdate),
+    UserStatusMuteUpdate(UserStatusMuteUpdate),
     DeleteMessageForMeUpdate(DeleteMessageForMeUpdate),
     LabelEditUpdate(LabelEditUpdate),
     LabelAssociationUpdate(LabelAssociationUpdate),
@@ -722,6 +724,7 @@ impl Event {
             Event::MarkChatAsReadUpdate(_) => EventKind::MarkChatAsReadUpdate,
             Event::DeleteChatUpdate(_) => EventKind::DeleteChatUpdate,
             Event::ClearChatUpdate(_) => EventKind::ClearChatUpdate,
+            Event::UserStatusMuteUpdate(_) => EventKind::UserStatusMuteUpdate,
             Event::DeleteMessageForMeUpdate(_) => EventKind::DeleteMessageForMeUpdate,
             Event::LabelEditUpdate(_) => EventKind::LabelEditUpdate,
             Event::LabelAssociationUpdate(_) => EventKind::LabelAssociationUpdate,
@@ -1171,6 +1174,18 @@ pub struct ClearChatUpdate {
     pub delete_media: bool,
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::ClearChatAction>,
+    pub from_full_sync: bool,
+}
+
+/// A contact/group/newsletter's status updates were muted/unmuted on a linked device.
+#[derive(Debug, Clone, Serialize)]
+pub struct UserStatusMuteUpdate {
+    /// The entity whose status was (un)muted.
+    pub jid: Jid,
+    /// `true` = status muted, `false` = unmuted.
+    pub muted: bool,
+    pub timestamp: DateTime<Utc>,
+    pub action: Box<wa::sync_action_value::UserStatusMuteAction>,
     pub from_full_sync: bool,
 }
 


### PR DESCRIPTION
Closes the features (user-status-mute-action-unsupported-both-directions) gap.

WA Web's `userStatusMute` action (`SyncActionValue.user_status_mute_action`, collection `regular_high`, version 7) mutes/unmutes a contact/group/newsletter's status updates across linked devices. The client handled neither direction: an incoming `userStatusMute` mutation fell through `dispatch_chat_mutation` and was dropped (no event), and there was no outgoing API.

**Incoming:** `userStatusMute` added to the dispatch guard, emitting a new `Event::UserStatusMuteUpdate` (mirroring the sibling chat-action events), carrying the `muted` bool.

**Outgoing:** `ChatActions::set_user_status_mute(jid, muted)`, modeled on the existing chat-action senders. The `USER_STATUS_MUTE` schema already exists in the auto-generated registry with index `["userStatusMute", id]` and value `userStatusMuteAction { muted }`.

`EventKind`/`Event` are `#[non_exhaustive]`, so the new variant is non-breaking. Same proven shape as the merged clearChat support (#755).

Test: the `userStatusMute` index shape is added to `build_index_matches_legacy_shapes`.

Note: I swapped this in for the originally-planned poll add-option (features-07) — the add-option's *encrypted* inner-proto shape couldn't be pinned down cleanly from the captured-js without more reverse-engineering, and shipping the wrong proto would be a broken feature, so I picked this confirmed, lower-risk gap instead.