### PR TITLE
perf(send): skip the unused DeviceSentMessage plaintext on companion-less DMs

### DIFF
--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -1395,6 +1395,51 @@ mod device_sent_tests {
         }
     }
 
+    /// `prepare_dm_stanza` skips the DeviceSentMessage buffer (and its destination-jid
+    /// stringify) when there are no own companion devices, encoding the recipient via
+    /// `encode_and_pad_with_context` instead of `encode_dm_plaintexts`. That swap is only
+    /// sound while both agree on the recipient bytes for messages without a top-level
+    /// `message_context_info` — exactly the gate `prepare_dm_stanza` uses. Pin that
+    /// agreement (with and without a reporting context) so a change to either encoder
+    /// can't silently corrupt the no-own-device send path.
+    #[test]
+    fn recipient_only_encode_matches_dm_recipient_without_top_level_mci() {
+        let dest = "5511999998888:3@s.whatsapp.net";
+        let reporting_ctx = reporting_context(&[0x5Au8; 32]);
+
+        let shapes = [
+            wa::Message {
+                conversation: Some("ping".into()),
+                ..Default::default()
+            },
+            wa::Message {
+                image_message: Some(Box::new(wa::message::ImageMessage {
+                    url: Some("https://mmg.example/abc".into()),
+                    media_key: Some(vec![9u8; 32]),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+        ];
+
+        for message in shapes {
+            assert!(
+                message.message_context_info.is_none(),
+                "fast path only applies to messages without a top-level mci"
+            );
+            for extra in [None, Some(&reporting_ctx)] {
+                let recipient_only = MessageUtils::encode_and_pad_with_context(&message, extra);
+                let dm_recipient =
+                    MessageUtils::encode_dm_plaintexts(&message, extra, dest).recipient;
+                assert_eq!(
+                    decode_padded(&recipient_only),
+                    decode_padded(&dm_recipient),
+                    "recipient-only encode diverged from encode_dm_plaintexts ({message:?}, extra={extra:?})"
+                );
+            }
+        }
+    }
+
     /// `encode_and_pad_with_context` (the group path) with a reporting context must
     /// decode to `prepare_message_with_context(msg, secret)` encoded by prost; with
     /// `None` it must equal plain `encode_and_pad`.

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -80,15 +80,8 @@ pub async fn prepare_dm_stanza(
     // via prepare_message_with_context just to attach two fields.
     let extra_context = reporting_result.as_ref().map(reporting_context_info);
 
-    // Encode the shared content once and splice it into both the recipient
-    // plaintext and the own-device DeviceSentMessage plaintext, instead of encoding
-    // the message twice (recipient + DSM) and boxing it via wrap_device_sent.
-    let crate::messages::DmPlaintexts {
-        recipient: recipient_plaintext,
-        own_devices: own_devices_plaintext,
-    } = MessageUtils::encode_dm_plaintexts(message, extra_context.as_ref(), &to_jid.to_string());
-
-    // Partition first so phash reflects the actual sent set (sender excluded)
+    // Partition first so phash reflects the actual sent set (sender excluded) and so
+    // the own-device plaintext can be skipped when there's nothing to send it to.
     let total_devices = all_devices.len();
     let (recipient_devices, own_other_devices) =
         partition_dm_devices(all_devices, own_jid, own_lid);
@@ -97,6 +90,27 @@ pub async fn prepare_dm_stanza(
         recipient_devices.iter().chain(own_other_devices.iter()),
     )
     .ok();
+
+    // Encode the shared content once and splice it into both the recipient plaintext
+    // and the own-device DeviceSentMessage plaintext, instead of encoding the message
+    // twice (recipient + DSM) and boxing it via wrap_device_sent.
+    //
+    // With no own companion devices (e.g. an account with nothing else linked), the
+    // DeviceSentMessage plaintext — and the destination-jid stringify it needs — would
+    // be built only to go unused below, so encode just the recipient. The mci-hoist
+    // path (message carries a top-level message_context_info) keeps the exact shared
+    // splice so its on-wire recipient encoding is unchanged.
+    let crate::messages::DmPlaintexts {
+        recipient: recipient_plaintext,
+        own_devices: own_devices_plaintext,
+    } = if own_other_devices.is_empty() && message.message_context_info.is_none() {
+        crate::messages::DmPlaintexts {
+            recipient: MessageUtils::encode_and_pad_with_context(message, extra_context.as_ref()),
+            own_devices: Vec::new(),
+        }
+    } else {
+        MessageUtils::encode_dm_plaintexts(message, extra_context.as_ref(), &to_jid.to_string())
+    };
 
     let mut participant_nodes = Vec::with_capacity(total_devices);
     let mut includes_prekey_message = false;


### PR DESCRIPTION
## What

`prepare_dm_stanza` encoded **both** the recipient plaintext and the own-device
`DeviceSentMessage` (DSM) plaintext up front — but the DSM plaintext is only
consumed when the sender has other linked devices (`own_other_devices`
non-empty). For an account with nothing else linked — and every freshly-paired
client in the integration bench — that buffer, plus the `to_jid.to_string()`
stringify and a second full message encode + padding it needs, was built only to
be dropped.

This partitions the device set first, then encodes the recipient via the
existing `encode_and_pad_with_context`, skipping the DSM buffer entirely when
there are no own devices to send it to.

## Why it's safe

The swap relies on `encode_and_pad_with_context(msg)` producing the same
recipient bytes as `encode_dm_plaintexts(msg).recipient`. That was already
proven transitively — both are independently pinned to decode to
`prepare_message_with_context` (`group_encode_with_context_matches_prepare` and
`splice_with_reporting_context_matches_prepare`). The fast path is gated on the
message having **no top-level `message_context_info`**, so the mci-hoist
encoding (the only case where the recipient bytes differ on the wire) is left on
the original `encode_dm_plaintexts` path unchanged.

A new test (`recipient_only_encode_matches_dm_recipient_without_top_level_mci`)
pins that equivalence directly at the gate the fast path uses, with and without
a reporting context.

## Impact

Per companion-less DM send this drops one `String`, one `Vec` (content + pad), a
full message re-encode, and a padding pass. It's a modest, allocation-side win —
the remaining `malloc`/`free` on the path is largely intrinsic. The bench's
clients are single-device, so the fast path fires on every measured send in
`send_message[*]` / `send_and_receive[*]`; CodSpeed will show the real delta.

In production it applies to any account with no other linked devices; accounts
with companions fall through to the original (unchanged) shared-splice path.
