### PR TITLE
fix(wasm): relax networking traits Send+Sync via MaybeSendSync

### DIFF
--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -78,7 +78,7 @@ pub enum TransportEvent {
 /// The transport is a dumb pipe for bytes with no knowledge of WhatsApp framing.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait Transport: Send + Sync {
+pub trait Transport: crate::sync_marker::MaybeSendSync {
     /// Sends raw data to the server.
     async fn send(&self, data: Bytes) -> Result<(), anyhow::Error>;
 
@@ -89,7 +89,7 @@ pub trait Transport: Send + Sync {
 /// A factory responsible for creating new transport instances.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait TransportFactory: Send + Sync {
+pub trait TransportFactory: crate::sync_marker::MaybeSendSync {
     /// Creates a new transport and returns it, along with a stream of events.
     async fn create_transport(
         &self,
@@ -163,7 +163,7 @@ pub type UploadBody = Box<dyn std::io::Read + Send>;
 /// Trait for executing HTTP requests in a runtime-agnostic way
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait HttpClient: Send + Sync {
+pub trait HttpClient: crate::sync_marker::MaybeSendSync {
     /// Executes a given HTTP request and returns the response.
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse>;
 


### PR DESCRIPTION
## What

The three networking traits in `wacore/src/net.rs` (`Transport`, `TransportFactory`, `HttpClient`) hardcoded a `Send + Sync` supertrait, forcing a wasm32 transport/HTTP implementation to be `Send + Sync` even though the client is intentionally `!Send` there and a browser WebSocket/fetch backend holds `!Send` JS handles.

This mirrors the established convention (`EventHandler`, `SendContextResolver`, and the recently-merged `EncHandler` in #793): the supertrait becomes `crate::sync_marker::MaybeSendSync`, which is `Send + Sync` on native and no bound on wasm32. The `async_trait(?Send)` gates already existed and are now consistent with the relaxed supertrait.

## Why

Unblocks `!Send`-handle-backed transport/HTTP implementations on the wasm port.

## Native impact

None. The blanket `MaybeSendSync` impl keeps `dyn Transport`/`dyn HttpClient` `Send + Sync` on native, so the `Arc<dyn Transport>` / `Arc<dyn HttpClient>` cross-thread storage is unchanged.

## Scope note

This intentionally does **not** include the sibling store/`Backend` traits (portability-05). I tried it and that relaxation cascades into 128 errors: `impl_store_wrapper` and the `Device` hold `Arc<dyn Backend>` and require it to be `Send + Sync`, so relaxing the store traits needs the wrapper macro and `Device` made wasm-aware too. That is a separate, larger change, not a one-line supertrait swap.

## Verification

Native build + `cargo clippy --all-targets -- -D warnings` clean, and the wasm32 lib build (`cargo build -p whatsapp-rust --lib --release --target wasm32-unknown-unknown --no-default-features --features debug-diagnostics`) passes.