### PR TITLE
test(bench): add an in-order DM decrypt benchmark

### DIFF
--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -530,6 +530,119 @@ fn bench_dm_encrypt_subsequent_message(bencher: divan::Bencher) {
         });
 }
 
+// Establish a DM session and advance it to where Alice sends plain
+// SignalMessages on an existing Bob receiver chain, then return the next
+// strictly in-order ciphertext. Decrypting it exercises the steady-state path
+// (existing chain, counter == chain index) — the common case for an active
+// chat, distinct from the first-message (PreKeySignalMessage) path.
+fn setup_dm_with_inorder_subsequent_message() -> (User, User, Vec<u8>) {
+    let (mut alice, mut bob) = setup_established_dm_session();
+
+    futures::executor::block_on(async {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+        // Bob replies and Alice decrypts it, clearing Alice's pending prekey so
+        // her subsequent messages are plain SignalMessages.
+        let reply = message_encrypt(
+            b"ack",
+            &alice.address,
+            &mut bob.session_store,
+            &mut bob.identity_store,
+        )
+        .await
+        .expect("bob reply");
+        let reply_bytes = reply.serialize().to_vec();
+        let reply_msg = CiphertextMessage::SignalMessage(
+            wacore_libsignal::protocol::SignalMessage::try_from(reply_bytes.as_slice()).unwrap(),
+        );
+        message_decrypt(
+            &reply_msg,
+            &bob.address,
+            &mut alice.session_store,
+            &mut alice.identity_store,
+            &mut alice.prekey_store,
+            &alice.signed_prekey_store,
+            &mut rng,
+            UsePQRatchet::No,
+        )
+        .await
+        .expect("alice decrypts reply");
+
+        // Alice sends a first SignalMessage; Bob decrypts it so his receiver
+        // chain for Alice's current ephemeral exists and is advanced. The
+        // benchmarked message below is then strictly in-order on that chain.
+        let m1 = message_encrypt(
+            b"first subsequent",
+            &bob.address,
+            &mut alice.session_store,
+            &mut alice.identity_store,
+        )
+        .await
+        .expect("alice m1");
+        let m1_bytes = m1.serialize().to_vec();
+        let m1_msg = CiphertextMessage::SignalMessage(
+            wacore_libsignal::protocol::SignalMessage::try_from(m1_bytes.as_slice()).unwrap(),
+        );
+        message_decrypt(
+            &m1_msg,
+            &alice.address,
+            &mut bob.session_store,
+            &mut bob.identity_store,
+            &mut bob.prekey_store,
+            &bob.signed_prekey_store,
+            &mut rng,
+            UsePQRatchet::No,
+        )
+        .await
+        .expect("bob decrypts m1");
+
+        // The in-order message to benchmark (same sending chain as m1, next counter).
+        let m2 = message_encrypt(
+            b"in-order subsequent message",
+            &bob.address,
+            &mut alice.session_store,
+            &mut alice.identity_store,
+        )
+        .await
+        .expect("alice m2");
+
+        (alice, bob, m2.serialize().to_vec())
+    })
+}
+
+#[divan::bench]
+fn bench_dm_decrypt_subsequent_message(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_dm_with_inorder_subsequent_message)
+        .bench_refs(|data| {
+            let (alice, bob, ciphertext_bytes) = data;
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+            let plaintext = futures::executor::block_on(async {
+                let ciphertext = CiphertextMessage::SignalMessage(
+                    wacore_libsignal::protocol::SignalMessage::try_from(
+                        ciphertext_bytes.as_slice(),
+                    )
+                    .unwrap(),
+                );
+                message_decrypt(
+                    &ciphertext,
+                    &alice.address,
+                    &mut bob.session_store,
+                    &mut bob.identity_store,
+                    &mut bob.prekey_store,
+                    &bob.signed_prekey_store,
+                    &mut rng,
+                    UsePQRatchet::No,
+                )
+                .await
+                .expect("decryption")
+            });
+
+            black_box(plaintext);
+        });
+}
+
 #[divan::bench]
 fn bench_group_create_distribution_message(bencher: divan::Bencher) {
     bencher.with_inputs(setup_group_sender).bench_refs(|data| {


### PR DESCRIPTION
## What

Adds `bench_dm_decrypt_subsequent_message` to the existing `libsignal_benchmark` CodSpeed target.

The suite already benches the first-message decrypt (`bench_dm_decrypt_first_message`), but that's a `PreKeySignalMessage` on a brand-new session. It does not cover the steady-state case that dominates an active chat: an in-order `SignalMessage` on an existing receiver chain (`counter == that chain's current index`). This bench fills that gap so CodSpeed tracks the path's CPU and allocation cost per PR.

The fixture (outside the measured window) establishes a session, drives a Bob reply so Alice clears her pending prekey and sends plain SignalMessages, has Bob decrypt one message so his receiver chain exists and is advanced, and returns the next strictly in-order ciphertext. The measured closure is a single `message_decrypt` of that message through the public dispatcher. Uses `with_inputs` + `bench_refs` per the suite's conventions; no production code change.

## Why now

This is the exact path #877 (perf: skip the rollback clone for in-order decrypts) optimizes. Landing the bench on main first means #877, once rebased, will show the before/after delta in CodSpeed automatically — and any future change to the Double Ratchet decrypt path gets continuous regression/improvement detection plus a per-PR profile, instead of relying on a manual local heap profile.

## Verification

`cargo-codspeed` isn't installed locally, but the bench builds and runs under the normal harness: `cargo bench -p wacore-libsignal --bench libsignal_benchmark -- --test` runs it once cleanly, and `cargo clippy -p wacore-libsignal --all-targets` is clean (only the pre-existing `chrono::Local::now` clippy.toml notice). It uses the same divan API as the other targets, which already build under `cargo codspeed build` in CI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

