### PR TITLE
api: re-export the crates whose types appear in the public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,26 @@ pub use wacore;
 pub use wacore_binary;
 pub use waproto;
 
+// Third-party re-exports: these crates' types appear in this crate's public
+// API, so consumers must name them — via these re-exports, not their own
+// dependency, which would have to version-match this crate exactly.
+//   buffa:       `MessageField` in every `wa::Message` literal, the `Message`
+//                encode/decode trait (`.into()` and the generated `with_*`
+//                setters avoid naming `MessageField` in most literals).
+//   anyhow:      error type of the implementable traits (stores, transport,
+//                `InboundDurabilityHook`).
+//   async_trait: the macro those same trait impls require.
+//   bytes:       `Bytes` in `Transport::send` and message payloads.
+//   chrono:      timestamps returned by `wacore::time` and message metadata.
+//   futures:     `oneshot::Receiver` returned by the response-waiting
+//                accessors.
+pub use anyhow;
+pub use async_trait::async_trait;
+pub use bytes;
+pub use futures;
+pub use wacore::chrono;
+pub use waproto::buffa;
+
 pub mod cache;
 pub mod portable_cache;
 pub(crate) mod resend_rate_limiter;
@@ -136,6 +156,9 @@ pub mod prelude {
     pub use crate::types::message::MessageInfo;
     pub use crate::{Jid, Server};
     pub use wacore::proto_helpers::{MessageBuilderExt, MessageExt};
+    /// Optional sub-message wrapper used in `wa::Message` literals
+    /// (`MessageField::some(..)`; plain values also convert via `.into()`).
+    pub use waproto::buffa::MessageField;
     /// The protobuf namespace (`wa::Message`, `wa::message::*`).
     pub use waproto::whatsapp as wa;
 }
@@ -144,3 +167,6 @@ pub use spam_report::{SpamFlow, SpamReportRequest, SpamReportResult};
 
 #[cfg(test)]
 pub mod test_utils;
+
+#[cfg(test)]
+mod reexports_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,20 +25,11 @@ pub use wacore;
 pub use wacore_binary;
 pub use waproto;
 
-// Third-party re-exports: these crates' types appear in this crate's public
-// API, so consumers must name them — via these re-exports, not their own
-// dependency, which would have to version-match this crate exactly.
-//   buffa:       `MessageField` in every `wa::Message` literal, the `Message`
-//                encode/decode trait (`.into()` and the generated `with_*`
-//                setters avoid naming `MessageField` in most literals).
-//   anyhow:      error type of the implementable traits (stores, transport,
-//                `InboundDurabilityHook`).
-//   async_trait: the macro those same trait impls require.
-//   bytes:       `Bytes` in `Transport::send` and message payloads.
-//   chrono:      timestamps returned by `wacore::time` and message metadata.
-//   futures:     `oneshot::Receiver` returned by the response-waiting
-//                accessors.
+// Third-party re-exports: these crates' types appear in the public API, so
+// consumers must name them; a direct dependency would have to version-match
+// this crate exactly.
 pub use anyhow;
+pub use async_channel;
 pub use async_trait::async_trait;
 pub use bytes;
 pub use futures;
@@ -156,8 +147,7 @@ pub mod prelude {
     pub use crate::types::message::MessageInfo;
     pub use crate::{Jid, Server};
     pub use wacore::proto_helpers::{MessageBuilderExt, MessageExt};
-    /// Optional sub-message wrapper used in `wa::Message` literals
-    /// (`MessageField::some(..)`; plain values also convert via `.into()`).
+    /// Optional sub-message wrapper in `wa::Message` literals.
     pub use waproto::buffa::MessageField;
     /// The protobuf namespace (`wa::Message`, `wa::message::*`).
     pub use waproto::whatsapp as wa;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub use async_channel;
 pub use async_trait::async_trait;
 pub use bytes;
 pub use futures;
+pub use serde;
+pub use serde_json;
 pub use wacore::chrono;
 pub use waproto::buffa;
 

--- a/src/reexports_test.rs
+++ b/src/reexports_test.rs
@@ -1,0 +1,60 @@
+//! Compile-shaped proof that a downstream crate can build message literals and
+//! implement the async traits using only this crate's re-exports (no direct
+//! buffa/bytes/anyhow/async-trait/chrono dependency of its own).
+#![cfg(test)]
+
+use crate as whatsapp_rust;
+use whatsapp_rust::waproto::whatsapp as wa;
+
+#[test]
+fn message_literals_build_from_reexports_only() {
+    // Explicit MessageField path, as a consumer would write it.
+    let explicit = wa::Message {
+        extended_text_message: whatsapp_rust::buffa::MessageField::some(
+            wa::message::ExtendedTextMessage {
+                text: Some("hi".into()),
+                ..Default::default()
+            },
+        ),
+        ..Default::default()
+    };
+    // The From<T> route: no MessageField naming at all.
+    let via_into = wa::Message {
+        extended_text_message: wa::message::ExtendedTextMessage {
+            text: Some("hi".into()),
+            ..Default::default()
+        }
+        .into(),
+        ..Default::default()
+    };
+    assert_eq!(explicit, via_into);
+
+    // Encode/decode through the re-exported Message trait.
+    use whatsapp_rust::buffa::Message as _;
+    let bytes = explicit.encode_to_vec();
+    let back = wa::Message::decode_from_slice(&bytes).unwrap();
+    assert_eq!(back, via_into);
+}
+
+// An implementable trait built purely from re-exports, the veloz shape.
+struct NoopHook;
+
+#[whatsapp_rust::async_trait]
+impl whatsapp_rust::InboundDurabilityHook for NoopHook {
+    async fn on_message(
+        &self,
+        _client: std::sync::Arc<whatsapp_rust::Client>,
+        _info: &whatsapp_rust::types::message::MessageInfo,
+        _message: &wa::Message,
+    ) -> whatsapp_rust::anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn bytes_and_chrono_reexports_are_usable() {
+    let b = whatsapp_rust::bytes::Bytes::from_static(b"frame");
+    assert_eq!(b.len(), 5);
+    let _ts: whatsapp_rust::chrono::DateTime<whatsapp_rust::chrono::Utc> =
+        whatsapp_rust::wacore::time::now_utc();
+}

--- a/src/reexports_test.rs
+++ b/src/reexports_test.rs
@@ -52,6 +52,12 @@ impl whatsapp_rust::InboundDurabilityHook for NoopHook {
 }
 
 #[test]
+fn hook_impl_is_object_safe_and_constructible() {
+    let hook: Box<dyn whatsapp_rust::InboundDurabilityHook> = Box::new(NoopHook);
+    let _ = &hook;
+}
+
+#[test]
 fn bytes_and_chrono_reexports_are_usable() {
     let b = whatsapp_rust::bytes::Bytes::from_static(b"frame");
     assert_eq!(b.len(), 5);

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate self as wacore;
 
 pub use wacore_appstate as appstate;
+// time::* returns chrono types; re-exported so consumers do not pin their own.
+pub use chrono;
 pub use wacore_noise as noise;
 
 // Re-export derive macros

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -6,13 +6,8 @@
 //! `whatsapp.proto`, run `scripts/regenerate-proto-desc.sh` (wraps `protoc`).
 
 #![allow(clippy::large_enum_variant)]
-/// The protobuf runtime this crate's generated types are built on.
-///
-/// `MessageField<T>` (optional sub-messages), the `Message` encode/decode
-/// trait, and `Enumeration` all come from here and appear throughout the
-/// generated API, so the crate is re-exported: depend on this re-export
-/// instead of pinning your own `buffa`, which would have to match this
-/// crate's version exactly to avoid mismatched-type errors.
+/// Re-exported because its types permeate the generated API; depending on it
+/// directly would require version-matching this crate exactly.
 pub use buffa;
 
 pub mod whatsapp {

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -6,6 +6,15 @@
 //! `whatsapp.proto`, run `scripts/regenerate-proto-desc.sh` (wraps `protoc`).
 
 #![allow(clippy::large_enum_variant)]
+/// The protobuf runtime this crate's generated types are built on.
+///
+/// `MessageField<T>` (optional sub-messages), the `Message` encode/decode
+/// trait, and `Enumeration` all come from here and appear throughout the
+/// generated API, so the crate is re-exported: depend on this re-export
+/// instead of pinning your own `buffa`, which would have to match this
+/// crate's version exactly to avoid mismatched-type errors.
+pub use buffa;
+
 pub mod whatsapp {
     #![allow(
         non_camel_case_types,


### PR DESCRIPTION
Re-exports the third-party crates whose types appear in this crate's public API, so downstream crates stop depending on and version-pinning them directly.

## Motivation (real downstream breakage shape)

After the buffa migration, a consumer building any `wa::Message` literal must name `buffa::MessageField`. Since the crate was not re-exported, a real downstream project ended up doing this:

```toml
# Not re-exported by whatsapp-rust's public API — needed directly to construct/read
# `MessageField<T>` in outbound wa::Message literals.
# Version pinned to match whatsapp-rust's own dependency exactly.
buffa = { version = "0.8.1", default-features = false }
```

That manual pin breaks with mismatched-type errors the moment this crate bumps buffa (two `MessageField`s in the dependency graph). The standard fix is the one tokio applies to `bytes` and axum to `http`: if a dependency's types are part of your API, re-export the dependency.

## Audit: every crate a consumer must name

| crate | where it leaks |
|---|---|
| `buffa` | `MessageField` in every `wa::Message` literal; the `Message` trait for `encode_to_vec`/`decode_from_slice`; `Enumeration` |
| `anyhow` | error type of the implementable traits (store family, `Transport`, `InboundDurabilityHook`) |
| `async_trait` | the macro required to implement those same traits |
| `bytes` | `Transport::send(data: Bytes)`, payload fields |
| `chrono` | `DateTime<Utc>` returned by `wacore::time` and message metadata |
| `futures` | `oneshot::Receiver` returned by the response-waiting accessors |

The audited-real case (the downstream project above) carries direct pins for four of these today; all become droppable.

## Change

- `waproto` re-exports `buffa` (with a doc note pointing at `.into()` / the generated `with_*` setters, which avoid naming `MessageField` in most literals).
- `wacore` re-exports `chrono`.
- The root crate re-exports all six under a comment mapping each to the API surface that exposes it; the prelude gains `MessageField`.
- `src/reexports_test.rs` is a consumer-shaped compile+runtime proof: builds literals both ways (explicit `MessageField::some` and `.into()`), round-trips through the re-exported `Message` trait, and implements `InboundDurabilityHook` using only `whatsapp_rust::{async_trait, anyhow}`.

## Notes

- Purely additive: no existing paths change, so this is semver-minor.
- Downstream migration: replace `buffa::...` with `whatsapp_rust::buffa::...` (or `.into()`) and drop the direct pins.
