### PR TITLE
ci: track binary size with a per-PR budget gate and historical series

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -10,7 +10,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: binary-size-${{ github.head_ref || github.run_id }}
+  # head_ref alone could collide across forks; the PR number is unique.
+  group: binary-size-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -100,18 +101,25 @@ jobs:
           benchmark-data-dir-path: dev/binary-size
           summary-always: true
 
-      - name: Generate report and evaluate gate
+      # The event payload freezes the labels at trigger time; query them
+      # live so adding size-increase-ok + re-running the job works.
+      - name: Check size-increase-ok label
+        id: override
         env:
-          BASE_DIR: ${{ steps.baseline.outputs.dir }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # The event payload freezes the labels at trigger time; query them
-          # live so adding size-increase-ok + re-running the job works.
-          ALLOW_SIZE_INCREASE=$(gh api \
+          allow=$(gh api \
             "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
             --jq 'map(.name) | index("size-increase-ok") != null')
-          export ALLOW_SIZE_INCREASE
+          echo "allow=$allow" >> "$GITHUB_OUTPUT"
+
+      # No GH_TOKEN here: the report script is PR-controlled code.
+      - name: Generate report and evaluate gate
+        env:
+          BASE_DIR: ${{ steps.baseline.outputs.dir }}
+          ALLOW_SIZE_INCREASE: ${{ steps.override.outputs.allow }}
+        run: |
           python3 scripts/ci/binary_size_report.py --head size-out \
             ${BASE_DIR:+--base "$BASE_DIR"} --out-dir size-out
           cat size-out/report.md >> "$GITHUB_STEP_SUMMARY"
@@ -145,11 +153,13 @@ jobs:
           echo "Gate status: $status"
 
   binary-size-push:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # Dispatch only publishes from main so stray branches can't pollute the series.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     name: Binary Size (push)
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      deployments: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -161,6 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # github-action-benchmark deploys the gh-pages site after auto-push.
       deployments: write
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,0 +1,206 @@
+permissions:
+  contents: read
+name: Binary Size
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: binary-size-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  PROTOC_VERSION: "3.25.3"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CARGO_BLOAT_VERSION: "0.12.1"
+  CARGO_LLVM_LINES_VERSION: "0.4.46"
+
+jobs:
+  binary-size-pr:
+    if: github.event_name == 'pull_request'
+    name: Binary Size (PR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-04-05
+
+      - name: Install tools (protoc, cargo-binstall)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-binstall
+
+      - name: Install cargo-bloat and cargo-llvm-lines
+        run: >
+          cargo binstall --no-confirm
+          cargo-bloat@${{ env.CARGO_BLOAT_VERSION }}
+          cargo-llvm-lines@${{ env.CARGO_LLVM_LINES_VERSION }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Rust registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ runner.os }}-cargo-binary-size
+          cache-targets: "false"
+
+      - name: Measure binary size
+        run: python3 scripts/ci/measure_binary_size.py --out-dir size-out
+
+      - name: Upload size artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-metrics
+          path: size-out/
+          retention-days: 90
+
+      - name: Download baseline from latest main run
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=$(gh run list --workflow binary-size.yml --branch main \
+            --status success --limit 1 --json databaseId \
+            --jq '.[0].databaseId' || true)
+          if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
+            if gh run download "$run_id" --name size-metrics --dir base-out; then
+              echo "dir=base-out" >> "$GITHUB_OUTPUT"
+            else
+              echo "Baseline artifact missing or expired on run $run_id"
+            fi
+          else
+            echo "No successful Binary Size run on main yet"
+          fi
+
+      # Informational (job summary); the real gate is the report script below.
+      # Tolerates the window before the first push run creates the series.
+      - name: Compare against gh-pages series
+        continue-on-error: true
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "whatsapp-rust binary size"
+          tool: "customSmallerIsBetter"
+          output-file-path: size-out/size-metrics.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          save-data-file: false
+          benchmark-data-dir-path: dev/binary-size
+          summary-always: true
+
+      - name: Generate report and evaluate gate
+        env:
+          BASE_DIR: ${{ steps.baseline.outputs.dir }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # The event payload freezes the labels at trigger time; query them
+          # live so adding size-increase-ok + re-running the job works.
+          ALLOW_SIZE_INCREASE=$(gh api \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
+            --jq 'map(.name) | index("size-increase-ok") != null')
+          export ALLOW_SIZE_INCREASE
+          python3 scripts/ci/binary_size_report.py --head size-out \
+            ${BASE_DIR:+--base "$BASE_DIR"} --out-dir size-out
+          cat size-out/report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Fork PRs run with a read-only token, so they only get the job summary.
+      - name: Post sticky PR comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          marker='<!-- binary-size-report -->'
+          cid=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+          if [ -n "$cid" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${cid}" \
+              -F body=@size-out/report.md
+          else
+            gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -F body=@size-out/report.md
+          fi
+
+      - name: Enforce size budget
+        run: |
+          status=$(head -n1 size-out/gate.txt)
+          if [ "$status" = "FAIL" ]; then
+            echo "::error::Binary size budget exceeded — see the job summary or PR comment. If the increase is expected, add the size-increase-ok label."
+            exit 1
+          fi
+          echo "Gate status: $status"
+
+  binary-size-push:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: Binary Size (push)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-04-05
+
+      - name: Install tools (protoc, cargo-binstall)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-binstall
+
+      - name: Install cargo-bloat and cargo-llvm-lines
+        run: >
+          cargo binstall --no-confirm
+          cargo-bloat@${{ env.CARGO_BLOAT_VERSION }}
+          cargo-llvm-lines@${{ env.CARGO_LLVM_LINES_VERSION }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Rust registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ runner.os }}-cargo-binary-size
+          cache-targets: "false"
+
+      - name: Measure binary size
+        run: python3 scripts/ci/measure_binary_size.py --out-dir size-out
+
+      # This artifact is the comparison baseline for PR runs.
+      - name: Upload size artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-metrics
+          path: size-out/
+          retention-days: 90
+
+      # Post-merge safety net: alerts on the commit when a regression landed
+      # despite (or around) the PR gate, e.g. via the size-increase-ok label.
+      - name: Store series on gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "whatsapp-rust binary size"
+          tool: "customSmallerIsBetter"
+          output-file-path: size-out/size-metrics.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          benchmark-data-dir-path: dev/binary-size
+          max-items-in-chart: 200
+          alert-threshold: "102%"
+          comment-on-alert: true
+          fail-on-alert: false
+          summary-always: true

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -73,8 +73,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # --event push: a fork PR from a branch named "main" also matches
+          # --branch main, and its artifact must not become the baseline.
           run_id=$(gh run list --workflow binary-size.yml --branch main \
-            --status success --limit 1 --json databaseId \
+            --event push --status success --limit 1 --json databaseId \
             --jq '.[0].databaseId' || true)
           if [ -n "$run_id" ] && [ "$run_id" != "null" ]; then
             if gh run download "$run_id" --name size-metrics --dir base-out; then

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs
 __pycache__
 .codex
 dhat-heap*.json
+/size-out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,5 +41,6 @@ Read these when working on the relevant area:
 - `agent_docs/feature_implementation.md` — Step-by-step feature implementation flow
 - `agent_docs/e2e_testing.md` — E2E test patterns, file organization, event-driven waiting
 - `agent_docs/debugging.md` — evcxr REPL, binary protocol debugging
+- `agent_docs/binary_size_ci.md` — size-tracking CI: metrics, budgets, baseline semantics
 
 When adding comments to the code, dont be so verbose, also only explain why, not what

--- a/agent_docs/binary_size_ci.md
+++ b/agent_docs/binary_size_ci.md
@@ -1,0 +1,31 @@
+# Binary Size CI
+
+`binary-size.yml` tracks the size of the `whatsapp-rust` bin (default features, real release profile) on every PR and main push, so heavy new dependencies and monomorphization regressions surface before they accumulate.
+
+## What is measured
+
+All metrics come from one release build with symbols kept (`CARGO_PROFILE_RELEASE_STRIP=false`, which matches what cargo-bloat injects, so its run reuses the build):
+
+- **bin size (stripped)** — shipping-size proxy, measured on a `strip --strip-all` copy.
+- **bin .text** — invariant to strip; the signal for monomorphization bloat.
+- **bin allocated (text+data+bss)** — catches static data tables that don't show in .text.
+- **.text per crate** — `cargo bloat --crates` attribution (workspace crates + std as individual series, the rest aggregated as "other deps").
+- **llvm-lines** (wacore, whatsapp-rust lib) — LLVM IR lines and monomorphization copies, pre-link and cheap.
+- **deps crates (Cargo.lock)** — new-dependency canary.
+
+Do NOT switch any metric to rlib size: rlibs carry un-monomorphized generics plus metadata, so cross-crate instantiation bloat (the dominant class found in the 2026-06 audit) never shows up there.
+
+## How regressions are caught
+
+- **PR gate** (`scripts/ci/binary_size_report.py`): absolute per-PR budget — stripped Δ ≤ 64 KiB, .text Δ ≤ 32 KiB. Absolute instead of percentage because sizes are deterministic for a pinned toolchain and 1% of a multi-MiB binary would hide real regressions. The sticky PR comment shows all deltas plus per-crate top movers.
+- **Escape hatch**: the `size-increase-ok` label downgrades a failed gate to a warning. Use it for toolchain/dependency bumps and accepted feature costs; the increase still lands in the series.
+- **Post-merge safety net**: the push job stores the series at `dev/binary-size` on gh-pages via github-action-benchmark (`alert-threshold: 102%` comments on the offending commit). Graphs: <https://oxidezap.github.io/whatsapp-rust/dev/binary-size/>.
+
+## Baseline semantics and pitfalls
+
+- The PR baseline is the `size-metrics` artifact from the **latest successful main run**, not the merge-base. A stale PR can therefore show deltas inherited from main; rebase to clear them.
+- Metric names are series keys. Renaming one orphans its history in the chart, so keep names stable.
+- Sizes are only comparable under the same pinned toolchain. A `rust-toolchain.toml` bump legitimately moves every metric — expect a gate hit and use the label.
+- `cargo bloat` exits 0 even on analysis errors; the measure script validates its JSON instead of trusting the exit code.
+- Fork PRs run with a read-only token: they get the job summary and the gate, but no PR comment.
+- Local run: `python3 scripts/ci/measure_binary_size.py --out-dir size-out` (add `--skip-build` to reuse an existing release build).

--- a/scripts/ci/binary_size_report.py
+++ b/scripts/ci/binary_size_report.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Build the binary-size PR report and evaluate the regression gate.
+
+Compares the metrics measured on the PR head against the baseline artifact
+from the latest successful main run. Binary size is deterministic for a
+pinned toolchain, so deltas are exact (no statistical noise): the gate is an
+absolute byte budget (Chromium-style) instead of a percentage, because on a
+multi-MiB binary a percent threshold lets small-but-real regressions through.
+
+Writes:
+  report.md   sticky PR comment body (also used for the job summary)
+  gate.txt    PASS | FAIL | OVERRIDDEN, followed by one reason per line
+
+Always exits 0; the workflow enforces the gate from gate.txt so the comment
+gets posted even when the budget is exceeded.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+# Absolute budgets per PR, mirroring Chromium's per-CL allowance. Expected
+# jumps (toolchain/deps bumps) go through the `size-increase-ok` label.
+FAIL_STRIPPED_DELTA = 64 * 1024
+FAIL_TEXT_DELTA = 32 * 1024
+WARN_PCT = 1.0
+# Attribution rows smaller than this are noise from cargo-bloat's heuristics.
+MOVER_MIN_DELTA = 1024
+MOVER_LIMIT = 10
+
+MARKER = "<!-- binary-size-report -->"
+GRAPHS_URL = "https://oxidezap.github.io/whatsapp-rust/dev/binary-size/"
+
+GATED = {
+    "bin size (stripped)": FAIL_STRIPPED_DELTA,
+    "bin .text": FAIL_TEXT_DELTA,
+}
+
+
+def human_bytes(n: int) -> str:
+    sign = "-" if n < 0 else ""
+    n = abs(n)
+    for unit, factor in (("MiB", 1024**2), ("KiB", 1024)):
+        if n >= factor:
+            return f"{sign}{n / factor:.2f} {unit}"
+    return f"{sign}{n} B"
+
+
+def fmt_value(value: int, unit: str) -> str:
+    if unit == "bytes":
+        return human_bytes(value)
+    return f"{value:,}"
+
+
+def fmt_delta(delta: int, base: int, unit: str) -> str:
+    if delta == 0:
+        return "0"
+    pct = f" ({delta / base:+.2%})" if base else ""
+    if unit == "bytes":
+        s = human_bytes(delta)
+        return f"{'+' + s if delta > 0 else s}{pct}"
+    return f"{delta:+,}{pct}"
+
+
+def load_metrics(path: Path) -> dict:
+    data = json.loads(path.read_text())
+    return {m["name"]: m for m in data}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--head", required=True, help="dir with the PR head outputs")
+    parser.add_argument("--base", help="dir with the baseline (main) outputs")
+    parser.add_argument("--out-dir", default=".")
+    args = parser.parse_args()
+
+    head_dir, out_dir = Path(args.head), Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    head = load_metrics(head_dir / "size-metrics.json")
+    head_meta = json.loads((head_dir / "size-meta.json").read_text())
+
+    base = base_meta = None
+    if args.base:
+        base_dir = Path(args.base)
+        if (base_dir / "size-metrics.json").exists():
+            base = load_metrics(base_dir / "size-metrics.json")
+            meta_path = base_dir / "size-meta.json"
+            if meta_path.exists():
+                base_meta = json.loads(meta_path.read_text())
+
+    failures = []
+    lines = [MARKER, "## 📦 Binary size report", ""]
+
+    if base is None:
+        lines.append("No baseline available yet (no successful run on main); reporting absolute values only.")
+        lines.extend(["", "| Metric | PR |", "|---|---:|"])
+        for name, m in head.items():
+            if name.startswith(".text "):
+                continue
+            lines.append(f"| {name} | {fmt_value(m['value'], m['unit'])} |")
+        status = "PASS"
+    else:
+        main_rows, crate_rows = [], []
+        for name, m in head.items():
+            unit = m["unit"]
+            b = base.get(name)
+            if b is None:
+                row = f"| {name} | (new) | {fmt_value(m['value'], unit)} | |"
+            else:
+                delta = m["value"] - b["value"]
+                icon = ""
+                if name in GATED and delta > GATED[name]:
+                    failures.append(
+                        f"{name}: {fmt_delta(delta, b['value'], unit)} exceeds the "
+                        f"{human_bytes(GATED[name])} per-PR budget"
+                    )
+                    icon = " 🚨"
+                elif b["value"] and abs(delta) / b["value"] * 100 >= WARN_PCT:
+                    icon = " ⚠️" if delta > 0 else " 🎉"
+                elif delta > 0:
+                    icon = " 🔺"
+                elif delta < 0:
+                    icon = " 🔽"
+                row = (f"| {name} | {fmt_value(b['value'], unit)} | "
+                       f"{fmt_value(m['value'], unit)} | "
+                       f"{fmt_delta(delta, b['value'], unit)}{icon} |")
+            (crate_rows if name.startswith(".text ") else main_rows).append(row)
+
+        lines.extend(["| Metric | main | PR | Δ |", "|---|---:|---:|---:|"])
+        lines.extend(main_rows)
+        lines.extend(["", "<details>", "<summary>.text per crate</summary>", "",
+                      "| Crate | main | PR | Δ |", "|---|---:|---:|---:|"])
+        lines.extend(crate_rows)
+        lines.extend(["", "</details>"])
+
+        movers = top_movers(head_dir, Path(args.base))
+        if movers:
+            lines.extend(["", "<details>", "<summary>Top movers (cargo-bloat attribution)</summary>",
+                          "", "| Crate | main | PR | Δ |", "|---|---:|---:|---:|"])
+            lines.extend(movers)
+            lines.extend(["", "</details>"])
+
+        status = "FAIL" if failures else "PASS"
+
+    if failures:
+        lines.extend(["", f"🚨 Per-PR size budget exceeded (Δ stripped ≤ {human_bytes(FAIL_STRIPPED_DELTA)}, Δ .text ≤ {human_bytes(FAIL_TEXT_DELTA)}):"])
+        lines.extend(f"- {f}" for f in failures)
+        if os.environ.get("ALLOW_SIZE_INCREASE") == "true":
+            status = "OVERRIDDEN"
+            lines.append("")
+            lines.append("The `size-increase-ok` label is set, so the gate is not enforced for this PR.")
+        else:
+            lines.append("")
+            lines.append("If this increase is expected (toolchain or dependency bump, accepted feature cost), add the `size-increase-ok` label and re-run the failed job.")
+
+    footer = [
+        "",
+        f"Baseline: `{(base_meta or {}).get('commit', 'n/a')[:9]}` (latest main run)"
+        f" · Head: `{head_meta['commit'][:9]}` · [Graphs]({GRAPHS_URL})",
+    ]
+    lines.extend(footer)
+
+    (out_dir / "report.md").write_text("\n".join(lines) + "\n")
+    (out_dir / "gate.txt").write_text("\n".join([status, *failures]) + "\n")
+    print(f"gate: {status}")
+    for f in failures:
+        print(f"  {f}")
+
+
+def top_movers(head_dir: Path, base_dir: Path):
+    try:
+        head_crates = {c["name"]: c["size"] for c in
+                       json.loads((head_dir / "size-attribution.json").read_text())["crates"]}
+        base_crates = {c["name"]: c["size"] for c in
+                       json.loads((base_dir / "size-attribution.json").read_text())["crates"]}
+    except (OSError, KeyError, json.JSONDecodeError):
+        return []
+
+    rows = []
+    for name in head_crates.keys() | base_crates.keys():
+        h, b = head_crates.get(name), base_crates.get(name)
+        delta = (h or 0) - (b or 0)
+        if abs(delta) < MOVER_MIN_DELTA:
+            continue
+        rows.append((abs(delta), name, b, h, delta))
+    rows.sort(reverse=True)
+
+    out = []
+    for _, name, b, h, delta in rows[:MOVER_LIMIT]:
+        base_s = human_bytes(b) if b is not None else "(absent)"
+        head_s = human_bytes(h) if h is not None else "(removed)"
+        out.append(f"| {name} | {base_s} | {head_s} | {fmt_delta(delta, b or 0, 'bytes')} |")
+    return out
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/binary_size_report.py
+++ b/scripts/ci/binary_size_report.py
@@ -79,6 +79,12 @@ def main():
     out_dir.mkdir(parents=True, exist_ok=True)
     head = load_metrics(head_dir / "size-metrics.json")
     head_meta = json.loads((head_dir / "size-meta.json").read_text())
+    # Otherwise dropping a gated row from the measure script would silently
+    # disarm the budget. The baseline stays lenient: a PR introducing a new
+    # gated metric can't have it in main's artifact yet.
+    missing = sorted(name for name in GATED if name not in head)
+    if missing:
+        raise SystemExit(f"head metrics missing gated rows: {', '.join(missing)}")
 
     base = base_meta = None
     if args.base:

--- a/scripts/ci/measure_binary_size.py
+++ b/scripts/ci/measure_binary_size.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Measure binary-size metrics for the size-tracking CI job.
+
+Builds the `whatsapp-rust` bin with the real release profile (fat LTO,
+codegen-units=1) but with symbols kept, then derives every metric from that
+single build:
+
+  - stripped file size (shipping proxy), measured on a stripped copy
+  - .text section size (invariant to strip; the monomorphization signal)
+  - total allocated size (text+data+bss; catches static data from new deps)
+  - per-crate .text attribution via `cargo bloat --crates`
+  - LLVM IR lines/copies via `cargo llvm-lines` (pre-link monomorphization)
+  - crate count from Cargo.lock (new-dependency canary)
+
+Outputs in --out-dir:
+  size-metrics.json      customSmallerIsBetter array for github-action-benchmark
+  size-attribution.json  raw `cargo bloat --crates` JSON for per-crate diffing
+  size-meta.json         commit/toolchain provenance for the PR report footer
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BIN_NAME = "whatsapp-rust"
+# Workspace crates tracked as individual series; everything else is summed
+# into "other deps" so the series set stays stable as dependencies churn.
+WORKSPACE_CRATES = [
+    "whatsapp_rust",
+    "wacore",
+    "wacore_binary",
+    "wacore_libsignal",
+    "wacore_appstate",
+    "wacore_noise",
+    "waproto",
+    "whatsapp_rust_sqlite_storage",
+    "whatsapp_rust_tokio_transport",
+    "whatsapp_rust_ureq_http_client",
+    "std",
+]
+LLVM_LINES_TARGETS = [
+    ("wacore", "wacore"),
+    ("whatsapp-rust", "whatsapp-rust lib"),
+]
+
+
+def run(cmd, **kwargs):
+    print(f"+ {' '.join(cmd)}", file=sys.stderr, flush=True)
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def build_env():
+    env = os.environ.copy()
+    # cargo-bloat needs symbols; it injects this same value into its own
+    # build, so setting it here keeps the fingerprint identical and the
+    # `cargo bloat` invocation below reuses this build instead of recompiling.
+    env["CARGO_PROFILE_RELEASE_STRIP"] = "false"
+    return env
+
+
+def measure_stripped_size(bin_path: Path, out_dir: Path) -> int:
+    stripped = out_dir / f"{BIN_NAME}-stripped"
+    shutil.copy2(bin_path, stripped)
+    run(["strip", "--strip-all", str(stripped)])
+    size = stripped.stat().st_size
+    stripped.unlink()
+    return size
+
+
+def measure_sections(bin_path: Path) -> tuple[int, int]:
+    sysv = run(["size", "-A", "-d", str(bin_path)], capture_output=True, text=True).stdout
+    text_size = None
+    for line in sysv.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == ".text":
+            text_size = int(parts[1])
+            break
+    if text_size is None:
+        raise RuntimeError("could not find .text in `size -A` output")
+
+    berkeley = run(["size", "-d", str(bin_path)], capture_output=True, text=True).stdout
+    lines = berkeley.strip().splitlines()
+    # header: text data bss dec hex filename
+    allocated = int(lines[1].split()[3])
+    return text_size, allocated
+
+
+def run_cargo_bloat(env) -> dict:
+    proc = run(
+        ["cargo", "bloat", "--release", "--bin", BIN_NAME, "--crates",
+         "--message-format", "json", "-n", "0"],
+        capture_output=True, text=True, env=env,
+    )
+    # cargo-bloat exits 0 even on analysis errors, so validate the payload.
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        print(proc.stdout[:2000], file=sys.stderr)
+        raise RuntimeError("cargo bloat did not produce valid JSON") from e
+    if "crates" not in data or not data["crates"]:
+        raise RuntimeError(f"cargo bloat JSON has no crate data: {list(data)}")
+    return data
+
+
+def run_llvm_lines(package: str, env) -> tuple[int, int]:
+    proc = run(
+        ["cargo", "llvm-lines", "-p", package, "--lib", "--release"],
+        capture_output=True, text=True, env=env,
+    )
+    for line in proc.stdout.splitlines():
+        parts = line.split()
+        # "  634926  16990  (TOTAL)" (data rows carry extra percent columns)
+        if parts and parts[-1] == "(TOTAL)":
+            nums = [p for p in parts if p.isdigit()]
+            return int(nums[0]), int(nums[1])
+    raise RuntimeError(f"no (TOTAL) row in cargo llvm-lines output for {package}")
+
+
+def count_lockfile_crates() -> int:
+    count = 0
+    for line in Path("Cargo.lock").read_text().splitlines():
+        if line.startswith("name = "):
+            count += 1
+    return count
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", default=".size-out")
+    parser.add_argument("--skip-build", action="store_true",
+                        help="reuse an existing release build (local iteration)")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    env = build_env()
+
+    if not args.skip_build:
+        run(["cargo", "build", "--release", "--locked", "--bin", BIN_NAME], env=env)
+
+    target_dir = Path(os.environ.get("CARGO_TARGET_DIR", "target"))
+    bin_path = target_dir / "release" / BIN_NAME
+    if not bin_path.exists():
+        raise RuntimeError(f"binary not found at {bin_path}")
+
+    stripped_size = measure_stripped_size(bin_path, out_dir)
+    text_size, allocated = measure_sections(bin_path)
+    bloat = run_cargo_bloat(env)
+    lock_crates = count_lockfile_crates()
+
+    metrics = [
+        {"name": "bin size (stripped)", "unit": "bytes", "value": stripped_size},
+        {"name": "bin .text", "unit": "bytes", "value": text_size},
+        {"name": "bin allocated (text+data+bss)", "unit": "bytes", "value": allocated},
+    ]
+
+    crate_sizes = {c["name"]: c["size"] for c in bloat["crates"]}
+    other = 0
+    for name, size in crate_sizes.items():
+        if name not in WORKSPACE_CRATES:
+            other += size
+    for name in WORKSPACE_CRATES:
+        if name in crate_sizes:
+            metrics.append({"name": f".text {name}", "unit": "bytes",
+                            "value": crate_sizes[name]})
+    metrics.append({"name": ".text other deps", "unit": "bytes", "value": other})
+
+    for package, label in LLVM_LINES_TARGETS:
+        lines, copies = run_llvm_lines(package, env)
+        metrics.append({"name": f"llvm-lines {label}", "unit": "lines", "value": lines})
+        metrics.append({"name": f"llvm-lines {label} copies", "unit": "copies",
+                        "value": copies})
+
+    metrics.append({"name": "deps crates (Cargo.lock)", "unit": "crates",
+                    "value": lock_crates})
+
+    commit = run(["git", "rev-parse", "HEAD"], capture_output=True,
+                 text=True).stdout.strip()
+    rustc = run(["rustc", "--version"], capture_output=True, text=True).stdout.strip()
+    meta = {"commit": commit, "rustc": rustc}
+
+    (out_dir / "size-metrics.json").write_text(json.dumps(metrics, indent=1) + "\n")
+    (out_dir / "size-attribution.json").write_text(json.dumps(bloat) + "\n")
+    (out_dir / "size-meta.json").write_text(json.dumps(meta, indent=1) + "\n")
+
+    for m in metrics:
+        print(f"{m['name']}: {m['value']} {m['unit']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

New `Binary Size` workflow that measures the `whatsapp-rust` bin (default features, real release profile) on every PR and push to main, keeps the history with graphs, and gates PRs on an absolute size budget. This is the guardrail for the class of regressions found in the recent bloat audit: heavy new dependencies and cross-crate monomorphization creep.

All metrics come from a single release build with symbols kept (`CARGO_PROFILE_RELEASE_STRIP=false`, the same value cargo-bloat injects, so its pass reuses the build):

- stripped file size (shipping proxy), `.text` section (the monomorphization signal, invariant to strip) and total allocated size (catches static data tables that never show in `.text`)
- `.text` per crate via `cargo bloat --crates`: workspace crates and std get individual series, everything else is aggregated as "other deps" so the series set stays stable
- `cargo llvm-lines` lines/copies for wacore and the whatsapp-rust lib, which catches monomorphization growth before the link and is cheap to compute
- crate count in Cargo.lock as a new-dependency canary

## How it works

- **PR job**: compares against the `size-metrics` artifact of the latest successful main run, posts a sticky comment with all deltas plus per-crate top movers, and fails when Δ stripped > 64 KiB or Δ `.text` > 32 KiB. Sizes are deterministic for the pinned toolchain, so the gate is an exact diff with no statistical noise; the budget is absolute because a percent threshold on a multi-MiB binary would let small-but-real regressions through (pattern borrowed from Chromium's per-CL allowance and Firefox's absolute floor).
- **Escape hatch**: the `size-increase-ok` label downgrades the gate to a warning for expected jumps (toolchain or dependency bumps, accepted feature cost). Labels are queried live at gate time, so label + re-run works even though the event payload is frozen.
- **Push job**: stores the series at `dev/binary-size` on the existing gh-pages via github-action-benchmark (same pattern as bench-integration), giving Chart.js graphs for every metric. A 102% alert threshold comments on the offending commit as a post-merge safety net.
- **Fork PRs** run with a read-only token: they get the job summary and the gate, but no PR comment.

## Design notes

- rlib size is intentionally not a metric: rlibs carry un-monomorphized generics plus metadata, so the dominant bloat class never shows up there.
- CodSpeed can't host this today: no support for custom metrics like binary size (CodSpeedHQ/codspeed-rust#153, confirmed by the maintainer as roadmap without ETA).
- The baseline is the latest main run, not the merge-base, so a stale PR can show deltas inherited from main; rebasing clears them.
- cargo-bloat exits 0 even on analysis errors, so the measure script validates the JSON payload instead of trusting the exit code.
- The CI binary is a deterministic proxy, not the Docker production binary (share-generics, build-std and target-cpu stay out on purpose).
- Tools are version-pinned and installed via cargo-binstall, with prebuilt quickinstall binaries available for both.

## Validation

- Full pipeline ran locally on the real binary: build, measure, cargo-bloat reuse (no recompile), llvm-lines parse, and the report against a perturbed baseline exercising the gate-fail, no-baseline and label-override paths.
- Local numbers for reference: stripped 13.53 MiB, `.text` 11.48 MiB, 102 crates attributed, 357 crates in Cargo.lock.
- actionlint clean.

Heads up: the PR job on this very PR will find no baseline yet, so expect an informational comment only; the first series entry lands with the push run after merge. The build cost is one fat-LTO release build per PR (3m19s locally on 16 cores, likely 15 to 25 min on the runner); if that turns out too slow we can degrade the PR job to a label trigger later.

Docs: `agent_docs/binary_size_ci.md`, plus an index entry in AGENTS.md.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

