### PR TITLE
fix(protocol): tighten error handling gaps

### DIFF
--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -90,7 +90,11 @@ impl<'a> Contacts<'a> {
                     known_lid: None,
                 });
             } else {
-                unreachable!("validated is_on_whatsapp JID type at entry");
+                debug_assert!(
+                    jid.is_pn() || jid.is_lid(),
+                    "validated is_on_whatsapp JID type"
+                );
+                continue;
             }
         }
 

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -14,7 +14,7 @@ use wacore_binary::{Jid, JidExt};
 
 // Re-export types from wacore
 pub use wacore::iq::contacts::ProfilePicture;
-pub use wacore::iq::usync::{IsOnWhatsAppResult, UserInfo};
+pub use wacore::iq::usync::{IsOnWhatsAppResult, UserInfo, UsyncSubprotocolError};
 pub use wacore::stanza::business::VerifiedName;
 
 fn ensure_is_on_whatsapp_jids_supported(jids: &[Jid]) -> Result<()> {

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -90,7 +90,11 @@ impl<'a> Contacts<'a> {
                     known_lid: None,
                 });
             } else {
-                unreachable!("validated is_on_whatsapp JID type");
+                debug_assert!(
+                    jid.is_pn() || jid.is_lid(),
+                    "validated is_on_whatsapp JID type"
+                );
+                continue;
             }
         }
 

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -90,10 +90,10 @@ impl<'a> Contacts<'a> {
                     known_lid: None,
                 });
             } else {
-                debug_assert!(
-                    jid.is_pn() || jid.is_lid(),
-                    "validated is_on_whatsapp JID type"
-                );
+                #[cfg(debug_assertions)]
+                panic!("is_on_whatsapp: unexpected JID type {jid} after validation");
+
+                #[cfg(not(debug_assertions))]
                 continue;
             }
         }

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -5,7 +5,7 @@
 
 use crate::client::Client;
 use crate::request::IqError;
-use anyhow::Result;
+use anyhow::{Result, bail};
 use log::debug;
 use std::collections::HashMap;
 use wacore::iq::contacts::{ProfilePictureSpec, ProfilePictureType};
@@ -16,6 +16,13 @@ use wacore_binary::{Jid, JidExt};
 pub use wacore::iq::contacts::ProfilePicture;
 pub use wacore::iq::usync::{IsOnWhatsAppResult, UserInfo};
 pub use wacore::stanza::business::VerifiedName;
+
+fn ensure_is_on_whatsapp_jids_supported(jids: &[Jid]) -> Result<()> {
+    if let Some(jid) = jids.iter().find(|jid| !jid.is_pn() && !jid.is_lid()) {
+        bail!("is_on_whatsapp only supports PN and LID JIDs, got {jid}");
+    }
+    Ok(())
+}
 
 pub struct Contacts<'a> {
     client: &'a Client,
@@ -64,6 +71,7 @@ impl<'a> Contacts<'a> {
         if jids.is_empty() {
             return Ok(Vec::new());
         }
+        ensure_is_on_whatsapp_jids_supported(jids)?;
 
         debug!("is_on_whatsapp: checking {} JIDs", jids.len());
 
@@ -82,7 +90,7 @@ impl<'a> Contacts<'a> {
                     known_lid: None,
                 });
             } else {
-                log::warn!("is_on_whatsapp: skipping unsupported JID type: {jid}");
+                unreachable!("validated is_on_whatsapp JID type");
             }
         }
 
@@ -205,5 +213,19 @@ mod tests {
         assert_eq!(pic.id, "123456789");
         assert_eq!(pic.url, "https://example.com/pic.jpg");
         assert!(pic.direct_path.is_some());
+    }
+
+    #[test]
+    fn is_on_whatsapp_accepts_pn_and_lid_jids() {
+        ensure_is_on_whatsapp_jids_supported(&[Jid::pn("15550000001"), Jid::lid("100000001")])
+            .unwrap();
+    }
+
+    #[test]
+    fn is_on_whatsapp_rejects_unsupported_jid_type() {
+        let err = ensure_is_on_whatsapp_jids_supported(&[Jid::group("15550000001-1234567890")])
+            .unwrap_err();
+
+        assert!(err.to_string().contains("only supports PN and LID JIDs"));
     }
 }

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -90,11 +90,7 @@ impl<'a> Contacts<'a> {
                     known_lid: None,
                 });
             } else {
-                debug_assert!(
-                    jid.is_pn() || jid.is_lid(),
-                    "validated is_on_whatsapp JID type"
-                );
-                continue;
+                unreachable!("validated is_on_whatsapp JID type at entry");
             }
         }
 

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -29,7 +29,9 @@ pub use community::{
 
 pub use chatstate::{ChatStateType, Chatstate};
 
-pub use contacts::{Contacts, IsOnWhatsAppResult, ProfilePicture, UserInfo, VerifiedName};
+pub use contacts::{
+    Contacts, IsOnWhatsAppResult, ProfilePicture, UserInfo, UsyncSubprotocolError, VerifiedName,
+};
 
 pub use events::{EventCreationParams, EventResponseType, Events};
 

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -39,9 +39,10 @@ fn classify_keepalive_error(e: &IqError) -> KeepaliveResult {
         | IqError::EncodeError(_) => KeepaliveResult::FatalFailure,
         // Exhaustive: forces a compile error when new IqError variants are added
         // so the developer must decide the classification.
-        IqError::Timeout | IqError::ServerError { .. } | IqError::ParseError(_) => {
-            KeepaliveResult::TransientFailure
-        }
+        IqError::Timeout
+        | IqError::ServerError { .. }
+        | IqError::UnexpectedResponseType { .. }
+        | IqError::ParseError(_) => KeepaliveResult::TransientFailure,
     }
 }
 
@@ -341,6 +342,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_classify_unexpected_response_type_is_transient() {
+        assert_eq!(
+            classify_keepalive_error(&IqError::UnexpectedResponseType {
+                got: Some("get".to_string()),
+            }),
+            KeepaliveResult::TransientFailure,
+        );
+    }
+
     // Happy path: the connection was already gone, so a failed ping is just
     // teardown collateral and is logged quietly.
     #[test]
@@ -376,6 +387,9 @@ mod tests {
             text: "internal".to_string(),
             error_type: None,
             backoff: None,
+        }));
+        assert!(!is_benign_teardown(&IqError::UnexpectedResponseType {
+            got: Some("get".to_string()),
         }));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,8 @@ pub use features::{
     ParticipantChangeResponse, ParticipantType, PictureType, Presence, PresenceError,
     PresenceStatus, Profile, ProfilePicture, SecretEncKind, SecretEncrypted,
     SetProfilePictureResponse, Signal, Status, StatusPrivacySetting, StatusSendOptions,
-    SyncActionMessageRange, TcToken, UnlinkSubgroupsResult, UserInfo, VerifiedName, group_type,
-    message_key, message_range,
+    SyncActionMessageRange, TcToken, UnlinkSubgroupsResult, UserInfo, UsyncSubprotocolError,
+    VerifiedName, group_type, message_key, message_range,
 };
 
 pub mod bot;

--- a/src/request.rs
+++ b/src/request.rs
@@ -73,23 +73,6 @@ impl From<wacore::request::IqError> for IqError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::IqError;
-
-    #[test]
-    fn converts_unexpected_response_type() {
-        let err = IqError::from(wacore::request::IqError::UnexpectedResponseType {
-            got: Some("get".to_string()),
-        });
-
-        match err {
-            IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
-            other => panic!("expected UnexpectedResponseType, got {other:?}"),
-        }
-    }
-}
-
 impl Client {
     pub(crate) fn generate_request_id(&self) -> String {
         self.get_request_utils().generate_request_id()
@@ -310,5 +293,22 @@ impl Client {
             Err(_) => "error",
         });
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IqError;
+
+    #[test]
+    fn converts_unexpected_response_type() {
+        let err = IqError::from(wacore::request::IqError::UnexpectedResponseType {
+            got: Some("get".to_string()),
+        });
+
+        match err {
+            IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
+            other => panic!("expected UnexpectedResponseType, got {other:?}"),
+        }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -35,6 +35,8 @@ pub enum IqError {
         /// Server-directed retry delay in seconds from the `backoff` attr; `None` if absent.
         backoff: Option<u32>,
     },
+    #[error("received unexpected IQ response type: {got:?}")]
+    UnexpectedResponseType { got: Option<String> },
     #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
     #[error("failed to encode IQ request")]
@@ -60,10 +62,30 @@ impl From<wacore::request::IqError> for IqError {
                 error_type,
                 backoff,
             },
+            wacore::request::IqError::UnexpectedResponseType { got } => {
+                Self::UnexpectedResponseType { got }
+            }
             wacore::request::IqError::InternalChannelClosed => Self::InternalChannelClosed,
             // wacore::IqError is #[non_exhaustive]; a new upstream variant should
             // get its own arm above. Until then treat it as an unexpected internal error.
             _ => Self::InternalChannelClosed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IqError;
+
+    #[test]
+    fn converts_unexpected_response_type() {
+        let err = IqError::from(wacore::request::IqError::UnexpectedResponseType {
+            got: Some("get".to_string()),
+        });
+
+        match err {
+            IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
+            other => panic!("expected UnexpectedResponseType, got {other:?}"),
         }
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -112,7 +112,7 @@ fn resolve_retry_chat_info(
     node: &NodeRef<'_>,
     own_pn: Option<&Jid>,
     own_lid: Option<&Jid>,
-) -> RetryChatInfo {
+) -> Option<RetryChatInfo> {
     let from = &receipt.source.chat;
 
     if from.is_group() || from.is_status_broadcast() {
@@ -122,13 +122,13 @@ fn resolve_retry_chat_info(
             .attrs()
             .optional_jid("participant")
             .unwrap_or_else(|| receipt.source.sender.clone());
-        RetryChatInfo {
+        Some(RetryChatInfo {
             chat: from.clone(),
             requester,
             original_from: from.clone(),
             recipient: node.attrs().optional_jid("recipient"),
             is_bot: false,
-        }
+        })
     } else {
         // DM: resolve chat target via getTargetChat logic.
         let recipient = node.attrs().optional_jid("recipient");
@@ -138,9 +138,6 @@ fn resolve_retry_chat_info(
         // 1. Bot + recipient → chat = recipient
         // 2. Peer device + recipient → chat = recipient
         // 3. Peer device without recipient → WA Web aborts (returns null).
-        //    We log+fall back to `from.to_non_ad()` rather than dropping
-        //    the receipt; the message lookup will likely miss but the
-        //    retry receipt is at least acknowledged downstream.
         // 4. Normal user → chat = asUserWidOrThrow(from) = from.to_non_ad()
         let is_peer = own_pn.is_some_and(|pn| from.is_same_user_as(pn))
             || own_lid.is_some_and(|lid| from.is_same_user_as(lid));
@@ -150,13 +147,9 @@ fn resolve_retry_chat_info(
         } else if is_peer {
             match recipient.as_ref() {
                 Some(r) => r.to_non_ad(),
-                // No recipient on peer retry — chat will be our own JID,
-                // message lookup will likely fail. WA Web returns null here.
                 None => {
-                    log::warn!(
-                        "Peer device retry without recipient attr — message lookup may fail"
-                    );
-                    from.to_non_ad()
+                    log::warn!("Ignoring peer device retry without recipient attr");
+                    return None;
                 }
             }
         } else {
@@ -169,13 +162,13 @@ fn resolve_retry_chat_info(
             from.clone()
         };
 
-        RetryChatInfo {
+        Some(RetryChatInfo {
             chat,
             requester,
             original_from: from.clone(),
             recipient,
             is_bot,
-        }
+        })
     }
 }
 
@@ -228,12 +221,14 @@ impl Client {
         }
 
         let device_snapshot = self.persistence_manager.get_device_snapshot();
-        let mut info = resolve_retry_chat_info(
+        let Some(mut info) = resolve_retry_chat_info(
             receipt,
             nr,
             device_snapshot.pn.as_ref(),
             device_snapshot.lid.as_ref(),
-        );
+        ) else {
+            return Ok(());
+        };
         let is_group_or_status = info.chat.is_group() || info.chat.is_status_broadcast();
 
         // WA Web doesn't dedupe receipts (Message/Queue.js just serializes per-chat);
@@ -1247,6 +1242,25 @@ mod tests {
     use wacore::types::jid::JidExt as _;
     use wacore_binary::{Jid, JidExt};
     use waproto::whatsapp as wa;
+
+    fn resolve_retry_chat_info(
+        receipt: &Receipt,
+        node: &NodeRef<'_>,
+        own_pn: Option<&Jid>,
+        own_lid: Option<&Jid>,
+    ) -> RetryChatInfo {
+        super::resolve_retry_chat_info(receipt, node, own_pn, own_lid)
+            .expect("retry should resolve a target chat")
+    }
+
+    fn maybe_resolve_retry_chat_info(
+        receipt: &Receipt,
+        node: &NodeRef<'_>,
+        own_pn: Option<&Jid>,
+        own_lid: Option<&Jid>,
+    ) -> Option<RetryChatInfo> {
+        super::resolve_retry_chat_info(receipt, node, own_pn, own_lid)
+    }
 
     #[tokio::test]
     async fn recent_message_cache_insert_and_take() {
@@ -3188,16 +3202,15 @@ mod tests {
     fn resolve_retry_chat_info_peer_device_without_recipient() {
         use wacore_binary::builder::NodeBuilder;
 
-        // Peer retry without recipient attr — should fall back to from
+        // Peer retry without recipient attr has no target chat in WA Web.
         let our_pn: Jid = "5511999999999@s.whatsapp.net".parse().unwrap();
         let node = NodeBuilder::new("receipt").build();
         let receipt = make_test_receipt("5511999999999:2@s.whatsapp.net");
 
-        let info = resolve_retry_chat_info(&receipt, &node.as_node_ref(), Some(&our_pn), None);
+        let info =
+            maybe_resolve_retry_chat_info(&receipt, &node.as_node_ref(), Some(&our_pn), None);
 
-        // Falls back to from.to_non_ad() (our own bare JID)
-        assert_eq!(info.chat.user, our_pn.user);
-        assert_eq!(info.chat.device(), 0);
+        assert!(info.is_none());
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -952,7 +952,7 @@ impl Client {
                         "device-identity ADV validation failed for companion {requester_jid}"
                     ));
                 }
-                wacore::adv::AdvValidation::NoAccountKey => log::warn!(
+                wacore::adv::AdvValidation::NoAccountKey => log::debug!(
                     "retry key bundle for companion {requester_jid} omits account_signature_key and no stored account identity; proceeding without ADV validation"
                 ),
             }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -173,16 +173,6 @@ fn resolve_retry_chat_info(
     }
 }
 
-fn validate_retry_prekey_presence(
-    keys_node: &NodeRef<'_>,
-    is_bot_retry: bool,
-) -> Result<(), anyhow::Error> {
-    if !is_bot_retry && keys_node.get_optional_child("key").is_none() {
-        anyhow::bail!("regular retry key bundle missing one-time prekey");
-    }
-    Ok(())
-}
-
 // No retry_count in the key: concurrent receipts for the same participant must
 // serialize, otherwise two update_local_signal_session calls race on session state.
 fn build_retry_processing_key(chat: &Jid, message_id: &str, participant_jid: &Jid) -> String {
@@ -627,7 +617,7 @@ impl Client {
         //    `!is_status_broadcast()`; WA Web runs it unconditionally.
         let keys_node_present = node.get_optional_child("keys").is_some();
         let key_bundle_result = self
-            .process_retry_key_bundle(node, resolved_jid, is_peer, info.is_bot)
+            .process_retry_key_bundle(node, resolved_jid, is_peer)
             .await;
         let key_bundle_processed = key_bundle_result.is_ok();
 
@@ -852,19 +842,16 @@ impl Client {
     /// * `node` - The retry receipt node containing the key bundle
     /// * `requester_jid` - The JID of the device requesting the retry
     /// * `is_peer` - Whether this is a peer device (our own device)
-    /// * `is_bot_retry` - Whether the retry follows the bot_retry parser rules
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.process_key_bundle", level = "debug", skip_all, fields(peer = %requester_jid.observe(), is_peer, is_bot_retry), err(Debug)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.process_key_bundle", level = "debug", skip_all, fields(peer = %requester_jid.observe(), is_peer), err(Debug)))]
     async fn process_retry_key_bundle(
         &self,
         node: &NodeRef<'_>,
         requester_jid: &wacore_binary::Jid,
         is_peer: bool,
-        is_bot_retry: bool,
     ) -> Result<(), anyhow::Error> {
         let keys_node = node
             .get_optional_child("keys")
             .ok_or_else(|| anyhow::anyhow!("<keys> child missing from retry receipt"))?;
-        validate_retry_prekey_presence(keys_node, is_bot_retry)?;
 
         let registration_node = node.get_optional_child("registration");
 
@@ -1253,6 +1240,7 @@ mod tests {
     use crate::test_utils::MockHttpClient;
     use std::borrow::Cow;
     use std::sync::Arc;
+    use wacore::libsignal::protocol::IdentityKeyPair;
     use wacore::types::jid::JidExt as _;
     use wacore_binary::{Jid, JidExt};
     use waproto::whatsapp as wa;
@@ -2292,6 +2280,75 @@ mod tests {
             .expect("no-op when session exists");
     }
 
+    #[tokio::test]
+    async fn retry_key_bundle_allows_signed_prekey_without_one_time_prekey() {
+        let backend = crate::test_utils::create_test_backend().await;
+        let pm = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("persistence manager should initialize"),
+        );
+        let (client, _sync_rx) = Client::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            pm,
+            Arc::new(crate::transport::mock::MockTransportFactory::new()),
+            Arc::new(MockHttpClient),
+            None,
+        )
+        .await;
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let remote_identity = IdentityKeyPair::generate(&mut rng);
+        let signed_prekey = KeyPair::generate(&mut rng);
+        let signed_prekey_signature = remote_identity
+            .private_key()
+            .calculate_signature(&signed_prekey.public_key.serialize(), &mut rng)
+            .expect("signed prekey signature should be valid");
+
+        let requester = Jid::pn_device("559922223333", 1);
+        let keys = NodeBuilder::new("keys")
+            .children([
+                NodeBuilder::new("type").bytes(vec![5]).build(),
+                NodeBuilder::new("identity")
+                    .bytes(
+                        remote_identity
+                            .identity_key()
+                            .public_key()
+                            .public_key_bytes()
+                            .to_vec(),
+                    )
+                    .build(),
+                SignedPreKeyNode::new(
+                    100,
+                    signed_prekey.public_key.public_key_bytes().to_vec(),
+                    signed_prekey_signature.to_vec(),
+                )
+                .into_node(),
+            ])
+            .build();
+        let receipt = NodeBuilder::new("receipt")
+            .children([
+                NodeBuilder::new("registration")
+                    .bytes(12345u32.to_be_bytes().to_vec())
+                    .build(),
+                keys,
+            ])
+            .build();
+
+        client
+            .process_retry_key_bundle(&receipt.as_node_ref(), &requester, false)
+            .await
+            .expect("signed-prekey-only retry bundle should establish a session");
+
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        let session = client
+            .signal_cache
+            .peek_session(&requester.to_protocol_address(), &*snapshot.backend)
+            .await
+            .expect("session lookup should succeed");
+        assert!(session.is_some());
+    }
+
     #[test]
     fn bot_jid_detection() {
         // Test bot JID detection for bot message filtering
@@ -2316,30 +2373,6 @@ mod tests {
         // Similar but not bot (doesn't start with exact prefix)
         let not_bot: Jid = "1313556123456@s.whatsapp.net".parse().unwrap();
         assert!(!not_bot.is_bot());
-    }
-
-    #[test]
-    fn regular_retry_requires_one_time_prekey() {
-        let keys = NodeBuilder::new("keys").build();
-
-        let err = validate_retry_prekey_presence(&keys.as_node_ref(), false).unwrap_err();
-        assert!(err.to_string().contains("missing one-time prekey"));
-    }
-
-    #[test]
-    fn bot_retry_allows_missing_one_time_prekey() {
-        let keys = NodeBuilder::new("keys").build();
-
-        validate_retry_prekey_presence(&keys.as_node_ref(), true).unwrap();
-    }
-
-    #[test]
-    fn regular_retry_allows_present_one_time_prekey() {
-        let keys = NodeBuilder::new("keys")
-            .children([NodeBuilder::new("key").build()])
-            .build();
-
-        validate_retry_prekey_presence(&keys.as_node_ref(), false).unwrap();
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -122,12 +122,13 @@ fn resolve_retry_chat_info(
             .attrs()
             .optional_jid("participant")
             .unwrap_or_else(|| receipt.source.sender.clone());
+        let is_bot = requester.is_bot();
         Some(RetryChatInfo {
             chat: from.clone(),
             requester,
             original_from: from.clone(),
             recipient: node.attrs().optional_jid("recipient"),
-            is_bot: false,
+            is_bot,
         })
     } else {
         // DM: resolve chat target via getTargetChat logic.
@@ -170,6 +171,16 @@ fn resolve_retry_chat_info(
             is_bot,
         })
     }
+}
+
+fn validate_retry_prekey_presence(
+    keys_node: &NodeRef<'_>,
+    is_bot_retry: bool,
+) -> Result<(), anyhow::Error> {
+    if !is_bot_retry && keys_node.get_optional_child("key").is_none() {
+        anyhow::bail!("regular retry key bundle missing one-time prekey");
+    }
+    Ok(())
 }
 
 // No retry_count in the key: concurrent receipts for the same participant must
@@ -616,7 +627,7 @@ impl Client {
         //    `!is_status_broadcast()`; WA Web runs it unconditionally.
         let keys_node_present = node.get_optional_child("keys").is_some();
         let key_bundle_result = self
-            .process_retry_key_bundle(node, resolved_jid, is_peer)
+            .process_retry_key_bundle(node, resolved_jid, is_peer, info.is_bot)
             .await;
         let key_bundle_processed = key_bundle_result.is_ok();
 
@@ -841,16 +852,19 @@ impl Client {
     /// * `node` - The retry receipt node containing the key bundle
     /// * `requester_jid` - The JID of the device requesting the retry
     /// * `is_peer` - Whether this is a peer device (our own device)
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.process_key_bundle", level = "debug", skip_all, fields(peer = %requester_jid.observe(), is_peer), err(Debug)))]
+    /// * `is_bot_retry` - Whether the retry follows the bot_retry parser rules
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.process_key_bundle", level = "debug", skip_all, fields(peer = %requester_jid.observe(), is_peer, is_bot_retry), err(Debug)))]
     async fn process_retry_key_bundle(
         &self,
         node: &NodeRef<'_>,
         requester_jid: &wacore_binary::Jid,
         is_peer: bool,
+        is_bot_retry: bool,
     ) -> Result<(), anyhow::Error> {
         let keys_node = node
             .get_optional_child("keys")
             .ok_or_else(|| anyhow::anyhow!("<keys> child missing from retry receipt"))?;
+        validate_retry_prekey_presence(keys_node, is_bot_retry)?;
 
         let registration_node = node.get_optional_child("registration");
 
@@ -2305,6 +2319,30 @@ mod tests {
     }
 
     #[test]
+    fn regular_retry_requires_one_time_prekey() {
+        let keys = NodeBuilder::new("keys").build();
+
+        let err = validate_retry_prekey_presence(&keys.as_node_ref(), false).unwrap_err();
+        assert!(err.to_string().contains("missing one-time prekey"));
+    }
+
+    #[test]
+    fn bot_retry_allows_missing_one_time_prekey() {
+        let keys = NodeBuilder::new("keys").build();
+
+        validate_retry_prekey_presence(&keys.as_node_ref(), true).unwrap();
+    }
+
+    #[test]
+    fn regular_retry_allows_present_one_time_prekey() {
+        let keys = NodeBuilder::new("keys")
+            .children([NodeBuilder::new("key").build()])
+            .build();
+
+        validate_retry_prekey_presence(&keys.as_node_ref(), false).unwrap();
+    }
+
+    #[test]
     fn extract_registration_id_from_node_test() {
         use wacore_binary::{Attrs, Node};
 
@@ -2714,6 +2752,31 @@ mod tests {
         assert_eq!(info.chat.user, "120363021033254949");
         assert!(info.requester.is_lid());
         assert_eq!(info.requester.device(), 33);
+    }
+
+    #[test]
+    fn resolve_retry_chat_info_group_bot_participant_marks_bot_retry() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let node = NodeBuilder::new("receipt")
+            .attr("participant", "somebot:4@bot")
+            .build();
+        let receipt = Receipt {
+            source: crate::types::message::MessageSource {
+                chat: "120363021033254949@g.us".parse().unwrap(),
+                sender: "somebot:4@bot".parse().unwrap(),
+                ..Default::default()
+            },
+            message_ids: vec!["MSG001".to_string()],
+            timestamp: wacore::time::now_utc(),
+            r#type: crate::types::presence::ReceiptType::Retry,
+            offline: false,
+        };
+
+        let info = resolve_retry_chat_info(&receipt, &node.as_node_ref(), None, None);
+
+        assert!(info.chat.is_group());
+        assert!(info.is_bot);
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -102,6 +102,12 @@ struct RetryChatInfo {
     recipient: Option<Jid>,
     /// True if the requester is a bot JID (skip namespace normalization).
     is_bot: bool,
+    /// WA Web's `bot_retry` parser path: only primary `@bot` JIDs, not legacy PN bots.
+    is_fbid_bot_retry: bool,
+}
+
+fn is_fbid_bot_retry_jid(jid: &Jid) -> bool {
+    jid.server == wacore_binary::Server::Bot && jid.device() == 0
 }
 
 /// Resolve the chat and requester JIDs from a retry receipt, separating
@@ -118,10 +124,10 @@ fn resolve_retry_chat_info(
     if from.is_group() || from.is_status_broadcast() {
         // Groups/status: chat is already the group/broadcast JID.
         // Requester is the participant attr (the actual retrying device).
-        let requester = node
-            .attrs()
-            .optional_jid("participant")
-            .unwrap_or_else(|| receipt.source.sender.clone());
+        let participant = node.attrs().optional_jid("participant");
+        let is_fbid_bot_retry =
+            from.is_group() && participant.as_ref().is_some_and(is_fbid_bot_retry_jid);
+        let requester = participant.unwrap_or_else(|| receipt.source.sender.clone());
         let is_bot = requester.is_bot();
         Some(RetryChatInfo {
             chat: from.clone(),
@@ -129,6 +135,7 @@ fn resolve_retry_chat_info(
             original_from: from.clone(),
             recipient: node.attrs().optional_jid("recipient"),
             is_bot,
+            is_fbid_bot_retry,
         })
     } else {
         // DM: resolve chat target via getTargetChat logic.
@@ -169,8 +176,19 @@ fn resolve_retry_chat_info(
             original_from: from.clone(),
             recipient,
             is_bot,
+            is_fbid_bot_retry: is_fbid_bot_retry_jid(from),
         })
     }
+}
+
+fn validate_retry_prekey_presence(
+    keys_node: &NodeRef<'_>,
+    is_fbid_bot_retry: bool,
+) -> Result<(), anyhow::Error> {
+    if !is_fbid_bot_retry && keys_node.get_optional_child("key").is_none() {
+        anyhow::bail!("regular retry key bundle missing one-time prekey");
+    }
+    Ok(())
 }
 
 // No retry_count in the key: concurrent receipts for the same participant must
@@ -418,15 +436,19 @@ impl Client {
         // Mirror WAWebUpdateLocalSignalSession for all chat types: markForgetSenderKey
         // (group/status) + processKeyBundle + regId-mismatch delete + base-key logic.
         // Must run before ensureE2ESessions so any session deletion here is rebuilt there.
-        self.update_local_signal_session(
-            &info,
-            &resolved_jid,
-            &message_id,
-            retry_count,
-            nr,
-            is_peer,
-        )
-        .await;
+        if !self
+            .update_local_signal_session(
+                &info,
+                &resolved_jid,
+                &message_id,
+                retry_count,
+                nr,
+                is_peer,
+            )
+            .await
+        {
+            return Ok(());
+        }
 
         // Whatsmeow parity (`retry.go:284`). WA Web's regId/base-key check
         // doesn't catch silently-diverged sessions; this fallback does.
@@ -581,7 +603,7 @@ impl Client {
         retry_count: u8,
         node: &NodeRef<'_>,
         is_peer: bool,
-    ) {
+    ) -> bool {
         // 1. markForgetSenderKey (WA Web L33-38). Rust unifies group and status
         //    under a single storage (chat JID as the key) — markForgetSenderKey
         //    handles both `@g.us` and `status@broadcast` as opaque group_jid.
@@ -617,7 +639,7 @@ impl Client {
         //    `!is_status_broadcast()`; WA Web runs it unconditionally.
         let keys_node_present = node.get_optional_child("keys").is_some();
         let key_bundle_result = self
-            .process_retry_key_bundle(node, resolved_jid, is_peer)
+            .process_retry_key_bundle(node, resolved_jid, is_peer, info.is_fbid_bot_retry)
             .await;
         let key_bundle_processed = key_bundle_result.is_ok();
 
@@ -627,10 +649,11 @@ impl Client {
         //    doesn't trigger destructive session deletion as a side effect.
         if !key_bundle_processed && keys_node_present {
             log::warn!(
-                "Key bundle present but rejected for {}: {:?} — skipping regId mismatch deletion",
+                "Key bundle present but rejected for {}: {:?} — aborting retry resend",
                 resolved_jid.observe(),
                 key_bundle_result.as_ref().err()
             );
+            return false;
         }
         if !key_bundle_processed && !keys_node_present {
             if let Err(ref e) = key_bundle_result {
@@ -687,10 +710,10 @@ impl Client {
             .flatten();
 
         let Some(session) = session else {
-            return;
+            return true;
         };
         let Ok(current_base_key) = session.alice_base_key() else {
-            return;
+            return true;
         };
 
         let addr_str = signal_address.as_str();
@@ -712,7 +735,7 @@ impl Client {
                     e
                 ),
             }
-            return;
+            return true;
         }
 
         if retry_count > MIN_RETRY_FOR_BASE_KEY_CHECK {
@@ -762,6 +785,7 @@ impl Client {
                 }
             }
         }
+        true
     }
 
     /// Mirrors whatsmeow's `shouldRecreateSession`. Returns `Some(reason)`
@@ -842,16 +866,18 @@ impl Client {
     /// * `node` - The retry receipt node containing the key bundle
     /// * `requester_jid` - The JID of the device requesting the retry
     /// * `is_peer` - Whether this is a peer device (our own device)
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.process_key_bundle", level = "debug", skip_all, fields(peer = %requester_jid.observe(), is_peer), err(Debug)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.process_key_bundle", level = "debug", skip_all, fields(peer = %requester_jid.observe(), is_peer, is_fbid_bot_retry), err(Debug)))]
     async fn process_retry_key_bundle(
         &self,
         node: &NodeRef<'_>,
         requester_jid: &wacore_binary::Jid,
         is_peer: bool,
+        is_fbid_bot_retry: bool,
     ) -> Result<(), anyhow::Error> {
         let keys_node = node
             .get_optional_child("keys")
             .ok_or_else(|| anyhow::anyhow!("<keys> child missing from retry receipt"))?;
+        validate_retry_prekey_presence(keys_node, is_fbid_bot_retry)?;
 
         let registration_node = node.get_optional_child("registration");
 
@@ -1839,6 +1865,7 @@ mod tests {
             original_from: resolved_jid.clone(),
             recipient: None,
             is_bot: false,
+            is_fbid_bot_retry: false,
         }
     }
 
@@ -2062,6 +2089,7 @@ mod tests {
             original_from: group_chat,
             recipient: None,
             is_bot: false,
+            is_fbid_bot_retry: false,
         };
 
         let node = build_retry_receipt_without_keys();
@@ -2281,7 +2309,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_key_bundle_allows_signed_prekey_without_one_time_prekey() {
+    async fn retry_key_bundle_requires_one_time_prekey_except_fbid_bot() {
         let backend = crate::test_utils::create_test_backend().await;
         let pm = Arc::new(
             PersistenceManager::new(backend)
@@ -2305,7 +2333,7 @@ mod tests {
             .calculate_signature(&signed_prekey.public_key.serialize(), &mut rng)
             .expect("signed prekey signature should be valid");
 
-        let requester = Jid::pn_device("559922223333", 1);
+        let regular_requester = Jid::pn_device("559922223333", 1);
         let keys = NodeBuilder::new("keys")
             .children([
                 NodeBuilder::new("type").bytes(vec![5]).build(),
@@ -2335,15 +2363,28 @@ mod tests {
             ])
             .build();
 
-        client
-            .process_retry_key_bundle(&receipt.as_node_ref(), &requester, false)
+        let err = client
+            .process_retry_key_bundle(&receipt.as_node_ref(), &regular_requester, false, false)
             .await
-            .expect("signed-prekey-only retry bundle should establish a session");
+            .expect_err("regular retry without one-time prekey must be rejected");
+        assert!(
+            err.to_string()
+                .contains("regular retry key bundle missing one-time prekey")
+        );
+
+        let fbid_bot_requester = Jid::new("200000000000002", wacore_binary::Server::Bot);
+        client
+            .process_retry_key_bundle(&receipt.as_node_ref(), &fbid_bot_requester, false, true)
+            .await
+            .expect("fbid bot retry without one-time prekey should establish a session");
 
         let snapshot = client.persistence_manager.get_device_snapshot();
         let session = client
             .signal_cache
-            .peek_session(&requester.to_protocol_address(), &*snapshot.backend)
+            .peek_session(
+                &fbid_bot_requester.to_protocol_address(),
+                &*snapshot.backend,
+            )
             .await
             .expect("session lookup should succeed");
         assert!(session.is_some());
@@ -2788,7 +2829,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_retry_chat_info_group_bot_participant_marks_bot_retry() {
+    fn resolve_retry_chat_info_group_bot_device_marks_bot_namespace_only() {
         use wacore_binary::builder::NodeBuilder;
 
         let node = NodeBuilder::new("receipt")
@@ -2810,6 +2851,33 @@ mod tests {
 
         assert!(info.chat.is_group());
         assert!(info.is_bot);
+        assert!(!info.is_fbid_bot_retry);
+    }
+
+    #[test]
+    fn resolve_retry_chat_info_group_primary_fbid_bot_marks_bot_retry() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let node = NodeBuilder::new("receipt")
+            .attr("participant", "somebot@bot")
+            .build();
+        let receipt = Receipt {
+            source: crate::types::message::MessageSource {
+                chat: "120363021033254949@g.us".parse().unwrap(),
+                sender: "somebot@bot".parse().unwrap(),
+                ..Default::default()
+            },
+            message_ids: vec!["MSG001".to_string()],
+            timestamp: wacore::time::now_utc(),
+            r#type: crate::types::presence::ReceiptType::Retry,
+            offline: false,
+        };
+
+        let info = resolve_retry_chat_info(&receipt, &node.as_node_ref(), None, None);
+
+        assert!(info.chat.is_group());
+        assert!(info.is_bot);
+        assert!(info.is_fbid_bot_retry);
     }
 
     #[test]
@@ -3322,6 +3390,10 @@ mod tests {
         let info = resolve_retry_chat_info(&receipt, &node.as_node_ref(), None, None);
 
         assert!(info.is_bot, "bot JID should be detected");
+        assert!(
+            !info.is_fbid_bot_retry,
+            "legacy PN bots use the regular retry parser"
+        );
         // Chat should be the recipient
         assert_eq!(info.chat.user, "5522888888888");
         assert_eq!(info.chat.device(), 0);
@@ -3338,8 +3410,25 @@ mod tests {
         let info = resolve_retry_chat_info(&receipt, &node.as_node_ref(), None, None);
 
         assert!(info.is_bot);
+        assert!(!info.is_fbid_bot_retry);
         // Without recipient, falls to from.to_non_ad()
         assert_eq!(info.chat.user, "131355500001");
+    }
+
+    #[test]
+    fn resolve_retry_chat_info_fbid_bot_dm_marks_bot_retry() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let node = NodeBuilder::new("receipt")
+            .attr("recipient", "5522888888888@s.whatsapp.net")
+            .build();
+        let receipt = make_test_receipt("200000000000002@bot");
+
+        let info = resolve_retry_chat_info(&receipt, &node.as_node_ref(), None, None);
+
+        assert!(info.is_bot);
+        assert!(info.is_fbid_bot_retry);
+        assert_eq!(info.chat.user, "5522888888888");
     }
 
     #[test]

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -29,8 +29,8 @@ impl Default for HashState {
 pub struct HashUpdateResult {
     /// Whether a REMOVE mutation was missing its previous value.
     /// This happens when the server has an entry we don't have locally.
-    /// WhatsApp Web tracks this as `hasMissingRemove` and uses it to
-    /// determine if MAC validation failures should be fatal.
+    /// WhatsApp Web tracks this as telemetry for MAC-failure diagnostics;
+    /// it must not make MAC validation failures non-fatal.
     pub has_missing_remove: bool,
 }
 

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -340,8 +340,8 @@ fn detect_duplicate_index_in_patch(mutations: &[wa::SyncdMutation]) -> Result<()
 ///   can't anchor the ltHash) is rejected upstream in `process_patch_list`, which marks
 ///   the collection retryable so it re-syncs via snapshot, matching WhatsApp Web.
 /// * `has_missing_remove` - If true, a REMOVE mutation was missing its previous value.
-///   WhatsApp Web tracks this and makes MAC validation failures non-fatal in this case,
-///   because the ltHash is expected to diverge when we can't subtract a value we don't have.
+///   WhatsApp Web reports this as MAC-failure telemetry, but it does not make
+///   aggregate MAC mismatches acceptable.
 pub fn validate_patch_macs(
     patch: &wa::SyncdPatch,
     state: &HashState,
@@ -370,26 +370,15 @@ pub fn validate_patch_macs(
             hex::encode(snap_mac)
         );
         if computed_snap != *snap_mac {
-            // WhatsApp Web behavior: if hasMissingRemove is true, MAC mismatch is expected
-            // because we couldn't subtract the value we don't have. Log and continue.
-            if has_missing_remove {
-                log::warn!(
-                    target: "AppState",
-                    "Patch {} v{} snapshotMAC mismatch (expected due to hasMissingRemove=true), continuing",
-                    collection_name,
-                    state.version
-                );
-                // Don't fail - WhatsApp Web continues processing in this case
-            } else {
-                debug!(
-                    target: "AppState",
-                    "Patch {} v{} snapshotMAC MISMATCH! ltHash=...{}",
-                    collection_name,
-                    state.version,
-                    hex::encode(&state.hash[120..])
-                );
-                return Err(AppStateError::PatchSnapshotMACMismatch);
-            }
+            debug!(
+                target: "AppState",
+                "Patch {} v{} snapshotMAC MISMATCH! ltHash=...{}, hasMissingRemove={}",
+                collection_name,
+                state.version,
+                hex::encode(&state.hash[120..]),
+                has_missing_remove
+            );
+            return Err(AppStateError::PatchSnapshotMACMismatch);
         }
     }
 
@@ -397,17 +386,14 @@ pub fn validate_patch_macs(
         let version = patch.version.as_ref().and_then(|v| v.version).unwrap_or(0);
         let computed_patch = generate_patch_mac(patch, collection_name, &keys.patch_mac, version);
         if computed_patch != *patch_mac {
-            // Also skip patchMac validation if hasMissingRemove, since snapshotMac is part of it
-            if has_missing_remove {
-                log::warn!(
-                    target: "AppState",
-                    "Patch {} v{} patchMAC mismatch (expected due to hasMissingRemove=true), continuing",
-                    collection_name,
-                    state.version
-                );
-            } else {
-                return Err(AppStateError::PatchMACMismatch);
-            }
+            debug!(
+                target: "AppState",
+                "Patch {} v{} patchMAC MISMATCH, hasMissingRemove={}",
+                collection_name,
+                state.version,
+                has_missing_remove
+            );
+            return Err(AppStateError::PatchMACMismatch);
         }
     }
 
@@ -641,6 +627,48 @@ mod tests {
             result.added_macs[0].value_mac
         );
         assert!(result.removed_index_macs.is_empty());
+    }
+
+    #[test]
+    fn validate_patch_macs_rejects_snapshot_mismatch_even_with_missing_remove() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(2) }),
+            snapshot_mac: Some(vec![0u8; 32]),
+            ..Default::default()
+        };
+        let state = HashState {
+            version: 2,
+            hash: [3u8; 128],
+            index_value_map: HashMap::new(),
+        };
+
+        let err = validate_patch_macs(&patch, &state, &keys, "regular", false, true)
+            .expect_err("hasMissingRemove is telemetry, not a snapshotMAC bypass");
+
+        assert!(matches!(err, AppStateError::PatchSnapshotMACMismatch));
+    }
+
+    #[test]
+    fn validate_patch_macs_rejects_patch_mismatch_even_with_missing_remove() {
+        let master_key = [7u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let patch = wa::SyncdPatch {
+            version: Some(wa::SyncdVersion { version: Some(2) }),
+            patch_mac: Some(vec![0u8; 32]),
+            ..Default::default()
+        };
+        let state = HashState {
+            version: 2,
+            hash: [5u8; 128],
+            index_value_map: HashMap::new(),
+        };
+
+        let err = validate_patch_macs(&patch, &state, &keys, "regular", false, true)
+            .expect_err("hasMissingRemove is telemetry, not a patchMAC bypass");
+
+        assert!(matches!(err, AppStateError::PatchMACMismatch));
     }
 
     #[test]

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -137,17 +137,19 @@ impl<'a> Decoder<'a> {
             .read_value_as_string()?
             .ok_or(BinaryError::InvalidNode)?;
 
-        // Domain type mapping — must mirror encoder's server_to_domain_type().
+        // Domain type mapping must mirror WA Web decodeJidU.
         // WA Web: 0=WHATSAPP, 1=LID, even+bit7=HOSTED, 129=HOSTED_LID, else throw.
-        // server_to_domain_type encodes Pn/unknown as the agent value directly,
-        // so unmapped agents round-trip as Pn with the original agent preserved.
         let server = match agent {
             0 => crate::jid::Server::Pn,
             1 => crate::jid::Server::Lid,
             128 => crate::jid::Server::Hosted,
             129 => crate::jid::Server::HostedLid,
             n if (n & 128) != 0 && (n & 1) == 0 => crate::jid::Server::Hosted,
-            _ => crate::jid::Server::Pn,
+            _ => {
+                return Err(BinaryError::AttrParse(format!(
+                    "read_ad_jid - Invalid domain type encoding {agent}"
+                )));
+            }
         };
 
         Ok(JidRef {
@@ -683,6 +685,23 @@ mod tests {
         let mut decoder = Decoder::new(&data);
         let result = decoder.read_value_as_string();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ad_jid_rejects_invalid_domain_type() {
+        let data = vec![token::AD_JID, 2, 1, token::BINARY_8, 3, b'1', b'2', b'3'];
+        let mut decoder = Decoder::new(&data);
+        let result = decoder.read_value_as_string();
+
+        match result {
+            Err(BinaryError::AttrParse(msg)) => {
+                assert!(
+                    msg.contains("Invalid domain type encoding 2"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected AttrParse for invalid AD_JID domain type, got {other:?}"),
+        }
     }
 
     /// Test read_bytes with exact length

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -310,15 +310,15 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         (user_combined, None)
     };
 
-    let (user_end, _agent_override) = if let Some(underscore_idx) = user_agent.find('_') {
+    let user_end = if let Some(underscore_idx) = user_agent.find('_') {
         let agent_part = &user_agent[underscore_idx + 1..];
-        if let Ok(parsed_agent) = agent_part.parse::<u8>() {
-            (underscore_idx, Some(parsed_agent))
+        if agent_part.parse::<u8>().is_ok() {
+            underscore_idx
         } else {
-            (user_agent.len(), None)
+            user_agent.len()
         }
     } else {
-        (user_agent.len(), None)
+        user_agent.len()
     };
 
     let server_kind = jid::Server::try_from(server).ok();

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -310,7 +310,7 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         (user_combined, None)
     };
 
-    let (user_end, agent_override) = if let Some(underscore_idx) = user_agent.find('_') {
+    let (user_end, _agent_override) = if let Some(underscore_idx) = user_agent.find('_') {
         let agent_part = &user_agent[underscore_idx + 1..];
         if let Ok(parsed_agent) = agent_part.parse::<u8>() {
             (underscore_idx, Some(parsed_agent))
@@ -321,22 +321,19 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         (user_agent.len(), None)
     };
 
-    let agent_byte = agent_override.unwrap_or(0);
-    let domain_type = if server == jid::HIDDEN_USER_SERVER {
-        1
-    } else if server == jid::HOSTED_SERVER {
-        128
-    } else if server == jid::HOSTED_LID_SERVER {
-        129
-    } else {
-        agent_byte
+    let server_kind = jid::Server::try_from(server).ok();
+    let domain_type = match server_kind {
+        Some(jid::Server::Pn) => 0,
+        Some(jid::Server::Lid) => 1,
+        Some(jid::Server::Hosted) => 128,
+        Some(jid::Server::HostedLid) => 129,
+        _ => 0,
     };
 
     // Single source of truth: only servers whose `domain_type` the decoder
     // round-trips back can use AD_JID. For everyone else drop the device
     // and fall through to JID_PAIR (which preserves the server name).
-    let device = jid::Server::try_from(server)
-        .ok()
+    let device = server_kind
         .filter(|s| server_supports_ad_jid(*s))
         .and(device);
 
@@ -361,29 +358,27 @@ fn split_jid_from_meta(input: &str, meta: ParsedJidMeta) -> (&str, &str) {
 ///   128 = hosted
 ///   129 = hosted.lid
 ///
-/// For unmapped servers, falls back to `agent` to match the string-path
-/// behavior in `parse_jid_meta` (which uses `agent_byte` as the default).
-///
 /// WARNING: This must stay in sync with the string-path mapping in
 /// `classify_string_hint` / `parse_jid_meta` and the inverse mapping in
 /// `decoder.rs read_ad_jid`. Writing `jid.agent` unconditionally here
 /// (instead of only as a fallback) was the root cause of a regression
 /// where LID group messages were silently rejected by the server (error 421).
 #[inline]
-fn server_to_domain_type(server: jid::Server, agent: u8) -> u8 {
+fn server_to_domain_type(server: jid::Server) -> u8 {
     match server {
+        jid::Server::Pn => 0,
         jid::Server::Lid => 1,
         jid::Server::Hosted => 128,
         jid::Server::HostedLid => 129,
-        _ => agent,
+        _ => 0,
     }
 }
 
 /// AD_JID round-trips back to a server via `domain_type` only for the four
 /// servers the decoder explicitly maps. For everything else (bot, group,
-/// broadcast, newsletter, call, interop, msgr, legacy) the decoder collapses
-/// the byte to Pn and the original server string is lost. Writers must check
-/// this and emit JID_PAIR for non-AD-capable servers even when `device > 0`.
+/// broadcast, newsletter, call, interop, msgr, legacy) no valid AD_JID domain
+/// type exists. Writers must check this and emit JID_PAIR for non-AD-capable
+/// servers even when `device > 0`.
 /// Matches whatsmeow `writeJID` and WA Web `WAWap.De`.
 #[inline]
 fn server_supports_ad_jid(server: jid::Server) -> bool {
@@ -787,7 +782,7 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
                 BinaryError::AttrParse(format!("AD_JID device id out of range: {}", jid.device))
             })?;
             self.write_u8(token::AD_JID)?;
-            self.write_u8(server_to_domain_type(jid.server, jid.agent))?;
+            self.write_u8(server_to_domain_type(jid.server))?;
             self.write_u8(device)?;
             self.write_string(&jid.user)?;
         } else {
@@ -812,7 +807,7 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
                 BinaryError::AttrParse(format!("AD_JID device id out of range: {}", jid.device))
             })?;
             self.write_u8(token::AD_JID)?;
-            self.write_u8(server_to_domain_type(jid.server, jid.agent))?;
+            self.write_u8(server_to_domain_type(jid.server))?;
             self.write_u8(device)?;
             self.write_string(&jid.user)?;
         } else {
@@ -1387,6 +1382,40 @@ mod tests {
             domain_type, 0,
             "s.whatsapp.net JID must encode domain_type=0, got {domain_type}"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ad_jid_domain_type_whatsapp_ignores_hidden_agent() -> TestResult {
+        use crate::decoder::Decoder;
+
+        let mut pn_jid = Jid::pn_device("551199887766", 33);
+        pn_jid.agent = 2;
+        let node = NodeBuilder::new("to").attr("jid", pn_jid.clone()).build();
+
+        let mut buffer = Vec::new();
+        let mut encoder = Encoder::new(Cursor::new(&mut buffer))?;
+        encoder.write_node(&node)?;
+
+        let ad_jid_pos = buffer
+            .iter()
+            .position(|&b| b == token::AD_JID)
+            .expect("AD_JID token must be present for device JID");
+
+        assert_eq!(
+            buffer[ad_jid_pos + 1],
+            0,
+            "PN JID must encode the WA Web domain_type=0 even if a hidden agent is present"
+        );
+
+        let decoded = Decoder::new(&buffer[1..]).read_node_ref()?.to_owned();
+        let decoded_jid = decoded
+            .attrs()
+            .optional_jid("jid")
+            .expect("jid attr must decode");
+        assert!(pn_jid.is_same_chat_as(&decoded_jid));
+        assert_eq!(decoded_jid.agent, 0);
 
         Ok(())
     }

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -123,32 +123,96 @@ fn build_user_nodes(users: &[IsOnWhatsAppUser]) -> Vec<Node> {
         .collect()
 }
 
-/// Parse LID JID from a `<lid val="..."/>` child node.
-fn parse_lid_jid(user_node: &NodeRef<'_>) -> Option<Jid> {
-    user_node.get_optional_child("lid").and_then(|lid_node| {
-        lid_node
-            .attrs()
-            .optional_string("val")
-            .and_then(|val| val.parse::<Jid>().ok())
-    })
-}
-
 /// Common fields parsed from a usync `<user>` node.
 struct ParsedUserFields {
     jid: Jid,
     lid: Option<Jid>,
+    lid_error: Option<UsyncSubprotocolError>,
     is_business: bool,
+    business_error: Option<UsyncSubprotocolError>,
     status: Option<String>,
+    status_error: Option<UsyncSubprotocolError>,
     verified_name: Option<VerifiedName>,
 }
 
-/// Parses the `<business><verified_name>` certificate that usync returns for
-/// business accounts (the `name` lives inside the cert protobuf). Mirrors
-/// WAWebUsyncBusiness `businessParser`.
-fn parse_verified_name(user_node: &NodeRef<'_>) -> Option<VerifiedName> {
-    let vn_node = user_node
-        .get_optional_child("business")?
-        .get_optional_child("verified_name")?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncSubprotocolError {
+    pub code: Option<u16>,
+    pub text: Option<String>,
+    pub backoff: Option<u32>,
+}
+
+fn parse_subprotocol_error(protocol_node: &NodeRef<'_>) -> Option<UsyncSubprotocolError> {
+    let error_node = protocol_node.get_optional_child("error")?;
+    Some(UsyncSubprotocolError {
+        code: error_node
+            .attrs()
+            .optional_string("code")
+            .and_then(|s| s.parse().ok()),
+        text: error_node
+            .attrs()
+            .optional_string("text")
+            .map(|s| s.to_string()),
+        backoff: error_node
+            .attrs()
+            .optional_string("backoff")
+            .and_then(|s| s.parse().ok()),
+    })
+}
+
+fn usync_subprotocol_error_message(tag: &str, error: &UsyncSubprotocolError) -> String {
+    let code = error
+        .code
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let text = error.text.as_deref().unwrap_or("");
+    format!("usync {tag} error {code}: {text}")
+}
+
+fn parse_lid_fields(user_node: &NodeRef<'_>) -> (Option<Jid>, Option<UsyncSubprotocolError>) {
+    match user_node.get_optional_child("lid") {
+        Some(lid_node) => {
+            if let Some(error) = parse_subprotocol_error(lid_node) {
+                (None, Some(error))
+            } else {
+                (
+                    lid_node
+                        .attrs()
+                        .optional_string("val")
+                        .and_then(|val| val.parse::<Jid>().ok()),
+                    None,
+                )
+            }
+        }
+        None => (None, None),
+    }
+}
+
+fn parse_contact_fields(
+    user_node: &NodeRef<'_>,
+    jid: &Jid,
+) -> (bool, Option<UsyncSubprotocolError>) {
+    match user_node.get_optional_child("contact") {
+        Some(contact_node) => {
+            if let Some(error) = parse_subprotocol_error(contact_node) {
+                (false, Some(error))
+            } else {
+                (
+                    contact_node
+                        .get_attr("type")
+                        .is_some_and(|value| value.as_str() == "in"),
+                    None,
+                )
+            }
+        }
+        None if jid.is_lid() => (true, None),
+        None => (false, None),
+    }
+}
+
+fn parse_verified_name_from_business(business_node: &NodeRef<'_>) -> Option<VerifiedName> {
+    let vn_node = business_node.get_optional_child("verified_name")?;
     // Treat an <error> child or an empty marker (no name, no cert) as absent,
     // mirroring the status/picture parsers, so `verified_name.is_some()` means a
     // real verified name was returned.
@@ -162,6 +226,21 @@ fn parse_verified_name(user_node: &NodeRef<'_>) -> Option<VerifiedName> {
     Some(parsed)
 }
 
+fn parse_business_fields(
+    user_node: &NodeRef<'_>,
+) -> (bool, Option<VerifiedName>, Option<UsyncSubprotocolError>) {
+    match user_node.get_optional_child("business") {
+        Some(business_node) => {
+            if let Some(error) = parse_subprotocol_error(business_node) {
+                (false, None, Some(error))
+            } else {
+                (true, parse_verified_name_from_business(business_node), None)
+            }
+        }
+        None => (false, None, None),
+    }
+}
+
 /// Parse common fields from a usync `<user>` node.
 fn parse_user_common_fields(user_node: &NodeRef<'_>) -> Option<ParsedUserFields> {
     let jid = user_node
@@ -170,45 +249,56 @@ fn parse_user_common_fields(user_node: &NodeRef<'_>) -> Option<ParsedUserFields>
         .parse::<Jid>()
         .ok()?;
 
-    let lid = parse_lid_jid(user_node);
+    let (lid, lid_error) = parse_lid_fields(user_node);
 
-    let status = user_node
-        .get_optional_child("status")
-        .and_then(|status_node| {
-            if status_node.get_optional_child("error").is_some() {
-                return None;
+    let (status, status_error) = match user_node.get_optional_child("status") {
+        Some(status_node) => {
+            if let Some(error) = parse_subprotocol_error(status_node) {
+                (None, Some(error))
+            } else {
+                let status = match status_node.content.as_deref() {
+                    Some(NodeContentRef::String(s)) if !s.is_empty() => Some(s.to_string()),
+                    _ => None,
+                };
+                (status, None)
             }
-            match status_node.content.as_deref() {
-                Some(NodeContentRef::String(s)) if !s.is_empty() => Some(s.to_string()),
-                _ => None,
-            }
-        });
+        }
+        None => (None, None),
+    };
 
-    let is_business = user_node.get_optional_child("business").is_some();
-    let verified_name = parse_verified_name(user_node);
+    let (is_business, verified_name, business_error) = parse_business_fields(user_node);
 
     Some(ParsedUserFields {
         jid,
         lid,
+        lid_error,
         is_business,
+        business_error,
         status,
+        status_error,
         verified_name,
     })
 }
 
-/// Parse picture ID as String (used in UserInfo).
-fn parse_picture_id_string(user_node: &NodeRef<'_>) -> Option<String> {
-    user_node
-        .get_optional_child("picture")
-        .and_then(|pic_node| {
-            if pic_node.get_optional_child("error").is_some() {
-                return None;
+fn parse_picture_id_fields(
+    user_node: &NodeRef<'_>,
+) -> (Option<String>, Option<UsyncSubprotocolError>) {
+    match user_node.get_optional_child("picture") {
+        Some(pic_node) => {
+            if let Some(error) = parse_subprotocol_error(pic_node) {
+                (None, Some(error))
+            } else {
+                (
+                    pic_node
+                        .attrs()
+                        .optional_string("id")
+                        .map(|s| s.to_string()),
+                    None,
+                )
             }
-            pic_node
-                .attrs()
-                .optional_string("id")
-                .map(|s| s.to_string())
-        })
+        }
+        None => (None, None),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -219,7 +309,10 @@ pub struct IsOnWhatsAppResult {
     /// From `pn_jid` response attribute; present when server returns LID as primary JID.
     pub pn_jid: Option<Jid>,
     pub is_registered: bool,
+    pub contact_error: Option<UsyncSubprotocolError>,
+    pub lid_error: Option<UsyncSubprotocolError>,
     pub is_business: bool,
+    pub business_error: Option<UsyncSubprotocolError>,
     /// Verified business name (decoded from `<business><verified_name>`), if any.
     pub verified_name: Option<VerifiedName>,
 }
@@ -230,14 +323,19 @@ pub struct IsOnWhatsAppResult {
 pub struct UserInfo {
     pub jid: Jid,
     pub lid: Option<Jid>,
+    pub lid_error: Option<UsyncSubprotocolError>,
     pub status: Option<String>,
+    pub status_error: Option<UsyncSubprotocolError>,
     pub picture_id: Option<String>,
+    pub picture_error: Option<UsyncSubprotocolError>,
     pub is_business: bool,
+    pub business_error: Option<UsyncSubprotocolError>,
     /// Verified business name (decoded from `<business><verified_name>`), if any.
     pub verified_name: Option<VerifiedName>,
     /// Device IDs from the `<devices version="2">` sublist the same usync query
     /// returns (device 0 is the primary). Empty if the server omitted it.
     pub devices: Vec<u16>,
+    pub devices_error: Option<UsyncSubprotocolError>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -285,19 +383,11 @@ fn check_usync_result_errors(usync: &NodeRef<'_>) -> Result<(), anyhow::Error> {
     let Some(result_node) = usync.get_optional_child("result") else {
         return Ok(());
     };
-    for tag in ["contact", "lid", "business"] {
+    for tag in ["contact", "lid", "business", "status", "picture", "devices"] {
         if let Some(protocol_node) = result_node.get_optional_child(tag)
-            && let Some(error_node) = protocol_node.get_optional_child("error")
+            && let Some(error) = parse_subprotocol_error(protocol_node)
         {
-            let code = error_node
-                .attrs()
-                .optional_string("code")
-                .unwrap_or_default();
-            let text = error_node
-                .attrs()
-                .optional_string("text")
-                .unwrap_or_default();
-            return Err(anyhow!("usync {tag} error {code}: {text}"));
+            return Err(anyhow!(usync_subprotocol_error_message(tag, &error)));
         }
     }
     Ok(())
@@ -361,27 +451,19 @@ impl IqSpec for IsOnWhatsAppSpec {
                 .optional_string("pn_jid")
                 .and_then(|s| s.parse::<Jid>().ok());
 
-            let lid = parse_lid_jid(user_node);
-
-            let contact_node = user_node.get_optional_child("contact");
-            // LID queries omit contact protocol; presence in response implies registered
-            let is_registered = if jid.is_lid() && contact_node.is_none() {
-                true
-            } else {
-                contact_node
-                    .map(|c| c.get_attr("type").is_some_and(|v| v.as_str() == "in"))
-                    .unwrap_or(false)
-            };
-
-            let is_business = user_node.get_optional_child("business").is_some();
-            let verified_name = parse_verified_name(user_node);
+            let (lid, lid_error) = parse_lid_fields(user_node);
+            let (is_registered, contact_error) = parse_contact_fields(user_node, &jid);
+            let (is_business, verified_name, business_error) = parse_business_fields(user_node);
 
             results.push(IsOnWhatsAppResult {
                 jid,
                 lid,
                 pn_jid,
                 is_registered,
+                contact_error,
+                lid_error,
                 is_business,
+                business_error,
                 verified_name,
             });
         }
@@ -454,6 +536,7 @@ impl IqSpec for UserInfoSpec {
         let usync = response
             .get_optional_child("usync")
             .ok_or_else(|| anyhow!("Response missing <usync> node"))?;
+        check_usync_result_errors(usync)?;
 
         let list = usync
             .get_optional_child("list")
@@ -463,16 +546,23 @@ impl IqSpec for UserInfoSpec {
 
         for user_node in list.get_children_by_tag("user") {
             if let Some(fields) = parse_user_common_fields(user_node) {
+                let (picture_id, picture_error) = parse_picture_id_fields(user_node);
+                let (devices, devices_error) = parse_user_device_ids(user_node);
                 results.insert(
                     fields.jid.clone(),
                     UserInfo {
                         jid: fields.jid,
                         lid: fields.lid,
+                        lid_error: fields.lid_error,
                         status: fields.status,
-                        picture_id: parse_picture_id_string(user_node),
+                        status_error: fields.status_error,
+                        picture_id,
+                        picture_error,
                         is_business: fields.is_business,
+                        business_error: fields.business_error,
                         verified_name: fields.verified_name,
-                        devices: parse_user_device_ids(user_node),
+                        devices,
+                        devices_error,
                     },
                 );
             }
@@ -482,16 +572,22 @@ impl IqSpec for UserInfoSpec {
     }
 }
 
-/// Device IDs from a `<user>`'s `<devices><device-list><device id="N"/>` sublist.
-/// Returns empty when the server omitted the sublist or every id is malformed.
-fn parse_user_device_ids(user_node: &NodeRef<'_>) -> Vec<u16> {
-    let Some(device_list) = user_node.get_optional_child_by_tag(&["devices", "device-list"]) else {
-        return Vec::new();
+/// Device IDs plus a subprotocol error if `<devices><error>` was returned.
+fn parse_user_device_ids(user_node: &NodeRef<'_>) -> (Vec<u16>, Option<UsyncSubprotocolError>) {
+    let Some(devices_node) = user_node.get_optional_child("devices") else {
+        return (Vec::new(), None);
     };
-    device_list
+    if let Some(error) = parse_subprotocol_error(devices_node) {
+        return (Vec::new(), Some(error));
+    }
+    let Some(device_list) = devices_node.get_optional_child("device-list") else {
+        return (Vec::new(), None);
+    };
+    let devices = device_list
         .get_children_by_tag("device")
         .filter_map(|d| d.attrs().optional_string("id").and_then(|s| s.parse().ok()))
-        .collect()
+        .collect();
+    (devices, None)
 }
 
 // Re-export types from wacore::usync for convenience
@@ -619,9 +715,13 @@ impl IqSpec for DeviceListSpec {
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        let list_node = response
-            .get_optional_child_by_tag(&["usync", "list"])
-            .ok_or_else(|| anyhow!("<usync> or <list> not found in usync response"))?;
+        let usync = response
+            .get_optional_child("usync")
+            .ok_or_else(|| anyhow!("<usync> not found in usync response"))?;
+        check_usync_result_errors(usync)?;
+        let list_node = usync
+            .get_optional_child("list")
+            .ok_or_else(|| anyhow!("<list> not found in usync response"))?;
 
         let mut device_lists = Vec::new();
         let mut lid_mappings = Vec::new();
@@ -631,6 +731,14 @@ impl IqSpec for DeviceListSpec {
                 .attrs()
                 .optional_jid("jid")
                 .ok_or_else(|| anyhow!("user node missing required 'jid' attribute"))?;
+            if let Some(devices_node) = user_node.get_optional_child("devices")
+                && let Some(error) = parse_subprotocol_error(devices_node)
+            {
+                return Err(anyhow!(
+                    "{} for {user_jid}",
+                    usync_subprotocol_error_message("devices", &error)
+                ));
+            }
 
             // Extract LID mapping if present
             if user_jid.server == wacore_binary::Server::Pn
@@ -787,9 +895,24 @@ impl IqSpec for LidQuerySpec {
             .get_optional_child("usync")
             .ok_or_else(|| anyhow!("LID query response missing <usync> node"))?;
         check_usync_result_errors(usync)?;
-        usync
+        let list = usync
             .get_optional_child("list")
             .ok_or_else(|| anyhow!("LID query response missing <list> node"))?;
+        for user_node in list.get_children_by_tag("user") {
+            let user_jid = user_node
+                .attrs()
+                .optional_string("jid")
+                .map(|jid| jid.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string());
+            if let Some(lid_node) = user_node.get_optional_child("lid")
+                && let Some(error) = parse_subprotocol_error(lid_node)
+            {
+                return Err(anyhow!(
+                    "{} for {user_jid}",
+                    usync_subprotocol_error_message("lid", &error)
+                ));
+            }
+        }
 
         let lid_mappings = crate::usync::parse_lid_mappings_from_response(response);
         Ok(LidQueryResponse { lid_mappings })
@@ -1023,6 +1146,55 @@ mod tests {
     }
 
     #[test]
+    fn is_on_whatsapp_preserves_user_subprotocol_errors() {
+        let spec = IsOnWhatsAppSpec::new(
+            vec![pn_user("1234567890")],
+            "test-sid",
+            IsOnWhatsAppQueryType::Pn,
+        );
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1234567890@s.whatsapp.net")
+                        .children([
+                            NodeBuilder::new("contact")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "403")
+                                    .attr("text", "blocked")
+                                    .build()])
+                                .build(),
+                            NodeBuilder::new("lid")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "404")
+                                    .attr("text", "missing")
+                                    .build()])
+                                .build(),
+                            NodeBuilder::new("business")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "500")
+                                    .attr("text", "server")
+                                    .build()])
+                                .build(),
+                        ])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let results = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].is_registered);
+        assert_eq!(results[0].contact_error.as_ref().unwrap().code, Some(403));
+        assert!(results[0].lid.is_none());
+        assert_eq!(results[0].lid_error.as_ref().unwrap().code, Some(404));
+        assert!(!results[0].is_business);
+        assert_eq!(results[0].business_error.as_ref().unwrap().code, Some(500));
+    }
+
+    #[test]
     fn test_user_info_spec_build_iq() {
         let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
         let spec = UserInfoSpec::new(vec![jid], "test-sid");
@@ -1087,6 +1259,99 @@ mod tests {
         assert!(info.lid.is_some());
         // The <devices> sublist the same query returns is now surfaced, not dropped.
         assert_eq!(info.devices, vec![0, 1]);
+    }
+
+    #[test]
+    fn user_info_preserves_subprotocol_errors() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let spec = UserInfoSpec::new(vec![jid.clone()], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1234567890@s.whatsapp.net")
+                        .children([
+                            NodeBuilder::new("lid")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "409")
+                                    .attr("text", "lid-conflict")
+                                    .build()])
+                                .build(),
+                            NodeBuilder::new("status")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "401")
+                                    .attr("text", "privacy")
+                                    .build()])
+                                .build(),
+                            NodeBuilder::new("picture")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "404")
+                                    .attr("text", "missing")
+                                    .build()])
+                                .build(),
+                            NodeBuilder::new("devices")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "500")
+                                    .attr("text", "server")
+                                    .build()])
+                                .build(),
+                            NodeBuilder::new("business")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "406")
+                                    .attr("text", "business-error")
+                                    .build()])
+                                .build(),
+                        ])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let results = spec.parse_response(&response.as_node_ref()).unwrap();
+        let info = results.get(&jid).unwrap();
+
+        assert!(info.lid.is_none());
+        assert_eq!(info.lid_error.as_ref().unwrap().code, Some(409));
+        assert!(info.status.is_none());
+        assert_eq!(info.status_error.as_ref().unwrap().code, Some(401));
+        assert_eq!(
+            info.status_error.as_ref().unwrap().text.as_deref(),
+            Some("privacy")
+        );
+        assert!(info.picture_id.is_none());
+        assert_eq!(info.picture_error.as_ref().unwrap().code, Some(404));
+        assert!(info.devices.is_empty());
+        assert_eq!(info.devices_error.as_ref().unwrap().code, Some(500));
+        assert!(!info.is_business);
+        assert_eq!(info.business_error.as_ref().unwrap().code, Some(406));
+    }
+
+    #[test]
+    fn user_info_result_subprotocol_error_is_rejected() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let spec = UserInfoSpec::new(vec![jid], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([
+                    NodeBuilder::new("result")
+                        .children([NodeBuilder::new("status")
+                            .children([NodeBuilder::new("error")
+                                .attr("code", "403")
+                                .attr("text", "blocked")
+                                .build()])
+                            .build()])
+                        .build(),
+                    NodeBuilder::new("list").build(),
+                ])
+                .build()])
+            .build();
+
+        let err = spec.parse_response(&response.as_node_ref()).unwrap_err();
+        assert!(err.to_string().contains("usync status error 403: blocked"));
     }
 
     #[test]
@@ -1255,6 +1520,64 @@ mod tests {
     }
 
     #[test]
+    fn device_list_devices_error_is_rejected() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let spec = DeviceListSpec::new(vec![jid], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1234567890@s.whatsapp.net")
+                        .children([NodeBuilder::new("devices")
+                            .children([NodeBuilder::new("error")
+                                .attr("code", "500")
+                                .attr("text", "server")
+                                .build()])
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let err = spec.parse_response(&response.as_node_ref()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("usync devices error 500: server for 1234567890@s.whatsapp.net")
+        );
+    }
+
+    #[test]
+    fn lid_query_lid_error_is_rejected() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let spec = LidQuerySpec::new(vec![jid], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1234567890@s.whatsapp.net")
+                        .children([NodeBuilder::new("lid")
+                            .children([NodeBuilder::new("error")
+                                .attr("code", "404")
+                                .attr("text", "missing")
+                                .build()])
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let err = spec.parse_response(&response.as_node_ref()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("usync lid error 404: missing for 1234567890@s.whatsapp.net")
+        );
+    }
+
+    #[test]
     fn test_device_list_spec_parse_response_multiple_users() {
         let jid1: Jid = "1111111111@s.whatsapp.net".parse().unwrap();
         let jid2: Jid = "2222222222@s.whatsapp.net".parse().unwrap();
@@ -1340,32 +1663,28 @@ mod tests {
 
     #[test]
     fn parse_verified_name_skips_error_and_empty() {
-        let user = |vn: Node| {
-            NodeBuilder::new("user")
-                .children([NodeBuilder::new("business").children([vn]).build()])
-                .build()
-        };
+        let business = |vn: Node| NodeBuilder::new("business").children([vn]).build();
 
         // <verified_name><error/></verified_name> -> absent
-        let err = user(
+        let err = business(
             NodeBuilder::new("verified_name")
                 .children([NodeBuilder::new("error").attr("code", "404").build()])
                 .build(),
         );
-        assert!(parse_verified_name(&err.as_node_ref()).is_none());
+        assert!(parse_verified_name_from_business(&err.as_node_ref()).is_none());
 
         // empty <verified_name/> (no attrs, no cert) -> absent
-        let empty = user(NodeBuilder::new("verified_name").build());
-        assert!(parse_verified_name(&empty.as_node_ref()).is_none());
+        let empty = business(NodeBuilder::new("verified_name").build());
+        assert!(parse_verified_name_from_business(&empty.as_node_ref()).is_none());
 
         // real name attr -> present
-        let real = user(
+        let real = business(
             NodeBuilder::new("verified_name")
                 .attr("name", "Acme")
                 .build(),
         );
         assert_eq!(
-            parse_verified_name(&real.as_node_ref())
+            parse_verified_name_from_business(&real.as_node_ref())
                 .expect("real name")
                 .name
                 .as_deref(),

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -380,10 +380,20 @@ fn build_business_query_node() -> Node {
 
 /// Check `<usync><result>` for per-protocol errors.
 fn check_usync_result_errors(usync: &NodeRef<'_>) -> Result<(), anyhow::Error> {
+    check_usync_result_errors_for(
+        usync,
+        &["contact", "lid", "business", "status", "picture", "devices"],
+    )
+}
+
+fn check_usync_result_errors_for(
+    usync: &NodeRef<'_>,
+    tags: &[&'static str],
+) -> Result<(), anyhow::Error> {
     let Some(result_node) = usync.get_optional_child("result") else {
         return Ok(());
     };
-    for tag in ["contact", "lid", "business", "status", "picture", "devices"] {
+    for &tag in tags {
         if let Some(protocol_node) = result_node.get_optional_child(tag)
             && let Some(error) = parse_subprotocol_error(protocol_node)
         {
@@ -391,6 +401,19 @@ fn check_usync_result_errors(usync: &NodeRef<'_>) -> Result<(), anyhow::Error> {
         }
     }
     Ok(())
+}
+
+fn warn_usync_result_error(usync: &NodeRef<'_>, tag: &'static str) {
+    if let Some(result_node) = usync.get_optional_child("result")
+        && let Some(protocol_node) = result_node.get_optional_child(tag)
+        && let Some(error) = parse_subprotocol_error(protocol_node)
+    {
+        warn!(
+            target: "usync",
+            "{}; continuing with returned users",
+            usync_subprotocol_error_message(tag, &error)
+        );
+    }
 }
 
 impl IqSpec for IsOnWhatsAppSpec {
@@ -718,7 +741,8 @@ impl IqSpec for DeviceListSpec {
         let usync = response
             .get_optional_child("usync")
             .ok_or_else(|| anyhow!("<usync> not found in usync response"))?;
-        check_usync_result_errors(usync)?;
+        check_usync_result_errors_for(usync, &["contact", "lid", "business", "status", "picture"])?;
+        warn_usync_result_error(usync, "devices");
         let list_node = usync
             .get_optional_child("list")
             .ok_or_else(|| anyhow!("<list> not found in usync response"))?;
@@ -734,10 +758,12 @@ impl IqSpec for DeviceListSpec {
             if let Some(devices_node) = user_node.get_optional_child("devices")
                 && let Some(error) = parse_subprotocol_error(devices_node)
             {
-                return Err(anyhow!(
-                    "{} for {user_jid}",
+                warn!(
+                    target: "usync",
+                    "{} for {user_jid}; skipping user",
                     usync_subprotocol_error_message("devices", &error)
-                ));
+                );
+                continue;
             }
 
             // Extract LID mapping if present
@@ -907,10 +933,12 @@ impl IqSpec for LidQuerySpec {
             if let Some(lid_node) = user_node.get_optional_child("lid")
                 && let Some(error) = parse_subprotocol_error(lid_node)
             {
-                return Err(anyhow!(
-                    "{} for {user_jid}",
+                warn!(
+                    target: "usync",
+                    "{} for {user_jid}; skipping user",
                     usync_subprotocol_error_message("lid", &error)
-                ));
+                );
+                continue;
             }
         }
 
@@ -1520,61 +1548,126 @@ mod tests {
     }
 
     #[test]
-    fn device_list_devices_error_is_rejected() {
+    fn device_list_devices_error_skips_only_that_user() {
+        let jid1: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let jid2: Jid = "9876543210@s.whatsapp.net".parse().unwrap();
+        let spec = DeviceListSpec::new(vec![jid1, jid2], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([
+                        NodeBuilder::new("user")
+                            .attr("jid", "1234567890@s.whatsapp.net")
+                            .children([NodeBuilder::new("devices")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "500")
+                                    .attr("text", "server")
+                                    .build()])
+                                .build()])
+                            .build(),
+                        NodeBuilder::new("user")
+                            .attr("jid", "9876543210@s.whatsapp.net")
+                            .children([NodeBuilder::new("devices")
+                                .children([
+                                    NodeBuilder::new("device-list")
+                                        .attr("hash", "2:ok")
+                                        .children([NodeBuilder::new("device")
+                                            .attr("id", "0")
+                                            .build()])
+                                        .build(),
+                                    build_test_key_index_list_node(&[0]),
+                                ])
+                                .build()])
+                            .build(),
+                    ])
+                    .build()])
+                .build()])
+            .build();
+
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(result.device_lists.len(), 1);
+        assert_eq!(result.device_lists[0].user.user, "9876543210");
+    }
+
+    #[test]
+    fn device_list_result_devices_error_is_warn_only() {
         let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
         let spec = DeviceListSpec::new(vec![jid], "test-sid");
 
         let response = NodeBuilder::new("iq")
             .attr("type", "result")
             .children([NodeBuilder::new("usync")
-                .children([NodeBuilder::new("list")
-                    .children([NodeBuilder::new("user")
-                        .attr("jid", "1234567890@s.whatsapp.net")
+                .children([
+                    NodeBuilder::new("result")
                         .children([NodeBuilder::new("devices")
                             .children([NodeBuilder::new("error")
                                 .attr("code", "500")
                                 .attr("text", "server")
                                 .build()])
                             .build()])
-                        .build()])
-                    .build()])
+                        .build(),
+                    NodeBuilder::new("list")
+                        .children([NodeBuilder::new("user")
+                            .attr("jid", "1234567890@s.whatsapp.net")
+                            .children([NodeBuilder::new("devices")
+                                .children([
+                                    NodeBuilder::new("device-list")
+                                        .attr("hash", "2:ok")
+                                        .children([NodeBuilder::new("device")
+                                            .attr("id", "0")
+                                            .build()])
+                                        .build(),
+                                    build_test_key_index_list_node(&[0]),
+                                ])
+                                .build()])
+                            .build()])
+                        .build(),
+                ])
                 .build()])
             .build();
 
-        let err = spec.parse_response(&response.as_node_ref()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("usync devices error 500: server for 1234567890@s.whatsapp.net")
-        );
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(result.device_lists.len(), 1);
+        assert_eq!(result.device_lists[0].user.user, "1234567890");
     }
 
     #[test]
-    fn lid_query_lid_error_is_rejected() {
-        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
-        let spec = LidQuerySpec::new(vec![jid], "test-sid");
+    fn lid_query_lid_error_skips_only_that_user() {
+        let jid1: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let jid2: Jid = "9876543210@s.whatsapp.net".parse().unwrap();
+        let spec = LidQuerySpec::new(vec![jid1, jid2], "test-sid");
 
         let response = NodeBuilder::new("iq")
             .attr("type", "result")
             .children([NodeBuilder::new("usync")
                 .children([NodeBuilder::new("list")
-                    .children([NodeBuilder::new("user")
-                        .attr("jid", "1234567890@s.whatsapp.net")
-                        .children([NodeBuilder::new("lid")
-                            .children([NodeBuilder::new("error")
-                                .attr("code", "404")
-                                .attr("text", "missing")
+                    .children([
+                        NodeBuilder::new("user")
+                            .attr("jid", "1234567890@s.whatsapp.net")
+                            .children([NodeBuilder::new("lid")
+                                .children([NodeBuilder::new("error")
+                                    .attr("code", "404")
+                                    .attr("text", "missing")
+                                    .build()])
                                 .build()])
-                            .build()])
-                        .build()])
+                            .build(),
+                        NodeBuilder::new("user")
+                            .attr("jid", "9876543210@s.whatsapp.net")
+                            .children([NodeBuilder::new("lid")
+                                .attr("val", "100000000000987@lid")
+                                .build()])
+                            .build(),
+                    ])
                     .build()])
                 .build()])
             .build();
 
-        let err = spec.parse_response(&response.as_node_ref()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("usync lid error 404: missing for 1234567890@s.whatsapp.net")
-        );
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(result.lid_mappings.len(), 1);
+        assert_eq!(result.lid_mappings[0].phone_number, "9876543210");
+        assert_eq!(result.lid_mappings[0].lid, "100000000000987");
     }
 
     #[test]

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -310,7 +310,7 @@ impl PreKeyUtils {
                             "device-identity ADV validation failed for companion {jid}"
                         ));
                     }
-                    crate::adv::AdvValidation::NoAccountKey => log::warn!(
+                    crate::adv::AdvValidation::NoAccountKey => log::debug!(
                         "prekey bundle for companion {jid} omits account_signature_key and no stored account identity; proceeding without ADV validation"
                     ),
                 },

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -214,8 +214,11 @@ impl RequestUtils {
             return Err(IqError::Disconnected(response_node.to_owned()));
         }
 
-        if let Some(res_type) = response_node.get_attr("type")
-            && res_type.as_str() == "error"
+        let response_type = response_node.get_attr("type");
+
+        if response_type
+            .as_ref()
+            .is_some_and(|res_type| res_type.as_str() == "error")
         {
             let error_child = response_node.get_optional_child_by_tag(&["error"]);
             if let Some(error_node) = error_child {
@@ -248,9 +251,7 @@ impl RequestUtils {
             });
         }
 
-        let got = response_node
-            .get_attr("type")
-            .map(|res_type| res_type.to_string());
+        let got = response_type.map(|res_type| res_type.to_string());
         if got.as_deref() != Some("result") {
             return Err(IqError::UnexpectedResponseType { got });
         }

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -97,6 +97,8 @@ pub enum IqError {
         /// WA Web honors this (`setProtocolBackoffMs`) before retrying throttled IQs.
         backoff: Option<u32>,
     },
+    #[error("received unexpected IQ response type: {got:?}")]
+    UnexpectedResponseType { got: Option<String> },
     #[error("internal channel closed unexpectedly")]
     InternalChannelClosed,
 }
@@ -246,6 +248,13 @@ impl RequestUtils {
             });
         }
 
+        let got = response_node
+            .get_attr("type")
+            .map(|res_type| res_type.to_string());
+        if got.as_deref() != Some("result") {
+            return Err(IqError::UnexpectedResponseType { got });
+        }
+
         Ok(())
     }
 }
@@ -306,6 +315,43 @@ mod iq_error_tests {
                 assert!(backoff.is_none());
             }
             other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_iq_response_accepts_result_type() {
+        let node = NodeBuilder::new("iq").attr("type", "result").build();
+
+        RequestUtils::new("t".to_string())
+            .parse_iq_response(&node.as_node_ref())
+            .unwrap();
+    }
+
+    #[test]
+    fn parse_iq_response_rejects_unexpected_type() {
+        let node = NodeBuilder::new("iq").attr("type", "get").build();
+
+        let err = RequestUtils::new("t".to_string())
+            .parse_iq_response(&node.as_node_ref())
+            .unwrap_err();
+
+        match err {
+            IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
+            other => panic!("expected UnexpectedResponseType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_iq_response_rejects_missing_type() {
+        let node = NodeBuilder::new("iq").build();
+
+        let err = RequestUtils::new("t".to_string())
+            .parse_iq_response(&node.as_node_ref())
+            .unwrap_err();
+
+        match err {
+            IqError::UnexpectedResponseType { got } => assert!(got.is_none()),
+            other => panic!("expected UnexpectedResponseType, got {other:?}"),
         }
     }
 }

--- a/wacore/tests/appstate_external_mutations_test.rs
+++ b/wacore/tests/appstate_external_mutations_test.rs
@@ -230,10 +230,7 @@ fn test_external_mutations_decode_from_syncd_mutations() {
 }
 
 #[test]
-fn test_validate_patch_macs_skips_on_has_missing_remove() {
-    // When has_missing_remove is true, MAC validation should not fail
-    // because we expect the hash to diverge
-
+fn test_validate_patch_macs_rejects_on_has_missing_remove() {
     let master_key = [7u8; 32];
     let keys = expand_app_state_keys(&master_key);
     let key_id = b"test_key";
@@ -260,7 +257,6 @@ fn test_validate_patch_macs_skips_on_has_missing_remove() {
         client_debug_data: None,
     };
 
-    // Without has_missing_remove, this would fail
     let result_without_flag =
         validate_patch_macs(&patch, &state, &keys, collection_name, false, false);
     assert!(
@@ -268,11 +264,10 @@ fn test_validate_patch_macs_skips_on_has_missing_remove() {
         "Should fail MAC validation without has_missing_remove"
     );
 
-    // With has_missing_remove, this should succeed (MAC mismatch is expected)
     let result_with_flag = validate_patch_macs(&patch, &state, &keys, collection_name, false, true);
     assert!(
-        result_with_flag.is_ok(),
-        "Should pass MAC validation with has_missing_remove=true"
+        result_with_flag.is_err(),
+        "Should reject MAC mismatch even with has_missing_remove=true"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR tightens several protocol/API paths that were accepting malformed data or hiding errors:

- reject App State snapshot/patch MAC mismatches even when `has_missing_remove` is set
- reject invalid AD-JID domain type bytes instead of mapping them to PN
- make `contacts().is_on_whatsapp()` fail on unsupported JID types instead of silently dropping inputs
- preserve USync subprotocol errors for user-info style queries while making device-list/LID batch queries degrade per returned user, matching WA Web behavior for noisy users in a larger batch
- reject IQ responses whose `type` is neither `result` nor `error`
- abort malformed peer-device retry receipts without `recipient`
- require the one-time `<key>` for regular retry key bundles; only primary `@bot` FBID bot retries may proceed with identity + signed prekey alone
- abort retry resend when a present key bundle is rejected
- downgrade missing ADV account-key fallback logs from warn to debug

## Impact

The main user-visible change is stricter failure signaling where WA Web treats malformed data as fatal: callers now get explicit errors or error metadata instead of ambiguous empty results, skipped inputs, or best-effort fallbacks.

Device-list and LID batch parsing now degrade per user instead of failing the whole batch, so one server-side per-user subprotocol error does not block sends to the rest of a group. Retry recovery follows the WA Web parser split: regular retry receipts need an OPK, while FBID bot retries keep the signed-prekey-only fallback.

The ADV log downgrade reduces noise for a server shape that can legitimately be unverifiable when no account identity is stored.

## Validation

- `cargo +nightly-2026-04-05 clippy --all --tests -- -D warnings`
- `cargo test -p wacore`
- `cargo test -p whatsapp-rust`
- `cargo test -p wacore device_list_`
- `cargo test -p wacore lid_query_lid_error_skips_only_that_user`
- `cargo test -p whatsapp-rust retry_key_bundle`
- `cargo test -p whatsapp-rust resolve_retry_chat_info`
- `cargo test -p whatsapp-rust is_on_whatsapp`
- `cargo test -p wacore-binary test_ad_jid -- --nocapture`
- `cargo test -p wacore-appstate validate_patch_macs_rejects -- --nocapture`