### PR TITLE
fix(retry): dedup registration-id parsing and reject oversized payloads

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -35,42 +35,6 @@ fn get_bytes_content_ref<'a>(node: &'a NodeRef<'_>) -> Option<&'a [u8]> {
     }
 }
 
-/// Helper to extract registration ID from a Node (used in tests).
-#[cfg(test)]
-fn extract_registration_id_from_node(node: &Node) -> Option<u32> {
-    let registration_node = node.get_optional_child("registration")?;
-    let bytes = get_bytes_content(registration_node)?;
-
-    if bytes.len() >= 4 {
-        Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
-    } else if !bytes.is_empty() {
-        let mut arr = [0u8; 4];
-        let start = 4 - bytes.len();
-        arr[start..].copy_from_slice(bytes);
-        Some(u32::from_be_bytes(arr))
-    } else {
-        None
-    }
-}
-
-/// Helper to extract registration ID from a NodeRef (4 bytes big-endian).
-fn extract_registration_id_from_node_ref(node: &NodeRef<'_>) -> Option<u32> {
-    let registration_node = node.get_optional_child("registration")?;
-    let bytes = get_bytes_content_ref(registration_node)?;
-
-    if bytes.len() >= 4 {
-        Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
-    } else if !bytes.is_empty() {
-        // Handle variable-length encoding.
-        let mut arr = [0u8; 4];
-        let start = 4 - bytes.len();
-        arr[start..].copy_from_slice(bytes);
-        Some(u32::from_be_bytes(arr))
-    } else {
-        None
-    }
-}
-
 /// Maximum retry attempts we'll honor (matches WhatsApp Web's MAX_RETRY = 5).
 /// We refuse to resend if the requester has already retried this many times.
 const MAX_RETRY_COUNT: u8 = 5;
@@ -694,7 +658,9 @@ impl Client {
                 );
             }
 
-            if let Some(received_reg_id) = extract_registration_id_from_node_ref(node) {
+            if let Some(received_reg_id) =
+                wacore::protocol::retry::extract_registration_id_from_node_ref(node)
+            {
                 let signal_address = resolved_jid.to_protocol_address();
                 let device_snapshot = self.persistence_manager.get_device_snapshot();
                 let session = self
@@ -2561,59 +2527,67 @@ mod tests {
 
     #[test]
     fn extract_registration_id_from_node_test() {
+        use wacore::protocol::retry::{
+            extract_registration_id_from_node, extract_registration_id_from_node_ref,
+        };
         use wacore_binary::{Attrs, Node};
 
-        // Test with 4-byte registration ID
-        let reg_bytes = vec![0x00, 0x01, 0x02, 0x03]; // = 66051
-        let reg_node = Node {
-            tag: Cow::Borrowed("registration"),
-            attrs: Attrs::new(),
-            content: Some(NodeContent::Bytes(reg_bytes)),
-        };
-        let parent = Node {
+        let reg_receipt = |bytes: Vec<u8>| Node {
             tag: Cow::Borrowed("receipt"),
             attrs: Attrs::new(),
-            content: Some(NodeContent::Nodes(vec![reg_node])),
+            content: Some(NodeContent::Nodes(vec![Node {
+                tag: Cow::Borrowed("registration"),
+                attrs: Attrs::new(),
+                content: Some(NodeContent::Bytes(bytes)),
+            }])),
         };
-        assert_eq!(extract_registration_id_from_node(&parent), Some(0x00010203));
 
-        // Test with 3-byte registration ID (variable length)
-        let reg_bytes_short = vec![0x01, 0x02, 0x03]; // = 66051
-        let reg_node_short = Node {
-            tag: Cow::Borrowed("registration"),
-            attrs: Attrs::new(),
-            content: Some(NodeContent::Bytes(reg_bytes_short)),
-        };
-        let parent_short = Node {
-            tag: Cow::Borrowed("receipt"),
-            attrs: Attrs::new(),
-            content: Some(NodeContent::Nodes(vec![reg_node_short])),
-        };
+        // 4-byte registration ID.
+        let parent = reg_receipt(vec![0x00, 0x01, 0x02, 0x03]);
+        assert_eq!(extract_registration_id_from_node(&parent), Some(0x00010203));
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent.as_node_ref()),
+            Some(0x00010203)
+        );
+
+        // 3-byte registration ID (variable length, left zero-padded).
+        let parent_short = reg_receipt(vec![0x01, 0x02, 0x03]);
         assert_eq!(
             extract_registration_id_from_node(&parent_short),
             Some(0x00010203)
         );
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent_short.as_node_ref()),
+            Some(0x00010203)
+        );
 
-        // Test with no registration node
+        // Oversized (>4 byte) payload: rejected, not truncated, on both paths.
+        let parent_oversized = reg_receipt(vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+        assert_eq!(extract_registration_id_from_node(&parent_oversized), None);
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent_oversized.as_node_ref()),
+            None
+        );
+
+        // No registration node.
         let parent_no_reg = Node {
             tag: Cow::Borrowed("receipt"),
             attrs: Attrs::new(),
             content: Some(NodeContent::Nodes(vec![])),
         };
         assert_eq!(extract_registration_id_from_node(&parent_no_reg), None);
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent_no_reg.as_node_ref()),
+            None
+        );
 
-        // Test with empty bytes
-        let reg_node_empty = Node {
-            tag: Cow::Borrowed("registration"),
-            attrs: Attrs::new(),
-            content: Some(NodeContent::Bytes(vec![])),
-        };
-        let parent_empty = Node {
-            tag: Cow::Borrowed("receipt"),
-            attrs: Attrs::new(),
-            content: Some(NodeContent::Nodes(vec![reg_node_empty])),
-        };
+        // Empty bytes.
+        let parent_empty = reg_receipt(vec![]);
         assert_eq!(extract_registration_id_from_node(&parent_empty), None);
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent_empty.as_node_ref()),
+            None
+        );
     }
 
     #[test]

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -880,25 +880,10 @@ impl Client {
             .ok_or_else(|| anyhow::anyhow!("<keys> child missing from retry receipt"))?;
         validate_retry_prekey_presence(keys_node, is_fbid_bot_retry)?;
 
-        let registration_node = node.get_optional_child("registration");
-
-        // Extract registration ID (4 bytes big-endian).
-        let registration_id = registration_node
-            .and_then(get_bytes_content_ref)
-            .map(|bytes| {
-                if bytes.len() >= 4 {
-                    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
-                } else if !bytes.is_empty() {
-                    // Handle variable-length encoding.
-                    let mut arr = [0u8; 4];
-                    let start = 4 - bytes.len();
-                    arr[start..].copy_from_slice(bytes);
-                    u32::from_be_bytes(arr)
-                } else {
-                    0
-                }
-            })
-            .unwrap_or(0);
+        // Use the centralized extractor so the >4-byte rejection rule applies
+        // here too, not just on the no-keys retry path.
+        let registration_id =
+            wacore::protocol::retry::extract_registration_id_from_node_ref(node).unwrap_or(0);
 
         if registration_id == 0 {
             return Err(anyhow::anyhow!("Invalid registration ID in retry receipt"));

--- a/wacore/src/protocol/retry.rs
+++ b/wacore/src/protocol/retry.rs
@@ -9,7 +9,7 @@ use crate::iq::prekeys::{OneTimePreKeyNode, SignedPreKeyNode};
 use crate::libsignal::protocol::PublicKey;
 use crate::protocol::ProtocolNode;
 use wacore_binary::builder::NodeBuilder;
-use wacore_binary::{Node, NodeContent};
+use wacore_binary::{Node, NodeContent, NodeRef};
 
 /// Maximum retry attempts we'll honor (matches WhatsApp Web's MAX_RETRY = 5).
 /// We refuse to resend if the requester has already retried this many times.
@@ -91,29 +91,38 @@ pub fn get_bytes_content(node: &Node) -> Option<&[u8]> {
     }
 }
 
+/// Parses a `<registration>` payload as a big-endian `u32`. Registration IDs are
+/// u32, so payloads longer than 4 bytes are rejected rather than silently
+/// truncated; shorter payloads (1-3 bytes) are left-zero-padded.
+fn parse_registration_id(bytes: &[u8]) -> Option<u32> {
+    match bytes.len() {
+        4 => Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])),
+        // Reject oversized payloads rather than silently truncating.
+        n if n > 4 => None,
+        0 => None,
+        _ => {
+            let mut arr = [0u8; 4];
+            let start = 4 - bytes.len();
+            arr[start..].copy_from_slice(bytes);
+            Some(u32::from_be_bytes(arr))
+        }
+    }
+}
+
 /// Helper to extract registration ID from a node (4 bytes big-endian).
 ///
 /// Looks for a `<registration>` child node and parses its bytes content
-/// as a big-endian `u32`. Handles variable-length encoding (1-4 bytes)
-/// by zero-padding on the left.
+/// as a big-endian `u32`. See [`parse_registration_id`] for the parse rules.
 pub fn extract_registration_id_from_node(node: &Node) -> Option<u32> {
     let registration_node = node.get_optional_child("registration")?;
-    let bytes = get_bytes_content(registration_node)?;
+    parse_registration_id(get_bytes_content(registration_node)?)
+}
 
-    if bytes.len() == 4 {
-        Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
-    } else if bytes.len() > 4 {
-        // Registration IDs are u32; reject oversized payloads rather than silently truncating.
-        None
-    } else if !bytes.is_empty() {
-        // Handle variable-length encoding.
-        let mut arr = [0u8; 4];
-        let start = 4 - bytes.len();
-        arr[start..].copy_from_slice(bytes);
-        Some(u32::from_be_bytes(arr))
-    } else {
-        None
-    }
+/// `NodeRef` counterpart of [`extract_registration_id_from_node`]; shares the
+/// same parse rules via [`parse_registration_id`].
+pub fn extract_registration_id_from_node_ref(node: &NodeRef<'_>) -> Option<u32> {
+    let registration_node = node.get_optional_child("registration")?;
+    parse_registration_id(registration_node.content_bytes()?)
 }
 
 /// Returns whether keys should be included in a retry receipt for the given
@@ -266,6 +275,61 @@ mod tests {
             content: Some(NodeContent::Nodes(vec![reg_node])),
         };
         assert_eq!(extract_registration_id_from_node(&parent), None);
+    }
+
+    // Registration IDs are u32; an oversized payload must be rejected, not truncated
+    // to its first 4 bytes.
+    #[test]
+    fn extract_registration_id_rejects_oversized() {
+        let reg_node = Node {
+            tag: Cow::Borrowed("registration"),
+            attrs: Attrs::new(),
+            content: Some(NodeContent::Bytes(vec![0x01, 0x02, 0x03, 0x04, 0x05])),
+        };
+        let parent = Node {
+            tag: Cow::Borrowed("receipt"),
+            attrs: Attrs::new(),
+            content: Some(NodeContent::Nodes(vec![reg_node])),
+        };
+        assert_eq!(extract_registration_id_from_node(&parent), None);
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent.as_node_ref()),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_registration_id_from_node_ref_matches_owned() {
+        let reg_node = Node {
+            tag: Cow::Borrowed("registration"),
+            attrs: Attrs::new(),
+            content: Some(NodeContent::Bytes(vec![0x00, 0x01, 0x02, 0x03])),
+        };
+        let parent = Node {
+            tag: Cow::Borrowed("receipt"),
+            attrs: Attrs::new(),
+            content: Some(NodeContent::Nodes(vec![reg_node])),
+        };
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent.as_node_ref()),
+            Some(0x00010203)
+        );
+
+        // Variable-length (3-byte) payloads zero-pad on the left, same as the owned path.
+        let reg_node_short = Node {
+            tag: Cow::Borrowed("registration"),
+            attrs: Attrs::new(),
+            content: Some(NodeContent::Bytes(vec![0x01, 0x02, 0x03])),
+        };
+        let parent_short = Node {
+            tag: Cow::Borrowed("receipt"),
+            attrs: Attrs::new(),
+            content: Some(NodeContent::Nodes(vec![reg_node_short])),
+        };
+        assert_eq!(
+            extract_registration_id_from_node_ref(&parent_short.as_node_ref()),
+            Some(0x00010203)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The registration-id parser was duplicated in `src/retry.rs` and had diverged from the canonical `wacore` version. The runtime crate carried its own `extract_registration_id_from_node` (`#[cfg(test)]`) and `extract_registration_id_from_node_ref` (the production path), both of which silently truncated oversized payloads (`bytes.len() >= 4` took the first 4 bytes), while `wacore::protocol::retry::extract_registration_id_from_node` rejected `> 4`-byte payloads. Since `src/retry.rs` already imports its siblings (`should_include_keys`, `build_retry_keys_node`, ...) from `wacore`, this was exactly the copy-paste-then-drift the core/runtime split exists to prevent.

This consolidates onto a single `wacore` implementation:
- Factor the byte rule into one private `parse_registration_id(&[u8])` helper (`len == 4` parse, `len > 4` reject, `1..=3` left-zero-pad, empty -> `None`).
- `extract_registration_id_from_node` (behavior unchanged) and a new `extract_registration_id_from_node_ref` (`NodeRef`, via `content_bytes()`) both delegate to it.
- Delete both local copies in `src/retry.rs` and point the production call site at `wacore::protocol::retry::extract_registration_id_from_node_ref`.

## Why

Registration IDs are `u32`, so an over-length `<registration>` payload is malformed and should be rejected, not silently truncated to its first 4 bytes. Production was on the `NodeRef` (truncating) path. Reconciling on the reject-oversized rule removes the divergence by construction. Valid registration IDs are always 4 bytes, so this is a behavior change only for malformed `>4`-byte input: the call site now skips the reg-ID-mismatch session check on garbage instead of acting on a truncated value.

## Tests

The shared `extract_registration_id_from_node_test` now exercises both the `Node` and `NodeRef` variants, with added assertions that an oversized (`>4`-byte) payload returns `None` on both paths (locking in the non-truncating behavior); matching coverage added in `wacore`.

`cargo fmt --all`, `cargo clippy --all --tests` (clean), `cargo build --all`, and `cargo test -p wacore -p whatsapp-rust` all pass.