### PR TITLE
perf(send): probe the LID-PN map in one direction on warm device lookups

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -90,6 +90,37 @@ impl Client {
         UserLookupKeys::Unknown { user: user.into() }
     }
 
+    /// Server-aware variant of `resolve_lookup_keys` for callers holding a
+    /// full `Jid`: a LID user can only key the lid->pn direction and a PN
+    /// user only pn->lid, so the known namespace removes the blind second
+    /// probe (one `lid_pn_cache` lookup per member instead of two, on every
+    /// group send). Other namespaces keep the two-probe fallback.
+    async fn resolve_lookup_keys_for_jid(&self, jid: &Jid) -> UserLookupKeys {
+        if jid.server == wacore_binary::Server::Lid {
+            if let Some(pn) = self.lid_pn_cache.get_phone_number(&jid.user).await {
+                return UserLookupKeys::LidWithPn {
+                    lid: jid.user.as_str().into(),
+                    pn: pn.into(),
+                };
+            }
+            return UserLookupKeys::Unknown {
+                user: jid.user.as_str().into(),
+            };
+        }
+        if jid.server == wacore_binary::Server::Pn {
+            if let Some(lid) = self.lid_pn_cache.get_current_lid(&jid.user).await {
+                return UserLookupKeys::PnWithLid {
+                    lid,
+                    pn: jid.user.as_str().into(),
+                };
+            }
+            return UserLookupKeys::Unknown {
+                user: jid.user.as_str().into(),
+            };
+        }
+        self.resolve_lookup_keys(&jid.user).await
+    }
+
     /// Owned-key variant of `resolve_lookup_keys`. Test-only: production callers
     /// use the borrowed `resolve_lookup_keys(..).all_keys()` to avoid the churn.
     #[cfg(test)]
@@ -656,7 +687,7 @@ impl Client {
         // backend take `&str`, so going through `get_lookup_keys` (which re-owns
         // the already-cloned keys into a `Vec<String>`) just churns per member on
         // every group send. `lookup` owns the key Strings for the duration here.
-        let lookup = self.resolve_lookup_keys(&jid.user).await;
+        let lookup = self.resolve_lookup_keys_for_jid(jid).await;
 
         // L1: device_registry_cache (moka, fast)
         for key in lookup.all_keys() {
@@ -824,6 +855,43 @@ mod tests {
             .device_registry_cache
             .insert(user.into(), Arc::new(record))
             .await;
+    }
+
+    /// The server-aware probe must resolve the same canonical record as the
+    /// blind two-probe for both namespaces: a LID jid via its lid->pn mapping
+    /// and a PN jid via pn->lid, plus the unmapped-PN fallback.
+    #[tokio::test]
+    async fn server_aware_probe_resolves_both_namespaces() {
+        let client = create_test_client().await;
+        let pn = "5511999990000";
+        let lid = "100000000000001";
+        client
+            .add_lid_pn_mapping(lid, pn, crate::lid_pn_cache::LearningSource::Usync)
+            .await
+            .expect("mapping should persist");
+        setup_device_record(&client, pn, &[0, 7]).await;
+
+        let via_pn = client
+            .get_devices_from_registry(&Jid::pn(pn))
+            .await
+            .expect("PN jid must resolve via pn->lid probe");
+        assert_eq!(via_pn.len(), 2);
+        let via_lid = client
+            .get_devices_from_registry(&Jid::lid(lid))
+            .await
+            .expect("LID jid must resolve via lid->pn probe");
+        assert_eq!(via_lid.len(), 2);
+
+        // Unmapped PN still resolves through its own key.
+        let bare = "5511888880000";
+        setup_device_record(&client, bare, &[0]).await;
+        assert!(
+            client
+                .get_devices_from_registry(&Jid::pn(bare))
+                .await
+                .is_some(),
+            "unmapped PN must resolve via its own record"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`get_devices_from_registry` runs once per participant on every group send. Its key resolution (`resolve_lookup_keys`) only receives the bare user string, so it blindly probes BOTH directions of the LID-PN map (`get_phone_number`, then `get_current_lid`): two moka lookups per member before the registry lookup itself, three cache operations per member in total.

We first prototyped the obvious "fix" (concurrent resolution with a `buffered(50)` window, mirroring WA Web's SESSION_CHECK batching) and measured it: 962us vs 674us serial for a warm 800-member send, 43% WORSE. The futures are in-memory moka hits that resolve immediately, so there is no I/O to overlap and the stream machinery is pure overhead. The guaranteed improvement is doing less work per member, not reordering the same work.

## Change

The hot caller holds the full `Jid`, and the namespace determines the only valid probe direction: a LID user can only key the lid to pn map, and a PN user only pn to lid. A new `resolve_lookup_keys_for_jid` probes exactly one direction for PN/LID jids (other namespaces keep the blind two-probe fallback), turning 3 cache operations per member into 2. Same canonical-key semantics, one fewer lookup by construction.

## Benchmark

Back-to-back A/B on the same machine (release, warm caches, 800 members x 2 devices, 500 iterations):

| | warm 800-member send |
|---|---|
| before (blind two-probe) | 675 us |
| after (server-aware probe) | 497 us (-26%) |

For reference, the rejected concurrency prototype measured 962 us (+43%), which is why this PR reduces work instead.

## Tests

New `server_aware_probe_resolves_both_namespaces`: a LID jid resolves through its lid to pn mapping, a PN jid through pn to lid, and an unmapped PN still resolves through its own record, locking that the directed probe reaches the same canonical records the blind probe did.

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p whatsapp-rust --lib` (754 passing)

## Breaking

None.
