### PR TITLE
feat(client): opt-in force_pn_addressing to keep outbound DMs on PN JIDs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -652,6 +652,13 @@ pub struct Client {
     /// or processed. Set via `BotBuilder::skip_history_sync()`.
     pub(crate) skip_history_sync: AtomicBool,
 
+    /// When true, outbound DM addressing (device fanout, session creation,
+    /// stanza prep and session locks) keeps the PN namespace instead of
+    /// upgrading to LID. Inbound decrypt addressing is not affected. Escape
+    /// hatch for companion registrations whose LID-addressed DMs are 400-nacked
+    /// by the server (see issue #941); PN addressing matches pre-0.6 behavior.
+    pub(crate) force_pn_addressing: AtomicBool,
+
     /// Number of one-time pre-keys generated per upload batch. Defaults to
     /// [`crate::prekeys::DEFAULT_WANTED_PRE_KEY_COUNT`]; set via
     /// [`BotBuilder::with_wanted_pre_key_count`] or [`Client::set_wanted_pre_key_count`].

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -48,6 +48,11 @@ impl Client {
     /// mapping is known. Some companion registrations get LID-addressed DMs
     /// 400-nacked by the server (issue #941); this restores pre-0.6 PN
     /// addressing for the outbound path only.
+    ///
+    /// Intended as deployment configuration: set once before `connect()`.
+    /// Flipping it while sends are in flight is not synchronized — the
+    /// addressing decisions inside an in-flight send may observe different
+    /// values (the fanout/lock pair is snapshotted together, the rest is not).
     pub fn set_force_pn_addressing(&self, enabled: bool) {
         self.force_pn_addressing.store(enabled, Ordering::Relaxed);
     }

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -44,6 +44,19 @@ impl Client {
         self.skip_history_sync.load(Ordering::Relaxed)
     }
 
+    /// Keep outbound DM addressing on phone-number JIDs even when a LID
+    /// mapping is known. Some companion registrations get LID-addressed DMs
+    /// 400-nacked by the server (issue #941); this restores pre-0.6 PN
+    /// addressing for the outbound path only.
+    pub fn set_force_pn_addressing(&self, enabled: bool) {
+        self.force_pn_addressing.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if outbound DM addressing is pinned to phone-number JIDs.
+    pub fn force_pn_addressing_enabled(&self) -> bool {
+        self.force_pn_addressing.load(Ordering::Relaxed)
+    }
+
     /// Set how many one-time pre-keys are generated per upload batch.
     ///
     /// Defaults to WA Web's UPLOAD_KEYS_COUNT (812). Call before connecting; it

--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -53,6 +53,11 @@ impl SendContextResolver for Client {
     }
 
     async fn get_lid_for_phone(&self, phone_user: &str) -> Option<wacore_binary::CompactString> {
+        // Reporting no mapping keeps stanza prep (participants, enc nodes) on
+        // the PN namespace (see Client::set_force_pn_addressing).
+        if self.force_pn_addressing_enabled() {
+            return None;
+        }
         self.lid_pn_cache.get_current_lid(phone_user).await
     }
 

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -676,7 +676,10 @@ mod tests {
             .await;
         assert_eq!(mapped, vec![pn_jid.clone()]);
         let locks = client
-            .build_session_lock_keys(std::slice::from_ref(&pn_jid))
+            .build_session_lock_keys(
+                std::slice::from_ref(&pn_jid),
+                client.force_pn_addressing_enabled(),
+            )
             .await;
         assert_eq!(locks, vec![pn_jid.clone()]);
 

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -332,6 +332,12 @@ impl Client {
     /// This checks the local cache for existing mappings. For JIDs without cached mappings,
     /// the caller should consider fetching them via usync query if establishing sessions.
     pub(crate) async fn resolve_lid_mappings(&self, jids: &[Jid]) -> Vec<Jid> {
+        // Outbound sessions must stay on the PN namespace when PN addressing
+        // is forced, or encryption would look up sessions the fanout never
+        // created (see Client::set_force_pn_addressing).
+        if self.force_pn_addressing_enabled() {
+            return jids.to_vec();
+        }
         let mut resolved = Vec::with_capacity(jids.len());
 
         for jid in jids {
@@ -648,6 +654,45 @@ mod tests {
         let resolved = client.resolve_encryption_jid(&lid_jid).await;
 
         assert_eq!(resolved, lid_jid);
+    }
+
+    #[tokio::test]
+    async fn test_force_pn_addressing_scopes_to_outbound_paths() {
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "55999999999";
+        let lid = "100000012345678";
+
+        client
+            .add_lid_pn_mapping(lid, pn, LearningSource::PeerPnMessage)
+            .await
+            .unwrap();
+        client.set_force_pn_addressing(true);
+
+        let pn_jid = Jid::pn(pn);
+
+        // Outbound fanout/session paths keep the PN namespace as given.
+        let mapped = client
+            .resolve_lid_mappings(std::slice::from_ref(&pn_jid))
+            .await;
+        assert_eq!(mapped, vec![pn_jid.clone()]);
+        let locks = client
+            .build_session_lock_keys(std::slice::from_ref(&pn_jid))
+            .await;
+        assert_eq!(locks, vec![pn_jid.clone()]);
+
+        // Inbound decrypt addressing is NOT gated: the upgrade still applies
+        // so sessions migrated to LID keep resolving.
+        let resolved = client.resolve_encryption_jid(&pn_jid).await;
+        assert_eq!(resolved.user, lid);
+        assert_eq!(resolved.server, Server::Lid);
+
+        // Turning the flag off restores stock outbound behavior.
+        client.set_force_pn_addressing(false);
+        let mapped = client
+            .resolve_lid_mappings(std::slice::from_ref(&pn_jid))
+            .await;
+        assert_eq!(mapped[0].user, lid);
+        assert_eq!(mapped[0].server, Server::Lid);
     }
 
     #[tokio::test]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -260,6 +260,7 @@ impl Client {
             http_client,
             override_version,
             skip_history_sync: AtomicBool::new(false),
+            force_pn_addressing: AtomicBool::new(false),
             wanted_pre_key_count: AtomicUsize::new(crate::prekeys::DEFAULT_WANTED_PRE_KEY_COUNT),
             cache_config,
             self_weak: std::sync::OnceLock::new(),

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -298,7 +298,10 @@ impl<'a> Signal<'a> {
         self.client.ensure_e2e_sessions(&device_jids).await?;
 
         // Acquire per-device session locks before encrypting (matches DM send path)
-        let lock_jids = self.client.build_session_lock_keys(&device_jids).await;
+        let lock_jids = self
+            .client
+            .build_session_lock_keys(&device_jids, self.client.force_pn_addressing_enabled())
+            .await;
         let session_mutexes = self.client.session_mutexes_for(&lock_jids).await;
         let mut _session_guards = Vec::with_capacity(session_mutexes.len());
         for mutex in &session_mutexes {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1680,7 +1680,14 @@ impl Client {
             // DM fanout: all known recipient devices + own companions.
             // WAWebSendUserMsgJob reads local device table only on the send
             // path; WAWebDBDeviceListFanout excludes hosted devices.
-            let recipient_bare = self.resolve_encryption_jid(&to).await.into_non_ad();
+            // With PN addressing forced the fanout keys stay on the namespace
+            // the caller gave us (see Client::set_force_pn_addressing), which
+            // also keeps stanza_to below on PN.
+            let recipient_bare = if self.force_pn_addressing_enabled() {
+                to.to_non_ad()
+            } else {
+                self.resolve_encryption_jid(&to).await.into_non_ad()
+            };
             let recipient_is_lid = recipient_bare.is_lid();
 
             // The outer `<message to>`, the DeviceSentMessage destinationJid, and
@@ -1974,7 +1981,13 @@ impl Client {
     pub(crate) async fn build_session_lock_keys(&self, device_jids: &[Jid]) -> Vec<Jid> {
         let mut keys: Vec<Jid> = Vec::with_capacity(device_jids.len());
         for jid in device_jids {
-            keys.push(self.resolve_encryption_jid(jid).await);
+            // Locks must key the same namespace encryption will use; with PN
+            // addressing forced that is the JID as given.
+            if self.force_pn_addressing_enabled() {
+                keys.push(jid.clone());
+            } else {
+                keys.push(self.resolve_encryption_jid(jid).await);
+            }
         }
         keys.sort_unstable_by(wacore::types::jid::cmp_for_lock_order);
         keys.dedup_by(|a, b| wacore::types::jid::cmp_for_lock_order(a, b).is_eq());

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -4097,6 +4097,236 @@ mod tests {
         }
     }
 
+    /// With `force_pn_addressing` on, a DM to a LID-mapped peer must keep the
+    /// whole stanza on the PN namespace: outer `<message to>` and every
+    /// participant. Regression for the opt-out added for issue #941.
+    #[tokio::test]
+    async fn force_pn_addressing_keeps_dm_stanza_on_pn() {
+        let client = crate::test_utils::create_test_client_with_name("force_pn_dm").await;
+
+        let own_pn: Jid = "111111111111@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "222222222222@lid".parse().unwrap();
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+            .await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(Some(own_lid)))
+            .await;
+
+        // The peer is LID-mapped; without the flag the send would upgrade it.
+        let peer_pn: Jid = "100000000000777@s.whatsapp.net".parse().unwrap();
+        let peer_lid: Jid = "555000000000777@lid".parse().unwrap();
+        client
+            .add_lid_pn_mapping(
+                peer_lid.user.as_str(),
+                peer_pn.user.as_str(),
+                crate::lid_pn_cache::LearningSource::Usync,
+            )
+            .await
+            .expect("seed lid mapping");
+
+        // PN fanout ⇒ registry and Signal session live under the PN user.
+        for user in [peer_pn.user.to_string(), own_pn.user.to_string()] {
+            client
+                .update_device_list(wacore::store::traits::DeviceListRecord {
+                    user,
+                    devices: vec![wacore::store::traits::DeviceInfo {
+                        device_id: 0,
+                        key_index: None,
+                    }],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                })
+                .await
+                .expect("seed device registry");
+        }
+        client.complete_offline_sync(0);
+        seed_peer_send_state(&client, &peer_pn.to_non_ad()).await;
+
+        client.set_force_pn_addressing(true);
+
+        let request_id = "FORCE_PN_DM_1";
+        let waiter = client
+            .wait_for_sent_node(crate::client::NodeFilter::tag("message").attr("id", request_id));
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+        let result = client
+            .send_message_impl(
+                peer_pn.clone(),
+                &msg,
+                Some(request_id.to_string()),
+                false,
+                false,
+                None,
+                vec![],
+                None,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "test client has no socket; send captures the stanza then errors"
+        );
+
+        let node = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("sent node should be captured")
+            .expect("sent node waiter should resolve");
+
+        let to_str = node
+            .attrs()
+            .optional_string("to")
+            .expect("message has a to")
+            .into_owned();
+        let to_jid: Jid = to_str.parse().expect("to parses");
+        assert!(
+            to_jid.is_pn(),
+            "outer <message to> must stay PN with force_pn_addressing, got {to_str}"
+        );
+        assert_eq!(to_jid.user.as_str(), peer_pn.user.as_str());
+
+        let participants = node
+            .get_optional_child("participants")
+            .expect("stanza has participants");
+        let entries = participants.children().expect("participants has children");
+        assert!(!entries.is_empty());
+        for entry in entries {
+            let pj: Jid = entry
+                .attrs()
+                .optional_string("jid")
+                .expect("participant jid")
+                .parse()
+                .expect("participant jid parses");
+            assert!(
+                pj.is_pn(),
+                "participant {pj} must stay PN with force_pn_addressing"
+            );
+        }
+    }
+
+    /// `force_pn_addressing` must NOT leak into status@broadcast reactions:
+    /// they share the DM fanout but must keep LID addressing (WA Web's
+    /// toUserLid). Regression for the review finding on the #941 opt-out.
+    #[tokio::test]
+    async fn force_pn_addressing_excludes_status_reactions() {
+        let client = crate::test_utils::create_test_client_with_name("force_pn_status").await;
+
+        let own_pn: Jid = "111111111111@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "222222222222@lid".parse().unwrap();
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+            .await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(Some(own_lid)))
+            .await;
+
+        let author_pn: Jid = "100000000000777@s.whatsapp.net".parse().unwrap();
+        let author_lid: Jid = "555000000000777@lid".parse().unwrap();
+        client
+            .add_lid_pn_mapping(
+                author_lid.user.as_str(),
+                author_pn.user.as_str(),
+                crate::lid_pn_cache::LearningSource::Usync,
+            )
+            .await
+            .expect("seed lid mapping");
+
+        // Status reactions keep LID addressing ⇒ registry and session under LID.
+        for user in [author_lid.user.to_string(), own_pn.user.to_string()] {
+            client
+                .update_device_list(wacore::store::traits::DeviceListRecord {
+                    user,
+                    devices: vec![wacore::store::traits::DeviceInfo {
+                        device_id: 0,
+                        key_index: None,
+                    }],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                })
+                .await
+                .expect("seed device registry");
+        }
+        client.complete_offline_sync(0);
+        seed_peer_send_state(&client, &author_lid.to_non_ad()).await;
+
+        client.set_force_pn_addressing(true);
+
+        let request_id = "FORCE_PN_STATUS_1";
+        let waiter = client
+            .wait_for_sent_node(crate::client::NodeFilter::tag("message").attr("id", request_id));
+        let msg = wa::Message {
+            reaction_message: Some(Box::new(wa::message::ReactionMessage {
+                key: Some(wa::MessageKey {
+                    remote_jid: Some(Jid::status_broadcast().to_string()),
+                    from_me: Some(false),
+                    id: Some("STATUS_MSG_1".into()),
+                    participant: Some(author_pn.to_string()),
+                }),
+                text: Some("👍".into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let result = client
+            .send_message_impl(
+                Jid::status_broadcast(),
+                &msg,
+                Some(request_id.to_string()),
+                false,
+                false,
+                None,
+                vec![],
+                None,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "test client has no socket; send captures the stanza then errors"
+        );
+
+        let node = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("sent node should be captured")
+            .expect("sent node waiter should resolve");
+
+        // Status reactions keep their broadcast envelope; the namespace that
+        // the flag could have leaked into is the participant fanout.
+        let to_str = node
+            .attrs()
+            .optional_string("to")
+            .expect("message has a to")
+            .into_owned();
+        assert_eq!(
+            to_str, "status@broadcast",
+            "status reaction keeps the broadcast envelope"
+        );
+
+        let participants = node
+            .get_optional_child("participants")
+            .expect("stanza has participants");
+        let entries = participants.children().expect("participants has children");
+        assert!(!entries.is_empty());
+        for entry in entries {
+            let pj: Jid = entry
+                .attrs()
+                .optional_string("jid")
+                .expect("participant jid")
+                .parse()
+                .expect("participant jid parses");
+            assert!(
+                pj.is_lid(),
+                "status reaction participant {pj} must stay LID despite force_pn_addressing"
+            );
+        }
+    }
+
     /// Newsletter JIDs must be rejected at the E2E send path root (covers the
     /// mis-routed pin/edit/revoke producers that call send_message_impl directly).
     #[tokio::test]

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1682,8 +1682,11 @@ impl Client {
             // path; WAWebDBDeviceListFanout excludes hosted devices.
             // With PN addressing forced the fanout keys stay on the namespace
             // the caller gave us (see Client::set_force_pn_addressing), which
-            // also keeps stanza_to below on PN.
-            let recipient_bare = if self.force_pn_addressing_enabled() {
+            // also keeps stanza_to below on PN. Status reactions share this
+            // fanout but must keep LID addressing (WA Web's toUserLid), so
+            // the flag is scoped to actual DMs.
+            let force_pn_for_dm = self.force_pn_addressing_enabled() && !is_status_addon;
+            let recipient_bare = if force_pn_for_dm {
                 to.to_non_ad()
             } else {
                 self.resolve_encryption_jid(&to).await.into_non_ad()
@@ -1791,7 +1794,9 @@ impl Client {
                 debug!(target: "Client/TcToken", "Scheduled tc token issuance after send for {}", to.observe());
             }
 
-            let lock_jids = self.build_session_lock_keys(&all_dm_jids).await;
+            let lock_jids = self
+                .build_session_lock_keys(&all_dm_jids, force_pn_for_dm)
+                .await;
             let _session_mutexes = self.session_mutexes_for(&lock_jids).await;
             let mut _session_guards = Vec::with_capacity(_session_mutexes.len());
             for mutex in &_session_mutexes {
@@ -1978,12 +1983,17 @@ impl Client {
     /// INVARIANT: Keys are sorted to prevent deadlocks when acquiring multiple
     /// session locks (e.g. DM sends that encrypt for recipient + own devices).
     /// Resolve encryption JIDs and sort for deadlock-free lock acquisition.
-    pub(crate) async fn build_session_lock_keys(&self, device_jids: &[Jid]) -> Vec<Jid> {
+    pub(crate) async fn build_session_lock_keys(
+        &self,
+        device_jids: &[Jid],
+        force_pn_addressing: bool,
+    ) -> Vec<Jid> {
         let mut keys: Vec<Jid> = Vec::with_capacity(device_jids.len());
         for jid in device_jids {
             // Locks must key the same namespace encryption will use; with PN
-            // addressing forced that is the JID as given.
-            if self.force_pn_addressing_enabled() {
+            // addressing forced that is the JID as given. Callers pass their
+            // scoped decision (e.g. DMs exclude status reactions).
+            if force_pn_addressing {
                 keys.push(jid.clone());
             } else {
                 keys.push(self.resolve_encryption_jid(jid).await);
@@ -3554,7 +3564,7 @@ mod tests {
             .collect();
 
             // Uses the production helper (resolve_encryption_jid + sort + dedup)
-            let send_lock_keys = client.build_session_lock_keys(&devices).await;
+            let send_lock_keys = client.build_session_lock_keys(&devices, false).await;
 
             assert_eq!(send_lock_keys.len(), 3);
             // Sorted by (server, user, device_numeric): 0, 5, 33
@@ -3678,7 +3688,7 @@ mod tests {
                 .to_non_ad();
 
             let all_dm_jids = vec![recipient_bare.clone(), own_device_5.clone()];
-            let lock_jids = client.build_session_lock_keys(&all_dm_jids).await;
+            let lock_jids = client.build_session_lock_keys(&all_dm_jids, false).await;
 
             // Recipient lock key must be BARE (device 0), matching decrypt path
             assert_eq!(

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -308,7 +308,10 @@ impl<'a> OutgoingCall<'a> {
             // would_emit_pkmsg does a load_session + store_session round-trip (a redundant write-back
             // in the shared pre-flight); hold the per-device session locks place_call's encrypt also
             // takes, so it can't clobber a concurrent send advancing the same session.
-            let lock_jids = self.client.build_session_lock_keys(&devices).await;
+            let lock_jids = self
+                .client
+                .build_session_lock_keys(&devices, self.client.force_pn_addressing_enabled())
+                .await;
             let session_mutexes = self.client.session_mutexes_for(&lock_jids).await;
             let mut session_guards = Vec::with_capacity(session_mutexes.len());
             for mutex in &session_mutexes {
@@ -448,7 +451,9 @@ async fn place_call(
     // Take the per-device session locks once (the send path's batch model) instead of a per-device
     // lock; concurrent ratchet mutations would corrupt session state.
     let raw = {
-        let lock_jids = client.build_session_lock_keys(devices).await;
+        let lock_jids = client
+            .build_session_lock_keys(devices, client.force_pn_addressing_enabled())
+            .await;
         let session_mutexes = client.session_mutexes_for(&lock_jids).await;
         let mut _session_guards = Vec::with_capacity(session_mutexes.len());
         for mutex in &session_mutexes {


### PR DESCRIPTION
Fixes #941. Supersedes #940 (same change, now reimplemented against current `main` — the old branch was based on v0.6.0 and conflicted after the send-path restructuring).

## Summary

Adds an opt-in `Client::set_force_pn_addressing(true)` that keeps **outbound** DM addressing on the namespace the caller provided instead of upgrading PN → LID. The flag gates the four addressing decisions the outbound path makes:

- **recipient fanout keys** in `send_message_impl` (`src/send/mod.rs`) — which also keeps the #731 `stanza_to` on PN, so the stanza stays namespace-consistent;
- **session creation** — `resolve_lid_mappings` (via `ensure_e2e_sessions`);
- **stanza prep** (participants / enc nodes) — `SendContextResolver::get_lid_for_phone`;
- **session lock keys** — `build_session_lock_keys`, kept aligned with the namespace encryption actually uses so the per-session lock invariant against concurrent inbound decrypt holds.

Inbound decrypt addressing (`resolve_encryption_jid` on sender JIDs), LID↔PN mapping learning, and inbound session migration are deliberately untouched. Mirrors the `skip_history_sync` runtime-flag pattern. Default behavior is unchanged.

## Motivation

See #941 for full evidence. Short version: on at least one companion registration, every LID-addressed DM — including the consistent-LID stanza shape from #731 — is rejected by the server with `ack error="400"` and never delivered, while the same message with pre-0.6 PN addressing is delivered within ~2 seconds. With unified addressing there is no caller-side workaround: passing a PN JID gets re-upgraded once the mapping is cached, and the first DM to a fresh PN learns the mapping via usync, so the first message goes through and every subsequent one is dropped.

An opt-in escape hatch seemed like the minimal-surface fix rather than changing default behavior; happy to rework into a `BotBuilder` option, or an automatic PN fallback on 400-nack, if you prefer either direction.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` (0 warnings), `cargo test --workspace --exclude e2e-tests` (all green) — same commands as the `Rust CI` workflow, on `nightly-2026-06-16`.
- New unit test `test_force_pn_addressing_scopes_to_outbound_paths`: asserts outbound paths keep PN with the flag on, that inbound `resolve_encryption_jid` is deliberately NOT gated, and that turning the flag off restores stock behavior.
- Live validation on the affected deployment (backported to v0.6.0): with the flag, repeated DMs against a warm mapping cache all drew `Delivered` receipts within ~2s including full round-trips; without it, reproducible 400-nacks (logs in #941).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

