### PR TITLE
feat(api): adopt the impl Into<Jid> convention across the public surface

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -65,7 +65,7 @@ impl MessageContext {
         message: wa::Message,
     ) -> Result<crate::send::SendResult, anyhow::Error> {
         self.client
-            .send_message(self.info.source.chat.clone(), message)
+            .send_message(&self.info.source.chat, message)
             .await
     }
 
@@ -103,11 +103,7 @@ impl MessageContext {
         new_message: wa::Message,
     ) -> Result<String, anyhow::Error> {
         self.client
-            .edit_message(
-                self.info.source.chat.clone(),
-                original_message_id,
-                new_message,
-            )
+            .edit_message(&self.info.source.chat, original_message_id, new_message)
             .await
     }
 
@@ -119,7 +115,7 @@ impl MessageContext {
         revoke_type: crate::send::RevokeType,
     ) -> Result<(), anyhow::Error> {
         self.client
-            .revoke_message(self.info.source.chat.clone(), message_id, revoke_type)
+            .revoke_message(&self.info.source.chat, message_id, revoke_type)
             .await
     }
 

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -56,15 +56,23 @@ impl Client {
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.edit", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
     pub async fn edit_message(
         &self,
-        to: Jid,
+        to: impl Into<Jid>,
         original_id: impl Into<String>,
         new_content: wa::Message,
     ) -> Result<String, anyhow::Error> {
-        let original_id = original_id.into();
+        self.edit_message_inner(to.into(), original_id.into(), new_content)
+            .await
+    }
 
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.edit", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
+    async fn edit_message_inner(
+        &self,
+        to: Jid,
+        original_id: String,
+        new_content: wa::Message,
+    ) -> Result<String, anyhow::Error> {
         // WhatsApp Web uses getMeUserLidOrJidForChat(chat, EditMessage) which
         // returns LID for LID-addressing groups and PN otherwise.
         let participant = if to.is_group() {
@@ -117,11 +125,27 @@ impl Client {
     /// `message_secret` is the *original* message's 32-byte secret (you generated it when
     /// you sent that message). You can only edit your own messages, so the original
     /// sender and the editor are both you.
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.edit_encrypted", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
     pub async fn edit_message_encrypted(
         &self,
-        to: Jid,
+        to: impl Into<Jid>,
         original_id: impl Into<String>,
+        message_secret: &[u8],
+        new_content: wa::Message,
+    ) -> Result<String, anyhow::Error> {
+        self.edit_message_encrypted_inner(
+            to.into(),
+            original_id.into(),
+            message_secret,
+            new_content,
+        )
+        .await
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.edit_encrypted", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
+    async fn edit_message_encrypted_inner(
+        &self,
+        to: Jid,
+        original_id: String,
         message_secret: &[u8],
         new_content: wa::Message,
     ) -> Result<String, anyhow::Error> {
@@ -137,7 +161,6 @@ impl Client {
             "message_secret must be exactly 32 bytes, got {}",
             message_secret.len()
         );
-        let original_id = original_id.into();
 
         let self_jid = if to.is_group() {
             self.get_own_jid_for_group(&to).await?.to_non_ad()

--- a/src/features/comments.rs
+++ b/src/features/comments.rs
@@ -35,10 +35,11 @@ impl<'a> Comments<'a> {
     /// received).
     pub async fn send_text(
         &self,
-        chat: &Jid,
+        chat: impl Into<Jid>,
         parent_key: wa::MessageKey,
         text: &str,
     ) -> Result<SendResult> {
+        let chat = &chat.into();
         // WA Web encryptExtendedTextComment: the body is an extendedTextMessage.
         let body = wa::Message {
             extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
@@ -53,10 +54,11 @@ impl<'a> Comments<'a> {
     /// Comment on a channel post with an arbitrary body `Message`.
     pub async fn send_message(
         &self,
-        chat: &Jid,
+        chat: impl Into<Jid>,
         mut parent_key: wa::MessageKey,
         body: wa::Message,
     ) -> Result<SendResult> {
+        let chat = &chat.into();
         let client = self.client;
         let (author, secret) = client
             .resolve_outgoing_addon_parent(chat, &parent_key)
@@ -107,7 +109,7 @@ impl<'a> Comments<'a> {
             }),
             ..Default::default()
         };
-        let result = client.send_message(chat.clone(), message).await?;
+        let result = client.send_message(chat, message).await?;
 
         // The send path only persists reporting-token secrets, so store the
         // comment's own secret here or we could never decrypt add-ons

--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -157,7 +157,8 @@ impl<'a> Community<'a> {
     }
 
     /// Deactivate (delete) a community. Subgroups are unlinked but not deleted.
-    pub async fn deactivate(&self, community_jid: &Jid) -> Result<(), anyhow::Error> {
+    pub async fn deactivate(&self, community_jid: impl Into<Jid>) -> Result<(), anyhow::Error> {
+        let community_jid = &community_jid.into();
         self.client
             .execute(DeleteCommunityIq::new(community_jid))
             .await?;
@@ -167,9 +168,10 @@ impl<'a> Community<'a> {
     /// Link existing groups as subgroups of a community.
     pub async fn link_subgroups(
         &self,
-        community_jid: &Jid,
+        community_jid: impl Into<Jid>,
         subgroup_jids: &[Jid],
     ) -> Result<LinkSubgroupsResult, anyhow::Error> {
+        let community_jid = &community_jid.into();
         let response = self
             .client
             .execute(LinkSubgroupsIq::new(community_jid, subgroup_jids))
@@ -195,10 +197,11 @@ impl<'a> Community<'a> {
     /// Unlink subgroups from a community.
     pub async fn unlink_subgroups(
         &self,
-        community_jid: &Jid,
+        community_jid: impl Into<Jid>,
         subgroup_jids: &[Jid],
         remove_orphan_members: bool,
     ) -> Result<UnlinkSubgroupsResult, anyhow::Error> {
+        let community_jid = &community_jid.into();
         let response = self
             .client
             .execute(UnlinkSubgroupsIq::new(
@@ -323,9 +326,11 @@ impl<'a> Community<'a> {
     /// Query a linked subgroup's metadata from the parent community.
     pub async fn query_linked_group(
         &self,
-        community_jid: &Jid,
-        subgroup_jid: &Jid,
+        community_jid: impl Into<Jid>,
+        subgroup_jid: impl Into<Jid>,
     ) -> Result<GroupMetadata, anyhow::Error> {
+        let community_jid = &community_jid.into();
+        let subgroup_jid = &subgroup_jid.into();
         let response = self
             .client
             .execute(QueryLinkedGroupIq::new(community_jid, subgroup_jid))
@@ -336,9 +341,11 @@ impl<'a> Community<'a> {
     /// Join a linked subgroup via the parent community.
     pub async fn join_subgroup(
         &self,
-        community_jid: &Jid,
-        subgroup_jid: &Jid,
+        community_jid: impl Into<Jid>,
+        subgroup_jid: impl Into<Jid>,
     ) -> Result<GroupMetadata, anyhow::Error> {
+        let community_jid = &community_jid.into();
+        let subgroup_jid = &subgroup_jid.into();
         let response = self
             .client
             .execute(JoinLinkedGroupIq::new(community_jid, subgroup_jid))
@@ -349,8 +356,9 @@ impl<'a> Community<'a> {
     /// Get all participants across all linked groups of a community.
     pub async fn get_linked_groups_participants(
         &self,
-        community_jid: &Jid,
+        community_jid: impl Into<Jid>,
     ) -> Result<Vec<GroupParticipant>, anyhow::Error> {
+        let community_jid = &community_jid.into();
         let response = self
             .client
             .execute(GetLinkedGroupsParticipantsIq::new(community_jid))

--- a/src/features/events.rs
+++ b/src/features/events.rs
@@ -36,9 +36,10 @@ impl<'a> Events<'a> {
     /// later responses (RSVPs) via [`wacore::event::decrypt_event_response_with_secret`].
     pub async fn create(
         &self,
-        to: &Jid,
+        to: impl Into<Jid>,
         params: EventCreationParams,
     ) -> Result<(SendResult, Vec<u8>)> {
+        let to = &to.into();
         if params.name.trim().is_empty() {
             return Err(anyhow!("Event name must not be empty"));
         }
@@ -62,7 +63,7 @@ impl<'a> Events<'a> {
             ..Default::default()
         });
 
-        let result = self.client.send_message(to.clone(), message).await?;
+        let result = self.client.send_message(to, message).await?;
         Ok((result, message_secret))
     }
 
@@ -70,13 +71,14 @@ impl<'a> Events<'a> {
     /// message); `event_creator_jid` is who created the event.
     pub async fn respond(
         &self,
-        chat_jid: &Jid,
+        chat_jid: impl Into<Jid>,
         event_msg_id: &str,
         event_creator_jid: &Jid,
         message_secret: &[u8],
         response: EventResponseType,
         extra_guest_count: Option<i32>,
     ) -> Result<SendResult> {
+        let chat_jid = &chat_jid.into();
         let my_jid = self
             .client
             .get_pn()
@@ -124,7 +126,7 @@ impl<'a> Events<'a> {
             ..Default::default()
         };
 
-        self.client.send_message(chat_jid.clone(), message).await
+        self.client.send_message(chat_jid, message).await
     }
 
     /// The responder (self) JID keys the RSVP's HKDF/AAD, so it must use the event

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -391,7 +391,12 @@ impl<'a> Groups<'a> {
         })
     }
 
-    pub async fn set_subject(&self, jid: &Jid, subject: GroupSubject) -> Result<(), anyhow::Error> {
+    pub async fn set_subject(
+        &self,
+        jid: impl Into<Jid>,
+        subject: GroupSubject,
+    ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetGroupSubjectIq::new(jid, subject))
@@ -404,17 +409,19 @@ impl<'a> Groups<'a> {
     /// conflict detection. Pass `None` if unknown.
     pub async fn set_description(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         description: Option<GroupDescription>,
         prev: Option<&str>,
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetGroupDescriptionIq::new(jid, description, prev))
             .await?)
     }
 
-    pub async fn leave(&self, jid: &Jid) -> Result<(), anyhow::Error> {
+    pub async fn leave(&self, jid: impl Into<Jid>) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         self.client.execute(LeaveGroupIq::new(jid)).await?;
         self.client.get_group_cache().await.invalidate(jid).await;
         // Drop the persisted blob too: we're no longer in the group, so a stale
@@ -433,9 +440,10 @@ impl<'a> Groups<'a> {
 
     pub async fn add_participants(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<Vec<ParticipantChangeResponse>, anyhow::Error> {
+        let jid = &jid.into();
         let iq = if self
             .client
             .ab_props()
@@ -471,9 +479,10 @@ impl<'a> Groups<'a> {
 
     pub async fn remove_participants(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<Vec<ParticipantChangeResponse>, anyhow::Error> {
+        let jid = &jid.into();
         let result = self
             .client
             .execute(RemoveParticipantsIq::new(jid, participants))
@@ -503,9 +512,10 @@ impl<'a> Groups<'a> {
 
     pub async fn promote_participants(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(PromoteParticipantsIq::new(jid, participants))
@@ -514,16 +524,22 @@ impl<'a> Groups<'a> {
 
     pub async fn demote_participants(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(DemoteParticipantsIq::new(jid, participants))
             .await?)
     }
 
-    pub async fn get_invite_link(&self, jid: &Jid, reset: bool) -> Result<String, anyhow::Error> {
+    pub async fn get_invite_link(
+        &self,
+        jid: impl Into<Jid>,
+        reset: bool,
+    ) -> Result<String, anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(GetGroupInviteLinkIq::new(jid, reset))
@@ -531,7 +547,8 @@ impl<'a> Groups<'a> {
     }
 
     /// Lock the group so only admins can change group info.
-    pub async fn set_locked(&self, jid: &Jid, locked: bool) -> Result<(), anyhow::Error> {
+    pub async fn set_locked(&self, jid: impl Into<Jid>, locked: bool) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         let spec = if locked {
             SetGroupLockedIq::lock(jid)
         } else {
@@ -541,7 +558,12 @@ impl<'a> Groups<'a> {
     }
 
     /// Set announcement mode. When enabled, only admins can send messages.
-    pub async fn set_announce(&self, jid: &Jid, announce: bool) -> Result<(), anyhow::Error> {
+    pub async fn set_announce(
+        &self,
+        jid: impl Into<Jid>,
+        announce: bool,
+    ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         let spec = if announce {
             SetGroupAnnouncementIq::announce(jid)
         } else {
@@ -554,7 +576,12 @@ impl<'a> Groups<'a> {
     ///
     /// Common values: 86400 (24h), 604800 (7d), 7776000 (90d).
     /// Pass 0 to disable.
-    pub async fn set_ephemeral(&self, jid: &Jid, expiration: u32) -> Result<(), anyhow::Error> {
+    pub async fn set_ephemeral(
+        &self,
+        jid: impl Into<Jid>,
+        expiration: u32,
+    ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         let spec = match std::num::NonZeroU32::new(expiration) {
             Some(exp) => SetGroupEphemeralIq::enable(jid, exp),
             None => SetGroupEphemeralIq::disable(jid),
@@ -565,9 +592,10 @@ impl<'a> Groups<'a> {
     /// Set membership approval mode. When on, new members must be approved by an admin.
     pub async fn set_membership_approval(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         mode: MembershipApprovalMode,
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetGroupMembershipApprovalIq::new(jid, mode))
@@ -587,11 +615,13 @@ impl<'a> Groups<'a> {
     /// Accept a V4 invite (received as a GroupInviteMessage, not a link).
     pub async fn join_with_invite_v4(
         &self,
-        group_jid: &Jid,
+        group_jid: impl Into<Jid>,
         code: &str,
         expiration: i64,
-        admin_jid: &Jid,
+        admin_jid: impl Into<Jid>,
     ) -> Result<JoinGroupResult, anyhow::Error> {
+        let group_jid = &group_jid.into();
+        let admin_jid = &admin_jid.into();
         if expiration > 0 {
             let now = wacore::time::now_millis() / 1000;
             if expiration < now {
@@ -620,8 +650,9 @@ impl<'a> Groups<'a> {
     /// Get pending membership approval requests.
     pub async fn get_membership_requests(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
     ) -> Result<Vec<MembershipRequest>, anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(GetMembershipRequestsIq::new(jid))
@@ -631,9 +662,10 @@ impl<'a> Groups<'a> {
     /// Approve pending membership requests.
     pub async fn approve_membership_requests(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<Vec<ParticipantChangeResponse>, anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(MembershipRequestActionIq::approve(jid, participants))
@@ -643,9 +675,10 @@ impl<'a> Groups<'a> {
     /// Reject pending membership requests.
     pub async fn reject_membership_requests(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<Vec<ParticipantChangeResponse>, anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(MembershipRequestActionIq::reject(jid, participants))
@@ -655,9 +688,10 @@ impl<'a> Groups<'a> {
     /// Set who can add members to the group.
     pub async fn set_member_add_mode(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         mode: MemberAddMode,
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetMemberAddModeIq::new(jid, mode))
@@ -667,9 +701,10 @@ impl<'a> Groups<'a> {
     /// Restrict or allow frequently-forwarded messages in the group.
     pub async fn set_no_frequently_forwarded(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         restrict: bool,
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetNoFrequentlyForwardedIq::new(jid, restrict))
@@ -679,9 +714,10 @@ impl<'a> Groups<'a> {
     /// Enable or disable admin reports in the group.
     pub async fn set_allow_admin_reports(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         allow: bool,
     ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetAllowAdminReportsIq::new(jid, allow))
@@ -689,7 +725,12 @@ impl<'a> Groups<'a> {
     }
 
     /// Enable or disable group history sharing.
-    pub async fn set_group_history(&self, jid: &Jid, enabled: bool) -> Result<(), anyhow::Error> {
+    pub async fn set_group_history(
+        &self,
+        jid: impl Into<Jid>,
+        enabled: bool,
+    ) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(SetGroupHistoryIq::new(jid, enabled))
@@ -739,9 +780,10 @@ impl<'a> Groups<'a> {
     /// Cancel pending membership requests (from the requesting user's side).
     pub async fn cancel_membership_requests(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<Vec<ParticipantChangeResponse>, anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(CancelMembershipRequestsIq::new(jid, participants))
@@ -751,9 +793,10 @@ impl<'a> Groups<'a> {
     /// Revoke invitation codes from specific participants (admin operation).
     pub async fn revoke_request_code(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         participants: &[Jid],
     ) -> Result<Vec<ParticipantChangeResponse>, anyhow::Error> {
+        let jid = &jid.into();
         Ok(self
             .client
             .execute(RevokeRequestCodeIq::new(jid, participants))
@@ -761,7 +804,8 @@ impl<'a> Groups<'a> {
     }
 
     /// Acknowledge a group notification.
-    pub async fn acknowledge(&self, jid: &Jid) -> Result<(), anyhow::Error> {
+    pub async fn acknowledge(&self, jid: impl Into<Jid>) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         Ok(self.client.execute(AcknowledgeGroupIq::new(jid)).await?)
     }
 
@@ -826,9 +870,10 @@ impl<'a> Groups<'a> {
     /// ```
     pub async fn set_profile_picture(
         &self,
-        group_jid: &Jid,
+        group_jid: impl Into<Jid>,
         image_data: Vec<u8>,
     ) -> Result<SetProfilePictureResponse, anyhow::Error> {
+        let group_jid = &group_jid.into();
         Ok(self
             .client
             .execute(SetProfilePictureSpec::for_group(group_jid, image_data))
@@ -838,8 +883,9 @@ impl<'a> Groups<'a> {
     /// Remove a group's profile picture (admin operation).
     pub async fn remove_profile_picture(
         &self,
-        group_jid: &Jid,
+        group_jid: impl Into<Jid>,
     ) -> Result<SetProfilePictureResponse, anyhow::Error> {
+        let group_jid = &group_jid.into();
         Ok(self
             .client
             .execute(SetProfilePictureSpec::remove_group(group_jid))
@@ -885,9 +931,10 @@ impl<'a> Groups<'a> {
     /// not as an IQ.
     pub async fn update_member_label(
         &self,
-        group_jid: &Jid,
+        group_jid: impl Into<Jid>,
         label: impl Into<String>,
     ) -> Result<(), anyhow::Error> {
+        let group_jid = &group_jid.into();
         if !group_jid.is_group() {
             return Err(anyhow::anyhow!(
                 "update_member_label requires a group JID, got {group_jid}"

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -371,7 +371,8 @@ impl<'a> Newsletter<'a> {
     /// The server will send `<notification type="newsletter">` stanzas with
     /// `<live_updates>` children, dispatched as `Event::NewsletterLiveUpdate`.
     /// Returns the subscription duration in seconds.
-    pub async fn subscribe_live_updates(&self, jid: &Jid) -> Result<u64, anyhow::Error> {
+    pub async fn subscribe_live_updates(&self, jid: impl Into<Jid>) -> Result<u64, anyhow::Error> {
+        let jid = &jid.into();
         let iq = InfoQuery::set(
             NEWSLETTER_XMLNS,
             jid.clone(),
@@ -472,10 +473,11 @@ impl<'a> Newsletter<'a> {
     /// response to paginate backwards through history.
     pub async fn get_messages(
         &self,
-        jid: &Jid,
+        jid: impl Into<Jid>,
         count: u32,
         before: Option<u64>,
     ) -> Result<Vec<NewsletterMessage>, anyhow::Error> {
+        let jid = &jid.into();
         let mut messages_node = NodeBuilder::new("messages").attr("count", count);
         if let Some(before_id) = before {
             messages_node = messages_node.attr("before", before_id);

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -30,11 +30,12 @@ impl<'a> Polls<'a> {
     /// Caller needs the returned `message_secret` to decrypt votes.
     pub async fn create(
         &self,
-        to: &Jid,
+        to: impl Into<Jid>,
         name: &str,
         options: &[String],
         selectable_count: u32,
     ) -> Result<(SendResult, Vec<u8>)> {
+        let to = &to.into();
         self.create_inner(to, name, options, selectable_count, None)
             .await
     }
@@ -46,11 +47,12 @@ impl<'a> Polls<'a> {
     /// so the count is fixed at 1. Returns the `message_secret` needed to decrypt votes.
     pub async fn create_quiz(
         &self,
-        to: &Jid,
+        to: impl Into<Jid>,
         name: &str,
         options: &[String],
         correct_index: usize,
     ) -> Result<(SendResult, Vec<u8>)> {
+        let to = &to.into();
         self.create_inner(to, name, options, 1, Some(correct_index))
             .await
     }
@@ -92,18 +94,19 @@ impl<'a> Polls<'a> {
             ..Default::default()
         });
 
-        let result = self.client.send_message(to.clone(), message).await?;
+        let result = self.client.send_message(to, message).await?;
         Ok((result, message_secret))
     }
 
     pub async fn vote(
         &self,
-        chat_jid: &Jid,
+        chat_jid: impl Into<Jid>,
         poll_msg_id: &str,
         poll_creator_jid: &Jid,
         message_secret: &[u8],
         option_names: &[String],
     ) -> Result<SendResult> {
+        let chat_jid = &chat_jid.into();
         let my_jid = self
             .client
             .get_pn()
@@ -157,7 +160,7 @@ impl<'a> Polls<'a> {
             ..Default::default()
         };
 
-        self.client.send_message(chat_jid.clone(), message).await
+        self.client.send_message(chat_jid, message).await
     }
 
     /// The voter (self) JID keys the vote's HKDF/AAD, so it must use the poll

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -133,7 +133,8 @@ impl<'a> Presence<'a> {
     ///   <tctoken><!-- raw token bytes --></tctoken>
     /// </presence>
     /// ```
-    pub async fn subscribe(&self, jid: &Jid) -> Result<(), anyhow::Error> {
+    pub async fn subscribe(&self, jid: impl Into<Jid>) -> Result<(), anyhow::Error> {
+        let jid = &jid.into();
         debug!("presence subscribe: subscribing to {}", jid);
         let node = self.build_subscription_node(jid).await;
         self.client

--- a/src/features/reaction.rs
+++ b/src/features/reaction.rs
@@ -34,10 +34,11 @@ impl Client {
     /// author is read from `target_key.participant` by the send path.
     pub async fn send_reaction(
         &self,
-        chat: &Jid,
+        chat: impl Into<Jid>,
         target_key: wa::MessageKey,
         emoji: &str,
     ) -> Result<SendResult, anyhow::Error> {
+        let chat = &chat.into();
         if chat.is_group() && self.is_community_announce_group(chat).await? {
             return self.send_enc_reaction(chat, target_key, emoji).await;
         }
@@ -46,7 +47,7 @@ impl Client {
             emoji,
             wacore::time::now_millis(),
         );
-        self.send_message(chat.clone(), reaction).await
+        self.send_message(chat, reaction).await
     }
 
     /// Whether `chat` is a Community Announcement Group (WA Web `isCag`).
@@ -109,6 +110,6 @@ impl Client {
             }),
             ..Default::default()
         };
-        self.send_message(chat.clone(), message).await
+        self.send_message(chat, message).await
     }
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -4736,7 +4736,34 @@ mod jid_into_convention {
         let _ = client
             .send_reaction(&jid, wa::MessageKey::default(), "x")
             .await;
-        // Owned style: moves, no clone.
-        let _ = client.send_message(jid, msg).await;
+        // Owned style: moves, no clone. Each method consumes its own copy so
+        // the whole core surface is pinned, not just send_message.
+        let _ = client.send_message(jid.clone(), msg.clone()).await;
+        let _ = client
+            .send_message_with_options(jid.clone(), msg.clone(), SendOptions::default())
+            .await;
+        let _ = client.forward_message(jid.clone(), &msg).await;
+        let _ = client
+            .edit_message(jid.clone(), "ID", wa::Message::default())
+            .await;
+        let _ = client
+            .revoke_message(jid.clone(), "ID", RevokeType::Sender)
+            .await;
+        let _ = client
+            .pin_message(
+                jid.clone(),
+                wa::MessageKey::default(),
+                PinDuration::default(),
+            )
+            .await;
+        let _ = client
+            .unpin_message(jid.clone(), wa::MessageKey::default())
+            .await;
+        let _ = client
+            .send_reaction(jid.clone(), wa::MessageKey::default(), "x")
+            .await;
+        let _ = client
+            .keep_message(jid, wa::MessageKey::default(), true)
+            .await;
     }
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -4736,6 +4736,9 @@ mod jid_into_convention {
         let _ = client
             .send_reaction(&jid, wa::MessageKey::default(), "x")
             .await;
+        let _ = client
+            .keep_message(&jid, wa::MessageKey::default(), true)
+            .await;
         // Owned style: moves, no clone. Each method consumes its own copy so
         // the whole core surface is pinned, not just send_message.
         let _ = client.send_message(jid.clone(), msg.clone()).await;

--- a/src/send.rs
+++ b/src/send.rs
@@ -411,10 +411,10 @@ impl Client {
     /// For status/story updates use [`Client::status()`] instead.
     pub async fn send_message(
         &self,
-        to: Jid,
+        to: impl Into<Jid>,
         message: wa::Message,
     ) -> Result<SendResult, anyhow::Error> {
-        self.send_message_with_options(to, message, SendOptions::default())
+        self.send_message_with_options_inner(to.into(), message, SendOptions::default())
             .await
     }
 
@@ -428,17 +428,30 @@ impl Client {
     /// from the same CDN blob rather than re-uploaded.
     pub async fn forward_message(
         &self,
-        to: Jid,
+        to: impl Into<Jid>,
         message: &wa::Message,
     ) -> Result<SendResult, anyhow::Error> {
         use wacore::proto_helpers::MessageExt;
         let body = *message.get_base_message().prepare_for_forward();
-        self.send_message(to, body).await
+        self.send_message_with_options_inner(to.into(), body, SendOptions::default())
+            .await
     }
 
     /// Send a message with additional options.
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.message", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
     pub async fn send_message_with_options(
+        &self,
+        to: impl Into<Jid>,
+        message: wa::Message,
+        options: SendOptions,
+    ) -> Result<SendResult, anyhow::Error> {
+        // Thin generic shim: the large async body below stays monomorphic so
+        // each `Into<Jid>` instantiation does not duplicate the state machine.
+        self.send_message_with_options_inner(to.into(), message, options)
+            .await
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.message", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
+    async fn send_message_with_options_inner(
         &self,
         to: Jid,
         mut message: wa::Message,
@@ -1088,14 +1101,23 @@ impl Client {
     /// * `message_id` - The ID of the message to delete
     /// * `revoke_type` - Use `RevokeType::Sender` to delete your own message,
     ///   or `RevokeType::Admin { original_sender }` to delete another user's message as group admin
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.revoke", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
     pub async fn revoke_message(
         &self,
-        to: Jid,
+        to: impl Into<Jid>,
         message_id: impl Into<String>,
         revoke_type: RevokeType,
     ) -> Result<(), anyhow::Error> {
-        let message_id = message_id.into();
+        self.revoke_message_inner(to.into(), message_id.into(), revoke_type)
+            .await
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.revoke", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
+    async fn revoke_message_inner(
+        &self,
+        to: Jid,
+        message_id: String,
+        revoke_type: RevokeType,
+    ) -> Result<(), anyhow::Error> {
         self.require_pn()?;
 
         let (from_me, participant, edit_attr) = match &revoke_type {
@@ -1159,10 +1181,11 @@ impl Client {
     /// text add-on and maps the undo case to a sender-revoke edit attribute.
     pub async fn keep_message(
         &self,
-        chat: Jid,
+        chat: impl Into<Jid>,
         key: wa::MessageKey,
         keep: bool,
     ) -> Result<SendResult, anyhow::Error> {
+        let chat = chat.into();
         let message = wacore::proto_helpers::build_keep_in_chat_message(
             key,
             keep,
@@ -1174,12 +1197,12 @@ impl Client {
     /// Pin a message in a chat for all participants.
     pub async fn pin_message(
         &self,
-        chat: Jid,
+        chat: impl Into<Jid>,
         key: wa::MessageKey,
         duration: PinDuration,
     ) -> Result<(), anyhow::Error> {
         self.send_pin(
-            chat,
+            chat.into(),
             key,
             wa::message::pin_in_chat_message::Type::PinForAll,
             duration.as_secs(),
@@ -1188,9 +1211,13 @@ impl Client {
     }
 
     /// Unpin a previously pinned message.
-    pub async fn unpin_message(&self, chat: Jid, key: wa::MessageKey) -> Result<(), anyhow::Error> {
+    pub async fn unpin_message(
+        &self,
+        chat: impl Into<Jid>,
+        key: wa::MessageKey,
+    ) -> Result<(), anyhow::Error> {
         self.send_pin(
-            chat,
+            chat.into(),
             key,
             wa::message::pin_in_chat_message::Type::UnpinForAll,
             0,
@@ -4680,5 +4707,36 @@ mod tests {
             message_secret: Some(result.message_secret),
         };
         assert_eq!(prepared.message_secret.as_ref().unwrap().len(), 32);
+    }
+}
+
+#[cfg(test)]
+mod jid_into_convention {
+    use super::*;
+
+    /// Compile-time guard for the `impl Into<Jid>` convention: every core
+    /// method must accept BOTH an owned `Jid` (move, zero copy) and a `&Jid`
+    /// (one clone via `From<&Jid>`). Never executed; compilation is the test.
+    #[allow(dead_code)]
+    async fn both_call_styles_compile(client: &crate::client::Client, jid: Jid) {
+        let msg = wa::Message::default();
+        let _ = client.send_message(&jid, msg.clone()).await;
+        let _ = client
+            .send_message_with_options(&jid, msg.clone(), SendOptions::default())
+            .await;
+        let _ = client.forward_message(&jid, &msg).await;
+        let _ = client
+            .edit_message(&jid, "ID", wa::Message::default())
+            .await;
+        let _ = client.revoke_message(&jid, "ID", RevokeType::Sender).await;
+        let _ = client
+            .pin_message(&jid, wa::MessageKey::default(), PinDuration::default())
+            .await;
+        let _ = client.unpin_message(&jid, wa::MessageKey::default()).await;
+        let _ = client
+            .send_reaction(&jid, wa::MessageKey::default(), "x")
+            .await;
+        // Owned style: moves, no clone.
+        let _ = client.send_message(jid, msg).await;
     }
 }

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -963,6 +963,15 @@ impl From<Jid> for String {
     }
 }
 
+/// Lets `impl Into<Jid>` APIs accept `&Jid` transparently: borrow-callers pay
+/// one cheap clone (the user part is inline for typical numeric ids), owned
+/// callers move for free.
+impl From<&Jid> for Jid {
+    fn from(jid: &Jid) -> Self {
+        jid.clone()
+    }
+}
+
 impl<'a> From<JidRef<'a>> for String {
     fn from(jid: JidRef<'a>) -> Self {
         jid.to_string()


### PR DESCRIPTION
## Problem

The four most-used methods of the library (`send_message`, `edit_message`, `pin/unpin_message`, `revoke_message`) took `Jid` by value while the entire feature surface took `&Jid`. The common caller keeps the jid and sends repeatedly, so every call site read `client.send_message(jid.clone(), msg)`; the library itself paid the inverse cost, with 10 internal `send_message(chat.clone(), ...)` sites because features hold references. Two conventions on one surface, and the noisy one sat on the hottest entry points. Pre-1.0 is the last cheap moment to fix the signature of the methods every consumer touches.

## Change

One convention: **public methods that end up owning their `Jid` take `impl Into<Jid>`**, backed by a new `From<&Jid> for Jid` impl.

- Callers with a reference call `client.send_message(&jid, msg)` and pay one clone inside (the user part is `CompactString`-inline for typical numeric ids, so no heap).
- Callers done with the jid pass it by value and move for free.
- The 10 internal forced clones are gone.

**Monomorphization discipline:** the large async bodies (`send_message_with_options`, `edit_message`, `edit_message_encrypted`, `revoke_message`) keep a monomorphic `_inner` behind a thin generic shim that only does `.into()`, so `Into` instantiations cannot duplicate the send state machines. Small delegating methods take the generic directly. The internal `send_message_impl` stays monomorphic on purpose.

**Scope (classified by an adversarially-verified sweep of the whole public surface):** ~53 methods converted across the messaging core and the owning feature surface (`groups` 26, `community` 6, `newsletter` 2, `presence` 1, `events`, `polls`, `comments`, `reactions`, `keep_message`). Deliberate exceptions:

- Read-only methods keep `&Jid`: converting them would force a clone on borrow-callers. The clearest case the verification caught is `groups().query_info`, whose cache hit only reads the jid on the per-send hot path; ~59 read-only methods stay as they are.
- `&[Jid]` slices and `Option<&Jid>` params are out of scope.
- HKDF identity params that are only read (`event_creator_jid`, `poll_creator_jid`) stay `&Jid`.

## Compatibility

Call sites passing owned `Jid` compile unchanged. Call sites that previously had to clone can drop the clone. Feature methods that took `&Jid` keep accepting `&jid` through the `From<&Jid>` impl, so this is source-compatible for the dominant call style; pre-1.0 breaking surface is limited to type-inference edge cases (e.g. passing `.parse()?` results now needs no change either, since `Jid: Into<Jid>`).

## Tests

- A never-executed compile guard (`jid_into_convention`) pins BOTH call styles (`&jid` and owned) for every core method, so removing `From<&Jid>` or regressing a signature fails the build.
- Full workspace suite green (2165 tests), `cargo clippy --all-targets -- -D warnings` clean, both wasm32 CI variants reproduced locally.

## Breaking

Signatures of the converted methods change from `Jid`/`&Jid` to `impl Into<Jid>` (source-compatible for owned and `&jid` callers; trait-object/fn-pointer uses of these inherent methods, if any exist downstream, would need a closure). Pre-1.0.
