### PR TITLE
fix(retry): cap outbound resends per (chat, msg, requester)

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -195,6 +195,12 @@ pub struct CacheConfig {
     /// Session-recreate throttle history (time_to_live). Default: 1h TTL, 256
     /// entries. Replaces a global `Mutex<HashMap>` scanned O(n) per retry receipt.
     pub session_recreate_history: CacheEntryConfig,
+    /// Outbound resend cap per (chat, msg, requester): a hard ceiling on how
+    /// many times we re-encrypt+resend a message in response to peer retry
+    /// receipts, independent of the peer-echoed `count`. Without it a single
+    /// looping device under PN→LID churn drives a resend storm into
+    /// AccountLocked. Default: 10m TTL, 10000 entries.
+    pub resend_counts: CacheEntryConfig,
 
     // --- Coordination caches (capacity-only, no TTL) ---
     /// Per-device Signal session lock capacity. Default: 10000.
@@ -271,6 +277,7 @@ impl std::fmt::Debug for CacheConfig {
             .field("pdo_requested", &self.pdo_requested)
             .field("sender_key_devices_cache", &self.sender_key_devices_cache)
             .field("session_recreate_history", &self.session_recreate_history)
+            .field("resend_counts", &self.resend_counts)
             .field("session_locks_capacity", &self.session_locks_capacity)
             .field("chat_lanes_capacity", &self.chat_lanes_capacity)
             .field("sent_message_ttl_secs", &self.sent_message_ttl_secs)
@@ -324,6 +331,9 @@ impl Default for CacheConfig {
             pdo_requested: CacheEntryConfig::new(Some(Duration::from_secs(24 * 3600)), 512),
             sender_key_devices_cache: CacheEntryConfig::new(one_hour, 500),
             session_recreate_history: CacheEntryConfig::new(one_hour, 256),
+            // 10m covers a message's realistic retry window; 10k entries is
+            // sized for a storm spanning many (chat,msg,device) keys at once.
+            resend_counts: CacheEntryConfig::new(Some(Duration::from_secs(600)), 10_000),
             // Coordination caches hold live mutexes/senders; capacity eviction
             // while a reference is held creates a second lock for the same key,
             // breaking serialization. Size generously to avoid eviction pressure.

--- a/src/client.rs
+++ b/src/client.rs
@@ -188,6 +188,7 @@ pub struct MemoryDiagnostics {
     pub recent_messages: u64,
     pub sender_key_device_cache: u64,
     pub message_retry_counts: u64,
+    pub resend_counts: u64,
     pub undecryptable_dispatched: u64,
     pub pdo_pending_requests: u64,
     pub pdo_requested: u64,
@@ -229,6 +230,7 @@ impl std::fmt::Display for MemoryDiagnostics {
             self.sender_key_device_cache
         )?;
         writeln!(f, "  message_retry_counts:   {}", self.message_retry_counts)?;
+        writeln!(f, "  resend_counts:          {}", self.resend_counts)?;
         writeln!(
             f,
             "  undec_dispatched:       {}",
@@ -454,6 +456,12 @@ pub struct Client {
     /// stay stuck. This map throttles the fallback so a noisy peer can't
     /// loop us through prekey fetches.
     pub(crate) session_recreate_history: Cache<wacore_binary::jid::Jid, wacore::time::Instant>,
+
+    /// Hard cap on outbound resends keyed by "{chat}:{msg_id}:{requester}":
+    /// counts the resends we actually performed, independent of the peer's
+    /// echoed `count`. A looping device under PN→LID churn can keep the
+    /// echoed count low; this is the real ceiling that stops the resend storm.
+    pub(crate) resend_counts: Cache<String, u32>,
 
     /// Dispatch-once gate for `UndecryptableMessage`: a server resend of a
     /// failed id re-enters the failure path and would otherwise fire a

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -90,6 +90,7 @@ impl Client {
             recent_messages: self.recent_messages.entry_count(),
             sender_key_device_cache: self.sender_key_device_cache.entry_count(),
             message_retry_counts: self.message_retry_counts.entry_count(),
+            resend_counts: self.resend_counts.entry_count(),
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count(),
             pdo_pending_requests: self.pdo_pending_requests.entry_count(),
             pdo_requested: self.pdo_requested.entry_count(),

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -185,6 +185,8 @@ impl Client {
 
             session_recreate_history: cache_config.session_recreate_history.build_with_ttl(),
 
+            resend_counts: cache_config.resend_counts.build_with_ttl(),
+
             undecryptable_dispatched: cache_config.undecryptable_dispatched.build_with_ttl(),
 
             offline_sync_metrics: Arc::new(OfflineSyncMetrics {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -293,7 +293,10 @@ impl Client {
         // the tally happens once the send is committed, so cache-miss/status
         // early returns don't consume the budget.
         if self.resend_counts.get(&resend_key).await.unwrap_or(0) >= MAX_RESENDS_PER_MESSAGE {
-            warn!(
+            // debug, not warn: hitting the cap is expected, healthy behavior for
+            // a churning chat — it would otherwise spam the console on every
+            // refused resend.
+            debug!(
                 "Refusing resend of {} to {} in {}: exceeds resend cap {}",
                 message_id,
                 info.requester.observe(),

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -287,13 +287,14 @@ impl Client {
         });
 
         // Hard cap on real resends. MAX_RETRY_COUNT above trusts the peer's
-        // echoed `count`, which a looping device can keep low; this counts what
-        // we actually resent and stops the storm before it trips AccountLocked.
-        let resends = next_resend_count(self.resend_counts.get(&resend_key).await);
-        self.resend_counts.insert(resend_key, resends).await;
-        if resends > MAX_RESENDS_PER_MESSAGE {
+        // echoed `count`, which a looping device can keep low; this counts the
+        // resends we actually commit to (tallied past the early returns below)
+        // and stops the storm before it trips AccountLocked. Check only here —
+        // the tally happens once the send is committed, so cache-miss/status
+        // early returns don't consume the budget.
+        if self.resend_counts.get(&resend_key).await.unwrap_or(0) >= MAX_RESENDS_PER_MESSAGE {
             warn!(
-                "Refusing resend #{resends} of {} to {} in {}: exceeds resend cap {}",
+                "Refusing resend of {} to {} in {}: exceeds resend cap {}",
                 message_id,
                 info.requester.observe(),
                 info.chat.observe(),
@@ -525,6 +526,13 @@ impl Client {
             info.chat.observe(),
             retry_count
         );
+
+        // Tally now that a real resend is committed (cache-miss and status
+        // early returns above don't reach here). Counting a committed attempt —
+        // not only a successful send_node — is deliberate: a session-prepare
+        // loop that keeps erroring is exactly the churn the cap must bound.
+        let resends = next_resend_count(self.resend_counts.get(&resend_key).await);
+        self.resend_counts.insert(resend_key, resends).await;
 
         if info.chat.is_group() {
             // Group retry: pairwise encrypt to failing device only (RetryMsgJob.js:71).

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -75,6 +75,13 @@ fn extract_registration_id_from_node_ref(node: &NodeRef<'_>) -> Option<u32> {
 /// We refuse to resend if the requester has already retried this many times.
 const MAX_RETRY_COUNT: u8 = 5;
 
+/// Hard ceiling on resends we actually perform per (chat, msg, requester),
+/// independent of the peer-echoed `count`. A device looping retry receipts
+/// (common under PN→LID churn) keeps the echoed count low, so MAX_RETRY_COUNT
+/// alone never fires; this is the real cap that stops the resend storm that
+/// trips AccountLocked. Generous enough for legitimate spaced redeliveries.
+const MAX_RESENDS_PER_MESSAGE: u32 = 8;
+
 /// Minimum retry count before we start tracking base keys.
 /// WhatsApp Web saves base key on retry 2, checks on retry > 2.
 const MIN_RETRY_FOR_BASE_KEY_CHECK: u8 = 2;
@@ -190,6 +197,13 @@ fn validate_retry_prekey_presence(
 
 // No retry_count in the key: concurrent receipts for the same participant must
 // serialize, otherwise two update_local_signal_session calls race on session state.
+/// Next resend tally for a (chat,msg,requester) key. Saturates so a wrapped
+/// counter can't silently re-open the cap.
+#[inline]
+fn next_resend_count(prev: Option<u32>) -> u32 {
+    prev.unwrap_or(0).saturating_add(1)
+}
+
 fn build_retry_processing_key(chat: &Jid, message_id: &str, participant_jid: &Jid) -> String {
     let mut key = String::with_capacity(message_id.len() + 64);
     chat.push_to(&mut key);
@@ -261,8 +275,9 @@ impl Client {
             log::debug!("Ignoring retry for {processing_key}: a retry is already in progress.");
             return Ok(());
         }
-        // processing_key isn't needed by name after this point — move it into
-        // the scopeguard instead of cloning again.
+        // Clone once for the resend cap below; the original moves into the
+        // scopeguard that clears the in-progress marker.
+        let resend_key = processing_key.clone();
         let pending = Arc::clone(&self.pending_retries);
         let _guard = scopeguard::guard((), move |()| {
             pending
@@ -270,6 +285,22 @@ impl Client {
                 .unwrap_or_else(|p| p.into_inner())
                 .remove(&processing_key);
         });
+
+        // Hard cap on real resends. MAX_RETRY_COUNT above trusts the peer's
+        // echoed `count`, which a looping device can keep low; this counts what
+        // we actually resent and stops the storm before it trips AccountLocked.
+        let resends = next_resend_count(self.resend_counts.get(&resend_key).await);
+        self.resend_counts.insert(resend_key, resends).await;
+        if resends > MAX_RESENDS_PER_MESSAGE {
+            warn!(
+                "Refusing resend #{resends} of {} to {} in {}: exceeds resend cap {}",
+                message_id,
+                info.requester.observe(),
+                info.chat.observe(),
+                MAX_RESENDS_PER_MESSAGE
+            );
+            return Ok(());
+        }
 
         // A retry from a device missing from our registry signals a stale device
         // list for this user, so refresh it (rate-limited, dedup'd) to learn the
@@ -1252,6 +1283,28 @@ mod tests {
     use crate::store::persistence_manager::PersistenceManager;
     use crate::test_utils::MockHttpClient;
     use std::borrow::Cow;
+
+    #[test]
+    fn resend_cap_refuses_after_threshold() {
+        // Counts 1..=cap stay within the ceiling; the next one exceeds it.
+        let mut prev = None;
+        for expected in 1..=MAX_RESENDS_PER_MESSAGE {
+            let n = next_resend_count(prev);
+            assert_eq!(n, expected);
+            assert!(n <= MAX_RESENDS_PER_MESSAGE);
+            prev = Some(n);
+        }
+        let over = next_resend_count(prev);
+        assert_eq!(over, MAX_RESENDS_PER_MESSAGE + 1);
+        assert!(over > MAX_RESENDS_PER_MESSAGE);
+    }
+
+    #[test]
+    fn next_resend_count_saturates() {
+        assert_eq!(next_resend_count(None), 1);
+        assert_eq!(next_resend_count(Some(7)), 8);
+        assert_eq!(next_resend_count(Some(u32::MAX)), u32::MAX);
+    }
     use std::sync::Arc;
     use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair};
     use wacore::types::jid::JidExt as _;


### PR DESCRIPTION
## Problem

`handle_retry_receipt` resends a message on **every** incoming retry receipt, with no ceiling independent of the peer-echoed `count`. The existing `MAX_RETRY_COUNT = 5` trusts that echoed count, which a looping device keeps low — so it never fires.

Under WhatsApp's mass PN→LID migration this turns into a resend storm. Observed in production on a bot running this lib:

- **36,374 resends in 66h**, sustained 9–25/min.
- **99.4% to a single group**; one `msg_id` resent **576 times**.
- Ended in `<failure reason="403" location="vll"/>` → **AccountLocked**.

`freshSKDM == resends` 1:1 across every log — each resend is driven by a `Marked … for fresh SKDM … due to retry receipt`. Notably `fix/device-list-preserve-primary` (#797) was already active during the incident and did **not** prevent the storm: the existing fixes reduce churn at the source but none impose a **volume ceiling**.

## Fix

A hard cap (`MAX_RESENDS_PER_MESSAGE = 8`) on the resends we actually perform, keyed by the **existing** processing key (`chat:msg:requester`) via a new `resend_counts` cache (10m TTL, 10k entries):

- Counts real resends, independent of the peer-echoed `count` — the ceiling `MAX_RETRY_COUNT` can't provide.
- **Per-requester** granularity: legitimate resends to distinct failing devices keep working; only a single device looping the same message is capped.
- On exceed: refuses the resend with a `warn!` naming the chat/device (so storm groups are visible).
- `resend_counts` exposed in `ClientStats` for monitoring.

## Test plan

- [x] `cargo test -p whatsapp-rust resend` — new unit tests for the cap arithmetic/threshold (`resend_cap_refuses_after_threshold`, `next_resend_count_saturates`).
- [x] `cargo fmt --all`, `cargo clippy -p whatsapp-rust` clean.
- [x] Downstream bot compiles against the change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

