### PR TITLE
Per-session metrics: wire I/O counters, memory report in bytes, runtime-agnostic task instrumentation

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -41,7 +41,7 @@ jobs:
         run: >
           cargo build -p whatsapp-rust --lib --release
           --target wasm32-unknown-unknown
-          --no-default-features --features debug-diagnostics
+          --no-default-features
       # The sans-IO VoIP core (wacore::voip: the CallEngine, the portable run_call driver,
       # the RelayTransport seam, the MLow codec, SRTP/SFrame crypto) must stay wasm-buildable
       # so the WASM bridge can drive 1:1 calls. whatsapp-rust's `voip` feature compile-errors on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,5 +42,6 @@ Read these when working on the relevant area:
 - `agent_docs/e2e_testing.md` — E2E test patterns, file organization, event-driven waiting
 - `agent_docs/debugging.md` — evcxr REPL, binary protocol debugging
 - `agent_docs/binary_size_ci.md` — size-tracking CI: metrics, budgets, baseline semantics
+- `agent_docs/observability.md` — per-session stats (I/O, memory report, TaskInstrument/CPU), design rules
 
 When adding comments to the code, dont be so verbose, also only explain why, not what

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ yoke = { version = "0.8", features = ["derive"] }
 zlib-rs = { version = "0.6.5", default-features = false, features = ["std", "rust-allocator"] }
 
 [features]
-debug-diagnostics = ["wacore/debug-diagnostics"]
 debug-snapshots = ["wacore/debug-snapshots"]
 # Optional observability. Off by default: no `tracing` dep, zero overhead.
 # Emits tracing spans/events only; the application installs the subscriber

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -52,19 +52,22 @@ figures come from the `wacore::stats::HeapSize` trait:
 - Store-backed caches (Redis etc.) report `bytes: 0` — their entries are not
   process memory.
 
-Semantics: honest estimates for attribution and leak detection (the e2e
-`memory_soak.rs` asserts growth bounds on it), not byte-exact accounting.
-When a new cache is added to `Client`, add it to `memory_report()` and — if
-it can dominate memory — implement `HeapSize` for its value type next to that
-type's definition.
+Semantics: honest estimates for attribution and leak detection, not
+byte-exact accounting. The e2e `memory_soak.rs` logs the byte totals next to
+RSS; its growth-bound assertions are on entry counts.
+When a new cache is added to `Client`, add it to `memory_report()` (the
+`MemoryReport::collections()` list keeps the total and `Display` in sync) and
+— if it can dominate memory — implement `HeapSize` for its value type next to
+that type's definition.
 
 ### 3. `BotBuilder::with_task_instrument` — CPU / custom attribution (opt-in)
 
 `wacore::stats::TaskInstrument` is an object-safe enter/exit hook called
 around every poll of the client's internal tasks and around its blocking
 work. Wiring: `build()` wraps the runtime in `InstrumentedRuntime`, so all
-spawns are covered without touching call sites; `None` (default) keeps spawns
-unwrapped — the cost is one `Option` check per spawn, nothing per poll.
+spawns through the `Runtime` trait are covered without touching call sites.
+The `Option` is resolved once at `build()` — `None` (default) leaves the
+runtime untouched, so there is no per-spawn or per-poll cost when unset.
 
 - `CpuMeter` (built-in): busy time (direct CPU proxy) + poll count via
   `wacore::time::Instant`. Works on wasm/embedded once a monotonic provider
@@ -74,9 +77,11 @@ unwrapped — the cost is one `Option` check per spawn, nothing per poll.
   ESP-IDF `heap_caps` sampling, etc. The library never learns what the hook
   does.
 
-Scope caveat: the hook covers tasks spawned *by the client*. Work executed on
-the caller's own task (e.g. awaiting `send_message`) belongs to the caller —
-instrument that side yourself if you need it.
+Scope caveats: the hook covers tasks spawned *by the client* through the
+`Runtime` trait. Work executed on the caller's own task (e.g. awaiting
+`send_message`) belongs to the caller — instrument that side yourself if you
+need it. The `voip` feature's media tasks (call driver, relay I/O) currently
+spawn directly on Tokio and are not instrumented.
 
 ## Relation to the `metrics`/`tracing` features
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -1,0 +1,87 @@
+# Observability & Per-Session Metrics
+
+How to measure what one client session costs (memory, I/O, CPU) — including
+several clients inside the same process — and the design rules any extension
+must follow.
+
+## Design rules
+
+- **Runtime/platform agnostic.** Everything in `wacore::stats` builds on every
+  target (Tokio, wasm32, ESP32): counters are `portable_atomic`, CPU metering
+  reads the pluggable `wacore::time` monotonic clock, task instrumentation
+  wraps the `Runtime` trait. Never add a Tokio/allocator/`tracing` dependency
+  to this layer — platform-specific mechanisms plug in from the application
+  through the hooks.
+- **Zero overhead when unused, no feature gates.** Always-on counters are one
+  relaxed `fetch_add` on paths that already do AEAD + a transport write.
+  Report code runs only when called; unused public report methods are removed
+  by fat LTO (the binary-size CI proves it, see `binary_size_ci.md`). This is
+  why there is no `debug-diagnostics`-style feature: dead code elimination
+  replaces the cfg-gates.
+- **No PII.** Snapshots and reports carry numbers only, never JIDs/phone
+  numbers, matching the `wacore::telemetry` label rules.
+
+## The three surfaces
+
+### 1. `Client::stats()` — wire I/O counters (always on)
+
+`wacore::stats::SessionStats`, owned by each `Client`. Recorded at exactly two
+chokepoints:
+
+- **Sent**: the noise sender task (`NoiseSocket::with_stats`) after the
+  transport write — post-noise wire bytes (frame header + AEAD tag included).
+- **Received**: the read loop (`node_io.rs`) per `DataReceived` batch.
+
+It also owns the `last_data_sent_ms`/`last_data_received_ms` activity
+timestamps the keepalive dead-socket watchdog reads (they were loose fields on
+`Client` before). Message-level counters piggyback on the existing
+`telemetry::send`/`recv` chokepoints; reconnect attempts are counted in the
+run loop. VoIP relay sockets pass `None` and are not counted — this is the
+main WA session socket only.
+
+### 2. `Client::memory_report()` — retained memory (on demand)
+
+Walks every internal collection and returns entry counts plus estimated
+retained bytes (`MemoryReport`, per-collection `CollectionStats`). Byte
+figures come from the `wacore::stats::HeapSize` trait:
+
+- Signal records use their protobuf encoded size (`SessionRecord::
+  estimated_size`, buffa `compute_size` — no encode buffer allocated).
+- Collections sum key/payload capacities (`GroupInfo`, `DeviceListRecord`,
+  `LidPnEntry`, `ResolvedGroupDevices`, ...).
+- Store-backed caches (Redis etc.) report `bytes: 0` — their entries are not
+  process memory.
+
+Semantics: honest estimates for attribution and leak detection (the e2e
+`memory_soak.rs` asserts growth bounds on it), not byte-exact accounting.
+When a new cache is added to `Client`, add it to `memory_report()` and — if
+it can dominate memory — implement `HeapSize` for its value type next to that
+type's definition.
+
+### 3. `BotBuilder::with_task_instrument` — CPU / custom attribution (opt-in)
+
+`wacore::stats::TaskInstrument` is an object-safe enter/exit hook called
+around every poll of the client's internal tasks and around its blocking
+work. Wiring: `build()` wraps the runtime in `InstrumentedRuntime`, so all
+spawns are covered without touching call sites; `None` (default) keeps spawns
+unwrapped — the cost is one `Option` check per spawn, nothing per poll.
+
+- `CpuMeter` (built-in): busy time (direct CPU proxy) + poll count via
+  `wacore::time::Instant`. Works on wasm/embedded once a monotonic provider
+  is registered.
+- Custom hooks: allocator attribution (see `examples/alloc_tracking.rs` for a
+  dependency-free pattern; `tracking-allocator` slots in the same way),
+  ESP-IDF `heap_caps` sampling, etc. The library never learns what the hook
+  does.
+
+Scope caveat: the hook covers tasks spawned *by the client*. Work executed on
+the caller's own task (e.g. awaiting `send_message`) belongs to the caller —
+instrument that side yourself if you need it.
+
+## Relation to the `metrics`/`tracing` features
+
+`wacore::telemetry` (cargo feature `metrics`) emits process-global counters
+through the `metrics` facade — no per-client dimension, by design (label
+cardinality). The `stats` layer is the per-client dimension: snapshots you
+poll and export however you like. `examples/multi_session_metrics.rs` shows
+two clients in one process reporting independently.

--- a/examples/alloc_tracking.rs
+++ b/examples/alloc_tracking.rs
@@ -1,0 +1,160 @@
+//! Per-session ALLOCATOR attribution through the `TaskInstrument` hook.
+//!
+//! Run with:
+//!     cargo run --example alloc_tracking
+//!
+//! [`Client::memory_report`] answers "how many bytes do this session's
+//! structures retain right now". This example answers the complementary
+//! question — "how many bytes does this session's work allocate, including
+//! transients" — by combining:
+//!
+//! 1. a hand-rolled counting global allocator (no external crates), and
+//! 2. a [`TaskInstrument`] that marks, per thread, which session's task is
+//!    currently being polled, so the allocator knows whom to charge.
+//!
+//! The library knows nothing about allocators: the hook is just enter/exit
+//! around every poll of a client's internal tasks. The same pattern plugs in
+//! `tracking-allocator`, dhat, or ESP-IDF `heap_caps` sampling instead of
+//! this toy allocator. Expect a measurable overhead while enabled (Vector
+//! reports ~10-20% for the equivalent design); it is a diagnostics tool, not
+//! an always-on meter. Allocations outside instrumented tasks (your own
+//! caller-side code, other libraries) land in the "untracked" bucket.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
+
+use log::{error, info};
+use wacore::stats::TaskInstrument;
+use whatsapp_rust::prelude::*;
+
+/// Live allocation counters for one attribution bucket.
+#[derive(Default)]
+struct Bucket {
+    current_bytes: AtomicI64,
+    total_allocs: AtomicI64,
+}
+
+static SESSION_A: Bucket = Bucket {
+    current_bytes: AtomicI64::new(0),
+    total_allocs: AtomicI64::new(0),
+};
+static UNTRACKED: Bucket = Bucket {
+    current_bytes: AtomicI64::new(0),
+    total_allocs: AtomicI64::new(0),
+};
+
+thread_local! {
+    /// Which bucket the currently-polled task belongs to. `None` = untracked.
+    static CURRENT: Cell<Option<&'static Bucket>> = const { Cell::new(None) };
+}
+
+struct AttributingAllocator;
+
+impl AttributingAllocator {
+    fn bucket() -> &'static Bucket {
+        CURRENT
+            .try_with(|c| c.get())
+            .ok()
+            .flatten()
+            .unwrap_or(&UNTRACKED)
+    }
+}
+
+// SAFETY-adjacent caveat: deallocations are charged to the CURRENT bucket,
+// not the allocating one, so a buffer allocated inside session A but freed
+// elsewhere skews both buckets. Fine for a demo; real deployments use a
+// tracker that stores the group per allocation (e.g. tracking-allocator).
+unsafe impl GlobalAlloc for AttributingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let bucket = Self::bucket();
+        bucket
+            .current_bytes
+            .fetch_add(layout.size() as i64, Ordering::Relaxed);
+        bucket.total_allocs.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        Self::bucket()
+            .current_bytes
+            .fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: AttributingAllocator = AttributingAllocator;
+
+/// TaskInstrument that scopes the thread to a bucket for the poll's duration.
+struct SessionAllocScope(&'static Bucket);
+
+impl TaskInstrument for SessionAllocScope {
+    fn on_poll_start(&self) {
+        CURRENT.with(|c| c.set(Some(self.0)));
+    }
+    fn on_poll_end(&self) {
+        CURRENT.with(|c| c.set(None));
+    }
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime");
+
+    rt.block_on(async {
+        let store = match SqliteStore::new("session_a.db").await {
+            Ok(store) => store,
+            Err(e) => {
+                error!("failed to create SQLite backend: {e}");
+                return;
+            }
+        };
+
+        let bot = Bot::builder()
+            .with_backend(store)
+            .with_task_instrument(Arc::new(SessionAllocScope(&SESSION_A)))
+            .on_qr_code(|code, timeout| async move {
+                info!("QR code (valid {}s):\n{code}", timeout.as_secs());
+            })
+            .build()
+            .await;
+
+        let bot = match bot {
+            Ok(bot) => bot,
+            Err(e) => {
+                error!("failed to build bot: {e}");
+                return;
+            }
+        };
+
+        let client = bot.client();
+        let run = tokio::spawn(bot.run());
+
+        let mut ticker = tokio::time::interval(Duration::from_secs(10));
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    info!(
+                        "session A: {}B live across {} allocs | untracked: {}B live",
+                        SESSION_A.current_bytes.load(Ordering::Relaxed),
+                        SESSION_A.total_allocs.load(Ordering::Relaxed),
+                        UNTRACKED.current_bytes.load(Ordering::Relaxed),
+                    );
+                }
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Shutting down...");
+                    client.disconnect().await;
+                    break;
+                }
+            }
+        }
+        let _ = run.await;
+    });
+}

--- a/examples/alloc_tracking.rs
+++ b/examples/alloc_tracking.rs
@@ -20,10 +20,10 @@
 //! an always-on meter. Allocations outside instrumented tasks (your own
 //! caller-side code, other libraries) land in the "untracked" bucket.
 
+use portable_atomic::{AtomicI64, Ordering};
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
 use log::{error, info};

--- a/examples/multi_session_metrics.rs
+++ b/examples/multi_session_metrics.rs
@@ -1,0 +1,123 @@
+//! Two WhatsApp sessions in ONE process, each with its own precise metrics.
+//!
+//! Run with:
+//!     cargo run --example multi_session_metrics
+//!
+//! Demonstrates the per-session observability surface:
+//! - [`Client::stats`] — always-on wire I/O counters (bytes/frames/messages,
+//!   reconnects, activity timestamps). One relaxed atomic add per frame.
+//! - [`Client::memory_report`] — on-demand entry counts + estimated retained
+//!   heap bytes of every internal collection. Costs nothing unless called.
+//! - [`CpuMeter`] via `BotBuilder::with_task_instrument` — busy time (CPU
+//!   proxy) and poll count of each client's internal tasks. Runtime-agnostic:
+//!   the same hook works on Tokio, wasm or embedded runtimes.
+//!
+//! Each client gets its own SQLite store (multi-account pattern), its own
+//! `CpuMeter`, and reports independently — no process spawning needed.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{error, info};
+use wacore::stats::CpuMeter;
+use whatsapp_rust::prelude::*;
+
+async fn build_session(db_path: &str, label: &'static str) -> Option<(Bot, Arc<CpuMeter>)> {
+    let store = match SqliteStore::new(db_path).await {
+        Ok(store) => store,
+        Err(e) => {
+            error!("[{label}] failed to create SQLite backend: {e}");
+            return None;
+        }
+    };
+
+    // Keep a clone of the meter: the builder takes it as the task hook, we
+    // read snapshots from ours.
+    let cpu_meter = Arc::new(CpuMeter::new());
+
+    let bot = Bot::builder()
+        .with_backend(store)
+        .with_task_instrument(cpu_meter.clone())
+        .on_qr_code(move |code, timeout| async move {
+            info!("[{label}] QR code (valid {}s):\n{code}", timeout.as_secs());
+        })
+        .build()
+        .await;
+
+    match bot {
+        Ok(bot) => Some((bot, cpu_meter)),
+        Err(e) => {
+            error!("[{label}] failed to build bot: {e}");
+            None
+        }
+    }
+}
+
+async fn print_session_metrics(label: &str, client: &Arc<Client>, cpu: &CpuMeter) {
+    let stats = client.stats();
+    let memory = client.memory_report().await;
+    let cpu = cpu.snapshot();
+
+    info!(
+        "[{label}] wire: {}B out / {}B in ({} / {} frames) | msgs: {} sent / {} recv | reconnects: {}",
+        stats.bytes_sent,
+        stats.bytes_received,
+        stats.frames_sent,
+        stats.frames_received,
+        stats.messages_sent,
+        stats.messages_received,
+        stats.reconnects,
+    );
+    info!(
+        "[{label}] cpu: {:?} busy over {} polls | retained heap (est.): {}B (signal: {}B in {} sessions)",
+        cpu.busy,
+        cpu.polls,
+        memory.total_estimated_bytes(),
+        memory.signal_sessions.bytes,
+        memory.signal_sessions.entries,
+    );
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime");
+
+    rt.block_on(async {
+        let Some((bot_a, cpu_a)) = build_session("session_a.db", "A").await else {
+            return;
+        };
+        let Some((bot_b, cpu_b)) = build_session("session_b.db", "B").await else {
+            return;
+        };
+
+        let client_a = bot_a.client();
+        let client_b = bot_b.client();
+
+        let run_a = tokio::spawn(bot_a.run());
+        let run_b = tokio::spawn(bot_b.run());
+
+        // Report both sessions side by side every 10s.
+        let mut ticker = tokio::time::interval(Duration::from_secs(10));
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    print_session_metrics("A", &client_a, &cpu_a).await;
+                    print_session_metrics("B", &client_b, &cpu_b).await;
+                }
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Shutting down both sessions...");
+                    client_a.disconnect().await;
+                    client_b.disconnect().await;
+                    break;
+                }
+            }
+        }
+
+        let _ = run_a.await;
+        let _ = run_b.await;
+    });
+}

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -541,6 +541,7 @@ pub struct BotBuilder<
     cache_config: CacheConfig,
     wanted_pre_key_count: Option<usize>,
     resend_rate_limit: Option<(u32, u32)>,
+    task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
     _marker: PhantomData<(B, T, H, R)>,
 }
 
@@ -563,6 +564,7 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             cache_config: CacheConfig::default(),
             wanted_pre_key_count: None,
             resend_rate_limit: None,
+            task_instrument: None,
             _marker: PhantomData,
         }
     }
@@ -589,6 +591,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             cache_config: self.cache_config,
             wanted_pre_key_count: self.wanted_pre_key_count,
             resend_rate_limit: self.resend_rate_limit,
+            task_instrument: self.task_instrument,
             _marker: PhantomData,
         }
     }
@@ -643,6 +646,23 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     pub fn with_runtime<Rt: Runtime>(mut self, runtime: Rt) -> BotBuilder<B, T, H, Provided> {
         self.runtime = Some(Arc::new(runtime));
         self.cast()
+    }
+
+    /// Instrument every internal task of this client with a
+    /// [`TaskInstrument`](wacore::stats::TaskInstrument) hook, called around
+    /// each poll (and around blocking work).
+    ///
+    /// Runtime-agnostic: the hook wraps whatever runtime the client uses. Pass
+    /// a [`CpuMeter`](wacore::stats::CpuMeter) for per-session CPU accounting
+    /// (keep a clone to read snapshots), or a custom hook to scope
+    /// allocator-attribution or platform samplers to this client's work.
+    /// Default: no hook, no per-poll overhead.
+    pub fn with_task_instrument(
+        mut self,
+        instrument: Arc<dyn wacore::stats::TaskInstrument>,
+    ) -> Self {
+        self.task_instrument = Some(instrument);
+        self
     }
 
     // ── Event handler registration (additive; order of registration is kept,
@@ -986,6 +1006,16 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             self.http_client,
         ) else {
             unreachable!("typestate guarantees all required fields are Provided")
+        };
+
+        // Instrument the runtime before anything spawns through it, so every
+        // internal task (read loop, noise sender, saver, workers) reports to
+        // the hook. Default (None): the original runtime is used untouched.
+        let runtime: Arc<dyn Runtime> = match self.task_instrument {
+            Some(instrument) => {
+                Arc::new(wacore::stats::InstrumentedRuntime::new(runtime, instrument))
+            }
+            None => runtime,
         };
 
         // Note: For multi-account mode, create the backend with SqliteStore::new_for_device()

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -659,6 +659,20 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// (keep a clone to read snapshots), or a custom hook to scope
     /// allocator-attribution or platform samplers to this client's work.
     /// Default: no hook — the runtime is used untouched.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// use std::sync::Arc;
+    /// use wacore::stats::CpuMeter;
+    ///
+    /// let cpu = Arc::new(CpuMeter::new());
+    /// let bot = Bot::builder()
+    ///     .with_backend(backend)
+    ///     .with_task_instrument(cpu.clone())
+    ///     .build()
+    ///     .await?;
+    /// // later: cpu.snapshot().busy
+    /// ```
     pub fn with_task_instrument(
         mut self,
         instrument: Arc<dyn wacore::stats::TaskInstrument>,

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -648,15 +648,17 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         self.cast()
     }
 
-    /// Instrument every internal task of this client with a
+    /// Instrument the client's internal tasks with a
     /// [`TaskInstrument`](wacore::stats::TaskInstrument) hook, called around
     /// each poll (and around blocking work).
     ///
-    /// Runtime-agnostic: the hook wraps whatever runtime the client uses. Pass
-    /// a [`CpuMeter`](wacore::stats::CpuMeter) for per-session CPU accounting
+    /// Runtime-agnostic: the hook wraps whatever runtime the client uses, so
+    /// every task spawned through the `Runtime` trait is covered (`voip`
+    /// media tasks spawn directly on Tokio and are not). Pass a
+    /// [`CpuMeter`](wacore::stats::CpuMeter) for per-session CPU accounting
     /// (keep a clone to read snapshots), or a custom hook to scope
     /// allocator-attribution or platform samplers to this client's work.
-    /// Default: no hook, no per-poll overhead.
+    /// Default: no hook — the runtime is used untouched.
     pub fn with_task_instrument(
         mut self,
         instrument: Arc<dyn wacore::stats::TaskInstrument>,

--- a/src/cache_store.rs
+++ b/src/cache_store.rs
@@ -217,6 +217,16 @@ where
         }
     }
 
+    /// Iterate the in-process backend's entries. `None` for custom stores,
+    /// whose entries live outside this process (memory reports treat them as
+    /// zero retained bytes for the same reason).
+    pub fn iter_local(&self) -> Option<std::vec::IntoIter<(Arc<K>, V)>> {
+        match &self.inner {
+            Inner::Local(cache) => Some(cache.iter()),
+            Inner::Custom { .. } => None,
+        }
+    }
+
     /// Approximate entry count (sync). Returns `0` for custom backends.
     ///
     /// For diagnostics that need custom backend counts, use

--- a/src/cache_store.rs
+++ b/src/cache_store.rs
@@ -227,6 +227,20 @@ where
         }
     }
 
+    /// Entry count plus estimated retained bytes, summing `per_entry` over the
+    /// in-process backend (a reliable by-reference walk — no clones, cannot
+    /// degrade to an empty snapshot under write contention). Custom stores
+    /// report zero: their entries live outside this process.
+    pub async fn memory_stats(
+        &self,
+        per_entry: impl FnMut(&K, &V) -> usize,
+    ) -> wacore::stats::CollectionStats {
+        match &self.inner {
+            Inner::Local(cache) => cache.memory_stats(per_entry).await,
+            Inner::Custom { .. } => wacore::stats::CollectionStats::default(),
+        }
+    }
+
     /// Approximate entry count (sync). Returns `0` for custom backends.
     ///
     /// For diagnostics that need custom backend counts, use

--- a/src/client.rs
+++ b/src/client.rs
@@ -259,10 +259,13 @@ impl std::fmt::Display for MemoryReport {
         ) -> std::fmt::Result {
             writeln!(f, "  {name:<22} {:>7} entries {:>10} B", c.entries, c.bytes)
         }
+        // First TTL_BOUNDED entries of collections() are the TTL-bounded
+        // caches; the rest are the Signal store caches.
+        const TTL_BOUNDED: usize = 7;
         let collections = self.collections();
         writeln!(f, "=== Memory Report ===")?;
         writeln!(f, "--- TTL-bounded caches ---")?;
-        for (name, c) in &collections[..7] {
+        for (name, c) in &collections[..TTL_BOUNDED] {
             line(f, name, c)?;
         }
         writeln!(f, "  message_retry_counts:   {}", self.message_retry_counts)?;
@@ -296,7 +299,8 @@ impl std::fmt::Display for MemoryReport {
             self.app_state_key_requests
         )?;
         writeln!(f, "  app_state_syncing:      {}", self.app_state_syncing)?;
-        for (name, c) in &collections[7..] {
+        writeln!(f, "--- Signal store caches ---")?;
+        for (name, c) in &collections[TTL_BOUNDED..] {
             line(f, name, c)?;
         }
         writeln!(f, "--- Misc ---")?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -226,18 +226,27 @@ pub struct MemoryReport {
 }
 
 impl MemoryReport {
+    /// Every byte-carrying collection with its display name — the single list
+    /// [`Self::total_estimated_bytes`] and `Display` derive from, so a new
+    /// collection cannot be summed but not shown (or vice versa).
+    fn collections(&self) -> [(&'static str, &CollectionStats); 10] {
+        [
+            ("group_cache:", &self.group_cache),
+            ("device_registry_cache:", &self.device_registry_cache),
+            ("lid_pn (lid):", &self.lid_pn_lid_entries),
+            ("lid_pn (pn):", &self.lid_pn_pn_entries),
+            ("recent_messages:", &self.recent_messages),
+            ("sk_device_cache:", &self.sender_key_device_cache),
+            ("group_devices_memo:", &self.group_devices_memo),
+            ("signal_sessions:", &self.signal_sessions),
+            ("signal_identities:", &self.signal_identities),
+            ("signal_sender_keys:", &self.signal_sender_keys),
+        ]
+    }
+
     /// Sum of every estimated byte figure in the report.
     pub fn total_estimated_bytes(&self) -> u64 {
-        self.group_cache.bytes
-            + self.device_registry_cache.bytes
-            + self.lid_pn_lid_entries.bytes
-            + self.lid_pn_pn_entries.bytes
-            + self.recent_messages.bytes
-            + self.sender_key_device_cache.bytes
-            + self.group_devices_memo.bytes
-            + self.signal_sessions.bytes
-            + self.signal_identities.bytes
-            + self.signal_sender_keys.bytes
+        self.collections().iter().map(|(_, c)| c.bytes).sum()
     }
 }
 
@@ -250,15 +259,12 @@ impl std::fmt::Display for MemoryReport {
         ) -> std::fmt::Result {
             writeln!(f, "  {name:<22} {:>7} entries {:>10} B", c.entries, c.bytes)
         }
+        let collections = self.collections();
         writeln!(f, "=== Memory Report ===")?;
         writeln!(f, "--- TTL-bounded caches ---")?;
-        line(f, "group_cache:", &self.group_cache)?;
-        line(f, "device_registry_cache:", &self.device_registry_cache)?;
-        line(f, "lid_pn (lid):", &self.lid_pn_lid_entries)?;
-        line(f, "lid_pn (pn):", &self.lid_pn_pn_entries)?;
-        line(f, "recent_messages:", &self.recent_messages)?;
-        line(f, "sk_device_cache:", &self.sender_key_device_cache)?;
-        line(f, "group_devices_memo:", &self.group_devices_memo)?;
+        for (name, c) in &collections[..7] {
+            line(f, name, c)?;
+        }
         writeln!(f, "  message_retry_counts:   {}", self.message_retry_counts)?;
         writeln!(
             f,
@@ -290,9 +296,9 @@ impl std::fmt::Display for MemoryReport {
             self.app_state_key_requests
         )?;
         writeln!(f, "  app_state_syncing:      {}", self.app_state_syncing)?;
-        line(f, "signal_sessions:", &self.signal_sessions)?;
-        line(f, "signal_identities:", &self.signal_identities)?;
-        line(f, "signal_sender_keys:", &self.signal_sender_keys)?;
+        for (name, c) in &collections[7..] {
+            line(f, name, c)?;
+        }
         writeln!(f, "--- Misc ---")?;
         writeln!(f, "  chatstate_handlers:     {}", self.chatstate_handlers)?;
         writeln!(f, "  custom_enc_handlers:    {}", self.custom_enc_handlers)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,12 +187,16 @@ pub use wacore::stats::{CollectionStats, StatsSnapshot};
 ///
 /// Call [`Client::memory_report`] to obtain one. Nothing is computed unless
 /// called.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct MemoryReport {
     // -- TTL/capacity-bounded caches --
     pub group_cache: CollectionStats,
     pub device_registry_cache: CollectionStats,
     pub lid_pn_lid_entries: CollectionStats,
+    /// Entry count of the PN-direction map. Always `bytes: 0`: both maps
+    /// share the same `Arc<LidPnEntry>` payloads, attributed entirely to
+    /// [`Self::lid_pn_lid_entries`] so the total counts them once.
     pub lid_pn_pn_entries: CollectionStats,
     pub recent_messages: CollectionStats,
     pub sender_key_device_cache: CollectionStats,

--- a/src/client.rs
+++ b/src/client.rs
@@ -194,9 +194,10 @@ pub struct MemoryReport {
     pub group_cache: CollectionStats,
     pub device_registry_cache: CollectionStats,
     pub lid_pn_lid_entries: CollectionStats,
-    /// Entry count of the PN-direction map. Always `bytes: 0`: both maps
-    /// share the same `Arc<LidPnEntry>` payloads, attributed entirely to
-    /// [`Self::lid_pn_lid_entries`] so the total counts them once.
+    /// Entry count of the PN-direction map. Both maps share the same
+    /// `Arc<LidPnEntry>` payloads, attributed to
+    /// [`Self::lid_pn_lid_entries`]; bytes here cover only entries the LID
+    /// map no longer holds (normally 0), so the total counts each once.
     pub lid_pn_pn_entries: CollectionStats,
     pub recent_messages: CollectionStats,
     pub sender_key_device_cache: CollectionStats,

--- a/src/client.rs
+++ b/src/client.rs
@@ -173,32 +173,38 @@ const APP_STATE_RETRY_MAX_ATTEMPTS: u32 = 6;
 /// DGW `connectTimeoutMs` defaults to `20000ms`.
 const TRANSPORT_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Snapshot of internal collection sizes for memory leak detection.
+pub use wacore::stats::{CollectionStats, StatsSnapshot};
+
+/// On-demand report of the client's internal collections: entry counts plus
+/// estimated retained heap bytes for the memory-dominant caches.
 ///
-/// All counts are approximate (caches may have pending evictions).
-/// Call [`Client::memory_diagnostics`] to obtain a snapshot.
+/// Counts are approximate (caches may have pending evictions); byte figures
+/// are honest estimates (encoded-size proxies for Signal records, payload
+/// sums elsewhere — see [`wacore::stats::HeapSize`]), suitable for
+/// per-session attribution and leak detection, not byte-exact accounting.
+/// Store-backed caches report `bytes: 0` — their entries live outside this
+/// process.
 ///
-/// Requires the `debug-diagnostics` feature.
-#[cfg(feature = "debug-diagnostics")]
+/// Call [`Client::memory_report`] to obtain one. Nothing is computed unless
+/// called.
 #[derive(Debug, Clone)]
-pub struct MemoryDiagnostics {
-    // -- Moka caches (TTL/capacity-bounded) --
-    pub group_cache: u64,
-    pub device_registry_cache: u64,
-    pub lid_pn_lid_entries: u64,
-    pub lid_pn_pn_entries: u64,
-    pub recent_messages: u64,
-    pub sender_key_device_cache: u64,
+pub struct MemoryReport {
+    // -- TTL/capacity-bounded caches --
+    pub group_cache: CollectionStats,
+    pub device_registry_cache: CollectionStats,
+    pub lid_pn_lid_entries: CollectionStats,
+    pub lid_pn_pn_entries: CollectionStats,
+    pub recent_messages: CollectionStats,
+    pub sender_key_device_cache: CollectionStats,
+    pub group_devices_memo: CollectionStats,
     pub message_retry_counts: u64,
     pub undecryptable_dispatched: u64,
     pub pdo_pending_requests: u64,
     pub pdo_requested: u64,
-    // -- Capacity-only caches (no TTL) --
+    // -- Capacity-only caches (coordination, counts only) --
     pub session_locks: u64,
     pub chat_lanes: u64,
     pub resend_rate_limiter_chats: u64,
-    /// Total outbound resends dropped by the per-chat rate limiter since start.
-    pub resends_throttled_total: u64,
     // -- Unbounded collections --
     pub response_waiters: usize,
     pub node_waiters: usize,
@@ -206,33 +212,48 @@ pub struct MemoryDiagnostics {
     pub presence_subscriptions: usize,
     pub app_state_key_requests: usize,
     pub app_state_syncing: usize,
-    pub signal_cache_sessions: usize,
-    pub signal_cache_identities: usize,
-    pub signal_cache_sender_keys: usize,
+    pub signal_sessions: CollectionStats,
+    pub signal_identities: CollectionStats,
+    pub signal_sender_keys: CollectionStats,
     // -- Misc --
     pub chatstate_handlers: usize,
     pub custom_enc_handlers: usize,
 }
 
-#[cfg(feature = "debug-diagnostics")]
-impl std::fmt::Display for MemoryDiagnostics {
+impl MemoryReport {
+    /// Sum of every estimated byte figure in the report.
+    pub fn total_estimated_bytes(&self) -> u64 {
+        self.group_cache.bytes
+            + self.device_registry_cache.bytes
+            + self.lid_pn_lid_entries.bytes
+            + self.lid_pn_pn_entries.bytes
+            + self.recent_messages.bytes
+            + self.sender_key_device_cache.bytes
+            + self.group_devices_memo.bytes
+            + self.signal_sessions.bytes
+            + self.signal_identities.bytes
+            + self.signal_sender_keys.bytes
+    }
+}
+
+impl std::fmt::Display for MemoryReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "=== Memory Diagnostics ===")?;
+        fn line(
+            f: &mut std::fmt::Formatter<'_>,
+            name: &str,
+            c: &CollectionStats,
+        ) -> std::fmt::Result {
+            writeln!(f, "  {name:<22} {:>7} entries {:>10} B", c.entries, c.bytes)
+        }
+        writeln!(f, "=== Memory Report ===")?;
         writeln!(f, "--- TTL-bounded caches ---")?;
-        writeln!(f, "  group_cache:            {}", self.group_cache)?;
-        writeln!(
-            f,
-            "  device_registry_cache:  {}",
-            self.device_registry_cache
-        )?;
-        writeln!(f, "  lid_pn (lid):           {}", self.lid_pn_lid_entries)?;
-        writeln!(f, "  lid_pn (pn):            {}", self.lid_pn_pn_entries)?;
-        writeln!(f, "  recent_messages:        {}", self.recent_messages)?;
-        writeln!(
-            f,
-            "  sk_device_cache:        {}",
-            self.sender_key_device_cache
-        )?;
+        line(f, "group_cache:", &self.group_cache)?;
+        line(f, "device_registry_cache:", &self.device_registry_cache)?;
+        line(f, "lid_pn (lid):", &self.lid_pn_lid_entries)?;
+        line(f, "lid_pn (pn):", &self.lid_pn_pn_entries)?;
+        line(f, "recent_messages:", &self.recent_messages)?;
+        line(f, "sk_device_cache:", &self.sender_key_device_cache)?;
+        line(f, "group_devices_memo:", &self.group_devices_memo)?;
         writeln!(f, "  message_retry_counts:   {}", self.message_retry_counts)?;
         writeln!(
             f,
@@ -249,11 +270,6 @@ impl std::fmt::Display for MemoryDiagnostics {
             "  resend_rl_chats:        {}",
             self.resend_rate_limiter_chats
         )?;
-        writeln!(
-            f,
-            "  resends_throttled:      {}",
-            self.resends_throttled_total
-        )?;
         writeln!(f, "--- Unbounded collections ---")?;
         writeln!(f, "  response_waiters:       {}", self.response_waiters)?;
         writeln!(f, "  node_waiters:           {}", self.node_waiters)?;
@@ -269,24 +285,17 @@ impl std::fmt::Display for MemoryDiagnostics {
             self.app_state_key_requests
         )?;
         writeln!(f, "  app_state_syncing:      {}", self.app_state_syncing)?;
-        writeln!(
-            f,
-            "  signal_sessions:        {}",
-            self.signal_cache_sessions
-        )?;
-        writeln!(
-            f,
-            "  signal_identities:      {}",
-            self.signal_cache_identities
-        )?;
-        writeln!(
-            f,
-            "  signal_sender_keys:     {}",
-            self.signal_cache_sender_keys
-        )?;
+        line(f, "signal_sessions:", &self.signal_sessions)?;
+        line(f, "signal_identities:", &self.signal_identities)?;
+        line(f, "signal_sender_keys:", &self.signal_sender_keys)?;
         writeln!(f, "--- Misc ---")?;
         writeln!(f, "  chatstate_handlers:     {}", self.chatstate_handlers)?;
         writeln!(f, "  custom_enc_handlers:    {}", self.custom_enc_handlers)?;
+        writeln!(
+            f,
+            "  total estimated:        {} B",
+            self.total_estimated_bytes()
+        )?;
         Ok(())
     }
 }
@@ -389,14 +398,10 @@ pub struct Client {
     /// error / connect_failure / disconnect. Per-connection subscribers
     /// (keepalive, request waiters, read loop, offline flush) observe this.
     pub(crate) connection_shutdown: std::sync::Mutex<wacore::runtime::ShutdownNotifier>,
-    /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
-    /// Updated on every `DataReceived` transport event.
-    /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
-    pub(crate) last_data_received_ms: Arc<AtomicU64>,
-    /// Timestamp (ms since UNIX epoch) of the last sent WebSocket data.
-    /// Updated on every `send_node` call.
-    /// WA Web: `callStanza` → `deadSocketTimer.onOrBefore(deadSocketTime)`.
-    pub(crate) last_data_sent_ms: Arc<AtomicU64>,
+    /// Per-session wire I/O and activity counters. Written at the transport
+    /// chokepoints (noise sender task, read loop); the keepalive dead-socket
+    /// watchdog reads its activity timestamps. Snapshot via [`Client::stats`].
+    pub(crate) stats: Arc<wacore::stats::SessionStats>,
 
     pub(crate) transport: Arc<Mutex<Option<Arc<dyn crate::transport::Transport>>>>,
     pub(crate) transport_events:
@@ -504,7 +509,9 @@ pub struct Client {
     pub(crate) undecryptable_dispatched: Cache<ChatMessageId, ()>,
 
     pub enable_auto_reconnect: Arc<AtomicBool>,
-    pub auto_reconnect_errors: Arc<AtomicU32>,
+    /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
+    /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
+    pub(crate) auto_reconnect_errors: Arc<AtomicU32>,
 
     pub(crate) needs_initial_full_sync: Arc<AtomicBool>,
 

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -83,41 +83,88 @@ impl Client {
         self.resend_rate_limiter.set_rate(burst, refill_per_min);
     }
 
-    /// Total outbound resends dropped by the per-chat rate limiter since start.
-    /// Surfaces storm chats without the `debug-diagnostics` feature.
-    pub fn resends_throttled_total(&self) -> u64 {
-        self.resend_rate_limiter.throttled_total()
+    /// Cumulative wire I/O and activity counters for this client session.
+    ///
+    /// Always available, no feature gate: recording costs one relaxed atomic
+    /// add per wire frame. Byte counts are post-noise wire bytes (frame
+    /// headers and AEAD tags included; handshake and TLS/WebSocket overhead
+    /// excluded), so two clients in one process can be compared directly.
+    pub fn stats(&self) -> StatsSnapshot {
+        let mut snapshot = self.stats.snapshot();
+        snapshot.reconnect_errors = self.auto_reconnect_errors.load(Ordering::Relaxed);
+        snapshot.resends_throttled = self.resend_rate_limiter.throttled_total();
+        snapshot
     }
 
-    /// Returns a snapshot of all internal collection sizes for memory leak detection.
+    /// Entry counts plus estimated retained heap bytes for the client's
+    /// internal collections. See [`MemoryReport`] for the semantics of the
+    /// byte figures.
     ///
-    /// Moka caches report approximate counts (pending evictions may not be reflected).
-    /// Call `run_pending_tasks()` on individual caches first if you need exact counts.
-    ///
-    /// Requires the `debug-diagnostics` feature.
-    #[cfg(feature = "debug-diagnostics")]
-    pub async fn memory_diagnostics(&self) -> MemoryDiagnostics {
-        let (sig_sessions, sig_identities, sig_sender_keys) =
-            self.signal_cache.entry_counts().await;
-        let (lid_lid, lid_pn) = self.lid_pn_cache.entry_counts();
+    /// On-demand only: walks the in-process caches under their locks when
+    /// called, costs nothing otherwise. Counts are approximate (caches may
+    /// have pending evictions); call `run_pending_tasks()` on individual
+    /// caches first if you need exact counts.
+    pub async fn memory_report(&self) -> MemoryReport {
+        use wacore::stats::{CollectionStats, HeapSize};
+
+        let (signal_sessions, signal_identities, signal_sender_keys) =
+            self.signal_cache.memory_stats().await;
+        let (lid_pn_lid_entries, lid_pn_pn_entries) = self.lid_pn_cache.memory_stats();
         let pending_retries_count = self
             .pending_retries
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .len();
 
-        MemoryDiagnostics {
-            group_cache: self
-                .group_cache
-                .lock()
-                .await
-                .as_ref()
-                .map_or(0, |c| c.entry_count()),
-            device_registry_cache: self.device_registry_cache.entry_count(),
-            lid_pn_lid_entries: lid_lid,
-            lid_pn_pn_entries: lid_pn,
-            recent_messages: self.recent_messages.entry_count(),
-            sender_key_device_cache: self.sender_key_device_cache.entry_count(),
+        let group_cache = match self.group_cache.lock().await.as_ref() {
+            Some(cache) => {
+                let bytes: usize = cache
+                    .iter_local()
+                    .map(|iter| {
+                        iter.map(|(k, v)| {
+                            k.heap_bytes()
+                                + std::mem::size_of::<wacore::client::context::GroupInfo>()
+                                + v.heap_bytes()
+                        })
+                        .sum()
+                    })
+                    .unwrap_or(0);
+                CollectionStats::new(cache.entry_count(), bytes as u64)
+            }
+            None => CollectionStats::default(),
+        };
+
+        let recent_messages = {
+            let bytes: usize = self
+                .recent_messages
+                .iter()
+                .map(|(k, v)| k.chat.heap_bytes() + k.id.len() + v.capacity())
+                .sum();
+            CollectionStats::new(self.recent_messages.entry_count(), bytes as u64)
+        };
+
+        let group_devices_memo = {
+            let bytes: usize = self
+                .group_devices_memo
+                .iter()
+                .map(|(k, v)| {
+                    k.heap_bytes()
+                        + v.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
+                        + v.members.len() * std::mem::size_of::<wacore_binary::CompactString>()
+                        + v.devices.heap_bytes()
+                })
+                .sum();
+            CollectionStats::new(self.group_devices_memo.entry_count(), bytes as u64)
+        };
+
+        MemoryReport {
+            group_cache,
+            device_registry_cache: self.device_registry_cache.memory_stats(),
+            lid_pn_lid_entries,
+            lid_pn_pn_entries,
+            recent_messages,
+            sender_key_device_cache: self.sender_key_device_cache.memory_stats(),
+            group_devices_memo,
             message_retry_counts: self.message_retry_counts.entry_count(),
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count(),
             pdo_pending_requests: self.pdo_pending_requests.entry_count(),
@@ -125,16 +172,15 @@ impl Client {
             session_locks: self.session_locks.entry_count(),
             chat_lanes: self.chat_lanes.entry_count(),
             resend_rate_limiter_chats: self.resend_rate_limiter.entry_count(),
-            resends_throttled_total: self.resend_rate_limiter.throttled_total(),
             response_waiters: self.response_waiters.lock().await.len(),
             node_waiters: self.node_waiter_count.load(Ordering::Relaxed),
             pending_retries: pending_retries_count,
             presence_subscriptions: self.presence_subscriptions.lock().await.len(),
             app_state_key_requests: self.app_state_key_requests.lock().await.len(),
             app_state_syncing: self.app_state_syncing.lock().await.len(),
-            signal_cache_sessions: sig_sessions,
-            signal_cache_identities: sig_identities,
-            signal_cache_sender_keys: sig_sender_keys,
+            signal_sessions,
+            signal_identities,
+            signal_sender_keys,
             chatstate_handlers: self.chatstate_handlers.read().await.len(),
             custom_enc_handlers: self.custom_enc_handlers.get().map_or(0, |m| m.len()),
         }

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -118,16 +118,10 @@ impl Client {
 
         let group_cache = match self.group_cache.lock().await.as_ref() {
             Some(cache) => {
+                // Arc<T>'s HeapSize already includes size_of::<GroupInfo>().
                 let bytes: usize = cache
                     .iter_local()
-                    .map(|iter| {
-                        iter.map(|(k, v)| {
-                            k.heap_bytes()
-                                + std::mem::size_of::<wacore::client::context::GroupInfo>()
-                                + v.heap_bytes()
-                        })
-                        .sum()
-                    })
+                    .map(|iter| iter.map(|(k, v)| k.heap_bytes() + v.heap_bytes()).sum())
                     .unwrap_or(0);
                 CollectionStats::new(cache.entry_count(), bytes as u64)
             }
@@ -150,7 +144,7 @@ impl Client {
                 .map(|(k, v)| {
                     k.heap_bytes()
                         + v.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
-                        + v.members.len() * std::mem::size_of::<wacore_binary::CompactString>()
+                        + v.members.capacity() * std::mem::size_of::<wacore_binary::CompactString>()
                         + v.devices.heap_bytes()
                 })
                 .sum();

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -109,55 +109,50 @@ impl Client {
 
         let (signal_sessions, signal_identities, signal_sender_keys) =
             self.signal_cache.memory_stats().await;
-        let (lid_pn_lid_entries, lid_pn_pn_entries) = self.lid_pn_cache.memory_stats();
+        let (lid_pn_lid_entries, lid_pn_pn_entries) = self.lid_pn_cache.memory_stats().await;
         let pending_retries_count = self
             .pending_retries
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .len();
 
-        let group_cache = match self.group_cache.lock().await.as_ref() {
+        // Only the Arc is taken under the mutex — the walk must not block
+        // get_group_cache(), which every group send goes through.
+        let group_cache_arc = self.group_cache.lock().await.clone();
+        let group_cache = match group_cache_arc {
+            // Arc<T>'s HeapSize already includes size_of::<GroupInfo>().
             Some(cache) => {
-                // Arc<T>'s HeapSize already includes size_of::<GroupInfo>().
-                let bytes: usize = cache
-                    .iter_local()
-                    .map(|iter| iter.map(|(k, v)| k.heap_bytes() + v.heap_bytes()).sum())
-                    .unwrap_or(0);
-                CollectionStats::new(cache.entry_count(), bytes as u64)
+                cache
+                    .memory_stats(|k, v| k.heap_bytes() + v.heap_bytes())
+                    .await
             }
             None => CollectionStats::default(),
         };
 
-        let recent_messages = {
-            let bytes: usize = self
-                .recent_messages
-                .iter()
-                .map(|(k, v)| k.chat.heap_bytes() + k.id.len() + v.capacity())
-                .sum();
-            CollectionStats::new(self.recent_messages.entry_count(), bytes as u64)
-        };
+        let recent_messages = self
+            .recent_messages
+            .memory_stats(|k, v| k.chat.heap_bytes() + k.id.heap_bytes() + v.heap_bytes())
+            .await;
 
-        let group_devices_memo = {
-            let bytes: usize = self
-                .group_devices_memo
-                .iter()
-                .map(|(k, v)| {
-                    k.heap_bytes()
-                        + v.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
-                        + v.members.capacity() * std::mem::size_of::<wacore_binary::CompactString>()
-                        + v.devices.heap_bytes()
-                })
-                .sum();
-            CollectionStats::new(self.group_devices_memo.entry_count(), bytes as u64)
-        };
+        let group_devices_memo = self
+            .group_devices_memo
+            .memory_stats(|k, v| k.heap_bytes() + v.heap_bytes())
+            .await;
+
+        // Each count read into a local so no two guards are ever held at once.
+        let response_waiters = self.response_waiters.lock().await.len();
+        let presence_subscriptions = self.presence_subscriptions.lock().await.len();
+        let app_state_key_requests = self.app_state_key_requests.lock().await.len();
+        let app_state_syncing = self.app_state_syncing.lock().await.len();
+        let chatstate_handlers = self.chatstate_handlers.read().await.len();
 
         MemoryReport {
             group_cache,
-            device_registry_cache: self.device_registry_cache.memory_stats(),
+            device_registry_cache: self.device_registry_cache.memory_stats().await,
             lid_pn_lid_entries,
             lid_pn_pn_entries,
             recent_messages,
-            sender_key_device_cache: self.sender_key_device_cache.memory_stats(),
+            sender_key_device_cache: self.sender_key_device_cache.memory_stats().await,
             group_devices_memo,
             message_retry_counts: self.message_retry_counts.entry_count(),
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count(),
@@ -166,16 +161,16 @@ impl Client {
             session_locks: self.session_locks.entry_count(),
             chat_lanes: self.chat_lanes.entry_count(),
             resend_rate_limiter_chats: self.resend_rate_limiter.entry_count(),
-            response_waiters: self.response_waiters.lock().await.len(),
+            response_waiters,
             node_waiters: self.node_waiter_count.load(Ordering::Relaxed),
             pending_retries: pending_retries_count,
-            presence_subscriptions: self.presence_subscriptions.lock().await.len(),
-            app_state_key_requests: self.app_state_key_requests.lock().await.len(),
-            app_state_syncing: self.app_state_syncing.lock().await.len(),
+            presence_subscriptions,
+            app_state_key_requests,
+            app_state_syncing,
             signal_sessions,
             signal_identities,
             signal_sender_keys,
-            chatstate_handlers: self.chatstate_handlers.read().await.len(),
+            chatstate_handlers,
             custom_enc_handlers: self.custom_enc_handlers.get().map_or(0, |m| m.len()),
         }
     }

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -27,6 +27,16 @@ pub(crate) struct GroupDevicesMemo {
     pub(crate) devices: Arc<wacore::send::ResolvedGroupDevices>,
 }
 
+impl wacore::stats::HeapSize for GroupDevicesMemo {
+    fn heap_bytes(&self) -> usize {
+        // The Weak keeps only the GroupInfo allocation header alive; the memo
+        // does not retain its payload.
+        self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
+            + self.members.capacity() * std::mem::size_of::<wacore_binary::CompactString>()
+            + self.devices.heap_bytes()
+    }
+}
+
 /// Result of resolving a user identifier to lookup keys.
 /// This makes the LID/PN relationship explicit instead of using magic indices.
 #[derive(Debug, Clone)]

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -153,9 +153,16 @@ impl DeviceRegistryCache {
         self.cache.insert(key, record).await;
     }
 
-    #[cfg(feature = "debug-diagnostics")]
-    pub(crate) fn entry_count(&self) -> u64 {
-        self.cache.entry_count()
+    /// Approximate entry count plus estimated retained bytes. Bytes are `0`
+    /// when backed by a custom store (entries live outside this process).
+    pub(crate) fn memory_stats(&self) -> wacore::stats::CollectionStats {
+        use wacore::stats::HeapSize;
+        let bytes: usize = self
+            .cache
+            .iter_local()
+            .map(|iter| iter.map(|(k, v)| k.capacity() + v.heap_bytes()).sum())
+            .unwrap_or(0);
+        wacore::stats::CollectionStats::new(self.cache.entry_count(), bytes as u64)
     }
 
     /// Test-only passthrough for cache maintenance flushes.

--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -155,14 +155,11 @@ impl DeviceRegistryCache {
 
     /// Approximate entry count plus estimated retained bytes. Bytes are `0`
     /// when backed by a custom store (entries live outside this process).
-    pub(crate) fn memory_stats(&self) -> wacore::stats::CollectionStats {
+    pub(crate) async fn memory_stats(&self) -> wacore::stats::CollectionStats {
         use wacore::stats::HeapSize;
-        let bytes: usize = self
-            .cache
-            .iter_local()
-            .map(|iter| iter.map(|(k, v)| k.capacity() + v.heap_bytes()).sum())
-            .unwrap_or(0);
-        wacore::stats::CollectionStats::new(self.cache.entry_count(), bytes as u64)
+        self.cache
+            .memory_stats(|k, v| k.capacity() + v.heap_bytes())
+            .await
     }
 
     /// Test-only passthrough for cache maintenance flushes.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -129,8 +129,7 @@ impl Client {
             ik_handshake_failures: Arc::new(AtomicU32::new(0)),
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
-            last_data_received_ms: Arc::new(AtomicU64::new(0)),
-            last_data_sent_ms: Arc::new(AtomicU64::new(0)),
+            stats: Arc::new(wacore::stats::SessionStats::new()),
 
             transport: Arc::new(Mutex::new(None)),
             transport_events: Arc::new(Mutex::new(None)),
@@ -382,10 +381,12 @@ impl Client {
             // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately
             if self.expected_disconnect.load(Ordering::Relaxed) {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
+                self.stats.record_reconnect();
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
                 continue;
             }
 
+            self.stats.record_reconnect();
             let error_count = self.auto_reconnect_errors.fetch_add(1, Ordering::SeqCst);
             // WA Web: Fibonacci backoff with 10% jitter, max 900s.
             // algo: { type: "fibonacci", first: 1000, second: 1000 }
@@ -493,6 +494,7 @@ impl Client {
             &self.ik_handshake_failures,
             transport.clone(),
             &mut transport_events,
+            Some(self.stats.clone()),
         )
         .await
         {
@@ -745,8 +747,7 @@ impl Client {
         self.swap_message_semaphore(1);
         // Reset dead-socket timestamps so stale values from the previous
         // connection don't trigger an immediate reconnect on the next one.
-        self.last_data_received_ms.store(0, Ordering::Relaxed);
-        self.last_data_sent_ms.store(0, Ordering::Relaxed);
+        self.stats.reset_connection_activity();
         self.pending_device_sync.clear().await;
         // Reset offline sync state for next connection
         self.offline_sync_completed.store(false, Ordering::Relaxed);

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -309,7 +309,16 @@ impl Client {
             warn!("Client `run` method called while already running.");
             return;
         }
+        // Reconnects are counted at iteration start: every pass after the
+        // first is an attempt actually being made. Counting at the branches
+        // below would also count a final pass that never reconnects (a user
+        // disconnect() flips is_running while the branch runs).
+        let mut first_connect = true;
         while self.is_running.load(Ordering::Relaxed) {
+            if !first_connect {
+                self.stats.record_reconnect();
+            }
+            first_connect = false;
             self.expected_disconnect.store(false, Ordering::Relaxed);
 
             if let Err(connect_err) = self.connect().await {
@@ -381,12 +390,10 @@ impl Client {
             // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately
             if self.expected_disconnect.load(Ordering::Relaxed) {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
-                self.stats.record_reconnect();
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
                 continue;
             }
 
-            self.stats.record_reconnect();
             let error_count = self.auto_reconnect_errors.fetch_add(1, Ordering::SeqCst);
             // WA Web: Fibonacci backoff with 10% jitter, max 900s.
             // algo: { type: "fibonacci", first: 1000, second: 1000 }

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -13,11 +13,11 @@ impl Client {
     /// [`send_node`](Client::send_node) for normal stanza sending.
     pub async fn send_raw_bytes(&self, plaintext: Vec<u8>) -> Result<(), ClientError> {
         let noise_socket = self.get_noise_socket().await?;
+        // Wire bytes and the last-sent timestamp are recorded by the noise
+        // sender task at the actual transport write.
         noise_socket
             .encrypt_and_send(bytes::Bytes::from(plaintext))
             .await?;
-        self.last_data_sent_ms
-            .store(wacore::time::now_millis().max(0) as u64, Ordering::Relaxed);
         Ok(())
     }
 

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -119,10 +119,8 @@ impl Client {
                         match event_result {
                             Ok(crate::transport::TransportEvent::DataReceived(data)) => {
                                 // Update dead-socket timer (WA Web: deadSocketTimer reset)
-                                self.last_data_received_ms.store(
-                                    wacore::time::now_millis().max(0) as u64,
-                                    Ordering::Relaxed,
-                                );
+                                self.stats.mark_recv_activity();
+                                let wire_bytes = data.len();
 
                                 // Feed data into the frame decoder. The payload is
                                 // adopted zero-copy when it is the sole reference
@@ -174,16 +172,12 @@ impl Client {
                                     }
                                 }
 
-                                // Refresh timestamp after processing the entire batch so
-                                // the keepalive loop sees the batch completion time, not
-                                // just the arrival time. Prevents stale reads when a
-                                // large batch (e.g. offline sync) takes seconds to drain.
-                                if frames_in_batch > 1 {
-                                    self.last_data_received_ms.store(
-                                        wacore::time::now_millis().max(0) as u64,
-                                        Ordering::Relaxed,
-                                    );
-                                }
+                                // Count the batch and refresh the timestamp after
+                                // processing so the keepalive loop sees the batch
+                                // completion time, not just the arrival time. Prevents
+                                // stale reads when a large batch (e.g. offline sync)
+                                // takes seconds to drain.
+                                self.stats.record_recv_batch(wire_bytes, frames_in_batch);
                             },
                             Ok(crate::transport::TransportEvent::Disconnected(reason)) => {
                                 if !self.expected_disconnect.load(Ordering::Relaxed) {

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -160,6 +160,10 @@ impl Client {
                                     // Check if we should exit after processing (e.g., after 515 stream error)
                                     if self.expected_disconnect.load(Ordering::Relaxed) {
                                         debug!("Expected disconnect signaled during frame processing. Exiting message loop.");
+                                        // The batch (this frame included — its counter
+                                        // increment is below) must not vanish from the
+                                        // wire counters on this exit path.
+                                        self.stats.record_recv_batch(wire_bytes, frames_in_batch + 1);
                                         return Ok(ReadLoopExit::Expected);
                                     }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2879,3 +2879,99 @@ async fn ack_miss_path_does_not_heap_allocate() {
     }
     assert_eq!(min_delta, 0, "ack miss path must not allocate");
 }
+
+/// The public stats snapshot must reflect the client's counters plus the
+/// client-level fields (reconnect errors, throttled resends) it fills in.
+#[tokio::test]
+async fn stats_snapshot_reflects_counters() {
+    let client = crate::test_utils::create_test_client().await;
+
+    client.stats.record_frame_sent(150);
+    client.stats.record_recv_batch(300, 2);
+    client.stats.record_message_sent();
+    client.auto_reconnect_errors.store(3, Ordering::Relaxed);
+
+    let snap = client.stats();
+    assert_eq!(snap.bytes_sent, 150);
+    assert_eq!(snap.frames_sent, 1);
+    assert_eq!(snap.bytes_received, 300);
+    assert_eq!(snap.frames_received, 2);
+    assert_eq!(snap.messages_sent, 1);
+    assert_eq!(snap.reconnect_errors, 3);
+    assert_eq!(snap.resends_throttled, 0);
+}
+
+/// memory_report must be callable on a fresh client and internally
+/// consistent: empty collections report zero entries and zero bytes.
+#[tokio::test]
+async fn memory_report_on_fresh_client() {
+    // recent_messages is capacity-0 (disabled) by default; enable it so the
+    // byte-attribution assertion below has a collection to land in.
+    let mut cache_config = crate::cache_config::CacheConfig::default();
+    cache_config.recent_messages =
+        crate::cache_config::CacheEntryConfig::new(Some(std::time::Duration::from_secs(300)), 64);
+    let client = crate::test_utils::create_test_client_with_config(
+        "memory_report",
+        std::sync::Arc::new(crate::test_utils::MockHttpClient),
+        cache_config,
+    )
+    .await;
+
+    let report = client.memory_report().await;
+    assert_eq!(report.recent_messages.entries, 0);
+    assert_eq!(report.recent_messages.bytes, 0);
+    assert_eq!(report.signal_sessions.entries, 0);
+    assert_eq!(report.response_waiters, 0);
+
+    // Retained bytes must appear once something is cached.
+    let key = wacore::types::message::ChatMessageId::new(
+        "559980000001@s.whatsapp.net".parse().unwrap(),
+        "3EB0TESTMSGID".to_string(),
+    );
+    client
+        .recent_messages
+        .insert(key, std::sync::Arc::new(vec![0u8; 2048]))
+        .await;
+    let report = client.memory_report().await;
+    assert_eq!(report.recent_messages.entries, 1);
+    assert!(
+        report.recent_messages.bytes >= 2048,
+        "cached payload bytes must be attributed (got {})",
+        report.recent_messages.bytes
+    );
+    assert!(report.total_estimated_bytes() >= 2048);
+    // Display must render without panicking.
+    let _ = report.to_string();
+}
+
+/// InstrumentedRuntime must invoke the TaskInstrument around polls of spawned
+/// futures and blocking closures, and CpuMeter must accumulate them.
+#[tokio::test]
+async fn instrumented_runtime_reports_to_cpu_meter() {
+    use wacore::runtime::Runtime as _;
+    use wacore::stats::{CpuMeter, InstrumentedRuntime};
+
+    let meter = std::sync::Arc::new(CpuMeter::new());
+    let runtime = InstrumentedRuntime::new(
+        std::sync::Arc::new(crate::runtime_impl::TokioRuntime),
+        meter.clone(),
+    );
+
+    let (tx, rx) = futures::channel::oneshot::channel::<()>();
+    runtime
+        .spawn(Box::pin(async move {
+            let _ = tx.send(());
+        }))
+        .detach();
+    rx.await.expect("spawned future ran");
+
+    let after_spawn = meter.snapshot();
+    assert!(after_spawn.polls >= 1, "spawned future polls are metered");
+
+    runtime.spawn_blocking(Box::new(|| {})).await;
+    let after_blocking = meter.snapshot();
+    assert!(
+        after_blocking.polls > after_spawn.polls,
+        "blocking work is metered too"
+    );
+}

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -162,6 +162,7 @@ pub async fn do_handshake(
     ik_handshake_failures: &AtomicU32,
     transport: Arc<dyn Transport>,
     transport_events: &mut async_channel::Receiver<TransportEvent>,
+    stats: Option<Arc<wacore::stats::SessionStats>>,
 ) -> Result<Arc<NoiseSocket>> {
     let device_snapshot = persistence_manager.get_device_snapshot();
     let now_secs = wacore::time::now_secs();
@@ -208,11 +209,12 @@ pub async fn do_handshake(
                     .await;
             }
             ik_handshake_failures.store(0, Ordering::Release);
-            Ok(Arc::new(NoiseSocket::new(
+            Ok(Arc::new(NoiseSocket::with_stats(
                 runtime,
                 transport,
                 success.write_cipher,
                 success.read_cipher,
+                stats,
             )))
         }
         Err(e) => {

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -4,7 +4,6 @@ use futures::FutureExt;
 use log::{debug, warn};
 use rand::RngExt;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use wacore::iq::spec::IqSpec;
 use wacore::protocol::keepalive::{
@@ -162,7 +161,7 @@ impl Client {
                         self.spawn_retention_cleanup(sent_msg_ttl);
                     }
 
-                    let last_recv = self.last_data_received_ms.load(Ordering::Relaxed);
+                    let last_recv = self.stats.last_data_received_ms();
 
                     // WA Web: maybeScheduleHealthCheck — only send ping when idle.
                     // If we recently received data, the connection is proven alive;
@@ -208,8 +207,8 @@ impl Client {
                     // a failed ping. This catches scenarios where pending IQs caused
                     // the ping to be skipped, or where the ping "succeeded" but the
                     // connection died immediately after.
-                    let last_sent = self.last_data_sent_ms.load(Ordering::Relaxed);
-                    let last_recv = self.last_data_received_ms.load(Ordering::Relaxed);
+                    let last_sent = self.stats.last_data_sent_ms();
+                    let last_recv = self.stats.last_data_received_ms();
                     if is_dead_socket(last_sent, last_recv) {
                         let elapsed = ms_since(last_sent).unwrap_or(0);
                         warn!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,9 @@ pub use client::Client;
 /// Shared base error for transport/connection concerns; the per-domain error
 /// types embed it.
 pub use client::ClientError;
-#[cfg(feature = "debug-diagnostics")]
-pub use client::MemoryDiagnostics;
 pub use client::NodeFilter;
 pub use client::{CallError, Voip};
+pub use client::{CollectionStats, MemoryReport, StatsSnapshot};
 pub use types::durability_hook::InboundDurabilityHook;
 pub mod download;
 pub mod handlers;

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -120,38 +120,32 @@ impl LidPnCache {
     /// the LID map no longer holds (transient eviction asymmetry), keeping
     /// every entry counted exactly once. `Arc<T>`'s `HeapSize` already
     /// includes `size_of::<LidPnEntry>()`.
-    pub fn memory_stats(
+    pub async fn memory_stats(
         &self,
     ) -> (
         wacore::stats::CollectionStats,
         wacore::stats::CollectionStats,
     ) {
-        use wacore::stats::{CollectionStats, HeapSize};
+        use wacore::stats::HeapSize;
         let mut lid_ptrs = std::collections::HashSet::new();
-        let lid_bytes: usize = self
+        let lid = self
             .lid_to_entry
-            .iter_local()
-            .map(|iter| {
-                iter.map(|(_, v)| {
-                    lid_ptrs.insert(Arc::as_ptr(&v));
-                    v.heap_bytes()
-                })
-                .sum()
+            .memory_stats(|_, v| {
+                lid_ptrs.insert(Arc::as_ptr(v));
+                v.heap_bytes()
             })
-            .unwrap_or(0);
-        let pn_bytes: usize = self
+            .await;
+        let pn = self
             .pn_to_entry
-            .iter_local()
-            .map(|iter| {
-                iter.filter(|(_, v)| !lid_ptrs.contains(&Arc::as_ptr(v)))
-                    .map(|(_, v)| v.heap_bytes())
-                    .sum()
+            .memory_stats(|_, v| {
+                if lid_ptrs.contains(&Arc::as_ptr(v)) {
+                    0
+                } else {
+                    v.heap_bytes()
+                }
             })
-            .unwrap_or(0);
-        (
-            CollectionStats::new(self.lid_to_entry.entry_count(), lid_bytes as u64),
-            CollectionStats::new(self.pn_to_entry.entry_count(), pn_bytes as u64),
-        )
+            .await;
+        (lid, pn)
     }
 
     /// Get the current LID for a phone number.

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -115,11 +115,11 @@ impl LidPnCache {
     /// PN maps. Bytes are `0` when backed by a custom store (entries live
     /// outside this process).
     ///
-    /// The payload is attributed entirely to the LID map: `add()` stores the
-    /// same `Arc<LidPnEntry>` under both directions (and the `Arc<str>` keys
-    /// share the entry's own strings), so the PN map retains only map slots —
-    /// counting it again would double the report. The PN side therefore
-    /// carries its entry count with `bytes: 0`.
+    /// `add()` stores the same `Arc<LidPnEntry>` under both directions, so the
+    /// payload is attributed to the LID map; the PN side counts only entries
+    /// the LID map no longer holds (transient eviction asymmetry), keeping
+    /// every entry counted exactly once. `Arc<T>`'s `HeapSize` already
+    /// includes `size_of::<LidPnEntry>()`.
     pub fn memory_stats(
         &self,
     ) -> (
@@ -127,15 +127,30 @@ impl LidPnCache {
         wacore::stats::CollectionStats,
     ) {
         use wacore::stats::{CollectionStats, HeapSize};
-        // Arc<T>'s HeapSize already includes size_of::<LidPnEntry>().
+        let mut lid_ptrs = std::collections::HashSet::new();
         let lid_bytes: usize = self
             .lid_to_entry
             .iter_local()
-            .map(|iter| iter.map(|(_, v)| v.heap_bytes()).sum())
+            .map(|iter| {
+                iter.map(|(_, v)| {
+                    lid_ptrs.insert(Arc::as_ptr(&v));
+                    v.heap_bytes()
+                })
+                .sum()
+            })
+            .unwrap_or(0);
+        let pn_bytes: usize = self
+            .pn_to_entry
+            .iter_local()
+            .map(|iter| {
+                iter.filter(|(_, v)| !lid_ptrs.contains(&Arc::as_ptr(v)))
+                    .map(|(_, v)| v.heap_bytes())
+                    .sum()
+            })
             .unwrap_or(0);
         (
             CollectionStats::new(self.lid_to_entry.entry_count(), lid_bytes as u64),
-            CollectionStats::new(self.pn_to_entry.entry_count(), 0),
+            CollectionStats::new(self.pn_to_entry.entry_count(), pn_bytes as u64),
         )
     }
 

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -113,8 +113,13 @@ impl LidPnCache {
 
     /// Approximate entry counts plus estimated retained bytes for the LID and
     /// PN maps. Bytes are `0` when backed by a custom store (entries live
-    /// outside this process). Entry heap bytes cover the identifier strings,
-    /// which the `Arc<str>` keys share — keys are not counted again.
+    /// outside this process).
+    ///
+    /// The payload is attributed entirely to the LID map: `add()` stores the
+    /// same `Arc<LidPnEntry>` under both directions (and the `Arc<str>` keys
+    /// share the entry's own strings), so the PN map retains only map slots —
+    /// counting it again would double the report. The PN side therefore
+    /// carries its entry count with `bytes: 0`.
     pub fn memory_stats(
         &self,
     ) -> (
@@ -122,17 +127,16 @@ impl LidPnCache {
         wacore::stats::CollectionStats,
     ) {
         use wacore::stats::{CollectionStats, HeapSize};
-        let measure = |cache: &TypedCache<Arc<str>, Arc<LidPnEntry>>| {
-            let bytes: usize = cache
-                .iter_local()
-                .map(|iter| {
-                    iter.map(|(_, v)| std::mem::size_of::<LidPnEntry>() + v.heap_bytes())
-                        .sum()
-                })
-                .unwrap_or(0);
-            CollectionStats::new(cache.entry_count(), bytes as u64)
-        };
-        (measure(&self.lid_to_entry), measure(&self.pn_to_entry))
+        // Arc<T>'s HeapSize already includes size_of::<LidPnEntry>().
+        let lid_bytes: usize = self
+            .lid_to_entry
+            .iter_local()
+            .map(|iter| iter.map(|(_, v)| v.heap_bytes()).sum())
+            .unwrap_or(0);
+        (
+            CollectionStats::new(self.lid_to_entry.entry_count(), lid_bytes as u64),
+            CollectionStats::new(self.pn_to_entry.entry_count(), 0),
+        )
     }
 
     /// Get the current LID for a phone number.

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -111,13 +111,28 @@ impl LidPnCache {
         let _ = self.topology.set(topology);
     }
 
-    /// Returns approximate entry counts for the LID and PN maps.
-    #[cfg(feature = "debug-diagnostics")]
-    pub fn entry_counts(&self) -> (u64, u64) {
-        (
-            self.lid_to_entry.entry_count(),
-            self.pn_to_entry.entry_count(),
-        )
+    /// Approximate entry counts plus estimated retained bytes for the LID and
+    /// PN maps. Bytes are `0` when backed by a custom store (entries live
+    /// outside this process). Entry heap bytes cover the identifier strings,
+    /// which the `Arc<str>` keys share — keys are not counted again.
+    pub fn memory_stats(
+        &self,
+    ) -> (
+        wacore::stats::CollectionStats,
+        wacore::stats::CollectionStats,
+    ) {
+        use wacore::stats::{CollectionStats, HeapSize};
+        let measure = |cache: &TypedCache<Arc<str>, Arc<LidPnEntry>>| {
+            let bytes: usize = cache
+                .iter_local()
+                .map(|iter| {
+                    iter.map(|(_, v)| std::mem::size_of::<LidPnEntry>() + v.heap_bytes())
+                        .sum()
+                })
+                .unwrap_or(0);
+            CollectionStats::new(cache.entry_count(), bytes as u64)
+        };
+        (measure(&self.lid_to_entry), measure(&self.pn_to_entry))
     }
 
     /// Get the current LID for a phone number.

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -12,6 +12,7 @@ impl Client {
     ) {
         use wacore::proto_helpers::MessageExt;
         wacore::telemetry::recv("decrypted");
+        self.stats.record_message_received();
 
         let mut info = Arc::clone(info);
         if info.ephemeral_expiration.is_none()

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -325,6 +325,30 @@ where
         Self::snapshot(&guard)
     }
 
+    /// Reliable awaited fold over `(&K, &V)`. Unlike the snapshot walks this
+    /// clones nothing — memory reports must not themselves allocate in
+    /// proportion to the cache — and unlike [`iter`](Self::iter) it cannot
+    /// degrade to an empty walk under write contention.
+    pub async fn fold_entries<A>(&self, init: A, mut f: impl FnMut(A, &K, &V) -> A) -> A {
+        let guard = self.inner.read().await;
+        guard
+            .map
+            .iter()
+            .fold(init, |acc, (k, e)| f(acc, k, &e.value))
+    }
+
+    /// Entry count plus estimated retained bytes, summing `per_entry` under a
+    /// single awaited read guard so the pair is mutually consistent (and never
+    /// the empty best-effort snapshot [`iter`](Self::iter) can degrade to).
+    pub async fn memory_stats(
+        &self,
+        mut per_entry: impl FnMut(&K, &V) -> usize,
+    ) -> wacore::stats::CollectionStats {
+        let guard = self.inner.read().await;
+        let bytes: usize = guard.map.iter().map(|(k, e)| per_entry(k, &e.value)).sum();
+        wacore::stats::CollectionStats::new(guard.map.len() as u64, bytes as u64)
+    }
+
     /// Eager snapshot iterator over `(Arc<K>, V)`: snapshot, not lazy. Includes
     /// expired-but-not-yet-evicted entries (consistent with `entry_count`).
     /// Best-effort (`try_read` spin); use [`snapshot_entries`](Self::snapshot_entries)

--- a/src/resend_rate_limiter.rs
+++ b/src/resend_rate_limiter.rs
@@ -132,7 +132,6 @@ impl ResendRateLimiter {
     }
 
     /// Number of chats holding a live bucket (diagnostics).
-    #[cfg_attr(not(feature = "debug-diagnostics"), allow(dead_code))]
     pub(crate) fn entry_count(&self) -> u64 {
         self.buckets.entry_count()
     }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -2201,7 +2201,7 @@ mod tests {
     }
 
     /// The resend rate limiter is reachable and tunable through the public
-    /// `Client` API, and its drops surface on `resends_throttled_total`. Covers
+    /// `Client` API, and its drops surface on `stats().resends_throttled`. Covers
     /// the wiring the `handle_retry_receipt` hook relies on; the bucket logic
     /// itself is unit-tested in `resend_rate_limiter`.
     #[tokio::test]
@@ -2220,7 +2220,7 @@ mod tests {
         }
         assert_eq!(allowed, 3, "client honors the configured per-chat burst");
         assert_eq!(
-            client.resends_throttled_total(),
+            client.stats().resends_throttled,
             7,
             "public counter tracks dropped resends"
         );
@@ -2304,7 +2304,7 @@ mod tests {
             "a throttled retry returns Ok(()), not an error"
         );
         assert_eq!(
-            client.resends_throttled_total(),
+            client.stats().resends_throttled,
             1,
             "the resend was dropped by the limiter"
         );

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -594,6 +594,7 @@ impl Client {
         self.record_identity_on_span(&tracing::Span::current());
 
         let _t = wacore::telemetry::timer(wacore::telemetry::SEND_DURATION);
+        self.stats.record_message_sent();
         wacore::telemetry::send(match to.server {
             wacore_binary::Server::Group => "group",
             wacore_binary::Server::Broadcast => "status",
@@ -702,6 +703,7 @@ impl Client {
 
         // Status posts don't go through send_message_with_options, so count them here.
         let _t = wacore::telemetry::timer(wacore::telemetry::SEND_DURATION);
+        self.stats.record_message_sent();
         wacore::telemetry::send("status");
 
         let to = Jid::status_broadcast();

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -111,11 +111,9 @@ impl SenderKeyDeviceCache {
     }
 
     /// Approximate entry count plus estimated retained bytes.
-    pub(crate) fn memory_stats(&self) -> wacore::stats::CollectionStats {
-        let bytes: usize = self
-            .inner
-            .iter()
-            .map(|(k, v)| {
+    pub(crate) async fn memory_stats(&self) -> wacore::stats::CollectionStats {
+        self.inner
+            .memory_stats(|k, v| {
                 k.capacity()
                     + v.devices
                         .iter()
@@ -126,7 +124,6 @@ impl SenderKeyDeviceCache {
                         })
                         .sum::<usize>()
             })
-            .sum();
-        wacore::stats::CollectionStats::new(self.inner.entry_count(), bytes as u64)
+            .await
     }
 }

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -112,15 +112,16 @@ impl SenderKeyDeviceCache {
 
     /// Approximate entry count plus estimated retained bytes.
     pub(crate) async fn memory_stats(&self) -> wacore::stats::CollectionStats {
+        // Slot allocations use capacity() (outer and inner maps alike);
+        // per-entry heap is summed by iteration.
         self.inner
             .memory_stats(|k, v| {
                 k.capacity()
+                    + v.devices.capacity() * std::mem::size_of::<(Arc<str>, HashMap<u16, bool>)>()
                     + v.devices
                         .iter()
                         .map(|(user, by_device)| {
-                            user.len()
-                                + std::mem::size_of::<(Arc<str>, HashMap<u16, bool>)>()
-                                + by_device.capacity() * std::mem::size_of::<(u16, bool)>()
+                            user.len() + by_device.capacity() * std::mem::size_of::<(u16, bool)>()
                         })
                         .sum::<usize>()
             })

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -110,8 +110,23 @@ impl SenderKeyDeviceCache {
         }
     }
 
-    #[cfg(feature = "debug-diagnostics")]
-    pub(crate) fn entry_count(&self) -> u64 {
-        self.inner.entry_count()
+    /// Approximate entry count plus estimated retained bytes.
+    pub(crate) fn memory_stats(&self) -> wacore::stats::CollectionStats {
+        let bytes: usize = self
+            .inner
+            .iter()
+            .map(|(k, v)| {
+                k.capacity()
+                    + v.devices
+                        .iter()
+                        .map(|(user, by_device)| {
+                            user.len()
+                                + std::mem::size_of::<(Arc<str>, HashMap<u16, bool>)>()
+                                + by_device.capacity() * std::mem::size_of::<(u16, bool)>()
+                        })
+                        .sum::<usize>()
+            })
+            .sum();
+        wacore::stats::CollectionStats::new(self.inner.entry_count(), bytes as u64)
     }
 }

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -39,6 +39,19 @@ impl NoiseSocket {
         write_key: NoiseCipher,
         read_key: NoiseCipher,
     ) -> Self {
+        Self::with_stats(runtime, transport, write_key, read_key, None)
+    }
+
+    /// Like [`Self::new`], recording sent frames into `stats` (the main WA
+    /// session socket passes the client's [`SessionStats`]; VoIP relay
+    /// sockets and tests pass `None`).
+    pub fn with_stats(
+        runtime: Arc<dyn Runtime>,
+        transport: Arc<dyn Transport>,
+        write_key: NoiseCipher,
+        read_key: NoiseCipher,
+        stats: Option<Arc<wacore::stats::SessionStats>>,
+    ) -> Self {
         let write_key = Arc::new(write_key);
         let read_key = Arc::new(read_key);
 
@@ -56,6 +69,7 @@ impl NoiseSocket {
             transport_clone,
             write_key_clone,
             send_job_rx,
+            stats,
         )));
 
         Self {
@@ -74,6 +88,7 @@ impl NoiseSocket {
         transport: Arc<dyn Transport>,
         write_key: Arc<NoiseCipher>,
         send_job_rx: async_channel::Receiver<SendJob>,
+        stats: Option<Arc<wacore::stats::SessionStats>>,
     ) {
         let mut write_counter: u32 = 0;
         let mut enc_buf = Vec::with_capacity(4096);
@@ -90,6 +105,7 @@ impl NoiseSocket {
                 job.plaintext,
                 &mut enc_buf,
                 &mut out_buf,
+                stats.as_deref(),
             )
             .await;
 
@@ -98,6 +114,7 @@ impl NoiseSocket {
     }
 
     /// Process a single send job: encrypt and send the message.
+    #[allow(clippy::too_many_arguments)]
     async fn process_send_job(
         runtime: &Arc<dyn Runtime>,
         transport: &Arc<dyn Transport>,
@@ -106,6 +123,7 @@ impl NoiseSocket {
         plaintext: bytes::Bytes,
         enc_buf: &mut Vec<u8>,
         out_buf: &mut BytesMut,
+        stats: Option<&wacore::stats::SessionStats>,
     ) -> SendResult {
         let counter = *write_counter;
         // Refuse to wrap the per-direction frame counter: reusing an AES-GCM nonce
@@ -151,8 +169,12 @@ impl NoiseSocket {
         // freeze() converts it to Bytes. The original out_buf retains its
         // allocated capacity for the next frame.
         let frame = out_buf.split().freeze();
+        let wire_bytes = frame.len();
         if let Err(e) = transport.send(frame).await {
             return Err(EncryptSendError::transport(e));
+        }
+        if let Some(stats) = stats {
+            stats.record_frame_sent(wire_bytes);
         }
 
         *write_counter = write_counter.wrapping_add(1);
@@ -465,6 +487,38 @@ mod tests {
                 size, expected_max, actual_encrypted_size
             );
         }
+    }
+
+    /// Locks the SessionStats wire accounting to the transport truth: bytes
+    /// counted must equal the frames the transport actually saw.
+    #[tokio::test]
+    async fn session_stats_match_transport_bytes() {
+        let factory = crate::transport::mock::CapturingMockTransportFactory::new();
+        let transport = factory.transport();
+        let key = [0u8; 32];
+        let stats = Arc::new(wacore::stats::SessionStats::new());
+
+        let socket = NoiseSocket::with_stats(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            transport.clone(),
+            NoiseCipher::new(&key).expect("32-byte key"),
+            NoiseCipher::new(&key).expect("32-byte key"),
+            Some(stats.clone()),
+        );
+
+        for size in [0usize, 100, 5000] {
+            socket
+                .encrypt_and_send(bytes::Bytes::from(vec![0u8; size]))
+                .await
+                .expect("send");
+        }
+
+        let sent = transport.sent();
+        let wire_total: usize = sent.iter().map(|f| f.len()).sum();
+        let snap = stats.snapshot();
+        assert_eq!(snap.frames_sent, sent.len() as u64);
+        assert_eq!(snap.bytes_sent, wire_total as u64);
+        assert!(snap.last_data_sent_ms > 0);
     }
 
     /// Tests edge cases for buffer sizing

--- a/tests/bench-integration/Cargo.toml
+++ b/tests/bench-integration/Cargo.toml
@@ -11,7 +11,6 @@ env_logger = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 whatsapp-rust = { path = "../..", default-features = false, features = [
   "danger-skip-tls-verify",
-  "debug-diagnostics",
   "simd",
   "tokio-runtime",
   "tokio-native",

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -22,7 +22,6 @@ wacore-binary = { path = "../../wacore/binary" }
 whatsapp-rust = { path = "../..", default-features = false, features = [
   "danger-skip-cert-chain-verify",
   "danger-skip-tls-verify",
-  "debug-diagnostics",
   "simd",
   "tokio-runtime",
   "tokio-native",

--- a/tests/e2e/tests/memory_soak.rs
+++ b/tests/e2e/tests/memory_soak.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::io::Read as _;
 use wacore::types::events::Event;
 use whatsapp_rust::Jid;
-use whatsapp_rust::client::MemoryDiagnostics;
+use whatsapp_rust::client::MemoryReport;
 use whatsapp_rust::features::{GroupCreateOptions, GroupParticipantOptions};
 use whatsapp_rust::waproto::whatsapp as wa;
 
@@ -45,27 +45,28 @@ fn rss_kib() -> usize {
 #[derive(Debug, Clone)]
 struct Snapshot {
     round: usize,
-    diag: MemoryDiagnostics,
+    diag: MemoryReport,
     rss_kib: usize,
     #[cfg(feature = "dhat-heap")]
     heap_bytes: usize,
 }
 
 async fn snapshot(label: &str, round: usize, client: &whatsapp_rust::client::Client) -> Snapshot {
-    let diag = client.memory_diagnostics().await;
+    let diag = client.memory_report().await;
     let rss = rss_kib();
     #[cfg(feature = "dhat-heap")]
     let heap_bytes = dhat::HeapStats::get().curr_bytes;
 
     info!(
-        "[round {round:>4}] {label} | RSS={rss}K | bounded(recent_msg={},session_locks={},chat_lanes={},device_reg={}) | unbounded(signal_sess={},signal_id={},signal_sk={},resp_waiters={},pending_retries={},presence_subs={},app_state_kr={},app_state_sync={})",
-        diag.recent_messages,
+        "[round {round:>4}] {label} | RSS={rss}K | est_heap={}B | bounded(recent_msg={},session_locks={},chat_lanes={},device_reg={}) | unbounded(signal_sess={},signal_id={},signal_sk={},resp_waiters={},pending_retries={},presence_subs={},app_state_kr={},app_state_sync={})",
+        diag.total_estimated_bytes(),
+        diag.recent_messages.entries,
         diag.session_locks,
         diag.chat_lanes,
-        diag.device_registry_cache,
-        diag.signal_cache_sessions,
-        diag.signal_cache_identities,
-        diag.signal_cache_sender_keys,
+        diag.device_registry_cache.entries,
+        diag.signal_sessions.entries,
+        diag.signal_identities.entries,
+        diag.signal_sender_keys.entries,
         diag.response_waiters,
         diag.pending_retries,
         diag.presence_subscriptions,
@@ -127,18 +128,18 @@ fn analyze_growth(label: &str, snapshots: &[Snapshot]) {
         ),
         (
             "signal_sessions",
-            first.diag.signal_cache_sessions,
-            last.diag.signal_cache_sessions,
+            first.diag.signal_sessions.entries as usize,
+            last.diag.signal_sessions.entries as usize,
         ),
         (
             "signal_identities",
-            first.diag.signal_cache_identities,
-            last.diag.signal_cache_identities,
+            first.diag.signal_identities.entries as usize,
+            last.diag.signal_identities.entries as usize,
         ),
         (
             "signal_sender_keys",
-            first.diag.signal_cache_sender_keys,
-            last.diag.signal_cache_sender_keys,
+            first.diag.signal_sender_keys.entries as usize,
+            last.diag.signal_sender_keys.entries as usize,
         ),
         (
             "chatstate_handlers",
@@ -179,8 +180,8 @@ fn analyze_growth(label: &str, snapshots: &[Snapshot]) {
     let bounded = [
         (
             "recent_messages",
-            first.diag.recent_messages,
-            last.diag.recent_messages,
+            first.diag.recent_messages.entries,
+            last.diag.recent_messages.entries,
         ),
         (
             "session_locks",
@@ -190,10 +191,14 @@ fn analyze_growth(label: &str, snapshots: &[Snapshot]) {
         ("chat_lanes", first.diag.chat_lanes, last.diag.chat_lanes),
         (
             "device_registry_cache",
-            first.diag.device_registry_cache,
-            last.diag.device_registry_cache,
+            first.diag.device_registry_cache.entries,
+            last.diag.device_registry_cache.entries,
         ),
-        ("group_cache", first.diag.group_cache, last.diag.group_cache),
+        (
+            "group_cache",
+            first.diag.group_cache.entries,
+            last.diag.group_cache.entries,
+        ),
     ];
     info!("  Bounded caches:");
     for (name, fv, lv) in &bounded {

--- a/tests/handshake_integration.rs
+++ b/tests/handshake_integration.rs
@@ -308,6 +308,7 @@ async fn cold_start_xx_then_cached_ik_reconnect() {
         counter2.as_ref(),
         transport.clone(),
         &mut events_rx,
+        None,
     )
     .await;
 
@@ -351,6 +352,7 @@ async fn cold_start_xx_then_cached_ik_reconnect() {
         counter3.as_ref(),
         transport2.clone(),
         &mut events_rx2,
+        None,
     )
     .await;
 
@@ -450,6 +452,7 @@ async fn post_xxfallback_failure_does_not_invalidate_ik_cache() {
         counter.as_ref(),
         transport.clone(),
         &mut events_rx,
+        None,
     )
     .await;
     task.await.unwrap();
@@ -519,6 +522,7 @@ async fn ik_continue_does_not_overwrite_cached_chain() {
         counter.as_ref(),
         transport.clone(),
         &mut events_rx,
+        None,
     )
     .await;
     task.await.unwrap();
@@ -566,6 +570,7 @@ async fn xx_after_pair_success_persists_cert_chain() {
         counter.as_ref(),
         transport1.clone(),
         &mut events_rx1,
+        None,
     )
     .await
     .expect("unpaired XX must succeed");
@@ -595,6 +600,7 @@ async fn xx_after_pair_success_persists_cert_chain() {
         counter.as_ref(),
         transport2.clone(),
         &mut events_rx2,
+        None,
     )
     .await
     .expect("paired XX must succeed");
@@ -637,6 +643,7 @@ async fn unpaired_xx_does_not_persist_cert_chain() {
         counter.as_ref(),
         transport.clone(),
         &mut events_rx,
+        None,
     )
     .await;
     task.await.unwrap();
@@ -768,6 +775,7 @@ async fn ik_rejected_recovers_via_xxfallback_and_repopulates_cache() {
         counter.as_ref(),
         transport.clone(),
         &mut events_rx,
+        None,
     )
     .await;
     task.await.unwrap();
@@ -861,6 +869,7 @@ async fn ik_with_stale_cache_invalidates_and_increments_counter() {
         counter.as_ref(),
         transport.clone(),
         &mut events_rx,
+        None,
     )
     .await;
 

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -18,7 +18,6 @@ ignored = ["getrandom"]
 [features]
 default = ["simd"]
 simd = ["wacore-appstate/simd"]
-debug-diagnostics = []
 debug-snapshots = []
 # Optional observability: emit tracing spans/events. Off by default (no dep).
 tracing = ["dep:tracing"]

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -562,6 +562,21 @@ impl SenderKeyRecord {
     pub fn serialize(&self) -> Result<Vec<u8>, SignalProtocolError> {
         Ok(self.as_protobuf().encode_to_vec())
     }
+
+    /// Estimated in-memory footprint proxy: encoded size of each state's
+    /// structure plus the out-of-order message-key backlog (held outside the
+    /// protobuf in memory). Size computation only — nothing is cloned or
+    /// encoded. Used by per-session memory reports.
+    pub fn estimated_size(&self) -> usize {
+        let mut cache = buffa::SizeCache::new();
+        self.states
+            .iter()
+            .map(|s| {
+                s.state.compute_size(&mut cache) as usize
+                    + s.message_keys.len() * std::mem::size_of::<StoredMessageKey>()
+            })
+            .sum()
+    }
 }
 
 #[cfg(test)]

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -893,6 +893,24 @@ impl SessionRecord {
         }
     }
 
+    /// Estimated in-memory footprint proxy: the protobuf-encoded size of the
+    /// current plus archived states. Size computation only — no encode buffer
+    /// is allocated. Used by per-session memory reports.
+    pub fn estimated_size(&self) -> usize {
+        let mut cache = buffa::SizeCache::new();
+        let current = self
+            .current_session
+            .as_ref()
+            .map(|s| s.session.compute_size(&mut cache) as usize)
+            .unwrap_or(0);
+        let previous: usize = self
+            .previous_sessions
+            .iter()
+            .map(|s| s.compute_size(&mut cache) as usize)
+            .sum();
+        current + previous
+    }
+
     pub fn remote_registration_id(&self) -> Result<u32, SignalProtocolError> {
         Ok(self
             .session_state()

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -164,6 +164,30 @@ impl GroupInfo {
     }
 }
 
+impl crate::stats::HeapSize for GroupInfo {
+    fn heap_bytes(&self) -> usize {
+        let participants = self.participants.capacity() * size_of::<Jid>()
+            + self
+                .participants
+                .iter()
+                .map(|j| j.heap_bytes())
+                .sum::<usize>();
+        let lid_to_pn = self.lid_to_pn_map.capacity() * size_of::<(CompactString, Jid)>()
+            + self
+                .lid_to_pn_map
+                .iter()
+                .map(|(k, v)| k.heap_bytes() + v.heap_bytes())
+                .sum::<usize>();
+        let pn_to_lid = self.pn_to_lid_map.capacity() * size_of::<(CompactString, CompactString)>()
+            + self
+                .pn_to_lid_map
+                .iter()
+                .map(|(k, v)| k.heap_bytes() + v.heap_bytes())
+                .sum::<usize>();
+        participants + lid_to_pn + pn_to_lid
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -44,6 +44,7 @@ pub mod send;
 pub mod session;
 pub mod shortcake;
 pub mod stanza;
+pub mod stats;
 pub mod sticker_pack;
 
 pub mod store;

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -25,6 +25,13 @@ pub struct ResolvedGroupDevices {
     phash: OnceLock<(Jid, CompactString)>,
 }
 
+impl crate::stats::HeapSize for ResolvedGroupDevices {
+    fn heap_bytes(&self) -> usize {
+        self.devices.capacity() * size_of::<Jid>()
+            + self.devices.iter().map(|j| j.heap_bytes()).sum::<usize>()
+    }
+}
+
 impl ResolvedGroupDevices {
     pub fn new(devices: Vec<Jid>) -> Self {
         Self {

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -29,6 +29,10 @@ impl crate::stats::HeapSize for ResolvedGroupDevices {
     fn heap_bytes(&self) -> usize {
         self.devices.capacity() * size_of::<Jid>()
             + self.devices.iter().map(|j| j.heap_bytes()).sum::<usize>()
+            + self
+                .phash
+                .get()
+                .map_or(0, |(jid, p)| jid.heap_bytes() + p.heap_bytes())
     }
 }
 

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -11,8 +11,8 @@
 //!   on a path that already does AEAD crypto plus a transport write.
 //! - [`HeapSize`] / memory reports only run when called; unused report code
 //!   is dropped by fat LTO.
-//! - [`TaskInstrument`] costs one `Option` check per *spawn* when unset. Only
-//!   an installed instrument pays the per-poll hook.
+//! - [`TaskInstrument`] is resolved once at client build: unset leaves the
+//!   runtime untouched. Only an installed instrument pays the per-poll hook.
 
 use core::future::Future;
 use core::pin::Pin;
@@ -95,18 +95,27 @@ impl SessionStats {
     }
 
     /// One transport data event carrying `frames` decodable frames.
+    ///
+    /// Refreshes the receive timestamp only for multi-frame batches: the
+    /// arrival stamp ([`Self::mark_recv_activity`]) is still fresh in the
+    /// single-frame steady state, and the completion re-stamp exists to keep
+    /// the dead-socket watchdog quiet while a long batch (offline sync)
+    /// drains — not to pay a second clock read per frame.
     #[inline]
     pub fn record_recv_batch(&self, wire_bytes: usize, frames: u32) {
         self.bytes_received
             .fetch_add(wire_bytes as u64, Ordering::Relaxed);
         self.frames_received
             .fetch_add(frames as u64, Ordering::Relaxed);
-        self.last_data_received_ms
-            .store(Self::now_ms(), Ordering::Relaxed);
+        if frames > 1 {
+            self.last_data_received_ms
+                .store(Self::now_ms(), Ordering::Relaxed);
+        }
     }
 
-    /// Refresh the receive-activity timestamp without counting traffic
-    /// (batch completion, so keepalive sees drain time, not arrival time).
+    /// Stamp receive activity at data arrival, without counting traffic
+    /// (WA Web: deadSocketTimer reset). Batch completion is re-stamped by
+    /// [`Self::record_recv_batch`].
     #[inline]
     pub fn mark_recv_activity(&self) {
         self.last_data_received_ms
@@ -319,24 +328,27 @@ impl CpuMeter {
 }
 
 std::thread_local! {
-    /// Poll start of the innermost metered poll on this thread. Executors do
-    /// not nest polls of separately spawned tasks; if a caller ever does, the
-    /// inner poll wins and the outer one records nothing (never double).
-    static POLL_START: core::cell::Cell<Option<crate::time::Instant>> =
-        const { core::cell::Cell::new(None) };
+    /// Start times of the metered polls active on this thread, innermost
+    /// last. A stack, not a single slot: metered scopes can nest (an executor
+    /// may poll a freshly spawned task inline from within an already-metered
+    /// poll, and several meters can share one thread), and each scope must
+    /// keep its own start. Poll scopes strictly nest, so LIFO holds; a nested
+    /// scope's time is also part of its enclosing scope's elapsed.
+    static POLL_START: core::cell::RefCell<Vec<crate::time::Instant>> =
+        const { core::cell::RefCell::new(Vec::new()) };
 }
 
 impl TaskInstrument for CpuMeter {
     fn on_poll_start(&self) {
-        POLL_START.with(|s| s.set(Some(crate::time::Instant::now())));
+        POLL_START.with(|s| s.borrow_mut().push(crate::time::Instant::now()));
     }
 
     fn on_poll_end(&self) {
-        if let Some(start) = POLL_START.with(|s| s.take()) {
+        if let Some(start) = POLL_START.with(|s| s.borrow_mut().pop()) {
             self.busy_nanos
                 .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            self.polls.fetch_add(1, Ordering::Relaxed);
         }
-        self.polls.fetch_add(1, Ordering::Relaxed);
     }
 }
 

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -1,0 +1,479 @@
+//! Per-session resource accounting: wire I/O counters, retained-memory
+//! estimation and a runtime-agnostic task instrumentation hook.
+//!
+//! Everything here is dependency-free and portable (wasm32/ESP32): counters
+//! use `portable_atomic`, CPU metering reads the pluggable
+//! [`crate::time::Instant`] clock, and nothing knows which executor or
+//! allocator the host application uses.
+//!
+//! Cost model:
+//! - [`SessionStats`] is always on: one relaxed `fetch_add` per wire frame,
+//!   on a path that already does AEAD crypto plus a transport write.
+//! - [`HeapSize`] / memory reports only run when called; unused report code
+//!   is dropped by fat LTO.
+//! - [`TaskInstrument`] costs one `Option` check per *spawn* when unset. Only
+//!   an installed instrument pays the per-poll hook.
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::sync::Arc;
+use std::time::Duration;
+
+use portable_atomic::{AtomicU64, Ordering};
+
+use crate::sync_marker::MaybeSendSync;
+
+// ── Wire/session counters ────────────────────────────────────────────────────
+
+/// Cumulative per-session counters, updated at the client's wire chokepoints.
+///
+/// All counters are monotonic over the lifetime of the owning client (they
+/// survive reconnects); only the activity timestamps are reset on connection
+/// teardown. Reads are relaxed: values are statistics, not synchronization.
+#[derive(Debug, Default)]
+pub struct SessionStats {
+    bytes_sent: AtomicU64,
+    bytes_received: AtomicU64,
+    frames_sent: AtomicU64,
+    frames_received: AtomicU64,
+    messages_sent: AtomicU64,
+    messages_received: AtomicU64,
+    reconnects: AtomicU64,
+    /// Timestamp (ms since UNIX epoch) of the last sent WebSocket frame.
+    /// WA Web: `callStanza` → `deadSocketTimer.onOrBefore(deadSocketTime)`.
+    last_data_sent_ms: AtomicU64,
+    /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
+    /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
+    last_data_received_ms: AtomicU64,
+}
+
+/// Point-in-time copy of [`SessionStats`], plus client-level counters the
+/// client fills in ([`Self::reconnect_errors`], [`Self::resends_throttled`]).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StatsSnapshot {
+    /// Post-noise wire bytes written to the transport (includes frame headers
+    /// and AEAD tags; excludes the handshake and TLS/WebSocket overhead).
+    pub bytes_sent: u64,
+    /// Wire bytes received from the transport (same framing semantics).
+    pub bytes_received: u64,
+    pub frames_sent: u64,
+    pub frames_received: u64,
+    /// Outgoing message send attempts (DM/group/status).
+    pub messages_sent: u64,
+    /// Incoming messages successfully decrypted and dispatched.
+    pub messages_received: u64,
+    /// Reconnect attempts started by the auto-reconnect loop.
+    pub reconnects: u64,
+    /// Consecutive reconnect failures (resets on success).
+    pub reconnect_errors: u32,
+    /// Outbound resends dropped by the per-chat rate limiter. Surfaces storm
+    /// chats.
+    pub resends_throttled: u64,
+    pub last_data_sent_ms: u64,
+    pub last_data_received_ms: u64,
+}
+
+impl SessionStats {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn now_ms() -> u64 {
+        crate::time::now_millis().max(0) as u64
+    }
+
+    /// One encrypted frame written to the transport.
+    #[inline]
+    pub fn record_frame_sent(&self, wire_bytes: usize) {
+        self.bytes_sent
+            .fetch_add(wire_bytes as u64, Ordering::Relaxed);
+        self.frames_sent.fetch_add(1, Ordering::Relaxed);
+        self.last_data_sent_ms
+            .store(Self::now_ms(), Ordering::Relaxed);
+    }
+
+    /// One transport data event carrying `frames` decodable frames.
+    #[inline]
+    pub fn record_recv_batch(&self, wire_bytes: usize, frames: u32) {
+        self.bytes_received
+            .fetch_add(wire_bytes as u64, Ordering::Relaxed);
+        self.frames_received
+            .fetch_add(frames as u64, Ordering::Relaxed);
+        self.last_data_received_ms
+            .store(Self::now_ms(), Ordering::Relaxed);
+    }
+
+    /// Refresh the receive-activity timestamp without counting traffic
+    /// (batch completion, so keepalive sees drain time, not arrival time).
+    #[inline]
+    pub fn mark_recv_activity(&self) {
+        self.last_data_received_ms
+            .store(Self::now_ms(), Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_message_sent(&self) {
+        self.messages_sent.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_message_received(&self) {
+        self.messages_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn record_reconnect(&self) {
+        self.reconnects.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Zero the activity timestamps on connection teardown so the dead-socket
+    /// watchdog never reads a previous connection's values. Traffic counters
+    /// are cumulative and survive.
+    pub fn reset_connection_activity(&self) {
+        self.last_data_sent_ms.store(0, Ordering::Relaxed);
+        self.last_data_received_ms.store(0, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn last_data_sent_ms(&self) -> u64 {
+        self.last_data_sent_ms.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn last_data_received_ms(&self) -> u64 {
+        self.last_data_received_ms.load(Ordering::Relaxed)
+    }
+
+    /// Copy the session-level counters. Client-level fields
+    /// (`reconnect_errors`, `resends_throttled`) are left zero for the owner
+    /// to fill.
+    pub fn snapshot(&self) -> StatsSnapshot {
+        StatsSnapshot {
+            bytes_sent: self.bytes_sent.load(Ordering::Relaxed),
+            bytes_received: self.bytes_received.load(Ordering::Relaxed),
+            frames_sent: self.frames_sent.load(Ordering::Relaxed),
+            frames_received: self.frames_received.load(Ordering::Relaxed),
+            messages_sent: self.messages_sent.load(Ordering::Relaxed),
+            messages_received: self.messages_received.load(Ordering::Relaxed),
+            reconnects: self.reconnects.load(Ordering::Relaxed),
+            reconnect_errors: 0,
+            resends_throttled: 0,
+            last_data_sent_ms: self.last_data_sent_ms.load(Ordering::Relaxed),
+            last_data_received_ms: self.last_data_received_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+// ── Retained-memory estimation ───────────────────────────────────────────────
+
+/// Estimated heap bytes owned by a value, excluding `size_of::<Self>()` and
+/// allocator overhead.
+///
+/// Implementations are honest approximations (protobuf-encoded size for
+/// Signal records, string/collection payload sums elsewhere): good for
+/// per-session attribution and growth tracking, not for byte-exact accounting.
+pub trait HeapSize {
+    fn heap_bytes(&self) -> usize;
+}
+
+impl<T: HeapSize> HeapSize for Arc<T> {
+    /// Counted where the owning collection holds it; sharing is intra-client
+    /// in practice, so attributing the full size to each holder's client is
+    /// the useful semantics.
+    fn heap_bytes(&self) -> usize {
+        core::mem::size_of::<T>() + T::heap_bytes(self)
+    }
+}
+
+impl HeapSize for Vec<u8> {
+    fn heap_bytes(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl HeapSize for String {
+    fn heap_bytes(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl HeapSize for str {
+    fn heap_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+impl HeapSize for wacore_binary::CompactString {
+    fn heap_bytes(&self) -> usize {
+        if self.is_heap_allocated() {
+            self.len()
+        } else {
+            0
+        }
+    }
+}
+
+impl HeapSize for wacore_binary::Jid {
+    fn heap_bytes(&self) -> usize {
+        self.user.heap_bytes()
+    }
+}
+
+/// Entry count plus estimated retained bytes for one internal collection.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CollectionStats {
+    pub entries: u64,
+    /// Estimated retained heap bytes. `0` for store-backed caches whose
+    /// entries live outside this process.
+    pub bytes: u64,
+}
+
+impl CollectionStats {
+    pub fn new(entries: u64, bytes: u64) -> Self {
+        Self { entries, bytes }
+    }
+}
+
+// ── Task instrumentation ─────────────────────────────────────────────────────
+
+/// Runtime-agnostic hook called around every poll of the client's internal
+/// tasks (and around its blocking work).
+///
+/// The library never installs one by itself; the application opts in at build
+/// time. Implementations plug in whatever the platform offers: the built-in
+/// [`CpuMeter`], an allocator-attribution guard on native, `heap_caps`
+/// sampling on ESP32, etc. Calls are balanced: every `on_poll_start` is
+/// followed by `on_poll_end` on the same thread.
+pub trait TaskInstrument: MaybeSendSync {
+    fn on_poll_start(&self);
+    fn on_poll_end(&self);
+}
+
+/// Future wrapper invoking a [`TaskInstrument`] around each poll.
+pub struct MeteredFuture<F> {
+    inner: F,
+    instrument: Arc<dyn TaskInstrument>,
+}
+
+impl<F> MeteredFuture<F> {
+    pub fn new(inner: F, instrument: Arc<dyn TaskInstrument>) -> Self {
+        Self { inner, instrument }
+    }
+}
+
+impl<F: Future + Unpin> Future for MeteredFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        this.instrument.on_poll_start();
+        let result = Pin::new(&mut this.inner).poll(cx);
+        this.instrument.on_poll_end();
+        result
+    }
+}
+
+/// Built-in [`TaskInstrument`]: accumulates poll count and busy time (a
+/// direct CPU proxy) via the pluggable monotonic clock.
+///
+/// On wasm32/embedded this works as soon as the application registers a
+/// monotonic provider (see [`crate::time`]).
+#[derive(Debug, Default)]
+pub struct CpuMeter {
+    busy_nanos: AtomicU64,
+    polls: AtomicU64,
+}
+
+/// Point-in-time copy of a [`CpuMeter`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CpuSnapshot {
+    /// Total time spent inside `poll` (and blocking closures) of the
+    /// instrumented tasks.
+    pub busy: Duration,
+    pub polls: u64,
+}
+
+impl CpuMeter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn snapshot(&self) -> CpuSnapshot {
+        CpuSnapshot {
+            busy: Duration::from_nanos(self.busy_nanos.load(Ordering::Relaxed)),
+            polls: self.polls.load(Ordering::Relaxed),
+        }
+    }
+}
+
+std::thread_local! {
+    /// Poll start of the innermost metered poll on this thread. Executors do
+    /// not nest polls of separately spawned tasks; if a caller ever does, the
+    /// inner poll wins and the outer one records nothing (never double).
+    static POLL_START: core::cell::Cell<Option<crate::time::Instant>> =
+        const { core::cell::Cell::new(None) };
+}
+
+impl TaskInstrument for CpuMeter {
+    fn on_poll_start(&self) {
+        POLL_START.with(|s| s.set(Some(crate::time::Instant::now())));
+    }
+
+    fn on_poll_end(&self) {
+        if let Some(start) = POLL_START.with(|s| s.take()) {
+            self.busy_nanos
+                .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        }
+        self.polls.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+// ── Runtime decorator ────────────────────────────────────────────────────────
+
+use crate::runtime::{AbortHandle, Runtime};
+
+/// [`Runtime`] decorator that instruments every spawned future (and blocking
+/// closure) with a [`TaskInstrument`]. Wraps any runtime — Tokio, wasm,
+/// embedded — since it only intercepts the trait surface.
+pub struct InstrumentedRuntime {
+    inner: Arc<dyn Runtime>,
+    instrument: Arc<dyn TaskInstrument>,
+}
+
+impl InstrumentedRuntime {
+    pub fn new(inner: Arc<dyn Runtime>, instrument: Arc<dyn TaskInstrument>) -> Self {
+        Self { inner, instrument }
+    }
+}
+
+// The Runtime trait requires Send + Sync even on wasm32 (where concrete
+// runtimes use the same escape hatch); single-threaded, so this is sound.
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for InstrumentedRuntime {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for InstrumentedRuntime {}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait::async_trait]
+impl Runtime for InstrumentedRuntime {
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+        self.inner.spawn(Box::pin(MeteredFuture::new(
+            future,
+            self.instrument.clone(),
+        )))
+    }
+
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        self.inner.sleep(duration)
+    }
+
+    fn spawn_blocking(
+        &self,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        let instrument = self.instrument.clone();
+        self.inner.spawn_blocking(Box::new(move || {
+            instrument.on_poll_start();
+            f();
+            instrument.on_poll_end();
+        }))
+    }
+
+    fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+        self.inner.yield_now()
+    }
+
+    fn yield_frequency(&self) -> u32 {
+        self.inner.yield_frequency()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait::async_trait(?Send)]
+impl Runtime for InstrumentedRuntime {
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + 'static>>) -> AbortHandle {
+        self.inner.spawn(Box::pin(MeteredFuture::new(
+            future,
+            self.instrument.clone(),
+        )))
+    }
+
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()>>> {
+        self.inner.sleep(duration)
+    }
+
+    fn spawn_blocking(&self, f: Box<dyn FnOnce() + 'static>) -> Pin<Box<dyn Future<Output = ()>>> {
+        let instrument = self.instrument.clone();
+        self.inner.spawn_blocking(Box::new(move || {
+            instrument.on_poll_start();
+            f();
+            instrument.on_poll_end();
+        }))
+    }
+
+    fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()>>>> {
+        self.inner.yield_now()
+    }
+
+    fn yield_frequency(&self) -> u32 {
+        self.inner.yield_frequency()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_reflects_recorded_traffic() {
+        let stats = SessionStats::new();
+        stats.record_frame_sent(100);
+        stats.record_frame_sent(50);
+        stats.record_recv_batch(300, 2);
+        stats.record_message_sent();
+        stats.record_message_received();
+        stats.record_reconnect();
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.bytes_sent, 150);
+        assert_eq!(snap.frames_sent, 2);
+        assert_eq!(snap.bytes_received, 300);
+        assert_eq!(snap.frames_received, 2);
+        assert_eq!(snap.messages_sent, 1);
+        assert_eq!(snap.messages_received, 1);
+        assert_eq!(snap.reconnects, 1);
+        assert!(snap.last_data_sent_ms > 0);
+        assert!(snap.last_data_received_ms > 0);
+    }
+
+    #[test]
+    fn reset_connection_activity_keeps_traffic() {
+        let stats = SessionStats::new();
+        stats.record_frame_sent(10);
+        stats.record_recv_batch(20, 1);
+        stats.reset_connection_activity();
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.last_data_sent_ms, 0);
+        assert_eq!(snap.last_data_received_ms, 0);
+        assert_eq!(snap.bytes_sent, 10);
+        assert_eq!(snap.bytes_received, 20);
+    }
+
+    #[test]
+    fn cpu_meter_counts_polls_and_busy_time() {
+        let meter = Arc::new(CpuMeter::new());
+        let instrument: Arc<dyn TaskInstrument> = meter.clone();
+
+        let mut fut = MeteredFuture::new(Box::pin(async {}), instrument);
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        assert!(Pin::new(&mut fut).poll(&mut cx).is_ready());
+
+        let snap = meter.snapshot();
+        assert_eq!(snap.polls, 1);
+    }
+}

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -263,15 +263,24 @@ impl<F> MeteredFuture<F> {
     }
 }
 
+/// Calls `on_poll_end` on drop, so a panicking poll (or blocking closure)
+/// still closes the instrument scope — implementors that scope allocator
+/// attribution would otherwise leak it across the unwind.
+struct PollGuard<'a>(&'a dyn TaskInstrument);
+impl Drop for PollGuard<'_> {
+    fn drop(&mut self) {
+        self.0.on_poll_end();
+    }
+}
+
 impl<F: Future + Unpin> Future for MeteredFuture<F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         this.instrument.on_poll_start();
-        let result = Pin::new(&mut this.inner).poll(cx);
-        this.instrument.on_poll_end();
-        result
+        let _guard = PollGuard(&*this.instrument);
+        Pin::new(&mut this.inner).poll(cx)
     }
 }
 
@@ -377,8 +386,8 @@ impl Runtime for InstrumentedRuntime {
         let instrument = self.instrument.clone();
         self.inner.spawn_blocking(Box::new(move || {
             instrument.on_poll_start();
+            let _guard = PollGuard(&*instrument);
             f();
-            instrument.on_poll_end();
         }))
     }
 
@@ -409,8 +418,8 @@ impl Runtime for InstrumentedRuntime {
         let instrument = self.instrument.clone();
         self.inner.spawn_blocking(Box::new(move || {
             instrument.on_poll_start();
+            let _guard = PollGuard(&*instrument);
             f();
-            instrument.on_poll_end();
         }))
     }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -758,6 +758,9 @@ impl SignalStoreCache {
     /// (sessions, identities, sender_keys). Sizes use the records' encoded-size
     /// proxy (see `SessionRecord::estimated_size`); on-demand only — walks the
     /// caches under their locks.
+    ///
+    /// Session entry counts include negative (`Absent`) and checked-out slots
+    /// — they occupy the map — while bytes cover present records only.
     pub async fn memory_stats(
         &self,
     ) -> (

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -754,13 +754,53 @@ impl SignalStoreCache {
         Ok(())
     }
 
-    /// Returns the number of entries in each store (sessions, identities, sender_keys).
-    #[cfg(feature = "debug-diagnostics")]
-    pub async fn entry_counts(&self) -> (usize, usize, usize) {
-        let s = self.sessions.lock().await;
-        let i = self.identities.lock().await;
-        let sk = self.sender_keys.lock().await;
-        (s.cache.len(), i.cache.len(), sk.cache.len())
+    /// Entry counts and estimated retained bytes for each store
+    /// (sessions, identities, sender_keys). Sizes use the records' encoded-size
+    /// proxy (see `SessionRecord::estimated_size`); on-demand only — walks the
+    /// caches under their locks.
+    pub async fn memory_stats(
+        &self,
+    ) -> (
+        crate::stats::CollectionStats,
+        crate::stats::CollectionStats,
+        crate::stats::CollectionStats,
+    ) {
+        use crate::stats::CollectionStats;
+
+        let sessions = {
+            let s = self.sessions.lock().await;
+            let bytes: usize = s
+                .cache
+                .iter()
+                .map(|(k, v)| {
+                    k.len()
+                        + match v {
+                            SessionEntry::Present(rec) => rec.estimated_size(),
+                            SessionEntry::Absent | SessionEntry::CheckedOut => 0,
+                        }
+                })
+                .sum();
+            CollectionStats::new(s.cache.len() as u64, bytes as u64)
+        };
+        let identities = {
+            let i = self.identities.lock().await;
+            let bytes: usize = i
+                .cache
+                .iter()
+                .map(|(k, v)| k.len() + v.as_ref().map_or(0, |b| b.len()))
+                .sum();
+            CollectionStats::new(i.cache.len() as u64, bytes as u64)
+        };
+        let sender_keys = {
+            let sk = self.sender_keys.lock().await;
+            let bytes: usize = sk
+                .cache
+                .iter()
+                .map(|(k, v)| k.len() + v.as_ref().map_or(0, |r| r.estimated_size()))
+                .sum();
+            CollectionStats::new(sk.cache.len() as u64, bytes as u64)
+        };
+        (sessions, identities, sender_keys)
     }
 
     /// Clear all cached state (used on disconnect/reconnect).

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -767,21 +767,34 @@ impl SignalStoreCache {
     ) {
         use crate::stats::CollectionStats;
 
-        let sessions = {
+        // Sizing a record walks its whole protobuf tree, and these mutexes
+        // serialize the Signal encrypt/decrypt path — so only key lengths and
+        // Arc refcount bumps happen under the locks; the estimated_size walks
+        // run after each guard drops. Identities are raw bytes (len is free)
+        // and stay fully under their lock.
+        let (session_count, session_keys_len, session_recs): (u64, usize, Vec<_>) = {
             let s = self.sessions.lock().await;
-            let bytes: usize = s
+            let mut keys_len = 0usize;
+            let recs = s
                 .cache
                 .iter()
-                .map(|(k, v)| {
-                    k.len()
-                        + match v {
-                            SessionEntry::Present(rec) => rec.estimated_size(),
-                            SessionEntry::Absent | SessionEntry::CheckedOut => 0,
-                        }
+                .filter_map(|(k, v)| {
+                    keys_len += k.len();
+                    match v {
+                        SessionEntry::Present(rec) => Some(rec.clone()),
+                        SessionEntry::Absent | SessionEntry::CheckedOut => None,
+                    }
                 })
-                .sum();
-            CollectionStats::new(s.cache.len() as u64, bytes as u64)
+                .collect();
+            (s.cache.len() as u64, keys_len, recs)
         };
+        let session_bytes: usize = session_keys_len
+            + session_recs
+                .iter()
+                .map(|r| r.estimated_size())
+                .sum::<usize>();
+        let sessions = CollectionStats::new(session_count, session_bytes as u64);
+
         let identities = {
             let i = self.identities.lock().await;
             let bytes: usize = i
@@ -791,15 +804,24 @@ impl SignalStoreCache {
                 .sum();
             CollectionStats::new(i.cache.len() as u64, bytes as u64)
         };
-        let sender_keys = {
+
+        let (sk_count, sk_keys_len, sk_recs): (u64, usize, Vec<_>) = {
             let sk = self.sender_keys.lock().await;
-            let bytes: usize = sk
+            let mut keys_len = 0usize;
+            let recs = sk
                 .cache
                 .iter()
-                .map(|(k, v)| k.len() + v.as_ref().map_or(0, |r| r.estimated_size()))
-                .sum();
-            CollectionStats::new(sk.cache.len() as u64, bytes as u64)
+                .filter_map(|(k, v)| {
+                    keys_len += k.len();
+                    v.clone()
+                })
+                .collect();
+            (sk.cache.len() as u64, keys_len, recs)
         };
+        let sk_bytes: usize =
+            sk_keys_len + sk_recs.iter().map(|r| r.estimated_size()).sum::<usize>();
+        let sender_keys = CollectionStats::new(sk_count, sk_bytes as u64);
+
         (sessions, identities, sender_keys)
     }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -760,7 +760,8 @@ impl SignalStoreCache {
     /// caches under their locks.
     ///
     /// Session entry counts include negative (`Absent`) and checked-out slots
-    /// — they occupy the map — while bytes cover present records only.
+    /// — they occupy the map. Byte totals include the key length for every
+    /// slot, but the estimated record payload only for `Present` entries.
     pub async fn memory_stats(
         &self,
     ) -> (

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -96,6 +96,14 @@ pub struct DeviceListRecord {
     pub raw_id: Option<u32>,
 }
 
+impl crate::stats::HeapSize for DeviceListRecord {
+    fn heap_bytes(&self) -> usize {
+        self.user.capacity()
+            + self.devices.capacity() * size_of::<DeviceInfo>()
+            + self.phash.as_ref().map_or(0, |p| p.capacity())
+    }
+}
+
 /// Signal protocol cryptographic storage operations.
 ///
 /// Handles identity keys, sessions, pre-keys, signed pre-keys, and sender keys

--- a/wacore/src/types/lid_pn.rs
+++ b/wacore/src/types/lid_pn.rs
@@ -76,6 +76,14 @@ pub struct LidPnEntry {
     pub learning_source: LearningSource,
 }
 
+impl crate::stats::HeapSize for LidPnEntry {
+    /// The identifier strings are shared with the cache keys (`Arc<str>`), so
+    /// counting them here means the report must not count the keys again.
+    fn heap_bytes(&self) -> usize {
+        self.lid.len() + self.phone_number.len()
+    }
+}
+
 impl LidPnEntry {
     /// Create a new entry with the current timestamp
     pub fn new(


### PR DESCRIPTION
# Per-session metrics (memory, I/O, CPU) — agnostic, zero-cost when unused

Answers "what does one client session cost?" precisely — including N clients in a single process — while staying runtime/platform agnostic (Tokio, wasm32, ESP32) and adding **zero dependencies** and **no new feature flags** (net: −1 feature).

## The three surfaces

### 1. `Client::stats()` — always-on wire I/O counters
New `wacore::stats::SessionStats` per client: post-noise wire bytes/frames in+out, messages sent/received, reconnect attempts, plus the activity timestamps. Recorded at exactly two chokepoints — the noise sender task (`NoiseSocket::with_stats`) and the read loop — one relaxed `portable_atomic` add per frame, on a path that already does AEAD + a transport write. The loose `last_data_sent_ms`/`last_data_received_ms` fields on `Client` were absorbed into it (keepalive dead-socket watchdog reads them from here now).

### 2. `Client::memory_report()` — retained memory in bytes, on demand
`MemoryReport` returns entry counts **and estimated retained heap bytes** (`CollectionStats`) for every internal collection, via the new `wacore::stats::HeapSize` trait:
- Signal records use their protobuf encoded size (buffa `compute_size` — size computation only, no encode buffer);
- collections sum key/payload capacities (`GroupInfo`, `DeviceListRecord`, `LidPnEntry`, `ResolvedGroupDevices`, …);
- store-backed caches (Redis etc.) report `bytes: 0` — their entries are not process memory.

On-demand only; unused report code is eliminated by fat LTO (the binary-size CI can prove the zero cost), which is what makes the `debug-diagnostics` feature removable below.

### 3. `BotBuilder::with_task_instrument` — CPU / custom attribution, opt-in
`wacore::stats::TaskInstrument` is an object-safe enter/exit hook called around every poll of the client's internal tasks and around blocking work. Wiring is a `Runtime`-trait decorator (`InstrumentedRuntime`) applied once at `Bot::build` — no spawn-site changes, one `Option` check per spawn when unset, works with any executor because it only touches the trait surface (wasm gets the same `unsafe impl Send/Sync` escape hatch the concrete runtimes use).
- Built-in `CpuMeter`: busy time (direct CPU proxy) + poll count via the pluggable `wacore::time` monotonic clock.
- Custom hooks: allocator attribution, ESP-IDF `heap_caps`, … — the library never learns what the hook does.

## Removed (pre-1.0 breaking changes) — replaced by the above

| Removed | Replacement |
|---|---|
| `debug-diagnostics` feature (root + wacore) and ~15 `#[cfg]` gates | always-compiled report + LTO elimination |
| `MemoryDiagnostics` (counts only) | `MemoryReport` (counts + bytes) |
| `entry_counts()` helpers (signal cache, lid-pn, device registry, sk-device cache) | `memory_stats()` returning `CollectionStats` |
| `Client::resends_throttled_total()` accessor | `StatsSnapshot::resends_throttled` (the accessor existed only because `MemoryDiagnostics` was feature-gated) |
| `pub Client::auto_reconnect_errors` | `pub(crate)`, exposed read-only via `StatsSnapshot::reconnect_errors` |

The e2e `memory_soak.rs` migrated to `MemoryReport` and now also logs estimated heap bytes next to RSS. The wasm CI build drops the feature flag.

## Examples & docs
- `examples/multi_session_metrics.rs` — **two clients in one process**, each reporting wire I/O, retained memory and CPU side by side (the motivating use case).
- `examples/alloc_tracking.rs` — dependency-free counting global allocator attributed per session through the hook (the `tracking-allocator`/dhat pattern).
- `agent_docs/observability.md` — design rules (agnosticism, LTO-elimination instead of feature gates, no PII) and how to extend.

## Verification
- `cargo fmt --all`, `cargo clippy --all --tests` (clean), `cargo test` — 1042 lib tests + suites, all passing, including new tests:
  - `session_stats_match_transport_bytes` — counted bytes == frames the transport actually saw (capturing transport);
  - `stats_snapshot_reflects_counters`, `memory_report_on_fresh_client` (byte attribution asserted), `instrumented_runtime_reports_to_cpu_meter` (spawn + blocking paths);
  - `wacore::stats` unit tests (counters, timestamp reset semantics, CpuMeter).
- `cargo check -p e2e-tests -p bench-integration --tests --benches` — compile clean.
- wasm32: `cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features` — clean (covers the new wasm `InstrumentedRuntime` impl).

VoIP relay sockets deliberately pass `None` stats — `stats()` measures the main WA session socket.