### PR TITLE
fix(contacts): use fn items for LID mapping extractors so boxed futures compile

### DIFF
--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -30,10 +30,12 @@ fn ensure_is_on_whatsapp_jids_supported(jids: &[Jid]) -> Result<()> {
 /// that box those futures (`#[async_trait]`, `Box<dyn Future + Send>`) hit
 /// "implementation of `FnOnce` is not general enough" (issue #825). Fn items
 /// implement `Fn` for every lifetime by construction.
+/// PN-primary result -> (PN, LID mapping).
 fn forward_lid_pair(r: &IsOnWhatsAppResult) -> (&Jid, Option<&Jid>) {
     (&r.jid, r.lid.as_ref())
 }
 
+/// LID-primary result inverted to (PN, LID); None when not LID-primary.
 fn reverse_lid_pair(r: &IsOnWhatsAppResult) -> Option<(&Jid, Option<&Jid>)> {
     if r.jid.is_lid() {
         r.pn_jid.as_ref().map(|pn| (pn, Some(&r.jid)))
@@ -42,6 +44,7 @@ fn reverse_lid_pair(r: &IsOnWhatsAppResult) -> Option<(&Jid, Option<&Jid>)> {
     }
 }
 
+/// UserInfo entry -> (queried JID, LID mapping).
 fn user_info_lid_pair(entry: &UserInfo) -> (&Jid, Option<&Jid>) {
     (&entry.jid, entry.lid.as_ref())
 }
@@ -55,6 +58,10 @@ impl<'a> Contacts<'a> {
         Self { client }
     }
 
+    /// Callers must pass `fn` items (e.g. [`forward_lid_pair`]), NOT
+    /// closures: a closure returning borrowed pairs embeds a non-HRTB type in
+    /// the public caller's future and breaks `#[async_trait]` consumers
+    /// (issue #825, guarded by tests/async_trait_boxed_future_compat.rs).
     async fn persist_lid_mappings<'b, I>(&self, entries: I)
     where
         I: IntoIterator<Item = (&'b Jid, Option<&'b Jid>)>,

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -24,6 +24,28 @@ fn ensure_is_on_whatsapp_jids_supported(jids: &[Jid]) -> Result<()> {
     Ok(())
 }
 
+/// Mapping extractors as fn items, NOT closures. A closure returning
+/// references tied to its argument is inferred at a concrete lifetime, and
+/// because its type is embedded in the public methods' future types, callers
+/// that box those futures (`#[async_trait]`, `Box<dyn Future + Send>`) hit
+/// "implementation of `FnOnce` is not general enough" (issue #825). Fn items
+/// implement `Fn` for every lifetime by construction.
+fn forward_lid_pair(r: &IsOnWhatsAppResult) -> (&Jid, Option<&Jid>) {
+    (&r.jid, r.lid.as_ref())
+}
+
+fn reverse_lid_pair(r: &IsOnWhatsAppResult) -> Option<(&Jid, Option<&Jid>)> {
+    if r.jid.is_lid() {
+        r.pn_jid.as_ref().map(|pn| (pn, Some(&r.jid)))
+    } else {
+        None
+    }
+}
+
+fn user_info_lid_pair(entry: &UserInfo) -> (&Jid, Option<&Jid>) {
+    (&entry.jid, entry.lid.as_ref())
+}
+
 pub struct Contacts<'a> {
     client: &'a Client,
 }
@@ -112,16 +134,10 @@ impl<'a> Contacts<'a> {
             results.extend(self.client.execute(spec).await?);
         }
 
-        self.persist_lid_mappings(results.iter().map(|r| (&r.jid, r.lid.as_ref())))
+        self.persist_lid_mappings(results.iter().map(forward_lid_pair))
             .await;
-        self.persist_lid_mappings(results.iter().filter_map(|r| {
-            if r.jid.is_lid() {
-                r.pn_jid.as_ref().map(|pn| (pn, Some(&r.jid)))
-            } else {
-                None
-            }
-        }))
-        .await;
+        self.persist_lid_mappings(results.iter().filter_map(reverse_lid_pair))
+            .await;
 
         Ok(results)
     }
@@ -189,7 +205,7 @@ impl<'a> Contacts<'a> {
         let spec = UserInfoSpec::new(jids.to_vec(), request_id);
 
         let info = self.client.execute(spec).await?;
-        self.persist_lid_mappings(info.values().map(|entry| (&entry.jid, entry.lid.as_ref())))
+        self.persist_lid_mappings(info.values().map(user_info_lid_pair))
             .await;
         Ok(info)
     }

--- a/tests/async_trait_boxed_future_compat.rs
+++ b/tests/async_trait_boxed_future_compat.rs
@@ -1,0 +1,66 @@
+//! Compile-time regression guard for issue #825.
+//!
+//! Public async methods whose future type embeds a closure returning
+//! references (e.g. an iterator adapter passed to a generic helper) fail with
+//! "implementation of `FnOnce` is not general enough" ONLY when a downstream
+//! caller boxes the future, which is exactly what `#[async_trait]` does. The
+//! library's own tests never box that way, so this file reproduces the
+//! consumer shape: if it compiles, the guard passes.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wacore_binary::Jid;
+use whatsapp_rust::client::Client;
+
+#[async_trait]
+pub trait WhatsAppGateway: Send + Sync {
+    async fn check_phones(&self, phones: Vec<String>) -> Result<Vec<bool>, String>;
+    async fn statuses(&self, phones: Vec<String>) -> Result<Vec<Option<String>>, String>;
+}
+
+pub struct GatewayImpl {
+    client: RwLock<Option<Arc<Client>>>,
+}
+
+#[async_trait]
+impl WhatsAppGateway for GatewayImpl {
+    async fn check_phones(&self, phones: Vec<String>) -> Result<Vec<bool>, String> {
+        let guard = self.client.read().await;
+        let client = guard.as_ref().expect("client").clone();
+        drop(guard);
+
+        let jids: Vec<Jid> = phones.iter().map(|p| Jid::pn(p.as_str())).collect();
+        let results = client
+            .contacts()
+            .is_on_whatsapp(&jids)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(results.into_iter().map(|r| r.is_registered).collect())
+    }
+
+    async fn statuses(&self, phones: Vec<String>) -> Result<Vec<Option<String>>, String> {
+        let guard = self.client.read().await;
+        let client = guard.as_ref().expect("client").clone();
+        drop(guard);
+
+        let jids: Vec<Jid> = phones.iter().map(|p| Jid::pn(p.as_str())).collect();
+        let info = client
+            .contacts()
+            .get_user_info(&jids)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(jids
+            .iter()
+            .map(|jid| info.get(jid).and_then(|i| i.status.clone()))
+            .collect())
+    }
+}
+
+/// The guard is the compilation itself; this just keeps the test binary
+/// non-empty and the trait impl reachable.
+#[test]
+fn async_trait_consumers_compile() {
+    fn assert_impl<T: WhatsAppGateway>() {}
+    assert_impl::<GatewayImpl>();
+}


### PR DESCRIPTION
## Problem

`is_on_whatsapp()` and `get_user_info()` failed to compile for any consumer that boxes their futures, which is exactly what `#[async_trait]` does:

```
error: implementation of `FnOnce` is not general enough
  = note: closure with signature `fn(&'0 IsOnWhatsAppResult) -> (&Jid, Option<&Jid>)`
          must implement `FnOnce<(&'1 IsOnWhatsAppResult,)>`, for any two lifetimes `'0` and `'1`...
```

Reported in #825 with an excellent minimal repro. The `RwLock` in the report is incidental: the trigger is the `Box<dyn Future + Send>` that `async_trait` produces, which forces the compiler to prove auto traits and higher-ranked bounds for the whole future tree. The real culprit lives in this library: the `persist_lid_mappings` call sites passed closures returning references tied to their argument (`|r| (&r.jid, r.lid.as_ref())`). Rust infers such closures at a concrete lifetime rather than the higher-ranked `for<'r> Fn(&'r _)`, and since the closure types are embedded in the public methods' future types, the unprovable obligation leaks to every boxing consumer. None of the user-side workarounds can fix it, since the problem is inside the library's future type.

## Fix

Replace the three borrowing closures (two in `is_on_whatsapp`, one in `get_user_info`) with fn items, which implement `Fn` for every lifetime by construction. Zero clones, zero public API change, identical behavior.

Swept the rest of the workspace for the same class: the other generic helpers with borrowed-item bounds (`GroupInfo::add_participants`, `DeviceTopology::record`, `DeviceRegistryCache::insert`, `participant_list_hash`) are either synchronous (the iterator never lives inside a future) or only ever receive closure-free iterators (slices/`Chain`), and the `FDownload` closures in appstate return owned values, which generalize fine. The contacts call sites were the only affected surface.

## Tests

New `tests/async_trait_boxed_future_compat.rs`: a compile-time regression guard reproducing the consumer shape from the report (`#[async_trait]` + `RwLock<Option<Arc<Client>>>` calling both methods). This class of error only manifests in the downstream crate's context, so the guard IS the compilation. Verified it catches the regression: with the previous closures restored, the guard fails with six "not general enough" errors; with the fn items it compiles and passes.

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p whatsapp-rust --lib` (765 passing)
- `cargo test -p whatsapp-rust --test async_trait_boxed_future_compat`

## Breaking

None.

Fixes #825
