### PR TITLE
perf(tracing): drop client-lifetime wa.conn.run span

### DIFF
--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -301,30 +301,16 @@ impl Client {
         (arc, rx)
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(
-            name = "wa.conn.run",
-            level = "info",
-            skip_all,
-            fields(lid = tracing::field::Empty, pn = tracing::field::Empty)
-        )
-    )]
+    // Deliberately NOT instrumented: this span would live for the entire client
+    // lifetime, distorting duration/throughput metrics just like the removed
+    // keepalive-loop span. Identity (lid/pn) attribution comes from the
+    // per-operation spans (send/request), which record it themselves.
     pub async fn run(self: &Arc<Self>) {
         if self.is_running.swap(true, Ordering::SeqCst) {
             warn!("Client `run` method called while already running.");
             return;
         }
         while self.is_running.load(Ordering::Relaxed) {
-            // Re-record every iteration, not just once before the loop: a freshly-paired
-            // device has no lid/pn yet on the first pass, and dispatch_connected() (where
-            // pairing actually resolves them) runs in a detached spawned task with no
-            // ambient span to record onto. The next reconnect iteration — which happens
-            // routinely (server-initiated stream-end, network blips) — picks up the
-            // by-then-known identity on this same span instead.
-            #[cfg(feature = "tracing")]
-            self.record_identity_on_span(&tracing::Span::current());
-
             self.expected_disconnect.store(false, Ordering::Relaxed);
 
             if let Err(connect_err) = self.connect().await {


### PR DESCRIPTION
Follow-up to #958, applying the same treatment to the last remaining long-lived span.

## What

Removes the `wa.conn.run` tracing span from `Client::run` (and the `record_identity_on_span` call that fed its `lid`/`pn` fields).

## Why

`wa.conn.run` wrapped the entire auto-reconnect loop, so a single span lived for the whole client lifetime and only reported at shutdown — the exact pathology #958 removed from the keepalive loop. Production GlitchTip dashboards showed it with ~39.6 min `avgDuration` and meaningless throughput numbers, drowning out the per-operation spans that carry real signal.

Its one counter-argument was identity attribution: it carried `lid`/`pn` as a root span. In practice that adds nothing:

- The per-operation spans already record identity themselves via `record_identity_on_span` (`wa.send.message` in `src/send/mod.rs`, `wa.iq` in `src/request.rs`), so every span with meaningful duration keeps its `lid`/`pn`.
- Backends like GlitchTip don't attribute child spans through the parent chain anyway, so the root-span fields were never queryable where it mattered.

## What stays

All per-operation instrumentation is untouched: `wa.conn.connect`, `wa.conn.keepalive.ping`, `wa.send.*`, `wa.iq`, `wa.usync.*`, etc. Connection-lifecycle visibility remains through `wacore::telemetry::connect("ok"/"fail")` counters and the connect/disconnect events.

## Validation

- `cargo fmt` / `cargo clippy -p whatsapp-rust --features tracing --tests` clean
- 905 tests pass with `--features tracing` (the `send_app_state_action` doctest recursion-limit failure under this feature is pre-existing on main, unrelated)
- CodSpeed expectation: no changes (tracing feature is off in benches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T53MPuGRg4kvRjRxW6fUvd)_