### PR TITLE
chore(deps): prune the aes-gcm dev-dep and tidy dependency declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aead"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
-dependencies = [
- "bytes",
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "aes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,20 +26,6 @@ dependencies = [
  "cipher",
  "cpubits",
  "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.11.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
 ]
 
 [[package]]
@@ -195,12 +170,10 @@ dependencies = [
  "dhat",
  "e2e-tests",
  "env_logger",
- "log",
  "serde",
  "serde_json",
  "tokio",
  "wacore",
- "whatsapp-rust",
 ]
 
 [[package]]
@@ -2812,7 +2785,6 @@ name = "wacore"
 version = "0.6.0"
 dependencies = [
  "aes",
- "aes-gcm",
  "anyhow",
  "async-channel",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ disallowed_methods = "deny"
 [workspace.dependencies]
 # Shared dependencies
 aes = "0.9.0"
-aes-gcm = { version = "0.11.0-rc.3", default-features = false, features = ["aes", "alloc", "bytes"] }
 anyhow = { version = "1.0", default-features = false }
 async-channel = { version = "2.5.0", default-features = false, features = ["std"] }
 async-lock = { version = "3", default-features = false }
@@ -55,6 +54,7 @@ async-trait = "0.1.89"
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bytemuck = { version = "1.22", default-features = false }
 bytes = { version = "1.5", default-features = false }
+cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", default-features = false }
 compact_str = { version = "0.9", default-features = false }
 ctr = { version = "0.10", default-features = false }
@@ -170,7 +170,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 aes = { workspace = true }
-cbc = { version = "0.2", features = ["alloc", "block-padding"] }
+cbc = { workspace = true, features = ["block-padding"] }
 env_logger = { workspace = true }
 flate2 = { workspace = true }
 hkdf = { workspace = true }

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT"
 repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "SQLite storage backend for whatsapp-rust"
 
+# `libsqlite3-sys` is pulled only to activate its `bundled` feature (compile
+# SQLite in-tree); there is no direct `use`, so static analysers flag it.
+[package.metadata.cargo-machete]
+ignored = ["libsqlite3-sys"]
+
 [features]
 default = ["bundled-sqlite"]
 bundled-sqlite = ["libsqlite3-sys/bundled"]

--- a/tests/bench-integration/Cargo.toml
+++ b/tests/bench-integration/Cargo.toml
@@ -19,19 +19,10 @@ anyhow = { workspace = true }
 dhat = { version = "0.3", optional = true }
 e2e-tests = { path = "../e2e" }
 env_logger = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 wacore = { path = "../../wacore" }
-whatsapp-rust = { path = "../..", default-features = false, features = [
-  "danger-skip-tls-verify",
-  "debug-diagnostics",
-  "simd",
-  "tokio-runtime",
-  "tokio-native",
-  "signal",
-] }
 
 [lints]
 workspace = true

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT"
 repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "Core WhatsApp protocol implementation without runtime dependencies"
 
+# `getrandom` is pulled only to forward the `js` feature (wasm getrandom backend);
+# there is no direct `use`, so static analysers flag it as unused.
+[package.metadata.cargo-machete]
+ignored = ["getrandom"]
+
 [features]
 default = ["simd"]
 simd = ["wacore-appstate/simd"]
@@ -67,7 +72,6 @@ wacore-noise = { workspace = true }
 waproto = { workspace = true }
 
 [dev-dependencies]
-aes-gcm = { workspace = true }
 divan = { workspace = true }
 futures = { workspace = true, features = ["executor", "thread-pool"] }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -10,6 +10,10 @@ description = "Binary data and constants for WhatsApp protocol"
 [package.metadata.cargo-shear]
 ignored = ["hashify"]
 
+# `hashify` is used only through its lookup macros, so static analysers miss it.
+[package.metadata.cargo-machete]
+ignored = ["hashify"]
+
 [lib]
 crate-type = ["rlib"]
 

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -13,7 +13,7 @@ arrayref = "0.3.9"
 async-lock = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
-cbc = { version = "0.2", features = ["alloc"] }
+cbc = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 ctr = { workspace = true }
 curve25519-dalek = "5.0.0-rc.0"
@@ -29,7 +29,7 @@ rand = { workspace = true }
 serde = { workspace = true, features = ["alloc"] }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
-subtle = "2.6.1"
+subtle = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 waproto = { workspace = true }

--- a/wacore/tests/noise_handshake_test.rs
+++ b/wacore/tests/noise_handshake_test.rs
@@ -1,9 +1,8 @@
-use aes_gcm::Aes256Gcm;
-use aes_gcm::aead::{Aead, KeyInit, Payload};
 use hkdf::Hkdf;
 use sha2::Sha256;
 use wacore::handshake::NoiseHandshake;
 use wacore::libsignal::crypto::CryptographicHash;
+use wacore::libsignal::crypto::aes_256_gcm_decrypt;
 use wacore::libsignal::protocol::{PrivateKey, PublicKey};
 use wacore::noise::generate_iv;
 use wacore_binary::consts::{NOISE_PATTERN_XX, WA_CONN_HEADER};
@@ -69,17 +68,16 @@ fn test_server_static_key_decryption_with_go_values() {
         "Derived SALT does not match Go's value!"
     );
 
-    let cipher =
-        Aes256Gcm::new_from_slice(&rust_key_for_decrypt).expect("Failed to prepare GCM cipher");
-
     let iv = generate_iv(0);
-    let payload = Payload {
-        msg: &ciphertext,
-        aad: &aad_for_decrypt,
-    };
-
-    let rust_plaintext = cipher.decrypt((&iv).into(), payload)
-        .expect("AEAD DECRYPTION FAILED! The test inputs are correct, so the GCM primitive or its inputs are flawed.");
+    let mut rust_plaintext = Vec::new();
+    aes_256_gcm_decrypt(
+        &rust_key_for_decrypt,
+        &iv,
+        &aad_for_decrypt,
+        &ciphertext,
+        &mut rust_plaintext,
+    )
+    .expect("AEAD DECRYPTION FAILED! The test inputs are correct, so the GCM primitive or its inputs are flawed.");
 
     assert_eq!(
         hex::encode(rust_plaintext),
@@ -92,32 +90,25 @@ fn test_server_static_key_decryption_with_go_values() {
 
 #[test]
 fn test_live_decryption_with_go_values() {
-    use aes_gcm::aead::{Aead, Payload};
-    use hex;
-
     let go_derived_key_hex = "0e34efece6dc4516c05c53bb7e0c2128bc66c053da4e0b18afb0afe8e648c05d";
     let go_aad_hex = "78b3c79d1c15cf84ec402678ac0478106a6f201a77e4d2364de1e096d65c7bfe";
     let go_ciphertext_hex = "920d8096b1c0e4376e0667c877d746fb2697c72b940beb73e89f87cc79e43aae6a23ed5c5ec7a4e37f04a9c4a9a25f02";
     let go_expected_plaintext_hex =
         "5854d333d8e13975abd6597bbaddd49d6935ced25c93a44bd3ade508f2bec330";
 
-    let go_derived_key = hex::decode(go_derived_key_hex).expect("test hex data should be valid");
+    let go_derived_key: [u8; 32] = hex::decode(go_derived_key_hex)
+        .expect("test hex data should be valid")
+        .try_into()
+        .expect("derived key should be 32 bytes");
     let aad = hex::decode(go_aad_hex).expect("test hex data should be valid");
     let ciphertext = hex::decode(go_ciphertext_hex).expect("test hex data should be valid");
     let expected_plaintext =
         hex::decode(go_expected_plaintext_hex).expect("test hex data should be valid");
 
-    let cipher = Aes256Gcm::new_from_slice(&go_derived_key).expect("Failed to prepare GCM cipher");
-
     let iv = generate_iv(0);
 
-    let payload = Payload {
-        msg: &ciphertext,
-        aad: &aad,
-    };
-
-    let rust_plaintext = cipher
-        .decrypt((&iv).into(), payload)
+    let mut rust_plaintext = Vec::new();
+    aes_256_gcm_decrypt(&go_derived_key, &iv, &aad, &ciphertext, &mut rust_plaintext)
         .expect("AEAD DECRYPTION FAILED! The GCM primitive or its inputs are flawed.");
 
     assert_eq!(

--- a/waproto/Cargo.toml
+++ b/waproto/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT"
 repository = "https://github.com/jlucaso1/whatsapp-rust"
 description = "Protocol Buffers definitions for WhatsApp"
 
+# `serde` is referenced only by derives injected into the generated code by
+# `build.rs` (`#[derive(serde::Serialize)]`), so static analysers miss it.
+[package.metadata.cargo-machete]
+ignored = ["serde"]
+
 [features]
 default = []
 serde-deserialize = []


### PR DESCRIPTION
## What

A dependency-hygiene pass over the workspace. The one change that actually shrinks a build graph, plus a few tidy-ups:

- **Drop the `aes-gcm` dev-dependency from `wacore`.** It was used by a single test (`tests/noise_handshake_test.rs`), while production AES-256-GCM already runs through libsignal's in-tree implementation (`aes` + `ctr` + `ghash`). The two decryption assertions are ported to `libsignal::crypto::aes_256_gcm_decrypt`, which is the exact one-shot equivalent. This removes `aes-gcm` **and** `aead` from the test build graph and from `Cargo.lock`.
- **Trim `tests/bench-integration`.** Remove the unused `log` dependency and the redundant `whatsapp-rust` entry. The latter's feature set is a strict subset of what `e2e-tests` (a dependency of this crate) already enables, so Cargo's feature unification keeps the resolved build byte-identical — it was just a second, drifting copy of the feature list to maintain.
- **Consolidate `cbc`/`subtle`.** libsignal declared these with literal versions; move them to the shared `[workspace.dependencies]` (where `subtle` already lived) so versions stay aligned across the workspace.
- **Silence cargo-machete false positives.** `serde` (waproto — injected into generated code by `build.rs`), `getrandom` (wacore — only forwards the `js`/wasm feature), `hashify` (wacore-binary — macro-only), and `libsqlite3-sys` (sqlite-storage — only activates the `bundled` feature) have no direct `use` and were flagged as unused. Document them via `[package.metadata.cargo-machete]`. `cargo-machete` now reports a clean tree.

## Why

A codebase sweep for dependency-reduction opportunities found the direct dependencies already lean — the large transitive subtrees (`tokio-websockets`, `diesel`, `ureq`) are essential and already gated behind optional features, and the two HTTP clients already share the same `rustls`/`ring` stack. The only genuinely removable crate was the `aes-gcm` dev-dep, since production never used it. The rest of this PR is hygiene: removing redundant declarations and making static analysis (`cargo-machete`) pass cleanly so future unused-dep regressions are easy to spot.

No production dependency or feature resolution changes; the net effect is `aes-gcm` + `aead` leaving the test/dev graph.

## Verification

- `cargo test -p wacore --test noise_handshake_test` — 5/5 pass (both ported tests included).
- `cargo clippy --workspace --all-targets` — clean, 0 warnings.
- `cargo test -p wacore-libsignal -p wacore-binary -p whatsapp-rust-sqlite-storage` — all pass (libsignal's crypto suite exercises the `cbc`/`subtle` paths under the workspace declarations).
- `cargo-machete` — "didn't find any unused dependencies".
- `Cargo.lock` diff: only `aes-gcm` and `aead` removed; no version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLgHUqHiDMszF9NbwxqMc1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLgHUqHiDMszF9NbwxqMc1)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

