### PR TITLE
perf(receive): adopt inbound payloads zero-copy in FrameDecoder

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -62,8 +62,10 @@ impl Client {
                                     Ordering::Relaxed,
                                 );
 
-                                // Feed data into the frame decoder
-                                frame_decoder.feed(&data);
+                                // Feed data into the frame decoder. The payload is
+                                // adopted zero-copy when it is the sole reference
+                                // and no partial frame is pending (steady state).
+                                frame_decoder.feed_bytes(data);
 
                                 // Process all complete frames.
                                 // Frame decryption must be sequential (noise protocol counter),

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use log::trace;
 
 pub const FRAME_LENGTH_SIZE: usize = 3;
@@ -105,6 +105,26 @@ impl FrameDecoder {
         self.buffer.extend_from_slice(data);
     }
 
+    /// Feed an owned payload, adopting its allocation when possible.
+    ///
+    /// In steady state each transport message starts on a frame boundary
+    /// (`buffer` is empty) and the payload has no other references, so
+    /// `try_into_mut` succeeds and the bytes are adopted wholesale — the one
+    /// remaining full copy of inbound traffic on the receive path is skipped.
+    /// A pending partial frame or a shared payload falls back to [`feed`].
+    ///
+    /// [`feed`]: Self::feed
+    pub fn feed_bytes(&mut self, data: Bytes) {
+        if self.buffer.is_empty() {
+            match data.try_into_mut() {
+                Ok(owned) => self.buffer = owned,
+                Err(shared) => self.buffer.extend_from_slice(&shared),
+            }
+        } else {
+            self.buffer.extend_from_slice(&data);
+        }
+    }
+
     pub fn decode_frame(&mut self) -> Option<BytesMut> {
         if self.buffer.len() < FRAME_LENGTH_SIZE {
             return None;
@@ -208,6 +228,72 @@ mod tests {
             .expect("frame operation should succeed");
         assert_eq!(&frame2[..], &[0xCC, 0xDD, 0xEE]);
 
+        assert!(decoder.decode_frame().is_none());
+    }
+
+    #[test]
+    fn test_feed_bytes_adopts_unique_payload_without_copy() {
+        let mut data = vec![0, 0, 5];
+        data.extend_from_slice(&[1, 2, 3, 4, 5]);
+        let payload_addr = data.as_ptr() as usize;
+
+        let mut decoder = FrameDecoder::new();
+        decoder.feed_bytes(Bytes::from(data));
+
+        let frame = decoder.decode_frame().expect("complete frame");
+        assert_eq!(&frame[..], &[1, 2, 3, 4, 5]);
+        // Zero-copy: the frame points into the original allocation, offset by
+        // the 3-byte length prefix.
+        assert_eq!(frame.as_ptr() as usize, payload_addr + FRAME_LENGTH_SIZE);
+    }
+
+    #[test]
+    fn test_feed_bytes_shared_payload_falls_back_to_copy() {
+        let mut data = vec![0, 0, 2];
+        data.extend_from_slice(&[0xAA, 0xBB]);
+        let shared = Bytes::from(data);
+        let keep_alive = shared.clone(); // refcount > 1 → try_into_mut fails
+
+        let mut decoder = FrameDecoder::new();
+        decoder.feed_bytes(shared);
+
+        let frame = decoder.decode_frame().expect("complete frame");
+        assert_eq!(&frame[..], &[0xAA, 0xBB]);
+        assert_eq!(&keep_alive[3..], &[0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn test_feed_bytes_partial_frame_accumulates() {
+        let mut decoder = FrameDecoder::new();
+
+        decoder.feed_bytes(Bytes::from(vec![0, 0, 4, 1, 2]));
+        assert!(decoder.decode_frame().is_none());
+
+        // Buffer non-empty → append path; the frame completes across feeds.
+        decoder.feed_bytes(Bytes::from(vec![3, 4]));
+        let frame = decoder.decode_frame().expect("complete frame");
+        assert_eq!(&frame[..], &[1, 2, 3, 4]);
+
+        // Drained again → the next unique payload is adopted zero-copy.
+        let mut data = vec![0, 0, 1];
+        data.push(0xCC);
+        let payload_addr = data.as_ptr() as usize;
+        decoder.feed_bytes(Bytes::from(data));
+        let frame = decoder.decode_frame().expect("complete frame");
+        assert_eq!(frame.as_ptr() as usize, payload_addr + FRAME_LENGTH_SIZE);
+    }
+
+    #[test]
+    fn test_feed_bytes_multiple_frames_single_payload() {
+        let mut decoder = FrameDecoder::new();
+        decoder.feed_bytes(Bytes::from(vec![
+            0, 0, 2, 0xAA, 0xBB, 0, 0, 3, 0xCC, 0xDD, 0xEE,
+        ]));
+
+        let frame1 = decoder.decode_frame().expect("first frame");
+        assert_eq!(&frame1[..], &[0xAA, 0xBB]);
+        let frame2 = decoder.decode_frame().expect("second frame");
+        assert_eq!(&frame2[..], &[0xCC, 0xDD, 0xEE]);
         assert!(decoder.decode_frame().is_none());
     }
 


### PR DESCRIPTION
## Problem

The receive path is zero-copy from noise decrypt onward (in-place AES-GCM → `unpack_bytes` freeze → yoke-backed `OwnedNodeRef`), but the very first step still copies every inbound byte: the transport delivers an owned `Bytes` payload and `read_messages_loop` feeds it via `FrameDecoder::feed(&data)`, which `extend_from_slice`s it into the staging `BytesMut` (`wacore/noise/src/framing.rs`) — only for `decode_frame` to immediately split those same bytes back out.

## Change

`FrameDecoder::feed_bytes(Bytes)`: when no partial frame is pending (staging buffer empty — the steady state, since the WebSocket transport is message-oriented and each message starts on a frame boundary), the payload is adopted wholesale via `Bytes::try_into_mut`, which is zero-copy when the payload is the sole reference. Shared payloads and partial-frame leftovers fall back to the existing copying path, so correctness never depends on the fast path firing.

`read_messages_loop` moves the payload into `feed_bytes` instead of borrowing it for `feed`. The borrowing `feed` stays for the handshake path and existing tests.

Side benefit for long-running RSS: each adopted payload is its own allocation, so a node retained by the app (queued chat lane, `Event::RawNode`) pins only its own WebSocket message's bytes instead of whatever else accumulated in the shared staging buffer.

## Correctness

- `test_feed_bytes_adopts_unique_payload_without_copy` proves the fast path by pointer identity: the decoded frame points into the original payload allocation at offset 3 (the length prefix).
- `test_feed_bytes_shared_payload_falls_back_to_copy` pins the fallback when refcount &gt; 1.
- `test_feed_bytes_partial_frame_accumulates` covers a frame split across two feeds, and that the decoder returns to the zero-copy path once drained.
- `test_feed_bytes_multiple_frames_single_payload` mirrors the existing multi-frame test through the new entry point.

## Verification

`cargo fmt` clean; `cargo clippy -p wacore-noise -p whatsapp-rust --tests` clean; `cargo test -p wacore-noise --lib` 33 passed (4 new). Not benchmarked end-to-end (the pingpong harness needs the external mock server); the win is one full `memcpy` of every inbound byte in steady state, with no new allocations on any path.

## Breaking

None. `feed` is unchanged; `feed_bytes` is additive.