### PR TITLE
perf(history-sync): size the secret-record accumulator by sampled density

### DIFF
--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -129,6 +129,14 @@ impl<'a> InflateReader<'a> {
         self.total_out
     }
 
+    /// Compressed input consumed so far plus the input's full length. The
+    /// ratio lets callers extrapolate totals (e.g. record counts) from a
+    /// prefix without a second pass over the blob.
+    #[inline]
+    pub fn compressed_progress(&self) -> (usize, usize) {
+        (self.in_pos, self.input.len())
+    }
+
     /// Whether zlib reported a proper stream end (terminator + adler32
     /// checksum). An EOF (`ensure` returning false) without this means the
     /// input was truncated, not finished.

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -113,6 +113,29 @@ impl<'a> FieldWalker<'a> {
         self.reader.total_out()
     }
 
+    /// Decompressed bytes already handed to the parser. Excludes the buffered
+    /// not-yet-parsed window, so a density observed over this prefix is not
+    /// diluted by data the inflater ran ahead on.
+    fn parsed_bytes(&self) -> u64 {
+        self.reader
+            .total_out()
+            .saturating_sub(self.reader.available().len() as u64)
+    }
+
+    /// Total decompressed size extrapolated from the zlib ratio observed so
+    /// far; exact once the stream has fully inflated.
+    fn estimated_total_out(&self) -> u64 {
+        let (in_pos, in_len) = self.reader.compressed_progress();
+        if in_pos == 0 {
+            return self.reader.total_out();
+        }
+        self.reader
+            .total_out()
+            .saturating_mul(in_len as u64)
+            .checked_div(in_pos as u64)
+            .unwrap_or(0)
+    }
+
     /// Re-borrow the payload of the field most recently yielded by
     /// [`FieldWalker::next_field`] (it stays buffered until the next call).
     fn pending_payload(&self, payload_start: usize) -> &[u8] {
@@ -250,6 +273,20 @@ fn process_history_sync_streaming(
         decompressed_size: 0,
     };
 
+    // One-shot capacity extrapolation for the secret-record accumulator. A
+    // full pre-count pass (see the field comment above) was measured at ~2.5%
+    // of the decode, so instead the record density observed over a prefix is
+    // scaled to the blob's extrapolated decompressed size. Costs O(1), adapts
+    // to blobs with few secrets, and an off estimate just falls back to
+    // doubling. Extrapolating from the first conversation alone overshot to
+    // the clamp on measured blobs (doubling the transient peak), so the
+    // sample must first reach RESERVE_SAMPLE_RECORDS; the doubling ladder up
+    // to that point copies only ~2x its own bytes, which is noise. The clamp
+    // bounds over-allocation to ~2 MB.
+    const RESERVE_SAMPLE_RECORDS: usize = 128;
+    const RECORD_RESERVE_CAP: usize = 16384;
+    let mut density_reserved = false;
+
     while let Some(field) = walker.next_field()? {
         if field.wire_type != wire_type::LENGTH_DELIMITED {
             continue;
@@ -263,6 +300,19 @@ fn process_history_sync_streaming(
                     extract_conversation_fields(value, &mut result.msg_secret_records)
                 {
                     result.tc_token_candidates.push(candidate);
+                }
+                if !density_reserved && result.msg_secret_records.len() >= RESERVE_SAMPLE_RECORDS {
+                    density_reserved = true;
+                    let parsed = walker.parsed_bytes().max(1);
+                    let records = result.msg_secret_records.len();
+                    let estimated = (records as u64)
+                        .saturating_mul(walker.estimated_total_out())
+                        .checked_div(parsed)
+                        .map_or(records, |est| est as usize)
+                        .min(RECORD_RESERVE_CAP);
+                    result
+                        .msg_secret_records
+                        .reserve(estimated.saturating_sub(records));
                 }
             }
             // pushnames (repeated) — only our own is needed

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -113,13 +113,17 @@ impl<'a> FieldWalker<'a> {
         self.reader.total_out()
     }
 
-    /// Decompressed bytes already handed to the parser. Excludes the buffered
-    /// not-yet-parsed window, so a density observed over this prefix is not
-    /// diluted by data the inflater ran ahead on.
+    /// Decompressed bytes already handed to the parser, INCLUDING the field
+    /// most recently yielded by `next_field` (its bytes stay buffered until
+    /// the next call, but the caller has already processed them). Excludes
+    /// only the tail beyond it, so a density observed over this prefix is
+    /// neither diluted by inflater read-ahead nor inflated by dropping the
+    /// very conversation whose records were just counted: on a blob whose
+    /// first conversation alone reaches the sample threshold, the old
+    /// exclusive form left a near-zero denominator and the estimate clamped.
     fn parsed_bytes(&self) -> u64 {
-        self.reader
-            .total_out()
-            .saturating_sub(self.reader.available().len() as u64)
+        let unparsed_tail = self.reader.available().len().saturating_sub(self.pending);
+        self.reader.total_out().saturating_sub(unparsed_tail as u64)
     }
 
     /// Total decompressed size extrapolated from the zlib ratio observed so
@@ -303,13 +307,13 @@ fn process_history_sync_streaming(
                 }
                 if !density_reserved && result.msg_secret_records.len() >= RESERVE_SAMPLE_RECORDS {
                     density_reserved = true;
+                    // max(1) makes the division safe; parsed_bytes is only 0
+                    // if nothing decompressed yet, impossible past a record.
                     let parsed = walker.parsed_bytes().max(1);
                     let records = result.msg_secret_records.len();
-                    let estimated = (records as u64)
-                        .saturating_mul(walker.estimated_total_out())
-                        .checked_div(parsed)
-                        .map_or(records, |est| est as usize)
-                        .min(RECORD_RESERVE_CAP);
+                    let estimated = ((records as u64).saturating_mul(walker.estimated_total_out())
+                        / parsed) as usize;
+                    let estimated = estimated.min(RECORD_RESERVE_CAP);
                     result
                         .msg_secret_records
                         .reserve(estimated.saturating_sub(records));
@@ -2341,6 +2345,65 @@ mod tests {
         process_history_sync(compressed, None, false)
             .unwrap()
             .msg_secret_records
+    }
+
+    /// The density reserve must not clamp when a SINGLE conversation reaches
+    /// the sample threshold: parsed_bytes includes the pending (just yielded)
+    /// field, so the denominator covers the conversation whose records were
+    /// counted. With the exclusive form the denominator was ~0 and the
+    /// estimate hit RECORD_RESERVE_CAP, over-reserving ~2 MB.
+    #[test]
+    fn test_reserve_single_big_conversation_does_not_clamp() {
+        let chat = "5511777776666@s.whatsapp.net";
+        let mut conv = Vec::new();
+        emit_len_field(&mut conv, tags::conversation::ID, chat.as_bytes());
+        let total_msgs = 200usize;
+        for i in 0..total_msgs {
+            let wm = wa::WebMessageInfo {
+                key: wa::MessageKey {
+                    from_me: Some(false),
+                    id: Some(format!("MSG{i:04}")),
+                    ..Default::default()
+                },
+                // Varied payload so zlib does not flatten the blob to nothing.
+                message_secret: Some(vec![(i % 251) as u8; 32]),
+                ..Default::default()
+            }
+            .encode_to_vec();
+            let mut history_msg = Vec::new();
+            emit_len_field(&mut history_msg, tags::history_sync_msg::MESSAGE, &wm);
+            emit_len_field(&mut conv, tags::conversation::MESSAGES, &history_msg);
+        }
+        let mut hs = Vec::new();
+        emit_len_field(&mut hs, tags::history_sync::CONVERSATIONS, &conv);
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&hs).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let records = process_history_sync(compressed, None, false)
+            .unwrap()
+            .msg_secret_records;
+        assert_eq!(records.len(), total_msgs);
+        assert!(
+            records.capacity() < 2048,
+            "estimate should track the real count (~{total_msgs}), got capacity {}",
+            records.capacity()
+        );
+    }
+
+    /// The zlib-ratio extrapolation is exact once the stream fully inflates.
+    #[test]
+    fn test_estimated_total_out_exact_after_drain() {
+        let mut hs = Vec::new();
+        emit_len_field(&mut hs, tags::history_sync::PUSHNAMES, b"\x0a\x03abc");
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&hs).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let mut walker = FieldWalker::new(&compressed, MAX_DECOMPRESSED);
+        while walker.next_field().unwrap().is_some() {}
+        assert_eq!(walker.estimated_total_out(), walker.total_out());
+        assert_eq!(walker.total_out(), hs.len() as u64);
     }
 
     /// A (malformed) conversation that carries messages BEFORE its id must not

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -269,9 +269,11 @@ fn process_history_sync_streaming(
         nct_salt: None,
         conversations_processed: 0,
         tc_token_candidates: Vec::new(),
-        // Grown on demand: a full pre-count pass scanned the whole blob just to
-        // size a Vec that only holds the secret-record subset (it over-allocated
-        // and cost ~2.5% of the decode); plain growth is cheaper here.
+        // Starts empty and gets a one-shot density-based reserve once the
+        // walk has seen RESERVE_SAMPLE_RECORDS (see below). A full pre-count
+        // pass was tried before: it scanned the whole blob just to size a Vec
+        // holding only the secret-record subset (over-allocating, ~2.5% of
+        // the decode).
         msg_secret_records: Vec::new(),
         compressed_bytes: None,
         decompressed_size: 0,


### PR DESCRIPTION
Sizes the history-sync secret-record accumulator from a sampled record density instead of growing it by plain doubling.

## Problem

`msg_secret_records` grew from empty by repeated doubling, which copies roughly 2x the final byte volume through `realloc` per chunk. Profiling the history-sync scenario (300 convs x 20 msgs, 4 chunks) showed this single site was the client's largest allocation-churn source, and CodSpeed's flamegraph attributed 5.6% of `bench_process_history_sync` to the resulting realloc+memcpy chain.

A full pre-count pass was already tried and removed in #690: it re-scanned the whole blob and cost ~2.5% of the decode while over-allocating. This takes a third route: once the accumulator reaches 128 records, extrapolate the density observed so far to the blob's estimated decompressed size (from the zlib input ratio) and `reserve` once. O(1), no second pass; an under-estimate just resumes doubling, and the clamp bounds over-allocation to ~2 MB. The 128-record sample is load-bearing: extrapolating from the first conversation alone overshot to the clamp and doubled the transient peak on the same workload.

## Before / after

Production harness (whatsapp-benchs `history-sync`, 300x20, MODE=dhat):

| metric | before | after | delta |
|---|---|---|---|
| record-site bytes through allocator | 9.96 MB | 4.53 MB | -55% |
| record-site allocs | 48 | 32 | -33% |
| record-site transient peak | 1245 KB | 1056 KB | -15% |
| client total allocation churn | 27.1 MB | 21.8 MB | -20% |
| client peak (t-gmax) | 5.59 MB | 5.39 MB | -3.5% |

Micro (`bench_process_history_sync`, 500x40 fixture, valgrind dhat on the record site): 4.98 MB / 13 allocs -> 1.89 MB / 8 allocs.

Wall time on the same bench is neutral-to-slightly-better under an interleaved A/B (baseline ~8.1 ms vs patched ~7.7 ms median-of-3, within machine noise); the deterministic instruction-count delta will show in this PR's CodSpeed run.

## Regressions considered

- Blobs with fewer than 128 records never reserve and keep the exact previous behavior; the ladder up to 128 records copies ~35 KB total.
- A wrong density estimate can only over-reserve up to the 16384-record clamp (~2 MB transient); the sampled estimate landed within ~2x of the true count on both measured workloads, vs ~10x overshoot when sampling a single conversation (that variant was measured and rejected).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

