### PR TITLE
bench: borrow inputs in the benches that only read them

### DIFF
--- a/wacore/benches/reporting_token_benchmark.rs
+++ b/wacore/benches/reporting_token_benchmark.rs
@@ -51,18 +51,14 @@ fn setup_extended_message() -> wa::Message {
 fn bench_content_extraction_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_simple_message)
-        .bench_values(|msg| {
-            let _ = black_box(generate_reporting_token_content(&msg));
-        });
+        .bench_refs(|msg| black_box(generate_reporting_token_content(msg)));
 }
 
 #[divan::bench]
 fn bench_content_extraction_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_extended_message)
-        .bench_values(|msg| {
-            let _ = black_box(generate_reporting_token_content(&msg));
-        });
+        .bench_refs(|msg| black_box(generate_reporting_token_content(msg)));
 }
 
 // Key derivation benchmark
@@ -117,14 +113,14 @@ fn setup_full_gen_extended() -> FullGenSetup {
 fn bench_full_token_generation_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_full_gen_simple)
-        .bench_values(|data| {
-            let _ = black_box(generate_reporting_token(
+        .bench_refs(|data| {
+            black_box(generate_reporting_token(
                 &data.msg,
                 "STANZA123",
                 &data.sender,
                 &data.remote,
                 Some(&data.secret),
-            ));
+            ))
         });
 }
 
@@ -132,14 +128,14 @@ fn bench_full_token_generation_simple(bencher: divan::Bencher) {
 fn bench_full_token_generation_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_full_gen_extended)
-        .bench_values(|data| {
-            let _ = black_box(generate_reporting_token(
+        .bench_refs(|data| {
+            black_box(generate_reporting_token(
                 &data.msg,
                 "STANZA123",
                 &data.sender,
                 &data.remote,
                 Some(&data.secret),
-            ));
+            ))
         });
 }
 
@@ -148,12 +144,12 @@ fn bench_full_token_generation_extended(bencher: divan::Bencher) {
 fn bench_message_encoding_simple(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_simple_message)
-        .bench_values(|msg| black_box(msg.encode_to_vec()));
+        .bench_refs(|msg| black_box(msg.encode_to_vec()));
 }
 
 #[divan::bench]
 fn bench_message_encoding_extended(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_extended_message)
-        .bench_values(|msg| black_box(msg.encode_to_vec()));
+        .bench_refs(|msg| black_box(msg.encode_to_vec()));
 }

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -378,7 +378,7 @@ fn bench_roundtrip_exact_large(bencher: divan::Bencher) {
 fn bench_get_children_by_tag(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_usync_like_node)
-        .bench_values(|node| {
+        .bench_refs(|node| {
             let usync = node.get_optional_child("usync").unwrap();
             let list = usync.get_optional_child("list").unwrap();
 
@@ -411,7 +411,7 @@ fn setup_jid_heavy_marshaled() -> Vec<u8> {
 fn bench_jid_to_owned_access(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_jid_heavy_marshaled)
-        .bench_values(|marshaled| {
+        .bench_refs(|marshaled| {
             // Skip the flag byte at position 0
             let node_ref = unmarshal_ref(&marshaled[1..]).unwrap();
 
@@ -427,5 +427,6 @@ fn bench_jid_to_owned_access(bencher: divan::Bencher) {
             black_box(parser.optional_jid("notify"));
             black_box(parser.optional_string("id"));
             black_box(parser.optional_string("type"));
+            node
         });
 }


### PR DESCRIPTION
Follow-up to #837, found while flamegraphing `bench_get_children_by_tag` (57.1 us in Simulation): 66% of that time is `drop_in_place` of the input Node tree, because the bench consumed its pre-built input with `bench_values` and the drop ran inside the measured window. The actual traversal costs about 2 us.

Eight benches had the pattern: `get_children_by_tag`, `jid_to_owned_access`, the six reporting-token benches (content extraction, full generation, message encoding). All of them only read the input, so they now use `bench_refs`, and values produced inside the closure are returned so divan drops them outside the timing. `process_history_sync` keeps `bench_values`: that operation genuinely takes ownership of its blob, so the consume is part of the measured contract (and its result was already returned).

The CodSpeed report on this PR will show large "improvements" on these eight benchmarks; that is measurement correction, not a performance change. No library code is touched.