### PR TITLE
fix(usync): refetch an empty device record instead of trusting it

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -636,7 +636,15 @@ impl Client {
         // L1: device_registry_cache (moka, fast)
         for key in lookup.all_keys() {
             if let Some(record) = self.device_registry_cache.get(key).await {
-                return Some(Self::reconstruct_device_jids(jid, &record));
+                let devices = Self::reconstruct_device_jids(jid, &record);
+                // An empty record is never a valid device set — WA Web always keeps
+                // the primary (device 0) — so read it as a miss instead of `Some([])`.
+                // The 1:1 send path reads this directly and only warms from the network
+                // on `None`; returning `Some([])` would shadow that warmup and the
+                // bare-JID fallback, leaving a corrupted empty row unhealed.
+                if !devices.is_empty() {
+                    return Some(devices);
+                }
             }
         }
 
@@ -646,6 +654,10 @@ impl Client {
             match backend.get_devices(key).await {
                 Ok(Some(record)) => {
                     let devices = Self::reconstruct_device_jids(jid, &record);
+                    // Same invariant as L1: an empty row is corruption, treat as a miss.
+                    if devices.is_empty() {
+                        continue;
+                    }
                     self.device_registry_cache
                         .insert(record.user.clone(), Arc::new(record))
                         .await;
@@ -1232,6 +1244,25 @@ mod tests {
         assert_eq!(devices.len(), 1);
         assert!(devices[0].is_lid(), "device JID should be LID-typed");
         assert_eq!(devices[0].user, lid, "device JID user should be the LID");
+    }
+
+    // A present-but-empty record must read as a miss (None), not Some([]). The
+    // 1:1 send path reads get_devices_from_registry directly and only warms from
+    // the network on None, so an empty Some would shadow that warmup and the
+    // bare-JID fallback, leaving the corrupted row unhealed on the send path.
+    #[tokio::test]
+    async fn get_devices_from_registry_reads_empty_record_as_miss() {
+        let client = create_test_client().await;
+        let user = "15551234567";
+        setup_device_record(&client, user, &[]).await;
+
+        assert!(
+            client
+                .get_devices_from_registry(&Jid::pn(user))
+                .await
+                .is_none(),
+            "an empty record must read as a miss, not Some([])"
+        );
     }
 
     // ── DB-fallback tests for patch helpers ──────────────────────────────

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -15,8 +15,15 @@ impl Client {
         let mut all_devices = Vec::with_capacity(jids.len() * 2);
 
         for jid in jids.iter().map(|j| j.to_non_ad()) {
-            // Device registry (in-memory cache + DB) is the single source of truth
-            if let Some(devices) = self.get_devices_from_registry(&jid).await {
+            // Device registry (in-memory cache + DB) is the single source of truth.
+            // An empty list is never a valid device set: WA Web always keeps the
+            // primary (device 0) in a user's device list, so an empty record is local
+            // corruption. Treating it as authoritative would leave the user
+            // permanently unreachable, since a present record otherwise suppresses
+            // the usync re-fetch forever. Fall through to the network instead.
+            if let Some(devices) = self.get_devices_from_registry(&jid).await
+                && !devices.is_empty()
+            {
                 all_devices.extend(devices);
                 continue;
             }
@@ -391,6 +398,32 @@ mod tests {
         let devices = client.get_user_devices(&[user_jid]).await.unwrap();
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].device, 5);
+    }
+
+    // A present-but-empty device record is local corruption and must not be
+    // treated as authoritative: get_user_devices falls through to the network so
+    // the list can self-heal. Offline, that surfaces as an error, which proves the
+    // fetch was attempted (the old behavior returned Ok([]) with no fetch).
+    #[tokio::test]
+    async fn test_empty_device_record_falls_through_to_network() {
+        let client = create_test_client().await;
+
+        let user_jid: Jid = "5551230000@s.whatsapp.net".parse().unwrap();
+
+        let record = DeviceListRecord {
+            user: "5551230000".into(),
+            devices: vec![],
+            timestamp: wacore::time::now_secs(),
+            phash: None,
+            raw_id: None,
+        };
+        client.update_device_list(record).await.unwrap();
+
+        let result = client.get_user_devices(&[user_jid]).await;
+        assert!(
+            result.is_err(),
+            "empty record must fall through to the network, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -191,6 +191,14 @@ impl Client {
                 fetched_devices.push(jid);
             }
 
+            // An empty device list is never valid — WA Web always keeps the primary
+            // (device 0), so a usync returning no devices for a user is transient or
+            // corrupt. Persisting it would clobber a good cached record, or store an
+            // empty one that get_user_devices then re-fetches on every send.
+            if devices.is_empty() {
+                continue;
+            }
+
             device_records.push(wacore::store::traits::DeviceListRecord {
                 user: user_list.user.user.to_string(),
                 devices,
@@ -507,6 +515,67 @@ mod tests {
             b_devices.len(),
             2,
             "omitted user's devices must be preserved"
+        );
+    }
+
+    /// A usync that returns an empty device list for a user is transient or
+    /// corrupt (WA Web always keeps device 0). `process_device_list_response`
+    /// must not persist it: a good cached record stays intact instead of being
+    /// clobbered with an empty list that `get_user_devices` then re-fetches on
+    /// every send.
+    #[tokio::test]
+    async fn process_response_skips_empty_device_list() {
+        use wacore::usync::UserDeviceList;
+
+        let client = create_test_client().await;
+
+        client
+            .update_device_list(DeviceListRecord {
+                user: "3333333333".into(),
+                devices: vec![
+                    DeviceInfo {
+                        device_id: 0,
+                        key_index: None,
+                    },
+                    DeviceInfo {
+                        device_id: 4,
+                        key_index: None,
+                    },
+                ],
+                timestamp: wacore::time::now_secs(),
+                phash: Some("3:old".to_string()),
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+
+        // The same user comes back from usync with no devices.
+        let response = DeviceListResponse {
+            device_lists: vec![UserDeviceList {
+                user: "3333333333@s.whatsapp.net".parse().unwrap(),
+                devices: vec![],
+                phash: Some("3:empty".to_string()),
+                key_index_bytes: None,
+            }],
+            lid_mappings: vec![],
+        };
+
+        let fetched = client.process_device_list_response(&response).await;
+        assert!(
+            !fetched.iter().any(|j| j.user == "3333333333"),
+            "an empty returned list contributes no devices"
+        );
+
+        // The good cached record survives — not clobbered with an empty list.
+        let jid: Jid = "3333333333@s.whatsapp.net".parse().unwrap();
+        let devices = client
+            .get_devices_from_registry(&jid)
+            .await
+            .expect("the good record must survive an empty usync response");
+        assert_eq!(
+            devices.len(),
+            2,
+            "empty response must not clobber the record"
         );
     }
 

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -16,14 +16,10 @@ impl Client {
 
         for jid in jids.iter().map(|j| j.to_non_ad()) {
             // Device registry (in-memory cache + DB) is the single source of truth.
-            // An empty list is never a valid device set: WA Web always keeps the
-            // primary (device 0) in a user's device list, so an empty record is local
-            // corruption. Treating it as authoritative would leave the user
-            // permanently unreachable, since a present record otherwise suppresses
-            // the usync re-fetch forever. Fall through to the network instead.
-            if let Some(devices) = self.get_devices_from_registry(&jid).await
-                && !devices.is_empty()
-            {
+            // get_devices_from_registry returns None for an empty record (never a
+            // valid set — WA Web always keeps device 0), so a corrupted empty row
+            // falls through to the network here instead of being trusted.
+            if let Some(devices) = self.get_devices_from_registry(&jid).await {
                 all_devices.extend(devices);
                 continue;
             }


### PR DESCRIPTION
## Problem

`get_user_devices` only goes to the network when a user is completely absent from the device registry. A record that exists but is empty is returned as-is, and because a present record is treated as authoritative, the usync re-fetch never fires again. An empty device list means the user has no devices at all, so we cannot send to them, and the state never self-heals.

An empty device list is never valid: WA Web always keeps the primary (device 0) in a user's device list, so an empty record can only be local corruption.

## Fix

Treat an empty registry result as a miss. `get_user_devices` now falls through to the usync fetch when the resolved device list is empty, so a corrupted empty record self-heals from the server instead of leaving the user permanently unreachable.

This is intentionally narrow. A record with real devices (including the common single-device `[0]` case) is still served from the registry with no network round-trip, so there is no change to the hot send path. Only the empty case, which is always broken, is refetched.

## Tests

`cargo test -p whatsapp-rust --lib usync::tests` (7 passing), full `cargo test -p whatsapp-rust --lib` (738 passing), and `cargo clippy --all-targets -- -D warnings`.

New test `test_empty_device_record_falls_through_to_network` seeds a present-but-empty record and asserts `get_user_devices` reaches the network path instead of returning an empty result. It guards the exact regression: the old behavior returned `Ok([])` with no fetch.

## Breaking

None.
