### PR TITLE
bench: deterministic rng and hashers; pin and shard the CodSpeed CI

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,8 +3,10 @@ name: CodSpeed
 on:
   push:
     branches: [main]
+    paths-ignore: ["**.md", "docs/**"]
   pull_request:
     branches: [main]
+    paths-ignore: ["**.md", "docs/**"]
   # Allows CodSpeed to trigger backtest performance analysis to generate
   # initial baseline data.
   workflow_dispatch:
@@ -20,11 +22,28 @@ concurrency:
 env:
   CARGO_TERM_COLOR: never
   PROTOC_VERSION: "3.25.3"
+  # Freeze glibc malloc's adaptive thresholds: mmap/trim/arena decisions vary
+  # with allocation history and read as spurious instruction/memory deltas
+  # under the deterministic instruments (codspeed.io/docs -> reducing-variance).
+  MALLOC_ARENA_MAX: "1"
+  MALLOC_MMAP_THRESHOLD_: "131072"
+  MALLOC_TRIM_THRESHOLD_: "131072"
+  MALLOC_TOP_PAD_: "131072"
 
 jobs:
   benchmarks:
-    name: Run CodSpeed benchmarks
-    runs-on: ubuntu-latest
+    name: Run CodSpeed benchmarks (${{ matrix.shard.name }})
+    runs-on: ubuntu-24.04
+    strategy:
+      # Shards split by package within one workflow (same OIDC auth), halving
+      # the serial wall time; CodSpeed merges shard results into one run
+      # (codspeed.io/docs -> sharded-benchmarks).
+      matrix:
+        shard:
+          - name: core
+            packages: -p wacore -p wacore-noise
+          - name: proto-signal
+            packages: -p wacore-binary -p wacore-libsignal -p wacore-appstate
     steps:
       - uses: actions/checkout@v6
         with:
@@ -42,7 +61,7 @@ jobs:
       - name: Cache Rust registry
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: ${{ runner.os }}-cargo-codspeed
+          prefix-key: ${{ runner.os }}-cargo-codspeed-${{ matrix.shard.name }}
           cache-targets: "false"
 
       # simulation and memory share the same instrumented build, so one
@@ -50,8 +69,7 @@ jobs:
       - name: Build the benchmark targets
         run: >
           cargo codspeed build -m simulation -m memory
-          -p wacore -p wacore-binary -p wacore-libsignal
-          -p wacore-appstate -p wacore-noise
+          ${{ matrix.shard.packages }}
 
       # Both instruments run serially in a single invocation so each
       # benchmark uploads as one run carrying CPU and memory metrics.
@@ -59,14 +77,14 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation,memory
-          run: cargo codspeed run
+          run: cargo codspeed run ${{ matrix.shard.packages }}
 
   # Integration benches drive the real async client against the bartender mock
   # server, so they need the service container + MOCK_SERVER_URL. Kept as a
   # separate job so the unit-bench job above stays fast and mock-server-free.
   integration-benchmarks:
     name: Run CodSpeed integration benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # These benches drive the real client (connect/reconnect handshakes) under
     # Valgrind, so they are slow; cap the job so a stuck run can't hang CI
     # indefinitely. A healthy run finishes well under this even on slow runners.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2
         with:
-          tool: protoc@${{ env.PROTOC_VERSION }},cargo-codspeed@4.7.0
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-codspeed@5.0.1
 
       - name: Cache Rust registry
         uses: Swatinem/rust-cache@v2
@@ -115,7 +115,7 @@ jobs:
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2
         with:
-          tool: protoc@${{ env.PROTOC_VERSION }},cargo-codspeed@4.7.0
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-codspeed@5.0.1
 
       - name: Cache Rust registry
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,6 +35,9 @@ jobs:
     name: Run CodSpeed benchmarks (${{ matrix.shard.name }})
     runs-on: ubuntu-24.04
     strategy:
+      # One shard failing must not cancel the other: CodSpeed merges shards
+      # into a single run, and a cancelled shard leaves it incomplete.
+      fail-fast: false
       # Shards split by package within one workflow (same OIDC auth), halving
       # the serial wall time; CodSpeed merges shard results into one run
       # (codspeed.io/docs -> sharded-benchmarks).
@@ -67,17 +70,21 @@ jobs:
       # simulation and memory share the same instrumented build, so one
       # build covers both instruments.
       - name: Build the benchmark targets
+        env:
+          SHARD_PACKAGES: ${{ matrix.shard.packages }}
         run: >
           cargo codspeed build -m simulation -m memory
-          ${{ matrix.shard.packages }}
+          $SHARD_PACKAGES
 
       # Both instruments run serially in a single invocation so each
       # benchmark uploads as one run carrying CPU and memory metrics.
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
+        env:
+          SHARD_PACKAGES: ${{ matrix.shard.packages }}
         with:
           mode: simulation,memory
-          run: cargo codspeed run ${{ matrix.shard.packages }}
+          run: cargo codspeed run $SHARD_PACKAGES
 
   # Integration benches drive the real async client against the bartender mock
   # server, so they need the service container + MOCK_SERVER_URL. Kept as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,14 +637,14 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codspeed"
-version = "4.7.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57af92d1db7f6871b7e82c79cd87f2501db66f36b0eab924be6ea83dd6b2f3f3"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
 dependencies = [
  "anyhow",
  "cc",
  "colored",
- "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "glob",
  "libc",
  "nix 0.31.3",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat"
-version = "4.7.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ea79fd0b1f2128cfac6308369013dba92df47baf4a4f66b57d8158224a361d"
+checksum = "bc1065d507e1cbab731a7976db4cef7e47e49b87b4dbc0a925df07d343558420"
 dependencies = [
  "clap",
  "codspeed",
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-macros"
-version = "4.7.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70e4ddd6beedefeb48f59d5f85fc21365a66e7976408c3d39f6cbbc4f03e08c"
+checksum = "2fd05482a95823ffe421e8a9ba24fa22a6a30d594e2c60455cbb43a41bf2d8fa"
 dependencies = [
  "divan-macros",
  "itertools",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-walltime"
-version = "4.7.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490c04f6076be6eacfafb496b8b237f3efbbed93838f2689115cc6f35fcf81c9"
+checksum = "d2f8eae75b8fa85357020a404899c4280d590c9fd1c47640b3ce53106c62d2ee"
 dependencies = [
  "cfg-if",
  "clap",
@@ -697,12 +697,11 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4515,15 +4514,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", default-features = false }
 compact_str = { version = "0.9", default-features = false }
 ctr = { version = "0.10", default-features = false }
-divan = { package = "codspeed-divan-compat", version = "4.7.0" }
+divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 env_logger = { version = "0.11", default-features = false }
 event-listener = { version = "5", default-features = false }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -3,6 +3,11 @@
 use async_trait::async_trait;
 use buffa::Message as ProtoMessage;
 use std::collections::HashMap;
+
+/// SipHash with fixed keys: the default RandomState seeds per process, so
+/// bucket layout (and thus cache behavior) differed between benchmark runs.
+type DetState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
+type DetHashMap<K, V> = HashMap<K, V, DetState>;
 use std::hint::black_box;
 use wacore::client::context::{GroupInfo, SendContextResolver};
 use wacore::messages::MessageUtils;
@@ -143,7 +148,7 @@ impl Runtime for BenchRuntime {
 struct MemIdentityStore {
     key_pair: IdentityKeyPair,
     reg_id: u32,
-    identities: std::sync::Arc<std::sync::Mutex<HashMap<ProtocolAddress, IdentityKey>>>,
+    identities: std::sync::Arc<std::sync::Mutex<DetHashMap<ProtocolAddress, IdentityKey>>>,
 }
 
 impl MemIdentityStore {
@@ -151,7 +156,7 @@ impl MemIdentityStore {
         Self {
             key_pair,
             reg_id,
-            identities: std::sync::Arc::new(std::sync::Mutex::new(HashMap::new())),
+            identities: std::sync::Arc::new(std::sync::Mutex::new(DetHashMap::default())),
         }
     }
 }
@@ -188,7 +193,7 @@ impl IdentityKeyStore for MemIdentityStore {
     }
 }
 
-struct MemPreKeyStore(HashMap<PreKeyId, PreKeyRecord>);
+struct MemPreKeyStore(DetHashMap<PreKeyId, PreKeyRecord>);
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -209,7 +214,7 @@ impl PreKeyStore for MemPreKeyStore {
     }
 }
 
-struct MemSignedPreKeyStore(HashMap<SignedPreKeyId, SignedPreKeyRecord>);
+struct MemSignedPreKeyStore(DetHashMap<SignedPreKeyId, SignedPreKeyRecord>);
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -233,7 +238,9 @@ impl SignedPreKeyStore for MemSignedPreKeyStore {
 /// Bench fixture wrapping shared session state — see `MemIdentityStore`
 /// for the rationale.
 #[derive(Clone, Default)]
-struct MemSessionStore(std::sync::Arc<std::sync::Mutex<HashMap<ProtocolAddress, SessionRecord>>>);
+struct MemSessionStore(
+    std::sync::Arc<std::sync::Mutex<DetHashMap<ProtocolAddress, SessionRecord>>>,
+);
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -250,7 +257,7 @@ impl SessionStore for MemSessionStore {
     }
 }
 
-struct MemSenderKeyStore(HashMap<SenderKeyName, SenderKeyRecord>);
+struct MemSenderKeyStore(DetHashMap<SenderKeyName, SenderKeyRecord>);
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -300,8 +307,8 @@ impl User {
         let spk_record =
             SignedPreKeyRecord::new(spk_id, Timestamp::from_epoch_millis(0), &spk_pair, &spk_sig);
 
-        let mut prekeys = MemPreKeyStore(HashMap::new());
-        let mut signed_prekeys = MemSignedPreKeyStore(HashMap::new());
+        let mut prekeys = MemPreKeyStore(DetHashMap::default());
+        let mut signed_prekeys = MemSignedPreKeyStore(DetHashMap::default());
         futures::executor::block_on(async {
             prekeys.save_pre_key(pk_id, &pk_record).await.unwrap();
             signed_prekeys
@@ -324,7 +331,7 @@ impl User {
             prekeys,
             signed_prekeys,
             sessions: MemSessionStore::default(),
-            sender_keys: MemSenderKeyStore(HashMap::new()),
+            sender_keys: MemSenderKeyStore(DetHashMap::default()),
             prekey_pair: pk_pair,
             signed_prekey_pair: spk_pair,
             signed_prekey_sig: spk_sig.to_vec(),

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -264,7 +264,7 @@ impl User {
         // Same deterministic stream: the id is varint-encoded into prekey
         // bundles, so an entropy draw here still shifted payload sizes.
         let registration_id = {
-            use rand::Rng as _;
+            use rand::RngExt as _;
             rng.random::<u32>() & 0x3FFF
         };
 

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -10,10 +10,10 @@ type DetHashMap<K, V> = HashMap<K, V, DetState>;
 /// bits), which CodSpeed reads as noise. A counter keeps distinct call sites
 /// on distinct streams so parties never share key material.
 fn bench_rng() -> rand::rngs::StdRng {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static CTR: AtomicU64 = AtomicU64::new(0);
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static CTR: AtomicU32 = AtomicU32::new(0);
     <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(
-        0xB3AC_0000 + CTR.fetch_add(1, Ordering::Relaxed),
+        0xB3AC_0000 + u64::from(CTR.fetch_add(1, Ordering::Relaxed)),
     )
 }
 

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -261,7 +261,9 @@ impl User {
         let mut rng = bench_rng();
 
         let identity_key_pair = IdentityKeyPair::generate(&mut rng);
-        let registration_id = rand::random::<u32>() & 0x3FFF;
+        // Same deterministic stream: the id is varint-encoded into prekey
+        // bundles, so an entropy draw here still shifted payload sizes.
+        let registration_id = rand::Rng::random::<u32>(&mut rng) & 0x3FFF;
 
         let prekey_id: PreKeyId = 1.into();
         let prekey_pair = KeyPair::generate(&mut rng);

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -1,5 +1,22 @@
 use std::collections::HashMap;
 
+/// SipHash with fixed keys: the default RandomState seeds per process, so
+/// bucket layout (and thus cache behavior) differed between benchmark runs.
+type DetState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
+type DetHashMap<K, V> = HashMap<K, V, DetState>;
+
+/// Deterministic per-call-site RNG: entropy-seeded keys made every run measure
+/// different instruction counts (vartime signature paths depend on scalar
+/// bits), which CodSpeed reads as noise. A counter keeps distinct call sites
+/// on distinct streams so parties never share key material.
+fn bench_rng() -> rand::rngs::StdRng {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(
+        0xB3AC_0000 + CTR.fetch_add(1, Ordering::Relaxed),
+    )
+}
+
 use async_trait::async_trait;
 use divan::black_box;
 
@@ -20,7 +37,7 @@ use wacore_libsignal::store::sender_key_name::SenderKeyName;
 struct InMemoryIdentityKeyStore {
     identity_key_pair: IdentityKeyPair,
     registration_id: u32,
-    identities: HashMap<ProtocolAddress, IdentityKey>,
+    identities: DetHashMap<ProtocolAddress, IdentityKey>,
 }
 
 impl InMemoryIdentityKeyStore {
@@ -28,7 +45,7 @@ impl InMemoryIdentityKeyStore {
         Self {
             identity_key_pair,
             registration_id,
-            identities: HashMap::new(),
+            identities: DetHashMap::default(),
         }
     }
 }
@@ -77,13 +94,13 @@ impl IdentityKeyStore for InMemoryIdentityKeyStore {
 }
 
 struct InMemoryPreKeyStore {
-    prekeys: HashMap<PreKeyId, PreKeyRecord>,
+    prekeys: DetHashMap<PreKeyId, PreKeyRecord>,
 }
 
 impl InMemoryPreKeyStore {
     fn new() -> Self {
         Self {
-            prekeys: HashMap::new(),
+            prekeys: DetHashMap::default(),
         }
     }
 }
@@ -120,13 +137,13 @@ impl PreKeyStore for InMemoryPreKeyStore {
 }
 
 struct InMemorySignedPreKeyStore {
-    signed_prekeys: HashMap<SignedPreKeyId, SignedPreKeyRecord>,
+    signed_prekeys: DetHashMap<SignedPreKeyId, SignedPreKeyRecord>,
 }
 
 impl InMemorySignedPreKeyStore {
     fn new() -> Self {
         Self {
-            signed_prekeys: HashMap::new(),
+            signed_prekeys: DetHashMap::default(),
         }
     }
 }
@@ -155,13 +172,13 @@ impl SignedPreKeyStore for InMemorySignedPreKeyStore {
 }
 
 struct InMemorySessionStore {
-    sessions: HashMap<ProtocolAddress, SessionRecord>,
+    sessions: DetHashMap<ProtocolAddress, SessionRecord>,
 }
 
 impl InMemorySessionStore {
     fn new() -> Self {
         Self {
-            sessions: HashMap::new(),
+            sessions: DetHashMap::default(),
         }
     }
 }
@@ -194,13 +211,13 @@ impl SessionStore for InMemorySessionStore {
 }
 
 struct InMemorySenderKeyStore {
-    sender_keys: HashMap<SenderKeyName, SenderKeyRecord>,
+    sender_keys: DetHashMap<SenderKeyName, SenderKeyRecord>,
 }
 
 impl InMemorySenderKeyStore {
     fn new() -> Self {
         Self {
-            sender_keys: HashMap::new(),
+            sender_keys: DetHashMap::default(),
         }
     }
 }
@@ -241,7 +258,7 @@ struct User {
 
 impl User {
     fn new(name: &str, device_id: u32) -> Self {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
 
         let identity_key_pair = IdentityKeyPair::generate(&mut rng);
         let registration_id = rand::random::<u32>() & 0x3FFF;
@@ -321,7 +338,7 @@ fn setup_dm_session() -> (User, User) {
     let (mut alice, bob) = setup_dm_users();
 
     let bob_bundle = bob.get_prekey_bundle();
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
 
     futures::executor::block_on(async {
         process_prekey_bundle(
@@ -374,7 +391,7 @@ fn setup_established_dm_session() -> (User, User) {
         let ct_msg = CiphertextMessage::PreKeySignalMessage(
             wacore_libsignal::protocol::PreKeySignalMessage::try_from(ct.serialize()).unwrap(),
         );
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
         message_decrypt(
             &ct_msg,
             &alice.address,
@@ -404,7 +421,7 @@ fn setup_group_with_distribution() -> (User, User, SenderKeyName) {
     let mut bob = User::new("bob", 1);
 
     futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
         let skdm = create_sender_key_distribution_message(
             &sender_key_name,
             &mut alice.sender_key_store,
@@ -434,7 +451,7 @@ fn bench_dm_session_establishment(bencher: divan::Bencher) {
     bencher.with_inputs(setup_dm_users).bench_refs(|data| {
         let (alice, bob) = data;
         let bob_bundle = bob.get_prekey_bundle();
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
 
         futures::executor::block_on(async {
             process_prekey_bundle(
@@ -480,7 +497,7 @@ fn bench_dm_decrypt_first_message(bencher: divan::Bencher) {
         .with_inputs(setup_dm_with_first_message)
         .bench_refs(|data| {
             let (alice, bob, ciphertext_bytes) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             let plaintext = futures::executor::block_on(async {
                 let ciphertext = CiphertextMessage::PreKeySignalMessage(
@@ -539,7 +556,7 @@ fn setup_dm_with_inorder_subsequent_message() -> (User, User, Vec<u8>) {
     let (mut alice, mut bob) = setup_established_dm_session();
 
     futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
 
         // Bob replies and Alice decrypts it, clearing Alice's pending prekey so
         // her subsequent messages are plain SignalMessages.
@@ -616,7 +633,7 @@ fn bench_dm_decrypt_subsequent_message(bencher: divan::Bencher) {
         .with_inputs(setup_dm_with_inorder_subsequent_message)
         .bench_refs(|data| {
             let (alice, bob, ciphertext_bytes) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             let plaintext = futures::executor::block_on(async {
                 let ciphertext = CiphertextMessage::SignalMessage(
@@ -647,7 +664,7 @@ fn bench_dm_decrypt_subsequent_message(bencher: divan::Bencher) {
 fn bench_group_create_distribution_message(bencher: divan::Bencher) {
     bencher.with_inputs(setup_group_sender).bench_refs(|data| {
         let (alice, sender_key_name) = data;
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
 
         let skdm = futures::executor::block_on(async {
             create_sender_key_distribution_message(
@@ -670,7 +687,7 @@ fn bench_group_encrypt_message(bencher: divan::Bencher) {
         .bench_refs(|data| {
             let (alice, _bob, sender_key_name) = data;
             let plaintext = b"Hello group! This is a group message from Alice.";
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             let ciphertext = futures::executor::block_on(async {
                 group_encrypt(
@@ -691,7 +708,7 @@ fn setup_group_with_encrypted_message() -> (User, User, SenderKeyName, Vec<u8>) 
     let (mut alice, bob, sender_key_name) = setup_group_with_distribution();
 
     let ciphertext = futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
         let skm = group_encrypt(
             &mut alice.sender_key_store,
             &sender_key_name,
@@ -738,7 +755,7 @@ fn bench_full_dm_conversation(bencher: divan::Bencher) {
         .with_inputs(setup_conversation_data)
         .bench_refs(|data| {
             let (alice, bob) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             futures::executor::block_on(async {
                 let bob_bundle = bob.get_prekey_bundle();
@@ -836,7 +853,7 @@ fn bench_full_dm_conversation(bencher: divan::Bencher) {
 
 // Signature-specific benchmarks to measure the XEdDSA optimization
 fn setup_keypair_with_message() -> (KeyPair, [u8; 64]) {
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
     let keypair = KeyPair::generate(&mut rng);
     let message = [0x42u8; 64]; // Fixed message for consistent benchmarking
     (keypair, message)
@@ -850,7 +867,7 @@ fn bench_signature_creation(bencher: divan::Bencher) {
         .with_inputs(setup_keypair_with_message)
         .bench_refs(|data| {
             let (keypair, message) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             // Sign multiple times to amortize any setup overhead
             for _ in 0..10 {
@@ -869,7 +886,7 @@ fn bench_signature_verification(bencher: divan::Bencher) {
         .with_inputs(setup_keypair_with_message)
         .bench_refs(|data| {
             let (keypair, message) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
             let signature = keypair
                 .calculate_signature(&message[..], &mut rng)
                 .expect("signature");
@@ -887,7 +904,7 @@ fn bench_signature_verification(bencher: divan::Bencher) {
 // Benchmark key generation (shows the added cost of caching)
 #[divan::bench]
 fn bench_key_generation() {
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
     for _ in 0..10 {
         let keypair = KeyPair::generate(&mut rng);
         black_box(keypair);
@@ -899,7 +916,7 @@ fn bench_key_generation() {
 fn setup_with_archived_sessions() -> (User, User, Vec<Vec<u8>>) {
     let mut alice = User::new("alice", 1);
     let mut bob = User::new("bob", 1);
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
 
     // Store ciphertexts encrypted with each session version
     let mut old_ciphertexts = Vec::new();
@@ -1026,7 +1043,7 @@ fn bench_decrypt_with_previous_session(bencher: divan::Bencher) {
         .with_inputs(setup_with_archived_sessions)
         .bench_refs(|data| {
             let (alice, bob, ciphertexts) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             // Try to decrypt an old message (encrypted with a previous session)
             // This forces the decryption to iterate through previous sessions
@@ -1062,7 +1079,7 @@ fn setup_out_of_order_messages() -> (User, User, Vec<Vec<u8>>) {
     let mut messages = Vec::new();
 
     futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
 
         // Alice sends initial PreKey message to Bob
         let msg = message_encrypt(
@@ -1142,7 +1159,7 @@ fn bench_out_of_order_decryption(bencher: divan::Bencher) {
         .with_inputs(setup_out_of_order_messages)
         .bench_refs(|data| {
             let (alice, bob, messages) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             futures::executor::block_on(async {
                 // Decrypt messages in reverse order (worst case for message key storage)
@@ -1175,7 +1192,7 @@ fn bench_out_of_order_decryption(bencher: divan::Bencher) {
 fn setup_promote_matching_session() -> (User, User, Vec<u8>) {
     let mut alice = User::new("alice", 1);
     let mut bob = User::new("bob", 1);
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
 
     let prekey_message = futures::executor::block_on(async {
         // Create initial session
@@ -1293,7 +1310,7 @@ fn bench_promote_matching_session(bencher: divan::Bencher) {
         .with_inputs(setup_promote_matching_session)
         .bench_refs(|data| {
             let (alice, bob, prekey_message) = data;
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut rng = bench_rng();
 
             futures::executor::block_on(async {
                 // Process multiple PreKey messages to exercise promote_matching_session
@@ -1336,7 +1353,7 @@ fn create_test_session_state(
     version: u8,
     base_key: &wacore_libsignal::protocol::PublicKey,
 ) -> SessionState {
-    let mut csprng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut csprng = bench_rng();
     let identity_keypair = KeyPair::generate(&mut csprng);
     let their_identity = IdentityKey::new(identity_keypair.public_key);
     let our_identity = IdentityKey::new(KeyPair::generate(&mut csprng).public_key);
@@ -1355,7 +1372,7 @@ fn create_test_session_state(
 /// Setup for message key eviction benchmark.
 /// Creates a session with a receiver chain pre-filled near capacity.
 fn setup_message_key_eviction() -> (SessionState, wacore_libsignal::protocol::PublicKey) {
-    let mut csprng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut csprng = bench_rng();
     let base_key = KeyPair::generate(&mut csprng).public_key;
     let mut state = create_test_session_state(3, &base_key);
 
@@ -1424,7 +1441,7 @@ fn setup_group_out_of_order_worst_case() -> (User, SenderKeyName, Vec<u8>) {
     );
 
     let worst_case_ct = futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
         let mut ciphertexts: Vec<Vec<u8>> = Vec::with_capacity((N + 1) as usize);
         for i in 0..=N {
             let skm = group_encrypt(
@@ -1495,7 +1512,7 @@ fn setup_group_in_order_decrypt_with_backlog() -> (User, SenderKeyName, Vec<u8>)
     );
 
     let in_order_ct = futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
         let mut ciphertexts: Vec<Vec<u8>> = Vec::with_capacity((N + 2) as usize);
         for i in 0..=(N + 1) {
             let skm = group_encrypt(
@@ -1560,7 +1577,7 @@ fn setup_skdm_ingest() -> (
         alice.address.name().to_string(),
     );
     let skdm = futures::executor::block_on(async {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut rng = bench_rng();
         create_sender_key_distribution_message(
             &sender_key_name,
             &mut alice.sender_key_store,

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -263,7 +263,10 @@ impl User {
         let identity_key_pair = IdentityKeyPair::generate(&mut rng);
         // Same deterministic stream: the id is varint-encoded into prekey
         // bundles, so an entropy draw here still shifted payload sizes.
-        let registration_id = rand::Rng::random::<u32>(&mut rng) & 0x3FFF;
+        let registration_id = {
+            use rand::Rng as _;
+            rng.random::<u32>() & 0x3FFF
+        };
 
         let prekey_id: PreKeyId = 1.into();
         let prekey_pair = KeyPair::generate(&mut rng);


### PR DESCRIPTION
Applies the CodSpeed variance-reduction guidance (regression-causes / reducing-variance / sharded-benchmarks docs) to the bench suite and its CI, after the buffa-merge investigation showed 4 of the 6 reported regressions were measurement artifacts rather than code changes.

## Bench code

**Deterministic RNG in `libsignal_benchmark`.** All 27 setup sites used `rand::make_rng` (entropy-seeded), so every run generated different key material. Signature verification is vartime over scalar bits, so the same benchmark legitimately executed a different instruction count on every run. `bench_rng()` now derives a distinct `StdRng` stream per call site from a fixed base seed (distinct streams so no two parties ever share keys; deterministic because divan's setup order is fixed).

Measured (callgrind, same binary, two consecutive runs of `bench_group_decrypt_message`):

| | run1 vs run2 delta |
|---|---:|
| before (entropy) | ~5,960 Ir |
| after (seeded) | ~160 Ir |

The residual is divan's wall-time calibration, which the CodSpeed instrumented runner does not execute.

**Fixed-seed hashers for bench MemStores.** The in-memory stores in `send_receive_benchmark` and `libsignal_benchmark` used `HashMap` with the default `RandomState`, whose per-process seed shuffles bucket layout, probe sequences, and therefore cache behavior between runs. They now use `BuildHasherDefault<DefaultHasher>` (SipHash with fixed keys, std-only). Trait-mandated signatures (`fetch_prekeys`) keep the std type.

`send_receive_benchmark` already had a deterministic `BenchRng`; this brings the rest of the suite to the same standard.

## CI (codspeed.yml)

- **`runs-on` pinned to `ubuntu-24.04`**: image drift (glibc, system libs) reads as toolchain-shaped regressions. The Rust toolchain and cargo-codspeed were already pinned.
- **glibc malloc adaptive thresholds frozen** (`MALLOC_ARENA_MAX/MMAP_THRESHOLD_/TRIM_THRESHOLD_/TOP_PAD_`): mmap-vs-brk and trim decisions depend on allocation history and surface as spurious deltas under both instruments.
- **Unit benches sharded into two package-level jobs** in the same workflow with the same OIDC auth (`core` = wacore+noise, `proto-signal` = binary+libsignal+appstate), roughly halving the serial bench wall time (the single job was taking 30-60 min); CodSpeed merges shards into a single run per the sharded-benchmarks contract.
- **`paths-ignore` for docs-only changes.**

## Not done (documented for later)

- One-binary-per-benchmark (the docs' strongest layout-isolation lever) is impractical at 188 benchmarks; the artifact class it prevents (code-layout shifts on ns-scale benches, e.g. `bench_unpad_message_ref` swinging -10% on a protobuf-only change) is now understood and cheap to triage instead.
- The library's internal `random_pad_len` (1..=16 pad) still adds a few bytes of legitimate per-run variance to send-path benches; benchable-seams for it were not worth the intrusion.
