### PR TITLE
perf(send): keep send_message's future pointer-sized

### DIFF
--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -628,7 +628,12 @@ impl Client {
 
         let extra_nodes =
             build_extra_stanza_nodes(&to, inferred_meta, biz, options.extra_stanza_nodes);
-        self.send_message_impl(
+        // send_message_impl's state machine is ~13 KB (the whole send path in
+        // one async fn). Boxing keeps `send_message`'s future pointer-sized, so
+        // callers embedding it in their own futures (event handlers, spawned
+        // tasks) don't inherit those 13 KB per instance; the box is allocated
+        // only when a send actually runs.
+        Box::pin(self.send_message_impl(
             to,
             &message,
             Some(request_id),
@@ -637,7 +642,7 @@ impl Client {
             edit,
             extra_nodes,
             stanza_type_override,
-        )
+        ))
         .await
         .map_err(SendError::from_anyhow)?;
         Ok(result)


### PR DESCRIPTION
Found by chasing the largest remaining allocator in the group-send bench profile: ~284 MB / run of handler-dispatch churn, at 14.4 KB per dispatched event.

## Root cause

`send_message_impl` compiles to a ~13 KB state machine (the entire send path lives in one async fn). Rust async composition embeds awaited futures inline, so every caller that embeds `send_message` inside its own future inherits those 13 KB per instance. The typical bot shape makes this quadratic-feeling in practice: an event handler that matches on the event and *may* reply pays the full 14.4 KB boxed future for **every** dispatched event (receipts, acks, QR events), because the box is sized for the union of all match arms, send path included. Measured with `size_of_val`: the handler's future was 14.4 KB, of which the embedded `send_message` future was 13.2 KB.

## Fix

Box `send_message_impl` at its call site inside `send_message_with_options_inner`. The public `send_message` future shrinks 13.2 KB -> 4.7 KB (remaining locals: the `wa::Message` by value plus the newsletter branch), and the 13 KB body is heap-allocated only when a send actually executes, not wherever the future is merely composed.

## Measured (group-send bench: 802-member LID group, 10k messages, ~20k dispatched events)

- Handler-dispatch allocation churn: 284 MB -> 140 MB
- dhat allocation peak: 60 MB -> 23 MB; total allocation: 966 MB -> 574 MB (run also carries #937)
- Behavior unchanged: 10000/10000 pongs, 0 sender-key failures, rate/latency flat

`cargo clippy --all-targets` clean, send test suite green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

