### PR TITLE
fix(retry): recover from unknown-device retries that carry a key bundle

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -307,10 +307,14 @@ impl Client {
         };
 
         let sender_device_id = info.requester.device() as u32;
-        if !self
+        let keys_node_present = nr.get_optional_child("keys").is_some();
+        let device_known = self
             .has_device(&info.requester.user, sender_device_id)
-            .await
-        {
+            .await;
+        if wacore::protocol::retry::should_drop_unknown_device_retry(
+            keys_node_present,
+            device_known,
+        ) {
             warn!(
                 "handle_retry_receipt: device not found for device={}, user={}",
                 sender_device_id, info.requester.user

--- a/wacore/src/protocol/retry.rs
+++ b/wacore/src/protocol/retry.rs
@@ -128,6 +128,20 @@ pub fn should_include_keys(retry_count: u8, reason: RetryReason) -> bool {
     retry_count >= MIN_RETRY_COUNT_FOR_KEYS || include_keys_early
 }
 
+/// Whether a retry from a device that is not in our device registry must be
+/// dropped instead of resent.
+///
+/// WA Web (`WAWebHandleRetryRequest`) bails on an unknown device, but that is
+/// safe only because it keeps participant device lists fresh via a pre-send
+/// sync, so a legitimate requester is already known. When the retry carries a
+/// `<keys>` bundle the requester's ADV-signed identity and prekeys are in hand,
+/// so the session can be re-established and the message resent without a registry
+/// entry. whatsmeow builds the session straight from the receipt bundle the same
+/// way. Only drop when there is no bundle to recover from.
+pub fn should_drop_unknown_device_retry(keys_present: bool, device_known: bool) -> bool {
+    !keys_present && !device_known
+}
+
 /// Builds the `<keys>` bundle embedded in a retry receipt (type, identity, one-time prekey,
 /// signed prekey, device identity) so a peer can re-establish the Signal session.
 ///
@@ -290,6 +304,18 @@ mod tests {
     fn should_include_keys_retry_3_any_reason() {
         assert!(should_include_keys(3, RetryReason::InvalidMessage));
         assert!(should_include_keys(3, RetryReason::UnknownError));
+    }
+
+    #[test]
+    fn drop_unknown_device_retry_only_without_bundle() {
+        // The regression this guards: a retry that carries a <keys> bundle from a
+        // device missing from our registry must be recovered, not dropped.
+        assert!(!should_drop_unknown_device_retry(true, false));
+        // No bundle and unknown device: nothing to recover from, so drop.
+        assert!(should_drop_unknown_device_retry(false, false));
+        // A known device is always handled, bundle or not.
+        assert!(!should_drop_unknown_device_retry(true, true));
+        assert!(!should_drop_unknown_device_retry(false, true));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`handle_retry_receipt` drops a retry whenever the requesting device is not in our device registry: it logs `device not found` and returns without resending. When a participant's device is missing from our (possibly stale) device list, that device can receive a group `skmsg` from the server, fail to decrypt it because it never got a sender key, and send a retry receipt. We refuse every one of those retries, so the device never recovers and keeps re-requesting on a fixed interval.

The retry receipt for exactly this case carries a full `<keys>` bundle (the ADV-signed `device-identity`, the identity key, a one-time prekey, and the signed prekey), which is everything needed to establish a session with that device. We already have the machinery to consume it (`process_retry_key_bundle`, `ensure_e2e_sessions_resolved`, `prepare_group_retry_stanza`), but the early `has_device` bail returns before reaching it.

## Fix

Only drop an unknown-device retry when there is no bundle to recover from.

WA Web's `WAWebHandleRetryRequest` bails on an unknown device, but that is safe only because it keeps participant device lists fresh via a pre-send sync, so a legitimate requester is already known. whatsmeow takes the direct route that fits a library: when the receipt has a `<keys>` child it builds the prekey bundle straight from the receipt and re-encrypts, with no device-registry gate at all (`nodeToPreKeyBundle` then `encryptMessageForDevice`). The embedded `device-identity` is ADV-signed, so processing it is safe: a device that does not belong to the account cannot forge it.

The decision now lives in a small predicate, `should_drop_unknown_device_retry(keys_present, device_known)`, in `wacore::protocol::retry` next to `should_include_keys`, and the handler bails only when both are false.

## Tests

`cargo test -p wacore` (new `drop_unknown_device_retry_only_without_bundle` truth-table test), `cargo test -p whatsapp-rust --lib retry` (65 passing), full `cargo test -p whatsapp-rust --lib` (737 passing), and `cargo clippy --all-targets -- -D warnings`.

The predicate test locks the exact regression: a retry that carries a `<keys>` bundle from a device missing from our registry must be recovered, not dropped, while a retry with no bundle and no known device is still dropped.

## Breaking

None.
