### PR TITLE
perf(sqlite): skip the per-checkout SELECT 1 liveness probe

### DIFF
--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -160,8 +160,15 @@ impl SqliteStore {
 
         let pool_size = 2;
 
+        // Local SQLite file connections don't spontaneously drop, so r2d2's
+        // default per-checkout liveness probe (a SELECT 1 via Diesel's
+        // is_valid) is pure overhead on every store op: any real failure
+        // surfaces as a StoreError on the next actual query, so the probe
+        // guards nothing here. Skipping it saves a cached SELECT 1 (reset+step)
+        // per pool.get().
         let pool = Pool::builder()
             .max_size(pool_size)
+            .test_on_check_out(false)
             .connection_customizer(Box::new(ConnectionOptions))
             .build(manager)
             .map_err(|e| StoreError::Connection(Box::new(e)))?;


### PR DESCRIPTION
## What

Set `.test_on_check_out(false)` on the r2d2 SQLite pool builder (`storages/sqlite-storage/src/sqlite_store.rs`).

## Why

r2d2 0.8.10 defaults `test_on_check_out` to `true`, so Diesel runs `is_valid()` = `SELECT 1` on every `pool.get()`. With `pool_size=2` + `db_semaphore=Semaphore::new(1)`, essentially every store op (per-message Signal session/identity/sender-key/prekey writes plus the write-behind flush drains) checks out a connection and pays that probe.

For a local SQLite file DB, pooled connections don't spontaneously drop, so the per-checkout re-validation is pure overhead. The probe is not load-bearing for correctness: `SELECT 1` validates nothing about the application tables or cached statements, and any real failure (disk full, corruption, I/O, schema change) surfaces as a `StoreError` on the next actual query regardless; dirty transaction state is still caught at check-in via `has_broken`. New connections are still exercised at creation via the connection customizer (`on_acquire` runs the pragmas); only the redundant per-checkout probe is skipped. Pattern from matrix-rust-sdk #5841.

Caveat (theoretical, non-issue for local SQLite): a connection that fails `SELECT 1` but is not transaction-broken would no longer be evicted at checkout and would keep returning `StoreError` until naturally replaced. This does not occur for a local embedded SQLite file.

## Measurements

There is no CI benchmark for this path, so I measured locally (release build).

Isolated same-run A/B of `pool.get()` — two identical r2d2 pools differing only in `test_on_check_out`, N=200k checkouts:

- probe ON: 253.5 ns/checkout
- probe OFF: 160.7 ns/checkout
- the `SELECT 1` probe = **~93 ns/checkout (36.6% of the bare checkout cost)**, removed.

In context: a full op through the real `SqliteStore` (`get_session`/`put_session`, N=30k) is **~9–11 µs/op**, dominated by `spawn_blocking` dispatch + WAL frame writes. So the ~93 ns probe is **~1% of a real store op** — below the run-to-run variance (~±15%) on the full async path. Honest framing: this won't move a latency graph; it removes provable wasted work (a cached `SELECT 1`, reset+step) on every store checkout, at zero cost.

## Cost

One line. No new dependency, no `.text` growth, no behavior change for local SQLite (validity still surfaces on real queries + creation-time `on_acquire`).

## Verify

- `cargo test -p whatsapp-rust-sqlite-storage` pass.
- `cargo clippy --all-targets -- -D warnings` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

