### PR TITLE
fix(retry): resync the device list on a retry from an unknown device

### DIFF
--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1236,14 +1236,26 @@ impl Client {
     /// WA Web: online → `syncDeviceListJob`, offline → `OfflinePendingDeviceCache`.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.unknown_device_sync", level = "debug", skip_all, fields(sender = %info.source.sender.observe(), msg_id = %info.id)))]
     async fn handle_unknown_device_sync(self: &Arc<Self>, info: &MessageInfo) {
-        let user_jid = info.source.sender.to_non_ad();
+        self.schedule_unknown_device_sync(info.source.sender.to_non_ad(), info.is_offline)
+            .await;
+    }
 
+    /// Refresh a user's device list after encountering one of their devices that
+    /// is missing from our registry. Dedups per user (skips a sync already
+    /// pending/in-flight), then offline → batch for `doPendingDeviceSync`, online
+    /// → invalidate + usync immediately. WA Web: online `syncDeviceListJob`,
+    /// offline `OfflinePendingDeviceCache`.
+    pub(crate) async fn schedule_unknown_device_sync(
+        self: &Arc<Self>,
+        user_jid: Jid,
+        is_offline: bool,
+    ) {
         // Dedup: skip if we already have a sync pending/in-flight for this user
         if !self.pending_device_sync.add(user_jid.clone()).await {
             return;
         }
 
-        if info.is_offline {
+        if is_offline {
             log::debug!(
                 "Queueing {} for pending device sync (offline)",
                 user_jid.observe()
@@ -1562,5 +1574,31 @@ impl Client {
         let default_jid = Jid::default();
         let own_jid = own_pn.as_ref().unwrap_or(&default_jid);
         wacore::messages::parse_message_info(node, own_jid, own_lid.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::create_test_client_with_failing_http;
+    use wacore_binary::Jid;
+
+    // The offline path batches the user for a deferred usync and dedups repeated
+    // requests, so a retry storm from one unknown device cannot fan out into a
+    // usync storm.
+    #[tokio::test]
+    async fn schedule_unknown_device_sync_batches_and_dedups() {
+        let client = create_test_client_with_failing_http("schedule_resync").await;
+        let user: Jid = "12345678901234@lid".parse().unwrap();
+
+        client
+            .schedule_unknown_device_sync(user.clone(), true)
+            .await;
+        // Same user again is deduped, not enqueued twice.
+        client
+            .schedule_unknown_device_sync(user.clone(), true)
+            .await;
+
+        let pending = client.pending_device_sync.take_all().await;
+        assert_eq!(pending, vec![user]);
     }
 }

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1251,7 +1251,7 @@ impl Client {
         is_offline: bool,
     ) {
         // Dedup: skip if we already have a sync pending/in-flight for this user
-        if !self.pending_device_sync.add(user_jid.clone()).await {
+        if !self.pending_device_sync.add(&user_jid).await {
             return;
         }
 

--- a/src/pending_device_sync.rs
+++ b/src/pending_device_sync.rs
@@ -16,8 +16,17 @@ impl PendingDeviceSync {
     }
 
     /// Insert a user. Returns `true` if newly inserted, `false` if already present.
-    pub(crate) async fn add(&self, jid: Jid) -> bool {
-        self.pending.lock().await.insert(jid)
+    ///
+    /// Takes `&Jid` and clones only on a real insert, so the dedup path (the common
+    /// case during a retry storm) does no allocation.
+    pub(crate) async fn add(&self, jid: &Jid) -> bool {
+        let mut pending = self.pending.lock().await;
+        if pending.contains(jid) {
+            false
+        } else {
+            pending.insert(jid.clone());
+            true
+        }
     }
 
     pub(crate) async fn take_all(&self) -> Vec<Jid> {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -311,6 +311,21 @@ impl Client {
         let device_known = self
             .has_device(&info.requester.user, sender_device_id)
             .await;
+
+        if !device_known {
+            // A retry from a device missing from our registry is itself the signal
+            // that our device list for this user is stale: the device can receive
+            // our group skmsg yet never got a sender key. Refresh the list
+            // (rate-limited, dedup'd) so the device is learned and the next send
+            // includes it, whether or not we can recover this particular retry from
+            // its <keys> bundle. WA Web triggers syncDeviceListJob on an unknown
+            // device for the same reason; the reconciliation that runs on a 406
+            // during send never fires here, since the device is not in the set we
+            // send to.
+            self.schedule_unknown_device_sync(info.requester.to_non_ad(), false)
+                .await;
+        }
+
         if wacore::protocol::retry::should_drop_unknown_device_retry(
             keys_node_present,
             device_known,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -260,15 +260,10 @@ impl Client {
                 .remove(&processing_key);
         });
 
-        // A retry from a device missing from our registry is itself the signal that
-        // our device list for this user is stale: the device can receive our group
-        // skmsg yet never got a sender key. Refresh the list (rate-limited, dedup'd)
-        // so the device is learned and the next send includes it, whether or not this
-        // retry carries a <keys> bundle. Done before the message-cache lookup so an
-        // evicted or already-handled message still triggers the refresh. The
-        // 406-driven reconciliation during send never fires for this device, since it
-        // is not in the set we send to. An offline-drained retry batches like an
-        // offline unknown-device message instead of forcing an immediate usync.
+        // A retry from a device missing from our registry signals a stale device
+        // list for this user, so refresh it (rate-limited, dedup'd) to learn the
+        // device for the next send. Done before the message-cache lookup so an
+        // evicted retry still triggers it.
         let sender_device_id = info.requester.device() as u32;
         let device_known = self
             .has_device(&info.requester.user, sender_device_id)

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -260,6 +260,24 @@ impl Client {
                 .remove(&processing_key);
         });
 
+        // A retry from a device missing from our registry is itself the signal that
+        // our device list for this user is stale: the device can receive our group
+        // skmsg yet never got a sender key. Refresh the list (rate-limited, dedup'd)
+        // so the device is learned and the next send includes it, whether or not this
+        // retry carries a <keys> bundle. Done before the message-cache lookup so an
+        // evicted or already-handled message still triggers the refresh. The
+        // 406-driven reconciliation during send never fires for this device, since it
+        // is not in the set we send to. An offline-drained retry batches like an
+        // offline unknown-device message instead of forcing an immediate usync.
+        let sender_device_id = info.requester.device() as u32;
+        let device_known = self
+            .has_device(&info.requester.user, sender_device_id)
+            .await;
+        if !device_known {
+            self.schedule_unknown_device_sync(info.requester.to_non_ad(), receipt.offline)
+                .await;
+        }
+
         // Peek keeps the message in the cache, so we avoid the decode + re-encode
         // and the background DB delete + re-store that take + re-add did on every
         // retry (pure churn during retry storms). Fall back to the consuming take +
@@ -306,26 +324,7 @@ impl Client {
             self.resolve_encryption_jid(&info.requester).await
         };
 
-        let sender_device_id = info.requester.device() as u32;
         let keys_node_present = nr.get_optional_child("keys").is_some();
-        let device_known = self
-            .has_device(&info.requester.user, sender_device_id)
-            .await;
-
-        if !device_known {
-            // A retry from a device missing from our registry is itself the signal
-            // that our device list for this user is stale: the device can receive
-            // our group skmsg yet never got a sender key. Refresh the list
-            // (rate-limited, dedup'd) so the device is learned and the next send
-            // includes it, whether or not we can recover this particular retry from
-            // its <keys> bundle. WA Web triggers syncDeviceListJob on an unknown
-            // device for the same reason; the reconciliation that runs on a 406
-            // during send never fires here, since the device is not in the set we
-            // send to.
-            self.schedule_unknown_device_sync(info.requester.to_non_ad(), false)
-                .await;
-        }
-
         if wacore::protocol::retry::should_drop_unknown_device_retry(
             keys_node_present,
             device_known,

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -297,7 +297,7 @@ impl Client {
                     "Pending device sync failed, re-enqueueing {} users: {e:?}",
                     pending.len()
                 );
-                for jid in pending {
+                for jid in &pending {
                     self.pending_device_sync.add(jid).await;
                 }
             }


### PR DESCRIPTION
## Problem

A retry from a device that is missing from our device registry is dropped (when it carries no `<keys>` bundle) without refreshing the device list. The previous fix recovers a retry that carries a key bundle, but a retry with no bundle is still just dropped, and nothing else updates that user's device list.

This leaves a real loop. A user links a new device after our last sync, our registry does not have it, and the device receives our group `skmsg` but never got a sender key, so it can only fail to decrypt and retry. The reconciliation that runs when a prekey fetch returns 406 during a send never fires for this device, because the device is not in the set we send to, so it never 406s. The device is never learned and retries forever.

## Fix

Treat a retry from an unknown device as the staleness signal it is: refresh that user's device list. `handle_retry_receipt` now schedules a device-list resync whenever the requester is missing from our registry, whether or not the retry carries a bundle to recover this particular message.

This reuses the existing unknown-device sync path (`handle_unknown_device_sync`), extracted into `schedule_unknown_device_sync`. It dedups per user (so a retry storm cannot fan out into a usync storm), then invalidates and re-fetches via usync. WA Web keeps device lists fresh by triggering `syncDeviceListJob` on an unknown device; this is the equivalent trigger on the retry path.

Once the resync learns the device, the next send includes it in the sender-key distribution and the retries stop.

## Tests

`cargo test -p whatsapp-rust --lib` (744 passing), `cargo clippy --all-targets -- -D warnings`.

New test `schedule_unknown_device_sync_batches_and_dedups` locks the dedup so repeated unknown-device retries enqueue a single sync.

## Breaking

None.
