### PR TITLE
refactor(framing): drop dead, would-desync oversize check in decode_frame

### DIFF
--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -110,18 +110,15 @@ impl FrameDecoder {
             return None;
         }
 
+        // The 3-byte length caps frame_len at 0xFFFFFF (= FRAME_MAX_SIZE - 1), so an
+        // oversize read is structurally impossible; the size limit is enforced on
+        // send (encode_frame_into) and WA Web's convertBufferedToFrames likewise
+        // trusts the decoded length. A previous `frame_len > FRAME_MAX_SIZE` branch
+        // here was dead, and its handling (advancing only the 3 length bytes, leaving
+        // the payload to be misread as the next length) would have desynced the stream.
         let frame_len = ((self.buffer[0] as usize) << 16)
             | ((self.buffer[1] as usize) << 8)
             | (self.buffer[2] as usize);
-
-        if frame_len > FRAME_MAX_SIZE {
-            trace!(
-                "Frame length {} exceeds maximum size {}, dropping invalid frame",
-                frame_len, FRAME_MAX_SIZE
-            );
-            self.buffer.advance(FRAME_LENGTH_SIZE);
-            return None;
-        }
 
         if self.buffer.len() >= FRAME_LENGTH_SIZE + frame_len {
             self.buffer.advance(FRAME_LENGTH_SIZE);


### PR DESCRIPTION
`encode_frame` writes the frame length in 3 bytes (max `0xFFFFFF` = `FRAME_MAX_SIZE - 1`), and `decode_frame` reconstructs `frame_len` from exactly those 3 bytes — so `frame_len` is always in `[0, 0xFFFFFF]` and the `frame_len > FRAME_MAX_SIZE` branch was unreachable. It gave the false impression of a read-side size guard.

Worse, if it had ever fired, it advanced only the 3 length bytes and returned `None`, leaving the payload in the buffer to be reinterpreted as the next frame's length — a cascading stream desync — rather than dropping the connection.

The actual size limit is enforced on send (`encode_frame_into` errors at `payload_len >= FRAME_MAX_SIZE`), and the read side trusts the decoded length, matching WA Web's `convertBufferedToFrames`. This removes the dead branch and documents why no read-side guard is needed. `FRAME_MAX_SIZE` stays in use on the send path; existing framing round-trip tests cover `decode_frame`.
