### PR TITLE
api: mark lib-constructed response/result structs #[non_exhaustive] for 1.0

### DIFF
--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -60,12 +60,14 @@ impl CreateCommunityOptions {
 
 /// Result of creating a community.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct CreateCommunityResult {
     pub metadata: GroupMetadata,
 }
 
 /// A subgroup within a community.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct CommunitySubgroup {
     pub id: Jid,
     pub subject: String,
@@ -76,6 +78,7 @@ pub struct CommunitySubgroup {
 
 /// Result of linking subgroups to a community.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct LinkSubgroupsResult {
     pub linked_jids: Vec<Jid>,
     pub failed_groups: Vec<(Jid, u32)>,
@@ -83,6 +86,7 @@ pub struct LinkSubgroupsResult {
 
 /// Result of unlinking subgroups from a community.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct UnlinkSubgroupsResult {
     pub unlinked_jids: Vec<Jid>,
     pub failed_groups: Vec<(Jid, u32)>,

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -205,6 +205,7 @@ impl From<GroupInfoResponse> for GroupMetadata {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct CreateGroupResult {
     pub metadata: GroupMetadata,
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -53,6 +53,7 @@ pub struct SendOptions {
 
 /// Result of a successfully sent message.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct SendResult {
     pub message_id: String,
     pub to: Jid,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -263,6 +263,7 @@ where
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct UploadResponse {
     pub url: String,
     pub direct_path: String,

--- a/wacore/src/iq/business.rs
+++ b/wacore/src/iq/business.rs
@@ -49,6 +49,7 @@ fn node_text(node: &NodeRef<'_>) -> Option<String> {
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
+#[non_exhaustive]
 pub struct BusinessProfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wid: Option<Jid>,
@@ -64,6 +65,7 @@ pub struct BusinessProfile {
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
+#[non_exhaustive]
 pub struct BusinessHours {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
@@ -72,6 +74,7 @@ pub struct BusinessHours {
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
+#[non_exhaustive]
 pub struct BusinessHoursConfig {
     pub day_of_week: DayOfWeek,
     pub mode: BusinessHourMode,
@@ -80,6 +83,7 @@ pub struct BusinessHoursConfig {
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
+#[non_exhaustive]
 pub struct BusinessCategory {
     pub id: String,
     pub name: String,

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -496,6 +496,7 @@ pub struct GroupQueryRequest {
 
 /// A participant in a group response.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct GroupParticipantResponse {
     pub jid: Jid,
     pub phone_number: Option<Jid>,
@@ -542,6 +543,7 @@ impl ProtocolNode for GroupParticipantResponse {
 
 /// Response from a group info query.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct GroupInfoResponse {
     pub id: Jid,
     pub subject: GroupSubject,
@@ -986,6 +988,7 @@ impl ProtocolNode for GroupParticipatingRequest {
 
 /// Response containing all groups the user is participating in.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct GroupParticipatingResponse {
     pub groups: Vec<GroupInfoResponse>,
 }
@@ -1166,6 +1169,7 @@ pub struct AddRequestInfo {
 /// `type` is often omitted by the server. On `error == "403"` the
 /// `<add_request>` child (`add_request` field) carries the V4 invite token.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ParticipantChangeResponse {
     pub jid: Jid,
     pub status: Option<String>,

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -226,6 +226,7 @@ pub struct IsOnWhatsAppResult {
 
 /// User information from usync.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct UserInfo {
     pub jid: Jid,
     pub lid: Option<Jid>,
@@ -739,6 +740,7 @@ impl LidQuerySpec {
 
 /// Response: just the LID mappings learned.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct LidQueryResponse {
     pub lid_mappings: Vec<UsyncLidMapping>,
 }


### PR DESCRIPTION
## What

Adds `#[non_exhaustive]` to the public response/result structs the library returns to consumers. Before this, only `IsOnWhatsAppResult` carried the attribute (the convention exists but was applied to exactly one of ~23 such types), so adding a field to any of the others is a breaking change for downstream crates (Veloz, ESP32 firmware, whatsapp-ui). This lands the attribute before 1.0, while it is still cheap.

## Scope and why it is safe

`#[non_exhaustive]` only restricts construction and exhaustive matching from **other** crates. I limited the change to structs constructed exclusively within their defining crate (verified: zero struct-literal constructions outside the defining crate), so the attribute is purely additive: field reads keep working, and only external struct-literal construction and exhaustive matching of types nobody outside the lib builds are blocked.

- **wacore IQ responses:** `UserInfo`, `LidQueryResponse`, `BusinessProfile`, `BusinessHours`, `BusinessHoursConfig`, `BusinessCategory`, `GroupInfoResponse`, `GroupParticipantResponse`, `ParticipantChangeResponse`, `GroupParticipatingResponse`
- **whatsapp-rust returns:** `UploadResponse`, `SendResult`, `CreateGroupResult`, `CreateCommunityResult`, `CommunitySubgroup`, `LinkSubgroupsResult`, `UnlinkSubgroupsResult`

## Deliberately excluded (separate follow-ups)

- **Event payload structs** (`Receipt`, `ConnectFailure`, ...) plus `MessageSource` and `DeviceListResponse`: defined in wacore but constructed in the whatsapp-rust crate (cross-crate), so `#[non_exhaustive]` would break the build. They need wacore-side constructors first.
- **`SendOptions`**: users construct it via struct literal, so it needs a builder alongside `#[non_exhaustive]` (an API-design change), not a one-line attribute.

## Verification

Whole-workspace `--all-targets` build passes (this compiles every crate's tests, so any cross-crate exhaustive-match break would have surfaced), and the exact CI clippy command (`cargo clippy --all-targets -- -D warnings`) passes. No behavior change.