### PR TITLE
feat!: overhaul the public bot API ahead of 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,44 +19,76 @@ A high-performance, async Rust library for the WhatsApp Web API. Inspired by [wh
 - **Chat Actions** — Archive, pin, mute, star messages
 - **Profile** — Set push name, status text, profile picture
 - **Privacy** — Fetch/set privacy settings, disappearing messages
-- **Modular** — Pluggable storage, transport, HTTP client, and async runtime
+- **Modular** — Pluggable storage, transport, HTTP client, and async runtime; SQLite, Tokio WebSocket, and ureq ship as the defaults, swap any of them with `default-features = false`
 - **Runtime agnostic** — Bring your own async runtime via the `Runtime` trait (Tokio included by default)
 
 For the full API reference and guides, see the **[documentation](https://whatsapp-rust.jlucaso.com)**.
 
 ## Quick Start
 
-```rust
-use std::sync::Arc;
-use whatsapp_rust::bot::Bot;
-use whatsapp_rust::store::SqliteStore;
-use whatsapp_rust::TokioRuntime;
-use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
-use whatsapp_rust_ureq_http_client::UreqHttpClient;
-use wacore::types::events::Event;
+```toml
+[dependencies]
+whatsapp-rust = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+```rust,no_run
+use whatsapp_rust::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let backend = Arc::new(SqliteStore::new("whatsapp.db").await?);
-
-    let mut bot = Bot::builder()
-        .with_backend(backend)
-        .with_transport_factory(TokioWebSocketTransportFactory::new())
-        .with_http_client(UreqHttpClient::new())
-        .with_runtime(TokioRuntime)
-        .on_event(|event, _client| async move {
-            match event {
-                Event::PairingQrCode { code, .. } => println!("QR:\n{}", code),
-                Event::Message(msg, info) => {
-                    println!("Message from {}: {:?}", info.source.sender, msg);
-                }
-                _ => {}
+    let bot = Bot::builder()
+        .with_backend(SqliteStore::new("whatsapp.db").await?)
+        .on_qr_code(|code, _timeout| async move {
+            println!("Scan to pair:\n{code}");
+        })
+        .on_message(|ctx| async move {
+            if ctx.message.text_content() == Some("ping") {
+                let _ = ctx.reply("pong").await;
             }
         })
         .build()
         .await?;
 
-    bot.run().await?.await?;
+    // Runs until logout or shutdown; a single await.
+    bot.run().await;
+    Ok(())
+}
+```
+
+The default cargo features wire up the Tokio WebSocket transport, the ureq HTTP client, the SQLite store, and the Tokio runtime; only the storage backend has to be chosen explicitly. Every piece is replaceable through the builder (`with_transport_factory`, `with_http_client`, `with_runtime`) for custom environments such as wasm or embedded targets.
+
+### One dependency is enough
+
+`whatsapp-rust` re-exports the whole stack, so you never need to declare the sibling crates (`wacore`, `wacore-binary`, `waproto`, `whatsapp-rust-tokio-transport`, `whatsapp-rust-ureq-http-client`, `whatsapp-rust-sqlite-storage`) yourself, including when pinning a git revision:
+
+```toml
+[dependencies]
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "<commit>" }
+```
+
+- Protobuf types: `whatsapp_rust::waproto::whatsapp` (aliased as `wa` in the prelude)
+- Core protocol/types: `whatsapp_rust::wacore`, `whatsapp_rust::wacore_binary` (`Jid` is also at the crate root)
+- Bundled implementations: `whatsapp_rust::transport::TokioWebSocketTransportFactory`, `whatsapp_rust::http::UreqHttpClient`, `whatsapp_rust::store::SqliteStore`, each behind its default-on cargo feature (`tokio-transport`, `ureq-client`, `sqlite-storage`)
+
+With `default-features = false`, pick only what you need (e.g. `features = ["tokio-runtime", "tokio-transport", "ureq-client"]` for a custom store while keeping the bundled networking).
+
+To run the bot in the background instead of blocking, use `spawn()` and keep the handle:
+
+```rust,no_run
+use whatsapp_rust::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let bot = Bot::builder()
+        .with_backend(SqliteStore::new("whatsapp.db").await?)
+        .build()
+        .await?;
+
+    let handle = bot.spawn(); // full Client API stays available via handle.client()
+
+    tokio::signal::ctrl_c().await?;
+    handle.shutdown().await; // graceful: flushes pending state, then stops
     Ok(())
 }
 ```
@@ -71,7 +103,7 @@ cargo run -- -p 15551234567 -c MYCODE  # Custom pair code
 
 ## Project Structure
 
-```
+```text
 whatsapp-rust/
 ├── src/                    # Main client library
 ├── wacore/                 # Platform-agnostic core (no runtime deps)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For the full API reference and guides, see the **[documentation](https://whatsap
 ```toml
 [dependencies]
 whatsapp-rust = "0.6"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 
 ```rust,no_run

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,4 +1,3 @@
-use chrono::Local;
 use log::{error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -6,7 +5,6 @@ use wacore::net::{HttpClient, HttpRequest};
 use wacore::proto_helpers::MessageExt;
 use wacore::store::InMemoryBackend;
 use wacore::types::events::{Event, EventKind};
-use waproto::whatsapp as wa;
 use whatsapp_rust::TokioRuntime;
 use whatsapp_rust::bot::{Bot, MessageContext};
 use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
@@ -37,7 +35,7 @@ fn main() {
             writeln!(
                 buf,
                 "{} [{:<5}] [{}] - {}",
-                Local::now().format("%H:%M:%S"),
+                wacore::time::now_utc().format("%H:%M:%S"),
                 record.level(),
                 record.target(),
                 record.args()
@@ -51,8 +49,6 @@ fn main() {
         .expect("Failed to build tokio runtime");
 
     rt.block_on(async {
-        let backend = Arc::new(InMemoryBackend::new());
-
         // Accept either WHATSAPP_WS_URL or MOCK_SERVER_URL — the latter
         // matches the convention the e2e suite uses.
         let configured_ws_url = std::env::var("WHATSAPP_WS_URL")
@@ -71,12 +67,12 @@ fn main() {
         let http_client = UreqHttpClient::new();
 
         let builder = Bot::builder()
-            .with_backend(backend)
+            .with_backend(InMemoryBackend::new())
             .with_transport_factory(transport_factory)
             .with_http_client(http_client)
             .with_runtime(TokioRuntime);
 
-        let mut bot = builder
+        let bot = builder
             .on_event_for(
                 &[
                     EventKind::Message,
@@ -92,16 +88,12 @@ fn main() {
                                 if let Some(text) = msg.text_content()
                                     && text == "ping"
                                 {
-                                    let ctx = MessageContext::from_parts(msg, info, client);
+                                    let ctx =
+                                        MessageContext::from_arc(Arc::clone(msg), info, client);
                                     info!("Received text ping, sending pong...");
 
                                     let pong_text = format!("pong {}", ctx.info.id);
-                                    let reply_message = wa::Message {
-                                        conversation: Some(pong_text),
-                                        ..Default::default()
-                                    };
-
-                                    if let Err(e) = ctx.send_message(reply_message).await {
+                                    if let Err(e) = ctx.reply(pong_text).await {
                                         error!("Failed to send pong reply: {}", e);
                                     }
                                 }
@@ -154,16 +146,6 @@ fn main() {
             .await
             .expect("Failed to build bot");
 
-        let bot_handle = match bot.run().await {
-            Ok(handle) => handle,
-            Err(e) => {
-                error!("Bot failed to start: {}", e);
-                return;
-            }
-        };
-
-        bot_handle
-            .await
-            .expect("Bot task should complete without panicking");
+        bot.run().await;
     });
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2,12 +2,12 @@ use crate::cache_config::CacheConfig;
 use crate::client::Client;
 use crate::pair_code::PairCodeOptions;
 use crate::store::commands::DeviceCommand;
+use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
 use crate::store::traits::Backend;
 use crate::types::enc_handler::EncHandler;
 use crate::types::events::{Event, EventHandler, EventInterest, EventKind};
 use crate::types::message::MessageInfo;
-use anyhow::Result;
 use log::{info, warn};
 use std::collections::HashMap;
 use std::future::Future;
@@ -15,20 +15,76 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 use thiserror::Error;
+use wacore::proto_helpers::MessageBuilderExt;
 use wacore::runtime::Runtime;
 use wacore::store::DevicePropsOverride;
 use waproto::whatsapp as wa;
 
-/// Typestate marker: a required builder field has not been provided yet.
-pub struct Missing;
-/// Typestate marker: a required builder field has been provided.
+/// Typestate marker: the builder field has been provided (or pre-filled by a
+/// feature-gated default).
 pub struct Provided;
+/// Typestate marker: no storage [`Backend`] has been provided yet.
+pub struct MissingBackend;
+/// Typestate marker: no transport factory has been provided yet. Enabled
+/// `tokio-transport` (default) pre-fills this slot.
+pub struct MissingTransport;
+/// Typestate marker: no HTTP client has been provided yet. Enabled
+/// `ureq-client` (default) pre-fills this slot.
+pub struct MissingHttpClient;
+/// Typestate marker: no async runtime has been provided yet. Enabled
+/// `tokio-runtime` (default) pre-fills this slot.
+pub struct MissingRuntime;
+
+#[cfg(feature = "tokio-transport")]
+type DefaultTransportState = Provided;
+#[cfg(not(feature = "tokio-transport"))]
+type DefaultTransportState = MissingTransport;
+
+#[cfg(feature = "ureq-client")]
+type DefaultHttpState = Provided;
+#[cfg(not(feature = "ureq-client"))]
+type DefaultHttpState = MissingHttpClient;
+
+#[cfg(feature = "tokio-runtime")]
+type DefaultRuntimeState = Provided;
+#[cfg(not(feature = "tokio-runtime"))]
+type DefaultRuntimeState = MissingRuntime;
+
+#[cfg(feature = "tokio-transport")]
+fn default_transport_factory() -> Option<Arc<dyn crate::transport::TransportFactory>> {
+    Some(Arc::new(
+        crate::transport::TokioWebSocketTransportFactory::new(),
+    ))
+}
+#[cfg(not(feature = "tokio-transport"))]
+fn default_transport_factory() -> Option<Arc<dyn crate::transport::TransportFactory>> {
+    None
+}
+
+#[cfg(feature = "ureq-client")]
+fn default_http_client() -> Option<Arc<dyn crate::http::HttpClient>> {
+    Some(Arc::new(crate::http::UreqHttpClient::new()))
+}
+#[cfg(not(feature = "ureq-client"))]
+fn default_http_client() -> Option<Arc<dyn crate::http::HttpClient>> {
+    None
+}
+
+#[cfg(feature = "tokio-runtime")]
+fn default_runtime() -> Option<Arc<dyn Runtime>> {
+    Some(Arc::new(crate::runtime_impl::TokioRuntime))
+}
+#[cfg(not(feature = "tokio-runtime"))]
+fn default_runtime() -> Option<Arc<dyn Runtime>> {
+    None
+}
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BotBuilderError {
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    /// Initializing the device row in the storage backend failed.
+    #[error("failed to initialize the device store: {0}")]
+    Store(#[from] StoreError),
 }
 
 /// `message` is `Arc` so cloning the context across spawned tasks only bumps a
@@ -42,6 +98,9 @@ pub struct MessageContext {
 }
 
 impl MessageContext {
+    /// Builds a context from borrowed parts, deep-cloning `message`. Prefer
+    /// [`MessageContext::from_arc`]/[`MessageContext::from_event`] when an
+    /// `Arc<wa::Message>` is already at hand (the event bus always has one).
     pub fn from_parts(message: &wa::Message, info: &MessageInfo, client: Arc<Client>) -> Self {
         Self::from_arc(Arc::new(message.clone()), info, client)
     }
@@ -66,6 +125,24 @@ impl MessageContext {
     ) -> Result<crate::send::SendResult, anyhow::Error> {
         self.client
             .send_message(&self.info.source.chat, message)
+            .await
+    }
+
+    /// Reply with plain text in the same chat, without quoting.
+    pub async fn reply(
+        &self,
+        text: impl Into<String>,
+    ) -> Result<crate::send::SendResult, anyhow::Error> {
+        self.send_message(wa::Message::text(text)).await
+    }
+
+    /// Reply with plain text, quoting the received message.
+    pub async fn reply_quoting(
+        &self,
+        text: impl Into<String>,
+    ) -> Result<crate::send::SendResult, anyhow::Error> {
+        let context = self.build_quote_context();
+        self.send_message(wa::Message::text_with_context(text, context))
             .await
     }
 
@@ -141,63 +218,99 @@ struct RegisteredHandler {
     interest: EventInterest,
 }
 
-struct BotEventHandler {
-    client: Arc<Client>,
-    event_handler: Option<RegisteredHandler>,
+/// Union of every registered callback's interest, so the bus only materializes
+/// events at least one callback wants.
+fn combined_interest(handlers: &[RegisteredHandler]) -> EventInterest {
+    handlers
+        .iter()
+        .fold(EventInterest::none(), |acc, h| acc.union(h.interest))
 }
 
-impl EventHandler for BotEventHandler {
+/// Bridges the registered closures onto the core event bus. Each interested
+/// callback runs on its own spawned task, so a slow handler stalls neither the
+/// bus nor its sibling handlers; in exchange, ordering across events is not
+/// guaranteed.
+struct CallbackBusAdapter {
+    client: Arc<Client>,
+    handlers: Vec<RegisteredHandler>,
+    interest: EventInterest,
+}
+
+impl EventHandler for CallbackBusAdapter {
     fn handle_event(&self, event: Arc<Event>) {
-        if let Some(handler) = &self.event_handler {
-            let handler_clone = handler.callback.clone();
-            let client_clone = self.client.clone();
+        let kind = event.kind();
+        for handler in &self.handlers {
+            if !handler.interest.wants(kind) {
+                continue;
+            }
+            let callback = handler.callback.clone();
+            let client = self.client.clone();
+            let event = Arc::clone(&event);
 
             self.client
                 .runtime
                 .spawn(Box::pin(async move {
-                    handler_clone(event, client_clone).await;
+                    callback(event, client).await;
                 }))
                 .detach();
         }
     }
 
     fn interest(&self) -> EventInterest {
-        self.event_handler
-            .as_ref()
-            .map(|h| h.interest)
-            .unwrap_or(EventInterest::none())
+        self.interest
     }
 }
 
-/// Handle returned by [`Bot::run`] that can be awaited to wait for the
-/// client's run loop to finish.
+/// Handle to a bot started in the background via [`Bot::spawn`]. Awaiting it
+/// resolves once the run loop exits (logout, [`BotHandle::shutdown`], or abort).
+///
+/// Dropping the handle aborts the bot task. Keep it alive for as long as the
+/// bot should run, and prefer [`BotHandle::shutdown`] to stop it.
 pub struct BotHandle {
+    client: Arc<Client>,
     done_rx: futures::channel::oneshot::Receiver<()>,
-    _abort_handle: wacore::runtime::AbortHandle,
+    abort_handle: wacore::runtime::AbortHandle,
 }
 
 impl BotHandle {
-    /// Abort the bot's run task.
+    pub fn client(&self) -> Arc<Client> {
+        self.client.clone()
+    }
+
+    /// Gracefully stop the bot: disconnects (flushing the device snapshot,
+    /// buffered receipts and message secrets) and waits for the run loop to
+    /// exit.
+    pub async fn shutdown(mut self) {
+        self.client.disconnect().await;
+        let _ = (&mut self.done_rx).await;
+    }
+
+    /// Abort the bot task immediately. Skips the flush work
+    /// [`BotHandle::shutdown`] performs, so recently captured state may be
+    /// lost; escape hatch only.
     pub fn abort(&self) {
-        self._abort_handle.abort();
+        self.abort_handle.abort();
     }
 }
 
 impl std::future::Future for BotHandle {
-    type Output = Result<(), futures::channel::oneshot::Canceled>;
+    type Output = ();
 
     fn poll(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        Pin::new(&mut self.done_rx).poll(cx)
+        // Canceled only happens when the run task was aborted; both outcomes
+        // mean "the bot is no longer running", which is all awaiters care about.
+        Pin::new(&mut self.done_rx).poll(cx).map(|_| ())
     }
 }
 
 pub struct Bot {
     client: Arc<Client>,
     sync_task_receiver: Option<async_channel::Receiver<crate::sync_task::MajorSyncTask>>,
-    event_handler: Option<RegisteredHandler>,
+    event_handlers: Vec<RegisteredHandler>,
+    raw_handlers: Vec<Arc<dyn EventHandler>>,
     pair_code_options: Option<PairCodeOptions>,
 }
 
@@ -206,14 +319,17 @@ impl std::fmt::Debug for Bot {
         f.debug_struct("Bot")
             .field("client", &"<Client>")
             .field("sync_task_receiver", &self.sync_task_receiver.is_some())
-            .field("event_handler", &self.event_handler.is_some())
+            .field("event_handlers", &self.event_handlers.len())
+            .field("raw_handlers", &self.raw_handlers.len())
             .field("pair_code_options", &self.pair_code_options.is_some())
             .finish()
     }
 }
 
 impl Bot {
-    pub fn builder() -> BotBuilder<Missing, Missing, Missing, Missing> {
+    pub fn builder()
+    -> BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, DefaultRuntimeState>
+    {
         BotBuilder::new()
     }
 
@@ -221,28 +337,67 @@ impl Bot {
         self.client.clone()
     }
 
+    /// Run the bot on the current task until it shuts down (logout, or
+    /// [`Client::disconnect`] called on [`Bot::client`] from another task).
+    ///
+    /// To run in the background instead, use [`Bot::spawn`].
+    ///
     /// Coroutines are LocalCopy across crates: a consumer crate that awaits
     /// this future re-codegens the whole state machine graph behind it in its
     /// own binary. The boxed barrier below type-erases the graph in a plain
     /// (linker-shared) function, so callers poll through a vtable and the
     /// graph is compiled once, here. One allocation per process.
-    pub async fn run(&mut self) -> Result<BotHandle> {
+    pub async fn run(self) {
         self.run_boxed().await
     }
 
     #[inline(never)]
-    fn run_boxed(&mut self) -> wacore::runtime::BoxFuture<'_, Result<BotHandle>> {
+    fn run_boxed(self) -> wacore::runtime::BoxFuture<'static, ()> {
         Box::pin(self.run_graph())
     }
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "wa.bot.run", level = "debug", skip_all, err(Debug))
+        tracing::instrument(name = "wa.bot.run", level = "debug", skip_all)
     )]
-    async fn run_graph(&mut self) -> Result<BotHandle> {
-        if let Some(receiver) = self.sync_task_receiver.take() {
-            let worker_client = Arc::downgrade(&self.client);
-            self.client
+    async fn run_graph(self) {
+        let client = self.start_background();
+        client.run().await;
+    }
+
+    /// Start the bot on its runtime and return a [`BotHandle`] to await,
+    /// gracefully shut down, or abort it.
+    pub fn spawn(self) -> BotHandle {
+        let client = self.start_background();
+
+        let run_client = client.clone();
+        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
+        let abort_handle = client.runtime.spawn(Box::pin(async move {
+            run_client.run().await;
+            let _ = done_tx.send(());
+        }));
+
+        BotHandle {
+            client,
+            done_rx,
+            abort_handle,
+        }
+    }
+
+    /// Wires the background workers and event handlers, returning the client
+    /// that drives the connection. Shared by [`Bot::run`] and [`Bot::spawn`].
+    fn start_background(self) -> Arc<Client> {
+        let Bot {
+            client,
+            sync_task_receiver,
+            event_handlers,
+            raw_handlers,
+            pair_code_options,
+        } = self;
+
+        if let Some(receiver) = sync_task_receiver {
+            let worker_client = Arc::downgrade(&client);
+            client
                 .runtime
                 .spawn(Box::pin(async move {
                     while let Ok(task) = receiver.recv().await {
@@ -257,16 +412,25 @@ impl Bot {
                 .detach();
         }
 
-        let handler = Arc::new(BotEventHandler {
-            client: self.client.clone(),
-            event_handler: self.event_handler.take(),
-        });
-        self.client.core.event_bus.add_handler(handler);
+        if !event_handlers.is_empty() {
+            let interest = combined_interest(&event_handlers);
+            client
+                .core
+                .event_bus
+                .add_handler(Arc::new(CallbackBusAdapter {
+                    client: client.clone(),
+                    handlers: event_handlers,
+                    interest,
+                }));
+        }
+        for handler in raw_handlers {
+            client.core.event_bus.add_handler(handler);
+        }
 
         // If pair code options are set, spawn a task to request pair code after socket is ready
-        if let Some(options) = self.pair_code_options.take() {
-            let client_for_pair = self.client.clone();
-            self.client.runtime.spawn(Box::pin(async move {
+        if let Some(options) = pair_code_options {
+            let client_for_pair = client.clone();
+            client.runtime.spawn(Box::pin(async move {
                 // Wait for socket to be ready (before login) with 30 second timeout
                 if let Err(e) = client_for_pair
                     .wait_for_socket(std::time::Duration::from_secs(30))
@@ -294,34 +458,32 @@ impl Bot {
             })).detach();
         }
 
-        let client_for_run = self.client.clone();
-        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
-        let abort_handle = self.client.runtime.spawn(Box::pin(async move {
-            client_for_run.run().await;
-            let _ = done_tx.send(());
-        }));
-
-        Ok(BotHandle {
-            done_rx,
-            _abort_handle: abort_handle,
-        })
+        client
     }
 }
 
 /// Builder for [`Bot`] using the typestate pattern.
 ///
-/// The four type parameters (`B`, `T`, `H`, `R`) track whether the required
-/// fields (backend, transport_factory, http_client, runtime) have been
-/// provided. The `build()` method is only available when all four are
-/// [`Provided`], turning missing-field errors into compile-time errors.
-pub struct BotBuilder<B = Missing, T = Missing, H = Missing, R = Missing> {
+/// The four type parameters track whether the required fields (backend,
+/// transport factory, HTTP client, runtime) have been provided: `build()` is
+/// only available once all four are [`Provided`], turning missing-field errors
+/// into compile-time errors. With the default cargo features, transport, HTTP
+/// client and runtime start [`Provided`] (Tokio WebSocket, ureq, Tokio), so
+/// only the backend is required.
+pub struct BotBuilder<
+    B = MissingBackend,
+    T = MissingTransport,
+    H = MissingHttpClient,
+    R = MissingRuntime,
+> {
     // Required fields (guaranteed present when B/T/H/R = Provided)
     backend: Option<Arc<dyn Backend>>,
     transport_factory: Option<Arc<dyn crate::transport::TransportFactory>>,
     http_client: Option<Arc<dyn crate::http::HttpClient>>,
     runtime: Option<Arc<dyn Runtime>>,
     // Optional fields
-    event_handler: Option<RegisteredHandler>,
+    event_handlers: Vec<RegisteredHandler>,
+    raw_handlers: Vec<Arc<dyn EventHandler>>,
     custom_enc_handlers: HashMap<String, Arc<dyn EncHandler>>,
     override_version: Option<(u32, u32, u32)>,
     device_props_override: Option<DevicePropsOverride>,
@@ -333,14 +495,15 @@ pub struct BotBuilder<B = Missing, T = Missing, H = Missing, R = Missing> {
     _marker: PhantomData<(B, T, H, R)>,
 }
 
-impl BotBuilder<Missing, Missing, Missing, Missing> {
+impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, DefaultRuntimeState> {
     fn new() -> Self {
         Self {
             backend: None,
-            transport_factory: None,
-            http_client: None,
-            runtime: None,
-            event_handler: None,
+            transport_factory: default_transport_factory(),
+            http_client: default_http_client(),
+            runtime: default_runtime(),
+            event_handlers: Vec::new(),
+            raw_handlers: Vec::new(),
             custom_enc_handlers: HashMap::new(),
             override_version: None,
             device_props_override: None,
@@ -354,30 +517,17 @@ impl BotBuilder<Missing, Missing, Missing, Missing> {
     }
 }
 
-// ── Required-field setters (each transitions one type parameter) ──────────
-
-impl<T, H, R> BotBuilder<Missing, T, H, R> {
-    /// Use a backend implementation for storage.
-    /// This is the only way to configure storage - there are no defaults.
-    ///
-    /// # Arguments
-    /// * `backend` - The backend implementation that provides all storage operations
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let backend = Arc::new(SqliteStore::new("whatsapp.db").await?);
-    /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .build()
-    ///     .await?;
-    /// ```
-    pub fn with_backend(self, backend: Arc<dyn Backend>) -> BotBuilder<Provided, T, H, R> {
+impl<B, T, H, R> BotBuilder<B, T, H, R> {
+    /// Re-tags the typestate without touching any field, so each required-field
+    /// setter states only its own transition and the field list lives here.
+    fn cast<B2, T2, H2, R2>(self) -> BotBuilder<B2, T2, H2, R2> {
         BotBuilder {
-            backend: Some(backend),
+            backend: self.backend,
             transport_factory: self.transport_factory,
             http_client: self.http_client,
             runtime: self.runtime,
-            event_handler: self.event_handler,
+            event_handlers: self.event_handlers,
+            raw_handlers: self.raw_handlers,
             custom_enc_handlers: self.custom_enc_handlers,
             override_version: self.override_version,
             device_props_override: self.device_props_override,
@@ -389,114 +539,63 @@ impl<T, H, R> BotBuilder<Missing, T, H, R> {
             _marker: PhantomData,
         }
     }
-}
 
-impl<B, H, R> BotBuilder<B, Missing, H, R> {
-    /// Set the transport factory for creating network connections.
-    /// This is required to build a bot.
+    // ── Required-field setters (each transitions one type parameter) ──────
+
+    /// Use a backend implementation for storage. This is the only required
+    /// field when the default transport/HTTP/runtime features are enabled.
     ///
-    /// # Arguments
-    /// * `factory` - The transport factory implementation
+    /// The backend is wrapped in an `Arc` internally; use
+    /// [`BotBuilder::with_backend_arc`] to pass an already-shared backend.
     ///
     /// # Example
     /// ```rust,ignore
-    /// use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
-    ///
     /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .with_transport_factory(TokioWebSocketTransportFactory::new())
+    ///     .with_backend(SqliteStore::new("whatsapp.db").await?)
     ///     .build()
     ///     .await?;
     /// ```
-    pub fn with_transport_factory<F>(self, factory: F) -> BotBuilder<B, Provided, H, R>
+    pub fn with_backend(self, backend: impl Backend + 'static) -> BotBuilder<Provided, T, H, R> {
+        self.with_backend_arc(Arc::new(backend))
+    }
+
+    /// [`BotBuilder::with_backend`] for an already-shared `Arc<dyn Backend>`.
+    pub fn with_backend_arc(mut self, backend: Arc<dyn Backend>) -> BotBuilder<Provided, T, H, R> {
+        self.backend = Some(backend);
+        self.cast()
+    }
+
+    /// Set the transport factory for creating network connections, replacing
+    /// the `tokio-transport` default when that feature is enabled.
+    pub fn with_transport_factory<F>(mut self, factory: F) -> BotBuilder<B, Provided, H, R>
     where
         F: crate::transport::TransportFactory + 'static,
     {
-        BotBuilder {
-            backend: self.backend,
-            transport_factory: Some(Arc::new(factory)),
-            http_client: self.http_client,
-            runtime: self.runtime,
-            event_handler: self.event_handler,
-            custom_enc_handlers: self.custom_enc_handlers,
-            override_version: self.override_version,
-            device_props_override: self.device_props_override,
-            pair_code_options: self.pair_code_options,
-            skip_history_sync: self.skip_history_sync,
-            initial_push_name: self.initial_push_name,
-            cache_config: self.cache_config,
-            wanted_pre_key_count: self.wanted_pre_key_count,
-            _marker: PhantomData,
-        }
+        self.transport_factory = Some(Arc::new(factory));
+        self.cast()
     }
-}
 
-impl<B, T, R> BotBuilder<B, T, Missing, R> {
-    /// Configure the HTTP client used for media operations and version fetching.
-    ///
-    /// # Arguments
-    /// * `client` - The HTTP client implementation
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// use whatsapp_rust_ureq_http_client::UreqHttpClient;
-    ///
-    /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .with_http_client(UreqHttpClient::new())
-    ///     .build()
-    ///     .await?;
-    /// ```
-    pub fn with_http_client<C>(self, client: C) -> BotBuilder<B, T, Provided, R>
+    /// Set the HTTP client used for media operations and version fetching,
+    /// replacing the `ureq-client` default when that feature is enabled.
+    pub fn with_http_client<C>(mut self, client: C) -> BotBuilder<B, T, Provided, R>
     where
         C: crate::http::HttpClient + 'static,
     {
-        BotBuilder {
-            backend: self.backend,
-            transport_factory: self.transport_factory,
-            http_client: Some(Arc::new(client)),
-            runtime: self.runtime,
-            event_handler: self.event_handler,
-            custom_enc_handlers: self.custom_enc_handlers,
-            override_version: self.override_version,
-            device_props_override: self.device_props_override,
-            pair_code_options: self.pair_code_options,
-            skip_history_sync: self.skip_history_sync,
-            initial_push_name: self.initial_push_name,
-            cache_config: self.cache_config,
-            wanted_pre_key_count: self.wanted_pre_key_count,
-            _marker: PhantomData,
-        }
+        self.http_client = Some(Arc::new(client));
+        self.cast()
     }
-}
 
-impl<B, T, H> BotBuilder<B, T, H, Missing> {
-    /// Set the async runtime implementation to use.
-    ///
-    /// This is required to build a bot.
-    pub fn with_runtime<Rt: Runtime>(self, runtime: Rt) -> BotBuilder<B, T, H, Provided> {
-        BotBuilder {
-            backend: self.backend,
-            transport_factory: self.transport_factory,
-            http_client: self.http_client,
-            runtime: Some(Arc::new(runtime)),
-            event_handler: self.event_handler,
-            custom_enc_handlers: self.custom_enc_handlers,
-            override_version: self.override_version,
-            device_props_override: self.device_props_override,
-            pair_code_options: self.pair_code_options,
-            skip_history_sync: self.skip_history_sync,
-            initial_push_name: self.initial_push_name,
-            cache_config: self.cache_config,
-            wanted_pre_key_count: self.wanted_pre_key_count,
-            _marker: PhantomData,
-        }
+    /// Set the async runtime implementation, replacing the `tokio-runtime`
+    /// default when that feature is enabled.
+    pub fn with_runtime<Rt: Runtime>(mut self, runtime: Rt) -> BotBuilder<B, T, H, Provided> {
+        self.runtime = Some(Arc::new(runtime));
+        self.cast()
     }
-}
 
-// ── Optional-field setters (available in any state) ──────────────────────
+    // ── Event handler registration (additive; order of registration is kept,
+    //    but handlers run on their own tasks, so cross-event ordering is not
+    //    guaranteed) ──────────────────────────────────────────────────────
 
-impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Register a handler that receives every event kind.
     pub fn on_event<F, Fut>(self, handler: F) -> Self
     where
@@ -517,26 +616,122 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         self.register_event_handler(EventInterest::of(kinds), handler)
     }
 
+    /// Run `handler` for every incoming message, with a ready
+    /// [`MessageContext`] (reply/react/edit helpers included).
+    pub fn on_message<F, Fut>(self, handler: F) -> Self
+    where
+        F: Fn(MessageContext) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_event_for(&[EventKind::Message], move |event, client| {
+            let fut = MessageContext::from_event(&event, client).map(&handler);
+            async move {
+                if let Some(fut) = fut {
+                    fut.await
+                }
+            }
+        })
+    }
+
+    /// Run `handler` with the QR payload (and validity window) each time a
+    /// pairing QR code is issued. Render `code` as a QR image for scanning.
+    pub fn on_qr_code<F, Fut>(self, handler: F) -> Self
+    where
+        F: Fn(String, std::time::Duration) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_event_for(&[EventKind::PairingQrCode], move |event, _client| {
+            let fut = match &*event {
+                Event::PairingQrCode { code, timeout } => Some(handler(code.clone(), *timeout)),
+                _ => None,
+            };
+            async move {
+                if let Some(fut) = fut {
+                    fut.await
+                }
+            }
+        })
+    }
+
+    /// Run `handler` with the 8-character pairing code (and validity window)
+    /// generated by [`BotBuilder::with_pair_code`] linking.
+    pub fn on_pair_code<F, Fut>(self, handler: F) -> Self
+    where
+        F: Fn(String, std::time::Duration) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_event_for(&[EventKind::PairingCode], move |event, _client| {
+            let fut = match &*event {
+                Event::PairingCode { code, timeout } => Some(handler(code.clone(), *timeout)),
+                _ => None,
+            };
+            async move {
+                if let Some(fut) = fut {
+                    fut.await
+                }
+            }
+        })
+    }
+
+    /// Run `handler` once the client is connected and authenticated.
+    pub fn on_connected<F, Fut>(self, handler: F) -> Self
+    where
+        F: Fn(Arc<Client>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_event_for(&[EventKind::Connected], move |_event, client| {
+            handler(client)
+        })
+    }
+
+    /// Run `handler` when the device is logged out (unlinked from the phone).
+    pub fn on_logged_out<F, Fut>(self, handler: F) -> Self
+    where
+        F: Fn(crate::types::events::LoggedOut) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_event_for(&[EventKind::LoggedOut], move |event, _client| {
+            let fut = match &*event {
+                Event::LoggedOut(info) => Some(handler(info.clone())),
+                _ => None,
+            };
+            async move {
+                if let Some(fut) = fut {
+                    fut.await
+                }
+            }
+        })
+    }
+
     fn register_event_handler<F, Fut>(mut self, interest: EventInterest, handler: F) -> Self
     where
         F: Fn(Arc<Event>, Arc<Client>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
-        self.event_handler = Some(RegisteredHandler {
+        self.event_handlers.push(RegisteredHandler {
             callback: Arc::new(move |event, client| Box::pin(handler(event, client))),
             interest,
         });
         self
     }
 
+    /// Register a struct-based [`EventHandler`] directly on the event bus.
+    ///
+    /// Unlike the closure registrars, the handler keeps its state in `&self`
+    /// (no per-field clone dance) and `handle_event` runs inline on the
+    /// dispatch path: spawn your own task for slow work.
+    pub fn with_event_handler(mut self, handler: impl EventHandler + 'static) -> Self {
+        self.raw_handlers.push(Arc::new(handler));
+        self
+    }
+
+    // ── Optional configuration ─────────────────────────────────────────────
+
     /// Register a custom handler for a specific encrypted message type
     ///
     /// # Arguments
     /// * `enc_type` - The encrypted message type (e.g., "frskmsg")
     /// * `handler` - The handler implementation for this type
-    ///
-    /// # Returns
-    /// The updated BotBuilder
     pub fn with_enc_handler<Eh>(mut self, enc_type: impl Into<String>, handler: Eh) -> Self
     where
         Eh: EncHandler + 'static,
@@ -553,15 +748,6 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     ///
     /// # Arguments
     /// * `version` - A tuple of (primary, secondary, tertiary) version numbers
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .with_version((2, 3000, 1027868167))
-    ///     .build()
-    ///     .await?;
-    /// ```
     pub fn with_version(mut self, version: (u32, u32, u32)) -> Self {
         self.override_version = Some(version);
         self
@@ -594,11 +780,9 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Configure pair code authentication to run automatically after connecting.
     ///
     /// When set, the pair code request will be sent automatically after establishing
-    /// a connection, and the pairing code will be dispatched via `Event::PairingCode`.
-    /// This runs concurrently with QR code pairing - whichever completes first wins.
-    ///
-    /// # Arguments
-    /// * `options` - Configuration for pair code authentication
+    /// a connection, and the pairing code will be dispatched via `Event::PairingCode`
+    /// (see [`BotBuilder::on_pair_code`]). This runs concurrently with QR code
+    /// pairing - whichever completes first wins.
     ///
     /// # Example
     /// ```rust,ignore
@@ -609,20 +793,13 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// // are optional — omit them to let derivation do the right thing.
     /// let bot = Bot::builder()
     ///     .with_backend(backend)
-    ///     .with_transport_factory(transport)
-    ///     .with_http_client(http_client)
     ///     .with_pair_code(PairCodeOptions {
     ///         phone_number: "15551234567".to_string(),
     ///         custom_code: Some("ABCD1234".to_string()),
     ///         ..Default::default()
     ///     })
-    ///     .on_event(|event, client| async move {
-    ///         match &*event {
-    ///             Event::PairingCode { code, timeout } => {
-    ///                 println!("Enter this code on your phone: {}", code);
-    ///             }
-    ///             _ => {}
-    ///         }
+    ///     .on_pair_code(|code, _timeout| async move {
+    ///         println!("Enter this code on your phone: {code}");
     ///     })
     ///     .build()
     ///     .await?;
@@ -642,17 +819,6 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// is not needed.
     ///
     /// Default: `false` (history sync is processed normally).
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .with_transport_factory(transport)
-    ///     .with_http_client(http_client)
-    ///     .skip_history_sync()
-    ///     .build()
-    ///     .await?;
-    /// ```
     pub fn skip_history_sync(mut self) -> Self {
         self.skip_history_sync = true;
         self
@@ -663,17 +829,6 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Defaults to WA Web's UPLOAD_KEYS_COUNT (812). The value is clamped to the
     /// protocol-safe range at upload time. Useful for memory-constrained or
     /// embedded consumers that want a smaller batch.
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let bot = Bot::builder()
-    ///     .with_backend(backend)
-    ///     .with_transport_factory(transport)
-    ///     .with_http_client(http_client)
-    ///     .with_wanted_pre_key_count(200)
-    ///     .build()
-    ///     .await?;
-    /// ```
     pub fn with_wanted_pre_key_count(mut self, count: usize) -> Self {
         self.wanted_pre_key_count = Some(count);
         self
@@ -701,8 +856,6 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// // Disable TTL for group and device caches (good for bots with few groups)
     /// let bot = Bot::builder()
     ///     .with_backend(backend)
-    ///     .with_transport_factory(transport)
-    ///     .with_http_client(http_client)
     ///     .with_cache_config(CacheConfig {
     ///         group_cache: CacheEntryConfig::new(None, 1_000),
     ///         device_registry_cache: CacheEntryConfig::new(None, 5_000),
@@ -750,12 +903,8 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         };
 
         // Note: For multi-account mode, create the backend with SqliteStore::new_for_device()
-        // before passing it to with_backend()
-        let persistence_manager = Arc::new(
-            PersistenceManager::new(backend)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to create persistence manager: {}", e))?,
-        );
+        // before passing it to with_backend_arc()
+        let persistence_manager = Arc::new(PersistenceManager::new(backend).await?);
 
         // Apply initial push name if specified (for deterministic mock server phone assignment)
         if let Some(name) = self.initial_push_name {
@@ -809,7 +958,8 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         Ok(Bot {
             client,
             sync_task_receiver: Some(sync_task_receiver),
-            event_handler: self.event_handler,
+            event_handlers: self.event_handlers,
+            raw_handlers: self.raw_handlers,
             pair_code_options: self.pair_code_options,
         })
     }
@@ -821,6 +971,7 @@ mod tests {
     use crate::TokioRuntime;
     use crate::http::{HttpClient, HttpRequest, HttpResponse};
     use crate::store::SqliteStore;
+    use anyhow::Result;
     use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
 
     // Mock HTTP client for testing
@@ -869,7 +1020,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_runtime(TokioRuntime)
@@ -888,7 +1039,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -901,49 +1052,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_bot_builder_with_custom_backend() {
-        // Create an in-memory backend for testing
-        let backend = create_test_sqlite_backend().await;
-        let transport = TokioWebSocketTransportFactory::new();
-        let http_client = MockHttpClient;
+    async fn test_bot_builder_defaults_only_need_backend() {
+        // With the default features on, transport/HTTP/runtime are pre-filled,
+        // so providing the backend alone must reach build().
+        let temp_db = format!(
+            "file:memdb_bot_{}?mode=memory&cache=shared",
+            uuid::Uuid::new_v4()
+        );
+        let store = SqliteStore::new(&temp_db)
+            .await
+            .expect("Failed to create test SqliteStore");
+
         let bot = Bot::builder()
-            .with_backend(backend)
-            .with_transport_factory(transport)
-            .with_http_client(http_client)
-            .with_runtime(TokioRuntime)
+            .with_backend(store)
+            // Override the default HTTP client so the test doesn't hit the network.
+            .with_http_client(MockHttpClient)
             .build()
             .await
-            .expect("Failed to build bot with custom backend");
+            .expect("Failed to build bot from defaults");
 
-        // Verify the bot was created successfully
         let _client = bot.client();
     }
-
-    #[tokio::test]
-    async fn test_bot_builder_with_custom_backend_specific_device() {
-        // Create a backend configured for device ID 100
-        let backend = create_test_sqlite_backend_for_device(100).await;
-        let transport = TokioWebSocketTransportFactory::new();
-        let http_client = MockHttpClient;
-
-        // Build a bot with the custom backend
-        let bot = Bot::builder()
-            .with_backend(backend)
-            .with_http_client(http_client)
-            .with_transport_factory(transport)
-            .with_runtime(TokioRuntime)
-            .build()
-            .await
-            .expect("Failed to build bot with custom backend for specific device");
-
-        // Verify the bot was created successfully
-        let _client = bot.client();
-    }
-
-    // NOTE: test_bot_builder_missing_backend, test_bot_builder_missing_transport,
-    // and test_bot_builder_missing_http_client have been removed because the
-    // typestate pattern now makes those cases compile-time errors instead of
-    // runtime errors.
 
     #[tokio::test]
     async fn test_bot_builder_with_version_override() {
@@ -952,7 +1081,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_version((2, 3000, 123456789))
@@ -983,7 +1112,7 @@ mod tests {
         };
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_device_props(
@@ -1014,7 +1143,7 @@ mod tests {
         let custom_os = "CustomOS".to_string();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_device_props(DevicePropsOverride::new().with_os(custom_os.clone()))
@@ -1050,7 +1179,7 @@ mod tests {
         };
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_http_client(http_client)
             .with_transport_factory(transport)
             .with_device_props(DevicePropsOverride::new().with_version(custom_version))
@@ -1079,7 +1208,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_device_props(
@@ -1127,7 +1256,7 @@ mod tests {
         let custom_platform = wa::device_props::PlatformType::Safari;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_device_props(
@@ -1161,7 +1290,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .skip_history_sync()
@@ -1180,7 +1309,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_runtime(TokioRuntime)
@@ -1198,7 +1327,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_wanted_pre_key_count(200)
@@ -1217,7 +1346,7 @@ mod tests {
         let http_client = MockHttpClient;
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_runtime(TokioRuntime)
@@ -1232,10 +1361,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registered_handlers_accumulate_instead_of_replacing() {
+        let backend = create_test_sqlite_backend().await;
+
+        let bot = Bot::builder()
+            .with_backend_arc(backend)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .on_message(|_ctx| async {})
+            .on_qr_code(|_code, _timeout| async {})
+            .on_event(|_event, _client| async {})
+            .build()
+            .await
+            .expect("Failed to build bot");
+
+        assert_eq!(bot.event_handlers.len(), 3);
+
+        // The catch-all handler widens the union to every kind.
+        let interest = combined_interest(&bot.event_handlers);
+        assert_eq!(interest, EventInterest::ALL);
+    }
+
+    #[test]
+    fn combined_interest_is_the_union_of_handler_interests() {
+        let noop: EventHandlerCallback = Arc::new(|_event, _client| Box::pin(async {}));
+        let handlers = vec![
+            RegisteredHandler {
+                callback: noop.clone(),
+                interest: EventInterest::of(&[EventKind::Message]),
+            },
+            RegisteredHandler {
+                callback: noop,
+                interest: EventInterest::of(&[EventKind::PairingQrCode]),
+            },
+        ];
+
+        let interest = combined_interest(&handlers);
+        assert!(interest.wants(EventKind::Message));
+        assert!(interest.wants(EventKind::PairingQrCode));
+        assert!(!interest.wants(EventKind::Receipt));
+    }
+
+    #[tokio::test]
     async fn from_arc_does_not_deep_clone() {
         let backend = create_test_sqlite_backend().await;
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -1258,7 +1430,7 @@ mod tests {
     async fn test_context_with_info(info: MessageInfo) -> MessageContext {
         let backend = create_test_sqlite_backend().await;
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(TokioWebSocketTransportFactory::new())
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -290,7 +290,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -325,7 +325,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -367,7 +367,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -409,7 +409,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -433,7 +433,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)
@@ -460,7 +460,7 @@ mod tests {
         let transport = TokioWebSocketTransportFactory::new();
 
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(MockHttpClient)
             .with_runtime(TokioRuntime)

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,1 +1,4 @@
 pub use wacore::net::{HttpClient, HttpRequest, HttpResponse};
+
+#[cfg(feature = "ureq-client")]
+pub use whatsapp_rust_ureq_http_client::UreqHttpClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Compile-checks the README examples as doctests, so the advertised quick
+// start can never silently rot.
+#![doc = include_str!("../README.md")]
 // Instrumenting large async fns (e.g. process_sync_task) wraps them in deep
 // `Instrumented` future types; the default depth limit overflows when the
 // `tracing` + `tracing-pii` paths combine. Raise it (compile-time only).
@@ -14,6 +17,12 @@ pub use wacore_binary::CompactString;
 pub use wacore_binary::OwnedNodeRef;
 pub use wacore_binary::builder::NodeBuilder;
 pub use wacore_binary::{Jid, Server};
+
+// Whole-crate re-exports so a git consumer needs a single dependency:
+// every `wacore::…`/`wacore_binary::…`/`waproto::…` path is reachable as
+// `whatsapp_rust::wacore::…` (etc.) without declaring the sibling crates.
+pub use wacore;
+pub use wacore_binary;
 pub use waproto;
 
 pub mod cache;
@@ -102,6 +111,24 @@ pub mod lid_pn_cache;
 pub mod spam_report;
 pub mod sync_task;
 pub mod version;
+
+/// One-import surface for the common bot path:
+/// `use whatsapp_rust::prelude::*;`.
+pub mod prelude {
+    pub use crate::bot::{Bot, BotBuilder, BotHandle, MessageContext};
+    pub use crate::client::Client;
+    #[cfg(feature = "tokio-runtime")]
+    pub use crate::runtime_impl::TokioRuntime;
+    pub use crate::send::{SendOptions, SendResult};
+    #[cfg(feature = "sqlite-storage")]
+    pub use crate::store::SqliteStore;
+    pub use crate::types::events::{Event, EventKind};
+    pub use crate::types::message::MessageInfo;
+    pub use crate::{Jid, Server};
+    pub use wacore::proto_helpers::{MessageBuilderExt, MessageExt};
+    /// The protobuf namespace (`wa::Message`, `wa::message::*`).
+    pub use waproto::whatsapp as wa;
+}
 
 pub use spam_report::{SpamFlow, SpamReportRequest, SpamReportResult};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,8 @@
 #![recursion_limit = "512"]
 
 use log::{error, info};
-use std::sync::Arc;
-use wacore::proto_helpers::MessageExt;
-use wacore::types::events::{Event, EventKind};
-use waproto::whatsapp as wa;
-use whatsapp_rust::TokioRuntime;
-use whatsapp_rust::bot::{Bot, MessageContext};
 use whatsapp_rust::pair_code::PairCodeOptions;
-use whatsapp_rust::store::SqliteStore;
-use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
-use whatsapp_rust_ureq_http_client::UreqHttpClient;
+use whatsapp_rust::prelude::*;
 
 const PING_TRIGGER: &str = "🦀ping";
 const PONG_TEXT: &str = "🏓 Pong!";
@@ -24,7 +16,6 @@ const REACTION_EMOJI: &str = "🏓";
 //   cargo run -- -p 15551234567                    # Short form
 //   cargo run -- -p 15551234567 --code MYCODE12    # Custom 8-char pair code
 //   cargo run -- -p 15551234567 -c MYCODE12        # Short form
-
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let phone_number = parse_arg(&args, "--phone", "-p");
@@ -57,8 +48,8 @@ fn main() {
         .expect("Failed to build tokio runtime");
 
     rt.block_on(async {
-        let backend = match SqliteStore::new("whatsapp.db").await {
-            Ok(store) => Arc::new(store),
+        let store = match SqliteStore::new("whatsapp.db").await {
+            Ok(store) => store,
             Err(e) => {
                 error!("Failed to create SQLite backend: {}", e);
                 return;
@@ -66,14 +57,46 @@ fn main() {
         };
         info!("SQLite backend initialized successfully.");
 
-        let transport_factory = TokioWebSocketTransportFactory::new();
-        let http_client = UreqHttpClient::new();
-
+        // Transport, HTTP client and runtime fall back to the defaults shipped
+        // with the default cargo features (Tokio WebSocket, ureq, Tokio).
         let mut builder = Bot::builder()
-            .with_backend(backend)
-            .with_transport_factory(transport_factory)
-            .with_http_client(http_client)
-            .with_runtime(TokioRuntime);
+            .with_backend(store)
+            .on_qr_code(|code, timeout| async move {
+                info!("----------------------------------------");
+                info!(
+                    "QR code received (valid for {} seconds):",
+                    timeout.as_secs()
+                );
+                info!("\n{}\n", code);
+                info!("----------------------------------------");
+            })
+            .on_pair_code(|code, timeout| async move {
+                info!("========================================");
+                info!("PAIR CODE (valid for {} seconds):", timeout.as_secs());
+                info!("Enter this code on your phone:");
+                info!("WhatsApp > Linked Devices > Link a Device");
+                info!("> Link with phone number instead");
+                info!("");
+                info!("    >>> {} <<<", code);
+                info!("");
+                info!("========================================");
+            })
+            .on_connected(|_client| async {
+                info!("✅ Bot connected successfully!");
+            })
+            .on_logged_out(|_info| async {
+                error!("❌ Bot was logged out!");
+            })
+            .on_message(|ctx| async move {
+                if let Some(reply) = build_media_pong(&ctx.message) {
+                    info!("Received media ping from {}", ctx.info.source.sender);
+                    if let Err(e) = ctx.send_message(reply).await {
+                        error!("Failed to send media pong: {}", e);
+                    }
+                } else if ctx.message.text_content() == Some(PING_TRIGGER) {
+                    handle_text_ping(&ctx).await;
+                }
+            });
 
         if let Some(phone) = phone_number {
             builder = builder.with_pair_code(PairCodeOptions {
@@ -83,126 +106,40 @@ fn main() {
             });
         }
 
-        let mut bot = builder
-            .on_event_for(
-                &[
-                    EventKind::PairingQrCode,
-                    EventKind::PairingCode,
-                    EventKind::Message,
-                    EventKind::Connected,
-                    EventKind::LoggedOut,
-                ],
-                move |event, client| async move {
-                    match &*event {
-                        Event::PairingQrCode { code, timeout } => {
-                            info!("----------------------------------------");
-                            info!(
-                                "QR code received (valid for {} seconds):",
-                                timeout.as_secs()
-                            );
-                            info!("\n{}\n", code);
-                            info!("----------------------------------------");
-                        }
-                        Event::PairingCode { code, timeout } => {
-                            info!("========================================");
-                            info!("PAIR CODE (valid for {} seconds):", timeout.as_secs());
-                            info!("Enter this code on your phone:");
-                            info!("WhatsApp > Linked Devices > Link a Device");
-                            info!("> Link with phone number instead");
-                            info!("");
-                            info!("    >>> {} <<<", code);
-                            info!("");
-                            info!("========================================");
-                        }
-                        Event::Message(msg, info) => {
-                            let ctx = MessageContext::from_parts(msg, info, client);
-                            if let Some(reply) = build_media_pong(msg) {
-                                info!("Received media ping from {}", ctx.info.source.sender);
-                                if let Err(e) = ctx.send_message(reply).await {
-                                    error!("Failed to send media pong: {}", e);
-                                }
-                            } else if msg.text_content() == Some(PING_TRIGGER) {
-                                handle_text_ping(&ctx).await;
-                            }
-                        }
-                        Event::Connected(_) => info!("✅ Bot connected successfully!"),
-                        Event::LoggedOut(_) => error!("❌ Bot was logged out!"),
-                        _ => {}
-                    }
-                },
-            )
-            .build()
-            .await
-            .expect("Failed to build bot");
-
-        let client = bot.client();
-
-        let bot_handle = match bot.run().await {
-            Ok(handle) => handle,
+        let bot = match builder.build().await {
+            Ok(bot) => bot,
             Err(e) => {
-                error!("Bot failed to start: {}", e);
+                error!("Failed to build bot: {}", e);
                 return;
             }
         };
 
         #[cfg(feature = "signal")]
         {
+            let mut handle = bot.spawn();
             tokio::select! {
-                _ = bot_handle => {}
+                _ = &mut handle => {}
                 _ = tokio::signal::ctrl_c() => {
                     info!("Received Ctrl+C, shutting down...");
-                    client.disconnect().await;
+                    handle.shutdown().await;
                 }
             }
         }
 
         #[cfg(not(feature = "signal"))]
-        {
-            bot_handle
-                .await
-                .expect("Bot task should complete without panicking");
-        }
+        bot.run().await;
     });
 }
 
 async fn handle_text_ping(ctx: &MessageContext) {
     info!("Received text ping, sending pong...");
 
-    let key = wa::MessageKey {
-        remote_jid: Some(ctx.info.source.chat.to_string()),
-        id: Some(ctx.info.id.clone()),
-        from_me: Some(ctx.info.source.is_from_me),
-        participant: ctx
-            .info
-            .source
-            .is_group
-            .then(|| ctx.info.source.sender.to_string()),
-    };
-    let reaction = wa::Message {
-        reaction_message: Some(wa::message::ReactionMessage {
-            key: Some(key),
-            text: Some(REACTION_EMOJI.to_string()),
-            sender_timestamp_ms: Some(wacore::time::now_millis()),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
-    if let Err(e) = ctx.send_message(reaction).await {
+    if let Err(e) = ctx.react(REACTION_EMOJI).await {
         error!("Failed to send reaction: {}", e);
     }
 
     let start = wacore::time::Instant::now();
-    let context_info = ctx.build_quote_context();
-    let reply = wa::Message {
-        extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
-            text: Some(PONG_TEXT.to_string()),
-            context_info: Some(Box::new(context_info)),
-            ..Default::default()
-        })),
-        ..Default::default()
-    };
-
-    let sent = match ctx.send_message(reply).await {
+    let sent = match ctx.reply_quoting(PONG_TEXT).await {
         Ok(r) => r,
         Err(e) => {
             error!("Failed to send pong: {}", e);

--- a/src/send.rs
+++ b/src/send.rs
@@ -417,6 +417,21 @@ impl Client {
             .await
     }
 
+    /// Plain-text convenience over [`Client::send_message`].
+    pub async fn send_text(
+        &self,
+        to: impl Into<Jid>,
+        text: impl Into<String>,
+    ) -> Result<SendResult, anyhow::Error> {
+        use wacore::proto_helpers::MessageBuilderExt;
+        self.send_message_with_options_inner(
+            to.into(),
+            wa::Message::text(text),
+            SendOptions::default(),
+        )
+        .await
+    }
+
     /// Forward an existing message to a chat.
     ///
     /// Builds a forward-ready copy of `message` (sets `is_forwarded`, bumps the

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6,9 +6,6 @@ pub use whatsapp_rust_tokio_transport::{
     Connector, TokioWebSocketTransportFactory, default_tls_connector, from_websocket,
 };
 
-#[cfg(feature = "ureq-client")]
-pub use whatsapp_rust_ureq_http_client::UreqHttpClient;
-
 #[cfg(test)]
 pub mod mock {
     use super::*;

--- a/src/types/enc_handler.rs
+++ b/src/types/enc_handler.rs
@@ -83,7 +83,7 @@ mod tests {
         let transport = whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory::new();
         let http_client = whatsapp_rust_ureq_http_client::UreqHttpClient::new();
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_enc_handler("frskmsg", mock_handler)
@@ -115,7 +115,7 @@ mod tests {
         let transport = whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory::new();
         let http_client = whatsapp_rust_ureq_http_client::UreqHttpClient::new();
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_enc_handler("frskmsg", handler1)
@@ -143,7 +143,7 @@ mod tests {
         let transport = whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory::new();
         let http_client = whatsapp_rust_ureq_http_client::UreqHttpClient::new();
         let bot = Bot::builder()
-            .with_backend(backend)
+            .with_backend_arc(backend)
             .with_transport_factory(transport)
             .with_http_client(http_client)
             .with_runtime(TokioRuntime)

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -8,7 +8,6 @@ use wacore::types::events::{ChannelEventHandler, Event};
 use wacore_binary::node::Node;
 use whatsapp_rust::Jid;
 use whatsapp_rust::bot::Bot;
-use whatsapp_rust::store::traits::Backend;
 use whatsapp_rust::waproto::whatsapp as wa;
 use whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory;
 use whatsapp_rust_ureq_http_client::UreqHttpClient;
@@ -119,12 +118,11 @@ impl TestClient {
     }
 
     async fn connect_inner(_prefix: &str, push_name: Option<String>) -> anyhow::Result<Self> {
-        let backend = Arc::new(InMemoryBackend::new()) as Arc<dyn Backend>;
         let transport_factory = TokioWebSocketTransportFactory::new().with_url(mock_server_url());
         let (event_handler, event_rx) = ChannelEventHandler::new();
 
         let mut builder = Bot::builder()
-            .with_backend(backend)
+            .with_backend(InMemoryBackend::new())
             .with_transport_factory(transport_factory)
             .with_http_client(UreqHttpClient::new())
             .with_runtime(whatsapp_rust::TokioRuntime)
@@ -135,7 +133,7 @@ impl TestClient {
             builder = builder.with_push_name(name);
         }
 
-        let mut bot = builder.build().await?;
+        let bot = builder.build().await?;
 
         let client = bot.client();
         // with_push_name pre-seeds the name so the setting_pushName mutation has old==new (skipping auto set_available), so force active to keep delivery receipts from being type="inactive".
@@ -154,7 +152,7 @@ impl TestClient {
         client.register_handler(qr_handler);
         let _qr_responder = spawn_qr_autoresponder_http(qr_rx);
 
-        let run_handle = bot.run().await?;
+        let run_handle = bot.spawn();
 
         // Wait for PairSuccess + Connected.
         //

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -87,6 +87,38 @@ macro_rules! find_context_info_impl {
     }};
 }
 
+/// Constructors for common outbound message bodies, so simple sends don't
+/// hand-assemble protobuf structs. Import the trait and call the associated
+/// functions on [`wa::Message`] (`wa::Message::text("hi")`).
+pub trait MessageBuilderExt {
+    /// Plain text body. WA Web sends bare text as `conversation`.
+    fn text(text: impl Into<String>) -> wa::Message;
+
+    /// Text carrying a [`wa::ContextInfo`] (quote, mentions). WA Web switches
+    /// from `conversation` to `extendedTextMessage` once context is attached.
+    fn text_with_context(text: impl Into<String>, context: wa::ContextInfo) -> wa::Message;
+}
+
+impl MessageBuilderExt for wa::Message {
+    fn text(text: impl Into<String>) -> wa::Message {
+        wa::Message {
+            conversation: Some(text.into()),
+            ..Default::default()
+        }
+    }
+
+    fn text_with_context(text: impl Into<String>, context: wa::ContextInfo) -> wa::Message {
+        wa::Message {
+            extended_text_message: Some(Box::new(wa::message::ExtendedTextMessage {
+                text: Some(text.into()),
+                context_info: Some(Box::new(context)),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+}
+
 /// Extension trait for wa::Message
 pub trait MessageExt {
     /// Recursively unwraps ephemeral/view-once/document_with_caption/edited wrappers to get the core message.

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -302,6 +302,12 @@ impl EventInterest {
     pub const fn wants(self, kind: EventKind) -> bool {
         self.0 & (1u64 << (kind as u8)) != 0
     }
+
+    /// Set union, for aggregating the interests of several handlers behind one
+    /// bus registration.
+    pub const fn union(self, other: Self) -> Self {
+        EventInterest(self.0 | other.0)
+    }
 }
 
 pub trait EventHandler: crate::sync_marker::MaybeSendSync {


### PR DESCRIPTION
## Why

A rigorous pass over our public API against serenity 0.12 and teloxide surfaced a set of first-mile problems worth fixing before 1.0, while breaking changes are still cheap.

The two biggest ones were embarrassing in hello world itself: the README quick start did not compile (the handler receives `Arc<Event>` but the example matched on `Event`, E0308, verified empirically), and the lifecycle required `bot.run().await?.await?` where the first `.await` and the first `?` were literally free of function (the old `run_graph` had zero await points and no error path).

On top of that, a survey of real consumers on GitHub ([moltis](https://github.com/moltis-org/moltis/blob/main/crates/whatsapp/Cargo.toml), [picobot](https://github.com/shantanugoel/picobot), [Papo](https://github.com/AmanoTeam/Papo), [zeroclaw](https://github.com/zeroclaw-labs/zeroclaw)) showed every single one declaring 5 to 7 of our crates as separate git dependencies (`whatsapp-rust` + `wacore` + `wacore-binary` + `waproto` + both satellites), because the README taught imports from the satellite crates and `wacore`/`wacore-binary` were not reachable through the main crate.

## What changed

**Lifecycle.** `Bot::run(self)` now runs the bot on the current task with a single await, and `Bot::spawn(self)` starts it in the background and returns a `BotHandle` with `client()`, a graceful `shutdown()` (flushes the device snapshot, buffered receipts and message secrets via `Client::disconnect`, then waits for the loop to exit), and `abort()` as a documented escape hatch. Awaiting the handle resolves to `()` instead of leaking `futures::channel::oneshot::Canceled`. Dropping the handle still aborts the task (the e2e harness relies on that).

**Builder defaults.** With the default cargo features, transport, HTTP client and runtime start as `Provided` (Tokio WebSocket, ureq, Tokio), so only the backend has to be chosen; the `with_*` setters are now available in every typestate, so they also work as overrides. The typestate markers got names (`MissingBackend`, `MissingTransport`, `MissingHttpClient`, `MissingRuntime`), so a missing-field compile error now says which field is missing. `with_backend` takes `impl Backend + 'static` (no caller-side `Arc`), with `with_backend_arc` for an already-shared backend. `BotBuilderError` lost its fake `Other(anyhow)` variant and now carries the typed `Store(StoreError)` that `build()` can actually produce.

**Event handlers.** Registrations accumulate instead of silently replacing the previous handler. New typed registrars cover the common path: `on_message` (receives a ready `MessageContext`), `on_qr_code`, `on_pair_code`, `on_connected`, `on_logged_out`, with `on_event`/`on_event_for` unchanged as the catch-all. `with_event_handler` registers a struct-based `EventHandler` directly on the bus for stateful handlers (kills the clone-dance that closure captures force on consumers). The bus still skips materializing events nobody wants: the adapter registers the union of all handler interests (`EventInterest::union`) and filters per handler at dispatch.

**Messaging sugar.** `wa::Message::text(...)` and `wa::Message::text_with_context(...)` via the new `MessageBuilderExt` in `wacore::proto_helpers`, `ctx.reply(...)` and `ctx.reply_quoting(...)` on `MessageContext`, and `Client::send_text(jid, text)`. The raw protobuf path stays untouched for advanced cases.

**Single-dependency consumption.** The crate now re-exports `wacore`, `wacore_binary` and `waproto` wholesale, so every path is reachable as `whatsapp_rust::wacore::...` and a git consumer needs exactly one dependency line. `UreqHttpClient` moved from the misplaced `whatsapp_rust::transport` re-export to `whatsapp_rust::http`. A new `whatsapp_rust::prelude` covers the common bot path in one import (including `wa` as the protobuf alias).

**Docs that cannot rot.** The README was rewritten around the new API (quick start is one dependency plus tokio) and is now included as crate docs via `#![doc = include_str!]`, so both README examples compile as doctests on every CI run. The demo `main.rs` showcases the typed registrars, `ctx.reply_quoting`, and ctrl-c handling via `handle.shutdown()`.

## Breaking changes and migration

- `bot.run().await?.await?` becomes `bot.run().await` (foreground) or `let handle = bot.spawn();` (background, what Veloz-style consumers want). `run` consumes the bot; grab `bot.client()` before, or use `handle.client()`.
- `.with_backend(arc_backend)` becomes `.with_backend_arc(arc_backend)`; plain stores can drop the `Arc::new` entirely.
- `use whatsapp_rust::transport::UreqHttpClient` becomes `use whatsapp_rust::http::UreqHttpClient`.
- `bot::Missing` was replaced by the named markers; code that spelled out builder types must update.
- `BotBuilderError::Other` is gone; the only variant is `Store(StoreError)`.
- Registering two handlers now runs both (previously the second silently replaced the first).

The send/connect anyhow-to-typed-errors migration from the same review is intentionally staged as a follow-up PR to keep this one reviewable.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings` clean (also fixed a latent `chrono::Local::now` disallowed-method hit in the benchmark example that workspace-level feature unification exposes).
- `cargo test -p whatsapp-rust -p wacore`: 1769 unit tests plus doctests green, including the two README examples as compile-checked doctests.
- wasm32 guard locally: `cargo build -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features --features debug-diagnostics` builds (exercises the no-defaults typestate path).
- e2e harness and benchmark example migrated and compiling under workspace clippy.
