### PR TITLE
perf(receive): resolve the noise socket once per read loop, drop ack re-encode copy

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -43,6 +43,14 @@ impl Client {
             .ok_or_else(|| anyhow::anyhow!("Cannot start message loop: not connected"))?;
         drop(rx_guard);
 
+        // The noise socket is installed before this loop starts (connect_internal)
+        // and replaced only across reconnects, which tear this loop down first —
+        // so resolve it once instead of locking the mutex per frame.
+        let noise_socket = self
+            .get_noise_socket()
+            .await
+            .map_err(|_| anyhow::anyhow!("Cannot start message loop: no noise socket"))?;
+
         // Frame decoder to parse incoming data
         let mut frame_decoder = wacore::framing::FrameDecoder::new();
         let shutdown = self.connection_shutdown_signal();
@@ -72,7 +80,7 @@ impl Client {
 
                                 while let Some(encrypted_frame) = frame_decoder.decode_frame() {
                                     // Decrypt the frame synchronously (required for noise counter ordering)
-                                    if let Some(node) = self.decrypt_frame(encrypted_frame).await {
+                                    if let Some(node) = self.decrypt_frame(&noise_socket, encrypted_frame) {
                                         // Determine processing mode for this node:
                                         // - Critical nodes (success/failure/stream:error): inline, required for state
                                         // - Message nodes: inline, preserves arrival order for per-chat queues
@@ -165,18 +173,11 @@ impl Client {
         feature = "tracing",
         tracing::instrument(name = "wa.conn.decrypt_frame", level = "trace", skip_all)
     )]
-    pub(crate) async fn decrypt_frame(
-        self: &Arc<Self>,
+    pub(crate) fn decrypt_frame(
+        &self,
+        noise_socket: &crate::socket::noise_socket::NoiseSocket,
         encrypted_frame: bytes::BytesMut,
     ) -> Option<wacore_binary::OwnedNodeRef> {
-        let noise_socket = match self.get_noise_socket().await {
-            Ok(s) => s,
-            Err(_) => {
-                log::error!("Cannot process frame: not connected (no noise socket)");
-                return None;
-            }
-        };
-
         let decrypted_payload = match noise_socket.decrypt_frame(encrypted_frame) {
             Ok(p) => p,
             Err(e) => {
@@ -958,9 +959,10 @@ impl Client {
             // ACK responses are infrequent; re-encode into OwnedNodeRef for the channel.
             // marshal_ref prepends a leading 0x00 format byte; OwnedNodeRef::new expects raw
             // protocol bytes without it, matching what unpack() produces from the network.
-            match wacore_binary::marshal::marshal_ref(node)
-                .and_then(|bytes| wacore_binary::OwnedNodeRef::new(bytes[1..].to_vec()))
-            {
+            // slice(1..) drops that byte as a zero-copy view instead of re-allocating.
+            match wacore_binary::marshal::marshal_ref(node).and_then(|buf| {
+                wacore_binary::OwnedNodeRef::new(bytes::Bytes::from(buf).slice(1..))
+            }) {
                 Ok(onr) => {
                     if waiter.send(Arc::new(onr)).is_err() {
                         warn!(target: "Client/Ack", "Failed to send ACK response to waiter for ID {id}. Receiver was likely dropped.");


### PR DESCRIPTION
## What

Two small per-frame overheads on the receive path:

1. **Noise socket lookup per frame.** `decrypt_frame` acquired the `noise_socket` async mutex and cloned the `Arc` for every inbound frame. The socket is installed before `read_messages_loop` starts (`connect_internal` sets it at lifecycle.rs:436, before the loop is spawned) and is only replaced across reconnects, which tear this loop down first. The loop now resolves the socket once at startup and passes `&NoiseSocket` down; `decrypt_frame` loses its only `.await` and becomes a plain sync call — one less mutex round-trip and await point per frame.

2. **Ack waiter re-encode copy.** `handle_ack_response` re-encodes the ack node for the oneshot channel via `marshal_ref`, then stripped the leading format byte with `bytes[1..].to_vec()` — a second full allocation just to drop one byte. `Bytes::from(buf).slice(1..)` drops it as a zero-copy view into the same allocation.

## Why

(1) is on the hot loop for every stanza received; (2) is infrequent (ack waiters are per tracked send) but the fix is strictly less work. Neither changes behavior: the startup failure mode for a missing socket moves from a per-frame `log::error` + dropped frame to failing the loop start with the same "not connected" semantics the `transport_events` check directly above it already has.

## Verification

`cargo fmt` clean; `cargo clippy -p whatsapp-rust --tests` clean; `cargo test -p whatsapp-rust --lib`: 744 passed, 0 failed. `decrypt_frame` has a single call site (the read loop), so no other paths are affected.

## Breaking

None (`decrypt_frame` is `pub(crate)`).