### PR TITLE
fix(wasm): relax EncHandler Send+Sync via MaybeSendSync, gate async_trait

### DIFF
--- a/src/types/enc_handler.rs
+++ b/src/types/enc_handler.rs
@@ -4,9 +4,16 @@ use anyhow::Result;
 use std::sync::Arc;
 use wacore_binary::Node;
 
-/// Trait for handling custom encrypted message types
-#[async_trait::async_trait]
-pub trait EncHandler: Send + Sync {
+/// Trait for handling custom encrypted message types.
+///
+/// Mirrors the wasm-portability convention of the sibling extension points
+/// (EventHandler, SendContextResolver): the `MaybeSendSync` supertrait keeps the
+/// `Send + Sync` requirement on native (the client stores `Arc<dyn EncHandler>`
+/// across receive lanes) while dropping it on wasm32, where the client is `!Send`
+/// and a handler may hold `!Send` JS handles.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait EncHandler: wacore::sync_marker::MaybeSendSync {
     /// Handle an encrypted node of a specific type
     ///
     /// # Arguments


### PR DESCRIPTION
## What

`EncHandler` is a public custom-enc extension point (`BotBuilder::with_enc_handler`, stored as `Arc<dyn EncHandler>` on `Client`). Unlike its sibling extension points `EventHandler` and `SendContextResolver`, it hardcoded a `Send + Sync` supertrait and a plain `#[async_trait]` with no wasm32 gate.

The high-level crate builds for wasm32, where the client is intentionally `!Send` and a handler may capture `!Send` JS handles. So a wasm custom enc handler failed to compile on the supertrait bound.

This mirrors the established convention: the supertrait becomes `wacore::sync_marker::MaybeSendSync` (which is `Send + Sync` on native, no bound on wasm32) and `async_trait` gets the dual `cfg_attr(..., async_trait(?Send))` gate.

## Why

Unblocks a `!Send`-handle-backed custom enc handler on the wasm port, consistent with how `EventHandler` (events.rs) and `SendContextResolver` (context.rs) already relax their bounds.

## Risk

None on native: the blanket `MaybeSendSync` impl keeps `dyn EncHandler` `Send + Sync`, so the `Arc<dyn EncHandler>` cross-thread storage on `Client` is untouched. The only `impl EncHandler` blocks are test-only (native). Verified the native build plus tests AND the wasm32 lib build (`cargo build -p whatsapp-rust --lib --release --target wasm32-unknown-unknown --no-default-features --features debug-diagnostics`).