### PR TITLE
perf(cache): raise device_registry_cache default capacity 1000 -> 5000

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -160,7 +160,8 @@ impl CacheStores {
 pub struct CacheConfig {
     /// Group metadata cache (time_to_live). Default: 1h TTL, 250 entries.
     pub group_cache: CacheEntryConfig,
-    /// Device registry cache (time_to_live). Default: 1h TTL, 1000 entries.
+    /// Device registry cache (time_to_live). Default: 1h TTL, 5000 entries
+    /// (holds a large group's per-member device set; a near-max group is ~1024).
     pub device_registry_cache: CacheEntryConfig,
     /// LID-to-phone cache. WAWebLidPnCache uses plain Maps with no expiry
     /// and no size cap; evicting a still-valid mapping silently downgrades
@@ -301,7 +302,9 @@ impl Default for CacheConfig {
 
         Self {
             group_cache: CacheEntryConfig::new(one_hour, 250),
-            device_registry_cache: CacheEntryConfig::new(one_hour, 1_000),
+            // One entry per group member; 1000 was below a near-max (~1024) group,
+            // so large-group warm sends thrashed to the serial per-user DB path.
+            device_registry_cache: CacheEntryConfig::new(one_hour, 5_000),
             lid_pn_cache: CacheEntryConfig::new(None, u64::MAX),
             recent_messages: CacheEntryConfig::new(five_min, 0),
             // 1h so the MAX_DECRYPT_RETRIES cap survives spaced redeliveries; a


### PR DESCRIPTION
Closes the data-structures-16 gap.

The device-registry L1 cache is keyed per user, so a warm group send occupies ~one entry per member. The 1000 default was below a single near-max (~1024) WhatsApp group, so a large-group bot's working set overflowed the cap and every "warm" send fell through to the serial per-user DB path (`backend.get_devices` once per user, awaited in a loop in `usync.rs`) — turning a warm group send into hundreds of serial SQLite round-trips before any encryption.

Raise the default to 5000, which holds several large groups. The capacity is a ceiling, not a preallocation, so smaller clients (which never approach 1000 distinct users) are unaffected; the cost is only paid as the cache actually fills.

Pure default change — no API surface change (`device_registry_cache.capacity` was already a public `CacheEntryConfig` knob a consumer could raise).