### PR TITLE
deps: upgrade curve25519-dalek and x25519-dalek to the 5.0/3.0 release candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -506,15 +506,6 @@ checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -575,12 +566,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -888,9 +879,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1746,7 +1737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -1925,12 +1916,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2264,7 +2249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2275,7 +2260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -3487,13 +3472,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "f17b575e04fcdb37e5509a85a14ff08116678a1c9724befb8b571db742dbdbb0"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -3566,20 +3550,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zlib-rs"

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -16,7 +16,7 @@ bytes = { workspace = true }
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { workspace = true, features = ["now"] }
 ctr = { workspace = true }
-curve25519-dalek = "4.1.3"
+curve25519-dalek = "5.0.0-rc.0"
 derive_more = { version = "2.1.0", features = ["from", "into", "try_from"] }
 displaydoc = "0.2.5"
 ghash = "0.6.0"
@@ -33,7 +33,7 @@ subtle = "2.6.1"
 thiserror = { workspace = true }
 uuid = { workspace = true }
 waproto = { workspace = true }
-x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+x25519-dalek = { version = "3.0.0-rc.0", features = ["static_secrets"] }
 
 [dev-dependencies]
 divan = { workspace = true }


### PR DESCRIPTION
## What

- `curve25519-dalek` 4.1.3 -> **5.0.0-rc.0**
- `x25519-dalek` 2.0.1 -> **3.0.0-rc.0**

`ed25519-dalek` is not a dependency: the Ed25519/XEdDSA layer is implemented in the vendored libsignal directly over curve25519.

## Changelog review (vs our usage)

Checked both upstream CHANGELOGs; the code compiles with zero changes because it only touches the stable surface (`EdwardsPoint`, `MontgomeryPoint`, `Scalar`, `clamp_integer`, `StaticSecret::from`). Item by item:

- `Scalar::batch_invert` rename, `FieldElement::as_bytes()` / `EdwardsPoint::nonspec_map_to_curve()` removal, deprecated `*Secret::new()` removal: none used (verified by grep and by the compile).
- **Constant-time equality for compressed Edwards/Ristretto points**: behavioral change in our favor (timing-safety hardening; results identical).
- `Zeroize` impl removed from x25519 secret types: they still zeroize on drop, and we never called `.zeroize()` explicitly, so no change.
- `rand_core` -> 0.10: unifies with the workspace `rand` 0.10 and **removes the duplicate `rand_core` 0.6 + `zeroize_derive`** that the dalek 4.x pin forced into the dependency graph (a leftover from the binary-size audit).
- `digest`/`sha2` bumps align with the workspace 0.11 series; `fiat-crypto` moves to 0.3.
- **MSRV 1.60 -> 1.85** and edition 2024: both CI lanes (pinned nightly and latest stable) already satisfy it. Worth keeping in mind for any downstream pinning an older stable.

## Validation

- Full workspace suites pass (2180 tests, including the libsignal protocol vectors, XEdDSA, noise handshake and pairing crypto); clippy strict clean.
- wasm32 release build green with the usual guard flags.
- Local A/B of the libsignal crypto benches (key generation, XEdDSA sign/verify, DM session establishment/first message): neutral, medians within 2%. The CodSpeed run on this PR is the official check.

## Caveat

These are **release candidates**; pre-1.0 of our own crate that's acceptable, but if upstream ships a breaking rc.1 the lockfile pins us safely in the meantime.
