### PR TITLE
perf(client): borrow the ack id instead of allocating a String per stanza

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -922,7 +922,7 @@ impl Client {
         // resolves Ok to the caller, so without this the failure is invisible.
         if let Some(error_code) = node.get_attr("error") {
             let code = error_code.as_str();
-            let id = node.get_attr("id").map(|v| v.as_str().into_owned());
+            let id = node.get_attr("id").map(|v| v.as_str());
             match code.as_ref() {
                 "463" => {
                     warn!(
@@ -953,9 +953,8 @@ impl Client {
             }
         }
 
-        let id_opt = node.get_attr("id").map(|v| v.as_str().into_owned());
-        if let Some(id) = id_opt
-            && let Some(waiter) = self.response_waiters.lock().await.remove(&id)
+        if let Some(id) = node.get_attr("id").map(|v| v.as_str())
+            && let Some(waiter) = self.response_waiters.lock().await.remove(id.as_ref())
         {
             // ACK responses are infrequent; re-encode into OwnedNodeRef for the channel.
             // marshal_ref prepends a leading 0x00 format byte; OwnedNodeRef::new expects raw

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2825,3 +2825,55 @@ async fn terminal_disconnect_propagates_to_per_connection_signal() {
         "disconnect must also fire terminal"
     );
 }
+
+// Counting allocator for the empirical allocation guard below. Process-wide
+// for the unit-test binary, but the only cost is one relaxed atomic add per
+// alloc; tests that never read the counter are unaffected.
+mod counting_alloc {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub(super) static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+    struct CountingAlloc;
+
+    unsafe impl GlobalAlloc for CountingAlloc {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            unsafe { System.alloc(layout) }
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+    }
+
+    #[global_allocator]
+    static GLOBAL: CountingAlloc = CountingAlloc;
+}
+
+/// Locks the zero-allocation property of the ack miss path: id resolution and
+/// the waiter probe must borrow from the node buffer. An `into_owned()` here
+/// costs one String per received ack, which the e2e dhat profile caught live.
+#[tokio::test]
+async fn ack_miss_path_does_not_heap_allocate() {
+    let client = crate::test_utils::create_test_client().await;
+
+    let ack_node = NodeBuilder::new("ack")
+        .attr("id", "3EB0A9252A8F12B7E2")
+        .attr("from", SERVER_JID)
+        .build();
+    let node_ref = ack_node.as_node_ref();
+
+    // Min-delta over many windows: sibling tests share the process-global
+    // counter, but their allocations are sporadic. A per-call String shows up
+    // in every window, so the minimum only reaches 0 when the path is clean.
+    let mut min_delta = u64::MAX;
+    for _ in 0..100 {
+        let before = counting_alloc::ALLOCS.load(std::sync::atomic::Ordering::Relaxed);
+        let handled = client.handle_ack_response(&node_ref).await;
+        let after = counting_alloc::ALLOCS.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(!handled, "no waiter is registered for this id");
+        min_delta = min_delta.min(after - before);
+    }
+    assert_eq!(min_delta, 0, "ack miss path must not allocate");
+}


### PR DESCRIPTION
## Problem

`handle_ack_response` runs once per received `<ack>` stanza, which means once per sent message. It extracted the `id` attribute with `v.as_str().into_owned()`, heap-allocating a `String` from what is already a borrowed `Cow<str>` view into the node's backing buffer, just to probe the `response_waiters` map. The allocation is wasted in both the hit and the miss case because `HashMap<String, V>::remove` accepts `&str` through `Borrow<str>`. The nack diagnostic branch in the same function had the identical wasted copy feeding a `{:?}` log.

This is visible in real profiles: the committed e2e dhat profile (`tests/e2e/dhat-heap.json`) captures this exact allocation site (`Option::map::<alloc::string::String, handle_ack_response::...>`).

## Change

Keep the `Cow<'_, str>` and pass `id.as_ref()` to `remove()`, mirroring the pattern the IQ waiter path in the same file already uses. Same change in the nack branch; `Debug` output of `Option<Cow<str>>` is byte-identical to `Option<String>`, so the log format is unchanged. `ValueRef::as_str()` returns `Cow::Borrowed` for the `String` variant, and an ack `id` is never a JID token, so the saved allocation fires on every ack.

## Benchmark

Counting-allocator measurement of the miss path (the common case), min-delta over 100 windows:

| | allocations per ack |
|---|---|
| before | 1 |
| after | 0 |

The counterproof was run against the previous code with the new test in place and fails with `left: 1, right: 0` in every window. This is an allocation-churn win on the receive loop, not a wall-clock win.

## Tests

- New `ack_miss_path_does_not_heap_allocate`: counting global allocator with min-delta over 100 iterations, race-immune against sibling tests sharing the process-global counter (same rationale as `wacore/binary/tests/attrs_inline_alloc.rs`). The allocator is a relaxed atomic add over `System`, so the rest of the unit-test binary is unaffected.
- Existing `test_ack_waiter_resolves` and `test_ack_without_matching_waiter` cover hit and miss semantics unchanged.
- `cargo clippy --all-targets -- -D warnings` clean, full workspace suite green.

## Breaking

None.
