### PR TITLE
perf(send): resolve group SKDM warm gate with one inner-map lookup per device

### DIFF
--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -958,11 +958,9 @@ impl Client {
                 // WA Web parity (ParticipantStore.js skDistribList): a device is
                 // warm only when it AND its primary (device 0) hold the key, so a
                 // forgotten primary redistributes the whole user while a forgotten
-                // companion redistributes only itself.
-                !cached_map
-                    .device_has_key(&device.user, device.device)
-                    .unwrap_or(false)
-                    || !cached_map.device_has_key(&device.user, 0).unwrap_or(false)
+                // companion redistributes only itself. One inner-map resolution
+                // per device (single user-string hash) instead of two.
+                !cached_map.device_and_primary_warm(&device.user, device.device)
             })
             .cloned()
             .collect();

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -42,8 +42,23 @@ impl SenderKeyDeviceMap {
         self.devices.is_empty()
     }
 
+    /// Single (user, device) lookup. Retained for tests that cross-check the
+    /// warm gate; production resolves both lookups via `device_and_primary_warm`.
+    #[cfg(test)]
     pub fn device_has_key(&self, user: &str, device: u16) -> Option<bool> {
         self.devices.get(user)?.get(&device).copied()
+    }
+
+    /// WA Web warm gate (ParticipantStore.js): a device is warm only when it AND
+    /// its primary (device 0) hold the key. Resolves the per-user inner map once
+    /// so the two device lookups share a single outer (user-string) hash instead
+    /// of re-hashing the user per call. A missing entry counts as cold (`?? false`).
+    pub fn device_and_primary_warm(&self, user: &str, device: u16) -> bool {
+        let Some(by_device) = self.devices.get(user) else {
+            return false;
+        };
+        by_device.get(&device).copied().unwrap_or(false)
+            && by_device.get(&0).copied().unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
## What
Adds `SenderKeyDeviceMap::device_and_primary_warm`, which resolves a user's inner device map **once** and performs both `u16` device lookups (the device and its primary, device 0) on that single reference. `filter_skdm_targets` now calls it instead of two separate `device_has_key` calls.

## Why
The per-device warm gate in `filter_skdm_targets` previously called `device_has_key` twice — once for the device, once for its primary — and each call re-hashed the `user` string to look up the *same* inner map. For a 256-device group fan-out that doubled the outer (string-keyed) hashing on the hot path. Resolving the inner map once halves it.

Behavior is identical by De Morgan: the old gate redistributed when `!deviceWarm || !primaryWarm`; the new gate redistributes when `!(deviceWarm && primaryWarm)`. A missing entry still counts as cold. The single-lookup `device_has_key` is retained (now `#[cfg(test)]`) for the tests that cross-check the gate.

## Scope note — the other two fan-out allocations were evaluated and deferred
The original idea also flagged two allocations in `wacore/src/send/encrypt.rs`. Both are load-bearing for the concurrent fan-out design, not safe micro-opts:

- **`clone_box()` ×2 per device → shared `Arc`:** each spawned encrypt task is handed its *own independently-mutable* session/identity store (`&mut *session_store`) and they run concurrently (`ENCRYPT_FANOUT_CONCURRENCY` in flight). A shared `Arc` can't hand out independent `&mut`, so this would require reworking the per-task mutable-store model — an architectural change with behavior risk, out of scope for a perf pass.
- **`to_protocol_address` buffer reuse:** the per-device address is moved into a concurrent `'static` spawned task that owns it for its lifetime. With multiple tasks in flight simultaneously, a single reused buffer is not possible without restructuring the fan-out.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p whatsapp-rust --all-targets -- -D warnings` — clean
- SKDM / warm-gate tests (`filter_skdm_targets_uses_primary_device_gate`, `test_skdm_recipient_filtering_*`, `empty_sender_key_device_map_marks_all_devices_for_skdm`, …) — 35 passed, 0 failed