### PR TITLE
feat: opt-in inbound durability hook (at-least-once delivery)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 aes = { workspace = true }
+async-trait = { workspace = true }
 cbc = { workspace = true, features = ["block-padding"] }
 env_logger = { workspace = true }
 flate2 = { workspace = true }

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -14,19 +14,40 @@
 //!   cargo run --example durability_hook
 
 use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use anyhow::Context;
 use log::{error, info};
 use whatsapp_rust::InboundDurabilityHook;
 use whatsapp_rust::prelude::*;
 
-/// A toy hook that "commits" each message into an in-memory set, deduplicating
-/// by message id. A real implementation would INSERT into a database or enqueue
-/// to a broker, and return `Err` only when that commit genuinely failed.
-#[derive(Default)]
+/// A hook that durably appends each message to a file (with fsync) before
+/// returning `Ok`, deduplicating by message id. A real implementation would
+/// INSERT into a database or enqueue to a broker; the important property is that
+/// the commit is durable BEFORE the hook returns `Ok` (which lets the SDK ack),
+/// and that the hook returns `Err` when the commit genuinely failed.
 struct InboxArchiver {
+    file: Mutex<File>,
+    /// Message ids already committed, for idempotency. A real store would dedupe
+    /// with a unique constraint on the id column instead.
     seen: Mutex<HashSet<String>>,
+}
+
+impl InboxArchiver {
+    fn open(path: &str) -> anyhow::Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .with_context(|| format!("opening archive file {path}"))?;
+        Ok(Self {
+            file: Mutex::new(file),
+            seen: Mutex::new(HashSet::new()),
+        })
+    }
 }
 
 #[async_trait::async_trait]
@@ -37,17 +58,38 @@ impl InboundDurabilityHook for InboxArchiver {
         info: &MessageInfo,
         message: &wa::Message,
     ) -> anyhow::Result<()> {
-        // Idempotency: a redelivery (or a replay after a crash between commit
-        // and ack) can hand us the same message id more than once.
-        let first_time = self.seen.lock().unwrap().insert(info.id.clone());
-        if !first_time {
+        // Idempotency: a redelivery (or a replay after a crash between commit and
+        // ack) can hand us the same message id more than once. Check, but only
+        // record it as committed AFTER the durable write below succeeds.
+        if self
+            .seen
+            .lock()
+            .map_err(|_| anyhow::anyhow!("seen lock poisoned"))?
+            .contains(&info.id)
+        {
             info!("[{}] already committed, skipping (dedup)", info.id);
             return Ok(());
         }
 
-        // Durably persist here. Returning Ok means "safe to ack"; returning Err
-        // suppresses the ack so the server redelivers the message later.
         let preview = message.conversation.as_deref().unwrap_or("<non-text>");
+        let line = format!("{}\t{preview}\n", info.id);
+
+        // Durable commit: append then fsync. Returning Ok only after sync_all
+        // means "safe to ack"; any error here returns Err, so the ack is
+        // suppressed and the server redelivers the message later.
+        {
+            let mut file = self
+                .file
+                .lock()
+                .map_err(|_| anyhow::anyhow!("file lock poisoned"))?;
+            file.write_all(line.as_bytes())?;
+            file.sync_all()?;
+        }
+
+        self.seen
+            .lock()
+            .map_err(|_| anyhow::anyhow!("seen lock poisoned"))?
+            .insert(info.id.clone());
         info!("[{}] committed durably: {preview}", info.id);
         Ok(())
     }
@@ -70,11 +112,19 @@ fn main() {
             }
         };
 
+        let archiver = match InboxArchiver::open("inbox.jsonl") {
+            Ok(archiver) => archiver,
+            Err(e) => {
+                error!("failed to open archive file: {e}");
+                return;
+            }
+        };
+
         let bot = Bot::builder()
             .with_backend(store)
             // Opt in to at-least-once delivery. Without this call the client
             // keeps its default at-most-once behavior.
-            .with_inbound_durability_hook(InboxArchiver::default())
+            .with_inbound_durability_hook(archiver)
             .on_qr_code(|code, _timeout| async move {
                 info!("scan to pair:\n{code}");
             })

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -1,0 +1,90 @@
+//! Inbound durability hook: at-least-once delivery.
+//!
+//! By default the client acknowledges a message to the server as soon as it is
+//! decrypted (at-most-once): if the process crashes or your storage write fails
+//! before you persist the message, it is lost — the server already considers it
+//! delivered and never resends it.
+//!
+//! Registering an [`InboundDurabilityHook`] defers that acknowledgement until
+//! your hook durably commits the message. On success the message is acked; on
+//! failure (or a crash) it stays in the server's offline queue and is
+//! redelivered on the next connect, where the hook runs again. This is
+//! at-least-once: the hook MUST be idempotent — deduplicate by `info.id`.
+//!
+//!   cargo run --example durability_hook
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use log::{error, info};
+use whatsapp_rust::InboundDurabilityHook;
+use whatsapp_rust::prelude::*;
+
+/// A toy hook that "commits" each message into an in-memory set, deduplicating
+/// by message id. A real implementation would INSERT into a database or enqueue
+/// to a broker, and return `Err` only when that commit genuinely failed.
+#[derive(Default)]
+struct InboxArchiver {
+    seen: Mutex<HashSet<String>>,
+}
+
+#[async_trait::async_trait]
+impl InboundDurabilityHook for InboxArchiver {
+    async fn on_message(
+        &self,
+        _client: Arc<Client>,
+        info: &MessageInfo,
+        message: &wa::Message,
+    ) -> anyhow::Result<()> {
+        // Idempotency: a redelivery (or a replay after a crash between commit
+        // and ack) can hand us the same message id more than once.
+        let first_time = self.seen.lock().unwrap().insert(info.id.clone());
+        if !first_time {
+            info!("[{}] already committed, skipping (dedup)", info.id);
+            return Ok(());
+        }
+
+        // Durably persist here. Returning Ok means "safe to ack"; returning Err
+        // suppresses the ack so the server redelivers the message later.
+        let preview = message.conversation.as_deref().unwrap_or("<non-text>");
+        info!("[{}] committed durably: {preview}", info.id);
+        Ok(())
+    }
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+
+    rt.block_on(async {
+        let store = match SqliteStore::new("whatsapp.db").await {
+            Ok(store) => store,
+            Err(e) => {
+                error!("failed to create SQLite backend: {e}");
+                return;
+            }
+        };
+
+        let bot = Bot::builder()
+            .with_backend(store)
+            // Opt in to at-least-once delivery. Without this call the client
+            // keeps its default at-most-once behavior.
+            .with_inbound_durability_hook(InboxArchiver::default())
+            .on_qr_code(|code, _timeout| async move {
+                info!("scan to pair:\n{code}");
+            })
+            .on_connected(|_client| async {
+                info!("connected; inbound messages are now committed before ack");
+            })
+            .build()
+            .await
+            .expect("failed to build bot");
+
+        bot.run().await;
+    });
+}

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -30,22 +30,36 @@ use whatsapp_rust::prelude::*;
 /// the commit is durable BEFORE the hook returns `Ok` (which lets the SDK ack),
 /// and that the hook returns `Err` when the commit genuinely failed.
 struct InboxArchiver {
-    file: Mutex<File>,
-    /// Message ids already committed, for idempotency. A real store would dedupe
-    /// with a unique constraint on the id column instead.
+    // `Arc` so the file can be moved into `spawn_blocking` (the write/fsync must
+    // not run on the async receive thread).
+    file: Arc<Mutex<File>>,
+    /// Message ids already committed, for idempotency. Seeded from the archive on
+    /// startup so dedupe survives a restart; a real store would dedupe with a
+    /// unique constraint on the id column instead.
     seen: Mutex<HashSet<String>>,
 }
 
 impl InboxArchiver {
     fn open(path: &str) -> anyhow::Result<Self> {
+        // Rebuild the dedupe set from already-committed ids so a replay after a
+        // restart does not append the same message twice.
+        let mut seen = HashSet::new();
+        if let Ok(existing) = File::open(path) {
+            for line in BufReader::new(existing).lines() {
+                let line = line?;
+                if let Some((id, _)) = line.split_once('\t') {
+                    seen.insert(id.to_string());
+                }
+            }
+        }
         let file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)
             .with_context(|| format!("opening archive file {path}"))?;
         Ok(Self {
-            file: Mutex::new(file),
-            seen: Mutex::new(HashSet::new()),
+            file: Arc::new(Mutex::new(file)),
+            seen: Mutex::new(seen),
         })
     }
 }
@@ -74,17 +88,18 @@ impl InboundDurabilityHook for InboxArchiver {
         let preview = message.conversation.as_deref().unwrap_or("<non-text>");
         let line = format!("{}\t{preview}\n", info.id);
 
-        // Durable commit: append then fsync. Returning Ok only after sync_all
-        // means "safe to ack"; any error here returns Err, so the ack is
-        // suppressed and the server redelivers the message later.
-        {
-            let mut file = self
-                .file
-                .lock()
-                .map_err(|_| anyhow::anyhow!("file lock poisoned"))?;
+        // Durable commit on a blocking thread: append then fsync. Returning Ok
+        // only after sync_all means "safe to ack"; any error returns Err, so the
+        // ack is suppressed and the server redelivers the message later. The hook
+        // is awaited on the receive path, so the disk I/O goes to spawn_blocking.
+        let file = Arc::clone(&self.file);
+        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let mut file = file.lock().expect("file lock poisoned");
             file.write_all(line.as_bytes())?;
-            file.sync_all()?;
-        }
+            file.sync_all()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("archive write task failed: {e}"))??;
 
         self.seen
             .lock()

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -24,39 +24,60 @@ use log::{error, info};
 use whatsapp_rust::InboundDurabilityHook;
 use whatsapp_rust::prelude::*;
 
+/// Idempotency key: stanza ids are only unique within a `(chat, sender)`.
+type CommitKey = (String, String, String);
+
 /// A hook that durably appends each message to a file (with fsync) before
-/// returning `Ok`, deduplicating by message id. A real implementation would
-/// INSERT into a database or enqueue to a broker; the important property is that
-/// the commit is durable BEFORE the hook returns `Ok` (which lets the SDK ack),
-/// and that the hook returns `Err` when the commit genuinely failed.
+/// returning `Ok`, deduplicating by `(chat, sender, id)`. A real implementation
+/// would INSERT into a database or enqueue to a broker; the important property is
+/// that the commit is durable BEFORE the hook returns `Ok` (which lets the SDK
+/// ack), and that the hook returns `Err` when the commit genuinely failed.
 struct InboxArchiver {
     // `Arc` so the file can be moved into `spawn_blocking` (the write/fsync must
     // not run on the async receive thread).
     file: Arc<Mutex<File>>,
-    /// Message ids already committed, for idempotency. Seeded from the archive on
+    /// Keys already committed, for idempotency. Seeded from the archive on
     /// startup so dedupe survives a restart; a real store would dedupe with a
-    /// unique constraint on the id column instead.
-    seen: Mutex<HashSet<String>>,
+    /// unique constraint on `(chat, sender, id)` instead.
+    seen: Mutex<HashSet<CommitKey>>,
 }
 
 impl InboxArchiver {
-    fn open(path: &str) -> anyhow::Result<Self> {
-        // Rebuild the dedupe set from already-committed ids so a replay after a
-        // restart does not append the same message twice.
-        let mut seen = HashSet::new();
-        if let Ok(existing) = File::open(path) {
-            for line in BufReader::new(existing).lines() {
-                let line = line?;
-                if let Some((id, _)) = line.split_once('\t') {
-                    seen.insert(id.to_string());
+    async fn open(path: &str) -> anyhow::Result<Self> {
+        let path = path.to_string();
+        // Seed the dedupe set and open the file off the async runtime thread so a
+        // large archive does not stall boot.
+        let (file, seen) = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+            let mut seen = HashSet::new();
+            match File::open(&path) {
+                Ok(existing) => {
+                    for line in BufReader::new(existing).lines() {
+                        let line = line?;
+                        let mut parts = line.splitn(4, '\t');
+                        if let (Some(c), Some(s), Some(i)) =
+                            (parts.next(), parts.next(), parts.next())
+                        {
+                            seen.insert((c.to_string(), s.to_string(), i.to_string()));
+                        }
+                    }
+                }
+                // A missing archive is a fresh start; any other error is real and
+                // must not silently empty the dedupe set.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(anyhow::Error::from(e).context(format!("reading archive {path}")));
                 }
             }
-        }
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .with_context(|| format!("opening archive file {path}"))?;
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .with_context(|| format!("opening archive file {path}"))?;
+            Ok((file, seen))
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("archive open task failed: {e}"))??;
+
         Ok(Self {
             file: Arc::new(Mutex::new(file)),
             seen: Mutex::new(seen),
@@ -72,21 +93,32 @@ impl InboundDurabilityHook for InboxArchiver {
         info: &MessageInfo,
         message: &wa::Message,
     ) -> anyhow::Result<()> {
+        let key: CommitKey = (
+            info.source.chat.to_string(),
+            info.source.sender.to_string(),
+            info.id.clone(),
+        );
+
         // Idempotency: a redelivery (or a replay after a crash between commit and
-        // ack) can hand us the same message id more than once. Check, but only
-        // record it as committed AFTER the durable write below succeeds.
+        // ack) can hand us the same key more than once. Check, but only record it
+        // as committed AFTER the durable write below succeeds.
         if self
             .seen
             .lock()
             .map_err(|_| anyhow::anyhow!("seen lock poisoned"))?
-            .contains(&info.id)
+            .contains(&key)
         {
             info!("[{}] already committed, skipping (dedup)", info.id);
             return Ok(());
         }
 
-        let preview = message.conversation.as_deref().unwrap_or("<non-text>");
-        let line = format!("{}\t{preview}\n", info.id);
+        // Sanitize so the tab-delimited archive stays parseable on restart.
+        let preview = message
+            .conversation
+            .as_deref()
+            .unwrap_or("<non-text>")
+            .replace(['\t', '\n'], " ");
+        let line = format!("{}\t{}\t{}\t{preview}\n", key.0, key.1, key.2);
 
         // Durable commit on a blocking thread: append then fsync. Returning Ok
         // only after sync_all means "safe to ack"; any error returns Err, so the
@@ -104,7 +136,7 @@ impl InboundDurabilityHook for InboxArchiver {
         self.seen
             .lock()
             .map_err(|_| anyhow::anyhow!("seen lock poisoned"))?
-            .insert(info.id.clone());
+            .insert(key);
         info!("[{}] committed durably: {preview}", info.id);
         Ok(())
     }
@@ -127,7 +159,7 @@ fn main() {
             }
         };
 
-        let archiver = match InboxArchiver::open("inbox.jsonl") {
+        let archiver = match InboxArchiver::open("inbox.jsonl").await {
             Ok(archiver) => archiver,
             Err(e) => {
                 error!("failed to open archive file: {e}");

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -9,7 +9,9 @@
 //! your hook durably commits the message. On success the message is acked; on
 //! failure (or a crash) it stays in the server's offline queue and is
 //! redelivered on the next connect, where the hook runs again. This is
-//! at-least-once: the hook MUST be idempotent — deduplicate by `info.id`.
+//! at-least-once: the hook MUST be idempotent — deduplicate by
+//! `(info.source.chat, info.source.sender, info.id)`, since stanza ids are only
+//! unique within a chat/sender.
 //!
 //!   cargo run --example durability_hook
 

--- a/examples/durability_hook.rs
+++ b/examples/durability_hook.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -49,11 +49,17 @@ impl InboxArchiver {
         // large archive does not stall boot.
         let (file, seen) = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
             let mut seen = HashSet::new();
-            match File::open(&path) {
-                Ok(existing) => {
-                    for line in BufReader::new(existing).lines() {
-                        let line = line?;
-                        let mut parts = line.splitn(4, '\t');
+            match std::fs::read_to_string(&path) {
+                Ok(content) => {
+                    for line in content.split_inclusive('\n') {
+                        // Only seed from complete records: a record is durable
+                        // once its terminating newline is on disk. A torn trailing
+                        // line (crash mid-append) lacks it, so skip it — otherwise
+                        // a never-committed message would be dropped as a dup.
+                        if !line.ends_with('\n') {
+                            continue;
+                        }
+                        let mut parts = line.trim_end_matches('\n').splitn(4, '\t');
                         if let (Some(c), Some(s), Some(i)) =
                             (parts.next(), parts.next(), parts.next())
                         {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -5,6 +5,7 @@ use crate::store::commands::DeviceCommand;
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
 use crate::store::traits::Backend;
+use crate::types::durability_hook::InboundDurabilityHook;
 use crate::types::enc_handler::EncHandler;
 use crate::types::events::{Event, EventHandler, EventInterest, EventKind};
 use crate::types::message::MessageInfo;
@@ -488,6 +489,7 @@ pub struct BotBuilder<
     event_handlers: Vec<RegisteredHandler>,
     raw_handlers: Vec<Arc<dyn EventHandler>>,
     custom_enc_handlers: HashMap<String, Arc<dyn EncHandler>>,
+    inbound_durability_hook: Option<Arc<dyn InboundDurabilityHook>>,
     override_version: Option<(u32, u32, u32)>,
     device_props_override: Option<DevicePropsOverride>,
     pair_code_options: Option<PairCodeOptions>,
@@ -509,6 +511,7 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             event_handlers: Vec::new(),
             raw_handlers: Vec::new(),
             custom_enc_handlers: HashMap::new(),
+            inbound_durability_hook: None,
             override_version: None,
             device_props_override: None,
             pair_code_options: None,
@@ -534,6 +537,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             event_handlers: self.event_handlers,
             raw_handlers: self.raw_handlers,
             custom_enc_handlers: self.custom_enc_handlers,
+            inbound_durability_hook: self.inbound_durability_hook,
             override_version: self.override_version,
             device_props_override: self.device_props_override,
             pair_code_options: self.pair_code_options,
@@ -744,6 +748,22 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     {
         self.custom_enc_handlers
             .insert(enc_type.into(), Arc::new(handler));
+        self
+    }
+
+    /// Register an inbound durability hook for at-least-once delivery.
+    ///
+    /// By default the client acks a message as soon as it is decrypted
+    /// (at-most-once): a crash or failed commit before the consumer persists it
+    /// loses the message. With a hook registered, the ack is deferred until the
+    /// hook commits the message; on failure the message is redelivered on the
+    /// next connect. The hook must be idempotent (dedupe by message id). See
+    /// [`InboundDurabilityHook`] for the full contract and caveats.
+    pub fn with_inbound_durability_hook<Dh>(mut self, hook: Dh) -> Self
+    where
+        Dh: InboundDurabilityHook + 'static,
+    {
+        self.inbound_durability_hook = Some(Arc::new(hook));
         self
     }
 
@@ -968,6 +988,12 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         // Register custom enc handlers. Immutable after build, so set the whole
         // map once; the receive hot path then reads it lock-free.
         let _ = client.custom_enc_handlers.set(self.custom_enc_handlers);
+
+        // Inbound durability hook (opt-in). Immutable after build; the receive
+        // path reads it lock-free.
+        if let Some(hook) = self.inbound_durability_hook {
+            let _ = client.inbound_durability_hook.set(hook);
+        }
 
         if self.skip_history_sync {
             client.set_skip_history_sync(true);

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -98,11 +98,18 @@ pub enum BotBuilderError {
 async fn probe_durability_backend(
     backend: &std::sync::Arc<dyn Backend>,
 ) -> std::result::Result<(), BotBuilderError> {
-    // A real JID (a backend may validate the format) and a process-unique id so
-    // concurrent builders on the same store do not race on a shared probe row.
+    // A real JID (a backend may validate the format) and an id unique per probe
+    // invocation (pid + atomic counter) so concurrent builders on the same store
+    // never race on a shared probe row and false-fail.
+    use portable_atomic::{AtomicU64, Ordering};
+    static PROBE_SEQ: AtomicU64 = AtomicU64::new(0);
     const PROBE_JID: &str = "0@s.whatsapp.net";
     const PROBE_PAYLOAD: &[u8] = b"probe";
-    let probe_id = format!("__wa_durability_probe_{}__", std::process::id());
+    let probe_id = format!(
+        "__wa_durability_probe_{}_{}__",
+        std::process::id(),
+        PROBE_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
     let map_err = |e: StoreError| BotBuilderError::UnsupportedDurabilityBackend(e.to_string());
     backend
         .store_pending_inbound(PROBE_JID, PROBE_JID, &probe_id, PROBE_PAYLOAD)

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -98,19 +98,22 @@ pub enum BotBuilderError {
 async fn probe_durability_backend(
     backend: &std::sync::Arc<dyn Backend>,
 ) -> std::result::Result<(), BotBuilderError> {
-    const PROBE_ID: &str = "__wa_durability_probe__";
+    // A real JID (a backend may validate the format) and a process-unique id so
+    // concurrent builders on the same store do not race on a shared probe row.
+    const PROBE_JID: &str = "0@s.whatsapp.net";
     const PROBE_PAYLOAD: &[u8] = b"probe";
+    let probe_id = format!("__wa_durability_probe_{}__", std::process::id());
     let map_err = |e: StoreError| BotBuilderError::UnsupportedDurabilityBackend(e.to_string());
     backend
-        .store_pending_inbound("", "", PROBE_ID, PROBE_PAYLOAD)
+        .store_pending_inbound(PROBE_JID, PROBE_JID, &probe_id, PROBE_PAYLOAD)
         .await
         .map_err(map_err)?;
     let got = backend
-        .get_pending_inbound("", "", PROBE_ID)
+        .get_pending_inbound(PROBE_JID, PROBE_JID, &probe_id)
         .await
         .map_err(map_err)?;
     backend
-        .delete_pending_inbound("", "", PROBE_ID)
+        .delete_pending_inbound(PROBE_JID, PROBE_JID, &probe_id)
         .await
         .map_err(map_err)?;
     if got.as_deref() != Some(PROBE_PAYLOAD) {
@@ -790,7 +793,8 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// (at-most-once): a crash or failed commit before the consumer persists it
     /// loses the message. With a hook registered, the ack is deferred until the
     /// hook commits the message; on failure the message is redelivered on the
-    /// next connect. The hook must be idempotent (dedupe by message id). See
+    /// next connect. The hook must be idempotent (dedupe by `(chat, sender, id)`,
+    /// since stanza ids are only unique within a chat/sender). See
     /// [`InboundDurabilityHook`] for the full contract and caveats.
     pub fn with_inbound_durability_hook<Dh>(mut self, hook: Dh) -> Self
     where

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -86,6 +86,39 @@ pub enum BotBuilderError {
     /// Initializing the device row in the storage backend failed.
     #[error("failed to initialize the device store: {0}")]
     Store(#[from] StoreError),
+    /// An inbound durability hook was registered with a backend that does not
+    /// implement the pending-inbound buffer it requires.
+    #[error("the configured backend does not support the inbound durability hook: {0}")]
+    UnsupportedDurabilityBackend(String),
+}
+
+/// Verify the backend round-trips a pending-inbound buffer entry before we accept
+/// an inbound durability hook. A backend relying on the no-op/`Err` trait
+/// defaults fails here instead of silently looping every inbound message unacked.
+async fn probe_durability_backend(
+    backend: &std::sync::Arc<dyn Backend>,
+) -> std::result::Result<(), BotBuilderError> {
+    const PROBE_ID: &str = "__wa_durability_probe__";
+    const PROBE_PAYLOAD: &[u8] = b"probe";
+    let map_err = |e: StoreError| BotBuilderError::UnsupportedDurabilityBackend(e.to_string());
+    backend
+        .store_pending_inbound("", "", PROBE_ID, PROBE_PAYLOAD)
+        .await
+        .map_err(map_err)?;
+    let got = backend
+        .get_pending_inbound("", "", PROBE_ID)
+        .await
+        .map_err(map_err)?;
+    backend
+        .delete_pending_inbound("", "", PROBE_ID)
+        .await
+        .map_err(map_err)?;
+    if got.as_deref() != Some(PROBE_PAYLOAD) {
+        return Err(BotBuilderError::UnsupportedDurabilityBackend(
+            "pending-inbound buffer did not round-trip".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// `message` is `Arc` so cloning the context across spawned tasks only bumps a
@@ -990,8 +1023,12 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         let _ = client.custom_enc_handlers.set(self.custom_enc_handlers);
 
         // Inbound durability hook (opt-in). Immutable after build; the receive
-        // path reads it lock-free.
+        // path reads it lock-free. Probe the backend first: a backend that does
+        // not implement the pending-inbound buffer would otherwise leave every
+        // inbound message unacked and looping forever at runtime, so reject it
+        // here with a clear error instead.
         if let Some(hook) = self.inbound_durability_hook {
+            probe_durability_backend(&client.persistence_manager.backend()).await?;
             let _ = client.inbound_durability_hook.set(hook);
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -563,6 +563,14 @@ pub struct Client {
     /// `OnceLock::get` (no lock) and no per-node guard acquisition.
     pub custom_enc_handlers: std::sync::OnceLock<HashMap<String, Arc<dyn EncHandler>>>,
 
+    /// Optional inbound durability hook. When set, the transport ack for a
+    /// decrypted user message is deferred until the hook commits it, converting
+    /// the consumer to at-least-once delivery. Set once at `Bot::build` and read
+    /// lock-free on the receive path. `None` (default) keeps the current
+    /// at-most-once behavior with zero overhead.
+    pub(crate) inbound_durability_hook:
+        std::sync::OnceLock<Arc<dyn crate::types::durability_hook::InboundDurabilityHook>>,
+
     /// Chat state (typing indicator) handlers registered by external consumers.
     /// Each handler receives a `ChatStateEvent` describing the chat, optional participant and state.
     pub(crate) chatstate_handlers: Arc<RwLock<Vec<ChatStateHandler>>>,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -226,6 +226,7 @@ impl Client {
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pair_code_state: Arc::new(Mutex::new(wacore::pair_code::PairCodeState::default())),
             custom_enc_handlers: std::sync::OnceLock::new(),
+            inbound_durability_hook: std::sync::OnceLock::new(),
             chatstate_handlers: Arc::new(RwLock::new(Vec::new())),
             pdo_pending_requests: cache_config.pdo_pending_requests.build_with_ttl(),
             pdo_requested: cache_config.pdo_requested.build_with_ttl(),

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -249,6 +249,23 @@ impl Client {
                 .detach();
         }
 
+        // Pending inbound buffer retention (inbound durability hook): a row a
+        // permanently-failing hook never commits would otherwise linger once the
+        // server stops redelivering it. Only sweep when a hook is configured;
+        // the table is empty otherwise.
+        if self.inbound_durability_hook().is_some() {
+            const PENDING_INBOUND_TTL_SECS: u64 = 7 * 24 * 60 * 60;
+            let backend = self.persistence_manager.backend();
+            let cutoff = cutoff_for(PENDING_INBOUND_TTL_SECS);
+            self.runtime
+                .spawn(Box::pin(async move {
+                    if let Err(e) = backend.delete_expired_pending_inbound(cutoff).await {
+                        log::debug!(target: "Client/Keepalive", "Pending inbound cleanup error: {e}");
+                    }
+                }))
+                .detach();
+        }
+
         // msg_secrets retention: prune rows whose per-row deadline has passed.
         // expires_at is absolute, so the cutoff is simply "now"; per-kind
         // horizons and never-expire (0) rows are baked in at write time.

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -251,9 +251,11 @@ impl Client {
 
         // Pending inbound buffer retention (inbound durability hook): a row a
         // permanently-failing hook never commits would otherwise linger once the
-        // server stops redelivering it. Only sweep when a hook is configured;
-        // the table is empty otherwise.
-        if self.inbound_durability_hook().is_some() {
+        // server stops redelivering it. Run unconditionally (not gated on the hook
+        // being set now) so rows buffered by a hook in a previous run are still
+        // swept after it is disabled. Backends without the buffer return 0 from
+        // the default impl, so this is a cheap no-op there.
+        {
             const PENDING_INBOUND_TTL_SECS: u64 = 7 * 24 * 60 * 60;
             let backend = self.persistence_manager.backend();
             let cutoff = cutoff_for(PENDING_INBOUND_TTL_SECS);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub use client::ClientError;
 #[cfg(feature = "debug-diagnostics")]
 pub use client::MemoryDiagnostics;
 pub use client::NodeFilter;
+pub use types::durability_hook::InboundDurabilityHook;
 pub mod download;
 pub mod handlers;
 pub use handlers::chatstate::ChatStateEvent;

--- a/src/message.rs
+++ b/src/message.rs
@@ -136,6 +136,7 @@ fn decrypt_fail_log_level(mode: crate::types::events::DecryptFailMode) -> log::L
 pub(crate) use wacore::protocol::retry::RetryReason;
 
 mod dispatch;
+mod durability;
 mod msg_secret;
 mod receive;
 mod retry;

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -36,12 +36,23 @@ impl Client {
         {
             Arc::make_mut(&mut info).comment_target = Some(target);
         }
-        let dispatch_msg = decrypted.unwrap_or(msg);
-        self.ack_received_message(&info);
+        let dispatch_msg = Arc::new(decrypted.unwrap_or(msg));
 
-        self.core
-            .event_bus
-            .dispatch(Event::Message(Arc::new(dispatch_msg), info));
+        if let Some(hook) = self.inbound_durability_hook() {
+            // At-least-once: in-process handlers still fire, but the transport
+            // ack is deferred until the hook durably commits the message.
+            self.core
+                .event_bus
+                .dispatch(Event::Message(Arc::clone(&dispatch_msg), Arc::clone(&info)));
+            self.run_inbound_durability_hook(hook, &info, &dispatch_msg)
+                .await;
+        } else {
+            // Default at-most-once path (unchanged): ack, then dispatch.
+            self.ack_received_message(&info);
+            self.core
+                .event_bus
+                .dispatch(Event::Message(dispatch_msg, info));
+        }
     }
 
     /// Acknowledge a received message so the server drops it from the offline

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -23,6 +23,8 @@ impl Client {
         msg: &Arc<wa::Message>,
     ) {
         let backend = self.persistence_manager.backend();
+        let chat = info.source.chat.to_string();
+        let sender = info.source.sender.to_string();
         // Persist before the Signal ratchet is flushed (which happens after this
         // returns) so a crash mid-commit replays the message instead of losing it.
         // `message_to_vec` is the shared non-generic encoder so this call does not
@@ -31,7 +33,10 @@ impl Client {
         // Fail closed: if we cannot durably buffer the message, do not run the
         // hook and do not ack. The server keeps it queued and redelivers it once
         // storage recovers, rather than us acking a message we cannot replay.
-        if let Err(e) = backend.store_pending_inbound(&info.id, &bytes).await {
+        if let Err(e) = backend
+            .store_pending_inbound(&chat, &sender, &info.id, &bytes)
+            .await
+        {
             log::error!(
                 "[msg:{}] failed to buffer inbound message; suppressing ack for redelivery: {e:?}",
                 info.id
@@ -41,7 +46,10 @@ impl Client {
 
         match hook.on_message(self.clone(), info, msg).await {
             Ok(()) => {
-                if let Err(e) = backend.delete_pending_inbound(&info.id).await {
+                if let Err(e) = backend
+                    .delete_pending_inbound(&chat, &sender, &info.id)
+                    .await
+                {
                     log::debug!(
                         "[msg:{}] failed to clear buffered inbound message: {e:?}",
                         info.id
@@ -66,14 +74,19 @@ impl Client {
     pub(crate) async fn ack_or_replay_to_hook(self: &Arc<Self>, info: &Arc<MessageInfo>) {
         if let Some(hook) = self.inbound_durability_hook() {
             let backend = self.persistence_manager.backend();
-            match backend.get_pending_inbound(&info.id).await {
+            let chat = info.source.chat.to_string();
+            let sender = info.source.sender.to_string();
+            match backend.get_pending_inbound(&chat, &sender, &info.id).await {
                 Ok(Some(bytes)) => {
                     match waproto::codec::message_decode(&bytes) {
                         Ok(msg) => {
                             let msg = Arc::new(msg);
                             match hook.on_message(self.clone(), info, &msg).await {
                                 Ok(()) => {
-                                    if let Err(e) = backend.delete_pending_inbound(&info.id).await {
+                                    if let Err(e) = backend
+                                        .delete_pending_inbound(&chat, &sender, &info.id)
+                                        .await
+                                    {
                                         log::debug!(
                                             "[msg:{}] failed to clear buffered inbound message: {e:?}",
                                             info.id
@@ -96,7 +109,9 @@ impl Client {
                                 "[msg:{}] failed to decode buffered inbound message; acking to unstick queue: {e:?}",
                                 info.id
                             );
-                            let _ = backend.delete_pending_inbound(&info.id).await;
+                            let _ = backend
+                                .delete_pending_inbound(&chat, &sender, &info.id)
+                                .await;
                             self.ack_received_message(info);
                         }
                     }
@@ -146,8 +161,14 @@ mod tests {
     }
 
     fn test_info(id: &str) -> Arc<MessageInfo> {
+        use crate::types::message::MessageSource;
         Arc::new(MessageInfo {
             id: id.to_string(),
+            source: MessageSource {
+                chat: "100@g.us".parse().unwrap(),
+                sender: "200@s.whatsapp.net".parse().unwrap(),
+                ..Default::default()
+            },
             ..Default::default()
         })
     }
@@ -182,7 +203,11 @@ mod tests {
         let backend = client.persistence_manager.backend();
         assert!(
             backend
-                .get_pending_inbound("MSG_OK")
+                .get_pending_inbound(
+                    &info.source.chat.to_string(),
+                    &info.source.sender.to_string(),
+                    "MSG_OK",
+                )
                 .await
                 .unwrap()
                 .is_none(),
@@ -214,7 +239,11 @@ mod tests {
         assert_eq!(hook.calls.load(Ordering::SeqCst), 1);
         assert!(
             backend
-                .get_pending_inbound("MSG_ERR")
+                .get_pending_inbound(
+                    &info.source.chat.to_string(),
+                    &info.source.sender.to_string(),
+                    "MSG_ERR",
+                )
                 .await
                 .unwrap()
                 .is_some(),
@@ -230,7 +259,11 @@ mod tests {
         );
         assert!(
             backend
-                .get_pending_inbound("MSG_ERR")
+                .get_pending_inbound(
+                    &info.source.chat.to_string(),
+                    &info.source.sender.to_string(),
+                    "MSG_ERR",
+                )
                 .await
                 .unwrap()
                 .is_some(),
@@ -243,7 +276,11 @@ mod tests {
         assert_eq!(hook.calls.load(Ordering::SeqCst), 3);
         assert!(
             backend
-                .get_pending_inbound("MSG_ERR")
+                .get_pending_inbound(
+                    &info.source.chat.to_string(),
+                    &info.source.sender.to_string(),
+                    "MSG_ERR",
+                )
                 .await
                 .unwrap()
                 .is_none(),

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -25,21 +25,23 @@ impl Client {
         let backend = self.persistence_manager.backend();
         // Persist before the Signal ratchet is flushed (which happens after this
         // returns) so a crash mid-commit replays the message instead of losing it.
-        let bytes = msg.encode_to_vec();
-        let buffered = match backend.store_pending_inbound(&info.id, &bytes).await {
-            Ok(()) => true,
-            Err(e) => {
-                log::error!(
-                    "[msg:{}] failed to buffer inbound message for durability hook: {e:?}",
-                    info.id
-                );
-                false
-            }
-        };
+        // `message_to_vec` is the shared non-generic encoder so this call does not
+        // monomorphize the whole `wa::Message` proto tree into this crate.
+        let bytes = waproto::codec::message_to_vec(msg);
+        // Fail closed: if we cannot durably buffer the message, do not run the
+        // hook and do not ack. The server keeps it queued and redelivers it once
+        // storage recovers, rather than us acking a message we cannot replay.
+        if let Err(e) = backend.store_pending_inbound(&info.id, &bytes).await {
+            log::error!(
+                "[msg:{}] failed to buffer inbound message; suppressing ack for redelivery: {e:?}",
+                info.id
+            );
+            return;
+        }
 
         match hook.on_message(self.clone(), info, msg).await {
             Ok(()) => {
-                if buffered && let Err(e) = backend.delete_pending_inbound(&info.id).await {
+                if let Err(e) = backend.delete_pending_inbound(&info.id).await {
                     log::debug!(
                         "[msg:{}] failed to clear buffered inbound message: {e:?}",
                         info.id
@@ -58,53 +60,59 @@ impl Client {
 
     /// Redelivery path: when the server replays an already-decrypted message
     /// (`DuplicatedMessage`), re-run the hook from the buffered copy instead of
-    /// acking. Falls back to a plain ack when no hook is set, no buffered copy
-    /// exists (a genuine duplicate), or the buffer is unreadable.
+    /// acking. A plain ack is sent only for a genuine duplicate (no buffered
+    /// copy). A read failure fails closed (no ack) so a transient storage error
+    /// cannot drop a message that still needs its hook to commit.
     pub(crate) async fn ack_or_replay_to_hook(self: &Arc<Self>, info: &Arc<MessageInfo>) {
         if let Some(hook) = self.inbound_durability_hook() {
             let backend = self.persistence_manager.backend();
             match backend.get_pending_inbound(&info.id).await {
-                Ok(Some(bytes)) => match wa::Message::decode(bytes.as_slice()) {
-                    Ok(msg) => {
-                        let msg = Arc::new(msg);
-                        match hook.on_message(self.clone(), info, &msg).await {
-                            Ok(()) => {
-                                if let Err(e) = backend.delete_pending_inbound(&info.id).await {
-                                    log::debug!(
-                                        "[msg:{}] failed to clear buffered inbound message: {e:?}",
+                Ok(Some(bytes)) => {
+                    match waproto::codec::message_decode(&bytes) {
+                        Ok(msg) => {
+                            let msg = Arc::new(msg);
+                            match hook.on_message(self.clone(), info, &msg).await {
+                                Ok(()) => {
+                                    if let Err(e) = backend.delete_pending_inbound(&info.id).await {
+                                        log::debug!(
+                                            "[msg:{}] failed to clear buffered inbound message: {e:?}",
+                                            info.id
+                                        );
+                                    }
+                                    self.ack_received_message(info);
+                                }
+                                Err(e) => {
+                                    log::warn!(
+                                        "[msg:{}] inbound durability hook still failing on redelivery; keeping for retry: {e:?}",
                                         info.id
                                     );
                                 }
-                                self.ack_received_message(info);
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "[msg:{}] inbound durability hook still failing on redelivery; keeping for retry: {e:?}",
-                                    info.id
-                                );
                             }
                         }
-                        return;
+                        Err(e) => {
+                            // Corrupt row (our own serialization): it can never be
+                            // replayed, so drop it and ack to unstick the queue.
+                            log::error!(
+                                "[msg:{}] failed to decode buffered inbound message; acking to unstick queue: {e:?}",
+                                info.id
+                            );
+                            let _ = backend.delete_pending_inbound(&info.id).await;
+                            self.ack_received_message(info);
+                        }
                     }
-                    Err(e) => {
-                        // Corrupt row: drop it and ack so the queue is not stuck forever.
-                        log::error!(
-                            "[msg:{}] failed to decode buffered inbound message; acking to unstick queue: {e:?}",
-                            info.id
-                        );
-                        let _ = backend.delete_pending_inbound(&info.id).await;
-                    }
-                },
-                Ok(None) => {}
-                Err(e) => {
-                    log::debug!(
-                        "[msg:{}] failed to read pending inbound buffer: {e:?}",
-                        info.id
-                    );
                 }
+                // Genuine duplicate (never buffered, or already committed): ack it.
+                Ok(None) => self.ack_received_message(info),
+                // Fail closed: a transient read error must not ack a message whose
+                // hook may not have committed. Leave it unacked for the next replay.
+                Err(e) => log::warn!(
+                    "[msg:{}] failed to read pending inbound buffer; suppressing ack for redelivery: {e:?}",
+                    info.id
+                ),
             }
+        } else {
+            self.ack_received_message(info);
         }
-        self.ack_received_message(info);
     }
 }
 

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -1,0 +1,263 @@
+//! Inbound durability hook: opt-in at-least-once delivery by gating the
+//! transport ack on a consumer-provided durable commit. See
+//! [`crate::types::durability_hook::InboundDurabilityHook`] for the contract.
+
+use super::*;
+use crate::types::durability_hook::InboundDurabilityHook;
+
+impl Client {
+    /// The registered inbound durability hook, if any. `None` (default) keeps
+    /// the at-most-once ack path with zero overhead.
+    pub(crate) fn inbound_durability_hook(&self) -> Option<Arc<dyn InboundDurabilityHook>> {
+        self.inbound_durability_hook.get().cloned()
+    }
+
+    /// First-receipt path: buffer the decrypted message durably, run the hook,
+    /// and ack only on success. On failure the buffered row is left for the
+    /// server's redelivery to retry. Replaces the plain ack for a freshly
+    /// dispatched user message when a hook is configured.
+    pub(crate) async fn run_inbound_durability_hook(
+        self: &Arc<Self>,
+        hook: Arc<dyn InboundDurabilityHook>,
+        info: &Arc<MessageInfo>,
+        msg: &Arc<wa::Message>,
+    ) {
+        let backend = self.persistence_manager.backend();
+        // Persist before the Signal ratchet is flushed (which happens after this
+        // returns) so a crash mid-commit replays the message instead of losing it.
+        let bytes = msg.encode_to_vec();
+        let buffered = match backend.store_pending_inbound(&info.id, &bytes).await {
+            Ok(()) => true,
+            Err(e) => {
+                log::error!(
+                    "[msg:{}] failed to buffer inbound message for durability hook: {e:?}",
+                    info.id
+                );
+                false
+            }
+        };
+
+        match hook.on_message(self.clone(), info, msg).await {
+            Ok(()) => {
+                if buffered && let Err(e) = backend.delete_pending_inbound(&info.id).await {
+                    log::debug!(
+                        "[msg:{}] failed to clear buffered inbound message: {e:?}",
+                        info.id
+                    );
+                }
+                self.ack_received_message(info);
+            }
+            Err(e) => {
+                log::warn!(
+                    "[msg:{}] inbound durability hook failed; suppressing ack for redelivery: {e:?}",
+                    info.id
+                );
+            }
+        }
+    }
+
+    /// Redelivery path: when the server replays an already-decrypted message
+    /// (`DuplicatedMessage`), re-run the hook from the buffered copy instead of
+    /// acking. Falls back to a plain ack when no hook is set, no buffered copy
+    /// exists (a genuine duplicate), or the buffer is unreadable.
+    pub(crate) async fn ack_or_replay_to_hook(self: &Arc<Self>, info: &Arc<MessageInfo>) {
+        if let Some(hook) = self.inbound_durability_hook() {
+            let backend = self.persistence_manager.backend();
+            match backend.get_pending_inbound(&info.id).await {
+                Ok(Some(bytes)) => match wa::Message::decode(bytes.as_slice()) {
+                    Ok(msg) => {
+                        let msg = Arc::new(msg);
+                        match hook.on_message(self.clone(), info, &msg).await {
+                            Ok(()) => {
+                                if let Err(e) = backend.delete_pending_inbound(&info.id).await {
+                                    log::debug!(
+                                        "[msg:{}] failed to clear buffered inbound message: {e:?}",
+                                        info.id
+                                    );
+                                }
+                                self.ack_received_message(info);
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "[msg:{}] inbound durability hook still failing on redelivery; keeping for retry: {e:?}",
+                                    info.id
+                                );
+                            }
+                        }
+                        return;
+                    }
+                    Err(e) => {
+                        // Corrupt row: drop it and ack so the queue is not stuck forever.
+                        log::error!(
+                            "[msg:{}] failed to decode buffered inbound message; acking to unstick queue: {e:?}",
+                            info.id
+                        );
+                        let _ = backend.delete_pending_inbound(&info.id).await;
+                    }
+                },
+                Ok(None) => {}
+                Err(e) => {
+                    log::debug!(
+                        "[msg:{}] failed to read pending inbound buffer: {e:?}",
+                        info.id
+                    );
+                }
+            }
+        }
+        self.ack_received_message(info);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::create_test_client_with_failing_http;
+    use crate::types::message::MessageInfo;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct CountingHook {
+        calls: AtomicUsize,
+        succeed: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl InboundDurabilityHook for CountingHook {
+        async fn on_message(
+            &self,
+            _client: Arc<Client>,
+            _info: &MessageInfo,
+            _message: &wa::Message,
+        ) -> anyhow::Result<()> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.succeed.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                Err(anyhow::anyhow!("commit failed"))
+            }
+        }
+    }
+
+    fn test_info(id: &str) -> Arc<MessageInfo> {
+        Arc::new(MessageInfo {
+            id: id.to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn test_msg() -> Arc<wa::Message> {
+        Arc::new(wa::Message {
+            conversation: Some("hello".to_string()),
+            ..Default::default()
+        })
+    }
+
+    // A successful hook acks the message and clears the buffered copy.
+    #[tokio::test]
+    async fn hook_ok_clears_buffer() {
+        let client = create_test_client_with_failing_http("durability_ok").await;
+        let hook = Arc::new(CountingHook {
+            calls: AtomicUsize::new(0),
+            succeed: AtomicBool::new(true),
+        });
+        let _ = client.inbound_durability_hook.set(hook.clone());
+
+        let info = test_info("MSG_OK");
+        client
+            .run_inbound_durability_hook(
+                client.inbound_durability_hook().unwrap(),
+                &info,
+                &test_msg(),
+            )
+            .await;
+
+        assert_eq!(hook.calls.load(Ordering::SeqCst), 1);
+        let backend = client.persistence_manager.backend();
+        assert!(
+            backend
+                .get_pending_inbound("MSG_OK")
+                .await
+                .unwrap()
+                .is_none(),
+            "a committed message must not stay buffered"
+        );
+    }
+
+    // A failing hook suppresses the ack and keeps the buffered copy; a later
+    // redelivery re-runs the hook and, once it succeeds, clears the buffer.
+    #[tokio::test]
+    async fn hook_err_keeps_buffer_then_replays() {
+        let client = create_test_client_with_failing_http("durability_err").await;
+        let hook = Arc::new(CountingHook {
+            calls: AtomicUsize::new(0),
+            succeed: AtomicBool::new(false),
+        });
+        let _ = client.inbound_durability_hook.set(hook.clone());
+        let backend = client.persistence_manager.backend();
+
+        let info = test_info("MSG_ERR");
+        client
+            .run_inbound_durability_hook(
+                client.inbound_durability_hook().unwrap(),
+                &info,
+                &test_msg(),
+            )
+            .await;
+
+        assert_eq!(hook.calls.load(Ordering::SeqCst), 1);
+        assert!(
+            backend
+                .get_pending_inbound("MSG_ERR")
+                .await
+                .unwrap()
+                .is_some(),
+            "a failed commit must keep the message buffered for redelivery"
+        );
+
+        // Redelivery while the hook still fails: re-runs but keeps the buffer.
+        client.ack_or_replay_to_hook(&info).await;
+        assert_eq!(
+            hook.calls.load(Ordering::SeqCst),
+            2,
+            "redelivery must re-run the hook"
+        );
+        assert!(
+            backend
+                .get_pending_inbound("MSG_ERR")
+                .await
+                .unwrap()
+                .is_some(),
+            "a still-failing hook keeps the buffered copy"
+        );
+
+        // Redelivery once the commit succeeds clears the buffer.
+        hook.succeed.store(true, Ordering::SeqCst);
+        client.ack_or_replay_to_hook(&info).await;
+        assert_eq!(hook.calls.load(Ordering::SeqCst), 3);
+        assert!(
+            backend
+                .get_pending_inbound("MSG_ERR")
+                .await
+                .unwrap()
+                .is_none(),
+            "a successful replay must clear the buffered copy"
+        );
+    }
+
+    // A genuine duplicate (no buffered copy) just acks without invoking the hook.
+    #[tokio::test]
+    async fn replay_without_buffer_just_acks() {
+        let client = create_test_client_with_failing_http("durability_dup").await;
+        let hook = Arc::new(CountingHook {
+            calls: AtomicUsize::new(0),
+            succeed: AtomicBool::new(true),
+        });
+        let _ = client.inbound_durability_hook.set(hook.clone());
+
+        client.ack_or_replay_to_hook(&test_info("MSG_NONE")).await;
+        assert_eq!(
+            hook.calls.load(Ordering::SeqCst),
+            0,
+            "no buffered copy means the hook must not run"
+        );
+    }
+}

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -480,8 +480,9 @@ impl Client {
             // server drops it from the offline queue (whatsmeow/WA Web treat
             // old-counter like success). status is acked by the should_ack gate
             // (a status SKDM pkmsg can reach here), so skip it to avoid a
-            // redundant receipt.
-            self.ack_received_message(&info);
+            // redundant receipt. With a durability hook, a buffered copy here
+            // means the original commit never acked, so replay it instead.
+            self.ack_or_replay_to_hook(&info).await;
         } else if should_ack_skdm_only_session_fallback(session_outcome, bot_payloads.is_empty()) {
             // SKDM-only session decrypts skip dispatch, so this stanza would
             // otherwise stay queued. WA Web and whatsmeow ack every decrypted
@@ -1164,9 +1165,10 @@ impl Client {
                     );
                     // Redelivered duplicate: ack it so the server drops it from the
                     // offline queue. status is already acked by the should_ack gate,
-                    // so skip it to avoid a redundant receipt.
+                    // so skip it to avoid a redundant receipt. With a durability hook,
+                    // a buffered copy means the original commit never acked: replay it.
                     if !info.source.chat.is_status_broadcast() {
-                        self.ack_received_message(info);
+                        self.ack_or_replay_to_hook(info).await;
                     }
                 }
                 Err(SignalProtocolError::NoSenderKeyState(msg)) => {

--- a/src/types/durability_hook.rs
+++ b/src/types/durability_hook.rs
@@ -1,0 +1,46 @@
+use crate::client::Client;
+use crate::types::message::MessageInfo;
+use anyhow::Result;
+use std::sync::Arc;
+use waproto::whatsapp as wa;
+
+/// Hook invoked for every decrypted inbound user message before it is
+/// acknowledged to the server, turning the consumer from at-most-once into
+/// at-least-once delivery.
+///
+/// The transport ack tells the server to drop the message from its offline
+/// queue. By default the SDK acks as soon as a message is decrypted, so a crash
+/// (or a failed DB write) before the consumer persists the message loses it for
+/// good. When a hook is registered, the ack is deferred until the hook returns
+/// `Ok`: the decrypted message is buffered durably first, the hook runs, and
+/// only on success is the ack sent and the buffer cleared. On `Err` (or a
+/// crash) the message stays unacked and the server redelivers it on the next
+/// connect, where the hook runs again from the buffered copy.
+///
+/// This is at-least-once, not exactly-once: a crash after the consumer commits
+/// but before the ack lands replays the message, so the hook MUST be
+/// idempotent — deduplicate by [`MessageInfo::id`].
+///
+/// Durable replay across process crashes requires a backend that implements the
+/// `ProtocolStore` pending-inbound methods (the bundled `SqliteStore` does).
+/// With a backend that does not, the hook still runs and still gates the ack for
+/// the live attempt, but a crash mid-commit cannot be replayed.
+///
+/// The hook is awaited inside the receive pipeline, so a slow hook backpressures
+/// inbound processing (the same trade-off as whatsmeow's synchronous ack). Do
+/// not perform blocking client operations for the same sender inside it (e.g. a
+/// synchronous reply) — that can deadlock against the per-sender Signal lock held
+/// while a 1:1 message is processed; persist and return, and spawn any reply.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait InboundDurabilityHook: wacore::sync_marker::MaybeSendSync {
+    /// Durably commit `message` (e.g. INSERT into your DB, enqueue to a broker).
+    /// Return `Ok(())` only after the commit is durable; the SDK then acks the
+    /// message. Return `Err` to suppress the ack and have the server redeliver.
+    async fn on_message(
+        &self,
+        client: Arc<Client>,
+        info: &MessageInfo,
+        message: &wa::Message,
+    ) -> Result<()>;
+}

--- a/src/types/durability_hook.rs
+++ b/src/types/durability_hook.rs
@@ -18,8 +18,10 @@ use waproto::whatsapp as wa;
 /// connect, where the hook runs again from the buffered copy.
 ///
 /// This is at-least-once, not exactly-once: a crash after the consumer commits
-/// but before the ack lands replays the message, so the hook MUST be
-/// idempotent — deduplicate by [`MessageInfo::id`].
+/// but before the ack lands replays the message, so the hook MUST be idempotent.
+/// Deduplicate by the message source AND id — `(info.source.chat,
+/// info.source.sender, info.id)` — not `info.id` alone: stanza ids are only
+/// unique within a `(chat, sender)`, so two chats can reuse the same id.
 ///
 /// Durable replay across process crashes requires a backend that implements the
 /// `ProtocolStore` pending-inbound methods (the bundled `SqliteStore` does).

--- a/src/types/durability_hook.rs
+++ b/src/types/durability_hook.rs
@@ -31,6 +31,19 @@ use waproto::whatsapp as wa;
 /// not perform blocking client operations for the same sender inside it (e.g. a
 /// synchronous reply) — that can deadlock against the per-sender Signal lock held
 /// while a 1:1 message is processed; persist and return, and spawn any reply.
+///
+/// Scope and known limitations:
+/// - Covers end-to-end encrypted messages (1:1 and group). Newsletter / broadcast
+///   channel messages are not encrypted and are acked on their own path, so the
+///   hook does not gate them.
+/// - If the durable buffer write itself fails (e.g. disk full, after retries),
+///   the ack is suppressed, but if the process does not crash the Signal ratchet
+///   still advances and that one message degrades to at-most-once on its next
+///   redelivery (it can no longer be decrypted, and there is no buffered copy to
+///   replay). The guarantee holds whenever the buffer write succeeds.
+/// - On a redelivery replay the `info` is re-parsed from the stanza, so a few
+///   fields derived during the first dispatch (the ephemeral timer, encrypted
+///   comment threading) may be absent. The `message` body is always the original.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait InboundDurabilityHook: wacore::sync_marker::MaybeSendSync {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,4 +2,5 @@
 pub use wacore::types::*;
 
 // Local type definitions
+pub mod durability_hook;
 pub mod enc_handler;

--- a/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/down.sql
+++ b/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pending_inbound_inserted;
+DROP TABLE IF EXISTS pending_inbound_messages;

--- a/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/up.sql
+++ b/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/up.sql
@@ -11,4 +11,5 @@ CREATE TABLE pending_inbound_messages (
     PRIMARY KEY (id, device_id)
 );
 
-CREATE INDEX idx_pending_inbound_inserted ON pending_inbound_messages (inserted_at, device_id);
+-- device_id first (equality) then inserted_at (range) for the retention sweep.
+CREATE INDEX idx_pending_inbound_inserted ON pending_inbound_messages (device_id, inserted_at);

--- a/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/up.sql
+++ b/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/up.sql
@@ -1,14 +1,21 @@
 -- Durable buffer for decrypted inbound messages awaiting an inbound-durability
 -- hook commit. The hook gates the transport ack: a row lives here until the
 -- hook confirms the message is committed, so a crash before the commit replays
--- the message on the next connect instead of losing it. Keyed by the stanza id.
+-- the message on the next connect instead of losing it.
+--
+-- Keyed by (chat, sender, id): stanza ids are only unique within a (chat,
+-- sender), matching how msg_secrets and the retry cache scope message ids. A
+-- bare id key would let a same-id message in another chat clobber a still
+-- pending buffer.
 
 CREATE TABLE pending_inbound_messages (
+    chat TEXT NOT NULL,
+    sender TEXT NOT NULL,
     id TEXT NOT NULL,
     message BLOB NOT NULL,
     device_id INTEGER NOT NULL DEFAULT 1,
     inserted_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
-    PRIMARY KEY (id, device_id)
+    PRIMARY KEY (chat, sender, id, device_id)
 );
 
 -- device_id first (equality) then inserted_at (range) for the retention sweep.

--- a/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/up.sql
+++ b/storages/sqlite-storage/migrations/2026-06-26-000000_add_pending_inbound_messages/up.sql
@@ -1,0 +1,14 @@
+-- Durable buffer for decrypted inbound messages awaiting an inbound-durability
+-- hook commit. The hook gates the transport ack: a row lives here until the
+-- hook confirms the message is committed, so a crash before the commit replays
+-- the message on the next connect instead of losing it. Keyed by the stanza id.
+
+CREATE TABLE pending_inbound_messages (
+    id TEXT NOT NULL,
+    message BLOB NOT NULL,
+    device_id INTEGER NOT NULL DEFAULT 1,
+    inserted_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    PRIMARY KEY (id, device_id)
+);
+
+CREATE INDEX idx_pending_inbound_inserted ON pending_inbound_messages (inserted_at, device_id);

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -170,6 +170,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    pending_inbound_messages (id, device_id) {
+        id -> Text,
+        message -> Binary,
+        device_id -> Integer,
+        inserted_at -> BigInt,
+    }
+}
+
+diesel::table! {
     msg_secrets (chat, sender, msg_id, device_id) {
         chat -> Text,
         sender -> Text,
@@ -193,6 +202,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     identities,
     lid_pn_mapping,
     msg_secrets,
+    pending_inbound_messages,
     prekeys,
     sender_key_devices,
     sender_keys,

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -170,7 +170,9 @@ diesel::table! {
 }
 
 diesel::table! {
-    pending_inbound_messages (id, device_id) {
+    pending_inbound_messages (chat, sender, id, device_id) {
+        chat -> Text,
+        sender -> Text,
         id -> Text,
         message -> Binary,
         device_id -> Integer,

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2837,6 +2837,86 @@ impl ProtocolStore for SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))?
     }
+
+    async fn store_pending_inbound(&self, id: &str, message: &[u8]) -> Result<()> {
+        let id = id.to_string();
+        // Arc avoids cloning the payload bytes on each retry iteration.
+        let message: Arc<Vec<u8>> = Arc::new(message.to_vec());
+        let device_id = self.device_id;
+        self.with_retry("store_pending_inbound", || {
+            let id = id.clone();
+            let message = Arc::clone(&message);
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::replace_into(pending_inbound_messages::table)
+                    .values((
+                        pending_inbound_messages::id.eq(&id),
+                        pending_inbound_messages::message.eq(message.as_slice()),
+                        pending_inbound_messages::device_id.eq(device_id),
+                    ))
+                    .execute(conn)?;
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    async fn get_pending_inbound(&self, id: &str) -> Result<Option<Vec<u8>>> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let id = id.to_string();
+        self.with_semaphore(move || -> Result<Option<Vec<u8>>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let row: Option<Vec<u8>> = pending_inbound_messages::table
+                .select(pending_inbound_messages::message)
+                .filter(pending_inbound_messages::id.eq(&id))
+                .filter(pending_inbound_messages::device_id.eq(device_id))
+                .first(&mut conn)
+                .optional()
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(row)
+        })
+        .await
+    }
+
+    async fn delete_pending_inbound(&self, id: &str) -> Result<()> {
+        let id = id.to_string();
+        let device_id = self.device_id;
+        self.with_retry("delete_pending_inbound", || {
+            let id = id.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                diesel::delete(
+                    pending_inbound_messages::table
+                        .filter(pending_inbound_messages::id.eq(&id))
+                        .filter(pending_inbound_messages::device_id.eq(device_id)),
+                )
+                .execute(conn)?;
+                Ok(())
+            })
+        })
+        .await
+    }
+
+    async fn delete_expired_pending_inbound(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        tokio::task::spawn_blocking(move || -> Result<u32> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let deleted = diesel::delete(
+                pending_inbound_messages::table
+                    .filter(pending_inbound_messages::inserted_at.lt(cutoff_timestamp))
+                    .filter(pending_inbound_messages::device_id.eq(device_id)),
+            )
+            .execute(&mut conn)
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(deleted as u32)
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))?
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2838,17 +2838,29 @@ impl ProtocolStore for SqliteStore {
         .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
-    async fn store_pending_inbound(&self, id: &str, message: &[u8]) -> Result<()> {
+    async fn store_pending_inbound(
+        &self,
+        chat: &str,
+        sender: &str,
+        id: &str,
+        message: &[u8],
+    ) -> Result<()> {
+        let chat = chat.to_string();
+        let sender = sender.to_string();
         let id = id.to_string();
         // Arc avoids cloning the payload bytes on each retry iteration.
         let message: Arc<Vec<u8>> = Arc::new(message.to_vec());
         let device_id = self.device_id;
         self.with_retry("store_pending_inbound", || {
+            let chat = chat.clone();
+            let sender = sender.clone();
             let id = id.clone();
             let message = Arc::clone(&message);
             Box::new(move |conn: &mut SqliteConnection| {
                 diesel::replace_into(pending_inbound_messages::table)
                     .values((
+                        pending_inbound_messages::chat.eq(&chat),
+                        pending_inbound_messages::sender.eq(&sender),
                         pending_inbound_messages::id.eq(&id),
                         pending_inbound_messages::message.eq(message.as_slice()),
                         pending_inbound_messages::device_id.eq(device_id),
@@ -2860,16 +2872,27 @@ impl ProtocolStore for SqliteStore {
         .await
     }
 
-    async fn get_pending_inbound(&self, id: &str) -> Result<Option<Vec<u8>>> {
+    async fn get_pending_inbound(
+        &self,
+        chat: &str,
+        sender: &str,
+        id: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        let chat = chat.to_string();
+        let sender = sender.to_string();
         let id = id.to_string();
         let device_id = self.device_id;
         // Retry on SQLITE_BUSY: a transient lock here must not surface as a read
         // failure, which fails closed and forces an unnecessary redelivery.
         self.with_retry("get_pending_inbound", || {
+            let chat = chat.clone();
+            let sender = sender.clone();
             let id = id.clone();
             Box::new(move |conn: &mut SqliteConnection| {
                 let row: Option<Vec<u8>> = pending_inbound_messages::table
                     .select(pending_inbound_messages::message)
+                    .filter(pending_inbound_messages::chat.eq(&chat))
+                    .filter(pending_inbound_messages::sender.eq(&sender))
                     .filter(pending_inbound_messages::id.eq(&id))
                     .filter(pending_inbound_messages::device_id.eq(device_id))
                     .first(conn)
@@ -2880,14 +2903,20 @@ impl ProtocolStore for SqliteStore {
         .await
     }
 
-    async fn delete_pending_inbound(&self, id: &str) -> Result<()> {
+    async fn delete_pending_inbound(&self, chat: &str, sender: &str, id: &str) -> Result<()> {
+        let chat = chat.to_string();
+        let sender = sender.to_string();
         let id = id.to_string();
         let device_id = self.device_id;
         self.with_retry("delete_pending_inbound", || {
+            let chat = chat.clone();
+            let sender = sender.clone();
             let id = id.clone();
             Box::new(move |conn: &mut SqliteConnection| {
                 diesel::delete(
                     pending_inbound_messages::table
+                        .filter(pending_inbound_messages::chat.eq(&chat))
+                        .filter(pending_inbound_messages::sender.eq(&sender))
                         .filter(pending_inbound_messages::id.eq(&id))
                         .filter(pending_inbound_messages::device_id.eq(device_id)),
                 )

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2861,21 +2861,21 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_pending_inbound(&self, id: &str) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
-        let device_id = self.device_id;
         let id = id.to_string();
-        self.with_semaphore(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            let row: Option<Vec<u8>> = pending_inbound_messages::table
-                .select(pending_inbound_messages::message)
-                .filter(pending_inbound_messages::id.eq(&id))
-                .filter(pending_inbound_messages::device_id.eq(device_id))
-                .first(&mut conn)
-                .optional()
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-            Ok(row)
+        let device_id = self.device_id;
+        // Retry on SQLITE_BUSY: a transient lock here must not surface as a read
+        // failure, which fails closed and forces an unnecessary redelivery.
+        self.with_retry("get_pending_inbound", || {
+            let id = id.clone();
+            Box::new(move |conn: &mut SqliteConnection| {
+                let row: Option<Vec<u8>> = pending_inbound_messages::table
+                    .select(pending_inbound_messages::message)
+                    .filter(pending_inbound_messages::id.eq(&id))
+                    .filter(pending_inbound_messages::device_id.eq(device_id))
+                    .first(conn)
+                    .optional()?;
+                Ok(row)
+            })
         })
         .await
     }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -64,6 +64,8 @@ struct InMemoryState {
     group_metadata: HashMap<String, Vec<u8>>,
     tc_tokens: HashMap<String, TcTokenEntry>,
     sent_messages: HashMap<SentMessageKey, SentMessageEntry>,
+    /// Pending inbound durability buffer: stanza id -> (message bytes, inserted_at).
+    pending_inbound: HashMap<String, (Vec<u8>, i64)>,
 
     // --- MsgSecret ---
     /// `expires_at = 0` means never expire; `message_ts = 0` means the parent
@@ -624,6 +626,39 @@ impl ProtocolStore for InMemoryBackend {
         s.sent_messages
             .retain(|_, entry| entry.timestamp >= cutoff_timestamp);
         Ok((before - s.sent_messages.len()) as u32)
+    }
+
+    async fn store_pending_inbound(&self, id: &str, message: &[u8]) -> Result<()> {
+        let now = crate::time::now_secs();
+        self.state
+            .lock()
+            .await
+            .pending_inbound
+            .insert(id.to_string(), (message.to_vec(), now));
+        Ok(())
+    }
+
+    async fn get_pending_inbound(&self, id: &str) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .state
+            .lock()
+            .await
+            .pending_inbound
+            .get(id)
+            .map(|(bytes, _)| bytes.clone()))
+    }
+
+    async fn delete_pending_inbound(&self, id: &str) -> Result<()> {
+        self.state.lock().await.pending_inbound.remove(id);
+        Ok(())
+    }
+
+    async fn delete_expired_pending_inbound(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let mut s = self.state.lock().await;
+        let before = s.pending_inbound.len();
+        s.pending_inbound
+            .retain(|_, (_, inserted_at)| *inserted_at >= cutoff_timestamp);
+        Ok((before - s.pending_inbound.len()) as u32)
     }
 }
 

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -64,8 +64,8 @@ struct InMemoryState {
     group_metadata: HashMap<String, Vec<u8>>,
     tc_tokens: HashMap<String, TcTokenEntry>,
     sent_messages: HashMap<SentMessageKey, SentMessageEntry>,
-    /// Pending inbound durability buffer: stanza id -> (message bytes, inserted_at).
-    pending_inbound: HashMap<String, (Vec<u8>, i64)>,
+    /// Pending inbound durability buffer: (chat, sender, id) -> (message, inserted_at).
+    pending_inbound: HashMap<(String, String, String), (Vec<u8>, i64)>,
 
     // --- MsgSecret ---
     /// `expires_at = 0` means never expire; `message_ts = 0` means the parent
@@ -628,28 +628,40 @@ impl ProtocolStore for InMemoryBackend {
         Ok((before - s.sent_messages.len()) as u32)
     }
 
-    async fn store_pending_inbound(&self, id: &str, message: &[u8]) -> Result<()> {
+    async fn store_pending_inbound(
+        &self,
+        chat: &str,
+        sender: &str,
+        id: &str,
+        message: &[u8],
+    ) -> Result<()> {
         let now = crate::time::now_secs();
-        self.state
-            .lock()
-            .await
-            .pending_inbound
-            .insert(id.to_string(), (message.to_vec(), now));
+        self.state.lock().await.pending_inbound.insert(
+            (chat.to_string(), sender.to_string(), id.to_string()),
+            (message.to_vec(), now),
+        );
         Ok(())
     }
 
-    async fn get_pending_inbound(&self, id: &str) -> Result<Option<Vec<u8>>> {
+    async fn get_pending_inbound(
+        &self,
+        chat: &str,
+        sender: &str,
+        id: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        let key = (chat.to_string(), sender.to_string(), id.to_string());
         Ok(self
             .state
             .lock()
             .await
             .pending_inbound
-            .get(id)
+            .get(&key)
             .map(|(bytes, _)| bytes.clone()))
     }
 
-    async fn delete_pending_inbound(&self, id: &str) -> Result<()> {
-        self.state.lock().await.pending_inbound.remove(id);
+    async fn delete_pending_inbound(&self, chat: &str, sender: &str, id: &str) -> Result<()> {
+        let key = (chat.to_string(), sender.to_string(), id.to_string());
+        self.state.lock().await.pending_inbound.remove(&key);
         Ok(())
     }
 

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -495,10 +495,13 @@ pub trait ProtocolStore: Send + Sync {
 
     /// Remove a buffered inbound message once its durability hook has committed.
     async fn delete_pending_inbound(&self, _chat: &str, _sender: &str, _id: &str) -> Result<()> {
-        Ok(())
+        Err(unsupported_pending_inbound())
     }
 
-    /// Delete buffered inbound messages older than cutoff (unix seconds). Returns count deleted.
+    /// Delete buffered inbound messages older than cutoff (unix seconds). Returns
+    /// count deleted. Unlike the other defaults this is a benign `Ok(0)`: the
+    /// keepalive sweep calls it unconditionally for every backend, so it must not
+    /// error when the buffer is unsupported.
     async fn delete_expired_pending_inbound(&self, _cutoff_timestamp: i64) -> Result<u32> {
         Ok(0)
     }

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -450,6 +450,35 @@ pub trait ProtocolStore: Send + Sync {
 
     /// Delete sent messages older than cutoff (unix timestamp seconds). Returns count deleted.
     async fn delete_expired_sent_messages(&self, cutoff_timestamp: i64) -> Result<u32>;
+
+    // --- Pending Inbound Buffer (inbound durability hook) ---
+    //
+    // Backs the at-least-once inbound durability hook: a decrypted message is
+    // buffered here (keyed by its stanza id) before the Signal ratchet is
+    // flushed, so a crash or failed commit before the hook acks replays the
+    // message on redelivery instead of dropping it. No-op defaults keep this
+    // non-breaking for backends that do not support the hook; such a backend
+    // still runs the hook for the live attempt but cannot replay after a crash.
+
+    /// Persist a decrypted inbound message awaiting a durability-hook commit.
+    async fn store_pending_inbound(&self, _id: &str, _message: &[u8]) -> Result<()> {
+        Ok(())
+    }
+
+    /// Read a buffered inbound message by id without removing it.
+    async fn get_pending_inbound(&self, _id: &str) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    /// Remove a buffered inbound message once its durability hook has committed.
+    async fn delete_pending_inbound(&self, _id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    /// Delete buffered inbound messages older than cutoff (unix seconds). Returns count deleted.
+    async fn delete_expired_pending_inbound(&self, _cutoff_timestamp: i64) -> Result<u32> {
+        Ok(0)
+    }
 }
 
 /// Device data persistence operations.

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -471,17 +471,30 @@ pub trait ProtocolStore: Send + Sync {
     // message stays unacked) instead of silently degrading to at-most-once.
 
     /// Persist a decrypted inbound message awaiting a durability-hook commit.
-    async fn store_pending_inbound(&self, _id: &str, _message: &[u8]) -> Result<()> {
+    /// Scoped by `(chat, sender, id)` because stanza ids are only unique within
+    /// a `(chat, sender)`.
+    async fn store_pending_inbound(
+        &self,
+        _chat: &str,
+        _sender: &str,
+        _id: &str,
+        _message: &[u8],
+    ) -> Result<()> {
         Err(unsupported_pending_inbound())
     }
 
-    /// Read a buffered inbound message by id without removing it.
-    async fn get_pending_inbound(&self, _id: &str) -> Result<Option<Vec<u8>>> {
+    /// Read a buffered inbound message by `(chat, sender, id)` without removing it.
+    async fn get_pending_inbound(
+        &self,
+        _chat: &str,
+        _sender: &str,
+        _id: &str,
+    ) -> Result<Option<Vec<u8>>> {
         Err(unsupported_pending_inbound())
     }
 
     /// Remove a buffered inbound message once its durability hook has committed.
-    async fn delete_pending_inbound(&self, _id: &str) -> Result<()> {
+    async fn delete_pending_inbound(&self, _chat: &str, _sender: &str, _id: &str) -> Result<()> {
         Ok(())
     }
 

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -302,6 +302,15 @@ pub trait AppSyncStore: Send + Sync {
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>>;
 }
 
+/// Error returned by the default pending-inbound methods so a backend that does
+/// not implement the durability buffer fails closed (no silent at-most-once).
+fn unsupported_pending_inbound() -> crate::store::error::StoreError {
+    crate::store::error::StoreError::Validation(
+        "backend does not support the pending inbound buffer required by the durability hook"
+            .to_string(),
+    )
+}
+
 /// WhatsApp Web protocol alignment storage.
 ///
 /// Handles SKDM tracking, LID-PN mapping, base key collision detection,
@@ -456,18 +465,19 @@ pub trait ProtocolStore: Send + Sync {
     // Backs the at-least-once inbound durability hook: a decrypted message is
     // buffered here (keyed by its stanza id) before the Signal ratchet is
     // flushed, so a crash or failed commit before the hook acks replays the
-    // message on redelivery instead of dropping it. No-op defaults keep this
-    // non-breaking for backends that do not support the hook; such a backend
-    // still runs the hook for the live attempt but cannot replay after a crash.
+    // message on redelivery instead of dropping it. The defaults are non-breaking
+    // for backends that do not implement the hook, but fail CLOSED rather than
+    // no-op: an unsupported backend used with a hook surfaces an error (and the
+    // message stays unacked) instead of silently degrading to at-most-once.
 
     /// Persist a decrypted inbound message awaiting a durability-hook commit.
     async fn store_pending_inbound(&self, _id: &str, _message: &[u8]) -> Result<()> {
-        Ok(())
+        Err(unsupported_pending_inbound())
     }
 
     /// Read a buffered inbound message by id without removing it.
     async fn get_pending_inbound(&self, _id: &str) -> Result<Option<Vec<u8>>> {
-        Ok(None)
+        Err(unsupported_pending_inbound())
     }
 
     /// Remove a buffered inbound message once its durability hook has committed.


### PR DESCRIPTION
## What

Adds an **opt-in** `InboundDurabilityHook` that converts the inbound consumer from at-most-once to at-least-once delivery. Default behavior is unchanged: with no hook registered, nothing is buffered and the ack path is identical to before.

## Why

The client acks a message to the server as soon as it is decrypted, before any event handler runs (the dispatch is fire-and-forget). The ack tells the server to drop the message from its offline queue and never resend it. So if the process crashes, or the consumer's storage write fails, before the message is persisted, it is lost for good and no event handler can fix this because the ack timing is decoupled from handler completion.

This is the same gap whatsmeow closes with `SynchronousAck` + `EnableDecryptedEventBuffer`. We compared whatsmeow (Go), zapo (TS) and WA Web: only whatsmeow offers this guarantee, and it does so with a decrypt buffer rather than a global gate. This PR follows that design.

## How

When a hook is registered, the transport ack for a decrypted user message is deferred until the hook commits it:

- The decrypted `Message` is buffered durably (new `pending_inbound_messages` table, keyed by stanza id) **before** the Signal ratchet is flushed, so the buffer is durable whenever the ratchet is. No cross-table transaction is needed: the write ordering alone gives the "ratchet durable implies buffer durable" invariant.
- On hook `Ok`: the message is acked and the buffered row is cleared.
- On hook `Err` (or a crash): the message stays unacked. The server redelivers it on the next connect, where the `DuplicatedMessage` path replays it from the buffer instead of acking. Once the hook succeeds, the row is cleared.
- A retention sweep (7 days, only when a hook is configured) bounds rows a permanently-failing hook would otherwise leak.

## Caveats (documented on the trait)

- **At-least-once, not exactly-once.** A crash after the consumer commits but before the ack lands replays the message, so the hook MUST be idempotent (dedupe by `info.id`).
- The hook is awaited in the receive pipeline, so a slow hook backpressures inbound processing (same trade-off as whatsmeow's synchronous ack). Do not perform blocking client operations for the same sender inside it; persist and return, and spawn any reply.
- Durable cross-crash replay requires a backend implementing the new `ProtocolStore` pending-inbound methods. The bundled `SqliteStore` does; the methods have no-op defaults so external backends are non-breaking (the hook still gates the ack for the live attempt there, just without crash replay).

## Wiring

`Bot::builder().with_inbound_durability_hook(hook)`. See `examples/durability_hook.rs`.

## Tests

`cargo test`, `cargo clippy --all-targets -D warnings`, `cargo fmt` all green. New unit tests drive the full state machine against the real `SqliteStore` (ack+clear on `Ok`, keep buffer on `Err`, replay on redelivery, plain ack for a genuine duplicate).



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
