### PR TITLE
perf(signal): share the sender-key message backlog behind an Arc

### DIFF
--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -1474,6 +1474,77 @@ fn bench_group_out_of_order_decrypt_worst_case(bencher: divan::Bencher) {
         });
 }
 
+/// In-order group decrypt while a large skipped-key backlog is still buffered.
+/// Once a receiver falls ~2000 messages behind and catches up, the backlog
+/// persists; every subsequent in-order message ratchets the chain forward
+/// without ever reading the backlog, yet `load_sender_key` still clones the
+/// whole backlog-sized record. The backlog fill and the catch-up run in
+/// `with_inputs` (untimed); only the in-order decrypt — whose sole backlog cost
+/// is that load clone — is measured.
+fn setup_group_in_order_decrypt_with_backlog() -> (User, SenderKeyName, Vec<u8>) {
+    // Fill just under MAX_MESSAGE_KEYS so the whole backlog survives intact
+    // (eviction only starts past MAX + MESSAGE_KEY_PRUNE_THRESHOLD), then send
+    // one more message that bob decrypts in order on top of that backlog.
+    const N: u32 = (consts::MAX_MESSAGE_KEYS - 1) as u32;
+
+    let (mut alice, mut bob, sender_key_name) = setup_group_with_distribution();
+
+    let bob_sender_key_name = SenderKeyName::new(
+        sender_key_name.group_id().to_string(),
+        alice.address.name().to_string(),
+    );
+
+    let in_order_ct = futures::executor::block_on(async {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut ciphertexts: Vec<Vec<u8>> = Vec::with_capacity((N + 2) as usize);
+        for i in 0..=(N + 1) {
+            let skm = group_encrypt(
+                &mut alice.sender_key_store,
+                &sender_key_name,
+                format!("group msg {i}").as_bytes(),
+                &mut rng,
+            )
+            .await
+            .expect("group encrypt");
+            ciphertexts.push(skm.serialized().to_vec());
+        }
+
+        // Decrypting message N first ratchets bob's chain to N+1 and buffers the
+        // N skipped keys (iterations 0..N-1) in the backlog.
+        group_decrypt(
+            &ciphertexts[N as usize],
+            &mut bob.sender_key_store,
+            &bob_sender_key_name,
+        )
+        .await
+        .expect("group decrypt newest");
+
+        // Message N+1 is exactly in order (jump == 0): it advances the chain and
+        // never touches the buffered backlog.
+        ciphertexts[(N + 1) as usize].clone()
+    });
+
+    (bob, bob_sender_key_name, in_order_ct)
+}
+
+#[divan::bench(sample_count = 30)]
+fn bench_group_in_order_decrypt_with_backlog(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_group_in_order_decrypt_with_backlog)
+        .bench_refs(|(bob, sender_key_name, ciphertext)| {
+            let plaintext = futures::executor::block_on(async {
+                group_decrypt(
+                    black_box(ciphertext.as_slice()),
+                    &mut bob.sender_key_store,
+                    sender_key_name,
+                )
+                .await
+                .expect("group decrypt in order with backlog")
+            });
+            black_box(plaintext);
+        });
+}
+
 /// SKDM ingest: installing a sender's distribution message into a fresh
 /// receiver store, the work done on the first group message from each new
 /// sender and on every sender-key rotation. The SKDM build and the fresh empty

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -169,6 +169,16 @@ impl SenderChainKey {
 #[derive(Clone)]
 pub struct SenderKeyState {
     state: SenderKeyStateStructure,
+    /// The cached out-of-order message keys, held behind an `Arc` so cloning the
+    /// state (and thus the whole `SenderKeyRecord` on every group load) is a
+    /// refcount bump instead of a deep copy of up to `MAX_MESSAGE_KEYS` keys.
+    /// The in-order decrypt path never touches it, so a load there clones nothing
+    /// even when a prior out-of-order burst left a large backlog; a mutation
+    /// (skip-ahead caching or an out-of-order removal) pays one copy-on-write via
+    /// `Arc::make_mut`, leaving any sharing clone (the cache's copy) intact.
+    /// `state.sender_message_keys` is kept empty in memory; this is the source of
+    /// truth, reassembled into the protobuf only at `as_protobuf` (serialization).
+    message_keys: std::sync::Arc<Vec<sender_key_state_structure::SenderMessageKey>>,
     /// Parsed signing key with its XEdDSA cache pre-derived, memoized so the
     /// per-send signature skips a basepoint multiplication (~18% of a warm
     /// group send when re-derived from bytes every message). Clones carry the
@@ -194,7 +204,7 @@ impl std::fmt::Debug for SenderKeyState {
                 "chain_iteration",
                 &self.sender_chain_key().map(|c| c.iteration()),
             )
-            .field("message_keys", &self.state.sender_message_keys.len())
+            .field("message_keys", &self.message_keys.len())
             .field("signing_key", &"<redacted>")
             .finish_non_exhaustive()
     }
@@ -242,14 +252,19 @@ impl SenderKeyState {
         }
         Self {
             state,
+            message_keys: std::sync::Arc::new(Vec::new()),
             signing_key_memo,
             verifying_key_memo,
         }
     }
 
-    pub(crate) fn from_protobuf(state: SenderKeyStateStructure) -> Self {
+    pub(crate) fn from_protobuf(mut state: SenderKeyStateStructure) -> Self {
+        // Move the backlog out of the protobuf into the shared Arc so the
+        // in-memory `state` stays empty; see `message_keys` field docs.
+        let message_keys = std::sync::Arc::new(std::mem::take(&mut state.sender_message_keys));
         Self {
             state,
+            message_keys,
             signing_key_memo: std::sync::OnceLock::new(),
             verifying_key_memo: std::sync::OnceLock::new(),
         }
@@ -340,34 +355,36 @@ impl SenderKeyState {
     }
 
     pub(crate) fn as_protobuf(&self) -> SenderKeyStateStructure {
-        self.state.clone()
+        debug_assert!(
+            self.state.sender_message_keys.is_empty(),
+            "backlog must live only in `message_keys`; the protobuf copy stays empty"
+        );
+        let mut state = self.state.clone();
+        state.sender_message_keys = self.message_keys.as_ref().clone();
+        state
     }
 
     pub fn add_sender_message_key(&mut self, sender_message_key: &SenderMessageKey) {
-        self.state
-            .sender_message_keys
-            .push(sender_message_key.as_protobuf());
+        let keys = std::sync::Arc::make_mut(&mut self.message_keys);
+        keys.push(sender_message_key.as_protobuf());
         // AMORTIZED EVICTION: Only prune when exceeding MAX + threshold.
         // This reduces O(n) drain() calls from every insert to once every PRUNE_THRESHOLD inserts.
-        let len = self.state.sender_message_keys.len();
+        let len = keys.len();
         if len > consts::MAX_MESSAGE_KEYS + consts::MESSAGE_KEY_PRUNE_THRESHOLD {
             let excess = len - consts::MAX_MESSAGE_KEYS;
-            self.state.sender_message_keys.drain(..excess);
+            keys.drain(..excess);
         }
     }
 
     pub(crate) fn remove_sender_message_key(&mut self, iteration: u32) -> Option<SenderMessageKey> {
-        if let Some(index) = self
-            .state
-            .sender_message_keys
+        // Find first so a miss (e.g. a duplicate message) returns without the
+        // copy-on-write clone that `make_mut` would force.
+        let index = self
+            .message_keys
             .iter()
-            .position(|x| x.iteration.unwrap_or_default() == iteration)
-        {
-            let smk = self.state.sender_message_keys.remove(index);
-            Some(SenderMessageKey::from_protobuf(smk))
-        } else {
-            None
-        }
+            .position(|x| x.iteration.unwrap_or_default() == iteration)?;
+        let smk = std::sync::Arc::make_mut(&mut self.message_keys).remove(index);
+        Some(SenderMessageKey::from_protobuf(smk))
     }
 }
 
@@ -793,6 +810,75 @@ mod tests {
                 i
             );
         }
+    }
+
+    /// The backlog lives in a separate `Arc` while the protobuf copy stays
+    /// empty; a serialize/deserialize roundtrip must still carry every key.
+    #[test]
+    fn serialize_roundtrip_preserves_message_key_backlog() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let keypair = KeyPair::generate(&mut rng);
+        let chain_key = [0x42u8; 32];
+
+        let mut record = SenderKeyRecord::new_empty();
+        record.add_sender_key_state(
+            3,
+            12345,
+            0,
+            &chain_key,
+            keypair.public_key,
+            Some(keypair.private_key),
+        );
+
+        {
+            let state = record.sender_key_state_mut().expect("state exists");
+            for i in 0..5u32 {
+                state.add_sender_message_key(&SenderMessageKey::new(i, [i as u8; 32]));
+            }
+            // The protobuf copy must stay empty in memory.
+            assert!(state.state.sender_message_keys.is_empty());
+        }
+
+        let serialized = record.serialize().expect("serialize");
+        let mut deserialized = SenderKeyRecord::deserialize(&serialized).expect("deserialize");
+
+        let state = deserialized.sender_key_state_mut().expect("state exists");
+        // After a cold load the backlog lives in the Arc, the protobuf stays empty.
+        assert!(state.state.sender_message_keys.is_empty());
+        for i in 0..5u32 {
+            let smk = state
+                .remove_sender_message_key(i)
+                .unwrap_or_else(|| panic!("key {i} should survive the roundtrip"));
+            assert_eq!(smk.iteration(), i);
+        }
+    }
+
+    /// Cloning a state is a refcount bump; a later mutation must copy-on-write so
+    /// the clone (the in-cache record) is never touched through the loaded copy.
+    /// This is the invariant the whole `Arc`-backed backlog relies on.
+    #[test]
+    fn backlog_mutation_after_clone_is_isolated() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let keypair = KeyPair::generate(&mut rng);
+        let chain_key = [0x42u8; 32];
+
+        let mut original = SenderKeyState::new(3, 1, 0, &chain_key, keypair.public_key, None);
+        original.add_sender_message_key(&SenderMessageKey::new(7, [7u8; 32]));
+
+        // Clone shares the backlog Arc (mirrors the cache keeping its copy while
+        // the loaded record is handed out).
+        let mut loaded = original.clone();
+
+        // Adding through the loaded copy must not appear in the original.
+        loaded.add_sender_message_key(&SenderMessageKey::new(8, [8u8; 32]));
+        assert!(original.remove_sender_message_key(8).is_none());
+
+        // Removing through the loaded copy must not drop it from the original.
+        assert!(loaded.remove_sender_message_key(7).is_some());
+        assert!(
+            original.remove_sender_message_key(7).is_some(),
+            "the cache's copy must keep its key after the loaded copy removed it"
+        );
     }
 
     /// Test SenderKeyRecord basic operations


### PR DESCRIPTION
## What

Every group decrypt loads the `SenderKeyRecord` from the cache, and because the cache keeps its own `Arc`, `load_sender_key` clones the inner record (`Arc::unwrap_or_clone`). That deep-copies each state's skipped-key backlog (`sender_message_keys`, up to `MAX_MESSAGE_KEYS` entries). Once a receiver falls behind and catches up, the backlog stays populated, so every later in-order message pays the full copy even though the in-order path never reads the backlog at all (it only advances the chain key).

This moves the backlog into an `Arc<Vec<...>>` so a load is a refcount bump instead of a deep copy. The in-order path leaves the `Arc` shared; a mutation (skip-ahead caching or an out-of-order removal) pays exactly one copy-on-write via `Arc::make_mut`, which leaves any sharing clone (the cache's copy) untouched. The protobuf `state.sender_message_keys` is kept empty in memory and reassembled only at `as_protobuf` (serialize), so nothing on the persistence path changes.

## Why Arc-COW and not a persistent (structural-sharing) structure

I deliberately did not reach for an immutable/persistent collection (e.g. `rpds`). Adding a dependency to this crate is expensive here: it is security-critical crypto, it is under the binary-size gate, and it is built for wasm32 and esp32. A persistent structure would additionally make the rare out-of-order catch-up worst case cheaper, but that path is a synthetic worst case, not the recurring cost. The dep-free `Arc`-COW split captures the common recurring win (in-order decrypts while a backlog exists) at zero dependency cost, and the only thing it gives up is speeding up that rare catch-up, which stays exactly as it is today.

## Measurements

New bench `bench_group_in_order_decrypt_with_backlog`: a receiver with a ~2000-key backlog decrypting one in-order message on top of it. A/B on the same machine (stashing only the impl):

before (deep clone): median 97us, mean 110us, with a long allocator tail (slowest 600us)
after (Arc-COW): median 33us, mean 33us, tight (slowest 38us)

So roughly 3x faster on the median and the allocation jitter tail disappears, which is the ~82KB backlog `Vec` allocation no longer happening per decrypt.

No regression elsewhere: the out-of-order worst-case bench stays flat (the load-time clone simply becomes one `make_mut` clone of the same size when the backlog is mutated), and the empty-backlog decrypt is unchanged (cloning an empty `Vec` was already free).

CodSpeed will track the new bench going forward and should show the existing group benches flat.

## Safety / tests

The correctness property the whole change rests on is that mutating the loaded copy must never touch the cache's copy. Two new tests cover it:

`backlog_mutation_after_clone_is_isolated` clones a state (mirroring the cache keeping its copy while the loaded record is handed out), then adds and removes keys through the loaded copy and asserts the original is unaffected.
`serialize_roundtrip_preserves_message_key_backlog` proves the split survives persistence: it builds a backlog, asserts the in-memory protobuf copy stays empty, serializes, deserializes, and recovers every key.

A `debug_assert` in `as_protobuf` guards the "protobuf copy stays empty" invariant. `sender_message_keys` is only accessed inside `sender_keys.rs`, so the invariant is fully contained.

`cargo test -p wacore-libsignal` (117 tests) and `cargo test -p whatsapp-rust --lib` (827 tests) pass; `cargo clippy -p wacore-libsignal --all-targets -- -D warnings` is clean. The change was also verified to build and pass in isolation from other unrelated work in the tree.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

