### PR TITLE
perf(binary): length-bucketed token lookup (tiny_map) on the encode hot path

### DIFF
--- a/wacore/binary/build.rs
+++ b/wacore/binary/build.rs
@@ -48,14 +48,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Generate hashify PTHash lookup (FNV-1a, compile-time perfect hash)
+    // Length-bucketed lookup (match key.len() + byte discriminator, no full-key
+    // hash). On the miss-heavy encode path (every stanza string is probed, most
+    // miss) this beats the PTHash map, which folds every key byte before probing.
     writeln!(
         file,
-        "fn hashify_lookup(key: &[u8]) -> Option<&'static TokenKind> {{"
+        "fn hashify_lookup(key: &[u8]) -> Option<TokenKind> {{"
     )?;
-    writeln!(file, "    hashify::map! {{")?;
+    writeln!(file, "    hashify::tiny_map! {{")?;
     writeln!(file, "        key,")?;
-    writeln!(file, "        TokenKind,")?;
     for (token, kind) in &values {
         writeln!(file, "        {:?} => {},", token.as_bytes(), kind)?;
     }

--- a/wacore/binary/src/token.rs
+++ b/wacore/binary/src/token.rs
@@ -31,7 +31,7 @@ pub enum TokenKind {
 include!(concat!(env!("OUT_DIR"), "/token_maps.rs"));
 
 pub fn index_of_token(token: &str) -> Option<TokenKind> {
-    hashify_lookup(token.as_bytes()).copied()
+    hashify_lookup(token.as_bytes())
 }
 
 pub fn get_single_token(index: u8) -> Option<&'static str> {
@@ -119,5 +119,59 @@ mod tests {
         assert!(get_double_token(4, 0).is_none());
         assert!(get_double_token(5, 100).is_none());
         assert!(get_double_token(255, 0).is_none());
+    }
+
+    /// Exhaustive equivalence guard: against a reference map built from the token
+    /// tables, every one-byte input and every single-byte mutation (all 256
+    /// values) of every token must resolve to the reference value (the token or
+    /// `None`). Probes the length-bucketed lookup for any discriminator collision
+    /// that would silently map a non-token (a JID/id) onto a token and corrupt the
+    /// wire, and stays durable against future token-set edits.
+    #[test]
+    fn lookup_matches_reference_under_byte_mutation() {
+        use std::collections::HashMap;
+
+        let mut reference: HashMap<Vec<u8>, TokenKind> = HashMap::new();
+        for i in 0u8..=235 {
+            if let Some(t) = get_single_token(i) {
+                reference
+                    .entry(t.as_bytes().to_vec())
+                    .or_insert(TokenKind::Single(i));
+            }
+        }
+        for dict in 0..4u8 {
+            for idx in 0..=255u8 {
+                if let Some(t) = get_double_token(dict, idx) {
+                    reference
+                        .entry(t.as_bytes().to_vec())
+                        .or_insert(TokenKind::Double(dict, idx));
+                }
+            }
+        }
+
+        let check = |bytes: &[u8]| {
+            assert_eq!(
+                hashify_lookup(bytes),
+                reference.get(bytes).copied(),
+                "lookup disagrees with reference for {bytes:?}",
+            );
+        };
+
+        for b in 0u8..=255 {
+            check(&[b]);
+        }
+
+        let keys: Vec<Vec<u8>> = reference.keys().cloned().collect();
+        for key in &keys {
+            let mut m = key.clone();
+            for pos in 0..m.len() {
+                let orig = m[pos];
+                for b in 0u8..=255 {
+                    m[pos] = b;
+                    check(&m);
+                }
+                m[pos] = orig;
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Switch the binary-protocol string->token lookup (`index_of_token`) from hashify's PTHash map (`hashify::map!`) to its length-bucketed `hashify::tiny_map!`. This is the technique from Bun PR oven-sh/bun#31875 (replace a perfect-hash that folds every key byte with a `match key.len()` + byte-discriminator dispatch).

## Why

`index_of_token` runs on the encode hot path: `classify_string_hint` probes every string of every outgoing stanza, and the production send path (`marshal_auto` -> `Encoder::new_vec`) has no StringHintCache, so it runs uncached per string. The PTHash map folds the full key (FNV-1a) + probes + memcmp on every call, including the many misses (JIDs, ids, timestamps, content, all within the token length range). The length-bucketed lookup dispatches on length first and compares only discriminator/key bytes, no hashing.

## Measured (divan A/B, median, main vs branch)

- marshal_auto_small 168.7ns -> 111.8ns (-34%) — dominant stanza shape (message/receipt/ack)
- marshal_plain_large 1.241us -> 911ns (-27%)
- marshal_auto_large 1.116us -> 905ns (-19%)
- marshal_to_reused_buffer_large 1.104us -> 916ns (-17%)
- marshal_auto_many_children 184.5us -> 165.4us (-10%)
- marshal_auto_huge_bytes ~0 (dominated by byte copy)

CodSpeed already benches these marshal_auto targets, so the gain is CI-observable and regression-guarded.

## Correctness

Pure code-gen change (still generated from tokens.json, same byte-array keys), no new dependency. tiny_map does a full `__key == #key` compare on multi-byte leaves and an exact single-byte match in the len==1 bucket, so it cannot map a non-token onto a token; it fails loud at build time if a bucket is ever unresolvable. New test `lookup_matches_reference_under_byte_mutation` proves equivalence to a reference map across all one-byte inputs and every single-byte mutation (all 256 values) of every token.

## Verify

- `cargo test -p wacore-binary` (incl. 8 token tests) and `cargo test -p whatsapp-rust --lib` (827) pass.
- `cargo clippy --all-targets -- -D warnings` clean.
- wasm32-unknown-unknown build of wacore-binary succeeds.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

