### PR TITLE
perf(binary): validate wire strings with smoothutf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,6 +3332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoothutf8"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3934,6 +3940,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "smoothutf8",
  "stable_deref_trait",
  "yoke",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,6 +3891,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "smoothutf8",
  "subtle",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ serde-big-array = "0.5"
 serde_json = { version = "1.0", default-features = false }
 sha1 = { version = "0.11.0", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
+smoothutf8 = { version = "0.2.3", default-features = false }
 subtle = { version = "2.6", default-features = false }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", default-features = false }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -72,6 +72,7 @@ serde-big-array = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
+smoothutf8 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -33,6 +33,7 @@ hashify = { version = "0.2.9", default-features = false }
 itoa = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = "1.15"
+smoothutf8 = { workspace = true }
 stable_deref_trait = "1.2.1"
 yoke = { workspace = true }
 

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -99,9 +99,16 @@ impl<'a> Decoder<'a> {
     #[inline(always)]
     fn read_string(&mut self, len: usize) -> Result<NodeStr<'a>> {
         let bytes = self.read_bytes(len)?;
-        match std::str::from_utf8(bytes) {
-            Ok(s) => Ok(NodeStr::Borrowed(s)),
-            Err(e) => Err(BinaryError::InvalidUtf8(e)),
+        // smoothutf8 has a faster fast-path for the short strings dominating the
+        // wire (tags, attribute values, JID parts). It only answers valid/invalid,
+        // so the cold rejection path reuses std to recover the precise Utf8Error.
+        if let Some(s) = smoothutf8::from_utf8(bytes) {
+            Ok(NodeStr::Borrowed(s))
+        } else {
+            match std::str::from_utf8(bytes) {
+                Ok(s) => Ok(NodeStr::Borrowed(s)),
+                Err(e) => Err(BinaryError::InvalidUtf8(e)),
+            }
         }
     }
 

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -501,7 +501,7 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
                 pos += vlen;
                 let len = usize::try_from(len).ok()?;
                 let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
-                let id = std::str::from_utf8(data.get(pos..end)?).ok()?;
+                let id = smoothutf8::from_utf8(data.get(pos..end)?)?;
                 id_match = id == own_user;
                 if !id_match {
                     return None; // wrong user, skip entirely
@@ -514,7 +514,7 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
                 pos += vlen;
                 let len = usize::try_from(len).ok()?;
                 let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
-                let name = std::str::from_utf8(data.get(pos..end)?).ok()?;
+                let name = smoothutf8::from_utf8(data.get(pos..end)?)?;
                 pushname = Some(name.to_string());
                 pos = end;
             }
@@ -1239,13 +1239,13 @@ fn fast_extract(history_msg: &[u8]) -> FastExtract<'_> {
                                     from_me = f.varint != 0;
                                 }
                                 tags::message_key::ID => {
-                                    let Some(Ok(s)) = f.value.map(std::str::from_utf8) else {
+                                    let Some(s) = f.value.and_then(smoothutf8::from_utf8) else {
                                         return FastExtract::NoRecord;
                                     };
                                     msg_id = Some(s);
                                 }
                                 tags::message_key::PARTICIPANT => {
-                                    let Some(Ok(s)) = f.value.map(std::str::from_utf8) else {
+                                    let Some(s) = f.value.and_then(smoothutf8::from_utf8) else {
                                         return FastExtract::NoRecord;
                                     };
                                     key_participant = Some(s);
@@ -1272,7 +1272,7 @@ fn fast_extract(history_msg: &[u8]) -> FastExtract<'_> {
                         timestamp = Some(f.varint);
                     }
                     tags::web_message_info::PARTICIPANT => {
-                        let Some(Ok(s)) = f.value.map(std::str::from_utf8) else {
+                        let Some(s) = f.value.and_then(smoothutf8::from_utf8) else {
                             return FastExtract::NoRecord;
                         };
                         web_msg_participant = Some(s);
@@ -1546,7 +1546,7 @@ fn extract_conversation_fields(
                 let Ok(end) = checked_end(pos, len, data.len(), "conv-id") else {
                     break;
                 };
-                let Ok(id) = std::str::from_utf8(&data[pos..end]) else {
+                let Some(id) = smoothutf8::from_utf8(&data[pos..end]) else {
                     // A real conversation id is a JID (always UTF-8). If it
                     // isn't, the conversation is malformed; skip it rather than
                     // pushing its secrets under an empty chat id. The id


### PR DESCRIPTION
## What

Swaps the binary protocol decoder's UTF-8 validation from `std::str::from_utf8` to [`smoothutf8`](https://github.com/iainmcgin/smooth-utf8) on the hot path.

Every raw string field read off the wire (`BINARY_8`/`BINARY_20`/`BINARY_32`) goes through `Decoder::read_string`. On a normal connection these are overwhelmingly short strings: element tags, attribute values, and JID parts. `smoothutf8` is a `#![no_std]`, zero-dependency validator specifically tuned for short inputs (claims 2–5× over std on ASCII ≤32 bytes) while matching std on larger data.

## How

`read_string` now tries `smoothutf8::from_utf8` first. That API only answers valid/invalid, so the cold rejection branch falls back to `std::str::from_utf8` to recover the precise `Utf8Error` we still surface as `BinaryError::InvalidUtf8`. Behaviour on both valid and malformed input is unchanged; only the fast-path validator differs.

The dependency is pulled with `default-features = false`, so it stays `no_std` and adds no transitive crates (kept out of the `simdutf8`/`verus` optional features on purpose).

## Why this PR exists

The theoretical win is clear but marginal against modern std's ASCII fast-path, so this is deliberately opened to let CI measure it. The CodSpeed benchmarks over the binary decode path are the real metric here. If they don't show a meaningful improvement, this isn't worth the extra dependency and should be closed.

## Verification

- `cargo test -p wacore-binary` — 99 + roundtrip proptests pass
- `cargo clippy -p wacore-binary --all-targets` — clean
- `cargo check --workspace` — clean
- `cargo fmt --all`

https://claude.ai/code/session_01NGEfhAP41Csiy7ptQWZrf3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

