### PR TITLE
chore: bump nightly toolchain to nightly-2026-06-16

### DIFF
--- a/.github/workflows/bench-integration.yml
+++ b/.github/workflows/bench-integration.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Install protoc
         uses: taiki-e/install-action@v2
@@ -124,7 +124,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Install protoc
         uses: taiki-e/install-action@v2

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Install tools (protoc, cargo-binstall)
         uses: taiki-e/install-action@v2
@@ -168,7 +168,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Install tools (protoc, cargo-binstall)
         uses: taiki-e/install-action@v2

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Cache install-action tools
         uses: actions/cache@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
       - name: Install protoc
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
           components: clippy
       - name: Install protoc
         uses: taiki-e/install-action@v2
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
       - name: Install protoc
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
 
       - name: Install protoc
         uses: taiki-e/install-action@v2

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-04-05
+          toolchain: nightly-2026-06-16
           targets: wasm32-unknown-unknown
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-04-05"
+channel = "nightly-2026-06-16"
 components = ["rustfmt", "clippy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ async fn handle_text_ping(ctx: &MessageContext) {
     let duration = format!("{:.2?}", start.elapsed());
     info!(
         "Send took {}. Editing message {}...",
-        duration, &sent.message_id
+        duration, sent.message_id
     );
 
     let edit = wa::Message {

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -301,7 +301,7 @@ async fn handle_pair_success<'a>(
             }
 
             if !business_name.is_empty() {
-                info!("✅ Setting push_name during pairing: '{}'", &business_name);
+                info!("✅ Setting push_name during pairing: '{}'", business_name);
                 client
                     .persistence_manager
                     .process_command(crate::store::commands::DeviceCommand::SetPushName(

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -709,15 +709,8 @@ impl Node {
     pub fn get_optional_child_by_tag<'a>(&'a self, tags: &[&str]) -> Option<&'a Node> {
         let mut current_node = self;
         for &tag in tags {
-            if let Some(children) = current_node.children() {
-                if let Some(found) = children.iter().find(|c| c.tag == tag) {
-                    current_node = found;
-                } else {
-                    return None;
-                }
-            } else {
-                return None;
-            }
+            let children = current_node.children()?;
+            current_node = children.iter().find(|c| c.tag == tag)?;
         }
         Some(current_node)
     }
@@ -803,15 +796,8 @@ impl<'a> NodeRef<'a> {
     pub fn get_optional_child_by_tag(&self, tags: &[&str]) -> Option<&NodeRef<'a>> {
         let mut current_node = self;
         for &tag in tags {
-            if let Some(children) = current_node.children() {
-                if let Some(found) = children.iter().find(|c| c.tag == tag) {
-                    current_node = found;
-                } else {
-                    return None;
-                }
-            } else {
-                return None;
-            }
+            let children = current_node.children()?;
+            current_node = children.iter().find(|c| c.tag == tag)?;
         }
         Some(current_node)
     }


### PR DESCRIPTION
## What

Bump the pinned nightly toolchain from `nightly-2026-04-05` to `nightly-2026-06-16` (rustc 1.98.0-nightly).

Files touched:
- `rust-toolchain.toml` (channel)
- All CI workflows that pin the toolchain: `.github/workflows/main.yml`, `binary-size.yml`, `bench-integration.yml`, `codspeed.yml`, `copilot-setup-steps.yml`, `e2e.yml`, `release.yml`, `wasm.yml`

The `Dockerfile` is unchanged: it inherits the channel from `rust-toolchain.toml` and pins no date of its own.

## Clippy fixes required by the new toolchain

clippy 0.1.98 introduced a couple of lints that the bump surfaced; fixed minimally:
- `question_mark` — the two `get_optional_child_by_tag` helpers in `wacore/binary/src/node.rs` are rewritten with `?` (behavior-identical: `None` when there are no children or the tag is absent).
- `useless_borrows_in_formatting` — removed redundant `&` borrows in two log arguments (`src/pair.rs`, `src/main.rs`).

`cargo fmt --all` produced no changes under the new rustfmt. `cargo clippy --all --tests -- -D warnings` is clean on `nightly-2026-06-16`.

Note: may need a rebase if it overlaps with an in-flight CI-workflow PR.