### PR TITLE
refactor(groups): get_participating returns HashMap<Jid, GroupMetadata>

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -321,14 +321,14 @@ impl<'a> Groups<'a> {
         Ok(info)
     }
 
-    pub async fn get_participating(&self) -> Result<HashMap<String, GroupMetadata>, anyhow::Error> {
+    pub async fn get_participating(&self) -> Result<HashMap<Jid, GroupMetadata>, anyhow::Error> {
         let response = self.client.execute(GroupParticipatingIq::new()).await?;
 
         let result = response
             .groups
             .into_iter()
             .map(|group| {
-                let key = group.id.to_string();
+                let key = group.id.clone();
                 let metadata = GroupMetadata::from(group);
                 (key, metadata)
             })


### PR DESCRIPTION
Closes the api-12 gap.

`Groups::get_participating` returned a stringly-typed `HashMap<String, GroupMetadata>` while every sibling JID-keyed map (`get_user_info`, usync results, `fetch_pre_keys`) uses `Jid`. Switch the key to `Jid` (keyed on `group.id`, cloned before `GroupMetadata::from` consumes `group`), which also drops the per-group `to_string()` allocation.

Breaking, but pre-1.0 is the right time to align the public surface. No in-tree callers needed updating.