### PR TITLE
perf(send): share one message encode between the group reporting token and skmsg plaintext

### DIFF
--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -142,17 +142,32 @@ pub async fn prepare_group_stanza(
         crate::types::message::AddressingMode::Pn => (own_jid.clone(), "pn"),
     };
 
-    // Generate reporting token if the message type supports it
+    // Encode the message once and thread those bytes through both the reporting token
+    // (whitelisted-field extraction) and the skmsg wire plaintext below, instead of
+    // encoding it twice per send. The rare mci-hoist path (message carries a top-level
+    // message_context_info) can't share: its plaintext folds the reporting secret into the
+    // existing mci, diverging from the bytes the token is computed over, so it re-encodes.
+    let shared_content = message
+        .message_context_info
+        .is_none()
+        .then(|| waproto::codec::message_to_vec(message));
+
+    // Generate reporting token if the message type supports it.
     // For groups, both sender_jid and remote_jid are the group JID (to_jid) per Baileys implementation.
     // Reuse the message's own secret when the caller set one (e.g. polls) instead of minting a fresh
     // one that would overwrite it, matching WA Web (the reporting token derives from messageSecret).
-    let reporting_result = generate_reporting_token(
-        message,
-        &request_id,
-        &to_jid,
-        &to_jid,
-        crate::reporting_token::extract_message_secret(message),
-    );
+    let existing_secret = crate::reporting_token::extract_message_secret(message);
+    let reporting_result = match &shared_content {
+        Some(content) => generate_reporting_token_from_encoded(
+            message,
+            content,
+            &request_id,
+            &to_jid,
+            &to_jid,
+            existing_secret,
+        ),
+        None => generate_reporting_token(message, &request_id, &to_jid, &to_jid, existing_secret),
+    };
 
     // The reporting token's MessageContextInfo (message_secret + version) is spliced
     // onto the encoded plaintext instead of deep-cloning the whole message via
@@ -442,7 +457,14 @@ pub async fn prepare_group_stanza(
         }
     }
 
-    let plaintext = MessageUtils::encode_and_pad_with_context(message, reporting_context.as_ref());
+    // Reuse the shared encode (also fed to the reporting token) for the skmsg plaintext
+    // instead of encoding the message a second time; the mci-hoist path re-encodes.
+    let plaintext = match &shared_content {
+        Some(content) => {
+            MessageUtils::pad_with_context_from_encoded(content, reporting_context.as_ref())
+        }
+        None => MessageUtils::encode_and_pad_with_context(message, reporting_context.as_ref()),
+    };
     let skmsg = encrypt_group_message(
         stores.sender_key_store,
         &sender_key_name,

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3035,6 +3035,113 @@ mod mark_full_distribution_list {
         );
     }
 
+    /// The group send shares one message encode between the reporting token and the skmsg
+    /// plaintext (gated on no top-level `message_context_info`). The byte-equivalence of
+    /// the shared-encode helpers is locked in `messages`/`reporting_token`; pin the
+    /// group-level wiring here: a token-bearing send still mints a secret and attaches the
+    /// `<reporting>` node via that path, while an excluded type (reaction) omits both.
+    #[tokio::test]
+    async fn group_send_attaches_reporting_token_via_shared_encode() {
+        let group: Jid = "120363000000000003@g.us".parse().unwrap();
+        let own_jid: Jid = "559900000000@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "100000000000000@lid".parse().unwrap();
+        let a: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let group_info =
+            GroupInfo::new(vec![own_jid.to_non_ad(), a.to_non_ad()], AddressingMode::Pn);
+
+        async fn prepare(
+            group: &Jid,
+            own_jid: &Jid,
+            own_lid: &Jid,
+            a: &Jid,
+            group_info: &GroupInfo,
+            msg: &wa::Message,
+            req: &str,
+        ) -> (wacore_binary::Node, bool) {
+            let (mut ss, mut is) = established_stores(a).await;
+            let mut sks = MemSenderKeyStore::default();
+            let mut pks = UnusedPreKeyStore;
+            let spks = UnusedSignedPreKeyStore;
+            let mut stores = SignalStores {
+                sender_key_store: &mut sks,
+                session_store: &mut ss,
+                identity_store: &mut is,
+                prekey_store: &mut pks,
+                signed_prekey_store: &spks,
+            };
+            let resolver = MockSendContextResolver::new();
+            let rt = TokioTestRuntime;
+            let prepared = prepare_group_stanza(
+                &rt,
+                &mut stores,
+                &resolver,
+                group_info,
+                own_jid,
+                own_lid,
+                None,
+                group.clone(),
+                msg,
+                req.into(),
+                false,
+                Some(vec![a.clone()]),
+                None,
+                None,
+                &[],
+            )
+            .await
+            .expect("prepare_group_stanza should succeed");
+            (prepared.node, prepared.message_secret.is_some())
+        }
+
+        // Token-bearing message → secret minted + <reporting> node carrying a token.
+        let text = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+        let (node, has_secret) = prepare(
+            &group,
+            &own_jid,
+            &own_lid,
+            &a,
+            &group_info,
+            &text,
+            "REQTEXT",
+        )
+        .await;
+        assert!(has_secret, "token-bearing send must mint a message secret");
+        let reporting = node
+            .get_optional_child("reporting")
+            .expect("token-bearing group send must carry a <reporting> node");
+        assert!(
+            reporting.get_optional_child("reporting_token").is_some(),
+            "reporting node must contain a reporting_token"
+        );
+
+        // Excluded type (reaction) → no secret, no <reporting> node.
+        let reaction = wa::Message {
+            reaction_message: Some(Box::new(wa::message::ReactionMessage {
+                text: Some("👍".into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let (node, has_secret) = prepare(
+            &group,
+            &own_jid,
+            &own_lid,
+            &a,
+            &group_info,
+            &reaction,
+            "REQREACT",
+        )
+        .await;
+        assert!(!has_secret, "excluded type must not mint a secret");
+        assert!(
+            node.get_optional_child("reporting").is_none(),
+            "excluded type must not carry a reporting node"
+        );
+    }
+
     /// Regression: the prekey fetch (network RTT) must run BEFORE the
     /// sender-key chain lock is taken, so concurrent sends to the same group
     /// don't serialize behind a slow fetch. The probe try_locks the actual


### PR DESCRIPTION
## What

The group-send follow-up to #904. A token-bearing **group** send encoded its message **twice** per send, the same waste #904 fixed for DMs:

- once inside `generate_reporting_token` (`message_to_vec`, to extract the token's whitelisted fields), and
- once for the skmsg wire plaintext (`encode_and_pad_with_context`).

`prepare_group_stanza` now encodes the message **once** (`shared_content`) and threads those bytes through both:

- `generate_reporting_token_from_encoded` extracts the token fields from the shared bytes, and
- `pad_with_context_from_encoded` splices the reporting context + pad onto the shared bytes instead of re-encoding the message.

The rare **mci-hoist path** (message carries a top-level `message_context_info`, e.g. a forward or a poll with a caller-set secret) can't share — its plaintext folds the reporting secret into the existing mci, diverging from the bytes the token is computed over — so it keeps the separate encode via `encode_and_pad_with_context`. Same gate (`message_context_info.is_none()`) the DM path uses.

The SKDM wrapper encode (`encode_and_pad(&skdm_wrapper_msg)`) is a *different* message and is untouched.

## Why it's correct

This reuses the exact `_from_encoded` helpers introduced in #904, whose **byte-for-byte equivalence** to re-encoding is already locked:

- `pad_with_context_from_encoded(message_to_vec(m), ctx)` ≡ `encode_and_pad_with_context(m, ctx)` — `from_encoded_encoders_match_reencoding_without_top_level_mci` (across plain/unicode/media shapes, with and without a reporting context).
- `generate_reporting_token_from_encoded(m, message_to_vec(m), …)` ≡ `generate_reporting_token(m, …)` — `from_encoded_matches_generate_and_skips_excluded_types`.

The change is a mechanical substitution of those locked equivalences, gated on the precondition the tests assert.

## Tests

- New `group_send_attaches_reporting_token_via_shared_encode` pins the **group-level wiring** at the `prepare_group_stanza` level (not previously covered): a token-bearing send mints a secret and attaches the `<reporting>` node via the shared encode, while an excluded type (reaction) omits both.
- Existing `prepare_group_stanza` tests (`failed_device_is_still_marked_has_key`, `prekey_fetch_runs_outside_chain_lock`) exercise the token-bearing path and still pass.
- Full suite: `cargo test -p wacore --lib` (998) + `whatsapp-rust --lib` (828) green; `cargo fmt` + `cargo clippy --all --tests` clean.

## Perf expectation

Removes one full message encode per token-bearing group send (the high-frequency case). Should show on the group-send memory bench the same way #904's DM dedup did (−10% on `bench_dm_send_encode_work[text_reply]`).

