### PR TITLE
fix: shut down on SIGTERM, not just SIGINT (docker stop timeout)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,6 +4281,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "itoa",
+ "libc",
  "log",
  "metrics-exporter-prometheus",
  "opus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,8 @@ env_logger = { workspace = true }
 flate2 = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }
+# Raises real SIGINT/SIGTERM at the current process in the shutdown-signal test.
+libc = "0.2"
 metrics-exporter-prometheus = "0.18"
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -127,8 +127,11 @@ fn main() {
             let mut handle = bot.spawn();
             tokio::select! {
                 _ = &mut handle => {}
-                _ = tokio::signal::ctrl_c() => {
-                    info!("Received Ctrl+C, shutting down...");
+                // SIGINT (Ctrl+C) or SIGTERM (`docker stop`, k8s, systemd). Watching
+                // only Ctrl+C left `docker stop` to time out and SIGKILL the PID-1
+                // container, skipping the graceful flush below.
+                _ = whatsapp_rust::shutdown_signal() => {
+                    info!("Received shutdown signal, shutting down...");
                     handle.shutdown().await;
                 }
             }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -978,7 +978,8 @@ async fn run_bot(mode: Mode) -> Result<()> {
 
     tokio::select! {
         _ = bot.run() => {}
-        _ = tokio::signal::ctrl_c() => { info!("shutting down"); }
+        // SIGINT or SIGTERM: react to `docker stop`/k8s, not just Ctrl+C.
+        _ = whatsapp_rust::shutdown_signal() => { info!("shutting down"); }
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,10 @@ pub use features::{
 
 pub mod bot;
 pub mod lid_pn_cache;
+#[cfg(feature = "signal")]
+pub mod shutdown;
+#[cfg(feature = "signal")]
+pub use shutdown::shutdown_signal;
 pub mod spam_report;
 pub mod sync_task;
 pub mod version;
@@ -143,6 +147,8 @@ pub mod prelude {
     #[cfg(feature = "tokio-runtime")]
     pub use crate::runtime_impl::TokioRuntime;
     pub use crate::send::{SendError, SendOptions, SendResult};
+    #[cfg(feature = "signal")]
+    pub use crate::shutdown::shutdown_signal;
     #[cfg(feature = "sqlite-storage")]
     pub use crate::store::SqliteStore;
     pub use crate::types::events::{Event, EventKind};

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,27 +1,13 @@
-//! Process shutdown-signal handling for the bundled binaries.
+//! Graceful-shutdown signal for the bundled binaries.
 //!
-//! Container/service supervisors stop a process by sending **SIGTERM** and only
-//! escalate to an unblockable SIGKILL after a grace period (`docker stop`
-//! defaults to 10s). Watching only SIGINT (`Ctrl+C`) means SIGTERM goes
-//! unhandled, so the process burns the whole grace period and is hard-killed —
-//! skipping the flush/disconnect that graceful shutdown performs.
-//!
-//! This bites hardest under this project's Docker image: the static binary is
-//! the `scratch` entrypoint, so it runs as **PID 1**, and the kernel drops any
-//! signal for which PID 1 has no handler installed. An unhandled SIGTERM is
-//! therefore silently ignored rather than terminating the process, guaranteeing
-//! the 10s timeout on every `docker stop`.
-//!
-//! [`shutdown_signal`] resolves on the first of SIGINT or SIGTERM (Ctrl+C only
-//! on non-Unix, the sole portable stop signal Tokio exposes there), so wiring it
-//! into a `tokio::select!` is enough to make `docker stop` graceful.
+//! Watches SIGINT *and* SIGTERM (Ctrl+C only on non-Unix): supervisors like
+//! `docker stop` send SIGTERM, and as PID 1 in a `scratch` image the kernel
+//! silently drops any signal without an installed handler — so a `ctrl_c()`-only
+//! wait never runs cleanup and is SIGKILLed after the stop timeout.
 
-/// Resolves when the process is asked to stop (SIGINT or SIGTERM on Unix,
-/// Ctrl+C elsewhere).
-///
-/// Both signal handlers are installed synchronously before the returned future
-/// first suspends, so a signal that arrives afterwards is delivered rather than
-/// lost. Compose it with the run loop:
+/// Resolves on the first stop signal: SIGINT or SIGTERM on Unix, Ctrl+C
+/// elsewhere. Both handlers are armed before the future first suspends, so a
+/// signal arriving afterwards is delivered, not missed.
 ///
 /// ```no_run
 /// # async fn f(mut handle: whatsapp_rust::bot::BotHandle) {
@@ -35,23 +21,27 @@
 pub async fn shutdown_signal() {
     use tokio::signal::unix::{Signal, SignalKind, signal};
 
+    // Realistically unreachable for SIGINT/SIGTERM (only uncatchable signals
+    // fail to register); degrade to whichever installs instead of panicking in
+    // a top-level shutdown path.
     fn install(kind: SignalKind, name: &str) -> Option<Signal> {
-        match signal(kind) {
-            Ok(sig) => Some(sig),
-            // Realistically unreachable for SIGINT/SIGTERM (only uncatchable
-            // signals fail to register). Degrade to whichever handler did
-            // install instead of panicking in a top-level shutdown path.
-            Err(e) => {
-                log::error!("shutdown_signal: failed to install {name} handler: {e}");
-                None
-            }
-        }
+        signal(kind)
+            .inspect_err(|e| log::error!("shutdown_signal: cannot watch {name}: {e}"))
+            .ok()
     }
 
     // Registered up front (before the first await) so both are armed by the
     // time either can fire.
     let mut sigint = install(SignalKind::interrupt(), "SIGINT");
     let mut sigterm = install(SignalKind::terminate(), "SIGTERM");
+
+    if sigint.is_none() && sigterm.is_none() {
+        // Neither installed: the future below can never resolve, so graceful
+        // stop is off. Say so loudly rather than parking silently forever.
+        log::error!(
+            "shutdown_signal: no stop signal could be installed; graceful shutdown disabled"
+        );
+    }
 
     async fn wait(sig: &mut Option<Signal>) {
         match sig {

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,75 @@
+//! Process shutdown-signal handling for the bundled binaries.
+//!
+//! Container/service supervisors stop a process by sending **SIGTERM** and only
+//! escalate to an unblockable SIGKILL after a grace period (`docker stop`
+//! defaults to 10s). Watching only SIGINT (`Ctrl+C`) means SIGTERM goes
+//! unhandled, so the process burns the whole grace period and is hard-killed —
+//! skipping the flush/disconnect that graceful shutdown performs.
+//!
+//! This bites hardest under this project's Docker image: the static binary is
+//! the `scratch` entrypoint, so it runs as **PID 1**, and the kernel drops any
+//! signal for which PID 1 has no handler installed. An unhandled SIGTERM is
+//! therefore silently ignored rather than terminating the process, guaranteeing
+//! the 10s timeout on every `docker stop`.
+//!
+//! [`shutdown_signal`] resolves on the first of SIGINT or SIGTERM (Ctrl+C only
+//! on non-Unix, the sole portable stop signal Tokio exposes there), so wiring it
+//! into a `tokio::select!` is enough to make `docker stop` graceful.
+
+/// Resolves when the process is asked to stop (SIGINT or SIGTERM on Unix,
+/// Ctrl+C elsewhere).
+///
+/// Both signal handlers are installed synchronously before the returned future
+/// first suspends, so a signal that arrives afterwards is delivered rather than
+/// lost. Compose it with the run loop:
+///
+/// ```no_run
+/// # async fn f(mut handle: whatsapp_rust::bot::BotHandle) {
+/// tokio::select! {
+///     _ = &mut handle => {}
+///     _ = whatsapp_rust::shutdown_signal() => handle.shutdown().await,
+/// }
+/// # }
+/// ```
+#[cfg(unix)]
+pub async fn shutdown_signal() {
+    use tokio::signal::unix::{Signal, SignalKind, signal};
+
+    fn install(kind: SignalKind, name: &str) -> Option<Signal> {
+        match signal(kind) {
+            Ok(sig) => Some(sig),
+            // Realistically unreachable for SIGINT/SIGTERM (only uncatchable
+            // signals fail to register). Degrade to whichever handler did
+            // install instead of panicking in a top-level shutdown path.
+            Err(e) => {
+                log::error!("shutdown_signal: failed to install {name} handler: {e}");
+                None
+            }
+        }
+    }
+
+    // Registered up front (before the first await) so both are armed by the
+    // time either can fire.
+    let mut sigint = install(SignalKind::interrupt(), "SIGINT");
+    let mut sigterm = install(SignalKind::terminate(), "SIGTERM");
+
+    async fn wait(sig: &mut Option<Signal>) {
+        match sig {
+            Some(sig) => {
+                sig.recv().await;
+            }
+            None => std::future::pending::<()>().await,
+        }
+    }
+
+    tokio::select! {
+        _ = wait(&mut sigint) => {}
+        _ = wait(&mut sigterm) => {}
+    }
+}
+
+/// Non-Unix fallback: Ctrl+C is the only portable stop signal Tokio exposes.
+#[cfg(not(unix))]
+pub async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/tests/shutdown_signal.rs
+++ b/tests/shutdown_signal.rs
@@ -1,0 +1,88 @@
+//! Regression guard for graceful shutdown under `docker stop` / k8s / systemd.
+//!
+//! Those supervisors stop a process with **SIGTERM** and only escalate to
+//! SIGKILL after a grace period. The bundled binaries once watched only SIGINT
+//! (`Ctrl+C`), so SIGTERM went unhandled and every `docker stop` timed out and
+//! hard-killed the container (as PID 1 in a `scratch` image the kernel drops an
+//! unhandled SIGTERM entirely). [`whatsapp_rust::shutdown_signal`] must resolve
+//! on SIGTERM as well as SIGINT.
+//!
+//! All scenarios live in one `#[tokio::test]` on purpose: signals are
+//! process-global, so running signal-raising cases in parallel (the default
+//! across test fns) would let one case's signal wake another's future. Keeping
+//! them sequential makes delivery deterministic.
+#![cfg(all(feature = "signal", unix))]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::signal::unix::{SignalKind, signal};
+
+/// Polls a pinned future once with a no-op waker and asserts it has not resolved.
+fn assert_pending<F: Future + ?Sized>(mut fut: Pin<&mut F>, msg: &str) {
+    let waker = whatsapp_rust::futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert!(matches!(fut.as_mut().poll(&mut cx), Poll::Pending), "{msg}");
+}
+
+/// Post `sig` to the current process. A Tokio handler for it is always installed
+/// first (see the safety nets in the test), so the signal becomes an async
+/// notification instead of the default process-terminating disposition.
+fn raise(sig: libc::c_int) {
+    // SAFETY: `raise` only posts a signal to the calling process; it has no
+    // memory-safety preconditions.
+    let rc = unsafe { libc::raise(sig) };
+    assert_eq!(rc, 0, "raise({sig}) failed");
+}
+
+#[tokio::test]
+async fn shutdown_signal_resolves_on_sigint_and_sigterm() {
+    // Safety nets: install handlers for both signals up front. Two purposes:
+    //  1. A raised signal can never fall through to the default disposition
+    //     (which would terminate this test process) even if the code under test
+    //     regresses and stops watching one of them — a regression then surfaces
+    //     as a clean timeout, not a killed test binary.
+    //  2. `recv()` on a net confirms a signal was actually *delivered* before we
+    //     assert anything about it.
+    let _sigint_net = signal(SignalKind::interrupt()).expect("install SIGINT net");
+    let mut sigterm_net = signal(SignalKind::terminate()).expect("install SIGTERM net");
+
+    // --- Reproduction of the original bug: a Ctrl+C-only future (the pre-fix
+    //     demo) ignores SIGTERM, which is exactly what `docker stop` sends. ---
+    {
+        let mut ctrlc = Box::pin(tokio::signal::ctrl_c());
+        // First poll registers ctrl_c's SIGINT handler; it must be pending.
+        assert_pending(ctrlc.as_mut(), "ctrl_c() resolved before any signal");
+        raise(libc::SIGTERM);
+        // Block until the SIGTERM is delivered, so the assertion below reflects a
+        // *delivered* signal rather than one still in flight.
+        sigterm_net.recv().await;
+        assert_pending(
+            ctrlc.as_mut(),
+            "ctrl_c() resolved on SIGTERM — it must only react to SIGINT (this is the bug)",
+        );
+    }
+
+    // --- The fix: shutdown_signal() resolves on SIGTERM. ---
+    {
+        let mut fut = Box::pin(whatsapp_rust::shutdown_signal());
+        // First poll installs both SIGINT and SIGTERM handlers.
+        assert_pending(fut.as_mut(), "shutdown_signal() resolved before any signal");
+        raise(libc::SIGTERM);
+        tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("shutdown_signal() must resolve on SIGTERM (docker stop / k8s / systemd)");
+    }
+
+    // --- The fix keeps the original behaviour: it still resolves on SIGINT. ---
+    {
+        let mut fut = Box::pin(whatsapp_rust::shutdown_signal());
+        assert_pending(fut.as_mut(), "shutdown_signal() resolved before any signal");
+        raise(libc::SIGINT);
+        tokio::time::timeout(Duration::from_secs(5), fut)
+            .await
+            .expect("shutdown_signal() must resolve on SIGINT (Ctrl+C)");
+    }
+}


### PR DESCRIPTION
## Problem

In production (the `Dockerfile` in this repo, running `examples/demo.rs` as the `scratch` entrypoint), every deploy hangs the full **10s `docker stop` grace period** and the container is then hard-killed:

```
23:39:52.397  docker stop --time=10 nyyb1objzni3xdbi4k3hiydu
23:40:02.531  nyyb1objzni3xdbi4k3hiydu            # ~10.13s later → SIGKILL
```

### Root cause

The bundled binaries watched only `tokio::signal::ctrl_c()`, i.e. **SIGINT**. But `docker stop` (and k8s / systemd) sends **SIGTERM** first and only escalates to an unblockable SIGKILL after the grace period. SIGTERM was never handled, so graceful shutdown (`BotHandle::shutdown()` → `Client::disconnect()`, which flushes the device snapshot, buffered receipts and message secrets) never ran.

It's worse under this project's image specifically: the static binary is the `scratch` `ENTRYPOINT`, so it runs as **PID 1**, and the Linux kernel *drops* any signal for which PID 1 has no installed handler. The unhandled SIGTERM is therefore silently ignored rather than terminating the process — guaranteeing the timeout on every stop.

## Fix

Add `whatsapp_rust::shutdown_signal()` (feature `signal`, on by default): a future that resolves on the first of **SIGINT or SIGTERM** on Unix, and Ctrl+C on non-Unix (the only portable stop signal Tokio exposes there). Both handlers are installed synchronously before the future first suspends, so a signal arriving afterwards is delivered, not lost; if a handler somehow fails to register it degrades gracefully instead of panicking in a top-level path.

Wire it into the demo (the Docker entrypoint) and the voip-cli in place of the bare `ctrl_c()`.

## Tests

`tests/shutdown_signal.rs` raises real SIGINT/SIGTERM at the test process and:
- **reproduces the original bug** — a `ctrl_c()`-only future stays pending across a *delivered* SIGTERM;
- asserts the new helper resolves on **both** SIGTERM and SIGINT.

Safety-net handlers are installed first so a future regression surfaces as a clean timeout/assertion failure rather than a killed test binary, and all scenarios run in one test to keep process-global signal delivery deterministic.

## Verification

- `cargo test --test shutdown_signal` — passes
- `cargo clippy -p whatsapp-rust --tests` — clean
- `cargo build --example demo` (the Docker binary) and `cargo check -p whatsapp-rust-voip-cli` — build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hy7RDaXb1A2qPpnwg3CXJu)_