### PR TITLE
perf(libsignal): evict skipped message keys without shifting the buffer

### DIFF
--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -465,9 +465,8 @@ impl SessionState {
         }
 
         if let Some(position) = message_key_position {
-            // Only now do we mutate. swap_remove: lookup is by counter, so
-            // slot order is free to scramble; remove(position) would shift
-            // every later key down (O(n) on a buffer of up to 2000).
+            // swap_remove: lookup is by counter, so slot order is free to
+            // scramble.
             let message_key = self.session.receiver_chains[chain_idx]
                 .message_keys
                 .swap_remove(position);
@@ -496,22 +495,23 @@ impl SessionState {
         let len = chain.message_keys.len();
         if len > consts::MAX_MESSAGE_KEYS + consts::MESSAGE_KEY_PRUNE_THRESHOLD {
             let excess = len - consts::MAX_MESSAGE_KEYS;
-            // Evict the oldest (lowest-counter) keys. Selection must be by
-            // counter value, not slot position: swap_remove here and in
-            // get_message_keys scrambles slot order, so the front is not the
-            // oldest after the first prune. select_nth + swap_remove writes
-            // only O(excess) entries where drain(..excess) memmoved every
-            // survivor (~200 KB per prune at MAX = 2000).
+            // Evict the oldest keys by counter value, not slot position:
+            // swap_remove (here and in get_message_keys) scrambles slot
+            // order, so the front is not the oldest after the first prune.
             let mut counters: Vec<u32> = chain
                 .message_keys
                 .iter()
                 .map(|m| m.index.unwrap_or(0))
                 .collect();
             let (_, &mut threshold, _) = counters.select_nth_unstable(excess - 1);
+            // The removal ceiling keeps duplicate counters at the threshold
+            // (impossible in a valid session) from evicting extra keys.
+            let mut removed = 0;
             let mut i = 0;
-            while i < chain.message_keys.len() {
+            while i < chain.message_keys.len() && removed < excess {
                 if chain.message_keys[i].index.unwrap_or(0) <= threshold {
                     chain.message_keys.swap_remove(i);
+                    removed += 1;
                 } else {
                     i += 1;
                 }

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -465,10 +465,12 @@ impl SessionState {
         }
 
         if let Some(position) = message_key_position {
-            // Only now do we mutate - remove the message key directly
+            // Only now do we mutate. swap_remove: lookup is by counter, so
+            // slot order is free to scramble; remove(position) would shift
+            // every later key down (O(n) on a buffer of up to 2000).
             let message_key = self.session.receiver_chains[chain_idx]
                 .message_keys
-                .remove(position);
+                .swap_remove(position);
             let keys = MessageKeyGenerator::from_pb(message_key).map_err(InvalidSessionError)?;
             return Ok(Some(keys));
         }
@@ -488,13 +490,32 @@ impl SessionState {
         let chain = &mut self.session.receiver_chains[chain_idx];
 
         // AMORTIZED EVICTION: Only prune when exceeding MAX + threshold.
-        // This reduces O(n) drain() calls from every insert to once every PRUNE_THRESHOLD inserts.
+        // This reduces O(n) prunes from every insert to once every PRUNE_THRESHOLD inserts.
         // The lookup in get_message_keys() does a linear search by counter value, so order
         // doesn't matter for correctness.
         let len = chain.message_keys.len();
         if len > consts::MAX_MESSAGE_KEYS + consts::MESSAGE_KEY_PRUNE_THRESHOLD {
             let excess = len - consts::MAX_MESSAGE_KEYS;
-            chain.message_keys.drain(..excess);
+            // Evict the oldest (lowest-counter) keys. Selection must be by
+            // counter value, not slot position: swap_remove here and in
+            // get_message_keys scrambles slot order, so the front is not the
+            // oldest after the first prune. select_nth + swap_remove writes
+            // only O(excess) entries where drain(..excess) memmoved every
+            // survivor (~200 KB per prune at MAX = 2000).
+            let mut counters: Vec<u32> = chain
+                .message_keys
+                .iter()
+                .map(|m| m.index.unwrap_or(0))
+                .collect();
+            let (_, &mut threshold, _) = counters.select_nth_unstable(excess - 1);
+            let mut i = 0;
+            while i < chain.message_keys.len() {
+                if chain.message_keys[i].index.unwrap_or(0) <= threshold {
+                    chain.message_keys.swap_remove(i);
+                } else {
+                    i += 1;
+                }
+            }
         }
         chain.message_keys.push(message_keys.into_pb());
 
@@ -1157,6 +1178,40 @@ mod tests {
 
         // Newer keys should still exist
         for counter in evicted_count as u32..total_keys as u32 {
+            let key = state.get_message_keys(&sender_key, counter).unwrap();
+            assert!(key.is_some(), "Key {} should exist", counter);
+        }
+    }
+
+    /// Eviction must drop the lowest counters on EVERY prune, not just the
+    /// first: swap_remove scrambles slot order, so a position-based prune
+    /// would evict the freshly skipped (most likely to arrive) keys from the
+    /// second prune on.
+    #[test]
+    fn test_message_keys_eviction_stays_oldest_across_prunes() {
+        let base_key = KeyPair::generate(&mut rng()).public_key;
+        let mut state = create_test_session_state(3, &base_key);
+
+        let sender_key = KeyPair::generate(&mut rng()).public_key;
+        let chain_key = crate::protocol::ratchet::ChainKey::new([2u8; 32], 0);
+        state.add_receiver_chain(&sender_key, &chain_key);
+
+        // Enough inserts for two prunes: pushing counter 2051 prunes 0..=50,
+        // pushing counter 2102 prunes 51..=101 (the trigger re-arms only
+        // after the buffer refills past MAX + THRESHOLD).
+        let total_keys =
+            (consts::MAX_MESSAGE_KEYS + 2 * (consts::MESSAGE_KEY_PRUNE_THRESHOLD + 1) + 1) as u32;
+        for counter in 0..total_keys {
+            let keys = create_test_message_key_generator(counter);
+            state.set_message_keys(&sender_key, keys).unwrap();
+        }
+
+        let evicted = 2 * (consts::MESSAGE_KEY_PRUNE_THRESHOLD + 1) as u32;
+        for counter in 0..evicted {
+            let key = state.get_message_keys(&sender_key, counter).unwrap();
+            assert!(key.is_none(), "Key {} should have been evicted", counter);
+        }
+        for counter in evicted..total_keys {
             let key = state.get_message_keys(&sender_key, counter).unwrap();
             assert!(key.is_some(), "Key {} should exist", counter);
         }


### PR DESCRIPTION
Removes the two O(n) shifts on the skipped-message-key buffer in libsignal's session state.

## Problem

CodSpeed's flamegraph for `bench_message_key_eviction` attributed 21.7% of the benchmark to a single `memcpy` inside `SessionState::set_message_keys`: the amortized prune used `Vec::drain(..excess)`, which memmoves all ~2000 surviving keys (~104 B each, ~200 KB) on every prune. `get_message_keys` had the same shape on the consume side: `Vec::remove(position)` shifts every later entry each time an out-of-order key is used. Both matter under flood / offline-drain workloads, where skipped keys accumulate and prunes fire every 50 inserts.

## Change

Lookup is a linear scan by counter, so slot order is free; both paths now use `swap_remove` (O(1) writes per removed key).

The one subtlety is eviction policy: victims are selected by counter value (`select_nth_unstable` threshold scan) rather than by slot position. `swap_remove` scrambles slot order, so from the second prune on, the front slots hold the newest keys, and a position-based prune would evict exactly the freshly skipped keys that are most likely to still arrive. A new regression test (`test_message_keys_eviction_stays_oldest_across_prunes`) covers the two-prune case; the naive position-based variant fails it.

## Before / after

Interleaved A/B, 3 runs each (divan wall time, fastest column):

| bench | before | after | delta |
|---|---|---|---|
| `bench_message_key_eviction` | 161-168 µs | 124-137 µs | ~-20% |
| `bench_group_out_of_order_decrypt_worst_case` | 94.3 µs | 85.8 µs | ~-9% |
| `bench_out_of_order_decryption` | 153 µs | 148 µs | neutral |

CodSpeed on this PR will show the deterministic instruction-count delta (the 21.7% memcpy should disappear from the eviction bench's profile).

## Cost / regressions considered

- Each prune now allocates a scratch `Vec<u32>` (~8 KB) for the counter selection; that is once every 50 inserts, vs a ~200 KB memmove it replaces.
- The buffer is no longer counter-sorted after a prune or an out-of-order consume. Nothing depends on order: lookup scans by counter (covered by the existing `test_message_keys_lookup_by_counter_not_order`), and the serialized session's `message_keys` is a repeated field with no order contract.
- All 120 libsignal tests pass, including the pre-existing eviction-set test (`test_message_keys_eviction_at_max`), which pins the exact evicted counter set.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

