### PR TITLE
fix(receive): skip PDO placeholder-resend for view-once, ack instead

### DIFF
--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -93,11 +93,31 @@ impl Client {
                 Some("view_once") => crate::types::events::UnavailableType::ViewOnce,
                 _ => crate::types::events::UnavailableType::Unknown,
             };
-            log::info!(
-                "[msg:{}] Message has <unavailable> child (type: {:?}), requesting from phone via PDO",
-                info.id,
-                unavailable_type
+            // View-once media is never fanned out to companion/linked devices,
+            // so a PDO placeholder-resend to our own phone always comes back
+            // empty — the content is unrecoverable by design. Worse, that peer
+            // round-trip is surfaced by the phone as a spurious "Finished
+            // syncing with WhatsApp on <device>" notification for every
+            // view-once message received. Skip the PDO for view-once; still
+            // dispatch the event (so consumers see the failure) and still ack
+            // so the offline queue is cleared and the stanza is not redelivered.
+            let is_view_once = matches!(
+                unavailable_type,
+                crate::types::events::UnavailableType::ViewOnce
             );
+            if is_view_once {
+                log::info!(
+                    "[msg:{}] Message has <unavailable> child (type: ViewOnce); \
+                     unrecoverable via PDO — skipping request and acking",
+                    info.id,
+                );
+            } else {
+                log::info!(
+                    "[msg:{}] Message has <unavailable> child (type: {:?}), requesting from phone via PDO",
+                    info.id,
+                    unavailable_type
+                );
+            }
             // PDO is the only recovery here (no retry receipt), so run it before
             // the transport ack in one flush task: the ack must not clear the
             // offline queue before the PDO request goes out. status is acked by
@@ -113,10 +133,16 @@ impl Client {
             let info2 = Arc::clone(&info);
             let skip_ack = info.source.chat.is_status_broadcast();
             self.outbound_flush.spawn(&*self.runtime, async move {
-                // Only ack once the PDO request is out (or skipped as ancient);
-                // a transient send failure leaves it queued for redelivery.
-                let pdo_sent = client.run_pdo_request(&info2).await;
-                if !skip_ack && pdo_sent {
+                // View-once has no recoverable content, so skip the PDO entirely
+                // and ack directly. Otherwise PDO is the only recovery: ack only
+                // once the request is out (or skipped as ancient); a transient
+                // send failure leaves it queued for redelivery.
+                let should_ack = if is_view_once {
+                    true
+                } else {
+                    client.run_pdo_request(&info2).await
+                };
+                if !skip_ack && should_ack {
                     client.send_transport_ack(&info2).await;
                 }
             });

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5218,8 +5218,9 @@ async fn test_unavailable_with_enc_skips_unavailable_shortcut() {
 
 /// Untrusted companions (web-class `PlatformType`) get the bare stub —
 /// `<unavailable>` without `<enc>`. That path must still emit a
-/// `ViewOnce` `UndecryptableMessage` so consumers surface the failure
-/// while the phone relays via PDO.
+/// `ViewOnce` `UndecryptableMessage` so consumers surface the failure.
+/// (The PDO resend is deliberately skipped for view-once — see
+/// `view_once_stub_acks_without_pdo`.)
 #[tokio::test]
 async fn test_unavailable_without_enc_dispatches_view_once_event() {
     let client = create_test_client_for_retry_with_id("unavailable_stub").await;
@@ -5233,6 +5234,44 @@ async fn test_unavailable_without_enc_dispatches_view_once_event() {
         recorder.view_once_unavailable_count(),
         1,
         "bare <unavailable> stub must dispatch exactly one ViewOnce UndecryptableMessage",
+    );
+}
+
+/// View-once media is never shared with companion/linked devices, so a PDO
+/// placeholder-resend to our own phone comes back empty — and that peer
+/// round-trip surfaces as a spurious "Finished syncing with WhatsApp on
+/// <device>" notification on the user's phone for every view-once received.
+/// The bare view-once stub must therefore ack the stanza directly (so the
+/// server stops redelivering it) instead of gating the ack on a futile PDO
+/// request, while still surfacing the failure to consumers.
+#[tokio::test]
+async fn view_once_stub_acks_without_pdo() {
+    let (client, transport) = capturing_client("view_once_ack").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.register_handler(recorder.clone());
+
+    let node = build_unavailable_stanza("5511777776666@s.whatsapp.net", "VIEW_ONCE_ACK_1", false);
+    client.clone().handle_incoming_message(node).await;
+
+    // The (unrecoverable) failure still surfaces to consumers.
+    assert_eq!(
+        recorder.view_once_unavailable_count(),
+        1,
+        "bare view-once stub must still dispatch a ViewOnce UndecryptableMessage",
+    );
+
+    // The stanza is acked so the offline queue drains, without gating on a PDO.
+    let mut acked = false;
+    for _ in 0..80 {
+        if find_message_ack(&transport.sent()).is_some() {
+            acked = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert!(
+        acked,
+        "view-once stub must emit an <ack class=\"message\"> to drain the offline queue",
     );
 }
 


### PR DESCRIPTION
## Problem

A message that arrives with only an `<unavailable type="view_once">` child (no `<enc>`) currently triggers a PDO placeholder-resend to our own phone (`run_pdo_request`). But WhatsApp never fans view-once media out to companion/linked devices, so that request **always comes back empty** — the content is unrecoverable by design (the code already documents this expectation elsewhere).

Worse, the peer round-trip is surfaced by the phone as a spurious **"Finished syncing with WhatsApp on \<device\>"** notification — once for every view-once message the companion receives. This is a visible, repeated annoyance for anyone running a linked/companion client.

## Fix

In the `<unavailable>`-child branch of `handle_incoming_message`, when the type is `ViewOnce`:

- **Skip** `run_pdo_request` entirely (it can only return empty and only causes the notification).
- Still **dispatch** the `UndecryptableMessage` event, so consumers keep seeing the failure.
- Still **ack** the stanza directly. Previously the transport ack was gated on the PDO going out (`pdo_sent`); with the PDO skipped we ack unconditionally (outside status-broadcast) so the offline queue drains and the server does not redeliver the stanza.

`Unknown` unavailables keep the existing PDO recovery path completely unchanged — only view-once, which is provably unrecoverable, is short-circuited.

## Test

Adds `view_once_stub_acks_without_pdo`, which drives a bare view-once stub through `handle_incoming_message` on the capturing-transport harness and asserts both that the `ViewOnce` `UndecryptableMessage` still fires **and** that an `<ack class="message">` is sent. Also updates the now-stale comment on `test_unavailable_without_enc_dispatches_view_once_event` (it claimed view-once "relays via PDO").

## Validation

- `cargo test -p whatsapp-rust --lib` — new test passes; the full view-once/PDO/unavailable suite (24 tests) is green, no regressions.
- `cargo fmt --check` clean.
- `cargo clippy -p whatsapp-rust --lib -- -D warnings` clean.

Rebased on current `main`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

