### PR TITLE
perf(send): share one message encode between the reporting token and DM plaintext

### DIFF
--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -63,6 +63,32 @@ impl MessageUtils {
         buf
     }
 
+    /// Same wire output as [`encode_and_pad_with_context`](Self::encode_and_pad_with_context)
+    /// but the message is already encoded into `content`. The DM send path shares one
+    /// encode between the reporting token (field extraction) and the wire plaintext, so
+    /// the shared bytes are spliced + padded here instead of re-encoding the message.
+    /// `content` must be the message's encoding with no reporting context spliced on (the
+    /// caller only takes this path when the message has no top-level message_context_info).
+    pub fn pad_with_context_from_encoded(
+        content: &[u8],
+        extra_context: Option<&wa::MessageContextInfo>,
+    ) -> Vec<u8> {
+        let pad = Self::random_pad_len();
+        let extra_len = extra_context.map_or(0, |c| {
+            len_delimited_len(
+                TAG_MESSAGE_CONTEXT_INFO,
+                waproto::codec::message_context_info_encoded_len(c),
+            )
+        });
+        let mut buf = Vec::with_capacity(content.len() + extra_len + pad as usize);
+        buf.extend_from_slice(content);
+        if let Some(c) = extra_context {
+            push_message_field(TAG_MESSAGE_CONTEXT_INFO, c, &mut buf);
+        }
+        buf.resize(buf.len() + pad as usize, pad);
+        buf
+    }
+
     /// Build both DM plaintexts (recipient and own-device DeviceSentMessage) from a
     /// single encode of the shared message content, splicing in the reporting-token
     /// `extra_context` (message_secret + reporting_token_version) without cloning the
@@ -147,6 +173,52 @@ impl MessageUtils {
         }
 
         // Finish the recipient now that its content has been spliced into own_devices.
+        if let Some(extra) = extra_context {
+            push_message_field(TAG_MESSAGE_CONTEXT_INFO, extra, &mut recipient);
+        }
+
+        DmPlaintexts {
+            recipient: Self::pad_message_v2(recipient),
+            own_devices: Self::pad_message_v2(own_devices),
+        }
+    }
+
+    /// Same wire output as [`encode_dm_plaintexts`](Self::encode_dm_plaintexts)'s common
+    /// (no top-level message_context_info) path, but the shared content is already encoded
+    /// into `content`. The DM send path reuses the single message encode it also feeds to
+    /// the reporting token, so the message is no longer encoded twice per send. `content`
+    /// must be the message's encoding with no reporting context spliced on.
+    pub fn dm_plaintexts_from_encoded(
+        content: &[u8],
+        extra_context: Option<&wa::MessageContextInfo>,
+        destination_jid: &str,
+    ) -> DmPlaintexts {
+        const MAX_PAD: usize = 16;
+
+        let mci_field_len = extra_context.map_or(0, |m| {
+            len_delimited_len(
+                TAG_MESSAGE_CONTEXT_INFO,
+                waproto::codec::message_context_info_encoded_len(m),
+            )
+        });
+        let content_len = content.len();
+        let dest = destination_jid.as_bytes();
+
+        let mut recipient = Vec::with_capacity(content_len + mci_field_len + MAX_PAD);
+        recipient.extend_from_slice(content);
+
+        let dsm_len = len_delimited_len(TAG_DSM_DESTINATION_JID, dest.len())
+            + len_delimited_len(TAG_DSM_MESSAGE, content_len);
+        let own_cap = len_delimited_len(TAG_DEVICE_SENT_MESSAGE, dsm_len) + mci_field_len + MAX_PAD;
+        let mut own_devices = Vec::with_capacity(own_cap);
+        push_varint((TAG_DEVICE_SENT_MESSAGE << 3) | 2, &mut own_devices); // field 31 key
+        push_varint(dsm_len as u64, &mut own_devices); // DeviceSentMessage length
+        push_len_delimited(TAG_DSM_DESTINATION_JID, dest, &mut own_devices);
+        push_len_delimited(TAG_DSM_MESSAGE, content, &mut own_devices);
+        if let Some(extra) = extra_context {
+            push_message_field(TAG_MESSAGE_CONTEXT_INFO, extra, &mut own_devices);
+        }
+
         if let Some(extra) = extra_context {
             push_message_field(TAG_MESSAGE_CONTEXT_INFO, extra, &mut recipient);
         }
@@ -1435,6 +1507,68 @@ mod device_sent_tests {
                     decode_padded(&recipient_only),
                     decode_padded(&dm_recipient),
                     "recipient-only encode diverged from encode_dm_plaintexts ({message:?}, extra={extra:?})"
+                );
+            }
+        }
+    }
+
+    /// The `_from_encoded` encoders let the DM send path reuse the single message encode
+    /// it also feeds to the reporting token. They must produce byte-identical wire output
+    /// (modulo random padding) to re-encoding the message via `encode_and_pad_with_context`
+    /// / `encode_dm_plaintexts`, or the shared-encode send path would corrupt the payload.
+    /// Their precondition is a message with no top-level mci, so only those shapes apply.
+    #[test]
+    fn from_encoded_encoders_match_reencoding_without_top_level_mci() {
+        let dest = "5511999998888:3@s.whatsapp.net";
+        let reporting_ctx = reporting_context(&[0x5Au8; 32]);
+
+        let unpad = |b: &[u8]| MessageUtils::unpad_message_ref(b, 2).unwrap().to_vec();
+
+        let shapes = [
+            wa::Message {
+                conversation: Some("ping".into()),
+                ..Default::default()
+            },
+            wa::Message {
+                conversation: Some("héllo 🚀 ".repeat(500)),
+                ..Default::default()
+            },
+            wa::Message {
+                image_message: Some(Box::new(wa::message::ImageMessage {
+                    url: Some("https://mmg.example/abc".into()),
+                    media_key: Some(vec![9u8; 32]),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+        ];
+
+        for message in shapes {
+            assert!(
+                message.message_context_info.is_none(),
+                "the _from_encoded path only applies to messages without a top-level mci"
+            );
+            let content = waproto::codec::message_to_vec(&message);
+            for extra in [None, Some(&reporting_ctx)] {
+                assert_eq!(
+                    unpad(&MessageUtils::pad_with_context_from_encoded(
+                        &content, extra
+                    )),
+                    unpad(&MessageUtils::encode_and_pad_with_context(&message, extra)),
+                    "pad_with_context_from_encoded diverged ({message:?}, extra={extra:?})"
+                );
+
+                let from_encoded = MessageUtils::dm_plaintexts_from_encoded(&content, extra, dest);
+                let reencoded = MessageUtils::encode_dm_plaintexts(&message, extra, dest);
+                assert_eq!(
+                    unpad(&from_encoded.recipient),
+                    unpad(&reencoded.recipient),
+                    "dm_plaintexts_from_encoded recipient diverged ({message:?}, extra={extra:?})"
+                );
+                assert_eq!(
+                    unpad(&from_encoded.own_devices),
+                    unpad(&reencoded.own_devices),
+                    "dm_plaintexts_from_encoded own_devices diverged ({message:?}, extra={extra:?})"
                 );
             }
         }

--- a/wacore/src/reporting_token.rs
+++ b/wacore/src/reporting_token.rs
@@ -569,6 +569,41 @@ pub fn generate_reporting_token(
     remote_jid: &Jid,
     existing_secret: Option<&[u8]>,
 ) -> Option<ReportingTokenResult> {
+    // Message types that carry no reporting token (reactions, poll votes, keep-in-chat)
+    // bail before encoding the message / minting a secret / deriving the key: the field
+    // extraction below would return None and discard all of it.
+    if !should_include_reporting_token(message) {
+        return None;
+    }
+    let encoded = waproto::codec::message_to_vec(message);
+    generate_reporting_token_from_encoded(
+        message,
+        &encoded,
+        stanza_id,
+        sender_jid,
+        remote_jid,
+        existing_secret,
+    )
+}
+
+/// Like [`generate_reporting_token`] but reuses `encoded_message` (the protobuf encoding
+/// of `message`, with no reporting context spliced on) instead of encoding `message`
+/// again. The DM send path encodes the message once for the wire plaintext and threads
+/// those same bytes here, so a token-bearing DM no longer encodes its message a second
+/// time per send just to extract the token's whitelisted fields.
+pub fn generate_reporting_token_from_encoded(
+    message: &wa::Message,
+    encoded_message: &[u8],
+    stanza_id: &str,
+    sender_jid: &Jid,
+    remote_jid: &Jid,
+    existing_secret: Option<&[u8]>,
+) -> Option<ReportingTokenResult> {
+    if !should_include_reporting_token(message) {
+        return None;
+    }
+    let content = extract_reporting_token_content(encoded_message, REPORTING_FIELDS)?;
+
     let message_secret: [u8; MESSAGE_SECRET_SIZE] = if let Some(secret) = existing_secret {
         if secret.len() != MESSAGE_SECRET_SIZE {
             log::warn!("Invalid existing secret size, generating new one");
@@ -587,7 +622,6 @@ pub fn generate_reporting_token(
         derive_reporting_token_key(&message_secret, stanza_id, &sender_jid_str, &remote_jid_str)
             .ok()?;
 
-    let content = generate_reporting_token_content(message)?;
     let token = calculate_reporting_token(&key, &content).ok()?;
 
     Some(ReportingTokenResult {
@@ -935,6 +969,60 @@ mod tests {
         )
         .expect("valid message with existing secret should generate token");
         assert_eq!(result.message_secret, existing_secret);
+    }
+
+    #[test]
+    fn from_encoded_matches_generate_and_skips_excluded_types() {
+        let sender = Jid::pn("5511999887766");
+        let remote = Jid::pn("5511888776655");
+        let secret = [0x5Au8; MESSAGE_SECRET_SIZE];
+
+        // Token-bearing message: feeding the message's own encoding to the _from_encoded
+        // variant yields the same token the all-in-one path derives — the contract the DM
+        // send path relies on when it shares one encode between the token and the plaintext.
+        let message = wa::Message {
+            conversation: Some("Test message".to_string()),
+            ..Default::default()
+        };
+        let encoded = waproto::codec::message_to_vec(&message);
+        let direct = generate_reporting_token(&message, "SID", &sender, &remote, Some(&secret))
+            .expect("token-bearing message");
+        let shared = generate_reporting_token_from_encoded(
+            &message,
+            &encoded,
+            "SID",
+            &sender,
+            &remote,
+            Some(&secret),
+        )
+        .expect("token-bearing message");
+        assert_eq!(direct.reporting_token, shared.reporting_token);
+        assert_eq!(direct.message_secret, shared.message_secret);
+
+        // Excluded type (reaction): both paths bail before extraction/secret/key (the
+        // reorder makes that skip explicit) and return None.
+        let reaction = wa::Message {
+            reaction_message: Some(Box::new(wa::message::ReactionMessage {
+                text: Some("👍".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let reaction_encoded = waproto::codec::message_to_vec(&reaction);
+        assert!(
+            generate_reporting_token(&reaction, "SID", &sender, &remote, Some(&secret)).is_none()
+        );
+        assert!(
+            generate_reporting_token_from_encoded(
+                &reaction,
+                &reaction_encoded,
+                "SID",
+                &sender,
+                &remote,
+                Some(&secret)
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -7,7 +7,8 @@ use crate::libsignal::protocol::{
 use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::messages::MessageUtils;
 use crate::reporting_token::{
-    build_reporting_node, generate_reporting_token, reporting_context_info,
+    build_reporting_node, generate_reporting_token, generate_reporting_token_from_encoded,
+    reporting_context_info,
 };
 use crate::runtime::{AbortHandle, Runtime};
 use crate::types::jid::JidExt;

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -61,19 +61,34 @@ pub async fn prepare_dm_stanza(
     extra_stanza_nodes: &[Node],
     all_devices: Vec<Jid>,
 ) -> Result<PreparedDmStanza> {
+    // Encode the message once and thread those bytes through both the reporting token
+    // (whitelisted-field extraction) and the wire plaintext below, instead of encoding it
+    // twice per send. The rare mci-hoist path (message carries a top-level
+    // message_context_info) can't share: its plaintext folds the reporting secret into the
+    // existing mci, diverging from the bytes the token is computed over, so it re-encodes.
+    let shared_content = message
+        .message_context_info
+        .is_none()
+        .then(|| waproto::codec::message_to_vec(message));
+
     // sender is the author's own jid, remote is the chat jid (WAWebReportingTokenUtils:
     // getSender vs e.to). Both previously used to_jid, conflating sender with remote.
     // Reuse the message's own secret when the caller set one (e.g. polls), instead of
     // minting a fresh one that would overwrite it: WA Web derives the reporting token
     // from the message's existing messageSecret (`p ?? e.messageSecret`), and a poll's
     // creator must keep the secret that ends up on the wire to decrypt later votes.
-    let reporting_result = generate_reporting_token(
-        message,
-        &request_id,
-        own_jid,
-        &to_jid,
-        crate::reporting_token::extract_message_secret(message),
-    );
+    let existing_secret = crate::reporting_token::extract_message_secret(message);
+    let reporting_result = match &shared_content {
+        Some(content) => generate_reporting_token_from_encoded(
+            message,
+            content,
+            &request_id,
+            own_jid,
+            &to_jid,
+            existing_secret,
+        ),
+        None => generate_reporting_token(message, &request_id, own_jid, &to_jid, existing_secret),
+    };
 
     // The reporting token's MessageContextInfo (message_secret + version) is spliced
     // straight onto the encoded plaintexts instead of deep-cloning the whole message
@@ -91,25 +106,27 @@ pub async fn prepare_dm_stanza(
     )
     .ok();
 
-    // Encode the shared content once and splice it into both the recipient plaintext
-    // and the own-device DeviceSentMessage plaintext, instead of encoding the message
-    // twice (recipient + DSM) and boxing it via wrap_device_sent.
-    //
-    // With no own companion devices (e.g. an account with nothing else linked), the
-    // DeviceSentMessage plaintext — and the destination-jid stringify it needs — would
-    // be built only to go unused below, so encode just the recipient. The mci-hoist
-    // path (message carries a top-level message_context_info) keeps the exact shared
-    // splice so its on-wire recipient encoding is unchanged.
+    // Splice the shared content into the recipient plaintext and, when present, the
+    // own-device DeviceSentMessage plaintext. With no own companion devices (e.g. an
+    // account with nothing else linked), the DSM plaintext — and the destination-jid
+    // stringify it needs — would be built only to go unused, so encode just the recipient.
+    // The mci-hoist path re-encodes via `encode_dm_plaintexts` (see `shared_content`).
     let crate::messages::DmPlaintexts {
         recipient: recipient_plaintext,
         own_devices: own_devices_plaintext,
-    } = if own_other_devices.is_empty() && message.message_context_info.is_none() {
-        crate::messages::DmPlaintexts {
-            recipient: MessageUtils::encode_and_pad_with_context(message, extra_context.as_ref()),
+    } = match &shared_content {
+        Some(content) if own_other_devices.is_empty() => crate::messages::DmPlaintexts {
+            recipient: MessageUtils::pad_with_context_from_encoded(content, extra_context.as_ref()),
             own_devices: Vec::new(),
+        },
+        Some(content) => MessageUtils::dm_plaintexts_from_encoded(
+            content,
+            extra_context.as_ref(),
+            &to_jid.to_string(),
+        ),
+        None => {
+            MessageUtils::encode_dm_plaintexts(message, extra_context.as_ref(), &to_jid.to_string())
         }
-    } else {
-        MessageUtils::encode_dm_plaintexts(message, extra_context.as_ref(), &to_jid.to_string())
     };
 
     let mut participant_nodes = Vec::with_capacity(total_devices);


### PR DESCRIPTION
## What

Two wasted-work cuts in the reporting-token path, which runs on every DM. Same "skip work the common case throws away" shape as #903.

### 1. Share one message encode (dedup)

A token-bearing DM encoded its message **twice** per send:

- once inside `generate_reporting_token` (`message_to_vec`, to extract the token's whitelisted fields), and
- once for the wire plaintext (`encode_and_pad_with_context` / `encode_dm_plaintexts`).

Now `prepare_dm_stanza` encodes the message **once** and threads those bytes through both:

- `generate_reporting_token_from_encoded` extracts the token fields from the shared bytes, and
- `pad_with_context_from_encoded` / `dm_plaintexts_from_encoded` splice the reporting context + pad onto the shared bytes instead of re-encoding the message.

The rare **mci-hoist path** (message carries a top-level `message_context_info`, e.g. a forward or a poll with a caller-set secret) can't share: its plaintext folds the reporting secret into the existing mci, diverging from the bytes the token is computed over — so it keeps the separate encodes via `encode_dm_plaintexts`.

### 2. Reorder `generate_reporting_token` (skip discarded work)

The message types that carry no reporting token (reactions, poll votes, keep-in-chat) used to generate a secret, stringify both JIDs, derive the HKDF key, and encode the message — then `generate_reporting_token_content` returned `None` at the end and discarded all of it. The `should_include_reporting_token` check now runs first, so those sends bail before any of that work. Benefits both the DM and group send paths automatically.

## Why it's correct

`message_to_vec` (`encode_to_vec`) and `message_encode_into` (`encode`) produce byte-identical output, so the shared bytes are exactly what the plaintext path would have re-encoded. The reorder is behavior-preserving: the result was already `None` for excluded types — only the wasted work before that `None` is removed.

## Tests

- `from_encoded_encoders_match_reencoding_without_top_level_mci` pins `pad_with_context_from_encoded` / `dm_plaintexts_from_encoded` **byte-for-byte** (via `unpad_message_ref`) against re-encoding through the existing encoders, for plain/unicode/media shapes, with and without a reporting context.
- `from_encoded_matches_generate_and_skips_excluded_types` pins the token contract (`_from_encoded` ≡ all-in-one given the message's own encoding) and the reorder returning `None` for reactions.
- Full suite: `cargo test -p wacore --lib` (997) + `whatsapp-rust` send tests (83) green; `cargo fmt` + `cargo clippy --all --tests` clean.

## Perf expectation

The **dedup** removes one full message encode per token-bearing DM, so it should show on the small-message send CodSpeed bench. The **reorder** doesn't move the text bench but removes real work from reactions/poll-votes (high frequency in production).

## Follow-up (not in this PR)

The group send path has the same double-encode (`group.rs` reporting token at ~149 + SKDM plaintext at ~445); deduping it means threading the shared bytes across the SKDM distribution logic. Left out to keep this focused on the DM hot path.

