### PR TITLE
perf(signal): skip the rollback clone for in-order decrypts

### DIFF
--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -843,10 +843,25 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
     let their_ephemeral = ciphertext.sender_ratchet_key();
     let counter = ciphertext.counter();
 
-    // Transactional decrypt — roll back chain advance / new-chain DH
-    // step on any failure so the next msg derives from an
-    // uncorrupted ratchet. See `SessionState::decrypt_snapshot`.
-    let snapshot = state.decrypt_snapshot();
+    // Transactional decrypt — roll back chain advance / new-chain DH step on any
+    // failure so the next msg derives from an uncorrupted ratchet.
+    //
+    // Fast path for the common in-order message on an existing receiver chain
+    // (counter == the chain's current index): the only mutation is a single
+    // `set_receiver_chain_key` advance — no DH ratchet, no skipped-key caching,
+    // no chain eviction — so saving the old `ChainKey` (a `Copy`) is a complete
+    // rollback and avoids cloning the whole receiver-chain set. Every other case
+    // (new chain, skip-ahead, out-of-order key removal) and any lookup error
+    // falls through to the full `decrypt_snapshot`, unchanged.
+    let fast_rollback: Option<ChainKey> = match state.get_receiver_chain_key(their_ephemeral) {
+        Ok(Some(chain_key)) if chain_key.index() == counter => Some(chain_key),
+        _ => None,
+    };
+    let full_snapshot = match fast_rollback {
+        Some(_) => None,
+        None => Some(state.decrypt_snapshot()),
+    };
+
     let result = decrypt_with_pending_state(
         current_or_previous,
         state,
@@ -859,12 +874,18 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
     );
     match result {
         Ok(ptext) => {
-            drop(snapshot);
+            drop(full_snapshot);
             state.clear_unacknowledged_pre_key_message();
             Ok(ptext)
         }
         Err(e) => {
-            state.restore_decrypt_snapshot(snapshot);
+            if let Some(chain_key) = fast_rollback {
+                // The chain still exists (in-order decrypt never removes it), so
+                // restoring its key cannot fail; keep the original decrypt error.
+                let _ = state.set_receiver_chain_key(their_ephemeral, &chain_key);
+            } else if let Some(snapshot) = full_snapshot {
+                state.restore_decrypt_snapshot(snapshot);
+            }
             Err(e)
         }
     }
@@ -1621,6 +1642,111 @@ mod tests {
                 matches!(err, SignalProtocolError::BadMac(_)),
                 "expected BadMac, got: {err}"
             );
+        });
+    }
+
+    /// Fast-path rollback: a MAC failure on an in-order message (the path that
+    /// now rolls back via the single saved chain key instead of the full
+    /// `decrypt_snapshot` clone) must leave the receiver chain untouched, so the
+    /// next legitimate message on the same chain still decrypts. A regressed
+    /// rollback would leave the chain advanced and surface `DuplicatedMessage`.
+    #[test]
+    fn inorder_macfail_rolls_back_chain_and_recovers() {
+        let mut tp = setup_established_session();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+        futures::executor::block_on(async {
+            // Bob replies so Alice clears her pending prekey and sends plain
+            // SignalMessages from here on.
+            let bob_reply = message_encrypt(
+                b"ack",
+                &tp.alice_addr,
+                &mut tp.bob_sessions,
+                &mut tp.bob_identity,
+            )
+            .await
+            .expect("Bob encrypt reply");
+            let bob_msg =
+                SignalMessage::try_from(bob_reply.serialize()).expect("reply is a SignalMessage");
+            message_decrypt_signal(
+                &bob_msg,
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+                &mut rng,
+            )
+            .await
+            .expect("Alice decrypts reply");
+
+            // Alice sends two consecutive messages on the same sending chain.
+            let m1 = message_encrypt(
+                b"first",
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+            )
+            .await
+            .expect("encrypt m1");
+            let m2 = message_encrypt(
+                b"second",
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+            )
+            .await
+            .expect("encrypt m2");
+            assert!(
+                matches!(m2, CiphertextMessage::SignalMessage(_)),
+                "m2 should be a SignalMessage"
+            );
+
+            // Bob decrypts m1 → advances the receiver chain, so m2 is an in-order
+            // message on an existing chain (the fast path).
+            let m1_sig = SignalMessage::try_from(m1.serialize()).expect("m1 SignalMessage");
+            let p1 = message_decrypt_signal(
+                &m1_sig,
+                &tp.alice_addr,
+                &mut tp.bob_sessions,
+                &mut tp.bob_identity,
+                &mut rng,
+            )
+            .await
+            .expect("Bob decrypts m1");
+            assert_eq!(p1.plaintext, b"first");
+
+            // Corrupt m2's MAC and decrypt → BadMac, exercising the fast-path rollback.
+            let raw = m2.serialize();
+            let mut corrupted = raw.to_vec();
+            let off = corrupted.len() - 4;
+            corrupted[off] ^= 0xFF;
+            let corrupted_msg =
+                SignalMessage::try_from(corrupted.as_slice()).expect("protobuf intact");
+            let err = message_decrypt_signal(
+                &corrupted_msg,
+                &tp.alice_addr,
+                &mut tp.bob_sessions,
+                &mut tp.bob_identity,
+                &mut rng,
+            )
+            .await
+            .expect_err("corrupted m2 must fail");
+            assert!(
+                matches!(err, SignalProtocolError::BadMac(_)),
+                "expected BadMac, got: {err}"
+            );
+
+            // The legit m2 must still decrypt — proving the chain key was rolled back.
+            let m2_sig = SignalMessage::try_from(m2.serialize()).expect("m2 SignalMessage");
+            let p2 = message_decrypt_signal(
+                &m2_sig,
+                &tp.alice_addr,
+                &mut tp.bob_sessions,
+                &mut tp.bob_identity,
+                &mut rng,
+            )
+            .await
+            .expect("Bob decrypts legit m2 after rollback");
+            assert_eq!(p2.plaintext, b"second");
         });
     }
 


### PR DESCRIPTION
## What

`decrypt_message_with_state` takes a full `decrypt_snapshot()` before every decrypt — cloning `receiver_chains` + `sender_chain` + `root_key` — purely so a MAC/decrypt failure can roll the ratchet back. On success that clone is dropped unused, which is essentially every message.

This adds a fast path for the common case: an in-order message on an existing receiver chain (`counter == that chain's current index`). There the only mutation is a single `set_receiver_chain_key` advance — no DH ratchet, no skipped-key caching, no chain eviction — so saving the old `ChainKey` (which is `Copy`) is a complete rollback. That case skips the snapshot and restores the one chain key on failure. Every other case (new chain, skip-ahead, out-of-order cached-key removal) and any lookup error falls through to the existing full `decrypt_snapshot`, unchanged.

## Why it's safe

The rollback guarantee is identical because the full snapshot is kept everywhere a single-chain-key undo is not provably sufficient. This is the load-bearing part: `store_session` runs unconditionally after the decrypt (even on failure), so a failed decrypt that mutated the session would otherwise be persisted — the rollback protects durability, not just in-memory state. The fast path only triggers where the mutation set is provably `{one chain key advance}`.

The idea came out of a cross-model review (an earlier pass had rejected this whole class of change as unsafe because of the eviction `drain`s on the new-chain / skipped-key paths; the in-order path has no such drain, which is what makes the narrow fast path correct).

## Measurement

No CI churn benchmark exists for this path, so this is a local heap profile (dhat) on the pingpong flood scenario (5000 messages, in-order dominant). Isolating the `decrypt_snapshot` / `Chain::clone` allocation site:

before: 9.12 allocs/msg, 824 B/msg
after: 0.04 allocs/msg, 3 B/msg

The residual 0.04 allocs/msg is the new-chain messages that still take the full snapshot, exactly as intended. Steady-state heap and end-of-run heap are unchanged (~2.86 MB, no leak before or after). This is allocation churn on the per-message decrypt path; it won't move a latency graph, but it removes a near-per-message clone from the hot path at zero behavioral cost.

## Tests

New: `inorder_macfail_rolls_back_chain_and_recovers` — an in-order message that fails MAC must leave the chain decryptable for the next legitimate message; a regressed rollback would surface `DuplicatedMessage`. The existing `decrypt_corrupted_mac_returns_bad_mac` continues to cover the BadMac path.

`cargo test -p wacore-libsignal` (116) and `cargo test -p whatsapp-rust --lib` (827) pass; clippy `--all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

