### PR TITLE
perf(retry): peek the cached message on resend instead of take + re-add

### DIFF
--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -244,6 +244,63 @@ impl Client {
         }
     }
 
+    /// Non-consuming variant of [`Self::take_recent_message`]: returns the cached
+    /// message (and the alternate-namespace chat it matched, if any) WITHOUT
+    /// removing it from L1 or touching the DB. The retry handler uses this so a
+    /// resend doesn't decode-then-re-encode the message and churn the DB (delete +
+    /// re-store) on every retry. Returns `None` on an L1 miss (including DB-only
+    /// mode, capacity 0); the caller falls back to take + re-add there.
+    pub(crate) async fn peek_recent_message(
+        &self,
+        to: &Jid,
+        id: &str,
+    ) -> Option<(wa::Message, Option<Jid>)> {
+        let primary_key = self.make_chat_message_id(to, id).await;
+        if let Some(msg) = self.peek_by_key(&primary_key).await {
+            return Some((msg, None));
+        }
+
+        let alt_chat = if primary_key.chat.server != to.server {
+            Some(to.clone())
+        } else {
+            self.swap_pn_lid_namespace(&primary_key.chat).await
+        };
+
+        if let Some(alt_chat) = alt_chat {
+            let alt_key = ChatMessageId {
+                chat: alt_chat,
+                id: primary_key.id,
+            };
+            if let Some(msg) = self.peek_by_key(&alt_key).await {
+                return Some((msg, Some(alt_key.chat)));
+            }
+        }
+
+        None
+    }
+
+    /// L1-only, non-consuming lookup. Returns `None` when L1 is disabled
+    /// (capacity 0) or misses; the DB is intentionally not read here so the caller
+    /// can fall back to the consuming take + re-add path.
+    async fn peek_by_key(&self, key: &ChatMessageId) -> Option<wa::Message> {
+        use prost::Message;
+        if self.cache_config.recent_messages.capacity == 0 {
+            return None;
+        }
+        let bytes = self.recent_messages.get(key).await?;
+        match wa::Message::decode(bytes.as_slice()) {
+            Ok(msg) => Some(msg),
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode cached message for {}:{}: {e}",
+                    key.chat.observe(),
+                    key.id
+                );
+                None
+            }
+        }
+    }
+
     /// Store a sent message for retry handling. Always writes to DB; when L1 cache
     /// is enabled (capacity > 0) also stores in-memory for fast retrieval.
     /// In DB-only mode (capacity = 0), the DB write is awaited to guarantee persistence.

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -260,21 +260,28 @@ impl Client {
                 .remove(&processing_key);
         });
 
-        let (original_msg, alt_chat) = match self.take_recent_message(&info.chat, &message_id).await
+        // Peek keeps the message in the cache, so we avoid the decode + re-encode
+        // and the background DB delete + re-store that take + re-add did on every
+        // retry (pure churn during retry storms). Fall back to the consuming take +
+        // re-add only on an L1 miss (DB-only mode, or after eviction), where peek
+        // can't serve it; that path still re-adds so other devices can retry.
+        let (original_msg, alt_chat) = match self.peek_recent_message(&info.chat, &message_id).await
         {
             Some(result) => result,
-            None => {
-                log::debug!(
-                    "Ignoring retry for message {message_id}: already handled or not found in cache."
-                );
-                return Ok(());
-            }
+            None => match self.take_recent_message(&info.chat, &message_id).await {
+                Some(result) => {
+                    self.add_recent_message(&info.chat, &message_id, &result.0)
+                        .await;
+                    result
+                }
+                None => {
+                    log::debug!(
+                        "Ignoring retry for message {message_id}: already handled or not found in cache."
+                    );
+                    return Ok(());
+                }
+            },
         };
-
-        // take_recent_message consumes the cached message; re-add it so other
-        // devices for the same chat can still request a retry.
-        self.add_recent_message(&info.chat, &message_id, &original_msg)
-            .await;
 
         // When message was found via alternate PN<->LID key, the Signal session
         // lives in the stored message's namespace (not the receipt's). Build the
@@ -1269,6 +1276,47 @@ mod tests {
         // Second take should return None
         let taken_again = client.take_recent_message(&chat, &msg_id).await;
         assert!(taken_again.is_none());
+    }
+
+    #[tokio::test]
+    async fn peek_recent_message_does_not_consume() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let backend = crate::test_utils::create_test_backend().await;
+        let pm = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("persistence manager should initialize"),
+        );
+        let mut config = crate::cache_config::CacheConfig::default();
+        config.recent_messages.capacity = 1_000;
+        let (client, _sync_rx) = Client::new_with_cache_config(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            pm.clone(),
+            Arc::new(crate::transport::mock::MockTransportFactory::new()),
+            Arc::new(MockHttpClient),
+            None,
+            config,
+        )
+        .await;
+
+        let chat: Jid = "120363021033254949@g.us".parse().unwrap();
+        let msg_id = "PEEK1".to_string();
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+        client.add_recent_message(&chat, &msg_id, &msg).await;
+
+        // Peeking twice both return the message and leave it in the cache...
+        for _ in 0..2 {
+            let peeked = client.peek_recent_message(&chat, &msg_id).await;
+            let (m, alt) = peeked.expect("peek should find the cached message");
+            assert!(alt.is_none());
+            assert_eq!(m.conversation.as_deref(), Some("hi"));
+        }
+        // ...so a subsequent take still finds it (peek didn't remove it).
+        assert!(client.take_recent_message(&chat, &msg_id).await.is_some());
     }
 
     #[test]


### PR DESCRIPTION
`handle_retry_receipt` resolved the cached outgoing message with `take_recent_message` (which decodes the cached bytes into a `wa::Message` and spawns a background DB delete) and then immediately called `add_recent_message` (which re-encodes the message via `encode_to_vec`, inserts a fresh `Arc` into L1, and spawns a background DB store) to put the very same row back so other devices can still retry.

So a single resend did: one prost decode + one prost encode + a backgrounded DB delete **and** a backgrounded DB store of an identical row — per retry. During the documented retry storms (232 resends) that's pure churn, and the detached delete racing the detached store is a latent ordering hazard. The cache already holds the exact serialized bytes; nothing needs re-encoding.

This adds `peek_recent_message`: an L1, non-consuming lookup (cache `get`, no DB touch) that returns the message without removing it, so the re-encode and the DB delete/store disappear. It falls back to the consuming `take` + re-add only on an L1 miss (DB-only mode `capacity == 0`, or after eviction), where peek can't serve it — preserving behavior there. Internal change only; covered by a new test that peeking twice leaves the entry so a later take still finds it.
