### PR TITLE
perf(connect): move own-device sync off the pre-active path; drop keepalive loop span

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -662,12 +662,6 @@ impl Client {
                 // Don't fail login - PDO will retry via ensure_e2e_sessions fallback
             }
 
-            // Sync own device list so DM fan-out includes all companions
-            check_generation!();
-            if let Err(e) = client_clone.sync_own_device_list().await {
-                client_clone.log_sync_error("sync own device list", &e);
-            }
-
             check_generation!();
             if !client_clone.is_connected() {
                 debug!("Skipping passive tasks: connection closed");
@@ -722,7 +716,7 @@ impl Client {
                 }
 
                 debug!(
-                    "Sending background initialization queries (Props, Blocklist, Privacy, Digest)..."
+                    "Sending background initialization queries (Props, Blocklist, Privacy, Digest, Devices)..."
                 );
 
                 let props_fut = bg_client.fetch_props();
@@ -730,9 +724,19 @@ impl Client {
                 let blocklist_fut = binding.get_blocklist();
                 let privacy_fut = bg_client.fetch_privacy_settings();
                 let digest_fut = bg_client.validate_digest_key();
+                // Off the pre-active critical path: WA Web's passive tasks don't
+                // include an own-device usync (it resolves device lists on demand
+                // at send time), so syncing here instead of before the active IQ
+                // starts offline delivery one round-trip sooner.
+                let device_list_fut = bg_client.sync_own_device_list();
 
-                let (r_props, r_block, r_priv, r_digest) =
-                    futures::join!(props_fut, blocklist_fut, privacy_fut, digest_fut);
+                let (r_props, r_block, r_priv, r_digest, r_devices) = futures::join!(
+                    props_fut,
+                    blocklist_fut,
+                    privacy_fut,
+                    digest_fut,
+                    device_list_fut
+                );
 
                 // Suppress warnings if connection closed while queries were in-flight
                 if !bg_client.is_shutting_down() {
@@ -747,6 +751,9 @@ impl Client {
                     }
                     if let Err(e) = r_digest {
                         warn!("Background init: Failed to validate digest key: {e:?}");
+                    }
+                    if let Err(e) = r_devices {
+                        bg_client.log_sync_error("sync own device list", &e);
                     }
                 }
 

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -123,10 +123,10 @@ impl Client {
         }
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(name = "wa.conn.keepalive", level = "debug", skip_all)
-    )]
+    // Deliberately NOT instrumented: a span here would live for the whole
+    // connection (tens of minutes), polluting duration/throughput metrics and
+    // only reporting at disconnect. Per-ping visibility comes from
+    // `wa.conn.keepalive.ping` on send_keepalive.
     pub(crate) async fn keepalive_loop(self: Arc<Self>) {
         let mut error_count = 0u32;
         let mut cleanup_counter = 0u32;


### PR DESCRIPTION
## Summary

First PR driven by **production tracing data** (GlitchTip spans from a downstream consumer) rather than CodSpeed flamegraphs. Two findings, both verified against the captured WA Web JS before touching anything.

### A) `sync_own_device_list` was serial before the active IQ (~360 ms per reconnect)

Production traces: `wa.usync.sync_own_device_list` averages **360 ms** (one usync round-trip) and ran in the post-login sequence *before* `set_passive(false)` — so every reconnect delayed the start of offline message delivery by that round-trip.

The captured WA Web JS settles the parity question:
- `WAWebPassiveModeManager.executePassiveTasks` runs its registered tasks via **`Promise.all`** (60 s cap), then sends the active IQ
- The only registered passive tasks are `SendOnlineDanglingReceipts`, `SendDanglingReceipts`, `KeyUpload` (only when the server lacks prekeys) and `SyncABProps` — **no own-device usync**
- WA Web resolves device lists on demand at send time (the same usync-with-device-hashes flow our `get_user_devices` implements)

So the pre-active sync was a divergence *against* us. This moves it into the existing post-active background `futures::join!` (alongside props/blocklist/privacy/digest), keeping its error logging. Offline delivery now starts one round-trip sooner on every connect, and parity improves.

### B) Stop instrumenting `keepalive_loop`

The `wa.conn.keepalive` span wrapped the whole loop: it lived for the entire connection (production showed a **39-minute** span), only reported at disconnect, and turned dashboard metrics into artifacts (avgDuration 39 min, throughput 469/s for a ping loop). Per-ping visibility is unchanged via the existing `wa.conn.keepalive.ping` span.

### Verified and deliberately NOT changed

- **Per-stanza Signal-cache flush on receive**: WA Web's `ProcessingDecryptApi` also flushes once per stanza (`flushBufferToDiskIfNotMemOnlyMode` after the enc-payload loop) — our granularity is parity-correct and guards ratchet durability before ack. The ~4 ms avg on `wa.recv.incoming` is inherent per-message I/O.
- The ~200-660 ms cluster on IQ-shaped spans is network RTT (avg `wa.iq` = 225 ms ≈ 1 round-trip), not compute.

## Validation

- `cargo fmt` / `cargo clippy --all-targets --features tracing` clean
- `cargo test -p whatsapp-rust`: 914 tests pass
- No wire-format or protocol changes; the moved sync keeps its generation/connection guards via the background task's existing checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)