### PR TITLE
feat(media): support ContextInfo in media options

### DIFF
--- a/src/features/status.rs
+++ b/src/features/status.rs
@@ -84,7 +84,7 @@ impl<'a> Status<'a> {
             crate::media::ImageOptions {
                 caption: caption.map(|c| c.to_string()),
                 jpeg_thumbnail: Some(thumbnail),
-                mimetype: None,
+                ..Default::default()
             },
         );
 
@@ -112,8 +112,7 @@ impl<'a> Status<'a> {
                 caption: caption.map(|c| c.to_string()),
                 jpeg_thumbnail: Some(thumbnail),
                 duration_seconds: Some(duration_seconds),
-                mimetype: None,
-                gif_playback: None,
+                ..Default::default()
             },
         );
 

--- a/src/media.rs
+++ b/src/media.rs
@@ -23,6 +23,7 @@ pub struct ImageOptions {
     /// Defaults to `image/jpeg`.
     pub mimetype: Option<String>,
     pub jpeg_thumbnail: Option<Vec<u8>>,
+    pub context_info: Option<Box<wa::ContextInfo>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -34,6 +35,7 @@ pub struct VideoOptions {
     pub duration_seconds: Option<u32>,
     /// Send as a looping GIF-style clip.
     pub gif_playback: Option<bool>,
+    pub context_info: Option<Box<wa::ContextInfo>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -46,6 +48,7 @@ pub struct DocumentOptions {
     pub caption: Option<String>,
     pub page_count: Option<u32>,
     pub jpeg_thumbnail: Option<Vec<u8>>,
+    pub context_info: Option<Box<wa::ContextInfo>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -57,6 +60,7 @@ pub struct AudioOptions {
     pub ptt: Option<bool>,
     /// PCM waveform preview bytes (voice notes).
     pub waveform: Option<Vec<u8>>,
+    pub context_info: Option<Box<wa::ContextInfo>>,
 }
 
 /// Build an image message from an upload result.
@@ -73,6 +77,7 @@ pub fn image_message(upload: UploadResponse, opts: ImageOptions) -> wa::Message 
             mimetype: Some(opts.mimetype.unwrap_or_else(|| "image/jpeg".to_string())),
             caption: opts.caption,
             jpeg_thumbnail: opts.jpeg_thumbnail,
+            context_info: opts.context_info,
             ..Default::default()
         })),
         ..Default::default()
@@ -97,6 +102,7 @@ pub fn video_message(upload: UploadResponse, opts: VideoOptions) -> wa::Message 
             jpeg_thumbnail: opts.jpeg_thumbnail,
             seconds: opts.duration_seconds,
             gif_playback: opts.gif_playback,
+            context_info: opts.context_info,
             ..Default::default()
         })),
         ..Default::default()
@@ -123,6 +129,7 @@ pub fn document_message(upload: UploadResponse, opts: DocumentOptions) -> wa::Me
             caption: opts.caption,
             page_count: opts.page_count,
             jpeg_thumbnail: opts.jpeg_thumbnail,
+            context_info: opts.context_info,
             ..Default::default()
         })),
         ..Default::default()
@@ -149,6 +156,7 @@ pub fn audio_message(upload: UploadResponse, opts: AudioOptions) -> wa::Message 
             seconds: opts.duration_seconds,
             ptt: opts.ptt,
             waveform: opts.waveform,
+            context_info: opts.context_info,
             ..Default::default()
         })),
         ..Default::default()
@@ -234,5 +242,39 @@ mod tests {
         assert_eq!(audio.ptt, Some(true));
         assert_eq!(audio.seconds, Some(5));
         assert_eq!(audio.streaming_sidecar.as_deref(), Some(&[9, 9, 9][..]));
+    }
+
+    #[test]
+    fn image_maps_context_info() {
+        let context = Box::new(wa::ContextInfo::default());
+
+        let image_msg = image_message(
+            sample_upload(),
+            ImageOptions {
+                context_info: Some(context),
+                ..Default::default()
+            },
+        );
+
+        let image = image_msg.image_message.unwrap();
+
+        assert!(image.context_info.is_some());
+    }
+
+    #[test]
+    fn video_maps_context_info() {
+        let context = Box::new(wa::ContextInfo::default());
+
+        let video_msg = video_message(
+            sample_upload(),
+            VideoOptions {
+                context_info: Some(context),
+                ..Default::default()
+            },
+        );
+
+        let video = video_msg.video_message.unwrap();
+
+        assert!(video.context_info.is_some());
     }
 }


### PR DESCRIPTION
## Summary

Add an optional `context_info` field to all media option structs and forward it to the generated media message.

## Why

This enables creating quoted/reply media messages directly through the helper API without manually modifying the generated protobuf.

## Breaking changes

None.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

