### PR TITLE
perf(receive): make custom enc handlers an immutable set-once snapshot

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -770,14 +770,9 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         // drops the AbortHandle and aborts the task.
         let _ = client.saver_handle.set(saver_handle);
 
-        // Register custom enc handlers
-        for (enc_type, handler) in self.custom_enc_handlers {
-            client
-                .custom_enc_handlers
-                .write()
-                .await
-                .insert(enc_type, handler);
-        }
+        // Register custom enc handlers. Immutable after build, so set the whole
+        // map once; the receive hot path then reads it lock-free.
+        let _ = client.custom_enc_handlers.set(self.custom_enc_handlers);
 
         if self.skip_history_sync {
             client.set_skip_history_sync(true);

--- a/src/client.rs
+++ b/src/client.rs
@@ -506,8 +506,10 @@ pub struct Client {
     /// Tracks the pending pair code request and ephemeral keys.
     pub(crate) pair_code_state: Arc<Mutex<wacore::pair_code::PairCodeState>>,
 
-    /// Custom handlers for encrypted message types
-    pub custom_enc_handlers: Arc<async_lock::RwLock<HashMap<String, Arc<dyn EncHandler>>>>,
+    /// Custom handlers for encrypted message types. Set once at `Bot::build` and
+    /// immutable afterward, so the receive hot path reads it with a plain
+    /// `OnceLock::get` (no lock) and no per-node guard acquisition.
+    pub custom_enc_handlers: std::sync::OnceLock<HashMap<String, Arc<dyn EncHandler>>>,
 
     /// Chat state (typing indicator) handlers registered by external consumers.
     /// Each handler receives a `ChatStateEvent` describing the chat, optional participant and state.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -104,7 +104,7 @@ impl Client {
             signal_cache_identities: sig_identities,
             signal_cache_sender_keys: sig_sender_keys,
             chatstate_handlers: self.chatstate_handlers.read().await.len(),
-            custom_enc_handlers: self.custom_enc_handlers.read().await.len(),
+            custom_enc_handlers: self.custom_enc_handlers.get().map_or(0, |m| m.len()),
         }
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -211,7 +211,7 @@ impl Client {
             major_sync_task_sender: tx,
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pair_code_state: Arc::new(Mutex::new(wacore::pair_code::PairCodeState::default())),
-            custom_enc_handlers: Arc::new(async_lock::RwLock::new(HashMap::new())),
+            custom_enc_handlers: std::sync::OnceLock::new(),
             chatstate_handlers: Arc::new(RwLock::new(Vec::new())),
             pdo_pending_requests: cache_config.pdo_pending_requests.build_with_ttl(),
             device_registry_cache: cache_config.device_registry_cache.build_typed_ttl(

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -131,6 +131,11 @@ impl Client {
         let mut had_unknown_enc = false;
         let mut had_custom_handler = false;
 
+        // Custom enc handlers are set once at Bot::build and immutable after, so
+        // read the map lock-free once instead of acquiring an async RwLock guard
+        // per enc node. `None` (the common zero-handler bot) skips the lookup.
+        let custom_enc_handlers = self.custom_enc_handlers.get();
+
         for enc_node in &all_enc_nodes {
             // Parse sender retry count (WA Web: e.maybeAttrInt("count") ?? 0)
             // Clamp to MAX_DECRYPT_RETRIES to prevent u64→u8 truncation on unexpected values.
@@ -159,12 +164,8 @@ impl Client {
                 }
             };
 
-            if let Some(handler) = self
-                .custom_enc_handlers
-                .read()
-                .await
-                .get(enc_type.as_ref())
-                .cloned()
+            if let Some(handler) =
+                custom_enc_handlers.and_then(|m| m.get(enc_type.as_ref()).cloned())
             {
                 let handler_clone = handler;
                 let client_clone = self.clone();

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7053,11 +7053,16 @@ async fn custom_handler_only_skips_fallback_ack() {
     let handler = Arc::new(NoopHandler {
         calls: Arc::clone(&calls),
     });
-    client
-        .custom_enc_handlers
-        .write()
-        .await
-        .insert("frskmsg".to_string(), handler as Arc<dyn EncHandler>);
+    // custom_enc_handlers is set-once (immutable after build); capturing_client
+    // builds via Client::new and leaves it unset, so set it here.
+    let mut handlers = std::collections::HashMap::new();
+    handlers.insert("frskmsg".to_string(), handler as Arc<dyn EncHandler>);
+    // set() returns Err(map) on the already-set path; the map isn't Debug, so
+    // assert via is_ok() rather than expect().
+    assert!(
+        client.custom_enc_handlers.set(handlers).is_ok(),
+        "custom_enc_handlers not yet set"
+    );
 
     let node = NodeBuilder::new("message")
         .attr("from", "5511777776666@s.whatsapp.net")

--- a/src/types/enc_handler.rs
+++ b/src/types/enc_handler.rs
@@ -90,7 +90,8 @@ mod tests {
             bot.client()
                 .custom_enc_handlers
                 .get()
-                .is_some_and(|m| m.contains_key("frskmsg"))
+                .unwrap()
+                .contains_key("frskmsg")
         );
     }
 
@@ -119,10 +120,10 @@ mod tests {
 
         // Verify both handlers were registered
         let client = bot.client();
-        let handlers = client.custom_enc_handlers.get();
-        assert!(handlers.is_some_and(|m| m.contains_key("frskmsg")));
-        assert!(handlers.is_some_and(|m| m.contains_key("customtype")));
-        assert_eq!(handlers.map_or(0, |m| m.len()), 2);
+        let handlers = client.custom_enc_handlers.get().unwrap();
+        assert!(handlers.contains_key("frskmsg"));
+        assert!(handlers.contains_key("customtype"));
+        assert_eq!(handlers.len(), 2);
     }
 
     #[tokio::test]
@@ -143,13 +144,7 @@ mod tests {
             .await
             .expect("Failed to build bot");
 
-        // Verify no custom handlers are registered
-        assert_eq!(
-            bot.client()
-                .custom_enc_handlers
-                .get()
-                .map_or(0, |m| m.len()),
-            0
-        );
+        // Verify no custom handlers are registered (the map is set, just empty)
+        assert_eq!(bot.client().custom_enc_handlers.get().unwrap().len(), 0);
     }
 }

--- a/src/types/enc_handler.rs
+++ b/src/types/enc_handler.rs
@@ -89,9 +89,8 @@ mod tests {
         assert!(
             bot.client()
                 .custom_enc_handlers
-                .read()
-                .await
-                .contains_key("frskmsg")
+                .get()
+                .is_some_and(|m| m.contains_key("frskmsg"))
         );
     }
 
@@ -119,21 +118,11 @@ mod tests {
             .expect("Failed to build bot");
 
         // Verify both handlers were registered
-        assert!(
-            bot.client()
-                .custom_enc_handlers
-                .read()
-                .await
-                .contains_key("frskmsg")
-        );
-        assert!(
-            bot.client()
-                .custom_enc_handlers
-                .read()
-                .await
-                .contains_key("customtype")
-        );
-        assert_eq!(bot.client().custom_enc_handlers.read().await.len(), 2);
+        let client = bot.client();
+        let handlers = client.custom_enc_handlers.get();
+        assert!(handlers.is_some_and(|m| m.contains_key("frskmsg")));
+        assert!(handlers.is_some_and(|m| m.contains_key("customtype")));
+        assert_eq!(handlers.map_or(0, |m| m.len()), 2);
     }
 
     #[tokio::test]
@@ -155,6 +144,12 @@ mod tests {
             .expect("Failed to build bot");
 
         // Verify no custom handlers are registered
-        assert_eq!(bot.client().custom_enc_handlers.read().await.len(), 0);
+        assert_eq!(
+            bot.client()
+                .custom_enc_handlers
+                .get()
+                .map_or(0, |m| m.len()),
+            0
+        );
     }
 }


### PR DESCRIPTION
## What

`Client.custom_enc_handlers` was `Arc<RwLock<HashMap<String, Arc<dyn EncHandler>>>>`, read once per `<enc>` node (1-4 per inbound message) via an async `RwLock` read guard plus a HashMap probe. The map is populated once at `Bot::build` and never mutated at runtime.

This replaces the `RwLock` with a `std::sync::OnceLock<HashMap<...>>`: `Bot::build` sets the whole map once, and the receive hot path reads it with a plain lock-free `OnceLock::get` (`None` for the common zero-handler bot, which skips the lookup entirely).

## Why

Removes the per-node async guard acquisition on the receive hot path. More importantly, because the type itself is set-once, the immutable-after-build contract is now **enforced** rather than assumed. The original PR hoisted the read guard and snapshotted an `is_empty()` boolean, which CodeRabbit correctly flagged: the `pub RwLock` field left runtime mutation technically possible, so a single read snapshot could diverge from a concurrent write. `OnceLock` makes that unrepresentable.

## Breaking

The `pub` field type changes (acceptable pre-1.0). Registration still happens only through `BotBuilder::with_enc_handler`. Tests that inspected or seeded the field are updated to `OnceLock::get`/`set`; behavior is unchanged.

## Verification

Native build + clippy `--all-targets -D warnings` + fmt clean; enc-handler tests and `custom_handler_only_skips_fallback_ack` pass.