### PR TITLE
perf(send): de-monomorphize Signal encrypt fan-out to dyn dispatch

### DIFF
--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -70,15 +70,7 @@ impl SignalProtocolStoreAdapter {
         }
     }
 
-    pub fn as_signal_stores(
-        &mut self,
-    ) -> wacore::send::SignalStores<
-        '_,
-        SessionAdapter,
-        IdentityAdapter,
-        PreKeyAdapter,
-        SignedPreKeyAdapter,
-    > {
+    pub fn as_signal_stores(&mut self) -> wacore::send::SignalStores<'_> {
         wacore::send::SignalStores {
             session_store: &mut self.session_store,
             identity_store: &mut self.identity_store,

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -47,15 +47,9 @@ pub struct PreparedDmStanza {
 
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.dm_prepare", level = "debug", skip_all, fields(to = %to_jid.observe()), err(Debug)))]
 #[allow(clippy::too_many_arguments)]
-pub async fn prepare_dm_stanza<
-    'a,
-    S: crate::libsignal::protocol::SessionStore + Clone + Send + Sync + 'static,
-    I: crate::libsignal::protocol::IdentityKeyStore + Clone + Send + Sync + 'static,
-    P: crate::libsignal::protocol::PreKeyStore + Send + Sync,
-    SP: crate::libsignal::protocol::SignedPreKeyStore + Send + Sync,
->(
+pub async fn prepare_dm_stanza(
     runtime: &dyn Runtime,
-    stores: &mut SignalStores<'a, S, I, P, SP>,
+    stores: &mut SignalStores<'_>,
     resolver: &dyn SendContextResolver,
     own_jid: &Jid,
     own_lid: Option<&Jid>,

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -77,12 +77,48 @@ where
     Ok(skm)
 }
 
-pub struct SignalStores<'a, S, I, P, SP> {
+/// Object-safe `SessionStore` that can clone itself into an owned box. The
+/// encrypt fan-out hands each spawned task its own owned store handle; erasing
+/// the concrete type here (instead of a generic `S: Clone`) keeps the whole
+/// encrypt tree as a single instantiation instead of one ~60 KiB copy per
+/// concrete adapter set. Blanket-impl'd for every `Clone` store, so concrete
+/// adapters need no changes.
+pub trait CloneableSessionStore: crate::libsignal::protocol::SessionStore {
+    fn clone_box(&self) -> Box<dyn CloneableSessionStore + Send + Sync>;
+}
+
+impl<T> CloneableSessionStore for T
+where
+    T: crate::libsignal::protocol::SessionStore + Clone + Send + Sync + 'static,
+{
+    fn clone_box(&self) -> Box<dyn CloneableSessionStore + Send + Sync> {
+        Box::new(self.clone())
+    }
+}
+
+/// See [`CloneableSessionStore`].
+pub trait CloneableIdentityStore: crate::libsignal::protocol::IdentityKeyStore {
+    fn clone_box(&self) -> Box<dyn CloneableIdentityStore + Send + Sync>;
+}
+
+impl<T> CloneableIdentityStore for T
+where
+    T: crate::libsignal::protocol::IdentityKeyStore + Clone + Send + Sync + 'static,
+{
+    fn clone_box(&self) -> Box<dyn CloneableIdentityStore + Send + Sync> {
+        Box::new(self.clone())
+    }
+}
+
+/// Borrowed handles to the Signal stores for one send. The stores are
+/// type-erased (`dyn`) so the encrypt/session functions compile to a single
+/// instantiation rather than one per concrete adapter set.
+pub struct SignalStores<'a> {
     pub sender_key_store: &'a mut (dyn crate::libsignal::protocol::SenderKeyStore + Send + Sync),
-    pub session_store: &'a mut S,
-    pub identity_store: &'a mut I,
-    pub prekey_store: &'a mut P,
-    pub signed_prekey_store: &'a SP,
+    pub session_store: &'a mut (dyn CloneableSessionStore + Send + Sync),
+    pub identity_store: &'a mut (dyn CloneableIdentityStore + Send + Sync),
+    pub prekey_store: &'a mut (dyn crate::libsignal::protocol::PreKeyStore + Send + Sync),
+    pub signed_prekey_store: &'a (dyn crate::libsignal::protocol::SignedPreKeyStore + Send + Sync),
 }
 
 /// Check if an anyhow error is a 406 "not-acceptable" server error (device unregistered).
@@ -294,21 +330,15 @@ fn push_encrypt_result(
 ///
 /// Callers must hold per-device session locks before calling this function —
 /// concurrent ratchet mutations will corrupt Signal session state.
-pub async fn encrypt_for_devices<'a, S, I, P, SP>(
+pub async fn encrypt_for_devices(
     runtime: &dyn Runtime,
-    stores: &mut SignalStores<'a, S, I, P, SP>,
+    stores: &mut SignalStores<'_>,
     resolver: &dyn SendContextResolver,
     devices: &[Jid],
     plaintext_to_encrypt: &[u8],
     hide_decrypt_fail: bool,
     mediatype: Option<&str>,
-) -> Result<EncryptResult>
-where
-    S: crate::libsignal::protocol::SessionStore + Clone + Send + Sync + 'static,
-    I: crate::libsignal::protocol::IdentityKeyStore + Clone + Send + Sync + 'static,
-    P: crate::libsignal::protocol::PreKeyStore + Send + Sync,
-    SP: crate::libsignal::protocol::SignedPreKeyStore + Send + Sync,
-{
+) -> Result<EncryptResult> {
     let plan = ensure_sessions_for_devices(runtime, stores, resolver, devices).await?;
     encrypt_for_devices_with_sessions(
         runtime,
@@ -337,18 +367,12 @@ pub struct SessionPlan {
 /// fan-out and touches only session/identity state — never a sender-key
 /// chain — so group sends run it before taking the chain lock.
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.ensure_sessions", level = "debug", skip_all, fields(count = devices.len()), err(Debug)))]
-pub async fn ensure_sessions_for_devices<'a, S, I, P, SP>(
+pub async fn ensure_sessions_for_devices(
     runtime: &dyn Runtime,
-    stores: &mut SignalStores<'a, S, I, P, SP>,
+    stores: &mut SignalStores<'_>,
     resolver: &dyn SendContextResolver,
     devices: &[Jid],
-) -> Result<SessionPlan>
-where
-    S: crate::libsignal::protocol::SessionStore + Clone + Send + Sync + 'static,
-    I: crate::libsignal::protocol::IdentityKeyStore + Clone + Send + Sync + 'static,
-    P: crate::libsignal::protocol::PreKeyStore + Send + Sync,
-    SP: crate::libsignal::protocol::SignedPreKeyStore + Send + Sync,
-{
+) -> Result<SessionPlan> {
     // Per-device LID upgrade map: encryption_overrides[i] mirrors devices[i].
     // None = use devices[i] as-is; Some(jid) = use this LID-upgraded version.
     // The Vec replaces a HashMap<&Jid, Jid> that paid hash + alloc per insert
@@ -465,8 +489,8 @@ where
 
             let lookup_jid = device_jid.normalize_for_prekey_bundle();
             let bundles = prekey_bundles.clone();
-            let mut session_store = stores.session_store.clone();
-            let mut identity_store = stores.identity_store.clone();
+            let mut session_store = stores.session_store.clone_box();
+            let mut identity_store = stores.identity_store.clone_box();
 
             spawn_oneshot(runtime, async move {
                 let mut addr = crate::types::jid::make_reusable_protocol_address();
@@ -488,8 +512,8 @@ where
                 // process_prekey_bundle persists rotations transparently.
                 match process_prekey_bundle(
                     &addr,
-                    &mut session_store,
-                    &mut identity_store,
+                    &mut *session_store,
+                    &mut *identity_store,
                     bundle,
                     &mut rng,
                     UsePQRatchet::No,
@@ -547,21 +571,15 @@ where
 /// missing (e.g. its bundle was absent) fails its encrypt and is skipped,
 /// matching the combined path's behavior.
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.encrypt_fanout", level = "debug", skip_all, fields(count = devices.len()), err(Debug)))]
-pub async fn encrypt_for_devices_with_sessions<'a, S, I, P, SP>(
+pub async fn encrypt_for_devices_with_sessions(
     runtime: &dyn Runtime,
-    stores: &mut SignalStores<'a, S, I, P, SP>,
+    stores: &mut SignalStores<'_>,
     devices: &[Jid],
     plaintext_to_encrypt: &[u8],
     hide_decrypt_fail: bool,
     mediatype: Option<&str>,
     plan: SessionPlan,
-) -> Result<EncryptResult>
-where
-    S: crate::libsignal::protocol::SessionStore + Clone + Send + Sync + 'static,
-    I: crate::libsignal::protocol::IdentityKeyStore + Clone + Send + Sync + 'static,
-    P: crate::libsignal::protocol::PreKeyStore + Send + Sync,
-    SP: crate::libsignal::protocol::SignedPreKeyStore + Send + Sync,
-{
+) -> Result<EncryptResult> {
     debug_assert_eq!(
         plan.encryption_overrides.len(),
         devices.len(),
@@ -626,15 +644,15 @@ where
                 .unwrap_or(&devices[idx])
                 .to_protocol_address();
             let plaintext = plaintext_arc.clone();
-            let mut session_store = stores.session_store.clone();
-            let mut identity_store = stores.identity_store.clone();
+            let mut session_store = stores.session_store.clone_box();
+            let mut identity_store = stores.identity_store.clone_box();
 
             spawn_oneshot(runtime, async move {
                 encrypt_one_device(
                     &plaintext,
                     &addr,
-                    &mut session_store,
-                    &mut identity_store,
+                    &mut *session_store,
+                    &mut *identity_store,
                     device_jid,
                     hide_decrypt_fail,
                 )

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -114,15 +114,9 @@ pub struct PreparedGroupStanza {
 
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.group_prepare", level = "debug", skip_all, fields(to = %to_jid.observe()), err(Debug)))]
 #[allow(clippy::too_many_arguments)]
-pub async fn prepare_group_stanza<
-    'a,
-    S: crate::libsignal::protocol::SessionStore + Clone + Send + Sync + 'static,
-    I: crate::libsignal::protocol::IdentityKeyStore + Clone + Send + Sync + 'static,
-    P: crate::libsignal::protocol::PreKeyStore + Send + Sync,
-    SP: crate::libsignal::protocol::SignedPreKeyStore + Send + Sync,
->(
+pub async fn prepare_group_stanza(
     runtime: &dyn Runtime,
-    stores: &mut SignalStores<'a, S, I, P, SP>,
+    stores: &mut SignalStores<'_>,
     resolver: &dyn SendContextResolver,
     // Caller guarantees `own_base_jid` is already present in `participants`, so
     // this reads the shared (Arc-backed) metadata without cloning it.


### PR DESCRIPTION
## What

The encrypt/session-prepare functions (`encrypt_for_devices`,
`ensure_sessions_for_devices`, `encrypt_for_devices_with_sessions`,
`prepare_dm_stanza`, `prepare_group_stanza`) were generic over four
store types `<S, I, P, SP>`, threaded through `SignalStores<'a, S, I, P, SP>`.
This replaces those generics with type-erased `dyn` fields on a
non-generic `SignalStores<'_>`, so the whole encrypt tree compiles to a
single instantiation instead of one copy per concrete adapter set.

The fan-out hands each spawned task an *owned* store handle, which
previously required `S: Clone`. To keep that without a generic bound, two
small object-safe traits — `CloneableSessionStore` and
`CloneableIdentityStore` — expose a `clone_box()` returning an owned
`Box<dyn …>`. Both are blanket-impl'd for every `Clone` store, so the
concrete adapters need no changes; the fan-out's per-task
`store.clone()` becomes `store.clone_box()`. The single-device fast path
and the SKDM/skmsg paths upcast the `dyn Cloneable…Store` handle to the
plain `dyn SessionStore` / `dyn IdentityKeyStore` that
`message_encrypt` / `process_prekey_bundle` already take.

## Why

Pure binary-size cleanup, no behavior change. The generic signatures
forced rustc to monomorphize the entire encrypt + session-establishment
tree per concrete store-type set; `dyn` collapses that to one copy.

## Measurement

Fat-LTO release build (`CARGO_PROFILE_RELEASE_STRIP=false cargo build
--release --locked --bin whatsapp-rust`), then `strip`, comparing `main`
vs this branch built identically:

| metric | main | this branch | delta |
| --- | --- | --- | --- |
| `.text` | 11,856,758 | 11,840,246 | **−16,512 B (~16 KiB)** |
| stripped binary | 13,996,056 | 13,982,136 | **−13,920 B (~13.6 KiB)** |

Modest — production ships a single concrete adapter set, so most of the
duplication was already folded — but a real, zero-risk `.text`
reduction. The binary-size CI gate will confirm the delta.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --all --tests` — clean
- `cargo test --workspace --exclude e2e-tests` — pass (incl. 103 `wacore` send tests)

https://claude.ai/code/session_01GdWEj1tkYCJBtPtv97Aena

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdWEj1tkYCJBtPtv97Aena)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

