### PR TITLE
perf(wacore): drop the proto PartialEq anchor from the skdm-only check

### DIFF
--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -422,7 +422,9 @@ pub fn is_sender_key_distribution_only(msg: &mut wa::Message) -> bool {
     let fast = msg.fast_ratchet_key_sender_key_distribution_message.take();
     let ctx = msg.message_context_info.take();
 
-    let only = *msg == wa::Message::default();
+    // Same predicate as `== Message::default()` (proto2 fields only encode
+    // when set), without anchoring prost's derived PartialEq tree.
+    let only = waproto::codec::message_encoded_len(msg) == 0;
 
     msg.sender_key_distribution_message = skdm;
     msg.fast_ratchet_key_sender_key_distribution_message = fast;


### PR DESCRIPTION
## Problem

`cargo llvm-lines` flagged prost's derived `PartialEq` as the largest codegen item in wacore (`Message::eq` alone is 4.2k IR lines, with the whole nested tree behind it). In the release binary that materializes as 94 KiB of `.text` across 148 `eq` functions, and symbol tracing showed exactly one production caller keeping all of it alive: the skdm-only check in `wacore::messages`, which compares the carrier-stripped message against `Message::default()`.

## Change

`encoded_len() == 0` is the same predicate: under proto2 presence rules a field only contributes encoded bytes when it is set, so zero encoded length means every remaining field is unset, which is exactly equality with `Message::default()`. It routes through `waproto::codec::message_encoded_len`, the tree already pinned by #842, so no new codegen appears anywhere.

Cost-wise the paths are equivalent where it matters: for a true skdm-only message both walks visit every (unset) field once; the fast path above the slow path still short-circuits typical content messages before either runs.

## Measured

Release bin: `.text` 11.65 MiB -> 11.55 MiB (**-102 KiB**); proto `eq` impls 148 -> 0. Unlike the Dockerfile flags, this one applies to stable and nightly consumers alike.

## Tests

wacore (1008) and lib (830) suites pass; the skdm-only behavior is locked by the existing dedicated tests.
