### PR TITLE
fix(appstate): re-sync unsynced collection that gets patches without a snapshot

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -14,7 +14,7 @@ mod tests {
     use wacore::appstate::hash::HashState;
     use wacore::appstate::hash::generate_content_mac;
     use wacore::appstate::keys::expand_app_state_keys;
-    use wacore::appstate::patch_decode::{PatchList, WAPatchName};
+    use wacore::appstate::patch_decode::{CollectionSyncError, PatchList, WAPatchName};
     use wacore::appstate::processor::AppStateMutationMAC;
     use wacore::libsignal::crypto::aes_256_cbc_encrypt_into;
     use wacore::store::error::Result as StoreResult;
@@ -584,5 +584,40 @@ mod tests {
             1,
             "version must not advance when the MAC reset fails"
         );
+    }
+
+    #[tokio::test]
+    async fn non_genesis_patch_on_empty_collection_is_retried() {
+        let backend = Arc::new(MockBackend::default());
+        let processor =
+            AppStateProcessor::new(backend.clone(), Arc::new(crate::runtime_impl::TokioRuntime));
+
+        // Empty collection (version 0), patches without a snapshot, first patch v5.
+        let patch_list = PatchList {
+            name: WAPatchName::Regular,
+            has_more_patches: false,
+            patches: vec![wa::SyncdPatch {
+                version: Some(wa::SyncdVersion { version: Some(5) }),
+                ..Default::default()
+            }],
+            snapshot: None,
+            snapshot_ref: None,
+            error: None,
+        };
+
+        let (mutations, state, pl) = processor
+            .process_patch_list(patch_list, true)
+            .await
+            .expect("guard returns Ok with a retryable error, not a hard failure");
+
+        assert!(
+            mutations.is_empty(),
+            "the unanchored patch must not be applied"
+        );
+        assert_eq!(
+            state.version, 0,
+            "version stays 0 so the refetch re-requests a snapshot"
+        );
+        assert!(matches!(pl.error, Some(CollectionSyncError::Retry { .. })));
     }
 }

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -350,12 +350,11 @@ pub fn validate_patch_macs(
     had_no_prior_state: bool,
     has_missing_remove: bool,
 ) -> Result<(), AppStateError> {
-    // Skip ALL MAC validation if we had no prior state.
-    // When we receive patches without a snapshot for a never-synced collection,
-    // WhatsApp Web throws a retryable "empty lthash" error. We can't properly validate
-    // either the snapshotMac (computed from wrong baseline) or the patchMac (which
-    // includes the snapshotMac). Instead, we process the mutations and rely on
-    // future syncs with snapshots to correct the state.
+    // Skip ALL MAC validation only for the genesis patch (version 1) seeding an
+    // empty baseline: there is no prior snapshotMac/patchMac baseline to validate
+    // against. The empty + non-genesis case (a patch without a snapshot that can't
+    // anchor the ltHash) is rejected upstream in `process_patch_list` as a retryable
+    // resync, so it never reaches here.
     if had_no_prior_state {
         return Ok(());
     }

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -334,11 +334,11 @@ fn detect_duplicate_index_in_patch(mutations: &[wa::SyncdMutation]) -> Result<()
 /// * `state` - The hash state AFTER applying the patch mutations
 /// * `keys` - The expanded app state keys for MAC computation
 /// * `collection_name` - The collection name
-/// * `had_no_prior_state` - If true, skip ALL MAC validation. This should be true
-///   when processing patches without a prior local state (e.g., first sync without snapshot).
-///   WhatsApp Web handles this case by throwing a retryable error ("empty lthash"), but we
-///   can safely skip validation and process the mutations for usability. The state will be
-///   corrected on the next proper sync with a snapshot.
+/// * `had_no_prior_state` - If true, skip ALL MAC validation. On an empty collection
+///   this is only reached for the genesis patch (version 1), which has no prior baseline
+///   to validate against. The empty + non-genesis case (a patch without a snapshot that
+///   can't anchor the ltHash) is rejected upstream in `process_patch_list`, which marks
+///   the collection retryable so it re-syncs via snapshot, matching WhatsApp Web.
 /// * `has_missing_remove` - If true, a REMOVE mutation was missing its previous value.
 ///   WhatsApp Web tracks this and makes MAC validation failures non-fatal in this case,
 ///   because the ltHash is expected to diverge when we can't subtract a value we don't have.

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -543,6 +543,10 @@ impl AppStateProcessor {
         FDownload: Fn(&wa::ExternalBlobReference) -> Result<Vec<u8>> + Send + Sync,
     {
         let mut all = Vec::new();
+        // Bound re-fetches so a server that keeps returning a retryable collection
+        // (e.g. an empty-ltHash patch without a snapshot) can't loop forever.
+        const MAX_RETRIES: usize = 5;
+        let mut retries = 0;
         loop {
             let state = self.backend.get_version(name.as_str()).await?;
             let node = driver.fetch_collection(name, state.version).await?;
@@ -550,6 +554,21 @@ impl AppStateProcessor {
                 .decode_patch_list(&node, &download, validate_macs)
                 .await?;
             all.append(&mut muts);
+            // A retryable error (or conflict-with-more) left the version unadvanced;
+            // re-fetch (now requesting a snapshot, since the version is still 0)
+            // rather than reporting success. Mirrors the batched path's needs_refetch.
+            // Fatal / conflict-without-more fall through and end the loop.
+            if matches!(
+                list.error,
+                Some(CollectionSyncError::Retry { .. })
+                    | Some(CollectionSyncError::Conflict { has_more: true })
+            ) {
+                retries += 1;
+                if retries >= MAX_RETRIES {
+                    break;
+                }
+                continue;
+            }
             if !list.has_more_patches {
                 break;
             }

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -256,7 +256,7 @@ impl AppStateProcessor {
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.process_list", level = "debug", skip_all, fields(name = ?pl.name), err(Debug)))]
     pub async fn process_patch_list(
         &self,
-        pl: PatchList,
+        mut pl: PatchList,
         validate_macs: bool,
     ) -> Result<(Vec<Mutation>, HashState, PatchList)> {
         // Pre-fetch all keys we'll need
@@ -329,6 +329,33 @@ impl AppStateProcessor {
             self.backend
                 .set_version(collection_name, state.clone())
                 .await?;
+        }
+
+        // WA Web AntiTampering: an unsynced collection (empty ltHash) can only be
+        // seeded by a snapshot or the genesis patch (version 1). If no snapshot was
+        // applied and the first patch is non-genesis, applying it would anchor the
+        // aggregate ltHash to nothing and persist unverified mutations, then advance
+        // the version so the next sync no longer requests a snapshot. Mark the
+        // collection retryable instead; the version stays 0, so the refetch re-requests
+        // a snapshot. (whatsmeow/WA Web force a snapshot re-sync here.)
+        if state.version == 0 && state.hash == [0u8; 128] {
+            let first_version = pl
+                .patches
+                .first()
+                .and_then(|p| p.version.as_ref())
+                .and_then(|v| v.version)
+                .unwrap_or(0);
+            if !pl.patches.is_empty() && first_version != 1 {
+                log::warn!(
+                    target: "AppState",
+                    "Collection {collection_name} has empty ltHash and a non-genesis first patch v{first_version} without a snapshot; will refetch"
+                );
+                pl.error = Some(CollectionSyncError::Retry {
+                    code: 0,
+                    text: "empty lthash".to_string(),
+                });
+                return Ok((new_mutations, state, pl));
+            }
         }
 
         // Snapshot the key cache once for all patches (prefetch_keys already populated it)


### PR DESCRIPTION
When a collection had never synced (version 0, empty ltHash) and the server returned patches without a snapshot, `process_patch_list` skipped *all* MAC validation, applied the mutations, and advanced the version. That both persists unverified state and stops the next sync from requesting a snapshot (`want_snapshot` keys on `version == 0`), locking in a patch whose aggregate ltHash (snapshotMac/patchMac) was never anchored. The per-record valueMac is still checked in `decode_record`, but the aggregate integrity anchors are not.

WA Web's AntiTampering throws a retryable "empty lthash" error when the local ltHash is empty and the patch version != 1, forcing a snapshot re-sync; only the genesis patch (v1) is allowed to seed an empty collection.

This mirrors that: when no snapshot was applied, the state is empty, and the first patch is non-genesis, the collection is marked `CollectionSyncError::Retry` and returned without applying anything. The version stays 0, so the existing refetch path re-requests a snapshot (the same mechanism #759 uses for failed external-blob fetches). The genesis-v1 path is unchanged (still seeded via the `had_no_prior_state` skip in `validate_patch_macs`). The guard lives in `process_patch_list`, so both the batched and single-collection sync paths are covered.

In practice this is an anomalous path (we request `return_snapshot=true` whenever version is 0, so the server should send a snapshot), but it's a real integrity hole if the server returns patches anyway. Added a test that a non-genesis patch on an empty collection yields `Retry` with the version left at 0; verified it fails without the guard (version advances to 5).
