### PR TITLE
fix(receive): skip PDO placeholder-resend for bot and hosted unavailable too

### DIFF
--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -88,40 +88,45 @@ impl Client {
         if let Some(unavailable) = unavailable_node
             && all_enc_nodes.is_empty()
         {
-            let unavailable_type = match unavailable.get_attr("type").map(|v| v.as_str()).as_deref()
-            {
-                Some("view_once") => crate::types::events::UnavailableType::ViewOnce,
-                _ => crate::types::events::UnavailableType::Unknown,
-            };
-            // View-once media is never fanned out to companion/linked devices,
-            // so a PDO placeholder-resend to our own phone always comes back
-            // empty — the content is unrecoverable by design. Worse, that peer
-            // round-trip is surfaced by the phone as a spurious "Finished
-            // syncing with WhatsApp on <device>" notification for every
-            // view-once message received. Skip the PDO for view-once; still
-            // dispatch the event (so consumers see the failure) and still ack
-            // so the offline queue is cleared and the stanza is not redelivered.
-            let is_view_once = matches!(
-                unavailable_type,
-                crate::types::events::UnavailableType::ViewOnce
+            // WA Web never placeholder-resends bot, hosted or view-once
+            // <unavailable> fanouts (WAWebNonMessageDataRequestPlaceholderMessageResendUtils
+            // skips those subtypes). The phone won't share that content with a
+            // companion, so a resend to our own device only comes back empty and
+            // surfaces a spurious "Finished syncing" notification for each one.
+            // Detect the three the way WA Web's parser does (bot via a <bot>
+            // child, hosted via the `hosted` attr, view-once via the `type`
+            // attr) and skip the PDO for them, still dispatching the event and
+            // acking. A plain fanout (Unknown) stays recoverable via PDO.
+            let is_bot = nr.get_optional_child("bot").is_some();
+            let is_hosted = unavailable
+                .get_attr("hosted")
+                .map(|v| v.as_str())
+                .as_deref()
+                == Some("true");
+            let is_view_once =
+                unavailable.get_attr("type").map(|v| v.as_str()).as_deref() == Some("view_once");
+            let unavailable_type = crate::types::events::UnavailableType::from_fanout_flags(
+                is_bot,
+                is_hosted,
+                is_view_once,
             );
-            if is_view_once {
+            let unrecoverable = unavailable_type.is_unrecoverable_fanout();
+
+            if unrecoverable {
                 log::info!(
-                    "[msg:{}] Message has <unavailable> child (type: ViewOnce); \
-                     unrecoverable via PDO — skipping request and acking",
+                    "[msg:{}] Message has unrecoverable <unavailable> child (type: {:?}); \
+                     skipping futile PDO placeholder-resend and acking directly",
                     info.id,
+                    unavailable_type,
                 );
             } else {
                 log::info!(
                     "[msg:{}] Message has <unavailable> child (type: {:?}), requesting from phone via PDO",
                     info.id,
-                    unavailable_type
+                    unavailable_type,
                 );
             }
-            // PDO is the only recovery here (no retry receipt), so run it before
-            // the transport ack in one flush task: the ack must not clear the
-            // offline queue before the PDO request goes out. status is acked by
-            // the should_ack gate. Mirrors whatsmeow's request-then-ack.
+
             self.dispatch_undecryptable_event(
                 Arc::clone(&info),
                 true,
@@ -133,11 +138,11 @@ impl Client {
             let info2 = Arc::clone(&info);
             let skip_ack = info.source.chat.is_status_broadcast();
             self.outbound_flush.spawn(&*self.runtime, async move {
-                // View-once has no recoverable content, so skip the PDO entirely
-                // and ack directly. Otherwise PDO is the only recovery: ack only
-                // once the request is out (or skipped as ancient); a transient
-                // send failure leaves it queued for redelivery.
-                let should_ack = if is_view_once {
+                // Unrecoverable fanouts have no content the phone will resend, so
+                // ack directly. Otherwise PDO is the only recovery (no retry
+                // receipt): ack only once the request is out, or skipped as
+                // ancient, so a transient send failure leaves it queued.
+                let should_ack = if unrecoverable {
                     true
                 } else {
                     client.run_pdo_request(&info2).await

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -98,13 +98,11 @@ impl Client {
             // attr) and skip the PDO for them, still dispatching the event and
             // acking. A plain fanout (Unknown) stays recoverable via PDO.
             let is_bot = nr.get_optional_child("bot").is_some();
-            let is_hosted = unavailable
-                .get_attr("hosted")
-                .map(|v| v.as_str())
-                .as_deref()
-                == Some("true");
-            let is_view_once =
-                unavailable.get_attr("type").map(|v| v.as_str()).as_deref() == Some("view_once");
+            // `hosted` is a wire boolean (server sends "true"/"1"), so coerce it
+            // instead of matching one spelling and misclassifying the rest.
+            let is_hosted = unavailable.attrs().optional_bool("hosted");
+            let is_view_once = unavailable.get_attr("type").map(|v| v.as_str()).as_deref()
+                == Some(crate::types::events::UnavailableType::ViewOnce.as_str());
             let unavailable_type = crate::types::events::UnavailableType::from_fanout_flags(
                 is_bot,
                 is_hosted,

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5291,19 +5291,23 @@ async fn view_once_stub_acks_without_pdo() {
 
     // The stanza is acked so the offline queue drains, without gating on a PDO.
     assert!(
-        poll_for_message_ack(&transport).await,
+        poll_for_message_ack(&transport, "VIEW_ONCE_ACK_1").await,
         "view-once stub must emit an <ack class=\"message\"> to drain the offline queue",
     );
 }
 
-/// Polls the captured transport for an `<ack class="message">`, the signal the
-/// stub was cleared from the offline queue. In this harness a PDO can never
-/// complete (no self-session), so the ack appears only when the PDO was
-/// skipped: a regression routing one of these fanouts back through PDO would
-/// leave `should_ack` false and fail the assertion.
-async fn poll_for_message_ack(transport: &crate::transport::mock::CapturingMockTransport) -> bool {
+/// Polls the captured transport for the `<ack class="message">` of `id`, the
+/// signal that stub was cleared from the offline queue. Keyed to the id so an
+/// unrelated ack can't green the test. In this harness a PDO can never complete
+/// (no self-session), so the ack appears only when the PDO was skipped: a
+/// regression routing one of these fanouts back through PDO would leave
+/// `should_ack` false and fail the assertion.
+async fn poll_for_message_ack(
+    transport: &crate::transport::mock::CapturingMockTransport,
+    id: &str,
+) -> bool {
     for _ in 0..80 {
-        if find_message_ack(&transport.sent()).is_some() {
+        if find_message_ack_for(&transport.sent(), id).is_some() {
             return true;
         }
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
@@ -5335,7 +5339,7 @@ async fn bot_unavailable_stub_acks_without_pdo() {
         "bot <unavailable> stub must dispatch a Bot UndecryptableMessage",
     );
     assert!(
-        poll_for_message_ack(&transport).await,
+        poll_for_message_ack(&transport, "BOT_UNAVAIL_1").await,
         "bot stub must ack directly without a PDO round-trip",
     );
 }
@@ -5363,8 +5367,42 @@ async fn hosted_unavailable_stub_acks_without_pdo() {
         "hosted <unavailable> stub must dispatch a Hosted UndecryptableMessage",
     );
     assert!(
-        poll_for_message_ack(&transport).await,
+        poll_for_message_ack(&transport, "HOSTED_UNAVAIL_1").await,
         "hosted stub must ack directly without a PDO round-trip",
+    );
+}
+
+/// `hosted` is a wire boolean, so the numeric spelling `hosted="1"` must
+/// classify as Hosted just like `hosted="true"` and skip the futile PDO.
+#[tokio::test]
+async fn hosted_numeric_bool_unavailable_stub_acks_without_pdo() {
+    use crate::types::events::UnavailableType;
+    let (client, transport) = capturing_client("hosted_num_ack").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.register_handler(recorder.clone());
+
+    let t = wacore::time::now_secs().to_string();
+    let node = node_to_arc(
+        NodeBuilder::new("message")
+            .attr("from", "5511777776666@s.whatsapp.net")
+            .attr("id", "HOSTED_NUM_1")
+            .attr("t", &t)
+            .attr("type", "media")
+            .children(vec![
+                NodeBuilder::new("unavailable").attr("hosted", "1").build(),
+            ])
+            .build(),
+    );
+    client.clone().handle_incoming_message(node).await;
+
+    assert_eq!(
+        recorder.unavailable_count(UnavailableType::Hosted),
+        1,
+        "hosted=\"1\" must classify as Hosted via wire-boolean coercion",
+    );
+    assert!(
+        poll_for_message_ack(&transport, "HOSTED_NUM_1").await,
+        "numeric hosted stub must ack directly without a PDO round-trip",
     );
 }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -4898,12 +4898,10 @@ impl EventRecorder {
             .collect()
     }
 
-    /// Count of `UndecryptableMessage` events marked as the "stub"
-    /// variant (`is_unavailable=true`, `UnavailableType::ViewOnce`) —
-    /// i.e. the branch that routes to PDO instead of falling through to
-    /// decrypt.
-    fn view_once_unavailable_count(&self) -> usize {
-        use crate::types::events::UnavailableType;
+    /// Count of `UndecryptableMessage` stub events (`is_unavailable=true`)
+    /// carrying the given `UnavailableType` — i.e. the `<unavailable>` branch
+    /// rather than a decrypt failure.
+    fn unavailable_count(&self, ty: crate::types::events::UnavailableType) -> usize {
         self.events
             .lock()
             .unwrap()
@@ -4912,31 +4910,58 @@ impl EventRecorder {
                 matches!(
                     &***e,
                     Event::UndecryptableMessage(u)
-                        if u.is_unavailable
-                            && matches!(u.unavailable_type, UnavailableType::ViewOnce)
+                        if u.is_unavailable && u.unavailable_type == ty
                 )
             })
             .count()
     }
+
+    fn view_once_unavailable_count(&self) -> usize {
+        self.unavailable_count(crate::types::events::UnavailableType::ViewOnce)
+    }
 }
 
-fn build_unavailable_stanza(sender: &str, msg_id: &str, with_enc: bool) -> Arc<OwnedNodeRef> {
+/// The three unrecoverable `<unavailable>` fanout flavours WA Web signals
+/// distinctly, plus a plain (recoverable) fanout.
+#[derive(Clone, Copy)]
+enum UnavailableKind {
+    ViewOnce,
+    Hosted,
+    Bot,
+    Plain,
+}
+
+fn build_unavailable_kind_stanza(
+    sender: &str,
+    msg_id: &str,
+    kind: UnavailableKind,
+    with_enc: bool,
+) -> Arc<OwnedNodeRef> {
     let t = wacore::time::now_secs().to_string();
-    let unavailable = NodeBuilder::new("unavailable")
-        .attr("type", "view_once")
-        .build();
-    let children = if with_enc {
-        vec![
-            unavailable,
+    let unavailable = match kind {
+        UnavailableKind::ViewOnce => NodeBuilder::new("unavailable")
+            .attr("type", "view_once")
+            .build(),
+        UnavailableKind::Hosted => NodeBuilder::new("unavailable")
+            .attr("hosted", "true")
+            .build(),
+        UnavailableKind::Bot | UnavailableKind::Plain => NodeBuilder::new("unavailable").build(),
+    };
+    let mut children = Vec::new();
+    // Bot fanouts are marked by a sibling <bot> child, not by an <unavailable> attr.
+    if matches!(kind, UnavailableKind::Bot) {
+        children.push(NodeBuilder::new("bot").build());
+    }
+    children.push(unavailable);
+    if with_enc {
+        children.push(
             NodeBuilder::new("enc")
                 .attr("type", "msg")
                 .attr("v", "2")
                 .bytes(vec![0xDE, 0xAD, 0xBE, 0xEF])
                 .build(),
-        ]
-    } else {
-        vec![unavailable]
-    };
+        );
+    }
     node_to_arc(
         NodeBuilder::new("message")
             .attr("from", sender)
@@ -4946,6 +4971,10 @@ fn build_unavailable_stanza(sender: &str, msg_id: &str, with_enc: bool) -> Arc<O
             .children(children)
             .build(),
     )
+}
+
+fn build_unavailable_stanza(sender: &str, msg_id: &str, with_enc: bool) -> Arc<OwnedNodeRef> {
+    build_unavailable_kind_stanza(sender, msg_id, UnavailableKind::ViewOnce, with_enc)
 }
 
 /// Locks the dispatch ordering: consumers must see the event before any
@@ -5261,17 +5290,106 @@ async fn view_once_stub_acks_without_pdo() {
     );
 
     // The stanza is acked so the offline queue drains, without gating on a PDO.
-    let mut acked = false;
+    assert!(
+        poll_for_message_ack(&transport).await,
+        "view-once stub must emit an <ack class=\"message\"> to drain the offline queue",
+    );
+}
+
+/// Polls the captured transport for an `<ack class="message">`, the signal the
+/// stub was cleared from the offline queue. In this harness a PDO can never
+/// complete (no self-session), so the ack appears only when the PDO was
+/// skipped: a regression routing one of these fanouts back through PDO would
+/// leave `should_ack` false and fail the assertion.
+async fn poll_for_message_ack(transport: &crate::transport::mock::CapturingMockTransport) -> bool {
     for _ in 0..80 {
         if find_message_ack(&transport.sent()).is_some() {
-            acked = true;
-            break;
+            return true;
         }
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
+    false
+}
+
+/// Bot fanouts (a sibling `<bot>` child) are one of the three subtypes WA Web
+/// never placeholder-resends, so the bare stub must ack directly instead of
+/// gating on a futile PDO.
+#[tokio::test]
+async fn bot_unavailable_stub_acks_without_pdo() {
+    use crate::types::events::UnavailableType;
+    let (client, transport) = capturing_client("bot_unavail_ack").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.register_handler(recorder.clone());
+
+    let node = build_unavailable_kind_stanza(
+        "5511777776666@s.whatsapp.net",
+        "BOT_UNAVAIL_1",
+        UnavailableKind::Bot,
+        false,
+    );
+    client.clone().handle_incoming_message(node).await;
+
+    assert_eq!(
+        recorder.unavailable_count(UnavailableType::Bot),
+        1,
+        "bot <unavailable> stub must dispatch a Bot UndecryptableMessage",
+    );
     assert!(
-        acked,
-        "view-once stub must emit an <ack class=\"message\"> to drain the offline queue",
+        poll_for_message_ack(&transport).await,
+        "bot stub must ack directly without a PDO round-trip",
+    );
+}
+
+/// Hosted fanouts (`<unavailable hosted="true">`) are likewise excluded from
+/// placeholder-resend, so the bare stub acks directly.
+#[tokio::test]
+async fn hosted_unavailable_stub_acks_without_pdo() {
+    use crate::types::events::UnavailableType;
+    let (client, transport) = capturing_client("hosted_unavail_ack").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.register_handler(recorder.clone());
+
+    let node = build_unavailable_kind_stanza(
+        "5511777776666@s.whatsapp.net",
+        "HOSTED_UNAVAIL_1",
+        UnavailableKind::Hosted,
+        false,
+    );
+    client.clone().handle_incoming_message(node).await;
+
+    assert_eq!(
+        recorder.unavailable_count(UnavailableType::Hosted),
+        1,
+        "hosted <unavailable> stub must dispatch a Hosted UndecryptableMessage",
+    );
+    assert!(
+        poll_for_message_ack(&transport).await,
+        "hosted stub must ack directly without a PDO round-trip",
+    );
+}
+
+/// A plain `<unavailable>` fanout (no bot/hosted/view-once marker) stays
+/// recoverable, so it must classify as `Unknown` and keep the PDO path rather
+/// than being short-circuited like the three unrecoverable subtypes.
+#[tokio::test]
+async fn plain_unavailable_stub_classifies_as_unknown() {
+    use crate::types::events::UnavailableType;
+    let (client, _transport) = capturing_client("plain_unavail").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.register_handler(recorder.clone());
+
+    let node = build_unavailable_kind_stanza(
+        "5511777776666@s.whatsapp.net",
+        "PLAIN_UNAVAIL_1",
+        UnavailableKind::Plain,
+        false,
+    );
+    client.clone().handle_incoming_message(node).await;
+
+    assert_eq!(
+        recorder.unavailable_count(UnavailableType::Unknown),
+        1,
+        "plain <unavailable> fanout must classify as Unknown (recoverable via PDO)",
     );
 }
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -976,13 +976,43 @@ pub enum DecryptFailMode {
     Hide,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum UnavailableType {
     #[wire_default]
     #[wire = "unknown"]
     Unknown,
     #[wire = "view_once"]
     ViewOnce,
+    #[wire = "hosted"]
+    Hosted,
+    #[wire = "bot"]
+    Bot,
+}
+
+impl UnavailableType {
+    /// Classify an `<unavailable>` fanout the way WA Web picks its
+    /// placeholderType, honouring the same precedence (bot > hosted >
+    /// view_once). Anything else is a plain fanout (`Unknown`).
+    pub fn from_fanout_flags(is_bot: bool, is_hosted: bool, is_view_once: bool) -> Self {
+        if is_bot {
+            Self::Bot
+        } else if is_hosted {
+            Self::Hosted
+        } else if is_view_once {
+            Self::ViewOnce
+        } else {
+            Self::Unknown
+        }
+    }
+
+    /// Bot, hosted and view-once fanouts are the three subtypes
+    /// `WAWebNonMessageDataRequestPlaceholderMessageResendUtils` excludes from
+    /// placeholder-resend: the phone won't share that content with a companion,
+    /// so a resend to our own device only returns empty. A plain fanout
+    /// (`Unknown`) stays recoverable.
+    pub fn is_unrecoverable_fanout(&self) -> bool {
+        matches!(self, Self::ViewOnce | Self::Hosted | Self::Bot)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1263,6 +1293,37 @@ mod tests {
     use super::*;
     use prost::Message;
     use waproto::whatsapp as wa;
+
+    #[test]
+    fn unavailable_fanout_flags_follow_wa_web_precedence() {
+        use UnavailableType::*;
+        // bot wins over hosted and view_once
+        assert_eq!(UnavailableType::from_fanout_flags(true, true, true), Bot);
+        assert_eq!(UnavailableType::from_fanout_flags(true, false, false), Bot);
+        // hosted wins over view_once
+        assert_eq!(
+            UnavailableType::from_fanout_flags(false, true, true),
+            Hosted
+        );
+        assert_eq!(
+            UnavailableType::from_fanout_flags(false, false, true),
+            ViewOnce
+        );
+        // nothing set is a plain fanout
+        assert_eq!(
+            UnavailableType::from_fanout_flags(false, false, false),
+            Unknown
+        );
+    }
+
+    #[test]
+    fn only_plain_fanout_is_recoverable() {
+        use UnavailableType::*;
+        assert!(Bot.is_unrecoverable_fanout());
+        assert!(Hosted.is_unrecoverable_fanout());
+        assert!(ViewOnce.is_unrecoverable_fanout());
+        assert!(!Unknown.is_unrecoverable_fanout());
+    }
 
     /// Build a HistorySync proto with conversations, returning its
     /// zlib-compressed wire form plus the exact decompressed size.


### PR DESCRIPTION
Follow-up to #934. That PR stopped the futile PDO placeholder-resend for view-once `<unavailable>` stubs. It turns out WA Web excludes three subtypes from placeholder-resend, not one.

In `WAWebNonMessageDataRequestPlaceholderMessageResendUtils` (`handlePlaceholderMsgsSeen`), the resend candidates are filtered to skip `bot_unavailable_fanout`, `hosted_unavailable_fanout` and `view_once_unavailable_fanout`. We were only short-circuiting view-once, so bot and hosted stubs still fell into the `Unknown` branch, fired an empty PDO round-trip to our own phone, and surfaced the same spurious "Finished syncing with WhatsApp on <device>" notification for each one.

This extends the skip to all three, detected the way WA Web's parser does:

- bot: the message carries a sibling `<bot>` child (`msgBotInfo`)
- hosted: `<unavailable hosted="true">`
- view-once: `<unavailable type="view_once">`

A plain fanout (none of the three) stays `Unknown` and keeps the PDO path, since that content is genuinely recoverable from the phone. Production backs this up: of the view-once/bot/hosted stubs only the plain fanouts ever come back with content, the other three are always empty.

### Changes

- `UnavailableType` gains `Hosted` and `Bot` variants, a `from_fanout_flags` classifier that honours WA Web's precedence (bot > hosted > view-once), and an `is_unrecoverable_fanout` policy method. Both are pure and unit-tested in wacore.
- `receive.rs` computes the three flags from the node and skips the PDO for any unrecoverable fanout, still dispatching the `UndecryptableMessage` event and acking directly so the offline queue drains.

### Tests

- wacore unit tests lock the classification precedence and exactly which subtypes skip the resend.
- Integration tests for the bot, hosted and plain paths. The ack-present assertion is meaningful here: the mock transport has no self-session, so a PDO can never complete, which means the ack only appears when the PDO was skipped. A regression routing one of these back through PDO would leave `should_ack` false and fail the test.
- Also addresses the review note on #934 about the view-once test not proving the skip: it now shares the same ack helper, and the wacore policy tests pin the contract directly.

### Validation

- `cargo test -p wacore --lib` (1011) and `cargo test -p whatsapp-rust --lib` (844) green.
- `cargo clippy -p whatsapp-rust -p wacore --all-targets -- -D warnings` clean.
- `cargo fmt --all --check` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

