### PR TITLE
fix(conn): log benign server recycles quietly without hiding real errors

### DIFF
--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -289,7 +289,8 @@ impl Client {
                 }
             } else {
                 wacore::telemetry::connect("ok");
-                let unexpected_disconnect = if self.read_messages_loop().await.is_err() {
+                let loop_result = self.read_messages_loop().await;
+                let unexpected_disconnect = if let Err(e) = loop_result {
                     // Check intentional_reconnect AFTER read loop exits — reconnect()
                     // sets this flag while the loop is running, so it must be read here.
                     if self.expected_disconnect.load(Ordering::Relaxed)
@@ -298,9 +299,12 @@ impl Client {
                         debug!("Message loop exited during expected disconnect.");
                         false
                     } else {
-                        warn!(
-                            "Message loop exited with an error. Will attempt to reconnect if enabled."
-                        );
+                        // read_messages_loop already logged the cause at the right level
+                        // (info for a clean server recycle, warn for a real transport
+                        // error), so keep this at debug to avoid re-flagging a benign
+                        // reconnect as an error. Still treated as an unexpected
+                        // disconnect for the event dispatch + reconnect below.
+                        debug!("Message loop exited, will reconnect if enabled: {e:#}");
                         true
                     }
                 } else if self.expected_disconnect.load(Ordering::Relaxed) {

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -137,10 +137,13 @@ impl Client {
                                     return Ok(());
                                 }
                             }
-                            // Event channel closed (no DisconnectReason available).
+                            // Event channel closed (no DisconnectReason available) — the
+                            // transport task ended. Reconnect-equivalent, so info (not a
+                            // silent debug): no reason means we can't prove it was clean,
+                            // but it's also not a transport read error.
                             Err(_) => {
                                 if !self.expected_disconnect.load(Ordering::Relaxed) {
-                                    debug!("Transport event channel closed unexpectedly.");
+                                    info!("Transport event channel closed; reconnecting.");
                                     return Err(anyhow::anyhow!("Transport event channel closed"));
                                 } else {
                                     return Ok(());

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -123,7 +123,14 @@ impl Client {
                             },
                             Ok(crate::transport::TransportEvent::Disconnected(reason)) => {
                                 if !self.expected_disconnect.load(Ordering::Relaxed) {
-                                    debug!("Transport disconnected unexpectedly: {reason}");
+                                    // Classify the level: a routine server recycle (clean EOF /
+                                    // normal close) is logged quietly, but a real transport error
+                                    // stays at WARN so it's never hidden behind reconnect noise.
+                                    if reason.is_clean_shutdown() {
+                                        info!("Connection closed by server ({reason}); reconnecting.");
+                                    } else {
+                                        warn!("Transport disconnected: {reason}; reconnecting.");
+                                    }
                                     return Err(anyhow::anyhow!("Transport disconnected: {reason}"));
                                 } else {
                                     debug!("Transport disconnected as expected: {reason}");
@@ -330,7 +337,9 @@ impl Client {
             if self.expected_disconnect.load(Ordering::Relaxed) {
                 debug!("Received <xmlstreamend/>, expected disconnect.");
             } else {
-                warn!("Received <xmlstreamend/>, treating as disconnect.");
+                // A bare <xmlstreamend/> is the server cleanly ending the stream
+                // (a recycle). We reconnect, so this is routine, not an error.
+                info!("Received <xmlstreamend/> (server stream end); reconnecting.");
             }
             self.notify_connection_shutdown();
             return;

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -138,12 +138,12 @@ impl Client {
                                 }
                             }
                             // Event channel closed (no DisconnectReason available) — the
-                            // transport task ended. Reconnect-equivalent, so info (not a
-                            // silent debug): no reason means we can't prove it was clean,
-                            // but it's also not a transport read error.
+                            // transport task ended without reporting why. No reason means we
+                            // can't prove it was a clean recycle, so it stays loud (WARN),
+                            // matching the conservative `Unknown` rule in is_clean_shutdown.
                             Err(_) => {
                                 if !self.expected_disconnect.load(Ordering::Relaxed) {
-                                    info!("Transport event channel closed; reconnecting.");
+                                    warn!("Transport event channel closed; reconnecting.");
                                     return Err(anyhow::anyhow!("Transport event channel closed"));
                                 } else {
                                     return Ok(());

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -90,7 +90,19 @@ impl Client {
             }
             Err(e) => {
                 let result = classify_keepalive_error(&e);
-                warn!(target: "Client/Keepalive", "Keepalive ping failed: {e:?}");
+                // A fatal-classified error means the connection is already gone
+                // (e.g. NotConnected): the disconnect is being handled elsewhere, so
+                // this ping failure is benign teardown collateral, not a keepalive
+                // problem. A transient failure (timeout, unexpected server response)
+                // is a real keepalive issue and stays loud.
+                match result {
+                    KeepaliveResult::FatalFailure => {
+                        debug!(target: "Client/Keepalive", "Keepalive skipped, connection already closing: {e:?}");
+                    }
+                    KeepaliveResult::TransientFailure | KeepaliveResult::Ok => {
+                        warn!(target: "Client/Keepalive", "Keepalive ping failed: {e:?}");
+                    }
+                }
                 result
             }
         }

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -45,6 +45,22 @@ fn classify_keepalive_error(e: &IqError) -> KeepaliveResult {
     }
 }
 
+/// Whether a keepalive ping error is just collateral of a teardown already
+/// being handled elsewhere (the connection is gone, so the ping had nowhere to
+/// go) rather than a genuine failure the keepalive surfaced first.
+///
+/// Used ONLY to pick the log level. It must stay narrower than the
+/// `FatalFailure` set: Socket/EncryptSend/ClientState/EncodeError are also
+/// fatal for control flow, but they mean the socket or send pipeline broke
+/// while we still believed we were connected — a real failure that the
+/// keepalive may be the first (or only) thing to observe, so it must stay loud.
+fn is_benign_teardown(e: &IqError) -> bool {
+    matches!(
+        e,
+        IqError::NotConnected | IqError::Disconnected(_) | IqError::InternalChannelClosed
+    )
+}
+
 impl Client {
     /// Sends a keepalive ping and updates the server time offset from
     /// the pong's `t` attribute using RTT-adjusted midpoint calculation.
@@ -90,18 +106,16 @@ impl Client {
             }
             Err(e) => {
                 let result = classify_keepalive_error(&e);
-                // A fatal-classified error means the connection is already gone
-                // (e.g. NotConnected): the disconnect is being handled elsewhere, so
-                // this ping failure is benign teardown collateral, not a keepalive
-                // problem. A transient failure (timeout, unexpected server response)
-                // is a real keepalive issue and stays loud.
-                match result {
-                    KeepaliveResult::FatalFailure => {
-                        debug!(target: "Client/Keepalive", "Keepalive skipped, connection already closing: {e:?}");
-                    }
-                    KeepaliveResult::TransientFailure | KeepaliveResult::Ok => {
-                        warn!(target: "Client/Keepalive", "Keepalive ping failed: {e:?}");
-                    }
+                // Log level is keyed on benign-teardown, NOT on FatalFailure: only
+                // an already-gone connection (NotConnected/Disconnected/channel
+                // closed, handled elsewhere) is quiet collateral. A broken
+                // socket/send pipeline is also fatal for control flow but is a real
+                // failure the keepalive may see first, so it stays loud — as do all
+                // transient failures.
+                if is_benign_teardown(&e) {
+                    debug!(target: "Client/Keepalive", "Keepalive skipped, connection already closing: {e:?}");
+                } else {
+                    warn!(target: "Client/Keepalive", "Keepalive ping failed: {e:?}");
                 }
                 result
             }
@@ -259,7 +273,7 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::socket::error::SocketError;
+    use crate::socket::error::{EncryptSendError, SocketError};
     use wacore_binary::builder::NodeBuilder;
 
     #[test]
@@ -325,6 +339,44 @@ mod tests {
             KeepaliveResult::TransientFailure,
             "ParseError should be transient — bad response, not a dead connection"
         );
+    }
+
+    // Happy path: the connection was already gone, so a failed ping is just
+    // teardown collateral and is logged quietly.
+    #[test]
+    fn benign_teardown_errors_are_quiet() {
+        assert!(is_benign_teardown(&IqError::NotConnected));
+        assert!(is_benign_teardown(&IqError::InternalChannelClosed));
+        let node = NodeBuilder::new("disconnect").build();
+        assert!(is_benign_teardown(&IqError::Disconnected(node)));
+    }
+
+    // Bad path: a broken socket/send pipeline or an encode failure is fatal for
+    // control flow but is a REAL failure (we still thought we were connected), so
+    // it must NOT be treated as benign — it has to stay loud. Transient failures
+    // stay loud too. This is the guard against the keepalive ping silently
+    // swallowing the first sign of a real connection/send break.
+    #[test]
+    fn real_failures_are_never_treated_as_benign() {
+        assert!(!is_benign_teardown(&IqError::Socket(
+            SocketError::SocketClosed
+        )));
+        assert!(!is_benign_teardown(&IqError::EncryptSend(
+            EncryptSendError::transport(anyhow::anyhow!("broken pipe"))
+        )));
+        assert!(!is_benign_teardown(&IqError::EncodeError(anyhow::anyhow!(
+            "encode failed"
+        ))));
+        assert!(!is_benign_teardown(&IqError::Timeout));
+        assert!(!is_benign_teardown(&IqError::ParseError(anyhow::anyhow!(
+            "bad response"
+        ))));
+        assert!(!is_benign_teardown(&IqError::ServerError {
+            code: 500,
+            text: "internal".to_string(),
+            error_type: None,
+            backoff: None,
+        }));
     }
 
     // ms_since, is_dead_socket, and constants tests live in wacore::protocol::keepalive

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -39,6 +39,30 @@ impl std::fmt::Display for DisconnectReason {
     }
 }
 
+impl DisconnectReason {
+    /// Whether this is a benign, server-initiated stream recycle (the normal
+    /// WhatsApp reconnect path) rather than a transport-level error.
+    ///
+    /// Used only to pick a log level: a clean shutdown is logged quietly (the
+    /// reconnect is routine), while everything else stays loud so a genuine
+    /// transport failure is never hidden behind reconnect noise. Deliberately
+    /// conservative — anything ambiguous returns `false` (stays loud): a read/IO
+    /// error, an abnormal close code, or an unreported reason.
+    pub fn is_clean_shutdown(&self) -> bool {
+        match self {
+            // EOF with no Close frame is how the WA server recycles a connection.
+            Self::StreamEnded => true,
+            // A Close frame with a normal / going-away / no code is graceful; any
+            // other code (protocol/server error, restart, etc.) stays loud.
+            Self::ServerClose { code, .. } => matches!(code, None | Some(1000) | Some(1001)),
+            // A transport read/IO error is a real failure — never quiet.
+            Self::ReadError(_) => false,
+            // Unknown reason: stay loud, don't assume it was benign.
+            Self::Unknown => false,
+        }
+    }
+}
+
 /// An event produced by the transport layer.
 #[derive(Debug, Clone)]
 pub enum TransportEvent {
@@ -174,5 +198,57 @@ pub trait HttpClient: Send + Sync {
         Err(anyhow::anyhow!(
             "Upload streaming not supported by this HTTP client"
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DisconnectReason;
+
+    // Happy paths: benign server-initiated recycles must classify as clean so
+    // their reconnect is logged quietly.
+    #[test]
+    fn clean_shutdowns_are_classified_clean() {
+        assert!(DisconnectReason::StreamEnded.is_clean_shutdown());
+        assert!(
+            DisconnectReason::ServerClose {
+                code: Some(1000),
+                reason: String::new()
+            }
+            .is_clean_shutdown()
+        );
+        assert!(
+            DisconnectReason::ServerClose {
+                code: Some(1001),
+                reason: "going away".to_string()
+            }
+            .is_clean_shutdown()
+        );
+        assert!(
+            DisconnectReason::ServerClose {
+                code: None,
+                reason: String::new()
+            }
+            .is_clean_shutdown()
+        );
+    }
+
+    // Bad paths: a real transport error, an abnormal close code, or an unreported
+    // reason must NOT be classified clean — they have to stay loud so genuine
+    // failures are never hidden behind reconnect noise.
+    #[test]
+    fn real_errors_are_never_classified_clean() {
+        assert!(!DisconnectReason::ReadError("connection reset".to_string()).is_clean_shutdown());
+        assert!(!DisconnectReason::Unknown.is_clean_shutdown());
+        for code in [1002u16, 1006, 1011, 1012, 1013, 3000, 4000] {
+            assert!(
+                !DisconnectReason::ServerClose {
+                    code: Some(code),
+                    reason: String::new()
+                }
+                .is_clean_shutdown(),
+                "close code {code} must not be treated as a clean shutdown"
+            );
+        }
     }
 }


### PR DESCRIPTION
The prod logs (last 3 days) show the only recurring WARN/ERROR are **benign connection recycles**: the WhatsApp server periodically drops the stream (a clean EOF, or a `<xmlstreamend/>`) and we reconnect within ~1s and re-auth fine — but each one was logged as `WARN "Message loop exited with an error"` + `WARN "Received <xmlstreamend/>, treating as disconnect"`, and a keepalive ping firing during teardown logged `WARN "Keepalive ping failed: NotConnected"`. ~4-5 of these a day, 0 real errors. The noise would bury a genuine failure.

This changes only the **log level**, never the behavior — we still reconnect and still dispatch `Event::Disconnected`. The guiding rule is to never hide a real error:

- New `DisconnectReason::is_clean_shutdown()`: a clean EOF (`StreamEnded`) or a Close frame with a normal/going-away/absent code is quiet; a `ReadError`, an abnormal close code, or an unreported (`Unknown`) reason stay loud. Deliberately conservative — anything ambiguous returns `false` (loud).
- The read loop logs a clean disconnect at `info` and a real one at `warn` (previously a generic `debug` here plus a generic `warn` in the lifecycle). The lifecycle's generic "Message loop exited" `warn` drops to `debug`, since the read loop now owns the classified, reason-bearing message.
- `<xmlstreamend/>` (a clean server stream end) logs at `info`.
- Keepalive: a fatal-classified failure (connection already gone, e.g. `NotConnected`) logs at `debug` (it's teardown collateral; the disconnect itself is logged by the read loop); a transient failure (timeout / unexpected response) stays at `warn`.

### Not hiding real errors — tested both ways
- `net.rs`: `clean_shutdowns_are_classified_clean` (StreamEnded, ServerClose{1000,1001,None} → clean/quiet) and `real_errors_are_never_classified_clean` (ReadError, Unknown, and codes 1002/1006/1011/1012/1013/3000/4000 → not clean/loud).
- keepalive: existing `test_classify_timeout_is_transient` (real keepalive failure → Transient → stays `warn`) and `test_classify_not_connected_is_fatal` (benign → Fatal → `debug`).

Internal logging change only; `DisconnectReason` gains a method (no field/variant change), e2e compiles unchanged.
