### PR TITLE
perf(iq): de-monomorphize send_and_wait_iq via boxed send future

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -11,6 +11,17 @@ use wacore_binary::Node;
 
 pub use wacore::request::{InfoQuery, InfoQueryType, RequestUtils};
 
+/// Type-erased send future handed to [`Client::send_and_wait_iq`]. Boxing it
+/// keeps that function non-generic so it isn't re-monomorphized per `IqSpec`.
+/// `Send` on native (IQ awaits happen inside spawned handler tasks); dropped
+/// on wasm where the runtime is single-threaded.
+#[cfg(not(target_arch = "wasm32"))]
+type IqSendFuture<'a> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ClientError>> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type IqSendFuture<'a> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ClientError>> + 'a>>;
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum IqError {
@@ -171,8 +182,12 @@ impl Client {
         let request_utils = self.get_request_utils();
         let node = request_utils.build_iq_node(query, Some(req_id.clone()));
 
-        self.send_and_wait_iq(req_id, iq_timeout, async { self.send_node(node).await })
-            .await
+        self.send_and_wait_iq(
+            req_id,
+            iq_timeout,
+            Box::pin(async { self.send_node(node).await }),
+        )
+        .await
     }
 
     /// Executes an IQ specification and returns the typed response.
@@ -200,9 +215,11 @@ impl Client {
             match spec.encode_iq_direct(&req_id, &mut buf) {
                 Ok(true) => {
                     let response = self
-                        .send_and_wait_iq(req_id, Duration::from_secs(75), async {
-                            self.send_raw_bytes(buf).await
-                        })
+                        .send_and_wait_iq(
+                            req_id,
+                            Duration::from_secs(75),
+                            Box::pin(async { self.send_raw_bytes(buf).await }),
+                        )
                         .await?;
                     return spec
                         .parse_response(response.get())
@@ -223,15 +240,19 @@ impl Client {
     }
 
     /// Centralizes waiter registration and shutdown/timeout handling.
-    async fn send_and_wait_iq<F>(
+    ///
+    /// `send_fn` is type-erased (boxed) rather than a generic `F`: it's only
+    /// awaited once, inline, and `execute<S>` would otherwise stamp out a
+    /// fresh copy of this whole waiter/timeout body per IqSpec (the send
+    /// closure's type is distinct per `S`). One box allocation per IQ — all
+    /// control-plane, never the message hot path — collapses ~15 monomorphized
+    /// copies into one.
+    async fn send_and_wait_iq(
         &self,
         req_id: String,
         timeout: Duration,
-        send_fn: F,
-    ) -> Result<Arc<wacore_binary::OwnedNodeRef>, IqError>
-    where
-        F: std::future::Future<Output = Result<(), crate::client::ClientError>>,
-    {
+        send_fn: IqSendFuture<'_>,
+    ) -> Result<Arc<wacore_binary::OwnedNodeRef>, IqError> {
         let _t = wacore::telemetry::timer(wacore::telemetry::IQ_DURATION);
         if !self.is_running.load(Ordering::Relaxed) {
             wacore::telemetry::iq("error");


### PR DESCRIPTION
## What

`Client::send_and_wait_iq` was generic over the send future `F`. Because
`execute<S>` is generic per `IqSpec`, the send closure it passes
(`async { self.send_raw_bytes(buf).await }`) has a **distinct type per
spec** — so rustc stamped out the entire waiter-registration +
`select!` + timeout body of `send_and_wait_iq` once per `IqSpec`: ~15
identical copies (~951 LLVM-IR lines each) plus matching
`drop_in_place` copies (~335 lines each).

This boxes the send future behind a type alias `IqSendFuture` and drops
the generic parameter, so `send_and_wait_iq` compiles to a **single**
instantiation. The two call sites (`send_iq`, `execute`) now wrap their
closure in `Box::pin(...)`.

```rust
type IqSendFuture<'a> =
    Pin<Box<dyn Future<Output = Result<(), ClientError>> + Send + 'a>>;
```

(`+ Send` on native — IQ awaits happen inside spawned handler tasks;
dropped under `cfg(wasm32)` where the runtime is single-threaded.)

## Why

Same de-monomorphization pattern as #861, but a much bigger family. The
cost is **one box allocation per IQ request**, which is entirely
control-plane (prekey fetch, group queries, privacy/usync, etc.) and
never the per-message encrypt hot path — negligible against the network
round-trip each IQ already does.

## Measurement

Fat-LTO release build (`CARGO_PROFILE_RELEASE_STRIP=false cargo build
--release --locked --bin whatsapp-rust`), then `strip`, `main` vs this
branch built identically:

| metric | main | this branch | delta |
| --- | --- | --- | --- |
| `.text` | 11,856,758 | 11,751,222 | **−105,536 B (~103 KiB)** |
| stripped binary | 13,996,056 | 13,889,080 | **−106,976 B (~104.5 KiB)** |

`send_and_wait_iq` collapsed from 15 monomorphized body copies to one.
The Binary Size CI gate will confirm the delta.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --lib` — clean
- `cargo test --workspace --exclude e2e-tests` — pass (987 + 799 + 114 + 103 + … all green, 0 failures)

https://claude.ai/code/session_01GdWEj1tkYCJBtPtv97Aena

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdWEj1tkYCJBtPtv97Aena)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

