### PR TITLE
feat(retry): bound inbound retry-receipt rate per sender

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -208,6 +208,11 @@ pub struct CacheConfig {
     /// Default: 4096.
     pub resend_rate_limiter_capacity: u64,
 
+    /// Per-sender retry-receipt rate-limiter capacity: one token-bucket entry per
+    /// sender recently driving decrypt-failure retries. Same fail-open eviction
+    /// semantics as `resend_rate_limiter_capacity`. Default: 4096.
+    pub retry_receipt_limiter_capacity: u64,
+
     // --- Sent message DB cleanup ---
     /// TTL in seconds for sent messages in DB before periodic cleanup. Must
     /// outlive retry receipts (which can arrive well after a send) or the retry
@@ -283,6 +288,10 @@ impl std::fmt::Debug for CacheConfig {
                 "resend_rate_limiter_capacity",
                 &self.resend_rate_limiter_capacity,
             )
+            .field(
+                "retry_receipt_limiter_capacity",
+                &self.retry_receipt_limiter_capacity,
+            )
             .field("sent_message_ttl_secs", &self.sent_message_ttl_secs)
             .field("msg_secret_policy", &self.msg_secret_policy)
             .field("msg_secret_retention", &self.msg_secret_retention)
@@ -340,6 +349,7 @@ impl Default for CacheConfig {
             session_locks_capacity: 10_000,
             chat_lanes_capacity: 5_000,
             resend_rate_limiter_capacity: 4_096,
+            retry_receipt_limiter_capacity: 4_096,
             sent_message_ttl_secs: 7200,
             // Bounded by default: seed only the still-relevant slice of history
             // and prune by per-add-on-kind event-time horizons, so the store no

--- a/src/client.rs
+++ b/src/client.rs
@@ -199,6 +199,9 @@ pub struct MemoryDiagnostics {
     pub resend_rate_limiter_chats: u64,
     /// Total outbound resends dropped by the per-chat rate limiter since start.
     pub resends_throttled_total: u64,
+    pub retry_receipt_limiter_senders: u64,
+    /// Total inbound retry receipts dropped by the per-sender rate limiter since start.
+    pub retry_receipts_throttled_total: u64,
     // -- Unbounded collections --
     pub response_waiters: usize,
     pub node_waiters: usize,
@@ -253,6 +256,16 @@ impl std::fmt::Display for MemoryDiagnostics {
             f,
             "  resends_throttled:      {}",
             self.resends_throttled_total
+        )?;
+        writeln!(
+            f,
+            "  retry_receipt_rl_senders: {}",
+            self.retry_receipt_limiter_senders
+        )?;
+        writeln!(
+            f,
+            "  retry_receipts_throttled: {}",
+            self.retry_receipts_throttled_total
         )?;
         writeln!(f, "--- Unbounded collections ---")?;
         writeln!(f, "  response_waiters:       {}", self.response_waiters)?;
@@ -496,6 +509,11 @@ pub struct Client {
     /// to a chat (the anti-abuse signal) so a PN to LID fan-out cannot storm into
     /// AccountLocked. Throttled devices still recover via the fresh-SKDM mark.
     pub(crate) resend_rate_limiter: crate::resend_rate_limiter::ResendRateLimiter,
+
+    /// Per-sender inbound retry-receipt rate limiter: bounds the aggregate
+    /// retry-receipt rate to a sender so a chronically undecryptable peer cannot
+    /// storm us into AccountLocked. Throttled receipts are acked-and-dropped.
+    pub(crate) retry_receipt_limiter: crate::retry_receipt_limiter::RetryReceiptLimiter,
 
     /// Dispatch-once gate for `UndecryptableMessage`: a server resend of a
     /// failed id re-enters the failure path and would otherwise fire a

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -80,6 +80,24 @@ impl Client {
         self.resend_rate_limiter.throttled_total()
     }
 
+    /// Retune the per-sender inbound retry-receipt rate limit. Bounds the
+    /// aggregate retry-receipt rate to a sender so a chronically undecryptable
+    /// peer cannot storm us into AccountLocked; a throttled receipt is
+    /// acked-and-dropped instead. A `burst` of 0 disables the limiter.
+    ///
+    /// Takes effect on each sender's next decrypt failure; a lowered `burst`
+    /// clamps a live bucket on its next access.
+    pub fn set_retry_receipt_rate_limit(&self, burst: u32, refill_per_min: u32) {
+        self.retry_receipt_limiter.set_rate(burst, refill_per_min);
+    }
+
+    /// Total inbound retry receipts dropped by the per-sender rate limiter since
+    /// start. Surfaces chronically broken senders without the
+    /// `debug-diagnostics` feature.
+    pub fn retry_receipts_throttled_total(&self) -> u64 {
+        self.retry_receipt_limiter.throttled_total()
+    }
+
     /// Returns a snapshot of all internal collection sizes for memory leak detection.
     ///
     /// Moka caches report approximate counts (pending evictions may not be reflected).
@@ -117,6 +135,8 @@ impl Client {
             chat_lanes: self.chat_lanes.entry_count(),
             resend_rate_limiter_chats: self.resend_rate_limiter.entry_count(),
             resends_throttled_total: self.resend_rate_limiter.throttled_total(),
+            retry_receipt_limiter_senders: self.retry_receipt_limiter.entry_count(),
+            retry_receipts_throttled_total: self.retry_receipt_limiter.throttled_total(),
             response_waiters: self.response_waiters.lock().await.len(),
             node_waiters: self.node_waiter_count.load(Ordering::Relaxed),
             pending_retries: pending_retries_count,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -191,6 +191,12 @@ impl Client {
                 crate::resend_rate_limiter::DEFAULT_RESEND_REFILL_PER_MIN,
             ),
 
+            retry_receipt_limiter: crate::retry_receipt_limiter::RetryReceiptLimiter::new(
+                cache_config.retry_receipt_limiter_capacity,
+                crate::retry_receipt_limiter::DEFAULT_RETRY_RECEIPT_BURST,
+                crate::retry_receipt_limiter::DEFAULT_RETRY_RECEIPT_REFILL_PER_MIN,
+            ),
+
             undecryptable_dispatched: cache_config.undecryptable_dispatched.build_with_ttl(),
 
             offline_sync_metrics: Arc::new(OfflineSyncMetrics {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use waproto;
 pub mod cache;
 pub mod portable_cache;
 pub(crate) mod resend_rate_limiter;
+pub(crate) mod retry_receipt_limiter;
 
 pub mod cache_config;
 pub use cache_config::{

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -62,6 +62,13 @@ impl Client {
     /// gate, which can be dropped mid-flush on disconnect; the server dedups the
     /// resulting duplicate ack.
     ///
+    /// Exception: when the per-sender [`retry_receipt_limiter`] is exhausted
+    /// (a sender whose session is chronically broken), the message is
+    /// deliberately ack-and-dropped — the ack goes out *without* a retry so the
+    /// server stops redelivering, rather than asking for a resend forever.
+    ///
+    /// [`retry_receipt_limiter`]: crate::retry_receipt_limiter
+    ///
     /// Returns `true` to be assigned to `dispatched_undecryptable` flag.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.decrypt_failure", level = "debug", skip_all, fields(chat = %info.source.chat.observe(), sender = %info.source.sender.observe(), msg_id = %info.id, reason = ?reason)))]
     pub(crate) async fn handle_decrypt_failure(
@@ -92,6 +99,25 @@ impl Client {
                 && Self::should_send_delivery_receipt(&info)
             {
                 client.send_delivery_receipt(&info).await;
+                return;
+            }
+            // Bound the aggregate retry-receipt rate per sender. A chronically
+            // broken session fails every message, so the per-id retry cap
+            // (MAX_DECRYPT_RETRIES) never bounds the per-sender total and we'd
+            // ask for a resend forever — an AccountLocked-class outbound storm.
+            // When throttled, ack-and-drop: clear the stanza from the offline
+            // queue (stops redelivery) rather than ask again. The session still
+            // self-heals as the bucket refills and a fresh handshake recovers it.
+            if !client
+                .retry_receipt_limiter
+                .try_acquire(&info.source.sender)
+                .await
+            {
+                log::debug!(
+                    "Throttling retry receipt to {}: per-sender retry-receipt rate cap reached",
+                    info.source.sender.observe()
+                );
+                client.send_transport_ack(&info).await;
                 return;
             }
             // Only ack once the resend request is actually out; otherwise leave

--- a/src/resend_rate_limiter.rs
+++ b/src/resend_rate_limiter.rs
@@ -32,14 +32,16 @@ pub(crate) const DEFAULT_RESEND_BURST: u32 = 20;
 /// yet above any healthy chat's steady resend need.
 pub(crate) const DEFAULT_RESEND_REFILL_PER_MIN: u32 = 10;
 
-struct TokenBucket {
+/// Lazy-refill token bucket. Shared with [`crate::retry_receipt_limiter`], which
+/// applies the same arithmetic per sender instead of per chat.
+pub(crate) struct TokenBucket {
     tokens: f64,
     last_refill: Instant,
 }
 
 impl TokenBucket {
     #[inline]
-    fn new(initial: f64, now: Instant) -> Self {
+    pub(crate) fn new(initial: f64, now: Instant) -> Self {
         Self {
             tokens: initial,
             last_refill: now,
@@ -52,7 +54,7 @@ impl TokenBucket {
     /// cannot accumulate an unbounded reserve and a lowered `burst` takes effect
     /// on the next access.
     #[inline]
-    fn try_take(&mut self, now: Instant, burst: f64, refill_per_sec: f64) -> bool {
+    pub(crate) fn try_take(&mut self, now: Instant, burst: f64, refill_per_sec: f64) -> bool {
         let elapsed = now
             .saturating_duration_since(self.last_refill)
             .as_secs_f64();

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -2233,6 +2233,40 @@ mod tests {
         }
     }
 
+    /// The per-sender retry-receipt limiter is reachable and tunable through the
+    /// public `Client` API, and its drops surface on
+    /// `retry_receipts_throttled_total`. Covers the wiring the
+    /// `handle_decrypt_failure` hook relies on; the bucket logic itself is
+    /// unit-tested in `retry_receipt_limiter`.
+    #[tokio::test]
+    async fn client_retry_receipt_limiter_is_wired_and_tunable() {
+        let client =
+            crate::test_utils::create_test_client_with_failing_http("retry_receipt_rl_wired").await;
+        let sender: Jid = "100000000000001@lid".parse().unwrap();
+
+        // Tight ceiling, no refill: the bucket holds exactly `burst` tokens.
+        client.set_retry_receipt_rate_limit(3, 0);
+        let mut allowed = 0;
+        for _ in 0..10 {
+            if client.retry_receipt_limiter.try_acquire(&sender).await {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, 3, "client honors the configured per-sender burst");
+        assert_eq!(
+            client.retry_receipts_throttled_total(),
+            7,
+            "public counter tracks dropped retry receipts"
+        );
+
+        // Disabling restores unthrottled behavior.
+        client.set_retry_receipt_rate_limit(0, 0);
+        let other: Jid = "100000000000002@lid".parse().unwrap();
+        for _ in 0..50 {
+            assert!(client.retry_receipt_limiter.try_acquire(&other).await);
+        }
+    }
+
     /// End-to-end: a throttled group retry drops the resend (returns Ok, sends
     /// nothing) while the path up to the limiter still runs, and the cached
     /// message is retained for the device's later re-request. Exercises the hook

--- a/src/retry_receipt_limiter.rs
+++ b/src/retry_receipt_limiter.rs
@@ -1,0 +1,199 @@
+//! Per-sender inbound retry-receipt rate limiter.
+//!
+//! When a peer's Signal session with us is chronically broken, every message
+//! they send fails to decrypt and we ask them to re-encrypt (a retry receipt).
+//! A peer that never re-establishes — or a draining offline queue of messages
+//! that can no longer decrypt — turns this into an unbounded outbound storm. The
+//! per-message cap [`MAX_DECRYPT_RETRIES`](crate::message::MAX_DECRYPT_RETRIES)
+//! bounds receipts per message id, not per sender, so a sender flooding distinct
+//! ids is never gated and the aggregate climbs into AccountLocked — the same
+//! anti-abuse class the per-chat [`resend_rate_limiter`](crate::resend_rate_limiter)
+//! bounds for outbound resends. This bounds it with one token bucket per sender.
+//!
+//! A throttled receipt is dropped and the stanza is acked instead (drained from
+//! the offline queue) so the server stops redelivering it: we give up on that
+//! one message rather than ask forever. The session still self-heals — the
+//! bucket refills lazily and any fresh handshake recovers it, so a transient
+//! desync (a handful of retries, well under the burst) is never penalized.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use async_lock::Mutex;
+use portable_atomic::AtomicU64;
+use wacore::time::Instant;
+use wacore_binary::jid::Jid;
+
+use crate::cache::Cache;
+use crate::resend_rate_limiter::TokenBucket;
+
+/// Burst of retry receipts allowed to one sender before the refill gates it.
+/// Buckets start full, so a sender's first failures (a real transient desync)
+/// always retry and recover; only a sustained flood crosses it.
+pub(crate) const DEFAULT_RETRY_RECEIPT_BURST: u32 = 10;
+
+/// Retry receipts replenished per minute per sender, i.e. the sustained ceiling.
+/// Low on purpose: a healthy sender never needs sustained retries, a bricked one
+/// is throttled to a trickle that still lets the session recover if the peer
+/// fixes itself, without storming the anti-abuse signal.
+pub(crate) const DEFAULT_RETRY_RECEIPT_REFILL_PER_MIN: u32 = 2;
+
+/// Pack `burst` (high 32 bits) + `refill_per_min` (low 32 bits) into one word.
+#[inline]
+fn pack_rate(burst: u32, refill_per_min: u32) -> u64 {
+    ((burst as u64) << 32) | refill_per_min as u64
+}
+
+#[inline]
+fn unpack_rate(packed: u64) -> (u32, u32) {
+    ((packed >> 32) as u32, packed as u32)
+}
+
+/// Per-sender token-bucket limiter for inbound retry receipts.
+pub(crate) struct RetryReceiptLimiter {
+    /// One bucket per sender. Capacity-only: evicting an idle sender's bucket
+    /// only forgives rate (it recreates full), never over-restricts.
+    buckets: Cache<Jid, Arc<Mutex<TokenBucket>>>,
+    /// `burst` and `refill_per_min` packed into one word so a live `set_rate`
+    /// publishes both as a single atomic snapshot — `try_acquire` can never read
+    /// a torn (new burst, old refill) pair.
+    rate: AtomicU64,
+    throttled_total: AtomicU64,
+}
+
+impl RetryReceiptLimiter {
+    pub(crate) fn new(capacity: u64, burst: u32, refill_per_min: u32) -> Self {
+        Self {
+            buckets: Cache::builder().max_capacity(capacity.max(1)).build(),
+            rate: AtomicU64::new(pack_rate(burst, refill_per_min)),
+            throttled_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Retune the rate live. Takes effect on each sender's next acquire; a
+    /// lowered `burst` clamps a live bucket on its next refill.
+    pub(crate) fn set_rate(&self, burst: u32, refill_per_min: u32) {
+        self.rate
+            .store(pack_rate(burst, refill_per_min), Ordering::Relaxed);
+    }
+
+    /// Try to consume one retry-receipt token for `sender`. `true` allows the
+    /// receipt, `false` drops it (caller acks-and-drops instead). A `burst` of 0
+    /// disables the limiter (always allows) and skips all bucket work.
+    pub(crate) async fn try_acquire(&self, sender: &Jid) -> bool {
+        // One load: burst and refill are always a consistent snapshot.
+        let (burst, refill_per_min) = unpack_rate(self.rate.load(Ordering::Relaxed));
+        if burst == 0 {
+            return true;
+        }
+        let burst = burst as f64;
+        let refill_per_sec = refill_per_min as f64 / 60.0;
+
+        // Single-flight get-or-create so concurrent failures for the same sender
+        // (each dispatched as a detached task) share one bucket; the per-bucket
+        // mutex then serializes the read-modify-write so the rate cannot be
+        // bypassed by interleaving.
+        let bucket = self
+            .buckets
+            .get_with_by_ref(sender, async move {
+                Arc::new(Mutex::new(TokenBucket::new(burst, Instant::now())))
+            })
+            .await;
+
+        let allowed = bucket
+            .lock()
+            .await
+            .try_take(Instant::now(), burst, refill_per_sec);
+        if !allowed {
+            self.throttled_total.fetch_add(1, Ordering::Relaxed);
+        }
+        allowed
+    }
+
+    /// Total retry receipts dropped by the limiter since start (observability).
+    pub(crate) fn throttled_total(&self) -> u64 {
+        self.throttled_total.load(Ordering::Relaxed)
+    }
+
+    /// Number of senders holding a live bucket (diagnostics).
+    #[cfg_attr(not(feature = "debug-diagnostics"), allow(dead_code))]
+    pub(crate) fn entry_count(&self) -> u64 {
+        self.buckets.entry_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sender(s: &str) -> Jid {
+        s.parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn under_burst_allows_then_over_burst_refuses() {
+        let limiter = RetryReceiptLimiter::new(100, 5, 0);
+        let s = sender("100000000000001@lid");
+        for _ in 0..5 {
+            assert!(limiter.try_acquire(&s).await, "within burst must pass");
+        }
+        assert!(!limiter.try_acquire(&s).await, "past burst must drop");
+        assert!(!limiter.try_acquire(&s).await);
+        assert_eq!(limiter.throttled_total(), 2);
+    }
+
+    #[tokio::test]
+    async fn disabled_limiter_allows_everything() {
+        let limiter = RetryReceiptLimiter::new(100, 0, 2);
+        let s = sender("100000000000001@lid");
+        for _ in 0..100 {
+            assert!(limiter.try_acquire(&s).await);
+        }
+        assert_eq!(
+            limiter.entry_count(),
+            0,
+            "disabled limiter creates no buckets"
+        );
+        assert_eq!(limiter.throttled_total(), 0);
+    }
+
+    #[tokio::test]
+    async fn buckets_are_per_sender() {
+        let limiter = RetryReceiptLimiter::new(100, 2, 0);
+        let a = sender("111@lid");
+        let b = sender("222@lid");
+        assert!(limiter.try_acquire(&a).await);
+        assert!(limiter.try_acquire(&a).await);
+        assert!(!limiter.try_acquire(&a).await, "a exhausted its own budget");
+        assert!(limiter.try_acquire(&b).await, "b has an independent budget");
+        assert!(limiter.try_acquire(&b).await);
+        assert!(!limiter.try_acquire(&b).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_acquires_for_one_sender_do_not_exceed_burst() {
+        let limiter = Arc::new(RetryReceiptLimiter::new(100, 10, 0));
+        let s = sender("100000000000001@lid");
+        let allowed = Arc::new(AtomicU64::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..40 {
+            let limiter = limiter.clone();
+            let s = s.clone();
+            let allowed = allowed.clone();
+            handles.push(tokio::spawn(async move {
+                if limiter.try_acquire(&s).await {
+                    allowed.fetch_add(1, Ordering::Relaxed);
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(
+            allowed.load(Ordering::Relaxed),
+            10,
+            "interleaved acquires cannot exceed the burst"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

A chronically undecryptable sender — a broken Signal session the peer never re-establishes, or a draining offline queue of messages that can no longer decrypt — fails **every** message it sends, and we emit a retry receipt for each one.

The per-message cap (`MAX_DECRYPT_RETRIES`) bounds receipts **per message id, not per sender**, so a sender flooding distinct ids is never gated and the aggregate outbound retry-receipt rate climbs into `AccountLocked`. This is the same anti-abuse class the per-chat resend limiter (#871) already bounds for outbound *resends*, but on the inbound decrypt-failure path.

Observed in production logs: **~25k retry receipts from ~15 senders over two days** (each sender failing 700–1300×), correlating with an `AccountLocked` incident.

## Solution

A per-sender token-bucket limiter (`retry_receipt_limiter`) mirroring `resend_rate_limiter`, keyed by sender. When a sender exhausts its budget in `handle_decrypt_failure`, **ack-and-drop** the stanza (send the transport ack to drain the offline queue so the server stops redelivering) instead of asking for a resend forever.

Key properties:
- **Self-healing:** the bucket refills lazily and any successful decrypt / fresh handshake recovers the sender. A transient desync (a handful of retries under the burst) is never penalized.
- **Non-invasive:** the `UndecryptableMessage` event still fires, so any app-side recovery (e.g. local session reset) is unaffected — only the *outbound retry receipt* is bounded.
- **Tunable live** via the public `Client` API, and drops surface on a counter for observability.

`TokenBucket` is now shared with `resend_rate_limiter` (made `pub(crate)`).

## API

- `Client::set_retry_receipt_rate_limit(burst, refill_per_min)` — retune live; `burst = 0` disables.
- `Client::retry_receipts_throttled_total()` — dropped-receipt counter.
- `MemoryDiagnostics`: `retry_receipt_limiter_senders`, `retry_receipts_throttled_total`.

Defaults: **burst 10, refill 2/min, capacity 4096 senders**.

## Testing

- Unit tests for the per-sender bucket (burst/refill, per-sender isolation, disabled, concurrency) mirroring the resend-limiter suite.
- A `Client`-level wiring test (`client_retry_receipt_limiter_is_wired_and_tunable`).
- Full lib suite green (`cargo test -p whatsapp-rust --lib`: 843 passed), `cargo clippy --tests` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

