### PR TITLE
feat(send): emit member_label meta attrs (appdata + tag_reason)

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -892,6 +892,11 @@ impl<'a> Groups<'a> {
             ));
         }
         let msg = wacore::send::build_member_label_message(label.into(), wacore::time::now_secs());
+        // This low-level send bypasses send_message_with_options (no reporting
+        // token for a protocol message), so compute the <meta> here and pass it
+        // as an extra node — otherwise the member_label appdata/tag_reason attrs
+        // never reach the wire.
+        let (_edit, meta) = crate::send::infer_stanza_metadata(&msg);
         self.client
             .send_message_impl(
                 group_jid.clone(),
@@ -900,7 +905,7 @@ impl<'a> Groups<'a> {
                 false,
                 false,
                 None,
-                vec![],
+                meta.into_iter().collect(),
                 None,
             )
             .await

--- a/src/send.rs
+++ b/src/send.rs
@@ -109,7 +109,7 @@ pub enum RevokeType {
 /// from `genMetaNode(...)`. A message can carry both (e.g. a poll vote sets
 /// `polltype=vote` meta; an event edit sets both `event_type=edit` meta and
 /// `edit="1"` attribute).
-fn infer_stanza_metadata(msg: &wa::Message) -> (Option<EditAttribute>, Option<Node>) {
+pub(crate) fn infer_stanza_metadata(msg: &wa::Message) -> (Option<EditAttribute>, Option<Node>) {
     use wacore::proto_helpers::MessageExt;
     let edit = EditAttribute::infer_from_message(msg);
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -142,6 +142,23 @@ fn infer_stanza_metadata(msg: &wa::Message) -> (Option<EditAttribute>, Option<No
     {
         meta = meta.attr("event_type", "edit");
         has_attr = true;
+    } else if let Some(ml) = msg
+        .protocol_message
+        .as_ref()
+        .and_then(|pm| pm.member_label.as_ref())
+    {
+        // genMetaNode (MsgMetaNode `d`/`p`): a member_label protocol message carries
+        // appdata="member_tag" and tag_reason="user_delete" when the label is cleared
+        // (empty/absent), "user_update" otherwise.
+        let tag_reason = if ml.label.as_deref().unwrap_or("").is_empty() {
+            "user_delete"
+        } else {
+            "user_update"
+        };
+        meta = meta
+            .attr("appdata", "member_tag")
+            .attr("tag_reason", tag_reason);
+        has_attr = true;
     }
 
     // genMetaNode: `view_once="true"` whenever the media is view-once (wrapper or
@@ -3004,6 +3021,39 @@ mod tests {
             let (edit, node) = infer_stanza_metadata(&wa::Message::default());
             assert!(edit.is_none());
             assert!(node.is_none());
+        }
+
+        #[test]
+        fn member_label_set_returns_member_tag_user_update() {
+            let msg = wacore::send::build_member_label_message("VIP".to_string(), 1_700_000_000);
+            let (_, node) = infer_stanza_metadata(&msg);
+            let node = node.expect("member_label should have meta node");
+            let mut attrs = node.attrs();
+            assert_eq!(
+                attrs.optional_string("appdata").unwrap().as_ref(),
+                "member_tag"
+            );
+            assert_eq!(
+                attrs.optional_string("tag_reason").unwrap().as_ref(),
+                "user_update"
+            );
+        }
+
+        #[test]
+        fn member_label_clear_returns_user_delete() {
+            // Empty label = clearing the tag → tag_reason "user_delete".
+            let msg = wacore::send::build_member_label_message(String::new(), 1_700_000_000);
+            let (_, node) = infer_stanza_metadata(&msg);
+            let node = node.expect("member_label should have meta node");
+            let mut attrs = node.attrs();
+            assert_eq!(
+                attrs.optional_string("appdata").unwrap().as_ref(),
+                "member_tag"
+            );
+            assert_eq!(
+                attrs.optional_string("tag_reason").unwrap().as_ref(),
+                "user_delete"
+            );
         }
 
         #[test]


### PR DESCRIPTION
`infer_stanza_metadata` (our `genMetaNode` equivalent) emitted `polltype` / `event_type` / `view_once`, but not the `<meta>` attributes WA Web's `MsgMetaNode` attaches to a `member_label` protocol message. So `Groups::update_member_label` went to the server without the meta attrs it expects.

Per `MsgMetaNode` functions `d` (appdata) and `p` (tag_reason): a member_label message carries `appdata="member_tag"`, and `tag_reason="user_delete"` when the label is cleared (empty/absent) or `"user_update"` otherwise. This adds that branch to the existing accumulate-onto-one-`<meta>` chain.

Scoped to `member_label`, the one such message we actually build and send (`build_member_label_message` → `update_member_label`): the peer `appdata="default"` case is already emitted on the PDO send path, and we don't send `MESSAGE_HISTORY_NOTICE` (`group_history`), so those branches would be dead code. Verified the mapping against `docs/captured-js/.../MsgMetaNode...js`.
