### PR TITLE
ci(codspeed): run simulation and memory instruments in a single job

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -45,51 +45,18 @@ jobs:
           prefix-key: ${{ runner.os }}-cargo-codspeed
           cache-targets: "false"
 
+      # simulation and memory share the same instrumented build, so one
+      # build covers both instruments.
       - name: Build the benchmark targets
         run: >
-          cargo codspeed build
+          cargo codspeed build -m simulation -m memory
           -p wacore -p wacore-binary -p wacore-libsignal
           -p wacore-appstate -p wacore-noise
 
+      # Both instruments run serially in a single invocation so each
+      # benchmark uploads as one run carrying CPU and memory metrics.
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: simulation
-          run: cargo codspeed run
-
-  benchmarks-memory:
-    name: Run CodSpeed memory benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2026-04-05
-
-      - name: Install tools (protoc, cargo-codspeed)
-        uses: taiki-e/install-action@v2
-        with:
-          tool: protoc@${{ env.PROTOC_VERSION }},cargo-codspeed@4.7.0
-
-      - name: Cache Rust registry
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: ${{ runner.os }}-cargo-codspeed-memory
-          cache-targets: "false"
-
-      # The memory instrument needs its own instrumented build
-      # (https://codspeed.io/docs/instruments/memory).
-      - name: Build the benchmark targets (memory instrumented)
-        run: >
-          cargo codspeed build --measurement-mode memory
-          -p wacore -p wacore-binary -p wacore-libsignal
-          -p wacore-appstate -p wacore-noise
-
-      - name: Run the benchmarks (memory)
-        uses: CodSpeedHQ/action@v4
-        with:
-          mode: memory
+          mode: simulation,memory
           run: cargo codspeed run


### PR DESCRIPTION
## Problem

The CodSpeed workflow ran two separate jobs (`benchmarks` for simulation, `benchmarks-memory` for memory). Each job uploaded its results independently, so every benchmark appears duplicated in the dashboard: one entry with CPU metrics and another with memory metrics, created by different uploads. The setup also paid for two full checkout + toolchain + build cycles per run.

## Change

- Merge the two jobs into a single `benchmarks` job.
- Build once with `cargo codspeed build -m simulation -m memory`. Both modes map to the same instrumented build in cargo-codspeed ([source](https://github.com/CodSpeedHQ/codspeed-rust/blob/v4.7.0/crates/cargo-codspeed/src/measurement_mode.rs): `Simulation | Memory => BuildMode::Analysis`), so the previous dedicated "memory instrumented" build was redundant. The docs confirm: "The resulting binaries are compatible across these modes, so you only need to build once."
- Run the action with `mode: simulation,memory`, which executes both instruments serially in one invocation and uploads a single run carrying both metrics ([docs: running multiple instruments serially](https://codspeed.io/docs/integrations/ci/github-actions/configuration#running-multiple-instruments-serially), supported since runner v4.12.0; `action@v4` currently resolves to 4.17.x).

## Verification

- Smoke-tested locally with the pinned cargo-codspeed 4.7.0: `cargo codspeed build -m simulation -m memory -p wacore-noise` builds the suite once and reports both measurement modes.
- YAML validated; no other workflow references the removed `benchmarks-memory` job.

## Notes

- Net effect on CI: one less job and one less full benchmark build; the two instrument passes now run serially in the same job.
- The stale duplicated benchmark entries from the previous two-job uploads can be archived in the dashboard once new runs land.
