### PR TITLE
refactor: move the demo binary to examples/ and make env_logger a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,6 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
-env_logger = { workspace = true }
 event-listener = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 hex = { workspace = true }
@@ -172,6 +171,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 [dev-dependencies]
 aes = { workspace = true }
 cbc = { version = "0.2", features = ["alloc", "block-padding"] }
+env_logger = { workspace = true }
 flate2 = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }
@@ -186,6 +186,11 @@ wacore-noise = { path = "./wacore/noise", features = [
 
 [lints]
 workspace = true
+
+# The demo client. Needs only the package default features, so a plain
+# `cargo build --example demo` works without `required-features`.
+[[example]]
+name = "demo"
 
 [[example]]
 name = "benchmark"

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,10 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN rustc -vV | sed -n 's/^host: //p' > /rust-target && test -s /rust-target
 RUN cargo chef cook --release --recipe-path recipe.json --target "$(cat /rust-target)"
 COPY . .
-RUN cargo build --release --target "$(cat /rust-target)" \
-    && cp "target/$(cat /rust-target)/release/whatsapp-rust" /app/whatsapp-rust-bin
+# The client lives in examples/demo.rs (the package no longer ships a bin); the
+# example artifact lands under release/examples/. Default features cover it.
+RUN cargo build --release --example demo --target "$(cat /rust-target)" \
+    && cp "target/$(cat /rust-target)/release/examples/demo" /app/whatsapp-rust-bin
 
 # --- Runtime: static binary on empty image ---
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Run the included demo bot:
 
 ```bash
-cargo run                              # QR code only
-cargo run -- -p 15551234567            # Pair code + QR code
-cargo run -- -p 15551234567 -c MYCODE  # Custom pair code
+cargo run --example demo                              # QR code only
+cargo run --example demo -- -p 15551234567            # Pair code + QR code
+cargo run --example demo -- -p 15551234567 -c MYCODE  # Custom pair code
 ```
 
 ## Project Structure

--- a/agent_docs/binary_size_ci.md
+++ b/agent_docs/binary_size_ci.md
@@ -1,6 +1,6 @@
 # Binary Size CI
 
-`binary-size.yml` tracks the size of the `whatsapp-rust` bin (default features, real release profile) on every PR and main push, so heavy new dependencies and monomorphization regressions surface before they accumulate.
+`binary-size.yml` tracks the size of the `demo` example — the default-feature binary entry point that links the whole library, since the package no longer ships a bin — (default features, real release profile) on every PR and main push, so heavy new dependencies and monomorphization regressions surface before they accumulate.
 
 ## What is measured
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -12,11 +12,11 @@ const PONG_TEXT: &str = "🏓 Pong!";
 const REACTION_EMOJI: &str = "🏓";
 
 // Usage:
-//   cargo run                                      # QR code pairing only
-//   cargo run -- --phone 15551234567               # Pair code + QR code (concurrent)
-//   cargo run -- -p 15551234567                    # Short form
-//   cargo run -- -p 15551234567 --code MYCODE12    # Custom 8-char pair code
-//   cargo run -- -p 15551234567 -c MYCODE12        # Short form
+//   cargo run --example demo                                      # QR code pairing only
+//   cargo run --example demo -- --phone 15551234567               # Pair code + QR code (concurrent)
+//   cargo run --example demo -- -p 15551234567                    # Short form
+//   cargo run --example demo -- -p 15551234567 --code MYCODE12    # Custom 8-char pair code
+//   cargo run --example demo -- -p 15551234567 -c MYCODE12        # Short form
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let phone_number = parse_arg(&args, "--phone", "-p");

--- a/scripts/ci/measure_binary_size.py
+++ b/scripts/ci/measure_binary_size.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Measure binary-size metrics for the size-tracking CI job.
 
-Builds the `whatsapp-rust` bin with the real release profile (fat LTO,
+Builds the `demo` example (the package's default-feature entry point, which
+links the whole library) with the real release profile (fat LTO,
 codegen-units=1) but with symbols kept, then derives every metric from that
 single build:
 
@@ -26,7 +27,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-BIN_NAME = "whatsapp-rust"
+# The demo example is the default-feature binary entry point (the package no
+# longer ships a `whatsapp-rust` bin); it links the whole library, so it is the
+# size proxy. The artifact lands at target/release/examples/<EXAMPLE_NAME>.
+EXAMPLE_NAME = "demo"
 # Workspace crates tracked as individual series; everything else is summed
 # into "other deps" so the series set stays stable as dependencies churn.
 WORKSPACE_CRATES = [
@@ -63,7 +67,7 @@ def build_env():
 
 
 def measure_stripped_size(bin_path: Path, out_dir: Path) -> int:
-    stripped = out_dir / f"{BIN_NAME}-stripped"
+    stripped = out_dir / f"{EXAMPLE_NAME}-stripped"
     shutil.copy2(bin_path, stripped)
     run(["strip", "--strip-all", str(stripped)])
     size = stripped.stat().st_size
@@ -91,7 +95,7 @@ def measure_sections(bin_path: Path) -> tuple[int, int]:
 
 def run_cargo_bloat(env) -> dict:
     proc = run(
-        ["cargo", "bloat", "--release", "--bin", BIN_NAME, "--crates",
+        ["cargo", "bloat", "--release", "--example", EXAMPLE_NAME, "--crates",
          "--message-format", "json", "-n", "0"],
         capture_output=True, text=True, env=env,
     )
@@ -140,10 +144,11 @@ def main():
     env = build_env()
 
     if not args.skip_build:
-        run(["cargo", "build", "--release", "--locked", "--bin", BIN_NAME], env=env)
+        run(["cargo", "build", "--release", "--locked", "--example", EXAMPLE_NAME],
+            env=env)
 
     target_dir = Path(os.environ.get("CARGO_TARGET_DIR", "target"))
-    bin_path = target_dir / "release" / BIN_NAME
+    bin_path = target_dir / "release" / "examples" / EXAMPLE_NAME
     if not bin_path.exists():
         raise RuntimeError(f"binary not found at {bin_path}")
 


### PR DESCRIPTION
## What

The demo app at `src/main.rs` was auto-detected as the package binary, so `env_logger` (and its transitive crates) had to be declared in `[dependencies]` and was pulled onto every library consumer. This moves the demo to `examples/demo.rs` and makes `env_logger` a dev-dependency, so it is only built for examples and tests.

The `whatsapp-rust` binary no longer exists; run the demo with:

```bash
cargo run --example demo                   # QR code only
cargo run --example demo -- -p 15551234567 # Pair code + QR code
```

Two consumers of the old bin are updated accordingly:

- `scripts/ci/measure_binary_size.py` now builds and bloat-analyzes `--example demo` and reads the artifact from `target/release/examples/demo`. The metric series names are unchanged, so the size chart history is preserved.
- `Dockerfile` builds `--example demo` and copies the example artifact from `release/examples/demo` (the runtime entrypoint is unchanged).

`README.md` and `agent_docs/binary_size_ci.md` are updated to match.

## Why

`env_logger` was a binary-only dependency leaking into the public dependency graph purely because the demo lived inside the package. Moving it to `examples/` and downgrading `env_logger` to a dev-dependency removes that cost for downstream library users while keeping the demo runnable via `cargo run --example demo`.

## Verification

- `cargo clippy --all-targets -- -D warnings` is clean (compiles every example, including `demo`, plus tests).
- `cargo test -p whatsapp-rust` passes.
- `python3 -m py_compile scripts/ci/measure_binary_size.py` succeeds.
- `env_logger` no longer appears under `[dependencies]` (only `[dev-dependencies]`).