### PR TITLE
feat(example): add 🦀send <jid> <text> chat command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use whatsapp_rust::pair_code::PairCodeOptions;
 use whatsapp_rust::prelude::*;
 
 const PING_TRIGGER: &str = "🦀ping";
+const SEND_TRIGGER: &str = "🦀send";
 const PONG_TEXT: &str = "🏓 Pong!";
 const REACTION_EMOJI: &str = "🏓";
 
@@ -93,8 +94,15 @@ fn main() {
                     if let Err(e) = ctx.send_message(reply).await {
                         error!("Failed to send media pong: {}", e);
                     }
-                } else if ctx.message.text_content() == Some(PING_TRIGGER) {
+                    return;
+                }
+                let Some(text) = ctx.message.text_content() else {
+                    return;
+                };
+                if text == PING_TRIGGER {
                     handle_text_ping(&ctx).await;
+                } else if let Some(args) = text.strip_prefix(SEND_TRIGGER) {
+                    handle_send_command(&ctx, args).await;
                 }
             });
 
@@ -162,6 +170,28 @@ async fn handle_text_ping(ctx: &MessageContext) {
     };
     if let Err(e) = ctx.edit_message(sent.message_id.clone(), edit).await {
         error!("Failed to edit message {}: {}", sent.message_id, e);
+    }
+}
+
+/// Handles `🦀send <jid> <text>`, relaying text to an arbitrary group or DM JID.
+async fn handle_send_command(ctx: &MessageContext, args: &str) {
+    let Some((target, text)) = args.trim_start().split_once(char::is_whitespace) else {
+        error!("Usage: {SEND_TRIGGER} <jid> <text>");
+        return;
+    };
+    let text = text.trim_start();
+
+    let jid: Jid = match target.parse() {
+        Ok(jid) => jid,
+        Err(e) => {
+            error!("Invalid JID '{target}': {e}");
+            return;
+        }
+    };
+
+    match ctx.client.send_message(jid, wa::Message::text(text)).await {
+        Ok(sent) => info!("Sent message {} to {}", sent.message_id, sent.to),
+        Err(e) => error!("Failed to send message: {e}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,9 +189,26 @@ async fn handle_send_command(ctx: &MessageContext, args: &str) {
         }
     };
 
-    match ctx.client.send_message(jid, wa::Message::text(text)).await {
-        Ok(sent) => info!("Sent message {} to {}", sent.message_id, sent.to),
-        Err(e) => error!("Failed to send message: {e}"),
+    let start = wacore::time::Instant::now();
+    let sent = match ctx.client.send_message(jid, wa::Message::text(text)).await {
+        Ok(sent) => sent,
+        Err(e) => {
+            error!("Failed to send message: {e}");
+            return;
+        }
+    };
+    let duration = format!("{:.2?}", start.elapsed());
+    info!(
+        "Sent message {} to {} in {}",
+        sent.message_id, sent.to, duration
+    );
+
+    // Report the timing back in the chat where the command was issued, not the target.
+    if let Err(e) = ctx
+        .reply_quoting(format!("✅ Sent to {}\n`{duration}`", sent.to))
+        .await
+    {
+        error!("Failed to send timing reply: {e}");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,10 @@ async fn handle_send_command(ctx: &MessageContext, args: &str) {
         return;
     };
     let text = text.trim_start();
+    if text.is_empty() {
+        error!("Usage: {SEND_TRIGGER} <jid> <text>");
+        return;
+    }
 
     let jid: Jid = match target.parse() {
         Ok(jid) => jid,


### PR DESCRIPTION
Adds a 🦀send command to the example bot in `src/main.rs`: reply `🦀send <jid> <text>` in any chat and the bot relays the text to an arbitrary group (`...@g.us`) or DM (`...@s.whatsapp.net`) JID.

The handler stays DRY and allocation-light: `text_content()` is fetched once via let-else, the trigger is matched with `strip_prefix`, args are split with a single `split_once(char::is_whitespace)` (no intermediate `Vec`/`split().collect()`), the JID goes straight through `FromStr`, and the only allocation is the one `wa::Message::text` needs to own the payload.

Failures (missing args, bad JID, send error) are logged rather than panicking, matching the rest of the example.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

