### PR TITLE
perf(upload): slice ciphertext zero-copy instead of copying per attempt

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -118,7 +118,7 @@ fn main() {
                                         url: url.clone(),
                                         method: "POST".into(),
                                         headers: HashMap::new(),
-                                        body: Some(code.as_bytes().to_vec()),
+                                        body: Some(code.as_bytes().to_vec().into()),
                                     };
                                     match http.execute(req).await {
                                         Ok(resp) if (200..300).contains(&resp.status_code) => {

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -363,7 +363,9 @@ impl Client {
             file_enc_sha256: enc.file_enc_sha256,
             streaming_sidecar: enc.streaming_sidecar,
         };
-        let ciphertext = enc.data_to_upload;
+        // Bytes so each retry/resume attempt slices with a refcount bump instead of
+        // copying the whole (multi-MB) ciphertext per attempt.
+        let ciphertext = bytes::Bytes::from(enc.data_to_upload);
 
         upload_media_with_retry(
             crypto,
@@ -375,7 +377,7 @@ impl Client {
             || async { self.invalidate_media_conn().await },
             |request| async move { self.http_client.execute(request).await },
             |request, offset, _remaining| {
-                let body = ciphertext[offset as usize..].to_vec();
+                let body = ciphertext.slice(offset as usize..);
                 async move { self.http_client.execute(request.with_body(body)).await }
             },
         )

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -50,7 +50,7 @@ fn spawn_qr_autoresponder_http(
                     url: url.clone(),
                     method: "POST".into(),
                     headers: HashMap::new(),
-                    body: Some(code.as_bytes().to_vec()),
+                    body: Some(code.as_bytes().to_vec().into()),
                 };
                 match http.execute(req).await {
                     Ok(resp) if (200..300).contains(&resp.status_code) => return,

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -78,7 +78,7 @@ pub struct HttpRequest {
     pub url: String,
     pub method: String, // "GET" or "POST"
     pub headers: HashMap<String, String>,
-    pub body: Option<Vec<u8>>,
+    pub body: Option<Bytes>,
 }
 
 impl HttpRequest {
@@ -105,8 +105,8 @@ impl HttpRequest {
         self
     }
 
-    pub fn with_body(mut self, body: Vec<u8>) -> Self {
-        self.body = Some(body);
+    pub fn with_body(mut self, body: impl Into<Bytes>) -> Self {
+        self.body = Some(body.into());
         self
     }
 }


### PR DESCRIPTION
The legacy in-memory upload closure ran `ciphertext[offset..].to_vec()` on every send attempt — a full copy of the (potentially multi-MB) encrypted media payload on the common first attempt (offset 0). It was forced only because `HttpRequest::with_body` took `Vec<u8>`; the closure is re-callable for retry/resume so the ciphertext can't be moved out, and the `Vec<u8>` body type required an owned copy.

This makes `HttpRequest.body` a `bytes::Bytes` (`with_body` now takes `impl Into<Bytes>`, so existing `Vec<u8>` callers are unchanged) and holds the ciphertext as `Bytes`, so each attempt becomes `ciphertext.slice(offset..)` — a refcount bump, no copy. The ureq client reads the body via `&body[..]` (`Bytes` derefs to `[u8]`), so it needs no change.

`upload_stream` already avoids the copy for large media; this fixes the buffered `upload()` path that's still the public API for in-memory media. Pure perf/type change; the existing upload retry/failover tests exercise the multi-attempt body path.
