### PR TITLE
perf(retry): fuse the retry count and reason into one cache entry

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -436,15 +436,16 @@ pub struct Client {
     pub(crate) pending_retries: Arc<std::sync::Mutex<HashSet<String>>>,
 
     /// Track retry attempts per message to prevent infinite retry loops.
-    /// Key: "{chat}:{msg_id}:{sender}", Value: retry count
-    /// Matches WhatsApp Web's MAX_RETRY = 5 behavior.
-    pub(crate) message_retry_counts: Cache<String, u8>,
-
-    /// Most recent `RetryReason` we attached to a retry receipt for this
-    /// message (same key shape as `message_retry_counts`). Lets diagnostics
-    /// and regression tests distinguish which decrypt-failure arm actually
-    /// ran (the count alone can't separate NoSession from BadMac etc.).
-    pub(crate) recent_retry_reasons: Cache<String, wacore::protocol::retry::RetryReason>,
+    /// Key: "{chat}:{msg_id}:{sender}", Value: retry count plus the most
+    /// recent `RetryReason` we attached, fused so the decrypt-failure path
+    /// does one cache write and the binary carries one moka instantiation
+    /// instead of two. The reason is `None` when the count was learned from
+    /// the sender's echoed stanza `count` attribute rather than a local
+    /// decrypt failure; diagnostics and regression tests read it to tell
+    /// which failure arm ran (the count alone can't separate NoSession from
+    /// BadMac etc.). Matches WhatsApp Web's MAX_RETRY = 5 behavior.
+    pub(crate) message_retry_counts:
+        Cache<String, (u8, Option<wacore::protocol::retry::RetryReason>)>,
 
     /// Per-peer timestamp of the last forced session recreate via the
     /// "no keys + retry≥2 + >1h since last" path (whatsmeow parity).

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -183,8 +183,6 @@ impl Client {
 
             message_retry_counts: cache_config.message_retry_counts.build_with_ttl(),
 
-            recent_retry_reasons: cache_config.message_retry_counts.build_with_ttl(),
-
             session_recreate_history: cache_config.session_recreate_history.build_with_ttl(),
 
             undecryptable_dispatched: cache_config.undecryptable_dispatched.build_with_ttl(),

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -291,10 +291,12 @@ impl Client {
             let cache_key = self
                 .make_retry_cache_key(&info.source.chat, &info.id, &info.source.sender)
                 .await;
-            let existing = self.message_retry_counts.get(&cache_key).await.unwrap_or(0);
-            if max_sender_retry_count > existing {
+            let existing = self.message_retry_counts.get(&cache_key).await;
+            if max_sender_retry_count > existing.map_or(0, |(count, _)| count) {
+                // Keep any locally recorded reason; the echoed count carries none.
+                let reason = existing.and_then(|(_, reason)| reason);
                 self.message_retry_counts
-                    .insert(cache_key, max_sender_retry_count)
+                    .insert(cache_key, (max_sender_retry_count, reason))
                     .await;
             }
             log::debug!(

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -137,14 +137,13 @@ impl Client {
         let cache_key = cache_key.to_owned();
         let current = self.message_retry_counts.get(&cache_key).await;
         let new_count = match current {
-            Some(count) if count >= MAX_DECRYPT_RETRIES => return None,
-            Some(count) => count + 1,
+            Some((count, _)) if count >= MAX_DECRYPT_RETRIES => return None,
+            Some((count, _)) => count + 1,
             None => 1,
         };
         self.message_retry_counts
-            .insert(cache_key.clone(), new_count)
+            .insert(cache_key, (new_count, Some(reason)))
             .await;
-        self.recent_retry_reasons.insert(cache_key, reason).await;
         Some(new_count)
     }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -1011,7 +1011,11 @@ async fn migration_plaintext_failure_nacks_without_signal_retry() {
         .make_retry_cache_key(&info.source.chat, &info.id, &info.source.sender)
         .await;
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         None,
         "local protobuf failure after migration must not request Signal retry"
     );
@@ -1156,21 +1160,18 @@ async fn await_retry_receipt(
         .make_retry_cache_key(&info.source.chat, &info.id, &info.source.sender)
         .await;
     for _ in 0..200 {
-        if let (Some(c), Some(r)) = (
-            client.message_retry_counts.get(&cache_key).await,
-            client.recent_retry_reasons.get(&cache_key).await,
-        ) && c == expected_count
+        if let Some((c, Some(r))) = client.message_retry_counts.get(&cache_key).await
+            && c == expected_count
             && r == expected_reason
         {
             return;
         }
         tokio::time::sleep(std::time::Duration::from_millis(5)).await;
     }
-    let count = client.message_retry_counts.get(&cache_key).await;
-    let reason = client.recent_retry_reasons.get(&cache_key).await;
+    let state = client.message_retry_counts.get(&cache_key).await;
     panic!(
         "expected retry ({expected_count}, {expected_reason:?}) for {cache_key}, \
-             got ({count:?}, {reason:?})"
+             got {state:?}"
     );
 }
 
@@ -3439,7 +3440,11 @@ async fn test_increment_retry_count_starts_at_one() {
     assert_eq!(count, Some(1), "First retry should be count 1");
 
     // Verify it's stored in cache
-    let stored = client.message_retry_counts.get(cache_key).await;
+    let stored = client
+        .message_retry_counts
+        .get(cache_key)
+        .await
+        .map(|(c, _)| c);
     assert_eq!(stored, Some(1), "Cache should store count 1");
 }
 
@@ -3489,7 +3494,11 @@ async fn test_increment_retry_count_respects_max_retries() {
     );
 
     // Verify cache still has max value
-    let stored = client.message_retry_counts.get(cache_key).await;
+    let stored = client
+        .message_retry_counts
+        .get(cache_key)
+        .await
+        .map(|(c, _)| c);
     assert_eq!(stored, Some(5), "Cache should retain max count");
 }
 
@@ -3524,9 +3533,18 @@ async fn test_retry_count_different_messages_are_independent() {
         .await; // key3 = 2
 
     // Verify each has independent counts
-    assert_eq!(client.message_retry_counts.get(key1).await, Some(3));
-    assert_eq!(client.message_retry_counts.get(key2).await, Some(1));
-    assert_eq!(client.message_retry_counts.get(key3).await, Some(2));
+    assert_eq!(
+        client.message_retry_counts.get(key1).await.map(|(c, _)| c),
+        Some(3)
+    );
+    assert_eq!(
+        client.message_retry_counts.get(key2).await.map(|(c, _)| c),
+        Some(1)
+    );
+    assert_eq!(
+        client.message_retry_counts.get(key3).await.map(|(c, _)| c),
+        Some(2)
+    );
 }
 
 #[tokio::test]
@@ -3615,7 +3633,11 @@ async fn test_concurrent_retry_increments() {
     );
 
     // Final count should be 5 (max)
-    let final_count = client.message_retry_counts.get(cache_key).await;
+    let final_count = client
+        .message_retry_counts
+        .get(cache_key)
+        .await
+        .map(|(c, _)| c);
     assert_eq!(final_count, Some(5), "Final count should be capped at 5");
 }
 
@@ -3680,7 +3702,11 @@ async fn test_retry_count_cache_expiration() {
     assert_eq!(count, Some(1));
 
     // Entry should still exist immediately after
-    let stored = client.message_retry_counts.get(cache_key).await;
+    let stored = client
+        .message_retry_counts
+        .get(cache_key)
+        .await
+        .map(|(c, _)| c);
     assert!(
         stored.is_some(),
         "Entry should exist immediately after insert"
@@ -3703,7 +3729,12 @@ async fn test_spawn_retry_receipt_basic_flow() {
 
     // Verify count starts at 0
     assert!(
-        client.message_retry_counts.get(&cache_key).await.is_none(),
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c)
+            .is_none(),
         "Cache should be empty initially"
     );
 
@@ -3715,7 +3746,11 @@ async fn test_spawn_retry_receipt_basic_flow() {
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Verify count was incremented (the actual send will fail due to no connection, but count should update)
-    let stored = client.message_retry_counts.get(&cache_key).await;
+    let stored = client
+        .message_retry_counts
+        .get(&cache_key)
+        .await
+        .map(|(c, _)| c);
     assert_eq!(stored, Some(1), "Retry count should be 1 after spawn");
 }
 
@@ -3733,12 +3768,16 @@ async fn test_spawn_retry_receipt_respects_max_retries() {
     // Pre-fill cache to max retries
     client
         .message_retry_counts
-        .insert(cache_key.clone(), MAX_DECRYPT_RETRIES)
+        .insert(cache_key.clone(), (MAX_DECRYPT_RETRIES, None))
         .await;
 
     // Verify count is at max
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         Some(MAX_DECRYPT_RETRIES)
     );
 
@@ -3750,7 +3789,11 @@ async fn test_spawn_retry_receipt_respects_max_retries() {
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Count should still be at max (not incremented)
-    let stored = client.message_retry_counts.get(&cache_key).await;
+    let stored = client
+        .message_retry_counts
+        .get(&cache_key)
+        .await
+        .map(|(c, _)| c);
     assert_eq!(
         stored,
         Some(MAX_DECRYPT_RETRIES),
@@ -3813,12 +3856,12 @@ async fn test_multiple_senders_same_message_id_tracked_separately() {
 
     // Verify independent tracking
     assert_eq!(
-        client.message_retry_counts.get(&key1).await,
+        client.message_retry_counts.get(&key1).await.map(|(c, _)| c),
         Some(3),
         "Sender1 should have 3 retries"
     );
     assert_eq!(
-        client.message_retry_counts.get(&key2).await,
+        client.message_retry_counts.get(&key2).await.map(|(c, _)| c),
         Some(1),
         "Sender2 should have 1 retry"
     );
@@ -4112,12 +4155,22 @@ async fn test_no_sender_key_sends_immediate_retry() {
         .await;
     for _ in 0..20 {
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-        if client.message_retry_counts.get(&retry_key).await.is_some() {
+        if client
+            .message_retry_counts
+            .get(&retry_key)
+            .await
+            .map(|(c, _)| c)
+            .is_some()
+        {
             break;
         }
     }
     assert_eq!(
-        client.message_retry_counts.get(&retry_key).await,
+        client
+            .message_retry_counts
+            .get(&retry_key)
+            .await
+            .map(|(c, _)| c),
         Some(1),
         "NoSenderKeyState should immediately trigger retry receipt (count=1)"
     );
@@ -4475,7 +4528,11 @@ async fn test_revoked_message_still_retries() {
         .make_retry_cache_key(&info.source.chat, &info.id, &info.source.sender)
         .await;
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         Some(1),
         "revoked message should still have retry count 1 (WA Web retries all messages)"
     );
@@ -4494,15 +4551,25 @@ async fn test_enc_count_preseeds_retry_cache() {
         .make_retry_cache_key(&chat_jid, msg_id, &chat_jid)
         .await;
     // Insert only if absent (portable alternative to moka's entry_by_ref().or_insert())
-    if client.message_retry_counts.get(&cache_key).await.is_none() {
+    if client
+        .message_retry_counts
+        .get(&cache_key)
+        .await
+        .map(|(c, _)| c)
+        .is_none()
+    {
         client
             .message_retry_counts
-            .insert(cache_key.clone(), max_sender_retry_count)
+            .insert(cache_key.clone(), (max_sender_retry_count, None))
             .await;
     }
 
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         Some(3),
         "cache should be pre-seeded with sender retry count"
     );
@@ -4521,10 +4588,16 @@ async fn test_enc_no_count_cache_empty() {
         let cache_key = client
             .make_retry_cache_key(&chat_jid, msg_id, &chat_jid)
             .await;
-        if client.message_retry_counts.get(&cache_key).await.is_none() {
+        if client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c)
+            .is_none()
+        {
             client
                 .message_retry_counts
-                .insert(cache_key, max_sender_retry_count)
+                .insert(cache_key, (max_sender_retry_count, None))
                 .await;
         }
     }
@@ -4533,7 +4606,12 @@ async fn test_enc_no_count_cache_empty() {
         .make_retry_cache_key(&chat_jid, msg_id, &chat_jid)
         .await;
     assert!(
-        client.message_retry_counts.get(&cache_key).await.is_none(),
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c)
+            .is_none(),
         "cache should be empty when no count attribute"
     );
 }
@@ -4552,7 +4630,7 @@ async fn test_enc_count_does_not_overwrite_higher() {
     // Pre-insert a higher value
     client
         .message_retry_counts
-        .insert(cache_key.clone(), 4)
+        .insert(cache_key.clone(), (4, None))
         .await;
 
     // max(existing, incoming) should NOT overwrite with a lower value
@@ -4561,16 +4639,21 @@ async fn test_enc_count_does_not_overwrite_higher() {
         .message_retry_counts
         .get(&cache_key)
         .await
+        .map(|(c, _)| c)
         .unwrap_or(0);
     if max_sender_retry_count > existing {
         client
             .message_retry_counts
-            .insert(cache_key.clone(), max_sender_retry_count)
+            .insert(cache_key.clone(), (max_sender_retry_count, None))
             .await;
     }
 
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         Some(4),
         "should not overwrite existing higher value"
     );
@@ -4590,7 +4673,7 @@ async fn test_enc_count_updates_when_sender_higher() {
     // Pre-insert a lower value
     client
         .message_retry_counts
-        .insert(cache_key.clone(), 1)
+        .insert(cache_key.clone(), (1, None))
         .await;
 
     // max(existing, incoming) SHOULD update with a higher value
@@ -4599,16 +4682,21 @@ async fn test_enc_count_updates_when_sender_higher() {
         .message_retry_counts
         .get(&cache_key)
         .await
+        .map(|(c, _)| c)
         .unwrap_or(0);
     if max_sender_retry_count > existing {
         client
             .message_retry_counts
-            .insert(cache_key.clone(), max_sender_retry_count)
+            .insert(cache_key.clone(), (max_sender_retry_count, None))
             .await;
     }
 
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         Some(3),
         "should update to higher sender count"
     );
@@ -4879,7 +4967,14 @@ async fn test_undecryptable_fires_before_retry_task() {
         .await;
 
     assert!(recorder.undecryptable().is_empty());
-    assert!(client.message_retry_counts.get(&cache_key).await.is_none());
+    assert!(
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c)
+            .is_none()
+    );
 
     let _ = client
         .handle_decrypt_failure(&info, RetryReason::InvalidKeyId, DecryptFailMode::Show)
@@ -4891,13 +4986,22 @@ async fn test_undecryptable_fires_before_retry_task() {
         "UndecryptableMessage dispatched inside handle_decrypt_failure",
     );
     assert!(
-        client.message_retry_counts.get(&cache_key).await.is_none(),
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c)
+            .is_none(),
         "retry task has not progressed yet",
     );
 
     tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
     assert_eq!(
-        client.message_retry_counts.get(&cache_key).await,
+        client
+            .message_retry_counts
+            .get(&cache_key)
+            .await
+            .map(|(c, _)| c),
         Some(1),
         "retry task runs after the dispatch",
     );


### PR DESCRIPTION
## Problem

`recent_retry_reasons` existed only so diagnostics and regression tests could tell which decrypt-failure arm produced a retry (the count alone can't separate NoSession from BadMac). As a separate `Cache<String, RetryReason>` it cost a full extra moka instantiation in every consumer binary (~60 KiB of duplicated cache codegen per crate that touches it, found by the cargo-bloat audit) plus a second cache insert and a `cache_key` clone on every decrypt failure.

## Change

The reason now rides in the `message_retry_counts` value as `(u8, Option<RetryReason>)`:

- `increment_retry_count` does one insert (no key clone) and records `Some(reason)`.
- Counts learned from the sender's echoed stanza `count` attribute carry no local failure reason; that path now stores `None` and preserves a previously recorded reason instead of implicitly dropping the pairing (before, the count moved ahead while the reasons cache kept a stale entry).
- The `await_retry_receipt` test helper reads one fused entry instead of polling two caches.

No public API or `CacheConfig` change: the reasons cache was internal and had no config entry of its own (it reused `message_retry_counts`'s).

## Tests

Full lib suite passes (830 tests), including the retry-reason regression tests now asserting on the fused entry.
