### PR TITLE
refactor(groups): set_description prev takes Option<&str>

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -404,7 +404,7 @@ impl<'a> Groups<'a> {
         &self,
         jid: &Jid,
         description: Option<GroupDescription>,
-        prev: Option<String>,
+        prev: Option<&str>,
     ) -> Result<(), anyhow::Error> {
         Ok(self
             .client

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1328,17 +1328,14 @@ pub struct SetGroupDescriptionIq {
 }
 
 impl SetGroupDescriptionIq {
-    pub fn new(
-        group_jid: &Jid,
-        description: Option<GroupDescription>,
-        prev: Option<String>,
-    ) -> Self {
+    pub fn new(group_jid: &Jid, description: Option<GroupDescription>, prev: Option<&str>) -> Self {
         let id = generate_description_id();
         Self {
             group_jid: group_jid.clone(),
             description,
             id,
-            prev,
+            // Owned because build_iq runs after the spec is moved into execute().
+            prev: prev.map(str::to_string),
         }
     }
 }
@@ -3129,7 +3126,7 @@ mod tests {
     fn test_set_group_description_with_id_and_prev() {
         let jid: Jid = "120363000000000001@g.us".parse().unwrap();
         let desc = GroupDescription::new("New description").unwrap();
-        let spec = SetGroupDescriptionIq::new(&jid, Some(desc), Some("AABBCCDD".to_string()));
+        let spec = SetGroupDescriptionIq::new(&jid, Some(desc), Some("AABBCCDD"));
         let iq = spec.build_iq();
 
         if let Some(NodeContent::Nodes(nodes)) = &iq.content {
@@ -3152,7 +3149,7 @@ mod tests {
     #[test]
     fn test_set_group_description_delete() {
         let jid: Jid = "120363000000000001@g.us".parse().unwrap();
-        let spec = SetGroupDescriptionIq::new(&jid, None, Some("PREV1234".to_string()));
+        let spec = SetGroupDescriptionIq::new(&jid, None, Some("PREV1234"));
         let iq = spec.build_iq();
 
         if let Some(NodeContent::Nodes(nodes)) = &iq.content {


### PR DESCRIPTION
`Groups::set_description` took `prev: Option<String>` (the previous description id, used for conflict detection). That value is read from `GroupMetadata`, which the caller borrows, so the owned `String` forced the caller to `.clone()` just to pass it — inconsistent with the rest of the group API, which borrows (`&Jid`, `&[Jid]`).

Change `set_description` and `SetGroupDescriptionIq::new` to `Option<&str>`. The spec still stores it owned (`build_iq` runs after the spec is moved into `execute()`, so it can't borrow a caller slice), but the one necessary `to_string()` now happens once inside `new()` instead of at every call site. Purely an ergonomics/consistency fix (low severity); the description path is covered by the existing `test_set_group_description_with_id_and_prev`.

Breaking for direct callers (pre-1.0); the only in-tree callers are `community.rs` (passes `None`) and the spec tests.
