### PR TITLE
refactor(download): remove dead, full-buffering download_to_file

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -267,26 +267,6 @@ impl Client {
         .await
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(
-            name = "wa.media.download_to_file",
-            level = "debug",
-            skip_all,
-            err(Debug)
-        )
-    )]
-    pub async fn download_to_file<W: Write + Seek + Send + Unpin>(
-        &self,
-        downloadable: &dyn Downloadable,
-        mut writer: W,
-    ) -> Result<()> {
-        let data = self.download(downloadable).await?;
-        writer.seek(SeekFrom::Start(0))?;
-        writer.write_all(&data)?;
-        Ok(())
-    }
-
     /// Fetch a first-party sticker pack's metadata and sticker list from the CDN.
     ///
     /// Each returned [`wacore::sticker_pack::StickerPackItem`] is [`Downloadable`],


### PR DESCRIPTION
`download_to_file` buffered the entire decrypted file in memory (it called `download()` which returns a full `Vec<u8>`, then wrote it to the writer), which is the opposite of what the `to_file` name suggests and contradicts the constant-memory download path the rest of the code uses. It also had zero callers anywhere in the tree.

It is leftover from before `download_to_writer` (constant memory, ~40KB regardless of file size) was added: `history_sync` and the `download_from_params_to_writer` wrapper were migrated to the streaming method, but the old buffered one was never removed.

Drop it. `download_to_writer` is the streaming method callers should use. Breaking change for any external caller (pre-1.0).
