### PR TITLE
bench: measure the operation, not the harness

### DIFF
--- a/wacore/appstate/benches/appstate_benchmark.rs
+++ b/wacore/appstate/benches/appstate_benchmark.rs
@@ -31,9 +31,9 @@ fn bench_lthash_subtract_then_add_812(bencher: divan::Bencher) {
                 .collect();
             (base, macs)
         })
-        .bench_values(|(base, macs)| {
+        .bench_refs(|(base, macs)| {
             const EMPTY: &[Vec<u8>] = &[];
-            black_box(WAPATCH_INTEGRITY.subtract_then_add(black_box(&base), EMPTY, &macs))
+            black_box(WAPATCH_INTEGRITY.subtract_then_add(black_box(&*base), EMPTY, macs))
         });
 }
 
@@ -124,7 +124,7 @@ fn setup_patch(n: usize) -> PatchFixture {
 fn bench_process_patch_50_validated(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| setup_patch(50))
-        .bench_values(|fixture| {
+        .bench_refs(|fixture| {
             let keys = Arc::clone(&fixture.keys);
             let mut state = HashState::default();
             black_box(

--- a/wacore/benches/history_sync_benchmark.rs
+++ b/wacore/benches/history_sync_benchmark.rs
@@ -13,6 +13,21 @@ fn main() {
     divan::main();
 }
 
+/// Deterministic xorshift-based filler: real chat text compresses ~2-4x;
+/// repeated literal filler compressed ~24x and masked the inflate cost.
+fn pseudo_text(mut seed: u64, len: usize) -> String {
+    seed = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15).max(1);
+    let mut out = String::with_capacity(len + 17);
+    while out.len() < len {
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        out.push_str(&format!("{seed:016x} "));
+    }
+    out.truncate(len);
+    out
+}
+
 fn build_realistic_history_sync(n_convos: usize, msgs_per_convo: usize) -> Vec<u8> {
     let mut conversations = Vec::with_capacity(n_convos);
     for c in 0..n_convos {
@@ -24,16 +39,13 @@ fn build_realistic_history_sync(n_convos: usize, msgs_per_convo: usize) -> Vec<u
             // 2-byte length varints, matching real chat history.
             let inner = if m % 3 == 0 {
                 wa::Message {
-                    conversation: Some(format!(
-                        "Mensagem de teste numero {m} no chat {c} com um pouco mais de texto \
-                         para variar o tamanho do campo e gerar varints de 2 bytes ocasionais."
-                    )),
+                    conversation: Some(pseudo_text((c * 41 + m) as u64, 130)),
                     ..Default::default()
                 }
             } else {
                 wa::Message {
                     extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
-                        text: Some(format!("Texto estendido curto {m}")),
+                        text: Some(pseudo_text((c * 43 + m) as u64, 24)),
                         context_info: Some(Box::new(wa::ContextInfo {
                             is_forwarded: Some(m % 4 == 0),
                             forwarding_score: Some((m % 7) as u32),
@@ -91,13 +103,14 @@ fn bench_process_history_sync(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_history_sync_blob)
         .bench_values(|blob| {
-            // retain_blob = true exercises the full-buffer path: count pass +
-            // main loop + per-conversation scan, the maximum varint volume.
-            let _ = black_box(wacore::history_sync::process_history_sync(
+            // retain_blob = true exercises the full-buffer path. The result
+            // (records + retained blob) is returned so the harness drops it
+            // outside the measured window, like a consumer would later.
+            black_box(wacore::history_sync::process_history_sync(
                 black_box(blob),
                 None,
                 true,
                 None,
-            ));
+            ))
         });
 }

--- a/wacore/benches/message_utils_benchmark.rs
+++ b/wacore/benches/message_utils_benchmark.rs
@@ -28,8 +28,8 @@ fn setup_device_list(users: usize, devices_per_user: u16) -> Vec<Jid> {
 fn bench_participant_list_hash_1600(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| setup_device_list(800, 2))
-        .bench_values(|devices| {
-            black_box(MessageUtils::participant_list_hash(black_box(&devices)).unwrap())
+        .bench_refs(|devices| {
+            black_box(MessageUtils::participant_list_hash(black_box(&**devices)).unwrap())
         });
 }
 
@@ -54,7 +54,7 @@ fn text_message() -> wa::Message {
 fn bench_encode_and_pad(bencher: divan::Bencher) {
     bencher
         .with_inputs(text_message)
-        .bench_values(|msg| black_box(MessageUtils::encode_and_pad(black_box(&msg))));
+        .bench_refs(|msg| black_box(MessageUtils::encode_and_pad(black_box(msg))));
 }
 
 /// Unpad of a received plaintext: runs once per decrypted message.
@@ -65,9 +65,9 @@ fn bench_unpad_message_ref(bencher: divan::Bencher) {
             use prost::Message as _;
             MessageUtils::pad_message_v2(text_message().encode_to_vec())
         })
-        .bench_values(|padded| {
+        .bench_refs(|padded| {
             black_box(
-                MessageUtils::unpad_message_ref(black_box(&padded), 2)
+                MessageUtils::unpad_message_ref(black_box(padded), 2)
                     .unwrap()
                     .len(),
             )

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -32,38 +32,51 @@ fn main() {
     divan::main();
 }
 
+/// Deterministically seeded RNG: fixtures must be identical across runs and
+/// builds so CodSpeed comparisons measure code, not key material.
+fn bench_rng(seed: u64) -> rand::rngs::StdRng {
+    use rand::SeedableRng;
+    rand::rngs::StdRng::seed_from_u64(seed)
+}
+
+/// FNV-1a fold of a fixture label into an RNG seed.
+fn seed_of(label: &str) -> u64 {
+    label.bytes().fold(0xcbf2_9ce4_8422_2325u64, |h, b| {
+        (h ^ b as u64).wrapping_mul(0x0000_0100_0000_01b3)
+    })
+}
+
 // ---------------------------------------------------------------------------
 // In-memory Signal stores
 // ---------------------------------------------------------------------------
 
-// Bench runtime: real thread-pool executor so `Runtime::spawn` actually
-// runs the spawned future in the background, mirroring how production
-// drives the parallel encrypt fan-out. `sleep` / `spawn_blocking` are not
-// exercised by the encrypt path.
-struct BenchRuntime {
-    pool: futures::executor::ThreadPool,
-}
-
-impl Default for BenchRuntime {
-    fn default() -> Self {
-        Self {
-            pool: futures::executor::ThreadPool::new().expect("create bench thread pool"),
-        }
-    }
-}
+// Bench runtime: runs spawned futures INLINE. CodSpeed's simulation
+// serializes threads, so a real pool would measure scheduler and
+// cross-thread synchronization overhead with zero parallelism benefit;
+// inline execution measures the encrypt work itself, deterministically.
+// `sleep` / `spawn_blocking` are not exercised by the encrypt path.
+#[derive(Default)]
+struct BenchRuntime;
 
 #[async_trait]
 impl Runtime for BenchRuntime {
     fn spawn(
         &self,
-        future: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
+        mut future: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
     ) -> AbortHandle {
-        use futures::task::SpawnExt;
-        // Silent spawn failure would skip a device's encrypt and fake the speedup.
-        self.pool
-            .spawn(future)
-            .expect("bench thread pool spawn failed");
-        AbortHandle::noop()
+        // Nested `futures::executor::block_on` panics, so drive the task with
+        // a noop-waker poll loop. Encrypt tasks are CPU-bound and complete
+        // without ever truly pending; the guard catches misuse.
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        for _ in 0..1_000_000 {
+            if future.as_mut().poll(&mut cx).is_ready() {
+                return AbortHandle::noop();
+            }
+        }
+        panic!(
+            "BenchRuntime::spawn: task pended forever; inline runtime only suits CPU-bound tasks"
+        );
     }
 
     fn sleep(
@@ -234,9 +247,9 @@ struct User {
 
 impl User {
     fn new(user: &str, server: &str) -> Self {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng(seed_of(user));
         let identity_key_pair = IdentityKeyPair::generate(&mut rng);
-        let reg_id = rand::random::<u32>() & 0x3FFF;
+        let reg_id = (seed_of(user) as u32) & 0x3FFF;
 
         let pk_id: PreKeyId = 1.into();
         let pk_pair = KeyPair::generate(&mut rng);
@@ -298,7 +311,7 @@ impl User {
 
 fn establish_session(sender: &mut User, receiver: &User) {
     let bundle = receiver.prekey_bundle();
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng(0xBE_5EED + 1);
     futures::executor::block_on(async {
         process_prekey_bundle(
             &receiver.address,
@@ -326,7 +339,7 @@ fn establish_bidirectional(a: &mut User, b: &mut User) {
         let ct_msg = CiphertextMessage::PreKeySignalMessage(
             PreKeySignalMessage::try_from(ct.serialize()).unwrap(),
         );
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng(0xBE_5EED + 2);
         message_decrypt(
             &ct_msg,
             &a.address,
@@ -440,7 +453,7 @@ fn decrypt_dm(
         } else {
             CiphertextMessage::SignalMessage(SignalMessage::try_from(ciphertext).unwrap())
         };
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng(0xBE_5EED + 3);
         let decrypted = message_decrypt(
             &parsed,
             sender_addr,
@@ -570,7 +583,7 @@ fn setup_group_send(n: usize) -> GrpSendData {
 
     let sk_name = make_sender_key_name(&group_jid, &alice.address);
     futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng(0xBE_5EED + 4);
         create_sender_key_distribution_message(&sk_name, &mut alice.sender_keys, &mut rng)
             .await
             .unwrap();
@@ -583,7 +596,7 @@ fn setup_group_send(n: usize) -> GrpSendData {
         force_skdm: false,
         resolver: MockResolver(devices),
         msg: text_msg(),
-        runtime: BenchRuntime::default(),
+        runtime: BenchRuntime,
     }
 }
 
@@ -631,7 +644,7 @@ fn setup_group_recv() -> GrpRecvData {
     // Alice creates sender key and distributes SKDM to Bob
     let sk_name = make_sender_key_name(&group_jid, &alice.address);
     futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng(0xBE_5EED + 5);
         let skdm =
             create_sender_key_distribution_message(&sk_name, &mut alice.sender_keys, &mut rng)
                 .await
@@ -656,7 +669,7 @@ fn setup_group_recv() -> GrpRecvData {
         signed_prekey_store: &alice.signed_prekeys,
     };
 
-    let runtime = BenchRuntime::default();
+    let runtime = BenchRuntime;
     let result = futures::executor::block_on(prepare_group_stanza(
         &runtime,
         &mut stores,
@@ -692,12 +705,12 @@ fn setup_group_recv() -> GrpRecvData {
 
 #[divan::bench]
 fn bench_dm_send(bencher: divan::Bencher) {
-    bencher.with_inputs(setup_dm_send).bench_values(|mut d| {
+    bencher.with_inputs(setup_dm_send).bench_refs(|d| {
         let signal_addr = d.bob_jid.to_protocol_address();
         let node = futures::executor::block_on(prepare_peer_stanza(
             &mut d.alice.sessions,
             &mut d.alice.identity,
-            d.bob_jid,
+            d.bob_jid.clone(),
             &signal_addr,
             &d.msg,
             "b-001".into(),
@@ -710,7 +723,7 @@ fn bench_dm_send(bencher: divan::Bencher) {
 
 #[divan::bench]
 fn bench_dm_recv(bencher: divan::Bencher) {
-    bencher.with_inputs(setup_dm_recv).bench_values(|mut d| {
+    bencher.with_inputs(setup_dm_recv).bench_refs(|d| {
         black_box(decrypt_dm(
             &d.ciphertext,
             &d.enc_type,
@@ -772,21 +785,21 @@ fn run_group_send(d: &mut GrpSendData) {
 fn bench_group_send_10(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_send_10)
-        .bench_values(|mut d| run_group_send(&mut d));
+        .bench_refs(run_group_send);
 }
 
 #[divan::bench]
 fn bench_group_send_50(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_send_50)
-        .bench_values(|mut d| run_group_send(&mut d));
+        .bench_refs(run_group_send);
 }
 
 #[divan::bench]
 fn bench_group_send_256(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_send_256)
-        .bench_values(|mut d| run_group_send(&mut d));
+        .bench_refs(run_group_send);
 }
 
 // First-message group send: forces SKDM distribution with N pairwise encryptions
@@ -794,26 +807,26 @@ fn bench_group_send_256(bencher: divan::Bencher) {
 fn bench_group_send_skdm_10(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_skdm_10)
-        .bench_values(|mut d| run_group_send(&mut d));
+        .bench_refs(run_group_send);
 }
 
 #[divan::bench]
 fn bench_group_send_skdm_50(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_skdm_50)
-        .bench_values(|mut d| run_group_send(&mut d));
+        .bench_refs(run_group_send);
 }
 
 #[divan::bench]
 fn bench_group_send_skdm_256(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_skdm_256)
-        .bench_values(|mut d| run_group_send(&mut d));
+        .bench_refs(run_group_send);
 }
 
 #[divan::bench]
 fn bench_group_recv(bencher: divan::Bencher) {
-    bencher.with_inputs(setup_group_recv).bench_values(|mut d| {
+    bencher.with_inputs(setup_group_recv).bench_refs(|d| {
         black_box(decrypt_group(
             &d.skmsg_bytes,
             &d.alice_addr,

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -32,11 +32,47 @@ fn main() {
     divan::main();
 }
 
+/// Deterministic bench RNG (SplitMix64). A local algorithm, so fixtures are
+/// stable across rand versions and platforms and baselines never shift on a
+/// dependency bump. The `CryptoRng` marker is satisfied for API purposes
+/// only: bench key material is synthetic by design.
+struct BenchRng(u64);
+
+impl BenchRng {
+    fn step(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+}
+
+// rand 0.10: `Rng`/`CryptoRng` are blanket-implemented over the infallible
+// Try* traits, so these two impls are the whole surface.
+impl rand::TryRng for BenchRng {
+    type Error = std::convert::Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok((self.step() >> 32) as u32)
+    }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.step())
+    }
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        for chunk in dst.chunks_mut(8) {
+            let bytes = self.step().to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+        Ok(())
+    }
+}
+
+impl rand::rand_core::TryCryptoRng for BenchRng {}
+
 /// Deterministically seeded RNG: fixtures must be identical across runs and
 /// builds so CodSpeed comparisons measure code, not key material.
-fn bench_rng(seed: u64) -> rand::rngs::StdRng {
-    use rand::SeedableRng;
-    rand::rngs::StdRng::seed_from_u64(seed)
+fn bench_rng(seed: u64) -> BenchRng {
+    BenchRng(seed)
 }
 
 /// FNV-1a fold of a fixture label into an RNG seed.

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -209,7 +209,8 @@ fn bench_marshal_to_reused_buffer_large(bencher: divan::Bencher) {
         .with_inputs(|| (create_large_node(), Vec::with_capacity(4096)))
         .bench_refs(|(node, buffer)| {
             marshal_to(black_box(node), buffer).unwrap();
-            black_box(buffer.len())
+            // Contents, not length: keeps the marshal writes observable.
+            black_box(buffer.as_slice());
         });
 }
 

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -157,35 +157,35 @@ fn create_many_children_node() -> Node {
 fn bench_marshal_auto_small(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_small_node)
-        .bench_values(|node| black_box(marshal_auto(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 
 #[divan::bench]
 fn bench_marshal_auto_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_large_node)
-        .bench_values(|node| black_box(marshal_auto(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 
 #[divan::bench]
 fn bench_marshal_auto_long_string(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_long_string_node)
-        .bench_values(|node| black_box(marshal_auto(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 
 #[divan::bench]
 fn bench_marshal_auto_huge_bytes(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_huge_bytes_node)
-        .bench_values(|node| black_box(marshal_auto(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 
 #[divan::bench]
 fn bench_marshal_auto_many_children(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_many_children_node)
-        .bench_values(|node| black_box(marshal_auto(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 
 // Strategy comparison on one shape.
@@ -193,23 +193,23 @@ fn bench_marshal_auto_many_children(bencher: divan::Bencher) {
 fn bench_marshal_plain_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_large_node)
-        .bench_values(|node| black_box(marshal(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal(black_box(node)).unwrap()));
 }
 
 #[divan::bench]
 fn bench_marshal_exact_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_large_node)
-        .bench_values(|node| black_box(marshal_exact(black_box(&node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_exact(black_box(node)).unwrap()));
 }
 
 #[divan::bench]
 fn bench_marshal_to_reused_buffer_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| (create_large_node(), Vec::with_capacity(4096)))
-        .bench_values(|(node, mut buffer)| {
-            marshal_to(black_box(&node), &mut buffer).unwrap();
-            black_box(buffer)
+        .bench_refs(|(node, buffer)| {
+            marshal_to(black_box(node), buffer).unwrap();
+            black_box(buffer.len())
         });
 }
 
@@ -227,7 +227,7 @@ fn setup_large_marshaled() -> Vec<u8> {
 fn bench_unmarshal_small(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_small_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
         });
 }
@@ -236,7 +236,7 @@ fn bench_unmarshal_small(bencher: divan::Bencher) {
 fn bench_unmarshal_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_large_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
         });
 }
@@ -264,8 +264,8 @@ fn setup_compressed_payload() -> Vec<u8> {
 fn bench_unpack_uncompressed(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_uncompressed_payload)
-        .bench_values(|payload| {
-            black_box(unpack(black_box(&payload)).unwrap());
+        .bench_refs(|payload| {
+            black_box(unpack(black_box(payload)).unwrap());
         });
 }
 
@@ -273,8 +273,8 @@ fn bench_unpack_uncompressed(bencher: divan::Bencher) {
 fn bench_unpack_compressed(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_compressed_payload)
-        .bench_values(|payload| {
-            black_box(unpack(black_box(&payload)).unwrap());
+        .bench_refs(|payload| {
+            black_box(unpack(black_box(payload)).unwrap());
         });
 }
 
@@ -289,7 +289,7 @@ fn setup_attr_marshaled() -> Vec<u8> {
 fn bench_attr_parser(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_attr_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(&marshaled[1..]).unwrap();
 
@@ -309,7 +309,7 @@ fn bench_attr_parser(bencher: divan::Bencher) {
 fn bench_roundtrip_small(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_small_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
             black_box(marshal_ref(&node_ref).unwrap())
@@ -320,7 +320,7 @@ fn bench_roundtrip_small(bencher: divan::Bencher) {
 fn bench_roundtrip_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_large_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
             black_box(marshal_ref(&node_ref).unwrap())
@@ -331,7 +331,7 @@ fn bench_roundtrip_large(bencher: divan::Bencher) {
 fn bench_roundtrip_auto_small(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_small_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
             black_box(marshal_ref_auto(&node_ref).unwrap())
@@ -342,7 +342,7 @@ fn bench_roundtrip_auto_small(bencher: divan::Bencher) {
 fn bench_roundtrip_auto_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_large_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
             black_box(marshal_ref_auto(&node_ref).unwrap())
@@ -353,7 +353,7 @@ fn bench_roundtrip_auto_large(bencher: divan::Bencher) {
 fn bench_roundtrip_exact_small(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_small_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
             black_box(marshal_ref_exact(&node_ref).unwrap())
@@ -364,7 +364,7 @@ fn bench_roundtrip_exact_small(bencher: divan::Bencher) {
 fn bench_roundtrip_exact_large(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_large_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
             black_box(marshal_ref_exact(&node_ref).unwrap())

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -26,7 +26,7 @@ fn bench_jid_to_string(bencher: divan::Bencher) {
             jid.device = 7;
             jid
         })
-        .bench_values(|jid| black_box(jid.to_string()));
+        .bench_refs(|jid| black_box(jid.to_string()));
 }
 
 #[divan::bench]
@@ -37,7 +37,7 @@ fn bench_jid_to_non_ad_string(bencher: divan::Bencher) {
             jid.device = 3;
             jid
         })
-        .bench_values(|jid| black_box(jid.to_non_ad_string()));
+        .bench_refs(|jid| black_box(jid.to_non_ad_string()));
 }
 
 /// The per-recipient fan-out formatter: writes the AD form into a reused
@@ -50,8 +50,8 @@ fn bench_jid_push_ad_to(bencher: divan::Bencher) {
             jid.device = 7;
             (jid, String::with_capacity(64))
         })
-        .bench_values(|(jid, mut buf)| {
-            jid.push_ad_to(&mut buf);
-            black_box(buf)
+        .bench_refs(|(jid, buf)| {
+            jid.push_ad_to(buf);
+            black_box(buf.len())
         });
 }

--- a/wacore/binary/benches/jid_benchmark.rs
+++ b/wacore/binary/benches/jid_benchmark.rs
@@ -52,6 +52,8 @@ fn bench_jid_push_ad_to(bencher: divan::Bencher) {
         })
         .bench_refs(|(jid, buf)| {
             jid.push_ad_to(buf);
-            black_box(buf.len())
+            // black-box the contents, not just the length: observing only
+            // `len` lets LLVM elide the actual formatting writes.
+            black_box(buf.as_bytes());
         });
 }

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -431,8 +431,8 @@ fn setup_group_with_distribution() -> (User, User, SenderKeyName) {
 
 #[divan::bench]
 fn bench_dm_session_establishment(bencher: divan::Bencher) {
-    bencher.with_inputs(setup_dm_users).bench_values(|data| {
-        let (mut alice, bob) = data;
+    bencher.with_inputs(setup_dm_users).bench_refs(|data| {
+        let (alice, bob) = data;
         let bob_bundle = bob.get_prekey_bundle();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
@@ -455,8 +455,8 @@ fn bench_dm_session_establishment(bencher: divan::Bencher) {
 
 #[divan::bench]
 fn bench_dm_encrypt_first_message(bencher: divan::Bencher) {
-    bencher.with_inputs(setup_dm_session).bench_values(|data| {
-        let (mut alice, bob) = data;
+    bencher.with_inputs(setup_dm_session).bench_refs(|data| {
+        let (alice, bob) = data;
         let plaintext = b"Hello Bob! This is the first message.";
 
         let ciphertext = futures::executor::block_on(async {
@@ -478,8 +478,8 @@ fn bench_dm_encrypt_first_message(bencher: divan::Bencher) {
 fn bench_dm_decrypt_first_message(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_dm_with_first_message)
-        .bench_values(|data| {
-            let (alice, mut bob, ciphertext_bytes) = data;
+        .bench_refs(|data| {
+            let (alice, bob, ciphertext_bytes) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             let plaintext = futures::executor::block_on(async {
@@ -511,8 +511,8 @@ fn bench_dm_decrypt_first_message(bencher: divan::Bencher) {
 fn bench_dm_encrypt_subsequent_message(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_established_dm_session)
-        .bench_values(|data| {
-            let (mut alice, bob) = data;
+        .bench_refs(|data| {
+            let (alice, bob) = data;
             let plaintext = b"This is a follow-up message after session is established.";
 
             let ciphertext = futures::executor::block_on(async {
@@ -532,39 +532,37 @@ fn bench_dm_encrypt_subsequent_message(bencher: divan::Bencher) {
 
 #[divan::bench]
 fn bench_group_create_distribution_message(bencher: divan::Bencher) {
-    bencher
-        .with_inputs(setup_group_sender)
-        .bench_values(|data| {
-            let (mut alice, sender_key_name) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    bencher.with_inputs(setup_group_sender).bench_refs(|data| {
+        let (alice, sender_key_name) = data;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
-            let skdm = futures::executor::block_on(async {
-                create_sender_key_distribution_message(
-                    &sender_key_name,
-                    &mut alice.sender_key_store,
-                    &mut rng,
-                )
-                .await
-                .expect("skdm")
-            });
-
-            black_box(skdm);
+        let skdm = futures::executor::block_on(async {
+            create_sender_key_distribution_message(
+                sender_key_name,
+                &mut alice.sender_key_store,
+                &mut rng,
+            )
+            .await
+            .expect("skdm")
         });
+
+        black_box(skdm);
+    });
 }
 
 #[divan::bench]
 fn bench_group_encrypt_message(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_with_distribution)
-        .bench_values(|data| {
-            let (mut alice, _bob, sender_key_name) = data;
+        .bench_refs(|data| {
+            let (alice, _bob, sender_key_name) = data;
             let plaintext = b"Hello group! This is a group message from Alice.";
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             let ciphertext = futures::executor::block_on(async {
                 group_encrypt(
                     &mut alice.sender_key_store,
-                    &sender_key_name,
+                    sender_key_name,
                     plaintext,
                     &mut rng,
                 )
@@ -599,8 +597,8 @@ fn setup_group_with_encrypted_message() -> (User, User, SenderKeyName, Vec<u8>) 
 fn bench_group_decrypt_message(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_group_with_encrypted_message)
-        .bench_values(|data| {
-            let (alice, mut bob, sender_key_name, ciphertext) = data;
+        .bench_refs(|data| {
+            let (alice, bob, sender_key_name, ciphertext) = data;
 
             let bob_sender_key_name = SenderKeyName::new(
                 sender_key_name.group_id().to_string(),
@@ -608,7 +606,7 @@ fn bench_group_decrypt_message(bencher: divan::Bencher) {
             );
 
             let plaintext = futures::executor::block_on(async {
-                group_decrypt(&ciphertext, &mut bob.sender_key_store, &bob_sender_key_name)
+                group_decrypt(ciphertext, &mut bob.sender_key_store, &bob_sender_key_name)
                     .await
                     .expect("group decrypt")
             });
@@ -625,8 +623,8 @@ fn setup_conversation_data() -> (User, User) {
 fn bench_full_dm_conversation(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_conversation_data)
-        .bench_values(|data| {
-            let (mut alice, mut bob) = data;
+        .bench_refs(|data| {
+            let (alice, bob) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             futures::executor::block_on(async {
@@ -737,14 +735,14 @@ fn setup_keypair_with_message() -> (KeyPair, [u8; 64]) {
 fn bench_signature_creation(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_keypair_with_message)
-        .bench_values(|data| {
+        .bench_refs(|data| {
             let (keypair, message) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             // Sign multiple times to amortize any setup overhead
             for _ in 0..10 {
                 let signature = keypair
-                    .calculate_signature(&message, &mut rng)
+                    .calculate_signature(&message[..], &mut rng)
                     .expect("signature");
                 black_box(signature);
             }
@@ -756,16 +754,18 @@ fn bench_signature_creation(bencher: divan::Bencher) {
 fn bench_signature_verification(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_keypair_with_message)
-        .bench_values(|data| {
+        .bench_refs(|data| {
             let (keypair, message) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
             let signature = keypair
-                .calculate_signature(&message, &mut rng)
+                .calculate_signature(&message[..], &mut rng)
                 .expect("signature");
 
             // Verify multiple times
             for _ in 0..10 {
-                let valid = keypair.public_key.verify_signature(&message, &signature);
+                let valid = keypair
+                    .public_key
+                    .verify_signature(&message[..], &signature);
                 black_box(valid);
             }
         });
@@ -911,8 +911,8 @@ fn setup_with_archived_sessions() -> (User, User, Vec<Vec<u8>>) {
 fn bench_decrypt_with_previous_session(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_with_archived_sessions)
-        .bench_values(|data| {
-            let (alice, mut bob, ciphertexts) = data;
+        .bench_refs(|data| {
+            let (alice, bob, ciphertexts) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             // Try to decrypt an old message (encrypted with a previous session)
@@ -1027,8 +1027,8 @@ fn setup_out_of_order_messages() -> (User, User, Vec<Vec<u8>>) {
 fn bench_out_of_order_decryption(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_out_of_order_messages)
-        .bench_values(|data| {
-            let (alice, mut bob, messages) = data;
+        .bench_refs(|data| {
+            let (alice, bob, messages) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             futures::executor::block_on(async {
@@ -1178,8 +1178,8 @@ fn setup_promote_matching_session() -> (User, User, Vec<u8>) {
 fn bench_promote_matching_session(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_promote_matching_session)
-        .bench_values(|data| {
-            let (alice, mut bob, prekey_message) = data;
+        .bench_refs(|data| {
+            let (alice, bob, prekey_message) = data;
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
             futures::executor::block_on(async {
@@ -1269,8 +1269,8 @@ fn setup_message_key_eviction() -> (SessionState, wacore_libsignal::protocol::Pu
 fn bench_message_key_eviction(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_message_key_eviction)
-        .bench_values(|data| {
-            let (mut state, sender_key) = data;
+        .bench_refs(|data| {
+            let (state, sender_key) = data;
             let start_counter = (consts::MAX_MESSAGE_KEYS - 1) as u32;
 
             // Insert 200 keys beyond capacity - this will trigger eviction cycles
@@ -1278,7 +1278,7 @@ fn bench_message_key_eviction(bencher: divan::Bencher) {
             for i in 0..200u32 {
                 let counter = start_counter + i;
                 let keys = create_test_message_key_generator(counter);
-                state.set_message_keys(&sender_key, keys).unwrap();
+                state.set_message_keys(sender_key, keys).unwrap();
             }
 
             black_box(state);

--- a/wacore/noise/benches/noise_benchmark.rs
+++ b/wacore/noise/benches/noise_benchmark.rs
@@ -19,9 +19,9 @@ fn frame(len: usize) -> Vec<u8> {
 fn bench_frame_encrypt_in_place(bencher: divan::Bencher, len: usize) {
     bencher
         .with_inputs(|| (NoiseCipher::new(&KEY).unwrap(), frame(len)))
-        .bench_values(|(cipher, mut buf)| {
-            cipher.encrypt_in_place_with_counter(7, &mut buf).unwrap();
-            black_box(buf)
+        .bench_refs(|(cipher, buf)| {
+            cipher.encrypt_in_place_with_counter(7, buf).unwrap();
+            black_box(buf.len())
         });
 }
 
@@ -34,8 +34,8 @@ fn bench_frame_decrypt_in_place(bencher: divan::Bencher, len: usize) {
             cipher.encrypt_in_place_with_counter(7, &mut buf).unwrap();
             (cipher, buf)
         })
-        .bench_values(|(cipher, mut buf)| {
-            cipher.decrypt_in_place_with_counter(7, &mut buf).unwrap();
-            black_box(buf)
+        .bench_refs(|(cipher, buf)| {
+            cipher.decrypt_in_place_with_counter(7, buf).unwrap();
+            black_box(buf.len())
         });
 }

--- a/wacore/noise/benches/noise_benchmark.rs
+++ b/wacore/noise/benches/noise_benchmark.rs
@@ -21,7 +21,8 @@ fn bench_frame_encrypt_in_place(bencher: divan::Bencher, len: usize) {
         .with_inputs(|| (NoiseCipher::new(&KEY).unwrap(), frame(len)))
         .bench_refs(|(cipher, buf)| {
             cipher.encrypt_in_place_with_counter(7, buf).unwrap();
-            black_box(buf.len())
+            // Contents, not length: keeps the in-place writes observable.
+            black_box(buf.as_slice());
         });
 }
 
@@ -36,6 +37,7 @@ fn bench_frame_decrypt_in_place(bencher: divan::Bencher, len: usize) {
         })
         .bench_refs(|(cipher, buf)| {
             cipher.decrypt_in_place_with_counter(7, buf).unwrap();
-            black_box(buf.len())
+            // Contents, not length: keeps the in-place writes observable.
+            black_box(buf.as_slice());
         });
 }


### PR DESCRIPTION
## Problem

The CodSpeed execution profiles showed the benchmark harness inside the measured windows. Worst cases: `bench_group_send_256` spent 45% of its window in `drop_in_place::<GrpSendData>` (tearing down 256 users' Signal stores, state that in production lives for the process lifetime), and `bench_group_send_skdm_256` had `ThreadPoolBuilder`/backtrace frames at the flamegraph root because `Runtime::spawn` dispatched encrypt tasks to a real thread pool, measuring scheduler plus cross-thread synchronization (CodSpeed's simulation serializes threads, so that is pure overhead with zero parallelism benefit).

## Changes

- **`bench_values` -> `bench_refs`** in every suite whose input has a non-trivial drop (send/receive fixtures, libsignal store fixtures, binary node trees, jid/device lists, appstate MAC vectors and patch fixtures, noise frame buffers). divan generates a fresh input per iteration either way; with refs the fixture teardown lands outside the measured window.
- **Inline bench runtime**: `BenchRuntime` drives spawned encrypt futures to completion with a noop-waker poll loop (nested `block_on` panics), so the group-send benches measure the encrypt work itself, deterministically. A guard panics if a task ever truly pends.
- **Deterministic fixtures**: send/receive key material is now seeded from the fixture label (FNV-1a), so the same code measures identically across runs and builds.
- **Honest history-sync blob**: message filler is xorshift-derived text compressing ~2-4x like real chat history; the previous literal filler compressed ~24x, understating the inflate share of the profile. The bench closure also returns the result so the harness drops records outside the window, like a consumer that uses them later would.

## Validation

- Whole-process instruction counts are unchanged vs the old harness (core-pinned perf stat, group_send_256 and skdm_256): the same work happens, only the measurement window moves.
- All 9 send/receive benches plus every converted suite smoke-run green (`cargo bench -- --test`), full workspace tests pass, clippy `--all-targets -D warnings` clean.

## Expected CodSpeed effect

This PR's run re-baselines the affected benchmarks: the send/receive family should report large "improvements" (the removed teardown/scheduler share) and history-sync shifts where the entropy fix changes the zlib share. That is the intent: from here on the numbers track the operations, not the harness.
