### PR TITLE
ci(docker): portable multi-arch image, unprivileged runtime, GHCR publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,20 +40,20 @@ jobs:
       - uses: actions/checkout@v6
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -70,7 +70,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -85,16 +85,16 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -104,7 +104,7 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,122 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+# Native per-arch runners instead of QEMU: build-std + fat LTO is far too slow
+# under emulation. Each arch builds in parallel, pushed by digest, then merged
+# into one multi-arch manifest.
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Prepare platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v6
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-arch cache scope so the two matrix legs never clobber each other.
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+
+      - name: Inspect
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,12 +5,23 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+  # Called by release.yml: a v* tag it pushes with GITHUB_TOKEN can't trigger
+  # the tag event above, so the release invokes this directly and passes the
+  # version to tag the image with.
+  workflow_call:
+    inputs:
+      version:
+        description: 'Image version tag, e.g. 0.6.0 (set by the release workflow)'
+        required: false
+        type: string
+        default: ''
 
 # Native per-arch runners instead of QEMU: build-std + fat LTO is far too slow
 # under emulation. Each arch builds in parallel, pushed by digest, then merged
 # into one multi-arch manifest.
+# event_name keys the group so a main push can't cancel a release's build.
 concurrency:
-  group: docker-${{ github.ref }}
+  group: docker-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -103,6 +114,7 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - uses: docker/login-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
   publish-docker:
     name: Publish Docker image
     needs: github-release
+    # docker.yml logs into GHCR and pushes the multi-arch image manifest.
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     name: Create GitHub Release
     needs: publish
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -97,3 +99,15 @@ jobs:
               --generate-notes \
               --latest
           fi
+
+  # The tag pushed above with GITHUB_TOKEN can't trigger docker.yml's tag event,
+  # so invoke it directly and pass the version for the :X.Y.Z image tag.
+  publish-docker:
+    name: Publish Docker image
+    needs: github-release
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      version: ${{ needs.github-release.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,11 @@ RUN rustc -vV > /rustc-version \
     && sed -n 's/^host: //p' /rustc-version > /rust-target \
     && test -s /rust-target \
     && rm /rustc-version
-# Cook with the same --example as the final build so the example's dev-deps
-# (env_logger, …) are cached here instead of recompiling after the source COPY.
-RUN cargo chef cook --release --recipe-path recipe.json --target "$(cat /rust-target)" --example demo
+# Cook examples so the demo's dev-deps (env_logger, …) are cached, not rebuilt
+# after the source COPY. cargo-chef exposes only the plural --examples (no
+# --example <name>); under default features that builds just demo, since the
+# other examples gate on extra features.
+RUN cargo chef cook --release --recipe-path recipe.json --target "$(cat /rust-target)" --examples
 COPY . .
 # The client lives in examples/demo.rs (the package no longer ships a bin); the
 # example artifact lands under release/examples/. Default features cover it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@
 # The /data volume persists the SQLite database across restarts. The image runs
 # unprivileged (uid 65532); use a named volume (as below) so it inherits that
 # ownership and stays writable — a host bind mount would need matching ownership.
+#
+# Upgrading from the old root-running image? An existing volume keeps its
+# root-owned files, which uid 65532 can't write. Chown it once with any image
+# that ships chown (scratch doesn't):
+#   docker run --rm -v whatsapp-data:/data alpine chown -R 65532:65532 /data
+#
 # Pass --phone <number> for pair code auth:
 #   docker run -v whatsapp-data:/data whatsapp-rust --phone 15551234567
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,11 @@ COPY rust-toolchain.toml .
 COPY --from=planner /app/recipe.json recipe.json
 # build-std demands an explicit --target; derive the image's own host triple so
 # buildx per-arch builds (linux/amd64, linux/arm64) each target their own arch.
-RUN rustc -vV | sed -n 's/^host: //p' > /rust-target && test -s /rust-target
+# No pipe, so a rustc failure isn't masked by sed's exit status (Hadolint DL4006).
+RUN rustc -vV > /rustc-version \
+    && sed -n 's/^host: //p' /rustc-version > /rust-target \
+    && test -s /rust-target \
+    && rm /rustc-version
 # Cook with the same --example as the final build so the example's dev-deps
 # (env_logger, …) are cached here instead of recompiling after the source COPY.
 RUN cargo chef cook --release --recipe-path recipe.json --target "$(cat /rust-target)" --example demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@
 # Build:  docker build -t whatsapp-rust .
 # Run:    docker run -v whatsapp-data:/data whatsapp-rust
 #
-# The /data volume persists the SQLite database across restarts.
+# The /data volume persists the SQLite database across restarts. The image runs
+# unprivileged (uid 65532); use a named volume (as below) so it inherits that
+# ownership and stays writable — a host bind mount would need matching ownership.
 # Pass --phone <number> for pair code auth:
 #   docker run -v whatsapp-data:/data whatsapp-rust --phone 15551234567
 
@@ -33,7 +35,11 @@ FROM chef AS builder
 # (measured: -666 KiB, -5.6% .text). Nightly-only, which this image already
 # pins via rust-toolchain.toml; with fat LTO the historical inlining downside
 # does not apply since LTO sees all bitcode anyway.
-ENV RUSTFLAGS="-C target-cpu=native -Zshare-generics=y"
+# No -C target-cpu: a published image must run on any host of its arch, so we
+# keep the portable musl baseline instead of pinning the build machine's CPU
+# (target-cpu=native would risk SIGILL on older/different hosts and is
+# meaningless under emulated cross-arch builds).
+ENV RUSTFLAGS="-Zshare-generics=y"
 
 # build-std recompiles std with the release profile so it participates in fat
 # LTO and dead-code elimination instead of linking the prebuilt rustup std
@@ -47,19 +53,29 @@ ENV CARGO_UNSTABLE_BUILD_STD="std,panic_abort"
 # chef stage's copy at /; the nightly-only RUSTFLAGS above depends on it.
 COPY rust-toolchain.toml .
 COPY --from=planner /app/recipe.json recipe.json
-# build-std demands an explicit --target; use the image's own host triple so
-# multi-arch builds (e.g. buildx linux/arm64) keep producing native binaries
-# exactly like the implicit-target build did.
+# build-std demands an explicit --target; derive the image's own host triple so
+# buildx per-arch builds (linux/amd64, linux/arm64) each target their own arch.
 RUN rustc -vV | sed -n 's/^host: //p' > /rust-target && test -s /rust-target
-RUN cargo chef cook --release --recipe-path recipe.json --target "$(cat /rust-target)"
+# Cook with the same --example as the final build so the example's dev-deps
+# (env_logger, …) are cached here instead of recompiling after the source COPY.
+RUN cargo chef cook --release --recipe-path recipe.json --target "$(cat /rust-target)" --example demo
 COPY . .
 # The client lives in examples/demo.rs (the package no longer ships a bin); the
 # example artifact lands under release/examples/. Default features cover it.
 RUN cargo build --release --example demo --target "$(cat /rust-target)" \
     && cp "target/$(cat /rust-target)/release/examples/demo" /app/whatsapp-rust-bin
 
-# --- Runtime: static binary on empty image ---
+# Empty dirs to stage into the scratch image; the COPY --chown below grants them
+# to the unprivileged uid so /data (DB; a fresh named volume inherits the
+# ownership) and /tmp (SQLite temp files, absent on scratch) stay writable.
+RUN mkdir -p /newroot/data /newroot/tmp
+
+# --- Runtime: static binary on empty image, unprivileged ---
 FROM scratch
+COPY --from=builder --chown=65532:65532 /newroot/tmp /tmp
+COPY --from=builder --chown=65532:65532 /newroot/data /data
 COPY --from=builder /app/whatsapp-rust-bin /whatsapp-rust
+ENV TMPDIR=/tmp
 WORKDIR /data
+USER 65532:65532
 ENTRYPOINT ["/whatsapp-rust"]


### PR DESCRIPTION
## Summary

Fixes correctness/security issues in the `Dockerfile` and adds a workflow that builds and publishes a single multi-arch image to GHCR.

## Dockerfile

- **Drop `-C target-cpu=native`.** A published image must run on any host of its arch; `native` tuned the binary to the *build machine's* CPU, risking `SIGILL` on older/different hosts and meaning nothing under emulated cross-arch builds — it directly contradicted the musl-portability rationale in the header. `RUSTFLAGS` is now just `-Zshare-generics=y`.
- **Fix the cargo-chef cache.** The dependency layer is now cooked with `--example demo`, matching the final build. The `demo` example pulls `env_logger` (a dev-dependency), so without matching flags those deps recompiled *after* the source `COPY` instead of landing in the cached layer.
- **Run unprivileged.** The runtime stage now runs as `USER 65532:65532`. `/data` and `/tmp` are staged as empty dirs and copied with `COPY --chown=65532:65532` (numeric uid → reliable, works on buildkit and the legacy builder). A fresh named volume inherits `/data`'s ownership, so the SQLite DB stays writable.
- **Provide `/tmp`.** `scratch` ships no `/tmp`; added one plus `ENV TMPDIR=/tmp` for any SQLite temp files.

## CI — `.github/workflows/docker.yml`

- Triggers on push to `main`, `v*` tags, and manual `workflow_dispatch`.
- Builds **`linux/amd64` and `linux/arm64` on native runners** (`ubuntu-latest` + `ubuntu-24.04-arm`) — not QEMU, which would be far too slow for this `build-std` + fat-LTO build.
- Each arch pushes by digest; a `merge` job assembles a **single multi-arch manifest** and publishes to `ghcr.io/oxidezap/whatsapp-rust` with branch/tag/semver/sha tags plus `latest` on the default branch. Per-arch `gha` cache scopes.

### One manifest, one URL

The image is published as a single manifest list, so consumers pull one reference and Docker resolves the right arch automatically:

```
docker pull ghcr.io/oxidezap/whatsapp-rust:latest   # → amd64 or arm64 per host
```

## Notes / to verify

- The `ubuntu-24.04-arm` runners are free for public repos but must be enabled in the org's Actions settings.
- No `docker build` was run in the dev environment (no daemon); first real validation happens when the workflow runs — it can be triggered manually via the Actions tab after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0161LFHLPTdCNyianZFH8dor)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

