### PR TITLE
fix(storage): serialize msg_secret reads through the db semaphore

### DIFF
--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2869,12 +2869,15 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>> {
+        // Serialized through the db semaphore for the same reason as
+        // get_msg_secret_with_ts: a read racing a write transaction must wait,
+        // not error out as a phantom miss.
         let pool = self.pool.clone();
         let device_id = self.device_id;
         let chat = chat.to_string();
         let sender = sender.to_string();
         let msg_id = msg_id.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
+        self.with_semaphore(move || -> Result<Option<Vec<u8>>> {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
@@ -2890,7 +2893,6 @@ impl MsgSecretStore for SqliteStore {
             Ok(row)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn get_msg_secret_with_ts(
@@ -2899,12 +2901,16 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<(Vec<u8>, i64)>> {
+        // Serialized through the db semaphore: a raw read racing a write
+        // transaction hits the shared-cache table lock on in-memory stores
+        // (SQLITE_LOCKED is not covered by busy_timeout) and callers treat the
+        // error as a missing secret.
         let pool = self.pool.clone();
         let device_id = self.device_id;
         let chat = chat.to_string();
         let sender = sender.to_string();
         let msg_id = msg_id.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<(Vec<u8>, i64)>> {
+        self.with_semaphore(move || -> Result<Option<(Vec<u8>, i64)>> {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
@@ -2920,7 +2926,6 @@ impl MsgSecretStore for SqliteStore {
             Ok(row)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_expired_msg_secrets(&self, cutoff_timestamp: i64) -> Result<u32> {


### PR DESCRIPTION
## Problem

`get_msg_secret` and `get_msg_secret_with_ts` ran their queries on raw `spawn_blocking`, bypassing the single-permit `db_semaphore` that every write path (`with_retry`) and most reads (`with_semaphore`) acquire. A read racing a write transaction hits the shared-cache table lock on in-memory stores and fails with SQLITE_LOCKED, which `busy_timeout` does not cover. Both call sites in `msg_secret.rs` treat a backend error as a miss, so an inbound add-on could spuriously fail to find its parent secret and surface undecrypted.

The write-behind drain from #831 made the overlap reachable in practice: the detached batch write races the very next message's secret lookup. The `enc_comment_inbound_dispatches_body_with_parent_link` pipeline test flaked at roughly coin-flip rate per process (reproduced on clean main, 2 failures in 6 runs), and the failure is silent because the lookup-miss path logs nothing. File-backed stores are shielded by WAL (readers don't block on writers), so this chiefly affects in-memory stores: the test suite and any embedded consumer using `:memory:`.

## Change

Route both reads through `with_semaphore`, like the rest of the store. A read that overlaps a write now waits for the permit instead of erroring out as a phantom miss.

## Tests

No new test: the existing pipeline test is the regression guard, and it goes from ~50% flake per process to 12/12 consecutive green runs with this fix. Full workspace suite green, `cargo clippy --all-targets -- -D warnings` clean.

## Breaking

None.
