### PR TITLE
perf(appstate): move snapshot mutations into the accumulator instead of extend

### DIFF
--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -307,7 +307,18 @@ impl AppStateProcessor {
             let (snapshot_result, snapshot_state) = result;
             state = snapshot_state;
 
-            new_mutations.extend(snapshot_result.mutations);
+            // The snapshot carries the whole collection, so its decoded Vec<Mutation>
+            // is the largest single allocation of a bootstrap. new_mutations was just
+            // initialized empty above and the snapshot branch runs before the patch
+            // loop, so move the Vec in instead of allocating a second buffer and
+            // copying every Mutation (extend on an empty Vec reallocates + memcpy with
+            // the source still live, doubling the peak). The is_empty guard keeps it
+            // correct if a future change ever pushes before this point.
+            if new_mutations.is_empty() {
+                new_mutations = snapshot_result.mutations;
+            } else {
+                new_mutations.extend(snapshot_result.mutations);
+            }
 
             // A snapshot is a fresh baseline, so wipe the collection's prior mutation
             // MACs first (unconditionally, even if the snapshot has none) — leftover

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -307,13 +307,9 @@ impl AppStateProcessor {
             let (snapshot_result, snapshot_state) = result;
             state = snapshot_state;
 
-            // The snapshot carries the whole collection, so its decoded Vec<Mutation>
-            // is the largest single allocation of a bootstrap. new_mutations was just
-            // initialized empty above and the snapshot branch runs before the patch
-            // loop, so move the Vec in instead of allocating a second buffer and
-            // copying every Mutation (extend on an empty Vec reallocates + memcpy with
-            // the source still live, doubling the peak). The is_empty guard keeps it
-            // correct if a future change ever pushes before this point.
+            // Snapshot owns the whole collection: move its Vec into the empty
+            // accumulator rather than extend, which would allocate + copy a second
+            // collection-sized buffer at the memory peak. is_empty falls back to extend.
             if new_mutations.is_empty() {
                 new_mutations = snapshot_result.mutations;
             } else {


### PR DESCRIPTION
## Problem

When applying an app-state snapshot, `process_patch_list` builds the decoded `Vec<Mutation>` in `process_snapshot` and then does `new_mutations.extend(snapshot_result.mutations)`. `new_mutations` was just initialized empty, so `extend` allocates a fresh second buffer and copies every `Mutation` into it while the source `Vec` is still alive. For an initial app-state sync the snapshot carries the whole collection, so that decoded `Vec<Mutation>` is the single largest allocation of the bootstrap, and the copy briefly doubles it at the memory peak.

This is on the app-state bootstrap/resume path (`process_snapshot` -> `update_hash_from_records`), the same path the `appstate` benchmark scenario exercises.

## Change

When `new_mutations` is empty (the snapshot branch runs before the patch loop), move the decoded `Vec` in instead of extending into a freshly allocated buffer. The `extend` path stays behind an `is_empty()` guard so it remains correct if a future change ever pushes into `new_mutations` before this point. Behavior is identical (same mutations, same order: snapshot first, then patches); only the transient peak allocation and the per-Mutation memcpy are removed.

## Benchmark

Measured A/B with the local harness (mock server + single client process), `main` vs this branch, scenario `appstate` with 20001 seeded mutations in a critical-block snapshot, sampling `/proc` plus a dhat allocator pass. dhat numbers are deterministic for a fixed workload.

| metric | main | this branch | delta |
|---|---|---|---|
| dhat peak (t-gmax) | 142.51 MB | 86.88 MB | -55.6 MB (-39%) |
| dhat total allocated | 203.62 MB | 142.84 MB | -60.8 MB (-30%) |
| RSS peak (VmHWM, kernel) | 168.4 MB | 112.4 MB | -56 MB (-33%) |
| heap RssAnon peak | 82.7 MB | 57.1 MB | -25.6 MB (-31%) |

dhat call-site view: on `main` two ~60.9 MB live blocks coexist at the peak (the `Vec<Mutation>` built inside `process_snapshot` and the second buffer from `extend`); on this branch only one remains (the `extend` site is gone). Same `mutations`/`mutation_macs` output, snapshot applied identically (connected, snapshot_served=1 in both).

## Tests

This is a behavior-identical refactor (move vs extend into an empty Vec yields the same contents and order), so there is no new behavior to lock with a fresh assertion; the existing suite is the regression guard.

- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p wacore -p wacore-appstate`: 1002 passed, 0 failed (includes `process_snapshot` and app-state sync unit/integration tests that exercise this path).
- e2e app-state sync runs in CI.

## Breaking

None.
