### PR TITLE
fix(stats): make Client::memory_report() Send

### DIFF
--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -442,3 +442,17 @@ impl Client {
         router
     }
 }
+
+#[cfg(test)]
+mod send_checks {
+    /// `Client::memory_report()` must stay `Send`: Veloz awaits it from a multi-threaded
+    /// sampler and it can run inside any `tokio::spawn` / axum handler. This is the regression
+    /// guard for the lid-pn dedup set — once a `HashSet<*const LidPnEntry>` (a raw-pointer set
+    /// is `!Send`) held across the report's `.await`, which silently made the whole future
+    /// `!Send`. Compile-time only: the future is constructed for its type, never polled.
+    #[allow(dead_code)]
+    fn memory_report_future_is_send(c: &super::Client) {
+        fn assert_send<T: Send>(_: &T) {}
+        assert_send(&c.memory_report());
+    }
+}

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -445,11 +445,9 @@ impl Client {
 
 #[cfg(test)]
 mod send_checks {
-    /// `Client::memory_report()` must stay `Send`: Veloz awaits it from a multi-threaded
-    /// sampler and it can run inside any `tokio::spawn` / axum handler. This is the regression
-    /// guard for the lid-pn dedup set — once a `HashSet<*const LidPnEntry>` (a raw-pointer set
-    /// is `!Send`) held across the report's `.await`, which silently made the whole future
-    /// `!Send`. Compile-time only: the future is constructed for its type, never polled.
+    /// Compile-time guard that `memory_report()` stays `Send`: a `!Send` value held
+    /// across an `.await` (e.g. a raw-pointer dedup set) would silently break
+    /// `tokio::spawn` / axum callers. Built for its type only, never polled.
     #[allow(dead_code)]
     fn memory_report_future_is_send(c: &super::Client) {
         fn assert_send<T: Send>(_: &T) {}

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -127,18 +127,26 @@ impl LidPnCache {
         wacore::stats::CollectionStats,
     ) {
         use wacore::stats::HeapSize;
-        let mut lid_ptrs = std::collections::HashSet::new();
+        // Dedup shared entries by their heap ADDRESS as a `usize`, not the raw
+        // `*const LidPnEntry`. A set of raw pointers is `!Send` (raw pointers are
+        // `!Send`/`!Sync`), which would infect this future — held across the two
+        // `.await`s below — and make `Client::memory_report()` `!Send`, unusable from
+        // a multi-threaded runtime. `usize` is `Send` on every target (wasm32 and the
+        // 32-bit MCUs included: `LidPnEntry` is `Sized`, so the pointer is thin and the
+        // `as usize` cast is a plain address on all of them). Address identity is exactly
+        // what we want — the same `Arc` payload counted once.
+        let mut lid_ptrs: std::collections::HashSet<usize> = std::collections::HashSet::new();
         let lid = self
             .lid_to_entry
             .memory_stats(|_, v| {
-                lid_ptrs.insert(Arc::as_ptr(v));
+                lid_ptrs.insert(Arc::as_ptr(v) as usize);
                 v.heap_bytes()
             })
             .await;
         let pn = self
             .pn_to_entry
             .memory_stats(|_, v| {
-                if lid_ptrs.contains(&Arc::as_ptr(v)) {
+                if lid_ptrs.contains(&(Arc::as_ptr(v) as usize)) {
                     0
                 } else {
                     v.heap_bytes()

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -127,14 +127,10 @@ impl LidPnCache {
         wacore::stats::CollectionStats,
     ) {
         use wacore::stats::HeapSize;
-        // Dedup shared entries by their heap ADDRESS as a `usize`, not the raw
-        // `*const LidPnEntry`. A set of raw pointers is `!Send` (raw pointers are
-        // `!Send`/`!Sync`), which would infect this future — held across the two
-        // `.await`s below — and make `Client::memory_report()` `!Send`, unusable from
-        // a multi-threaded runtime. `usize` is `Send` on every target (wasm32 and the
-        // 32-bit MCUs included: `LidPnEntry` is `Sized`, so the pointer is thin and the
-        // `as usize` cast is a plain address on all of them). Address identity is exactly
-        // what we want — the same `Arc` payload counted once.
+        // Dedup by heap address as `usize`, not `*const LidPnEntry`: a raw-pointer
+        // set is `!Send`, and held across the two `.await`s below it would make
+        // `Client::memory_report()` `!Send` (unusable off a single thread). The cast
+        // is a plain address on every target (`LidPnEntry: Sized` → thin pointer).
         let mut lid_ptrs: std::collections::HashSet<usize> = std::collections::HashSet::new();
         let lid = self
             .lid_to_entry


### PR DESCRIPTION
## The bug

`Client::memory_report()`'s future is `!Send`. `lid_pn_cache::memory_stats` dedups the shared `Arc<LidPnEntry>` (stored under both the LID and PN maps) with a `HashSet<*const LidPnEntry>`, and that set is held **across the two `.await`s** inside the report. Raw pointers are `!Send`, so the set poisons the whole future.

The effect: `memory_report()` cannot be awaited from a multi-threaded runtime — not in a `tokio::spawn` task, not in an axum handler. Any server that wants to sample per-session retained memory (the motivating use case of the new instrumentation) hits `*const LidPnEntry cannot be sent between threads safely`.

## The fix

Dedup by the entry's heap **address as `usize`** instead of the raw pointer. `usize` is `Send`, so the future becomes `Send`. Address identity is exactly the dedup key wanted — the same `Arc` payload counted once.

## Portability (wasm32 / esp32)

The cast is target-agnostic: `LidPnEntry` is `Sized`, so `*const LidPnEntry` is a thin pointer and `as usize` is a plain address on every target — wasm32 and the 32-bit MCUs included (both 32-bit, `usize` == pointer width). No `Send` bound is *required* on wasm (single-threaded, `MaybeSendSync` escape hatch), but the code still compiles there unchanged.

## Verification

- Native `cargo test --lib` compiles — including a new compile-time guard asserting the `memory_report()` future is `Send` (regression fence against re-introducing a raw-pointer set across the await).
- `cargo build -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features` passes.
- `cargo clippy --all-targets -- -D warnings` clean.

No behavior change.