### PR TITLE
perf: drop a ~67 KiB duplicate prost decode tree + hoist a per-message traversal

### DIFF
--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -15,10 +15,9 @@ impl Client {
 
         let mut info = Arc::clone(info);
         if info.ephemeral_expiration.is_none()
-            && msg.get_base_message().get_ephemeral_expiration().is_some()
+            && let Some(exp) = msg.get_base_message().get_ephemeral_expiration()
         {
-            Arc::make_mut(&mut info).ephemeral_expiration =
-                msg.get_base_message().get_ephemeral_expiration();
+            Arc::make_mut(&mut info).ephemeral_expiration = Some(exp);
         }
 
         // Keep this ordered with dispatch; add-on messages can immediately

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -1,7 +1,8 @@
 use crate::libsignal::crypto::CryptographicHash;
 use anyhow::{Result, anyhow};
 use base64::Engine as _;
-use prost::Message as ProtoMessage;
+#[cfg(test)]
+use prost::Message as _;
 use waproto::whatsapp as wa;
 
 pub struct MessageUtils;
@@ -98,8 +99,11 @@ impl MessageUtils {
                 let ctx = owned
                     .message_context_info
                     .get_or_insert_with(Default::default);
-                ctx.merge(waproto::codec::message_context_info_to_vec(extra).as_slice())
-                    .expect("merge MessageContextInfo");
+                waproto::codec::message_context_info_merge(
+                    ctx,
+                    &waproto::codec::message_context_info_to_vec(extra),
+                )
+                .expect("merge MessageContextInfo");
             }
             return Self::encode_dm_plaintexts_owned(owned, destination_jid);
         }

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -84,4 +84,20 @@ pub mod codec {
     pub fn message_context_info_to_vec(mci: &whatsapp::MessageContextInfo) -> Vec<u8> {
         mci.encode_to_vec()
     }
+
+    /// Merge wire bytes into an existing `MessageContextInfo` (prost merge
+    /// semantics: later-set fields win).
+    ///
+    /// Merges through a `&mut &mut &[u8]` buffer — the exact shape
+    /// `Message::decode` threads into its nested `MessageContextInfo` — so the
+    /// `BotMetadata` decode subtree reuses that instantiation instead of
+    /// emitting a second ~67 KiB copy in a distinct buffer-type shape.
+    #[inline(never)]
+    pub fn message_context_info_merge(
+        mci: &mut whatsapp::MessageContextInfo,
+        bytes: &[u8],
+    ) -> Result<(), prost::DecodeError> {
+        let mut cursor = bytes;
+        mci.merge(&mut &mut cursor)
+    }
 }


### PR DESCRIPTION
Two small, no-drawback perf cleanups found by auditing for binary bloat and per-message waste.

## 1. Binary: reuse the canonical buffer-type for `MessageContextInfo` merge (~67 KiB .text)

`MessageUtils::encode_dm_plaintexts` folds reporting context into a message's `MessageContextInfo` via `ctx.merge(vec.as_slice())`. The bare `&[u8]` buffer made prost monomorphize the entire `MessageContextInfo` → `BotMetadata` decode subtree in a **distinct** buffer-type shape, separate from the `&mut &mut &[u8]` tree that `Message::decode` already instantiates — so the binary shipped a second copy of that subtree (`BotMetadata::merge_field` alone is ~51–67 KiB).

Fix: route through a pinned `codec::message_context_info_merge` that merges via `&mut &mut &[u8]`, matching the shape the rest of the workspace decodes with (the `waproto::codec` module already exists for exactly this "pin one instantiation" purpose).

**Verified locally with `nm` on the release artifact** — each nested type drops from two `merge_field` copies to one:

| symbol | before | after |
|---|---|---|
| `BotMetadata::merge_field` | 2 copies (`&mut &mut &[u8]` + `&[u8]`) | **1** (`&mut &mut &[u8]`) |
| `MessageContextInfo::merge_field` | 2 | **1** |
| `ContextInfo::merge_field` | 2 | **1** |

Same merge semantics (later-set fields win); this is a cold path (only the rare case where the message already carries a top-level `message_context_info`). No behavior change.

## 2. Runtime: hoist a duplicated traversal in `dispatch_parsed_message`

On every inbound message, `msg.get_base_message().get_ephemeral_expiration()` was computed **twice** — once in the `if` condition, once in the assignment. Each call walks the wrapper levels and iterates the ~28-variant content list. Bind it once with a let-chain. Tiny, but pure waste on the hottest path.

---

Both ran `cargo fmt`/`clippy` clean and the `wacore` message tests pass locally. Leaving the full suite + the binary-size CI report (which should show a `.text` **decrease**) + CodSpeed to CI.

Context: this came out of a fresh audit after the appstate dedup PR (#868); the remaining heavy benchmarks are genuine crypto/zlib, so these target binary bloat and per-message overhead rather than a hot algorithmic loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHsbPwjaCRDHDL69HbEgR8)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

