### PR TITLE
fix(adv): fall back to stored account identity for ADV account_signature_key

### DIFF
--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -73,6 +73,14 @@ impl Client {
             None => PreKeyFetchSpec::new(jids.to_vec()),
         };
 
+        // Pre-load each companion's account (device 0) identity as the ADV
+        // `account_signature_key` fallback: the server omits that field from a
+        // contact's companion `<device-identity>` because it's the contact's
+        // primary identity the client already stores. Without it we'd reject the
+        // bundle and the device would stop receiving (WA Web uses the same stored
+        // identity as the fallback in validateADVwithIdentityKey).
+        let spec = spec.with_account_identities(self.collect_account_identities(jids).await);
+
         let bundles = self.execute(spec).await?;
 
         for jid in bundles.keys() {
@@ -80,6 +88,56 @@ impl Client {
         }
 
         Ok(bundles)
+    }
+
+    /// Load, for each companion JID, its account (device 0) identity key from the
+    /// store, keyed by the normalized companion JID so the prekey parser can use
+    /// it as the ADV `account_signature_key` fallback. Missing entries are simply
+    /// absent (no fallback for that JID).
+    async fn collect_account_identities(
+        &self,
+        jids: &[Jid],
+    ) -> std::collections::HashMap<Jid, [u8; 32]> {
+        let mut map = std::collections::HashMap::new();
+        for jid in jids.iter().filter(|j| j.device != 0) {
+            if let Some(id) = self.load_account_identity(jid).await {
+                map.insert(jid.normalize_for_prekey_bundle(), id);
+            }
+        }
+        map
+    }
+
+    /// Load a companion's account (device 0) identity from the store, for use as
+    /// the ADV `account_signature_key` fallback (WA Web `validateADVwithIdentityKey`
+    /// loads the same stored identity). Reads through the signal cache so an
+    /// identity established earlier this session (not yet flushed) is still found.
+    /// `None` when not stored.
+    pub(crate) async fn load_account_identity(&self, companion_jid: &Jid) -> Option<[u8; 32]> {
+        use wacore::types::jid::JidExt;
+
+        let account_jid = companion_jid.with_device(0);
+        let addr = account_jid.to_protocol_address();
+        let backend = {
+            let device_store = self.persistence_manager.get_device_arc().await;
+            let guard = device_store.read().await;
+            guard.backend.clone()
+        };
+        match self.signal_cache.get_identity(&addr, &*backend).await {
+            Ok(Some(id)) if id.len() == 32 => {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&id);
+                Some(arr)
+            }
+            Ok(_) => None,
+            Err(e) => {
+                log::debug!(
+                    "ADV fallback: failed to load account identity for {}: {}",
+                    account_jid.observe(),
+                    e
+                );
+                None
+            }
+        }
     }
 
     /// Query the WhatsApp server for how many pre-keys it currently has for this device.

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -923,7 +923,10 @@ impl Client {
 
         // Companion devices ADV-bind the fetched identity via <device-identity>;
         // reject a present-but-invalid one so a relay can't swap in a forged key.
-        // Mirrors the prekey-fetch path; a missing one is logged, not fatal.
+        // Mirrors the prekey-fetch path. The account key is the in-blob
+        // `account_signature_key` or, when the server omits it, the contact's
+        // primary (device 0) identity from the store. An unverifiable-for-lack-of-key
+        // chain or a missing device-identity is logged, not fatal.
         if requester_jid.device != 0
             && let Some(device_identity) = keys_node
                 .get_optional_child("device-identity")
@@ -932,10 +935,21 @@ impl Client {
             let fetched_identity: [u8; 32] = identity_bytes
                 .try_into()
                 .map_err(|_| anyhow::anyhow!("identity key in retry receipt is not 32 bytes"))?;
-            if !wacore::adv::validate_adv_with_identity_key(device_identity, &fetched_identity) {
-                return Err(anyhow::anyhow!(
-                    "device-identity ADV validation failed for companion {requester_jid}"
-                ));
+            let account_identity = self.load_account_identity(requester_jid).await;
+            match wacore::adv::validate_adv_with_identity_key(
+                device_identity,
+                &fetched_identity,
+                account_identity.as_ref(),
+            ) {
+                wacore::adv::AdvValidation::Valid => {}
+                wacore::adv::AdvValidation::Invalid => {
+                    return Err(anyhow::anyhow!(
+                        "device-identity ADV validation failed for companion {requester_jid}"
+                    ));
+                }
+                wacore::adv::AdvValidation::NoAccountKey => log::warn!(
+                    "retry key bundle for companion {requester_jid} omits account_signature_key and no stored account identity; proceeding without ADV validation"
+                ),
             }
         } else if requester_jid.device != 0 {
             log::warn!(

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -16,6 +16,22 @@ const ADV_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 1];
 const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 5];
 const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 6];
 
+/// Outcome of validating a fetched companion device's `ADVSignedDeviceIdentity`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdvValidation {
+    /// Both signatures verified against an available account key — trusted.
+    Valid,
+    /// The blob is malformed, or the signatures failed to verify against an
+    /// available account key. A relay swapping in a forged identity lands here;
+    /// the caller must reject the bundle.
+    Invalid,
+    /// No account key was available: the blob omits `account_signature_key` and
+    /// no trusted account identity was passed as a fallback, so the chain can't
+    /// be checked at all. The caller decides what to do (we log and proceed,
+    /// matching the existing "device-identity absent" handling).
+    NoAccountKey,
+}
+
 /// Verify a fetched companion device's `ADVSignedDeviceIdentity` binds the
 /// fetched identity key to the account's ADV chain, mirroring WA Web
 /// `WAWebAdvSignatureApi.validateADVwithIdentityKey`.
@@ -28,30 +44,47 @@ const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 6];
 /// the hosted prefix set rather than replicating WA Web's `bizHostedDevicesEnabled`
 /// gating: the prefix is only a domain separator, so accepting whichever the
 /// signer used stays sound (an attacker still can't forge the account signature).
+///
+/// The account key is `blob.account_signature_key || account_identity_fallback`,
+/// exactly as WA Web's `P`/`w` helpers (`e.accountSignatureKey || t`): the server
+/// legitimately omits `account_signature_key` for a contact's companion device
+/// because it's the contact's primary (device 0) identity the client already
+/// holds, so the caller passes that stored identity as the fallback. When neither
+/// source has a key the chain is unverifiable and we return `NoAccountKey` rather
+/// than rejecting a bundle we simply lack the material to check.
 pub fn validate_adv_with_identity_key(
     device_identity_bytes: &[u8],
     fetched_identity_key: &[u8; 32],
-) -> bool {
+    account_identity_fallback: Option<&[u8; 32]>,
+) -> AdvValidation {
     let Ok(signed) = waproto::whatsapp::AdvSignedDeviceIdentity::decode(device_identity_bytes)
     else {
-        return false;
+        return AdvValidation::Invalid;
     };
-    let (Some(details), Some(account_key), Some(account_sig), Some(device_sig)) = (
+    let (Some(details), Some(account_sig), Some(device_sig)) = (
         signed.details.as_deref(),
-        signed.account_signature_key.as_deref(),
         signed.account_signature.as_deref(),
         signed.device_signature.as_deref(),
     ) else {
-        return false;
+        return AdvValidation::Invalid;
+    };
+    // WA Web `e.accountSignatureKey || t`: prefer the in-blob key, else the
+    // caller-supplied trusted identity. An empty field counts as absent.
+    let account_key: &[u8] = match signed.account_signature_key.as_deref() {
+        Some(k) if !k.is_empty() => k,
+        _ => match account_identity_fallback {
+            Some(f) => f.as_slice(),
+            None => return AdvValidation::NoAccountKey,
+        },
     };
     let (Ok(account_pub), Ok(device_pub)) = (
         PublicKey::from_djb_public_key_bytes(account_key),
         PublicKey::from_djb_public_key_bytes(fetched_identity_key),
     ) else {
-        return false;
+        return AdvValidation::Invalid;
     };
 
-    [
+    let verified = [
         (ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE),
         (
             ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
@@ -64,7 +97,13 @@ pub fn validate_adv_with_identity_key(
         let device_msg = [device_prefix, details, fetched_identity_key, account_key].concat();
         account_pub.verify_signature(&account_msg, account_sig)
             && device_pub.verify_signature(&device_msg, device_sig)
-    })
+    });
+
+    if verified {
+        AdvValidation::Valid
+    } else {
+        AdvValidation::Invalid
+    }
 }
 
 /// Decoded fields from `ADVKeyIndexList` protobuf.
@@ -285,11 +324,16 @@ mod tests {
 
     use crate::libsignal::protocol::KeyPair;
 
-    fn signed_identity(
+    /// Build a signed device-identity. When `include_account_key` is false the
+    /// `account_signature_key` field is omitted (the trimmed shape the real
+    /// server sends for a contact's companion device); the signatures are still
+    /// made with the account key so a fallback can verify them.
+    fn signed_identity_opts(
         account: &KeyPair,
         device: &KeyPair,
         details: &[u8],
         hosted: bool,
+        include_account_key: bool,
     ) -> Vec<u8> {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let identity = device.public_key.public_key_bytes();
@@ -317,11 +361,20 @@ mod tests {
             .to_vec();
         waproto::whatsapp::AdvSignedDeviceIdentity {
             details: Some(details.to_vec()),
-            account_signature_key: Some(account_key.to_vec()),
+            account_signature_key: include_account_key.then(|| account_key.to_vec()),
             account_signature: Some(account_sig),
             device_signature: Some(device_sig),
         }
         .encode_to_vec()
+    }
+
+    fn signed_identity(
+        account: &KeyPair,
+        device: &KeyPair,
+        details: &[u8],
+        hosted: bool,
+    ) -> Vec<u8> {
+        signed_identity_opts(account, device, details, hosted, true)
     }
 
     fn id32(kp: &KeyPair) -> [u8; 32] {
@@ -334,7 +387,10 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         let bytes = signed_identity(&account, &device, b"details", false);
-        assert!(validate_adv_with_identity_key(&bytes, &id32(&device)));
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&device), None),
+            AdvValidation::Valid
+        );
     }
 
     #[test]
@@ -343,7 +399,10 @@ mod tests {
         let account = KeyPair::generate(&mut rng);
         let device = KeyPair::generate(&mut rng);
         let bytes = signed_identity(&account, &device, b"hosted-details", true);
-        assert!(validate_adv_with_identity_key(&bytes, &id32(&device)));
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&device), None),
+            AdvValidation::Valid
+        );
     }
 
     #[test]
@@ -355,7 +414,10 @@ mod tests {
         let device = KeyPair::generate(&mut rng);
         let attacker = KeyPair::generate(&mut rng);
         let bytes = signed_identity(&account, &device, b"details", false);
-        assert!(!validate_adv_with_identity_key(&bytes, &id32(&attacker)));
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&attacker), None),
+            AdvValidation::Invalid
+        );
     }
 
     #[test]
@@ -370,16 +432,79 @@ mod tests {
             device_signature: None,
         }
         .encode_to_vec();
-        assert!(!validate_adv_with_identity_key(&no_dev_sig, &id32(&device)));
+        assert_eq!(
+            validate_adv_with_identity_key(&no_dev_sig, &id32(&device), None),
+            AdvValidation::Invalid
+        );
     }
 
     #[test]
     fn adv_chain_rejects_garbage() {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let device = KeyPair::generate(&mut rng);
-        assert!(!validate_adv_with_identity_key(
-            &[1, 2, 3, 4],
-            &id32(&device)
-        ));
+        assert_eq!(
+            validate_adv_with_identity_key(&[1, 2, 3, 4], &id32(&device), None),
+            AdvValidation::Invalid
+        );
+    }
+
+    // The real server omits account_signature_key for a contact's companion
+    // device. With the contact's primary identity supplied as the fallback, the
+    // chain verifies — this is the regression #772 broke (it rejected outright).
+    #[test]
+    fn adv_chain_missing_account_key_verifies_with_fallback() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let bytes = signed_identity_opts(&account, &device, b"details", false, false);
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&device), Some(&id32(&account))),
+            AdvValidation::Valid
+        );
+    }
+
+    // No in-blob key and no fallback: the chain is unverifiable, so we must NOT
+    // reject (that would drop a legitimate device); the caller proceeds.
+    #[test]
+    fn adv_chain_missing_account_key_no_fallback_is_no_account_key() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let bytes = signed_identity_opts(&account, &device, b"details", false, false);
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&device), None),
+            AdvValidation::NoAccountKey
+        );
+    }
+
+    // A wrong fallback (relay-supplied account identity) must NOT verify: the
+    // account signature was made by the real account key, so a mismatched
+    // fallback yields Invalid, preserving the forgery protection.
+    #[test]
+    fn adv_chain_missing_account_key_wrong_fallback_is_invalid() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let attacker = KeyPair::generate(&mut rng);
+        let bytes = signed_identity_opts(&account, &device, b"details", false, false);
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&device), Some(&id32(&attacker))),
+            AdvValidation::Invalid
+        );
+    }
+
+    // The in-blob key takes precedence over the fallback (WA Web `|| t`): a valid
+    // full blob still verifies even if an unrelated fallback is passed.
+    #[test]
+    fn adv_chain_in_blob_key_takes_precedence_over_fallback() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let unrelated = KeyPair::generate(&mut rng);
+        let bytes = signed_identity(&account, &device, b"details", false);
+        assert_eq!(
+            validate_adv_with_identity_key(&bytes, &id32(&device), Some(&id32(&unrelated))),
+            AdvValidation::Valid
+        );
     }
 }

--- a/wacore/src/iq/prekeys.rs
+++ b/wacore/src/iq/prekeys.rs
@@ -110,18 +110,36 @@ pub enum PreKeyFetchReason {
 pub struct PreKeyFetchSpec {
     pub jids: Vec<Jid>,
     pub reason: Option<PreKeyFetchReason>,
+    /// Per-companion-JID account (device 0) identity keys, used as the ADV
+    /// `account_signature_key` fallback when the server omits it from
+    /// `<device-identity>`. Empty when the caller has no stored fallback.
+    pub account_identities: std::collections::HashMap<Jid, [u8; 32]>,
 }
 
 impl PreKeyFetchSpec {
     pub fn new(jids: Vec<Jid>) -> Self {
-        Self { jids, reason: None }
+        Self {
+            jids,
+            reason: None,
+            account_identities: std::collections::HashMap::new(),
+        }
     }
 
     pub fn with_reason(jids: Vec<Jid>, reason: PreKeyFetchReason) -> Self {
         Self {
             jids,
             reason: Some(reason),
+            account_identities: std::collections::HashMap::new(),
         }
+    }
+
+    /// Attach the ADV account-identity fallbacks (see [`Self::account_identities`]).
+    pub fn with_account_identities(
+        mut self,
+        account_identities: std::collections::HashMap<Jid, [u8; 32]>,
+    ) -> Self {
+        self.account_identities = account_identities;
+        self
     }
 }
 
@@ -142,7 +160,7 @@ impl IqSpec for PreKeyFetchSpec {
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        PreKeyUtils::parse_prekeys_response(response)
+        PreKeyUtils::parse_prekeys_response(response, &self.account_identities)
     }
 }
 

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -158,8 +158,16 @@ impl PreKeyUtils {
         ]
     }
 
+    /// Parse a prekey-fetch response into bundles.
+    ///
+    /// `account_identities` maps a (normalized) companion JID to its account's
+    /// primary (device 0) identity key, used as the ADV `account_signature_key`
+    /// fallback when the server omits that field from `<device-identity>` (the
+    /// normal case for a contact's companion device). The caller pre-loads these
+    /// from the identity store; pass an empty map when no fallback is available.
     pub fn parse_prekeys_response(
         resp_node: &NodeRef<'_>,
+        account_identities: &HashMap<Jid, [u8; 32]>,
     ) -> Result<HashMap<Jid, PreKeyBundle>, anyhow::Error> {
         let list_node = resp_node
             .get_optional_child("list")
@@ -186,13 +194,15 @@ impl PreKeyUtils {
                 jid.user = CompactString::from(user_base);
                 jid.device = device;
             }
-            let bundle = match Self::node_to_pre_key_bundle_ref(&jid, user_node_ref) {
-                Ok(b) => b,
-                Err(e) => {
-                    log::warn!("Failed to parse prekey bundle for {}: {}", jid, e);
-                    continue;
-                }
-            };
+            let account_identity = account_identities.get(&jid);
+            let bundle =
+                match Self::node_to_pre_key_bundle_ref(&jid, user_node_ref, account_identity) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::warn!("Failed to parse prekey bundle for {}: {}", jid, e);
+                        continue;
+                    }
+                };
             bundles.insert(jid, bundle);
         }
 
@@ -202,6 +212,7 @@ impl PreKeyUtils {
     fn node_to_pre_key_bundle_ref(
         jid: &Jid,
         node: &NodeRef<'_>,
+        account_identity: Option<&[u8; 32]>,
     ) -> Result<PreKeyBundle, anyhow::Error> {
         use crate::xml::DisplayableNodeRef;
         use wacore_binary::NodeContentRef;
@@ -272,10 +283,13 @@ impl PreKeyUtils {
 
         // Companion devices (device != 0) carry a <device-identity> that ADV-binds
         // the fetched identity key to the account, so a relay can't substitute a
-        // fabricated identity. Matches WA Web SessionApi.createSignalSession. When
-        // present-but-invalid we reject the bundle (the loop skips that device); a
-        // missing one is logged but not fatal, since the live/mock server set that
-        // omits it is unverified (WA Web throws here).
+        // fabricated identity. Matches WA Web SessionApi.createSignalSession. The
+        // account key is the in-blob `account_signature_key` or, when the server
+        // omits it (the normal case for a contact's companion), the account's
+        // primary identity from the store (`account_identity`). Invalid → reject
+        // the bundle; a missing device-identity or an unverifiable-for-lack-of-key
+        // chain is logged but not fatal (WA Web throws here, but our store-set is
+        // best-effort and a relay could already strip <device-identity> entirely).
         if jid.device != 0 {
             let device_identity = node
                 .get_optional_child("device-identity")
@@ -285,14 +299,21 @@ impl PreKeyUtils {
                     _ => None,
                 });
             match device_identity {
-                Some(di)
-                    if !crate::adv::validate_adv_with_identity_key(di, &identity_key_array) =>
-                {
-                    return Err(anyhow::anyhow!(
-                        "device-identity ADV validation failed for companion {jid}"
-                    ));
-                }
-                Some(_) => {}
+                Some(di) => match crate::adv::validate_adv_with_identity_key(
+                    di,
+                    &identity_key_array,
+                    account_identity,
+                ) {
+                    crate::adv::AdvValidation::Valid => {}
+                    crate::adv::AdvValidation::Invalid => {
+                        return Err(anyhow::anyhow!(
+                            "device-identity ADV validation failed for companion {jid}"
+                        ));
+                    }
+                    crate::adv::AdvValidation::NoAccountKey => log::warn!(
+                        "prekey bundle for companion {jid} omits account_signature_key and no stored account identity; proceeding without ADV validation"
+                    ),
+                },
                 None => log::warn!(
                     "prekey bundle for companion {jid} omits <device-identity>; proceeding without ADV validation"
                 ),
@@ -432,8 +453,8 @@ mod tests {
             .children([NodeBuilder::new("list").children([user_node]).build()])
             .build();
 
-        let bundles =
-            PreKeyUtils::parse_prekeys_response(&response.as_node_ref()).expect("parse bundles");
+        let bundles = PreKeyUtils::parse_prekeys_response(&response.as_node_ref(), &HashMap::new())
+            .expect("parse bundles");
         assert!(bundles.contains_key(&base_jid));
         assert!(!bundles.contains_key(&raw_jid));
 
@@ -451,7 +472,8 @@ mod tests {
         let response = NodeBuilder::new("iq")
             .children([NodeBuilder::new("list").children([user_node]).build()])
             .build();
-        PreKeyUtils::parse_prekeys_response(&response.as_node_ref()).expect("parse bundles")
+        PreKeyUtils::parse_prekeys_response(&response.as_node_ref(), &HashMap::new())
+            .expect("parse bundles")
     }
 
     #[test]
@@ -464,6 +486,28 @@ mod tests {
         );
     }
 
+    // A trimmed device-identity (no account_signature_key) with no stored
+    // account-identity fallback is unverifiable, not forged: the bundle must be
+    // KEPT (proceed without ADV), otherwise the companion stops receiving. This
+    // is the regression #772 introduced (it dropped the bundle outright).
+    #[test]
+    fn parse_keeps_companion_bundle_when_account_key_omitted_and_no_fallback() {
+        use crate::libsignal::protocol::KeyPair;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let account = KeyPair::generate(&mut rng);
+        let device = KeyPair::generate(&mut rng);
+        let companion = Jid::lid_device("100000012345678", 33);
+        // device-identity without account_signature_key, signatures over the
+        // bundle's identity key (create_mock_bundle's identity is unrelated, but
+        // the NoAccountKey path short-circuits before signature checks anyway).
+        let di = trimmed_device_identity(&account, &device, b"details");
+        let bundles = parse_one(companion.clone(), Some(di));
+        assert!(
+            bundles.contains_key(&companion),
+            "trimmed device-identity with no fallback must be kept, not dropped"
+        );
+    }
+
     #[test]
     fn parse_keeps_primary_bundle_ignoring_device_identity() {
         // device 0 is the account's primary: ADV validation does not apply, so a
@@ -471,5 +515,37 @@ mod tests {
         let primary = Jid::lid_device("100000012345678", 0);
         let bundles = parse_one(primary.clone(), Some(vec![0xDE, 0xAD, 0xBE, 0xEF]));
         assert!(bundles.contains_key(&primary));
+    }
+
+    /// Encode an ADVSignedDeviceIdentity without the account_signature_key field.
+    fn trimmed_device_identity(
+        account: &crate::libsignal::protocol::KeyPair,
+        device: &crate::libsignal::protocol::KeyPair,
+        details: &[u8],
+    ) -> Vec<u8> {
+        use prost::Message;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let identity = device.public_key.public_key_bytes();
+        let account_key = account.public_key.public_key_bytes();
+        let account_sig = account
+            .private_key
+            .calculate_signature(&[&[6u8, 0][..], details, identity].concat(), &mut rng)
+            .unwrap()
+            .to_vec();
+        let device_sig = device
+            .private_key
+            .calculate_signature(
+                &[&[6u8, 1][..], details, identity, account_key].concat(),
+                &mut rng,
+            )
+            .unwrap()
+            .to_vec();
+        waproto::whatsapp::AdvSignedDeviceIdentity {
+            details: Some(details.to_vec()),
+            account_signature_key: None,
+            account_signature: Some(account_sig),
+            device_signature: Some(device_sig),
+        }
+        .encode_to_vec()
     }
 }


### PR DESCRIPTION
## Regression

A user reported their contacts' companion devices (WhatsApp Web/Desktop) stopped receiving messages, with a flood of warnings:

```
WARN Failed to parse prekey bundle for 3325042933898:1@lid: device-identity ADV validation failed for companion 3325042933898:1@lid
...
WARN Failed to handle retry receipt for ...: session with 3325042933898:1@lid.0 not found
```

They decoded the `<device-identity>` at the wire level across 4+ contacts and found the same shape every time: field 1 (details), field 3 (account_signature), field 4 (device_signature) present, field 2 (`account_signature_key`) absent.

## Root cause

The server legitimately omits `account_signature_key` from the `<device-identity>` of a contact's companion device, because that field is the contact's primary (device 0) identity key the client already holds in its identity store. #772's `validate_adv_with_identity_key` required the field to be present in the blob and rejected the bundle when it was missing. So the companion session was never established, and every subsequent retry failed with "session not found". The devices simply stopped receiving.

This was a functional regression: before #772 there was no ADV validation and these devices received fine.

## What WA Web actually does

Confirmed against `docs/captured-js/WAWeb/Adv/SignatureApi.js`. `validateADVwithIdentityKey` loads the contact's primary identity from the signal store (`loadIdentityKey(createSignalAddress(asUserWidOrThrow(t)))`) and its signature helpers use `e.accountSignatureKey || t` (functions `P` and `w`), i.e. the in-blob key when present, else the stored identity. It does not require the field in the blob.

## Fix

`validate_adv_with_identity_key` now takes an `account_identity_fallback` and uses `blob.account_signature_key || fallback`, matching WA Web. It returns a three-state `AdvValidation`:

- `Valid`: both signatures verified against an available account key.
- `Invalid`: malformed, or signatures fail against an available key. A relay swapping in a forged identity still lands here, so the forgery protection from #772 is preserved.
- `NoAccountKey`: no key from either source, so the chain is unverifiable. The caller logs and proceeds, consistent with the existing "device-identity absent" handling. This opens no new bypass: a relay could already strip the whole `<device-identity>` element to reach that same path.

`fetch_pre_keys` (covering both the session and group-fanout paths) and the retry handler pre-load the contact's device 0 identity from the store via the signal cache and pass it as the fallback. The fallback is threaded into the pure prekey parser through a new `PreKeyFetchSpec::with_account_identities`.

## Divergence from WA Web (intentional, unchanged from #772)

When neither the blob nor the store has the account key, WA Web throws (rejects). We log and proceed (`NoAccountKey`), matching the existing #772 stance for an absent `<device-identity>`, so a brand new contact whose primary identity we have not seen yet is not dropped.

## Tests

- `adv`: account-key-omitted verifies with the correct fallback (`Valid`), is `NoAccountKey` with no fallback, is `Invalid` with a wrong (relay) fallback, and the in-blob key still takes precedence over an unrelated fallback.
- prekey parser: a trimmed companion bundle (no `account_signature_key`, no fallback) is now kept instead of dropped (the regression), while a garbage `<device-identity>` is still dropped.
- Full suite green: wacore 945, whatsapp-rust 747. `clippy --all-targets -D warnings` clean for wacore, whatsapp-rust, and e2e-tests. `cargo fmt` clean.