### PR TITLE
perf(binary): emit the Jid display as one write_str

### DIFF
--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -847,9 +847,63 @@ pub fn push_jid_to_compact(
     write_jid!(infallible buf, user, server, agent, device);
 }
 
+/// Stack writer sized for any realistic JID, so `Display` can emit a single
+/// `write_str`: a `ToString`-backed `String` then reserves once at the exact
+/// length instead of reallocating per fragment. Overflow errors out and the
+/// caller falls back to direct fragment writes.
+struct JidStackWriter {
+    buf: [u8; 64],
+    len: usize,
+}
+
+impl JidStackWriter {
+    #[inline]
+    fn new() -> Self {
+        Self {
+            buf: [0; 64],
+            len: 0,
+        }
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        // Whole `&str` fragments are appended, never split, so the bytes
+        // stay valid UTF-8.
+        std::str::from_utf8(&self.buf[..self.len]).expect("concatenated str fragments")
+    }
+}
+
+impl fmt::Write for JidStackWriter {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let end = self.len + s.len();
+        if end > self.buf.len() {
+            return Err(fmt::Error);
+        }
+        self.buf[self.len..end].copy_from_slice(s.as_bytes());
+        self.len = end;
+        Ok(())
+    }
+}
+
+#[inline]
+fn write_jid_fallible<W: fmt::Write>(
+    w: &mut W,
+    user: &str,
+    server: Server,
+    agent: u8,
+    device: u16,
+) -> fmt::Result {
+    write_jid!(fallible w, user, server, agent, device)
+}
+
 impl fmt::Display for Jid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_jid!(fallible f, &*self.user, self.server, self.agent, self.device)
+        let mut w = JidStackWriter::new();
+        if write_jid_fallible(&mut w, &self.user, self.server, self.agent, self.device).is_ok() {
+            return f.write_str(w.as_str());
+        }
+        write_jid_fallible(f, &self.user, self.server, self.agent, self.device)
     }
 }
 
@@ -953,7 +1007,11 @@ impl fmt::Display for ObservedJid<'_> {
 
 impl<'a> fmt::Display for JidRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_jid!(fallible f, &*self.user, self.server, self.agent, self.device)
+        let mut w = JidStackWriter::new();
+        if write_jid_fallible(&mut w, &self.user, self.server, self.agent, self.device).is_ok() {
+            return f.write_str(w.as_str());
+        }
+        write_jid_fallible(f, &self.user, self.server, self.agent, self.device)
     }
 }
 


### PR DESCRIPTION
## Problem

`bench_jid_to_string` sat at 3.4 µs in Simulation while `bench_jid_to_non_ad_string` (which builds the same string through the pre-sized `push_to` path) sat at 1 µs. The CodSpeed flamegraph explains the gap: 72% of the time is inside the allocator. `ToString` starts from an empty `String`, and `Jid`'s `Display` wrote up to seven fragments (`user`, `.`, `agent`, `:`, `device`, `@`, `server`), so every `jid.to_string()` paid one malloc plus a realloc chain as the buffer grew fragment by fragment.

`to_string()` on JIDs runs all over the warm paths: every `MessageKey` build, receipts, stanza attributes, PDO keys.

## Change

`Display` now renders the JID into a 64-byte stack writer first and emits a single `write_str`, so a `ToString`-backed `String` reserves once at the exact final length. The buffer covers any realistic JID (longest server suffix is 14 bytes and user parts are bounded in practice); an oversized user part falls back to the previous fragment-by-fragment writes, so behavior is unchanged for every input. Same change for `JidRef`. No unsafe: the stack bytes are validated as UTF-8 once before the final write (whole `&str` fragments are appended, so this cannot fail).

`format!`/log sites also benefit slightly (one `write_str` into the format buffer instead of seven); padding/width specifiers behave exactly as before (the old impl already bypassed `Formatter::pad`).

## Measured

Local wall-time A/B on `bench_jid_to_string`: median 176.7 ns -> 69.7 ns. The CodSpeed report on this PR has the Simulation numbers.

## Tests

wacore-binary, wacore and lib suites pass (1942 tests); clippy strict clean. Display output is pinned by the existing JID round-trip and formatting tests.
