### PR TITLE
perf(signal-cache): share cached sessions via Arc, peek without deep clone

### DIFF
--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -91,7 +91,9 @@ pub struct SignalStoreCache {
 /// Cache entry tracking whether a session is present, absent, or checked out
 /// by an encrypt/decrypt operation.
 enum SessionEntry {
-    Present(Box<SessionRecord>),
+    // `Arc` so `peek_session` (retry / LID-migration checks) bumps a refcount
+    // instead of deep-cloning the record (KBs with archived states).
+    Present(Arc<SessionRecord>),
     Absent,
     /// Taken by load_session; has_session treats as present, flush/eviction skip.
     CheckedOut,
@@ -124,7 +126,7 @@ impl SessionStoreState {
     fn put(&mut self, address: &str, record: SessionRecord) {
         let addr = self.key_for(address);
         self.cache
-            .insert(addr.clone(), SessionEntry::Present(Box::new(record)));
+            .insert(addr.clone(), SessionEntry::Present(Arc::new(record)));
         self.dirty.insert(addr.clone());
         self.deleted.remove(&addr);
     }
@@ -349,7 +351,11 @@ impl SignalStoreCache {
                     else {
                         unreachable!()
                     };
-                    return Ok(Some(*record));
+                    // Unique unless a peek's Arc is still alive (short-lived
+                    // inspection paths), so this is a move, not a clone.
+                    return Ok(Some(
+                        Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone()),
+                    ));
                 }
                 return Ok(None);
             }
@@ -386,13 +392,13 @@ impl SignalStoreCache {
         &self,
         address: &ProtocolAddress,
         backend: &dyn SignalStore,
-    ) -> Result<Option<SessionRecord>> {
+    ) -> Result<Option<Arc<SessionRecord>>> {
         let key = address.as_str();
         {
             let state = self.sessions.lock().await;
             if let Some(entry) = state.cache.get(key) {
                 return match entry {
-                    SessionEntry::Present(record) => Ok(Some((**record).clone())),
+                    SessionEntry::Present(record) => Ok(Some(record.clone())),
                     _ => Ok(None),
                 };
             }
@@ -402,12 +408,11 @@ impl SignalStoreCache {
         let mut state = self.sessions.lock().await;
         match backend_result {
             Some(bytes) => {
-                let record = SessionRecord::deserialize(&bytes)?;
+                let record = Arc::new(SessionRecord::deserialize(&bytes)?);
                 if !state.cache.contains_key(key) {
-                    state.cache.insert(
-                        Arc::from(key),
-                        SessionEntry::Present(Box::new(record.clone())),
-                    );
+                    state
+                        .cache
+                        .insert(Arc::from(key), SessionEntry::Present(record.clone()));
                     state.evict_if_needed(self.max_entries);
                 }
                 Ok(Some(record))


### PR DESCRIPTION
## Problem

The session object cache stores `SessionEntry::Present(Box&lt;SessionRecord&gt;)`, so `peek_session` — the non-destructive read used by retry-receipt handling and LID-migration checks — deep-clones the record on every call (`signal_cache.rs`): a `SessionRecord` carries archived session states plus skipped message keys, typically 1-2 KB. The backend-miss path cloned a second time to populate the cache. The sender-key cache already solved this exact problem with `Arc` ("bumps a refcount instead of deep-cloning the record's `VecDeque&lt;SenderKeyState&gt;`"); sessions just never got the same treatment.

## Change

`SessionEntry::Present(Arc&lt;SessionRecord&gt;)`, aligning sessions with the sender-key cache pattern:

- **peek**: returns `Option&lt;Arc&lt;SessionRecord&gt;&gt;` — cache hit is a refcount bump; the backend-miss path wraps once and shares the same `Arc` between the cache slot and the return value (the old code cloned here too).
- **checkout** (`get_session`): `Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone())` — the entry is unique in steady state, so this is a move exactly like the old `Box` deref; it clones only if a peek's short-lived `Arc` is still alive at checkout time, which is the rare race the old code paid for on *every* peek instead.
- **flush/eviction/has_session**: unchanged (serialize reads through the `Arc`).

## Verification

Callers (`retry.rs` ×3, message tests ×2) only call read methods through the record, so the `Arc` return is source-compatible at every site — no caller changes beyond what deref provides. `cargo test -p wacore --lib`: 947 passed; `cargo test -p whatsapp-rust --lib`: 744 passed; `cargo clippy --all-targets -- -D warnings` clean; fmt clean.

## Breaking

`peek_session` return type changes `Option&lt;SessionRecord&gt;` → `Option&lt;Arc&lt;SessionRecord&gt;&gt;` (pre-1.0; read-only consumers are unaffected by deref).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKdomTCXXcp3V44UgbMuJf)_