### PR TITLE
perf(receipt): pre-size the offline-aggregation dedup map to avoid rehashing

### DIFF
--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -212,7 +212,12 @@ fn group_delivery_receipts<'a>(
         recipient: Option<&'a Jid>,
     }
 
-    let mut index: std::collections::HashMap<Key, usize> = std::collections::HashMap::new();
+    // Pre-sized to the receipt count so the per-group dedup map never rehashes
+    // mid-grow on a large offline backlog; it's dropped here, so the transient
+    // over-allocation when grouping is heavy never outlives the call. `groups` is
+    // returned and grouping can shrink it sharply, so it's left to grow.
+    let mut index: std::collections::HashMap<Key, usize> =
+        std::collections::HashMap::with_capacity(infos.len());
     let mut groups: Vec<DeliveryReceiptGroup> = Vec::new();
     for info in infos {
         let is_status = info.source.chat.is_status_broadcast();


### PR DESCRIPTION
## What

`group_delivery_receipts` aggregates buffered offline messages into one `<receipt>` per group (WA Web's `sendAggregateOfflineReceipts`). It walks the full receipt batch building a per-group dedup `HashMap<Key, usize>` keyed by the receipt-level attrs (`to` / participant / type / recipient).

The map was `HashMap::new()`, so on reconnect — when the batch can carry a large offline backlog — it rehashed repeatedly as it grew (each resize re-inserts every live entry). Pre-size it to the receipt count (`infos.len()`), an upper bound on the distinct keys, so it reaches its final capacity in one allocation.

The companion `groups` Vec is deliberately left growth-sized: it's the returned value and grouping can shrink it far below `infos.len()` (many messages collapse into a few chats), so pre-sizing it to the input count would leave an over-allocated Vec alive past the call. The map has no such issue — it's dropped when the function returns, so a heavy-grouping over-allocation is purely transient.

## Why it's correct

Pure pre-sizing: `HashMap::with_capacity(n)` is behavior-identical to `HashMap::new()` — same entries, same lookup/insert semantics, only the initial capacity differs. No logic, ordering, or key handling changes, and `infos.len()` is always ≥ the number of distinct keys, so the hint never under-sizes.

## Tests

No behavior to pin — covered by the existing receipt suite. `cargo test -p whatsapp-rust --lib receipt` (81) green; `cargo fmt --all` + `cargo clippy` clean.

## Impact

Removes the incremental rehashing of the dedup map on the reconnect / offline-aggregation path; the win scales with backlog size and is nil for the common small-batch case (the map already fit). Modest and allocation-side — the rest of the path was already lean.
