### PR TITLE
refactor(polls): group enc_payload + enc_iv into PollVoteCiphertext

### DIFF
--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -54,7 +54,7 @@ pub use newsletter::{
     NewsletterReactionCount, NewsletterRole, NewsletterState, NewsletterVerification,
 };
 
-pub use polls::{PollOptionResult, Polls};
+pub use polls::{PollOptionResult, PollVoteCiphertext, Polls};
 
 pub use presence::{Presence, PresenceError, PresenceStatus};
 

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -10,6 +10,8 @@ use waproto::whatsapp as wa;
 use crate::client::Client;
 use crate::send::SendResult;
 
+pub use wacore::poll::PollVoteCiphertext;
+
 #[derive(Debug, Clone)]
 pub struct PollOptionResult {
     pub name: String,
@@ -189,8 +191,7 @@ impl<'a> Polls<'a> {
     /// the LID migration still open. Mirrors WA Web `WAWebAddonEncryption`.
     pub async fn decrypt_vote(
         &self,
-        enc_payload: &[u8],
-        enc_iv: &[u8],
+        ciphertext: poll::PollVoteCiphertext<'_>,
         message_secret: &[u8],
         poll_msg_id: &str,
         poll_creator_jid: &Jid,
@@ -206,8 +207,7 @@ impl<'a> Polls<'a> {
         let fallback = Self::build_fallback(&creator_alt, &voter_alt);
 
         poll::decrypt_poll_vote_with_fallback(
-            enc_payload,
-            enc_iv,
+            ciphertext,
             message_secret,
             poll_msg_id,
             poll::PollVoteAddressing {
@@ -251,7 +251,7 @@ impl<'a> Polls<'a> {
     pub async fn aggregate_votes(
         &self,
         poll_options: &[String],
-        votes: &[(&Jid, &[u8], &[u8])], // (voter_jid, enc_payload, enc_iv)
+        votes: &[(&Jid, poll::PollVoteCiphertext<'_>)],
         message_secret: &[u8],
         poll_msg_id: &str,
         poll_creator_jid: &Jid,
@@ -270,7 +270,7 @@ impl<'a> Polls<'a> {
         // as-received JID for the reported voters list. Last-vote-wins.
         let mut latest_votes: HashMap<String, (String, Vec<Vec<u8>>)> =
             HashMap::with_capacity(votes.len());
-        for (voter_jid, enc_payload, enc_iv) in votes {
+        for (voter_jid, ciphertext) in votes {
             let voter = voter_jid.to_non_ad();
             let voter_str = voter.to_string();
             let voter_alt = self.swapped_user(&voter).await;
@@ -281,8 +281,7 @@ impl<'a> Polls<'a> {
                 voter_alt.clone().unwrap_or_else(|| voter_str.clone())
             };
             match poll::decrypt_poll_vote_with_fallback(
-                enc_payload,
-                enc_iv,
+                *ciphertext,
                 message_secret,
                 poll_msg_id,
                 poll::PollVoteAddressing {
@@ -541,8 +540,10 @@ mod tests {
         let out = client
             .polls()
             .decrypt_vote(
-                &enc,
-                &iv,
+                poll::PollVoteCiphertext {
+                    enc_payload: &enc,
+                    enc_iv: &iv,
+                },
                 &secret,
                 stanza_id,
                 &Jid::lid(creator_lid),
@@ -573,8 +574,10 @@ mod tests {
         let res = client
             .polls()
             .decrypt_vote(
-                &enc,
-                &iv,
+                poll::PollVoteCiphertext {
+                    enc_payload: &enc,
+                    enc_iv: &iv,
+                },
                 &secret,
                 stanza_id,
                 &Jid::lid("111000111000111"),
@@ -615,7 +618,13 @@ mod tests {
         .unwrap();
 
         let voter_lid_jid = Jid::lid(voter_lid);
-        let votes: Vec<(&Jid, &[u8], &[u8])> = vec![(&voter_lid_jid, &enc, &iv)];
+        let votes: Vec<(&Jid, poll::PollVoteCiphertext)> = vec![(
+            &voter_lid_jid,
+            poll::PollVoteCiphertext {
+                enc_payload: &enc,
+                enc_iv: &iv,
+            },
+        )];
 
         let results = client
             .polls()
@@ -672,9 +681,21 @@ mod tests {
 
         let voter_pn_jid = Jid::pn(voter_pn);
         let voter_lid_jid = Jid::lid(voter_lid);
-        let votes: Vec<(&Jid, &[u8], &[u8])> = vec![
-            (&voter_pn_jid, &enc_pn, &iv_pn),
-            (&voter_lid_jid, &enc_lid, &iv_lid),
+        let votes: Vec<(&Jid, poll::PollVoteCiphertext)> = vec![
+            (
+                &voter_pn_jid,
+                poll::PollVoteCiphertext {
+                    enc_payload: &enc_pn,
+                    enc_iv: &iv_pn,
+                },
+            ),
+            (
+                &voter_lid_jid,
+                poll::PollVoteCiphertext {
+                    enc_payload: &enc_lid,
+                    enc_iv: &iv_lid,
+                },
+            ),
         ];
 
         let results = client
@@ -731,9 +752,21 @@ mod tests {
 
         let voter_pn_jid = Jid::pn(voter_pn);
         let voter_lid_jid = Jid::lid(voter_lid);
-        let votes: Vec<(&Jid, &[u8], &[u8])> = vec![
-            (&voter_pn_jid, &enc_pn, &iv_pn),
-            (&voter_lid_jid, &enc_clear, &iv_clear),
+        let votes: Vec<(&Jid, poll::PollVoteCiphertext)> = vec![
+            (
+                &voter_pn_jid,
+                poll::PollVoteCiphertext {
+                    enc_payload: &enc_pn,
+                    enc_iv: &iv_pn,
+                },
+            ),
+            (
+                &voter_lid_jid,
+                poll::PollVoteCiphertext {
+                    enc_payload: &enc_clear,
+                    enc_iv: &iv_clear,
+                },
+            ),
         ];
 
         let results = client

--- a/wacore/src/poll.rs
+++ b/wacore/src/poll.rs
@@ -150,6 +150,14 @@ pub struct PollVoteAddressing<'a> {
     pub voter_jid: &'a str,
 }
 
+/// The encrypted vote payload and its GCM IV, paired so the two same-typed
+/// byte slices can't be transposed at a call site.
+#[derive(Debug, Clone, Copy)]
+pub struct PollVoteCiphertext<'a> {
+    pub enc_payload: &'a [u8],
+    pub enc_iv: &'a [u8],
+}
+
 /// Decrypt a poll vote, retrying once under the alternate addressing.
 ///
 /// The creator and voter JIDs key the derivation, so a vote authored under LID
@@ -158,16 +166,14 @@ pub struct PollVoteAddressing<'a> {
 /// retries with both JIDs swapped together (never mixed), matching WA Web
 /// `WAWebAddonEncryption.decryptAddOn`.
 pub fn decrypt_poll_vote_with_fallback(
-    enc_payload: &[u8],
-    iv: &[u8],
+    ciphertext: PollVoteCiphertext<'_>,
     message_secret: &[u8],
     stanza_id: &str,
     primary: PollVoteAddressing<'_>,
     fallback: Option<PollVoteAddressing<'_>>,
 ) -> Result<Vec<Vec<u8>>> {
     match decrypt_poll_vote_with_secret(
-        enc_payload,
-        iv,
+        ciphertext,
         message_secret,
         stanza_id,
         primary.poll_creator_jid,
@@ -176,8 +182,7 @@ pub fn decrypt_poll_vote_with_fallback(
         Ok(v) => Ok(v),
         Err(primary_err) => match fallback {
             Some(fb) => decrypt_poll_vote_with_secret(
-                enc_payload,
-                iv,
+                ciphertext,
                 message_secret,
                 stanza_id,
                 fb.poll_creator_jid,
@@ -194,8 +199,7 @@ pub fn decrypt_poll_vote_with_fallback(
 /// Decrypt a poll vote given the poll's `messageSecret` directly. Preferred
 /// over the legacy two-step path that splits derive+decrypt.
 pub fn decrypt_poll_vote_with_secret(
-    enc_payload: &[u8],
-    iv: &[u8],
+    ciphertext: PollVoteCiphertext<'_>,
     message_secret: &[u8],
     stanza_id: &str,
     poll_creator_jid: &str,
@@ -204,8 +208,8 @@ pub fn decrypt_poll_vote_with_secret(
     use prost::Message as _;
 
     let plaintext = decrypt_addon(
-        enc_payload,
-        iv,
+        ciphertext.enc_payload,
+        ciphertext.enc_iv,
         message_secret,
         &poll_vote_addon_ctx(stanza_id, poll_creator_jid, voter_jid),
     )?;
@@ -241,8 +245,17 @@ mod tests {
 
         let (enc, iv) =
             encrypt_poll_vote_with_secret(&hashes, &secret, stanza_id, creator, voter).unwrap();
-        let out =
-            decrypt_poll_vote_with_secret(&enc, &iv, &secret, stanza_id, creator, voter).unwrap();
+        let out = decrypt_poll_vote_with_secret(
+            PollVoteCiphertext {
+                enc_payload: &enc,
+                enc_iv: &iv,
+            },
+            &secret,
+            stanza_id,
+            creator,
+            voter,
+        )
+        .unwrap();
         assert_eq!(out, hashes);
     }
 
@@ -276,8 +289,10 @@ mod tests {
 
         assert!(
             decrypt_poll_vote_with_secret(
-                &enc,
-                &iv,
+                PollVoteCiphertext {
+                    enc_payload: &enc,
+                    enc_iv: &iv,
+                },
                 &secret,
                 "id",
                 "c@s.whatsapp.net",
@@ -308,8 +323,10 @@ mod tests {
         let creator_lid = "111111111111111@lid";
         let voter_lid = "222222222222222@lid";
         let out = decrypt_poll_vote_with_fallback(
-            &enc,
-            &iv,
+            PollVoteCiphertext {
+                enc_payload: &enc,
+                enc_iv: &iv,
+            },
             &secret,
             stanza_id,
             PollVoteAddressing {
@@ -342,8 +359,10 @@ mod tests {
 
         // Primary matches; a deliberately-wrong fallback must never be reached.
         let out = decrypt_poll_vote_with_fallback(
-            &enc,
-            &iv,
+            PollVoteCiphertext {
+                enc_payload: &enc,
+                enc_iv: &iv,
+            },
             &secret,
             stanza_id,
             PollVoteAddressing {
@@ -373,8 +392,10 @@ mod tests {
         .unwrap();
 
         let err = decrypt_poll_vote_with_fallback(
-            &enc,
-            &iv,
+            PollVoteCiphertext {
+                enc_payload: &enc,
+                enc_iv: &iv,
+            },
             &secret,
             stanza_id,
             PollVoteAddressing {
@@ -405,8 +426,10 @@ mod tests {
         .unwrap();
         assert!(
             decrypt_poll_vote_with_fallback(
-                &enc,
-                &iv,
+                PollVoteCiphertext {
+                    enc_payload: &enc,
+                    enc_iv: &iv,
+                },
                 &secret,
                 "id",
                 PollVoteAddressing {
@@ -431,8 +454,10 @@ mod tests {
         )
         .unwrap();
         let out = decrypt_poll_vote_with_secret(
-            &enc,
-            &iv,
+            PollVoteCiphertext {
+                enc_payload: &enc,
+                enc_iv: &iv,
+            },
             &secret,
             "id",
             "c@s.whatsapp.net",


### PR DESCRIPTION
The poll-vote decrypt functions took three adjacent same-typed byte slices (`enc_payload`, `enc_iv`, `message_secret`), trivial to transpose at a call site with no compiler help. `aggregate_votes` hid two of them inside a `(&Jid, &[u8], &[u8])` tuple distinguished only by an inline comment.

This is the same footgun class as the `download_from_params` positional params (#768), applied to vote decryption. It introduces `PollVoteCiphertext { enc_payload, enc_iv }` (mirroring the `PollVoteAddressing` struct that already lives in the same module for the JID pair) and threads it through `decrypt_poll_vote_with_secret` / `decrypt_poll_vote_with_fallback`, `Polls::decrypt_vote`, and `aggregate_votes`. `message_secret` now stands alone next to a `&str` instead of in a run of three slices, and the aggregate tuple becomes `(&Jid, PollVoteCiphertext)`.

Zero-cost (the struct holds two borrowed slices) and re-exported via `features` so callers can name it. Breaking change for direct callers of these methods (pre-1.0); all in-tree callers updated. The legacy two-step `decrypt_poll_vote` (only `enc_payload`/`iv`, no third slice) is left untouched.
