### PR TITLE
perf(lid-pn): share identifier strings between cache keys and entries

### DIFF
--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -247,8 +247,8 @@ impl Client {
         use anyhow::anyhow;
 
         let storage_entry = LidPnMappingEntry {
-            lid: entry.lid,
-            phone_number: entry.phone_number,
+            lid: entry.lid.to_string(),
+            phone_number: entry.phone_number.to_string(),
             created_at: entry.created_at,
             updated_at: entry.created_at,
             learning_source: entry.learning_source.as_str().to_string(),
@@ -296,8 +296,8 @@ impl Client {
         let storage: Vec<LidPnMappingEntry> = entries
             .into_iter()
             .map(|entry| LidPnMappingEntry {
-                lid: entry.lid,
-                phone_number: entry.phone_number,
+                lid: entry.lid.to_string(),
+                phone_number: entry.phone_number.to_string(),
                 created_at: entry.created_at,
                 updated_at: entry.created_at,
                 learning_source: entry.learning_source.as_str().to_string(),
@@ -585,7 +585,7 @@ impl Client {
             return None;
         }
         match self.get_lid_pn_entry(jid).await {
-            Ok(Some(entry)) => Some(Jid::new(entry.lid, wacore_binary::Server::Lid)),
+            Ok(Some(entry)) => Some(Jid::new(&*entry.lid, wacore_binary::Server::Lid)),
             Ok(None) => None,
             Err(e) => {
                 log::warn!(
@@ -723,8 +723,8 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(entry.lid, lid);
-        assert_eq!(entry.phone_number, pn);
+        assert_eq!(&*entry.lid, lid);
+        assert_eq!(&*entry.phone_number, pn);
     }
 
     #[tokio::test]
@@ -751,8 +751,8 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(entry.lid, lid);
-        assert_eq!(entry.phone_number, pn);
+        assert_eq!(&*entry.lid, lid);
+        assert_eq!(&*entry.phone_number, pn);
     }
 
     /// Cache-aside fallback: if the in-memory cache is missing an entry the
@@ -783,8 +783,8 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(entry.lid, lid);
-        assert_eq!(entry.phone_number, pn);
+        assert_eq!(&*entry.lid, lid);
+        assert_eq!(&*entry.phone_number, pn);
 
         // Subsequent lookup served from cache.
         let entry = client
@@ -792,7 +792,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(entry.lid, lid);
+        assert_eq!(&*entry.lid, lid);
     }
 
     /// `learn_lid_pn_mapping_fast` must leave the in-memory cache populated
@@ -957,7 +957,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .lid,
-            lid
+            lid.into()
         );
     }
 

--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -39,9 +39,9 @@ impl<'a> Blocking<'a> {
                 ))
             })?;
         Ok(if bare.is_lid() {
-            (bare, Jid::pn(entry.phone_number))
+            (bare, Jid::pn(&*entry.phone_number))
         } else {
-            (Jid::lid(entry.lid), bare)
+            (Jid::lid(&*entry.lid), bare)
         })
     }
 
@@ -93,8 +93,8 @@ impl<'a> Blocking<'a> {
         let mapping = self.client.get_lid_pn_entry(&bare).await?;
         let mut users: Vec<&str> = vec![bare.user.as_str()];
         if let Some(entry) = mapping.as_ref() {
-            users.push(entry.lid.as_str());
-            users.push(entry.phone_number.as_str());
+            users.push(&*entry.lid);
+            users.push(&*entry.phone_number);
         }
 
         Ok(blocklist_contains(&blocklist, &users))

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -364,7 +364,7 @@ impl<'a> Groups<'a> {
                     .ok_or_else(|| {
                         anyhow::anyhow!("Missing phone number mapping for LID {}", participant.jid)
                     })?;
-                participant.with_phone_number(Jid::pn(entry.phone_number))
+                participant.with_phone_number(Jid::pn(&*entry.phone_number))
             } else {
                 participant
             };

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -39,10 +39,13 @@ const NS_PN: &str = "lid_pn_by_pn";
 /// The cache is thread-safe and can be shared across async tasks.
 pub struct LidPnCache {
     /// LID -> Entry mapping. `Arc` so the hot `get_*` lookups clone a refcount,
-    /// not the entry's two `String`s; only the owned-`LidPnEntry` accessors deep-clone.
-    lid_to_entry: TypedCache<String, Arc<LidPnEntry>>,
+    /// not the entry's strings; only the owned-`LidPnEntry` accessors deep-clone.
+    /// Keys are `Arc<str>` sharing the entry's own allocations — each identifier
+    /// is stored once per mapping, not once as key and again inside the entry
+    /// (this cache is unbounded by design, so per-entry bytes compound).
+    lid_to_entry: TypedCache<Arc<str>, Arc<LidPnEntry>>,
     /// Phone number -> Entry mapping (stores the most recent LID for that PN)
-    pn_to_entry: TypedCache<String, Arc<LidPnEntry>>,
+    pn_to_entry: TypedCache<Arc<str>, Arc<LidPnEntry>>,
     /// PN -> the LID this process durably persisted for it. Lets the learn hot
     /// path skip a re-persist without swallowing the first live persist of a
     /// mapping an offline replay only warmed in memory. Keyed by the pair so a
@@ -50,7 +53,7 @@ pub struct LidPnCache {
     /// LID, never a newer un-persisted one. `Arc<str>` value: the hot-path check
     /// clones a refcount and compares in place, no payload copy. In-memory only;
     /// cold after restart just replays the idempotent upsert.
-    persisted: TypedCache<String, Arc<str>>,
+    persisted: TypedCache<Arc<str>, Arc<str>>,
 }
 
 impl Default for LidPnCache {
@@ -109,7 +112,7 @@ impl LidPnCache {
         self.pn_to_entry
             .get(phone)
             .await
-            .map(|e| e.lid.as_str().into())
+            .map(|e| CompactString::from(&*e.lid))
     }
 
     /// Whether the learn fast path can skip re-recording `phone <-> lid`: the
@@ -125,12 +128,12 @@ impl LidPnCache {
                 .pn_to_entry
                 .get(phone)
                 .await
-                .is_some_and(|e| e.lid == lid)
+                .is_some_and(|e| &*e.lid == lid)
             && self
                 .lid_to_entry
                 .get(lid)
                 .await
-                .is_some_and(|e| e.phone_number == phone)
+                .is_some_and(|e| &*e.phone_number == phone)
     }
 
     /// Get the phone number for a LID.
@@ -140,7 +143,7 @@ impl LidPnCache {
         self.lid_to_entry
             .get(lid)
             .await
-            .map(|e| e.phone_number.clone())
+            .map(|e| e.phone_number.to_string())
     }
 
     /// Get the full entry for a LID.
@@ -164,21 +167,22 @@ impl LidPnCache {
     /// number can race. This is acceptable because the cache is best-effort
     /// and backed by persistent storage for correctness.
     pub async fn add(&self, entry: &LidPnEntry) {
-        let should_update_pn = match self.pn_to_entry.get(entry.phone_number.as_str()).await {
+        let should_update_pn = match self.pn_to_entry.get(&*entry.phone_number).await {
             Some(existing) => existing.created_at <= entry.created_at,
             None => true,
         };
 
-        // One heap copy of the entry, shared by both maps via the Arc refcount.
+        // One shared copy of the entry; the keys clone the entry's own
+        // Arc<str> allocations, so each identifier lives once per mapping.
         let shared = Arc::new(entry.clone());
         self.lid_to_entry
-            .insert(entry.lid.clone(), Arc::clone(&shared))
+            .insert(shared.lid.clone(), Arc::clone(&shared))
             .await;
 
         // Update PN -> Entry map (only if newer or equal timestamp)
         if should_update_pn {
             self.pn_to_entry
-                .insert(entry.phone_number.clone(), shared)
+                .insert(shared.phone_number.clone(), shared)
                 .await;
         }
     }
@@ -195,7 +199,7 @@ impl LidPnCache {
 
     pub(crate) async fn mark_persisted(&self, phone: &str, lid: &str) {
         self.persisted
-            .insert(phone.to_string(), Arc::from(lid))
+            .insert(Arc::from(phone), Arc::from(lid))
             .await;
     }
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -512,7 +512,7 @@ impl Client {
                 .await
                 .ok()
                 .flatten()
-                .map(|e| Jid::new(&e.phone_number, wacore_binary::Server::Pn))
+                .map(|e| Jid::new(&*e.phone_number, wacore_binary::Server::Pn))
         } else {
             None
         };

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -2942,8 +2942,8 @@ mod tests {
         client
             .lid_pn_cache
             .add(&wacore::types::lid_pn::LidPnEntry {
-                lid: lid_jid.user.to_string(),
-                phone_number: pn_jid.user.to_string(),
+                lid: lid_jid.user.as_str().into(),
+                phone_number: pn_jid.user.as_str().into(),
                 created_at: 0,
                 learning_source: wacore::types::lid_pn::LearningSource::Usync,
             })
@@ -2991,8 +2991,8 @@ mod tests {
         client
             .lid_pn_cache
             .add(&wacore::types::lid_pn::LidPnEntry {
-                lid: lid_jid.user.to_string(),
-                phone_number: pn_jid.user.to_string(),
+                lid: lid_jid.user.as_str().into(),
+                phone_number: pn_jid.user.as_str().into(),
                 created_at: 0,
                 learning_source: wacore::types::lid_pn::LearningSource::Usync,
             })
@@ -3059,8 +3059,8 @@ mod tests {
         client
             .lid_pn_cache
             .add(&wacore::types::lid_pn::LidPnEntry {
-                lid: lid_jid.user.to_string(),
-                phone_number: pn_jid.user.to_string(),
+                lid: lid_jid.user.as_str().into(),
+                phone_number: pn_jid.user.as_str().into(),
                 created_at: 0,
                 learning_source: wacore::types::lid_pn::LearningSource::Usync,
             })
@@ -3157,8 +3157,8 @@ mod tests {
         client
             .lid_pn_cache
             .add(&wacore::types::lid_pn::LidPnEntry {
-                lid: lid_jid.user.to_string(),
-                phone_number: pn_jid.user.to_string(),
+                lid: lid_jid.user.as_str().into(),
+                phone_number: pn_jid.user.as_str().into(),
                 created_at: 0,
                 learning_source: wacore::types::lid_pn::LearningSource::Usync,
             })

--- a/tests/e2e/tests/groups.rs
+++ b/tests/e2e/tests/groups.rs
@@ -761,8 +761,8 @@ async fn test_query_info_populates_lid_pn_cache_for_participants() -> anyhow::Re
         .get_lid_pn_entry(&jid_b_lid)
         .await?
         .expect("lid_pn_cache must have B's mapping after query_info");
-    assert_eq!(entry.lid, jid_b_lid.user);
-    assert_eq!(entry.phone_number, jid_b_pn.user);
+    assert_eq!(&*entry.lid, jid_b_lid.user.as_str());
+    assert_eq!(&*entry.phone_number, jid_b_pn.user.as_str());
 
     client_a.disconnect().await;
     client_b.disconnect().await;

--- a/wacore/src/types/lid_pn.rs
+++ b/wacore/src/types/lid_pn.rs
@@ -11,6 +11,8 @@
 //! When multiple LIDs exist for the same phone number (rare), the most recent one
 //! (by `created_at` timestamp) is considered "current".
 
+use std::sync::Arc;
+
 /// The source from which a LID-PN mapping was learned.
 /// Different sources have different trust levels and handling for identity changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
@@ -61,10 +63,13 @@ impl LearningSource {
 /// An entry in the LID-PN cache containing the full mapping information.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LidPnEntry {
-    /// The LID user part (e.g., "100000012345678")
-    pub lid: String,
+    /// The LID user part (e.g., "100000012345678").
+    /// `Arc<str>`: the cache stores each mapping under both directions, so the
+    /// identifier strings are shared between the entry and the cache keys
+    /// instead of re-allocated per copy (this cache is unbounded by design).
+    pub lid: Arc<str>,
     /// The phone number user part (e.g., "559980000001")
-    pub phone_number: String,
+    pub phone_number: Arc<str>,
     /// Unix timestamp when the mapping was first learned
     pub created_at: i64,
     /// The source from which this mapping was learned
@@ -73,12 +78,16 @@ pub struct LidPnEntry {
 
 impl LidPnEntry {
     /// Create a new entry with the current timestamp
-    pub fn new(lid: String, phone_number: String, learning_source: LearningSource) -> Self {
+    pub fn new(
+        lid: impl Into<Arc<str>>,
+        phone_number: impl Into<Arc<str>>,
+        learning_source: LearningSource,
+    ) -> Self {
         let now = crate::time::now_secs();
 
         Self {
-            lid,
-            phone_number,
+            lid: lid.into(),
+            phone_number: phone_number.into(),
             created_at: now,
             learning_source,
         }
@@ -86,14 +95,14 @@ impl LidPnEntry {
 
     /// Create an entry with a specific timestamp
     pub fn with_timestamp(
-        lid: String,
-        phone_number: String,
+        lid: impl Into<Arc<str>>,
+        phone_number: impl Into<Arc<str>>,
         created_at: i64,
         learning_source: LearningSource,
     ) -> Self {
         Self {
-            lid,
-            phone_number,
+            lid: lid.into(),
+            phone_number: phone_number.into(),
             created_at,
             learning_source,
         }
@@ -137,8 +146,8 @@ mod tests {
             LearningSource::Usync,
         );
 
-        assert_eq!(entry.lid, "100000012345678");
-        assert_eq!(entry.phone_number, "559980000001");
+        assert_eq!(&*entry.lid, "100000012345678");
+        assert_eq!(&*entry.phone_number, "559980000001");
         assert_eq!(entry.learning_source, LearningSource::Usync);
         assert!(entry.created_at > 0);
     }
@@ -152,8 +161,8 @@ mod tests {
             LearningSource::Pairing,
         );
 
-        assert_eq!(entry.lid, "100000012345678");
-        assert_eq!(entry.phone_number, "559980000001");
+        assert_eq!(&*entry.lid, "100000012345678");
+        assert_eq!(&*entry.phone_number, "559980000001");
         assert_eq!(entry.created_at, 1234567890);
         assert_eq!(entry.learning_source, LearningSource::Pairing);
     }


### PR DESCRIPTION
## Problem

`LidPnEntry` stores `lid`/`phone_number` as owned `String`s, and `LidPnCache` then re-allocates each identifier again as the key of both `TypedCache` directions (`src/lid_pn_cache.rs`). Net: every mapping carries ~4 separate heap strings for 2 identifiers — in the one cache that is **unbounded by design** (`WAWebLidPnCache` parity: no TTL, no capacity), so per-entry bytes compound over a long-running process's contact base.

## Change

`LidPnEntry.lid` / `.phone_number` become `Arc&lt;str&gt;` (`wacore/src/types/lid_pn.rs`), and `LidPnCache::add` clones the entry's own `Arc`s as the map keys — each identifier is allocated once per mapping and shared by the key and the entry across both directions. `entry.clone()` inside `add()` becomes two refcount bumps instead of two string copies, as a side effect. The `persisted` marker map keys follow suit.

- **Constructors** take `impl Into&lt;Arc&lt;str&gt;&gt;`, so every existing call site (`String` and `&amp;str` args) stays source-compatible.
- **Wire/persistence unchanged**: `Arc&lt;str&gt;` serializes as a plain JSON string, so persisted `lid_pn_mapping` rows, the `TypedCache` external-store path, and custom `CacheStore` backends are unaffected. Lookups are unchanged (`TypedCache::get` goes through `Borrow&lt;str&gt;`).
- Consumers that compared/converted fields adjust with a deref (`&amp;*entry.lid`); `get_phone_number` keeps its `String` return (it allocated a clone before too — cost-identical).

## Scale (honest)

This is the smallest of the memory series: ~40-80 B saved per mapping plus two allocations per learn. It matters specifically because this cache never evicts — 10k learned mappings ≈ 0.5-1 MB retained that this removes — and the change rides entirely on type coercion (no caller churn, no format change).

## Verification

`cargo test -p wacore --lib`: 947 passed; `cargo test -p whatsapp-rust --lib`: 744 passed; e2e tests compile; `cargo clippy --all-targets -- -D warnings` clean; fmt clean.

## Breaking

`LidPnEntry` public field types `String` → `Arc&lt;str&gt;` (pre-1.0). Constructor calls are unaffected; direct field consumers need a deref.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKdomTCXXcp3V44UgbMuJf)_