### PR TITLE
chore(send): log benign prekey-fetch skips at debug instead of warn

### DIFF
--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -382,10 +382,8 @@ where
         {
             Ok(bundles) => bundles,
             Err(e) if is_device_unregistered_error(&e) => {
-                // 406 means the server has no prekeys for these devices (unregistered
-                // this round). Skipping them is the correct, WA Web matching behavior,
-                // and the caller re-fetches on the next send, so this is benign noise
-                // rather than an error.
+                // No server prekeys for these devices this round; the next send
+                // re-fetches. Debug, not warn — a batch 406 would otherwise flood the log.
                 log::debug!(
                     "Prekey fetch returned 406 for {} device(s); skipping them this round",
                     jids_for_fetch.len()
@@ -430,10 +428,8 @@ where
                 encryption_jid.reset_protocol_address(&mut addr);
 
                 let Some(bundle) = bundles.get(&lookup_jid) else {
-                    // No bundle means the device has no usable key material this round
-                    // (commonly the cascade of a 406 batch). Skipping is expected and
-                    // the next send re-fetches, so log at debug to avoid one warn per
-                    // skipped device during a prekey-fetch failure.
+                    // No key material this round (usually the 406 cascade); the next
+                    // send re-fetches. Debug avoids one warn per skipped device.
                     log::debug!(
                         "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
                         addr

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -382,7 +382,11 @@ where
         {
             Ok(bundles) => bundles,
             Err(e) if is_device_unregistered_error(&e) => {
-                log::warn!(
+                // 406 means the server has no prekeys for these devices (unregistered
+                // this round). Skipping them is the correct, WA Web matching behavior,
+                // and the caller re-fetches on the next send, so this is benign noise
+                // rather than an error.
+                log::debug!(
                     "Prekey fetch returned 406 for {} device(s); skipping them this round",
                     jids_for_fetch.len()
                 );
@@ -426,7 +430,11 @@ where
                 encryption_jid.reset_protocol_address(&mut addr);
 
                 let Some(bundle) = bundles.get(&lookup_jid) else {
-                    log::warn!(
+                    // No bundle means the device has no usable key material this round
+                    // (commonly the cascade of a 406 batch). Skipping is expected and
+                    // the next send re-fetches, so log at debug to avoid one warn per
+                    // skipped device during a prekey-fetch failure.
+                    log::debug!(
                         "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
                         addr
                     );


### PR DESCRIPTION
## Problem

Two prekey-fetch skips during a send are logged at warn even though they are expected, benign outcomes:

- A 406 from a prekey fetch means the server has no prekeys for those devices this round. We mark the batch and continue, which matches WA Web's `GroupSkmsgJob` ("log, continue without those devices").
- When the bundle map has no entry for a device (commonly the cascade of that same 406 batch), the device is skipped for encryption.

During a 406 affecting N devices this produces one warn for the fetch plus one warn per skipped device, so a single benign event floods the log with warnings.

## Fix

Lower both of these to debug. They are normal, transient skips: the device has no usable key material this round and the next send re-fetches. The genuine encryption failure path (`Failed to encrypt for device`) stays at warn, so real errors are still surfaced.

This is a log-level change only. The 406 handling behavior (mark the batch, skip the devices, let the caller re-fetch) is unchanged and remains covered by the existing tests (`detects_406_server_error_code`, the `had_406` propagation tests, and the no-bundle skip test in `wacore/src/send/tests.rs`).

## Tests

`cargo test -p wacore send::` (89 passing) and `cargo clippy -p wacore --all-targets -- -D warnings`.

## Breaking

None.
