### PR TITLE
perf(prekeys): avoid full record decode on the pre-key upload path

### DIFF
--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -551,17 +551,19 @@ impl Client {
         }
 
         let pre_key_pairs = {
-            use prost::Message;
             let mut pairs: Vec<(u32, PublicKey)> = Vec::with_capacity(rows.len());
             for (id, record) in &rows {
-                let public_key = waproto::whatsapp::PreKeyRecordStructure::decode(&record[..])
-                    .map_err(anyhow::Error::from)
-                    .and_then(|structure| {
-                        let raw = structure
-                            .public_key
-                            .ok_or_else(|| anyhow::anyhow!("record missing public key"))?;
-                        Ok(PublicKey::from_djb_public_key_bytes(&raw)?)
-                    });
+                // Pull the public key straight out of the encoded record (field 2)
+                // rather than a full prost decode of the PreKeyRecordStructure: the
+                // upload only needs the public key, while a full decode also copies
+                // the private key into its own Vec. At the default batch of 812 keys
+                // that is ~2 throwaway allocations per record on the connect path.
+                let public_key = match wacore::prekeys::extract_prekey_public_key(record) {
+                    Some(raw) => {
+                        PublicKey::from_djb_public_key_bytes(raw).map_err(anyhow::Error::from)
+                    }
+                    None => Err(anyhow::anyhow!("record missing public key")),
+                };
                 match public_key {
                     Ok(public_key) => pairs.push((*id, public_key)),
                     Err(e) => log::warn!("skipping undecodable prekey record {id}: {e:?}"),

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -558,11 +558,15 @@ impl Client {
                 // upload only needs the public key, while a full decode also copies
                 // the private key into its own Vec. At the default batch of 812 keys
                 // that is ~2 throwaway allocations per record on the connect path.
+                // The extractor validates the record framing, so a malformed record
+                // returns None and is skipped here — same rejection the consume path
+                // (`get_pre_key`'s full decode) makes, so we never upload a key this
+                // device couldn't later decode with.
                 let public_key = match wacore::prekeys::extract_prekey_public_key(record) {
                     Some(raw) => {
                         PublicKey::from_djb_public_key_bytes(raw).map_err(anyhow::Error::from)
                     }
-                    None => Err(anyhow::anyhow!("record missing public key")),
+                    None => Err(anyhow::anyhow!("record missing or malformed public key")),
                 };
                 match public_key {
                     Ok(public_key) => pairs.push((*id, public_key)),

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -455,6 +455,11 @@ impl Client {
             wanted,
         );
 
+        // Public keys of the freshly generated batch, kept from generation so the
+        // upload never reads them back out of the store and never decodes protobuf
+        // to recover a key it just held in hand. Empty when the plan only re-offers
+        // leftover window keys (gen_count == 0).
+        let mut fresh_pre_keys: Vec<(u32, PublicKey)> = Vec::new();
         if plan.gen_count > 0 {
             let gen_start = plan.gen_start;
             let gen_count = plan.gen_count as usize;
@@ -462,16 +467,18 @@ impl Client {
             // batch size is caller-configurable, so offload the whole batch to keep
             // the async executor responsive. Records are encoded into one contiguous
             // buffer with zero-copy Bytes slices instead of an alloc per record.
-            let encoded_batch = wacore::runtime::blocking(&*self.runtime, move || {
+            let (encoded_batch, generated) = wacore::runtime::blocking(&*self.runtime, move || {
                 use prost::Message;
 
                 // Seed one CSPRNG and advance it per key, rather than reseeding from
                 // entropy on every iteration.
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
                 let mut records = Vec::with_capacity(gen_count);
+                let mut pubkeys = Vec::with_capacity(gen_count);
                 for i in 0..gen_count {
                     let pre_key_id = gen_start + i as u32;
                     let key_pair = KeyPair::generate(&mut rng);
+                    pubkeys.push((pre_key_id, key_pair.public_key));
                     records.push((pre_key_id, new_pre_key_record(pre_key_id, &key_pair)));
                 }
 
@@ -490,7 +497,7 @@ impl Client {
                     .into_iter()
                     .map(|(id, range)| (id, shared.slice(range)))
                     .collect();
-                encoded_batch
+                (encoded_batch, pubkeys)
             })
             .await;
 
@@ -500,6 +507,7 @@ impl Client {
             // Propagate errors — uploading a key we can't store locally would cause
             // decryption failures when the server hands it out.
             backend.store_prekeys_batch(&encoded_batch, false).await?;
+            fresh_pre_keys = generated;
         }
 
         // Advance NEXT at GENERATION time (WA Web savePreKeys) and initialise
@@ -522,57 +530,64 @@ impl Client {
             .await
             .map_err(|e| anyhow::anyhow!("failed to flush prekey watermarks: {e:?}"))?;
 
-        // Load the upload window: leftover keys plus the fresh ones. Gaps are
-        // tolerated (a window key consumed via a retry receipt leaves a hole).
-        let window_ids: Vec<u32> = (0..wanted as u32).map(|i| plan.window_start + i).collect();
-        let mut rows = backend.load_prekeys_batch(&window_ids).await?;
-        rows.sort_unstable_by_key(|(id, _)| *id);
-        if rows.is_empty() {
-            // A fully consumed/missing window with no generation would bail
-            // forever (available > 0 keeps gen_count at 0). Collapse the
-            // window and rerun the pass so a one-shot caller still uploads.
-            if plan.gen_count == 0 {
-                self.persistence_manager
-                    .process_command(DeviceCommand::SetPreKeyWatermarks {
-                        next_pre_key_id: plan.new_next,
-                        first_unupload_pre_key_id: plan.new_next,
-                    })
-                    .await;
-                if allow_collapse_retry {
-                    log::warn!(
-                        "prekey window [{}, {}) fully missing; collapsed, regenerating",
-                        plan.window_start,
-                        plan.new_next
-                    );
-                    return Box::pin(self.upload_pre_keys_pass(false)).await;
-                }
+        // Only the leftover (already-stored) window keys are read back and decoded;
+        // the fresh ones are already in `fresh_pre_keys`. On the common connect path
+        // the window is all-fresh, so this reads and decodes nothing. Leftover gaps
+        // are tolerated (a window key consumed via a retry receipt leaves a hole).
+        let leftover_ids: Vec<u32> = (0..plan.available).map(|i| plan.window_start + i).collect();
+        let mut leftover_rows = if leftover_ids.is_empty() {
+            Vec::new()
+        } else {
+            backend.load_prekeys_batch(&leftover_ids).await?
+        };
+        leftover_rows.sort_unstable_by_key(|(id, _)| *id);
+
+        if plan.gen_count == 0 && leftover_rows.is_empty() {
+            // A fully consumed/missing leftover window with no generation would bail
+            // forever (available > 0 keeps gen_count at 0). Collapse the window and
+            // rerun the pass so a one-shot caller still uploads.
+            self.persistence_manager
+                .process_command(DeviceCommand::SetPreKeyWatermarks {
+                    next_pre_key_id: plan.new_next,
+                    first_unupload_pre_key_id: plan.new_next,
+                })
+                .await;
+            if allow_collapse_retry {
+                log::warn!(
+                    "prekey window [{}, {}) fully missing; collapsed, regenerating",
+                    plan.window_start,
+                    plan.new_next
+                );
+                return Box::pin(self.upload_pre_keys_pass(false)).await;
             }
             anyhow::bail!("no prekey available to upload");
         }
 
         let pre_key_pairs = {
-            let mut pairs: Vec<(u32, PublicKey)> = Vec::with_capacity(rows.len());
-            for (id, record) in &rows {
-                // Pull the public key straight out of the encoded record (field 2)
-                // rather than a full prost decode of the PreKeyRecordStructure: the
-                // upload only needs the public key, while a full decode also copies
-                // the private key into its own Vec. At the default batch of 812 keys
-                // that is ~2 throwaway allocations per record on the connect path.
-                // The extractor validates the record framing, so a malformed record
-                // returns None and is skipped here — same rejection the consume path
-                // (`get_pre_key`'s full decode) makes, so we never upload a key this
-                // device couldn't later decode with.
-                let public_key = match wacore::prekeys::extract_prekey_public_key(record) {
-                    Some(raw) => {
-                        PublicKey::from_djb_public_key_bytes(raw).map_err(anyhow::Error::from)
-                    }
-                    None => Err(anyhow::anyhow!("record missing or malformed public key")),
-                };
+            let mut pairs: Vec<(u32, PublicKey)> =
+                Vec::with_capacity(leftover_rows.len() + fresh_pre_keys.len());
+            // Leftover keys live only in the store, so decode them in full — the same
+            // `PreKeyRecordStructure::decode` the consume path runs, so a record
+            // accepted here is one this device can later decrypt with. Fresh keys skip
+            // decode entirely; their public keys never left memory.
+            use prost::Message;
+            for (id, record) in &leftover_rows {
+                let public_key = waproto::whatsapp::PreKeyRecordStructure::decode(&record[..])
+                    .map_err(anyhow::Error::from)
+                    .and_then(|s| {
+                        let raw = s
+                            .public_key
+                            .ok_or_else(|| anyhow::anyhow!("record missing public key"))?;
+                        PublicKey::from_djb_public_key_bytes(&raw).map_err(anyhow::Error::from)
+                    });
                 match public_key {
                     Ok(public_key) => pairs.push((*id, public_key)),
                     Err(e) => log::warn!("skipping undecodable prekey record {id}: {e:?}"),
                 }
             }
+            // Fresh ids exceed every leftover id and were generated in ascending
+            // order, so appending keeps `pairs` sorted (last_id reads the tail).
+            pairs.extend(fresh_pre_keys);
             if pairs.is_empty() {
                 anyhow::bail!("no decodable prekey available to upload");
             }

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -443,6 +443,22 @@ mod tests {
         let truncated = &record[..record.len() - 1];
         assert!(waproto::whatsapp::PreKeyRecordStructure::decode(truncated).is_err());
         assert_eq!(extract_prekey_public_key(truncated), None);
+
+        // A malformed varint in a trailing field (10 continuation bytes that never
+        // terminate): a full decode errors on the bad varint, and the extractor
+        // agrees even though a valid publicKey precedes it.
+        let mut bad_varint = record.clone();
+        bad_varint.push(0x08); // field 1, wire type 0 (varint)
+        bad_varint.extend_from_slice(&[0xFF; 10]);
+        assert!(waproto::whatsapp::PreKeyRecordStructure::decode(&bad_varint[..]).is_err());
+        assert_eq!(extract_prekey_public_key(&bad_varint), None);
+
+        // An unsupported wire type (3 = start group): prost rejects the dangling
+        // group, and the extractor rejects every wire type it cannot frame.
+        let mut bad_wire = record.clone();
+        bad_wire.push(0x0B); // field 1, wire type 3 (start group)
+        assert!(waproto::whatsapp::PreKeyRecordStructure::decode(&bad_wire[..]).is_err());
+        assert_eq!(extract_prekey_public_key(&bad_wire), None);
     }
 
     fn create_mock_bundle(device_id: u32) -> PreKeyBundle {

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -28,9 +28,16 @@ pub fn compute_key_bundle_digest(
     hasher.finalize().to_vec()
 }
 
-/// Extract the `publicKey` field (tag 2) from a protobuf-encoded PreKeyRecordStructure
-/// without full prost decode. Uses last-one-wins semantics per protobuf spec.
-/// Skips unknown fields gracefully.
+/// Extract the `publicKey` field (tag 2) from a protobuf-encoded
+/// PreKeyRecordStructure without a full prost decode.
+///
+/// Validates the record framing end-to-end: a malformed varint, a truncated
+/// length-delimited/fixed field, or an unsupported wire type (e.g. the
+/// deprecated group types) yields `None` — the same records a full
+/// `PreKeyRecordStructure::decode` rejects. This keeps callers that skip on
+/// `None` (the pre-key upload and the digestKey check) from admitting a record
+/// this device could not later decode. Uses last-one-wins semantics for a
+/// repeated `publicKey` field, per the protobuf spec.
 pub fn extract_prekey_public_key(record: &[u8]) -> Option<&[u8]> {
     let mut pos = 0;
     let mut result: Option<&[u8]> = None;
@@ -51,7 +58,7 @@ pub fn extract_prekey_public_key(record: &[u8]) -> Option<&[u8]> {
                 pos += c;
                 let len = len as usize;
                 if pos + len > record.len() {
-                    return result;
+                    return None;
                 }
                 if field_number == 2 {
                     result = Some(&record[pos..pos + len]);
@@ -61,19 +68,19 @@ pub fn extract_prekey_public_key(record: &[u8]) -> Option<&[u8]> {
             // fixed64
             1 => {
                 if pos + 8 > record.len() {
-                    return result;
+                    return None;
                 }
                 pos += 8;
             }
             // fixed32
             5 => {
                 if pos + 4 > record.len() {
-                    return result;
+                    return None;
                 }
                 pos += 4;
             }
-            // Unknown wire type -- skip gracefully
-            _ => return result,
+            // Unsupported / invalid wire type (groups, reserved): reject the record.
+            _ => return None,
         }
     }
     result
@@ -411,6 +418,32 @@ mod tests {
     use crate::protocol::ProtocolNode;
 
     use wacore_binary::NodeValue;
+
+    #[test]
+    fn extract_prekey_public_key_matches_full_decode_validation() {
+        use prost::Message;
+        let public_key = vec![0x05u8; 33];
+        let record = waproto::whatsapp::PreKeyRecordStructure {
+            id: Some(1),
+            public_key: Some(public_key.clone()),
+            private_key: Some(vec![0x09u8; 32]),
+        }
+        .encode_to_vec();
+
+        // Well-formed record: the extractor returns the public key.
+        assert_eq!(
+            extract_prekey_public_key(&record),
+            Some(public_key.as_slice())
+        );
+
+        // Truncating into the trailing private_key field leaves a valid publicKey
+        // earlier in the buffer but a malformed tail. A full prost decode rejects
+        // it; the extractor must agree (return None) so the upload path never ships
+        // a record the consume path's full decode would later reject.
+        let truncated = &record[..record.len() - 1];
+        assert!(waproto::whatsapp::PreKeyRecordStructure::decode(truncated).is_err());
+        assert_eq!(extract_prekey_public_key(truncated), None);
+    }
 
     fn create_mock_bundle(device_id: u32) -> PreKeyBundle {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();


### PR DESCRIPTION
## What
A profile-guided allocation trim on the connect/registration path. `upload_pre_keys_pass` was running a full `PreKeyRecordStructure::decode` (prost) on **every** stored record just to read the public key for the upload IQ — and a full decode also allocates a throwaway copy of the private key the upload never touches. On a fresh registration that means 812 records decoded straight back out of the store, immediately after being written to it.

Now the pass carries the public keys **straight out of generation**: it already mints the keypairs in its blocking offload, so it keeps their public keys in hand and uploads those directly — the freshly generated keys are never written-then-reloaded-and-decoded. Only the rare *leftover* (already-stored, not-yet-uploaded) window keys are read back, and those go through the full `PreKeyRecordStructure::decode` — the exact same call the consume path (`Device::load_prekey`) uses — with any record that fails to decode skipped (warn), not uploaded.

## Why
Profiling `connect_to_ready` on CodSpeed (the run from #898) shows connect is dominated by generating + uploading the one-time pre-key batch on a fresh registration. Two parts:
- **The X25519 keygen (~63% of the simulation)** — intentional WA Web fidelity (`DEFAULT_WANTED_PRE_KEY_COUNT = 812`, mirroring `WAWebUploadPreKeysJob`). **Left untouched** — real, required crypto, not waste.
- **The store round-trip + full-decode on upload** — pure overhead on a fresh registration, since the records being reloaded and decoded are the ones the same call just generated. Eliminated: the fresh public keys are carried in memory, so for the common fresh-registration case there is no store reload and no decode at all (~2 throwaway `Vec` allocations per record × 812 ≈ 1,600 fewer allocations, plus 812 fewer store reads).

## Safety / behavior
The upload and consume paths now parse stored records with the **same** `PreKeyRecordStructure::decode`, so they can no longer disagree about which records are valid — a record that fails to decode is skipped on upload exactly as `Device::load_prekey` would reject it on consume.

An earlier revision of this PR read the public key with a hand-rolled byte scan (`extract_prekey_public_key`); that helper is now **off** the upload path entirely. It survives only on the digestKey path (`validate_digest_key`, a local hash compare that skips on mismatch and never uploads), where this PR also tightens its framing validation (rejects truncated length-delimited/fixed fields and unsupported wire types) and adds malformed-varint + wire-type 3/4 test coverage.

Ordering is preserved: leftovers (sorted) precede the fresh keys, and the plan guarantees every fresh id is greater than every leftover id, so the assembled batch stays globally sorted and `last_id` stays correct.

## Verification
- `cargo fmt --all` / `cargo clippy --all --tests` — clean
- `cargo test -p whatsapp-rust --lib prekeys` — 16 tests pass, including the `window_tests` that drive `upload_pre_keys_pass` against a mock backend (upload-window, retry-single-key, collapse/regenerate paths)
- `cargo test -p wacore prekeys` — extractor framing tests, including the malformed-record / full-decode-parity cases
- CodSpeed will quantify the `connect_to_ready` Memory delta on this PR.

## Scope / follow-ups (intentionally not here)
- This targets allocation **count/volume**, not peak memory; peak is dominated by the 812 keygens plus holding the batch + encoded buffer, and would need streaming to move. No peak-memory claim until CodSpeed measures it.