### PR TITLE
perf(history-sync): keep heap-error types off the scanner happy path

### DIFF
--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -147,7 +147,7 @@ impl<'a> FieldWalker<'a> {
         self.reader
             .ensure(10)
             .map_err(HistorySyncError::DecompressionError)?;
-        let (tag, tlen) = read_varint(self.reader.available())?;
+        let (tag, tlen) = read_varint(self.reader.available()).ok_or_else(malformed_varint)?;
         let field_number = (tag >> 3) as u32;
         let wire_type_raw = (tag & 0x7) as u32;
 
@@ -156,7 +156,8 @@ impl<'a> FieldWalker<'a> {
                 self.reader
                     .ensure(tlen + 10)
                     .map_err(HistorySyncError::DecompressionError)?;
-                let (len, vlen) = read_varint(&self.reader.available()[tlen..])?;
+                let (len, vlen) =
+                    read_varint(&self.reader.available()[tlen..]).ok_or_else(malformed_varint)?;
                 let len = usize::try_from(len).map_err(|_| {
                     HistorySyncError::MalformedProtobuf(format!(
                         "field length overflows usize: {len}"
@@ -183,7 +184,8 @@ impl<'a> FieldWalker<'a> {
                 self.reader
                     .ensure(tlen + 10)
                     .map_err(HistorySyncError::DecompressionError)?;
-                let (_, vlen) = read_varint(&self.reader.available()[tlen..])?;
+                let (_, vlen) =
+                    read_varint(&self.reader.available()[tlen..]).ok_or_else(malformed_varint)?;
                 (tlen + vlen, tlen)
             }
             wire_type::FIXED64 => {
@@ -396,41 +398,38 @@ impl<'a> HistorySyncStream<'a> {
 
 /// Compute `pos + len` with overflow and bounds checking.
 #[inline(always)]
-fn checked_end(
-    pos: usize,
-    len: u64,
-    buf_len: usize,
-    field: &str,
-) -> Result<usize, HistorySyncError> {
-    let len = usize::try_from(len).map_err(|_| {
-        HistorySyncError::MalformedProtobuf(format!("{field} length overflows usize: {len}"))
-    })?;
-    let end = pos.checked_add(len).ok_or_else(|| {
-        HistorySyncError::MalformedProtobuf(format!(
-            "{field} field overflows: pos={pos}, len={len}"
-        ))
-    })?;
-    if end > buf_len {
-        return Err(HistorySyncError::MalformedProtobuf(format!(
-            "{field} field overflows buffer: pos={pos}, len={len}, buf={buf_len}"
-        )));
-    }
-    Ok(end)
+/// Bounds-checked `pos + len` within `buf_len`. `None` on overflow or
+/// truncation; kept `Copy` for the same happy-path reason as
+/// [`read_varint`]. `?` sites map `None` via [`field_overflow`].
+#[inline]
+fn checked_end(pos: usize, len: u64, buf_len: usize) -> Option<usize> {
+    let len = usize::try_from(len).ok()?;
+    let end = pos.checked_add(len)?;
+    (end <= buf_len).then_some(end)
+}
+
+/// Rich error for `?` boundaries around [`checked_end`]; failure-path only.
+#[cold]
+fn field_overflow(field: &str, pos: usize, len: u64, buf_len: usize) -> HistorySyncError {
+    HistorySyncError::MalformedProtobuf(format!(
+        "{field} field overflows buffer: pos={pos}, len={len}, buf={buf_len}"
+    ))
 }
 
 /// Read a protobuf varint from `data`, returning (value, bytes_consumed).
+/// `None` covers truncation and 64-bit overflow alike; the walk loops call
+/// this per field and discard the failure, so the type must stay `Copy`. A
+/// `Result` carrying a heap error here put `drop_glue` on the happy path of
+/// every field visit (~2% of a full-blob decode). `?` sites map `None` via
+/// [`malformed_varint`].
 // inline(always): per-field hot path; the thin-LTO bench profile keeps plain
 // #[inline] candidates outlined and the call overhead dominates the walk.
 #[inline(always)]
-fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
+fn read_varint(data: &[u8]) -> Option<(u64, usize)> {
     // Single-byte fast-path: most history-sync varints (tags, small lengths) fit in one byte.
-    let Some(&first) = data.first() else {
-        return Err(HistorySyncError::MalformedProtobuf(
-            "unexpected end of data in varint".into(),
-        ));
-    };
+    let &first = data.first()?;
     if first < 0x80 {
-        return Ok((first as u64, 1));
+        return Some((first as u64, 1));
     }
     let mut value = (first & 0x7F) as u64;
     let mut shift = 7u32;
@@ -438,24 +437,25 @@ fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
         // The 10th byte of a 64-bit varint may only carry one bit; prost
         // rejects the overflow instead of silently truncating it.
         if shift == 63 && byte > 1 {
-            return Err(HistorySyncError::MalformedProtobuf(
-                "varint overflows 64 bits".into(),
-            ));
+            return None;
         }
         value |= ((byte & 0x7F) as u64) << shift;
         if byte & 0x80 == 0 {
-            return Ok((value, i + 2));
+            return Some((value, i + 2));
         }
         shift += 7;
         if shift >= 64 {
-            return Err(HistorySyncError::MalformedProtobuf(
-                "varint too long".into(),
-            ));
+            return None;
         }
     }
-    Err(HistorySyncError::MalformedProtobuf(
-        "unexpected end of data in varint".into(),
-    ))
+    None
+}
+
+/// Rich error for `?` boundaries around [`read_varint`]; built only on the
+/// (malformed-blob) failure path so the walk loops stay allocation-free.
+#[cold]
+fn malformed_varint() -> HistorySyncError {
+    HistorySyncError::MalformedProtobuf("truncated or overlong varint".into())
 }
 
 /// Skip a protobuf field based on wire type, returning the new position.
@@ -463,15 +463,18 @@ fn read_varint(data: &[u8]) -> Result<(u64, usize), HistorySyncError> {
 fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySyncError> {
     match wire_type {
         wire_type::VARINT => {
-            let (_, vlen) = read_varint(&buf[pos..])?;
+            let (_, vlen) = read_varint(&buf[pos..]).ok_or_else(malformed_varint)?;
             Ok(pos + vlen)
         }
-        wire_type::FIXED64 => checked_end(pos, 8, buf.len(), "fixed64"),
+        wire_type::FIXED64 => checked_end(pos, 8, buf.len())
+            .ok_or_else(|| field_overflow("fixed64", pos, 8, buf.len())),
         wire_type::LENGTH_DELIMITED => {
-            let (len, vlen) = read_varint(&buf[pos..])?;
-            checked_end(pos + vlen, len, buf.len(), "length-delimited")
+            let (len, vlen) = read_varint(&buf[pos..]).ok_or_else(malformed_varint)?;
+            checked_end(pos + vlen, len, buf.len())
+                .ok_or_else(|| field_overflow("length-delimited", pos + vlen, len, buf.len()))
         }
-        wire_type::FIXED32 => checked_end(pos, 4, buf.len(), "fixed32"),
+        wire_type::FIXED32 => checked_end(pos, 4, buf.len())
+            .ok_or_else(|| field_overflow("fixed32", pos, 4, buf.len())),
         _ => {
             log::warn!("Unknown wire type {wire_type} in history sync, cannot skip");
             Err(HistorySyncError::MalformedProtobuf(format!(
@@ -489,7 +492,7 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
     let mut pushname: Option<String> = None;
 
     while pos < data.len() {
-        let (tag, bytes_read) = read_varint(data.get(pos..)?).ok()?;
+        let (tag, bytes_read) = read_varint(data.get(pos..)?)?;
         pos += bytes_read;
         let field_number = (tag >> 3) as u32;
         let wt = (tag & 0x7) as u32;
@@ -497,7 +500,7 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
         match field_number {
             // id (string)
             tags::pushname::ID if wt == wire_type::LENGTH_DELIMITED => {
-                let (len, vlen) = read_varint(data.get(pos..)?).ok()?;
+                let (len, vlen) = read_varint(data.get(pos..)?)?;
                 pos += vlen;
                 let len = usize::try_from(len).ok()?;
                 let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
@@ -510,7 +513,7 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
             }
             // pushname (string)
             tags::pushname::PUSHNAME if wt == wire_type::LENGTH_DELIMITED => {
-                let (len, vlen) = read_varint(data.get(pos..)?).ok()?;
+                let (len, vlen) = read_varint(data.get(pos..)?)?;
                 pos += vlen;
                 let len = usize::try_from(len).ok()?;
                 let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
@@ -1110,7 +1113,7 @@ impl<'a> Iterator for FieldIter<'a> {
         if self.pos >= self.data.len() {
             return None;
         }
-        let Ok((tag, br)) = read_varint(&self.data[self.pos..]) else {
+        let Some((tag, br)) = read_varint(&self.data[self.pos..]) else {
             self.pos = self.data.len();
             return Some(Err(WalkStop::Malformed));
         };
@@ -1126,12 +1129,12 @@ impl<'a> Iterator for FieldIter<'a> {
         let wt = (tag & 0x7) as u32;
         match wt {
             wire_type::LENGTH_DELIMITED => {
-                let Ok((len, vl)) = read_varint(&self.data[self.pos..]) else {
+                let Some((len, vl)) = read_varint(&self.data[self.pos..]) else {
                     self.pos = self.data.len();
                     return Some(Err(WalkStop::Malformed));
                 };
                 self.pos += vl;
-                let Ok(end) = checked_end(self.pos, len, self.data.len(), "field") else {
+                let Some(end) = checked_end(self.pos, len, self.data.len()) else {
                     self.pos = self.data.len();
                     return Some(Err(WalkStop::Malformed));
                 };
@@ -1145,7 +1148,7 @@ impl<'a> Iterator for FieldIter<'a> {
                 }))
             }
             wire_type::VARINT => {
-                let Ok((v, vl)) = read_varint(&self.data[self.pos..]) else {
+                let Some((v, vl)) = read_varint(&self.data[self.pos..]) else {
                     self.pos = self.data.len();
                     return Some(Err(WalkStop::Malformed));
                 };
@@ -1531,7 +1534,7 @@ fn extract_conversation_fields(
     let mut tc_token_sender_timestamp: Option<u64> = None;
 
     while pos < data.len() {
-        let Ok((tag, br)) = read_varint(&data[pos..]) else {
+        let Some((tag, br)) = read_varint(&data[pos..]) else {
             break;
         };
         pos += br;
@@ -1539,11 +1542,11 @@ fn extract_conversation_fields(
         let wt = (tag & 0x7) as u32;
         match (field, wt) {
             (tags::conversation::ID, wire_type::LENGTH_DELIMITED) => {
-                let Ok((len, vl)) = read_varint(&data[pos..]) else {
+                let Some((len, vl)) = read_varint(&data[pos..]) else {
                     break;
                 };
                 pos += vl;
-                let Ok(end) = checked_end(pos, len, data.len(), "conv-id") else {
+                let Some(end) = checked_end(pos, len, data.len()) else {
                     break;
                 };
                 let Some(id) = smoothutf8::from_utf8(&data[pos..end]) else {
@@ -1559,11 +1562,11 @@ fn extract_conversation_fields(
                 pos = end;
             }
             (tags::conversation::MESSAGES, wire_type::LENGTH_DELIMITED) => {
-                let Ok((len, vl)) = read_varint(&data[pos..]) else {
+                let Some((len, vl)) = read_varint(&data[pos..]) else {
                     break;
                 };
                 pos += vl;
-                let Ok(end) = checked_end(pos, len, data.len(), "conv-msg") else {
+                let Some(end) = checked_end(pos, len, data.len()) else {
                     break;
                 };
                 // The id guard keeps records from a (malformed) blob that
@@ -1599,25 +1602,25 @@ fn extract_conversation_fields(
                 pos = end;
             }
             (tags::conversation::TC_TOKEN, wire_type::LENGTH_DELIMITED) => {
-                let Ok((len, vl)) = read_varint(&data[pos..]) else {
+                let Some((len, vl)) = read_varint(&data[pos..]) else {
                     break;
                 };
                 pos += vl;
-                let Ok(end) = checked_end(pos, len, data.len(), "conv-tctoken") else {
+                let Some(end) = checked_end(pos, len, data.len()) else {
                     break;
                 };
                 tc_token = &data[pos..end];
                 pos = end;
             }
             (tags::conversation::TC_TOKEN_TIMESTAMP, wire_type::VARINT) => {
-                let Ok((v, vl)) = read_varint(&data[pos..]) else {
+                let Some((v, vl)) = read_varint(&data[pos..]) else {
                     break;
                 };
                 tc_token_timestamp = Some(v);
                 pos += vl;
             }
             (tags::conversation::TC_TOKEN_SENDER_TIMESTAMP, wire_type::VARINT) => {
-                let Ok((v, vl)) = read_varint(&data[pos..]) else {
+                let Some((v, vl)) = read_varint(&data[pos..]) else {
                     break;
                 };
                 tc_token_sender_timestamp = Some(v);
@@ -2776,7 +2779,7 @@ mod tests {
                 tags::history_sync::CONVERSATIONS if wt == wire_type::LENGTH_DELIMITED => {
                     let (len, vlen) = read_varint(&decompressed[pos..]).unwrap();
                     pos += vlen;
-                    let end = checked_end(pos, len, decompressed.len(), "conversation").unwrap();
+                    let end = checked_end(pos, len, decompressed.len()).unwrap();
                     result.conversations_processed += 1;
                     if let Some(candidate) = extract_conversation_fields(
                         &decompressed[pos..end],
@@ -2793,7 +2796,7 @@ mod tests {
                 {
                     let (len, vlen) = read_varint(&decompressed[pos..]).unwrap();
                     pos += vlen;
-                    let end = checked_end(pos, len, decompressed.len(), "pushname").unwrap();
+                    let end = checked_end(pos, len, decompressed.len()).unwrap();
                     if let Some(own) = own_user
                         && let Some(name) = extract_own_pushname(&decompressed[pos..end], own)
                     {
@@ -2804,7 +2807,7 @@ mod tests {
                 tags::history_sync::NCT_SALT if wt == wire_type::LENGTH_DELIMITED => {
                     let (len, vlen) = read_varint(&decompressed[pos..]).unwrap();
                     pos += vlen;
-                    let end = checked_end(pos, len, decompressed.len(), "nctSalt").unwrap();
+                    let end = checked_end(pos, len, decompressed.len()).unwrap();
                     let salt = decompressed[pos..end].to_vec();
                     if !salt.is_empty() {
                         result.nct_salt = Some(salt);

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -398,10 +398,10 @@ impl<'a> HistorySyncStream<'a> {
 
 /// Compute `pos + len` with overflow and bounds checking.
 #[inline(always)]
-/// Bounds-checked `pos + len` within `buf_len`. `None` on overflow or
-/// truncation; kept `Copy` for the same happy-path reason as
-/// [`read_varint`]. `?` sites map `None` via [`field_overflow`].
-#[inline]
+/// `Option` (Copy) for the same happy-path drop_glue reason as
+/// [`read_varint`]; `?` sites map `None` via [`field_overflow`].
+// inline(always): same hot-path/thin-LTO rationale as read_varint.
+#[inline(always)]
 fn checked_end(pos: usize, len: u64, buf_len: usize) -> Option<usize> {
     let len = usize::try_from(len).ok()?;
     let end = pos.checked_add(len)?;
@@ -416,9 +416,8 @@ fn field_overflow(field: &str, pos: usize, len: u64, buf_len: usize) -> HistoryS
     ))
 }
 
-/// Read a protobuf varint from `data`, returning (value, bytes_consumed).
-/// `None` covers truncation and 64-bit overflow alike; the walk loops call
-/// this per field and discard the failure, so the type must stay `Copy`. A
+/// `None` covers truncation and 64-bit overflow alike: the walk loops call
+/// this per field and discard the failure, so the return must stay `Copy`. A
 /// `Result` carrying a heap error here put `drop_glue` on the happy path of
 /// every field visit (~2% of a full-blob decode). `?` sites map `None` via
 /// [`malformed_varint`].

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -396,8 +396,6 @@ impl<'a> HistorySyncStream<'a> {
     }
 }
 
-/// Compute `pos + len` with overflow and bounds checking.
-#[inline(always)]
 /// `Option` (Copy) for the same happy-path drop_glue reason as
 /// [`read_varint`]; `?` sites map `None` via [`field_overflow`].
 // inline(always): same hot-path/thin-LTO rationale as read_varint.


### PR DESCRIPTION
Keeps heap-carrying error types off the history-sync scanner's per-field happy path.

## Problem

`read_varint` and `checked_end` returned `Result<_, HistorySyncError>`. The error's `MalformedProtobuf(String)` variant makes the `Result` non-trivially droppable, so every per-field iteration of the walk loops (which discard the failure with `let Ok(..) else { break }`) paid a `drop_glue` call on the Ok value. CodSpeed's flamegraph for `bench_process_history_sync` attributed 1.85% of the decode to `drop_glue::<Result<(u64, usize), HistorySyncError>>` alone, invoked from `scan_message_level`'s loop. `checked_end` additionally `format!`-ed context strings eagerly in signatures even when callers discarded them.

## Change

- `read_varint` and `checked_end` now return `Option` (Copy, no drop glue). The hot loops bind with `let Some(..) else`, identical control flow, zero drop code.
- The few `?` propagation boundaries (FieldWalker, `skip_field`, remainder decode) map `None` through `#[cold]` constructors (`malformed_varint`, `field_overflow`), so malformed blobs still surface the same rich `HistorySyncError::MalformedProtobuf` and the allocation happens only on the failure path.
- Behavior on malformed input is unchanged: same cut points, same skip/fallback decisions; only the error message for truncated varints is now a single static phrase instead of three near-identical ones.

## Before / after

Local interleaved wall time on `bench_process_history_sync` is neutral (the ~2% is below machine noise); this change is measured by CodSpeed's deterministic instruction count, where the `drop_glue` frames disappear from the scanner's profile. Numbers will appear in this PR's CodSpeed report.

All 47 history-sync unit tests (including the malformed-blob oracle tests) pass unchanged.

## Regressions considered

- Error detail: truncated-varint diagnostics collapse from three specific strings to one static message; the buffer-overflow diagnostics keep their full per-field context (field name, pos, len, buf) via `field_overflow`.
- The `#[cold]` constructors add two tiny functions; binary-size delta is expected to be noise-level.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oxidezap/whatsapp-rust/pull/947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

