### PR TITLE
bench: map the per-send DM encode and token work

### DIFF
--- a/wacore/benches/message_utils_benchmark.rs
+++ b/wacore/benches/message_utils_benchmark.rs
@@ -134,6 +134,10 @@ fn bench_dm_send_encode_work(bencher: divan::Bencher, shape: &str) {
                 "5511888887777@s.whatsapp.net",
             );
             let retry_bytes = waproto::codec::message_to_vec(black_box(message));
-            black_box((plaintexts, retry_bytes))
+            // Observe the whole result, not just the secret reporting_context_info
+            // reads: reporting_token feeds nothing downstream, so without this the
+            // HMAC (and, by cascade, the HKDF and the content encode this bench
+            // exists to profile) is dead under the bench profile's thin LTO.
+            black_box((plaintexts, retry_bytes, reporting_result))
         });
 }

--- a/wacore/benches/message_utils_benchmark.rs
+++ b/wacore/benches/message_utils_benchmark.rs
@@ -73,3 +73,67 @@ fn bench_unpad_message_ref(bencher: divan::Bencher) {
             )
         });
 }
+
+fn dm_shape(shape: &str) -> wa::Message {
+    match shape {
+        "text_reply" => text_message(),
+        "media_refs" => wa::Message {
+            image_message: Some(Box::new(wa::message::ImageMessage {
+                url: Some("https://mmg.whatsapp.net/v/t62.7118-24/abc123".into()),
+                direct_path: Some("/v/t62.7118-24/abc123".into()),
+                mimetype: Some("image/jpeg".into()),
+                caption: Some("Benchmark media caption".into()),
+                media_key: Some(vec![0xA5; 32]),
+                file_sha256: Some(vec![0x11; 32]),
+                file_enc_sha256: Some(vec![0x22; 32]),
+                file_length: Some(184_320),
+                height: Some(1280),
+                width: Some(960),
+                jpeg_thumbnail: Some(vec![0x7F; 6 * 1024]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        "large_text" => wa::Message {
+            conversation: Some("Lorem ipsum dolor sit amet 0123456789 ".repeat(108)),
+            ..Default::default()
+        },
+        other => unreachable!("unknown shape {other}"),
+    }
+}
+
+/// The CPU a single DM send pays in the encode/token department, mirroring
+/// `wacore::send::dm` plus the retry-cache serialization the client does:
+/// reporting token (full content encode + HKDF + HMAC), the splice into the
+/// recipient and DeviceSentMessage plaintexts, and the recent-message bytes.
+/// Exists so flamegraphs keep the byte-identical encode pair (reporting
+/// content vs retry bytes) visible while it remains deduplicable.
+#[divan::bench(args = ["text_reply", "media_refs", "large_text"])]
+fn bench_dm_send_encode_work(bencher: divan::Bencher, shape: &str) {
+    use wacore::reporting_token::{
+        extract_message_secret, generate_reporting_token, reporting_context_info,
+    };
+
+    let own_jid: Jid = "5511999990000:7@s.whatsapp.net".parse().unwrap();
+    let to_jid: Jid = "5511888887777@s.whatsapp.net".parse().unwrap();
+
+    bencher
+        .with_inputs(|| dm_shape(shape))
+        .bench_refs(|message| {
+            let reporting_result = generate_reporting_token(
+                black_box(message),
+                "3EB0BENCHBENCHBENCH01",
+                &own_jid,
+                &to_jid,
+                extract_message_secret(message),
+            );
+            let extra_context = reporting_result.as_ref().map(reporting_context_info);
+            let plaintexts = MessageUtils::encode_dm_plaintexts(
+                black_box(message),
+                extra_context.as_ref(),
+                "5511888887777@s.whatsapp.net",
+            );
+            let retry_bytes = waproto::codec::message_to_vec(black_box(message));
+            black_box((plaintexts, retry_bytes))
+        });
+}


### PR DESCRIPTION
## Why

Benchmark-first step for the remaining half of the gap-analysis finding `performance-10`. After #787 deduplicated the recipient/DSM content encode via the splice, the send path still serializes the same original `wa::Message` twice per send: once inside `generate_reporting_token_content` (full encode, whitelist-filtered, buffer discarded) and once in `add_recent_message` for the retry cache. Before attempting the dedup, this PR gives CodSpeed a benchmark whose flamegraph keeps that byte-identical pair visible, so the optimization (and its actual share of the per-send cost) is driven by profile data instead of estimates.

## What it measures

`bench_dm_send_encode_work` mirrors the encode/token department of one DM send end to end: `generate_reporting_token` (content encode + HKDF + HMAC), `reporting_context_info`, the `encode_dm_plaintexts` splice into recipient + DeviceSentMessage plaintexts, and the `codec::message_to_vec` retry-cache serialization. Three shapes: a quoted text reply, a media message carrying refs/keys plus a 6 KB thumbnail, and a 4 KB plain text (the size-scaling case the #787 PoC flagged as unexercised by tiny fixtures).

No production code changes; one bench function added to the existing `message_utils_benchmark` target (target count unchanged). Local medians: ~4.4 µs (text reply), ~4.2 µs (media refs), ~7.7 µs (large text) per send.
