### PR TITLE
fix(appstate): validate index MAC even when the decrypted index field is absent

### DIFF
--- a/wacore/appstate/src/decode.rs
+++ b/wacore/appstate/src/decode.rs
@@ -79,19 +79,23 @@ pub fn decode_record(
     let action = wa::SyncActionData::decode(plaintext.as_slice())
         .map_err(|_| AppStateError::DecodeFailed)?;
 
+    // WA Web (syncdDecryptMutation) computes the index MAC unconditionally over the
+    // decoded index (empty buffer when the field is absent) and rejects on mismatch,
+    // so an absent index must still match the stored MAC rather than bypass the check.
+    if validate_macs {
+        let stored = record
+            .index
+            .as_ref()
+            .and_then(|i| i.blob.as_ref())
+            .ok_or(AppStateError::MissingIndexMAC)?;
+        validate_index_mac(action.index.as_deref().unwrap_or(&[]), stored, &keys.index)?;
+    }
+
     let mut index_list: Vec<String> = Vec::new();
-    if let Some(idx_bytes) = action.index.as_ref() {
-        if validate_macs {
-            let stored = record
-                .index
-                .as_ref()
-                .and_then(|i| i.blob.as_ref())
-                .ok_or(AppStateError::MissingIndexMAC)?;
-            validate_index_mac(idx_bytes, stored, &keys.index)?;
-        }
-        if let Ok(parsed) = serde_json::from_slice::<Vec<String>>(idx_bytes) {
-            index_list = parsed;
-        }
+    if let Some(idx_bytes) = action.index.as_ref()
+        && let Ok(parsed) = serde_json::from_slice::<Vec<String>>(idx_bytes)
+    {
+        index_list = parsed;
     }
 
     // A record without an index MAC is malformed; never persist an empty MAC
@@ -163,7 +167,7 @@ pub fn collect_key_ids_from_patch_list(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hash::generate_content_mac;
+    use crate::hash::{generate_content_mac, generate_index_mac};
     use crate::keys::expand_app_state_keys;
     use prost::Message;
     use wacore_libsignal::crypto::aes_256_cbc_encrypt_into;
@@ -186,9 +190,10 @@ mod tests {
         let mut value_blob = value_with_iv;
         value_blob.extend_from_slice(&value_mac);
 
+        let index_bytes = action_data.index.as_deref().unwrap_or(&[]);
         wa::SyncdRecord {
             index: Some(wa::SyncdIndex {
-                blob: Some(vec![1; 32]),
+                blob: Some(generate_index_mac(index_bytes, &keys.index)),
             }),
             value: Some(wa::SyncdValue {
                 blob: Some(value_blob),
@@ -235,8 +240,8 @@ mod tests {
         );
         assert_eq!(mutation.operation, wa::syncd_mutation::SyncdOperation::Set);
         // MACs are returned separately and must carry the real bytes, not empty
-        // or swapped values: the record's index blob is `vec![1; 32]`.
-        assert_eq!(macs.index_mac, vec![1u8; 32]);
+        // or swapped values: index_mac is the HMAC of the (absent here) index.
+        assert_eq!(macs.index_mac, generate_index_mac(&[], &keys.index));
         assert!(!macs.value_mac.is_empty());
         assert_ne!(macs.index_mac, macs.value_mac);
     }
@@ -262,7 +267,7 @@ mod tests {
             &action_data,
         );
 
-        // With MAC validation enabled but no index in action_data, should succeed
+        // No index field, but the stored index MAC matches the empty-index HMAC: passes.
         let result = decode_record(
             wa::syncd_mutation::SyncdOperation::Set,
             &record,
@@ -271,6 +276,42 @@ mod tests {
             true,
         );
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn index_mac_is_validated_even_when_index_field_absent() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let key_id = b"test_key_id".to_vec();
+
+        let action_data = wa::SyncActionData {
+            value: Some(wa::SyncActionValue {
+                timestamp: Some(1234567890),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &keys,
+            &key_id,
+            &action_data,
+        );
+        // Tamper the stored index MAC: with no index field the old code skipped the
+        // check entirely and accepted this; WA Web (and now we) reject it.
+        record.index = Some(wa::SyncdIndex {
+            blob: Some(vec![0xFF; 32]),
+        });
+
+        let err = decode_record(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &record,
+            &keys,
+            &key_id,
+            true,
+        )
+        .unwrap_err();
+        assert!(matches!(err, AppStateError::MismatchingIndexMAC));
     }
 
     #[test]

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -171,18 +171,19 @@ pub fn generate_content_mac(
     result
 }
 
+pub fn generate_index_mac(index_json_bytes: &[u8], key: &[u8; 32]) -> Vec<u8> {
+    let mut mac =
+        CryptographicMac::new("HmacSha256", key).expect("HmacSha256 is a valid algorithm");
+    mac.update(index_json_bytes);
+    mac.finalize()
+}
+
 pub fn validate_index_mac(
     index_json_bytes: &[u8],
     expected_mac: &[u8],
     key: &[u8; 32],
 ) -> Result<(), AppStateError> {
-    let computed = {
-        let mut mac =
-            CryptographicMac::new("HmacSha256", key).expect("HmacSha256 is a valid algorithm");
-        mac.update(index_json_bytes);
-        mac.finalize()
-    };
-    if computed.as_slice() != expected_mac {
+    if generate_index_mac(index_json_bytes, key).as_slice() != expected_mac {
         Err(AppStateError::MismatchingIndexMAC)
     } else {
         Ok(())

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -439,7 +439,7 @@ pub fn validate_snapshot_mac(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hash::generate_content_mac;
+    use crate::hash::{generate_content_mac, generate_index_mac};
     use crate::keys::expand_app_state_keys;
     use crate::lthash::WAPATCH_INTEGRITY;
     use prost::Message;
@@ -452,7 +452,10 @@ mod tests {
         key_id: &[u8],
         timestamp: i64,
     ) -> wa::SyncdRecord {
+        // The `index_mac` arg is the index identity bytes; the stored index blob is
+        // their HMAC, so the record stays valid under unconditional index-MAC checks.
         let action_data = wa::SyncActionData {
+            index: Some(index_mac.to_vec()),
             value: Some(wa::SyncActionValue {
                 timestamp: Some(timestamp),
                 ..Default::default()
@@ -474,7 +477,7 @@ mod tests {
 
         wa::SyncdRecord {
             index: Some(wa::SyncdIndex {
-                blob: Some(index_mac.to_vec()),
+                blob: Some(generate_index_mac(index_mac, &keys.index)),
             }),
             value: Some(wa::SyncdValue {
                 blob: Some(value_blob),
@@ -519,7 +522,10 @@ mod tests {
         assert_eq!(result.mutations.len(), 1);
         assert_eq!(result.mutation_macs.len(), 1);
         // Exact MAC bytes (not just counts): catches empty/swapped MACs.
-        assert_eq!(result.mutation_macs[0].index_mac, index_mac);
+        assert_eq!(
+            result.mutation_macs[0].index_mac,
+            generate_index_mac(&index_mac, &keys.index)
+        );
         assert!(!result.mutation_macs[0].value_mac.is_empty());
         assert_ne!(
             result.mutation_macs[0].index_mac,
@@ -626,7 +632,10 @@ mod tests {
         assert_eq!(result.mutations.len(), 1);
         assert_eq!(result.added_macs.len(), 1);
         // Exact MAC bytes (not just counts): catches empty/swapped MACs.
-        assert_eq!(result.added_macs[0].index_mac, index_mac);
+        assert_eq!(
+            result.added_macs[0].index_mac,
+            generate_index_mac(&index_mac, &keys.index)
+        );
         assert!(!result.added_macs[0].value_mac.is_empty());
         assert_ne!(
             result.added_macs[0].index_mac,
@@ -812,9 +821,10 @@ mod tests {
         };
 
         let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
-        // Return the previous value MAC when asked
+        // process_patch looks up by the stored index MAC (HMAC of the index bytes).
+        let stored_index_mac = generate_index_mac(&index_mac, &keys.index);
         let get_prev = |idx: &[u8]| {
-            if idx == index_mac.as_slice() {
+            if idx == stored_index_mac.as_slice() {
                 Ok(Some(initial_value_mac.clone()))
             } else {
                 Ok(None)


### PR DESCRIPTION
`decode_record` only ran `validate_index_mac` inside `if let Some(idx_bytes) = action.index`, so a decrypted `SyncActionData` whose `index` field decodes as absent skipped the index-MAC check entirely and was accepted with whatever index blob the server sent. WA Web (`syncdDecryptMutation`, `wa-kmp/syncd-engine-crypto.js` functions `C`/`y`) computes the index MAC unconditionally over the decoded index (an empty buffer when the field is absent) and throws "Index mac corrupt" on mismatch, with no presence guard.

This runs the index-MAC check unconditionally when validating, treating an absent index as an empty buffer, so the stored index MAC is always bound to the plaintext. It's defense-in-depth on top of the content MAC (you'd already have to defeat that first), but it closes a real WA Web integrity-parity gap.

Factored out `generate_index_mac` (compute side of `validate_index_mac`) so the test helpers can build records that are valid under the now-mandatory check. Added a regression test asserting an absent-index record with a tampered stored MAC is rejected with `MismatchingIndexMAC`.
