### PR TITLE
perf(signal): reuse the encrypt buffer instead of take + realloc

### DIFF
--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -52,6 +52,13 @@ impl EncryptionBuffer {
         &mut self.buffer
     }
 }
+
+/// Current capacity of this thread's encrypt buffer. Test-only: lets the
+/// oversized-buffer-release regression test observe the thread-local.
+#[cfg(test)]
+fn encryption_buffer_capacity() -> usize {
+    ENCRYPTION_BUFFER.with(|b| b.borrow().buffer.capacity())
+}
 use crate::protocol::consts::MAX_FORWARD_JUMPS;
 use crate::protocol::ratchet::keys::MessageKeyGenerator;
 use crate::protocol::ratchet::{ChainKey, UsePQRatchet};
@@ -208,6 +215,13 @@ async fn message_encrypt_inner(
                 &their_identity_key,
             )?)
         };
+        // A plaintext whose ciphertext exceeds MAX_CAPACITY leaves an oversized
+        // buffer in thread-local storage; release it now (the old take+realloc
+        // path did this implicitly) so a single large send doesn't pin memory
+        // per worker thread until get_buffer's periodic shrink fires.
+        if buf.capacity() > EncryptionBuffer::MAX_CAPACITY {
+            *buf = Vec::with_capacity(EncryptionBuffer::INITIAL_CAPACITY);
+        }
         Ok::<CiphertextMessage, SignalProtocolError>(message)
     })?;
 
@@ -1752,6 +1766,32 @@ mod tests {
             .await
             .expect("Bob decrypts legit m2 after rollback");
             assert_eq!(p2.plaintext, b"second");
+        });
+    }
+
+    /// Reusing the encrypt buffer must not pin an oversized allocation: a
+    /// plaintext larger than MAX_CAPACITY grows the thread-local buffer, which
+    /// has to be released after the message is built (the old take+realloc path
+    /// did this implicitly).
+    #[test]
+    fn encrypt_releases_oversized_buffer() {
+        let mut tp = setup_established_session();
+        futures::executor::block_on(async {
+            let big = vec![7u8; 32 * 1024]; // ciphertext far exceeds MAX_CAPACITY (16 KiB)
+            message_encrypt(
+                &big,
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+            )
+            .await
+            .expect("encrypt large message");
+
+            let cap = encryption_buffer_capacity();
+            assert!(
+                cap <= EncryptionBuffer::INITIAL_CAPACITY,
+                "encrypt buffer should be released after an oversized send, got capacity {cap}"
+            );
         });
     }
 

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -1787,9 +1787,14 @@ mod tests {
             .await
             .expect("encrypt large message");
 
+            // The fix's contract is "buffer must not exceed MAX_CAPACITY after a
+            // send". Asserting against MAX (not INITIAL) keeps the test robust:
+            // Vec::with_capacity only guarantees a lower bound, so an allocator
+            // that rounds up must not flake this. A 32 KiB plaintext without the
+            // release leaves the buffer well above MAX (~32 KiB).
             let cap = encryption_buffer_capacity();
             assert!(
-                cap <= EncryptionBuffer::INITIAL_CAPACITY,
+                cap <= EncryptionBuffer::MAX_CAPACITY,
                 "encrypt buffer should be released after an oversized send, got capacity {cap}"
             );
         });

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -148,63 +148,68 @@ async fn message_encrypt_inner(
         ));
     }
 
-    let ctext = ENCRYPTION_BUFFER.with(|buffer| {
+    // Encrypt into the thread-local buffer and build the message while still
+    // borrowing it: SignalMessage::new copies the ciphertext into its protobuf
+    // body, so no owned intermediate Vec is needed. The buffer is reused across
+    // calls (cleared, capacity kept) instead of being taken out and reallocated.
+    // aes_256_cbc_encrypt appends from buf.len(), so clear it first; this also
+    // drops any ciphertext left by a prior call that errored.
+    let message = ENCRYPTION_BUFFER.with(|buffer| {
         let mut buf_wrapper = buffer.borrow_mut();
         let buf = buf_wrapper.get_buffer();
+        buf.clear();
         aes_256_cbc_encrypt_into(ptext, message_keys.cipher_key(), message_keys.iv(), buf)
             .map_err(|_| {
                 log::error!("session state corrupt for {remote_address}");
                 SignalProtocolError::InvalidSessionStructure("invalid sender chain message keys")
             })?;
-        let result = std::mem::take(buf);
-        // Restore buffer capacity for next use (take() leaves empty Vec with 0 capacity)
-        buf.reserve(EncryptionBuffer::INITIAL_CAPACITY);
-        Ok::<Vec<u8>, SignalProtocolError>(result)
+        let ctext = buf.as_slice();
+
+        let message = if let Some(items) = session_state.unacknowledged_pre_key_message_items()? {
+            let local_registration_id = session_state.local_registration_id();
+
+            log::debug!(
+                "Building PreKeyWhisperMessage for: {} with preKeyId: {}",
+                remote_address,
+                items
+                    .pre_key_id()
+                    .map_or_else(|| "<none>".to_string(), |id| id.to_string()),
+            );
+
+            let message = SignalMessage::new(
+                session_version,
+                message_keys.mac_key(),
+                sender_ephemeral,
+                chain_key.index(),
+                previous_counter,
+                ctext,
+                &local_identity_key,
+                &their_identity_key,
+            )?;
+
+            CiphertextMessage::PreKeySignalMessage(PreKeySignalMessage::new(
+                session_version,
+                local_registration_id,
+                items.pre_key_id(),
+                items.signed_pre_key_id(),
+                *items.base_key(),
+                local_identity_key,
+                message,
+            )?)
+        } else {
+            CiphertextMessage::SignalMessage(SignalMessage::new(
+                session_version,
+                message_keys.mac_key(),
+                sender_ephemeral,
+                chain_key.index(),
+                previous_counter,
+                ctext,
+                &local_identity_key,
+                &their_identity_key,
+            )?)
+        };
+        Ok::<CiphertextMessage, SignalProtocolError>(message)
     })?;
-
-    let message = if let Some(items) = session_state.unacknowledged_pre_key_message_items()? {
-        let local_registration_id = session_state.local_registration_id();
-
-        log::debug!(
-            "Building PreKeyWhisperMessage for: {} with preKeyId: {}",
-            remote_address,
-            items
-                .pre_key_id()
-                .map_or_else(|| "<none>".to_string(), |id| id.to_string()),
-        );
-
-        let message = SignalMessage::new(
-            session_version,
-            message_keys.mac_key(),
-            sender_ephemeral,
-            chain_key.index(),
-            previous_counter,
-            &ctext,
-            &local_identity_key,
-            &their_identity_key,
-        )?;
-
-        CiphertextMessage::PreKeySignalMessage(PreKeySignalMessage::new(
-            session_version,
-            local_registration_id,
-            items.pre_key_id(),
-            items.signed_pre_key_id(),
-            *items.base_key(),
-            local_identity_key,
-            message,
-        )?)
-    } else {
-        CiphertextMessage::SignalMessage(SignalMessage::new(
-            session_version,
-            message_keys.mac_key(),
-            sender_ephemeral,
-            chain_key.index(),
-            previous_counter,
-            &ctext,
-            &local_identity_key,
-            &their_identity_key,
-        )?)
-    };
 
     identity_store
         .save_identity(remote_address, &their_identity_key)


### PR DESCRIPTION
## What

`message_encrypt` wrote the AES ciphertext into a thread-local buffer, then `mem::take`'d it out and `reserve`'d a fresh replacement on every call — only to have `SignalMessage::new` copy that ciphertext again into the protobuf body. Since the ciphertext is copied into the message regardless, the owned intermediate `Vec` is unnecessary.

This builds the `SignalMessage` while still borrowing the buffer, then keeps the buffer (cleared, capacity retained) for the next call. The net effect is that the thread-local buffer is *actually reused* now — previously the `take` + `reserve` defeated the whole point of it, allocating a fresh ~1 KiB on every send.

Encrypt-only on purpose: the decrypt buffer's output is the returned plaintext, which escapes to the caller (it's the real return value, not copied-then-dropped), so its `take` is the necessary owned result and is left unchanged.

## Why it's safe

Same ciphertext, same `SignalMessage::new`, same protobuf output — purely a buffer-lifecycle change, no protocol or wire change. `aes_256_cbc_encrypt` appends from `buf.len()`, so the buffer is `clear()`'d before encrypting; that also drops any ciphertext left by a prior errored call. The buffer only ever holds ciphertext (the public, on-the-wire bytes), not plaintext or keys.

## Measurement

Local dhat, pingpong (5000 messages, each one encrypt): total allocation churn drops from **262.8 to 261.6 allocs/msg** and **73.8 to 71.6 KB/msg** (about **-1.2 allocs and -2.2 KB per message**). End-of-run heap unchanged (~2.86 MB, no leak before or after). Small but free — it removes a per-send allocation and makes the existing buffer-reuse optimization actually work.

`bench_dm_send` on CodSpeed will track the per-send delta precisely (memory mode) going forward.

## Provenance

Found via a cross-model (Codex / GPT-5.5) read-only review of the 1:1 send/receive path — Codex spotted that the ciphertext is copied into the protobuf anyway, so the owned intermediate was avoidable. (The same review confirmed the rest of the path is crypto-dominated and already optimized.)

## Tests

`cargo test -p wacore-libsignal` (116, includes encrypt/decrypt roundtrips) and `cargo test -p whatsapp-rust --lib` (827) pass; `cargo clippy --all-targets` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

