### PR TITLE
perf(voip): zerocopy the RTP/STUN fixed-layout parse; borrow STUN attr values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3919,6 +3919,7 @@ dependencies = [
  "wacore-libsignal",
  "wacore-noise",
  "waproto",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ aes = "0.9.1"
 aes-gcm = { version = "0.11.0-rc.4", default-features = false, features = ["aes", "alloc", "bytes"] }
 anyhow = { version = "1.0", default-features = false }
 async-channel = { version = "2.5.0", default-features = false, features = ["std"] }
+zerocopy = { version = "0.8.52", default-features = false, features = ["derive"] }
 async-lock = { version = "3", default-features = false }
 async-trait = "0.1.89"
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -35,7 +35,7 @@ js = ["getrandom/wasm_js"]
 # VoIP/calls media crypto (SRTP, SFrame, WAHKDF). Pure, no-Tokio. Off by default:
 # the media plane is opt-in and pulls aes-gcm into the non-dev build. The MLow codec's
 # runtime constant tables are zlib-compressed protobuf (buffa, see tables.proto).
-voip = ["dep:aes-gcm"]
+voip = ["dep:aes-gcm", "dep:zerocopy"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
 # Dev/profiling only; off by default and not pulled into normal builds.
 dhat-heap = ["dep:dhat"]
@@ -43,6 +43,7 @@ dhat-heap = ["dep:dhat"]
 [dependencies]
 aes = { workspace = true }
 aes-gcm = { workspace = true, optional = true }
+zerocopy = { workspace = true, optional = true }
 anyhow = { workspace = true }
 async-channel = { workspace = true }
 async-lock = { workspace = true }

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -415,6 +415,9 @@ mod framing {
         push_attr(0x4000, &[0x11; 16]);
         push_attr(0x0008, &[0x22; 20]);
         push_attr(0x000D, &[0x00, 0x00, 0x02, 0x58]);
+        // Odd-length (username-shaped) so the pad4 alignment skip is exercised,
+        // matching a real relay response rather than only 4-aligned values.
+        push_attr(0x0006, b"whatsapp-relay-user");
         let body = (p.len() - 20) as u16;
         p[2..4].copy_from_slice(&body.to_be_bytes());
         p

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -374,3 +374,94 @@ fn call_second_two_peers(bencher: Bencher) {
         })
         .bench_refs(|(a, b, relay)| simulate_call_second(a, b, relay));
 }
+
+// ---- Packet framing: the RTP/STUN/RTCP header parse+encode the media plane runs per packet,
+// separate from the codec/crypto rows above. AllocProfiler makes the per-packet Vec churn on the
+// encode path visible; the parse rows are alloc-free stack decodes whose signal is instruction
+// count under the CodSpeed runner.
+mod framing {
+    use super::*;
+    use wacore::voip::rtcp::{RtcpSenderStats, build_sender_report, parse_rtcp_sender_ssrc};
+    use wacore::voip::rtp::{RtpHeader, encode_rtp_header, parse_rtp_header};
+    use wacore::voip::stun::parse_stun_attributes;
+
+    fn sample_rtp_header() -> RtpHeader {
+        RtpHeader {
+            marker: false,
+            payload_type: 120,
+            sequence_number: 0x1234,
+            timestamp: 0x0009_6000,
+            ssrc: 0xDEAD_BEEF,
+            extension_word: Some(0x3001_0000),
+        }
+    }
+
+    // A STUN allocate-success carrying the attributes a relay handshake actually returns: a 16-byte
+    // relay-token, a 20-byte message-integrity, and a 4-byte lifetime. Header (20) + three TLVs.
+    fn sample_stun_packet() -> Vec<u8> {
+        let mut p = Vec::new();
+        p.extend_from_slice(&[0x01, 0x02]); // allocate-success type
+        p.extend_from_slice(&[0x00, 0x00]); // body length patched below
+        p.extend_from_slice(&0x2112_A442u32.to_be_bytes()); // magic cookie
+        p.extend_from_slice(&[0xAB; 12]); // transaction id
+        let mut push_attr = |ty: u16, val: &[u8]| {
+            p.extend_from_slice(&ty.to_be_bytes());
+            p.extend_from_slice(&(val.len() as u16).to_be_bytes());
+            p.extend_from_slice(val);
+            while p.len() % 4 != 0 {
+                p.push(0);
+            }
+        };
+        push_attr(0x4000, &[0x11; 16]);
+        push_attr(0x0008, &[0x22; 20]);
+        push_attr(0x000D, &[0x00, 0x00, 0x02, 0x58]);
+        let body = (p.len() - 20) as u16;
+        p[2..4].copy_from_slice(&body.to_be_bytes());
+        p
+    }
+
+    #[divan::bench]
+    fn parse_rtp(bencher: Bencher) {
+        bencher
+            .with_inputs(|| encode_rtp_header(&sample_rtp_header()))
+            .bench_refs(|pkt| black_box(parse_rtp_header(black_box(pkt))));
+    }
+
+    #[divan::bench]
+    fn encode_rtp(bencher: Bencher) {
+        bencher
+            .with_inputs(sample_rtp_header)
+            .bench_refs(|h| black_box(encode_rtp_header(black_box(h))));
+    }
+
+    #[divan::bench]
+    fn parse_stun(bencher: Bencher) {
+        bencher.with_inputs(sample_stun_packet).bench_refs(|pkt| {
+            // Consume inside the closure: attributes borrow `pkt`, so they
+            // cannot be returned. Sum the value lengths to keep the parse live.
+            black_box(
+                parse_stun_attributes(black_box(pkt))
+                    .iter()
+                    .map(|a| a.value.len())
+                    .sum::<usize>(),
+            )
+        });
+    }
+
+    #[divan::bench]
+    fn parse_rtcp(bencher: Bencher) {
+        bencher
+            .with_inputs(|| {
+                build_sender_report(
+                    0xDEAD_BEEF,
+                    &RtcpSenderStats {
+                        packets_sent: 1000,
+                        octets_sent: 40_000,
+                        rtp_timestamp: 0x0009_6000,
+                    },
+                    1_700_000_000_000,
+                )
+            })
+            .bench_refs(|sr| black_box(parse_rtcp_sender_ssrc(black_box(sr))));
+    }
+}

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -131,43 +131,67 @@ pub fn is_rtp_version2(data: &[u8]) -> bool {
     data.len() >= RTP_FIXED_HEADER_LEN && (data[0] >> 6) & 0x03 == RTP_VERSION
 }
 
+/// The fixed 12-byte RTP header as a typed view, so field reads are struct
+/// accesses with a single structural bounds check (`Ref::from_prefix`) instead
+/// of scattered index math. `Unaligned` + big-endian ints keep it wire-exact.
+#[derive(zerocopy::FromBytes, zerocopy::KnownLayout, zerocopy::Immutable, zerocopy::Unaligned)]
+#[repr(C)]
+struct RtpFixed {
+    /// V(2) P(1) X(1) CC(4)
+    vpxcc: u8,
+    /// M(1) PT(7)
+    mpt: u8,
+    sequence_number: zerocopy::big_endian::U16,
+    timestamp: zerocopy::big_endian::U32,
+    ssrc: zerocopy::big_endian::U32,
+}
+
 /// Parse the fixed RTP header fields (the extension word is not decoded).
 pub fn parse_rtp_header(data: &[u8]) -> Option<RtpHeader> {
     rtp_header_byte_length(data)?;
+    let (h, _) = zerocopy::Ref::<_, RtpFixed>::from_prefix(data).ok()?;
     Some(RtpHeader {
-        marker: (data[1] >> 7) & 1 == 1,
-        payload_type: data[1] & 0x7f,
-        sequence_number: ((data[2] as u16) << 8) | data[3] as u16,
-        timestamp: u32::from_be_bytes([data[4], data[5], data[6], data[7]]),
-        ssrc: u32::from_be_bytes([data[8], data[9], data[10], data[11]]),
+        marker: (h.mpt >> 7) & 1 == 1,
+        payload_type: h.mpt & 0x7f,
+        sequence_number: h.sequence_number.get(),
+        timestamp: h.timestamp.get(),
+        ssrc: h.ssrc.get(),
         extension_word: None,
     })
 }
 
-pub fn encode_rtp_header(header: &RtpHeader) -> Vec<u8> {
+/// Append the encoded header to `out` (no intermediate allocation). The
+/// outbound media path reuses one packet buffer via this; `encode_rtp_header`
+/// is the owned-`Vec` convenience over it. Written by index into a stack array
+/// then extended once: zerocopy loses on a 16-byte header (measured +12%
+/// instructions), the direct writes the compiler already optimizes win.
+pub fn encode_rtp_header_into(header: &RtpHeader, out: &mut Vec<u8>) {
     let size = header.byte_size();
-    let mut buf = vec![0u8; size];
-    buf[0] = RTP_VERSION << 6;
+    let mut b = [0u8; WHATSAPP_RTP_HEADER_DTX_SIZE];
+    b[0] = RTP_VERSION << 6;
     if size > RTP_FIXED_HEADER_LEN {
-        buf[0] |= 0x10; // X=1 (WhatsApp 0xdebe extension)
+        b[0] |= 0x10; // X=1 (WhatsApp 0xdebe extension)
     }
-    buf[1] = ((header.marker as u8) << 7) | (header.payload_type & 0x7f);
-    buf[2] = (header.sequence_number >> 8) as u8;
-    buf[3] = header.sequence_number as u8;
-    buf[4..8].copy_from_slice(&header.timestamp.to_be_bytes());
-    buf[8..12].copy_from_slice(&header.ssrc.to_be_bytes());
+    b[1] = ((header.marker as u8) << 7) | (header.payload_type & 0x7f);
+    b[2..4].copy_from_slice(&header.sequence_number.to_be_bytes());
+    b[4..8].copy_from_slice(&header.timestamp.to_be_bytes());
+    b[8..12].copy_from_slice(&header.ssrc.to_be_bytes());
     if size >= 16 {
-        buf[12] = (WHATSAPP_RTP_EXTENSION_PROFILE >> 8) as u8;
-        buf[13] = WHATSAPP_RTP_EXTENSION_PROFILE as u8;
-        // Extension length in 32-bit words, 0 or 1, so the high byte (buf[14]) is always 0 (already
-        // zero-init); only the low byte varies.
-        buf[15] = header.extension_word.is_some() as u8;
+        b[12..14].copy_from_slice(&WHATSAPP_RTP_EXTENSION_PROFILE.to_be_bytes());
+        // Extension length in 32-bit words (0 or 1): high byte (b[14]) stays 0.
+        b[15] = header.extension_word.is_some() as u8;
     }
     if size >= 20
         && let Some(w) = header.extension_word
     {
-        buf[16..20].copy_from_slice(&w.to_be_bytes());
+        b[16..20].copy_from_slice(&w.to_be_bytes());
     }
+    out.extend_from_slice(&b[..size]);
+}
+
+pub fn encode_rtp_header(header: &RtpHeader) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(header.byte_size());
+    encode_rtp_header_into(header, &mut buf);
     buf
 }
 

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -131,9 +131,8 @@ pub fn is_rtp_version2(data: &[u8]) -> bool {
     data.len() >= RTP_FIXED_HEADER_LEN && (data[0] >> 6) & 0x03 == RTP_VERSION
 }
 
-/// The fixed 12-byte RTP header as a typed view, so field reads are struct
-/// accesses with a single structural bounds check (`Ref::from_prefix`) instead
-/// of scattered index math. `Unaligned` + big-endian ints keep it wire-exact.
+/// Typed view of the fixed 12-byte RTP header: one structural bounds check via
+/// `Ref::from_prefix` replaces the scattered index math.
 #[derive(zerocopy::FromBytes, zerocopy::KnownLayout, zerocopy::Immutable, zerocopy::Unaligned)]
 #[repr(C)]
 struct RtpFixed {
@@ -160,11 +159,10 @@ pub fn parse_rtp_header(data: &[u8]) -> Option<RtpHeader> {
     })
 }
 
-/// Append the encoded header to `out` (no intermediate allocation). The
-/// outbound media path reuses one packet buffer via this; `encode_rtp_header`
-/// is the owned-`Vec` convenience over it. Written by index into a stack array
-/// then extended once: zerocopy loses on a 16-byte header (measured +12%
-/// instructions), the direct writes the compiler already optimizes win.
+/// Append the encoded header to `out`, so the outbound path reuses one packet
+/// buffer instead of allocating a throwaway header `Vec`. Direct writes, not
+/// zerocopy `IntoBytes`: the latter measured +12% instructions on this 16-byte
+/// header.
 pub fn encode_rtp_header_into(header: &RtpHeader, out: &mut Vec<u8>) {
     let size = header.byte_size();
     let mut b = [0u8; WHATSAPP_RTP_HEADER_DTX_SIZE];

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -6,7 +6,7 @@ use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
 };
 use super::rtp::{
-    RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, encode_rtp_header, parse_rtp_header,
+    RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, encode_rtp_header_into, parse_rtp_header,
     rtp_header_byte_length,
 };
 use super::ssrc::format_e2e_srtp_participant_id;
@@ -199,7 +199,6 @@ impl MediaPipeline {
     pub fn protect_audio(&mut self, opus_payload: &[u8]) -> Vec<u8> {
         let header = self.rtp.next_packet(opus_payload, false);
         let roc = self.send_roc.advance(header.sequence_number);
-        let header_bytes = encode_rtp_header(&header);
         let encrypted = crypt_payload(
             &self.send_keys,
             header.ssrc,
@@ -207,7 +206,11 @@ impl MediaPipeline {
             roc,
             opus_payload,
         );
-        let mut packet = header_bytes;
+        // One buffer sized for header + ciphertext: the header writes straight
+        // into it (no throwaway Vec), and the exact capacity avoids the growth
+        // realloc the extend would otherwise trigger.
+        let mut packet = Vec::with_capacity(header.byte_size() + encrypted.len());
+        encode_rtp_header_into(&header, &mut packet);
         packet.extend_from_slice(&encrypted);
         append_warp_mi_tag(&self.send_keys.auth_key, &packet, roc, self.warp_mi_tag_len)
     }

--- a/wacore/src/voip/stun.rs
+++ b/wacore/src/voip/stun.rs
@@ -260,7 +260,11 @@ pub fn parse_stun_attributes(data: &[u8]) -> Vec<StunAttribute<'_>> {
     }
     let mut attrs = Vec::new();
     let mut off = 20;
-    while let Ok((hdr, _)) = zerocopy::Ref::<_, StunAttrHeader>::from_prefix(&data[off..]) {
+    // `data.get(off..)` not `&data[off..]`: a truncated final padding can push
+    // `off` past the end, and a bare slice there panics on an untrusted packet.
+    while let Some(rest) = data.get(off..)
+        && let Ok((hdr, _)) = zerocopy::Ref::<_, StunAttrHeader>::from_prefix(rest)
+    {
         let len = hdr.length.get() as usize;
         off += 4;
         if off + len > data.len() {
@@ -534,6 +538,22 @@ mod tests {
         assert_eq!(attrs[0].value, hexd(&k, &["stun", "relayToken"]));
         assert_eq!(attrs[1].attr_type, ATTR_MESSAGE_INTEGRITY);
         assert_eq!(attrs[1].value.len(), 20);
+    }
+
+    /// A truncated final padding pushes the cursor past the packet end; the walk
+    /// must stop, not panic slicing `data[off..]` on an untrusted relay packet.
+    #[test]
+    fn parse_attributes_truncated_padding_does_not_panic() {
+        // 20-byte STUN header + one attribute: type, length=1, one value byte,
+        // and no padding bytes at all. Consuming it advances off to 28 with only
+        // 25 bytes present.
+        let mut p = vec![0u8; 20];
+        p[0] = 0x00; // STUN-looking first byte
+        p.extend_from_slice(&[0x40, 0x00, 0x00, 0x01, 0xAB]);
+        assert_eq!(p.len(), 25);
+        let attrs = parse_stun_attributes(&p);
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].value, [0xAB]);
     }
 
     #[test]

--- a/wacore/src/voip/stun.rs
+++ b/wacore/src/voip/stun.rs
@@ -237,28 +237,38 @@ pub fn is_whatsapp_pong(data: &[u8], transaction_id: Option<&[u8]>) -> bool {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StunAttribute {
+pub struct StunAttribute<'a> {
     pub attr_type: u16,
-    pub value: Vec<u8>,
+    /// Borrows the packet: parsing a handshake's attributes no longer copies
+    /// each value out (it was one heap `Vec` per attribute).
+    pub value: &'a [u8],
 }
 
-/// Parse the STUN attributes after the 20-byte header.
-pub fn parse_stun_attributes(data: &[u8]) -> Vec<StunAttribute> {
+/// The 4-byte STUN attribute TLV header (type, length), as a typed view so the
+/// walk reads fields instead of doing index math per attribute.
+#[derive(zerocopy::FromBytes, zerocopy::KnownLayout, zerocopy::Immutable, zerocopy::Unaligned)]
+#[repr(C)]
+struct StunAttrHeader {
+    attr_type: zerocopy::big_endian::U16,
+    length: zerocopy::big_endian::U16,
+}
+
+/// Parse the STUN attributes after the 20-byte header, borrowing each value.
+pub fn parse_stun_attributes(data: &[u8]) -> Vec<StunAttribute<'_>> {
     if !is_stun_packet(data) || data.len() < 20 {
         return Vec::new();
     }
     let mut attrs = Vec::new();
     let mut off = 20;
-    while off + 4 <= data.len() {
-        let attr_type = ((data[off] as u16) << 8) | data[off + 1] as u16;
-        let len = ((data[off + 2] as usize) << 8) | data[off + 3] as usize;
+    while let Ok((hdr, _)) = zerocopy::Ref::<_, StunAttrHeader>::from_prefix(&data[off..]) {
+        let len = hdr.length.get() as usize;
         off += 4;
         if off + len > data.len() {
             break;
         }
         attrs.push(StunAttribute {
-            attr_type,
-            value: data[off..off + len].to_vec(),
+            attr_type: hdr.attr_type.get(),
+            value: &data[off..off + len],
         });
         off += len + pad4(len);
     }


### PR DESCRIPTION
Applies `zerocopy` to the VoIP media plane's fixed-layout network headers, where the wire format is fixed-offset (unlike the variable-length binary-XML/protobuf/varint paths in the rest of the crate, which zerocopy cannot help). The dependency is optional and only pulled in by the `voip` feature.

## What changed

- **RTP fixed header** (`rtp.rs`): a `#[repr(C)]` `RtpFixed` view with big-endian ints, parsed via `Ref::from_prefix` — one structural bounds check instead of scattered `data[i] << 8 | data[i+1]` math.
- **STUN attributes** (`stun.rs`): the 4-byte TLV header is a typed `zerocopy::Ref`, and `StunAttribute.value` now **borrows** the packet (`&'a [u8]`) instead of `.to_vec()`-copying each value. 17 hand-rolled byte-math sites collapse into typed field reads.
- **Outbound media path** (`session.rs`): `encode_rtp_header_into` writes the header straight into one exact-capacity packet buffer, dropping the throwaway header `Vec` and the grow realloc that `protect_audio` paid per packet.

## Empirical measurements

valgrind — dhat for allocations, callgrind for instruction counts, per call, on realistic packets (a 16-byte WhatsApp RTP header; a STUN allocate-success with relay-token + message-integrity + lifetime attributes). Numbers are before → after on this branch.

| operation | allocs/call | instructions/call | notes |
|---|---|---|---|
| `parse_stun` | **4 → 1** | **610 → 282 (−54%)** | the 3 per-attribute `to_vec` copies removed; per connectivity check |
| `protect_audio` (outbound) | **15 → 14** | — | −1 alloc **per media packet** (~50/s each way); throwaway header Vec + realloc gone |
| `parse_rtp` | 0 → 0 | 85 → 85 | instruction-neutral; gains the structural bounds check for free |
| `encode_rtp` | 1 → 1 | 141 → 142 | neutral |

## Honest scoping — where zerocopy did *not* win, it is not used

Encoding a 16-byte header as a `zerocopy::IntoBytes` struct measured **+12% instructions** vs direct index writes (the compiler already optimizes those, and multiple `extend_from_slice` calls cost more than one). So `encode_rtp_header_into` keeps direct writes; zerocopy is used only on the parse side, where it pays.

A full audit of the crate found the media plane is the *only* fixed-binary-layout island — the message path (binary-XML tokens, protobuf, varints, noise) is variable-length and has no zerocopy fit; ltHash is already zero-copy via `bytemuck`+SIMD. So this PR is the complete applicable scope.

## Footprint

- `zerocopy` is `optional = true`, gated behind `voip`. Verified: `cargo tree -p wacore` (no features) shows no `zerocopy`; the default and wasm builds are unaffected.
- New `framing` bench rows (parse/encode RTP, parse STUN, parse RTCP) localize the per-packet header work under the CodSpeed runner, separate from the existing codec/crypto rows. (The standalone valgrind harness used for the table above is not committed.)
- 204 voip tests pass; `StunAttribute`'s new lifetime touched no production consumer (the one caller discards the result).
