### PR TITLE
feat(retry): WA Web log-level parity and retry-flow observability counters

### DIFF
--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -247,15 +247,16 @@ impl Client {
                 reason
             );
         }
-        if retry_count >= MAX_DECRYPT_RETRIES {
-            // Parity with WA Web's MessageHighRetryCount WAM event (id 3132),
-            // which commits at retryCount >= MAX from the send-receipt path.
-            wacore::telemetry::high_retry(reason.as_str());
-        }
-
         let retry_sent = match self.send_retry_receipt(info, retry_count, reason).await {
             Ok(()) => {
                 wacore::telemetry::retry_receipt(reason.as_str());
+                if retry_count >= MAX_DECRYPT_RETRIES {
+                    // Parity with WA Web's MessageHighRetryCount WAM event (id
+                    // 3132): committed after the retry receipt is sent, not
+                    // before — WAWebHandleMsgSendReceipt awaits sendRetryReceipt
+                    // and only then calls maybePostMessageHighRetryCountMetric.
+                    wacore::telemetry::high_retry(reason.as_str());
+                }
                 debug!(
                     "Sent retry receipt #{} for message {} in chat {} from {} [{:?}]",
                     retry_count,

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -247,6 +247,11 @@ impl Client {
                 reason
             );
         }
+        if retry_count >= MAX_DECRYPT_RETRIES {
+            // Parity with WA Web's MessageHighRetryCount WAM event (id 3132),
+            // which commits at retryCount >= MAX from the send-receipt path.
+            wacore::telemetry::high_retry(reason.as_str());
+        }
 
         let retry_sent = match self.send_retry_receipt(info, retry_count, reason).await {
             Ok(()) => {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -225,8 +225,10 @@ impl Client {
 
         // Refuse to handle retries that have exceeded the maximum attempts.
         // This prevents infinite retry loops and matches WhatsApp Web's behavior.
+        // Logged at debug: remote-driven, expected and fully handled — WA Web
+        // emits this refusal via WALogger.LOG (informational), not WARN.
         if retry_count >= MAX_RETRY_COUNT {
-            warn!(
+            debug!(
                 "Refusing retry #{} for message {} from {}: exceeds max attempts ({})",
                 retry_count,
                 message_id,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -760,10 +760,15 @@ impl Client {
                 .await
             {
                 Ok(true) => {
-                    warn!(
-                        "Base key collision detected for {} at retry #{}. \
+                    // Informational, not WARN: this is the corrective action WA
+                    // Web takes here too (WAWebUpdateLocalSignalSession logs the
+                    // same-base-key delete via WALogger.LOG), and the three
+                    // sibling branches of this routine already log at info.
+                    info!(
+                        "Base key collision detected for {} (msg {}) at retry #{}. \
                          Session hasn't been regenerated. Forcing fresh session.",
                         wacore::types::jid::observe_protocol_address(&signal_address),
+                        message_id,
                         retry_count
                     );
                     let _ = device_snapshot
@@ -782,8 +787,9 @@ impl Client {
                 }
                 Ok(false) => {
                     info!(
-                        "Base key changed for {} at retry #{} - session regenerated",
+                        "Base key changed for {} (msg {}) at retry #{} - session regenerated",
                         wacore::types::jid::observe_protocol_address(&signal_address),
+                        message_id,
                         retry_count
                     );
                     let _ = device_snapshot

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -201,7 +201,7 @@ fn build_retry_processing_key(chat: &Jid, message_id: &str, participant_jid: &Ji
 }
 
 impl Client {
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.handle_receipt", level = "debug", skip_all, fields(chat = %receipt.source.chat.observe(), sender = %receipt.source.sender.observe()), err(Debug)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.handle_receipt", level = "debug", skip_all, fields(chat = %receipt.source.chat.observe(), sender = %receipt.source.sender.observe(), count = tracing::field::Empty), err(Debug)))]
     pub(crate) async fn handle_retry_receipt(
         self: &Arc<Self>,
         receipt: &Receipt,
@@ -222,6 +222,10 @@ impl Client {
             .map(|v| v.as_str())
             .and_then(|s| s.parse().ok())
             .unwrap_or(1);
+        // Record the count on the span so retry-storm depth is aggregable per
+        // sender even when the cap refuses early below.
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record("count", retry_count);
 
         // Refuse to handle retries that have exceeded the maximum attempts.
         // This prevents infinite retry loops and matches WhatsApp Web's behavior.

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -282,6 +282,14 @@ impl Client {
             .has_device(&info.requester.user, sender_device_id)
             .await;
         if !device_known {
+            // Parity with WA Web's MdRetryFromUnknownDevice WAM (id 2178), which
+            // commits here only — not from the shared inbound device sync, which
+            // schedule_unknown_device_sync is also called from elsewhere.
+            wacore::telemetry::retry_unknown_device(if sender_device_id == 0 {
+                "primary"
+            } else {
+                "companion"
+            });
             self.schedule_unknown_device_sync(info.requester.to_non_ad(), receipt.offline)
                 .await;
         }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -235,6 +235,7 @@ impl Client {
                 receipt.source.sender.observe(),
                 MAX_RETRY_COUNT
             );
+            wacore::telemetry::retry_refused();
             return Ok(());
         }
 
@@ -779,6 +780,7 @@ impl Client {
                         message_id,
                         retry_count
                     );
+                    wacore::telemetry::base_key_collision();
                     let _ = device_snapshot
                         .backend
                         .delete_base_key(addr_str, message_id)

--- a/wacore/src/telemetry.rs
+++ b/wacore/src/telemetry.rs
@@ -42,6 +42,11 @@ mod imp {
     pub fn high_retry(reason: &'static str) {
         counter!("wa_high_retry_total", "reason" => reason).increment(1);
     }
+    /// Retry receipt from a device not in our registry, by sender type
+    /// (`primary`/`companion`). Mirrors WA Web's MdRetryFromUnknownDevice WAM (id 2178).
+    pub fn retry_unknown_device(sender_type: &'static str) {
+        counter!("wa_retry_unknown_device_total", "sender_type" => sender_type).increment(1);
+    }
     /// IQ request completed, by result (`ok`/`timeout`/`error`). Emitted at the
     /// single request chokepoint, so it covers both raw and spec-based IQs.
     pub fn iq(result: &'static str) {
@@ -121,6 +126,11 @@ mod imp {
             "Retry receipts sent at the high-retry watermark (count >= MAX), by reason"
         );
         describe_counter!(
+            "wa_retry_unknown_device_total",
+            Unit::Count,
+            "Retries from devices not in our registry, by sender type"
+        );
+        describe_counter!(
             "wa_iq_total",
             Unit::Count,
             "IQ requests by result (ok/timeout/error)"
@@ -191,6 +201,8 @@ mod imp {
     pub fn retry_receipt(_reason: &'static str) {}
     #[inline]
     pub fn high_retry(_reason: &'static str) {}
+    #[inline]
+    pub fn retry_unknown_device(_sender_type: &'static str) {}
     #[inline]
     pub fn iq(_result: &'static str) {}
     #[inline]

--- a/wacore/src/telemetry.rs
+++ b/wacore/src/telemetry.rs
@@ -47,6 +47,16 @@ mod imp {
     pub fn retry_unknown_device(sender_type: &'static str) {
         counter!("wa_retry_unknown_device_total", "sender_type" => sender_type).increment(1);
     }
+    /// Retry refused at the MAX_RETRY loop guard. Aggregate health signal for a
+    /// chronically thrashing peer (WA Web logs this via WALogger.LOG, no WAM).
+    pub fn retry_refused() {
+        counter!("wa_retry_refused_total").increment(1);
+    }
+    /// Base-key collision that forced a fresh session (same base key after a
+    /// re-key, so the session was deleted and recreated).
+    pub fn base_key_collision() {
+        counter!("wa_base_key_collision_total").increment(1);
+    }
     /// IQ request completed, by result (`ok`/`timeout`/`error`). Emitted at the
     /// single request chokepoint, so it covers both raw and spec-based IQs.
     pub fn iq(result: &'static str) {
@@ -131,6 +141,16 @@ mod imp {
             "Retries from devices not in our registry, by sender type"
         );
         describe_counter!(
+            "wa_retry_refused_total",
+            Unit::Count,
+            "Retries refused at the MAX_RETRY loop guard"
+        );
+        describe_counter!(
+            "wa_base_key_collision_total",
+            Unit::Count,
+            "Base-key collisions that forced a fresh session"
+        );
+        describe_counter!(
             "wa_iq_total",
             Unit::Count,
             "IQ requests by result (ok/timeout/error)"
@@ -203,6 +223,10 @@ mod imp {
     pub fn high_retry(_reason: &'static str) {}
     #[inline]
     pub fn retry_unknown_device(_sender_type: &'static str) {}
+    #[inline]
+    pub fn retry_refused() {}
+    #[inline]
+    pub fn base_key_collision() {}
     #[inline]
     pub fn iq(_result: &'static str) {}
     #[inline]

--- a/wacore/src/telemetry.rs
+++ b/wacore/src/telemetry.rs
@@ -37,6 +37,11 @@ mod imp {
     pub fn retry_receipt(reason: &'static str) {
         counter!("wa_retry_receipt_total", "reason" => reason).increment(1);
     }
+    /// Retry receipt sent at the high-retry watermark (count >= MAX), by reason.
+    /// Mirrors WA Web's MessageHighRetryCount WAM event (id 3132).
+    pub fn high_retry(reason: &'static str) {
+        counter!("wa_high_retry_total", "reason" => reason).increment(1);
+    }
     /// IQ request completed, by result (`ok`/`timeout`/`error`). Emitted at the
     /// single request chokepoint, so it covers both raw and spec-based IQs.
     pub fn iq(result: &'static str) {
@@ -111,6 +116,11 @@ mod imp {
             "Retry receipts sent, by reason"
         );
         describe_counter!(
+            "wa_high_retry_total",
+            Unit::Count,
+            "Retry receipts sent at the high-retry watermark (count >= MAX), by reason"
+        );
+        describe_counter!(
             "wa_iq_total",
             Unit::Count,
             "IQ requests by result (ok/timeout/error)"
@@ -179,6 +189,8 @@ mod imp {
     pub fn send(_kind: &'static str) {}
     #[inline]
     pub fn retry_receipt(_reason: &'static str) {}
+    #[inline]
+    pub fn high_retry(_reason: &'static str) {}
     #[inline]
     pub fn iq(_result: &'static str) {}
     #[inline]


### PR DESCRIPTION
## What

Two threads, one commit per change.

Log levels (2 commits): two retry-flow `warn!`s that fire for benign, remote-driven, fully-handled conditions move to the level WA Web uses for them. `Refusing retry #N ... exceeds max attempts` (the MAX_RETRY loop guard) goes to `debug!`, and `Base key collision ... Forcing fresh session` goes to `info!`. The collision line and its `Base key changed` sibling also start carrying the `message_id`.

Observability (4 commits): four low-cardinality, PII-safe, zero-cost-when-off counters on the retry flow, plus the retry count recorded on the existing receipt span.

## Why

This came out of triaging ~14h of production logs from a group bot. The fleet was healthy (0 ERROR, 0 panic, 0 stanza errors), but the entire WARN budget was 25 lines of exactly two kinds, both produced by a single peer device thrashing prekeys during one group send. It was remote-driven and fully contained by the existing defenses (the MAX_RETRY cap, the per-chat resend rate limiter, the SKDM gate, base-key collision detection); the message was delivered and no ban occurred. A cross-model review (Codex/GPT-5.5) verified the oracle citations independently before this PR.

The core finding is that WA Web emits both of those conditions via `WALogger.LOG` (level 2, informational), not `WARN` (level 3):

- `WAWebHandleRetryRequest` logs the `retryCount >= MAX_RETRY` (5) refusal via `WALogger.LOG`, and reserves `WARN` in the same module for real errors (no-requester, device-not-found).
- `WAWebUpdateLocalSignalSession` logs the same-base-key session delete via `WALogger.LOG`.
- `WAWebLogger`: `LOG` is level 2, `WARN` is level 3.

`debug!` (rather than `info!`) for the cap matches the lib's own precedent for a frequent, expected, remote-driven event: the mirror receive-side capped-retry path in `message/retry.rs` already logs at `debug!`, and `decrypt_fail_log_level` downgrades expected fan-out failures to debug to avoid WARN spam. `info!` for the collision matches the three sibling branches of `update_local_signal_session`, which already log at info. The `message_id` is added because the collision is keyed by `(address, message_id)`, so the id makes the event correlatable to a specific message during a storm.

On observability: WA Web emits two dedicated WAM events on this flow that the lib had no aggregate equivalent for. `MessageHighRetryCount` (id 3132, committed at `retryCount >= 5` from the send-receipt path) maps to `wa_high_retry_total`, and `MdRetryFromUnknownDevice` (id 2178, committed when a retry arrives from a device not in our registry, tagged primary vs companion) maps to `wa_retry_unknown_device_total`, placed at the retry call-site rather than inside `schedule_unknown_device_sync` (which the shared inbound path also drives, so it would over-count). Two more counters cover the responder events WA Web only logs and has no dedicated WAM for: `wa_retry_refused_total` and `wa_base_key_collision_total`, so a chronically thrashing peer shows up in aggregate instead of via log scraping. All four are off by default and compile to no-ops without the `metrics` feature. The span change records the retry `count` so storm depth is aggregable per sender even when the cap returns early.

## What this PR deliberately leaves out

The retry logic itself is verbatim parity with the oracle and is untouched: the cap value and comparator, the base-key save/compare/delete, and the recovery path all stay as-is. Two latent parity divergences the review surfaced (peer regId-mismatch without `<keys>`, and offline-gating of the destructive key-bundle path) are intentionally not addressed here: both have zero occurrences in the analyzed logs, carry moderate regression risk on session recovery, and deserve a separate decision.

## Tests

`cargo clippy --all-targets -- -D warnings` is clean both at default (no-op telemetry, tracing off) and with `--features metrics,tracing` (real counters plus the span field).
`cargo test -p wacore --lib` (991) and `cargo test -p whatsapp-rust --lib` (827) pass.
There is no behavior change: every line is a log level, an added log field, a counter increment, or a span field.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

