### PR TITLE
ci: add an all-features build job and fix the --nocapture flag

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,4 +65,4 @@ jobs:
         env:
           MOCK_SERVER_URL: "wss://127.0.0.1:8080/ws/chat"
           RUST_LOG: info
-        run: cargo test -p e2e-tests -- --no-capture
+        run: cargo test -p e2e-tests -- --nocapture

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,34 @@ jobs:
       - name: Build project
         run: cargo build --workspace --exclude e2e-tests --all-targets --verbose
       - name: Run tests
-        run: cargo test --workspace --exclude e2e-tests --verbose -- --no-capture
+        run: cargo test --workspace --exclude e2e-tests --verbose -- --nocapture
+
+  test-all-features:
+    name: Build & Lint (all features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-06-16
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Cache Rust registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
+      - name: Build (all features)
+        run: cargo build --workspace --exclude e2e-tests --all-features --all-targets --verbose
+      - name: Clippy (all features)
+        run: cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings
+      # No `cargo test --all-features` here: `--all-features` turns on
+      # `danger-skip-cert-chain-verify` / `danger-skip-tls-verify`, which disable security
+      # verification (the cert-chain negative test is even `#![cfg]`'d out under it), so the
+      # suite would change behavior rather than catch rot. Build + clippy already cover that goal.
 
   test-stable:
     name: Test Stable (no-simd)

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,3 +1,7 @@
+// See the matching note in lib.rs: instrumented large async fns need a deeper
+// recursion limit when the `--all-features` paths (tracing + tracing-pii) combine.
+#![recursion_limit = "512"]
+
 use log::{error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/tests/bench-integration/src/main.rs
+++ b/tests/bench-integration/src/main.rs
@@ -1,3 +1,7 @@
+// See the matching note in lib.rs: large async fns need a deeper recursion limit
+// when the `--all-features` paths (tracing + tracing-pii) combine.
+#![recursion_limit = "512"]
+
 #[cfg(not(feature = "dhat-heap"))]
 mod counting_alloc;
 

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,3 +1,8 @@
+// `--all-features` feature-unifies extra deps onto `whatsapp-rust`, enlarging the
+// `send_and_expect_text()` future past the default layout-query depth. Matches the
+// `512` already used in `src/lib.rs` / `examples/demo.rs`.
+#![recursion_limit = "512"]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 


### PR DESCRIPTION
## What

Two CI changes, plus the minimal code fixes the first one surfaced.

- **New `test-all-features` job** in `.github/workflows/main.yml` ("Build & Lint (all features)"). It mirrors the existing `test` job's setup (same pinned `nightly-2026-06-16`, protoc, sccache, rust-cache) and runs:
  - `cargo build --workspace --exclude e2e-tests --all-features --all-targets --verbose`
  - `cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings`
- **`--nocapture` flag fix** in `main.yml` and `e2e.yml`: the libtest flag is one word (`--nocapture`), so the previous `--no-capture` was silently ignored.
- **`#[recursion_limit = "512"]`** added to three target roots (`examples/benchmark.rs`, `tests/bench-integration/src/main.rs`, `tests/e2e/src/lib.rs`). Under `--all-features`, feature unification enlarges those crates' async futures past the default layout-query depth, so the build failed without this. 512 matches the limit already set in `src/lib.rs` / `examples/demo.rs` for the same reason.

## Why

Feature-gated code (`tracing`, `metrics`, `debug-diagnostics`, `debug-snapshots`, `tracing-pii`, ...) was never built in CI on the full feature set, so it could rot unnoticed. Building + clippy-checking with `--all-features --all-targets` closes that gap.

The job intentionally does **not** run `cargo test --all-features`: `--all-features` enables `danger-skip-cert-chain-verify` / `danger-skip-tls-verify`, which disable security verification (the cert-chain negative test is even `#[cfg]`'d out under it). The suite would therefore change behavior rather than catch rot, so build + clippy already cover the "doesn't rot" goal. A comment in the workflow notes this.

Benchmark workflows (`bench-integration.yml`, `codspeed.yml`, `binary-size.yml`) stay non-gating and are untouched.

## Verification

On the pinned `nightly-2026-06-16`, all run clean locally:

- `cargo build --workspace --exclude e2e-tests --all-features --all-targets` passes.
- `cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings` is clean.
- `cargo fmt --all -- --check` is clean.
- Both workflow files parse as valid YAML.