### PR TITLE
perf(api): box the cold entry-point futures so consumers stop re-codegening the graphs

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -221,11 +221,25 @@ impl Bot {
         self.client.clone()
     }
 
+    /// Coroutines are LocalCopy across crates: a consumer crate that awaits
+    /// this future re-codegens the whole state machine graph behind it in its
+    /// own binary. The boxed barrier below type-erases the graph in a plain
+    /// (linker-shared) function, so callers poll through a vtable and the
+    /// graph is compiled once, here. One allocation per process.
+    pub async fn run(&mut self) -> Result<BotHandle> {
+        self.run_boxed().await
+    }
+
+    #[inline(never)]
+    fn run_boxed(&mut self) -> wacore::runtime::BoxFuture<'_, Result<BotHandle>> {
+        Box::pin(self.run_graph())
+    }
+
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.bot.run", level = "debug", skip_all, err(Debug))
     )]
-    pub async fn run(&mut self) -> Result<BotHandle> {
+    async fn run_graph(&mut self) -> Result<BotHandle> {
         if let Some(receiver) = self.sync_task_receiver.take() {
             let worker_client = Arc::downgrade(&self.client);
             self.client
@@ -706,11 +720,25 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
 // ── build() — only available when all 4 required fields are Provided ─────
 
 impl BotBuilder<Provided, Provided, Provided, Provided> {
+    /// Boxed barrier: see [`Bot::run`]. Building the client wires every cache
+    /// and background loop, so an unboxed await here would duplicate that
+    /// whole construction graph into the consumer crate.
+    pub async fn build(self) -> std::result::Result<Bot, BotBuilderError> {
+        self.build_boxed().await
+    }
+
+    #[inline(never)]
+    fn build_boxed(
+        self,
+    ) -> wacore::runtime::BoxFuture<'static, std::result::Result<Bot, BotBuilderError>> {
+        Box::pin(self.build_graph())
+    }
+
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.bot.build", level = "debug", skip_all, err(Debug))
     )]
-    pub async fn build(self) -> std::result::Result<Bot, BotBuilderError> {
+    async fn build_graph(self) -> std::result::Result<Bot, BotBuilderError> {
         // Destructure to extract required fields — typestate guarantees all are Some.
         let (Some(runtime), Some(backend), Some(transport_factory), Some(http_client)) = (
             self.runtime,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -377,11 +377,25 @@ impl Client {
         info!("Client run loop has shut down.");
     }
 
+    /// Boxed barrier: see [`crate::bot::Bot::run`]. Coroutines are LocalCopy
+    /// across crates, so consumers awaiting the connect graph directly would
+    /// re-codegen it; the box makes them poll through a vtable instead.
+    pub async fn connect(self: &Arc<Self>) -> Result<(), anyhow::Error> {
+        self.connect_boxed().await
+    }
+
+    #[inline(never)]
+    fn connect_boxed(
+        self: &Arc<Self>,
+    ) -> wacore::runtime::BoxFuture<'_, Result<(), anyhow::Error>> {
+        Box::pin(self.connect_graph())
+    }
+
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.conn.connect", level = "info", skip_all, err(Debug))
     )]
-    pub async fn connect(self: &Arc<Self>) -> Result<(), anyhow::Error> {
+    async fn connect_graph(self: &Arc<Self>) -> Result<(), anyhow::Error> {
         if self.is_connecting.swap(true, Ordering::SeqCst) {
             return Err(ClientError::AlreadyConnected.into());
         }

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -59,6 +59,14 @@ pub trait Runtime: Send + Sync + 'static {
     }
 }
 
+/// Boxed future with the target-correct thread bound: `Send` on native
+/// (multi-threaded executors), none on wasm32 (single-threaded). Use this for
+/// type-erased entry-point futures so the same signature builds on both.
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
 /// Bound for futures a [`Runtime`] can spawn: `Send + 'static` on native
 /// (work-stealing executors move tasks across threads), just `'static` on wasm
 /// (single-threaded). Generic spawn helpers carry this one bound so they stay


### PR DESCRIPTION
## Problem

Coroutines (async fn state machines) are LocalCopy items across crates: any consumer crate that awaits a lib future codegens the entire state machine graph behind it into its own binary, with per-crate symbols that fat LTO cannot merge. Measured on the demo bin, the consumer crate re-instantiated ~1.8 MiB of the lib this way. Inline attributes do not change coroutine instantiation mode; I measured a `#[inline(never)]` sweep at exactly zero effect before landing on this design.

## Change

`Bot::build`, `Bot::run` and `Client::connect` keep their public `async fn` signatures but now delegate through a `#[inline(never)]` plain function that returns the real graph as `Pin<Box<dyn Future>>`. The consumer's copy of the entry point shrinks to a tiny shim coroutine that polls through a vtable, so the construction, run-loop and connect graphs are compiled exactly once, in the lib. Cost: one heap allocation per process for each entry point (they are all once-per-session).

## Measured

On top of #842: `.text` 11.85 MiB -> 11.74 MiB (-113 KiB); consumer-crate reinstantiation 1815 KiB -> 1484 KiB.

## What deliberately stays

The remaining consumer-side duplication is the send graph reached from user handler closures (`send_message_impl` and the cache coroutines it awaits). Erasing that would cost a `Box::pin` per outgoing message, the same per-message boxing #673 removed for allocation churn, so it stays static. The only stable-Rust alternative is `-Zshare-generics`, which is nightly.

## Tests

No signature or behavior changes; full wacore + lib suites pass (1838 tests).

