### PR TITLE
perf(receive): bound the per-chat message queue

### DIFF
--- a/src/handlers/message.rs
+++ b/src/handlers/message.rs
@@ -7,6 +7,15 @@ use std::sync::Arc;
 /// WA Web: `WAWebMessageQueue` uses `promiseTimeout(r(), 2e4)` per queued handler.
 const MAX_MESSAGE_DELAY_MS: u64 = 20_000;
 
+/// Per-chat queue depth. The deepest legitimate burst is offline resume,
+/// which is server-paced at 200 stanzas per `<offline_batch>` request
+/// (`offline_resume`), so even a backlog landing entirely in one chat stays
+/// a few hundred deep. Each queued entry keeps its decoded frame buffer
+/// alive, so an unbounded queue turns a flood into unbounded memory; above
+/// this depth the enqueue fails, the ack is cancelled, and the server
+/// redelivers the stanza instead.
+const CHAT_LANE_QUEUE_DEPTH: usize = 2048;
+
 /// Handler for `<message>` stanzas.
 ///
 /// Messages are processed sequentially per-chat using a mailbox pattern to prevent
@@ -53,8 +62,10 @@ impl StanzaHandler for MessageHandler {
         let _guard = lane.enqueue_lock.lock().await;
 
         if let Err(e) = lane.queue_tx.try_send(node) {
+            // Full (lane backlogged past CHAT_LANE_QUEUE_DEPTH) or closed
+            // (stale lane racing a disconnect) — either way, cancel the ack
+            // so the server redelivers instead of buffering without bound.
             warn!("Failed to enqueue message for processing: {e}");
-            // Cancel ack so server redelivers
             *cancelled = true;
         }
 
@@ -65,7 +76,8 @@ impl StanzaHandler for MessageHandler {
 /// Construct a ChatLane with a spawned worker task. Extracted to keep the
 /// init closure passed to `get_with_by_ref` small.
 fn create_chat_lane(client: &Arc<Client>) -> ChatLane {
-    let (tx, rx) = async_channel::unbounded::<Arc<wacore_binary::OwnedNodeRef>>();
+    let (tx, rx) =
+        async_channel::bounded::<Arc<wacore_binary::OwnedNodeRef>>(CHAT_LANE_QUEUE_DEPTH);
 
     let client_for_worker = client.clone();
     let spawn_generation = client


### PR DESCRIPTION
## Problem

Each chat lane's mailbox (`src/handlers/message.rs`) is an `async_channel::unbounded`, so a flood into a single chat buffers `Arc&lt;OwnedNodeRef&gt;` entries without limit — and each queued entry keeps its decoded frame buffer alive, so queue depth translates directly into pinned memory. The enqueue path already has the right overflow handling (try_send failure → warn + `cancelled = true` → no ack → server redelivers), but on an unbounded channel that path can only fire for a closed lane; it was designed as backpressure that could never engage.

## Change

`bounded(CHAT_LANE_QUEUE_DEPTH = 2048)`. Sizing rationale: the deepest legitimate burst is offline resume, which is server-paced at 200 stanzas per `&lt;offline_batch&gt;` request (`src/client/offline_resume.rs`), so even a backlog landing entirely in one chat stays a few hundred deep — an order of magnitude under the bound. Only pathological floods trip it, and those now degrade to server redelivery (the stanza isn't acked, so it stays in the server's offline queue) instead of unbounded buffering.

## Trade-off (honest)

If the bound trips, a dropped stanza is redelivered later (offline replay), so a Signal message can be decrypted out of arrival order relative to its chat. The double ratchet handles skipped message keys, and the existing retry-receipt path covers a PreKey message deferred past a session message — same recovery as any out-of-order delivery today. At 10× the legitimate burst depth this is a degraded-flood mode, not a steady-state behavior change. The alternative (awaiting queue capacity in the handler) would block the read loop and head-of-line-block every other chat, which is worse.

## Verification

`cargo fmt` clean; `cargo clippy -p whatsapp-rust --tests` clean; `cargo test -p whatsapp-rust --lib`: 744 passed, 0 failed. The overflow path itself isn't unit-tested: the depth is a const and the lane worker drains concurrently, so filling 2048 entries deterministically would need either an injectable depth or a stalled-worker harness — happy to add either if preferred.

## Breaking

None (internal handler detail; `ChatLane`'s sender type is the same for bounded/unbounded).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKdomTCXXcp3V44UgbMuJf)_