### PR TITLE
perf(prekeys): stream prekey generation to cut the connect-time peak

### DIFF
--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -473,13 +473,14 @@ impl Client {
                 // Seed one CSPRNG and advance it per key, rather than reseeding from
                 // entropy on every iteration.
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-                // Encode each record into the shared buffer and drop it immediately, so
-                // the full batch of PreKeyRecordStructures (each owning two heap Vecs for
-                // its key bytes) is never resident at once — that batch was the dominant
-                // controllable peak on the connect path. A record is at most 73 wire bytes
-                // (id field <=5B + two 34B key fields), so reserving by that bound keeps
-                // the buffer at a single allocation.
-                const MAX_RECORD_LEN: usize = 73;
+                // Encode each record into the shared buffer and drop it immediately so the
+                // whole batch of PreKeyRecordStructures (each owns two heap Vecs of key bytes)
+                // is never resident at once — that batch was the dominant controllable peak on
+                // the connect path. MAX_RECORD_LEN keeps the buffer to a single allocation;
+                // being just a capacity hint, it uses the type-level upper bound (1-byte id
+                // tag + <=5-byte u32 varint + two 34 B key fields = 74) rather than depending
+                // on the tighter 24-bit id cap.
+                const MAX_RECORD_LEN: usize = 74;
                 let mut pubkeys = Vec::with_capacity(gen_count);
                 let mut offsets = Vec::with_capacity(gen_count);
                 let mut buf = Vec::with_capacity(gen_count * MAX_RECORD_LEN);

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -473,24 +473,25 @@ impl Client {
                 // Seed one CSPRNG and advance it per key, rather than reseeding from
                 // entropy on every iteration.
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-                let mut records = Vec::with_capacity(gen_count);
+                // Encode each record into the shared buffer and drop it immediately, so
+                // the full batch of PreKeyRecordStructures (each owning two heap Vecs for
+                // its key bytes) is never resident at once — that batch was the dominant
+                // controllable peak on the connect path. A record is at most 73 wire bytes
+                // (id field <=5B + two 34B key fields), so reserving by that bound keeps
+                // the buffer at a single allocation.
+                const MAX_RECORD_LEN: usize = 73;
                 let mut pubkeys = Vec::with_capacity(gen_count);
+                let mut offsets = Vec::with_capacity(gen_count);
+                let mut buf = Vec::with_capacity(gen_count * MAX_RECORD_LEN);
                 for i in 0..gen_count {
                     let pre_key_id = gen_start + i as u32;
                     let key_pair = KeyPair::generate(&mut rng);
-                    pubkeys.push((pre_key_id, key_pair.public_key));
-                    records.push((pre_key_id, new_pre_key_record(pre_key_id, &key_pair)));
-                }
-
-                let total_len: usize = records.iter().map(|(_, r)| r.encoded_len()).sum();
-                let mut buf = Vec::with_capacity(total_len);
-                let mut offsets = Vec::with_capacity(records.len());
-                for (id, record) in &records {
                     let start = buf.len();
-                    record
+                    new_pre_key_record(pre_key_id, &key_pair)
                         .encode(&mut buf)
                         .expect("prost encode into pre-sized Vec");
-                    offsets.push((*id, start..buf.len()));
+                    offsets.push((pre_key_id, start..buf.len()));
+                    pubkeys.push((pre_key_id, key_pair.public_key));
                 }
                 let shared = bytes::Bytes::from(buf);
                 let encoded_batch: Vec<(u32, bytes::Bytes)> = offsets


### PR DESCRIPTION
## What
Follow-up to #900. `upload_pre_keys_pass` generates the one-time pre-key batch (812 keys by default, WA Web fidelity) in a blocking offload, then carries their public keys to the upload IQ. That offload built **all** the records up front — a `Vec<(u32, PreKeyRecordStructure)>` where every record owns two heap `Vec`s (public + private key bytes) — so the whole batch sat resident at once, alongside the public keys and the encoded buffer, just to be encoded and dropped immediately after.

Encode each record straight into the shared batch buffer and drop it in the same iteration, keeping only its public key:

- No collective `records` Vec — at most one `PreKeyRecordStructure` is live at a time.
- The buffer is pre-sized by the 73-byte max record length (id field ≤5 B + two 34 B key fields) so it stays a single allocation, instead of relying on an up-front `encoded_len()` sum over the full materialized batch.

## Why
#900 cut allocation count/volume on the connect path by carrying generated public keys to the upload instead of reloading + decoding them, but it left the records batch fully materialized during generation — the dominant *controllable* contributor to `connect_to_ready`'s peak memory (the irreducible part being the 812 X25519 keygens themselves). Removing that batch's residency targets peak directly while preserving #900's allocation win.

## Verification
- `cargo fmt --all` / `cargo clippy -p whatsapp-rust --lib --tests` — clean
- `cargo test -p whatsapp-rust --lib prekeys` — 16 tests pass, including the `window_tests` that drive `upload_pre_keys_pass` against a mock backend (upload-window, retry-single-key, collapse/regenerate)
- Wire output is unchanged: the encoded records and the upload IQ are byte-identical; only the order of construction (and what stays resident) changes.
- CodSpeed will quantify the `connect_to_ready` peak-memory delta on this PR.

## Scope
Generation-phase only. The upload itself stays a single batched IQ (WA Web `WAWebUploadPreKeysJob`), and the public keys + final encoded frame are still resident at send time — that floor is inherent to the protocol and small.

---
_Generated by [Claude Code](https://claude.ai/code/session_014VC9pPVwJqgcic3KEn4y98)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

