### PR TITLE
feat(prekeys): track the first un-uploaded prekey and reuse the window like WA Web

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -71,6 +71,9 @@ mod tests {
         async fn remove_prekey(&self, _: u32) -> StoreResult<()> {
             Ok(())
         }
+        async fn mark_prekeys_uploaded(&self, _: &[u32]) -> StoreResult<()> {
+            Ok(())
+        }
         async fn get_max_prekey_id(&self) -> StoreResult<u32> {
             Ok(0)
         }

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -395,10 +395,12 @@ impl Client {
             })
             .await;
         // Same durability pairing as the batch path: the stored key is
-        // durable, so its watermarks must not ride the lazy saver.
-        if let Err(e) = self.persistence_manager.flush().await {
-            log::warn!("failed to flush prekey watermarks: {e:?}");
-        }
+        // durable, so its watermarks must not ride the lazy saver. A failed
+        // flush fails the allocation; the retry dance recovers later.
+        self.persistence_manager
+            .flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to flush prekey watermarks: {e:?}"))?;
         Ok((id, key_pair.public_key))
     }
 
@@ -503,10 +505,13 @@ impl Client {
             .await;
         // The generated rows are already durable; the watermarks ride the lazy
         // device saver. Flush them now so a crash before the IQ cannot reload
-        // pre-generation watermarks and orphan the stored window.
-        if let Err(e) = self.persistence_manager.flush().await {
-            log::warn!("failed to flush prekey watermarks: {e:?}");
-        }
+        // pre-generation watermarks and orphan the stored window. A failed
+        // flush aborts the pass: proceeding would upload keys whose
+        // accounting is not durable, the exact state this barrier prevents.
+        self.persistence_manager
+            .flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to flush prekey watermarks: {e:?}"))?;
 
         // Load the upload window: leftover keys plus the fresh ones. Gaps are
         // tolerated (a window key consumed via a retry receipt leaves a hole).
@@ -580,10 +585,12 @@ impl Client {
             .await;
         // The abandon watermark must be durable BEFORE the fallible send: a
         // crash after a failed IQ would otherwise reload FIRST=window_start
-        // and re-offer ids that may already be in the server pool.
-        if let Err(e) = self.persistence_manager.flush().await {
-            log::warn!("failed to flush prekey watermarks: {e:?}");
-        }
+        // and re-offer ids that may already be in the server pool. A failed
+        // flush aborts instead of sending with non-durable abandonment.
+        self.persistence_manager
+            .flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to flush abandon watermark: {e:?}"))?;
 
         self.execute(spec).await?;
 

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -555,6 +555,7 @@ impl Client {
             .map(|(id, _)| *id)
             .expect("non-empty checked above");
         let uploaded_count = pre_key_pairs.len();
+        let pre_key_ids: Vec<u32> = pre_key_pairs.iter().map(|(id, _)| *id).collect();
 
         let spec = PreKeyUploadSpec::new(
             device_snapshot.registration_id,
@@ -586,8 +587,13 @@ impl Client {
 
         self.execute(spec).await?;
 
-        // Mark the uploaded prekeys as server-synced (reuse loaded records).
-        if let Err(e) = backend.store_prekeys_batch(&rows, true).await {
+        // Mark the uploaded prekeys as server-synced. UPDATE semantics: a
+        // window key consumed by an inbound pkmsg while the IQ was in flight
+        // (retry-receipt keys are reachable that way, and consumption is not
+        // serialized by prekey_upload_lock) must stay deleted, not be
+        // resurrected by an upsert of the stale record.
+        let uploaded_ids: Vec<u32> = pre_key_ids;
+        if let Err(e) = backend.mark_prekeys_uploaded(&uploaded_ids).await {
             log::warn!("Failed to mark prekeys as uploaded: {:?}", e);
         }
 

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -370,10 +370,13 @@ impl Client {
         let id = if plan.gen_count > 0 {
             plan.gen_start
         } else {
-            // Empty window: generate at NEXT and collapse FIRST onto it.
-            device_snapshot
+            // Empty window: generate at NEXT and collapse FIRST onto it. This
+            // path bypasses the planner's boundary handling, so wrap to 1 at
+            // the 24-bit edge like the planner's collapse does.
+            let raw = device_snapshot
                 .next_pre_key_id
-                .max(plan.window_start.saturating_add(1))
+                .max(plan.window_start.saturating_add(1));
+            if raw > MAX_PREKEY_ID { 1 } else { raw }
         };
         let key_pair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
         let record = new_pre_key_record(id, &key_pair);
@@ -574,6 +577,12 @@ impl Client {
                 first_unupload_pre_key_id: plan.window_start.max(last_id.saturating_add(1)),
             })
             .await;
+        // The abandon watermark must be durable BEFORE the fallible send: a
+        // crash after a failed IQ would otherwise reload FIRST=window_start
+        // and re-offer ids that may already be in the server pool.
+        if let Err(e) = self.persistence_manager.flush().await {
+            log::warn!("failed to flush prekey watermarks: {e:?}");
+        }
 
         self.execute(spec).await?;
 

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -417,6 +417,15 @@ impl Client {
         )
     )]
     async fn upload_pre_keys_inner(&self) -> Result<(), anyhow::Error> {
+        self.upload_pre_keys_pass(true).await
+    }
+
+    /// One upload pass. `allow_collapse_retry` permits a single inline rerun
+    /// after collapsing a fully consumed window, so a one-shot caller (the
+    /// login path logs and moves on) still ends the pass with fresh keys; the
+    /// rerun cannot hit the empty branch again because the collapsed plan
+    /// generates a full batch.
+    async fn upload_pre_keys_pass(&self, allow_collapse_retry: bool) -> Result<(), anyhow::Error> {
         // INVARIANT: every caller holds `prekey_upload_lock` (login, prekey-low
         // notification, refresh, digest repair), serializing the watermark math
         // with the retry-receipt single-key path.
@@ -521,7 +530,7 @@ impl Client {
         if rows.is_empty() {
             // A fully consumed/missing window with no generation would bail
             // forever (available > 0 keeps gen_count at 0). Collapse the
-            // window so the next attempt generates a fresh batch.
+            // window and rerun the pass so a one-shot caller still uploads.
             if plan.gen_count == 0 {
                 self.persistence_manager
                     .process_command(DeviceCommand::SetPreKeyWatermarks {
@@ -529,6 +538,14 @@ impl Client {
                         first_unupload_pre_key_id: plan.new_next,
                     })
                     .await;
+                if allow_collapse_retry {
+                    log::warn!(
+                        "prekey window [{}, {}) fully missing; collapsed, regenerating",
+                        plan.window_start,
+                        plan.new_next
+                    );
+                    return Box::pin(self.upload_pre_keys_pass(false)).await;
+                }
             }
             anyhow::bail!("no prekey available to upload");
         }
@@ -1104,6 +1121,38 @@ mod window_tests {
         backend(&client).remove_prekey(11).await.expect("consume");
         let (id, _) = client.get_or_gen_single_pre_key().await.expect("heal 2");
         assert_eq!(id, 12);
+    }
+
+    /// A fully missing window must collapse AND regenerate within the same
+    /// pass: the login path is one-shot, so bailing without minting would
+    /// leave the device without prekeys until an unrelated trigger.
+    #[tokio::test]
+    async fn fully_missing_window_collapses_and_regenerates_in_one_pass() {
+        use wacore::store::commands::DeviceCommand;
+
+        let client =
+            crate::test_utils::create_test_client_with_name("prekey_window_collapse").await;
+        client.set_wanted_pre_key_count(5);
+        // Watermarks claim a 5-key window, but nothing is stored (all consumed).
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: 15,
+                first_unupload_pre_key_id: 10,
+            })
+            .await;
+
+        // The IQ still fails (disconnected), but the SAME pass must have
+        // collapsed and generated a fresh batch.
+        let _ = client.upload_pre_keys_inner().await;
+        let (next, first) = snapshot(&client);
+        assert_eq!(next, 20, "fresh batch minted at the collapsed NEXT");
+        assert_eq!(first, 20, "marked past the window before the send");
+        let rows = backend(&client)
+            .load_prekeys_batch(&[15, 16, 17, 18, 19])
+            .await
+            .expect("load");
+        assert_eq!(rows.len(), 5, "regeneration happened within the pass");
     }
 
     /// A retry-receipt single key lives in the unuploaded window, so the next

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -48,6 +48,85 @@ fn start_prekey_id(next_pre_key_id: u32, max_store_id: u32) -> u32 {
     ((raw - 1) % MAX_PREKEY_ID as u64) as u32 + 1
 }
 
+/// One upload pass's accounting, mirroring WA Web `getOrGenPreKeys` semantics
+/// (`WAWebSignalStoreApi`): the upload window starts at the FIRST_UNUPLOAD
+/// watermark and re-offers leftover generated-but-unuploaded keys, generating
+/// only enough new ones to reach the target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PreKeyUploadPlan {
+    /// First id of the upload window (the FIRST_UNUPLOAD watermark after
+    /// migration init / self-heal).
+    window_start: u32,
+    /// Leftover generated-but-unuploaded keys already in the store.
+    available: u32,
+    /// New keys to generate (`wanted - available`, floored at 0).
+    gen_count: u32,
+    /// First id of the newly generated range (`window_start + available`).
+    gen_start: u32,
+    /// NEXT_PK_ID after generation (`gen_start + gen_count`).
+    new_next: u32,
+}
+
+/// Compute the upload window and generation range from the two watermarks.
+///
+/// `first_unupload == 0` is the unset/legacy state: the window starts fresh at
+/// the legacy-safe `start_prekey_id` (which skips stored-but-unconfirmed rows
+/// from the pre-watermark model) with no leftovers. The same reset handles a
+/// corrupt `first > next` pair and a window that would cross the 24-bit id
+/// boundary; the wrap collapse keeps the window contiguous and is the same
+/// accepted tradeoff as the old per-id modulo (the server consumes keys well
+/// before a 16M cycle).
+fn plan_prekey_upload(
+    first_unupload: u32,
+    next: u32,
+    max_store_id: u32,
+    wanted: usize,
+) -> PreKeyUploadPlan {
+    let wanted = wanted as u64;
+    let first = first_unupload as u64;
+    let next_eff = next as u64;
+
+    let fresh_window = |start: u64| {
+        let start = if start + wanted - 1 > MAX_PREKEY_ID as u64 {
+            1
+        } else {
+            start
+        };
+        PreKeyUploadPlan {
+            window_start: start as u32,
+            available: 0,
+            gen_count: wanted as u32,
+            gen_start: start as u32,
+            new_next: (start + wanted) as u32,
+        }
+    };
+
+    if first == 0 || first > next_eff {
+        return fresh_window(start_prekey_id(next, max_store_id) as u64);
+    }
+    // Cap leftovers at the target: surplus stays in the window for next time
+    // (WA Web p <= 0 path uploads only getPreKeysByRange(s, wanted)). New
+    // generation always starts at NEXT (savePreKeys semantics), so a capped
+    // window never regresses the counter.
+    let available = (next_eff - first).min(wanted);
+    let gen_count = wanted - available;
+    if first + wanted - 1 > MAX_PREKEY_ID as u64
+        || (gen_count > 0 && next_eff + gen_count - 1 > MAX_PREKEY_ID as u64)
+    {
+        // Window or generation would cross the id boundary: collapse to a
+        // fresh window at 1 (old high-id rows are overwritten progressively,
+        // same acceptance as the previous modulo wrap).
+        return fresh_window(1);
+    }
+    PreKeyUploadPlan {
+        window_start: first as u32,
+        available: available as u32,
+        gen_count: gen_count as u32,
+        gen_start: next_eff as u32,
+        new_next: (next_eff + gen_count) as u32,
+    }
+}
+
 /// The upload IQ encodes the pre-key `<list>` length as a u16
 /// (`Encoder::write_list_start`), so a larger batch fails to encode after the
 /// keys were already generated and stored. Well below MAX_PREKEY_ID, so a single
@@ -221,36 +300,80 @@ impl Client {
         self.upload_pre_keys_inner().await
     }
 
-    /// Allocate the next one-time prekey id from the persistent monotonic `NEXT_PK_ID` counter
-    /// (the same namespace as uploads) and advance it, so a retry-receipt prekey can never
-    /// collide with a live pool key. The caller must hold `prekey_upload_lock` to serialize the
-    /// allocate+bump with the upload path. Mirrors WA Web's `getOrGenSinglePreKey -> NEXT_PK_ID`.
+    /// Get-or-generate ONE one-time prekey, mirroring WA Web's
+    /// `getOrGenSinglePreKey` = `getOrGenPreKeys(1)`: reuse the first
+    /// generated-but-unuploaded window key when one exists (it stays in the
+    /// window and is uploaded by the next batch, like WA Web), else generate a
+    /// fresh key at `NEXT_PK_ID` and advance the counter at generation time.
+    /// The caller must hold `prekey_upload_lock` to serialize the watermark
+    /// math with the upload path.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
-            name = "wa.session.allocate_prekey_id",
+            name = "wa.session.get_or_gen_prekey",
             level = "debug",
             skip_all,
             err(Debug)
         )
     )]
-    pub(crate) async fn allocate_next_one_time_prekey_id(&self) -> Result<u32, anyhow::Error> {
-        let next_pre_key_id = self
-            .persistence_manager
-            .get_device_snapshot()
-            .next_pre_key_id;
-        let backend = self
-            .persistence_manager
-            .get_device_snapshot()
-            .backend
-            .clone();
+    pub(crate) async fn get_or_gen_single_pre_key(
+        &self,
+    ) -> Result<(u32, PublicKey), anyhow::Error> {
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        let backend = device_snapshot.backend.clone();
         let max_id = backend.get_max_prekey_id().await?;
-        let id = start_prekey_id(next_pre_key_id, max_id);
-        let next = (id as u64 % MAX_PREKEY_ID as u64) as u32 + 1;
+        let plan = plan_prekey_upload(
+            device_snapshot.first_unupload_pre_key_id,
+            device_snapshot.next_pre_key_id,
+            max_id,
+            1,
+        );
+
+        if plan.gen_count == 0 {
+            let rows = backend.load_prekeys_batch(&[plan.window_start]).await?;
+            if let Some((id, record)) = rows.into_iter().next() {
+                use prost::Message;
+                let structure = waproto::whatsapp::PreKeyRecordStructure::decode(&record[..])?;
+                let record = wacore::libsignal::store::record_helpers::prekey_structure_to_record(
+                    structure,
+                )?;
+                return Ok((id, record.key_pair()?.public_key));
+            }
+            // The window head was consumed (a previously reused retry key the
+            // peer already spent). Skip the dead slot and generate fresh; WA
+            // Web throws here, but healing is strictly better and stays in
+            // the same id namespace.
+            log::warn!(
+                "prekey window head {} missing from store; skipping dead slot",
+                plan.window_start
+            );
+        }
+
+        let id = if plan.gen_count > 0 {
+            plan.gen_start
+        } else {
+            // Dead-slot heal: generate at NEXT and advance FIRST past the gap.
+            device_snapshot
+                .next_pre_key_id
+                .max(plan.window_start.saturating_add(1))
+        };
+        let key_pair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+        let record = new_pre_key_record(id, &key_pair);
+        use prost::Message;
+        backend
+            .store_prekey(id, &record.encode_to_vec(), false)
+            .await?;
         self.persistence_manager
-            .process_command(DeviceCommand::SetNextPreKeyId(next))
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: id.saturating_add(1),
+                first_unupload_pre_key_id: if plan.gen_count > 0 {
+                    plan.window_start
+                } else {
+                    id
+                },
+            })
             .await;
-        Ok(id)
+        Ok((id, key_pair.public_key))
     }
 
     /// Generate and upload the configured number of pre-keys (see
@@ -266,21 +389,11 @@ impl Client {
         )
     )]
     async fn upload_pre_keys_inner(&self) -> Result<(), anyhow::Error> {
+        // INVARIANT: every caller holds `prekey_upload_lock` (login, prekey-low
+        // notification, refresh, digest repair), serializing the watermark math
+        // with the retry-receipt single-key path.
         let device_snapshot = self.persistence_manager.get_device_snapshot();
         let backend = device_snapshot.backend.clone();
-
-        // Use the persistent counter, falling back to max(store_id)+1 for migration.
-        // The counter is the source of truth after the first upload; start_prekey_id wraps
-        // into the 24-bit range so lingering high-ID rows don't pin start_id above it.
-        let max_id = backend.get_max_prekey_id().await?;
-        if device_snapshot.next_pre_key_id == 0 {
-            log::info!(
-                "Migrating pre-key counter: MAX(key_id) in store = {}, starting from {}",
-                max_id,
-                max_id + 1
-            );
-        }
-        let start_id = start_prekey_id(device_snapshot.next_pre_key_id, max_id);
 
         let configured = self.wanted_pre_key_count.load(Ordering::Relaxed);
         let wanted = clamp_wanted_pre_key_count(configured);
@@ -288,52 +401,128 @@ impl Client {
             log::warn!("wanted_pre_key_count {configured} out of range, clamped to {wanted}");
         }
 
-        // Per-key X25519 generation and prost encoding are CPU-bound, and the
-        // batch size is caller-configurable, so offload the whole batch to keep
-        // the async executor responsive. Records are encoded into one contiguous
-        // buffer with zero-copy Bytes slices instead of an alloc per record.
-        let (encoded_batch, pre_key_pairs) = wacore::runtime::blocking(&*self.runtime, move || {
+        // WA Web getOrGenPreKeys: re-offer the leftover generated-but-unuploaded
+        // window first and only generate enough new keys to reach the target.
+        let max_id = backend.get_max_prekey_id().await?;
+        if device_snapshot.first_unupload_pre_key_id == 0 {
+            log::info!(
+                "Initialising prekey upload window (legacy counter = {}, MAX(key_id) = {})",
+                device_snapshot.next_pre_key_id,
+                max_id
+            );
+        }
+        let plan = plan_prekey_upload(
+            device_snapshot.first_unupload_pre_key_id,
+            device_snapshot.next_pre_key_id,
+            max_id,
+            wanted,
+        );
+
+        if plan.gen_count > 0 {
+            let gen_start = plan.gen_start;
+            let gen_count = plan.gen_count as usize;
+            // Per-key X25519 generation and prost encoding are CPU-bound, and the
+            // batch size is caller-configurable, so offload the whole batch to keep
+            // the async executor responsive. Records are encoded into one contiguous
+            // buffer with zero-copy Bytes slices instead of an alloc per record.
+            let encoded_batch = wacore::runtime::blocking(&*self.runtime, move || {
+                use prost::Message;
+
+                // Seed one CSPRNG and advance it per key, rather than reseeding from
+                // entropy on every iteration.
+                let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+                let mut records = Vec::with_capacity(gen_count);
+                for i in 0..gen_count {
+                    let pre_key_id = gen_start + i as u32;
+                    let key_pair = KeyPair::generate(&mut rng);
+                    records.push((pre_key_id, new_pre_key_record(pre_key_id, &key_pair)));
+                }
+
+                let total_len: usize = records.iter().map(|(_, r)| r.encoded_len()).sum();
+                let mut buf = Vec::with_capacity(total_len);
+                let mut offsets = Vec::with_capacity(records.len());
+                for (id, record) in &records {
+                    let start = buf.len();
+                    record
+                        .encode(&mut buf)
+                        .expect("prost encode into pre-sized Vec");
+                    offsets.push((*id, start..buf.len()));
+                }
+                let shared = bytes::Bytes::from(buf);
+                let encoded_batch: Vec<(u32, bytes::Bytes)> = offsets
+                    .into_iter()
+                    .map(|(id, range)| (id, shared.slice(range)))
+                    .collect();
+                encoded_batch
+            })
+            .await;
+
+            // Persist the freshly generated prekeys before uploading them so they are
+            // already available for local decryption if the server starts sending
+            // pkmsg traffic immediately after accepting the upload.
+            // Propagate errors — uploading a key we can't store locally would cause
+            // decryption failures when the server hands it out.
+            backend.store_prekeys_batch(&encoded_batch, false).await?;
+        }
+
+        // Advance NEXT at GENERATION time (WA Web savePreKeys) and initialise
+        // FIRST for a legacy device, in one command. From here the window
+        // covers every stored-but-unuploaded key, so a failure below never
+        // leads to regenerating over live ids.
+        self.persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: plan.new_next,
+                first_unupload_pre_key_id: plan.window_start,
+            })
+            .await;
+
+        // Load the upload window: leftover keys plus the fresh ones. Gaps are
+        // tolerated (a window key consumed via a retry receipt leaves a hole).
+        let window_ids: Vec<u32> = (0..wanted as u32).map(|i| plan.window_start + i).collect();
+        let mut rows = backend.load_prekeys_batch(&window_ids).await?;
+        rows.sort_unstable_by_key(|(id, _)| *id);
+        if rows.is_empty() {
+            // A fully consumed/missing window with no generation would bail
+            // forever (available > 0 keeps gen_count at 0). Collapse the
+            // window so the next attempt generates a fresh batch.
+            if plan.gen_count == 0 {
+                self.persistence_manager
+                    .process_command(DeviceCommand::SetPreKeyWatermarks {
+                        next_pre_key_id: plan.new_next,
+                        first_unupload_pre_key_id: plan.new_next,
+                    })
+                    .await;
+            }
+            anyhow::bail!("no prekey available to upload");
+        }
+
+        let pre_key_pairs = {
             use prost::Message;
-
-            // Seed one CSPRNG and advance it per key, rather than reseeding from
-            // entropy on every iteration.
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-            let mut records = Vec::with_capacity(wanted);
-            let mut pre_key_pairs: Vec<(u32, PublicKey)> = Vec::with_capacity(wanted);
-            for i in 0..wanted {
-                let pre_key_id =
-                    (((start_id as u64 - 1) + i as u64) % (MAX_PREKEY_ID as u64)) as u32 + 1;
-                let key_pair = KeyPair::generate(&mut rng);
-                records.push((pre_key_id, new_pre_key_record(pre_key_id, &key_pair)));
-                pre_key_pairs.push((pre_key_id, key_pair.public_key));
+            let mut pairs: Vec<(u32, PublicKey)> = Vec::with_capacity(rows.len());
+            for (id, record) in &rows {
+                let public_key = waproto::whatsapp::PreKeyRecordStructure::decode(&record[..])
+                    .map_err(anyhow::Error::from)
+                    .and_then(|structure| {
+                        let raw = structure
+                            .public_key
+                            .ok_or_else(|| anyhow::anyhow!("record missing public key"))?;
+                        Ok(PublicKey::from_djb_public_key_bytes(&raw)?)
+                    });
+                match public_key {
+                    Ok(public_key) => pairs.push((*id, public_key)),
+                    Err(e) => log::warn!("skipping undecodable prekey record {id}: {e:?}"),
+                }
             }
-
-            let total_len: usize = records.iter().map(|(_, r)| r.encoded_len()).sum();
-            let mut buf = Vec::with_capacity(total_len);
-            let mut offsets = Vec::with_capacity(records.len());
-            for (id, record) in &records {
-                let start = buf.len();
-                record
-                    .encode(&mut buf)
-                    .expect("prost encode into pre-sized Vec");
-                offsets.push((*id, start..buf.len()));
+            if pairs.is_empty() {
+                anyhow::bail!("no decodable prekey available to upload");
             }
-            let shared = bytes::Bytes::from(buf);
-            let encoded_batch: Vec<(u32, bytes::Bytes)> = offsets
-                .into_iter()
-                .map(|(id, range)| (id, shared.slice(range)))
-                .collect();
-
-            (encoded_batch, pre_key_pairs)
-        })
-        .await;
-
-        // Persist the freshly generated prekeys before uploading them so they are
-        // already available for local decryption if the server starts sending
-        // pkmsg traffic immediately after accepting the upload.
-        // Propagate errors — uploading a key we can't store locally would cause
-        // decryption failures when the server hands it out.
-        backend.store_prekeys_batch(&encoded_batch, false).await?;
+            pairs
+        };
+        let last_id = pre_key_pairs
+            .last()
+            .map(|(id, _)| *id)
+            .expect("non-empty checked above");
+        let uploaded_count = pre_key_pairs.len();
 
         let spec = PreKeyUploadSpec::new(
             device_snapshot.registration_id,
@@ -344,21 +533,25 @@ impl Client {
             pre_key_pairs,
         );
 
+        // Mark the window uploaded BEFORE the send, like WA Web's
+        // markKeyAsUploaded (PreKeysJob.js runs it ahead of the IQ). On a
+        // mid-flight failure the server state is unknown, so the keys are
+        // abandoned rather than re-offered: re-uploading an id a peer may
+        // already have consumed would corrupt the server pool. The keys stay
+        // stored locally and remain decryptable if the upload did land.
+        self.persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: plan.new_next,
+                first_unupload_pre_key_id: plan.window_start.max(last_id.saturating_add(1)),
+            })
+            .await;
+
         self.execute(spec).await?;
 
-        // Mark the uploaded prekeys as server-synced (reuse encoded batch)
-        if let Err(e) = backend.store_prekeys_batch(&encoded_batch, true).await {
+        // Mark the uploaded prekeys as server-synced (reuse loaded records).
+        if let Err(e) = backend.store_prekeys_batch(&rows, true).await {
             log::warn!("Failed to mark prekeys as uploaded: {:?}", e);
         }
-
-        // IDs wrap modulo MAX_PREKEY_ID. If the counter wraps while unconsumed
-        // high-ID prekeys still exist, the upsert (.on_conflict.do_update)
-        // silently overwrites them. Acceptable: the server consumes keys well
-        // before a full 16M cycle completes.
-        let next_id = (((start_id as u64 - 1) + wanted as u64) % (MAX_PREKEY_ID as u64)) as u32 + 1;
-        self.persistence_manager
-            .process_command(DeviceCommand::SetNextPreKeyId(next_id))
-            .await;
 
         // Persist flag matching WA Web's setServerHasPreKeys(true) (PreKeysJob.js:79)
         self.persistence_manager
@@ -366,9 +559,10 @@ impl Client {
             .await;
 
         log::debug!(
-            "Successfully uploaded {} new pre-keys with sequential IDs starting from {}.",
-            wanted,
-            start_id
+            "Successfully uploaded {} pre-keys ({} reused from the window) starting from {}.",
+            uploaded_count,
+            plan.available,
+            plan.window_start
         );
 
         Ok(())
@@ -591,8 +785,86 @@ impl Client {
 mod tests {
     use super::{
         DEFAULT_WANTED_PRE_KEY_COUNT, MAX_PRE_KEY_UPLOAD_BATCH, MAX_PREKEY_ID, MIN_PRE_KEY_COUNT,
-        clamp_wanted_pre_key_count, should_upload_pre_keys, start_prekey_id,
+        clamp_wanted_pre_key_count, plan_prekey_upload, should_upload_pre_keys, start_prekey_id,
     };
+
+    #[test]
+    fn plan_initialises_window_for_legacy_device() {
+        // first unset: fresh window at the legacy-safe start (max(counter, store+1)),
+        // full generation.
+        let p = plan_prekey_upload(0, 7, 20, 812);
+        assert_eq!(p.window_start, 21, "legacy start skips stored rows");
+        assert_eq!(p.available, 0);
+        assert_eq!(p.gen_count, 812);
+        assert_eq!(p.gen_start, 21);
+        assert_eq!(p.new_next, 833);
+    }
+
+    #[test]
+    fn plan_generates_full_batch_on_empty_window() {
+        let p = plan_prekey_upload(100, 100, 99, 812);
+        assert_eq!(p.window_start, 100);
+        assert_eq!(p.available, 0);
+        assert_eq!(p.gen_count, 812);
+        assert_eq!(p.gen_start, 100);
+        assert_eq!(p.new_next, 912);
+    }
+
+    #[test]
+    fn plan_reuses_leftovers_and_tops_up() {
+        // 50 leftover unuploaded keys: only 762 new ones, window re-offers all 812.
+        let p = plan_prekey_upload(100, 150, 149, 812);
+        assert_eq!(p.window_start, 100);
+        assert_eq!(p.available, 50);
+        assert_eq!(p.gen_count, 762);
+        assert_eq!(p.gen_start, 150, "generation starts at NEXT (savePreKeys)");
+        assert_eq!(p.new_next, 912);
+    }
+
+    #[test]
+    fn plan_full_window_generates_nothing_and_keeps_next() {
+        // More leftovers than the target (WA Web p <= 0): upload the first
+        // `wanted`, generate nothing, and never regress NEXT.
+        let p = plan_prekey_upload(100, 1500, 1499, 812);
+        assert_eq!(p.window_start, 100);
+        assert_eq!(p.available, 812);
+        assert_eq!(p.gen_count, 0);
+        assert_eq!(p.new_next, 1500, "a capped window must not regress NEXT");
+    }
+
+    #[test]
+    fn plan_heals_corrupt_first_past_next() {
+        let p = plan_prekey_upload(500, 100, 600, 812);
+        assert_eq!(p.window_start, 601, "heals via the legacy-safe start");
+        assert_eq!(p.available, 0);
+        assert_eq!(p.gen_count, 812);
+    }
+
+    #[test]
+    fn plan_collapses_window_at_id_boundary() {
+        // Window would cross the 24-bit boundary: collapse to a fresh window at 1.
+        let p = plan_prekey_upload(
+            MAX_PREKEY_ID - 10,
+            MAX_PREKEY_ID - 5,
+            MAX_PREKEY_ID - 6,
+            812,
+        );
+        assert_eq!(p.window_start, 1);
+        assert_eq!(p.available, 0);
+        assert_eq!(p.gen_count, 812);
+        assert_eq!(p.new_next, 813);
+    }
+
+    #[test]
+    fn plan_single_key_reuses_window_head() {
+        // getOrGenSinglePreKey = getOrGenPreKeys(1): a non-empty window means
+        // no generation; the head key is the answer.
+        let p = plan_prekey_upload(10, 12, 11, 1);
+        assert_eq!(p.window_start, 10);
+        assert_eq!(p.available, 1);
+        assert_eq!(p.gen_count, 0);
+        assert_eq!(p.new_next, 12);
+    }
 
     #[test]
     fn default_matches_wa_web_upload_keys_count() {
@@ -649,6 +921,152 @@ mod tests {
         assert!(
             should_upload_pre_keys(false, MIN_PRE_KEY_COUNT - 1),
             "below threshold uploads even without force"
+        );
+    }
+}
+
+#[cfg(test)]
+mod window_tests {
+    use wacore::libsignal::protocol::PublicKey;
+
+    fn snapshot(client: &crate::client::Client) -> (u32, u32) {
+        let d = client.persistence_manager.get_device_snapshot();
+        (d.next_pre_key_id, d.first_unupload_pre_key_id)
+    }
+
+    fn backend(
+        client: &crate::client::Client,
+    ) -> std::sync::Arc<dyn crate::store::traits::Backend> {
+        client.persistence_manager.backend()
+    }
+
+    /// A failed upload IQ must leave the watermarks past the generated window
+    /// (WA Web abandons on unknown server state) and the next attempt must
+    /// mint FRESH ids, never regenerating over the stored ones: that
+    /// regeneration was the prekey-collision class on partial success.
+    #[tokio::test]
+    async fn failed_upload_abandons_window_and_never_remints_ids() {
+        let client = crate::test_utils::create_test_client_with_name("prekey_window_fail").await;
+        client.set_wanted_pre_key_count(5);
+
+        let err = client.upload_pre_keys_inner().await;
+        assert!(err.is_err(), "IQ must fail on a disconnected client");
+
+        let (next, first) = snapshot(&client);
+        assert_eq!(next, 6, "NEXT advances at generation time");
+        assert_eq!(first, 6, "FIRST is marked past the window before the send");
+
+        let rows = backend(&client)
+            .load_prekeys_batch(&[1, 2, 3, 4, 5])
+            .await
+            .expect("load");
+        assert_eq!(rows.len(), 5, "the generated window stays stored");
+        let before: Vec<_> = rows.into_iter().collect();
+
+        let _ = client.upload_pre_keys_inner().await;
+        let (next, first) = snapshot(&client);
+        assert_eq!(next, 11, "second attempt mints fresh ids 6..=10");
+        assert_eq!(first, 11);
+
+        let rows2 = backend(&client)
+            .load_prekeys_batch(&[6, 7, 8, 9, 10])
+            .await
+            .expect("load");
+        assert_eq!(rows2.len(), 5);
+
+        let after = backend(&client)
+            .load_prekeys_batch(&[1, 2, 3, 4, 5])
+            .await
+            .expect("load");
+        assert_eq!(
+            before, after,
+            "abandoned rows must never be regenerated (collision class)"
+        );
+    }
+
+    /// getOrGenSinglePreKey parity: the window head is reused until an upload
+    /// (or consumption) moves past it, and a consumed head heals by skipping
+    /// the dead slot instead of failing like WA Web does.
+    #[tokio::test]
+    async fn single_prekey_is_reused_until_consumed() {
+        let client = crate::test_utils::create_test_client_with_name("prekey_single_reuse").await;
+
+        let (id1, pk1) = client.get_or_gen_single_pre_key().await.expect("gen");
+        let (id2, pk2) = client.get_or_gen_single_pre_key().await.expect("reuse");
+        assert_eq!(id1, id2, "window head must be reused");
+        assert_eq!(
+            pk1.serialize(),
+            pk2.serialize(),
+            "same stored key, not a regenerated one"
+        );
+        let (next, first) = snapshot(&client);
+        assert_eq!(first, id1);
+        assert_eq!(next, id1 + 1);
+
+        // The peer consumed it via pkmsg: the row is gone.
+        backend(&client).remove_prekey(id1).await.expect("remove");
+        let (id3, pk3) = client.get_or_gen_single_pre_key().await.expect("heal");
+        assert_eq!(id3, id1 + 1, "dead slot skipped, fresh id minted");
+        assert_ne!(pk3.serialize(), pk1.serialize());
+        let (next, first) = snapshot(&client);
+        assert_eq!(first, id3);
+        assert_eq!(next, id3 + 1);
+    }
+
+    /// A retry-receipt single key lives in the unuploaded window, so the next
+    /// batch upload re-offers the SAME stored key and only tops up the rest
+    /// (WA Web getOrGenPreKeys target-total semantics).
+    #[tokio::test]
+    async fn upload_window_includes_retry_single_key() {
+        let client = crate::test_utils::create_test_client_with_name("prekey_window_topup").await;
+        client.set_wanted_pre_key_count(5);
+
+        let (retry_id, retry_pk) = client.get_or_gen_single_pre_key().await.expect("gen");
+        let before = backend(&client)
+            .load_prekeys_batch(&[retry_id])
+            .await
+            .expect("load");
+        assert_eq!(before.len(), 1);
+
+        let _ = client.upload_pre_keys_inner().await;
+        let (next, _) = snapshot(&client);
+        assert_eq!(
+            next,
+            retry_id + 5,
+            "only wanted - available new keys are generated"
+        );
+
+        let after = backend(&client)
+            .load_prekeys_batch(&[retry_id])
+            .await
+            .expect("load");
+        assert_eq!(
+            before, after,
+            "the retry key is re-offered, not regenerated"
+        );
+        let window = backend(&client)
+            .load_prekeys_batch(&[
+                retry_id,
+                retry_id + 1,
+                retry_id + 2,
+                retry_id + 3,
+                retry_id + 4,
+            ])
+            .await
+            .expect("load");
+        assert_eq!(window.len(), 5, "window = retry key + top-up");
+
+        use prost::Message;
+        let structure = waproto::whatsapp::PreKeyRecordStructure::decode(&after[0].1[..])
+            .expect("decode structure");
+        let reloaded = PublicKey::from_djb_public_key_bytes(
+            structure.public_key.as_deref().expect("public key"),
+        )
+        .expect("pub");
+        assert_eq!(
+            reloaded.serialize(),
+            retry_pk.serialize(),
+            "stored record matches the key shipped in the receipt"
         );
     }
 }

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -330,8 +330,29 @@ impl Client {
         );
 
         if plan.gen_count == 0 {
-            let rows = backend.load_prekeys_batch(&[plan.window_start]).await?;
+            // Load the whole remaining window: a consumed head (a previously
+            // reused retry key the peer already spent) must not abandon the
+            // still-live keys behind it, so the heal advances FIRST to the
+            // next stored id instead of past the window. WA Web throws on a
+            // missing head; healing is strictly better and stays in the same
+            // id namespace.
+            let window_ids: Vec<u32> =
+                (plan.window_start..device_snapshot.next_pre_key_id).collect();
+            let mut rows = backend.load_prekeys_batch(&window_ids).await?;
+            rows.sort_unstable_by_key(|(id, _)| *id);
             if let Some((id, record)) = rows.into_iter().next() {
+                if id != plan.window_start {
+                    log::warn!(
+                        "prekey window head {} missing from store; advancing to {id}",
+                        plan.window_start
+                    );
+                    self.persistence_manager
+                        .process_command(DeviceCommand::SetPreKeyWatermarks {
+                            next_pre_key_id: device_snapshot.next_pre_key_id,
+                            first_unupload_pre_key_id: id,
+                        })
+                        .await;
+                }
                 use prost::Message;
                 let structure = waproto::whatsapp::PreKeyRecordStructure::decode(&record[..])?;
                 let record = wacore::libsignal::store::record_helpers::prekey_structure_to_record(
@@ -339,20 +360,17 @@ impl Client {
                 )?;
                 return Ok((id, record.key_pair()?.public_key));
             }
-            // The window head was consumed (a previously reused retry key the
-            // peer already spent). Skip the dead slot and generate fresh; WA
-            // Web throws here, but healing is strictly better and stays in
-            // the same id namespace.
             log::warn!(
-                "prekey window head {} missing from store; skipping dead slot",
-                plan.window_start
+                "prekey window [{}, {}) fully consumed; generating fresh",
+                plan.window_start,
+                device_snapshot.next_pre_key_id
             );
         }
 
         let id = if plan.gen_count > 0 {
             plan.gen_start
         } else {
-            // Dead-slot heal: generate at NEXT and advance FIRST past the gap.
+            // Empty window: generate at NEXT and collapse FIRST onto it.
             device_snapshot
                 .next_pre_key_id
                 .max(plan.window_start.saturating_add(1))
@@ -373,6 +391,11 @@ impl Client {
                 },
             })
             .await;
+        // Same durability pairing as the batch path: the stored key is
+        // durable, so its watermarks must not ride the lazy saver.
+        if let Err(e) = self.persistence_manager.flush().await {
+            log::warn!("failed to flush prekey watermarks: {e:?}");
+        }
         Ok((id, key_pair.public_key))
     }
 
@@ -475,6 +498,12 @@ impl Client {
                 first_unupload_pre_key_id: plan.window_start,
             })
             .await;
+        // The generated rows are already durable; the watermarks ride the lazy
+        // device saver. Flush them now so a crash before the IQ cannot reload
+        // pre-generation watermarks and orphan the stored window.
+        if let Err(e) = self.persistence_manager.flush().await {
+            log::warn!("failed to flush prekey watermarks: {e:?}");
+        }
 
         // Load the upload window: leftover keys plus the fresh ones. Gaps are
         // tolerated (a window key consumed via a retry receipt leaves a hole).
@@ -1011,6 +1040,48 @@ mod window_tests {
         let (next, first) = snapshot(&client);
         assert_eq!(first, id3);
         assert_eq!(next, id3 + 1);
+    }
+
+    /// A consumed window head must not abandon the live keys behind it: the
+    /// heal advances FIRST to the next stored id and reuses it.
+    #[tokio::test]
+    async fn consumed_head_advances_to_next_live_window_key() {
+        use prost::Message;
+        use wacore::libsignal::protocol::KeyPair;
+        use wacore::libsignal::store::record_helpers::new_pre_key_record;
+        use wacore::store::commands::DeviceCommand;
+
+        let client = crate::test_utils::create_test_client_with_name("prekey_window_heal").await;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut publics = std::collections::HashMap::new();
+        for id in 10u32..13 {
+            let kp = KeyPair::generate(&mut rng);
+            publics.insert(id, kp.public_key);
+            backend(&client)
+                .store_prekey(id, &new_pre_key_record(id, &kp).encode_to_vec(), false)
+                .await
+                .expect("store");
+        }
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: 13,
+                first_unupload_pre_key_id: 10,
+            })
+            .await;
+
+        backend(&client).remove_prekey(10).await.expect("consume");
+        let (id, pk) = client.get_or_gen_single_pre_key().await.expect("heal");
+        assert_eq!(id, 11, "heal must advance to the next LIVE window key");
+        assert_eq!(pk.serialize(), publics[&11].serialize());
+        let (next, first) = snapshot(&client);
+        assert_eq!(first, 11, "FIRST lands on the surviving key");
+        assert_eq!(next, 13, "NEXT untouched: 12 is still in the window");
+
+        // And the key behind it is still reachable afterwards.
+        backend(&client).remove_prekey(11).await.expect("consume");
+        let (id, _) = client.get_or_gen_single_pre_key().await.expect("heal 2");
+        assert_eq!(id, 12);
     }
 
     /// A retry-receipt single key lives in the unuploaded window, so the next

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -8,10 +8,7 @@ use wacore::types::message::MessageCategory;
 use scopeguard;
 use std::sync::Arc;
 use wacore::iq::prekeys::{OneTimePreKeyNode, SignedPreKeyNode};
-use wacore::libsignal::protocol::{
-    KeyPair, PreKeyBundle, PublicKey, UsePQRatchet, process_prekey_bundle,
-};
-use wacore::libsignal::store::PreKeyStore;
+use wacore::libsignal::protocol::{PreKeyBundle, PublicKey, UsePQRatchet, process_prekey_bundle};
 use wacore::protocol::ProtocolNode;
 use wacore::types::jid::JidExt;
 use wacore_binary::JidExt as _;
@@ -1110,25 +1107,15 @@ impl Client {
             .build();
 
         let keys_node = if wacore::protocol::retry::should_include_keys(retry_count, reason) {
-            // Allocate the one-time prekey from the same monotonic NEXT_PK_ID counter as the
-            // upload path (WA Web's getOrGenSinglePreKey) so it can never overwrite a live pool
-            // key. Hold prekey_upload_lock to serialize the allocate+bump with uploads.
+            // WA Web's getOrGenSinglePreKey = getOrGenPreKeys(1): the retry
+            // prekey is the first unuploaded window key (reused when one is
+            // left over, freshly generated and stored otherwise) and the next
+            // batch upload re-offers it to the server pool. Hold
+            // prekey_upload_lock to serialize the watermark math with uploads.
             let prekey_guard = self.prekey_upload_lock.lock().await;
-            let new_prekey_id = self.allocate_next_one_time_prekey_id().await?;
-            let new_prekey_keypair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
-            let new_prekey_record = wacore::libsignal::store::record_helpers::new_pre_key_record(
-                new_prekey_id,
-                &new_prekey_keypair,
-            );
-            // This key is not uploaded to the server pool, so mark as false
-            let device_snapshot = self.persistence_manager.get_device_snapshot();
-            if let Err(e) = device_snapshot
-                .store_prekey(new_prekey_id, new_prekey_record, false)
-                .await
-            {
-                warn!("Failed to store new prekey for retry receipt: {e:?}");
-            }
+            let (new_prekey_id, new_prekey_public) = self.get_or_gen_single_pre_key().await?;
             drop(prekey_guard);
+            let device_snapshot = self.persistence_manager.get_device_snapshot();
 
             let device_identity_bytes = device_snapshot
                 .account
@@ -1139,7 +1126,7 @@ impl Client {
             Some(wacore::protocol::retry::build_retry_keys_node(
                 &device_snapshot.identity_key.public_key,
                 new_prekey_id,
-                &new_prekey_keypair.public_key,
+                &new_prekey_public,
                 device_snapshot.signed_pre_key_id,
                 &device_snapshot.signed_pre_key.public_key,
                 device_snapshot.signed_pre_key_signature.to_vec(),
@@ -1266,7 +1253,7 @@ mod tests {
     use crate::test_utils::MockHttpClient;
     use std::borrow::Cow;
     use std::sync::Arc;
-    use wacore::libsignal::protocol::IdentityKeyPair;
+    use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair};
     use wacore::types::jid::JidExt as _;
     use wacore_binary::{Jid, JidExt};
     use waproto::whatsapp as wa;

--- a/storages/sqlite-storage/migrations/2026-06-10-000000_add_first_unupload_pk_id/down.sql
+++ b/storages/sqlite-storage/migrations/2026-06-10-000000_add_first_unupload_pk_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device DROP COLUMN first_unupload_pre_key_id;

--- a/storages/sqlite-storage/migrations/2026-06-10-000000_add_first_unupload_pk_id/up.sql
+++ b/storages/sqlite-storage/migrations/2026-06-10-000000_add_first_unupload_pk_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device ADD COLUMN first_unupload_pre_key_id INTEGER NOT NULL DEFAULT 0;

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -82,6 +82,7 @@ diesel::table! {
         server_has_prekeys -> Bool,
         server_cert_chain -> Nullable<Binary>,
         login_counter -> Integer,
+        first_unupload_pre_key_id -> Integer,
     }
 }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1669,6 +1669,28 @@ impl SignalStore for SqliteStore {
         })
     }
 
+    async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let device_id = self.device_id;
+        let ids: Vec<i32> = ids.iter().map(|&id| id as i32).collect();
+        self.with_retry("mark_prekeys_uploaded", move || {
+            let ids = ids.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::update(
+                    prekeys::table
+                        .filter(prekeys::id.eq_any(ids))
+                        .filter(prekeys::device_id.eq(device_id)),
+                )
+                .set(prekeys::uploaded.eq(true))
+                .execute(conn)?;
+                Ok(())
+            })
+        })
+        .await
+    }
+
     async fn get_max_prekey_id(&self) -> Result<u32> {
         let pool = self.pool.clone();
         let device_id = self.device_id;
@@ -3612,6 +3634,32 @@ mod tests {
             loaded.is_some(),
             "device data should be loadable by configured id"
         );
+    }
+
+    /// mark_prekeys_uploaded must be UPDATE-only: a row deleted between the
+    /// upload snapshot and the mark (consumed one-time key) stays deleted.
+    #[tokio::test]
+    async fn mark_prekeys_uploaded_never_resurrects_deleted_rows() {
+        let store = create_test_store().await;
+        store
+            .store_prekey(1, b"record-1", false)
+            .await
+            .expect("store");
+        store
+            .store_prekey(2, b"record-2", false)
+            .await
+            .expect("store");
+        store.remove_prekey(1).await.expect("consume");
+
+        store
+            .mark_prekeys_uploaded(&[1, 2])
+            .await
+            .expect("mark uploaded");
+
+        let gone = store.load_prekey(1).await.expect("load");
+        assert!(gone.is_none(), "consumed key must not be resurrected");
+        let live = store.load_prekey(2).await.expect("load");
+        assert!(live.is_some(), "live key still present");
     }
 
     /// Round-trips the prekey watermarks through the SQLite schema: save with

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -84,6 +84,7 @@ struct DeviceRow {
     server_has_prekeys: bool,
     server_cert_chain: Option<Vec<u8>>,
     login_counter: i32,
+    first_unupload_pre_key_id: i32,
 }
 
 #[derive(Clone)]
@@ -336,6 +337,7 @@ impl SqliteStore {
             device_data.edge_routing_info.as_deref().map(Arc::from);
         let props_hash: Option<Arc<str>> = device_data.props_hash.as_deref().map(Arc::from);
         let next_pre_key_id = device_data.next_pre_key_id as i32;
+        let first_unupload_pre_key_id = device_data.first_unupload_pre_key_id as i32;
         let server_has_prekeys = device_data.server_has_prekeys;
         let nct_salt: Option<Arc<[u8]>> = device_data.nct_salt.as_deref().map(Arc::from);
         let server_cert_chain: Option<Arc<[u8]>> = device_data
@@ -402,6 +404,7 @@ impl SqliteStore {
                         device::edge_routing_info.eq(edge_routing_info.as_deref()),
                         device::props_hash.eq(props_hash.as_deref()),
                         device::next_pre_key_id.eq(next_pre_key_id),
+                        device::first_unupload_pre_key_id.eq(first_unupload_pre_key_id),
                         device::server_has_prekeys.eq(server_has_prekeys),
                         device::nct_salt.eq(nct_salt.as_deref()),
                         device::server_cert_chain.eq(server_cert_chain.as_deref()),
@@ -430,6 +433,8 @@ impl SqliteStore {
                         device::edge_routing_info.eq(excluded(device::edge_routing_info)),
                         device::props_hash.eq(excluded(device::props_hash)),
                         device::next_pre_key_id.eq(excluded(device::next_pre_key_id)),
+                        device::first_unupload_pre_key_id
+                            .eq(excluded(device::first_unupload_pre_key_id)),
                         device::server_has_prekeys.eq(excluded(device::server_has_prekeys)),
                         device::nct_salt.eq(excluded(device::nct_salt)),
                         device::server_cert_chain.eq(excluded(device::server_cert_chain)),
@@ -461,6 +466,7 @@ impl SqliteStore {
         let app_version_tertiary = new_device.app_version_tertiary as i64;
         let app_version_last_fetched_ms = new_device.app_version_last_fetched_ms;
         let next_pre_key_id = new_device.next_pre_key_id as i32;
+        let first_unupload_pre_key_id = new_device.first_unupload_pre_key_id as i32;
         let server_has_prekeys = new_device.server_has_prekeys;
 
         self.with_retry("create_new_device", || {
@@ -493,6 +499,7 @@ impl SqliteStore {
                         device::edge_routing_info.eq(None::<&[u8]>),
                         device::props_hash.eq(None::<&str>),
                         device::next_pre_key_id.eq(next_pre_key_id),
+                        device::first_unupload_pre_key_id.eq(first_unupload_pre_key_id),
                         device::server_has_prekeys.eq(server_has_prekeys),
                         device::nct_salt.eq(None::<&[u8]>),
                         device::server_cert_chain.eq(None::<&[u8]>),
@@ -599,6 +606,7 @@ impl SqliteStore {
                 edge_routing_info: row.edge_routing_info,
                 props_hash: row.props_hash,
                 next_pre_key_id: row.next_pre_key_id as u32,
+                first_unupload_pre_key_id: row.first_unupload_pre_key_id as u32,
                 server_has_prekeys: row.server_has_prekeys,
                 nct_salt: row.nct_salt,
                 nct_salt_sync_seen: false,
@@ -3603,6 +3611,60 @@ mod tests {
         assert!(
             loaded.is_some(),
             "device data should be loadable by configured id"
+        );
+    }
+
+    /// Round-trips the prekey watermarks through the SQLite schema: save with
+    /// both counters set, reopen on the same db, load and compare. Exercises
+    /// the `2026-06-10-000000_add_first_unupload_pk_id` migration and the
+    /// column mapping in both upsert paths.
+    #[tokio::test]
+    async fn test_prekey_watermarks_survive_save_load_roundtrip() {
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+
+        static COUNTER: AtomicU64 = AtomicU64::new(300);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_name = format!(
+            "file:memdb_pkwatermark_{}_{}?mode=memory&cache=shared",
+            std::process::id(),
+            id
+        );
+
+        let device_id = 9;
+        let _writer = SqliteStore::new_for_device(&db_name, device_id)
+            .await
+            .expect("create store");
+        _writer.create_new_device().await.expect("create device");
+
+        let mut device = _writer
+            .load_device_data_for_device(device_id)
+            .await
+            .expect("load")
+            .expect("device should exist after create");
+        assert_eq!(
+            device.first_unupload_pre_key_id, 0,
+            "fresh device starts with the watermark unset"
+        );
+        device.next_pre_key_id = 913;
+        device.first_unupload_pre_key_id = 101;
+        _writer
+            .save_device_data_for_device(device_id, &device)
+            .await
+            .expect("save with watermarks");
+
+        let store = SqliteStore::new_for_device(&db_name, device_id)
+            .await
+            .expect("reopen store");
+        let loaded = store
+            .load_device_data_for_device(device_id)
+            .await
+            .expect("load")
+            .expect("device should exist after reopen");
+        assert_eq!(loaded.next_pre_key_id, 913);
+        assert_eq!(
+            loaded.first_unupload_pre_key_id, 101,
+            "first_unupload_pre_key_id must survive a save/load roundtrip"
         );
     }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -87,6 +87,9 @@ struct DeviceRow {
     first_unupload_pre_key_id: i32,
 }
 
+/// Max ids per `eq_any` list, under SQLite's default 999 host-parameter limit.
+const ID_PARAM_CHUNK: usize = 900;
+
 #[derive(Clone)]
 pub struct SqliteStore {
     pub(crate) pool: SqlitePool,
@@ -1603,16 +1606,22 @@ impl SignalStore for SqliteStore {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            let rows: Vec<(i32, Vec<u8>)> = prekeys::table
-                .select((prekeys::id, prekeys::key))
-                .filter(prekeys::id.eq_any(&ids))
-                .filter(prekeys::device_id.eq(device_id))
-                .load(&mut conn)
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-            Ok(rows
-                .into_iter()
-                .map(|(id, key)| (id as u32, Bytes::from(key)))
-                .collect())
+            // Chunked like mark_prekeys_uploaded: the upload window can carry
+            // more ids than SQLite's host-parameter limit.
+            let mut out = Vec::with_capacity(ids.len());
+            for chunk in ids.chunks(ID_PARAM_CHUNK) {
+                let rows: Vec<(i32, Vec<u8>)> = prekeys::table
+                    .select((prekeys::id, prekeys::key))
+                    .filter(prekeys::id.eq_any(chunk))
+                    .filter(prekeys::device_id.eq(device_id))
+                    .load(&mut conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                out.extend(
+                    rows.into_iter()
+                        .map(|(id, key)| (id as u32, Bytes::from(key))),
+                );
+            }
+            Ok(out)
         })
         .await
     }
@@ -1678,13 +1687,17 @@ impl SignalStore for SqliteStore {
         self.with_retry("mark_prekeys_uploaded", move || {
             let ids = ids.clone();
             Box::new(move |conn: &mut SqliteConnection| {
-                diesel::update(
-                    prekeys::table
-                        .filter(prekeys::id.eq_any(ids))
-                        .filter(prekeys::device_id.eq(device_id)),
-                )
-                .set(prekeys::uploaded.eq(true))
-                .execute(conn)?;
+                // Stay under SQLite's host-parameter limit (999 by default);
+                // the upload batch is configurable up to u16::MAX ids.
+                for chunk in ids.chunks(ID_PARAM_CHUNK) {
+                    diesel::update(
+                        prekeys::table
+                            .filter(prekeys::id.eq_any(chunk.to_vec()))
+                            .filter(prekeys::device_id.eq(device_id)),
+                    )
+                    .set(prekeys::uploaded.eq(true))
+                    .execute(conn)?;
+                }
                 Ok(())
             })
         })

--- a/wacore/src/store/commands.rs
+++ b/wacore/src/store/commands.rs
@@ -14,9 +14,10 @@ pub enum DeviceCommand {
     SetDeviceProps(DevicePropsOverride),
     SetClientProfile(ClientProfile),
     SetPropsHash(Option<String>),
-    SetNextPreKeyId(u32),
     /// Update both prekey watermarks in one command, so a generation-time
     /// NEXT advance and a FIRST init/advance can never be observed split.
+    /// The watermarks have no single-field setter on purpose: split updates
+    /// are how the pre-watermark model lost track of generated keys.
     SetPreKeyWatermarks {
         next_pre_key_id: u32,
         first_unupload_pre_key_id: u32,
@@ -63,9 +64,6 @@ pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
         }
         DeviceCommand::SetPropsHash(hash) => {
             device.props_hash = hash;
-        }
-        DeviceCommand::SetNextPreKeyId(id) => {
-            device.next_pre_key_id = id;
         }
         DeviceCommand::SetPreKeyWatermarks {
             next_pre_key_id,

--- a/wacore/src/store/commands.rs
+++ b/wacore/src/store/commands.rs
@@ -15,6 +15,12 @@ pub enum DeviceCommand {
     SetClientProfile(ClientProfile),
     SetPropsHash(Option<String>),
     SetNextPreKeyId(u32),
+    /// Update both prekey watermarks in one command, so a generation-time
+    /// NEXT advance and a FIRST init/advance can never be observed split.
+    SetPreKeyWatermarks {
+        next_pre_key_id: u32,
+        first_unupload_pre_key_id: u32,
+    },
     SetAdvSecretKey([u8; 32]),
     SetNctSalt(Option<Vec<u8>>),
     SetNctSaltFromHistorySync(Vec<u8>),
@@ -60,6 +66,13 @@ pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
         }
         DeviceCommand::SetNextPreKeyId(id) => {
             device.next_pre_key_id = id;
+        }
+        DeviceCommand::SetPreKeyWatermarks {
+            next_pre_key_id,
+            first_unupload_pre_key_id,
+        } => {
+            device.next_pre_key_id = next_pre_key_id;
+            device.first_unupload_pre_key_id = first_unupload_pre_key_id;
         }
         DeviceCommand::SetAdvSecretKey(key) => {
             device.adv_secret_key = key;

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -250,9 +250,16 @@ pub struct Device {
     pub props_hash: Option<String>,
     /// Monotonically increasing counter for one-time pre-key ID generation.
     /// Matches WhatsApp Web's `NEXT_PK_ID` pattern: only increases, never resets.
-    /// Prevents prekey ID collisions when prekeys are consumed non-sequentially.
+    /// Advances at GENERATION time (WA Web `savePreKeys`), so it covers every
+    /// key that exists in the store, uploaded or not.
     #[serde(default)]
     pub next_pre_key_id: u32,
+    /// Watermark of the first generated-but-not-yet-uploaded one-time prekey,
+    /// matching WA Web's `FIRST_UNUPLOAD_PK_ID`. `next_pre_key_id - this` is
+    /// the pool of leftover keys an upload re-offers before generating new
+    /// ones. `0` = unset (legacy device); initialised on the first upload.
+    #[serde(default)]
+    pub first_unupload_pre_key_id: u32,
     /// Persisted flag matching WA Web's `signal_sever_has_pre_keys` metadata.
     #[serde(default)]
     pub server_has_prekeys: bool,
@@ -366,6 +373,7 @@ impl Device {
             edge_routing_info: None,
             props_hash: None,
             next_pre_key_id: 1,
+            first_unupload_pre_key_id: 0,
             server_has_prekeys: false,
             nct_salt: None,
             nct_salt_sync_seen: false,

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -173,6 +173,13 @@ impl SignalStore for InMemoryBackend {
         Ok(())
     }
 
+    async fn mark_prekeys_uploaded(&self, _ids: &[u32]) -> Result<()> {
+        // The in-memory store does not track the uploaded flag (see
+        // store_prekey); the contract that matters is NOT resurrecting
+        // deleted rows, which a no-op trivially satisfies.
+        Ok(())
+    }
+
     async fn store_prekeys_batch(&self, keys: &[(u32, Bytes)], _uploaded: bool) -> Result<()> {
         let mut state = self.state.lock().await;
         for (id, record) in keys {

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1167,6 +1167,9 @@ mod consumed_prekey_atomicity_tests {
             async fn remove_prekey(&self, id: u32) -> crate::store::error::Result<()> {
                 self.0.remove_prekey(id).await
             }
+            async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> crate::store::error::Result<()> {
+                self.0.mark_prekeys_uploaded(ids).await
+            }
             async fn get_max_prekey_id(&self) -> crate::store::error::Result<u32> {
                 self.0.get_max_prekey_id().await
             }
@@ -1286,6 +1289,9 @@ mod consumed_prekey_atomicity_tests {
                     tokio::task::yield_now().await;
                 }
                 self.inner.put_sessions_batch(sessions).await
+            }
+            async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> crate::store::error::Result<()> {
+                self.inner.mark_prekeys_uploaded(ids).await
             }
             async fn remove_prekey(&self, id: u32) -> crate::store::error::Result<()> {
                 // The fix drains prekeys under the sessions lock, so a try_lock here

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -192,6 +192,12 @@ pub trait SignalStore: Send + Sync {
         Ok(result)
     }
 
+    /// Mark already-stored pre-keys as uploaded WITHOUT inserting. UPDATE
+    /// semantics on purpose: a key consumed (deleted) between the upload
+    /// snapshot and this call must stay deleted, never be resurrected by an
+    /// upsert.
+    async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> Result<()>;
+
     /// Remove a pre-key.
     async fn remove_prekey(&self, id: u32) -> Result<()>;
 


### PR DESCRIPTION
## Problem

Every prekey upload regenerated a full fresh 812-key batch. Our `next_pre_key_id` only advanced after a successful IQ, so it was really an "uploaded" watermark, and a failed upload left 812 stored rows that the next attempt skipped via `max(counter, max_store + 1)` and never re-offered: dead rows the server never hands out, and the exact fragility that made that `max()` load-bearing (removing it would re-introduce the prekey-collision class on partial success, the bug family behind the 131 MAC failures incident).

WA Web models this with two meta keys (`WAWebSignalStoreApi`, `Signal/Const.js`): `NEXT_PK_ID` advances at GENERATION time (`savePreKeys`) and `FIRST_UNUPLOAD_PK_ID` tracks the upload watermark (`markKeyAsUploaded`). `getOrGenPreKeys(812)` is target-total: it re-offers the leftover `[FIRST, NEXT)` window and only generates `812 - (NEXT - FIRST)` new keys (nothing when the window is full).

## Change

- `Device` persists `first_unupload_pre_key_id` (sqlite migration with default 0, serde-default for serialized blobs) and both watermarks move through a single `SetPreKeyWatermarks` command so a generation-time NEXT advance and a FIRST init can never be observed split.
- `upload_pre_keys_inner` plans the pass with a pure helper (`plan_prekey_upload`): window reuse, generation top-up starting at NEXT, legacy-device init through the old safe start (which now becomes migration/self-heal only), corrupt `first > next` heal, and a 24-bit-boundary collapse that keeps the window contiguous under the same wrap acceptance as before. Generation stores first, then the watermarks are published, then the window is loaded (gaps tolerated: a slot consumed via a retry receipt leaves a hole) and decoded through the canonical `PreKeyRecordStructure` path.
- FIRST is marked past the window BEFORE the send, exactly like WA Web's `markKeyAsUploaded` ordering in `PreKeysJob.js`. This is deliberate: after a mid-flight failure the server state is unknown, and re-offering an id a peer may already have consumed would corrupt the server pool. Abandoned keys stay stored locally and remain decryptable if the upload did land. What the reuse protects is everything before the send: generation that succeeded but never reached the IQ (process death, disconnect between phases) and the retry-receipt single keys.
- The retry-receipt prekey becomes WA Web's `getOrGenSinglePreKey` = `getOrGenPreKeys(1)`: it reuses the window head when a leftover exists (the next batch upload re-offers the same stored key, true WA Web parity) and only generates at NEXT otherwise. A consumed window head heals by skipping the dead slot where WA Web throws.
- An exhausted window (all slots consumed, nothing to generate) collapses so the next attempt generates fresh, instead of bailing forever.

The orphan-regeneration class is closed structurally: NEXT now covers every generated key, so no retry can ever mint over stored ids.

## Tests

- Pure planner: legacy init, empty-window full generation, leftover top-up (generation starts at NEXT), over-full window generates nothing and never regresses NEXT, corrupt-watermark heal, boundary collapse, single-key reuse.
- Integration against the real store: a failed upload IQ leaves both watermarks past the window and the second attempt mints strictly fresh ids while the abandoned rows stay byte-identical (the collision-class guard); `get_or_gen_single_pre_key` returns the same stored key twice, then heals past a consumed head; a batch upload after a retry key re-offers the SAME stored record and only tops up the difference.
- SQLite roundtrip for the new column across a simulated process restart (migration + both upsert paths).
- Full workspace suite green (2162), `cargo clippy --all-targets -- -D warnings` clean, both wasm32 CI variants reproduced locally.

## Breaking

`DeviceCommand` gains `SetPreKeyWatermarks`; `Device` gains `first_unupload_pre_key_id` (serde/sqlite defaults keep old state loading). `Client::allocate_next_one_time_prekey_id` is replaced by `get_or_gen_single_pre_key` (crate-private surface).

Note: CI may hit the `enc_comment_inbound` flake until #832 (the msg_secret read semaphore fix, found while validating this branch) merges.
