### PR TITLE
tracing: tag wa.iq / wa.send.message / wa.conn.run spans with account identity

### DIFF
--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -2,6 +2,15 @@
 
 use super::*;
 
+/// Identity for span/error tagging. Named fields, not a tuple — LID/PN transposition would
+/// otherwise be a silent, unchecked bug at call sites.
+#[cfg(feature = "tracing")]
+#[derive(Debug, Clone, Default)]
+pub struct IdentityTags {
+    pub lid: Option<String>,
+    pub pn: Option<String>,
+}
+
 impl Client {
     pub(crate) async fn get_group_cache(&self) -> Arc<GroupCache> {
         let mut guard = self.group_cache.lock().await;
@@ -156,35 +165,30 @@ impl Client {
         self.persistence_manager.get_device_snapshot().lid.clone()
     }
 
-    /// Identity pair for span/error tagging so operators can attribute traces to specific
-    /// accounts without exposing raw phone numbers in telemetry.
-    ///
-    /// Reads both fields from one snapshot (not two separate `get_lid()`/`get_pn()` calls) so
-    /// a concurrent pairing update — which commits `SetId` and `SetLid` as separate
-    /// `process_command` calls — can't produce a pair straddling two different snapshots.
+    /// Snapshot-consistent identity for span/error tagging (redacted PN, raw LID). Named
+    /// fields, not a tuple — LID/PN transposition would otherwise be a silent, unchecked bug.
     #[cfg(feature = "tracing")]
-    pub fn identity_tags(&self) -> (Option<String>, Option<String>) {
+    pub fn identity_tags(&self) -> IdentityTags {
         let snapshot = self.persistence_manager.get_device_snapshot();
-        let lid = snapshot.lid.as_ref().map(|j| j.to_string());
-        let pn = snapshot.pn.as_ref().map(|j| j.observe().to_string());
-        (lid, pn)
+        IdentityTags {
+            lid: snapshot.lid.as_ref().map(|j| j.to_string()),
+            pn: snapshot.pn.as_ref().map(|j| j.observe().to_string()),
+        }
     }
 
-    /// Records `identity_tags()` onto `span`'s `lid`/`pn` fields — the shared implementation
-    /// behind every instrumented span that tags account identity (`wa.conn.run`, `wa.iq`,
-    /// `wa.send.message`), so they stay consistent: absent (not `""`) when the account isn't
-    /// known yet, so `field:*` queries in GlitchTip/Sentry reliably mean "attributed", not
-    /// "attribution attempted". A no-op when the span is disabled, skipping the snapshot read.
+    /// Shared so every identity-tagged span leaves a field absent (not `""`) when unknown —
+    /// duplicating this per call site would drift out of sync. Skips the snapshot read when
+    /// the span is disabled.
     #[cfg(feature = "tracing")]
     pub(crate) fn record_identity_on_span(&self, span: &tracing::Span) {
         if span.is_disabled() {
             return;
         }
-        let (lid, pn) = self.identity_tags();
-        if let Some(lid) = lid {
+        let tags = self.identity_tags();
+        if let Some(lid) = tags.lid {
             span.record("lid", tracing::field::display(lid));
         }
-        if let Some(pn) = pn {
+        if let Some(pn) = tags.pn {
             span.record("pn", tracing::field::display(pn));
         }
     }

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -156,6 +156,17 @@ impl Client {
         self.persistence_manager.get_device_snapshot().lid.clone()
     }
 
+    /// Tracing-safe identity strings for this client's own account — LID as-is (not treated
+    /// as sensitive), phone number via `.observe()` (redacts it, matching every other place a
+    /// phone number is logged in this crate). For tagging spans/errors so operators can tell
+    /// which account an issue came from without exposing the raw number in telemetry.
+    #[cfg(feature = "tracing")]
+    pub fn identity_tags(&self) -> (Option<String>, Option<String>) {
+        let lid = self.get_lid().map(|j| j.to_string());
+        let pn = self.get_pn().map(|j| j.observe().to_string());
+        (lid, pn)
+    }
+
     pub(crate) fn require_pn(&self) -> Result<Jid> {
         self.get_pn().ok_or(ClientError::NotLoggedIn.into())
     }

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -156,15 +156,37 @@ impl Client {
         self.persistence_manager.get_device_snapshot().lid.clone()
     }
 
-    /// Tracing-safe identity strings for this client's own account — LID as-is (not treated
-    /// as sensitive), phone number via `.observe()` (redacts it, matching every other place a
-    /// phone number is logged in this crate). For tagging spans/errors so operators can tell
-    /// which account an issue came from without exposing the raw number in telemetry.
+    /// Identity pair for span/error tagging so operators can attribute traces to specific
+    /// accounts without exposing raw phone numbers in telemetry.
+    ///
+    /// Reads both fields from one snapshot (not two separate `get_lid()`/`get_pn()` calls) so
+    /// a concurrent pairing update — which commits `SetId` and `SetLid` as separate
+    /// `process_command` calls — can't produce a pair straddling two different snapshots.
     #[cfg(feature = "tracing")]
     pub fn identity_tags(&self) -> (Option<String>, Option<String>) {
-        let lid = self.get_lid().map(|j| j.to_string());
-        let pn = self.get_pn().map(|j| j.observe().to_string());
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        let lid = snapshot.lid.as_ref().map(|j| j.to_string());
+        let pn = snapshot.pn.as_ref().map(|j| j.observe().to_string());
         (lid, pn)
+    }
+
+    /// Records `identity_tags()` onto `span`'s `lid`/`pn` fields — the shared implementation
+    /// behind every instrumented span that tags account identity (`wa.conn.run`, `wa.iq`,
+    /// `wa.send.message`), so they stay consistent: absent (not `""`) when the account isn't
+    /// known yet, so `field:*` queries in GlitchTip/Sentry reliably mean "attributed", not
+    /// "attribution attempted". A no-op when the span is disabled, skipping the snapshot read.
+    #[cfg(feature = "tracing")]
+    pub(crate) fn record_identity_on_span(&self, span: &tracing::Span) {
+        if span.is_disabled() {
+            return;
+        }
+        let (lid, pn) = self.identity_tags();
+        if let Some(lid) = lid {
+            span.record("lid", tracing::field::display(lid));
+        }
+        if let Some(pn) = pn {
+            span.record("pn", tracing::field::display(pn));
+        }
     }
 
     pub(crate) fn require_pn(&self) -> Result<Jid> {

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -307,7 +307,7 @@ impl Client {
             name = "wa.conn.run",
             level = "info",
             skip_all,
-            fields(account = tracing::field::Empty)
+            fields(lid = tracing::field::Empty, pn = tracing::field::Empty)
         )
     )]
     pub async fn run(self: &Arc<Self>) {
@@ -315,11 +315,19 @@ impl Client {
             warn!("Client `run` method called while already running.");
             return;
         }
-        // Tag the session-root span with our own (pseudonymous) account id so
-        // connection-lifecycle traces are attributable per account.
+        // Tag the session-root span with our own identity so connection-lifecycle traces
+        // are attributable per account — `lid`/`pn` field names match every other
+        // instrumented span (wa.iq, wa.send.message) for consistent cross-transaction
+        // filtering in GlitchTip/Sentry.
         #[cfg(feature = "tracing")]
-        if let Some(lid) = self.get_lid() {
-            tracing::Span::current().record("account", tracing::field::display(lid.observe()));
+        {
+            let span = tracing::Span::current();
+            if let Some(lid) = self.get_lid() {
+                span.record("lid", tracing::field::display(lid));
+            }
+            if let Some(pn) = self.get_pn() {
+                span.record("pn", tracing::field::display(pn.observe()));
+            }
         }
         while self.is_running.load(Ordering::Relaxed) {
             self.expected_disconnect.store(false, Ordering::Relaxed);

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -315,21 +315,16 @@ impl Client {
             warn!("Client `run` method called while already running.");
             return;
         }
-        // Tag the session-root span with our own identity so connection-lifecycle traces
-        // are attributable per account — `lid`/`pn` field names match every other
-        // instrumented span (wa.iq, wa.send.message) for consistent cross-transaction
-        // filtering in GlitchTip/Sentry.
-        #[cfg(feature = "tracing")]
-        {
-            let span = tracing::Span::current();
-            if let Some(lid) = self.get_lid() {
-                span.record("lid", tracing::field::display(lid));
-            }
-            if let Some(pn) = self.get_pn() {
-                span.record("pn", tracing::field::display(pn.observe()));
-            }
-        }
         while self.is_running.load(Ordering::Relaxed) {
+            // Re-record every iteration, not just once before the loop: a freshly-paired
+            // device has no lid/pn yet on the first pass, and dispatch_connected() (where
+            // pairing actually resolves them) runs in a detached spawned task with no
+            // ambient span to record onto. The next reconnect iteration — which happens
+            // routinely (server-initiated stream-end, network blips) — picks up the
+            // by-then-known identity on this same span instead.
+            #[cfg(feature = "tracing")]
+            self.record_identity_on_span(&tracing::Span::current());
+
             self.expected_disconnect.store(false, Ordering::Relaxed);
 
             if let Err(connect_err) = self.connect().await {

--- a/src/request.rs
+++ b/src/request.rs
@@ -178,8 +178,8 @@ impl Client {
             fields(
                 ns = %query.namespace,
                 kind = ?query.query_type,
-                lid = %self.get_lid().map(|j| j.to_string()).unwrap_or_default(),
-                pn = %self.get_pn().map(|j| j.observe().to_string()).unwrap_or_default()
+                lid = tracing::field::Empty,
+                pn = tracing::field::Empty
             ),
             err(Debug)
         )
@@ -188,6 +188,9 @@ impl Client {
         &self,
         query: InfoQuery<'_>,
     ) -> Result<Arc<wacore_binary::OwnedNodeRef>, IqError> {
+        #[cfg(feature = "tracing")]
+        self.record_identity_on_span(&tracing::Span::current());
+
         let default_timeout = Duration::from_secs(75);
         let iq_timeout = query.timeout.unwrap_or(default_timeout);
         let req_id = query

--- a/src/request.rs
+++ b/src/request.rs
@@ -169,7 +169,21 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.iq", level = "debug", skip_all, fields(ns = %query.namespace, kind = ?query.query_type), err(Debug)))]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "wa.iq",
+            level = "debug",
+            skip_all,
+            fields(
+                ns = %query.namespace,
+                kind = ?query.query_type,
+                lid = %self.get_lid().map(|j| j.to_string()).unwrap_or_default(),
+                pn = %self.get_pn().map(|j| j.observe().to_string()).unwrap_or_default()
+            ),
+            err(Debug)
+        )
+    )]
     pub async fn send_iq(
         &self,
         query: InfoQuery<'_>,

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -570,7 +570,20 @@ impl Client {
         async move { Box::pin(self.send_message_with_options_inner(to, message, options)).await }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.message", level = "debug", skip_all, fields(to = %to.observe()), err(Debug)))]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "wa.send.message",
+            level = "debug",
+            skip_all,
+            fields(
+                to = %to.observe(),
+                lid = %self.get_lid().map(|j| j.to_string()).unwrap_or_default(),
+                pn = %self.get_pn().map(|j| j.observe().to_string()).unwrap_or_default()
+            ),
+            err(Debug)
+        )
+    )]
     async fn send_message_with_options_inner(
         &self,
         to: Jid,

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -578,8 +578,8 @@ impl Client {
             skip_all,
             fields(
                 to = %to.observe(),
-                lid = %self.get_lid().map(|j| j.to_string()).unwrap_or_default(),
-                pn = %self.get_pn().map(|j| j.observe().to_string()).unwrap_or_default()
+                lid = tracing::field::Empty,
+                pn = tracing::field::Empty
             ),
             err(Debug)
         )
@@ -590,6 +590,9 @@ impl Client {
         mut message: Box<wa::Message>,
         options: SendOptions,
     ) -> Result<SendResult, SendError> {
+        #[cfg(feature = "tracing")]
+        self.record_identity_on_span(&tracing::Span::current());
+
         let _t = wacore::telemetry::timer(wacore::telemetry::SEND_DURATION);
         wacore::telemetry::send(match to.server {
             wacore_binary::Server::Group => "group",


### PR DESCRIPTION
## Summary
- Add `lid`/`pn` fields to the `wa.iq` and `wa.send.message` instrumented spans, and rename `wa.conn.run`'s `account` field to the same `lid`/`pn` pair, so all three are filterable/groupable by the same tags in tracing backends.
- PN uses `Jid::observe()` (redacted), matching every other place a phone number is logged in this crate. LID is left as-is.
- Add `Client::identity_tags()` (behind the `tracing` feature), and a shared `record_identity_on_span()` helper used by all three spans — single snapshot read, consistent absent-vs-empty field semantics, no duplicated extraction logic.
- `wa.conn.run` re-records identity on every reconnect-loop iteration instead of once before the loop, since a freshly-paired device has no lid/pn yet on the first pass.

## Motivation
An issue surfaced in production with zero account context — no way to tell which account it came from without manually reading breadcrumbs.

## Test plan
- [x] `cargo check -p whatsapp-rust --features tracing` (with and without the feature)
- [x] `cargo clippy -p whatsapp-rust --features tracing --all-targets`
- [x] `cargo test -p whatsapp-rust --features tracing --lib`