### PR TITLE
refactor(appstate): scan instead of HashSet for index-mac dedup in the patch path

### DIFF
--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -58,15 +58,20 @@ impl HashState {
                 .and_then(|idx| idx.blob.as_deref())
         }
         let index_mode = mutations.iter().all(|m| index_mac_of(m).is_some());
-        let mut removed_in_patch: std::collections::HashSet<&[u8]> =
-            std::collections::HashSet::new();
+        // Membership set over REMOVE index_macs, which are HMAC outputs (uniformly
+        // random). A linear-scan Vec beats a SipHash HashSet at the patch sizes seen
+        // in practice — the same trade-off as detect_duplicate_index_in_patch and
+        // collect_unique_index_macs (#856). Only `.contains()` is queried below, so an
+        // unconditional push is membership-equivalent to the set (a malformed duplicate
+        // REMOVE is rejected by the duplicate-index guard regardless).
+        let mut removed_in_patch: Vec<&[u8]> = Vec::new();
         if index_mode {
             for mutation in mutations {
                 if mutation.operation.unwrap_or_default()
                     == wa::syncd_mutation::SyncdOperation::Remove as i32
                     && let Some(index_mac) = index_mac_of(mutation)
                 {
-                    removed_in_patch.insert(index_mac);
+                    removed_in_patch.push(index_mac);
                 }
             }
         }
@@ -88,7 +93,7 @@ impl HashState {
                 added.push(&blob[blob.len() - 32..]);
             }
             if let Some(index_mac) = index_mac_of(mutation) {
-                if is_set && removed_in_patch.contains(index_mac) {
+                if is_set && removed_in_patch.contains(&index_mac) {
                     continue;
                 }
                 match get_prev_set_value_mac(index_mac, i) {

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -10,7 +10,7 @@ use crate::hash::{HashState, generate_patch_mac};
 use crate::keys::ExpandedAppStateKeys;
 use log::{debug, trace};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use waproto::whatsapp as wa;
 
@@ -311,8 +311,13 @@ where
 /// WA Web keys on the decrypted index; the raw index_mac blob is a deterministic
 /// function of that index, so keying on it is equivalent for detection.
 fn detect_duplicate_index_in_patch(mutations: &[wa::SyncdMutation]) -> Result<(), AppStateError> {
-    let mut seen_set: HashSet<&[u8]> = HashSet::new();
-    let mut seen_remove: HashSet<&[u8]> = HashSet::new();
+    // index_macs are HMAC outputs (uniformly random), so a HashSet only buys
+    // SipHash setup plus an allocation for no distribution benefit. A linear scan
+    // wins at the patch sizes seen in practice — the same trade-off measured for
+    // collect_unique_index_macs (#856). Set and Remove are deduped independently:
+    // a Set and a Remove may legitimately carry the same index within one patch.
+    let mut seen_set: Vec<&[u8]> = Vec::new();
+    let mut seen_remove: Vec<&[u8]> = Vec::new();
     for m in mutations {
         let Some(rec) = &m.record else { continue };
         let Some(index_mac) = rec.index.as_ref().and_then(|i| i.blob.as_deref()) else {
@@ -324,9 +329,10 @@ fn detect_duplicate_index_in_patch(mutations: &[wa::SyncdMutation]) -> Result<()
             wa::syncd_mutation::SyncdOperation::Set => &mut seen_set,
             wa::syncd_mutation::SyncdOperation::Remove => &mut seen_remove,
         };
-        if !seen.insert(index_mac) {
+        if seen.contains(&index_mac) {
             return Err(AppStateError::DuplicateIndexInPatch);
         }
+        seen.push(index_mac);
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Two `HashSet<&[u8]>` over `index_mac` blobs in the patch-validation path are swapped for linear-scan `Vec<&[u8]>`:

1. `detect_duplicate_index_in_patch` (`processor.rs`) — the in-patch duplicate-index guard (Set/Remove deduped independently).
2. `HashState::update_hash`'s `removed_in_patch` (`hash.rs`) — the membership set that gates the SET-also-REMOVEd double-subtract.

## Why

The keys are `index_mac` blobs — HMAC outputs, i.e. uniformly random bytes. SipHash's distribution/DoS resistance buys nothing over a trivial byte compare; it only costs the per-key hash setup and a table allocation. This is the same trade-off the project already validated for the sibling `collect_unique_index_macs` in #856, where a HashSet measured **6–120% worse** than a linear scan at the patch sizes seen in practice (N≈10–50). Applying the same scan keeps the three functions consistent, and uses zero new dependencies (no fast-hash crate — consistent with the recent dependency trimming, e.g. #860).

## Honest measurement — this is NOT a measurable speedup

I profiled it with the CodSpeed MCP before claiming anything. CodSpeed reports **no performance change** across all 172 benchmarks, and a direct run-to-run compare came back at **−0.05% overall, attributed to an environment difference (AVX-512 flags), not the code**. In the `bench_process_patch_50_validated` flamegraph the dedup doesn't even surface as a ≥1% line: the 2 ms benchmark is crypto-bound (SHA-256 `compress256` 66%, lthash HKDF 59%, `decode_record` 32%, MAC validation). Deduping ~50 random 32-byte MACs is microscopic next to ~15 SHA compressions.

So this is reframed from `perf` to `refactor`: the concrete, measured win is **binary size** — the prior binary-size report showed `wacore_appstate` `.text` dropping **−1.1 KiB (−3.03%)** from dropping the monomorphized HashSet/SipHash machinery — plus one fewer allocation per patch and simpler code. No latency claim attached.

## Deliberately left as-is

- `in_patch` value-lookup `HashMap` (`processor.rs`) — an intentional O(1) map replacing an O(n²) reverse scan; converting it would regress.
- `collect_key_ids_from_patch_list`'s `seen` (`decode.rs`) — dedups key IDs (not MACs), tiny N, off the hot path.

## Correctness

Behaviour is byte-for-byte identical. Set and Remove stay deduped independently, and `removed_in_patch` is only queried via `.contains()`, so unconditional push is membership-equivalent. Existing tests unchanged and cover both paths: `process_patch_rejects_duplicate_set_index`, `process_patch_allows_same_index_across_set_and_remove`, plus the `update_hash` index-mode tests.

## Verification

- `cargo fmt --all` — clean (run locally)
- clippy + tests + CodSpeed run in CI

https://claude.ai/code/session_01XHsbPwjaCRDHDL69HbEgR8