### PR TITLE
ci(codspeed): drop the memory instrument from the integration benches

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -117,10 +117,17 @@ jobs:
           echo "Mock server failed to become ready"
           exit 1
 
-      # simulation and memory share the same instrumented build, so one
-      # build covers both instruments.
+      # Integration benches run only the simulation (instruction-count)
+      # instrument, NOT memory. send_and_receive drives a live async round-trip,
+      # whose in-flight pipeline buffers (TLS/websocket/noise/decrypt/dispatch)
+      # straddle divan sample boundaries, so its peakMemoryBytes tracked runner
+      # scheduling/CPU rather than code (freeCalls ~= 2x allocCalls; cross-CPU
+      # runs tripped a false memory regression on every send-path PR). Simulation
+      # counts are deterministic under Valgrind regardless of host CPU and stay a
+      # meaningful end-to-end signal; the deterministic memory signal lives in the
+      # single-threaded unit benches (other job), which keep the memory instrument.
       - name: Build the benchmark targets
-        run: cargo codspeed build -m simulation -m memory -p bench-integration
+        run: cargo codspeed build -m simulation -p bench-integration
 
       # `-p bench-integration` is required: `tests/bench-integration` is not a
       # workspace default-member, so a bare `cargo codspeed run` discovers no
@@ -131,5 +138,5 @@ jobs:
           MOCK_SERVER_URL: "wss://127.0.0.1:8080/ws/chat"
           RUST_LOG: warn
         with:
-          mode: simulation,memory
+          mode: simulation
           run: cargo codspeed run -p bench-integration


### PR DESCRIPTION
## Problem

CodSpeed's **memory** instrument flagged `send_and_receive[1]` on essentially every send-path PR (12.9 KB → 15.3 KB, *"Different runtime environments detected"*), forcing a manual acknowledge each time.

## Investigation

From `get_benchmark_result` (Memory mode), `freeCalls` ≈ **2× `allocCalls`** in every run — the measured window frees objects allocated **outside** it. `send_and_receive` drives a live async round-trip; its in-flight pipeline buffers (TLS / websocket / noise / decrypt / dispatch) straddle divan sample boundaries, so `peakMemoryBytes` (the gated metric) tracks *how many stragglers happen to overlap the measured window* — which shifts with runner scheduling and, most visibly, when base vs head land on different runner CPU models. Only `[1]` trips it (tiny baseline magnifies the swing; `[20]` amortizes, `send_message` has no receive side).

I first tried making the window self-contained by dropping the round-trip pair's background drainers and draining the event channels in unmeasured `with_inputs`. The before/after data showed it **did not work** — the `freeCalls/allocCalls` ratio stayed ~2.0 (base 744/368, fix 754/369) and the peak stayed in the noise band — because the stragglers are the client's internal pipeline buffers, not the `Arc<Event>`s I drained. So the per-sample peak of this benchmark isn't a signal worth gating on.

## Fix

Run **only the simulation (instruction-count) instrument** for the integration benches:

```diff
- cargo codspeed build -m simulation -m memory -p bench-integration
+ cargo codspeed build -m simulation -p bench-integration
  ...
- mode: simulation,memory
+ mode: simulation
```

Instruction counts are deterministic under Valgrind regardless of host CPU and stay a meaningful end-to-end signal. The **unit benches job keeps both instruments** — that's where the deterministic memory signal lives and where the send-path memory wins (#904/#905: `bench_dm_send_encode_work`, `bench_full_token_generation`) were actually measured. So we lose nothing actionable and remove a recurring false positive.

Workflow-only change; validated with a YAML parse. Supersedes the earlier self-contained-harness attempt on this branch (reverted).