### PR TITLE
perf(signal): flush the signal cache without holding the device read-lock

### DIFF
--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -59,10 +59,16 @@ impl Client {
     /// Flush the in-memory signal cache to the database backend.
     /// Called after each message is decrypted or after encryption operations.
     pub(crate) async fn flush_signal_cache(&self) -> Result<(), anyhow::Error> {
-        let device = self.persistence_manager.get_device_arc().await;
-        let device_guard = device.read().await;
+        // Clone the backend Arc out of the snapshot and hold no device lock across
+        // the flush: this batched SQLite write runs per message, and a device guard
+        // held for its duration would block every concurrent Device write.
+        let backend = self
+            .persistence_manager
+            .get_device_snapshot()
+            .backend
+            .clone();
         self.signal_cache
-            .flush(&*device_guard.backend)
+            .flush(&*backend)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to flush signal cache: {e}"))
     }

--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -59,9 +59,8 @@ impl Client {
     /// Flush the in-memory signal cache to the database backend.
     /// Called after each message is decrypted or after encryption operations.
     pub(crate) async fn flush_signal_cache(&self) -> Result<(), anyhow::Error> {
-        // Clone the backend Arc out of the snapshot and hold no device lock across
-        // the flush: this batched SQLite write runs per message, and a device guard
-        // held for its duration would block every concurrent Device write.
+        // Hold no device guard across the flush: this per-message batched SQLite
+        // write would otherwise block every concurrent Device write for its duration.
         let backend = self
             .persistence_manager
             .get_device_snapshot()


### PR DESCRIPTION
## What

`flush_signal_cache` took the `Device` `read()` guard and held it across the entire `signal_cache.flush(...)` call. The guard was only used to borrow `device.backend` (an `Arc<dyn Backend>`), so this clones the backend `Arc` out of the device snapshot and drops the guard before flushing — the batched SQLite write now runs holding no device lock.

## Why

`signal_cache.flush` is a batched SQLite write, and `flush_signal_cache` runs once per decrypted message and on most sends. Holding the device read-guard for the whole flush blocked every concurrent `modify_device`/`process_command` (a Device write) for the flush duration, creating read↔write lock contention on the per-message hot path. The backend handle is cheap to clone, so nothing needs the guard held during the I/O.

No behavior change: same backend, same flush, only the lock is no longer held across it. This mirrors the existing pattern in `prekeys.rs` (`get_device_snapshot().backend.clone()`).

## Tests

`cargo clippy --all --tests` clean; `cargo test -p whatsapp-rust` passes (862).