### PR TITLE
refactor(download): take DownloadParams struct instead of 6 positional args

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -22,14 +22,36 @@ impl From<&MediaConn> for wacore::download::MediaConnection {
     }
 }
 
-/// Implements `Downloadable` from raw media parameters.
-struct DownloadParams {
-    direct_path: String,
-    media_key: Option<Vec<u8>>,
-    file_sha256: Vec<u8>,
-    file_enc_sha256: Option<Vec<u8>>,
-    file_length: u64,
-    media_type: MediaType,
+/// `Downloadable` built from raw CDN fields, for re-downloading media without
+/// the original message in hand.
+pub struct DownloadParams {
+    pub direct_path: String,
+    pub media_key: Option<Vec<u8>>,
+    pub file_sha256: Vec<u8>,
+    pub file_enc_sha256: Option<Vec<u8>>,
+    pub file_length: u64,
+    pub media_type: MediaType,
+}
+
+impl DownloadParams {
+    /// Params for encrypted media. Slices are copied into the owned struct.
+    pub fn encrypted(
+        direct_path: impl Into<String>,
+        media_key: &[u8],
+        file_sha256: &[u8],
+        file_enc_sha256: &[u8],
+        file_length: u64,
+        media_type: MediaType,
+    ) -> Self {
+        Self {
+            direct_path: direct_path.into(),
+            media_key: Some(media_key.to_vec()),
+            file_sha256: file_sha256.to_vec(),
+            file_enc_sha256: Some(file_enc_sha256.to_vec()),
+            file_length,
+            media_type,
+        }
+    }
 }
 
 impl Downloadable for DownloadParams {
@@ -300,25 +322,9 @@ impl Client {
     }
 
     /// Downloads and decrypts media from raw parameters without needing the original message.
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.media.download_from_params", level = "debug", skip_all, fields(kind = ?media_type), err(Debug)))]
-    pub async fn download_from_params(
-        &self,
-        direct_path: &str,
-        media_key: &[u8],
-        file_sha256: &[u8],
-        file_enc_sha256: &[u8],
-        file_length: u64,
-        media_type: MediaType,
-    ) -> Result<Vec<u8>> {
-        let params = Self::build_download_params(
-            direct_path,
-            media_key,
-            file_sha256,
-            file_enc_sha256,
-            file_length,
-            media_type,
-        );
-        self.download(&params).await
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.media.download_from_params", level = "debug", skip_all, fields(kind = ?params.media_type), err(Debug)))]
+    pub async fn download_from_params(&self, params: &DownloadParams) -> Result<Vec<u8>> {
+        self.download(params).await
     }
 
     async fn prepare_requests(
@@ -409,45 +415,13 @@ impl Client {
 
     /// Streaming variant of `download_from_params` that writes to a writer
     /// instead of buffering in memory.
-    #[allow(clippy::too_many_arguments)]
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.media.download_from_params_to_writer", level = "debug", skip_all, fields(kind = ?media_type), err(Debug)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.media.download_from_params_to_writer", level = "debug", skip_all, fields(kind = ?params.media_type), err(Debug)))]
     pub async fn download_from_params_to_writer<W: Write + Seek + Send + 'static>(
         &self,
-        direct_path: &str,
-        media_key: &[u8],
-        file_sha256: &[u8],
-        file_enc_sha256: &[u8],
-        file_length: u64,
-        media_type: MediaType,
+        params: &DownloadParams,
         writer: W,
     ) -> Result<W> {
-        let params = Self::build_download_params(
-            direct_path,
-            media_key,
-            file_sha256,
-            file_enc_sha256,
-            file_length,
-            media_type,
-        );
-        self.download_to_writer(&params, writer).await
-    }
-
-    fn build_download_params(
-        direct_path: &str,
-        media_key: &[u8],
-        file_sha256: &[u8],
-        file_enc_sha256: &[u8],
-        file_length: u64,
-        media_type: MediaType,
-    ) -> DownloadParams {
-        DownloadParams {
-            direct_path: direct_path.to_string(),
-            media_key: Some(media_key.to_vec()),
-            file_sha256: file_sha256.to_vec(),
-            file_enc_sha256: Some(file_enc_sha256.to_vec()),
-            file_length,
-            media_type,
-        }
+        self.download_to_writer(params, writer).await
     }
 
     /// Download + decrypt to a writer. Uses streaming when available,

--- a/tests/e2e/tests/media.rs
+++ b/tests/e2e/tests/media.rs
@@ -1,7 +1,7 @@
 use e2e_tests::TestClient;
 use log::info;
 use wacore::types::events::Event;
-use whatsapp_rust::download::{Downloadable, MediaType};
+use whatsapp_rust::download::{DownloadParams, Downloadable, MediaType};
 use whatsapp_rust::upload::UploadResponse;
 use whatsapp_rust::waproto::whatsapp as wa;
 
@@ -232,14 +232,14 @@ async fn test_upload_then_download_image() -> anyhow::Result<()> {
     // Download using download_from_params
     let downloaded = client
         .client
-        .download_from_params(
+        .download_from_params(&DownloadParams::encrypted(
             &upload.direct_path,
             &upload.media_key,
             &upload.file_sha256,
             &upload.file_enc_sha256,
             upload.file_length,
             MediaType::Image,
-        )
+        ))
         .await?;
 
     assert_eq!(
@@ -265,14 +265,14 @@ async fn test_upload_then_download_video() -> anyhow::Result<()> {
 
     let downloaded = client
         .client
-        .download_from_params(
+        .download_from_params(&DownloadParams::encrypted(
             &upload.direct_path,
             &upload.media_key,
             &upload.file_sha256,
             &upload.file_enc_sha256,
             upload.file_length,
             MediaType::Video,
-        )
+        ))
         .await?;
 
     assert_eq!(downloaded, original);
@@ -295,14 +295,14 @@ async fn test_upload_then_download_document() -> anyhow::Result<()> {
 
     let downloaded = client
         .client
-        .download_from_params(
+        .download_from_params(&DownloadParams::encrypted(
             &upload.direct_path,
             &upload.media_key,
             &upload.file_sha256,
             &upload.file_enc_sha256,
             upload.file_length,
             MediaType::Document,
-        )
+        ))
         .await?;
 
     assert_eq!(downloaded, original);
@@ -361,12 +361,14 @@ async fn test_upload_then_download_to_writer() -> anyhow::Result<()> {
     let result_cursor = client
         .client
         .download_from_params_to_writer(
-            &upload.direct_path,
-            &upload.media_key,
-            &upload.file_sha256,
-            &upload.file_enc_sha256,
-            upload.file_length,
-            MediaType::Image,
+            &DownloadParams::encrypted(
+                &upload.direct_path,
+                &upload.media_key,
+                &upload.file_sha256,
+                &upload.file_enc_sha256,
+                upload.file_length,
+                MediaType::Image,
+            ),
             cursor,
         )
         .await?;
@@ -833,14 +835,14 @@ async fn test_upload_download_large_file() -> anyhow::Result<()> {
 
     let downloaded = client
         .client
-        .download_from_params(
+        .download_from_params(&DownloadParams::encrypted(
             &upload.direct_path,
             &upload.media_key,
             &upload.file_sha256,
             &upload.file_enc_sha256,
             upload.file_length,
             MediaType::Document,
-        )
+        ))
         .await?;
 
     assert_eq!(downloaded.len(), original.len());
@@ -871,14 +873,14 @@ async fn test_multiple_uploads_reuse_media_conn() -> anyhow::Result<()> {
         // Verify round-trip
         let downloaded = client
             .client
-            .download_from_params(
+            .download_from_params(&DownloadParams::encrypted(
                 &resp.direct_path,
                 &resp.media_key,
                 &resp.file_sha256,
                 &resp.file_enc_sha256,
                 resp.file_length,
                 MediaType::Image,
-            )
+            ))
             .await?;
         assert_eq!(downloaded, data);
     }


### PR DESCRIPTION
`download_from_params` and `download_from_params_to_writer` each took six positional arguments. Three of them are adjacent `&[u8]` (`media_key`, `file_sha256`, `file_enc_sha256`), which are trivial to transpose at the call site with no compiler help.

This makes `DownloadParams` a public `Downloadable` carrier with an `encrypted(...)` constructor, and changes both methods to accept `&DownloadParams`. Named fields make the call site self-documenting, and exposing the struct lets callers hand a `DownloadParams` straight to `download`/`download_to_writer` too.

Drops the private `build_download_params` helper and the `#[allow(clippy::too_many_arguments)]` it existed to satisfy.

Breaking change for anyone calling either method directly (pre-1.0). All in-tree callers (the e2e media round-trip tests) are updated.
