### PR TITLE
fix(groups): keep persisted group metadata in sync on membership change

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -415,6 +415,17 @@ impl<'a> Groups<'a> {
     pub async fn leave(&self, jid: &Jid) -> Result<(), anyhow::Error> {
         self.client.execute(LeaveGroupIq::new(jid)).await?;
         self.client.get_group_cache().await.invalidate(jid).await;
+        // Drop the persisted blob too: we're no longer in the group, so a stale
+        // phash from it would only force a needless full re-query if ever read.
+        if let Err(e) = self
+            .client
+            .persistence_manager
+            .backend()
+            .delete_group_metadata(&jid.to_string())
+            .await
+        {
+            log::warn!("Failed to delete persisted group metadata for {jid}: {e}");
+        }
         Ok(())
     }
 
@@ -446,6 +457,7 @@ impl<'a> Groups<'a> {
                         .filter(|r| r.is_ok())
                         .map(|r| (&r.jid, r.phone_number.as_ref())),
                 );
+                self.client.persist_group_metadata(jid, &info).await;
                 group_cache.insert(jid.clone(), Arc::new(info)).await;
             }
         }
@@ -471,6 +483,7 @@ impl<'a> Groups<'a> {
             if let Some(info) = group_cache.get(jid).await {
                 let mut info = Arc::unwrap_or_clone(info);
                 info.remove_participants(&accepted);
+                self.client.persist_group_metadata(jid, &info).await;
                 group_cache.insert(jid.clone(), Arc::new(info)).await;
             }
             self.client
@@ -993,6 +1006,23 @@ impl<'a> Groups<'a> {
 impl Client {
     pub fn groups(&self) -> Groups<'_> {
         Groups::new(self)
+    }
+
+    /// Re-serialize and persist a group's metadata after a local membership change
+    /// so the phash fast-path stays consistent: the in-memory cache expires after
+    /// ~1h, after which a stale persisted blob would force a needless full re-query
+    /// (or be compared against the server as an out-of-date phash). Shared by the
+    /// participant-mutation API and the inbound group-notification handler.
+    pub(crate) async fn persist_group_metadata(&self, jid: &Jid, info: &GroupInfo) {
+        let backend = self.persistence_manager.backend();
+        match serde_json::to_vec(info) {
+            Ok(blob) => {
+                if let Err(e) = backend.put_group_metadata(&jid.to_string(), &blob).await {
+                    log::warn!("Failed to persist group metadata for {jid}: {e}");
+                }
+            }
+            Err(e) => log::warn!("Failed to serialize group metadata for {jid}: {e}"),
+        }
     }
 }
 

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -459,6 +459,9 @@ impl<'a> Groups<'a> {
                 );
                 self.client.persist_group_metadata(jid, &info).await;
                 group_cache.insert(jid.clone(), Arc::new(info)).await;
+            } else {
+                // Cache expired: can't patch in place, so drop the now-stale blob.
+                self.client.invalidate_persisted_group_metadata(jid).await;
             }
         }
         Ok(result)
@@ -485,6 +488,9 @@ impl<'a> Groups<'a> {
                 info.remove_participants(&accepted);
                 self.client.persist_group_metadata(jid, &info).await;
                 group_cache.insert(jid.clone(), Arc::new(info)).await;
+            } else {
+                // Cache expired: can't patch in place, so drop the now-stale blob.
+                self.client.invalidate_persisted_group_metadata(jid).await;
             }
             self.client
                 .rotate_sender_key_on_participant_remove(&jid.to_string(), &accepted)
@@ -1022,6 +1028,21 @@ impl Client {
                 }
             }
             Err(e) => log::warn!("Failed to serialize group metadata for {jid}: {e}"),
+        }
+    }
+
+    /// Drop the persisted group metadata on a membership change we can't patch in
+    /// place (the in-memory cache had already expired), so the next query re-fetches
+    /// fresh instead of comparing a now-stale phash. Without this, persisting only on
+    /// a cache hit would miss the exact post-expiry case this fix targets.
+    pub(crate) async fn invalidate_persisted_group_metadata(&self, jid: &Jid) {
+        if let Err(e) = self
+            .persistence_manager
+            .backend()
+            .delete_group_metadata(&jid.to_string())
+            .await
+        {
+            log::warn!("Failed to invalidate persisted group metadata for {jid}: {e}");
         }
     }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -1222,6 +1222,38 @@ mod tests {
         assert_eq!(a.participants.len(), 2);
     }
 
+    #[tokio::test]
+    async fn invalidate_persisted_group_metadata_drops_blob() {
+        // The cache-miss branch of add/remove/leave relies on this to drop a now-stale
+        // persisted blob so the next query re-fetches fresh instead of sending a stale phash.
+        let client = crate::test_utils::create_test_client().await;
+        let backend = client.persistence_manager.backend();
+        let group_jid: Jid = "123456789@g.us".parse().unwrap();
+
+        backend
+            .put_group_metadata(&group_jid.to_string(), b"stale-blob")
+            .await
+            .unwrap();
+        assert!(
+            backend
+                .get_group_metadata(&group_jid.to_string())
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        client.invalidate_persisted_group_metadata(&group_jid).await;
+
+        assert!(
+            backend
+                .get_group_metadata(&group_jid.to_string())
+                .await
+                .unwrap()
+                .is_none(),
+            "invalidation must delete the persisted blob"
+        );
+    }
+
     // Protocol-level tests (node building, parsing, validation) are in wacore/src/iq/groups.rs
 
     #[test]

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1380,6 +1380,9 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
                             .iter()
                             .map(|p| (&p.jid, p.phone_number.as_ref())),
                     );
+                    client
+                        .persist_group_metadata(&notification.group_jid, &info)
+                        .await;
                     group_cache
                         .insert(notification.group_jid.clone(), Arc::new(info))
                         .await;
@@ -1396,6 +1399,9 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
                 if let Some(info) = group_cache.get(&notification.group_jid).await {
                     let mut info = Arc::unwrap_or_clone(info);
                     info.remove_participants(&users);
+                    client
+                        .persist_group_metadata(&notification.group_jid, &info)
+                        .await;
                     group_cache
                         .insert(notification.group_jid.clone(), Arc::new(info))
                         .await;

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1393,6 +1393,11 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
                     );
                 } else {
                     // Cache expired: can't patch in place, so drop the now-stale blob.
+                    debug!(
+                        target: "Client/Group",
+                        "Group cache expired for {}: invalidating persisted metadata (add)",
+                        notification.group_jid.observe()
+                    );
                     client
                         .invalidate_persisted_group_metadata(&notification.group_jid)
                         .await;
@@ -1417,6 +1422,11 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
                     );
                 } else {
                     // Cache expired: can't patch in place, so drop the now-stale blob.
+                    debug!(
+                        target: "Client/Group",
+                        "Group cache expired for {}: invalidating persisted metadata (remove)",
+                        notification.group_jid.observe()
+                    );
                     client
                         .invalidate_persisted_group_metadata(&notification.group_jid)
                         .await;

--- a/src/handlers/notification.rs
+++ b/src/handlers/notification.rs
@@ -1391,6 +1391,11 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
                         "Patched group cache for {}: added {} participants",
                         notification.group_jid.observe(), participants.len()
                     );
+                } else {
+                    // Cache expired: can't patch in place, so drop the now-stale blob.
+                    client
+                        .invalidate_persisted_group_metadata(&notification.group_jid)
+                        .await;
                 }
             }
             GroupNotificationAction::Remove { participants, .. } => {
@@ -1410,6 +1415,11 @@ async fn handle_group_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>
                         "Patched group cache for {}: removed {} participants",
                         notification.group_jid.observe(), participants.len()
                     );
+                } else {
+                    // Cache expired: can't patch in place, so drop the now-stale blob.
+                    client
+                        .invalidate_persisted_group_metadata(&notification.group_jid)
+                        .await;
                 }
                 client
                     .rotate_sender_key_on_participant_remove(

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -3670,6 +3670,10 @@ mod tests {
             store.get_group_metadata(jid).await.unwrap().as_deref(),
             Some(&b"blob-v2"[..])
         );
+
+        // Delete drops the blob so the next query re-fetches in full.
+        store.delete_group_metadata(jid).await.unwrap();
+        assert!(store.get_group_metadata(jid).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2538,6 +2538,28 @@ impl ProtocolStore for SqliteStore {
         Ok(())
     }
 
+    async fn delete_group_metadata(&self, group_jid: &str) -> Result<()> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let group_jid = group_jid.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            diesel::delete(
+                group_metadata::table
+                    .filter(group_metadata::group_jid.eq(&group_jid))
+                    .filter(group_metadata::device_id.eq(device_id)),
+            )
+            .execute(&mut conn)
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        Ok(())
+    }
+
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
         let pool = self.pool.clone();
         let device_id = self.device_id;

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -517,6 +517,11 @@ impl ProtocolStore for InMemoryBackend {
         Ok(())
     }
 
+    async fn delete_group_metadata(&self, group_jid: &str) -> Result<()> {
+        self.state.lock().await.group_metadata.remove(group_jid);
+        Ok(())
+    }
+
     // --- TcToken Storage ---
 
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
@@ -730,6 +735,9 @@ mod tests {
             backend.get_group_metadata(jid).await.unwrap().as_deref(),
             Some(&b"blob-v2"[..])
         );
+        // Delete drops the blob so the next query re-fetches in full.
+        backend.delete_group_metadata(jid).await.unwrap();
+        assert!(backend.get_group_metadata(jid).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -398,6 +398,13 @@ pub trait ProtocolStore: Send + Sync {
         Ok(())
     }
 
+    /// Remove the persisted group metadata blob for `group_jid` (e.g. on leave),
+    /// so the next query re-fetches in full instead of comparing a stale phash.
+    /// No-op by default.
+    async fn delete_group_metadata(&self, _group_jid: &str) -> Result<()> {
+        Ok(())
+    }
+
     // --- TcToken Storage ---
 
     /// Get a trusted contact token for a JID (stored under LID).


### PR DESCRIPTION
Closes the features-32 gap.

A participant add/remove updated only the in-memory group cache, never the persisted metadata blob. The in-memory cache expires after ~1h; the next `query_info` then loads the **stale** persisted blob and sends an out-of-date participant phash, defeating the not-modified fast-path (forcing a needless full re-query) and diverging from the actual membership. `leave()` likewise dropped the in-memory entry but left the persisted blob behind.

The fix keeps the persisted blob in sync:
- Re-serialize and persist the mutated `GroupInfo` after a successful add/remove in **both** the API methods (`Groups::add_participants`/`remove_participants`) **and** the inbound group-notification handler (the more common path), via a shared `Client::persist_group_metadata` (same `serde_json` format `query_info` already uses).
- On `leave()`, delete the persisted blob through a new `Backend::delete_group_metadata` (default no-op; implemented for sqlite + in-memory) — we're no longer in the group, so a stale phash from it would only cause a needless re-query if ever read.

Verified against WA Web (`WAWebQueryGroupJob` persists updated group metadata on membership mutations so the next not-modified comparison stays consistent).

Test: in-memory `delete_group_metadata` round-trip (put → get → delete → get None).