### PR TITLE
perf: inline index-MAC keys, reusable conversation decode, single-encode send

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -156,16 +156,16 @@ mod tests {
         async fn get_mutation_macs(
             &self,
             name: &str,
-            index_macs: &[Vec<u8>],
-        ) -> StoreResult<HashMap<Vec<u8>, Vec<u8>>> {
+            index_macs: &[[u8; 32]],
+        ) -> StoreResult<HashMap<[u8; 32], Vec<u8>>> {
             self.batch_mac_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let macs = self.macs.lock().await;
             Ok(index_macs
                 .iter()
                 .filter_map(|index_mac| {
-                    macs.get(&(name.to_string(), index_mac.clone()))
-                        .map(|mac| (index_mac.clone(), mac.clone()))
+                    macs.get(&(name.to_string(), index_mac.to_vec()))
+                        .map(|mac| (*index_mac, mac.clone()))
                 })
                 .collect())
         }

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -304,9 +304,19 @@ impl Client {
     /// In DB-only mode (capacity = 0), the DB write is awaited to guarantee persistence.
     /// With L1 cache, the DB write is backgrounded since the cache serves reads immediately.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.add_recent_message", level = "debug", skip_all, fields(peer = %to.observe())))]
-    pub(crate) async fn add_recent_message(&self, to: &Jid, id: &str, msg: &wa::Message) {
+    pub(crate) async fn add_recent_message(
+        &self,
+        to: &Jid,
+        id: &str,
+        msg: &wa::Message,
+        // The plain `message_to_vec(msg)` bytes when the send path already
+        // encoded them (the same buffer feeds the wire plaintext), so caching
+        // for retry doesn't re-encode the whole message.
+        encoded: Option<std::sync::Arc<Vec<u8>>>,
+    ) {
         let key = self.make_chat_message_id(to, id).await;
-        let bytes = waproto::codec::message_to_vec(msg);
+        let shared =
+            encoded.unwrap_or_else(|| std::sync::Arc::new(waproto::codec::message_to_vec(msg)));
         let has_l1_cache = self.cache_config.recent_messages.capacity > 0;
 
         if has_l1_cache {
@@ -315,7 +325,6 @@ impl Client {
             // hold the same buffer instead of memcpy-ing the whole message.
             let chat_str = key.chat.to_string();
             let msg_id = key.id.clone();
-            let shared = std::sync::Arc::new(bytes);
             self.recent_messages
                 .insert(key, std::sync::Arc::clone(&shared))
                 .await;
@@ -336,7 +345,7 @@ impl Client {
             if let Err(e) = self
                 .persistence_manager
                 .backend()
-                .store_sent_message(&chat_str, &key.id, &bytes)
+                .store_sent_message(&chat_str, &key.id, &shared)
                 .await
             {
                 log::warn!("Failed to store sent message to DB: {e}");

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -309,9 +309,7 @@ impl Client {
         to: &Jid,
         id: &str,
         msg: &wa::Message,
-        // The plain `message_to_vec(msg)` bytes when the send path already
-        // encoded them (the same buffer feeds the wire plaintext), so caching
-        // for retry doesn't re-encode the whole message.
+        // Avoids re-encoding when the send path already serialized `msg`.
         encoded: Option<std::sync::Arc<Vec<u8>>>,
     ) {
         let key = self.make_chat_message_id(to, id).await;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -273,7 +273,7 @@ impl Client {
             Some(result) => result,
             None => match self.take_recent_message(&info.chat, &message_id).await {
                 Some(result) => {
-                    self.add_recent_message(&info.chat, &message_id, &result.0)
+                    self.add_recent_message(&info.chat, &message_id, &result.0, None)
                         .await;
                     result
                 }
@@ -1299,7 +1299,7 @@ mod tests {
         };
 
         // Insert via the new async API
-        client.add_recent_message(&chat, &msg_id, &msg).await;
+        client.add_recent_message(&chat, &msg_id, &msg, None).await;
 
         // First take should return and remove it from cache
         let taken = client.take_recent_message(&chat, &msg_id).await;
@@ -1341,7 +1341,7 @@ mod tests {
             conversation: Some("hi".into()),
             ..Default::default()
         };
-        client.add_recent_message(&chat, &msg_id, &msg).await;
+        client.add_recent_message(&chat, &msg_id, &msg, None).await;
 
         // Peeking twice both return the message and leave it in the cache...
         for _ in 0..2 {
@@ -2265,6 +2265,7 @@ mod tests {
                     conversation: Some("hi".into()),
                     ..Default::default()
                 },
+                None,
             )
             .await;
 
@@ -3094,13 +3095,15 @@ mod tests {
             (Jid::status_broadcast(), "STATUS_MSG_001".to_string()),
             (Jid::pn("559911112222"), "DM_MSG_001".to_string()),
         ] {
-            client.add_recent_message(&chat, &msg_id, &msg).await;
+            client.add_recent_message(&chat, &msg_id, &msg, None).await;
 
             let taken = client.take_recent_message(&chat, &msg_id).await;
             assert!(taken.is_some(), "First take should succeed for {chat}");
 
             let (taken_msg, _) = taken.unwrap();
-            client.add_recent_message(&chat, &msg_id, &taken_msg).await;
+            client
+                .add_recent_message(&chat, &msg_id, &taken_msg, None)
+                .await;
 
             let taken2 = client.take_recent_message(&chat, &msg_id).await;
             assert!(
@@ -3153,7 +3156,9 @@ mod tests {
         };
 
         // Store under bare JID (how send_message stores it)
-        client.add_recent_message(&bare_jid, msg_id, &msg).await;
+        client
+            .add_recent_message(&bare_jid, msg_id, &msg, None)
+            .await;
 
         // Lookup via bare JID should succeed (this is what info.chat provides)
         let taken = client.take_recent_message(&bare_jid, msg_id).await;
@@ -3162,7 +3167,9 @@ mod tests {
         assert!(alt_chat.is_none(), "primary key should match for bare JID");
 
         // Re-add under bare JID
-        client.add_recent_message(&bare_jid, msg_id, &msg_out).await;
+        client
+            .add_recent_message(&bare_jid, msg_id, &msg_out, None)
+            .await;
 
         // Second take should also work
         let taken2 = client.take_recent_message(&bare_jid, msg_id).await;
@@ -3206,7 +3213,7 @@ mod tests {
         };
 
         // Store under PN (no LID mapping existed at send time)
-        client.add_recent_message(&pn_jid, msg_id, &msg).await;
+        client.add_recent_message(&pn_jid, msg_id, &msg, None).await;
 
         // Now add a LID mapping (simulates mapping arriving between send and retry)
         client
@@ -3323,7 +3330,7 @@ mod tests {
         };
 
         // Store under PN (no mapping at send time)
-        client.add_recent_message(&pn_jid, msg_id, &msg).await;
+        client.add_recent_message(&pn_jid, msg_id, &msg, None).await;
 
         // Add LID mapping
         client
@@ -3384,7 +3391,9 @@ mod tests {
         };
 
         // Store under LID, no PN mapping exists
-        client.add_recent_message(&lid_jid, msg_id, &msg).await;
+        client
+            .add_recent_message(&lid_jid, msg_id, &msg, None)
+            .await;
 
         // Lookup via LID: primary hits directly (same namespace)
         let taken = client.take_recent_message(&lid_jid, msg_id).await;

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -754,10 +754,7 @@ impl Client {
         let mut group_info =
             GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn_map);
 
-        // Encode once: the same bytes feed the retry cache here and the wire
-        // plaintext inside prepare_* (via `pre_encoded`), instead of two full
-        // Message encodes per send. `None` on the rare mci-hoist path, where
-        // prepare_* must re-encode with the folded context.
+        // One encode feeds retry cache and wire; mci-hoist re-encodes (folded context).
         let shared_content = message
             .message_context_info
             .is_unset()
@@ -1402,10 +1399,7 @@ impl Client {
                 .as_ref()
                 .ok_or_else(|| anyhow!("LID not set, cannot send to group"))?;
 
-            // Encode once: the same bytes feed the retry cache here and the wire
-            // plaintext inside prepare_* (via `pre_encoded`), instead of two full
-            // Message encodes per send. `None` on the rare mci-hoist path, where
-            // prepare_* must re-encode with the folded context.
+            // One encode feeds retry cache and wire; mci-hoist re-encodes (folded context).
             let shared_content = message
                 .message_context_info
                 .is_unset()
@@ -1678,10 +1672,7 @@ impl Client {
             // Per-device locking to match decrypt path (message.rs:684),
             // preventing ratchet desync on concurrent send/receive.
 
-            // Encode once: the same bytes feed the retry cache here and the wire
-            // plaintext inside prepare_* (via `pre_encoded`), instead of two full
-            // Message encodes per send. `None` on the rare mci-hoist path, where
-            // prepare_* must re-encode with the folded context.
+            // One encode feeds retry cache and wire; mci-hoist re-encodes (folded context).
             let shared_content = message
                 .message_context_info
                 .is_unset()

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -754,7 +754,16 @@ impl Client {
         let mut group_info =
             GroupInfo::with_lid_to_pn_map(participants, AddressingMode::Lid, lid_to_pn_map);
 
-        self.add_recent_message(&to, &request_id, &message).await;
+        // Encode once: the same bytes feed the retry cache here and the wire
+        // plaintext inside prepare_* (via `pre_encoded`), instead of two full
+        // Message encodes per send. `None` on the rare mci-hoist path, where
+        // prepare_* must re-encode with the folded context.
+        let shared_content = message
+            .message_context_info
+            .is_unset()
+            .then(|| std::sync::Arc::new(waproto::codec::message_to_vec(&message)));
+        self.add_recent_message(&to, &request_id, &message, shared_content.clone())
+            .await;
 
         let device_store_arc = self.persistence_manager.get_device_arc().await;
         let to_str = to.to_string();
@@ -835,6 +844,7 @@ impl Client {
             None,
             None,
             &extra_stanza_nodes,
+            shared_content.clone(),
         )
         .await
         {
@@ -878,6 +888,7 @@ impl Client {
                         None,
                         None,
                         &extra_stanza_nodes,
+                        shared_content.clone(),
                     )
                     .await?
                 } else {
@@ -1391,8 +1402,17 @@ impl Client {
                 .as_ref()
                 .ok_or_else(|| anyhow!("LID not set, cannot send to group"))?;
 
+            // Encode once: the same bytes feed the retry cache here and the wire
+            // plaintext inside prepare_* (via `pre_encoded`), instead of two full
+            // Message encodes per send. `None` on the rare mci-hoist path, where
+            // prepare_* must re-encode with the folded context.
+            let shared_content = message
+                .message_context_info
+                .is_unset()
+                .then(|| std::sync::Arc::new(waproto::codec::message_to_vec(message)));
             // Store serialized message bytes for retry (lightweight)
-            self.add_recent_message(&to, &request_id, message).await;
+            self.add_recent_message(&to, &request_id, message, shared_content.clone())
+                .await;
 
             let device_store_arc = self.persistence_manager.get_device_arc().await;
             let to_str = to.to_string();
@@ -1555,6 +1575,7 @@ impl Client {
                 all_devices_for_phash,
                 edit.clone(),
                 &extra_stanza_nodes,
+                shared_content.clone(),
             )
             .await
             {
@@ -1636,6 +1657,7 @@ impl Client {
                             retry_all,
                             edit.clone(),
                             &extra_stanza_nodes,
+                            shared_content.clone(),
                         )
                         .await?;
 
@@ -1656,13 +1678,27 @@ impl Client {
             // Per-device locking to match decrypt path (message.rs:684),
             // preventing ratchet desync on concurrent send/receive.
 
+            // Encode once: the same bytes feed the retry cache here and the wire
+            // plaintext inside prepare_* (via `pre_encoded`), instead of two full
+            // Message encodes per send. `None` on the rare mci-hoist path, where
+            // prepare_* must re-encode with the folded context.
+            let shared_content = message
+                .message_context_info
+                .is_unset()
+                .then(|| std::sync::Arc::new(waproto::codec::message_to_vec(message)));
             // Status reaction retries arrive with `from=status@broadcast`;
             // cache under the broadcast chat so take_recent_message hits.
             if is_status_addon {
-                self.add_recent_message(&Jid::status_broadcast(), &request_id, message)
-                    .await;
+                self.add_recent_message(
+                    &Jid::status_broadcast(),
+                    &request_id,
+                    message,
+                    shared_content.clone(),
+                )
+                .await;
             } else {
-                self.add_recent_message(&to, &request_id, message).await;
+                self.add_recent_message(&to, &request_id, message, shared_content.clone())
+                    .await;
             }
 
             let device_snapshot = self.persistence_manager.get_device_snapshot();
@@ -1828,6 +1864,7 @@ impl Client {
                 edit,
                 &extra_stanza_nodes,
                 all_dm_jids,
+                shared_content,
             )
             .await?;
             dm_phash = prepared.phash;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1385,34 +1385,39 @@ impl SqliteStore {
     pub async fn get_app_state_mutation_macs_batch_for_device(
         &self,
         name: &str,
-        index_macs: &[Vec<u8>],
+        index_macs: &[[u8; 32]],
         device_id: i32,
-    ) -> Result<std::collections::HashMap<Vec<u8>, Vec<u8>>> {
+    ) -> Result<std::collections::HashMap<[u8; 32], Vec<u8>>> {
         if index_macs.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
         let pool = self.pool.clone();
         let name = name.to_string();
-        let index_macs: Vec<Vec<u8>> = index_macs.to_vec();
+        let index_macs: Vec<[u8; 32]> = index_macs.to_vec();
         tokio::task::spawn_blocking(
-            move || -> Result<std::collections::HashMap<Vec<u8>, Vec<u8>>> {
+            move || -> Result<std::collections::HashMap<[u8; 32], Vec<u8>>> {
                 let mut conn = pool
                     .get()
                     .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let mut out = std::collections::HashMap::with_capacity(index_macs.len());
                 const CHUNK_SIZE: usize = 500;
                 for chunk in index_macs.chunks(CHUNK_SIZE) {
+                    let chunk_slices: Vec<&[u8]> = chunk.iter().map(|m| m.as_slice()).collect();
                     let rows: Vec<(Vec<u8>, Vec<u8>)> = app_state_mutation_macs::table
                         .select((
                             app_state_mutation_macs::index_mac,
                             app_state_mutation_macs::value_mac,
                         ))
                         .filter(app_state_mutation_macs::name.eq(&name))
-                        .filter(app_state_mutation_macs::index_mac.eq_any(chunk))
+                        .filter(app_state_mutation_macs::index_mac.eq_any(chunk_slices))
                         .filter(app_state_mutation_macs::device_id.eq(device_id))
                         .load(&mut conn)
                         .map_err(|e| StoreError::Database(Box::new(e)))?;
-                    out.extend(rows);
+                    // Rows with a non-32-byte index_mac cannot have come from the
+                    // 32-byte keys we just queried; skip defensively.
+                    out.extend(rows.into_iter().filter_map(|(k, v)| {
+                        <[u8; 32]>::try_from(k.as_slice()).ok().map(|k| (k, v))
+                    }));
                 }
                 Ok(out)
             },
@@ -2116,8 +2121,8 @@ impl AppSyncStore for SqliteStore {
     async fn get_mutation_macs(
         &self,
         name: &str,
-        index_macs: &[Vec<u8>],
-    ) -> Result<std::collections::HashMap<Vec<u8>, Vec<u8>>> {
+        index_macs: &[[u8; 32]],
+    ) -> Result<std::collections::HashMap<[u8; 32], Vec<u8>>> {
         self.get_app_state_mutation_macs_batch_for_device(name, index_macs, self.device_id)
             .await
     }
@@ -3462,9 +3467,12 @@ mod tests {
             .await
             .unwrap();
 
-        let mut index_macs: Vec<Vec<u8>> = macs.iter().map(|m| m.index_mac.clone()).collect();
+        let mut index_macs: Vec<[u8; 32]> = macs
+            .iter()
+            .map(|m| m.index_mac.as_slice().try_into().unwrap())
+            .collect();
         // an index that was never stored must be absent from the batch result
-        index_macs.push(vec![0xFF; 32]);
+        index_macs.push([0xFF; 32]);
 
         let batch = store
             .get_app_state_mutation_macs_batch_for_device(name, &index_macs, device_id)
@@ -3472,15 +3480,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(batch.len(), macs.len());
-        assert!(!batch.contains_key(&vec![0xFF; 32]));
+        assert!(!batch.contains_key(&[0xFF; 32]));
         for m in &macs {
+            let key: [u8; 32] = m.index_mac.as_slice().try_into().unwrap();
             // parity with the per-item path it replaces
             let per_item = store
                 .get_app_state_mutation_mac_for_device(name, &m.index_mac, device_id)
                 .await
                 .unwrap();
-            assert_eq!(per_item.as_ref(), batch.get(&m.index_mac));
-            assert_eq!(batch.get(&m.index_mac), Some(&m.value_mac));
+            assert_eq!(per_item.as_ref(), batch.get(&key));
+            assert_eq!(batch.get(&key), Some(&m.value_mac));
         }
 
         // empty input short-circuits to an empty map

--- a/wacore/benches/history_sync_benchmark.rs
+++ b/wacore/benches/history_sync_benchmark.rs
@@ -129,7 +129,8 @@ fn bench_history_sync_stream_drain(bencher: divan::Bencher) {
                 wacore::history_sync::MAX_DECOMPRESSED,
             );
             let mut messages = 0usize;
-            while let Some(conversation) = stream.next_conversation().unwrap() {
+            let mut conversation = waproto::whatsapp::Conversation::default();
+            while stream.next_conversation_into(&mut conversation).unwrap() {
                 messages += conversation.messages.len();
             }
             black_box((messages, stream.remainder().unwrap()))

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -746,6 +746,7 @@ fn setup_group_recv() -> GrpRecvData {
         None,
         None,
         &[],
+        None,
     ))
     .unwrap();
 
@@ -833,6 +834,7 @@ fn run_group_send(d: &mut GrpSendData) {
         all_devices_for_phash,
         None,
         &[],
+        None,
     ))
     .unwrap();
 

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -28,35 +28,46 @@ fn mutation_index_mac(m: &wa::SyncdMutation) -> Option<&[u8]> {
     m.record.as_option()?.index.as_option()?.blob.as_deref()
 }
 
+/// A mutation's index MAC as the fixed-size HMAC-SHA256 array; `None` for a
+/// missing OR malformed (non-32-byte) blob. A malformed MAC could never match a
+/// stored row, so dropping it from the batch lookup is equivalent to the miss
+/// the lookup would return anyway.
+fn mutation_index_mac_array(m: &wa::SyncdMutation) -> Option<IndexMac> {
+    mutation_index_mac(m).and_then(|b| b.try_into().ok())
+}
+
+/// An appstate mutation index MAC: a full HMAC-SHA256 output, so always 32
+/// bytes. Inline (`Copy`) so batch lookups sort/hash flat arrays with zero
+/// per-MAC heap allocations.
+pub type IndexMac = [u8; 32];
+
 /// Distinct index MACs of a patch's mutations, feeding the batched
 /// previous-value-MAC backend lookup. Both callers pass the result straight to a
 /// `get_mutation_macs` HashMap fetch, so the order is unspecified.
 ///
-/// Small patches dedup with a linear scan that allocates only the keepers,
-/// cheaper than a sort at small N. Larger patches sort + dedup borrowed MAC
-/// slices and only then materialize the keepers with an exact-sized `Vec`: the
-/// comparator works on borrows walked once (never re-walking the boxed
-/// record/index/blob `MessageField` chain, the part buffa makes pricier than
-/// prost's `Option` derefs), duplicates are dropped before ever owning bytes,
-/// and the pre-dedup scratch holds 16-byte slices instead of `Vec` headers.
-pub fn collect_unique_index_macs(mutations: &[wa::SyncdMutation]) -> Vec<Vec<u8>> {
+/// Small patches dedup with a linear scan; larger patches sort + dedup the
+/// inline arrays in place. Either way the only allocation is the returned `Vec`
+/// itself: the comparator touches contiguous 32-byte elements (never re-walking
+/// the boxed record/index/blob `MessageField` chain, the part buffa makes
+/// pricier than prost's `Option` derefs).
+pub fn collect_unique_index_macs(mutations: &[wa::SyncdMutation]) -> Vec<IndexMac> {
     if mutations.len() <= MAC_DEDUP_SCAN_LIMIT {
-        let mut out: Vec<Vec<u8>> = Vec::with_capacity(mutations.len());
+        let mut out: Vec<IndexMac> = Vec::with_capacity(mutations.len());
         for m in mutations {
-            if let Some(mac) = mutation_index_mac(m)
-                && !out.iter().any(|v| v.as_slice() == mac)
+            if let Some(mac) = mutation_index_mac_array(m)
+                && !out.contains(&mac)
             {
-                out.push(mac.to_vec());
+                out.push(mac);
             }
         }
         return out;
     }
 
-    let mut macs: Vec<&[u8]> = Vec::with_capacity(mutations.len());
-    macs.extend(mutations.iter().filter_map(mutation_index_mac));
+    let mut macs: Vec<IndexMac> = Vec::with_capacity(mutations.len());
+    macs.extend(mutations.iter().filter_map(mutation_index_mac_array));
     macs.sort_unstable();
     macs.dedup();
-    macs.into_iter().map(<[u8]>::to_vec).collect()
+    macs
 }
 
 /// Mutation count at or below which [`collect_unique_index_macs`] dedups with a
@@ -438,7 +449,7 @@ impl AppStateProcessor {
 
             // Fetch previous value MACs in one backend round-trip instead of a
             // spawn_blocking + query per mutation (N+1).
-            let db_prev: HashMap<Vec<u8>, Vec<u8>> = self
+            let db_prev: HashMap<IndexMac, Vec<u8>> = self
                 .backend
                 .get_mutation_macs(collection_name, &need_db_lookup)
                 .await?;
@@ -449,10 +460,13 @@ impl AppStateProcessor {
 
             // Offload CPU-intensive patch processing to a blocking thread
             let (result, patch) = crate::runtime::blocking(&*self.runtime, move || {
-                let get_prev_value_mac = |index_mac: &[u8]| -> Result<
-                    Option<Vec<u8>>,
-                    crate::appstate::AppStateError,
-                > { Ok(db_prev.get(index_mac).cloned()) };
+                let get_prev_value_mac =
+                    |index_mac: &[u8]| -> Result<Option<Vec<u8>>, crate::appstate::AppStateError> {
+                        Ok(<&IndexMac>::try_from(index_mac)
+                            .ok()
+                            .and_then(|k| db_prev.get(k))
+                            .cloned())
+                    };
 
                 let mut state = state_clone;
                 let result = process_patch(
@@ -537,14 +551,17 @@ impl AppStateProcessor {
         // the inbound patch path: one batched query instead of a
         // spawn_blocking + single-row SELECT per mutation.
         let need_db_lookup = collect_unique_index_macs(&mutations);
-        let db_prev: std::collections::HashMap<Vec<u8>, Vec<u8>> = self
+        let db_prev: std::collections::HashMap<IndexMac, Vec<u8>> = self
             .backend
             .get_mutation_macs(collection_name, &need_db_lookup)
             .await?;
 
         // Update hash state
         let (_, hash_result) = state.update_hash(&mutations, |index_mac, _| {
-            Ok(db_prev.get(index_mac).cloned())
+            Ok(<&IndexMac>::try_from(index_mac)
+                .ok()
+                .and_then(|k| db_prev.get(k))
+                .cloned())
         });
         hash_result?;
 
@@ -790,13 +807,13 @@ mod dedup_tests {
             .collect()
     }
 
-    fn mac_bytes(i: usize) -> Vec<u8> {
-        let mut mac = vec![0u8; 32];
+    fn mac_bytes(i: usize) -> IndexMac {
+        let mut mac = [0u8; 32];
         mac[..8].copy_from_slice(&(i as u64).to_le_bytes());
         mac
     }
 
-    fn expected(distinct: usize) -> Vec<Vec<u8>> {
+    fn expected(distinct: usize) -> Vec<IndexMac> {
         (0..distinct).map(mac_bytes).collect()
     }
 
@@ -828,8 +845,8 @@ mod dedup_tests {
         assert_eq!(
             macs,
             vec![
-                b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_vec(),
-                b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_vec()
+                *b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                *b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             ]
         );
     }

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -409,17 +409,40 @@ impl<'a> HistorySyncStream<'a> {
     /// LENIENT: a conversation that fails to decode is skipped and counted
     /// in [`HistorySyncStream::skipped_conversations`], not fatal — one
     /// corrupt entry doesn't void the rest of the blob.
+    ///
+    /// Allocates a fresh `Conversation` per call; a loop draining thousands of
+    /// entries should prefer [`HistorySyncStream::next_conversation_into`],
+    /// which reuses one struct's allocations across iterations.
     pub fn next_conversation(&mut self) -> Result<Option<wa::Conversation>, HistorySyncError> {
+        let mut conversation = wa::Conversation::default();
+        Ok(self
+            .next_conversation_into(&mut conversation)?
+            .then_some(conversation))
+    }
+
+    /// In-place variant of [`HistorySyncStream::next_conversation`]: decodes
+    /// the next entry into `conversation`, returning `Ok(false)` at clean EOF.
+    /// Same per-entry decode leniency.
+    ///
+    /// buffa's `clear()` retains `Vec` capacity, so reusing one struct across a
+    /// drain loop skips the per-conversation message-spine reallocations. After
+    /// `Ok(false)` (or an error) the struct contents are unspecified.
+    pub fn next_conversation_into(
+        &mut self,
+        conversation: &mut wa::Conversation,
+    ) -> Result<bool, HistorySyncError> {
         loop {
             match self.next_conversation_bytes()? {
-                None => return Ok(None),
-                Some(bytes) => match waproto::codec::conversation_decode(bytes) {
-                    Ok(conversation) => return Ok(Some(conversation)),
-                    Err(e) => {
-                        log::debug!("Skipping undecodable history-sync conversation: {e}");
-                        self.skipped_conversations += 1;
+                None => return Ok(false),
+                Some(bytes) => {
+                    match waproto::codec::conversation_merge_from_slice(conversation, bytes) {
+                        Ok(()) => return Ok(true),
+                        Err(e) => {
+                            log::debug!("Skipping undecodable history-sync conversation: {e}");
+                            self.skipped_conversations += 1;
+                        }
                     }
-                },
+                }
             }
         }
     }

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -60,16 +60,20 @@ pub async fn prepare_dm_stanza(
     edit: Option<crate::types::message::EditAttribute>,
     extra_stanza_nodes: &[Node],
     all_devices: Vec<Jid>,
+    // The plain `message_to_vec(message)` encoding when the caller already
+    // computed it (e.g. for the retry cache), so this send encodes at most once.
+    // Ignored on the mci-hoist path, which must re-encode (see `shared_content`).
+    pre_encoded: Option<std::sync::Arc<Vec<u8>>>,
 ) -> Result<PreparedDmStanza> {
-    // Encode the message once and thread those bytes through both the reporting token
-    // (whitelisted-field extraction) and the wire plaintext below, instead of encoding it
-    // twice per send. The rare mci-hoist path (message carries a top-level
-    // message_context_info) can't share: its plaintext folds the reporting secret into the
-    // existing mci, diverging from the bytes the token is computed over, so it re-encodes.
-    let shared_content = message
-        .message_context_info
-        .is_unset()
-        .then(|| waproto::codec::message_to_vec(message));
+    // Encode the message at most once (reusing the caller's `pre_encoded` bytes when
+    // provided) and thread those bytes through both the reporting token
+    // (whitelisted-field extraction) and the wire plaintext below. The rare mci-hoist
+    // path (message carries a top-level message_context_info) can't share: its
+    // plaintext folds the reporting secret into the existing mci, diverging from the
+    // bytes the token is computed over, so it re-encodes.
+    let shared_content = message.message_context_info.is_unset().then(|| {
+        pre_encoded.unwrap_or_else(|| std::sync::Arc::new(waproto::codec::message_to_vec(message)))
+    });
 
     // sender is the author's own jid, remote is the chat jid (WAWebReportingTokenUtils:
     // getSender vs e.to). Both previously used to_jid, conflating sender with remote.

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -60,9 +60,8 @@ pub async fn prepare_dm_stanza(
     edit: Option<crate::types::message::EditAttribute>,
     extra_stanza_nodes: &[Node],
     all_devices: Vec<Jid>,
-    // The plain `message_to_vec(message)` encoding when the caller already
-    // computed it (e.g. for the retry cache), so this send encodes at most once.
-    // Ignored on the mci-hoist path, which must re-encode (see `shared_content`).
+    // Avoids a second full encode when the caller already serialized the message;
+    // ignored on the mci-hoist path (see `shared_content`).
     pre_encoded: Option<std::sync::Arc<Vec<u8>>>,
 ) -> Result<PreparedDmStanza> {
     // Encode the message at most once (reusing the caller's `pre_encoded` bytes when

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -133,9 +133,8 @@ pub async fn prepare_group_stanza(
     all_devices_for_phash: Option<std::sync::Arc<super::ResolvedGroupDevices>>,
     edit: Option<crate::types::message::EditAttribute>,
     extra_stanza_nodes: &[Node],
-    // The plain `message_to_vec(message)` encoding when the caller already
-    // computed it (e.g. for the retry cache), so this send encodes at most once.
-    // Ignored on the mci-hoist path, which must re-encode (see `shared_content`).
+    // Avoids a second full encode when the caller already serialized the message;
+    // ignored on the mci-hoist path (see `shared_content`).
     pre_encoded: Option<std::sync::Arc<Vec<u8>>>,
 ) -> Result<PreparedGroupStanza> {
     let (own_sending_jid, _) = match group_info.addressing_mode {

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -133,21 +133,25 @@ pub async fn prepare_group_stanza(
     all_devices_for_phash: Option<std::sync::Arc<super::ResolvedGroupDevices>>,
     edit: Option<crate::types::message::EditAttribute>,
     extra_stanza_nodes: &[Node],
+    // The plain `message_to_vec(message)` encoding when the caller already
+    // computed it (e.g. for the retry cache), so this send encodes at most once.
+    // Ignored on the mci-hoist path, which must re-encode (see `shared_content`).
+    pre_encoded: Option<std::sync::Arc<Vec<u8>>>,
 ) -> Result<PreparedGroupStanza> {
     let (own_sending_jid, _) = match group_info.addressing_mode {
         crate::types::message::AddressingMode::Lid => (own_lid.clone(), "lid"),
         crate::types::message::AddressingMode::Pn => (own_jid.clone(), "pn"),
     };
 
-    // Encode the message once and thread those bytes through both the reporting token
-    // (whitelisted-field extraction) and the skmsg wire plaintext below, instead of
-    // encoding it twice per send. The rare mci-hoist path (message carries a top-level
-    // message_context_info) can't share: its plaintext folds the reporting secret into the
-    // existing mci, diverging from the bytes the token is computed over, so it re-encodes.
-    let shared_content = message
-        .message_context_info
-        .is_unset()
-        .then(|| waproto::codec::message_to_vec(message));
+    // Encode the message at most once (reusing the caller's `pre_encoded` bytes when
+    // provided) and thread those bytes through both the reporting token
+    // (whitelisted-field extraction) and the skmsg wire plaintext below. The rare
+    // mci-hoist path (message carries a top-level message_context_info) can't share:
+    // its plaintext folds the reporting secret into the existing mci, diverging from
+    // the bytes the token is computed over, so it re-encodes.
+    let shared_content = message.message_context_info.is_unset().then(|| {
+        pre_encoded.unwrap_or_else(|| std::sync::Arc::new(waproto::codec::message_to_vec(message)))
+    });
 
     // Generate reporting token if the message type supports it.
     // For groups, both sender_jid and remote_jid are the group JID (to_jid) per Baileys implementation.

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3012,6 +3012,7 @@ mod mark_full_distribution_list {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("prepare_group_stanza should succeed even when a device fails to encrypt");
@@ -3096,6 +3097,7 @@ mod mark_full_distribution_list {
                 None,
                 None,
                 &[],
+                None,
             )
             .await
             .expect("prepare_group_stanza should succeed");
@@ -3238,6 +3240,7 @@ mod mark_full_distribution_list {
             None,
             None,
             &[],
+            None,
         )
         .await
         .expect("prepare_group_stanza should succeed");

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -276,15 +276,19 @@ pub trait AppSyncStore: Send + Sync {
     /// single backend round-trip. The default delegates to per-item lookups;
     /// backends with a set-membership query (SQL `IN (...)`) should override to
     /// avoid an N+1 (one DB round-trip per mutation in appstate sync).
+    ///
+    /// Index MACs are full HMAC-SHA256 outputs, so the batch path passes them as
+    /// inline `[u8; 32]` arrays ([`crate::appstate_sync::IndexMac`]) — no per-MAC
+    /// heap allocation on either side of the call.
     async fn get_mutation_macs(
         &self,
         name: &str,
-        index_macs: &[Vec<u8>],
-    ) -> Result<std::collections::HashMap<Vec<u8>, Vec<u8>>> {
+        index_macs: &[[u8; 32]],
+    ) -> Result<std::collections::HashMap<[u8; 32], Vec<u8>>> {
         let mut out = std::collections::HashMap::with_capacity(index_macs.len());
         for index_mac in index_macs {
-            if let Some(mac) = self.get_mutation_mac(name, index_mac).await? {
-                out.insert(index_mac.clone(), mac);
+            if let Some(mac) = self.get_mutation_mac(name, index_mac.as_slice()).await? {
+                out.insert(*index_mac, mac);
             }
         }
         Ok(out)

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -115,6 +115,20 @@ pub mod codec {
         whatsapp::Conversation::decode_from_slice(bytes)
     }
 
+    /// [`conversation_decode`] into an existing struct. buffa's `clear()`
+    /// retains `Vec` capacity, so a caller draining thousands of conversations
+    /// through one reused struct skips the per-entry message-spine reallocs.
+    /// On error the struct is left cleared-then-partially-merged; callers must
+    /// treat it as garbage until the next successful merge.
+    #[inline(never)]
+    pub fn conversation_merge_from_slice(
+        conv: &mut whatsapp::Conversation,
+        bytes: &[u8],
+    ) -> Result<(), buffa::DecodeError> {
+        conv.clear();
+        conv.merge_from_slice(bytes)
+    }
+
     #[inline(never)]
     pub fn message_context_info_encoded_len(mci: &whatsapp::MessageContextInfo) -> usize {
         mci.encoded_len() as usize


### PR DESCRIPTION
## Summary

Fourth PR in the flamegraph-mining series (#949, #952, #953). Three allocation-path changes; two are **pre-1.0 breaking changes** as discussed.

### A) appstate: index MACs as inline `[u8; 32]` end-to-end (BREAKING)

Index MACs are full HMAC-SHA256 outputs — always 32 bytes. `collect_unique_index_macs` now returns `Vec<IndexMac>` (new alias for `[u8; 32]`) and `Backend::get_mutation_macs` takes `&[[u8; 32]]` / returns `HashMap<[u8; 32], Vec<u8>>`:

- Zero per-MAC heap allocations on either side of the batch lookup (previously one `Vec<u8>` per MAC on collect + `Vec<u8>` keys in the result map)
- The dedup sort now moves contiguous 32-byte elements instead of chasing `Vec` headers
- Malformed (non-32-byte) MACs are dropped from the lookup — equivalent to the miss they would produce anyway
- **Local wall-time: `collect[1000]` -19% (54.8 → 44.1 µs), `collect[10]` -72% (318 → 88 ns — the small-patch path is now fully alloc-free)**

Migration for external `Backend` implementors: only the `get_mutation_macs` override signature changes; `get_mutation_mac`/`put_mutation_macs`/`delete_mutation_macs` are untouched, and the default impl still delegates per-item.

### B) history sync: `next_conversation_into` with struct reuse

The drain flamegraph put ~25% of `bench_history_sync_stream_drain` in protobuf drop glue + realloc churn. New API `HistorySyncStream::next_conversation_into(&mut wa::Conversation) -> Result<bool>` decodes into a caller-reused struct — buffa's `clear()` retains `Vec` capacity, so a loop draining thousands of conversations skips the per-entry message-spine reallocations. `next_conversation` is unchanged in behavior and now delegates to it; the drain bench uses the new variant (that consumer loop is exactly what it models). Backed by a new pinned codec entry point `waproto::codec::conversation_merge_from_slice`.

### C) send: encode the Message once per send (BREAKING)

Every send paid **two full wide-struct `Message` encodes**: one inside `prepare_dm_stanza`/`prepare_group_stanza` (`shared_content`, feeding the reporting token + wire plaintext) and a second inside `add_recent_message` (retry cache). `send_message_impl` now computes the encoding once as `Arc<Vec<u8>>` and threads it into both: `add_recent_message` gains an `encoded: Option<Arc<Vec<u8>>>` param, and the prepare fns gain a trailing `pre_encoded: Option<Arc<Vec<u8>>>` param (pass `None` to keep the old behavior — the rare mci-hoist path still re-encodes internally, as before, since its bytes legitimately diverge).

## Validation

- `cargo fmt` / `cargo clippy --all-targets` clean on all touched crates
- **1918 tests pass** (wacore 1039, whatsapp-rust 879+, sqlite-storage, waproto), including the appstate batch/singular-path counters, sqlite batch parity test, and history-sync roundtrip suites
- Local wall-time A/B: numbers above for A; `stream_drain` ~-3.5% (zlib-dominated, as expected); C's gain is arithmetic (one fewer full encode per send, ~5-15 µs + allocation) and shows up in the client-layer integration benches
- CodSpeed benches to watch: `bench_collect_unique_index_macs[10/1000]`, `bench_history_sync_stream_drain`, `send_message`/`send_and_receive` (integration — known noisy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T53MPuGRg4kvRjRxW6fUvd

---
_Generated by [Claude Code](https://claude.ai/code/session_01T53MPuGRg4kvRjRxW6fUvd)_