### PR TITLE
perf(appstate): move snapshot and patches into the blocking handoff instead of deep-cloning

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -537,6 +537,69 @@ mod tests {
         (backend, processor, patch_list, stale_index_mac)
     }
 
+    /// Locks the move-and-restore handoff: the snapshot and each patch move into
+    /// blocking closures (instead of being deep-cloned for the 'static bound) and
+    /// must come back on the returned PatchList, because the caller reads
+    /// pl.snapshot/pl.patches afterwards (get_missing_key_ids, has_more bookkeeping).
+    #[tokio::test]
+    async fn process_patch_list_returns_snapshot_and_patches_to_caller() {
+        let (_backend, processor, mut patch_list, _) = snapshot_resync_scenario().await;
+
+        let key_id_bytes = b"snap_key_id".to_vec();
+        let master_key = [9u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+        let plaintext = wa::SyncActionData {
+            value: Some(wa::SyncActionValue {
+                timestamp: Some(3000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .encode_to_vec();
+        let mutation = create_encrypted_mutation(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &[0x22; 32],
+            &plaintext,
+            &keys,
+            &key_id_bytes,
+        );
+        patch_list.patches.push(wa::SyncdPatch {
+            mutations: vec![mutation],
+            version: Some(wa::SyncdVersion { version: Some(3) }),
+            key_id: Some(wa::KeyId {
+                id: Some(key_id_bytes),
+            }),
+            ..Default::default()
+        });
+
+        let (mutations, state, pl) = processor
+            .process_patch_list(patch_list, false)
+            .await
+            .expect("snapshot + patch should process");
+
+        assert_eq!(state.version, 3);
+        assert_eq!(mutations.len(), 2, "snapshot record + patch mutation");
+        assert!(
+            pl.snapshot.is_some(),
+            "snapshot must be handed back to the caller"
+        );
+        assert_eq!(
+            pl.patches.len(),
+            1,
+            "patches must be handed back to the caller"
+        );
+        assert_eq!(
+            pl.patches[0].version.as_ref().and_then(|v| v.version),
+            Some(3),
+            "patch content/order preserved through the handoff"
+        );
+        assert_eq!(
+            pl.patches[0].mutations.len(),
+            1,
+            "patch mutations preserved through the handoff"
+        );
+    }
+
     #[tokio::test]
     async fn snapshot_resync_drops_stale_mutation_macs() {
         let (backend, processor, patch_list, stale_index_mac) = snapshot_resync_scenario().await;

--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -556,47 +556,72 @@ mod tests {
             ..Default::default()
         }
         .encode_to_vec();
-        let mutation = create_encrypted_mutation(
-            wa::syncd_mutation::SyncdOperation::Set,
-            &[0x22; 32],
-            &plaintext,
-            &keys,
-            &key_id_bytes,
-        );
-        patch_list.patches.push(wa::SyncdPatch {
-            mutations: vec![mutation],
-            version: Some(wa::SyncdVersion { version: Some(3) }),
-            key_id: Some(wa::KeyId {
-                id: Some(key_id_bytes),
-            }),
-            ..Default::default()
-        });
+        for (version, index_mac) in [(3u64, [0x22u8; 32]), (4, [0x33; 32])] {
+            let mutation = create_encrypted_mutation(
+                wa::syncd_mutation::SyncdOperation::Set,
+                &index_mac,
+                &plaintext,
+                &keys,
+                &key_id_bytes,
+            );
+            patch_list.patches.push(wa::SyncdPatch {
+                mutations: vec![mutation],
+                version: Some(wa::SyncdVersion {
+                    version: Some(version),
+                }),
+                key_id: Some(wa::KeyId {
+                    id: Some(key_id_bytes.clone()),
+                }),
+                ..Default::default()
+            });
+        }
 
         let (mutations, state, pl) = processor
             .process_patch_list(patch_list, false)
             .await
-            .expect("snapshot + patch should process");
+            .expect("snapshot + patches should process");
 
-        assert_eq!(state.version, 3);
-        assert_eq!(mutations.len(), 2, "snapshot record + patch mutation");
-        assert!(
-            pl.snapshot.is_some(),
-            "snapshot must be handed back to the caller"
-        );
+        assert_eq!(state.version, 4);
         assert_eq!(
-            pl.patches.len(),
-            1,
-            "patches must be handed back to the caller"
+            mutations.len(),
+            3,
+            "snapshot record + one mutation per patch"
         );
+
+        let snapshot = pl.snapshot.as_ref().expect("snapshot handed back");
         assert_eq!(
-            pl.patches[0].version.as_ref().and_then(|v| v.version),
-            Some(3),
-            "patch content/order preserved through the handoff"
+            snapshot.version.as_ref().and_then(|v| v.version),
+            Some(2),
+            "the same snapshot must come back, not a substitute"
         );
+        assert_eq!(snapshot.records.len(), 1, "snapshot records preserved");
+
+        let patch_versions: Vec<_> = pl
+            .patches
+            .iter()
+            .map(|p| p.version.as_ref().and_then(|v| v.version))
+            .collect();
         assert_eq!(
-            pl.patches[0].mutations.len(),
-            1,
-            "patch mutations preserved through the handoff"
+            patch_versions,
+            vec![Some(3), Some(4)],
+            "patches handed back in processing order"
+        );
+        let patch_index_macs: Vec<_> = pl
+            .patches
+            .iter()
+            .map(|p| {
+                p.mutations[0]
+                    .record
+                    .as_ref()
+                    .and_then(|r| r.index.as_ref())
+                    .and_then(|i| i.blob.as_deref())
+                    .map(|b| b[0])
+            })
+            .collect();
+        assert_eq!(
+            patch_index_macs,
+            vec![Some(0x22), Some(0x33)],
+            "each patch keeps its own mutations through the handoff"
         );
     }
 

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -272,7 +272,7 @@ impl AppStateProcessor {
         // (persisted >= incoming) is discarded ("skip applying syncd old version") so it can't
         // roll the collection backward. No-op on the benign first-sync path, where snapshots
         // are requested only at version 0.
-        let snapshot_to_apply = pl.snapshot.as_ref().filter(|snapshot| {
+        let snapshot_fresh = pl.snapshot.as_ref().is_some_and(|snapshot| {
             let snapshot_version = snapshot.version.as_ref().and_then(|v| v.version).unwrap_or(0);
             if snapshot_is_stale(state.version, snapshot_version) {
                 log::warn!(
@@ -284,27 +284,30 @@ impl AppStateProcessor {
             }
             true
         });
-        if let Some(snapshot) = snapshot_to_apply {
+        if snapshot_fresh && let Some(snapshot) = pl.snapshot.take() {
             let keys_map = self.key_cache.lock().await.clone();
-            let snapshot_clone = snapshot.clone();
             let collection_name_owned = collection_name.to_string();
 
-            // Offload CPU-intensive snapshot processing to a blocking thread
+            // Offload CPU-intensive snapshot processing to a blocking thread. The
+            // snapshot moves into the closure (its 'static bound used to force a
+            // multi-MB deep clone on bootstrap) and comes back via the return tuple
+            // because the caller still reads pl.snapshot (get_missing_key_ids).
             let result = crate::runtime::blocking(&*self.runtime, move || {
                 let mut snapshot_state = HashState::default();
                 let result = process_snapshot(
-                    &snapshot_clone,
+                    &snapshot,
                     &mut snapshot_state,
                     |key_id| lookup_app_state_key(&keys_map, key_id),
                     validate_macs,
                     &collection_name_owned,
                 )?;
-                Ok::<_, crate::appstate::AppStateError>((result, snapshot_state))
+                Ok::<_, crate::appstate::AppStateError>((result, snapshot_state, snapshot))
             })
             .await
             .map_err(|e| anyhow!("{}", e))?;
 
-            let (snapshot_result, snapshot_state) = result;
+            let (snapshot_result, snapshot_state, snapshot) = result;
+            pl.snapshot = Some(snapshot);
             state = snapshot_state;
 
             // Snapshot owns the whole collection: move its Vec into the empty
@@ -365,12 +368,18 @@ impl AppStateProcessor {
             }
         }
 
-        // Snapshot the key cache once for all patches (prefetch_keys already populated it)
-        let keys_map = self.key_cache.lock().await.clone();
+        // Snapshot the key cache once for all patches (prefetch_keys already populated
+        // it); Arc so the per-patch closure handoff is a refcount bump, not a map copy.
+        let keys_map = Arc::new(self.key_cache.lock().await.clone());
         let collection_name_owned = collection_name.to_string();
 
-        // Process patches
-        for patch in &pl.patches {
+        // Each patch moves into its blocking closure and comes back via the return
+        // tuple: the 'static bound used to force a full deep clone per patch
+        // (multi-MB once external mutations are inlined), and the caller still
+        // reads pl.patches afterwards (get_missing_key_ids).
+        let patches = std::mem::take(&mut pl.patches);
+        let mut processed_patches = Vec::with_capacity(patches.len());
+        for patch in patches {
             // Collect index MACs we need to look up (pre-allocate with upper bound)
             let mut need_db_lookup: Vec<Vec<u8>> = Vec::with_capacity(patch.mutations.len());
             for m in &patch.mutations {
@@ -390,31 +399,31 @@ impl AppStateProcessor {
                 .get_mutation_macs(collection_name, &need_db_lookup)
                 .await?;
 
-            // Clone data for blocking task
-            let patch_clone = patch.clone();
             let state_clone = state.clone();
             let keys = keys_map.clone();
             let coll = collection_name_owned.clone();
 
             // Offload CPU-intensive patch processing to a blocking thread
-            let result = crate::runtime::blocking(&*self.runtime, move || {
+            let (result, patch) = crate::runtime::blocking(&*self.runtime, move || {
                 let get_prev_value_mac = |index_mac: &[u8]| -> Result<
                     Option<Vec<u8>>,
                     crate::appstate::AppStateError,
                 > { Ok(db_prev.get(index_mac).cloned()) };
 
                 let mut state = state_clone;
-                process_patch(
-                    &patch_clone,
+                let result = process_patch(
+                    &patch,
                     &mut state,
                     |key_id| lookup_app_state_key(&keys, key_id),
                     get_prev_value_mac,
                     validate_macs,
                     &coll,
-                )
+                )?;
+                Ok::<_, crate::appstate::AppStateError>((result, patch))
             })
             .await
             .map_err(|e| anyhow!("{}", e))?;
+            processed_patches.push(patch);
 
             // Update local state with the result from the blocking task
             state = result.state;
@@ -436,6 +445,7 @@ impl AppStateProcessor {
                     .await?;
             }
         }
+        pl.patches = processed_patches;
 
         // Handle case where we only have a snapshot and no patches
         if pl.patches.is_empty() && pl.snapshot.is_some() {


### PR DESCRIPTION
## Problem

`process_patch_list` offloads the CPU heavy snapshot and patch processing to `runtime::blocking`, whose closure requires `'static`. To satisfy that bound, the code deep-cloned the entire `SyncdSnapshot` once per sync and the entire `SyncdPatch` once per patch, and also re-cloned the key cache `HashMap` for every patch. After `download_external_blobs` inlines the external blobs, these clones are multi-MB copies that get dropped right after the blocking task finishes: the snapshot is typically the largest single blob of an app state bootstrap, and resume patches carrying `external_mutations` are MB-sized as well.

The clones only existed for the thread handoff. `process_snapshot` and `process_patch` both take their input by reference, and the `PatchList` cannot simply be consumed because the caller still reads `pl.snapshot` and `pl.patches` afterwards to collect missing key ids.

## Change

Move instead of clone, and hand the data back:

- The snapshot is taken out of the `PatchList`, moved into the blocking closure, and returned through the closure's result tuple, then restored into `pl.snapshot`. The staleness guard keeps the exact same check and warn log, it just runs on a borrow before the take.
- Patches are taken with `mem::take`, moved one by one into their blocking closure, returned the same way, and reassembled into `pl.patches` in the original order (processing is sequential, and the per patch version check already locks the ordering).
- The key cache snapshot is wrapped in `Arc` once, so the per patch handoff is a refcount bump instead of a `HashMap` copy.

On error paths the whole `PatchList` is dropped by `?` before any caller could observe the taken fields, so there is no window where `pl` is visible without its snapshot or patches.

## Benchmark

Temporary measurement (best of 3, release build, bench not committed), sizing the copies this change eliminates:

| eliminated copy | shape | cost |
|---|---|---|
| `snapshot.clone()` per bootstrap | 20k records x 1KB (~21MB) | ~8.4 ms, ~60k allocs |
| `patch.clone()` per resume patch | 1k mutations x 2KB (~2MB) | ~305 us, ~3k allocs |
| `keys_map.clone()` per patch | key cache `HashMap` | now an `Arc` refcount bump |

This is the cold app state bootstrap/resume path, so the win is allocation churn and peak copy traffic during sync, not steady state messaging.

## Tests

New `process_patch_list_returns_snapshot_and_patches_to_caller` locks the hand back contract: a snapshot (v2) plus a patch (v3) are processed and the returned `PatchList` must still carry both, with content and order preserved. That is exactly the regression a move without restore would cause, since `get_missing_key_ids` reads them after the call.

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p wacore` (994 passing)
- `cargo test -p whatsapp-rust --lib` (753 passing)

## Breaking

None. `process_patch_list` keeps its signature and the returned `PatchList` carries the same data as before.
