### PR TITLE
perf(appstate): pre-key the ltHash HKDF extract once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "codspeed-divan-compat",
  "hex",
  "hkdf",
+ "hmac",
  "log",
  "prost",
  "serde",

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 bytemuck = { workspace = true }
 hex = { workspace = true }
 hkdf = { workspace = true }
+hmac = { workspace = true }
 log = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -1,7 +1,16 @@
 #[cfg(feature = "simd")]
 use core::simd::u16x8;
 use hkdf::Hkdf;
+use hmac::digest::KeyInit;
+use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::sync::LazyLock;
+
+/// HKDF-extract with no salt keys HMAC with a zero block, identical for every
+/// input, so the key-schedule compressions run once and each derivation
+/// clones the keyed state.
+static EXTRACT_HMAC: LazyLock<Hmac<Sha256>> =
+    LazyLock::new(|| Hmac::<Sha256>::new_from_slice(&[0u8; 32]).expect("32-byte HMAC key"));
 
 #[derive(Clone, Debug)]
 pub struct LTHash {
@@ -42,7 +51,7 @@ impl LTHash {
         let mut derived = [0u8; u8::MAX as usize + 1];
         let derived = &mut derived[..self.hkdf_size as usize];
         for item in input {
-            hkdf_sha256_into(item.as_ref(), None, self.hkdf_info, derived);
+            hkdf_sha256_into(item.as_ref(), self.hkdf_info, derived);
             perform_pointwise_with_overflow(base, derived, subtract);
         }
     }
@@ -119,8 +128,11 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
     }
 }
 
-fn hkdf_sha256_into(key: &[u8], salt: Option<&[u8]>, info: &[u8], out: &mut [u8]) {
-    let hk = Hkdf::<Sha256>::new(salt, key);
+fn hkdf_sha256_into(key: &[u8], info: &[u8], out: &mut [u8]) {
+    let mut extract = EXTRACT_HMAC.clone();
+    extract.update(key);
+    let prk = extract.finalize().into_bytes();
+    let hk = Hkdf::<Sha256>::from_prk(&prk).expect("PRK is hash-sized");
     hk.expand(info, out).expect("hkdf expand");
 }
 
@@ -129,6 +141,22 @@ mod tests {
     use super::*;
 
     const EMPTY: &[Vec<u8>] = &[];
+
+    /// The pre-keyed extract must stay byte-identical to plain
+    /// `Hkdf::new(None, key)`; any drift would corrupt every ltHash.
+    #[test]
+    fn pre_keyed_extract_matches_plain_hkdf() {
+        let mut ours = [0u8; 128];
+        let mut reference = [0u8; 128];
+        for i in 0..16u8 {
+            let key = [i.wrapping_mul(17); 32];
+            hkdf_sha256_into(&key, WAPATCH_INTEGRITY_INFO.as_bytes(), &mut ours);
+            Hkdf::<Sha256>::new(None, &key)
+                .expand(WAPATCH_INTEGRITY_INFO.as_bytes(), &mut reference)
+                .expect("hkdf expand");
+            assert_eq!(ours, reference);
+        }
+    }
 
     #[test]
     fn pointwise_add_and_subtract() {

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -146,12 +146,15 @@ mod tests {
     /// `Hkdf::new(None, key)`; any drift would corrupt every ltHash.
     #[test]
     fn pre_keyed_extract_matches_plain_hkdf() {
+        let mut keys: Vec<Vec<u8>> = (0..16u8).map(|i| vec![i.wrapping_mul(17); 32]).collect();
+        keys.push(Vec::new());
+        keys.push(vec![0xAB; 3]);
+
         let mut ours = [0u8; 128];
         let mut reference = [0u8; 128];
-        for i in 0..16u8 {
-            let key = [i.wrapping_mul(17); 32];
-            hkdf_sha256_into(&key, WAPATCH_INTEGRITY_INFO.as_bytes(), &mut ours);
-            Hkdf::<Sha256>::new(None, &key)
+        for key in &keys {
+            hkdf_sha256_into(key, WAPATCH_INTEGRITY_INFO.as_bytes(), &mut ours);
+            Hkdf::<Sha256>::new(None, key)
                 .expand(WAPATCH_INTEGRITY_INFO.as_bytes(), &mut reference)
                 .expect("hkdf expand");
             assert_eq!(ours, reference);


### PR DESCRIPTION
## Problem

The CodSpeed flamegraph for `bench_lthash_subtract_then_add_812` (14.7 ms, Simulation) is 95.5% `sha2::compress256` inside the per-MAC HKDF: every MAC pays a full extract (~35% of the bench) plus expand (~65%). The expand side has no slack (the PRK differs per MAC and the hkdf crate already reuses the keyed state across its four output blocks), but the extract side keys HMAC with the same value for every single MAC: ltHash uses no salt, which RFC 5869 defines as a zero hash-length block.

## Change

The extract's keyed HMAC state (the ipad/opad key-schedule compressions) is now computed once in a `LazyLock` and cloned per derivation; the PRK then feeds `Hkdf::from_prk` as before. That removes two of the ~17 compressions each MAC costs, with byte-identical output. Same pattern as the PBKDF2 keying fix in #691.

Equivalence is pinned by a differential test comparing the new path against plain `Hkdf::new(None, key)` across multiple keys; the existing ltHash and patch-processing suites cover the rest.

## Measured

Local wall-time A/B on the 812-MAC bench (SHA-NI host): median 707 -> 670 us, mean 735 -> 654 us. The Simulation runner takes the software SHA path where the extract weighs more, so the CodSpeed report on this PR should show a larger relative win.

## Tests

appstate (37, including the new differential test), wacore and lib suites pass; clippy strict clean.
