### PR TITLE
perf(sqlite-storage): cut per-session memory & threads, with configurable tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,6 +4293,7 @@ dependencies = [
  "log",
  "portable-atomic",
  "prost",
+ "scheduled-thread-pool",
  "serde_json",
  "tokio",
  "wacore",

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,7 +8,7 @@ pub mod traits;
 
 // Re-export from the sqlite-storage crate when the feature is enabled
 #[cfg(feature = "sqlite-storage")]
-pub use whatsapp_rust_sqlite_storage::SqliteStore;
+pub use whatsapp_rust_sqlite_storage::{SqliteStore, SqliteStoreConfig, Synchronous};
 
 pub use crate::store::traits::*;
 use std::ops::{Deref, DerefMut};

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -30,6 +30,9 @@ diesel_migrations = { version = "2.3.2", default-features = false, features = [
 libsqlite3-sys = { version = "0.37", default-features = false, optional = true }
 log = { workspace = true }
 prost = { workspace = true }
+# Shared across all r2d2 pools so each per-session store doesn't spawn its own pool of
+# management threads. Already in the tree transitively via r2d2 0.8.
+scheduled-thread-pool = "0.2"
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
 wacore = { workspace = true }

--- a/storages/sqlite-storage/src/lib.rs
+++ b/storages/sqlite-storage/src/lib.rs
@@ -7,4 +7,4 @@ mod schema;
 mod sqlite_store;
 mod wire;
 
-pub use sqlite_store::SqliteStore;
+pub use sqlite_store::{SqliteStore, SqliteStoreConfig, Synchronous};

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -272,39 +272,49 @@ impl SqliteStore {
         let pool_size = config.pool_size.max(1);
         let thread_pool = config.thread_pool.unwrap_or_else(shared_r2d2_thread_pool);
 
-        // test_on_check_out(false): a local SQLite file connection doesn't spontaneously
-        // drop, so r2d2's per-checkout SELECT 1 liveness probe guards nothing — a real
-        // failure surfaces on the next query. The shared thread pool avoids r2d2's
-        // per-pool management threads (see shared_r2d2_thread_pool).
-        let pool = Pool::builder()
-            .max_size(pool_size)
-            .test_on_check_out(false)
-            .thread_pool(thread_pool)
-            .connection_customizer(Box::new(ConnectionOptions {
-                cache_size_kib: config.cache_size_kib,
-                busy_timeout_ms: config.busy_timeout.as_millis() as u64,
-                synchronous: config.synchronous,
-            }))
-            .build(manager)
-            .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        let options = ConnectionOptions {
+            cache_size_kib: config.cache_size_kib,
+            // Clamp a non-zero timeout up to >=1ms (and to SQLite's signed-int ms range):
+            // as_millis() would truncate a sub-millisecond Duration to 0, which disables the
+            // busy handler instead of keeping a short timeout.
+            busy_timeout_ms: if config.busy_timeout.is_zero() {
+                0
+            } else {
+                config.busy_timeout.as_millis().clamp(1, i32::MAX as u128) as u64
+            },
+            synchronous: config.synchronous,
+        };
 
-        let pool_clone = pool.clone();
-        tokio::task::spawn_blocking(move || -> std::result::Result<(), StoreError> {
-            let mut conn = pool_clone
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        // r2d2's build() synchronously opens the pool's initial connection, so build the
+        // pool AND run migrations inside one blocking task to keep the async runtime
+        // unblocked (matters when many stores open at once).
+        let pool =
+            tokio::task::spawn_blocking(move || -> std::result::Result<SqlitePool, StoreError> {
+                // test_on_check_out(false): a local SQLite file connection doesn't
+                // spontaneously drop, so r2d2's per-checkout SELECT 1 liveness probe guards
+                // nothing — a real failure surfaces on the next query. The shared thread pool
+                // avoids r2d2's per-pool management threads (see shared_r2d2_thread_pool).
+                let pool = Pool::builder()
+                    .max_size(pool_size)
+                    .test_on_check_out(false)
+                    .thread_pool(thread_pool)
+                    .connection_customizer(Box::new(options))
+                    .build(manager)
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
 
-            diesel::sql_query("PRAGMA journal_mode = WAL;")
-                .execute(&mut conn)
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
+                diesel::sql_query("PRAGMA journal_mode = WAL;")
+                    .execute(&mut conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                conn.run_pending_migrations(MIGRATIONS)
+                    .map_err(StoreError::Migration)?;
 
-            conn.run_pending_migrations(MIGRATIONS)
-                .map_err(StoreError::Migration)?;
-
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
+                Ok(pool)
+            })
+            .await
+            .map_err(|e| StoreError::Database(Box::new(e)))??;
 
         let database_path = parse_database_path(database_url)?;
 
@@ -3370,13 +3380,13 @@ mod tests {
         let config = SqliteStoreConfig {
             pool_size: 2,
             cache_size_kib: 4096,
+            busy_timeout: Duration::from_secs(7),
             synchronous: Synchronous::Full,
             thread_pool: Some(Arc::new(
                 scheduled_thread_pool::ScheduledThreadPool::builder()
                     .num_threads(1)
                     .build(),
             )),
-            ..Default::default()
         };
         let store = SqliteStore::with_config(&db_name, config)
             .await
@@ -3395,6 +3405,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(got, Some(mac.value_mac));
+
+        // The custom PRAGMAs actually reached SQLite, so the config wiring can't silently
+        // regress.
+        #[derive(diesel::QueryableByName)]
+        struct CacheSync {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            cache: i64,
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            sync: i64,
+        }
+        #[derive(diesel::QueryableByName)]
+        struct Busy {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            timeout: i64,
+        }
+        let mut conn = store.pool.get().unwrap();
+        let cs: CacheSync = diesel::sql_query(
+            "SELECT cs.cache_size AS cache, sy.synchronous AS sync \
+             FROM pragma_cache_size cs, pragma_synchronous sy",
+        )
+        .get_result(&mut conn)
+        .unwrap();
+        let busy: Busy = diesel::sql_query("PRAGMA busy_timeout")
+            .get_result(&mut conn)
+            .unwrap();
+        assert_eq!(cs.cache, -4096, "cache_size_kib applied as negative KiB");
+        assert_eq!(cs.sync, 2, "synchronous = FULL");
+        assert_eq!(busy.timeout, 7000, "busy_timeout = 7s");
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -9,6 +9,7 @@ use diesel::upsert::excluded;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use log::warn;
 use std::sync::Arc;
+use std::time::Duration;
 use wacore::appstate::hash::HashState;
 use wacore::appstate::processor::AppStateMutationMAC;
 use wacore::libsignal::protocol::{KeyPair, PrivateKey, PublicKey};
@@ -98,8 +99,65 @@ pub struct SqliteStore {
     device_id: i32,
 }
 
+/// `PRAGMA synchronous` durability level for a store's connections.
 #[derive(Debug, Clone, Copy)]
-struct ConnectionOptions;
+pub enum Synchronous {
+    Off,
+    Normal,
+    Full,
+}
+
+impl Synchronous {
+    fn as_pragma(self) -> &'static str {
+        match self {
+            Synchronous::Off => "OFF",
+            Synchronous::Normal => "NORMAL",
+            Synchronous::Full => "FULL",
+        }
+    }
+}
+
+/// Per-store connection tuning. [`Default`] is a low-memory profile sized for one
+/// `SqliteStore` per WhatsApp session on a single process: a single pooled connection
+/// (operations are serialized internally, so a second would only idle) sharing one
+/// process-wide r2d2 thread pool, with a 512 KiB page cache. Raise `pool_size` for real
+/// concurrent DB access — it drives both the pool and the internal serialization in
+/// lockstep — or `cache_size_kib` for a hotter/larger DB; pass a `thread_pool` to control
+/// r2d2's management threads (e.g. share your own across crates).
+#[derive(Clone)]
+pub struct SqliteStoreConfig {
+    /// Max concurrent operations: r2d2 `max_size` AND the internal semaphore permits,
+    /// kept in lockstep. Clamped to at least 1.
+    pub pool_size: u32,
+    /// `PRAGMA cache_size`, in KiB per connection.
+    pub cache_size_kib: u32,
+    /// `PRAGMA busy_timeout`.
+    pub busy_timeout: Duration,
+    /// `PRAGMA synchronous`.
+    pub synchronous: Synchronous,
+    /// r2d2 connection-management thread pool. `None` shares one process-wide pool so many
+    /// stores don't each spawn their own threads.
+    pub thread_pool: Option<Arc<scheduled_thread_pool::ScheduledThreadPool>>,
+}
+
+impl Default for SqliteStoreConfig {
+    fn default() -> Self {
+        Self {
+            pool_size: 1,
+            cache_size_kib: 512,
+            busy_timeout: Duration::from_secs(30),
+            synchronous: Synchronous::Normal,
+            thread_pool: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ConnectionOptions {
+    cache_size_kib: u32,
+    busy_timeout_ms: u64,
+    synchronous: Synchronous,
+}
 
 impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
     for ConnectionOptions
@@ -108,24 +166,19 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         &self,
         conn: &mut SqliteConnection,
     ) -> std::result::Result<(), diesel::r2d2::Error> {
-        diesel::sql_query("PRAGMA busy_timeout = 30000;")
-            .execute(conn)
-            .map_err(diesel::r2d2::Error::QueryError)?;
-        diesel::sql_query("PRAGMA synchronous = NORMAL;")
-            .execute(conn)
-            .map_err(diesel::r2d2::Error::QueryError)?;
-        // Negative = KiB. 512 KiB per connection (was 512 pages = ~2 MiB): a per-device
-        // session DB has a small hot working set, and with one store per WhatsApp session
-        // the page cache is a per-session cost that multiplies across a busy worker.
-        diesel::sql_query("PRAGMA cache_size = -512;")
-            .execute(conn)
-            .map_err(diesel::r2d2::Error::QueryError)?;
-        diesel::sql_query("PRAGMA temp_store = memory;")
-            .execute(conn)
-            .map_err(diesel::r2d2::Error::QueryError)?;
-        diesel::sql_query("PRAGMA foreign_keys = ON;")
-            .execute(conn)
-            .map_err(diesel::r2d2::Error::QueryError)?;
+        // cache_size negative = KiB (page-size independent). temp_store/foreign_keys are
+        // fixed: they guard correctness, not memory, so they're not user-tunable.
+        for pragma in [
+            format!("PRAGMA busy_timeout = {};", self.busy_timeout_ms),
+            format!("PRAGMA synchronous = {};", self.synchronous.as_pragma()),
+            format!("PRAGMA cache_size = -{};", self.cache_size_kib),
+            "PRAGMA temp_store = memory;".to_string(),
+            "PRAGMA foreign_keys = ON;".to_string(),
+        ] {
+            diesel::sql_query(pragma)
+                .execute(conn)
+                .map_err(diesel::r2d2::Error::QueryError)?;
+        }
         Ok(())
     }
 }
@@ -177,26 +230,61 @@ fn shared_r2d2_thread_pool() -> Arc<scheduled_thread_pool::ScheduledThreadPool> 
 }
 
 impl SqliteStore {
+    /// Open a store with the default low-memory [`SqliteStoreConfig`].
     pub async fn new(database_url: &str) -> std::result::Result<Self, StoreError> {
+        Self::build(database_url, 1, SqliteStoreConfig::default()).await
+    }
+
+    /// Open a store with a custom [`SqliteStoreConfig`] (the default favours low memory /
+    /// high session density; override to trade memory for concurrency or cache).
+    pub async fn with_config(
+        database_url: &str,
+        config: SqliteStoreConfig,
+    ) -> std::result::Result<Self, StoreError> {
+        Self::build(database_url, 1, config).await
+    }
+
+    pub async fn new_for_device(
+        database_url: &str,
+        device_id: i32,
+    ) -> std::result::Result<Self, StoreError> {
+        Self::build(database_url, device_id, SqliteStoreConfig::default()).await
+    }
+
+    /// Open a store for a specific device with a custom [`SqliteStoreConfig`].
+    pub async fn with_config_for_device(
+        database_url: &str,
+        device_id: i32,
+        config: SqliteStoreConfig,
+    ) -> std::result::Result<Self, StoreError> {
+        Self::build(database_url, device_id, config).await
+    }
+
+    async fn build(
+        database_url: &str,
+        device_id: i32,
+        config: SqliteStoreConfig,
+    ) -> std::result::Result<Self, StoreError> {
         let manager = ConnectionManager::<SqliteConnection>::new(database_url);
+        // pool_size drives both r2d2's max_size and the semaphore permits, so a serialized
+        // store (the default 1) carries exactly one connection, and raising it for real
+        // concurrency keeps the two in step.
+        let pool_size = config.pool_size.max(1);
+        let thread_pool = config.thread_pool.unwrap_or_else(shared_r2d2_thread_pool);
 
-        // One connection suffices: every store op is already serialized through
-        // `db_semaphore` (Semaphore::new(1)) below, so a second pooled connection was only
-        // ever idle overhead (its own SQLite page cache + per-connection structures).
-        let pool_size = 1;
-
-        // Local SQLite file connections don't spontaneously drop, so r2d2's
-        // default per-checkout liveness probe (a SELECT 1 via Diesel's
-        // is_valid) is pure overhead on every store op: any real failure
-        // surfaces as a StoreError on the next actual query, so the probe
-        // guards nothing here. Skipping it saves a cached SELECT 1 (reset+step)
-        // per pool.get(). The shared thread pool avoids r2d2's per-pool management
-        // threads (see shared_r2d2_thread_pool).
+        // test_on_check_out(false): a local SQLite file connection doesn't spontaneously
+        // drop, so r2d2's per-checkout SELECT 1 liveness probe guards nothing — a real
+        // failure surfaces on the next query. The shared thread pool avoids r2d2's
+        // per-pool management threads (see shared_r2d2_thread_pool).
         let pool = Pool::builder()
             .max_size(pool_size)
             .test_on_check_out(false)
-            .thread_pool(shared_r2d2_thread_pool())
-            .connection_customizer(Box::new(ConnectionOptions))
+            .thread_pool(thread_pool)
+            .connection_customizer(Box::new(ConnectionOptions {
+                cache_size_kib: config.cache_size_kib,
+                busy_timeout_ms: config.busy_timeout.as_millis() as u64,
+                synchronous: config.synchronous,
+            }))
             .build(manager)
             .map_err(|e| StoreError::Connection(Box::new(e)))?;
 
@@ -222,19 +310,10 @@ impl SqliteStore {
 
         Ok(Self {
             pool,
-            db_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+            db_semaphore: Arc::new(tokio::sync::Semaphore::new(pool_size as usize)),
             database_path,
-            device_id: 1,
+            device_id,
         })
-    }
-
-    pub async fn new_for_device(
-        database_url: &str,
-        device_id: i32,
-    ) -> std::result::Result<Self, StoreError> {
-        let mut store = Self::new(database_url).await?;
-        store.device_id = device_id;
-        Ok(store)
     }
 
     pub fn device_id(&self) -> i32 {
@@ -3267,6 +3346,55 @@ mod tests {
         SqliteStore::new(&db_name)
             .await
             .expect("Failed to create test store")
+    }
+
+    #[tokio::test]
+    async fn with_config_custom_tuning_builds_and_operates() {
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_name = format!(
+            "file:memdb_cfg_{}_{}?mode=memory&cache=shared",
+            std::process::id(),
+            id
+        );
+
+        // Default profile is the opinionated low-memory one (additive API: new() is unchanged).
+        let def = SqliteStoreConfig::default();
+        assert_eq!(def.pool_size, 1);
+        assert_eq!(def.cache_size_kib, 512);
+
+        // A non-default config (more concurrency, bigger cache, full durability, injected
+        // thread pool) must build and operate identically — only the resource profile differs.
+        let config = SqliteStoreConfig {
+            pool_size: 2,
+            cache_size_kib: 4096,
+            synchronous: Synchronous::Full,
+            thread_pool: Some(Arc::new(
+                scheduled_thread_pool::ScheduledThreadPool::builder()
+                    .num_threads(1)
+                    .build(),
+            )),
+            ..Default::default()
+        };
+        let store = SqliteStore::with_config(&db_name, config)
+            .await
+            .expect("custom-config store");
+
+        let mac = AppStateMutationMAC {
+            index_mac: vec![1u8; 32],
+            value_mac: vec![2u8; 32],
+        };
+        store
+            .put_app_state_mutation_macs_for_device("c", 1, std::slice::from_ref(&mac), 1)
+            .await
+            .unwrap();
+        let got = store
+            .get_app_state_mutation_mac_for_device("c", &mac.index_mac, 1)
+            .await
+            .unwrap();
+        assert_eq!(got, Some(mac.value_mac));
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -114,7 +114,10 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         diesel::sql_query("PRAGMA synchronous = NORMAL;")
             .execute(conn)
             .map_err(diesel::r2d2::Error::QueryError)?;
-        diesel::sql_query("PRAGMA cache_size = 512;")
+        // Negative = KiB. 512 KiB per connection (was 512 pages = ~2 MiB): a per-device
+        // session DB has a small hot working set, and with one store per WhatsApp session
+        // the page cache is a per-session cost that multiplies across a busy worker.
+        diesel::sql_query("PRAGMA cache_size = -512;")
             .execute(conn)
             .map_err(diesel::r2d2::Error::QueryError)?;
         diesel::sql_query("PRAGMA temp_store = memory;")
@@ -154,21 +157,45 @@ fn parse_database_path(database_url: &str) -> Result<String> {
     Ok(path.to_string())
 }
 
+/// One `ScheduledThreadPool` shared by EVERY store's r2d2 pool. By default r2d2 spawns its
+/// own pool of management threads (connection reaping/creation) per `Pool` — and with one
+/// `SqliteStore` per WhatsApp session that is ~3 idle threads PER SESSION (hundreds of
+/// threads on a busy worker, plus their stacks). Those threads only do infrequent
+/// connection housekeeping, so a single small shared pool serves all stores.
+fn shared_r2d2_thread_pool() -> Arc<scheduled_thread_pool::ScheduledThreadPool> {
+    static POOL: std::sync::OnceLock<Arc<scheduled_thread_pool::ScheduledThreadPool>> =
+        std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        Arc::new(
+            scheduled_thread_pool::ScheduledThreadPool::builder()
+                .num_threads(2)
+                .thread_name_pattern("r2d2-shared-{}")
+                .build(),
+        )
+    })
+    .clone()
+}
+
 impl SqliteStore {
     pub async fn new(database_url: &str) -> std::result::Result<Self, StoreError> {
         let manager = ConnectionManager::<SqliteConnection>::new(database_url);
 
-        let pool_size = 2;
+        // One connection suffices: every store op is already serialized through
+        // `db_semaphore` (Semaphore::new(1)) below, so a second pooled connection was only
+        // ever idle overhead (its own SQLite page cache + per-connection structures).
+        let pool_size = 1;
 
         // Local SQLite file connections don't spontaneously drop, so r2d2's
         // default per-checkout liveness probe (a SELECT 1 via Diesel's
         // is_valid) is pure overhead on every store op: any real failure
         // surfaces as a StoreError on the next actual query, so the probe
         // guards nothing here. Skipping it saves a cached SELECT 1 (reset+step)
-        // per pool.get().
+        // per pool.get(). The shared thread pool avoids r2d2's per-pool management
+        // threads (see shared_r2d2_thread_pool).
         let pool = Pool::builder()
             .max_size(pool_size)
             .test_on_check_out(false)
+            .thread_pool(shared_r2d2_thread_pool())
             .connection_customizer(Box::new(ConnectionOptions))
             .build(manager)
             .map_err(|e| StoreError::Connection(Box::new(e)))?;


### PR DESCRIPTION
## What

Cuts the **per-session** memory and thread cost of `SqliteStore`, and exposes the tuning as an additive `SqliteStoreConfig`. `SqliteStore::new` / `new_for_device` are unchanged (they delegate to a low-memory default) — **no API breaks**.

Each session gets its own `SqliteStore`, so the store's fixed costs are paid PER SESSION. On a host running many sessions, the per-store r2d2 thread pool, the second pooled connection, and the 2 MiB page cache multiply badly.

## How

Three changes, all internal to the backend:

1. **Shared r2d2 `ScheduledThreadPool`.** By default r2d2 spawns its own pool of ~3 management threads per `Pool`; with one store per session that is ~3 idle threads **per session** (hundreds on a busy host, plus their stacks). Share one process-wide pool via `.thread_pool(...)`, lazily created (0 threads until the first store opens).
2. **`pool_size` 2 → 1.** Every store op is already serialized through the store's internal `Semaphore(1)`, so the second pooled connection was pure idle overhead (its own page cache + per-connection state).
3. **`cache_size` 512 pages (~2 MiB) → 512 KiB** per connection. A per-device session DB has a small hot working set; the negative PRAGMA value is also page-size independent.

Then `SqliteStoreConfig` makes all of this configurable (additive, default = the low-memory profile above):

- `pool_size` drives **both** r2d2 `max_size` **and** the internal semaphore permits in lockstep, so raising it gives real concurrency and the default `1` stays serialized + single-connection (the two can no longer drift).
- `cache_size_kib`, `busy_timeout`, `synchronous`, and an optional injected `thread_pool` (mirrors the transport-factory / http-client injection style).
- `temp_store = memory` and `foreign_keys = ON` stay fixed (correctness, not tuning).

New `SqliteStore::with_config` / `with_config_for_device`.

## Measurements

Isolated (creating N stores), measured with thread enumeration + heaptrack:

| | before | after |
|---|---|---|
| threads / store | ~3.0 | ~0 (shared, flat) |
| 50 stores → total threads | 164 | 16 |
| peak heap, 25 stores (heaptrack) | 11.47M | 9.69M |

Downstream, a worker hosting two live sessions dropped from 27 → 16 threads and ~44.6 → ~17 MiB PSS (the per-session r2d2 thread explosion and the second connection are gone). At ~100 sessions the r2d2 thread count goes from ~300 → 2.

## Caveats

- The shared pool funnels all stores' connection housekeeping through 2 threads. The work is light (reaping + connection-open for local SQLite files); a mass restore at boot serializes connection-open across those 2 threads.
- `pool_size = 1` is correct only because the store serializes via its semaphore — the config now ties the two together so they can't drift.
- A 512 KiB cache trades a little I/O for memory under large scans (e.g. a very active account). Tunable via the config.

## Tests

`cargo fmt`, `cargo clippy --all-targets`, `cargo test` green. New unit test exercises `with_config` with a non-default profile (more concurrency, bigger cache, full durability, injected thread pool) and asserts the default profile is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

