### PR TITLE
fix(iq): pong server pings with an absent type, not only type=get

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1194,12 +1194,17 @@ impl Client {
         tracing::instrument(name = "wa.conn.iq_in", level = "debug", skip_all)
     )]
     pub(crate) async fn handle_iq(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) -> bool {
-        if node.get_attr("type").is_some_and(|s| s.as_str() == "get")
+        // Pong a server-initiated ping (a request: type="get" or, like WA Web's
+        // type-agnostic handleIq, an absent type), but not a type="result"/"error"
+        // ping — that's a response to our own ping, and ponging it back is wrong.
+        // The previous gate required type=="get" exactly, dropping an absent-type
+        // ping and risking a keepalive timeout/disconnect.
+        let is_ping_request = node.get_attr("type").is_none_or(|s| s.as_str() == "get")
             && (node.get_optional_child("ping").is_some()
                 || node
                     .get_attr("xmlns")
-                    .is_some_and(|s| s.as_str() == "urn:xmpp:ping"))
-        {
+                    .is_some_and(|s| s.as_str() == "urn:xmpp:ping"));
+        if is_ping_request {
             debug!("Received ping, sending pong.");
             let mut parser = node.attrs();
             let from_jid = parser.jid("from");

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1675,6 +1675,38 @@ async fn test_handle_iq_ping_with_both_child_and_xmlns() {
 }
 
 #[tokio::test]
+async fn test_handle_iq_ping_without_type_attr() {
+    // WA Web pongs for any xmlns="urn:xmpp:ping" regardless of (or absent) type.
+    // A ping with no type attr must still be answered, not dropped.
+    let backend = crate::test_utils::create_test_backend().await;
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager should initialize"),
+    );
+    let (client, _rx) = Client::new(
+        Arc::new(crate::runtime_impl::TokioRuntime),
+        pm,
+        Arc::new(crate::transport::mock::MockTransportFactory::new()),
+        Arc::new(MockHttpClient),
+        None,
+    )
+    .await;
+
+    let ping_node = NodeBuilder::new("iq")
+        .attr("from", SERVER_JID)
+        .attr("id", "ping-notype-1")
+        .attr("xmlns", "urn:xmpp:ping")
+        .build();
+
+    let handled = client.handle_iq(&ping_node.as_node_ref()).await;
+    assert!(
+        handled,
+        "handle_iq must pong a urn:xmpp:ping IQ even without a type attribute"
+    );
+}
+
+#[tokio::test]
 async fn test_handle_iq_non_ping_returns_false() {
     // A type="get" IQ without ping child or xmlns should NOT be handled as ping.
     let backend = crate::test_utils::create_test_backend().await;


### PR DESCRIPTION
The inbound ping handler gated on `type == "get"` exactly, so a `urn:xmpp:ping` IQ with no `type` attribute fell through to the "unhandled IQ" warning and never got a pong — and a missed keepalive pong can make the server consider the client dead (timeout cascade / forced reconnect). WA Web's `handleIq` is type-agnostic: it pongs whenever `xmlns === "urn:xmpp:ping"`.

This relaxes the gate to `type == "get"` **or absent**, so server-initiated pings are always answered. It deliberately keeps *not* ponging a `type="result"`/`"error"` ping: that's a response to our own ping (an unmatched one reaching this handler), and ponging it back is wrong — there's an existing test asserting this, so this is a narrower, safer alignment than WA Web's literal "any type". Added a test for the absent-type case.
