### PR TITLE
perf(appstate): batch the previous-MAC prefetch in build_patch like the inbound path

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -625,6 +625,101 @@ mod tests {
         );
     }
 
+    /// Locks that build_patch consults the previous value MACs (now via the
+    /// batched get_mutation_macs): a SET overwriting an existing index must
+    /// produce the subtract-then-add ltHash. If the prefetch wiring broke and
+    /// returned nothing, the old MAC would never be subtracted and the
+    /// emitted snapshot_mac would diverge.
+    #[tokio::test]
+    async fn build_patch_subtracts_previous_macs_fetched_in_batch() {
+        let backend = Arc::new(MockBackend::default());
+        let processor =
+            AppStateProcessor::new(backend.clone(), Arc::new(crate::runtime_impl::TokioRuntime));
+        let collection_name = WAPatchName::Regular;
+        let index_mac = vec![4; 32];
+        let key_id_bytes = b"patch_key_id".to_vec();
+        let master_key = [11u8; 32];
+        let keys = expand_app_state_keys(&master_key);
+
+        backend
+            .set_sync_key(
+                &key_id_bytes,
+                AppStateSyncKey {
+                    key_data: master_key.to_vec(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("test backend should accept sync key");
+
+        let old_value_mac = vec![0xAA; 32];
+        backend
+            .set_version(
+                collection_name.as_str(),
+                HashState {
+                    version: 1,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("test backend should accept version");
+        backend
+            .put_mutation_macs(
+                collection_name.as_str(),
+                1,
+                &[AppStateMutationMAC {
+                    index_mac: index_mac.clone(),
+                    value_mac: old_value_mac.clone(),
+                }],
+            )
+            .await
+            .expect("test backend should accept mutation MACs");
+
+        let plaintext = wa::SyncActionData {
+            value: Some(wa::SyncActionValue {
+                timestamp: Some(5000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .encode_to_vec();
+        let mutation = create_encrypted_mutation(
+            wa::syncd_mutation::SyncdOperation::Set,
+            &index_mac,
+            &plaintext,
+            &keys,
+            &key_id_bytes,
+        );
+
+        let (patch_bytes, base_version) = processor
+            .build_patch(collection_name.as_str(), vec![mutation.clone()])
+            .await
+            .expect("build_patch should succeed");
+        assert_eq!(base_version, 1);
+
+        // Recompute the expected post-patch state with the seeded prev MAC.
+        let mut expected_state = HashState {
+            version: 1,
+            ..Default::default()
+        };
+        let old_for_closure = old_value_mac.clone();
+        let (hash_result, res) = expected_state
+            .update_hash(std::slice::from_ref(&mutation), |mac, _| {
+                Ok((mac == index_mac.as_slice()).then(|| old_for_closure.clone()))
+            });
+        assert!(res.is_ok() && !hash_result.has_missing_remove);
+        expected_state.version = 2;
+        let expected_snapshot_mac =
+            expected_state.generate_snapshot_mac(collection_name.as_str(), &keys.snapshot_mac);
+
+        let patch = wa::SyncdPatch::decode(patch_bytes.as_slice()).expect("patch should decode");
+        assert_eq!(
+            patch.snapshot_mac.as_deref(),
+            Some(expected_snapshot_mac.as_slice()),
+            "snapshot_mac must reflect subtract(old)+add(new); a broken prev-MAC prefetch diverges here"
+        );
+    }
+
     #[tokio::test]
     async fn snapshot_resync_drops_stale_mutation_macs() {
         let (backend, processor, patch_list, stale_index_mac) = snapshot_resync_scenario().await;

--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -34,6 +34,10 @@ mod tests {
         latest_key_id: Arc<Mutex<Option<Vec<u8>>>>,
         // Fault injection: when set, clear_mutation_macs fails (transient store error).
         fail_clear_macs: Arc<Mutex<bool>>,
+        // Call counters distinguishing the batched MAC prefetch from per-item
+        // lookups, so tests can pin which path the processor takes.
+        singular_mac_calls: Arc<std::sync::atomic::AtomicU64>,
+        batch_mac_calls: Arc<std::sync::atomic::AtomicU64>,
     }
 
     // Implement SignalStore - Signal protocol cryptographic operations
@@ -135,12 +139,32 @@ mod tests {
             name: &str,
             index_mac: &[u8],
         ) -> StoreResult<Option<Vec<u8>>> {
+            self.singular_mac_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             Ok(self
                 .macs
                 .lock()
                 .await
                 .get(&(name.to_string(), index_mac.to_vec()))
                 .cloned())
+        }
+        // Real batch override (not the default singular-loop fallback) so the
+        // counters can prove which path the processor used.
+        async fn get_mutation_macs(
+            &self,
+            name: &str,
+            index_macs: &[Vec<u8>],
+        ) -> StoreResult<HashMap<Vec<u8>, Vec<u8>>> {
+            self.batch_mac_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let macs = self.macs.lock().await;
+            Ok(index_macs
+                .iter()
+                .filter_map(|index_mac| {
+                    macs.get(&(name.to_string(), index_mac.clone()))
+                        .map(|mac| (index_mac.clone(), mac.clone()))
+                })
+                .collect())
         }
         async fn delete_mutation_macs(&self, _: &str, _: &[Vec<u8>]) -> StoreResult<()> {
             Ok(())
@@ -652,7 +676,11 @@ mod tests {
             .await
             .expect("test backend should accept sync key");
 
-        let old_value_mac = vec![0xAA; 32];
+        let second_index_mac = vec![5; 32];
+        let old_value_macs: HashMap<Vec<u8>, Vec<u8>> = HashMap::from([
+            (index_mac.clone(), vec![0xAA; 32]),
+            (second_index_mac.clone(), vec![0xBB; 32]),
+        ]);
         backend
             .set_version(
                 collection_name.as_str(),
@@ -667,10 +695,13 @@ mod tests {
             .put_mutation_macs(
                 collection_name.as_str(),
                 1,
-                &[AppStateMutationMAC {
-                    index_mac: index_mac.clone(),
-                    value_mac: old_value_mac.clone(),
-                }],
+                &old_value_macs
+                    .iter()
+                    .map(|(index_mac, value_mac)| AppStateMutationMAC {
+                        index_mac: index_mac.clone(),
+                        value_mac: value_mac.clone(),
+                    })
+                    .collect::<Vec<_>>(),
             )
             .await
             .expect("test backend should accept mutation MACs");
@@ -683,30 +714,58 @@ mod tests {
             ..Default::default()
         }
         .encode_to_vec();
-        let mutation = create_encrypted_mutation(
-            wa::syncd_mutation::SyncdOperation::Set,
-            &index_mac,
-            &plaintext,
-            &keys,
-            &key_id_bytes,
-        );
+        let mutations: Vec<wa::SyncdMutation> = [&index_mac, &second_index_mac]
+            .into_iter()
+            .map(|mac| {
+                create_encrypted_mutation(
+                    wa::syncd_mutation::SyncdOperation::Set,
+                    mac,
+                    &plaintext,
+                    &keys,
+                    &key_id_bytes,
+                )
+            })
+            .collect();
+
+        let singular_before = backend
+            .singular_mac_calls
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let batch_before = backend
+            .batch_mac_calls
+            .load(std::sync::atomic::Ordering::Relaxed);
 
         let (patch_bytes, base_version) = processor
-            .build_patch(collection_name.as_str(), vec![mutation.clone()])
+            .build_patch(collection_name.as_str(), mutations.clone())
             .await
             .expect("build_patch should succeed");
         assert_eq!(base_version, 1);
 
-        // Recompute the expected post-patch state with the seeded prev MAC.
+        // The prefetch must be ONE batched round-trip, never per-mutation
+        // singular lookups (the N+1 this change removes).
+        assert_eq!(
+            backend
+                .batch_mac_calls
+                .load(std::sync::atomic::Ordering::Relaxed)
+                - batch_before,
+            1,
+            "previous MACs must be fetched via a single get_mutation_macs call"
+        );
+        assert_eq!(
+            backend
+                .singular_mac_calls
+                .load(std::sync::atomic::Ordering::Relaxed)
+                - singular_before,
+            0,
+            "build_patch must not fall back to per-mutation get_mutation_mac"
+        );
+
+        // Recompute the expected post-patch state with the seeded prev MACs.
         let mut expected_state = HashState {
             version: 1,
             ..Default::default()
         };
-        let old_for_closure = old_value_mac.clone();
-        let (hash_result, res) = expected_state
-            .update_hash(std::slice::from_ref(&mutation), |mac, _| {
-                Ok((mac == index_mac.as_slice()).then(|| old_for_closure.clone()))
-            });
+        let (hash_result, res) =
+            expected_state.update_hash(&mutations, |mac, _| Ok(old_value_macs.get(mac).cloned()));
         assert!(res.is_ok() && !hash_result.has_missing_remove);
         expected_state.version = 2;
         let expected_snapshot_mac =

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -489,21 +489,23 @@ impl AppStateProcessor {
         let mut state = self.backend.get_version(collection_name).await?;
         let base_version = state.version;
 
-        // Pre-fetch previous value MACs for all index MACs in the mutations
-        let mut db_prev: std::collections::HashMap<Vec<u8>, Vec<u8>> =
-            std::collections::HashMap::new();
+        // Pre-fetch previous value MACs in one backend round-trip, mirroring
+        // the inbound patch path: one batched query instead of a
+        // spawn_blocking + single-row SELECT per mutation.
+        let mut need_db_lookup: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
         for m in &mutations {
             if let Some(rec) = &m.record
                 && let Some(ind) = &rec.index
                 && let Some(index_mac) = &ind.blob
-                && let Some(mac) = self
-                    .backend
-                    .get_mutation_mac(collection_name, index_mac)
-                    .await?
+                && !need_db_lookup.iter().any(|v| v == index_mac)
             {
-                db_prev.insert(index_mac.clone(), mac);
+                need_db_lookup.push(index_mac.clone());
             }
         }
+        let db_prev: std::collections::HashMap<Vec<u8>, Vec<u8>> = self
+            .backend
+            .get_mutation_macs(collection_name, &need_db_lookup)
+            .await?;
 
         // Update hash state
         let (_, hash_result) = state.update_hash(&mutations, |index_mac, _| {


### PR DESCRIPTION
## Problem

`build_patch` prefetches the previous value MAC for each outbound mutation by calling the singular `backend.get_mutation_mac` in a loop, one spawn_blocking + single-row SELECT per mutation. The inbound apply path had the same N+1 shape and was fixed to use the batched `get_mutation_macs` (one round-trip, chunked IN query) back in #687; the outbound builder was never migrated.

Honest scope note: every current caller funnels through `send_app_state_patch` with a single-element mutation vector, so today the loop runs exactly once per outbound app state action and this is a latent N+1, not an active hot spot. The change is consistency with the inbound path plus future-proofing for multi-mutation patches.

## Change

Mirror the inbound prefetch: collect and dedup the mutations' index MACs, then fetch all previous value MACs with one `get_mutation_macs` call. Same dedup-before-query shape as the inbound loop, so the two paths now read identically.

## Tests

New `build_patch_subtracts_previous_macs_fetched_in_batch`: seeds a stored MAC for an index, builds a SET overwrite patch, and asserts the emitted `snapshot_mac` equals the independently recomputed subtract-then-add ltHash. If the prefetch wiring broke (e.g. returned an empty map), the old MAC would never be subtracted and the assertion diverges, so the test locks the behavior regardless of singular vs batched implementation.

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p whatsapp-rust --lib appstate_sync` (6 passing)
- `cargo test -p wacore` (994 passing)

## Breaking

None.
