### PR TITLE
feat(client): opt-in force_pn_addressing to keep outbound DMs on PN JIDs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -503,6 +503,14 @@ pub struct Client {
     /// or processed. Set via `BotBuilder::skip_history_sync()`.
     pub(crate) skip_history_sync: AtomicBool,
 
+    /// When true, outbound DM addressing (device fanout, session creation,
+    /// stanza prep and session locks) keeps the PN namespace instead of
+    /// upgrading to LID. Inbound decrypt addressing is not affected. Escape
+    /// hatch for companion registrations whose LID-addressed DMs are accepted
+    /// by the server but never delivered (no Delivered receipt); PN
+    /// addressing matches pre-0.6 behavior.
+    pub(crate) force_pn_addressing: AtomicBool,
+
     /// Cache configuration for TTL and capacity of all caches.
     /// Stored for use by lazily-initialized caches (group_cache).
     pub(crate) cache_config: CacheConfig,
@@ -626,6 +634,18 @@ impl Client {
     /// notifications but will not download or process the data.
     pub fn set_skip_history_sync(&self, enabled: bool) {
         self.skip_history_sync.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Keep DM addressing on phone-number JIDs even when a LID mapping is
+    /// known. Some companion registrations observe LID-addressed DMs being
+    /// accepted but never delivered; this restores pre-0.6 PN addressing.
+    pub fn set_force_pn_addressing(&self, enabled: bool) {
+        self.force_pn_addressing.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if DM addressing is pinned to phone-number JIDs.
+    pub fn force_pn_addressing_enabled(&self) -> bool {
+        self.force_pn_addressing.load(Ordering::Relaxed)
     }
 
     /// Override `DeviceProps` fields before the initial pairing. Only fields
@@ -841,6 +861,7 @@ impl Client {
             http_client,
             override_version,
             skip_history_sync: AtomicBool::new(false),
+            force_pn_addressing: AtomicBool::new(false),
             cache_config,
             self_weak: std::sync::OnceLock::new(),
             saver_handle: std::sync::OnceLock::new(),

--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -46,6 +46,11 @@ impl SendContextResolver for Client {
     }
 
     async fn get_lid_for_phone(&self, phone_user: &str) -> Option<String> {
+        // Reporting no mapping keeps stanza prep (participants, enc nodes) on
+        // the PN namespace (see Client::set_force_pn_addressing).
+        if self.force_pn_addressing_enabled() {
+            return None;
+        }
         self.lid_pn_cache.get_current_lid(phone_user).await
     }
 }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -267,6 +267,12 @@ impl Client {
     /// This checks the local cache for existing mappings. For JIDs without cached mappings,
     /// the caller should consider fetching them via usync query if establishing sessions.
     pub(crate) async fn resolve_lid_mappings(&self, jids: &[Jid]) -> Vec<Jid> {
+        // Outbound sessions must stay on the PN namespace when PN addressing
+        // is forced, or encryption would look up sessions the fanout never
+        // created (see Client::set_force_pn_addressing).
+        if self.force_pn_addressing_enabled() {
+            return jids.to_vec();
+        }
         let mut resolved = Vec::with_capacity(jids.len());
 
         for jid in jids {
@@ -511,6 +517,45 @@ mod tests {
 
         assert_eq!(resolved.user, lid);
         assert_eq!(resolved.server, Server::Lid);
+    }
+
+    #[tokio::test]
+    async fn test_force_pn_addressing_scopes_to_outbound_paths() {
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "55999999999";
+        let lid = "100000012345678";
+
+        client
+            .add_lid_pn_mapping(lid, pn, LearningSource::PeerPnMessage)
+            .await
+            .unwrap();
+        client.set_force_pn_addressing(true);
+
+        let pn_jid = Jid::pn(pn);
+
+        // Outbound fanout/session paths keep the PN namespace as given.
+        let mapped = client
+            .resolve_lid_mappings(std::slice::from_ref(&pn_jid))
+            .await;
+        assert_eq!(mapped, vec![pn_jid.clone()]);
+        let locks = client
+            .build_session_lock_keys(std::slice::from_ref(&pn_jid))
+            .await;
+        assert_eq!(locks, vec![pn_jid.clone()]);
+
+        // Inbound decrypt addressing is NOT gated: the upgrade still applies
+        // so sessions migrated to LID keep resolving.
+        let resolved = client.resolve_encryption_jid(&pn_jid).await;
+        assert_eq!(resolved.user, lid);
+        assert_eq!(resolved.server, Server::Lid);
+
+        // Turning the flag off restores stock outbound behavior.
+        client.set_force_pn_addressing(false);
+        let mapped = client
+            .resolve_lid_mappings(std::slice::from_ref(&pn_jid))
+            .await;
+        assert_eq!(mapped[0].user, lid);
+        assert_eq!(mapped[0].server, Server::Lid);
     }
 
     #[tokio::test]

--- a/src/send.rs
+++ b/src/send.rs
@@ -1170,7 +1170,13 @@ impl Client {
             // DM fanout: all known recipient devices + own companions.
             // WAWebSendUserMsgJob reads local device table only on the send
             // path; WAWebDBDeviceListFanout excludes hosted devices.
-            let recipient_bare = self.resolve_encryption_jid(&to).await.to_non_ad();
+            // With PN addressing forced the fanout keys stay on the namespace
+            // the caller gave us (see Client::set_force_pn_addressing).
+            let recipient_bare = if self.force_pn_addressing_enabled() {
+                to.to_non_ad()
+            } else {
+                self.resolve_encryption_jid(&to).await.to_non_ad()
+            };
 
             // Local registry first; network warm only on miss to avoid
             // unnecessary LID-migration side effects from get_user_devices
@@ -1664,7 +1670,13 @@ impl Client {
     pub(crate) async fn build_session_lock_keys(&self, device_jids: &[Jid]) -> Vec<Jid> {
         let mut keys: Vec<Jid> = Vec::with_capacity(device_jids.len());
         for jid in device_jids {
-            keys.push(self.resolve_encryption_jid(jid).await);
+            // Locks must key the same namespace encryption will use; with PN
+            // addressing forced that is the JID as given.
+            if self.force_pn_addressing_enabled() {
+                keys.push(jid.clone());
+            } else {
+                keys.push(self.resolve_encryption_jid(jid).await);
+            }
         }
         keys.sort_unstable_by(wacore::types::jid::cmp_for_lock_order);
         keys.dedup_by(|a, b| wacore::types::jid::cmp_for_lock_order(a, b).is_eq());


### PR DESCRIPTION
## Summary

Adds an opt-in `Client::set_force_pn_addressing(true)` that keeps outbound DM addressing on the namespace the caller provided instead of upgrading PN → LID. The flag is scoped to the four addressing decisions the outbound path makes — recipient fanout keys (`send_message_impl`), session creation (`resolve_lid_mappings` via `ensure_e2e_sessions`), stanza prep (`SendContextResolver::get_lid_for_phone`) and session lock keys (`build_session_lock_keys`, kept aligned with the namespace encryption actually uses so the per-session lock invariant against concurrent inbound decrypt holds) — while inbound decrypt addressing (`resolve_encryption_jid` on sender JIDs), LID↔PN mapping learning, and inbound session migration stay untouched. Mirrors the existing `skip_history_sync` runtime flag pattern.

## Motivation

On at least one companion registration (personal account, client linked as a companion device), DMs sent with LID addressing are accepted by the server but never delivered: no `Delivered` receipt ever arrives and the recipient never sees the message. The same message sent with pre-0.6 PN addressing is delivered within ~2 seconds (verified side by side against 0.5.0).

With 0.6's unified addressing there is currently no way to work around this from the caller side:

- passing a PN JID to `send_message` doesn't help, because the DM path re-upgrades it internally as soon as the LID mapping is in the cache, and
- the first DM to an unmapped PN triggers the usync LID query that learns and persists the mapping — so the *first* message to a fresh PN is delivered and every subsequent one is silently dropped, which made the failure mode quite confusing to diagnose.

Timeline observed live (numbers redacted):

1. fresh client start → `send_message(pn_jid)` → delivered ✔
2. inbound message arrives from that user (mapping learned/warmed)
3. `send_message(pn_jid)` → accepted by server, never delivered, no receipt ✘
4. same on every retry; rolling back to 0.5.0 (PN addressing) restores delivery immediately, receipts arrive in ~2s again ✔

I don't know how widespread this server behavior is (possibly related to account type or registration age), so an opt-in escape hatch seemed like the minimal-surface fix rather than changing default behavior. Happy to rework into a `BotBuilder` option or config field if you prefer.

## Why the flag gates four call sites instead of just `resolve_encryption_jid`

A first iteration gated only `resolve_encryption_jid`. That turned out to be both insufficient — `prepare_dm_stanza`/`encrypt_for_devices` upgrade PN → LID through a separate path (`SendContextResolver::get_lid_for_phone`), so participants and enc nodes still went out LID-addressed — and unsafe: session lock keys would have diverged from the namespace encryption actually used, breaking the documented per-session lock invariant (concurrent outbound encrypt and inbound decrypt of the same peer would no longer serialize on the same mutex). The final shape keeps every outbound addressing decision consistent on PN while leaving the inbound half of the pipeline stock.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` (0 warnings), `cargo test --workspace --exclude e2e-tests` (all suites green) — same commands as the `Rust CI` workflow.
- New unit test `test_force_pn_addressing_scopes_to_outbound_paths` asserting the outbound paths keep PN with the flag on, that inbound `resolve_encryption_jid` is deliberately NOT gated, and that turning the flag off restores stock behavior.
- Live validation on the affected deployment: with the flag, repeated DMs (warm mapping cache — the previously failing condition) all produced `Delivered` receipts within ~2s, including full inbound → reply round-trips; without it, silent drops as described above.

Default behavior is unchanged — the flag is off unless a caller opts in.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

