### PR TITLE
perf: keep droppy error/default construction off per-message happy paths

### DIFF
--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -446,9 +446,10 @@ impl<'a> Decoder<'a> {
             let Some(key) = self.read_value_as_string()? else {
                 return Err(BinaryError::NonStringKey);
             };
-            let value = self
-                .read_value()?
-                .unwrap_or(ValueRef::String(NodeStr::Borrowed("")));
+            let value = match self.read_value()? {
+                Some(v) => v,
+                None => ValueRef::String(NodeStr::Borrowed("")),
+            };
             v.push((key, value));
         }
         Ok(AttrsRef::from_vec(v))

--- a/wacore/libsignal/src/protocol/group_cipher.rs
+++ b/wacore/libsignal/src/protocol/group_cipher.rs
@@ -79,9 +79,9 @@ pub async fn group_encrypt<R: Rng + CryptoRng>(
         .try_into()
         .map_err(|_| SignalProtocolError::InvalidSenderKeySession)?;
 
-    let sender_chain_key = sender_key_state
-        .sender_chain_key()
-        .ok_or(SignalProtocolError::InvalidSenderKeySession)?;
+    let Some(sender_chain_key) = sender_key_state.sender_chain_key() else {
+        return Err(SignalProtocolError::InvalidSenderKeySession);
+    };
 
     let (message_keys, next_sender_chain_key) = sender_chain_key.step_with_message_key()?;
 
@@ -119,9 +119,9 @@ pub async fn group_encrypt<R: Rng + CryptoRng>(
 }
 
 fn get_sender_key(state: &mut SenderKeyState, iteration: u32) -> Result<SenderMessageKey> {
-    let sender_chain_key = state
-        .sender_chain_key()
-        .ok_or(SignalProtocolError::InvalidSenderKeySession)?;
+    let Some(sender_chain_key) = state.sender_chain_key() else {
+        return Err(SignalProtocolError::InvalidSenderKeySession);
+    };
     let current_iteration = sender_chain_key.iteration();
 
     if current_iteration > iteration {
@@ -292,9 +292,9 @@ fn build_skdm_from_record(record: &SenderKeyRecord) -> Result<SenderKeyDistribut
     let state = record
         .sender_key_state()
         .map_err(|_| SignalProtocolError::InvalidSenderKeySession)?;
-    let sender_chain_key = state
-        .sender_chain_key()
-        .ok_or(SignalProtocolError::InvalidSenderKeySession)?;
+    let Some(sender_chain_key) = state.sender_chain_key() else {
+        return Err(SignalProtocolError::InvalidSenderKeySession);
+    };
     let message_version = state
         .message_version()
         .try_into()

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -176,9 +176,10 @@ impl SignalMessage {
         let proto_bytes = &self.serialized[1..self.serialized.len() - Self::MAC_LENGTH];
         let view = waproto::whatsapp::SignalMessageView::decode_view(proto_bytes)
             .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-        view.ciphertext
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)
-            .map(Box::from)
+        match view.ciphertext {
+            Some(ciphertext) => Ok(Box::from(ciphertext)),
+            None => Err(SignalProtocolError::InvalidProtobufEncoding),
+        }
     }
 
     pub fn verify_mac(
@@ -253,18 +254,18 @@ impl TryFrom<&[u8]> for SignalMessage {
         )
         .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
 
-        let sender_ratchet_key = view
-            .ratchet_key
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let Some(sender_ratchet_key) = view.ratchet_key else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
         let sender_ratchet_key = PublicKey::deserialize(sender_ratchet_key)?;
-        let counter = view
-            .counter
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let Some(counter) = view.counter else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
         let previous_counter = view.previous_counter.unwrap_or(0);
-        let ciphertext = view
-            .ciphertext
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)
-            .map(Box::from)?;
+        let Some(ciphertext) = view.ciphertext else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let ciphertext: Box<[u8]> = Box::from(ciphertext);
 
         let ciphertext_cache = OnceLock::new();
         let _ = ciphertext_cache.set(ciphertext);
@@ -398,18 +399,18 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
         let view = waproto::whatsapp::PreKeySignalMessageView::decode_view(&value[1..])
             .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
 
-        let base_key = view
-            .base_key
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let identity_key = view
-            .identity_key
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let message = view
-            .message
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let signed_pre_key_id = view
-            .signed_pre_key_id
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let Some(base_key) = view.base_key else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let Some(identity_key) = view.identity_key else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let Some(message) = view.message else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let Some(signed_pre_key_id) = view.signed_pre_key_id else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
 
         let base_key = PublicKey::deserialize(base_key)?;
 
@@ -550,9 +551,10 @@ impl SenderKeyMessage {
         let proto_bytes = &self.serialized[1..self.serialized.len() - Self::SIGNATURE_LEN];
         let view = waproto::whatsapp::SenderKeyMessageView::decode_view(proto_bytes)
             .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-        view.ciphertext
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)
-            .map(Box::from)
+        match view.ciphertext {
+            Some(ciphertext) => Ok(Box::from(ciphertext)),
+            None => Err(SignalProtocolError::InvalidProtobufEncoding),
+        }
     }
 
     #[inline]
@@ -595,16 +597,16 @@ impl TryFrom<&[u8]> for SenderKeyMessage {
         )
         .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
 
-        let chain_id = view
-            .id
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let iteration = view
-            .iteration
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let ciphertext = view
-            .ciphertext
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)
-            .map(Box::from)?;
+        let Some(chain_id) = view.id else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let Some(iteration) = view.iteration else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let Some(ciphertext) = view.ciphertext else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let ciphertext: Box<[u8]> = Box::from(ciphertext);
 
         let ciphertext_cache = OnceLock::new();
         let _ = ciphertext_cache.set(ciphertext);

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -82,8 +82,10 @@ impl SenderMessageKey {
 }
 
 fn seed_to_array(seed: Option<&bytes::Bytes>) -> Result<[u8; 32], SignalProtocolError> {
-    seed.ok_or(SignalProtocolError::InvalidProtobufEncoding)?
-        .as_ref()
+    let Some(seed) = seed else {
+        return Err(SignalProtocolError::InvalidProtobufEncoding);
+    };
+    seed.as_ref()
         .try_into()
         .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)
 }

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -33,12 +33,12 @@ fn mutation_index_mac(m: &wa::SyncdMutation) -> Option<&[u8]> {
 /// `get_mutation_macs` HashMap fetch, so the order is unspecified.
 ///
 /// Small patches dedup with a linear scan that allocates only the keepers,
-/// cheaper than a sort at small N. Larger patches decode each MAC once into the
-/// returned `Vec` and sort + dedup in place: the comparator works on the owned
-/// bytes, never re-walking the boxed record/index/blob `MessageField` chain (the
-/// part buffa makes pricier than prost's `Option` derefs), with no scratch
-/// beyond the returned `Vec`. Distinct indices are the realistic patch shape, so
-/// the pre-dedup `Vec` is essentially already unique.
+/// cheaper than a sort at small N. Larger patches sort + dedup borrowed MAC
+/// slices and only then materialize the keepers with an exact-sized `Vec`: the
+/// comparator works on borrows walked once (never re-walking the boxed
+/// record/index/blob `MessageField` chain, the part buffa makes pricier than
+/// prost's `Option` derefs), duplicates are dropped before ever owning bytes,
+/// and the pre-dedup scratch holds 16-byte slices instead of `Vec` headers.
 pub fn collect_unique_index_macs(mutations: &[wa::SyncdMutation]) -> Vec<Vec<u8>> {
     if mutations.len() <= MAC_DEDUP_SCAN_LIMIT {
         let mut out: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
@@ -52,13 +52,11 @@ pub fn collect_unique_index_macs(mutations: &[wa::SyncdMutation]) -> Vec<Vec<u8>
         return out;
     }
 
-    let mut out: Vec<Vec<u8>> = mutations
-        .iter()
-        .filter_map(|m| mutation_index_mac(m).map(<[u8]>::to_vec))
-        .collect();
-    out.sort_unstable();
-    out.dedup();
-    out
+    let mut macs: Vec<&[u8]> = Vec::with_capacity(mutations.len());
+    macs.extend(mutations.iter().filter_map(mutation_index_mac));
+    macs.sort_unstable();
+    macs.dedup();
+    macs.into_iter().map(<[u8]>::to_vec).collect()
 }
 
 /// Mutation count at or below which [`collect_unique_index_macs`] dedups with a


### PR DESCRIPTION
## Summary

Follow-up to #949, applying the same eager-construction fix to the three remaining hot-path families found by mining the CodSpeed flamegraphs of the heaviest benchmarks plus a code sweep:

**1. libsignal message parsing (runs per inbound message).** `SignalProtocolError` carries drop glue (`InvalidArgument(String)`, `BackendError(_, Box<dyn Error>)`…), so each `.ok_or(SignalProtocolError::...)` on a present-field path constructed the enum and paid its drop:
- `SignalMessage::try_from` / `decode_ciphertext` — every 1:1 message
- `PreKeySignalMessage::try_from` — every pkmsg
- `SenderKeyMessage::try_from` / `decode_ciphertext` — every group message
- `group_cipher.rs` `sender_chain_key()` lookups — group encrypt/decrypt/SKDM build. The `format!` siblings on adjacent lines already use `ok_or_else`, confirming these unit-variant sites were simply missed.
- `sender_keys.rs` `seed_to_array` — per cached message key on record load (every group decrypt)

**2. Decoder attribute loop (hottest loop in the receive path).** `read_attributes` built the default `ValueRef::String(NodeStr::Borrowed(""))` eagerly per attribute via `unwrap_or` — `ValueRef` has drop glue via `CompactString`. This site was missed by #949.

**3. `collect_unique_index_macs` (appstate patch processing).** The large-patch path collected owned `Vec<u8>` MACs through a realloc-grown `Vec` (flamegraph: ~12% in the realloc chain), then sorted the 24-byte headers. Now sorts/dedups borrowed slices and materializes only the keepers into an exact-sized `Vec` — no realloc growth, no alloc+drop for duplicates, 16-byte scratch elements. Public signature unchanged.

As in #949, `let-else`/`match` is used instead of `ok_or_else`/`unwrap_or_else` because clippy's `unnecessary_lazy_evaluations` reverts the lazy form for unit variants, ignoring drop-glue cost.

No behavior change — same error variants on the same failure conditions, same MAC set returned.

## Validation

- `cargo fmt` / `cargo clippy --all-targets` on affected crates: clean (only the pre-existing `chrono::Local::now` warning, untouched by this diff)
- `cargo test -p wacore-libsignal -p wacore-binary -p wacore`: all pass (239+ tests)
- Local wall-time A/B is within noise, as expected for drop-glue-scale effects on crypto-dominated benches — CodSpeed's deterministic instruction counting on this PR is the arbiter (same as #949, which measured -7.2% on `bench_unmarshal_large`)
- Benches to watch: `bench_dm_decrypt_subsequent_message`, `bench_group_decrypt/encrypt_message`, `bench_attr_parser`, `bench_unmarshal_*`, `bench_collect_unique_index_macs[1000]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T53MPuGRg4kvRjRxW6fUvd

---
_Generated by [Claude Code](https://claude.ai/code/session_01T53MPuGRg4kvRjRxW6fUvd)_