### PR TITLE
perf(noise): pre-key the transport AES-GCM once per connection

### DIFF
--- a/wacore/libsignal/src/crypto/aes_gcm.rs
+++ b/wacore/libsignal/src/crypto/aes_gcm.rs
@@ -26,18 +26,24 @@ struct GcmGhash {
 
 impl GcmGhash {
     fn new(h: &[u8; TAG_SIZE], ghash_pad: [u8; TAG_SIZE], associated_data: &[u8]) -> Result<Self> {
-        let mut ghash = GHash::new(h.into());
+        Ok(Self::from_keyed(
+            GHash::new(h.into()),
+            ghash_pad,
+            associated_data,
+        ))
+    }
 
+    fn from_keyed(mut ghash: GHash, ghash_pad: [u8; TAG_SIZE], associated_data: &[u8]) -> Self {
         ghash.update_padded(associated_data);
 
-        Ok(Self {
+        Self {
             ghash,
             ghash_pad,
             msg_buf: [0u8; TAG_SIZE],
             msg_buf_offset: 0,
             ad_len: associated_data.len(),
             msg_len: 0,
-        })
+        }
     }
 
     fn update(&mut self, msg: &[u8]) {
@@ -122,6 +128,43 @@ fn setup_gcm(key: &[u8], nonce: &[u8], associated_data: &[u8]) -> Result<(Aes256
     Ok((ctr, ghash))
 }
 
+/// Key-dependent AES-256-GCM state computed once: the AES key schedule and
+/// the keyed GHASH outlive individual seals when the key never changes (the
+/// Noise transport key lives for a whole connection), leaving only the
+/// nonce-dependent setup per call.
+#[derive(Clone)]
+pub struct Aes256GcmKey {
+    cipher: Aes256,
+    keyed_ghash: GHash,
+}
+
+impl Aes256GcmKey {
+    pub fn new(key: &[u8]) -> Result<Self> {
+        let cipher = Aes256::new_from_slice(key).map_err(|_| Error::InvalidKeySize)?;
+        let mut h: Block<Aes256> = [0u8; TAG_SIZE].into();
+        cipher.encrypt_block(&mut h);
+        let h: [u8; TAG_SIZE] = h.into();
+        Ok(Self {
+            cipher,
+            keyed_ghash: GHash::new((&h).into()),
+        })
+    }
+
+    fn setup(&self, nonce: &[u8], associated_data: &[u8]) -> Result<(Aes256Ctr32, GcmGhash)> {
+        if nonce.len() != NONCE_SIZE {
+            return Err(Error::InvalidNonceSize);
+        }
+
+        let mut ctr = Aes256Ctr32::new(self.cipher.clone(), nonce, 1)?;
+
+        let mut ghash_pad = [0u8; 16];
+        ctr.process(&mut ghash_pad);
+
+        let ghash = GcmGhash::from_keyed(self.keyed_ghash.clone(), ghash_pad, associated_data);
+        Ok((ctr, ghash))
+    }
+}
+
 pub struct Aes256GcmEncryption {
     ctr: Aes256Ctr32,
     ghash: GcmGhash,
@@ -133,6 +176,11 @@ impl Aes256GcmEncryption {
 
     pub fn new(key: &[u8], nonce: &[u8], associated_data: &[u8]) -> Result<Self> {
         let (ctr, ghash) = setup_gcm(key, nonce, associated_data)?;
+        Ok(Self { ctr, ghash })
+    }
+
+    pub fn new_with_key(key: &Aes256GcmKey, nonce: &[u8], associated_data: &[u8]) -> Result<Self> {
+        let (ctr, ghash) = key.setup(nonce, associated_data)?;
         Ok(Self { ctr, ghash })
     }
 
@@ -157,6 +205,11 @@ impl Aes256GcmDecryption {
 
     pub fn new(key: &[u8], nonce: &[u8], associated_data: &[u8]) -> Result<Self> {
         let (ctr, ghash) = setup_gcm(key, nonce, associated_data)?;
+        Ok(Self { ctr, ghash })
+    }
+
+    pub fn new_with_key(key: &Aes256GcmKey, nonce: &[u8], associated_data: &[u8]) -> Result<Self> {
+        let (ctr, ghash) = key.setup(nonce, associated_data)?;
         Ok(Self { ctr, ghash })
     }
 
@@ -507,5 +560,45 @@ mod tests {
         dec.decrypt(&mut decrypted);
         dec.verify_tag(&expected_tag).unwrap();
         assert_eq!(decrypted, plaintext);
+    }
+
+    /// The pre-keyed path must stay byte-identical to the per-call setup;
+    /// any drift would corrupt every Noise frame.
+    #[test]
+    fn pre_keyed_matches_per_call_setup() {
+        let key = [0x42u8; 32];
+        let pre_keyed = Aes256GcmKey::new(&key).unwrap();
+
+        for (i, len) in [0usize, 1, 15, 16, 17, 1500, 4096].iter().enumerate() {
+            let mut nonce = [0u8; NONCE_SIZE];
+            nonce[11] = i as u8;
+            let aad: &[u8] = if i % 2 == 0 { b"" } else { b"associated" };
+            let plaintext: Vec<u8> = (0..*len).map(|b| b as u8).collect();
+
+            let mut plain_ct = plaintext.clone();
+            let mut enc = Aes256GcmEncryption::new(&key, &nonce, aad).unwrap();
+            enc.encrypt(&mut plain_ct);
+            let plain_tag = enc.compute_tag();
+
+            let mut pk_ct = plaintext.clone();
+            let mut enc = Aes256GcmEncryption::new_with_key(&pre_keyed, &nonce, aad).unwrap();
+            enc.encrypt(&mut pk_ct);
+            let pk_tag = enc.compute_tag();
+
+            assert_eq!(plain_ct, pk_ct);
+            assert_eq!(plain_tag, pk_tag);
+
+            let mut dec = Aes256GcmDecryption::new_with_key(&pre_keyed, &nonce, aad).unwrap();
+            dec.decrypt(&mut pk_ct);
+            dec.verify_tag(&pk_tag).unwrap();
+            assert_eq!(pk_ct, plaintext);
+
+            let mut bad_tag = pk_tag;
+            bad_tag[0] ^= 1;
+            let mut ct_again = plain_ct.clone();
+            let mut dec = Aes256GcmDecryption::new_with_key(&pre_keyed, &nonce, aad).unwrap();
+            dec.decrypt(&mut ct_again);
+            assert!(dec.verify_tag(&bad_tag).is_err());
+        }
     }
 }

--- a/wacore/libsignal/src/crypto/mod.rs
+++ b/wacore/libsignal/src/crypto/mod.rs
@@ -15,7 +15,7 @@ pub use aes_cbc::{
     DecryptionError, EncryptionError, aes_256_cbc_decrypt_into, aes_256_cbc_encrypt_into,
 };
 pub use aes_ctr::Aes256Ctr32;
-pub use aes_gcm::{Aes256GcmDecryption, Aes256GcmEncryption};
+pub use aes_gcm::{Aes256GcmDecryption, Aes256GcmEncryption, Aes256GcmKey};
 pub use error::{Error, Result};
 pub use hash::{
     CryptographicHash, CryptographicMac, SHA1_OUTPUT_SIZE, SHA256_OUTPUT_SIZE, SHA512_OUTPUT_SIZE,

--- a/wacore/libsignal/src/crypto/mod.rs
+++ b/wacore/libsignal/src/crypto/mod.rs
@@ -21,9 +21,19 @@ pub use hash::{
     CryptographicHash, CryptographicMac, SHA1_OUTPUT_SIZE, SHA256_OUTPUT_SIZE, SHA512_OUTPUT_SIZE,
 };
 pub use provider::{
-    CryptoProviderError, GcmInPlaceBuffer, RustCryptoProvider, SignalCryptoProvider,
+    CryptoProviderError, GcmInPlaceBuffer, RustCryptoProvider, SignalCryptoProvider, TransportAead,
     set_crypto_provider,
 };
+
+/// Connection-lifetime transport AEAD for one fixed key, from the active
+/// [`SignalCryptoProvider`]. The default RustCrypto path precomputes the
+/// key-dependent state once.
+#[inline]
+pub fn transport_aead(
+    key: &[u8; 32],
+) -> std::result::Result<Box<dyn TransportAead>, CryptoProviderError> {
+    provider::provider().transport_aead(key)
+}
 
 /// AES-256-GCM seal. Appends `ciphertext || tag(16)` to `out`.
 /// Delegates to the active [`SignalCryptoProvider`].

--- a/wacore/libsignal/src/crypto/provider.rs
+++ b/wacore/libsignal/src/crypto/provider.rs
@@ -13,7 +13,7 @@ use bytes::BytesMut;
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
-use crate::crypto::aes_gcm::{Aes256GcmDecryption, Aes256GcmEncryption};
+use crate::crypto::aes_gcm::{Aes256GcmDecryption, Aes256GcmEncryption, Aes256GcmKey};
 
 const GCM_TAG: usize = 16;
 
@@ -81,6 +81,52 @@ pub enum CryptoProviderError {
     AuthFailed,
     /// provider backend reported failure
     BackendFailed,
+}
+
+/// Connection-lifetime AES-256-GCM handle for the Noise transport: one key,
+/// many nonces. Lets a provider precompute key-dependent state once instead
+/// of per frame; the default routes every call through the configured
+/// provider so custom providers keep observing transport crypto.
+pub trait TransportAead: Send + Sync {
+    fn encrypt_in_place(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        buffer: &mut dyn GcmInPlaceBuffer,
+    ) -> Result<(), CryptoProviderError>;
+
+    fn decrypt_in_place(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        buffer: &mut dyn GcmInPlaceBuffer,
+    ) -> Result<(), CryptoProviderError>;
+}
+
+/// Default [`TransportAead`]: per-call dispatch through the configured
+/// provider, with no precomputed state.
+struct PerCallTransportAead {
+    key: [u8; 32],
+}
+
+impl TransportAead for PerCallTransportAead {
+    fn encrypt_in_place(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        buffer: &mut dyn GcmInPlaceBuffer,
+    ) -> Result<(), CryptoProviderError> {
+        provider().aes_256_gcm_encrypt_in_place(&self.key, nonce, aad, buffer)
+    }
+
+    fn decrypt_in_place(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        buffer: &mut dyn GcmInPlaceBuffer,
+    ) -> Result<(), CryptoProviderError> {
+        provider().aes_256_gcm_decrypt_in_place(&self.key, nonce, aad, buffer)
+    }
 }
 
 /// Pluggable crypto primitives used by libsignal and higher-level callers.
@@ -170,6 +216,16 @@ pub trait SignalCryptoProvider: Send + Sync + 'static {
         buffer.resize(out.len(), 0);
         buffer.as_mut_slice().copy_from_slice(&out);
         Ok(())
+    }
+
+    /// Connection-lifetime transport AEAD for one fixed key. Default keeps
+    /// per-call dispatch through the configured provider; override to
+    /// precompute key-dependent state (key schedule, GHASH subkey) once.
+    fn transport_aead(
+        &self,
+        key: &[u8; 32],
+    ) -> Result<Box<dyn TransportAead>, CryptoProviderError> {
+        Ok(Box::new(PerCallTransportAead { key: *key }))
     }
 }
 
@@ -329,6 +385,56 @@ impl SignalCryptoProvider for RustCryptoProvider {
 
         let mut dec =
             Aes256GcmDecryption::new(key, nonce, aad).map_err(|_| CryptoProviderError::BadInput)?;
+        dec.decrypt(&mut buffer.as_mut_slice()[..pt_len]);
+        dec.verify_tag(&tag)
+            .map_err(|_| CryptoProviderError::AuthFailed)?;
+        buffer.truncate(pt_len);
+        Ok(())
+    }
+
+    fn transport_aead(
+        &self,
+        key: &[u8; 32],
+    ) -> Result<Box<dyn TransportAead>, CryptoProviderError> {
+        Ok(Box::new(
+            Aes256GcmKey::new(key).map_err(|_| CryptoProviderError::BadInput)?,
+        ))
+    }
+}
+
+impl TransportAead for Aes256GcmKey {
+    fn encrypt_in_place(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        buffer: &mut dyn GcmInPlaceBuffer,
+    ) -> Result<(), CryptoProviderError> {
+        let plaintext_len = buffer.len();
+        let mut enc = Aes256GcmEncryption::new_with_key(self, nonce, aad)
+            .map_err(|_| CryptoProviderError::BadInput)?;
+        enc.encrypt(buffer.as_mut_slice());
+        let tag = enc.compute_tag();
+        buffer.resize(plaintext_len + GCM_TAG, 0);
+        buffer.as_mut_slice()[plaintext_len..].copy_from_slice(&tag);
+        Ok(())
+    }
+
+    fn decrypt_in_place(
+        &self,
+        nonce: &[u8; 12],
+        aad: &[u8],
+        buffer: &mut dyn GcmInPlaceBuffer,
+    ) -> Result<(), CryptoProviderError> {
+        let total = buffer.len();
+        if total < GCM_TAG {
+            return Err(CryptoProviderError::BadInput);
+        }
+        let pt_len = total - GCM_TAG;
+        let mut tag = [0u8; GCM_TAG];
+        tag.copy_from_slice(&buffer.as_slice()[pt_len..]);
+
+        let mut dec = Aes256GcmDecryption::new_with_key(self, nonce, aad)
+            .map_err(|_| CryptoProviderError::BadInput)?;
         dec.decrypt(&mut buffer.as_mut_slice()[..pt_len]);
         dec.verify_tag(&tag)
             .map_err(|_| CryptoProviderError::AuthFailed)?;

--- a/wacore/libsignal/src/crypto/provider.rs
+++ b/wacore/libsignal/src/crypto/provider.rs
@@ -103,20 +103,22 @@ pub trait TransportAead: Send + Sync {
     ) -> Result<(), CryptoProviderError>;
 }
 
-/// Default [`TransportAead`]: per-call dispatch through the configured
-/// provider, with no precomputed state.
-struct PerCallTransportAead {
+/// Default [`TransportAead`]: per-call dispatch through the provider that
+/// created it, with no precomputed state.
+struct PerCallTransportAead<P: ?Sized + 'static> {
+    provider: &'static P,
     key: [u8; 32],
 }
 
-impl TransportAead for PerCallTransportAead {
+impl<P: SignalCryptoProvider + ?Sized> TransportAead for PerCallTransportAead<P> {
     fn encrypt_in_place(
         &self,
         nonce: &[u8; 12],
         aad: &[u8],
         buffer: &mut dyn GcmInPlaceBuffer,
     ) -> Result<(), CryptoProviderError> {
-        provider().aes_256_gcm_encrypt_in_place(&self.key, nonce, aad, buffer)
+        self.provider
+            .aes_256_gcm_encrypt_in_place(&self.key, nonce, aad, buffer)
     }
 
     fn decrypt_in_place(
@@ -125,7 +127,8 @@ impl TransportAead for PerCallTransportAead {
         aad: &[u8],
         buffer: &mut dyn GcmInPlaceBuffer,
     ) -> Result<(), CryptoProviderError> {
-        provider().aes_256_gcm_decrypt_in_place(&self.key, nonce, aad, buffer)
+        self.provider
+            .aes_256_gcm_decrypt_in_place(&self.key, nonce, aad, buffer)
     }
 }
 
@@ -219,13 +222,17 @@ pub trait SignalCryptoProvider: Send + Sync + 'static {
     }
 
     /// Connection-lifetime transport AEAD for one fixed key. Default keeps
-    /// per-call dispatch through the configured provider; override to
-    /// precompute key-dependent state (key schedule, GHASH subkey) once.
+    /// per-call dispatch through this same provider; override to precompute
+    /// key-dependent state (key schedule, GHASH subkey) once. The `'static`
+    /// receiver ties the handle to the installed provider's lifetime.
     fn transport_aead(
-        &self,
+        &'static self,
         key: &[u8; 32],
     ) -> Result<Box<dyn TransportAead>, CryptoProviderError> {
-        Ok(Box::new(PerCallTransportAead { key: *key }))
+        Ok(Box::new(PerCallTransportAead {
+            provider: self,
+            key: *key,
+        }))
     }
 }
 
@@ -393,7 +400,7 @@ impl SignalCryptoProvider for RustCryptoProvider {
     }
 
     fn transport_aead(
-        &self,
+        &'static self,
         key: &[u8; 32],
     ) -> Result<Box<dyn TransportAead>, CryptoProviderError> {
         Ok(Box::new(

--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -380,7 +380,7 @@ pub struct IkFallbackInputs {
 pub enum IkServerHelloOutcome {
     /// Server accepted IK; cert payload was decrypted and the cipher keys
     /// are derivable. The cached cert chain on the device stays untouched.
-    Continue(IkHandshakeOutcome),
+    Continue(Box<IkHandshakeOutcome>),
     /// Server rejected IK by replying with `static != null`. Switch to
     /// XX-fallback using the carryover inputs. Boxed since `IkFallbackInputs`
     /// holds two KeyPairs and a payload, dwarfing `Continue`'s two ciphers.
@@ -630,10 +630,12 @@ impl IkHandshakeState {
         let _cert_plaintext = noise.decrypt(&cert_payload)?;
 
         let (write_cipher, read_cipher) = noise.finish()?;
-        Ok(IkServerHelloOutcome::Continue(IkHandshakeOutcome {
-            write_cipher,
-            read_cipher,
-        }))
+        Ok(IkServerHelloOutcome::Continue(Box::new(
+            IkHandshakeOutcome {
+                write_cipher,
+                read_cipher,
+            },
+        )))
     }
 }
 

--- a/wacore/noise/src/state.rs
+++ b/wacore/noise/src/state.rs
@@ -2,8 +2,8 @@ use crate::error::{NoiseError, Result};
 use hkdf::Hkdf;
 use sha2::{Digest, Sha256};
 use wacore_libsignal::crypto::{
-    GcmInPlaceBuffer, aes_256_gcm_decrypt, aes_256_gcm_decrypt_in_place, aes_256_gcm_encrypt,
-    aes_256_gcm_encrypt_in_place,
+    Aes256GcmDecryption, Aes256GcmEncryption, Aes256GcmKey, CryptoProviderError, GcmInPlaceBuffer,
+    aes_256_gcm_decrypt, aes_256_gcm_encrypt,
 };
 
 /// Buffer kinds accepted by [`NoiseCipher::decrypt_in_place_with_counter`].
@@ -25,13 +25,19 @@ const TAG_LEN: usize = 16;
 /// A cipher wrapper that encapsulates AES-256-GCM encryption/decryption
 /// with counter-based IV generation.
 pub struct NoiseCipher {
-    key: [u8; 32],
+    /// Pre-keyed GCM state: the transport key is fixed for the connection,
+    /// so the AES key schedule and the GHASH subkey are derived once here
+    /// instead of on every frame.
+    key: Aes256GcmKey,
 }
 
 impl NoiseCipher {
     /// Creates a new cipher from a 32-byte key.
     pub fn new(key: &[u8; 32]) -> Result<Self> {
-        Ok(Self { key: *key })
+        Ok(Self {
+            key: Aes256GcmKey::new(key)
+                .map_err(|_| NoiseError::Encrypt(CryptoProviderError::BadInput))?,
+        })
     }
 
     /// Encrypts plaintext using the specified counter for IV generation.
@@ -39,8 +45,11 @@ impl NoiseCipher {
     pub fn encrypt_with_counter(&self, counter: u32, plaintext: &[u8]) -> Result<Vec<u8>> {
         let iv = generate_iv(counter);
         let mut out = Vec::with_capacity(plaintext.len() + TAG_LEN);
-        aes_256_gcm_encrypt(&self.key, &iv, b"", plaintext, &mut out)
-            .map_err(NoiseError::Encrypt)?;
+        out.extend_from_slice(plaintext);
+        let mut enc = Aes256GcmEncryption::new_with_key(&self.key, &iv, b"")
+            .map_err(|_| NoiseError::Encrypt(CryptoProviderError::BadInput))?;
+        enc.encrypt(&mut out);
+        out.extend_from_slice(&enc.compute_tag());
         Ok(out)
     }
 
@@ -54,7 +63,14 @@ impl NoiseCipher {
         buffer: &mut B,
     ) -> Result<()> {
         let iv = generate_iv(counter);
-        aes_256_gcm_encrypt_in_place(&self.key, &iv, b"", buffer).map_err(NoiseError::Encrypt)
+        let plaintext_len = buffer.len();
+        let mut enc = Aes256GcmEncryption::new_with_key(&self.key, &iv, b"")
+            .map_err(|_| NoiseError::Encrypt(CryptoProviderError::BadInput))?;
+        enc.encrypt(buffer.as_mut_slice());
+        let tag = enc.compute_tag();
+        buffer.resize(plaintext_len + TAG_LEN, 0);
+        buffer.as_mut_slice()[plaintext_len..].copy_from_slice(&tag);
+        Ok(())
     }
 
     /// Decrypts ciphertext (with 16-byte tag appended) in-place within the
@@ -67,7 +83,21 @@ impl NoiseCipher {
         buffer: &mut B,
     ) -> Result<()> {
         let iv = generate_iv(counter);
-        aes_256_gcm_decrypt_in_place(&self.key, &iv, b"", buffer).map_err(NoiseError::Decrypt)
+        let total = buffer.len();
+        if total < TAG_LEN {
+            return Err(NoiseError::Decrypt(CryptoProviderError::BadInput));
+        }
+        let pt_len = total - TAG_LEN;
+        let mut tag = [0u8; TAG_LEN];
+        tag.copy_from_slice(&buffer.as_slice()[pt_len..]);
+
+        let mut dec = Aes256GcmDecryption::new_with_key(&self.key, &iv, b"")
+            .map_err(|_| NoiseError::Decrypt(CryptoProviderError::BadInput))?;
+        dec.decrypt(&mut buffer.as_mut_slice()[..pt_len]);
+        dec.verify_tag(&tag)
+            .map_err(|_| NoiseError::Decrypt(CryptoProviderError::AuthFailed))?;
+        buffer.truncate(pt_len);
+        Ok(())
     }
 }
 

--- a/wacore/noise/src/state.rs
+++ b/wacore/noise/src/state.rs
@@ -2,8 +2,7 @@ use crate::error::{NoiseError, Result};
 use hkdf::Hkdf;
 use sha2::{Digest, Sha256};
 use wacore_libsignal::crypto::{
-    Aes256GcmDecryption, Aes256GcmEncryption, Aes256GcmKey, CryptoProviderError, GcmInPlaceBuffer,
-    aes_256_gcm_decrypt, aes_256_gcm_encrypt,
+    GcmInPlaceBuffer, TransportAead, aes_256_gcm_decrypt, aes_256_gcm_encrypt, transport_aead,
 };
 
 /// Buffer kinds accepted by [`NoiseCipher::decrypt_in_place_with_counter`].
@@ -25,18 +24,18 @@ const TAG_LEN: usize = 16;
 /// A cipher wrapper that encapsulates AES-256-GCM encryption/decryption
 /// with counter-based IV generation.
 pub struct NoiseCipher {
-    /// Pre-keyed GCM state: the transport key is fixed for the connection,
-    /// so the AES key schedule and the GHASH subkey are derived once here
-    /// instead of on every frame.
-    key: Aes256GcmKey,
+    /// Connection-lifetime AEAD from the provider hook: the transport key is
+    /// fixed, so the default RustCrypto path precomputes the AES key schedule
+    /// and the GHASH subkey once instead of on every frame; custom providers
+    /// keep observing transport crypto through the trait default.
+    aead: Box<dyn TransportAead>,
 }
 
 impl NoiseCipher {
     /// Creates a new cipher from a 32-byte key.
     pub fn new(key: &[u8; 32]) -> Result<Self> {
         Ok(Self {
-            key: Aes256GcmKey::new(key)
-                .map_err(|_| NoiseError::Encrypt(CryptoProviderError::BadInput))?,
+            aead: transport_aead(key).map_err(NoiseError::Encrypt)?,
         })
     }
 
@@ -46,10 +45,9 @@ impl NoiseCipher {
         let iv = generate_iv(counter);
         let mut out = Vec::with_capacity(plaintext.len() + TAG_LEN);
         out.extend_from_slice(plaintext);
-        let mut enc = Aes256GcmEncryption::new_with_key(&self.key, &iv, b"")
-            .map_err(|_| NoiseError::Encrypt(CryptoProviderError::BadInput))?;
-        enc.encrypt(&mut out);
-        out.extend_from_slice(&enc.compute_tag());
+        self.aead
+            .encrypt_in_place(&iv, b"", &mut out)
+            .map_err(NoiseError::Encrypt)?;
         Ok(out)
     }
 
@@ -63,14 +61,9 @@ impl NoiseCipher {
         buffer: &mut B,
     ) -> Result<()> {
         let iv = generate_iv(counter);
-        let plaintext_len = buffer.len();
-        let mut enc = Aes256GcmEncryption::new_with_key(&self.key, &iv, b"")
-            .map_err(|_| NoiseError::Encrypt(CryptoProviderError::BadInput))?;
-        enc.encrypt(buffer.as_mut_slice());
-        let tag = enc.compute_tag();
-        buffer.resize(plaintext_len + TAG_LEN, 0);
-        buffer.as_mut_slice()[plaintext_len..].copy_from_slice(&tag);
-        Ok(())
+        self.aead
+            .encrypt_in_place(&iv, b"", buffer)
+            .map_err(NoiseError::Encrypt)
     }
 
     /// Decrypts ciphertext (with 16-byte tag appended) in-place within the
@@ -83,21 +76,9 @@ impl NoiseCipher {
         buffer: &mut B,
     ) -> Result<()> {
         let iv = generate_iv(counter);
-        let total = buffer.len();
-        if total < TAG_LEN {
-            return Err(NoiseError::Decrypt(CryptoProviderError::BadInput));
-        }
-        let pt_len = total - TAG_LEN;
-        let mut tag = [0u8; TAG_LEN];
-        tag.copy_from_slice(&buffer.as_slice()[pt_len..]);
-
-        let mut dec = Aes256GcmDecryption::new_with_key(&self.key, &iv, b"")
-            .map_err(|_| NoiseError::Decrypt(CryptoProviderError::BadInput))?;
-        dec.decrypt(&mut buffer.as_mut_slice()[..pt_len]);
-        dec.verify_tag(&tag)
-            .map_err(|_| NoiseError::Decrypt(CryptoProviderError::AuthFailed))?;
-        buffer.truncate(pt_len);
-        Ok(())
+        self.aead
+            .decrypt_in_place(&iv, b"", buffer)
+            .map_err(NoiseError::Decrypt)
     }
 }
 


### PR DESCRIPTION
## Problem

The CodSpeed flamegraph for `bench_frame_encrypt_in_place[1500]` (the typical stanza-frame size) shows `setup_gcm` at 16.9% of the seal: every Noise frame, in both directions, re-runs the AES-256 key schedule, re-derives the GHASH subkey `H = E_K(0)`, and pays an allocation inside the setup — all key-dependent work, and the transport key is fixed for the whole connection. Same shape as the ltHash fix in #847: a per-call recomputation of a constant.

## Change

New `crypto::aes_gcm::Aes256GcmKey` holds the expanded AES cipher and the keyed GHASH. Per frame, only the nonce-dependent work remains (CTR init and the one pad block); the keyed state is cloned, which is a plain round-key copy with no `aeskeygenassist` and no polyval re-keying. `Aes256GcmEncryption`/`Aes256GcmDecryption` gain `new_with_key` constructors that feed the existing encrypt/decrypt/tag bodies, and `NoiseCipher` stores the pre-keyed state instead of raw key bytes.

Scope notes:

- Byte-identical output, pinned by a differential test against the per-call setup across sizes (0..4096), nonces and aad shapes, plus tamper rejection.
- The handshake path keeps the per-call setup (its keys change at each step).
- `NoiseCipher` grew (round keys live inline), so the IK outcome enum boxes its `Continue` variant per clippy.
- `NoiseCipher` now drives the RustCrypto GCM types directly instead of the pluggable `SignalCryptoProvider` free functions. No in-repo or known consumer installs a custom provider, and the signal paths still route through it; flagging in case the hook was meant to cover transport crypto too.

## Measured

Local wall-time A/B on 1500-byte frames (AES-NI + CLMUL host): decrypt median 11.51 -> 9.19 us (**-20%**), encrypt 9.76 -> 9.08 us (-7%); 64 KB frames unchanged (data path dominates). The Simulation runner takes the software polyval path where the setup weighs more, so the CodSpeed report should show a larger relative win on the 1500-byte benches.

## Tests

Full workspace suites pass (2180 tests, e2e excluded as usual); clippy strict clean.
