### PR TITLE
fix(appstate): match WA Web index-mode ltHash for SET+REMOVE on the same index

### DIFF
--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -43,6 +43,34 @@ impl HashState {
     where
         F: FnMut(&[u8], usize) -> anyhow::Result<Option<Vec<u8>>>,
     {
+        // WA Web index-mode (WAWebSyncdAntiTampering, gate `d`): when every mutation
+        // carries an index, a SET whose index is also REMOVEd in the same patch must
+        // NOT subtract its previous value; the REMOVE owns that subtraction. Without
+        // the guard the previous value is subtracted twice and the SET's value is
+        // orphaned in the MAC store, leaving the ltHash and the store in permanent
+        // disagreement. The legacy non-index path keeps the old math, like WA Web.
+        // fn item, not a closure: the borrowed return needs HRTB (issue #825 class).
+        fn index_mac_of(mutation: &wa::SyncdMutation) -> Option<&[u8]> {
+            mutation
+                .record
+                .as_ref()
+                .and_then(|r| r.index.as_ref())
+                .and_then(|idx| idx.blob.as_deref())
+        }
+        let index_mode = mutations.iter().all(|m| index_mac_of(m).is_some());
+        let mut removed_in_patch: std::collections::HashSet<&[u8]> =
+            std::collections::HashSet::new();
+        if index_mode {
+            for mutation in mutations {
+                if mutation.operation.unwrap_or_default()
+                    == wa::syncd_mutation::SyncdOperation::Remove as i32
+                    && let Some(index_mac) = index_mac_of(mutation)
+                {
+                    removed_in_patch.insert(index_mac);
+                }
+            }
+        }
+
         // Borrow the MAC tails instead of copying; mirrors `update_hash_from_records`.
         let mut added: Vec<&[u8]> = Vec::with_capacity(mutations.len());
         let mut removed: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
@@ -50,7 +78,8 @@ impl HashState {
 
         for (i, mutation) in mutations.iter().enumerate() {
             let op = mutation.operation.unwrap_or_default();
-            if op == wa::syncd_mutation::SyncdOperation::Set as i32
+            let is_set = op == wa::syncd_mutation::SyncdOperation::Set as i32;
+            if is_set
                 && let Some(record) = &mutation.record
                 && let Some(value) = &record.value
                 && let Some(blob) = &value.blob
@@ -58,12 +87,10 @@ impl HashState {
             {
                 added.push(&blob[blob.len() - 32..]);
             }
-            let index_mac_opt = mutation
-                .record
-                .as_ref()
-                .and_then(|r| r.index.as_ref())
-                .and_then(|idx| idx.blob.as_ref());
-            if let Some(index_mac) = index_mac_opt {
+            if let Some(index_mac) = index_mac_of(mutation) {
+                if is_set && removed_in_patch.contains(index_mac) {
+                    continue;
+                }
                 match get_prev_set_value_mac(index_mac, i) {
                     Ok(Some(prev)) => removed.push(prev),
                     Ok(None) => {
@@ -292,6 +319,120 @@ mod tests {
             expected_final_hash.as_slice(),
             "The final hash state after overwrite and remove is incorrect."
         );
+    }
+
+    /// WA Web index-mode: a SET whose index is also REMOVEd in the same patch must
+    /// not subtract its previous value; only the REMOVE subtracts (the store value).
+    #[test]
+    fn test_update_hash_set_plus_remove_same_index_subtracts_once() {
+        const INDEX_MAC: &[u8] = &[1; 32];
+        const PREV_VALUE: &[u8] = &[10; 32];
+        const NEW_VALUE: &[u8] = &[20; 32];
+
+        let mutations = vec![
+            create_mutation(
+                wa::syncd_mutation::SyncdOperation::Set,
+                INDEX_MAC.to_vec(),
+                Some(NEW_VALUE.to_vec()),
+            ),
+            create_mutation(
+                wa::syncd_mutation::SyncdOperation::Remove,
+                INDEX_MAC.to_vec(),
+                Some(PREV_VALUE.to_vec()),
+            ),
+        ];
+
+        let mut state = HashState::default();
+        let mut lookups = 0usize;
+        let (hash_result, result) = state.update_hash(&mutations, |_, _| {
+            lookups += 1;
+            Ok(Some(PREV_VALUE.to_vec()))
+        });
+        assert!(result.is_ok());
+        assert!(!hash_result.has_missing_remove);
+        assert_eq!(lookups, 1, "the suppressed SET must not query the store");
+
+        let expected = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0; 128],
+            &[PREV_VALUE.to_vec()],
+            &[NEW_VALUE.to_vec()],
+        );
+        assert_eq!(state.hash.as_slice(), expected.as_slice());
+    }
+
+    /// Index-mode is gated on every mutation carrying an index (WA Web's `d`):
+    /// with one index-less mutation in the patch, the SET subtracts as before.
+    #[test]
+    fn test_update_hash_suppression_disabled_without_full_index_coverage() {
+        const INDEX_MAC: &[u8] = &[1; 32];
+        const PREV_VALUE: &[u8] = &[10; 32];
+        const NEW_VALUE: &[u8] = &[20; 32];
+
+        let mut index_less = create_mutation(
+            wa::syncd_mutation::SyncdOperation::Set,
+            vec![],
+            Some(vec![30; 32]),
+        );
+        if let Some(rec) = index_less.record.as_mut() {
+            rec.index = None;
+        }
+
+        let mutations = vec![
+            create_mutation(
+                wa::syncd_mutation::SyncdOperation::Set,
+                INDEX_MAC.to_vec(),
+                Some(NEW_VALUE.to_vec()),
+            ),
+            create_mutation(
+                wa::syncd_mutation::SyncdOperation::Remove,
+                INDEX_MAC.to_vec(),
+                Some(PREV_VALUE.to_vec()),
+            ),
+            index_less,
+        ];
+
+        let mut state = HashState::default();
+        let (_, result) = state.update_hash(&mutations, |_, _| Ok(Some(PREV_VALUE.to_vec())));
+        assert!(result.is_ok());
+
+        // Legacy math: SET and REMOVE each subtract the previous value.
+        let expected = WAPATCH_INTEGRITY.subtract_then_add(
+            &[0; 128],
+            &[PREV_VALUE.to_vec(), PREV_VALUE.to_vec()],
+            &[NEW_VALUE.to_vec(), vec![30; 32]],
+        );
+        assert_eq!(state.hash.as_slice(), expected.as_slice());
+    }
+
+    /// SET+REMOVE same index against an empty store: the SET still adds, the REMOVE
+    /// finds nothing and flags has_missing_remove, matching WA Web index-mode which
+    /// has no fallback query.
+    #[test]
+    fn test_update_hash_set_plus_remove_same_index_empty_store() {
+        const INDEX_MAC: &[u8] = &[1; 32];
+        const NEW_VALUE: &[u8] = &[20; 32];
+
+        let mutations = vec![
+            create_mutation(
+                wa::syncd_mutation::SyncdOperation::Set,
+                INDEX_MAC.to_vec(),
+                Some(NEW_VALUE.to_vec()),
+            ),
+            create_mutation(
+                wa::syncd_mutation::SyncdOperation::Remove,
+                INDEX_MAC.to_vec(),
+                Some(NEW_VALUE.to_vec()),
+            ),
+        ];
+
+        let mut state = HashState::default();
+        let (hash_result, result) = state.update_hash(&mutations, |_, _| Ok(None));
+        assert!(result.is_ok());
+        assert!(hash_result.has_missing_remove);
+
+        const EMPTY: &[Vec<u8>] = &[];
+        let expected = WAPATCH_INTEGRITY.subtract_then_add(&[0; 128], EMPTY, &[NEW_VALUE.to_vec()]);
+        assert_eq!(state.hash.as_slice(), expected.as_slice());
     }
 
     /// Known-answer test for generate_patch_mac to guard byte ordering and input

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -207,7 +207,13 @@ where
     // overwrites the same index earlier in the patch takes precedence over the DB value.
     let mut in_patch: HashMap<&[u8], &[u8]> = HashMap::with_capacity(patch.mutations.len());
     let (hash_update_result, result) = state.update_hash(&patch.mutations, |index_mac, idx| {
-        let prev = if let Some(value_mac) = in_patch.get(index_mac) {
+        // WA Web resolves every previous value against the store map fetched before
+        // the loop; the in-patch overlay only models SET-overwrite collapse and must
+        // never feed a REMOVE (a REMOVE preceded by a SET on the same index would
+        // otherwise subtract the in-patch value instead of the store's).
+        let is_remove = patch.mutations[idx].operation.unwrap_or_default()
+            == wa::syncd_mutation::SyncdOperation::Remove as i32;
+        let prev = if !is_remove && let Some(value_mac) = in_patch.get(index_mac) {
             Some(value_mac.to_vec())
         } else {
             get_prev_value_mac(index_mac).map_err(|e| anyhow::anyhow!(e))?
@@ -986,23 +992,20 @@ mod tests {
         );
     }
 
-    /// REMOVE carries a value blob (decode requires >= 48 bytes) and previous-value resolution
-    /// is operation-agnostic, like the reverse scan it replaces: a SET after a REMOVE on the
-    /// same index subtracts the REMOVE's tail, not the DB value.
+    /// SET+REMOVE on the same index in one patch: WA Web index-mode pre-collects the
+    /// REMOVEd indices and suppresses the SET's subtraction (the REMOVE owns it, and
+    /// it subtracts the STORE value, never the in-patch one). Net must be
+    /// base + set_tail - store_prev, which also agrees with the persisted MAC store
+    /// (delete removed_index_macs then put added_macs leaves the index present with
+    /// the SET's value).
     #[test]
-    fn test_process_patch_set_after_remove_uses_remove_tail() {
+    fn test_process_patch_set_plus_remove_same_index_wa_web_index_mode() {
         let master_key = [7u8; 32];
         let keys = expand_app_state_keys(&master_key);
         let key_id = b"test_key_id".to_vec();
         let index_mac = vec![3; 32];
+        let store_prev = vec![9u8; 32];
 
-        let remove = create_encrypted_record(
-            wa::syncd_mutation::SyncdOperation::Remove,
-            &index_mac,
-            &keys,
-            &key_id,
-            1000,
-        );
         let set = create_encrypted_record(
             wa::syncd_mutation::SyncdOperation::Set,
             &index_mac,
@@ -1010,55 +1013,79 @@ mod tests {
             &key_id,
             2000,
         );
+        let remove = create_encrypted_record(
+            wa::syncd_mutation::SyncdOperation::Remove,
+            &index_mac,
+            &keys,
+            &key_id,
+            1000,
+        );
 
         let tail = |rec: &wa::SyncdRecord| {
             let blob = rec.value.as_ref().unwrap().blob.as_ref().unwrap();
             blob[blob.len() - 32..].to_vec()
         };
-        let remove_tail = tail(&remove);
         let set_tail = tail(&set);
 
-        let patch = wa::SyncdPatch {
+        let build_patch = |mutations: Vec<wa::SyncdMutation>| wa::SyncdPatch {
             version: Some(wa::SyncdVersion { version: Some(1) }),
-            mutations: vec![
-                wa::SyncdMutation {
-                    operation: Some(wa::syncd_mutation::SyncdOperation::Remove as i32),
-                    record: Some(remove),
-                },
-                wa::SyncdMutation {
-                    operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
-                    record: Some(set),
-                },
-            ],
+            mutations,
             key_id: Some(wa::KeyId {
                 id: Some(key_id.clone()),
             }),
             ..Default::default()
         };
+        let set_mutation = wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::Set as i32),
+            record: Some(set),
+        };
+        let remove_mutation = wa::SyncdMutation {
+            operation: Some(wa::syncd_mutation::SyncdOperation::Remove as i32),
+            record: Some(remove),
+        };
 
         let get_keys = |_: &[u8]| Ok(Arc::new(keys.clone()));
-        let get_prev = |_: &[u8]| Ok(None);
+        let get_prev = |_: &[u8]| Ok(Some(store_prev.clone()));
 
-        let mut state = HashState::default();
-        let result = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
-            .expect("remove-then-set should process");
-
-        // The SET's previous value is the in-patch REMOVE tail, so it gets subtracted.
-        const EMPTY: &[Vec<u8>] = &[];
         let expected = WAPATCH_INTEGRITY.subtract_then_add(
             &[0u8; 128],
-            std::slice::from_ref(&remove_tail),
+            std::slice::from_ref(&store_prev),
             std::slice::from_ref(&set_tail),
         );
-        assert_eq!(result.state.hash.as_slice(), expected.as_slice());
 
-        // An op==Set guard would skip the REMOVE, dropping to the DB and leaving only +set_tail.
-        let if_remove_skipped = WAPATCH_INTEGRITY.subtract_then_add(
-            &[0u8; 128],
-            EMPTY,
-            std::slice::from_ref(&set_tail),
-        );
-        assert_ne!(result.state.hash.as_slice(), if_remove_skipped.as_slice());
+        // Both orderings must yield the same hash: the math is per-index, not
+        // per-position (WA Web accumulates adds/subtracts in maps).
+        for (label, mutations) in [
+            (
+                "set-then-remove",
+                vec![set_mutation.clone(), remove_mutation.clone()],
+            ),
+            ("remove-then-set", vec![remove_mutation, set_mutation]),
+        ] {
+            let patch = build_patch(mutations);
+            let mut state = HashState::default();
+            let result = process_patch(&patch, &mut state, get_keys, get_prev, false, "regular")
+                .unwrap_or_else(|e| panic!("{label} should process: {e:?}"));
+
+            assert_eq!(
+                result.state.hash.as_slice(),
+                expected.as_slice(),
+                "{label}: net must be base + set_tail - store_prev (WA Web index-mode)"
+            );
+
+            // The MAC store ends with the index present (delete-then-put), so the
+            // hash above is the only self-consistent answer. The wire blob is the
+            // HMAC of the index identity, recomputed by decode_record.
+            let wire_index_mac = generate_index_mac(&index_mac, &keys.index);
+            assert_eq!(result.added_macs.len(), 1, "{label}");
+            assert_eq!(result.added_macs[0].index_mac, wire_index_mac, "{label}");
+            assert_eq!(result.added_macs[0].value_mac, set_tail, "{label}");
+            assert_eq!(
+                result.removed_index_macs,
+                vec![wire_index_mac.clone()],
+                "{label}"
+            );
+        }
     }
 
     /// WA Web: validatePatchVersion checks `localVersion !== patchVersion - 1`.


### PR DESCRIPTION
## Problem

A syncd patch carrying a SET and a REMOVE for the same index is a valid input: WA Web's `validateNoSameIndexForMultipleMutations` keeps one set per operation, so the cross-operation pair passes validation (our `detect_duplicate_index_in_patch` mirrors that). But our ltHash math subtracted the previous value twice for that input: once via the SET's prev lookup against the store, and once via the REMOVE resolving its prev through the in-patch overlay (which returned the SET's value). The net hash dropped the index entirely (`base - v0`), while the persisted MAC store, which deletes `removed_index_macs` and then puts `added_macs`, kept the index present with the SET's value.

The consequences if the server ever emits such a patch: the locally computed snapshot MAC diverges from the patch's (`PatchSnapshotMACMismatch`, collection stuck in retry), and worse, the MAC store and the ltHash disagree permanently, so every subsequent snapshotMac for that collection re-fails even after refetch.

## Change

Mirror WA Web's index-mode (`WAWebSyncdAntiTampering`, gate `d`), captured in `docs/captured-js/WAWeb/Syncd/AntiTampering.js`:

- `update_hash` pre-collects the index MACs that appear in any REMOVE of the patch and skips the prev lookup for a SET on such an index: the REMOVE owns the subtraction. The suppression is gated on every mutation carrying an index, matching the `d` condition; an index-less mutation keeps the legacy math, like WA Web's legacy mode does.
- `process_patch`'s in-patch overlay no longer feeds REMOVE lookups. WA Web resolves every prev against the store map fetched before the loop and never consults in-patch values; the overlay's only WA-Web-faithful role is collapsing SET overwrite chains (per-index maps), which it keeps.

Net for `[SET X v1, REMOVE X]` with store `v0`: `base + v1 - v0`, in either mutation order, which is exactly the state the MAC store ends in (X present with v1). The hash and the store now agree by construction. The outbound `build_patch` path gets the same math for free since it goes through `update_hash`.

For context on the three-way divergence this resolves: our old math (`base - v0`) came from whatsmeow's strictly-prior scan; WA Web legacy mode computes `base + v1 - 2*v0` (both subtract maps survive the concat); WA Web index-mode computes `base + v1 - v0`. Three different answers for the same valid input is strong evidence the server does not emit it today, which is why this never fired in production. Index-mode is the only self-consistent answer and the one Meta is migrating to (the `syncd_use_index_for_lthash_lookup` AB prop gates the new path).

## Tests

- `test_process_patch_set_plus_remove_same_index_wa_web_index_mode`: both orderings against a populated store, asserting the net hash and that `added_macs`/`removed_index_macs` leave the store agreeing with the hash.
- `test_update_hash_set_plus_remove_same_index_subtracts_once`: unit-level, also asserts the suppressed SET performs no store lookup.
- `test_update_hash_set_plus_remove_same_index_empty_store`: SET still adds, REMOVE flags `has_missing_remove` (index-mode has no fallback query).
- `test_update_hash_suppression_disabled_without_full_index_coverage`: the `d` gate; with an index-less mutation in the patch the legacy math is preserved.
- The previous `test_process_patch_set_after_remove_uses_remove_tail` locked the divergent math and was replaced by the ordering-pair test above. `test_process_patch_in_patch_overwrite_last_write_wins` (SET chains) passes unchanged.
- Full workspace suite green, `cargo clippy --all-targets -- -D warnings` clean.

## Breaking

None (internal hash math; public API unchanged).
