### PR TITLE
perf(conn): reuse the shutdown listener across the read loop

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -54,10 +54,15 @@ impl Client {
         // Frame decoder to parse incoming data
         let mut frame_decoder = wacore::framing::FrameDecoder::new();
         let shutdown = self.connection_shutdown_signal();
+        // Subscribe once: a fresh wait_for_shutdown() inside the select allocated an
+        // event_listener on every frame. The signal is one-shot, so a single pinned
+        // listener still catches an in-loop firing.
+        let shutdown_fut = wacore::runtime::wait_for_shutdown(&shutdown).fuse();
+        futures::pin_mut!(shutdown_fut);
 
         loop {
             futures::select_biased! {
-                    _ = wacore::runtime::wait_for_shutdown(&shutdown).fuse() => {
+                    _ = shutdown_fut => {
                         debug!("Shutdown signaled in message loop. Exiting message loop.");
                         return Ok(());
                     },


### PR DESCRIPTION
## What

The message read loop (`read_messages_loop`) re-subscribed to the connection shutdown signal on every `select_biased!` iteration. Each `wait_for_shutdown(&shutdown)` call allocates an `event_listener`, so we paid one listener allocation per frame on the hottest per-message loop.

This hoists the subscription out of the loop: create the future once, `pin_mut!` it, and poll `&mut` each iteration. The shutdown signal is one-shot, so a single pinned listener still catches an in-loop firing, and `fired` is still checked once at creation to cover the pre-subscribe race (same guarantee `wait_for_shutdown` already provides). No behavior change.

## Why

Profiling the send/receive hot path (pingpong) with a heap profiler, this was the only pure-waste per-message allocation in our own code. The rest of the churn is transport (rustls + tokio-websockets), the Tokio runtime, or inherent crypto. It is small in absolute terms, but it is free to remove and keeps the per-frame loop allocation-clean.

## Measurement (dhat, pingpong, 5000 msgs)

The read-loop `wait_for_shutdown` site (`event_listener::listen` under `read_messages_loop`) was 3.41 allocs/msg and 191 B/msg, and is gone after the change.

Total churn dropped from 1,371,532 to 1,352,320 blocks, about -3.84 allocations/message. No leak before or after (steady-state heap unchanged at ~2.85 MB).

There is no churn benchmark in CI for this path, so the numbers above are from a local heap profile.

## Tests

Behavior-preserving micro-change. `cargo test -p whatsapp-rust --lib` passes (827 tests, including the shutdown-path test), clippy `--all-targets` is clean. The "shutdown exits the read loop" behavior is already exercised by the `wait_for_shutdown` race tests in `runtime.rs` and the reconnect/disconnect e2e path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

