### PR TITLE
fix(send): gate SKDM redistribution on the primary device (WA Web parity)

### DIFF
--- a/src/send.rs
+++ b/src/send.rs
@@ -860,11 +860,14 @@ impl Client {
                 if device.user == own_sending_jid.user && device.device == own_sending_jid.device {
                     return false;
                 }
-                // O(1) lookups into pre-indexed cache
+                // WA Web parity (ParticipantStore.js skDistribList): a device is
+                // warm only when it AND its primary (device 0) hold the key, so a
+                // forgotten primary redistributes the whole user while a forgotten
+                // companion redistributes only itself.
                 !cached_map
                     .device_has_key(&device.user, device.device)
                     .unwrap_or(false)
-                    || cached_map.is_user_forgotten(&device.user)
+                    || !cached_map.device_has_key(&device.user, 0).unwrap_or(false)
             })
             .cloned()
             .collect();
@@ -2927,7 +2930,6 @@ mod tests {
 
         let map = SenderKeyDeviceMap::from_db_rows(&[]);
         assert_eq!(map.device_has_key("271060335329480", 0), None);
-        assert!(!map.is_user_forgotten("271060335329480"));
 
         let all_resolved_devices: Vec<Jid> = [
             "271060335329480@lid",
@@ -2943,7 +2945,7 @@ mod tests {
             .filter(|device| {
                 !map.device_has_key(&device.user, device.device)
                     .unwrap_or(false)
-                    || map.is_user_forgotten(&device.user)
+                    || !map.device_has_key(&device.user, 0).unwrap_or(false)
             })
             .collect();
 
@@ -3009,7 +3011,6 @@ mod tests {
 
         let map = SenderKeyDeviceMap::from_db_rows(&[("271060335329480@lid".to_string(), false)]);
         assert_eq!(map.device_has_key("271060335329480", 0), Some(false));
-        assert!(map.is_user_forgotten("271060335329480"));
 
         let all_resolved_devices: Vec<Jid> = [
             "271060335329480@lid",
@@ -3025,7 +3026,7 @@ mod tests {
             .filter(|device| {
                 !map.device_has_key(&device.user, device.device)
                     .unwrap_or(false)
-                    || map.is_user_forgotten(&device.user)
+                    || !map.device_has_key(&device.user, 0).unwrap_or(false)
             })
             .collect();
 
@@ -3034,6 +3035,56 @@ mod tests {
             3,
             "after retry inserts one row, ALL devices correctly flagged for SKDM \
              (this is what unblocks redistribution on the SECOND message)"
+        );
+    }
+
+    /// WA Web primary-device gate (ParticipantStore.js): a companion is warm only
+    /// when it AND its primary (device 0) hold the key. A forgotten companion
+    /// redistributes only itself (no per-user amplification); a forgotten primary
+    /// redistributes the whole user. Drives the real `filter_skdm_targets`.
+    #[tokio::test]
+    async fn filter_skdm_targets_uses_primary_device_gate() {
+        use crate::sender_key_device_cache::SenderKeyDeviceMap;
+
+        let client = crate::test_utils::create_test_client().await;
+        let group = "120363161500776365@g.us";
+        let own = Jid::from_str("999999999999999:1@lid").unwrap();
+
+        // Companion forgotten, primary warm: only the companion redistributes.
+        let map = SenderKeyDeviceMap::from_db_rows(&[
+            ("100100100100100@lid".to_string(), true),
+            ("100100100100100:5@lid".to_string(), false),
+        ]);
+        let devices = [
+            Jid::from_str("100100100100100@lid").unwrap(),
+            Jid::from_str("100100100100100:5@lid").unwrap(),
+        ];
+        let needs = client.filter_skdm_targets(group, &devices, &map, &own);
+        assert_eq!(needs.len(), 1, "warm primary keeps the keyed companion out");
+        assert_eq!(needs[0].device, 5);
+
+        // Primary forgotten, companion warm: the whole user redistributes (WA Web
+        // marks a companion cold when its primary is cold).
+        let map = SenderKeyDeviceMap::from_db_rows(&[
+            ("200200200200200@lid".to_string(), false),
+            ("200200200200200:5@lid".to_string(), true),
+        ]);
+        let devices = [
+            Jid::from_str("200200200200200@lid").unwrap(),
+            Jid::from_str("200200200200200:5@lid").unwrap(),
+        ];
+        let needs = client.filter_skdm_targets(group, &devices, &map, &own);
+        assert_eq!(needs.len(), 2, "cold primary redistributes the whole user");
+
+        // Companion warm but the primary row is absent (None): WA Web's `?? false`
+        // treats a missing primary as cold, so the companion still redistributes.
+        let map = SenderKeyDeviceMap::from_db_rows(&[("300300300300300:5@lid".to_string(), true)]);
+        let devices = [Jid::from_str("300300300300300:5@lid").unwrap()];
+        let needs = client.filter_skdm_targets(group, &devices, &map, &own);
+        assert_eq!(
+            needs.len(),
+            1,
+            "absent primary is cold, companion redistributes"
         );
     }
 

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -1,7 +1,7 @@
 //! In-memory cache for per-group sender key device tracking.
 //! Avoids DB round-trips on group sends after the first.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::cache::Cache;
@@ -13,26 +13,20 @@ use wacore_binary::Jid;
 pub(crate) struct SenderKeyDeviceMap {
     /// user → (device_id → has_key)
     devices: HashMap<Arc<str>, HashMap<u16, bool>>,
-    /// Users with at least one `has_key=false` device.
-    forgotten_users: HashSet<Arc<str>>,
 }
 
 impl SenderKeyDeviceMap {
     pub fn from_db_rows(rows: &[(String, bool)]) -> Self {
         let mut devices: HashMap<Arc<str>, HashMap<u16, bool>> = HashMap::with_capacity(rows.len());
-        let mut forgotten_users = HashSet::with_capacity(rows.len() / 4);
 
         for (jid_str, has_key) in rows {
             match jid_str.parse::<Jid>() {
                 Ok(jid) => {
                     let user: Arc<str> = Arc::from(jid.user.as_str());
                     devices
-                        .entry(user.clone())
+                        .entry(user)
                         .or_default()
                         .insert(jid.device, *has_key);
-                    if !*has_key {
-                        forgotten_users.insert(user);
-                    }
                 }
                 Err(e) => {
                     log::warn!("Skipping malformed device JID '{}': {}", jid_str, e);
@@ -40,10 +34,7 @@ impl SenderKeyDeviceMap {
             }
         }
 
-        Self {
-            devices,
-            forgotten_users,
-        }
+        Self { devices }
     }
 
     #[cfg(test)]
@@ -53,10 +44,6 @@ impl SenderKeyDeviceMap {
 
     pub fn device_has_key(&self, user: &str, device: u16) -> Option<bool> {
         self.devices.get(user)?.get(&device).copied()
-    }
-
-    pub fn is_user_forgotten(&self, user: &str) -> bool {
-        self.forgotten_users.contains(user)
     }
 }
 


### PR DESCRIPTION
## Problem

During a retry storm (mass PN->LID migration), each retrying device is marked has_key=false individually, but the SKDM filter redistributed the sender key to ALL of that user's devices via a per-user `is_user_forgotten` clause, including devices that already hold the key. That is extra outbound SKDM volume during exactly the storms that risk AccountLocked, and it diverges from WhatsApp Web.

## Fix

Match WA Web's getGroupSenderKeyListFromParticipantRecord (ParticipantStore.js): a device is warm (skip SKDM) only when both it AND its primary device (device 0) hold the key. The filter predicate becomes "needs SKDM iff the device is cold OR its primary is cold", replacing the per-user `is_user_forgotten` clause with a primary-device gate.

Strictly more correct than both the old behavior and a naive per-device check:

- Old (`is_user_forgotten`): a single cold companion redistributed the whole user. Broader than WA Web.
- Naive per-device: would skip a warm companion when the primary is cold. Narrower than WA Web (drops a needed SKDM).
- Primary-gate (this PR): a cold companion redistributes only itself; a cold primary redistributes the whole user. Exact WA Web parity.

The now-dead `forgotten_users` set and `is_user_forgotten` method are removed.

## Tests

- `filter_skdm_targets_uses_primary_device_gate` drives the real filter across the three distinguishing cases (cold companion + warm primary => only companion; cold primary + warm companion => whole user; warm companion + absent primary => companion). It fails for both the old over-broad and the naive under-broad behaviors.
- Existing SKDM map tests updated to the primary-gate predicate.

## Verify

- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p whatsapp-rust --lib` (827 tests) pass.

## Notes (pre-existing, out of scope)

- `SenderKeyDeviceMap` indexes by user (not server+user). Safe in practice (PN and LID user-id spaces are disjoint, and a single send resolves one namespace).
- Identity / raw-id clears delete peer sessions but not `sender_key_devices` rows. The retry path self-heals (a re-added device fails, gets marked cold, next send redistributes). Worth a separate look.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

