### PR TITLE
test(binary): add decoder roundtrip property tests and unmarshal fuzz target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__
 .codex
 dhat-heap*.json
 /size-out
+# proptest persists failure seeds next to the test on failure; these are
+# environment-local replay caches, not source.
+*.proptest-regressions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1747,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1828,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1872,6 +1912,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_xoshiro"
@@ -2056,6 +2105,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2348,6 +2409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2651,6 +2713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2887,7 @@ dependencies = [
  "flate2",
  "hashify",
  "itoa",
+ "proptest",
  "serde",
  "serde_json",
  "smallvec",
@@ -2885,6 +2954,15 @@ dependencies = [
  "wacore-binary",
  "wacore-libsignal",
  "waproto",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 divan = { workspace = true }
+proptest = "1.11.0"
 serde_json = { workspace = true, features = ["std"] }
 
 [[bench]]

--- a/wacore/binary/fuzz/.gitignore
+++ b/wacore/binary/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/wacore/binary/fuzz/Cargo.toml
+++ b/wacore/binary/fuzz/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "wacore-binary-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+# Detach from the parent cargo workspace. The fuzz crate depends on
+# `libfuzzer-sys` (nightly + libFuzzer) and must never be pulled into
+# `cargo build --workspace`, clippy, or the binary-size CI. An empty
+# `[workspace]` table makes this directory its own workspace root.
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.wacore-binary]
+path = ".."
+
+[[bin]]
+name = "unmarshal_ref"
+path = "fuzz_targets/unmarshal_ref.rs"
+test = false
+doc = false
+bench = false
+
+# libFuzzer needs debug info and benefits from optimization; mirror the
+# defaults `cargo fuzz init` generates.
+[profile.release]
+debug = 1

--- a/wacore/binary/fuzz/fuzz_targets/unmarshal_ref.rs
+++ b/wacore/binary/fuzz/fuzz_targets/unmarshal_ref.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+//! Fuzz the WABinary decoder entry point.
+//!
+//! `unmarshal_ref` is the largest hostile-input surface in the crate: it parses
+//! attacker-controlled bytes straight off the wire into a `NodeRef` tree. The
+//! target feeds arbitrary bytes in and discards the `Result` — a malformed input
+//! must return `Err`, never panic, overflow the stack, or abort.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = wacore_binary::marshal::unmarshal_ref(data);
+});

--- a/wacore/binary/tests/roundtrip_proptest.rs
+++ b/wacore/binary/tests/roundtrip_proptest.rs
@@ -1,0 +1,94 @@
+//! Property test: `unmarshal(marshal(node)) == node` for randomly generated
+//! `Node` trees.
+//!
+//! The encoder canonicalizes losslessly (token compression, nibble/hex packing,
+//! JID packing), so not every syntactically-valid `Node` round-trips byte-for-byte
+//! into the same `Node`. Two encoder behaviors are genuinely lossy at the *type*
+//! level and the generator is constrained to avoid them rather than weakening the
+//! assertion:
+//!
+//!  * `@`-bearing strings ≤48 bytes are parsed as JIDs (legacy dot-device, agent
+//!    suffixes, unknown servers, ...), which is ambiguous/lossy — so no generated
+//!    string contains `@`.
+//!  * A `String` *content* that is not a protocol token and not nibble/hex-packable
+//!    is emitted as raw bytes and decodes back as `NodeContent::Bytes`, not
+//!    `String`. String content is therefore restricted to the nibble alphabet
+//!    (`[0-9.-]`), which stays `String` on decode; arbitrary payloads are exercised
+//!    through `NodeContent::Bytes`, which is always lossless.
+//!
+//! Attribute keys/values take the decoder's string path, which maps raw bytes back
+//! to `String`, so they may be arbitrary (`@`-free) text and still round-trip.
+
+use proptest::collection::{btree_map, vec};
+use proptest::prelude::*;
+use wacore_binary::marshal::{marshal, unmarshal_ref};
+use wacore_binary::node::{Attrs, Node, NodeContent, NodeValue};
+
+/// Bound recursion and collection sizes so the test is fast and the encoder's
+/// recursive descent can't blow the stack.
+const MAX_DEPTH: u32 = 4;
+const MAX_CHILDREN: usize = 4;
+const MAX_ATTRS: usize = 4;
+const MAX_BYTES: usize = 64;
+
+/// `@`-free string, kept short so we cover the token/packed/raw classification
+/// paths without generating megabytes.
+fn safe_string() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[^@]{0,16}").expect("valid regex")
+}
+
+/// Non-empty nibble-packable string: stays `NodeContent::String` after a
+/// round-trip. The empty string is excluded because the encoder emits it as a
+/// zero-length binary blob (`BINARY_8 + 0`), which decodes back as
+/// `NodeContent::Bytes([])` rather than `String("")`.
+fn nibble_string() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[0-9.-]{1,16}").expect("valid regex")
+}
+
+fn attrs_strategy() -> impl Strategy<Value = Attrs> {
+    // A BTreeMap keeps keys unique (duplicate keys also round-trip, but uniqueness
+    // makes shrinking output easier to read) and yields a deterministic order.
+    btree_map(safe_string(), safe_string(), 0..=MAX_ATTRS).prop_map(|map| {
+        let mut attrs = Attrs::new();
+        for (k, v) in map {
+            attrs.push(k, NodeValue::String(v.into()));
+        }
+        attrs
+    })
+}
+
+fn node_strategy() -> impl Strategy<Value = Node> {
+    let leaf_content = prop_oneof![
+        Just(None),
+        nibble_string().prop_map(|s| Some(NodeContent::String(s.into()))),
+        vec(any::<u8>(), 0..=MAX_BYTES).prop_map(|b| Some(NodeContent::Bytes(b))),
+    ];
+
+    let leaf = (safe_string(), attrs_strategy(), leaf_content)
+        .prop_map(|(tag, attrs, content)| Node::new(tag, attrs, content));
+
+    leaf.prop_recursive(MAX_DEPTH, 64, MAX_CHILDREN as u32, move |inner| {
+        (
+            safe_string(),
+            attrs_strategy(),
+            vec(inner, 1..=MAX_CHILDREN),
+        )
+            .prop_map(|(tag, attrs, children)| {
+                Node::new(tag, attrs, Some(NodeContent::Nodes(children)))
+            })
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2048))]
+
+    #[test]
+    fn marshal_unmarshal_roundtrip(node in node_strategy()) {
+        let bytes = marshal(&node).expect("marshal must succeed for a valid node");
+        // `marshal` writes a leading format byte that `unmarshal_ref` does not expect.
+        let decoded = unmarshal_ref(&bytes[1..])
+            .expect("decoding our own encoder output must succeed")
+            .to_owned();
+        prop_assert_eq!(decoded, node);
+    }
+}


### PR DESCRIPTION
## What
Adds the first property test and fuzz target for the `wacore-binary` crate
(the WhatsApp WABinary wire format).

- **Roundtrip proptest** (`wacore/binary/tests/roundtrip_proptest.rs`): a
  `proptest` strategy builds depth-bounded random `Node` trees (depth ≤4,
  ≤4 children/attrs, ≤64 content bytes) and asserts
  `unmarshal(marshal(node)) == node` over 2048 cases. Adds `proptest` to
  `[dev-dependencies]`.
- **Fuzz target** (`wacore/binary/fuzz/`): a `cargo-fuzz` / libFuzzer target
  that feeds arbitrary `&[u8]` into `unmarshal_ref` — the largest
  hostile-input attack surface — and discards the `Result`.

## Why
There was previously no property testing and no fuzzing anywhere in the
workspace. The marshal/unmarshal path is security- and correctness-critical
(it parses bytes straight off the wire), so it deserves both randomized
roundtrip coverage and a panic/overflow harness.

The encoder canonicalizes losslessly (token compression, nibble/hex packing,
JID packing), but two transforms are lossy at the *type* level, so the
generator is constrained to avoid them rather than weakening the assertion
(documented inline):
- `@`-bearing strings ≤48 bytes are parsed as JIDs (ambiguous), so no
  generated string contains `@`;
- non-token, non-packable `String` *content* re-decodes as `Bytes`, so
  `String` content is limited to the non-empty nibble alphabet, while
  arbitrary payloads go through the always-lossless `Bytes` variant.

The fuzz crate has its own `[workspace]` table so it stays out of the main
cargo workspace and cannot affect `cargo build --workspace`, clippy, or the
binary-size CI. It is intentionally **not** wired into gating CI (it needs
nightly + libFuzzer + time).

## Verification
- `cargo fmt --all --check` — clean
- `cargo build --workspace --exclude e2e-tests --all-targets` — ok
- `cargo build --workspace --exclude e2e-tests --all-features --all-targets` — ok
- `cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings` — clean
- `cargo test -p wacore-binary` — pass
- `cargo test -p wacore-binary --no-default-features --lib` — pass (roundtrip proptest also verified to pass under `--no-default-features`, exercising the non-SIMD decode path)
- `cargo metadata` confirms `wacore-binary-fuzz` is **not** a member of the main workspace
- The fuzz crate and target build/link cleanly via `cargo build --manifest-path wacore/binary/fuzz/Cargo.toml`

## Running the fuzzer
`cargo +nightly fuzz run unmarshal_ref` (from `wacore/binary/`, with `cargo install cargo-fuzz`).