### PR TITLE
fix(device-list): never drop the primary on a device-remove patch

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -497,6 +497,14 @@ impl Client {
     /// redistributed on the next group send.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.patch_device_remove", level = "debug", skip_all, fields(device_id = device_id)))]
     pub(crate) async fn patch_device_remove(&self, user: &str, device_id: u32) {
+        // WA Web's remove path re-adds the primary unconditionally, mirroring its
+        // add path: device 0 is never dropped. Without this guard a remove for the
+        // primary would both delete its sender-key rows and persist a record with no
+        // device 0, which then suppresses the usync re-fetch forever (the symmetric
+        // failure to the add path fixed above).
+        if device_id == 0 {
+            return;
+        }
         if let Some(mut record) = self.load_device_record(user).await {
             let before = record.devices.len();
             record.devices.retain(|d| d.device_id != device_id);
@@ -1902,6 +1910,27 @@ mod tests {
             .await
             .unwrap();
         assert!(rows.iter().all(|(jid, _)| jid != &device_jid));
+    }
+
+    // A remove targeting the primary (device 0) must be a no-op: WA Web never
+    // drops device 0. Regression guard for the symmetric failure to the add path
+    // — dropping the primary persists a record that suppresses usync forever.
+    #[tokio::test]
+    async fn patch_device_remove_keeps_primary() {
+        let client = create_test_client().await;
+        let user = "15551234567";
+        setup_device_record(&client, user, &[0, 5]).await;
+
+        client.patch_device_remove(user, 0).await;
+
+        let record = client.device_registry_cache.get(user).await.unwrap();
+        assert!(
+            record.devices.iter().any(|d| d.device_id == 0),
+            "remove for the primary must be ignored, got {:?}",
+            record.devices
+        );
+        // The companion is untouched too — the remove is a full no-op.
+        assert!(record.devices.iter().any(|d| d.device_id == 5));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Follow-up to #797

#797 made `patch_device_add` re-add the primary (device 0) unconditionally after a rebuild, mirroring WA Web. That PR noted WA Web's **remove** path keeps the same invariant ("_and the remove path does the same_"), but the merged change only covered the add path. This completes the symmetric case — raised as a non-blocking follow-up in the #797 review.

## Problem

`patch_device_remove` retains-by-`device_id` with no floor on the list. A remove notification targeting the primary would:
- delete device 0's sender-key rows, and
- persist a record with no device 0,

which then suppresses the usync re-fetch forever — the exact failure mode #797 fixed on the add path, reached from the remove side. The existing `device_id_u16 != 0` guard only skipped *session* cleanup for the primary; it did not stop the registry removal or the sender-key-row delete.

## Fix

Ignore a remove for device 0 entirely. WA Web never drops the primary, so a remove targeting it is never valid and is treated as a no-op.

## Tests

`cargo test -p whatsapp-rust --lib client::device_registry::tests::patch_device_remove` (4 passing) and `cargo clippy -p whatsapp-rust --lib --tests -- -D warnings`.

New test `patch_device_remove_keeps_primary`: a remove for device 0 leaves the record untouched (primary and companion both intact).

## Breaking

None.

https://claude.ai/code/session_015LKStwB5MLcjqi3A1HGeqy

---
_Generated by [Claude Code](https://claude.ai/code/session_015LKStwB5MLcjqi3A1HGeqy)_