### PR TITLE
perf(proto)!: shrink wa::Message ~75% by boxing inline content variants

### DIFF
--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -411,7 +411,7 @@ fn build_secret_message_edit(
         wacore::message_edit::encrypt_message_edit(&inner, message_secret, &ctx)?;
 
     Ok(wa::Message {
-        secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+        secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
             target_message_key: Some(wa::MessageKey {
                 remote_jid: Some(to.to_string()),
                 from_me: Some(true),
@@ -424,7 +424,7 @@ fn build_secret_message_edit(
                 wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
             ),
             remote_key_id: None,
-        }),
+        })),
         message_context_info: Some(Box::new(wa::MessageContextInfo {
             message_secret: Some(message_secret.to_vec()),
             ..Default::default()

--- a/src/features/comments.rs
+++ b/src/features/comments.rs
@@ -98,11 +98,11 @@ impl<'a> Comments<'a> {
         };
 
         let message = wa::Message {
-            enc_comment_message: Some(wa::message::EncCommentMessage {
+            enc_comment_message: Some(Box::new(wa::message::EncCommentMessage {
                 target_message_key: Some(parent_key),
                 enc_payload: Some(enc_payload),
                 enc_iv: Some(iv.to_vec()),
-            }),
+            })),
             message_context_info: Some(Box::new(wa::MessageContextInfo {
                 message_secret: Some(comment_secret.clone()),
                 ..Default::default()

--- a/src/features/events.rs
+++ b/src/features/events.rs
@@ -122,7 +122,7 @@ impl<'a> Events<'a> {
         };
 
         let message = wa::Message {
-            enc_event_response_message: Some(enc),
+            enc_event_response_message: Some(Box::new(enc)),
             ..Default::default()
         };
 

--- a/src/features/message_edit.rs
+++ b/src/features/message_edit.rs
@@ -405,7 +405,7 @@ pub fn decrypt_secret_encrypted(
                 &sender,
             )?;
             Ok(wa::Message {
-                reaction_message: Some(reaction),
+                reaction_message: Some(Box::new(reaction)),
                 ..Default::default()
             })
         }
@@ -586,7 +586,7 @@ mod tests {
     #[test]
     fn extract_envelope_recognises_message_edit() {
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("g@g.us".to_string()),
                     from_me: Some(false),
@@ -599,7 +599,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_envelope(&msg).expect("recognised");
@@ -615,7 +615,7 @@ mod tests {
     #[test]
     fn original_sender_jid_uses_my_jid_for_self_sent_edits() {
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("5510000@s.whatsapp.net".to_string()),
                     from_me: Some(true),
@@ -628,7 +628,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_envelope(&msg).expect("recognised");
@@ -647,7 +647,7 @@ mod tests {
         // editor's frame (from_me=true), so the receive path uses the envelope
         // sender via `original_sender_for_dispatch`, not this resolver.
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("5510000@s.whatsapp.net".to_string()),
                     from_me: Some(false),
@@ -660,7 +660,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_envelope(&msg).expect("recognised");
@@ -676,7 +676,7 @@ mod tests {
         // The MESSAGE_EDIT-specific consumer API resolves from the envelope
         // frame, ignoring the editor-framed target key (here from_me=true).
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("100000000000001@lid".to_string()),
                     from_me: Some(true),
@@ -689,7 +689,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_envelope(&msg).expect("recognised");
@@ -718,7 +718,7 @@ mod tests {
         // is always the author (you can only edit your own message), so the
         // sender must come from the envelope frame.
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("100000000000001@lid".to_string()), // our LID (editor's frame)
                     from_me: Some(true),
@@ -731,7 +731,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_secret_encrypted(&msg).expect("recognised");
@@ -751,7 +751,7 @@ mod tests {
         // Our own edit, synced from another linked device: the envelope IS from
         // me, so the original sender is us — device suffix stripped.
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("200000000000002@lid".to_string()),
                     from_me: Some(true),
@@ -764,7 +764,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_secret_encrypted(&msg).expect("recognised");
@@ -784,7 +784,7 @@ mod tests {
         // other than the target's author (e.g. a peer votes on our poll), so the
         // target key stays authoritative for non-edit kinds.
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("g@g.us".to_string()),
                     from_me: Some(false),
@@ -797,7 +797,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::PollEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_secret_encrypted(&msg).expect("recognised");
@@ -816,7 +816,7 @@ mod tests {
     #[test]
     fn extract_envelope_rejects_non_edit_secret_enc_type() {
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey::default()),
                 enc_payload: Some(vec![0u8; 32]),
                 enc_iv: Some(vec![0u8; 12]),
@@ -824,7 +824,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::EventEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         assert!(extract_envelope(&msg).is_none());
@@ -833,7 +833,7 @@ mod tests {
     #[test]
     fn extract_envelope_rejects_invalid_iv_size() {
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey::default()),
                 enc_payload: Some(vec![0u8; 32]),
                 enc_iv: Some(vec![0u8; 11]),
@@ -841,7 +841,7 @@ mod tests {
                     wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                 ),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         };
         assert!(extract_envelope(&msg).is_none());
@@ -912,7 +912,7 @@ mod tests {
 
     fn secret_msg(enc_type: SecretEncType, payload: Vec<u8>, iv: Vec<u8>) -> wa::Message {
         wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 target_message_key: Some(wa::MessageKey {
                     remote_jid: Some("5510000@s.whatsapp.net".to_string()),
                     from_me: Some(false),
@@ -923,7 +923,7 @@ mod tests {
                 enc_iv: Some(iv),
                 secret_enc_type: Some(enc_type as i32),
                 remote_key_id: None,
-            }),
+            })),
             ..Default::default()
         }
     }
@@ -1033,11 +1033,11 @@ mod enc_addon_tests {
     #[test]
     fn extract_recognises_enc_reaction_and_comment_envelopes() {
         let reaction = wa::Message {
-            enc_reaction_message: Some(wa::message::EncReactionMessage {
+            enc_reaction_message: Some(Box::new(wa::message::EncReactionMessage {
                 target_message_key: Some(key("PARENT1")),
                 enc_payload: Some(vec![0; 32]),
                 enc_iv: Some(vec![0; 12]),
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_secret_encrypted(&reaction).expect("reaction recognised");
@@ -1045,11 +1045,11 @@ mod enc_addon_tests {
         assert_eq!(env.target_id(), Some("PARENT1"));
 
         let comment = wa::Message {
-            enc_comment_message: Some(wa::message::EncCommentMessage {
+            enc_comment_message: Some(Box::new(wa::message::EncCommentMessage {
                 target_message_key: Some(key("PARENT2")),
                 enc_payload: Some(vec![0; 32]),
                 enc_iv: Some(vec![0; 12]),
-            }),
+            })),
             ..Default::default()
         };
         let env = extract_secret_encrypted(&comment).expect("comment recognised");
@@ -1060,21 +1060,21 @@ mod enc_addon_tests {
     #[test]
     fn extract_rejects_malformed_enc_reaction_envelope() {
         let bad_iv = wa::Message {
-            enc_reaction_message: Some(wa::message::EncReactionMessage {
+            enc_reaction_message: Some(Box::new(wa::message::EncReactionMessage {
                 target_message_key: Some(key("PARENT1")),
                 enc_payload: Some(vec![0; 32]),
                 enc_iv: Some(vec![0; 8]),
-            }),
+            })),
             ..Default::default()
         };
         assert!(extract_secret_encrypted(&bad_iv).is_none());
 
         let no_key = wa::Message {
-            enc_reaction_message: Some(wa::message::EncReactionMessage {
+            enc_reaction_message: Some(Box::new(wa::message::EncReactionMessage {
                 target_message_key: None,
                 enc_payload: Some(vec![0; 32]),
                 enc_iv: Some(vec![0; 12]),
-            }),
+            })),
             ..Default::default()
         };
         assert!(extract_secret_encrypted(&no_key).is_none());

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -156,7 +156,7 @@ impl<'a> Polls<'a> {
         };
 
         let message = wa::Message {
-            poll_update_message: Some(poll_update),
+            poll_update_message: Some(Box::new(poll_update)),
             ..Default::default()
         };
 

--- a/src/features/reaction.rs
+++ b/src/features/reaction.rs
@@ -103,11 +103,11 @@ impl Client {
         }
 
         let message = wa::Message {
-            enc_reaction_message: Some(wa::message::EncReactionMessage {
+            enc_reaction_message: Some(Box::new(wa::message::EncReactionMessage {
                 target_message_key: Some(target_key),
                 enc_payload: Some(enc_payload),
                 enc_iv: Some(iv.to_vec()),
-            }),
+            })),
             ..Default::default()
         };
         self.send_message(chat, message).await

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -4277,10 +4277,10 @@ fn test_unwrap_device_sent_extracts_reaction() {
         device_sent_message: Some(Box::new(wa::message::DeviceSentMessage {
             destination_jid: Some("5511999999999@s.whatsapp.net".to_string()),
             message: Some(Box::new(wa::Message {
-                reaction_message: Some(wa::message::ReactionMessage {
+                reaction_message: Some(Box::new(wa::message::ReactionMessage {
                     text: Some("\u{2764}".to_string()),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             })),
             phash: None,
@@ -7362,7 +7362,7 @@ fn encrypted_message_edit(
     .expect("test edit encryption");
 
     wa::Message {
-        secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+        secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
             target_message_key: Some(target_key),
             enc_payload: Some(enc_payload),
             enc_iv: Some(enc_iv.to_vec()),
@@ -7370,7 +7370,7 @@ fn encrypted_message_edit(
                 wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
             ),
             remote_key_id: None,
-        }),
+        })),
         ..Default::default()
     }
 }
@@ -9703,11 +9703,11 @@ async fn enc_reaction_inbound_decrypts_to_plaintext_shape() {
         participant: Some(author.to_string()),
     };
     let msg = wa::Message {
-        enc_reaction_message: Some(wa::message::EncReactionMessage {
+        enc_reaction_message: Some(Box::new(wa::message::EncReactionMessage {
             target_message_key: Some(target_key.clone()),
             enc_payload: Some(payload),
             enc_iv: Some(iv.to_vec()),
-        }),
+        })),
         ..Default::default()
     };
     let info = Arc::new(MessageInfo {
@@ -9795,7 +9795,7 @@ async fn enc_comment_inbound_dispatches_body_with_parent_link() {
     .expect("encrypt");
 
     let msg = wa::Message {
-        enc_comment_message: Some(wa::message::EncCommentMessage {
+        enc_comment_message: Some(Box::new(wa::message::EncCommentMessage {
             target_message_key: Some(wa::MessageKey {
                 remote_jid: Some(group.to_string()),
                 from_me: Some(false),
@@ -9804,7 +9804,7 @@ async fn enc_comment_inbound_dispatches_body_with_parent_link() {
             }),
             enc_payload: Some(payload),
             enc_iv: Some(iv.to_vec()),
-        }),
+        })),
         // WA Web ships the comment's own secret on the OUTER envelope (the
         // comment msgData), not inside the encrypted body.
         message_context_info: Some(Box::new(wa::MessageContextInfo {

--- a/src/send.rs
+++ b/src/send.rs
@@ -1260,11 +1260,11 @@ impl Client {
         duration_secs: u32,
     ) -> Result<(), anyhow::Error> {
         let message = wa::Message {
-            pin_in_chat_message: Some(wa::message::PinInChatMessage {
+            pin_in_chat_message: Some(Box::new(wa::message::PinInChatMessage {
                 key: Some(key),
                 r#type: Some(pin_type as i32),
                 sender_timestamp_ms: Some(wacore::time::now_millis()),
-            }),
+            })),
             message_context_info: Some(Box::new(wa::MessageContextInfo {
                 message_add_on_duration_in_secs: Some(duration_secs),
                 ..Default::default()
@@ -2402,7 +2402,7 @@ mod tests {
             .send_message(
                 to,
                 wa::Message {
-                    reaction_message: Some(wa::message::ReactionMessage {
+                    reaction_message: Some(Box::new(wa::message::ReactionMessage {
                         key: Some(wa::MessageKey {
                             remote_jid: Some("status@broadcast".into()),
                             from_me: Some(false),
@@ -2412,7 +2412,7 @@ mod tests {
                         text: Some("❤️".into()),
                         sender_timestamp_ms: Some(1),
                         ..Default::default()
-                    }),
+                    })),
                     ..Default::default()
                 },
             )
@@ -2432,7 +2432,7 @@ mod tests {
             .send_message(
                 to,
                 wa::Message {
-                    reaction_message: Some(wa::message::ReactionMessage {
+                    reaction_message: Some(Box::new(wa::message::ReactionMessage {
                         key: Some(wa::MessageKey {
                             remote_jid: Some("status@broadcast".into()),
                             from_me: Some(false),
@@ -2442,7 +2442,7 @@ mod tests {
                         text: Some("❤️".into()),
                         sender_timestamp_ms: Some(1),
                         ..Default::default()
-                    }),
+                    })),
                     ..Default::default()
                 },
             )
@@ -3084,7 +3084,7 @@ mod tests {
         #[test]
         fn pin_returns_edit_attribute() {
             let msg = wa::Message {
-                pin_in_chat_message: Some(wa::message::PinInChatMessage::default()),
+                pin_in_chat_message: Some(Box::default()),
                 ..Default::default()
             };
             let (edit, node) = infer_stanza_metadata(&msg);
@@ -3203,10 +3203,10 @@ mod tests {
         #[test]
         fn poll_vote_returns_meta_node() {
             let msg = wa::Message {
-                poll_update_message: Some(wa::message::PollUpdateMessage {
+                poll_update_message: Some(Box::new(wa::message::PollUpdateMessage {
                     vote: Some(wa::message::PollEncValue::default()),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let (edit, node) = infer_stanza_metadata(&msg);
@@ -3247,7 +3247,7 @@ mod tests {
         #[test]
         fn event_response_returns_meta_node() {
             let msg = wa::Message {
-                enc_event_response_message: Some(Default::default()),
+                enc_event_response_message: Some(Box::default()),
                 ..Default::default()
             };
             let (edit, node) = infer_stanza_metadata(&msg);
@@ -3264,10 +3264,10 @@ mod tests {
         #[test]
         fn poll_update_without_vote_returns_none() {
             let msg = wa::Message {
-                poll_update_message: Some(wa::message::PollUpdateMessage {
+                poll_update_message: Some(Box::new(wa::message::PollUpdateMessage {
                     vote: None,
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let (edit, node) = infer_stanza_metadata(&msg);
@@ -3278,10 +3278,10 @@ mod tests {
         #[test]
         fn revoked_reaction_returns_sender_revoke() {
             let msg = wa::Message {
-                reaction_message: Some(wa::message::ReactionMessage {
+                reaction_message: Some(Box::new(wa::message::ReactionMessage {
                     text: Some(String::new()),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let (edit, _) = infer_stanza_metadata(&msg);
@@ -3291,14 +3291,14 @@ mod tests {
         #[test]
         fn keep_in_chat_undo_returns_sender_revoke() {
             let msg = wa::Message {
-                keep_in_chat_message: Some(wa::message::KeepInChatMessage {
+                keep_in_chat_message: Some(Box::new(wa::message::KeepInChatMessage {
                     key: Some(wa::MessageKey {
                         from_me: Some(true),
                         ..Default::default()
                     }),
                     keep_type: Some(wa::KeepType::UndoKeepForAll as i32),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let (edit, _) = infer_stanza_metadata(&msg);
@@ -3308,12 +3308,12 @@ mod tests {
         #[test]
         fn secret_encrypted_message_edit_returns_message_edit() {
             let msg = wa::Message {
-                secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                     secret_enc_type: Some(
                         wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
                     ),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let (edit, _) = infer_stanza_metadata(&msg);
@@ -3325,12 +3325,12 @@ mod tests {
             // EVENT_EDIT is the one case where the edit attribute AND the
             // meta node both fire: `event_type=edit` meta + `edit="1"` attr.
             let msg = wa::Message {
-                secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+                secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                     secret_enc_type: Some(
                         wa::message::secret_encrypted_message::SecretEncType::EventEdit as i32,
                     ),
                     ..Default::default()
-                }),
+                })),
                 ..Default::default()
             };
             let (edit, node) = infer_stanza_metadata(&msg);

--- a/tests/discrepancy_pocs.rs
+++ b/tests/discrepancy_pocs.rs
@@ -13,10 +13,10 @@ use waproto::whatsapp as wa;
 #[test]
 fn regression_a1_revoked_reaction_returns_sender_revoke() {
     let msg = wa::Message {
-        reaction_message: Some(wa::message::ReactionMessage {
+        reaction_message: Some(Box::new(wa::message::ReactionMessage {
             text: Some(String::new()),
             ..Default::default()
-        }),
+        })),
         ..Default::default()
     };
     assert_eq!(
@@ -28,14 +28,14 @@ fn regression_a1_revoked_reaction_returns_sender_revoke() {
 #[test]
 fn regression_a1_keep_in_chat_undo_returns_sender_revoke() {
     let msg = wa::Message {
-        keep_in_chat_message: Some(wa::message::KeepInChatMessage {
+        keep_in_chat_message: Some(Box::new(wa::message::KeepInChatMessage {
             key: Some(wa::MessageKey {
                 from_me: Some(true),
                 ..Default::default()
             }),
             keep_type: Some(wa::KeepType::UndoKeepForAll as i32),
             ..Default::default()
-        }),
+        })),
         ..Default::default()
     };
     assert_eq!(
@@ -47,12 +47,12 @@ fn regression_a1_keep_in_chat_undo_returns_sender_revoke() {
 #[test]
 fn regression_a1_secret_encrypted_message_edit_returns_message_edit() {
     let msg = wa::Message {
-        secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+        secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
             secret_enc_type: Some(
                 wa::message::secret_encrypted_message::SecretEncType::MessageEdit as i32,
             ),
             ..Default::default()
-        }),
+        })),
         ..Default::default()
     };
     assert_eq!(
@@ -64,12 +64,12 @@ fn regression_a1_secret_encrypted_message_edit_returns_message_edit() {
 #[test]
 fn regression_a1_secret_encrypted_event_edit_returns_message_edit() {
     let msg = wa::Message {
-        secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+        secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
             secret_enc_type: Some(
                 wa::message::secret_encrypted_message::SecretEncType::EventEdit as i32,
             ),
             ..Default::default()
-        }),
+        })),
         ..Default::default()
     };
     assert_eq!(

--- a/wacore/src/proto_helpers.rs
+++ b/wacore/src/proto_helpers.rs
@@ -555,11 +555,11 @@ pub fn build_keep_in_chat_message(
         wa::KeepType::UndoKeepForAll
     };
     wa::Message {
-        keep_in_chat_message: Some(wa::message::KeepInChatMessage {
+        keep_in_chat_message: Some(Box::new(wa::message::KeepInChatMessage {
             key: Some(key),
             keep_type: Some(keep_type as i32),
             timestamp_ms: Some(timestamp_ms),
-        }),
+        })),
         ..Default::default()
     }
 }
@@ -768,12 +768,12 @@ pub fn build_reaction_message(
     sender_timestamp_ms: i64,
 ) -> wa::Message {
     wa::Message {
-        reaction_message: Some(wa::message::ReactionMessage {
+        reaction_message: Some(Box::new(wa::message::ReactionMessage {
             key: Some(key),
             text: Some(emoji.into()),
             sender_timestamp_ms: Some(sender_timestamp_ms),
             ..Default::default()
-        }),
+        })),
         ..Default::default()
     }
 }
@@ -1594,10 +1594,10 @@ mod tests {
             device_sent_message: Some(Box::new(wa::message::DeviceSentMessage {
                 destination_jid: Some("5511999999999@s.whatsapp.net".to_string()),
                 message: Some(Box::new(wa::Message {
-                    reaction_message: Some(wa::message::ReactionMessage {
+                    reaction_message: Some(Box::new(wa::message::ReactionMessage {
                         text: Some("\u{2764}".to_string()),
                         ..Default::default()
-                    }),
+                    })),
                     ..Default::default()
                 })),
                 phash: None,

--- a/wacore/src/reporting_token.rs
+++ b/wacore/src/reporting_token.rs
@@ -817,18 +817,18 @@ mod tests {
 
         // Reaction message should NOT include token
         let reaction_message = wa::Message {
-            reaction_message: Some(wa::message::ReactionMessage {
+            reaction_message: Some(Box::new(wa::message::ReactionMessage {
                 key: None,
                 text: Some("👍".to_string()),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         assert!(!should_include_reporting_token(&reaction_message));
 
         // Poll update should NOT include token
         let poll_update = wa::Message {
-            poll_update_message: Some(wa::message::PollUpdateMessage::default()),
+            poll_update_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(!should_include_reporting_token(&poll_update));
@@ -1345,29 +1345,29 @@ mod tests {
         // Verify all excluded message types return None/false
 
         let reaction = wa::Message {
-            reaction_message: Some(wa::message::ReactionMessage {
+            reaction_message: Some(Box::new(wa::message::ReactionMessage {
                 text: Some("👍".to_string()),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         assert!(!should_include_reporting_token(&reaction));
         assert!(generate_reporting_token_content(&reaction).is_none());
 
         let enc_reaction = wa::Message {
-            enc_reaction_message: Some(wa::message::EncReactionMessage::default()),
+            enc_reaction_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(!should_include_reporting_token(&enc_reaction));
 
         let poll_update = wa::Message {
-            poll_update_message: Some(wa::message::PollUpdateMessage::default()),
+            poll_update_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(!should_include_reporting_token(&poll_update));
 
         let keep_in_chat = wa::Message {
-            keep_in_chat_message: Some(wa::message::KeepInChatMessage::default()),
+            keep_in_chat_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(!should_include_reporting_token(&keep_in_chat));

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -222,10 +222,10 @@ mod status_carries_privacy_meta {
     #[test]
     fn false_for_reaction() {
         let msg = wa::Message {
-            reaction_message: Some(wa::message::ReactionMessage {
+            reaction_message: Some(Box::new(wa::message::ReactionMessage {
                 text: Some("💚".into()),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         assert!(
@@ -237,7 +237,7 @@ mod status_carries_privacy_meta {
     #[test]
     fn false_for_enc_reaction() {
         let msg = wa::Message {
-            enc_reaction_message: Some(wa::message::EncReactionMessage::default()),
+            enc_reaction_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(!status_carries_privacy_meta(&msg));
@@ -272,7 +272,7 @@ mod status_carries_privacy_meta {
     #[test]
     fn false_for_reaction_inside_ephemeral_wrapper() {
         let inner = wa::Message {
-            reaction_message: Some(wa::message::ReactionMessage::default()),
+            reaction_message: Some(Box::default()),
             ..Default::default()
         };
         let msg = wa::Message {
@@ -2119,7 +2119,7 @@ mod decrypt_fail {
     #[test]
     fn reaction() {
         let msg = wa::Message {
-            reaction_message: Some(Default::default()),
+            reaction_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(should_hide_decrypt_fail(&msg));
@@ -2128,7 +2128,7 @@ mod decrypt_fail {
     #[test]
     fn pin() {
         let msg = wa::Message {
-            pin_in_chat_message: Some(Default::default()),
+            pin_in_chat_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(should_hide_decrypt_fail(&msg));
@@ -2137,10 +2137,10 @@ mod decrypt_fail {
     #[test]
     fn poll_vote() {
         let msg = wa::Message {
-            poll_update_message: Some(wa::message::PollUpdateMessage {
+            poll_update_message: Some(Box::new(wa::message::PollUpdateMessage {
                 vote: Some(Default::default()),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         assert!(should_hide_decrypt_fail(&msg));
@@ -2149,7 +2149,7 @@ mod decrypt_fail {
     #[test]
     fn poll_update_without_vote() {
         let msg = wa::Message {
-            poll_update_message: Some(Default::default()),
+            poll_update_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(!should_hide_decrypt_fail(&msg));
@@ -2160,7 +2160,7 @@ mod decrypt_fail {
         let msg = wa::Message {
             ephemeral_message: Some(Box::new(wa::message::FutureProofMessage {
                 message: Some(Box::new(wa::Message {
-                    reaction_message: Some(Default::default()),
+                    reaction_message: Some(Box::default()),
                     ..Default::default()
                 })),
             })),
@@ -2172,7 +2172,7 @@ mod decrypt_fail {
     #[test]
     fn conditional_reveal() {
         let msg = wa::Message {
-            conditional_reveal_message: Some(Default::default()),
+            conditional_reveal_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(should_hide_decrypt_fail(&msg));
@@ -2182,10 +2182,10 @@ mod decrypt_fail {
     fn poll_add_option_edit() {
         use wa::message::secret_encrypted_message::SecretEncType;
         let msg = wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 secret_enc_type: Some(SecretEncType::PollAddOption as i32),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
         assert!(should_hide_decrypt_fail(&msg));
@@ -2231,7 +2231,7 @@ mod decrypt_fail_for_send {
     fn revoke_does_not_block_content_based_hide() {
         // A reaction still hides on its own merits even under a revoke edit.
         let msg = wa::Message {
-            reaction_message: Some(Default::default()),
+            reaction_message: Some(Box::default()),
             ..Default::default()
         };
         assert!(should_hide_decrypt_fail_for_send(
@@ -2247,10 +2247,10 @@ mod stanza_type {
 
     fn secret(enc: SecretEncType) -> wa::Message {
         wa::Message {
-            secret_encrypted_message: Some(wa::message::SecretEncryptedMessage {
+            secret_encrypted_message: Some(Box::new(wa::message::SecretEncryptedMessage {
                 secret_enc_type: Some(enc as i32),
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         }
     }
@@ -2345,15 +2345,15 @@ mod stanza_type {
                 ..Default::default()
             },
             wa::Message {
-                decline_payment_request_message: Some(Default::default()),
+                decline_payment_request_message: Some(Box::default()),
                 ..Default::default()
             },
             wa::Message {
-                cancel_payment_request_message: Some(Default::default()),
+                cancel_payment_request_message: Some(Box::default()),
                 ..Default::default()
             },
             wa::Message {
-                payment_invite_message: Some(Default::default()),
+                payment_invite_message: Some(Box::default()),
                 ..Default::default()
             },
         ];
@@ -2415,7 +2415,7 @@ mod stanza_type {
     #[test]
     fn preserved_classifier_branches() {
         let r = wa::Message {
-            reaction_message: Some(Default::default()),
+            reaction_message: Some(Box::default()),
             ..Default::default()
         };
         assert_eq!(stanza_type_from_message(&r), stanza::MSG_TYPE_REACTION);

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -648,7 +648,7 @@ mod tests {
 
         // Same for pin wrapped in view_once and device_sent (double nesting).
         let inner_pin = waproto::whatsapp::Message {
-            pin_in_chat_message: Some(waproto::whatsapp::message::PinInChatMessage::default()),
+            pin_in_chat_message: Some(Box::default()),
             ..Default::default()
         };
         let wrapped_pin = waproto::whatsapp::Message {

--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -65,12 +65,11 @@ fn main() -> std::io::Result<()> {
     config.boxed(".whatsapp.WebMessageInfo.statusMentionMessageInfo");
     config.boxed(".whatsapp.Message.messageContextInfo");
 
-    // Shrink `wa::Message` (~3.8 KiB: the sum of ~110 inline content variants,
-    // of which exactly one is ever set) by boxing the remaining inline
-    // message-typed fields. prost already boxes the variants in recursion
-    // cycles; these are the rest. The struct drops to ~0.9 KiB, so every
-    // `Arc<Message>` event is cheaper to allocate and hold, and decode/clone
-    // move far less. Each boxed field's set value costs one small heap alloc.
+    // Box the remaining inline message-typed fields so `wa::Message` — a union
+    // of ~110 content variants of which exactly one is ever set — stops paying
+    // for all of them inline. prost already boxes the variants in recursion
+    // cycles; these are the rest. Shrinking the struct makes every clone,
+    // decode, and `Arc<Message>` event cheaper to move and hold.
     for field in [
         "bcallMessage",
         "callLogMesssage",

--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -65,6 +65,46 @@ fn main() -> std::io::Result<()> {
     config.boxed(".whatsapp.WebMessageInfo.statusMentionMessageInfo");
     config.boxed(".whatsapp.Message.messageContextInfo");
 
+    // Shrink `wa::Message` (~3.8 KiB: the sum of ~110 inline content variants,
+    // of which exactly one is ever set) by boxing the remaining inline
+    // message-typed fields. prost already boxes the variants in recursion
+    // cycles; these are the rest. The struct drops to ~0.9 KiB, so every
+    // `Arc<Message>` event is cheaper to allocate and hold, and decode/clone
+    // move far less. Each boxed field's set value costs one small heap alloc.
+    for field in [
+        "bcallMessage",
+        "callLogMesssage",
+        "cancelPaymentRequestMessage",
+        "chat",
+        "conditionalRevealMessage",
+        "declinePaymentRequestMessage",
+        "encCommentMessage",
+        "encEventResponseMessage",
+        "encReactionMessage",
+        "groupRootKeyShare",
+        "invoiceMessage",
+        "keepInChatMessage",
+        "paymentInviteMessage",
+        "paymentReminderMessage",
+        "pinInChatMessage",
+        "placeholderMessage",
+        "pollAddOptionMessage",
+        "pollUpdateMessage",
+        "questionResponseMessage",
+        "reactionMessage",
+        "rootSecretDistributeMessage",
+        "scheduledCallCreationMessage",
+        "scheduledCallEditMessage",
+        "secretEncryptedMessage",
+        "statusNotificationMessage",
+        "statusQuestionAnswerMessage",
+        "statusQuotedMessage",
+        "statusStickerInteractionMessage",
+        "stickerSyncRmrMessage",
+    ] {
+        config.boxed(format!(".whatsapp.Message.{field}").as_str());
+    }
+
     // Bytes fields lack serde support; skip them (internal crypto state).
     config.field_attribute(
         ".whatsapp.SessionStructure.Chain.ChainKey.key",


### PR DESCRIPTION
## What

Shrinks `wa::Message` from **3784 → 952 bytes (−75%)** by boxing its remaining inline content variant fields.

> Note: this PR was re-scoped. It previously decoded `Message` onto the heap (`Box<Message>` threaded through the receive path). End-to-end measurement showed that trades a stack memcpy for a per-message heap allocation — CodSpeed net-negative on memory, no clean win. This approach instead attacks the root cause: the struct size itself.

## Why

`wa::Message` carries ~110 optional content fields and exactly one is ever set per message, yet it's laid out as the **sum** of all of them (~3.8 KiB). The inbound-decode profile (#857) attributed ~60% of decode to moving/dropping that struct. prost already boxes the variants caught in recursion cycles (image/video/template/…); this boxes the remaining inline message-typed fields.

Shrinking the struct is a win across the board:
- **Every `Arc<Message>` delivered to library users is ~4x cheaper to allocate and hold** — a direct benefit for high-throughput consumers, not just an internal detail.
- Decode moves/drops a far smaller struct.
- The retry-cache and reporting-token paths clone less.

The two `SenderKeyDistribution` fields stay inline (small, on the group-send hot path).

## Cost: ~nothing in binary

This was the surprise. Boxing a field that is only ever used boxed makes prost emit the `Box<T>` decode/encode tree **instead of** the inline one, not in addition — so the code size barely moves. Verified on a real fat-LTO release build:

- waproto+prost `.text`: **1,729,838 B vs main 1,736,322 B** (slightly smaller)
- `Message::merge_field` instantiations: **16, unchanged from main** (no duplication)

(The +566 KiB an earlier revision of this PR showed was entirely a separate buffer-type monomorphization bug in the heap-decode path, now gone with that approach.)

## Breaking change

The boxed content fields are now `Option<Box<T>>`. Construction sites wrap the value in `Box::new(...)`; field reads auto-deref and are unchanged. The PR updates all in-tree construction sites.

## Verification

- `cargo fmt --all`, `cargo clippy --all --tests`, `cargo check --workspace --tests --benches` (incl. `e2e-tests`) — clean locally
- Wire format / decode output / serde unchanged (prost encodes a boxed field identically; reads/serialization are transparent)
- Full test suite + CodSpeed run in CI — expecting faster decode and **no memory regression** (no heap-decode), at flat binary

https://claude.ai/code/session_01XHsbPwjaCRDHDL69HbEgR8