### PR TITLE
fix(appstate): clear stale mutation MACs on snapshot re-sync

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -32,6 +32,8 @@ mod tests {
         macs: MockMacMap,
         keys: Arc<Mutex<HashMap<Vec<u8>, AppStateSyncKey>>>,
         latest_key_id: Arc<Mutex<Option<Vec<u8>>>>,
+        // Fault injection: when set, clear_mutation_macs fails (transient store error).
+        fail_clear_macs: Arc<Mutex<bool>>,
     }
 
     // Implement SignalStore - Signal protocol cryptographic operations
@@ -143,7 +145,13 @@ mod tests {
         async fn delete_mutation_macs(&self, _: &str, _: &[Vec<u8>]) -> StoreResult<()> {
             Ok(())
         }
-        async fn clear_mutation_macs(&self, _: &str) -> StoreResult<()> {
+        async fn clear_mutation_macs(&self, name: &str) -> StoreResult<()> {
+            if *self.fail_clear_macs.lock().await {
+                return Err(wacore::store::error::StoreError::Io(std::io::Error::other(
+                    "injected clear_mutation_macs failure",
+                )));
+            }
+            self.macs.lock().await.retain(|(n, _), _| n != name);
             Ok(())
         }
         async fn get_latest_sync_key_id(&self) -> StoreResult<Option<Vec<u8>>> {
@@ -441,6 +449,140 @@ mod tests {
         assert_eq!(
             final_state.version, 2,
             "The version should be updated to that of the patch."
+        );
+    }
+
+    /// Builds a snapshot resync (incoming v2 over persisted v1) that carries one
+    /// record, after seeding an unrelated stale MAC at v1. Returns the backend,
+    /// processor, the patch list, and the stale index MAC that the resync must drop.
+    async fn snapshot_resync_scenario() -> (Arc<MockBackend>, AppStateProcessor, PatchList, Vec<u8>)
+    {
+        let backend = Arc::new(MockBackend::default());
+        let processor =
+            AppStateProcessor::new(backend.clone(), Arc::new(crate::runtime_impl::TokioRuntime));
+        let collection_name = WAPatchName::Regular;
+        let key_id_bytes = b"snap_key_id".to_vec();
+        let master_key = [9u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+
+        backend
+            .set_sync_key(
+                &key_id_bytes,
+                AppStateSyncKey {
+                    key_data: master_key.to_vec(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("test backend should accept sync key");
+
+        backend
+            .set_version(
+                collection_name.as_str(),
+                HashState {
+                    version: 1,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("test backend should accept version");
+
+        let stale_index_mac = vec![0xAB; 32];
+        backend
+            .put_mutation_macs(
+                collection_name.as_str(),
+                1,
+                &[AppStateMutationMAC {
+                    index_mac: stale_index_mac.clone(),
+                    value_mac: vec![0xCD; 32],
+                }],
+            )
+            .await
+            .expect("test backend should accept mutation MACs");
+
+        let plaintext = wa::SyncActionData {
+            value: Some(wa::SyncActionValue {
+                timestamp: Some(2000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .encode_to_vec();
+        let record = create_encrypted_mutation(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &[0x11; 32],
+            &plaintext,
+            &keys,
+            &key_id_bytes,
+        )
+        .record
+        .expect("mutation should carry a record");
+
+        let patch_list = PatchList {
+            name: collection_name,
+            has_more_patches: false,
+            patches: vec![],
+            snapshot: Some(wa::SyncdSnapshot {
+                version: Some(wa::SyncdVersion { version: Some(2) }),
+                records: vec![record],
+                key_id: Some(wa::KeyId {
+                    id: Some(key_id_bytes),
+                }),
+                ..Default::default()
+            }),
+            snapshot_ref: None,
+            error: None,
+        };
+
+        (backend, processor, patch_list, stale_index_mac)
+    }
+
+    #[tokio::test]
+    async fn snapshot_resync_drops_stale_mutation_macs() {
+        let (backend, processor, patch_list, stale_index_mac) = snapshot_resync_scenario().await;
+
+        processor
+            .process_patch_list(patch_list, false)
+            .await
+            .expect("snapshot resync should succeed");
+
+        assert_eq!(
+            backend
+                .get_mutation_mac(WAPatchName::Regular.as_str(), &stale_index_mac)
+                .await
+                .unwrap(),
+            None,
+            "stale MAC from the old baseline must be cleared by the snapshot resync"
+        );
+        assert_eq!(
+            backend
+                .get_version(WAPatchName::Regular.as_str())
+                .await
+                .unwrap()
+                .version,
+            2
+        );
+    }
+
+    /// Guards the write-ahead ordering: if clearing MACs fails, the version must
+    /// stay at the old baseline so the retry reapplies the snapshot instead of
+    /// skipping it as stale.
+    #[tokio::test]
+    async fn snapshot_resync_keeps_old_version_when_clear_fails() {
+        let (backend, processor, patch_list, _) = snapshot_resync_scenario().await;
+        *backend.fail_clear_macs.lock().await = true;
+
+        let err = processor.process_patch_list(patch_list, false).await;
+        assert!(err.is_err(), "clear failure must abort the resync");
+
+        assert_eq!(
+            backend
+                .get_version(WAPatchName::Regular.as_str())
+                .await
+                .unwrap()
+                .version,
+            1,
+            "version must not advance when the MAC reset fails"
         );
     }
 }

--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -143,6 +143,9 @@ mod tests {
         async fn delete_mutation_macs(&self, _: &str, _: &[Vec<u8>]) -> StoreResult<()> {
             Ok(())
         }
+        async fn clear_mutation_macs(&self, _: &str) -> StoreResult<()> {
+            Ok(())
+        }
         async fn get_latest_sync_key_id(&self) -> StoreResult<Option<Vec<u8>>> {
             Ok(self.latest_key_id.lock().await.clone())
         }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1935,6 +1935,24 @@ impl AppSyncStore for SqliteStore {
             .await
     }
 
+    async fn clear_mutation_macs(&self, name: &str) -> Result<()> {
+        let device_id = self.device_id;
+        let name = name.to_string();
+        self.with_retry("clear_mutation_macs", || {
+            let name = name.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::delete(
+                    app_state_mutation_macs::table
+                        .filter(app_state_mutation_macs::name.eq(&name))
+                        .filter(app_state_mutation_macs::device_id.eq(device_id)),
+                )
+                .execute(conn)?;
+                Ok(())
+            })
+        })
+        .await
+    }
+
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
         self.get_latest_app_state_sync_key_id_for_device(self.device_id)
             .await
@@ -3088,6 +3106,40 @@ mod tests {
             .await
             .unwrap();
         assert!(empty.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clear_mutation_macs_wipes_only_named_collection() {
+        let store = create_test_store().await;
+        let mac = |i: u8| AppStateMutationMAC {
+            index_mac: vec![i; 32],
+            value_mac: vec![i; 32],
+        };
+        store
+            .put_mutation_macs("regular", 1, &[mac(1)])
+            .await
+            .unwrap();
+        store
+            .put_mutation_macs("critical", 1, &[mac(2)])
+            .await
+            .unwrap();
+
+        store.clear_mutation_macs("regular").await.unwrap();
+
+        assert!(
+            store
+                .get_mutation_mac("regular", &[1; 32])
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .get_mutation_mac("critical", &[2; 32])
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -309,10 +309,14 @@ impl AppStateProcessor {
 
             new_mutations.extend(snapshot_result.mutations);
 
-            // Persist state and MACs
+            // Persist state and MACs. A snapshot is a fresh baseline, so wipe the
+            // collection's prior mutation MACs first (unconditionally, even if the
+            // snapshot has none) — leftover index->value entries would corrupt the
+            // next patch's ltHash.
             self.backend
                 .set_version(collection_name, state.clone())
                 .await?;
+            self.backend.clear_mutation_macs(collection_name).await?;
             if !snapshot_result.mutation_macs.is_empty() {
                 self.backend
                     .put_mutation_macs(

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -309,13 +309,13 @@ impl AppStateProcessor {
 
             new_mutations.extend(snapshot_result.mutations);
 
-            // Persist state and MACs. A snapshot is a fresh baseline, so wipe the
-            // collection's prior mutation MACs first (unconditionally, even if the
-            // snapshot has none) — leftover index->value entries would corrupt the
-            // next patch's ltHash.
-            self.backend
-                .set_version(collection_name, state.clone())
-                .await?;
+            // A snapshot is a fresh baseline, so wipe the collection's prior mutation
+            // MACs first (unconditionally, even if the snapshot has none) — leftover
+            // index->value entries would corrupt the next patch's ltHash.
+            //
+            // Commit the version LAST. If clear/put fails on a transient store error,
+            // an already-advanced version would make the retry treat this same snapshot
+            // as stale (snapshot_is_stale) and skip it, stranding the old MACs forever.
             self.backend.clear_mutation_macs(collection_name).await?;
             if !snapshot_result.mutation_macs.is_empty() {
                 self.backend
@@ -326,6 +326,9 @@ impl AppStateProcessor {
                     )
                     .await?;
             }
+            self.backend
+                .set_version(collection_name, state.clone())
+                .await?;
         }
 
         // Snapshot the key cache once for all patches (prefetch_keys already populated it)

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -342,6 +342,15 @@ impl AppSyncStore for InMemoryBackend {
         Ok(())
     }
 
+    async fn clear_mutation_macs(&self, name: &str) -> Result<()> {
+        self.state
+            .lock()
+            .await
+            .mutation_macs
+            .retain(|(n, _), _| n != name);
+        Ok(())
+    }
+
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
         Ok(self.state.lock().await.latest_sync_key_id.clone())
     }
@@ -738,6 +747,38 @@ mod tests {
         // Delete drops the blob so the next query re-fetches in full.
         backend.delete_group_metadata(jid).await.unwrap();
         assert!(backend.get_group_metadata(jid).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_mutation_macs_wipes_only_named_collection() {
+        use crate::store::traits::AppSyncStore;
+        let backend = InMemoryBackend::new();
+        let mac = |i: u8, v: u8| AppStateMutationMAC {
+            index_mac: vec![i],
+            value_mac: vec![v],
+        };
+        backend
+            .put_mutation_macs("regular", 1, &[mac(1, 10)])
+            .await
+            .unwrap();
+        backend
+            .put_mutation_macs("critical", 1, &[mac(2, 20)])
+            .await
+            .unwrap();
+
+        backend.clear_mutation_macs("regular").await.unwrap();
+
+        assert!(
+            backend
+                .get_mutation_mac("regular", &[1])
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            backend.get_mutation_mac("critical", &[2]).await.unwrap(),
+            Some(vec![20])
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -287,6 +287,11 @@ pub trait AppSyncStore: Send + Sync {
     /// Delete mutation MACs by their index MACs.
     async fn delete_mutation_macs(&self, name: &str, index_macs: &[Vec<u8>]) -> Result<()>;
 
+    /// Delete every mutation MAC for a collection. Called on snapshot re-sync so the
+    /// MAC store is rebuilt from the snapshot, matching the ltHash baseline; leftover
+    /// entries would corrupt the next patch's ltHash.
+    async fn clear_mutation_macs(&self, name: &str) -> Result<()>;
+
     /// Get the most recently stored app state sync key ID.
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>>;
 }


### PR DESCRIPTION
Closes the data-structures-15 gap.

The snapshot branch of `process_patch_list` persisted the snapshot's ltHash + mutation MACs but never cleared the collection's prior MACs. A snapshot is a fresh baseline, so leftover `index->value` MAC entries for indices not present in the snapshot survived as zombies; the next incremental patch then looked one up via `get_prev_value_mac`, subtracted a stale value, and corrupted the collection's ltHash (`PatchSnapshotMACMismatch` and an inconsistent MAC store afterward).

Adds `Backend::clear_mutation_macs(name)` (sqlite: `DELETE` by name+device; in-memory: `retain`) and calls it **unconditionally** before `put_mutation_macs` in the snapshot branch — even when the snapshot itself carries no MACs — so the MAC store is rebuilt from the snapshot exactly like the ltHash baseline.

This is the in-scope reachable case after #753's snapshot version guard: a strictly-newer snapshot on an already-populated collection still applies and would otherwise hit this. WA Web rebuilds the collection state on snapshot apply (bulkSet snapshot + bulkRemove dropped); whatsmeow likewise replaces collection state.

`clear_mutation_macs` is a required `AppSyncStore` method (consistent with `delete_mutation_macs`); implemented for sqlite + in-memory. Tests: clear wipes only the named collection, leaving sibling collections intact (in-memory + sqlite).