### PR TITLE
perf(send): single-flight cold group sender-key distribution

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -201,6 +201,11 @@ pub struct CacheConfig {
     pub session_locks_capacity: u64,
     /// Per-chat lane capacity (combined lock + queue). Default: 5000.
     pub chat_lanes_capacity: u64,
+    /// Per-group cold sender-key distribution lock capacity. Default: 512
+    /// (far above any realistic number of groups distributing at once; an
+    /// evicted live lock only lets one extra send repeat that group's
+    /// fan-out, the ratchet stays correct under the chain lock).
+    pub group_distribution_locks_capacity: u64,
     /// Per-chat resend rate-limiter capacity: one token-bucket entry per group
     /// recently driving retry resends. Keep above the count of concurrently
     /// storming groups: eviction is FIFO and fail-open (an evicted bucket is
@@ -280,6 +285,10 @@ impl std::fmt::Debug for CacheConfig {
             .field("session_locks_capacity", &self.session_locks_capacity)
             .field("chat_lanes_capacity", &self.chat_lanes_capacity)
             .field(
+                "group_distribution_locks_capacity",
+                &self.group_distribution_locks_capacity,
+            )
+            .field(
                 "resend_rate_limiter_capacity",
                 &self.resend_rate_limiter_capacity,
             )
@@ -339,6 +348,7 @@ impl Default for CacheConfig {
             // breaking serialization. Size generously to avoid eviction pressure.
             session_locks_capacity: 10_000,
             chat_lanes_capacity: 5_000,
+            group_distribution_locks_capacity: 512,
             resend_rate_limiter_capacity: 4_096,
             sent_message_ttl_secs: 7200,
             // Bounded by default: seed only the still-relevant slice of history

--- a/src/client.rs
+++ b/src/client.rs
@@ -619,6 +619,12 @@ pub struct Client {
     pub(crate) group_devices_memo:
         Cache<Jid, Arc<crate::client::device_registry::GroupDevicesMemo>>,
 
+    /// Single-flight for cold SKDM distribution, keyed per group. Concurrent
+    /// cold sends each re-ran the full per-member fan-out before any of them
+    /// marked the devices warm; the loser now waits here and re-resolves,
+    /// finding everything warm. Warm sends never touch it.
+    pub(crate) group_distribution_locks: Cache<Jid, Arc<async_lock::Mutex<()>>>,
+
     /// Last `(devices, sender-key-device map)` Arc pair with an empty `needs_skdm`,
     /// so a warm repeat send skips `filter_skdm_targets`. `Weak` keeps the pointer
     /// comparison ABA-safe, matching `GroupDevicesMemo`.

--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -45,6 +45,18 @@ impl Client {
             .await
     }
 
+    /// Acquire the per-group cold-distribution single-flight guard.
+    pub(crate) async fn group_distribution_lock(
+        &self,
+        group: &Jid,
+    ) -> async_lock::MutexGuardArc<()> {
+        self.group_distribution_locks
+            .get_with_by_ref(group, async { Arc::new(async_lock::Mutex::new(())) })
+            .await
+            .lock_arc()
+            .await
+    }
+
     /// Get the active noise socket, or error if not connected.
     pub(crate) async fn get_noise_socket(
         &self,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -245,6 +245,13 @@ impl Client {
             group_devices_memo: Cache::builder()
                 .max_capacity(GROUP_DEVICES_MEMO_CAPACITY)
                 .build(),
+            // Evicting a lock whose guard is still held only lets one extra
+            // send re-run that group's fan-out (the pre-single-flight
+            // behavior); the sender-key chain lock still guarantees ratchet
+            // correctness.
+            group_distribution_locks: Cache::builder()
+                .max_capacity(cache_config.group_distribution_locks_capacity.max(1))
+                .build(),
             skdm_warm_memo: Cache::builder()
                 .max_capacity(GROUP_DEVICES_MEMO_CAPACITY)
                 .build(),

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1310,6 +1310,11 @@ impl Client {
             stale_users: Vec<String>,
         }
         let mut skdm_update: Option<SkdmUpdate> = None;
+        // Single-flight for cold group sends: held from SKDM target resolution
+        // through `update_sender_key_devices` (bottom of this function) so a
+        // concurrent cold send re-resolves against the winner's warm marking
+        // instead of redoing the full per-member fan-out. None on warm sends.
+        let mut distribution_guard: Option<async_lock::MutexGuardArc<()>> = None;
         let mut should_issue_tc_token_after_send = false;
         let mut used_cached_tc_token_key: Option<String> = None;
         let tc_issue_target = to.clone();
@@ -1374,21 +1379,24 @@ impl Client {
             // participant list and expect self to be present.
             let group_info = ensure_self_in_group(group_info, &own_sending_jid);
 
-            let force_skdm = {
-                use wacore::libsignal::store::sender_key_name::SenderKeyName;
-                let sender_address = own_sending_jid.to_protocol_address();
-                let sender_key_name = SenderKeyName::from_parts(&to_str, sender_address.as_str());
-
+            // Side-effect-free cold check: does the sender key record exist,
+            // and has its chain advanced past the rotation threshold? Reads
+            // the record without deleting anything, so a false positive (a
+            // concurrent send already rotating/recreating) costs only the
+            // re-check under the lock below.
+            use wacore::libsignal::store::sender_key_name::SenderKeyName;
+            let sender_address = own_sending_jid.to_protocol_address();
+            let sender_key_name = SenderKeyName::from_parts(&to_str, sender_address.as_str());
+            // WA Web posts SenderKeyExpired with `PERIODIC_ROTATION` after
+            // a chain advances past a threshold. Captured-js doesn't show
+            // the value; 1000 mirrors common Signal hygiene defaults.
+            const SENDER_KEY_ROTATION_THRESHOLD: u32 = 1000;
+            let read_sender_key_state = || async {
                 let record = self
                     .signal_cache
                     .get_sender_key(&sender_key_name, &*device_snapshot.backend)
                     .await?;
                 let key_exists = record.is_some();
-
-                // WA Web posts SenderKeyExpired with `PERIODIC_ROTATION` after
-                // a chain advances past a threshold. Captured-js doesn't show
-                // the value; 1000 mirrors common Signal hygiene defaults.
-                const SENDER_KEY_ROTATION_THRESHOLD: u32 = 1000;
                 // Read the chain iteration through the shared `Arc` without cloning
                 // the record: borrow the current state instead of `*_mut().cloned()`.
                 let needs_rotation = record
@@ -1397,10 +1405,23 @@ impl Client {
                     .and_then(|state| state.sender_chain_key())
                     .map(|ck| ck.iteration())
                     .is_some_and(|iter| iter >= SENDER_KEY_ROTATION_THRESHOLD);
+                Ok::<(bool, bool), anyhow::Error>((key_exists, needs_rotation))
+            };
 
+            let (key_exists, needs_rotation) = read_sender_key_state().await?;
+            let mut force_skdm = force_key_distribution || !key_exists || needs_rotation;
+            if force_skdm {
+                // Serialize the whole rotation/redistribution under the
+                // per-group guard and RE-CHECK once inside it: a send that
+                // merely raced the winner's delete->recreate window sees the
+                // fresh record here and downgrades to a warm send instead of
+                // redistributing to every member again.
+                distribution_guard = Some(self.group_distribution_lock(&to).await);
+                let (key_exists, needs_rotation) = read_sender_key_state().await?;
+                force_skdm = force_key_distribution || !key_exists || needs_rotation;
                 if needs_rotation {
                     log::info!(
-                        "Periodic sender-key rotation for {} (chain iteration ≥ {SENDER_KEY_ROTATION_THRESHOLD})",
+                        "Periodic sender-key rotation for {} (chain iteration >= {SENDER_KEY_ROTATION_THRESHOLD})",
                         to.observe()
                     );
                     self.signal_cache
@@ -1415,9 +1436,10 @@ impl Client {
                     }
                     self.sender_key_device_cache.invalidate(&to_str).await;
                 }
-
-                force_key_distribution || !key_exists || needs_rotation
-            };
+                if !force_skdm {
+                    distribution_guard = None;
+                }
+            }
 
             let mut store_adapter = self.signal_adapter_from(device_store_arc.clone());
 
@@ -1445,7 +1467,42 @@ impl Client {
                     )
                     .await
                 {
-                    Some((all, needs)) => (Some(all), Some(needs)),
+                    Some((all, needs)) if needs.is_empty() => (Some(all), Some(needs)),
+                    Some((first_all, first_needs)) => {
+                        // Cold: wait for any in-flight distribution, then
+                        // re-resolve. The loser usually finds every device
+                        // already marked warm by the winner and downgrades to a
+                        // plain skmsg send; if the winner failed, the targets
+                        // are still cold and this send distributes normally.
+                        distribution_guard = Some(self.group_distribution_lock(&to).await);
+                        // Force a DB re-read: a concurrent warm send may have
+                        // started the cache init before the winner's marking
+                        // landed and then published that stale (empty) map,
+                        // which would otherwise turn this into a full
+                        // re-distribution to every member.
+                        self.sender_key_device_cache.invalidate(&to_str).await;
+                        match self
+                            .resolve_skdm_targets_memoized(
+                                &to,
+                                &to_str,
+                                &group_info_for_memo,
+                                &own_sending_jid,
+                            )
+                            .await
+                        {
+                            Some((all, needs)) => {
+                                if needs.is_empty() {
+                                    distribution_guard = None;
+                                }
+                                (Some(all), Some(needs))
+                            }
+                            // Transient re-resolve failure: keep the first
+                            // resolve's targets rather than silently sending
+                            // without the distribution it already knew was
+                            // needed.
+                            None => (Some(first_all), Some(first_needs)),
+                        }
+                    }
                     None => (None, None),
                 }
             };
@@ -1488,14 +1545,44 @@ impl Client {
                             to.observe()
                         );
 
-                        if let Err(e) = self
-                            .persistence_manager
-                            .clear_sender_key_devices(&to_str)
-                            .await
-                        {
-                            log::warn!("Failed to clear SKDM recipients: {:?}", e);
+                        // This retry redistributes, so it needs the same
+                        // single-flight guard as a cold send (a warm send that
+                        // lost its sender key arrives here without one).
+                        if distribution_guard.is_none() {
+                            distribution_guard = Some(self.group_distribution_lock(&to).await);
                         }
-                        self.sender_key_device_cache.invalidate(&to_str).await;
+
+                        // Re-check under the guard: a concurrent retry may have
+                        // already recreated the key and marked the devices, in
+                        // which case this send retries warm instead of clearing
+                        // the tracking and redistributing to every member again.
+                        let (key_recreated, _) = read_sender_key_state().await?;
+                        let warm_targets = if key_recreated {
+                            self.sender_key_device_cache.invalidate(&to_str).await;
+                            self.resolve_skdm_targets_memoized(
+                                &to,
+                                &to_str,
+                                &group_info_for_memo,
+                                &own_sending_jid,
+                            )
+                            .await
+                        } else {
+                            None
+                        };
+                        let (retry_force, retry_targets, retry_all) = match warm_targets {
+                            Some((all, needs)) => (false, Some(needs), Some(all)),
+                            None => {
+                                if let Err(e) = self
+                                    .persistence_manager
+                                    .clear_sender_key_devices(&to_str)
+                                    .await
+                                {
+                                    log::warn!("Failed to clear SKDM recipients: {:?}", e);
+                                }
+                                self.sender_key_device_cache.invalidate(&to_str).await;
+                                (true, None, None)
+                            }
+                        };
 
                         let mut store_adapter_retry =
                             self.signal_adapter_from(device_store_arc.clone());
@@ -1512,9 +1599,9 @@ impl Client {
                             to,
                             message,
                             request_id,
-                            true,
-                            None,
-                            None,
+                            retry_force,
+                            retry_targets,
+                            retry_all,
                             edit.clone(),
                             &extra_stanza_nodes,
                         )
@@ -1791,6 +1878,8 @@ impl Client {
                 self.invalidate_device_cache(user).await;
             }
         }
+        // Warm marking is visible; a waiting cold send may now re-resolve.
+        drop(distribution_guard);
 
         // Flush cached Signal state to DB after encryption
         self.flush_signal_cache_logged("send_message_impl", None)


### PR DESCRIPTION
Found by re-profiling the group send path after #936: a 10k-message flood to an 802-member LID group produced 44 full SKDM fan-outs where 13 sufficed.

## Root cause

The periodic sender-key rotation (chain iteration >= 1000) deletes and recreates the key record with no serialization, and the cold check (`force_skdm`) both performs that delete inline and never re-checks. Under concurrent sends, every message that hits the delete->recreate window observes `key_exists=false` and redistributes the sender key to the entire member list (~3-4 redundant full fan-outs per rotation), each paying the per-member pkmsg encrypt plus session writes.

## Fix

A per-group distribution lock (`group_distribution_locks`), held from the cold check through the post-send warm marking:

- The force check reads the record with no side effects; a send that decides to distribute acquires the guard and **re-checks inside it**. One that merely raced the winner's delete->recreate window sees the fresh record and downgrades to a plain warm skmsg send.
- The periodic-rotation delete now happens inside the guard, so the window is never observable by other senders.
- A cold send that lost the resolve race also invalidates the sender-key-device cache before re-resolving, so a stale snapshot published by a concurrent warm send's cache init cannot masquerade as an all-cold map.
- The `NoSenderKeyState` retry path acquires the same guard before redistributing.

Warm sends never touch the lock. Lock ordering is distribution -> chain (inside `prepare_group_stanza`); no path acquires them in reverse.

## Measured (group-send bench: 802-member LID group, 10k messages)

- Full fan-outs: 44 -> 13 (the remaining ones are the legitimate periodic rotations plus the initial distribution)
- Client CPU: 6.6s -> 3.8s
- Peak RSS: 41 MB -> 36.6 MB
- Pong latency: ~25ms -> ~23ms
- 9999/10000 pongs delivered, 0 sender-key failures on the receiving end

`cargo clippy --all-targets` clean, 862 lib tests green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

