### PR TITLE
feat(passkey): SHORTCAKE_PASSKEY companion linking

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -564,6 +564,11 @@ pub struct Client {
     /// per-attempt ephemeral linking cache, and the optional host authenticator.
     pub(crate) passkey_state: Arc<Mutex<crate::passkey::flow::PasskeyFlowState>>,
 
+    /// Wait-free "an open is in flight" reservation for the passkey flow. Kept
+    /// outside `passkey_state` so it can be released synchronously on drop (a
+    /// cancelled open can't leave it stuck), unlike a flag behind the async lock.
+    pub(crate) passkey_opening: AtomicBool,
+
     /// Custom handlers for encrypted message types. Set once at `Bot::build` and
     /// immutable afterward, so the receive hot path reads it with a plain
     /// `OnceLock::get` (no lock) and no per-node guard acquisition.

--- a/src/client.rs
+++ b/src/client.rs
@@ -560,6 +560,10 @@ pub struct Client {
     /// Tracks the pending pair code request and ephemeral keys.
     pub(crate) pair_code_state: Arc<Mutex<wacore::pair_code::PairCodeState>>,
 
+    /// SHORTCAKE_PASSKEY linking flow state: the pending handoff key, the
+    /// per-attempt ephemeral linking cache, and the optional host authenticator.
+    pub(crate) passkey_state: Arc<Mutex<crate::passkey::flow::PasskeyFlowState>>,
+
     /// Custom handlers for encrypted message types. Set once at `Bot::build` and
     /// immutable afterward, so the receive hot path reads it with a plain
     /// `OnceLock::get` (no lock) and no per-node guard acquisition.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -225,6 +225,7 @@ impl Client {
             major_sync_task_sender: tx,
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pair_code_state: Arc::new(Mutex::new(wacore::pair_code::PairCodeState::default())),
+            passkey_state: Arc::new(Mutex::new(crate::passkey::flow::PasskeyFlowState::default())),
             custom_enc_handlers: std::sync::OnceLock::new(),
             inbound_durability_hook: std::sync::OnceLock::new(),
             chatstate_handlers: Arc::new(RwLock::new(Vec::new())),

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -226,6 +226,7 @@ impl Client {
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pair_code_state: Arc::new(Mutex::new(wacore::pair_code::PairCodeState::default())),
             passkey_state: Arc::new(Mutex::new(crate::passkey::flow::PasskeyFlowState::default())),
+            passkey_opening: AtomicBool::new(false),
             custom_enc_handlers: std::sync::OnceLock::new(),
             inbound_durability_hook: std::sync::OnceLock::new(),
             chatstate_handlers: Arc::new(RwLock::new(Vec::new())),

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -61,10 +61,10 @@ async fn handle_notification_impl(client: &Arc<Client>, node: Arc<OwnedNodeRef>)
         "disappearing_mode" => handle_disappearing_mode_notification(client, nr),
         "newsletter" => handle_newsletter_notification(client, Arc::clone(&node)),
         "mex" => handle_mex_notification(client, nr),
-        "passkey_prologue_request" => {
+        crate::passkey::flow::NOTIF_PASSKEY_REQUEST => {
             crate::passkey::flow::handle_passkey_notification(client, Arc::clone(&node)).await;
         }
-        "crsc_continuation" => {
+        crate::passkey::flow::NOTIF_PASSKEY_CONTINUATION => {
             crate::passkey::flow::handle_passkey_continuation(client, Arc::clone(&node)).await;
         }
         "mediaretry" => {

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -61,6 +61,12 @@ async fn handle_notification_impl(client: &Arc<Client>, node: Arc<OwnedNodeRef>)
         "disappearing_mode" => handle_disappearing_mode_notification(client, nr),
         "newsletter" => handle_newsletter_notification(client, Arc::clone(&node)),
         "mex" => handle_mex_notification(client, nr),
+        "passkey_prologue_request" => {
+            crate::passkey::flow::handle_passkey_notification(client, Arc::clone(&node)).await;
+        }
+        "crsc_continuation" => {
+            crate::passkey::flow::handle_passkey_continuation(client, Arc::clone(&node)).await;
+        }
         "mediaretry" => {
             debug!(
                 "Received mediaretry notification for msg {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub mod message;
 pub(crate) mod msg_secret_buffer;
 pub mod pair;
 pub mod pair_code;
+pub mod passkey;
 pub mod request;
 pub use request::IqError;
 #[cfg(feature = "tokio-runtime")]

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -180,8 +180,7 @@ async fn handle_pair_success<'a>(
         }
     };
 
-    let device_identity_node = success_node.get_optional_child_by_tag(&["device-identity"]);
-    let device_identity_bytes = match device_identity_node.and_then(|n| n.content_bytes()) {
+    let device_identity_bytes = match PairUtils::extract_device_identity_bytes(success_node) {
         Some(b) => b,
         None => {
             let error_node = PairUtils::build_pair_error_node(&req_id, 500, "internal-error");

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -6,17 +6,23 @@
 //! identity prologue, both sides exchange nonces to derive a shared key, and the
 //! companion finally sends its rotated ADV secret encrypted under that key. Linking
 //! then completes through the ordinary `pair-success` path.
+//!
+//! The handshake state machine ([`ShortcakeSession`]) drives against a
+//! [`ShortcakeIo`] seam rather than the concrete [`Client`], so the full IQ
+//! sequence is unit-testable with a scripted stand-in.
 
 use crate::client::Client;
 use crate::passkey::{Assertion, PasskeyAuthenticator, PasskeyError, parse_request_options};
 use crate::request::InfoQuery;
 use crate::store::commands::DeviceCommand;
 use crate::types::events::{Event, PairPasskeyConfirmation, PairPasskeyError, PairPasskeyRequest};
+use async_trait::async_trait;
 use log::warn;
 use rand::RngExt;
 use std::sync::Arc;
 use wacore::libsignal::protocol::KeyPair;
 use wacore::shortcake::ShortcakeUtils;
+use wacore::sync_marker::MaybeSendSync;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeContent, NodeRef, OwnedNodeRef, SERVER_JID, Server};
 
@@ -39,31 +45,222 @@ const TAG_ENCRYPTED_PAIRING_REQUEST: &str = "encrypted_pairing_request";
 /// Length of each half of the "XXXX-XXXX" verification code grouping.
 const CODE_GROUP_LEN: usize = 4;
 
-struct LinkingCache {
+/// The device material the handshake reads: the companion's static public keys
+/// and the reported platform.
+#[derive(Clone)]
+struct DeviceMaterial {
+    noise_public: [u8; 32],
+    identity_public: [u8; 32],
+    device_type: i32,
+}
+
+/// The effects the handshake needs from its environment. Abstracted so the full
+/// IQ sequence can be driven by a scripted stand-in in tests.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+trait ShortcakeIo: MaybeSendSync {
+    async fn query(&self, query: InfoQuery<'static>) -> Result<Arc<OwnedNodeRef>, PasskeyError>;
+    fn device_material(&self) -> Result<DeviceMaterial, PasskeyError>;
+    async fn commit_adv_secret(&self, secret: [u8; 32]);
+    fn emit(&self, event: Event);
+}
+
+#[derive(PartialEq, Eq)]
+enum Stage {
+    AwaitingPrimaryIdentity,
+    AwaitingConfirmation,
+    Done,
+}
+
+/// The in-flight handshake, created by [`ShortcakeSession::open`] and advanced by
+/// the continuation + confirmation steps. Its rotated ADV secret is held here (not
+/// in the device store) until [`confirm`](Self::confirm) commits it, so an
+/// abandoned attempt never rotates to a secret the primary never received.
+struct ShortcakeSession {
     keypair: KeyPair,
     companion_nonce: [u8; 32],
     pairing_ref: String,
     device_type: i32,
-    skip_handoff_ux: bool,
-    encryption_key: Option<[u8; 32]>,
-    /// This attempt's freshly-rotated ADV secret, held here (not in the device
-    /// store) until the flow commits it, so an abandoned attempt never rotates to a
-    /// secret the primary never received. Per-attempt, so concurrent attempts can't
-    /// cross-contaminate the committed secret.
     new_adv_secret: [u8; 32],
+    skip_handoff_ux: bool,
+    stage: Stage,
+    encryption_key: Option<[u8; 32]>,
 }
 
+impl ShortcakeSession {
+    /// Fetch a fresh ref, build the ephemeral identity + commitment, attach the
+    /// handoff proof on a re-link, and send the `passkey_prologue` IQ.
+    async fn open(
+        io: &dyn ShortcakeIo,
+        assertion: Assertion,
+        handoff_key: Option<[u8; 32]>,
+    ) -> Result<Self, PasskeyError> {
+        let device_type = io.device_material()?.device_type;
+        let pairing_ref = fetch_ref(io).await?;
+
+        let keypair = ShortcakeUtils::generate_companion_ephemeral_keypair();
+        let companion_nonce = ShortcakeUtils::generate_companion_nonce();
+        let mut new_adv_secret = [0u8; 32];
+        rand::make_rng::<rand::rngs::StdRng>().fill(&mut new_adv_secret);
+
+        let companion_pub: [u8; 32] = keypair
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .map_err(|_| PasskeyError::Flow("ephemeral public key is not 32 bytes".into()))?;
+        let identity = ShortcakeUtils::build_companion_ephemeral_identity(
+            &companion_pub,
+            device_type,
+            &pairing_ref,
+        );
+        let commitment = ShortcakeUtils::commitment_hash(&identity, &companion_nonce);
+        let prologue_payload = ShortcakeUtils::build_prologue_payload(&identity, &commitment);
+
+        let handoff_proof = handoff_key
+            .map(|key| ShortcakeUtils::compute_pairing_handoff_proof(&key, &prologue_payload));
+        let skip_handoff_ux = handoff_proof.is_some();
+
+        let prologue = build_prologue_node(
+            assertion.credential_id,
+            assertion.assertion_json,
+            prologue_payload,
+            handoff_proof,
+        );
+        io.query(InfoQuery::set(
+            MD_NAMESPACE,
+            server_jid(),
+            Some(NodeContent::Nodes(vec![prologue])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("passkey_prologue iq failed: {e}")))?;
+
+        Ok(Self {
+            keypair,
+            companion_nonce,
+            pairing_ref,
+            device_type,
+            new_adv_secret,
+            skip_handoff_ux,
+            stage: Stage::AwaitingPrimaryIdentity,
+            encryption_key: None,
+        })
+    }
+
+    /// Agree on the shared secret, reveal the companion nonce, derive the code +
+    /// encryption key, and emit [`Event::PairPasskeyConfirmation`]. Returns whether
+    /// the handoff proof lets the code UX be skipped.
+    async fn on_primary_identity(
+        &mut self,
+        io: &dyn ShortcakeIo,
+        primary_bytes: &[u8],
+    ) -> Result<bool, PasskeyError> {
+        if self.stage != Stage::AwaitingPrimaryIdentity {
+            return Err(PasskeyError::Flow(
+                "unexpected continuation for this stage".into(),
+            ));
+        }
+        let primary = ShortcakeUtils::parse_primary_ephemeral_identity(primary_bytes)
+            .map_err(|e| PasskeyError::Flow(format!("primary ephemeral identity: {e}")))?;
+
+        let nonce_node = NodeBuilder::new(TAG_COMPANION_NONCE)
+            .bytes(self.companion_nonce.to_vec())
+            .build();
+        io.query(InfoQuery::set(
+            MD_NAMESPACE,
+            server_jid(),
+            Some(NodeContent::Nodes(vec![nonce_node])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("companion_nonce iq failed: {e}")))?;
+
+        let encryption_key = ShortcakeUtils::derive_encryption_key(
+            &self.keypair,
+            &primary.public_key,
+            self.device_type,
+            &self.pairing_ref,
+        )
+        .map_err(|e| PasskeyError::Flow(format!("encryption key: {e}")))?;
+        let bare = ShortcakeUtils::derive_verification_code(
+            &self.companion_nonce,
+            &primary.public_key,
+            &primary.nonce,
+        );
+        // Grouped "XXXX-XXXX" for display (the code is ASCII).
+        let code = format!("{}-{}", &bare[..CODE_GROUP_LEN], &bare[CODE_GROUP_LEN..]);
+
+        self.encryption_key = Some(encryption_key);
+        self.stage = Stage::AwaitingConfirmation;
+        io.emit(Event::PairPasskeyConfirmation(PairPasskeyConfirmation {
+            code,
+            skip_handoff_ux: self.skip_handoff_ux,
+        }));
+        Ok(self.skip_handoff_ux)
+    }
+
+    /// Encrypt the `PairingRequest` (companion static keys + rotated ADV secret)
+    /// and send `<encrypted_pairing_request>`, then commit the rotation.
+    async fn confirm(&mut self, io: &dyn ShortcakeIo) -> Result<(), PasskeyError> {
+        if self.stage != Stage::AwaitingConfirmation {
+            return Err(PasskeyError::Flow(
+                "confirmation before the verification stage".into(),
+            ));
+        }
+        let encryption_key = self.encryption_key.ok_or_else(|| {
+            PasskeyError::Flow("confirmation before encryption key derived".into())
+        })?;
+        let material = io.device_material()?;
+
+        let plaintext = ShortcakeUtils::build_pairing_request(
+            &material.noise_public,
+            &material.identity_public,
+            &self.new_adv_secret,
+        );
+        let encrypted = ShortcakeUtils::encrypt_pairing_request(&plaintext, &encryption_key)
+            .map_err(|e| PasskeyError::Flow(format!("encrypt pairing request: {e}")))?;
+        let wrapped = ShortcakeUtils::build_encrypted_pairing_request(&encrypted);
+
+        let node = NodeBuilder::new(TAG_ENCRYPTED_PAIRING_REQUEST)
+            .bytes(wrapped)
+            .build();
+        io.query(InfoQuery::set(
+            MD_NAMESPACE,
+            server_jid(),
+            Some(NodeContent::Nodes(vec![node])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("encrypted_pairing_request iq failed: {e}")))?;
+
+        // Primary has the secret now: commit the rotation (before pair-success
+        // validates against it).
+        io.commit_adv_secret(self.new_adv_secret).await;
+        self.stage = Stage::Done;
+        Ok(())
+    }
+}
+
+/// SHORTCAKE_PASSKEY flow state held on the [`Client`].
 #[derive(Default)]
 pub(crate) struct PasskeyFlowState {
     /// HMAC key from the pre-rotation ADV secret; presence marks the re-link path
     /// that lets the server skip the verification-code UX. Consumed once.
     handoff_key: Option<[u8; 32]>,
-    linking: Option<LinkingCache>,
+    session: Option<ShortcakeSession>,
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
 
 fn server_jid() -> Jid {
     Jid::new("", Server::Pn)
+}
+
+/// Pull a child node's payload as bytes, accepting either binary or string content
+/// (the server sends the options JSON as a text node).
+fn child_payload(nr: &NodeRef<'_>, tag: &str) -> Option<Vec<u8>> {
+    let child = nr.get_optional_child(tag)?;
+    if let Some(b) = child.content_bytes() {
+        Some(b.to_vec())
+    } else {
+        child.content_str().map(|s| s.as_bytes().to_vec())
+    }
 }
 
 /// Pure so the wire shape (child tags + conditional proof) is unit-testable.
@@ -96,14 +293,74 @@ fn build_prologue_node(
         .build()
 }
 
-/// Pull a child node's payload as bytes, accepting either binary or string content
-/// (the server sends the options JSON as a text node).
-fn child_payload(nr: &NodeRef<'_>, tag: &str) -> Option<Vec<u8>> {
-    let child = nr.get_optional_child(tag)?;
-    if let Some(b) = child.content_bytes() {
-        Some(b.to_vec())
-    } else {
-        child.content_str().map(|s| s.as_bytes().to_vec())
+async fn fetch_ref(io: &dyn ShortcakeIo) -> Result<String, PasskeyError> {
+    let resp = io
+        .query(InfoQuery::get(
+            MD_NAMESPACE,
+            server_jid(),
+            Some(NodeContent::Nodes(vec![NodeBuilder::new(TAG_REF).build()])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("ref iq failed: {e}")))?;
+    child_payload(resp.get(), TAG_REF)
+        .and_then(|b| String::from_utf8(b).ok())
+        .ok_or_else(|| PasskeyError::Flow("missing ref in server response".into()))
+}
+
+async fn fetch_request_options(io: &dyn ShortcakeIo) -> Result<String, PasskeyError> {
+    let resp = io
+        .query(InfoQuery::get(
+            MD_NAMESPACE,
+            server_jid(),
+            Some(NodeContent::Nodes(vec![
+                NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS).build(),
+            ])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("passkey_request_options iq failed: {e}")))?;
+    child_payload(resp.get(), TAG_PASSKEY_REQUEST_OPTIONS)
+        .and_then(|b| String::from_utf8(b).ok())
+        .ok_or_else(|| PasskeyError::Flow("missing passkey_request_options in response".into()))
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl ShortcakeIo for Client {
+    async fn query(&self, query: InfoQuery<'static>) -> Result<Arc<OwnedNodeRef>, PasskeyError> {
+        self.send_iq(query)
+            .await
+            .map_err(|e| PasskeyError::Flow(e.to_string()))
+    }
+
+    fn device_material(&self) -> Result<DeviceMaterial, PasskeyError> {
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        let noise_public: [u8; 32] = snapshot
+            .noise_key
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .map_err(|_| PasskeyError::Flow("noise public key is not 32 bytes".into()))?;
+        let identity_public: [u8; 32] = snapshot
+            .identity_key
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .map_err(|_| PasskeyError::Flow("identity public key is not 32 bytes".into()))?;
+        Ok(DeviceMaterial {
+            noise_public,
+            identity_public,
+            device_type: snapshot.device_props.platform_type.unwrap_or(0),
+        })
+    }
+
+    async fn commit_adv_secret(&self, secret: [u8; 32]) {
+        self.persistence_manager
+            .process_command(DeviceCommand::SetAdvSecretKey(secret))
+            .await;
+    }
+
+    fn emit(&self, event: Event) {
+        self.core.event_bus.dispatch(event);
     }
 }
 
@@ -120,246 +377,47 @@ impl Client {
         self.passkey_state.lock().await.authenticator.clone()
     }
 
-    /// Send the WebAuthn assertion to the server as `<passkey_prologue>`. Fetches a
-    /// fresh pairing ref, builds the companion ephemeral identity + commitment, and
-    /// attaches the pairing-handoff proof when this is a re-link. Call this after an
-    /// [`Event::PairPasskeyRequest`].
+    /// Send the WebAuthn assertion as `<passkey_prologue>` and open the handshake.
+    /// Call after an [`Event::PairPasskeyRequest`].
     pub async fn send_passkey_response(&self, assertion: Assertion) -> Result<(), PasskeyError> {
-        let server = server_jid();
-
-        let ref_query = InfoQuery::get(
-            MD_NAMESPACE,
-            server.clone(),
-            Some(NodeContent::Nodes(vec![NodeBuilder::new(TAG_REF).build()])),
-        );
-        let resp = self
-            .send_iq(ref_query)
-            .await
-            .map_err(|e| PasskeyError::Flow(format!("ref iq failed: {e}")))?;
-        let pairing_ref = child_payload(resp.get(), TAG_REF)
-            .and_then(|b| String::from_utf8(b).ok())
-            .ok_or_else(|| PasskeyError::Flow("missing ref in server response".into()))?;
-
-        let keypair = ShortcakeUtils::generate_companion_ephemeral_keypair();
-        let companion_nonce = ShortcakeUtils::generate_companion_nonce();
-        let mut new_adv_secret = [0u8; 32];
-        rand::make_rng::<rand::rngs::StdRng>().fill(&mut new_adv_secret);
-        let snapshot = self.persistence_manager.get_device_snapshot();
-        let device_type = snapshot.device_props.platform_type.unwrap_or(0);
-        let companion_pub: [u8; 32] = keypair
-            .public_key
-            .public_key_bytes()
-            .try_into()
-            .map_err(|_| PasskeyError::Flow("ephemeral public key is not 32 bytes".into()))?;
-
-        let identity = ShortcakeUtils::build_companion_ephemeral_identity(
-            &companion_pub,
-            device_type,
-            &pairing_ref,
-        );
-        let commitment = ShortcakeUtils::commitment_hash(&identity, &companion_nonce);
-        let prologue_payload = ShortcakeUtils::build_prologue_payload(&identity, &commitment);
-
-        let handoff_proof = {
-            let mut state = self.passkey_state.lock().await;
-            let proof = state
-                .handoff_key
-                .take()
-                .map(|key| ShortcakeUtils::compute_pairing_handoff_proof(&key, &prologue_payload));
-            state.linking = Some(LinkingCache {
-                keypair,
-                companion_nonce,
-                pairing_ref,
-                device_type,
-                skip_handoff_ux: proof.is_some(),
-                encryption_key: None,
-                new_adv_secret,
-            });
-            proof
-        };
-
-        let prologue = build_prologue_node(
-            assertion.credential_id,
-            assertion.assertion_json,
-            prologue_payload,
-            handoff_proof,
-        );
-        if let Err(e) = self
-            .send_iq(InfoQuery::set(
-                MD_NAMESPACE,
-                server,
-                Some(NodeContent::Nodes(vec![prologue])),
-            ))
-            .await
-        {
-            // Server never accepted this prologue: drop the half-armed attempt.
-            self.passkey_state.lock().await.linking = None;
-            return Err(PasskeyError::Flow(format!(
-                "passkey_prologue iq failed: {e}"
-            )));
-        }
+        let handoff_key = self.passkey_state.lock().await.handoff_key.take();
+        let session = ShortcakeSession::open(self, assertion, handoff_key).await?;
+        self.passkey_state.lock().await.session = Some(session);
         Ok(())
     }
 
-    /// Process the continuation notification: agree on the shared secret, send the
-    /// companion nonce, derive the verification code + encryption key, and emit
-    /// [`Event::PairPasskeyConfirmation`]. Spawned off the receive loop because it
-    /// awaits a `<companion_nonce>` IQ round-trip.
-    async fn process_passkey_continuation(
-        &self,
-        primary_bytes: Vec<u8>,
-    ) -> Result<(), PasskeyError> {
-        let primary = ShortcakeUtils::parse_primary_ephemeral_identity(&primary_bytes)
-            .map_err(|e| PasskeyError::Flow(format!("primary ephemeral identity: {e}")))?;
+    /// Finish the link. For a fresh link, call this only after the user confirms the
+    /// [`Event::PairPasskeyConfirmation`] code.
+    pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
+        // Taken out for the duration: on failure the attempt is dropped, not left
+        // half-committed.
+        let mut session = self
+            .passkey_state
+            .lock()
+            .await
+            .session
+            .take()
+            .ok_or_else(|| PasskeyError::Flow("confirmation without an active session".into()))?;
+        session.confirm(self).await
+    }
 
-        let (keypair, companion_nonce, pairing_ref, device_type, skip_handoff_ux) = {
-            let state = self.passkey_state.lock().await;
-            let cache = state
-                .linking
-                .as_ref()
-                .ok_or_else(|| PasskeyError::Flow("continuation without a linking cache".into()))?;
-            (
-                cache.keypair.clone(),
-                cache.companion_nonce,
-                cache.pairing_ref.clone(),
-                cache.device_type,
-                cache.skip_handoff_ux,
-            )
-        };
+    async fn drive_continuation(&self, primary_bytes: Vec<u8>) -> Result<(), PasskeyError> {
+        let mut session = self
+            .passkey_state
+            .lock()
+            .await
+            .session
+            .take()
+            .ok_or_else(|| PasskeyError::Flow("continuation without an active session".into()))?;
+        let skip = session.on_primary_identity(self, &primary_bytes).await?;
+        self.passkey_state.lock().await.session = Some(session);
 
-        let nonce_node = NodeBuilder::new(TAG_COMPANION_NONCE)
-            .bytes(companion_nonce.to_vec())
-            .build();
-        self.send_iq(InfoQuery::set(
-            MD_NAMESPACE,
-            server_jid(),
-            Some(NodeContent::Nodes(vec![nonce_node])),
-        ))
-        .await
-        .map_err(|e| PasskeyError::Flow(format!("companion_nonce iq failed: {e}")))?;
-
-        let encryption_key = ShortcakeUtils::derive_encryption_key(
-            &keypair,
-            &primary.public_key,
-            device_type,
-            &pairing_ref,
-        )
-        .map_err(|e| PasskeyError::Flow(format!("encryption key: {e}")))?;
-        let bare = ShortcakeUtils::derive_verification_code(
-            &companion_nonce,
-            &primary.public_key,
-            &primary.nonce,
-        );
-        // Grouped "XXXX-XXXX" for display (the code is ASCII).
-        let code = format!("{}-{}", &bare[..CODE_GROUP_LEN], &bare[CODE_GROUP_LEN..]);
-
-        {
-            let mut state = self.passkey_state.lock().await;
-            // A fresh attempt could have replaced the cache during the round-trip;
-            // arming an unrelated attempt with this key would break it.
-            let cache = state.linking.as_mut().ok_or_else(|| {
-                PasskeyError::Flow("linking cache cleared mid-continuation".into())
-            })?;
-            if cache.pairing_ref != pairing_ref || cache.companion_nonce != companion_nonce {
-                return Err(PasskeyError::Flow(
-                    "linking cache replaced by a newer attempt mid-continuation".into(),
-                ));
-            }
-            cache.encryption_key = Some(encryption_key);
-        }
-
-        self.core
-            .event_bus
-            .dispatch(Event::PairPasskeyConfirmation(PairPasskeyConfirmation {
-                code,
-                skip_handoff_ux,
-            }));
-
-        // Re-link: the handoff proof already established continuity, so no user code
-        // confirmation is needed. Auto-finish when an authenticator is driving.
-        if skip_handoff_ux && self.passkey_authenticator().await.is_some() {
+        // Re-link: continuity is already proven, so finish without a user code when
+        // an authenticator is driving.
+        if skip && self.passkey_authenticator().await.is_some() {
             self.send_passkey_confirmation().await?;
         }
         Ok(())
-    }
-
-    /// Finish the link: encrypt the `PairingRequest` (companion static keys + the
-    /// newly-rotated ADV secret) under the derived key and send
-    /// `<encrypted_pairing_request>`. For a fresh link, call this only after the
-    /// user has confirmed the [`Event::PairPasskeyConfirmation`] code.
-    pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
-        let (encryption_key, adv_secret) = {
-            let state = self.passkey_state.lock().await;
-            let cache = state
-                .linking
-                .as_ref()
-                .ok_or_else(|| PasskeyError::Flow("confirmation without a linking cache".into()))?;
-            let key = cache.encryption_key.ok_or_else(|| {
-                PasskeyError::Flow("confirmation before encryption key derived".into())
-            })?;
-            (key, cache.new_adv_secret)
-        };
-
-        let snapshot = self.persistence_manager.get_device_snapshot();
-        let companion_public: [u8; 32] = snapshot
-            .noise_key
-            .public_key
-            .public_key_bytes()
-            .try_into()
-            .map_err(|_| PasskeyError::Flow("noise public key is not 32 bytes".into()))?;
-        let companion_identity: [u8; 32] = snapshot
-            .identity_key
-            .public_key
-            .public_key_bytes()
-            .try_into()
-            .map_err(|_| PasskeyError::Flow("identity public key is not 32 bytes".into()))?;
-
-        let plaintext = ShortcakeUtils::build_pairing_request(
-            &companion_public,
-            &companion_identity,
-            &adv_secret,
-        );
-        let encrypted = ShortcakeUtils::encrypt_pairing_request(&plaintext, &encryption_key)
-            .map_err(|e| PasskeyError::Flow(format!("encrypt pairing request: {e}")))?;
-        let wrapped = ShortcakeUtils::build_encrypted_pairing_request(&encrypted);
-
-        let node = NodeBuilder::new(TAG_ENCRYPTED_PAIRING_REQUEST)
-            .bytes(wrapped)
-            .build();
-        self.send_iq(InfoQuery::set(
-            MD_NAMESPACE,
-            server_jid(),
-            Some(NodeContent::Nodes(vec![node])),
-        ))
-        .await
-        .map_err(|e| PasskeyError::Flow(format!("encrypted_pairing_request iq failed: {e}")))?;
-
-        // Primary has the new secret now: commit the rotation (before pair-success
-        // validates against it) and clear the attempt.
-        self.persistence_manager
-            .process_command(DeviceCommand::SetAdvSecretKey(adv_secret))
-            .await;
-        self.passkey_state.lock().await.linking = None;
-        Ok(())
-    }
-
-    /// Fetch the WebAuthn options from the server, for when a prologue-request
-    /// notification arrives without them inline.
-    async fn get_passkey_request_options(&self) -> Result<String, PasskeyError> {
-        let query = InfoQuery::get(
-            MD_NAMESPACE,
-            server_jid(),
-            Some(NodeContent::Nodes(vec![
-                NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS).build(),
-            ])),
-        );
-        let resp = self
-            .send_iq(query)
-            .await
-            .map_err(|e| PasskeyError::Flow(format!("passkey_request_options iq failed: {e}")))?;
-        child_payload(resp.get(), TAG_PASSKEY_REQUEST_OPTIONS)
-            .and_then(|b| String::from_utf8(b).ok())
-            .ok_or_else(|| PasskeyError::Flow("missing passkey_request_options in response".into()))
     }
 }
 
@@ -387,7 +445,7 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
                 .clone()
                 .runtime
                 .spawn(Box::pin(async move {
-                    match client.get_passkey_request_options().await {
+                    match fetch_request_options(client.as_ref()).await {
                         Ok(json) => drive_passkey_request(&client, json).await,
                         Err(e) => {
                             warn!("failed to fetch passkey request options: {e}");
@@ -408,9 +466,12 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
 async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
     // Handoff key from the current secret proves continuity to the server; presence
     // of a key marks this as a re-link. The rotated secret itself is generated
-    // per-attempt in send_passkey_response.
-    let snapshot = client.persistence_manager.get_device_snapshot();
-    let handoff_key = ShortcakeUtils::derive_pairing_handoff_hmac_key(&snapshot.adv_secret_key)
+    // per-attempt in the session.
+    let adv_secret = client
+        .persistence_manager
+        .get_device_snapshot()
+        .adv_secret_key;
+    let handoff_key = ShortcakeUtils::derive_pairing_handoff_hmac_key(&adv_secret)
         .inspect_err(|e| warn!("failed to derive pairing-handoff key: {e}"))
         .ok();
     client.passkey_state.lock().await.handoff_key = handoff_key;
@@ -468,7 +529,7 @@ pub(crate) async fn handle_passkey_continuation(client: &Arc<Client>, node: Arc<
     let primary_bytes = match child_payload(node.get(), TAG_PRIMARY_EPHEMERAL_IDENTITY) {
         Some(bytes) => bytes,
         None => {
-            warn!("passkey continuation missing <primary_ephemeral_identity>");
+            warn!("passkey continuation missing primary_ephemeral_identity");
             client
                 .core
                 .event_bus
@@ -485,7 +546,7 @@ pub(crate) async fn handle_passkey_continuation(client: &Arc<Client>, node: Arc<
         .clone()
         .runtime
         .spawn(Box::pin(async move {
-            if let Err(e) = client.process_passkey_continuation(primary_bytes).await {
+            if let Err(e) = client.drive_continuation(primary_bytes).await {
                 warn!("passkey continuation failed: {e}");
                 client
                     .core
@@ -504,12 +565,13 @@ mod tests {
     use super::*;
     use crate::test_utils::{TestEventCollector, create_test_client, node_to_owned_ref};
     use crate::types::events::EventHandler;
+    use prost::Message as _;
+    use std::sync::Mutex;
     use std::time::Duration;
+    use wacore::libsignal::protocol::PublicKey;
+    use waproto::whatsapp as wa;
 
-    fn server_notification(
-        notif_type: &'static str,
-        child: Option<wacore_binary::Node>,
-    ) -> Arc<OwnedNodeRef> {
+    fn server_notification(notif_type: &'static str, child: Option<Node>) -> Arc<OwnedNodeRef> {
         let mut builder = NodeBuilder::new("notification")
             .attr("type", notif_type)
             .attr("from", SERVER_JID);
@@ -529,45 +591,202 @@ mod tests {
         panic!("expected event was not observed within the timeout");
     }
 
-    #[test]
-    fn prologue_node_wire_shape() {
-        // re-link: the handoff proof child is present
-        let node = build_prologue_node(
-            b"cred-id".to_vec(),
-            b"{\"type\":\"public-key\"}".to_vec(),
-            b"prologue-proto".to_vec(),
-            Some([0x42; 32]),
-        );
-        let nr = node.as_node_ref();
-        assert_eq!(nr.tag.as_ref(), "passkey_prologue");
-        assert_eq!(
-            nr.get_optional_child("credential_id")
-                .and_then(|n| n.content_bytes()),
-            Some(&b"cred-id"[..])
-        );
-        assert_eq!(
-            nr.get_optional_child("webauthn_assertion")
-                .and_then(|n| n.content_bytes()),
-            Some(&b"{\"type\":\"public-key\"}"[..])
-        );
-        assert_eq!(
-            nr.get_optional_child("prologue_payload")
-                .and_then(|n| n.content_bytes()),
-            Some(&b"prologue-proto"[..])
-        );
-        assert_eq!(
-            nr.get_optional_child("pairing_handoff_proof")
-                .and_then(|n| n.content_bytes()),
-            Some(&[0x42u8; 32][..])
+    // Scripted IQ stand-in: answers each `md` IQ by its child tag and records the
+    // child that was sent, plus committed secret and emitted events.
+    struct MockIo {
+        device: DeviceMaterial,
+        pairing_ref: String,
+        options_json: String,
+        sent: Mutex<Vec<Node>>,
+        committed: Mutex<Option<[u8; 32]>>,
+        events: Mutex<Vec<Event>>,
+    }
+
+    impl MockIo {
+        fn sent_tags(&self) -> Vec<String> {
+            self.sent
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|n| n.tag.to_string())
+                .collect()
+        }
+
+        fn sent_node(&self, tag: &str) -> Node {
+            self.sent
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|n| n.tag == tag)
+                .cloned()
+                .unwrap_or_else(|| panic!("expected a {tag} IQ to have been sent"))
+        }
+    }
+
+    #[async_trait]
+    impl ShortcakeIo for MockIo {
+        async fn query(
+            &self,
+            query: InfoQuery<'static>,
+        ) -> Result<Arc<OwnedNodeRef>, PasskeyError> {
+            let child = match &query.content {
+                Some(NodeContent::Nodes(nodes)) => nodes.first().cloned(),
+                _ => None,
+            };
+            let child = child.expect("md IQ must carry a child node");
+            let tag = child.tag.to_string();
+            self.sent.lock().unwrap().push(child);
+
+            let response = if tag == TAG_REF {
+                NodeBuilder::new("iq")
+                    .children([NodeBuilder::new(TAG_REF)
+                        .bytes(self.pairing_ref.as_bytes().to_vec())
+                        .build()])
+                    .build()
+            } else if tag == TAG_PASSKEY_REQUEST_OPTIONS {
+                NodeBuilder::new("iq")
+                    .children([NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS)
+                        .bytes(self.options_json.as_bytes().to_vec())
+                        .build()])
+                    .build()
+            } else {
+                NodeBuilder::new("iq").build()
+            };
+            Ok(node_to_owned_ref(&response))
+        }
+
+        fn device_material(&self) -> Result<DeviceMaterial, PasskeyError> {
+            Ok(self.device.clone())
+        }
+
+        async fn commit_adv_secret(&self, secret: [u8; 32]) {
+            *self.committed.lock().unwrap() = Some(secret);
+        }
+
+        fn emit(&self, event: Event) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    fn child_bytes(node: &Node, tag: &str) -> Vec<u8> {
+        child_payload(&node.as_node_ref(), tag).unwrap_or_else(|| panic!("missing {tag} child"))
+    }
+
+    #[tokio::test]
+    async fn full_handshake_drives_the_iq_sequence_and_delivers_the_committed_secret() {
+        // Companion static keys (arbitrary but distinct) + a primary playing the peer.
+        let device = DeviceMaterial {
+            noise_public: [0x11; 32],
+            identity_public: [0x12; 32],
+            device_type: 1,
+        };
+        let io = MockIo {
+            device: device.clone(),
+            pairing_ref: "REF-XYZ".to_string(),
+            options_json: "{}".to_string(),
+            sent: Mutex::new(Vec::new()),
+            committed: Mutex::new(None),
+            events: Mutex::new(Vec::new()),
+        };
+
+        // A re-link: pass a handoff key so the prologue carries the proof.
+        let handoff_key = [0x55u8; 32];
+        let assertion = Assertion {
+            assertion_json: br#"{"type":"public-key"}"#.to_vec(),
+            credential_id: b"cred-id".to_vec(),
+        };
+
+        let mut session = ShortcakeSession::open(&io, assertion, Some(handoff_key))
+            .await
+            .unwrap();
+
+        // step 1-2: ref fetched, then a prologue with the handoff proof.
+        assert_eq!(io.sent_tags(), vec![TAG_REF, TAG_PASSKEY_PROLOGUE]);
+        let prologue = io.sent_node(TAG_PASSKEY_PROLOGUE);
+        assert_eq!(child_bytes(&prologue, TAG_CREDENTIAL_ID), b"cred-id");
+        assert!(
+            prologue
+                .as_node_ref()
+                .get_optional_child(TAG_PAIRING_HANDOFF_PROOF)
+                .is_some()
         );
 
-        // fresh link: no handoff proof child
-        let fresh = build_prologue_node(b"c".to_vec(), b"a".to_vec(), b"p".to_vec(), None);
-        assert!(
-            fresh
-                .as_node_ref()
-                .get_optional_child("pairing_handoff_proof")
-                .is_none()
+        // primary's ephemeral identity
+        let primary_kp = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+        let primary_pub: [u8; 32] = primary_kp.public_key.public_key_bytes().try_into().unwrap();
+        let primary_nonce = [0x77u8; 32];
+        let primary_bytes = wa::PrimaryEphemeralIdentity {
+            public_key: Some(primary_pub.to_vec()),
+            nonce: Some(primary_nonce.to_vec()),
+        }
+        .encode_to_vec();
+
+        // step 3: continuation sends the companion nonce and emits the code.
+        let skip = session
+            .on_primary_identity(&io, &primary_bytes)
+            .await
+            .unwrap();
+        assert!(skip, "re-link with a handoff proof skips the code UX");
+        assert_eq!(
+            io.sent_tags().last().map(String::as_str),
+            Some(TAG_COMPANION_NONCE)
+        );
+        assert!(matches!(
+            io.events.lock().unwrap().first(),
+            Some(Event::PairPasskeyConfirmation(c)) if c.skip_handoff_ux && c.code.len() == 9
+        ));
+
+        // step 4: confirm seals + sends the pairing request and commits the secret.
+        session.confirm(&io).await.unwrap();
+        assert_eq!(
+            io.sent_tags().last().map(String::as_str),
+            Some(TAG_ENCRYPTED_PAIRING_REQUEST)
+        );
+        let committed = io
+            .committed
+            .lock()
+            .unwrap()
+            .expect("secret must be committed");
+
+        // The primary decrypts the pairing request and reads the SAME secret that
+        // was committed — proving the deferred rotation delivers what it persists.
+        let prologue_payload = child_bytes(&prologue, TAG_PROLOGUE_PAYLOAD);
+        let companion_eph_pub = wa::CompanionEphemeralIdentity::decode(
+            wa::ProloguePayload::decode(prologue_payload.as_slice())
+                .unwrap()
+                .companion_ephemeral_identity
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap()
+        .public_key
+        .unwrap();
+        let shared = primary_kp
+            .private_key
+            .calculate_agreement(&PublicKey::from_djb_public_key_bytes(&companion_eph_pub).unwrap())
+            .unwrap();
+        let key = ShortcakeUtils::derive_encryption_key_from_shared_secret(&shared, 1, "REF-XYZ")
+            .unwrap();
+        let wrapped = match io.sent_node(TAG_ENCRYPTED_PAIRING_REQUEST).content {
+            Some(NodeContent::Bytes(bytes)) => bytes,
+            _ => panic!("encrypted_pairing_request must carry bytes"),
+        };
+        let epr = wa::EncryptedPairingRequest::decode(wrapped.as_slice()).unwrap();
+        let iv: [u8; 12] = epr.iv.unwrap().as_slice().try_into().unwrap();
+        let mut plaintext = Vec::new();
+        wacore::libsignal::crypto::aes_256_gcm_decrypt(
+            &key,
+            &iv,
+            b"",
+            &epr.encrypted_payload.unwrap(),
+            &mut plaintext,
+        )
+        .unwrap();
+        let pr = wa::PairingRequest::decode(plaintext.as_slice()).unwrap();
+        assert_eq!(pr.adv_secret.as_deref(), Some(&committed[..]));
+        assert_eq!(
+            pr.companion_public_key.as_deref(),
+            Some(&device.noise_public[..])
         );
     }
 
@@ -582,17 +801,15 @@ mod tests {
             .get_device_snapshot()
             .adv_secret_key;
 
-        // verbatim options JSON; the handler forwards it untouched in the event
         let options = r#"{"challenge":"YWJjZGVm","rpId":"web.whatsapp.com"}"#;
-        let child = NodeBuilder::new("passkey_request_options")
+        let child = NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS)
             .bytes(options.as_bytes().to_vec())
             .build();
         client
-            .process_node(server_notification("passkey_prologue_request", Some(child)))
+            .process_node(server_notification(NOTIF_PASSKEY_REQUEST, Some(child)))
             .await;
 
-        // The rotation is staged pending, not committed to the store until the flow
-        // confirms, so the device secret is unchanged at this point.
+        // The rotation is deferred to confirmation, so the stored secret is unchanged.
         let after = client
             .persistence_manager
             .get_device_snapshot()
@@ -616,29 +833,16 @@ mod tests {
         let collector = Arc::new(TestEventCollector::default());
         client.register_handler(collector.clone() as Arc<dyn EventHandler>);
 
-        let before = client
-            .persistence_manager
-            .get_device_snapshot()
-            .adv_secret_key;
-        let child = NodeBuilder::new("passkey_request_options")
+        let child = NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS)
             .bytes(b"{}".to_vec())
             .build();
-        // forge a notification from a non-server JID
         let node = NodeBuilder::new("notification")
-            .attr("type", "passkey_prologue_request")
+            .attr("type", NOTIF_PASSKEY_REQUEST)
             .attr("from", "12345@s.whatsapp.net")
             .children([child])
             .build();
         client.process_node(node_to_owned_ref(&node)).await;
 
-        let after = client
-            .persistence_manager
-            .get_device_snapshot()
-            .adv_secret_key;
-        assert_eq!(
-            before, after,
-            "a forged request must NOT rotate the ADV secret"
-        );
         assert!(
             !collector
                 .events()
@@ -654,15 +858,12 @@ mod tests {
         let collector = Arc::new(TestEventCollector::default());
         client.register_handler(collector.clone() as Arc<dyn EventHandler>);
 
-        // No inline <passkey_request_options>: the handler falls back to an IQ fetch.
-        // The test client isn't connected, so the fetch fails fast and surfaces a
-        // non-continuation error (proving the fallback path runs).
+        // No inline options: the handler falls back to an IQ fetch. The test client
+        // isn't connected, so the fetch fails and surfaces a non-continuation error.
         client
-            .process_node(server_notification("passkey_prologue_request", None))
+            .process_node(server_notification(NOTIF_PASSKEY_REQUEST, None))
             .await;
 
-        // Assert it's specifically the fetch that failed, so the test proves the IQ
-        // fallback ran (not some earlier immediate error).
         wait_for(&collector, |e| {
             matches!(
                 e,
@@ -674,29 +875,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn passkey_continuation_without_linking_cache_emits_error() {
+    async fn passkey_continuation_without_session_emits_error() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
         client.register_handler(collector.clone() as Arc<dyn EventHandler>);
 
-        // a well-formed primary identity, but no prior send_passkey_response ran, so
-        // there is no linking cache and the continuation must surface a continuation error.
-        let primary = waproto::whatsapp::PrimaryEphemeralIdentity {
+        let primary = wa::PrimaryEphemeralIdentity {
             public_key: Some(vec![0xAB; 32]),
             nonce: Some(vec![0xCD; 32]),
         };
-        let child = NodeBuilder::new("primary_ephemeral_identity")
+        let child = NodeBuilder::new(TAG_PRIMARY_EPHEMERAL_IDENTITY)
             .bytes(prost::Message::encode_to_vec(&primary))
             .build();
         client
-            .process_node(server_notification("crsc_continuation", Some(child)))
+            .process_node(server_notification(NOTIF_PASSKEY_CONTINUATION, Some(child)))
             .await;
 
-        // the continuation runs in a spawned task, so poll for the event
         wait_for(
             &collector,
             |e| matches!(e, Event::PairPasskeyError(err) if err.continuation),
         )
         .await;
+    }
+
+    #[test]
+    fn prologue_node_wire_shape() {
+        let node = build_prologue_node(
+            b"cred-id".to_vec(),
+            b"{\"type\":\"public-key\"}".to_vec(),
+            b"prologue-proto".to_vec(),
+            Some([0x42; 32]),
+        );
+        let nr = node.as_node_ref();
+        assert_eq!(nr.tag.as_ref(), TAG_PASSKEY_PROLOGUE);
+        assert_eq!(
+            nr.get_optional_child(TAG_CREDENTIAL_ID)
+                .and_then(|n| n.content_bytes()),
+            Some(&b"cred-id"[..])
+        );
+        assert_eq!(
+            nr.get_optional_child(TAG_PAIRING_HANDOFF_PROOF)
+                .and_then(|n| n.content_bytes()),
+            Some(&[0x42u8; 32][..])
+        );
+
+        let fresh = build_prologue_node(b"c".to_vec(), b"a".to_vec(), b"p".to_vec(), None);
+        assert!(
+            fresh
+                .as_node_ref()
+                .get_optional_child(TAG_PAIRING_HANDOFF_PROOF)
+                .is_none()
+        );
     }
 }

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -319,6 +319,26 @@ impl Client {
         self.passkey_state.lock().await.linking = None;
         Ok(())
     }
+
+    /// Fetch the WebAuthn `<passkey_request_options>` JSON from the server. Used as
+    /// a fallback when a `passkey_prologue_request` notification arrives without the
+    /// options inline (mirrors whatsmeow's `getPasskeyRequestOptions`).
+    async fn get_passkey_request_options(&self) -> Result<String, PasskeyError> {
+        let query = InfoQuery::get(
+            "md",
+            server_jid(),
+            Some(NodeContent::Nodes(vec![
+                NodeBuilder::new("passkey_request_options").build(),
+            ])),
+        );
+        let resp = self
+            .send_iq(query)
+            .await
+            .map_err(|e| PasskeyError::Flow(format!("passkey_request_options iq failed: {e}")))?;
+        child_payload(resp.get(), "passkey_request_options")
+            .and_then(|b| String::from_utf8(b).ok())
+            .ok_or_else(|| PasskeyError::Flow("missing passkey_request_options in response".into()))
+    }
 }
 
 /// `<notification type="passkey_prologue_request">`: derive the handoff key, rotate
@@ -336,23 +356,41 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
         return;
     }
 
-    let options_json = match child_payload(node.get(), "passkey_request_options")
+    match child_payload(node.get(), "passkey_request_options")
         .and_then(|b| String::from_utf8(b).ok())
     {
-        Some(json) => json,
+        // Options inline (the common case): proceed immediately.
+        Some(json) => drive_passkey_request(client, json).await,
+        // No inline options: fall back to fetching them via IQ (whatsmeow does the
+        // same). Spawned because it awaits a round-trip.
         None => {
-            warn!("passkey notification missing a valid <passkey_request_options>");
+            let client = client.clone();
             client
-                .core
-                .event_bus
-                .dispatch(Event::PairPasskeyError(PairPasskeyError {
-                    error: "missing passkey_request_options".into(),
-                    continuation: false,
-                }));
-            return;
+                .clone()
+                .runtime
+                .spawn(Box::pin(async move {
+                    match client.get_passkey_request_options().await {
+                        Ok(json) => drive_passkey_request(&client, json).await,
+                        Err(e) => {
+                            warn!("failed to fetch passkey request options: {e}");
+                            client.core.event_bus.dispatch(Event::PairPasskeyError(
+                                PairPasskeyError {
+                                    error: e.to_string(),
+                                    continuation: false,
+                                },
+                            ));
+                        }
+                    }
+                }))
+                .detach();
         }
-    };
+    }
+}
 
+/// Rotate the ADV secret (keeping the prior one's handoff key), emit
+/// [`Event::PairPasskeyRequest`], and — if an authenticator is registered —
+/// auto-drive the assertion + response.
+async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
     // Derive the handoff key from the CURRENT ADV secret, then rotate it: the proof
     // proves continuity from the prior secret, while the PairingRequest carries the
     // new one.
@@ -600,22 +638,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn passkey_prologue_request_without_options_emits_error() {
+    async fn passkey_prologue_request_without_inline_options_falls_back_to_fetch() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
         client.register_handler(collector.clone() as Arc<dyn EventHandler>);
 
+        // No inline <passkey_request_options>: the handler falls back to an IQ fetch.
+        // The test client isn't connected, so the fetch fails fast and surfaces a
+        // non-continuation error (proving the fallback path runs).
         client
             .process_node(server_notification("passkey_prologue_request", None))
             .await;
 
-        assert!(
-            collector.events().iter().any(|e| matches!(
-                e.as_ref(),
-                Event::PairPasskeyError(err) if !err.continuation
-            )),
-            "missing passkey_request_options must emit a non-continuation error"
-        );
+        wait_for(
+            &collector,
+            |e| matches!(e, Event::PairPasskeyError(err) if !err.continuation),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -1,0 +1,647 @@
+//! Client-side SHORTCAKE_PASSKEY linking flow — the runtime glue that drives the
+//! deterministic primitives in [`wacore::shortcake`] over real IQ exchanges.
+//!
+//! Mirrors whatsmeow's `pair-passkey.go`. The protocol is a four-step handshake
+//! on top of the normal companion-linking connection:
+//!  1. server pushes `<notification type="passkey_prologue_request">` carrying the
+//!     WebAuthn request options → [`handle_passkey_notification`] derives the
+//!     handoff key from the current ADV secret, ROTATES the ADV secret, and emits
+//!     [`Event::PairPasskeyRequest`];
+//!  2. host (or the registered authenticator) produces a WebAuthn assertion →
+//!     [`Client::send_passkey_response`] sends `<passkey_prologue>` (ephemeral
+//!     identity + commitment, plus a handoff proof on a re-link);
+//!  3. server pushes `<notification type="crsc_continuation">` with its
+//!     `<primary_ephemeral_identity>` → [`handle_passkey_continuation`] does the
+//!     X25519 agreement, sends `<companion_nonce>`, derives the verification code
+//!     and encryption key, and emits [`Event::PairPasskeyConfirmation`];
+//!  4. host (or auto, when the handoff proof skips the code UX) →
+//!     [`Client::send_passkey_confirmation`] sends the AES-256-GCM-encrypted
+//!     `<encrypted_pairing_request>` carrying the newly-rotated ADV secret.
+//!
+//! Linking then completes through the ordinary `pair-success` path.
+
+use crate::client::Client;
+use crate::passkey::{Assertion, PasskeyAuthenticator, PasskeyError, parse_request_options};
+use crate::request::InfoQuery;
+use crate::store::commands::DeviceCommand;
+use crate::types::events::{Event, PairPasskeyConfirmation, PairPasskeyError, PairPasskeyRequest};
+use log::warn;
+use rand::RngExt;
+use std::sync::Arc;
+use wacore::libsignal::protocol::KeyPair;
+use wacore::shortcake::ShortcakeUtils;
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::{Jid, Node, NodeContent, NodeRef, OwnedNodeRef, SERVER_JID, Server};
+
+/// Per-attempt linking state, set by [`Client::send_passkey_response`] and consumed
+/// by the continuation + confirmation steps.
+struct LinkingCache {
+    keypair: KeyPair,
+    companion_nonce: [u8; 32],
+    pairing_ref: String,
+    device_type: i32,
+    skip_handoff_ux: bool,
+    encryption_key: Option<[u8; 32]>,
+}
+
+/// SHORTCAKE_PASSKEY flow state held on the [`Client`].
+#[derive(Default)]
+pub(crate) struct PasskeyFlowState {
+    /// Handoff HMAC key derived from the ADV secret BEFORE rotation; consumed once
+    /// by the next [`Client::send_passkey_response`]. Presence ⇒ re-link path, which
+    /// lets the server skip the verification-code UX. We consume-once rather than
+    /// honor whatsmeow's 5-minute TTL: a new request always overwrites it.
+    handoff_key: Option<[u8; 32]>,
+    linking: Option<LinkingCache>,
+    authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
+}
+
+fn server_jid() -> Jid {
+    Jid::new("", Server::Pn)
+}
+
+/// Build the `<passkey_prologue>` node: credential id + WebAuthn assertion JSON +
+/// the prologue payload, plus the pairing-handoff proof on a re-link. Pure so the
+/// exact wire shape (child tags + conditional proof) is unit-testable without a
+/// live connection.
+fn build_prologue_node(
+    credential_id: Vec<u8>,
+    webauthn_assertion: Vec<u8>,
+    prologue_payload: Vec<u8>,
+    handoff_proof: Option<[u8; 32]>,
+) -> Node {
+    let mut children = vec![
+        NodeBuilder::new("credential_id")
+            .bytes(credential_id)
+            .build(),
+        NodeBuilder::new("webauthn_assertion")
+            .bytes(webauthn_assertion)
+            .build(),
+        NodeBuilder::new("prologue_payload")
+            .bytes(prologue_payload)
+            .build(),
+    ];
+    if let Some(proof) = handoff_proof {
+        children.push(
+            NodeBuilder::new("pairing_handoff_proof")
+                .bytes(proof.to_vec())
+                .build(),
+        );
+    }
+    NodeBuilder::new("passkey_prologue")
+        .children(children)
+        .build()
+}
+
+/// Pull a child node's payload as bytes, accepting either binary or string content
+/// (the server sends the options JSON as a text node).
+fn child_payload(nr: &NodeRef<'_>, tag: &str) -> Option<Vec<u8>> {
+    let child = nr.get_optional_child(tag)?;
+    if let Some(b) = child.content_bytes() {
+        Some(b.to_vec())
+    } else {
+        child.content_str().map(|s| s.as_bytes().to_vec())
+    }
+}
+
+impl Client {
+    /// Register a passkey authenticator. When set, the client AUTO-DRIVES the
+    /// WebAuthn assertion step, and auto-confirms a re-link whose handoff proof
+    /// makes the verification-code UX unnecessary. Hosts that want to show the code
+    /// or drive the steps manually can leave this unset and react to the
+    /// `Event::PairPasskey*` events with [`Client::send_passkey_response`] /
+    /// [`Client::send_passkey_confirmation`].
+    pub async fn set_passkey_authenticator(&self, authenticator: Arc<dyn PasskeyAuthenticator>) {
+        self.passkey_state.lock().await.authenticator = Some(authenticator);
+    }
+
+    async fn passkey_authenticator(&self) -> Option<Arc<dyn PasskeyAuthenticator>> {
+        self.passkey_state.lock().await.authenticator.clone()
+    }
+
+    /// Send the WebAuthn assertion to the server as `<passkey_prologue>`. Fetches a
+    /// fresh pairing ref, builds the companion ephemeral identity + commitment, and
+    /// attaches the pairing-handoff proof when this is a re-link. Call this after an
+    /// [`Event::PairPasskeyRequest`].
+    pub async fn send_passkey_response(&self, assertion: Assertion) -> Result<(), PasskeyError> {
+        let server = server_jid();
+
+        let ref_query = InfoQuery::get(
+            "md",
+            server.clone(),
+            Some(NodeContent::Nodes(vec![NodeBuilder::new("ref").build()])),
+        );
+        let resp = self
+            .send_iq(ref_query)
+            .await
+            .map_err(|e| PasskeyError::Flow(format!("ref iq failed: {e}")))?;
+        let pairing_ref = child_payload(resp.get(), "ref")
+            .and_then(|b| String::from_utf8(b).ok())
+            .ok_or_else(|| PasskeyError::Flow("missing <ref> in server response".into()))?;
+
+        let keypair = ShortcakeUtils::generate_companion_ephemeral_keypair();
+        let companion_nonce = ShortcakeUtils::generate_companion_nonce();
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        let device_type = snapshot.device_props.platform_type.unwrap_or(0);
+        let companion_pub: [u8; 32] = keypair
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .map_err(|_| PasskeyError::Flow("ephemeral public key is not 32 bytes".into()))?;
+
+        let identity = ShortcakeUtils::build_companion_ephemeral_identity(
+            &companion_pub,
+            device_type,
+            &pairing_ref,
+        );
+        let commitment = ShortcakeUtils::commitment_hash(&identity, &companion_nonce);
+        let prologue_payload = ShortcakeUtils::build_prologue_payload(&identity, &commitment);
+
+        let handoff_proof = {
+            let mut state = self.passkey_state.lock().await;
+            let proof = state
+                .handoff_key
+                .take()
+                .map(|key| ShortcakeUtils::compute_pairing_handoff_proof(&key, &prologue_payload));
+            state.linking = Some(LinkingCache {
+                keypair,
+                companion_nonce,
+                pairing_ref,
+                device_type,
+                skip_handoff_ux: proof.is_some(),
+                encryption_key: None,
+            });
+            proof
+        };
+
+        let prologue = build_prologue_node(
+            assertion.credential_id,
+            assertion.assertion_json,
+            prologue_payload,
+            handoff_proof,
+        );
+        self.send_iq(InfoQuery::set(
+            "md",
+            server,
+            Some(NodeContent::Nodes(vec![prologue])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("passkey_prologue iq failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Process the continuation notification: agree on the shared secret, send the
+    /// companion nonce, derive the verification code + encryption key, and emit
+    /// [`Event::PairPasskeyConfirmation`]. Spawned off the receive loop because it
+    /// awaits a `<companion_nonce>` IQ round-trip.
+    async fn process_passkey_continuation(
+        &self,
+        primary_bytes: Vec<u8>,
+    ) -> Result<(), PasskeyError> {
+        let primary = ShortcakeUtils::parse_primary_ephemeral_identity(&primary_bytes)
+            .map_err(|e| PasskeyError::Flow(format!("primary ephemeral identity: {e}")))?;
+
+        let (keypair, companion_nonce, pairing_ref, device_type, skip_handoff_ux) = {
+            let state = self.passkey_state.lock().await;
+            let cache = state
+                .linking
+                .as_ref()
+                .ok_or_else(|| PasskeyError::Flow("continuation without a linking cache".into()))?;
+            (
+                cache.keypair.clone(),
+                cache.companion_nonce,
+                cache.pairing_ref.clone(),
+                cache.device_type,
+                cache.skip_handoff_ux,
+            )
+        };
+
+        let nonce_node = NodeBuilder::new("companion_nonce")
+            .bytes(companion_nonce.to_vec())
+            .build();
+        self.send_iq(InfoQuery::set(
+            "md",
+            server_jid(),
+            Some(NodeContent::Nodes(vec![nonce_node])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("companion_nonce iq failed: {e}")))?;
+
+        let encryption_key = ShortcakeUtils::derive_encryption_key(
+            &keypair,
+            &primary.public_key,
+            device_type,
+            &pairing_ref,
+        )
+        .map_err(|e| PasskeyError::Flow(format!("encryption key: {e}")))?;
+        let bare = ShortcakeUtils::derive_verification_code(
+            &companion_nonce,
+            &primary.public_key,
+            &primary.nonce,
+        );
+        // Match WA Web's displayed "XXXX-XXXX" grouping (the code is 8 ASCII chars).
+        let code = format!("{}-{}", &bare[..4], &bare[4..]);
+
+        {
+            let mut state = self.passkey_state.lock().await;
+            if let Some(cache) = state.linking.as_mut() {
+                cache.encryption_key = Some(encryption_key);
+            }
+        }
+
+        self.core
+            .event_bus
+            .dispatch(Event::PairPasskeyConfirmation(PairPasskeyConfirmation {
+                code,
+                skip_handoff_ux,
+            }));
+
+        // Re-link: the handoff proof already established continuity, so no user code
+        // confirmation is needed — auto-finish when an authenticator is driving.
+        if skip_handoff_ux && self.passkey_authenticator().await.is_some() {
+            self.send_passkey_confirmation().await?;
+        }
+        Ok(())
+    }
+
+    /// Finish the link: encrypt the `PairingRequest` (companion static keys + the
+    /// newly-rotated ADV secret) under the derived key and send
+    /// `<encrypted_pairing_request>`. For a fresh link, call this only after the
+    /// user has confirmed the [`Event::PairPasskeyConfirmation`] code.
+    pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
+        let encryption_key = {
+            let state = self.passkey_state.lock().await;
+            let cache = state
+                .linking
+                .as_ref()
+                .ok_or_else(|| PasskeyError::Flow("confirmation without a linking cache".into()))?;
+            cache.encryption_key.ok_or_else(|| {
+                PasskeyError::Flow("confirmation before encryption key derived".into())
+            })?
+        };
+
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        let companion_public: [u8; 32] = snapshot
+            .noise_key
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .map_err(|_| PasskeyError::Flow("noise public key is not 32 bytes".into()))?;
+        let companion_identity: [u8; 32] = snapshot
+            .identity_key
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .map_err(|_| PasskeyError::Flow("identity public key is not 32 bytes".into()))?;
+        // The rotated ADV secret (set when the prologue request arrived).
+        let adv_secret = snapshot.adv_secret_key;
+
+        let plaintext = ShortcakeUtils::build_pairing_request(
+            &companion_public,
+            &companion_identity,
+            &adv_secret,
+        );
+        let encrypted = ShortcakeUtils::encrypt_pairing_request(&plaintext, &encryption_key)
+            .map_err(|e| PasskeyError::Flow(format!("encrypt pairing request: {e}")))?;
+        let wrapped = ShortcakeUtils::build_encrypted_pairing_request(&encrypted);
+
+        let node = NodeBuilder::new("encrypted_pairing_request")
+            .bytes(wrapped)
+            .build();
+        self.send_iq(InfoQuery::set(
+            "md",
+            server_jid(),
+            Some(NodeContent::Nodes(vec![node])),
+        ))
+        .await
+        .map_err(|e| PasskeyError::Flow(format!("encrypted_pairing_request iq failed: {e}")))?;
+
+        self.passkey_state.lock().await.linking = None;
+        Ok(())
+    }
+}
+
+/// `<notification type="passkey_prologue_request">`: derive the handoff key, rotate
+/// the ADV secret, emit [`Event::PairPasskeyRequest`], and (if an authenticator is
+/// registered) auto-drive the assertion + response.
+pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>) {
+    // The ADV-secret rotation below is security-sensitive: only honor a request
+    // that actually came from the server.
+    if node
+        .get()
+        .get_attr("from")
+        .is_none_or(|v| v.as_str() != SERVER_JID)
+    {
+        warn!("ignoring passkey notification from a non-server JID");
+        return;
+    }
+
+    let options_json = match child_payload(node.get(), "passkey_request_options")
+        .and_then(|b| String::from_utf8(b).ok())
+    {
+        Some(json) => json,
+        None => {
+            warn!("passkey notification missing a valid <passkey_request_options>");
+            client
+                .core
+                .event_bus
+                .dispatch(Event::PairPasskeyError(PairPasskeyError {
+                    error: "missing passkey_request_options".into(),
+                    continuation: false,
+                }));
+            return;
+        }
+    };
+
+    // Derive the handoff key from the CURRENT ADV secret, then rotate it: the proof
+    // proves continuity from the prior secret, while the PairingRequest carries the
+    // new one.
+    let snapshot = client.persistence_manager.get_device_snapshot();
+    match ShortcakeUtils::derive_pairing_handoff_hmac_key(&snapshot.adv_secret_key) {
+        Ok(key) => client.passkey_state.lock().await.handoff_key = Some(key),
+        Err(e) => warn!("failed to derive pairing-handoff key: {e}"),
+    }
+    let mut new_adv = [0u8; 32];
+    rand::make_rng::<rand::rngs::StdRng>().fill(&mut new_adv);
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetAdvSecretKey(new_adv))
+        .await;
+
+    client
+        .core
+        .event_bus
+        .dispatch(Event::PairPasskeyRequest(PairPasskeyRequest {
+            request_options_json: options_json.clone(),
+        }));
+
+    if let Some(authenticator) = client.passkey_authenticator().await {
+        let client = client.clone();
+        client
+            .clone()
+            .runtime
+            .spawn(Box::pin(async move {
+                if let Err(e) = auto_drive_response(&client, authenticator, &options_json).await {
+                    warn!("passkey auto-drive failed: {e}");
+                    client
+                        .core
+                        .event_bus
+                        .dispatch(Event::PairPasskeyError(PairPasskeyError {
+                            error: e.to_string(),
+                            continuation: false,
+                        }));
+                }
+            }))
+            .detach();
+    }
+}
+
+async fn auto_drive_response(
+    client: &Arc<Client>,
+    authenticator: Arc<dyn PasskeyAuthenticator>,
+    options_json: &str,
+) -> Result<(), PasskeyError> {
+    let request = parse_request_options(options_json)?;
+    let assertion = authenticator.get_assertion(&request).await?;
+    client.send_passkey_response(assertion).await
+}
+
+/// `<notification type="crsc_continuation">`: spawn the continuation processing
+/// (it awaits a `<companion_nonce>` IQ, so it must not block the receive loop).
+pub(crate) async fn handle_passkey_continuation(client: &Arc<Client>, node: Arc<OwnedNodeRef>) {
+    if node
+        .get()
+        .get_attr("from")
+        .is_none_or(|v| v.as_str() != SERVER_JID)
+    {
+        warn!("ignoring passkey continuation from a non-server JID");
+        return;
+    }
+
+    let primary_bytes = match child_payload(node.get(), "primary_ephemeral_identity") {
+        Some(bytes) => bytes,
+        None => {
+            warn!("passkey continuation missing <primary_ephemeral_identity>");
+            client
+                .core
+                .event_bus
+                .dispatch(Event::PairPasskeyError(PairPasskeyError {
+                    error: "missing primary_ephemeral_identity".into(),
+                    continuation: true,
+                }));
+            return;
+        }
+    };
+
+    let client = client.clone();
+    client
+        .clone()
+        .runtime
+        .spawn(Box::pin(async move {
+            if let Err(e) = client.process_passkey_continuation(primary_bytes).await {
+                warn!("passkey continuation failed: {e}");
+                client
+                    .core
+                    .event_bus
+                    .dispatch(Event::PairPasskeyError(PairPasskeyError {
+                        error: e.to_string(),
+                        continuation: true,
+                    }));
+            }
+        }))
+        .detach();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{TestEventCollector, create_test_client, node_to_owned_ref};
+    use crate::types::events::EventHandler;
+    use std::time::Duration;
+
+    fn server_notification(
+        notif_type: &'static str,
+        child: Option<wacore_binary::Node>,
+    ) -> Arc<OwnedNodeRef> {
+        let mut builder = NodeBuilder::new("notification")
+            .attr("type", notif_type)
+            .attr("from", SERVER_JID);
+        if let Some(child) = child {
+            builder = builder.children([child]);
+        }
+        node_to_owned_ref(&builder.build())
+    }
+
+    async fn wait_for(collector: &Arc<TestEventCollector>, pred: impl Fn(&Event) -> bool) {
+        for _ in 0..200 {
+            if collector.events().iter().any(|e| pred(e.as_ref())) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("expected event was not observed within the timeout");
+    }
+
+    #[test]
+    fn prologue_node_wire_shape() {
+        // re-link: the handoff proof child is present
+        let node = build_prologue_node(
+            b"cred-id".to_vec(),
+            b"{\"type\":\"public-key\"}".to_vec(),
+            b"prologue-proto".to_vec(),
+            Some([0x42; 32]),
+        );
+        let nr = node.as_node_ref();
+        assert_eq!(nr.tag.as_ref(), "passkey_prologue");
+        assert_eq!(
+            nr.get_optional_child("credential_id")
+                .and_then(|n| n.content_bytes()),
+            Some(&b"cred-id"[..])
+        );
+        assert_eq!(
+            nr.get_optional_child("webauthn_assertion")
+                .and_then(|n| n.content_bytes()),
+            Some(&b"{\"type\":\"public-key\"}"[..])
+        );
+        assert_eq!(
+            nr.get_optional_child("prologue_payload")
+                .and_then(|n| n.content_bytes()),
+            Some(&b"prologue-proto"[..])
+        );
+        assert_eq!(
+            nr.get_optional_child("pairing_handoff_proof")
+                .and_then(|n| n.content_bytes()),
+            Some(&[0x42u8; 32][..])
+        );
+
+        // fresh link: no handoff proof child
+        let fresh = build_prologue_node(b"c".to_vec(), b"a".to_vec(), b"p".to_vec(), None);
+        assert!(
+            fresh
+                .as_node_ref()
+                .get_optional_child("pairing_handoff_proof")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn passkey_prologue_request_rotates_adv_and_emits_event() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+
+        let before = client
+            .persistence_manager
+            .get_device_snapshot()
+            .adv_secret_key;
+
+        // verbatim options JSON; the handler forwards it untouched in the event
+        let options = r#"{"challenge":"YWJjZGVm","rpId":"web.whatsapp.com"}"#;
+        let child = NodeBuilder::new("passkey_request_options")
+            .bytes(options.as_bytes().to_vec())
+            .build();
+        client
+            .process_node(server_notification("passkey_prologue_request", Some(child)))
+            .await;
+
+        let after = client
+            .persistence_manager
+            .get_device_snapshot()
+            .adv_secret_key;
+        assert_ne!(before, after, "ADV secret must rotate on a passkey request");
+
+        let request = collector
+            .events()
+            .into_iter()
+            .find_map(|e| match e.as_ref() {
+                Event::PairPasskeyRequest(r) => Some(r.clone()),
+                _ => None,
+            })
+            .expect("a PairPasskeyRequest event must be dispatched");
+        assert_eq!(request.request_options_json, options);
+    }
+
+    #[tokio::test]
+    async fn passkey_prologue_request_from_non_server_is_ignored() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+
+        let before = client
+            .persistence_manager
+            .get_device_snapshot()
+            .adv_secret_key;
+        let child = NodeBuilder::new("passkey_request_options")
+            .bytes(b"{}".to_vec())
+            .build();
+        // forge a notification from a non-server JID
+        let node = NodeBuilder::new("notification")
+            .attr("type", "passkey_prologue_request")
+            .attr("from", "12345@s.whatsapp.net")
+            .children([child])
+            .build();
+        client.process_node(node_to_owned_ref(&node)).await;
+
+        let after = client
+            .persistence_manager
+            .get_device_snapshot()
+            .adv_secret_key;
+        assert_eq!(
+            before, after,
+            "a forged request must NOT rotate the ADV secret"
+        );
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(e.as_ref(), Event::PairPasskeyRequest(_))),
+            "no event for a non-server request"
+        );
+    }
+
+    #[tokio::test]
+    async fn passkey_prologue_request_without_options_emits_error() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+
+        client
+            .process_node(server_notification("passkey_prologue_request", None))
+            .await;
+
+        assert!(
+            collector.events().iter().any(|e| matches!(
+                e.as_ref(),
+                Event::PairPasskeyError(err) if !err.continuation
+            )),
+            "missing passkey_request_options must emit a non-continuation error"
+        );
+    }
+
+    #[tokio::test]
+    async fn passkey_continuation_without_linking_cache_emits_error() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+
+        // a well-formed primary identity, but no prior send_passkey_response ran, so
+        // there is no linking cache — the continuation must surface a continuation error.
+        let primary = waproto::whatsapp::PrimaryEphemeralIdentity {
+            public_key: Some(vec![0xAB; 32]),
+            nonce: Some(vec![0xCD; 32]),
+        };
+        let child = NodeBuilder::new("primary_ephemeral_identity")
+            .bytes(prost::Message::encode_to_vec(&primary))
+            .build();
+        client
+            .process_node(server_notification("crsc_continuation", Some(child)))
+            .await;
+
+        // the continuation runs in a spawned task, so poll for the event
+        wait_for(
+            &collector,
+            |e| matches!(e, Event::PairPasskeyError(err) if err.continuation),
+        )
+        .await;
+    }
+}

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use log::warn;
 use rand::RngExt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use wacore::libsignal::protocol::KeyPair;
 use wacore::shortcake::ShortcakeUtils;
 use wacore::sync_marker::MaybeSendSync;
@@ -243,41 +244,21 @@ pub(crate) struct PasskeyFlowState {
     /// HMAC key from the pre-rotation ADV secret; presence marks the re-link path
     /// that lets the server skip the verification-code UX. Consumed once.
     handoff_key: Option<[u8; 32]>,
-    /// Set while a `send_passkey_response` is mid-open (before its session exists),
-    /// so a concurrent open is rejected rather than clobbering the attempt.
-    opening: bool,
     session: Option<ShortcakeSession>,
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
 
-/// Releases the `opening` reservation on drop, so a `send_passkey_response` that is
-/// cancelled mid-open can't leave the flow permanently blocked. On the success path
-/// [`finish`](Self::finish) clears it under the already-held lock and disarms this.
+/// Holds the wait-free open reservation and releases it on drop. Because it clears
+/// a plain [`AtomicBool`] (not a flag behind the async lock), the release is a sync,
+/// always-succeeding store, so a `send_passkey_response` cancelled at any await
+/// can't leave the reservation stuck.
 struct OpeningGuard<'a> {
-    state: &'a async_lock::Mutex<PasskeyFlowState>,
-    armed: bool,
-}
-
-impl<'a> OpeningGuard<'a> {
-    fn new(state: &'a async_lock::Mutex<PasskeyFlowState>) -> Self {
-        Self { state, armed: true }
-    }
-
-    fn finish(mut self, state: &mut PasskeyFlowState) {
-        state.opening = false;
-        self.armed = false;
-    }
+    flag: &'a AtomicBool,
 }
 
 impl Drop for OpeningGuard<'_> {
     fn drop(&mut self) {
-        // The lock is free at any await point where cancellation can occur, so a
-        // best-effort try_lock reliably clears the reservation there.
-        if self.armed
-            && let Some(mut state) = self.state.try_lock()
-        {
-            state.opening = false;
-        }
+        self.flag.store(false, Ordering::Release);
     }
 }
 
@@ -409,27 +390,35 @@ impl Client {
     /// Send the WebAuthn assertion as `<passkey_prologue>` and open the handshake.
     /// Call after an [`Event::PairPasskeyRequest`].
     pub async fn send_passkey_response(&self, assertion: Assertion) -> Result<(), PasskeyError> {
-        // Reserve the single attempt slot BEFORE the opening awaits, so a concurrent
-        // response can't open a second overlapping handshake and clobber this one's
-        // nonce/ref (which would then commit the wrong ADV rotation).
+        // Reserve the single open slot BEFORE the awaits, so a concurrent response
+        // can't open a second overlapping handshake and clobber this one's nonce/ref
+        // (which would then commit the wrong ADV rotation). The guard releases the
+        // reservation on every exit, including cancellation mid-open.
+        if self
+            .passkey_opening
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(PasskeyError::Flow(
+                "a passkey open is already in progress".into(),
+            ));
+        }
+        let _guard = OpeningGuard {
+            flag: &self.passkey_opening,
+        };
+
         let handoff_key = {
             let mut state = self.passkey_state.lock().await;
-            if state.opening || state.session.is_some() {
+            if state.session.is_some() {
                 return Err(PasskeyError::Flow(
                     "a passkey link is already in progress".into(),
                 ));
             }
-            state.opening = true;
             state.handoff_key.take()
         };
-        // Releases the reservation on every exit, including if this future is
-        // cancelled mid-open, so a dropped attempt can't block the flow forever.
-        let guard = OpeningGuard::new(&self.passkey_state);
 
         let session = ShortcakeSession::open(self, assertion, handoff_key).await?;
-        let mut state = self.passkey_state.lock().await;
-        guard.finish(&mut state);
-        state.session = Some(session);
+        self.passkey_state.lock().await.session = Some(session);
         Ok(())
     }
 
@@ -876,12 +865,14 @@ mod tests {
     #[tokio::test]
     async fn cancelled_open_releases_the_reservation() {
         let client = create_test_client().await;
-        client.passkey_state.lock().await.opening = true;
-        // A guard dropped without `finish` stands in for a send_passkey_response
-        // future cancelled mid-open; it must release the reservation.
-        drop(OpeningGuard::new(&client.passkey_state));
+        client.passkey_opening.store(true, Ordering::Release);
+        // A dropped guard stands in for a send_passkey_response cancelled mid-open;
+        // the release is a sync store, so it holds even under lock contention.
+        drop(OpeningGuard {
+            flag: &client.passkey_opening,
+        });
         assert!(
-            !client.passkey_state.lock().await.opening,
+            !client.passkey_opening.load(Ordering::Acquire),
             "a cancelled open must release the reservation"
         );
     }

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -46,6 +46,11 @@ struct LinkingCache {
     device_type: i32,
     skip_handoff_ux: bool,
     encryption_key: Option<[u8; 32]>,
+    /// This attempt's freshly-rotated ADV secret, held here (not in the device
+    /// store) until the flow commits it, so an abandoned attempt never rotates to a
+    /// secret the primary never received. Per-attempt, so concurrent attempts can't
+    /// cross-contaminate the committed secret.
+    new_adv_secret: [u8; 32],
 }
 
 #[derive(Default)]
@@ -53,9 +58,6 @@ pub(crate) struct PasskeyFlowState {
     /// HMAC key from the pre-rotation ADV secret; presence marks the re-link path
     /// that lets the server skip the verification-code UX. Consumed once.
     handoff_key: Option<[u8; 32]>,
-    /// Rotated ADV secret, held out of the device store until the flow commits it,
-    /// so an abandoned attempt never rotates to a secret the primary never received.
-    pending_adv_secret: Option<[u8; 32]>,
     linking: Option<LinkingCache>,
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
@@ -140,6 +142,8 @@ impl Client {
 
         let keypair = ShortcakeUtils::generate_companion_ephemeral_keypair();
         let companion_nonce = ShortcakeUtils::generate_companion_nonce();
+        let mut new_adv_secret = [0u8; 32];
+        rand::make_rng::<rand::rngs::StdRng>().fill(&mut new_adv_secret);
         let snapshot = self.persistence_manager.get_device_snapshot();
         let device_type = snapshot.device_props.platform_type.unwrap_or(0);
         let companion_pub: [u8; 32] = keypair
@@ -169,6 +173,7 @@ impl Client {
                 device_type,
                 skip_handoff_ux: proof.is_some(),
                 encryption_key: None,
+                new_adv_secret,
             });
             proof
         };
@@ -292,11 +297,7 @@ impl Client {
             let key = cache.encryption_key.ok_or_else(|| {
                 PasskeyError::Flow("confirmation before encryption key derived".into())
             })?;
-            // The pending (not-yet-committed) rotated ADV secret staged at request time.
-            let adv = state.pending_adv_secret.ok_or_else(|| {
-                PasskeyError::Flow("confirmation without a pending ADV secret".into())
-            })?;
-            (key, adv)
+            (key, cache.new_adv_secret)
         };
 
         let snapshot = self.persistence_manager.get_device_snapshot();
@@ -338,11 +339,7 @@ impl Client {
         self.persistence_manager
             .process_command(DeviceCommand::SetAdvSecretKey(adv_secret))
             .await;
-        {
-            let mut state = self.passkey_state.lock().await;
-            state.linking = None;
-            state.pending_adv_secret = None;
-        }
+        self.passkey_state.lock().await.linking = None;
         Ok(())
     }
 
@@ -409,19 +406,14 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
 }
 
 async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
-    // Handoff key from the current secret (proves continuity); stage a fresh secret
-    // that only commits at confirmation, so a failed attempt doesn't diverge.
+    // Handoff key from the current secret proves continuity to the server; presence
+    // of a key marks this as a re-link. The rotated secret itself is generated
+    // per-attempt in send_passkey_response.
     let snapshot = client.persistence_manager.get_device_snapshot();
     let handoff_key = ShortcakeUtils::derive_pairing_handoff_hmac_key(&snapshot.adv_secret_key)
         .inspect_err(|e| warn!("failed to derive pairing-handoff key: {e}"))
         .ok();
-    let mut new_adv = [0u8; 32];
-    rand::make_rng::<rand::rngs::StdRng>().fill(&mut new_adv);
-    {
-        let mut state = client.passkey_state.lock().await;
-        state.handoff_key = handoff_key;
-        state.pending_adv_secret = Some(new_adv);
-    }
+    client.passkey_state.lock().await.handoff_key = handoff_key;
 
     client
         .core

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -250,6 +250,37 @@ pub(crate) struct PasskeyFlowState {
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
 
+/// Releases the `opening` reservation on drop, so a `send_passkey_response` that is
+/// cancelled mid-open can't leave the flow permanently blocked. On the success path
+/// [`finish`](Self::finish) clears it under the already-held lock and disarms this.
+struct OpeningGuard<'a> {
+    state: &'a async_lock::Mutex<PasskeyFlowState>,
+    armed: bool,
+}
+
+impl<'a> OpeningGuard<'a> {
+    fn new(state: &'a async_lock::Mutex<PasskeyFlowState>) -> Self {
+        Self { state, armed: true }
+    }
+
+    fn finish(mut self, state: &mut PasskeyFlowState) {
+        state.opening = false;
+        self.armed = false;
+    }
+}
+
+impl Drop for OpeningGuard<'_> {
+    fn drop(&mut self) {
+        // The lock is free at any await point where cancellation can occur, so a
+        // best-effort try_lock reliably clears the reservation there.
+        if self.armed
+            && let Some(mut state) = self.state.try_lock()
+        {
+            state.opening = false;
+        }
+    }
+}
+
 fn server_jid() -> Jid {
     Jid::new("", Server::Pn)
 }
@@ -391,11 +422,14 @@ impl Client {
             state.opening = true;
             state.handoff_key.take()
         };
+        // Releases the reservation on every exit, including if this future is
+        // cancelled mid-open, so a dropped attempt can't block the flow forever.
+        let guard = OpeningGuard::new(&self.passkey_state);
 
-        let opened = ShortcakeSession::open(self, assertion, handoff_key).await;
+        let session = ShortcakeSession::open(self, assertion, handoff_key).await?;
         let mut state = self.passkey_state.lock().await;
-        state.opening = false;
-        state.session = Some(opened?);
+        guard.finish(&mut state);
+        state.session = Some(session);
         Ok(())
     }
 
@@ -406,9 +440,10 @@ impl Client {
         // premature call must NOT drop the in-flight attempt.
         let mut session = {
             let mut state = self.passkey_state.lock().await;
-            match &state.session {
-                Some(s) if s.stage == Stage::AwaitingConfirmation => state.session.take().unwrap(),
-                Some(_) => {
+            match state.session.take() {
+                Some(s) if s.stage == Stage::AwaitingConfirmation => s,
+                Some(s) => {
+                    state.session = Some(s);
                     return Err(PasskeyError::Flow(
                         "confirmation before the verification stage".into(),
                     ));
@@ -835,6 +870,19 @@ mod tests {
         assert!(
             client.passkey_state.lock().await.session.is_some(),
             "a premature confirmation must not drop the in-flight attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_open_releases_the_reservation() {
+        let client = create_test_client().await;
+        client.passkey_state.lock().await.opening = true;
+        // A guard dropped without `finish` stands in for a send_passkey_response
+        // future cancelled mid-open; it must release the reservation.
+        drop(OpeningGuard::new(&client.passkey_state));
+        assert!(
+            !client.passkey_state.lock().await.opening,
+            "a cancelled open must release the reservation"
         );
     }
 

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -62,7 +62,6 @@ trait ShortcakeIo: MaybeSendSync {
     async fn query(&self, query: InfoQuery<'static>) -> Result<Arc<OwnedNodeRef>, PasskeyError>;
     fn device_material(&self) -> Result<DeviceMaterial, PasskeyError>;
     async fn commit_adv_secret(&self, secret: [u8; 32]);
-    fn emit(&self, event: Event);
 }
 
 #[derive(PartialEq, Eq)]
@@ -146,14 +145,15 @@ impl ShortcakeSession {
         })
     }
 
-    /// Agree on the shared secret, reveal the companion nonce, derive the code +
-    /// encryption key, and emit [`Event::PairPasskeyConfirmation`]. Returns whether
-    /// the handoff proof lets the code UX be skipped.
+    /// Agree on the shared secret, reveal the companion nonce, and derive the code
+    /// and encryption key. Returns the confirmation payload for the caller to
+    /// publish, so the caller can restore the session before a synchronous listener
+    /// that confirms observes it.
     async fn on_primary_identity(
         &mut self,
         io: &dyn ShortcakeIo,
         primary_bytes: &[u8],
-    ) -> Result<bool, PasskeyError> {
+    ) -> Result<PairPasskeyConfirmation, PasskeyError> {
         if self.stage != Stage::AwaitingPrimaryIdentity {
             return Err(PasskeyError::Flow(
                 "unexpected continuation for this stage".into(),
@@ -190,11 +190,10 @@ impl ShortcakeSession {
 
         self.encryption_key = Some(encryption_key);
         self.stage = Stage::AwaitingConfirmation;
-        io.emit(Event::PairPasskeyConfirmation(PairPasskeyConfirmation {
+        Ok(PairPasskeyConfirmation {
             code,
             skip_handoff_ux: self.skip_handoff_ux,
-        }));
-        Ok(self.skip_handoff_ux)
+        })
     }
 
     /// Encrypt the `PairingRequest` (companion static keys + rotated ADV secret)
@@ -244,6 +243,9 @@ pub(crate) struct PasskeyFlowState {
     /// HMAC key from the pre-rotation ADV secret; presence marks the re-link path
     /// that lets the server skip the verification-code UX. Consumed once.
     handoff_key: Option<[u8; 32]>,
+    /// Set while a `send_passkey_response` is mid-open (before its session exists),
+    /// so a concurrent open is rejected rather than clobbering the attempt.
+    opening: bool,
     session: Option<ShortcakeSession>,
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
@@ -358,10 +360,6 @@ impl ShortcakeIo for Client {
             .process_command(DeviceCommand::SetAdvSecretKey(secret))
             .await;
     }
-
-    fn emit(&self, event: Event) {
-        self.core.event_bus.dispatch(event);
-    }
 }
 
 impl Client {
@@ -380,24 +378,48 @@ impl Client {
     /// Send the WebAuthn assertion as `<passkey_prologue>` and open the handshake.
     /// Call after an [`Event::PairPasskeyRequest`].
     pub async fn send_passkey_response(&self, assertion: Assertion) -> Result<(), PasskeyError> {
-        let handoff_key = self.passkey_state.lock().await.handoff_key.take();
-        let session = ShortcakeSession::open(self, assertion, handoff_key).await?;
-        self.passkey_state.lock().await.session = Some(session);
+        // Reserve the single attempt slot BEFORE the opening awaits, so a concurrent
+        // response can't open a second overlapping handshake and clobber this one's
+        // nonce/ref (which would then commit the wrong ADV rotation).
+        let handoff_key = {
+            let mut state = self.passkey_state.lock().await;
+            if state.opening || state.session.is_some() {
+                return Err(PasskeyError::Flow(
+                    "a passkey link is already in progress".into(),
+                ));
+            }
+            state.opening = true;
+            state.handoff_key.take()
+        };
+
+        let opened = ShortcakeSession::open(self, assertion, handoff_key).await;
+        let mut state = self.passkey_state.lock().await;
+        state.opening = false;
+        state.session = Some(opened?);
         Ok(())
     }
 
     /// Finish the link. For a fresh link, call this only after the user confirms the
     /// [`Event::PairPasskeyConfirmation`] code.
     pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
-        // Taken out for the duration: on failure the attempt is dropped, not left
-        // half-committed.
-        let mut session = self
-            .passkey_state
-            .lock()
-            .await
-            .session
-            .take()
-            .ok_or_else(|| PasskeyError::Flow("confirmation without an active session".into()))?;
+        // Only consume the session once it's actually at the confirmation stage — a
+        // premature call must NOT drop the in-flight attempt.
+        let mut session = {
+            let mut state = self.passkey_state.lock().await;
+            match &state.session {
+                Some(s) if s.stage == Stage::AwaitingConfirmation => state.session.take().unwrap(),
+                Some(_) => {
+                    return Err(PasskeyError::Flow(
+                        "confirmation before the verification stage".into(),
+                    ));
+                }
+                None => {
+                    return Err(PasskeyError::Flow(
+                        "confirmation without an active session".into(),
+                    ));
+                }
+            }
+        };
         session.confirm(self).await
     }
 
@@ -409,8 +431,15 @@ impl Client {
             .session
             .take()
             .ok_or_else(|| PasskeyError::Flow("continuation without an active session".into()))?;
-        let skip = session.on_primary_identity(self, &primary_bytes).await?;
+        let confirmation = session.on_primary_identity(self, &primary_bytes).await?;
+        let skip = confirmation.skip_handoff_ux;
+
+        // Restore the session BEFORE publishing the event, so a synchronous listener
+        // that confirms from it sees an active session.
         self.passkey_state.lock().await.session = Some(session);
+        self.core
+            .event_bus
+            .dispatch(Event::PairPasskeyConfirmation(confirmation));
 
         // Re-link: continuity is already proven, so finish without a user code when
         // an authenticator is driving.
@@ -592,14 +621,13 @@ mod tests {
     }
 
     // Scripted IQ stand-in: answers each `md` IQ by its child tag and records the
-    // child that was sent, plus committed secret and emitted events.
+    // child that was sent, plus the committed secret.
     struct MockIo {
         device: DeviceMaterial,
         pairing_ref: String,
         options_json: String,
         sent: Mutex<Vec<Node>>,
         committed: Mutex<Option<[u8; 32]>>,
-        events: Mutex<Vec<Event>>,
     }
 
     impl MockIo {
@@ -662,10 +690,6 @@ mod tests {
         async fn commit_adv_secret(&self, secret: [u8; 32]) {
             *self.committed.lock().unwrap() = Some(secret);
         }
-
-        fn emit(&self, event: Event) {
-            self.events.lock().unwrap().push(event);
-        }
     }
 
     fn child_bytes(node: &Node, tag: &str) -> Vec<u8> {
@@ -686,7 +710,6 @@ mod tests {
             options_json: "{}".to_string(),
             sent: Mutex::new(Vec::new()),
             committed: Mutex::new(None),
-            events: Mutex::new(Vec::new()),
         };
 
         // A re-link: pass a handoff key so the prologue carries the proof.
@@ -721,20 +744,20 @@ mod tests {
         }
         .encode_to_vec();
 
-        // step 3: continuation sends the companion nonce and emits the code.
-        let skip = session
+        // step 3: continuation sends the companion nonce and yields the code.
+        let confirmation = session
             .on_primary_identity(&io, &primary_bytes)
             .await
             .unwrap();
-        assert!(skip, "re-link with a handoff proof skips the code UX");
+        assert!(
+            confirmation.skip_handoff_ux,
+            "re-link with a handoff proof skips the code UX"
+        );
+        assert_eq!(confirmation.code.len(), 9, "code is grouped XXXX-XXXX");
         assert_eq!(
             io.sent_tags().last().map(String::as_str),
             Some(TAG_COMPANION_NONCE)
         );
-        assert!(matches!(
-            io.events.lock().unwrap().first(),
-            Some(Event::PairPasskeyConfirmation(c)) if c.skip_handoff_ux && c.code.len() == 9
-        ));
 
         // step 4: confirm seals + sends the pairing request and commits the secret.
         session.confirm(&io).await.unwrap();
@@ -787,6 +810,31 @@ mod tests {
         assert_eq!(
             pr.companion_public_key.as_deref(),
             Some(&device.noise_public[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn premature_confirmation_keeps_the_session() {
+        let client = create_test_client().await;
+        // A session that hasn't reached the confirmation stage yet.
+        client.passkey_state.lock().await.session = Some(ShortcakeSession {
+            keypair: KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>()),
+            companion_nonce: [0; 32],
+            pairing_ref: "r".into(),
+            device_type: 1,
+            new_adv_secret: [1; 32],
+            skip_handoff_ux: false,
+            stage: Stage::AwaitingPrimaryIdentity,
+            encryption_key: None,
+        });
+
+        assert!(
+            client.send_passkey_confirmation().await.is_err(),
+            "confirming before the verification stage errors"
+        );
+        assert!(
+            client.passkey_state.lock().await.session.is_some(),
+            "a premature confirmation must not drop the in-flight attempt"
         );
     }
 

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -1,24 +1,11 @@
-//! Client-side SHORTCAKE_PASSKEY linking flow — the runtime glue that drives the
+//! Client-side SHORTCAKE_PASSKEY linking flow: the runtime glue that drives the
 //! deterministic primitives in [`wacore::shortcake`] over real IQ exchanges.
 //!
-//! Mirrors whatsmeow's `pair-passkey.go`. The protocol is a four-step handshake
-//! on top of the normal companion-linking connection:
-//!  1. server pushes `<notification type="passkey_prologue_request">` carrying the
-//!     WebAuthn request options → [`handle_passkey_notification`] derives the
-//!     handoff key from the current ADV secret, ROTATES the ADV secret, and emits
-//!     [`Event::PairPasskeyRequest`];
-//!  2. host (or the registered authenticator) produces a WebAuthn assertion →
-//!     [`Client::send_passkey_response`] sends `<passkey_prologue>` (ephemeral
-//!     identity + commitment, plus a handoff proof on a re-link);
-//!  3. server pushes `<notification type="crsc_continuation">` with its
-//!     `<primary_ephemeral_identity>` → [`handle_passkey_continuation`] does the
-//!     X25519 agreement, sends `<companion_nonce>`, derives the verification code
-//!     and encryption key, and emits [`Event::PairPasskeyConfirmation`];
-//!  4. host (or auto, when the handoff proof skips the code UX) →
-//!     [`Client::send_passkey_confirmation`] sends the AES-256-GCM-encrypted
-//!     `<encrypted_pairing_request>` carrying the newly-rotated ADV secret.
-//!
-//! Linking then completes through the ordinary `pair-success` path.
+//! The handshake sits on top of the normal companion-linking connection: the
+//! server requests a WebAuthn assertion, the companion answers with an ephemeral
+//! identity prologue, both sides exchange nonces to derive a shared key, and the
+//! companion finally sends its rotated ADV secret encrypted under that key. Linking
+//! then completes through the ordinary `pair-success` path.
 
 use crate::client::Client;
 use crate::passkey::{Assertion, PasskeyAuthenticator, PasskeyError, parse_request_options};
@@ -33,8 +20,25 @@ use wacore::shortcake::ShortcakeUtils;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeContent, NodeRef, OwnedNodeRef, SERVER_JID, Server};
 
-/// Per-attempt linking state, set by [`Client::send_passkey_response`] and consumed
-/// by the continuation + confirmation steps.
+/// `<notification type=...>` routing keys, consumed by the notification dispatcher.
+pub(crate) const NOTIF_PASSKEY_REQUEST: &str = "passkey_prologue_request";
+pub(crate) const NOTIF_PASSKEY_CONTINUATION: &str = "crsc_continuation";
+
+const MD_NAMESPACE: &str = "md";
+const TAG_REF: &str = "ref";
+const TAG_PASSKEY_REQUEST_OPTIONS: &str = "passkey_request_options";
+const TAG_PASSKEY_PROLOGUE: &str = "passkey_prologue";
+const TAG_CREDENTIAL_ID: &str = "credential_id";
+const TAG_WEBAUTHN_ASSERTION: &str = "webauthn_assertion";
+const TAG_PROLOGUE_PAYLOAD: &str = "prologue_payload";
+const TAG_PAIRING_HANDOFF_PROOF: &str = "pairing_handoff_proof";
+const TAG_PRIMARY_EPHEMERAL_IDENTITY: &str = "primary_ephemeral_identity";
+const TAG_COMPANION_NONCE: &str = "companion_nonce";
+const TAG_ENCRYPTED_PAIRING_REQUEST: &str = "encrypted_pairing_request";
+
+/// Length of each half of the "XXXX-XXXX" verification code grouping.
+const CODE_GROUP_LEN: usize = 4;
+
 struct LinkingCache {
     keypair: KeyPair,
     companion_nonce: [u8; 32],
@@ -44,14 +48,14 @@ struct LinkingCache {
     encryption_key: Option<[u8; 32]>,
 }
 
-/// SHORTCAKE_PASSKEY flow state held on the [`Client`].
 #[derive(Default)]
 pub(crate) struct PasskeyFlowState {
-    /// Handoff HMAC key derived from the ADV secret BEFORE rotation; consumed once
-    /// by the next [`Client::send_passkey_response`]. Presence ⇒ re-link path, which
-    /// lets the server skip the verification-code UX. We consume-once rather than
-    /// honor whatsmeow's 5-minute TTL: a new request always overwrites it.
+    /// HMAC key from the pre-rotation ADV secret; presence marks the re-link path
+    /// that lets the server skip the verification-code UX. Consumed once.
     handoff_key: Option<[u8; 32]>,
+    /// Rotated ADV secret, held out of the device store until the flow commits it,
+    /// so an abandoned attempt never rotates to a secret the primary never received.
+    pending_adv_secret: Option<[u8; 32]>,
     linking: Option<LinkingCache>,
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
@@ -60,10 +64,7 @@ fn server_jid() -> Jid {
     Jid::new("", Server::Pn)
 }
 
-/// Build the `<passkey_prologue>` node: credential id + WebAuthn assertion JSON +
-/// the prologue payload, plus the pairing-handoff proof on a re-link. Pure so the
-/// exact wire shape (child tags + conditional proof) is unit-testable without a
-/// live connection.
+/// Pure so the wire shape (child tags + conditional proof) is unit-testable.
 fn build_prologue_node(
     credential_id: Vec<u8>,
     webauthn_assertion: Vec<u8>,
@@ -71,24 +72,24 @@ fn build_prologue_node(
     handoff_proof: Option<[u8; 32]>,
 ) -> Node {
     let mut children = vec![
-        NodeBuilder::new("credential_id")
+        NodeBuilder::new(TAG_CREDENTIAL_ID)
             .bytes(credential_id)
             .build(),
-        NodeBuilder::new("webauthn_assertion")
+        NodeBuilder::new(TAG_WEBAUTHN_ASSERTION)
             .bytes(webauthn_assertion)
             .build(),
-        NodeBuilder::new("prologue_payload")
+        NodeBuilder::new(TAG_PROLOGUE_PAYLOAD)
             .bytes(prologue_payload)
             .build(),
     ];
     if let Some(proof) = handoff_proof {
         children.push(
-            NodeBuilder::new("pairing_handoff_proof")
+            NodeBuilder::new(TAG_PAIRING_HANDOFF_PROOF)
                 .bytes(proof.to_vec())
                 .build(),
         );
     }
-    NodeBuilder::new("passkey_prologue")
+    NodeBuilder::new(TAG_PASSKEY_PROLOGUE)
         .children(children)
         .build()
 }
@@ -105,12 +106,10 @@ fn child_payload(nr: &NodeRef<'_>, tag: &str) -> Option<Vec<u8>> {
 }
 
 impl Client {
-    /// Register a passkey authenticator. When set, the client AUTO-DRIVES the
-    /// WebAuthn assertion step, and auto-confirms a re-link whose handoff proof
-    /// makes the verification-code UX unnecessary. Hosts that want to show the code
-    /// or drive the steps manually can leave this unset and react to the
-    /// `Event::PairPasskey*` events with [`Client::send_passkey_response`] /
-    /// [`Client::send_passkey_confirmation`].
+    /// Register a passkey authenticator. When set, the client auto-drives the
+    /// assertion step and auto-confirms a re-link (where the handoff proof skips the
+    /// verification-code UX). Leave it unset to drive the steps manually via the
+    /// `Event::PairPasskey*` events.
     pub async fn set_passkey_authenticator(&self, authenticator: Arc<dyn PasskeyAuthenticator>) {
         self.passkey_state.lock().await.authenticator = Some(authenticator);
     }
@@ -127,17 +126,17 @@ impl Client {
         let server = server_jid();
 
         let ref_query = InfoQuery::get(
-            "md",
+            MD_NAMESPACE,
             server.clone(),
-            Some(NodeContent::Nodes(vec![NodeBuilder::new("ref").build()])),
+            Some(NodeContent::Nodes(vec![NodeBuilder::new(TAG_REF).build()])),
         );
         let resp = self
             .send_iq(ref_query)
             .await
             .map_err(|e| PasskeyError::Flow(format!("ref iq failed: {e}")))?;
-        let pairing_ref = child_payload(resp.get(), "ref")
+        let pairing_ref = child_payload(resp.get(), TAG_REF)
             .and_then(|b| String::from_utf8(b).ok())
-            .ok_or_else(|| PasskeyError::Flow("missing <ref> in server response".into()))?;
+            .ok_or_else(|| PasskeyError::Flow("missing ref in server response".into()))?;
 
         let keypair = ShortcakeUtils::generate_companion_ephemeral_keypair();
         let companion_nonce = ShortcakeUtils::generate_companion_nonce();
@@ -180,13 +179,20 @@ impl Client {
             prologue_payload,
             handoff_proof,
         );
-        self.send_iq(InfoQuery::set(
-            "md",
-            server,
-            Some(NodeContent::Nodes(vec![prologue])),
-        ))
-        .await
-        .map_err(|e| PasskeyError::Flow(format!("passkey_prologue iq failed: {e}")))?;
+        if let Err(e) = self
+            .send_iq(InfoQuery::set(
+                MD_NAMESPACE,
+                server,
+                Some(NodeContent::Nodes(vec![prologue])),
+            ))
+            .await
+        {
+            // Server never accepted this prologue: drop the half-armed attempt.
+            self.passkey_state.lock().await.linking = None;
+            return Err(PasskeyError::Flow(format!(
+                "passkey_prologue iq failed: {e}"
+            )));
+        }
         Ok(())
     }
 
@@ -216,11 +222,11 @@ impl Client {
             )
         };
 
-        let nonce_node = NodeBuilder::new("companion_nonce")
+        let nonce_node = NodeBuilder::new(TAG_COMPANION_NONCE)
             .bytes(companion_nonce.to_vec())
             .build();
         self.send_iq(InfoQuery::set(
-            "md",
+            MD_NAMESPACE,
             server_jid(),
             Some(NodeContent::Nodes(vec![nonce_node])),
         ))
@@ -239,14 +245,22 @@ impl Client {
             &primary.public_key,
             &primary.nonce,
         );
-        // Match WA Web's displayed "XXXX-XXXX" grouping (the code is 8 ASCII chars).
-        let code = format!("{}-{}", &bare[..4], &bare[4..]);
+        // Grouped "XXXX-XXXX" for display (the code is ASCII).
+        let code = format!("{}-{}", &bare[..CODE_GROUP_LEN], &bare[CODE_GROUP_LEN..]);
 
         {
             let mut state = self.passkey_state.lock().await;
-            if let Some(cache) = state.linking.as_mut() {
-                cache.encryption_key = Some(encryption_key);
+            // A fresh attempt could have replaced the cache during the round-trip;
+            // arming an unrelated attempt with this key would break it.
+            let cache = state.linking.as_mut().ok_or_else(|| {
+                PasskeyError::Flow("linking cache cleared mid-continuation".into())
+            })?;
+            if cache.pairing_ref != pairing_ref || cache.companion_nonce != companion_nonce {
+                return Err(PasskeyError::Flow(
+                    "linking cache replaced by a newer attempt mid-continuation".into(),
+                ));
             }
+            cache.encryption_key = Some(encryption_key);
         }
 
         self.core
@@ -257,7 +271,7 @@ impl Client {
             }));
 
         // Re-link: the handoff proof already established continuity, so no user code
-        // confirmation is needed — auto-finish when an authenticator is driving.
+        // confirmation is needed. Auto-finish when an authenticator is driving.
         if skip_handoff_ux && self.passkey_authenticator().await.is_some() {
             self.send_passkey_confirmation().await?;
         }
@@ -269,15 +283,20 @@ impl Client {
     /// `<encrypted_pairing_request>`. For a fresh link, call this only after the
     /// user has confirmed the [`Event::PairPasskeyConfirmation`] code.
     pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
-        let encryption_key = {
+        let (encryption_key, adv_secret) = {
             let state = self.passkey_state.lock().await;
             let cache = state
                 .linking
                 .as_ref()
                 .ok_or_else(|| PasskeyError::Flow("confirmation without a linking cache".into()))?;
-            cache.encryption_key.ok_or_else(|| {
+            let key = cache.encryption_key.ok_or_else(|| {
                 PasskeyError::Flow("confirmation before encryption key derived".into())
-            })?
+            })?;
+            // The pending (not-yet-committed) rotated ADV secret staged at request time.
+            let adv = state.pending_adv_secret.ok_or_else(|| {
+                PasskeyError::Flow("confirmation without a pending ADV secret".into())
+            })?;
+            (key, adv)
         };
 
         let snapshot = self.persistence_manager.get_device_snapshot();
@@ -293,8 +312,6 @@ impl Client {
             .public_key_bytes()
             .try_into()
             .map_err(|_| PasskeyError::Flow("identity public key is not 32 bytes".into()))?;
-        // The rotated ADV secret (set when the prologue request arrived).
-        let adv_secret = snapshot.adv_secret_key;
 
         let plaintext = ShortcakeUtils::build_pairing_request(
             &companion_public,
@@ -305,48 +322,54 @@ impl Client {
             .map_err(|e| PasskeyError::Flow(format!("encrypt pairing request: {e}")))?;
         let wrapped = ShortcakeUtils::build_encrypted_pairing_request(&encrypted);
 
-        let node = NodeBuilder::new("encrypted_pairing_request")
+        let node = NodeBuilder::new(TAG_ENCRYPTED_PAIRING_REQUEST)
             .bytes(wrapped)
             .build();
         self.send_iq(InfoQuery::set(
-            "md",
+            MD_NAMESPACE,
             server_jid(),
             Some(NodeContent::Nodes(vec![node])),
         ))
         .await
         .map_err(|e| PasskeyError::Flow(format!("encrypted_pairing_request iq failed: {e}")))?;
 
-        self.passkey_state.lock().await.linking = None;
+        // Primary has the new secret now: commit the rotation (before pair-success
+        // validates against it) and clear the attempt.
+        self.persistence_manager
+            .process_command(DeviceCommand::SetAdvSecretKey(adv_secret))
+            .await;
+        {
+            let mut state = self.passkey_state.lock().await;
+            state.linking = None;
+            state.pending_adv_secret = None;
+        }
         Ok(())
     }
 
-    /// Fetch the WebAuthn `<passkey_request_options>` JSON from the server. Used as
-    /// a fallback when a `passkey_prologue_request` notification arrives without the
-    /// options inline (mirrors whatsmeow's `getPasskeyRequestOptions`).
+    /// Fetch the WebAuthn options from the server, for when a prologue-request
+    /// notification arrives without them inline.
     async fn get_passkey_request_options(&self) -> Result<String, PasskeyError> {
         let query = InfoQuery::get(
-            "md",
+            MD_NAMESPACE,
             server_jid(),
             Some(NodeContent::Nodes(vec![
-                NodeBuilder::new("passkey_request_options").build(),
+                NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS).build(),
             ])),
         );
         let resp = self
             .send_iq(query)
             .await
             .map_err(|e| PasskeyError::Flow(format!("passkey_request_options iq failed: {e}")))?;
-        child_payload(resp.get(), "passkey_request_options")
+        child_payload(resp.get(), TAG_PASSKEY_REQUEST_OPTIONS)
             .and_then(|b| String::from_utf8(b).ok())
             .ok_or_else(|| PasskeyError::Flow("missing passkey_request_options in response".into()))
     }
 }
 
-/// `<notification type="passkey_prologue_request">`: derive the handoff key, rotate
-/// the ADV secret, emit [`Event::PairPasskeyRequest`], and (if an authenticator is
-/// registered) auto-drive the assertion + response.
+/// Handle a `passkey_prologue_request` notification: emit the request (and
+/// auto-drive it if an authenticator is registered).
 pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<OwnedNodeRef>) {
-    // The ADV-secret rotation below is security-sensitive: only honor a request
-    // that actually came from the server.
+    // The staged rotation is security-sensitive: only honor a server request.
     if node
         .get()
         .get_attr("from")
@@ -356,13 +379,11 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
         return;
     }
 
-    match child_payload(node.get(), "passkey_request_options")
+    match child_payload(node.get(), TAG_PASSKEY_REQUEST_OPTIONS)
         .and_then(|b| String::from_utf8(b).ok())
     {
-        // Options inline (the common case): proceed immediately.
         Some(json) => drive_passkey_request(client, json).await,
-        // No inline options: fall back to fetching them via IQ (whatsmeow does the
-        // same). Spawned because it awaits a round-trip.
+        // Options omitted: fetch them via IQ. Spawned because it awaits a round-trip.
         None => {
             let client = client.clone();
             client
@@ -387,24 +408,20 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
     }
 }
 
-/// Rotate the ADV secret (keeping the prior one's handoff key), emit
-/// [`Event::PairPasskeyRequest`], and — if an authenticator is registered —
-/// auto-drive the assertion + response.
 async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
-    // Derive the handoff key from the CURRENT ADV secret, then rotate it: the proof
-    // proves continuity from the prior secret, while the PairingRequest carries the
-    // new one.
+    // Handoff key from the current secret (proves continuity); stage a fresh secret
+    // that only commits at confirmation, so a failed attempt doesn't diverge.
     let snapshot = client.persistence_manager.get_device_snapshot();
-    match ShortcakeUtils::derive_pairing_handoff_hmac_key(&snapshot.adv_secret_key) {
-        Ok(key) => client.passkey_state.lock().await.handoff_key = Some(key),
-        Err(e) => warn!("failed to derive pairing-handoff key: {e}"),
-    }
+    let handoff_key = ShortcakeUtils::derive_pairing_handoff_hmac_key(&snapshot.adv_secret_key)
+        .inspect_err(|e| warn!("failed to derive pairing-handoff key: {e}"))
+        .ok();
     let mut new_adv = [0u8; 32];
     rand::make_rng::<rand::rngs::StdRng>().fill(&mut new_adv);
-    client
-        .persistence_manager
-        .process_command(DeviceCommand::SetAdvSecretKey(new_adv))
-        .await;
+    {
+        let mut state = client.passkey_state.lock().await;
+        state.handoff_key = handoff_key;
+        state.pending_adv_secret = Some(new_adv);
+    }
 
     client
         .core
@@ -444,8 +461,8 @@ async fn auto_drive_response(
     client.send_passkey_response(assertion).await
 }
 
-/// `<notification type="crsc_continuation">`: spawn the continuation processing
-/// (it awaits a `<companion_nonce>` IQ, so it must not block the receive loop).
+/// Handle a `crsc_continuation` notification. Spawned: it awaits an IQ round-trip
+/// and must not block the receive loop.
 pub(crate) async fn handle_passkey_continuation(client: &Arc<Client>, node: Arc<OwnedNodeRef>) {
     if node
         .get()
@@ -456,7 +473,7 @@ pub(crate) async fn handle_passkey_continuation(client: &Arc<Client>, node: Arc<
         return;
     }
 
-    let primary_bytes = match child_payload(node.get(), "primary_ephemeral_identity") {
+    let primary_bytes = match child_payload(node.get(), TAG_PRIMARY_EPHEMERAL_IDENTITY) {
         Some(bytes) => bytes,
         None => {
             warn!("passkey continuation missing <primary_ephemeral_identity>");
@@ -563,7 +580,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn passkey_prologue_request_rotates_adv_and_emits_event() {
+    async fn passkey_prologue_request_emits_event_without_committing_rotation() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
         client.register_handler(collector.clone() as Arc<dyn EventHandler>);
@@ -582,11 +599,13 @@ mod tests {
             .process_node(server_notification("passkey_prologue_request", Some(child)))
             .await;
 
+        // The rotation is staged pending, not committed to the store until the flow
+        // confirms, so the device secret is unchanged at this point.
         let after = client
             .persistence_manager
             .get_device_snapshot()
             .adv_secret_key;
-        assert_ne!(before, after, "ADV secret must rotate on a passkey request");
+        assert_eq!(before, after, "ADV secret must not commit at request time");
 
         let request = collector
             .events()
@@ -650,10 +669,15 @@ mod tests {
             .process_node(server_notification("passkey_prologue_request", None))
             .await;
 
-        wait_for(
-            &collector,
-            |e| matches!(e, Event::PairPasskeyError(err) if !err.continuation),
-        )
+        // Assert it's specifically the fetch that failed, so the test proves the IQ
+        // fallback ran (not some earlier immediate error).
+        wait_for(&collector, |e| {
+            matches!(
+                e,
+                Event::PairPasskeyError(err)
+                    if !err.continuation && err.error.contains("passkey_request_options iq failed")
+            )
+        })
         .await;
     }
 
@@ -664,7 +688,7 @@ mod tests {
         client.register_handler(collector.clone() as Arc<dyn EventHandler>);
 
         // a well-formed primary identity, but no prior send_passkey_response ran, so
-        // there is no linking cache — the continuation must surface a continuation error.
+        // there is no linking cache and the continuation must surface a continuation error.
         let primary = waproto::whatsapp::PrimaryEphemeralIdentity {
             public_key: Some(vec![0xAB; 32]),
             nonce: Some(vec![0xCD; 32]),

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -31,6 +31,8 @@
 //! generic [`CallbackAuthenticator`] (host provides the assertion) so no platform
 //! dependency leaks into headless/library builds.
 
+pub mod flow;
+
 use async_trait::async_trait;
 use base64::prelude::*;
 use std::future::Future;
@@ -98,13 +100,20 @@ pub enum PasskeyError {
     InvalidOptions(String),
     #[error("authenticator backend error: {0}")]
     Backend(String),
+    #[error("passkey linking flow error: {0}")]
+    Flow(String),
 }
 
 /// Produces a WebAuthn assertion for a SHORTCAKE_PASSKEY link. Implemented by a
 /// real authenticator (Android Credential Manager / hybrid / software vault).
+///
+/// The `MaybeSendSync` supertrait keeps this `Send + Sync` on native (the client
+/// stores it as `Arc<dyn PasskeyAuthenticator>` and drives it across threads) but
+/// drops the bound on wasm32, where a browser authenticator may hold `!Send` JS
+/// handles — matching the sibling extension points (`Transport`, `EventHandler`).
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait PasskeyAuthenticator: Send + Sync {
+pub trait PasskeyAuthenticator: wacore::sync_marker::MaybeSendSync {
     async fn get_assertion(&self, request: &AssertionRequest) -> Result<Assertion, PasskeyError>;
 }
 
@@ -116,6 +125,13 @@ type AssertionFuture = Pin<Box<dyn Future<Output = Result<Assertion, PasskeyErro
 #[cfg(target_arch = "wasm32")]
 type AssertionFuture = Pin<Box<dyn Future<Output = Result<Assertion, PasskeyError>>>>;
 
+// The stored closure: `Send + Sync` on native, relaxed on wasm to mirror
+// `AssertionFuture` (a browser closure may capture `!Send` JS handles).
+#[cfg(not(target_arch = "wasm32"))]
+type AssertionCallback = dyn Fn(AssertionRequest) -> AssertionFuture + Send + Sync;
+#[cfg(target_arch = "wasm32")]
+type AssertionCallback = dyn Fn(AssertionRequest) -> AssertionFuture;
+
 /// Generic [`PasskeyAuthenticator`] that defers to a host-provided async closure.
 ///
 /// This is the integration seam for the Android Credential Manager strategy: the
@@ -123,13 +139,13 @@ type AssertionFuture = Pin<Box<dyn Future<Output = Result<Assertion, PasskeyErro
 /// the future with the mapped [`Assertion`]. Keeps all platform code out of the lib.
 #[derive(Clone)]
 pub struct CallbackAuthenticator {
-    cb: Arc<dyn Fn(AssertionRequest) -> AssertionFuture + Send + Sync>,
+    cb: Arc<AssertionCallback>,
 }
 
 impl CallbackAuthenticator {
     pub fn new<F>(f: F) -> Self
     where
-        F: Fn(AssertionRequest) -> AssertionFuture + Send + Sync + 'static,
+        F: Fn(AssertionRequest) -> AssertionFuture + wacore::sync_marker::MaybeSendSync + 'static,
     {
         Self { cb: Arc::new(f) }
     }
@@ -156,6 +172,9 @@ pub fn parse_request_options(json: &str) -> Result<AssertionRequest, PasskeyErro
     let challenge = BASE64_URL_SAFE_NO_PAD
         .decode(challenge_b64.trim_end_matches('='))
         .map_err(|e| PasskeyError::InvalidOptions(format!("challenge b64url: {e}")))?;
+    if challenge.is_empty() {
+        return Err(PasskeyError::InvalidOptions("empty challenge".into()));
+    }
 
     let rp_id = v
         .get("rpId")
@@ -177,6 +196,11 @@ pub fn parse_request_options(json: &str) -> Result<AssertionRequest, PasskeyErro
             let bytes = BASE64_URL_SAFE_NO_PAD
                 .decode(id.trim_end_matches('='))
                 .map_err(|e| PasskeyError::InvalidOptions(format!("credential id b64url: {e}")))?;
+            if bytes.is_empty() {
+                return Err(PasskeyError::InvalidOptions(
+                    "allowCredentials[].id is empty".into(),
+                ));
+            }
             allow_credentials.push(bytes);
         }
     }
@@ -297,6 +321,26 @@ mod tests {
         })
         .to_string();
         assert!(parse_request_options(&json).is_err());
+
+        // present-but-empty id (all padding / empty string) decodes to zero bytes,
+        // which is never a real credential id — must error, not push an empty entry.
+        let json = serde_json::json!({
+            "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c"),
+            "allowCredentials": [{"type": "public-key", "id": ""}],
+        })
+        .to_string();
+        assert!(parse_request_options(&json).is_err());
+    }
+
+    #[test]
+    fn empty_challenge_is_rejected() {
+        // a present-but-empty challenge provides zero replay protection; reject it
+        // rather than handing a degenerate request to the authenticator.
+        let json = serde_json::json!({ "challenge": "" }).to_string();
+        assert!(matches!(
+            parse_request_options(&json),
+            Err(PasskeyError::InvalidOptions(_))
+        ));
     }
 
     #[test]

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -46,11 +46,16 @@ pub enum UserVerification {
 }
 
 impl UserVerification {
-    fn parse(s: &str) -> Self {
+    /// Fail closed: a present-but-unrecognized value is rejected rather than
+    /// silently downgraded to `Preferred` (absence is handled by the caller).
+    fn parse(s: &str) -> Result<Self, PasskeyError> {
         match s {
-            "required" => Self::Required,
-            "discouraged" => Self::Discouraged,
-            _ => Self::Preferred,
+            "required" => Ok(Self::Required),
+            "preferred" => Ok(Self::Preferred),
+            "discouraged" => Ok(Self::Discouraged),
+            other => Err(PasskeyError::InvalidOptions(format!(
+                "unsupported userVerification: {other}"
+            ))),
         }
     }
 }
@@ -103,7 +108,13 @@ pub trait PasskeyAuthenticator: Send + Sync {
     async fn get_assertion(&self, request: &AssertionRequest) -> Result<Assertion, PasskeyError>;
 }
 
+// Mirror the trait's `async_trait(?Send)` on wasm: a browser authenticator's
+// future (e.g. awaiting `navigator.credentials.get`) is `!Send`. `cb`/`new`
+// reference this alias, so they pick up the right bound per-target automatically.
+#[cfg(not(target_arch = "wasm32"))]
 type AssertionFuture = Pin<Box<dyn Future<Output = Result<Assertion, PasskeyError>> + Send>>;
+#[cfg(target_arch = "wasm32")]
+type AssertionFuture = Pin<Box<dyn Future<Output = Result<Assertion, PasskeyError>>>>;
 
 /// Generic [`PasskeyAuthenticator`] that defers to a host-provided async closure.
 ///
@@ -151,25 +162,31 @@ pub fn parse_request_options(json: &str) -> Result<AssertionRequest, PasskeyErro
         .and_then(|r| r.as_str())
         .map(|s| s.to_string());
 
+    // Reject malformed descriptors instead of dropping them: silently skipping
+    // entries can collapse a populated allowCredentials into an empty list, which
+    // this API treats as "discoverable" — a confusing, weaker outcome than failing.
     let mut allow_credentials = Vec::new();
-    if let Some(arr) = v.get("allowCredentials").and_then(|a| a.as_array()) {
+    if let Some(allow_credentials_value) = v.get("allowCredentials") {
+        let arr = allow_credentials_value.as_array().ok_or_else(|| {
+            PasskeyError::InvalidOptions("allowCredentials must be an array".into())
+        })?;
         for cred in arr {
-            if let Some(id) = cred.get("id").and_then(|i| i.as_str()) {
-                let bytes = BASE64_URL_SAFE_NO_PAD
-                    .decode(id.trim_end_matches('='))
-                    .map_err(|e| {
-                        PasskeyError::InvalidOptions(format!("credential id b64url: {e}"))
-                    })?;
-                allow_credentials.push(bytes);
-            }
+            let id = cred.get("id").and_then(|i| i.as_str()).ok_or_else(|| {
+                PasskeyError::InvalidOptions("allowCredentials[].id must be a string".into())
+            })?;
+            let bytes = BASE64_URL_SAFE_NO_PAD
+                .decode(id.trim_end_matches('='))
+                .map_err(|e| PasskeyError::InvalidOptions(format!("credential id b64url: {e}")))?;
+            allow_credentials.push(bytes);
         }
     }
 
-    let user_verification = v
-        .get("userVerification")
-        .and_then(|u| u.as_str())
-        .map(UserVerification::parse)
-        .unwrap_or(UserVerification::Preferred);
+    let user_verification = match v.get("userVerification") {
+        None => UserVerification::Preferred,
+        Some(u) => UserVerification::parse(u.as_str().ok_or_else(|| {
+            PasskeyError::InvalidOptions("userVerification must be a string".into())
+        })?)?,
+    };
 
     let timeout_ms = v.get("timeout").and_then(|t| t.as_u64());
 
@@ -240,6 +257,46 @@ mod tests {
     #[test]
     fn missing_challenge_is_error() {
         assert!(parse_request_options("{\"rpId\":\"x\"}").is_err());
+    }
+
+    #[test]
+    fn unknown_user_verification_fails_closed() {
+        let json = serde_json::json!({
+            "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c"),
+            "userVerification": "sometimes",
+        })
+        .to_string();
+        assert!(matches!(
+            parse_request_options(&json),
+            Err(PasskeyError::InvalidOptions(_))
+        ));
+    }
+
+    #[test]
+    fn absent_user_verification_defaults_to_preferred() {
+        let json =
+            serde_json::json!({ "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c") }).to_string();
+        let req = parse_request_options(&json).unwrap();
+        assert_eq!(req.user_verification, UserVerification::Preferred);
+    }
+
+    #[test]
+    fn malformed_allow_credentials_is_rejected() {
+        // non-array
+        let json = serde_json::json!({
+            "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c"),
+            "allowCredentials": "nope",
+        })
+        .to_string();
+        assert!(parse_request_options(&json).is_err());
+
+        // entry without a string id must error, not be silently dropped
+        let json = serde_json::json!({
+            "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c"),
+            "allowCredentials": [{"type": "public-key"}],
+        })
+        .to_string();
+        assert!(parse_request_options(&json).is_err());
     }
 
     #[test]

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -1,0 +1,285 @@
+//! `PasskeyAuthenticator` — the single pluggable point of the SHORTCAKE_PASSKEY
+//! login flow (see `wacore::shortcake` for the deterministic protocol core).
+//!
+//! WhatsApp's passkey linking gate requires ONE thing an unofficial client cannot
+//! reproduce on its own: a WebAuthn assertion (`navigator.credentials.get`) signed
+//! by a passkey ALREADY REGISTERED to the account. Everything else in the protocol
+//! is deterministic and lives in `wacore::shortcake`. This module abstracts that
+//! single step so the rest of the linking flow is platform-agnostic.
+//!
+//! ## Why a real authenticator (not a software forgery)
+//! The assertion's private key lives in a platform authenticator (Google Password
+//! Manager / iCloud Keychain), non-extractable. So we do what WhatsApp Web does:
+//! delegate to a real authenticator. The assertion signs only the SERVER
+//! challenge and origin/rpId (NOT the Shortcake payload), so producing it is a
+//! standard WebAuthn `get`. Using the real authenticator = a legitimate,
+//! user-verified assertion = low ban risk (forging without the key is
+//! impossible anyway).
+//!
+//! ## Strategies
+//! - **Android Credential Manager (recommended for GPM passkeys):** the Android
+//!   host app calls `CredentialManager.getCredential(...)` with the server's
+//!   `raw_options_json` (a `GetCredentialRequest` containing a
+//!   `GetPublicKeyCredentialOption(requestJson = raw_options_json)`); GPM signs
+//!   with biometric; the app maps the returned
+//!   `PublicKeyCredential.authenticationResponseJson` into an [`Assertion`] and
+//!   returns it via a [`CallbackAuthenticator`]. No private key ever touches Rust.
+//! - **hybrid/caBLE:** a desktop client tunnels CTAP2 to the phone's authenticator.
+//! - **software (`passkey-rs`):** only when the passkey lives in an exportable vault.
+//!
+//! All three implement [`PasskeyAuthenticator`]; the default build ships only the
+//! generic [`CallbackAuthenticator`] (host provides the assertion) so no platform
+//! dependency leaks into headless/library builds.
+
+use async_trait::async_trait;
+use base64::prelude::*;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// WebAuthn user-verification requirement from the server's request options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserVerification {
+    Required,
+    Preferred,
+    Discouraged,
+}
+
+impl UserVerification {
+    fn parse(s: &str) -> Self {
+        match s {
+            "required" => Self::Required,
+            "discouraged" => Self::Discouraged,
+            _ => Self::Preferred,
+        }
+    }
+}
+
+/// A WebAuthn assertion request, parsed from the server's
+/// `<passkey_request_options>` (a standard `PublicKeyCredentialRequestOptions`
+/// JSON). `challenge` and `allow_credentials` are already base64url-decoded.
+#[derive(Debug, Clone)]
+pub struct AssertionRequest {
+    /// Server challenge (raw bytes).
+    pub challenge: Vec<u8>,
+    /// Relying-party id (e.g. "web.whatsapp.com") the authenticator must sign for.
+    pub rp_id: Option<String>,
+    /// Allowed credential ids (raw bytes); empty = discoverable.
+    pub allow_credentials: Vec<Vec<u8>>,
+    pub user_verification: UserVerification,
+    pub timeout_ms: Option<u64>,
+    /// The verbatim server JSON — pass straight to Android Credential Manager's
+    /// `GetPublicKeyCredentialOption(requestJson = ...)` (it wants the original).
+    pub raw_options_json: String,
+}
+
+/// The result of a WebAuthn assertion, packaged for the `<passkey_prologue>` IQ.
+#[derive(Debug, Clone)]
+pub struct Assertion {
+    /// UTF-8 JSON for `<webauthn_assertion>`:
+    /// `{id, rawId(b64url), type:"public-key", response:{clientDataJSON, authenticatorData, signature, userHandle}}`.
+    pub assertion_json: Vec<u8>,
+    /// Raw credential rawId bytes for `<credential_id>`.
+    pub credential_id: Vec<u8>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PasskeyError {
+    #[error("no passkey registered for this account on the authenticator")]
+    NoCredential,
+    #[error("user cancelled or the ceremony timed out")]
+    Cancelled,
+    #[error("invalid request options: {0}")]
+    InvalidOptions(String),
+    #[error("authenticator backend error: {0}")]
+    Backend(String),
+}
+
+/// Produces a WebAuthn assertion for a SHORTCAKE_PASSKEY link. Implemented by a
+/// real authenticator (Android Credential Manager / hybrid / software vault).
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait PasskeyAuthenticator: Send + Sync {
+    async fn get_assertion(&self, request: &AssertionRequest) -> Result<Assertion, PasskeyError>;
+}
+
+type AssertionFuture = Pin<Box<dyn Future<Output = Result<Assertion, PasskeyError>> + Send>>;
+
+/// Generic [`PasskeyAuthenticator`] that defers to a host-provided async closure.
+///
+/// This is the integration seam for the Android Credential Manager strategy: the
+/// Kotlin/JNI layer performs `CredentialManager.getCredential(...)` and resolves
+/// the future with the mapped [`Assertion`]. Keeps all platform code out of the lib.
+#[derive(Clone)]
+pub struct CallbackAuthenticator {
+    cb: Arc<dyn Fn(AssertionRequest) -> AssertionFuture + Send + Sync>,
+}
+
+impl CallbackAuthenticator {
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn(AssertionRequest) -> AssertionFuture + Send + Sync + 'static,
+    {
+        Self { cb: Arc::new(f) }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl PasskeyAuthenticator for CallbackAuthenticator {
+    async fn get_assertion(&self, request: &AssertionRequest) -> Result<Assertion, PasskeyError> {
+        (self.cb)(request.clone()).await
+    }
+}
+
+/// Parse the server's `PublicKeyCredentialRequestOptions` JSON into an
+/// [`AssertionRequest`], base64url-decoding `challenge` and `allowCredentials[].id`.
+pub fn parse_request_options(json: &str) -> Result<AssertionRequest, PasskeyError> {
+    let v: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| PasskeyError::InvalidOptions(e.to_string()))?;
+
+    let challenge_b64 = v
+        .get("challenge")
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| PasskeyError::InvalidOptions("missing challenge".into()))?;
+    let challenge = BASE64_URL_SAFE_NO_PAD
+        .decode(challenge_b64.trim_end_matches('='))
+        .map_err(|e| PasskeyError::InvalidOptions(format!("challenge b64url: {e}")))?;
+
+    let rp_id = v
+        .get("rpId")
+        .and_then(|r| r.as_str())
+        .map(|s| s.to_string());
+
+    let mut allow_credentials = Vec::new();
+    if let Some(arr) = v.get("allowCredentials").and_then(|a| a.as_array()) {
+        for cred in arr {
+            if let Some(id) = cred.get("id").and_then(|i| i.as_str()) {
+                let bytes = BASE64_URL_SAFE_NO_PAD
+                    .decode(id.trim_end_matches('='))
+                    .map_err(|e| {
+                        PasskeyError::InvalidOptions(format!("credential id b64url: {e}"))
+                    })?;
+                allow_credentials.push(bytes);
+            }
+        }
+    }
+
+    let user_verification = v
+        .get("userVerification")
+        .and_then(|u| u.as_str())
+        .map(UserVerification::parse)
+        .unwrap_or(UserVerification::Preferred);
+
+    let timeout_ms = v.get("timeout").and_then(|t| t.as_u64());
+
+    Ok(AssertionRequest {
+        challenge,
+        rp_id,
+        allow_credentials,
+        user_verification,
+        timeout_ms,
+        raw_options_json: json.to_string(),
+    })
+}
+
+/// Assemble the `<webauthn_assertion>` JSON (WhatsApp Web's exact shape) from raw
+/// WebAuthn assertion components. For authenticator backends that return raw bytes
+/// rather than WA-shaped JSON (e.g. a software/hybrid authenticator). `user_handle`
+/// is optional. All binary fields are base64url-encoded (no padding).
+pub fn build_webauthn_assertion_json(
+    credential_id: &[u8],
+    client_data_json: &[u8],
+    authenticator_data: &[u8],
+    signature: &[u8],
+    user_handle: Option<&[u8]>,
+) -> Vec<u8> {
+    let id = BASE64_URL_SAFE_NO_PAD.encode(credential_id);
+    let assertion = serde_json::json!({
+        "id": id,
+        "rawId": id,
+        "type": "public-key",
+        "response": {
+            "clientDataJSON": BASE64_URL_SAFE_NO_PAD.encode(client_data_json),
+            "authenticatorData": BASE64_URL_SAFE_NO_PAD.encode(authenticator_data),
+            "signature": BASE64_URL_SAFE_NO_PAD.encode(signature),
+            "userHandle": user_handle.map(|u| BASE64_URL_SAFE_NO_PAD.encode(u)),
+        }
+    });
+    assertion.to_string().into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_request_options() {
+        let challenge = b"the-challenge-bytes!";
+        let cred = b"credential-id-1";
+        let json = serde_json::json!({
+            "challenge": BASE64_URL_SAFE_NO_PAD.encode(challenge),
+            "rpId": "web.whatsapp.com",
+            "userVerification": "required",
+            "timeout": 60000u64,
+            "allowCredentials": [
+                {"type": "public-key", "id": BASE64_URL_SAFE_NO_PAD.encode(cred)}
+            ]
+        })
+        .to_string();
+
+        let req = parse_request_options(&json).unwrap();
+        assert_eq!(req.challenge, challenge);
+        assert_eq!(req.rp_id.as_deref(), Some("web.whatsapp.com"));
+        assert_eq!(req.user_verification, UserVerification::Required);
+        assert_eq!(req.timeout_ms, Some(60000));
+        assert_eq!(req.allow_credentials, vec![cred.to_vec()]);
+        assert_eq!(req.raw_options_json, json); // verbatim for Credential Manager
+    }
+
+    #[test]
+    fn missing_challenge_is_error() {
+        assert!(parse_request_options("{\"rpId\":\"x\"}").is_err());
+    }
+
+    #[test]
+    fn builds_wa_assertion_json_shape() {
+        let bytes = build_webauthn_assertion_json(b"cid", b"cdj", b"authdata", b"sig", None);
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["type"], "public-key");
+        assert_eq!(v["id"], BASE64_URL_SAFE_NO_PAD.encode(b"cid"));
+        assert_eq!(v["rawId"], BASE64_URL_SAFE_NO_PAD.encode(b"cid"));
+        assert_eq!(
+            v["response"]["clientDataJSON"],
+            BASE64_URL_SAFE_NO_PAD.encode(b"cdj")
+        );
+        assert_eq!(
+            v["response"]["signature"],
+            BASE64_URL_SAFE_NO_PAD.encode(b"sig")
+        );
+        assert!(v["response"]["userHandle"].is_null());
+    }
+
+    #[tokio::test]
+    async fn callback_authenticator_invokes_closure() {
+        let auth = CallbackAuthenticator::new(|req: AssertionRequest| {
+            Box::pin(async move {
+                Ok(Assertion {
+                    assertion_json: req.raw_options_json.into_bytes(),
+                    credential_id: req.challenge,
+                })
+            })
+        });
+        let req = AssertionRequest {
+            challenge: vec![1, 2, 3],
+            rp_id: Some("web.whatsapp.com".into()),
+            allow_credentials: vec![],
+            user_verification: UserVerification::Preferred,
+            timeout_ms: None,
+            raw_options_json: "{}".into(),
+        };
+        let a = auth.get_assertion(&req).await.unwrap();
+        assert_eq!(a.credential_id, vec![1, 2, 3]);
+        assert_eq!(a.assertion_json, b"{}".to_vec());
+    }
+}

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -176,10 +176,16 @@ pub fn parse_request_options(json: &str) -> Result<AssertionRequest, PasskeyErro
         return Err(PasskeyError::InvalidOptions("empty challenge".into()));
     }
 
-    let rp_id = v
-        .get("rpId")
-        .and_then(|r| r.as_str())
-        .map(|s| s.to_string());
+    // Absent rpId is fine (the authenticator defaults it); a present-but-non-string
+    // value is malformed and must fail closed, not silently drop the RP binding.
+    let rp_id = match v.get("rpId") {
+        None => None,
+        Some(r) => Some(
+            r.as_str()
+                .ok_or_else(|| PasskeyError::InvalidOptions("rpId must be a string".into()))?
+                .to_string(),
+        ),
+    };
 
     // Reject malformed descriptors instead of dropping them: silently skipping
     // entries can collapse a populated allowCredentials into an empty list, which
@@ -337,6 +343,20 @@ mod tests {
         // a present-but-empty challenge provides zero replay protection; reject it
         // rather than handing a degenerate request to the authenticator.
         let json = serde_json::json!({ "challenge": "" }).to_string();
+        assert!(matches!(
+            parse_request_options(&json),
+            Err(PasskeyError::InvalidOptions(_))
+        ));
+    }
+
+    #[test]
+    fn non_string_rp_id_is_rejected() {
+        // present-but-malformed rpId must fail closed, not silently drop the RP.
+        let json = serde_json::json!({
+            "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c"),
+            "rpId": 123,
+        })
+        .to_string();
         assert!(matches!(
             parse_request_options(&json),
             Err(PasskeyError::InvalidOptions(_))

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -110,7 +110,7 @@ pub enum PasskeyError {
 /// The `MaybeSendSync` supertrait keeps this `Send + Sync` on native (the client
 /// stores it as `Arc<dyn PasskeyAuthenticator>` and drives it across threads) but
 /// drops the bound on wasm32, where a browser authenticator may hold `!Send` JS
-/// handles — matching the sibling extension points (`Transport`, `EventHandler`).
+/// handles, matching the sibling extension points (`Transport`, `EventHandler`).
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait PasskeyAuthenticator: wacore::sync_marker::MaybeSendSync {
@@ -323,7 +323,7 @@ mod tests {
         assert!(parse_request_options(&json).is_err());
 
         // present-but-empty id (all padding / empty string) decodes to zero bytes,
-        // which is never a real credential id — must error, not push an empty entry.
+        // which is never a real credential id, so it must error, not push an empty entry.
         let json = serde_json::json!({
             "challenge": BASE64_URL_SAFE_NO_PAD.encode(b"c"),
             "allowCredentials": [{"type": "public-key", "id": ""}],

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -40,6 +40,7 @@ pub mod runtime;
 pub mod secret_enc_addon;
 pub mod send;
 pub mod session;
+pub mod shortcake;
 pub mod stanza;
 pub mod sticker_pack;
 

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -688,6 +688,78 @@ mod tests {
         assert_eq!(err.text, "hmac-mismatch");
     }
 
+    // A SHORTCAKE_PASSKEY (QR-less) login converges to the SAME pair-success as the
+    // classic QR flow, but the node carries extra children: <jurisdiction>, a new
+    // <encryption-metadata algorithm="aes-256-gcm"> block, <client-props>, <platform>.
+    // RE of WAWebHandlePairSuccess (waVersion 2.3000.1042386815) confirmed the
+    // companion PARSES but never DECRYPTS <encryption-metadata> — linking completes
+    // purely via the classic <device-identity> HMAC vs the ADV secret. This guards
+    // that our handler still extracts device-identity (ignoring the new children) and
+    // verifies, i.e. NO encryption-metadata decryption is needed.
+    #[test]
+    fn pair_success_with_passkey_encryption_metadata_completes_via_device_identity() {
+        use wacore_binary::node::NodeContent;
+
+        let state = dummy_device_state();
+        let payload = build_pair_success_payload(&state, &state.adv_secret_key, false);
+
+        let pair_success = NodeBuilder::new("pair-success")
+            .children([
+                NodeBuilder::new("jurisdiction")
+                    .attr("iso", "BR")
+                    .attr("cc", "55")
+                    .build(),
+                NodeBuilder::new("encryption-metadata")
+                    .attr("version", "1")
+                    .attr("algorithm", "aes-256-gcm")
+                    .children([
+                        NodeBuilder::new("encrypted_key")
+                            .bytes(vec![0xAAu8; 48])
+                            .build(),
+                        NodeBuilder::new("nonce").bytes(vec![0xBBu8; 12]).build(),
+                        NodeBuilder::new("encrypted_data")
+                            .bytes(vec![0xCCu8; 280])
+                            .build(),
+                        NodeBuilder::new("auth_tag").bytes(vec![0xDDu8; 16]).build(),
+                    ])
+                    .build(),
+                NodeBuilder::new("client-props")
+                    .bytes(vec![0x08u8, 0x01])
+                    .build(),
+                NodeBuilder::new("platform").attr("name", "android").build(),
+                NodeBuilder::new("device-identity")
+                    .bytes(payload.clone())
+                    .build(),
+                NodeBuilder::new("device")
+                    .attr("jid", "559984726662:57@s.whatsapp.net")
+                    .build(),
+            ])
+            .build();
+
+        // The new passkey block is present in the stanza...
+        assert!(
+            pair_success
+                .get_optional_child_by_tag(&["encryption-metadata"])
+                .is_some(),
+            "test fixture should include the new encryption-metadata block"
+        );
+
+        // ...but the handler extracts <device-identity> by tag, ignoring all extras.
+        let di = pair_success
+            .get_optional_child_by_tag(&["device-identity"])
+            .expect("device-identity must be found among the new passkey children");
+        let di_bytes = match &di.content {
+            Some(NodeContent::Bytes(b)) => b.as_slice(),
+            _ => panic!("device-identity must carry bytes"),
+        };
+        assert_eq!(di_bytes, payload.as_slice());
+
+        // Classic crypto completes the passkey link (HMAC vs ADV secret) — no
+        // decryption of <encryption-metadata> required.
+        PairUtils::do_pair_crypto(&state, di_bytes)
+            .expect("device-identity HMAC must verify for the passkey pair-success");
+    }
+
     #[test]
     fn do_pair_crypto_accepts_matching_hmac_for_hosted_account() {
         let state = dummy_device_state();

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -118,6 +118,23 @@ impl PairUtils {
             .build()
     }
 
+    /// Extract the `<device-identity>` bytes from a `pair-success` node, ignoring
+    /// any extra children. SHORTCAKE_PASSKEY (QR-less) pair-success adds
+    /// `<encryption-metadata>`, `<jurisdiction>`, `<client-props>` siblings; the
+    /// companion completes linking purely via this `<device-identity>` (HMAC vs
+    /// the ADV secret), never decrypting the metadata. Returns `None` when the
+    /// child is absent or carries no byte content (caller maps that to a 500).
+    ///
+    /// This is the single production parse point shared by the live handler and
+    /// the passkey regression test, so a child-parsing regression breaks both.
+    pub fn extract_device_identity_bytes<'n, 'a>(
+        success_node: &'n NodeRef<'a>,
+    ) -> Option<&'n [u8]> {
+        success_node
+            .get_optional_child_by_tag(&["device-identity"])
+            .and_then(|n| n.content_bytes())
+    }
+
     /// Performs the cryptographic operations for pairing
     pub fn do_pair_crypto(
         device_state: &DeviceState,
@@ -698,8 +715,6 @@ mod tests {
     // verifies, i.e. NO encryption-metadata decryption is needed.
     #[test]
     fn pair_success_with_passkey_encryption_metadata_completes_via_device_identity() {
-        use wacore_binary::node::NodeContent;
-
         let state = dummy_device_state();
         let payload = build_pair_success_payload(&state, &state.adv_secret_key, false);
 
@@ -731,27 +746,25 @@ mod tests {
                     .bytes(payload.clone())
                     .build(),
                 NodeBuilder::new("device")
-                    .attr("jid", "559984726662:57@s.whatsapp.net")
+                    .attr("jid", "5511999999999:57@s.whatsapp.net")
                     .build(),
             ])
             .build();
 
+        let success_ref = pair_success.as_node_ref();
+
         // The new passkey block is present in the stanza...
         assert!(
-            pair_success
+            success_ref
                 .get_optional_child_by_tag(&["encryption-metadata"])
                 .is_some(),
             "test fixture should include the new encryption-metadata block"
         );
 
-        // ...but the handler extracts <device-identity> by tag, ignoring all extras.
-        let di = pair_success
-            .get_optional_child_by_tag(&["device-identity"])
-            .expect("device-identity must be found among the new passkey children");
-        let di_bytes = match &di.content {
-            Some(NodeContent::Bytes(b)) => b.as_slice(),
-            _ => panic!("device-identity must carry bytes"),
-        };
+        // ...but the PRODUCTION extraction (the same helper the live pair-success
+        // handler calls) pulls <device-identity> by tag, ignoring all extras.
+        let di_bytes = PairUtils::extract_device_identity_bytes(&success_ref)
+            .expect("production extraction must find device-identity among passkey children");
         assert_eq!(di_bytes, payload.as_slice());
 
         // Classic crypto completes the passkey link (HMAC vs ADV secret) — no

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -208,7 +208,9 @@ impl PairCodeUtils {
     /// Encodes 5 bytes to an 8-character Crockford Base32 string.
     ///
     /// 5 bytes = 40 bits = 8 × 5-bit groups, each mapped to the alphabet.
-    fn encode_crockford(bytes: &[u8; 5]) -> String {
+    /// `pub(crate)` so the Shortcake passkey flow reuses the exact same encoder
+    /// for its verification code (see `crate::shortcake`).
+    pub(crate) fn encode_crockford(bytes: &[u8; 5]) -> String {
         // Combine 5 bytes into a 40-bit value
         let mut accumulator: u64 = 0;
         for &byte in bytes {

--- a/wacore/src/shortcake.rs
+++ b/wacore/src/shortcake.rs
@@ -480,12 +480,9 @@ mod tests {
         assert_eq!(d.encrypted_payload, Some(enc.encrypted_payload));
     }
 
-    // End-to-end protocol interop: run BOTH the companion and a simulated primary
-    // through the real primitives and prove the two sides agree — the verification
-    // code matches, the X25519+HKDF encryption keys match, the primary can DECRYPT
-    // the companion's PairingRequest, and the handoff proof verifies. This is the
-    // guarantee that our output is interoperable with a real WhatsApp primary, not
-    // merely self-consistent.
+    // Runs both the companion and a simulated primary through the primitives: the
+    // verification codes match, the X25519+HKDF keys agree, the primary decrypts the
+    // companion's PairingRequest, and the handoff proof verifies.
     #[test]
     fn full_handshake_interops_with_a_simulated_primary() {
         use crate::libsignal::crypto::aes_256_gcm_decrypt;

--- a/wacore/src/shortcake.rs
+++ b/wacore/src/shortcake.rs
@@ -79,7 +79,7 @@ impl ShortcakeUtils {
     /// `public_key` is the RAW 32-byte X25519 pubkey (no 0x05 prefix).
     /// `device_type` is the numeric `DeviceProps.PlatformType` (CHROME = 1).
     pub fn build_companion_ephemeral_identity(
-        public_key: &[u8],
+        public_key: &[u8; 32],
         device_type: i32,
         ref_str: &str,
     ) -> Vec<u8> {
@@ -92,9 +92,10 @@ impl ShortcakeUtils {
     }
 
     /// commitment = SHA256(companionEphemeralIdentityBytes ‖ companionNonce).
+    /// The identity is a variable-length protobuf blob; the nonce is fixed 32 B.
     pub fn commitment_hash(
         companion_ephemeral_identity: &[u8],
-        companion_nonce: &[u8],
+        companion_nonce: &[u8; 32],
     ) -> [u8; 32] {
         let mut h = Sha256::new();
         h.update(companion_ephemeral_identity);
@@ -105,7 +106,7 @@ impl ShortcakeUtils {
     /// Encode the prologue payload protobuf (companion identity + commitment{hash}).
     pub fn build_prologue_payload(
         companion_ephemeral_identity: &[u8],
-        commitment_hash: &[u8],
+        commitment_hash: &[u8; 32],
     ) -> Vec<u8> {
         wa::ProloguePayload {
             companion_ephemeral_identity: Some(companion_ephemeral_identity.to_vec()),
@@ -120,17 +121,10 @@ impl ShortcakeUtils {
     /// `h = SHA256(companionNonce ‖ primaryPublicKey)`; `out[i] = primaryNonce[i] ^ h[i]`
     /// for the first 5 bytes; Crockford base32 → 8 chars.
     pub fn derive_verification_code(
-        companion_nonce: &[u8],
-        primary_public_key: &[u8],
-        primary_nonce: &[u8],
-    ) -> Result<String, ShortcakeError> {
-        if primary_nonce.len() < VERIFICATION_CODE_BYTES {
-            return Err(ShortcakeError::Length {
-                what: "primary_nonce",
-                expected: VERIFICATION_CODE_BYTES,
-                got: primary_nonce.len(),
-            });
-        }
+        companion_nonce: &[u8; 32],
+        primary_public_key: &[u8; 32],
+        primary_nonce: &[u8; 32],
+    ) -> String {
         let mut h = Sha256::new();
         h.update(companion_nonce);
         h.update(primary_public_key);
@@ -139,13 +133,13 @@ impl ShortcakeUtils {
         for (i, slot) in out.iter_mut().enumerate() {
             *slot = primary_nonce[i] ^ digest[i];
         }
-        Ok(PairCodeUtils::encode_crockford(&out))
+        PairCodeUtils::encode_crockford(&out)
     }
 
     /// Derive the AES-256 pairing-request encryption key from the shared secret
     /// (deterministic core, unit-testable). `device_type` is the numeric enum value.
     pub fn derive_encryption_key_from_shared_secret(
-        shared_secret: &[u8],
+        shared_secret: &[u8; 32],
         device_type: i32,
         ref_str: &str,
     ) -> Result<[u8; 32], ShortcakeError> {
@@ -176,9 +170,9 @@ impl ShortcakeUtils {
     /// Encode the inner `PairingRequest` plaintext (companion static + identity
     /// pubkeys + the NEWLY-ROTATED ADV secret) — this is what gets encrypted.
     pub fn build_pairing_request(
-        companion_public_key: &[u8],
-        companion_identity_key: &[u8],
-        adv_secret: &[u8],
+        companion_public_key: &[u8; 32],
+        companion_identity_key: &[u8; 32],
+        adv_secret: &[u8; 32],
     ) -> Vec<u8> {
         wa::PairingRequest {
             companion_public_key: Some(companion_public_key.to_vec()),
@@ -217,7 +211,7 @@ impl ShortcakeUtils {
     /// Derive the pairing-handoff HMAC key from a PRIOR session's 32-byte ADV
     /// secret: HKDF-SHA256(IKM = priorAdvSecret, salt = none, info = handoff label).
     pub fn derive_pairing_handoff_hmac_key(
-        prior_adv_secret: &[u8],
+        prior_adv_secret: &[u8; 32],
     ) -> Result<[u8; 32], ShortcakeError> {
         let hk = Hkdf::<Sha256>::new(None, prior_adv_secret);
         let mut key = [0u8; 32];
@@ -286,8 +280,7 @@ mod tests {
             &companion_nonce,
             &primary_pub,
             &primary_nonce,
-        )
-        .unwrap();
+        );
         // exactly 8 Crockford chars
         assert_eq!(code.len(), 8);
         const CROCKFORD: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTVWXYZ";
@@ -310,16 +303,13 @@ mod tests {
                 &primary_pub,
                 &primary_nonce
             )
-            .unwrap()
         );
     }
 
-    #[test]
-    fn verification_code_rejects_short_primary_nonce() {
-        assert!(
-            ShortcakeUtils::derive_verification_code(&[0u8; 32], &[0u8; 32], &[0u8; 4]).is_err()
-        );
-    }
+    // Note: non-32-byte inputs are now unrepresentable — every fixed-size crypto
+    // field is a `&[u8; 32]` parameter, so a wrong length is a compile error
+    // rather than a runtime `ShortcakeError::Length`. This is strictly stronger
+    // than the previous `verification_code_rejects_short_primary_nonce` test.
 
     #[test]
     fn encryption_key_uses_string_as_salt_not_info() {

--- a/wacore/src/shortcake.rs
+++ b/wacore/src/shortcake.rs
@@ -1,0 +1,407 @@
+//! SHORTCAKE_PASSKEY companion-linking — platform-independent crypto + protobuf.
+//!
+//! WhatsApp's 2026 passkey/WebAuthn linking gate adds a third `PairingType`
+//! (`QR_CODE`, `ALT_DEVICE_LINKING`, `SHORTCAKE_PASSKEY`). When the account has
+//! the server flag `shortcake_companion_prologue__passkeys__enabled`, linking a
+//! companion requires a WebAuthn assertion (the SOLE unforgeable step) followed
+//! by an ephemeral-identity handshake that ends in an AES-256-GCM-encrypted
+//! `PairingRequest` carrying the newly-rotated ADV secret.
+//!
+//! This module is the deterministic, offline-testable foundation: every function
+//! here is pure crypto / protobuf encoding. The single non-reproducible step —
+//! the WebAuthn assertion — is abstracted behind the host's `PasskeyAuthenticator`
+//! (see the main crate's `passkey` module); it is NOT in this file.
+//!
+//! All constants/labels are reverse-engineered verbatim from WhatsApp Web
+//! (waVersion 2.3000.1042386815, modules `WAWebShortcakeLinking*`). Key facts the
+//! RE pinned down (and which are easy to get wrong):
+//! - companion ephemeral pubkey is RAW 32 bytes (no 0x05 Signal prefix).
+//! - commitment = SHA256(companionEphemeralIdentityBytes ‖ companionNonce).
+//! - verification code = SHA256(companionNonce ‖ primaryPublicKey); then
+//!   `out[i] = primaryNonce[i] ^ digest[i]` for i in 0..5; Crockford-base32 → 8 chars.
+//! - encryption key = HKDF-SHA256(IKM = X25519(companionPriv, primaryPub),
+//!   **salt = "Companion Pairing {deviceTypeNumeric} with ref {ref}"**,
+//!   **info = "Pairing Information Encryption Key"**, len 32). The human-readable
+//!   string is the SALT, not the info; deviceType is the numeric enum (CHROME=1).
+//! - handoff key = HKDF-SHA256(IKM = priorAdvSecret, salt = none, info =
+//!   "shortcake-passkey-handoff-v1", len 32); proof = HMAC-SHA256(key, prologuePayload).
+//!   The handoff only proves ADV-secret continuity for a re-link (suppresses the
+//!   verification-code UX); it does NOT replace the WebAuthn assertion.
+
+use crate::libsignal::crypto::aes_256_gcm_encrypt;
+use crate::libsignal::protocol::{CurveError, KeyPair, PublicKey};
+use crate::pair_code::PairCodeUtils;
+use hkdf::Hkdf;
+use hmac::{Hmac, KeyInit as _, Mac};
+use prost::Message;
+use rand::RngExt;
+use sha2::{Digest, Sha256};
+use waproto::whatsapp as wa;
+
+/// HKDF `info` for the pairing-handoff HMAC key (RE: "shortcake-passkey-handoff-v1").
+const HANDOFF_INFO: &[u8] = b"shortcake-passkey-handoff-v1";
+/// HKDF `info` for the pairing-request encryption key (RE: "Pairing Information Encryption Key").
+const ENC_KEY_INFO: &[u8] = b"Pairing Information Encryption Key";
+/// First N bytes of the verification-code reveal (RE: const s=5 → 8 Crockford chars).
+const VERIFICATION_CODE_BYTES: usize = 5;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ShortcakeError {
+    #[error("invalid primary public key: {0}")]
+    InvalidPrimaryKey(CurveError),
+    #[error("X25519 agreement failed: {0}")]
+    KeyAgreement(CurveError),
+    #[error("HKDF expand failed for {0}")]
+    Hkdf(&'static str),
+    #[error("AES-256-GCM encryption failed")]
+    Aead,
+    #[error("unexpected length: {what} expected {expected} got {got}")]
+    Length {
+        what: &'static str,
+        expected: usize,
+        got: usize,
+    },
+}
+
+/// Output of [`ShortcakeUtils::encrypt_pairing_request`].
+pub struct EncryptedPairing {
+    /// AES-256-GCM ciphertext ‖ 16-byte tag (matches WebCrypto's single buffer).
+    pub encrypted_payload: Vec<u8>,
+    /// 12-byte random GCM IV.
+    pub iv: [u8; 12],
+}
+
+/// Platform-independent SHORTCAKE_PASSKEY crypto + protobuf builders.
+pub struct ShortcakeUtils;
+
+impl ShortcakeUtils {
+    /// Encode the companion ephemeral identity protobuf.
+    /// `public_key` is the RAW 32-byte X25519 pubkey (no 0x05 prefix).
+    /// `device_type` is the numeric `DeviceProps.PlatformType` (CHROME = 1).
+    pub fn build_companion_ephemeral_identity(
+        public_key: &[u8],
+        device_type: i32,
+        ref_str: &str,
+    ) -> Vec<u8> {
+        wa::CompanionEphemeralIdentity {
+            public_key: Some(public_key.to_vec()),
+            device_type: Some(device_type),
+            r#ref: Some(ref_str.to_string()),
+        }
+        .encode_to_vec()
+    }
+
+    /// commitment = SHA256(companionEphemeralIdentityBytes ‖ companionNonce).
+    pub fn commitment_hash(
+        companion_ephemeral_identity: &[u8],
+        companion_nonce: &[u8],
+    ) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(companion_ephemeral_identity);
+        h.update(companion_nonce);
+        h.finalize().into()
+    }
+
+    /// Encode the prologue payload protobuf (companion identity + commitment{hash}).
+    pub fn build_prologue_payload(
+        companion_ephemeral_identity: &[u8],
+        commitment_hash: &[u8],
+    ) -> Vec<u8> {
+        wa::ProloguePayload {
+            companion_ephemeral_identity: Some(companion_ephemeral_identity.to_vec()),
+            commitment: Some(wa::CompanionCommitment {
+                hash: Some(commitment_hash.to_vec()),
+            }),
+        }
+        .encode_to_vec()
+    }
+
+    /// Derive the 8-char verification code shown to the user (and the phone).
+    /// `h = SHA256(companionNonce ‖ primaryPublicKey)`; `out[i] = primaryNonce[i] ^ h[i]`
+    /// for the first 5 bytes; Crockford base32 → 8 chars.
+    pub fn derive_verification_code(
+        companion_nonce: &[u8],
+        primary_public_key: &[u8],
+        primary_nonce: &[u8],
+    ) -> Result<String, ShortcakeError> {
+        if primary_nonce.len() < VERIFICATION_CODE_BYTES {
+            return Err(ShortcakeError::Length {
+                what: "primary_nonce",
+                expected: VERIFICATION_CODE_BYTES,
+                got: primary_nonce.len(),
+            });
+        }
+        let mut h = Sha256::new();
+        h.update(companion_nonce);
+        h.update(primary_public_key);
+        let digest = h.finalize();
+        let mut out = [0u8; VERIFICATION_CODE_BYTES];
+        for (i, slot) in out.iter_mut().enumerate() {
+            *slot = primary_nonce[i] ^ digest[i];
+        }
+        Ok(PairCodeUtils::encode_crockford(&out))
+    }
+
+    /// Derive the AES-256 pairing-request encryption key from the shared secret
+    /// (deterministic core, unit-testable). `device_type` is the numeric enum value.
+    pub fn derive_encryption_key_from_shared_secret(
+        shared_secret: &[u8],
+        device_type: i32,
+        ref_str: &str,
+    ) -> Result<[u8; 32], ShortcakeError> {
+        let salt = format!("Companion Pairing {device_type} with ref {ref_str}");
+        let hk = Hkdf::<Sha256>::new(Some(salt.as_bytes()), shared_secret);
+        let mut key = [0u8; 32];
+        hk.expand(ENC_KEY_INFO, &mut key)
+            .map_err(|_| ShortcakeError::Hkdf("encryption_key"))?;
+        Ok(key)
+    }
+
+    /// Full encryption-key derivation: X25519(companionPriv, primaryPub) → HKDF.
+    pub fn derive_encryption_key(
+        companion_keypair: &KeyPair,
+        primary_public_key: &[u8; 32],
+        device_type: i32,
+        ref_str: &str,
+    ) -> Result<[u8; 32], ShortcakeError> {
+        let primary = PublicKey::from_djb_public_key_bytes(primary_public_key)
+            .map_err(ShortcakeError::InvalidPrimaryKey)?;
+        let shared = companion_keypair
+            .private_key
+            .calculate_agreement(&primary)
+            .map_err(ShortcakeError::KeyAgreement)?;
+        Self::derive_encryption_key_from_shared_secret(&shared, device_type, ref_str)
+    }
+
+    /// Encode the inner `PairingRequest` plaintext (companion static + identity
+    /// pubkeys + the NEWLY-ROTATED ADV secret) — this is what gets encrypted.
+    pub fn build_pairing_request(
+        companion_public_key: &[u8],
+        companion_identity_key: &[u8],
+        adv_secret: &[u8],
+    ) -> Vec<u8> {
+        wa::PairingRequest {
+            companion_public_key: Some(companion_public_key.to_vec()),
+            companion_identity_key: Some(companion_identity_key.to_vec()),
+            adv_secret: Some(adv_secret.to_vec()),
+        }
+        .encode_to_vec()
+    }
+
+    /// AES-256-GCM encrypt the pairing-request plaintext with a fresh 12-byte IV,
+    /// no AAD. Output is ciphertext‖tag in one buffer (matches WebCrypto).
+    pub fn encrypt_pairing_request(
+        plaintext: &[u8],
+        key: &[u8; 32],
+    ) -> Result<EncryptedPairing, ShortcakeError> {
+        let mut iv = [0u8; 12];
+        rand::make_rng::<rand::rngs::StdRng>().fill(&mut iv);
+        let mut encrypted_payload = Vec::with_capacity(plaintext.len() + 16);
+        aes_256_gcm_encrypt(key, &iv, b"", plaintext, &mut encrypted_payload)
+            .map_err(|_| ShortcakeError::Aead)?;
+        Ok(EncryptedPairing {
+            encrypted_payload,
+            iv,
+        })
+    }
+
+    /// Encode the `EncryptedPairingRequest` protobuf sent in the final IQ.
+    pub fn build_encrypted_pairing_request(enc: &EncryptedPairing) -> Vec<u8> {
+        wa::EncryptedPairingRequest {
+            encrypted_payload: Some(enc.encrypted_payload.clone()),
+            iv: Some(enc.iv.to_vec()),
+        }
+        .encode_to_vec()
+    }
+
+    /// Derive the pairing-handoff HMAC key from a PRIOR session's 32-byte ADV
+    /// secret: HKDF-SHA256(IKM = priorAdvSecret, salt = none, info = handoff label).
+    pub fn derive_pairing_handoff_hmac_key(
+        prior_adv_secret: &[u8],
+    ) -> Result<[u8; 32], ShortcakeError> {
+        let hk = Hkdf::<Sha256>::new(None, prior_adv_secret);
+        let mut key = [0u8; 32];
+        hk.expand(HANDOFF_INFO, &mut key)
+            .map_err(|_| ShortcakeError::Hkdf("handoff_key"))?;
+        Ok(key)
+    }
+
+    /// Compute the pairing-handoff proof = HMAC-SHA256(handoffKey, prologuePayload).
+    /// Proves continuity from a prior linked session (re-link UX skip); OPTIONAL.
+    pub fn compute_pairing_handoff_proof(
+        handoff_key: &[u8; 32],
+        prologue_payload: &[u8],
+    ) -> [u8; 32] {
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(handoff_key).expect("HMAC accepts any key length");
+        mac.update(prologue_payload);
+        mac.finalize().into_bytes().into()
+    }
+
+    /// Generate the companion ephemeral X25519 keypair for a new SHORTCAKE attempt.
+    pub fn generate_companion_ephemeral_keypair() -> KeyPair {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        KeyPair::generate(&mut rng)
+    }
+
+    /// Generate a fresh 32-byte companion nonce.
+    pub fn generate_companion_nonce() -> [u8; 32] {
+        let mut nonce = [0u8; 32];
+        rand::make_rng::<rand::rngs::StdRng>().fill(&mut nonce);
+        nonce
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Deterministic vectors guard the bug-prone concat/XOR/label details the RE flagged.
+
+    #[test]
+    fn commitment_is_sha256_of_identity_then_nonce() {
+        let identity = b"identity-bytes";
+        let nonce = [7u8; 32];
+        let got = ShortcakeUtils::commitment_hash(identity, &nonce);
+        // independent re-derivation, asserting the exact concat ORDER
+        let mut h = Sha256::new();
+        h.update(identity);
+        h.update(nonce);
+        let want: [u8; 32] = h.finalize().into();
+        assert_eq!(got, want);
+        // order matters: nonce-then-identity must differ
+        let mut h2 = Sha256::new();
+        h2.update(nonce);
+        h2.update(identity);
+        let wrong: [u8; 32] = h2.finalize().into();
+        assert_ne!(got, wrong);
+    }
+
+    #[test]
+    fn verification_code_format_and_xor_order() {
+        let companion_nonce = [1u8; 32];
+        let primary_pub = [2u8; 32];
+        let primary_nonce = [3u8; 32];
+        let code = ShortcakeUtils::derive_verification_code(
+            &companion_nonce,
+            &primary_pub,
+            &primary_nonce,
+        )
+        .unwrap();
+        // exactly 8 Crockford chars
+        assert_eq!(code.len(), 8);
+        const CROCKFORD: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTVWXYZ";
+        assert!(code.bytes().all(|b| CROCKFORD.contains(&b)));
+        // re-derive independently: SHA256(companionNonce ‖ primaryPub), XOR first 5 of primaryNonce
+        let mut h = Sha256::new();
+        h.update(companion_nonce);
+        h.update(primary_pub);
+        let d = h.finalize();
+        let mut out = [0u8; 5];
+        for i in 0..5 {
+            out[i] = primary_nonce[i] ^ d[i];
+        }
+        assert_eq!(code, PairCodeUtils::encode_crockford(&out));
+        // deterministic
+        assert_eq!(
+            code,
+            ShortcakeUtils::derive_verification_code(
+                &companion_nonce,
+                &primary_pub,
+                &primary_nonce
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn verification_code_rejects_short_primary_nonce() {
+        assert!(
+            ShortcakeUtils::derive_verification_code(&[0u8; 32], &[0u8; 32], &[0u8; 4]).is_err()
+        );
+    }
+
+    #[test]
+    fn encryption_key_uses_string_as_salt_not_info() {
+        let ikm = [9u8; 32];
+        let key =
+            ShortcakeUtils::derive_encryption_key_from_shared_secret(&ikm, 1, "REF123").unwrap();
+        // independent re-derivation with the documented salt/info placement
+        let salt = "Companion Pairing 1 with ref REF123";
+        let hk = Hkdf::<Sha256>::new(Some(salt.as_bytes()), &ikm);
+        let mut want = [0u8; 32];
+        hk.expand(b"Pairing Information Encryption Key", &mut want)
+            .unwrap();
+        assert_eq!(key, want);
+        // swapping salt<->info (a plausible bug) must produce a different key
+        let hk2 = Hkdf::<Sha256>::new(Some(b"Pairing Information Encryption Key"), &ikm);
+        let mut wrong = [0u8; 32];
+        hk2.expand(salt.as_bytes(), &mut wrong).unwrap();
+        assert_ne!(key, wrong);
+        // device_type and ref are bound into the key
+        assert_ne!(
+            key,
+            ShortcakeUtils::derive_encryption_key_from_shared_secret(&ikm, 2, "REF123").unwrap()
+        );
+        assert_ne!(
+            key,
+            ShortcakeUtils::derive_encryption_key_from_shared_secret(&ikm, 1, "OTHER").unwrap()
+        );
+    }
+
+    #[test]
+    fn handoff_key_and_proof() {
+        let prior = [5u8; 32];
+        let k = ShortcakeUtils::derive_pairing_handoff_hmac_key(&prior).unwrap();
+        // independent HKDF (salt none, info label)
+        let hk = Hkdf::<Sha256>::new(None, &prior);
+        let mut want = [0u8; 32];
+        hk.expand(b"shortcake-passkey-handoff-v1", &mut want)
+            .unwrap();
+        assert_eq!(k, want);
+        let proof = ShortcakeUtils::compute_pairing_handoff_proof(&k, b"prologue");
+        let mut mac = Hmac::<Sha256>::new_from_slice(&k).unwrap();
+        mac.update(b"prologue");
+        let want_proof: [u8; 32] = mac.finalize().into_bytes().into();
+        assert_eq!(proof, want_proof);
+    }
+
+    #[test]
+    fn protobufs_roundtrip_with_expected_fields() {
+        let id = ShortcakeUtils::build_companion_ephemeral_identity(&[0xAA; 32], 1, "theref");
+        let decoded = wa::CompanionEphemeralIdentity::decode(id.as_slice()).unwrap();
+        assert_eq!(decoded.public_key.as_deref(), Some(&[0xAA; 32][..]));
+        assert_eq!(decoded.device_type, Some(1));
+        assert_eq!(decoded.r#ref.as_deref(), Some("theref"));
+
+        let prologue = ShortcakeUtils::build_prologue_payload(&id, &[0xBB; 32]);
+        let dp = wa::ProloguePayload::decode(prologue.as_slice()).unwrap();
+        assert_eq!(
+            dp.companion_ephemeral_identity.as_deref(),
+            Some(id.as_slice())
+        );
+        assert_eq!(
+            dp.commitment.and_then(|c| c.hash).as_deref(),
+            Some(&[0xBB; 32][..])
+        );
+
+        let pr = ShortcakeUtils::build_pairing_request(&[1; 32], &[2; 32], &[3; 32]);
+        let dpr = wa::PairingRequest::decode(pr.as_slice()).unwrap();
+        assert_eq!(dpr.companion_public_key.as_deref(), Some(&[1u8; 32][..]));
+        assert_eq!(dpr.companion_identity_key.as_deref(), Some(&[2u8; 32][..]));
+        assert_eq!(dpr.adv_secret.as_deref(), Some(&[3u8; 32][..]));
+    }
+
+    #[test]
+    fn encrypt_pairing_request_shape() {
+        let key = [4u8; 32];
+        let enc = ShortcakeUtils::encrypt_pairing_request(b"hello pairing", &key).unwrap();
+        assert_eq!(enc.iv.len(), 12);
+        // ciphertext + 16-byte GCM tag
+        assert_eq!(enc.encrypted_payload.len(), b"hello pairing".len() + 16);
+        let wire = ShortcakeUtils::build_encrypted_pairing_request(&enc);
+        let d = wa::EncryptedPairingRequest::decode(wire.as_slice()).unwrap();
+        assert_eq!(d.iv.as_deref(), Some(&enc.iv[..]));
+        assert_eq!(d.encrypted_payload, Some(enc.encrypted_payload));
+    }
+}

--- a/wacore/src/shortcake.rs
+++ b/wacore/src/shortcake.rs
@@ -55,12 +55,21 @@ pub enum ShortcakeError {
     Hkdf(&'static str),
     #[error("AES-256-GCM encryption failed")]
     Aead,
+    #[error("failed to decode {0} protobuf")]
+    Decode(&'static str),
     #[error("unexpected length: {what} expected {expected} got {got}")]
     Length {
         what: &'static str,
         expected: usize,
         got: usize,
     },
+}
+
+/// Parsed `<primary_ephemeral_identity>` from the server's continuation
+/// notification: the primary's ephemeral X25519 pubkey + nonce, both fixed 32 B.
+pub struct PrimaryEphemeralIdentity {
+    pub public_key: [u8; 32],
+    pub nonce: [u8; 32],
 }
 
 /// Output of [`ShortcakeUtils::encrypt_pairing_request`].
@@ -115,6 +124,36 @@ impl ShortcakeUtils {
             }),
         }
         .encode_to_vec()
+    }
+
+    /// Decode + length-validate the `PrimaryEphemeralIdentity` protobuf from the
+    /// `<primary_ephemeral_identity>` continuation node. Both fields must be
+    /// exactly 32 bytes; a wrong length is rejected here rather than producing a
+    /// bogus shared secret / verification code downstream.
+    pub fn parse_primary_ephemeral_identity(
+        bytes: &[u8],
+    ) -> Result<PrimaryEphemeralIdentity, ShortcakeError> {
+        let parsed = wa::PrimaryEphemeralIdentity::decode(bytes)
+            .map_err(|_| ShortcakeError::Decode("primary_ephemeral_identity"))?;
+        let pk = parsed.public_key.unwrap_or_default();
+        let nc = parsed.nonce.unwrap_or_default();
+        let public_key: [u8; 32] =
+            pk.as_slice()
+                .try_into()
+                .map_err(|_| ShortcakeError::Length {
+                    what: "primary_public_key",
+                    expected: 32,
+                    got: pk.len(),
+                })?;
+        let nonce: [u8; 32] = nc
+            .as_slice()
+            .try_into()
+            .map_err(|_| ShortcakeError::Length {
+                what: "primary_nonce",
+                expected: 32,
+                got: nc.len(),
+            })?;
+        Ok(PrimaryEphemeralIdentity { public_key, nonce })
     }
 
     /// Derive the 8-char verification code shown to the user (and the phone).
@@ -306,10 +345,56 @@ mod tests {
         );
     }
 
-    // Note: non-32-byte inputs are now unrepresentable — every fixed-size crypto
-    // field is a `&[u8; 32]` parameter, so a wrong length is a compile error
-    // rather than a runtime `ShortcakeError::Length`. This is strictly stronger
-    // than the previous `verification_code_rejects_short_primary_nonce` test.
+    // The fixed-size crypto inputs are `&[u8; 32]` parameters, so a wrong length
+    // is a compile error rather than a runtime check. Length validation only
+    // survives at the wire boundary: `parse_primary_ephemeral_identity` below.
+
+    #[test]
+    fn parse_primary_ephemeral_identity_roundtrip_and_length_validation() {
+        let proto = wa::PrimaryEphemeralIdentity {
+            public_key: Some(vec![0xAB; 32]),
+            nonce: Some(vec![0xCD; 32]),
+        }
+        .encode_to_vec();
+        let parsed = ShortcakeUtils::parse_primary_ephemeral_identity(&proto).unwrap();
+        assert_eq!(parsed.public_key, [0xAB; 32]);
+        assert_eq!(parsed.nonce, [0xCD; 32]);
+
+        // wrong-length pubkey is rejected with a Length error
+        let bad_pk = wa::PrimaryEphemeralIdentity {
+            public_key: Some(vec![0xAB; 31]),
+            nonce: Some(vec![0xCD; 32]),
+        }
+        .encode_to_vec();
+        assert!(matches!(
+            ShortcakeUtils::parse_primary_ephemeral_identity(&bad_pk),
+            Err(ShortcakeError::Length {
+                what: "primary_public_key",
+                ..
+            })
+        ));
+
+        // wrong-length nonce is rejected
+        let bad_nonce = wa::PrimaryEphemeralIdentity {
+            public_key: Some(vec![0xAB; 32]),
+            nonce: Some(vec![0xCD; 1]),
+        }
+        .encode_to_vec();
+        assert!(matches!(
+            ShortcakeUtils::parse_primary_ephemeral_identity(&bad_nonce),
+            Err(ShortcakeError::Length {
+                what: "primary_nonce",
+                ..
+            })
+        ));
+
+        // garbage that isn't a valid protobuf for this message: an absent field
+        // decodes to empty (length 0), which is also a Length error, not a panic.
+        assert!(matches!(
+            ShortcakeUtils::parse_primary_ephemeral_identity(&[]),
+            Err(ShortcakeError::Length { got: 0, .. })
+        ));
+    }
 
     #[test]
     fn encryption_key_uses_string_as_salt_not_info() {
@@ -393,5 +478,122 @@ mod tests {
         let d = wa::EncryptedPairingRequest::decode(wire.as_slice()).unwrap();
         assert_eq!(d.iv.as_deref(), Some(&enc.iv[..]));
         assert_eq!(d.encrypted_payload, Some(enc.encrypted_payload));
+    }
+
+    // End-to-end protocol interop: run BOTH the companion and a simulated primary
+    // through the real primitives and prove the two sides agree — the verification
+    // code matches, the X25519+HKDF encryption keys match, the primary can DECRYPT
+    // the companion's PairingRequest, and the handoff proof verifies. This is the
+    // guarantee that our output is interoperable with a real WhatsApp primary, not
+    // merely self-consistent.
+    #[test]
+    fn full_handshake_interops_with_a_simulated_primary() {
+        use crate::libsignal::crypto::aes_256_gcm_decrypt;
+
+        let device_type = 1; // CHROME
+        let pairing_ref = "REF-XYZ";
+        let prior_adv_secret = [0x11u8; 32]; // a prior linked session's secret
+        let new_adv_secret = [0x22u8; 32]; // rotated for this link
+
+        // companion: ephemeral identity + commitment + prologue + handoff proof
+        let companion_kp = ShortcakeUtils::generate_companion_ephemeral_keypair();
+        let companion_nonce = ShortcakeUtils::generate_companion_nonce();
+        let companion_pub: [u8; 32] = companion_kp
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .unwrap();
+        let identity = ShortcakeUtils::build_companion_ephemeral_identity(
+            &companion_pub,
+            device_type,
+            pairing_ref,
+        );
+        let commitment = ShortcakeUtils::commitment_hash(&identity, &companion_nonce);
+        let prologue = ShortcakeUtils::build_prologue_payload(&identity, &commitment);
+        let companion_handoff =
+            ShortcakeUtils::derive_pairing_handoff_hmac_key(&prior_adv_secret).unwrap();
+        let proof = ShortcakeUtils::compute_pairing_handoff_proof(&companion_handoff, &prologue);
+
+        // primary: its own ephemeral identity, sent back as <primary_ephemeral_identity>
+        let primary_kp = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+        let primary_pub: [u8; 32] = primary_kp.public_key.public_key_bytes().try_into().unwrap();
+        let primary_nonce = [0x33u8; 32];
+        let primary_wire = wa::PrimaryEphemeralIdentity {
+            public_key: Some(primary_pub.to_vec()),
+            nonce: Some(primary_nonce.to_vec()),
+        }
+        .encode_to_vec();
+        let parsed = ShortcakeUtils::parse_primary_ephemeral_identity(&primary_wire).unwrap();
+
+        // the primary verifies the handoff proof against the shared prior secret
+        let primary_handoff =
+            ShortcakeUtils::derive_pairing_handoff_hmac_key(&prior_adv_secret).unwrap();
+        assert_eq!(
+            proof,
+            ShortcakeUtils::compute_pairing_handoff_proof(&primary_handoff, &prologue),
+            "handoff proof must verify on the primary"
+        );
+
+        // both sides derive the SAME verification code from the same inputs
+        let companion_code = ShortcakeUtils::derive_verification_code(
+            &companion_nonce,
+            &parsed.public_key,
+            &parsed.nonce,
+        );
+        let primary_code = ShortcakeUtils::derive_verification_code(
+            &companion_nonce,
+            &primary_pub,
+            &primary_nonce,
+        );
+        assert_eq!(companion_code, primary_code);
+
+        // X25519 is symmetric, so both sides derive the same AES key
+        let companion_key = ShortcakeUtils::derive_encryption_key(
+            &companion_kp,
+            &parsed.public_key,
+            device_type,
+            pairing_ref,
+        )
+        .unwrap();
+        let primary_shared = primary_kp
+            .private_key
+            .calculate_agreement(&PublicKey::from_djb_public_key_bytes(&companion_pub).unwrap())
+            .unwrap();
+        let primary_key = ShortcakeUtils::derive_encryption_key_from_shared_secret(
+            &primary_shared,
+            device_type,
+            pairing_ref,
+        )
+        .unwrap();
+        assert_eq!(companion_key, primary_key, "X25519+HKDF keys must agree");
+
+        // companion encrypts the PairingRequest; the primary decrypts it and reads
+        // the newly-rotated ADV secret out
+        let request =
+            ShortcakeUtils::build_pairing_request(&[0xAA; 32], &[0xBB; 32], &new_adv_secret);
+        let enc = ShortcakeUtils::encrypt_pairing_request(&request, &companion_key).unwrap();
+        let wire = ShortcakeUtils::build_encrypted_pairing_request(&enc);
+        let decoded = wa::EncryptedPairingRequest::decode(wire.as_slice()).unwrap();
+        let iv: [u8; 12] = decoded.iv.unwrap().as_slice().try_into().unwrap();
+
+        let mut plaintext = Vec::new();
+        aes_256_gcm_decrypt(
+            &primary_key,
+            &iv,
+            b"",
+            &decoded.encrypted_payload.unwrap(),
+            &mut plaintext,
+        )
+        .unwrap();
+        let recovered = wa::PairingRequest::decode(plaintext.as_slice()).unwrap();
+        assert_eq!(recovered.adv_secret.as_deref(), Some(&new_adv_secret[..]));
+        assert_eq!(
+            recovered.companion_public_key.as_deref(),
+            Some(&[0xAA; 32][..])
+        );
+        assert_eq!(
+            recovered.companion_identity_key.as_deref(),
+            Some(&[0xBB; 32][..])
+        );
     }
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -261,6 +261,9 @@ pub enum EventKind {
     NewsletterLiveUpdate,
     RawNode,
     MexNotification,
+    PairPasskeyRequest,
+    PairPasskeyConfirmation,
+    PairPasskeyError,
     // When adding a variant, mind the 64-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u64) and keep the guard pointing at the
     // last variant.
@@ -274,7 +277,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::MexNotification as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::PairPasskeyError as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. The event bus skips
 /// materializing and dispatching events whose kind no handler wants, so a
@@ -700,6 +703,46 @@ pub enum Event {
     /// Server-pushed MEX (GraphQL) update. Routed by the textual `op_name`,
     /// which is stable across WA Web bundle releases.
     MexNotification(MexNotification),
+
+    /// SHORTCAKE_PASSKEY: the server asked for a WebAuthn assertion to gate this
+    /// companion link. Carries the verbatim `PublicKeyCredentialRequestOptions`
+    /// JSON; the host obtains an assertion (via [`crate::sync_marker`]-agnostic
+    /// authenticator) and the client sends it back. If a passkey authenticator is
+    /// registered the client drives this automatically; this event is for hosts
+    /// that drive the assertion manually.
+    PairPasskeyRequest(PairPasskeyRequest),
+
+    /// SHORTCAKE_PASSKEY: the link reached the verification stage. `code` is the
+    /// 8-char (dashed) pairing code; when `skip_handoff_ux` is set, continuity was
+    /// proven via the handoff proof and the code need not be shown to the user.
+    PairPasskeyConfirmation(PairPasskeyConfirmation),
+
+    /// SHORTCAKE_PASSKEY: the passkey link failed. `continuation` distinguishes a
+    /// failure during the continuation/verification stage from the initial request.
+    PairPasskeyError(PairPasskeyError),
+}
+
+/// Payload for [`Event::PairPasskeyRequest`].
+#[derive(Debug, Clone, Serialize)]
+pub struct PairPasskeyRequest {
+    /// Verbatim `PublicKeyCredentialRequestOptions` JSON from the server. Pass it
+    /// straight to a WebAuthn `get` (e.g. Android Credential Manager) — or parse it
+    /// with `whatsapp_rust::passkey::parse_request_options`.
+    pub request_options_json: String,
+}
+
+/// Payload for [`Event::PairPasskeyConfirmation`].
+#[derive(Debug, Clone, Serialize)]
+pub struct PairPasskeyConfirmation {
+    pub code: String,
+    pub skip_handoff_ux: bool,
+}
+
+/// Payload for [`Event::PairPasskeyError`].
+#[derive(Debug, Clone, Serialize)]
+pub struct PairPasskeyError {
+    pub error: String,
+    pub continuation: bool,
 }
 
 /// `payload` shape depends on `op_name`. `offline` mirrors the raw string
@@ -771,6 +814,9 @@ impl Event {
             Event::NewsletterLiveUpdate(_) => EventKind::NewsletterLiveUpdate,
             Event::RawNode(_) => EventKind::RawNode,
             Event::MexNotification(_) => EventKind::MexNotification,
+            Event::PairPasskeyRequest(_) => EventKind::PairPasskeyRequest,
+            Event::PairPasskeyConfirmation(_) => EventKind::PairPasskeyConfirmation,
+            Event::PairPasskeyError(_) => EventKind::PairPasskeyError,
         }
     }
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -726,7 +726,7 @@ pub enum Event {
 #[derive(Debug, Clone, Serialize)]
 pub struct PairPasskeyRequest {
     /// Verbatim `PublicKeyCredentialRequestOptions` JSON from the server. Pass it
-    /// straight to a WebAuthn `get` (e.g. Android Credential Manager) — or parse it
+    /// straight to a WebAuthn `get` (e.g. Android Credential Manager), or parse it
     /// with `whatsapp_rust::passkey::parse_request_options`.
     pub request_options_json: String,
 }


### PR DESCRIPTION
Fix: https://github.com/oxidezap/whatsapp-rust/issues/930

Implements WhatsApp's SHORTCAKE_PASSKEY companion-linking flow (the passkey/WebAuthn device-link gate) end to end.

The companion answers the server's WebAuthn challenge, runs the ephemeral-identity handshake (commit/reveal nonce + X25519 shared key), and sends its rotated ADV secret in an AES-256-GCM envelope. Linking then completes through the normal pair-success path.

## Layout
- `wacore::shortcake`: pure crypto + protobuf (ephemeral identity, commitment, verification code, HKDF/AES-GCM envelope, handoff proof). No Tokio, wasm-buildable.
- `passkey`: the `PasskeyAuthenticator` seam for the one non-reproducible step (a real WebAuthn assertion), plus the request/assertion parsers.
- `passkey::flow`: the client driver. Routes the `passkey_prologue_request` and `crsc_continuation` notifications, runs the IQ handshake, emits `PairPasskey{Request,Confirmation,Error}` events, and exposes `send_passkey_response` / `send_passkey_confirmation` / `set_passkey_authenticator`. With an authenticator registered the flow runs automatically; otherwise the host drives it from the events.

## Notes
- The ADV secret is rotated per attempt and committed only after the primary receives it, so an abandoned attempt never leaves the device on an unshared secret.
- The handshake drives against an injectable IO seam, so the full IQ sequence is unit-tested (a test decrypts the pairing request as a simulated primary and checks the committed secret is the delivered one).

## Tests
Deterministic crypto/interop tests in wacore, plus flow tests: notification routing, ADV rotation, the full handshake, and error/edge paths.
