### PR TITLE
feat(prekeys): validate companion device-identity (ADV) on fetched bundles

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -914,6 +914,28 @@ impl Client {
             .ok_or_else(|| anyhow::anyhow!("Missing identity key in retry receipt"))?;
         let identity_key = PublicKey::from_djb_public_key_bytes(identity_bytes)?;
 
+        // Companion devices ADV-bind the fetched identity via <device-identity>;
+        // reject a present-but-invalid one so a relay can't swap in a forged key.
+        // Mirrors the prekey-fetch path; a missing one is logged, not fatal.
+        if requester_jid.device != 0
+            && let Some(device_identity) = keys_node
+                .get_optional_child("device-identity")
+                .and_then(get_bytes_content_ref)
+        {
+            let fetched_identity: [u8; 32] = identity_bytes
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("identity key in retry receipt is not 32 bytes"))?;
+            if !wacore::adv::validate_adv_with_identity_key(device_identity, &fetched_identity) {
+                return Err(anyhow::anyhow!(
+                    "device-identity ADV validation failed for companion {requester_jid}"
+                ));
+            }
+        } else if requester_jid.device != 0 {
+            log::warn!(
+                "retry key bundle for companion {requester_jid} omits <device-identity>; proceeding without ADV validation"
+            );
+        }
+
         // Extract prekey (optional in some cases).
         let prekey_data = if let Some(key_ref) = keys_node.get_optional_child("key") {
             let prekey_node = OneTimePreKeyNode::try_from_node_ref(key_ref)?;

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -5,8 +5,67 @@
 //!
 //! Reference: WAWebHandleAdvDeviceNotificationUtils.decodeSignedKeyIndexBytes()
 
+use crate::libsignal::protocol::PublicKey;
 use crate::store::traits::DeviceInfo;
 use prost::Message;
+
+// ADV signature prefixes (WAWebAdvSignatureConstants). The hosted ([6,5]/[6,6])
+// variants apply to business-hosted companion devices.
+const ADV_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 0];
+const ADV_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 1];
+const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 5];
+const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 6];
+
+/// Verify a fetched companion device's `ADVSignedDeviceIdentity` binds the
+/// fetched identity key to the account's ADV chain, mirroring WA Web
+/// `WAWebAdvSignatureApi.validateADVwithIdentityKey`.
+///
+/// Two checks must both hold under one prefix family: the account signature over
+/// `prefix || details || identity`, and the device signature (made with the
+/// fetched identity key) over `prefix || details || identity || accountKey`. The
+/// device signature is what binds the fetched identity to the account, so a relay
+/// that substitutes a fabricated identity key is rejected. We try the E2EE then
+/// the hosted prefix set rather than replicating WA Web's `bizHostedDevicesEnabled`
+/// gating: the prefix is only a domain separator, so accepting whichever the
+/// signer used stays sound (an attacker still can't forge the account signature).
+pub fn validate_adv_with_identity_key(
+    device_identity_bytes: &[u8],
+    fetched_identity_key: &[u8; 32],
+) -> bool {
+    let Ok(signed) = waproto::whatsapp::AdvSignedDeviceIdentity::decode(device_identity_bytes)
+    else {
+        return false;
+    };
+    let (Some(details), Some(account_key), Some(account_sig), Some(device_sig)) = (
+        signed.details.as_deref(),
+        signed.account_signature_key.as_deref(),
+        signed.account_signature.as_deref(),
+        signed.device_signature.as_deref(),
+    ) else {
+        return false;
+    };
+    let (Ok(account_pub), Ok(device_pub)) = (
+        PublicKey::from_djb_public_key_bytes(account_key),
+        PublicKey::from_djb_public_key_bytes(fetched_identity_key),
+    ) else {
+        return false;
+    };
+
+    [
+        (ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE),
+        (
+            ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
+            ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
+        ),
+    ]
+    .into_iter()
+    .any(|(account_prefix, device_prefix)| {
+        let account_msg = [account_prefix, details, fetched_identity_key].concat();
+        let device_msg = [device_prefix, details, fetched_identity_key, account_key].concat();
+        account_pub.verify_signature(&account_msg, account_sig)
+            && device_pub.verify_signature(&device_msg, device_sig)
+    })
+}
 
 /// Decoded fields from `ADVKeyIndexList` protobuf.
 #[derive(Debug, Clone)]
@@ -222,5 +281,105 @@ mod tests {
         assert_eq!(decoded.timestamp, 1000);
         assert_eq!(decoded.current_index, 5);
         assert_eq!(decoded.valid_indexes, vec![3, 5, 7]);
+    }
+
+    use crate::libsignal::protocol::KeyPair;
+
+    fn signed_identity(
+        account: &KeyPair,
+        device: &KeyPair,
+        details: &[u8],
+        hosted: bool,
+    ) -> Vec<u8> {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let identity = device.public_key.public_key_bytes();
+        let account_key = account.public_key.public_key_bytes();
+        let (acct_prefix, dev_prefix): (&[u8], &[u8]) = if hosted {
+            (
+                ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
+                ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
+            )
+        } else {
+            (ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE)
+        };
+        let account_sig = account
+            .private_key
+            .calculate_signature(&[acct_prefix, details, identity].concat(), &mut rng)
+            .unwrap()
+            .to_vec();
+        let device_sig = device
+            .private_key
+            .calculate_signature(
+                &[dev_prefix, details, identity, account_key].concat(),
+                &mut rng,
+            )
+            .unwrap()
+            .to_vec();
+        waproto::whatsapp::AdvSignedDeviceIdentity {
+            details: Some(details.to_vec()),
+            account_signature_key: Some(account_key.to_vec()),
+            account_signature: Some(account_sig),
+            device_signature: Some(device_sig),
+        }
+        .encode_to_vec()
+    }
+
+    fn id32(kp: &KeyPair) -> [u8; 32] {
+        kp.public_key.public_key_bytes().try_into().unwrap()
+    }
+
+    #[test]
+    fn adv_chain_valid_accepted() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let bytes = signed_identity(&account, &device, b"details", false);
+        assert!(validate_adv_with_identity_key(&bytes, &id32(&device)));
+    }
+
+    #[test]
+    fn adv_chain_hosted_prefix_accepted() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let bytes = signed_identity(&account, &device, b"hosted-details", true);
+        assert!(validate_adv_with_identity_key(&bytes, &id32(&device)));
+    }
+
+    #[test]
+    fn adv_chain_rejects_substituted_identity() {
+        // A relay swaps the bundle's <identity> to its own key, but the signed
+        // device-identity still binds the real one: validation must fail.
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let attacker = KeyPair::generate(&mut rng);
+        let bytes = signed_identity(&account, &device, b"details", false);
+        assert!(!validate_adv_with_identity_key(&bytes, &id32(&attacker)));
+    }
+
+    #[test]
+    fn adv_chain_rejects_missing_device_signature() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let no_dev_sig = waproto::whatsapp::AdvSignedDeviceIdentity {
+            details: Some(b"details".to_vec()),
+            account_signature_key: Some(account.public_key.public_key_bytes().to_vec()),
+            account_signature: Some(vec![0u8; 64]),
+            device_signature: None,
+        }
+        .encode_to_vec();
+        assert!(!validate_adv_with_identity_key(&no_dev_sig, &id32(&device)));
+    }
+
+    #[test]
+    fn adv_chain_rejects_garbage() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let device = KeyPair::generate(&mut rng);
+        assert!(!validate_adv_with_identity_key(
+            &[1, 2, 3, 4],
+            &id32(&device)
+        ));
     }
 }

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -270,6 +270,35 @@ impl PreKeyUtils {
             identity_key,
         )?;
 
+        // Companion devices (device != 0) carry a <device-identity> that ADV-binds
+        // the fetched identity key to the account, so a relay can't substitute a
+        // fabricated identity. Matches WA Web SessionApi.createSignalSession. When
+        // present-but-invalid we reject the bundle (the loop skips that device); a
+        // missing one is logged but not fatal, since the live/mock server set that
+        // omits it is unverified (WA Web throws here).
+        if jid.device != 0 {
+            let device_identity = node
+                .get_optional_child("device-identity")
+                .or_else(|| keys_node.get_optional_child("device-identity"))
+                .and_then(|n| match n.content.as_deref() {
+                    Some(NodeContentRef::Bytes(b)) => Some(b),
+                    _ => None,
+                });
+            match device_identity {
+                Some(di)
+                    if !crate::adv::validate_adv_with_identity_key(di, &identity_key_array) =>
+                {
+                    return Err(anyhow::anyhow!(
+                        "device-identity ADV validation failed for companion {jid}"
+                    ));
+                }
+                Some(_) => {}
+                None => log::warn!(
+                    "prekey bundle for companion {jid} omits <device-identity>; proceeding without ADV validation"
+                ),
+            }
+        }
+
         Ok(bundle)
     }
 
@@ -412,5 +441,35 @@ mod tests {
         assert_eq!(parsed_jid.user, base_jid.user);
         assert_eq!(parsed_jid.device, base_jid.device);
         assert_eq!(parsed_jid.agent, 0);
+    }
+
+    fn parse_one(jid: Jid, device_identity: Option<Vec<u8>>) -> HashMap<Jid, PreKeyBundle> {
+        let bundle = create_mock_bundle(jid.device as u32);
+        let user_node = PreKeyBundleUserNode::from_bundle(jid, &bundle, device_identity)
+            .expect("build bundle node")
+            .into_node();
+        let response = NodeBuilder::new("iq")
+            .children([NodeBuilder::new("list").children([user_node]).build()])
+            .build();
+        PreKeyUtils::parse_prekeys_response(&response.as_node_ref()).expect("parse bundles")
+    }
+
+    #[test]
+    fn parse_skips_companion_bundle_with_invalid_device_identity() {
+        let companion = Jid::lid_device("100000012345678", 33);
+        let bundles = parse_one(companion.clone(), Some(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+        assert!(
+            !bundles.contains_key(&companion),
+            "companion bundle with an unverifiable device-identity must be dropped"
+        );
+    }
+
+    #[test]
+    fn parse_keeps_primary_bundle_ignoring_device_identity() {
+        // device 0 is the account's primary: ADV validation does not apply, so a
+        // junk device-identity must not get it dropped.
+        let primary = Jid::lid_device("100000012345678", 0);
+        let bundles = parse_one(primary.clone(), Some(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+        assert!(bundles.contains_key(&primary));
     }
 }


### PR DESCRIPTION
When establishing a Signal session from a fetched prekey bundle for a companion device (`device != 0`), WA Web (`WAWebSignalSessionApi.createSignalSession` -> `WAWebAdvSignatureApi.validateADVwithIdentityKey`) cryptographically binds the fetched identity key to the account's ADV signature chain. We did not: the bundle was built straight from `<identity>`/`<skey>`/`<key>` and the `<device-identity>` child was ignored on both the prekey-fetch path and the retry path. A malicious or compromised relay could therefore substitute a fabricated identity key (and signed prekey) for a victim's companion device and we would silently set up a session with the attacker. `process_prekey_bundle` only checks the signed-prekey signature against the bundle's own identity key (self-signed), which a forger also controls.

This adds `wacore::adv::validate_adv_with_identity_key`, mirroring `validateADVwithIdentityKey`:
- account signature: `verify(accountSignatureKey, ADV_PREFIX_DEVICE_IDENTITY_ACCOUNT_SIGNATURE || details || fetchedIdentity, accountSignature)`
- device signature: `verify(fetchedIdentity, ADV_PREFIX_DEVICE_IDENTITY_DEVICE_SIGNATURE || details || fetchedIdentity || accountSignatureKey, deviceSignature)`

The device signature is made *with the fetched identity key*, so it's the check that actually binds the fetched identity to the account chain; a relay-substituted identity fails it. Both message constructions were cross-checked against the captured `SignatureApi.js` (`$`/`M`) and against our own pairing direction in `pair.rs` (which signs the same `[6,0]`/`[6,1]` prefixed buffers). It tries the E2EE prefixes then the business-hosted `[6,5]`/`[6,6]` set rather than replicating WA Web's `bizHostedDevicesEnabled` gating — the prefix is only a domain separator, so accepting whichever the signer used stays sound.

Wired into both session-establishment paths: `node_to_pre_key_bundle_ref` (prekey fetch) and `process_retry_key_bundle` (retry receipt).

Behavior on the absent/invalid cases, and a note for review:
- A present-but-invalid `<device-identity>` rejects the bundle. On the fetch path the parse loop then skips that device (matches WA Web's KeyBundleInWorker batch path).
- A *missing* `<device-identity>` for a companion is logged but not fatal. WA Web throws here, but the e2e mock server is external and its device-identity behavior is unverified; hard-requiring it could break session establishment against servers/mocks that omit it. This is the one intentional divergence — worth tightening to a hard requirement once verified against the live/mock server. Please watch the E2E job on this PR: if the mock sends a dummy (present-but-invalid) device-identity, this would (correctly, by design) reject it and we'd adjust.

Tests: `validate_adv_with_identity_key` has unit coverage (valid E2EE + hosted accepted; substituted identity, missing device signature, and garbage rejected), plus wiring tests that `parse_prekeys_response` drops a companion bundle with an unverifiable device-identity and keeps a primary (device 0) bundle regardless.
