### PR TITLE
fix(atomics): use portable_atomic for 64-bit atomics + lint against std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ default-members = [
 # Force the wacore::time abstraction so WASM/deterministic-test builds don't
 # regress. Exceptions carry `#[allow(clippy::disallowed_methods)]` inline.
 disallowed_methods = "deny"
+# Ban std 64-bit atomic types: absent on 32-bit targets (Xtensa/ESP32). Use
+# portable_atomic. Host-only test/bench counters carry an inline allow.
+disallowed_types = "deny"
 
 [workspace.dependencies]
 # Shared dependencies

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,3 +4,11 @@ disallowed-methods = [
     { path = "std::time::SystemTime::now", reason = "use wacore::time::now_millis() / now_utc()" },
     { path = "std::time::Instant::now", reason = "use wacore::time::Instant::now()" },
 ]
+
+# 64-bit atomic *types*: 32-bit targets (Xtensa/ESP32) have no native AtomicU64/
+# AtomicI64, so they are absent from std/core there. portable_atomic provides a
+# transparent fallback. Host-only test/bench counters carry an inline allow.
+disallowed-types = [
+    { path = "std::sync::atomic::AtomicU64", reason = "use portable_atomic::AtomicU64 (no native 64-bit atomics on 32-bit targets like Xtensa/ESP32)" },
+    { path = "std::sync::atomic::AtomicI64", reason = "use portable_atomic::AtomicI64 (no native 64-bit atomics on 32-bit targets like Xtensa/ESP32)" },
+]

--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -36,8 +36,8 @@ mod tests {
         fail_clear_macs: Arc<Mutex<bool>>,
         // Call counters distinguishing the batched MAC prefetch from per-item
         // lookups, so tests can pin which path the processor takes.
-        singular_mac_calls: Arc<std::sync::atomic::AtomicU64>,
-        batch_mac_calls: Arc<std::sync::atomic::AtomicU64>,
+        singular_mac_calls: Arc<portable_atomic::AtomicU64>,
+        batch_mac_calls: Arc<portable_atomic::AtomicU64>,
     }
 
     // Implement SignalStore - Signal protocol cryptographic operations

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2828,7 +2828,9 @@ async fn terminal_disconnect_propagates_to_per_connection_signal() {
 
 // Counting allocator for the empirical allocation guard below. Process-wide
 // for the unit-test binary, but the only cost is one relaxed atomic add per
-// alloc; tests that never read the counter are unaffected.
+// alloc; tests that never read the counter are unaffected. Host-only harness:
+// std's 64-bit atomic is fine here since this never compiles for embedded.
+#[allow(clippy::disallowed_types)]
 mod counting_alloc {
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/resend_rate_limiter.rs
+++ b/src/resend_rate_limiter.rs
@@ -13,9 +13,10 @@
 //! sessions, immune to clock jumps); the rate is atomic so it retunes live.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use async_lock::Mutex;
+use portable_atomic::AtomicU64;
 use wacore::time::Instant;
 use wacore_binary::jid::Jid;
 

--- a/tests/bench-integration/benches/integration.rs
+++ b/tests/bench-integration/benches/integration.rs
@@ -9,6 +9,9 @@
 // Large `--all-features` async fns (tracing + tracing-pii) need a deeper
 // recursion limit; matches `src/lib.rs` and the e2e crate.
 #![recursion_limit = "512"]
+// Host-only bench harness (counting allocator + unique-body counter); std's
+// 64-bit atomic is fine since this never builds for embedded targets.
+#![allow(clippy::disallowed_types)]
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::OnceLock;

--- a/wacore/binary/tests/attrs_inline_alloc.rs
+++ b/wacore/binary/tests/attrs_inline_alloc.rs
@@ -7,6 +7,10 @@
 //! concurrently running sibling test would bleed its allocations into the
 //! measurement (seen once in CI).
 
+// Host-only allocation-count harness; std's 64-bit atomic is fine (never built
+// for embedded targets).
+#![allow(clippy::disallowed_types)]
+
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicU64, Ordering};
 use wacore_binary::builder::NodeBuilder;

--- a/wacore/src/time.rs
+++ b/wacore/src/time.rs
@@ -208,14 +208,14 @@ impl MonotonicProvider for StdMonotonicProvider {
 /// a real provider via [`set_monotonic_provider`] for sub-ms precision.
 #[cfg(target_arch = "wasm32")]
 struct WallDerivedMonotonicProvider {
-    last: std::sync::atomic::AtomicU64,
+    last: portable_atomic::AtomicU64,
 }
 
 #[cfg(target_arch = "wasm32")]
 impl WallDerivedMonotonicProvider {
     const fn new() -> Self {
         Self {
-            last: std::sync::atomic::AtomicU64::new(0),
+            last: portable_atomic::AtomicU64::new(0),
         }
     }
 }


### PR DESCRIPTION
## Problem

`src/resend_rate_limiter.rs` (added on `main`) imported `std::sync::atomic::AtomicU64`:

```rust
use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
```

`AtomicU64`/`AtomicI64` **do not exist** in `std`/`core` on 32-bit targets without native 64-bit atomics — notably **Xtensa (ESP32 / ESP32-S3)**. This breaks downstream embedded builds with:

```
struct `crate::client::node_io::AtomicU64` exists but is inaccessible
error: could not compile `whatsapp-rust` (lib)
```

Every other site in the crate already routes 64-bit atomics through `portable_atomic` (e.g. `client`, `unified_session`, `msg_secret_buffer`, `wacore::request`) precisely for this reason; the new file was the only regression.

## Fix

- `resend_rate_limiter.rs` now uses `portable_atomic::AtomicU64` (keeping `AtomicU32` + `Ordering` in `std`, matching the crate convention — 32-bit atomics are native on Xtensa).
- The wasm-only `WallDerivedMonotonicProvider` in `wacore::time` also moves to `portable_atomic` for consistency.

## Guardrail (so it can't regress in CI / clippy)

Mirroring the existing `disallowed-methods` ban on std time APIs, this adds a clippy **`disallowed-types`** lint (`deny`, workspace-wide) for `std::sync::atomic::AtomicU64` and `AtomicI64`:

- `clippy.toml` — the two banned paths, each with a `reason` pointing at `portable_atomic`.
- `Cargo.toml` `[workspace.lints.clippy]` — `disallowed_types = "deny"`.

Host-only counting-allocator / bench harnesses (which never compile for embedded targets) keep std atomics behind an inline `#[allow(clippy::disallowed_types)]`, matching the documented exception style.

