### PR TITLE
bench(integration): cut CodSpeed variance with a fixed 2-worker runtime + deterministic allocator

### DIFF
--- a/tests/bench-integration/benches/integration.rs
+++ b/tests/bench-integration/benches/integration.rs
@@ -10,6 +10,7 @@
 // recursion limit; matches `src/lib.rs` and the e2e crate.
 #![recursion_limit = "512"]
 
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -17,13 +18,52 @@ use e2e_tests::{TestClient, text_msg};
 use tokio::sync::Mutex;
 use whatsapp_rust::Jid;
 
+// Deterministic allocator for CodSpeed's memory instrument: `realloc` always
+// allocates a fresh block and copies, never growing in place. Whether the system
+// allocator can grow in place depends on the live heap layout, which differs
+// run-to-run and would otherwise be charged to the benchmark as memory noise (the
+// CodSpeed `reducing-variance` recipe). Bench-only; production keeps the default.
+struct DeterministicAlloc;
+
+unsafe impl GlobalAlloc for DeterministicAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        unsafe {
+            let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
+            let new_ptr = System.alloc(new_layout);
+            if !new_ptr.is_null() {
+                std::ptr::copy_nonoverlapping(ptr, new_ptr, layout.size().min(new_size));
+                System.dealloc(ptr, layout);
+            }
+            new_ptr
+        }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: DeterministicAlloc = DeterministicAlloc;
+
 fn main() {
     divan::main();
 }
 
-// A single multi-thread runtime shared by every bench. Building one per
-// iteration would charge thread-pool startup syscalls to the measured region,
-// and the real client expects a multi-thread scheduler.
+// A single current-thread runtime shared by every bench. CodSpeed runs only the
+// Valgrind simulation+memory instruments, which serialize threads onto one core, so a
+// multi-thread scheduler buys no measurable signal — only variance, since its worker
+// count tracks the runner's CPU count (per-runner thread stacks + scheduling). The
+// client has no `block_in_place`, so current_thread drives it fine. Built once so
+// runtime startup isn't charged to the measured region.
 static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 fn rt() -> &'static tokio::runtime::Runtime {
@@ -33,10 +73,10 @@ fn rt() -> &'static tokio::runtime::Runtime {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
             .try_init()
             .ok();
-        tokio::runtime::Builder::new_multi_thread()
+        tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .expect("build multi-thread bench runtime")
+            .expect("build current-thread bench runtime")
     })
 }
 

--- a/tests/bench-integration/benches/integration.rs
+++ b/tests/bench-integration/benches/integration.rs
@@ -58,12 +58,13 @@ fn main() {
     divan::main();
 }
 
-// A single current-thread runtime shared by every bench. CodSpeed runs only the
-// Valgrind simulation+memory instruments, which serialize threads onto one core, so a
-// multi-thread scheduler buys no measurable signal — only variance, since its worker
-// count tracks the runner's CPU count (per-runner thread stacks + scheduling). The
-// client has no `block_in_place`, so current_thread drives it fine. Built once so
-// runtime startup isn't charged to the measured region.
+// A single multi-thread runtime pinned to a fixed worker count, shared by every
+// bench. The default worker count tracks the runner's CPU count, so thread stacks and
+// scheduling varied per runner; pinning it makes the benches runner-independent. A
+// fixed count rather than current_thread because the background event drainers
+// (connect_warmed_pair) must keep draining between divan samples to preserve
+// cross-sample isolation, and current_thread freezes spawned tasks outside block_on.
+// Built once so runtime startup isn't charged to the measured region.
 static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 fn rt() -> &'static tokio::runtime::Runtime {
@@ -73,10 +74,11 @@ fn rt() -> &'static tokio::runtime::Runtime {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
             .try_init()
             .ok();
-        tokio::runtime::Builder::new_current_thread()
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
             .enable_all()
             .build()
-            .expect("build current-thread bench runtime")
+            .expect("build bench runtime")
     })
 }
 


### PR DESCRIPTION
## Motivation

The integration benchmarks show run-to-run variance and trip CodSpeed's "Different runtime environments detected" warning (seen on #901, where `send_and_receive[20]` Memory and `send_message[20]` Simulation moved with no real code cause). This applies two techniques from CodSpeed's [reducing-variance](https://codspeed.io/docs/instruments/cpu/reducing-variance) and [regression-causes](https://codspeed.io/docs/instruments/cpu/regression-causes) guides, both scoped to the bench binary only — production code is untouched.

## Changes

**Fixed-size multi-thread runtime.** The default multi-thread runtime sizes its worker pool to the runner's CPU count, so thread-stack memory and scheduling varied per runner — a source of the cross-environment noise. The shared runtime is now pinned to a fixed `worker_threads(2)`, making the benches runner-independent.

> _Iteration note:_ the first commit used `new_current_thread()` for maximum determinism, but its CodSpeed run surfaced a real memory regression — with a current-thread runtime the background event drainers in `connect_warmed_pair` only advance inside `block_on`, so they freeze between divan samples and each sample's backlog leaks into the next (`send_message[20]` Memory 38.8 KB → 124.7 KB). A fixed 2-worker pool keeps those drainers running continuously between samples while still removing the per-runner thread-count variance. (Caught by Codex in review.)

**Deterministic global allocator (bench-only).** Added a `#[global_allocator]` whose `realloc` always allocates a fresh block and copies `min(old, new)` bytes instead of growing in place. Whether the system allocator can grow in place depends on the live heap layout, which varies run-to-run and was charged to the memory instrument as noise. Production keeps the system allocator.

## Expected effect

One-time re-baseline: the deterministic allocator may make the Memory number slightly higher but stable (the alloc+copy `realloc` has a transient old+new peak). After that step, variance should drop.

## Validation

- `cargo clippy -p bench-integration --benches` and `cargo fmt` clean.
- The `Run CodSpeed integration benchmarks` job passes — the client drives fine on the pinned runtime.
- Variance is validated by this PR's CodSpeed comparison.

## Out of scope (deferred)

Synchronous event draining in unmeasured setup (an alternative to the fixed pool), pinning the `bartender` mock image to a digest, and evaluating a dedicated CodSpeed runner — the last is the actual root cause of the cross-environment warning but is an infra/cost decision.