### PR TITLE
feat: WA Web parity fixes (offline drain, crypto caps, reconnect, groups)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -531,11 +531,12 @@ pub struct Client {
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,
     /// Wall-clock ms of the last successful authentication (`<success>`), or 0.
-    /// The Fibonacci backoff counter is reset only after a connection has been
-    /// stable for [`STABLE_CONNECTION_RESET_MS`](Self::STABLE_CONNECTION_RESET_MS)
-    /// — mirroring WA Web's `resetDelay: 30000` — so a server that authenticates
-    /// then immediately drops cannot defeat the exponential backoff.
+    /// Gates the WA Web `resetDelay` backoff reset (see [`should_reset_backoff`]).
     pub(crate) connected_at_ms: Arc<AtomicI64>,
+    /// Set when an explicit backoff penalty was applied this connection (429
+    /// rate-limit, manual `reconnect()`); cleared on the next `<success>`. Keeps
+    /// the stability reset from erasing a deliberate penalty (WA Web `cancelReset`).
+    pub(crate) backoff_reset_suppressed: Arc<AtomicBool>,
 
     pub(crate) needs_initial_full_sync: Arc<AtomicBool>,
 
@@ -944,13 +945,19 @@ fn is_encrypt_identity_notification(node: &wacore_binary::NodeRef<'_>) -> bool {
         && node.get_optional_child("identity").is_some()
 }
 
-/// Whether a connection that authenticated at `connected_at_ms` (0 = never
-/// authenticated this cycle) and dropped at `now_ms` stayed up long enough to
-/// reset the reconnect backoff — WA Web's `resetDelay` (30s) semantics. A
-/// server that authenticates then drops inside the window keeps the backoff
-/// escalating instead of snapping back to the 1s base.
-pub(crate) fn connection_was_stable(connected_at_ms: i64, now_ms: i64) -> bool {
-    connected_at_ms != 0
+/// Whether the reconnect backoff counter should snap back to its 1s base after
+/// a disconnect — WA Web's `resetDelay` (30s) semantics. `penalty_pending`
+/// mirrors WA Web's `cancelReset()`: an explicit penalty applied this cycle
+/// (429 rate-limit, or a manual `reconnect()` step) must survive, so a
+/// long-lived-then-rate-limited connection keeps its deliberate backoff instead
+/// of snapping to 1s.
+pub(crate) fn should_reset_backoff(
+    connected_at_ms: i64,
+    now_ms: i64,
+    penalty_pending: bool,
+) -> bool {
+    !penalty_pending
+        && connected_at_ms != 0
         && now_ms.saturating_sub(connected_at_ms) >= Client::STABLE_CONNECTION_RESET_MS
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,7 @@ use rand::{Rng, RngExt};
 use scopeguard;
 use wacore_binary::Jid;
 
-use portable_atomic::AtomicU64;
+use portable_atomic::{AtomicI64, AtomicU64};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 
@@ -530,6 +530,12 @@ pub struct Client {
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,
+    /// Wall-clock ms of the last successful authentication (`<success>`), or 0.
+    /// The Fibonacci backoff counter is reset only after a connection has been
+    /// stable for [`STABLE_CONNECTION_RESET_MS`](Self::STABLE_CONNECTION_RESET_MS)
+    /// — mirroring WA Web's `resetDelay: 30000` — so a server that authenticates
+    /// then immediately drops cannot defeat the exponential backoff.
+    pub(crate) connected_at_ms: Arc<AtomicI64>,
 
     pub(crate) needs_initial_full_sync: Arc<AtomicBool>,
 
@@ -936,6 +942,16 @@ fn is_encrypt_identity_notification(node: &wacore_binary::NodeRef<'_>) -> bool {
             .get_attr("type")
             .is_some_and(|v| v.as_str() == "encrypt")
         && node.get_optional_child("identity").is_some()
+}
+
+/// Whether a connection that authenticated at `connected_at_ms` (0 = never
+/// authenticated this cycle) and dropped at `now_ms` stayed up long enough to
+/// reset the reconnect backoff — WA Web's `resetDelay` (30s) semantics. A
+/// server that authenticates then drops inside the window keeps the backoff
+/// escalating instead of snapping back to the 1s base.
+pub(crate) fn connection_was_stable(connected_at_ms: i64, now_ms: i64) -> bool {
+    connected_at_ms != 0
+        && now_ms.saturating_sub(connected_at_ms) >= Client::STABLE_CONNECTION_RESET_MS
 }
 
 /// Computes a reconnect delay matching WhatsApp Web's Fibonacci backoff:

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -207,6 +207,7 @@ impl Client {
             enable_auto_reconnect: Arc::new(AtomicBool::new(true)),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
             connected_at_ms: Arc::new(portable_atomic::AtomicI64::new(0)),
+            backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
 
             needs_initial_full_sync: Arc::new(AtomicBool::new(false)),
 
@@ -397,16 +398,19 @@ impl Client {
             // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately
             if self.expected_disconnect.load(Ordering::Relaxed) {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
+                // Consume the auth timestamp so a later failed connect can't
+                // read this cycle's stale value as a "stable" connection.
+                self.connected_at_ms.store(0, Ordering::Relaxed);
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
                 continue;
             }
 
-            // Reset the backoff only after a stable connection (WA Web
-            // `resetDelay`): a socket that authenticated and then survived
-            // >= STABLE_CONNECTION_RESET_MS is healthy. A flapping server that
-            // authenticates then drops within the window keeps escalating.
+            // Reset the backoff only after a stable connection, unless an
+            // explicit penalty (429 / manual reconnect) must survive — WA Web
+            // `resetDelay` + `cancelReset`.
             let connected_at = self.connected_at_ms.swap(0, Ordering::Relaxed);
-            if connection_was_stable(connected_at, wacore::time::now_millis()) {
+            let penalty = self.backoff_reset_suppressed.load(Ordering::Relaxed);
+            if should_reset_backoff(connected_at, wacore::time::now_millis(), penalty) {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
             }
 
@@ -684,6 +688,8 @@ impl Client {
         self.intentional_reconnect.store(true, Ordering::Relaxed);
         self.auto_reconnect_errors
             .store(Self::RECONNECT_BACKOFF_STEP, Ordering::Relaxed);
+        // Deliberate step: the stability reset must not erase it.
+        self.backoff_reset_suppressed.store(true, Ordering::Relaxed);
 
         // Same durable-before-receipts gate as disconnect().
         if self

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -7,6 +7,10 @@ use super::*;
 const GROUP_DEVICES_MEMO_CAPACITY: u64 = 64;
 
 impl Client {
+    /// WA Web `resetDelay: 30000` — only after a connection has stayed up this
+    /// long is the reconnect backoff counter reset to its base.
+    pub(crate) const STABLE_CONNECTION_RESET_MS: i64 = 30_000;
+
     pub fn shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
         self.shutdown_notifier.subscribe()
     }
@@ -202,6 +206,7 @@ impl Client {
 
             enable_auto_reconnect: Arc::new(AtomicBool::new(true)),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
+            connected_at_ms: Arc::new(portable_atomic::AtomicI64::new(0)),
 
             needs_initial_full_sync: Arc::new(AtomicBool::new(false)),
 
@@ -394,6 +399,15 @@ impl Client {
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
                 continue;
+            }
+
+            // Reset the backoff only after a stable connection (WA Web
+            // `resetDelay`): a socket that authenticated and then survived
+            // >= STABLE_CONNECTION_RESET_MS is healthy. A flapping server that
+            // authenticates then drops within the window keeps escalating.
+            let connected_at = self.connected_at_ms.swap(0, Ordering::Relaxed);
+            if connection_was_stable(connected_at, wacore::time::now_millis()) {
+                self.auto_reconnect_errors.store(0, Ordering::Relaxed);
             }
 
             let error_count = self.auto_reconnect_errors.fetch_add(1, Ordering::SeqCst);

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -633,6 +633,9 @@ impl Client {
         // The run loop does the stability-gated reset on the next disconnect.
         self.connected_at_ms
             .store(wacore::time::now_millis(), Ordering::Relaxed);
+        // Fresh connection starts un-penalized (see backoff_reset_suppressed).
+        self.backoff_reset_suppressed
+            .store(false, Ordering::Relaxed);
 
         self.update_server_time_offset(node);
 
@@ -1159,6 +1162,9 @@ impl Client {
                     );
                     self.is_logged_in.store(false, Ordering::Relaxed);
                     self.auto_reconnect_errors.fetch_add(5, Ordering::Relaxed);
+                    // Deliberate rate-limit backoff: the stability reset must
+                    // not erase it even if the connection had been up >= 30s.
+                    self.backoff_reset_suppressed.store(true, Ordering::Relaxed);
                 }
                 "503" => {
                     // Server is going down/restarting: mark logged-out so sends fail

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -626,7 +626,13 @@ impl Client {
             "Successfully authenticated with WhatsApp servers! (gen={})",
             current_generation
         );
-        self.auto_reconnect_errors.store(0, Ordering::Relaxed);
+        // Record the auth time but DON'T reset the backoff counter yet: WA Web
+        // resets only after the connection has been stable for ~30s
+        // (`resetDelay`). Resetting on <success> alone lets a server that
+        // authenticates then immediately drops keep us in a 1s reconnect storm.
+        // The run loop does the stability-gated reset on the next disconnect.
+        self.connected_at_ms
+            .store(wacore::time::now_millis(), Ordering::Relaxed);
 
         self.update_server_time_offset(node);
 
@@ -1170,7 +1176,19 @@ impl Client {
                     // WA Web (StreamError.js) knows <stream:error><ack/> (type "ack");
                     // name it instead of "Unknown". Root cause is usually an un-acked
                     // offline stanza; the server's <xmlstreamend/> drives the reconnect.
-                    if let Some(ack) = node.get_optional_child("ack") {
+                    if node.get_optional_child("xml-not-well-formed").is_some() {
+                        // WA Web (Handle/StreamError.js): "bad xml, closing socket"
+                        // → CLOSE_SOCKET. A malformed frame desyncs the stream, so
+                        // recycle the socket proactively instead of keeping the
+                        // broken connection and waiting for the server to end it.
+                        // Counts toward the reconnect backoff (not an expected
+                        // disconnect); is_logged_in clears so sends bail fast.
+                        warn!(
+                            "Stream error <xml-not-well-formed>: closing socket to recycle the stream"
+                        );
+                        self.is_logged_in.store(false, Ordering::Relaxed);
+                        should_disconnect = true;
+                    } else if let Some(ack) = node.get_optional_child("ack") {
                         let id = ack
                             .get_attr("id")
                             .map(|v| v.as_str().to_string())

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -113,6 +113,23 @@ impl Client {
             return;
         }
 
+        self.force_rotate_own_sender_key(group_jid).await;
+    }
+
+    /// Unconditional forward-secrecy rotation: delete the bot's own sender key
+    /// for the group and wipe `sender_key_devices` so the next send takes the
+    /// `force_skdm=true` path and regenerates + redistributes a fresh key.
+    /// Used by the removal audit and by the `<modify>` (number/LID migration)
+    /// path, which WA Web (`modifyParticipantInfo`) rotates unconditionally.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "wa.session.force_rotate_sender_key",
+            level = "debug",
+            skip_all
+        )
+    )]
+    pub(crate) async fn force_rotate_own_sender_key(&self, group_jid: &str) {
         use wacore::libsignal::store::sender_key_name::SenderKeyName;
         use wacore::types::jid::JidExt;
         let snapshot = self.persistence_manager.get_device_snapshot();
@@ -123,7 +140,7 @@ impl Client {
                 .delete_sender_key(sk_name.cache_key())
                 .await;
         }
-        self.flush_signal_cache_batch_safe_logged("rotate_sender_key_on_participant_remove", None)
+        self.flush_signal_cache_batch_safe_logged("force_rotate_own_sender_key", None)
             .await;
 
         if let Err(e) = self
@@ -131,7 +148,7 @@ impl Client {
             .clear_sender_key_devices(group_jid)
             .await
         {
-            log::warn!("rotate_sender_key_on_participant_remove: clear DB failed: {e}");
+            log::warn!("force_rotate_own_sender_key: clear DB failed: {e}");
         }
         self.sender_key_device_cache.invalidate(group_jid).await;
     }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2362,23 +2362,26 @@ fn test_fibonacci_backoff_first_attempt_is_1s() {
 // ── connection stability / backoff reset (WA Web resetDelay) ────────
 
 #[test]
-fn connection_was_stable_requires_uptime_window() {
-    // Never authenticated this cycle → not stable, whatever the clock says.
-    assert!(!connection_was_stable(0, 1_000_000));
-    // Authenticated but dropped inside the 30s window → keep escalating.
+fn should_reset_backoff_requires_uptime_window_and_no_penalty() {
     let start = 1_000_000i64;
-    assert!(!connection_was_stable(
+    let stable = start + Client::STABLE_CONNECTION_RESET_MS;
+    // Never authenticated this cycle → not stable, whatever the clock says.
+    assert!(!should_reset_backoff(0, 1_000_000, false));
+    // Authenticated but dropped inside the 30s window → keep escalating.
+    assert!(!should_reset_backoff(
         start,
-        start + Client::STABLE_CONNECTION_RESET_MS - 1
+        start + Client::STABLE_CONNECTION_RESET_MS - 1,
+        false
     ));
-    // Survived the full window → eligible to reset the backoff.
-    assert!(connection_was_stable(
-        start,
-        start + Client::STABLE_CONNECTION_RESET_MS
-    ));
-    assert!(connection_was_stable(start, start + 60_000));
+    // Survived the full window with no penalty → reset the backoff.
+    assert!(should_reset_backoff(start, stable, false));
+    assert!(should_reset_backoff(start, start + 60_000, false));
+    // An explicit penalty (429 / manual reconnect) survives even a stable
+    // connection (WA Web cancelReset).
+    assert!(!should_reset_backoff(start, stable, true));
+    assert!(!should_reset_backoff(start, start + 60_000, true));
     // A backwards clock jump must not underflow into a spurious reset.
-    assert!(!connection_was_stable(start, start - 5_000));
+    assert!(!should_reset_backoff(start, start - 5_000, false));
 }
 
 // ── stream error tests ─────────────────────────────────────────────

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2359,6 +2359,28 @@ fn test_fibonacci_backoff_first_attempt_is_1s() {
     );
 }
 
+// ── connection stability / backoff reset (WA Web resetDelay) ────────
+
+#[test]
+fn connection_was_stable_requires_uptime_window() {
+    // Never authenticated this cycle → not stable, whatever the clock says.
+    assert!(!connection_was_stable(0, 1_000_000));
+    // Authenticated but dropped inside the 30s window → keep escalating.
+    let start = 1_000_000i64;
+    assert!(!connection_was_stable(
+        start,
+        start + Client::STABLE_CONNECTION_RESET_MS - 1
+    ));
+    // Survived the full window → eligible to reset the backoff.
+    assert!(connection_was_stable(
+        start,
+        start + Client::STABLE_CONNECTION_RESET_MS
+    ));
+    assert!(connection_was_stable(start, start + 60_000));
+    // A backwards clock jump must not underflow into a spurious reset.
+    assert!(!connection_was_stable(start, start - 5_000));
+}
+
 // ── stream error tests ─────────────────────────────────────────────
 
 #[tokio::test]

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -219,6 +219,15 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
                 client
                     .invalidate_persisted_group_metadata(&notification.group_jid)
                     .await;
+                // Also drop the in-memory blob: query_info() checks group_cache
+                // before storage, so a stale Arc<GroupInfo> here would let the
+                // next send rebuild the sender key against the old participant
+                // list (missing the migrated JID, still targeting the old one).
+                client
+                    .get_group_cache()
+                    .await
+                    .invalidate(&notification.group_jid)
+                    .await;
                 client
                     .force_rotate_own_sender_key(&notification.group_jid.to_string())
                     .await;

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -201,6 +201,28 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
                     )
                     .await;
             }
+            GroupNotificationAction::Modify { .. } => {
+                // A participant changed number / migrated PN<->LID. WA Web
+                // (`modifyParticipantInfo`) deletes the old user's sender-key
+                // entry, adds the new device, and sets `rotateKey`
+                // unconditionally. We can't granularly patch (the action
+                // carries only the new participants, not the old JID), so drop
+                // the now-stale metadata blob and force-rotate our own sender
+                // key so the next send regenerates and redistributes — matching
+                // WA Web's forward-secrecy rotation and clearing the stale
+                // has_key tracking for the departed number.
+                debug!(
+                    target: "Client/Group",
+                    "Group modify (number/LID migration) for {}: invalidating metadata and rotating sender key",
+                    notification.group_jid.observe()
+                );
+                client
+                    .invalidate_persisted_group_metadata(&notification.group_jid)
+                    .await;
+                client
+                    .force_rotate_own_sender_key(&notification.group_jid.to_string())
+                    .await;
+            }
             _ => {}
         }
 

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -779,6 +779,57 @@ mod tests {
         }
     }
 
+    /// Group `w:gp2` `<modify>` (number/LID migration): WA Web rotates the
+    /// sender key unconditionally, so our handler must force-rotate the own
+    /// group sender key (delete it) so the next send regenerates and
+    /// redistributes — and clear the stale has_key tracking for the old number.
+    #[tokio::test]
+    async fn test_group_modify_rotates_sender_key() {
+        use wacore::libsignal::store::sender_key_name::SenderKeyName;
+        use wacore::types::jid::JidExt;
+
+        let client = create_test_client().await;
+        let own_jid: Jid = "5511777777777@s.whatsapp.net".parse().unwrap();
+        client
+            .persistence_manager
+            .modify_device(|d| d.pn = Some(own_jid.clone()))
+            .await;
+
+        let group = "120363000000000000@g.us";
+        let sk_name = SenderKeyName::from_parts(group, own_jid.to_protocol_address().as_str());
+        client
+            .signal_cache
+            .put_sender_key(
+                &sk_name,
+                wacore::libsignal::protocol::SenderKeyRecord::new_empty(),
+            )
+            .await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("type", "w:gp2")
+            .attr("from", group)
+            .attr("id", "gp2-modify-1")
+            .attr("t", "1773519041")
+            .children([NodeBuilder::new("modify")
+                .children([NodeBuilder::new("participant")
+                    .attr("jid", "5511888888888@s.whatsapp.net")
+                    .build()])
+                .build()])
+            .build();
+        handle_notification_impl(&client, node_to_arc(node)).await;
+
+        let backend = client.persistence_manager.backend();
+        let sk = client
+            .signal_cache
+            .get_sender_key(&sk_name, &*backend)
+            .await
+            .unwrap();
+        assert!(
+            sk.is_none(),
+            "group <modify> must rotate (delete) the own group sender key"
+        );
+    }
+
     #[tokio::test]
     async fn test_contacts_update_hash_only_ignored() {
         // WA Web sends <update hash="Quvc"/> without jid when using hash-based lookup.

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -789,13 +789,26 @@ mod tests {
         use wacore::types::jid::JidExt;
 
         let client = create_test_client().await;
-        let own_jid: Jid = "5511777777777@s.whatsapp.net".parse().unwrap();
+        let own_jid: Jid = "12025550101@s.whatsapp.net".parse().unwrap();
         client
             .persistence_manager
             .modify_device(|d| d.pn = Some(own_jid.clone()))
             .await;
 
         let group = "120363000000000000@g.us";
+        // Seed has_key tracking for the migrating device so we can assert the
+        // rotation clears it (not just the cached sender key).
+        let migrated_jid: Jid = "12025550102@s.whatsapp.net".parse().unwrap();
+        client
+            .set_sender_key_status_for_devices(
+                group,
+                std::slice::from_ref(&migrated_jid),
+                true,
+                false,
+            )
+            .await
+            .unwrap();
+
         let sk_name = SenderKeyName::from_parts(group, own_jid.to_protocol_address().as_str());
         client
             .signal_cache
@@ -812,7 +825,7 @@ mod tests {
             .attr("t", "1773519041")
             .children([NodeBuilder::new("modify")
                 .children([NodeBuilder::new("participant")
-                    .attr("jid", "5511888888888@s.whatsapp.net")
+                    .attr("jid", "12025550102@s.whatsapp.net")
                     .build()])
                 .build()])
             .build();
@@ -827,6 +840,15 @@ mod tests {
         assert!(
             sk.is_none(),
             "group <modify> must rotate (delete) the own group sender key"
+        );
+        assert!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(group)
+                .await
+                .unwrap()
+                .is_empty(),
+            "group <modify> must clear stale sender_key_devices tracking"
         );
     }
 

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -771,6 +771,16 @@ impl Client {
         for item in items.iter() {
             self.ack_received_message(&item.info);
         }
+        // WA Web `createSnapshot` sends `sendAggregateOfflineReceipts` per
+        // snapshot, not once at drain end. Flush the receipts this batch's acks
+        // just buffered now that the batch is durable: bounds the buffer over a
+        // large backlog and caps redelivery on a mid-drain disconnect to a
+        // single snapshot instead of the whole backlog (a disconnect clears the
+        // buffer, so anything already flushed is not re-sent). Gated on the
+        // durable path — a non-durable batch returned above without acking.
+        if is_drain {
+            self.flush_offline_receipts();
+        }
         self.core.event_bus.dispatch(Event::Messages(MessageBatch {
             messages: items,
             origin,
@@ -1267,6 +1277,36 @@ mod tests {
                 .flush_inbound_commits_under_permit(false, None, None)
                 .await,
             "with the flush succeeding the empty commit reports durable"
+        );
+    }
+
+    // WA Web createSnapshot flushes aggregate offline receipts per snapshot;
+    // a durable OfflineDrain commit must drain the buffer instead of holding it
+    // until end-of-drain.
+    #[tokio::test]
+    async fn durable_drain_commit_flushes_offline_receipts_per_snapshot() {
+        let client = create_test_client_with_failing_http("batch_offline_flush").await;
+        client.inbound_commit_batch.reset(); // back into drain mode
+
+        // Batcher active → the receipt buffers instead of going 1:1.
+        let buffered = item("R1").info;
+        assert!(client.try_buffer_offline_receipt(&buffered));
+        assert_eq!(client.offline_receipt_buffer.lock().expect("buf").len(), 1);
+
+        client.commit_or_batch_inbound(item("D1")).await;
+        assert!(
+            client
+                .flush_inbound_commits_under_permit(false, None, None)
+                .await,
+            "the drain batch must commit durably"
+        );
+        assert!(
+            client
+                .offline_receipt_buffer
+                .lock()
+                .expect("buf")
+                .is_empty(),
+            "a durable drain commit flushes the buffered offline receipts per snapshot"
         );
     }
 

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -14,20 +14,15 @@ use std::sync::atomic::Ordering;
 use wacore::store::traits::{PendingInboundKey, PendingInboundRow};
 use wacore::types::events::{BatchOrigin, InboundMessage, MessageBatch};
 
-/// WA Web's message-processor cache flushes a snapshot every
-/// `web_message_processing_cache_size` messages (AB prop default 400). This is
-/// distinct from the offline *pull* size (`DEFAULT_MAX_BATCH_SIZE` = 200, the
-/// `<offline_batch count>` request); the snapshot granularity is 400.
+/// WA Web `web_message_processing_cache_size` (400) — the snapshot flush
+/// granularity, distinct from the 200-msg offline *pull* size.
 const MAX_BATCH_MESSAGES: usize = 400;
-/// Byte cap so a media-heavy backlog cannot hold multi-MB protos in memory;
-/// WA Web caps by count only, we are stricter.
+/// Byte cap so a media-heavy backlog cannot hold multi-MB protos in memory
+/// (WA Web caps by count only; we are stricter).
 const MAX_BATCH_BYTES: usize = 4 * 1024 * 1024;
-/// Deliberate safety-net timeout so a slow trickle still commits durably
-/// instead of sitting uncommitted until the size cap or end-of-drain. This is
-/// a divergence from WA Web on purpose: WA Web's message-cache timeout
-/// (`web_offline_message_processor_timeout_seconds`) defaults to 0/disabled
-/// because its cache flushes on the end-of-drain snapshot regardless; we keep a
-/// bounded window because our durability hook must not lag arbitrarily.
+/// Safety-net so a slow trickle still commits durably instead of waiting for
+/// the size cap or end-of-drain. Deliberately stricter than WA Web (whose cache
+/// timeout defaults to 0) because our durability hook must not lag.
 const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 #[derive(Default)]

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -14,15 +14,20 @@ use std::sync::atomic::Ordering;
 use wacore::store::traits::{PendingInboundKey, PendingInboundRow};
 use wacore::types::events::{BatchOrigin, InboundMessage, MessageBatch};
 
-/// WA Web pulls the offline backlog in server batches of 200
-/// (`DEFAULT_MAX_BATCH_SIZE`); one commit per server batch is the natural
-/// granularity.
-const MAX_BATCH_MESSAGES: usize = 200;
+/// WA Web's message-processor cache flushes a snapshot every
+/// `web_message_processing_cache_size` messages (AB prop default 400). This is
+/// distinct from the offline *pull* size (`DEFAULT_MAX_BATCH_SIZE` = 200, the
+/// `<offline_batch count>` request); the snapshot granularity is 400.
+const MAX_BATCH_MESSAGES: usize = 400;
 /// Byte cap so a media-heavy backlog cannot hold multi-MB protos in memory;
 /// WA Web caps by count only, we are stricter.
 const MAX_BATCH_BYTES: usize = 4 * 1024 * 1024;
-/// WA Web's offline pre-ack batcher uses `delayMs: 3000`; the message cache
-/// timeout is an AB prop of the same magnitude.
+/// Deliberate safety-net timeout so a slow trickle still commits durably
+/// instead of sitting uncommitted until the size cap or end-of-drain. This is
+/// a divergence from WA Web on purpose: WA Web's message-cache timeout
+/// (`web_offline_message_processor_timeout_seconds`) defaults to 0/disabled
+/// because its cache flushes on the end-of-drain snapshot regardless; we keep a
+/// bounded window because our durability hook must not lag arbitrarily.
 const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 #[derive(Default)]

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -924,7 +924,10 @@ mod tests {
         assert_eq!(batches.len(), 1, "one commit for the full batch");
         assert_eq!(batches[0].len(), MAX_BATCH_MESSAGES);
         assert_eq!(batches[0][0], "S0");
-        assert_eq!(batches[0][MAX_BATCH_MESSAGES - 1], "S199");
+        assert_eq!(
+            batches[0][MAX_BATCH_MESSAGES - 1],
+            format!("S{}", MAX_BATCH_MESSAGES - 1)
+        );
     }
 
     // Without a hook, the drain still batches the event dispatch.

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -426,12 +426,12 @@ impl Client {
         // wrapped low watermark so the next window is empty ([next_first,
         // next_first)). Keying on NEXT alone would wrongly discard a non-terminal
         // high-end window whose head sits just below MAX.
-        let next_pre_key_id = if id >= MAX_PREKEY_ID && device_snapshot.next_pre_key_id > MAX_PREKEY_ID
-        {
-            next_first
-        } else {
-            device_snapshot.next_pre_key_id
-        };
+        let next_pre_key_id =
+            if id >= MAX_PREKEY_ID && device_snapshot.next_pre_key_id > MAX_PREKEY_ID {
+                next_first
+            } else {
+                device_snapshot.next_pre_key_id
+            };
         self.persistence_manager
             .process_command(DeviceCommand::SetPreKeyWatermarks {
                 next_pre_key_id,
@@ -1213,7 +1213,11 @@ mod window_tests {
         drop(guard);
 
         let (next, first) = snapshot(&client);
-        assert_eq!(first, super::MAX_PREKEY_ID, "head advances onto the surviving key");
+        assert_eq!(
+            first,
+            super::MAX_PREKEY_ID,
+            "head advances onto the surviving key"
+        );
         assert_eq!(
             next,
             super::MAX_PREKEY_ID + 1,
@@ -1227,8 +1231,7 @@ mod window_tests {
     async fn marking_terminal_head_collapses_wrapped_window() {
         use wacore::store::commands::DeviceCommand;
 
-        let client =
-            crate::test_utils::create_test_client_with_name("prekey_mark_terminal").await;
+        let client = crate::test_utils::create_test_client_with_name("prekey_mark_terminal").await;
         client
             .persistence_manager
             .process_command(DeviceCommand::SetPreKeyWatermarks {
@@ -1246,7 +1249,10 @@ mod window_tests {
 
         let (next, first) = snapshot(&client);
         assert_eq!(first, 1, "head wraps to the low watermark");
-        assert_eq!(next, 1, "NEXT collapses onto the wrapped head: window empty");
+        assert_eq!(
+            next, 1,
+            "NEXT collapses onto the wrapped head: window empty"
+        );
     }
 
     /// A consumed window head must not abandon the live keys behind it: the

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -405,6 +405,33 @@ impl Client {
         Ok((id, key_pair.public_key))
     }
 
+    /// WA Web `markKeyAsUploaded`: exclude a one-time prekey that was handed out
+    /// directly (a retry-receipt `<keys>` bundle) from the next batch upload's
+    /// server offer, so the same id is never both direct-distributed AND pooled.
+    /// [`get_or_gen_single_pre_key`](Self::get_or_gen_single_pre_key) always
+    /// returns the current window head (`first_unupload_pre_key_id`), so marking
+    /// advances the low watermark one id past it (wrapping at the 24-bit edge
+    /// like the planner). Idempotent: a no-op if the head already moved (e.g. a
+    /// concurrent batch upload). Caller must hold `prekey_upload_lock`.
+    pub(crate) async fn mark_single_prekey_uploaded(&self, id: u32) -> Result<(), anyhow::Error> {
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        if device_snapshot.first_unupload_pre_key_id != id {
+            return Ok(());
+        }
+        let next_first = if id >= MAX_PREKEY_ID { 1 } else { id + 1 };
+        self.persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: device_snapshot.next_pre_key_id,
+                first_unupload_pre_key_id: next_first,
+            })
+            .await;
+        self.persistence_manager
+            .flush()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to flush prekey watermark after mark: {e:?}"))?;
+        Ok(())
+    }
+
     /// Generate and upload the configured number of pre-keys (see
     /// [`Client::set_wanted_pre_key_count`]). Shared by `upload_pre_keys` and
     /// `upload_pre_keys_at_login` to avoid redundant server count queries.
@@ -1102,6 +1129,37 @@ mod window_tests {
         let (next, first) = snapshot(&client);
         assert_eq!(first, id3);
         assert_eq!(next, id3 + 1);
+    }
+
+    /// WA Web `markKeyAsUploaded`: a retry-distributed prekey must leave the
+    /// unuploaded window so the next batch upload does not re-offer it (which
+    /// would let a third party consume the same one-time id).
+    #[tokio::test]
+    async fn marking_retry_prekey_uploaded_excludes_it_from_reuse() {
+        let client = crate::test_utils::create_test_client_with_name("prekey_mark_uploaded").await;
+
+        let (id1, _) = client.get_or_gen_single_pre_key().await.expect("gen");
+        let (next, first) = snapshot(&client);
+        assert_eq!(first, id1);
+        assert_eq!(next, id1 + 1);
+
+        client.mark_single_prekey_uploaded(id1).await.expect("mark");
+        let (next2, first2) = snapshot(&client);
+        assert_eq!(
+            first2,
+            id1 + 1,
+            "low watermark advances past the marked key"
+        );
+        assert_eq!(next2, id1 + 1, "window is now empty");
+
+        // The next retry key is a fresh id, not a reuse of the marked one.
+        let (id2, _) = client.get_or_gen_single_pre_key().await.expect("fresh");
+        assert_ne!(id2, id1, "marked key must not be reused");
+
+        // Marking with a now-stale id is a no-op (idempotent, head already moved).
+        client.mark_single_prekey_uploaded(id1).await.expect("noop");
+        let (_, first3) = snapshot(&client);
+        assert_eq!(first3, id2, "stale mark leaves the current head untouched");
     }
 
     /// A consumed window head must not abandon the live keys behind it: the

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -405,23 +405,33 @@ impl Client {
         Ok((id, key_pair.public_key))
     }
 
-    /// WA Web `markKeyAsUploaded`: exclude a one-time prekey that was handed out
-    /// directly (a retry-receipt `<keys>` bundle) from the next batch upload's
-    /// server offer, so the same id is never both direct-distributed AND pooled.
-    /// [`get_or_gen_single_pre_key`](Self::get_or_gen_single_pre_key) always
-    /// returns the current window head (`first_unupload_pre_key_id`), so marking
-    /// advances the low watermark one id past it (wrapping at the 24-bit edge
-    /// like the planner). Idempotent: a no-op if the head already moved (e.g. a
-    /// concurrent batch upload). Caller must hold `prekey_upload_lock`.
-    pub(crate) async fn mark_single_prekey_uploaded(&self, id: u32) -> Result<(), anyhow::Error> {
+    /// WA Web `markKeyAsUploaded`: exclude a retry-distributed one-time prekey
+    /// from the next batch upload's server offer, so the same id is never both
+    /// direct-distributed AND pooled. The `_guard` proof makes holding
+    /// `prekey_upload_lock` a compile-time requirement: the snapshot read and
+    /// the watermark write must be atomic against the batch upload path, or a
+    /// stale `next_pre_key_id` could roll the upper watermark back. Idempotent.
+    pub(crate) async fn mark_single_prekey_uploaded(
+        &self,
+        _guard: &async_lock::MutexGuard<'_, ()>,
+        id: u32,
+    ) -> Result<(), anyhow::Error> {
         let device_snapshot = self.persistence_manager.get_device_snapshot();
         if device_snapshot.first_unupload_pre_key_id != id {
             return Ok(());
         }
         let next_first = if id >= MAX_PREKEY_ID { 1 } else { id + 1 };
+        // At the 24-bit edge a preceding allocation leaves NEXT at MAX+1 (out of
+        // range); collapse it onto the wrapped low watermark so the next window
+        // is empty ([next_first, next_first)) instead of a ~16M range.
+        let next_pre_key_id = if device_snapshot.next_pre_key_id > MAX_PREKEY_ID {
+            next_first
+        } else {
+            device_snapshot.next_pre_key_id
+        };
         self.persistence_manager
             .process_command(DeviceCommand::SetPreKeyWatermarks {
-                next_pre_key_id: device_snapshot.next_pre_key_id,
+                next_pre_key_id,
                 first_unupload_pre_key_id: next_first,
             })
             .await;
@@ -1143,7 +1153,12 @@ mod window_tests {
         assert_eq!(first, id1);
         assert_eq!(next, id1 + 1);
 
-        client.mark_single_prekey_uploaded(id1).await.expect("mark");
+        let guard = client.prekey_upload_lock.lock().await;
+        client
+            .mark_single_prekey_uploaded(&guard, id1)
+            .await
+            .expect("mark");
+        drop(guard);
         let (next2, first2) = snapshot(&client);
         assert_eq!(
             first2,
@@ -1157,7 +1172,12 @@ mod window_tests {
         assert_ne!(id2, id1, "marked key must not be reused");
 
         // Marking with a now-stale id is a no-op (idempotent, head already moved).
-        client.mark_single_prekey_uploaded(id1).await.expect("noop");
+        let guard = client.prekey_upload_lock.lock().await;
+        client
+            .mark_single_prekey_uploaded(&guard, id1)
+            .await
+            .expect("noop");
+        drop(guard);
         let (_, first3) = snapshot(&client);
         assert_eq!(first3, id2, "stale mark leaves the current head untouched");
     }

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -421,10 +421,13 @@ impl Client {
             return Ok(());
         }
         let next_first = if id >= MAX_PREKEY_ID { 1 } else { id + 1 };
-        // At the 24-bit edge a preceding allocation leaves NEXT at MAX+1 (out of
-        // range); collapse it onto the wrapped low watermark so the next window
-        // is empty ([next_first, next_first)) instead of a ~16M range.
-        let next_pre_key_id = if device_snapshot.next_pre_key_id > MAX_PREKEY_ID {
+        // Only when marking the terminal id itself (id == MAX) does a preceding
+        // allocation leave NEXT at MAX+1 (out of range); collapse it onto the
+        // wrapped low watermark so the next window is empty ([next_first,
+        // next_first)). Keying on NEXT alone would wrongly discard a non-terminal
+        // high-end window whose head sits just below MAX.
+        let next_pre_key_id = if id >= MAX_PREKEY_ID && device_snapshot.next_pre_key_id > MAX_PREKEY_ID
+        {
             next_first
         } else {
             device_snapshot.next_pre_key_id
@@ -1180,6 +1183,70 @@ mod window_tests {
         drop(guard);
         let (_, first3) = snapshot(&client);
         assert_eq!(first3, id2, "stale mark leaves the current head untouched");
+    }
+
+    /// Marking a non-terminal head near the 24-bit edge must NOT collapse NEXT:
+    /// only advancing past MAX itself wraps. Here the head sits at MAX-1 while
+    /// the window still holds MAX; keying the collapse on NEXT alone would drop
+    /// the surviving terminal key.
+    #[tokio::test]
+    async fn marking_near_boundary_head_preserves_terminal_window_key() {
+        use wacore::store::commands::DeviceCommand;
+
+        let client =
+            crate::test_utils::create_test_client_with_name("prekey_mark_near_boundary").await;
+        // Window [MAX-1, MAX+1): holds ids MAX-1 and MAX. NEXT is legitimately
+        // out of range (exclusive upper bound past the terminal id).
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: super::MAX_PREKEY_ID + 1,
+                first_unupload_pre_key_id: super::MAX_PREKEY_ID - 1,
+            })
+            .await;
+
+        let guard = client.prekey_upload_lock.lock().await;
+        client
+            .mark_single_prekey_uploaded(&guard, super::MAX_PREKEY_ID - 1)
+            .await
+            .expect("mark");
+        drop(guard);
+
+        let (next, first) = snapshot(&client);
+        assert_eq!(first, super::MAX_PREKEY_ID, "head advances onto the surviving key");
+        assert_eq!(
+            next,
+            super::MAX_PREKEY_ID + 1,
+            "NEXT untouched: terminal key MAX is still in the window"
+        );
+    }
+
+    /// Marking the terminal id itself DOES collapse: with NEXT already pinned at
+    /// MAX+1, the window must wrap to an empty low range, not a ~16M span.
+    #[tokio::test]
+    async fn marking_terminal_head_collapses_wrapped_window() {
+        use wacore::store::commands::DeviceCommand;
+
+        let client =
+            crate::test_utils::create_test_client_with_name("prekey_mark_terminal").await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetPreKeyWatermarks {
+                next_pre_key_id: super::MAX_PREKEY_ID + 1,
+                first_unupload_pre_key_id: super::MAX_PREKEY_ID,
+            })
+            .await;
+
+        let guard = client.prekey_upload_lock.lock().await;
+        client
+            .mark_single_prekey_uploaded(&guard, super::MAX_PREKEY_ID)
+            .await
+            .expect("mark");
+        drop(guard);
+
+        let (next, first) = snapshot(&client);
+        assert_eq!(first, 1, "head wraps to the low watermark");
+        assert_eq!(next, 1, "NEXT collapses onto the wrapped head: window empty");
     }
 
     /// A consumed window head must not abandon the live keys behind it: the

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1111,13 +1111,18 @@ impl Client {
             .build();
 
         let keys_node = if wacore::protocol::retry::should_include_keys(retry_count, reason) {
-            // WA Web's getOrGenSinglePreKey = getOrGenPreKeys(1): the retry
-            // prekey is the first unuploaded window key (reused when one is
-            // left over, freshly generated and stored otherwise) and the next
-            // batch upload re-offers it to the server pool. Hold
-            // prekey_upload_lock to serialize the watermark math with uploads.
+            // WA Web's getOrGenSinglePreKey = getOrGenPreKeys(1) followed by
+            // markKeyAsUploaded + markPreKeyAsDirectDistribution: the retry
+            // prekey is handed directly to the peer, so it must NOT also be
+            // re-offered to the server pool — otherwise a third party could
+            // fetch and consume the same one-time id, and one of the two pkmsgs
+            // then fails to decrypt (we delete the private key on first use),
+            // forcing that party into its own retry cycle. Hold
+            // prekey_upload_lock so get-or-gen and the mark-uploaded watermark
+            // advance are one atomic step against the batch upload path.
             let prekey_guard = self.prekey_upload_lock.lock().await;
             let (new_prekey_id, new_prekey_public) = self.get_or_gen_single_pre_key().await?;
+            self.mark_single_prekey_uploaded(new_prekey_id).await?;
             drop(prekey_guard);
             let device_snapshot = self.persistence_manager.get_device_snapshot();
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1111,26 +1111,25 @@ impl Client {
             .build();
 
         let keys_node = if wacore::protocol::retry::should_include_keys(retry_count, reason) {
-            // WA Web's getOrGenSinglePreKey = getOrGenPreKeys(1) followed by
-            // markKeyAsUploaded + markPreKeyAsDirectDistribution: the retry
-            // prekey is handed directly to the peer, so it must NOT also be
-            // re-offered to the server pool — otherwise a third party could
-            // fetch and consume the same one-time id, and one of the two pkmsgs
-            // then fails to decrypt (we delete the private key on first use),
-            // forcing that party into its own retry cycle. Hold
-            // prekey_upload_lock so get-or-gen and the mark-uploaded watermark
-            // advance are one atomic step against the batch upload path.
-            let prekey_guard = self.prekey_upload_lock.lock().await;
-            let (new_prekey_id, new_prekey_public) = self.get_or_gen_single_pre_key().await?;
-            self.mark_single_prekey_uploaded(new_prekey_id).await?;
-            drop(prekey_guard);
-            let device_snapshot = self.persistence_manager.get_device_snapshot();
-
+            // Validate the account BEFORE reserving/marking the prekey: a missing
+            // account bails here, and marking after would abandon a one-time
+            // prekey from the upload window without any receipt going out.
             let device_identity_bytes = device_snapshot
                 .account
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("Missing device account info for retry receipt"))?
                 .encode_to_vec();
+
+            // markKeyAsUploaded: the retry prekey goes directly to the peer, so
+            // it must not also be re-offered to the server pool (a third party
+            // could consume the same one-time id and fail to decrypt). Hold
+            // prekey_upload_lock so get-or-gen and the mark are one atomic step
+            // against the batch upload path.
+            let prekey_guard = self.prekey_upload_lock.lock().await;
+            let (new_prekey_id, new_prekey_public) = self.get_or_gen_single_pre_key().await?;
+            self.mark_single_prekey_uploaded(&prekey_guard, new_prekey_id)
+                .await?;
+            drop(prekey_guard);
 
             Some(wacore::protocol::retry::build_retry_keys_node(
                 &device_snapshot.identity_key.public_key,

--- a/wacore/libsignal/src/protocol/consts.rs
+++ b/wacore/libsignal/src/protocol/consts.rs
@@ -3,7 +3,18 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-pub const MAX_FORWARD_JUMPS: usize = 25_000;
+/// Max chain steps derived in a single decrypt for a normal (peer) session or
+/// a group sender-key. Matches WA Web's `signalFutureMessagesMax` (2000): a
+/// message whose counter is more than this far ahead is rejected (→
+/// retry-receipt path) instead of forcing thousands of KDF derivations, which
+/// would be a per-message CPU amplification / DoS surface.
+pub const MAX_FORWARD_JUMPS: usize = 2_000;
+/// Wider bound for a pairwise session with our OWN other devices. Multi-device
+/// app-sync legitimately jumps far ahead and the peer is trusted, so the DoS
+/// concern does not apply; WA Web uses 2000 uniformly but we keep a wider (yet
+/// still bounded — previously this path was effectively unbounded) ceiling to
+/// avoid regressing self-sync decryption.
+pub const MAX_FORWARD_JUMPS_SELF: usize = 25_000;
 pub const MAX_MESSAGE_KEYS: usize = 2000;
 pub const MAX_RECEIVER_CHAINS: usize = 5;
 pub const ARCHIVED_STATES_MAX_LENGTH: usize = 40;

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -60,6 +60,17 @@ fn encryption_buffer_capacity() -> usize {
     ENCRYPTION_BUFFER.with(|b| b.borrow().buffer.capacity())
 }
 use crate::protocol::consts::MAX_FORWARD_JUMPS;
+
+/// Max chain steps a single decrypt may derive before rejecting a
+/// too-far-ahead counter. Peer sessions match WA Web's `signalFutureMessagesMax`
+/// (2000); a session with our own devices gets the wider self ceiling.
+const fn forward_jump_limit(is_self: bool) -> usize {
+    if is_self {
+        crate::protocol::consts::MAX_FORWARD_JUMPS_SELF
+    } else {
+        MAX_FORWARD_JUMPS
+    }
+}
 use crate::protocol::ratchet::keys::MessageKeyGenerator;
 use crate::protocol::ratchet::{ChainKey, UsePQRatchet};
 use crate::protocol::state::PreKeyId;
@@ -1057,20 +1068,17 @@ fn get_or_create_message_key(
 
     let jump = (counter - chain_index) as usize;
 
-    if jump > MAX_FORWARD_JUMPS {
-        if state.session_with_self()? {
-            log::info!(
-                "{remote_address} Jumping ahead {jump} messages (index: {chain_index}, counter: {counter})"
-            );
-        } else {
-            log::error!(
-                "{remote_address} Exceeded future message limit: {MAX_FORWARD_JUMPS}, index: {chain_index}, counter: {counter})"
-            );
-            return Err(SignalProtocolError::InvalidMessage(
-                original_message_type,
-                "message from too far into the future",
-            ));
-        }
+    // Trusted self-sessions get a wider (but no longer unbounded) ceiling; peer
+    // sessions match WA Web's `signalFutureMessagesMax`.
+    let limit = forward_jump_limit(state.session_with_self()?);
+    if jump > limit {
+        log::error!(
+            "{remote_address} Exceeded future message limit: {limit}, index: {chain_index}, counter: {counter})"
+        );
+        return Err(SignalProtocolError::InvalidMessage(
+            original_message_type,
+            "message from too far into the future",
+        ));
     }
 
     let mut chain_key = *chain_key;
@@ -1092,6 +1100,23 @@ mod tests {
     use crate::protocol::*;
     use async_trait::async_trait;
     use std::collections::HashMap;
+
+    #[test]
+    fn forward_jump_limit_matches_wa_web_signal_future_messages_max() {
+        // Peer sessions cap at WA Web's `signalFutureMessagesMax` (2000); the
+        // self ceiling stays wider but bounded (previously unbounded).
+        assert_eq!(forward_jump_limit(false), 2_000);
+        assert_eq!(
+            forward_jump_limit(false),
+            crate::protocol::consts::MAX_FORWARD_JUMPS
+        );
+        assert_eq!(forward_jump_limit(true), 25_000);
+        assert_eq!(
+            forward_jump_limit(true),
+            crate::protocol::consts::MAX_FORWARD_JUMPS_SELF
+        );
+        assert!(forward_jump_limit(true) > forward_jump_limit(false));
+    }
 
     // -- In-memory stores for test isolation --
 


### PR DESCRIPTION
## What

A blind comparison of the captured WhatsApp Web bundle against `whatsapp-rust` surfaced a set of behavioral divergences (delivery reliability, forward secrecy, DoS surface, reconnect robustness). This PR lands the ones that can be implemented **cleanly and tested**; each is verified against the specific WA Web module on one side and `file:line` on the other. The remaining findings all need a new subsystem or persisted state, so they land as **separate follow-up PRs** rather than being crammed in here (roadmap below).

## Implemented (with tests)

| # | Fix | WA Web ref | Rust |
|---|-----|-----------|------|
| 1 | Offline-drain snapshot size 200 → **400** | `web_message_processing_cache_size` | `commit_batch.rs` `MAX_BATCH_MESSAGES` |
| 2 | Signal forward-jump cap 25000 → **2000** (peer + group); previously-unbounded self-session bounded at 25000 | `signalFutureMessagesMax` (`Crypto/LibraryConfig`) | `libsignal consts.rs`, `session_cipher.rs`, `group_cipher.rs` |
| 3 | Reconnect backoff resets only after a **≥30s stable connection** (not on `<success>`), and an explicit penalty (429 rate-limit, manual `reconnect()`) survives that reset (WA Web `cancelReset`) | `resetDelay` (`Comms.js`) | `client.rs::should_reset_backoff`, `node_io.rs`, `lifecycle.rs` |
| 4 | `<xml-not-well-formed>` stream error **force-closes** the socket | `Handle/StreamError.js` → `CLOSE_SOCKET` | `node_io.rs::handle_stream_error` |
| 5 | Retry-receipt prekey **marked uploaded** so it is not also re-offered to the server pool (no one-time-prekey reuse); the mark is wrap-edge-safe and account prerequisites are validated before the prekey is reserved | `markKeyAsUploaded` (`Send/RetryReceiptJob`) | `retry.rs`, `prekeys.rs::mark_single_prekey_uploaded` |
| 6 | Offline delivery receipts flushed **per drain snapshot** (not only at drain end) | `createSnapshot` → `sendAggregateOfflineReceipts` | `commit_batch.rs::commit_inbound_batch` |
| 7 | Group `<modify>` (number/LID migration) now **rotates the sender key** + invalidates both persisted and in-memory group metadata (was unhandled) | `modifyParticipantInfo` `rotateKey: true` | `handlers/notification/groups.rs`, `sender_keys.rs::force_rotate_own_sender_key` |

New tests: `forward_jump_limit_matches_wa_web_signal_future_messages_max`, `should_reset_backoff_requires_uptime_window_and_no_penalty`, `marking_retry_prekey_uploaded_excludes_it_from_reuse`, `marking_near_boundary_head_preserves_terminal_window_key`, `marking_terminal_head_collapses_wrapped_window`, `durable_drain_commit_flushes_offline_receipts_per_snapshot`, `test_group_modify_rotates_sender_key`. Full workspace lib suite green; `clippy --all --tests` clean.

**Review-driven hardening** (folded in via later commits): backoff preserves explicit 429/manual-reconnect penalties and clears a stale auth timestamp on the expected-disconnect fast path; `mark_single_prekey_uploaded` collapses `next_pre_key_id` **only when marking the terminal id** at the 24-bit edge (a non-terminal high-end head keeps its surviving window key) and takes a `&MutexGuard` proof so the `prekey_upload_lock` contract is compile-enforced; the retry path validates the device account before reserving/marking the prekey; the `<modify>` handler invalidates the in-memory group cache too.

## Follow-up work — separate PRs (each needs new state/subsystem, kept out of this PR to hold the "no tech debt" bar)

- **Signed pre-key rotation job** (WA Web `RotateKeyJob`) — periodic re-generate + upload. Needs a persisted rotation-schedule timestamp (a `#[serde(default)]` Device field) **and** a multi-signed-prekey store keyed by id, so in-flight prekey messages targeting the *old* signed key still decrypt during the transition (today the Device holds a single `signed_pre_key`).
- **Typing auto-`paused` (2.5s) + `composing` refresh (10s)** managed helper (`Presence/ChatAction`) — a per-chat timer subsystem (Weak-ref lifecycle, teardown on disconnect).
- **Read/played receipt privacy gating** (`read-self` when `readreceipts=none`): needs a cached privacy setting populated on connect + refreshed on the privacy-change notification. (The type exists at `wacore/src/iq/privacy.rs`; the fetched settings are currently discarded.)
- **Incoming-retry eligibility ledger** (skip resend for already-delivered / identity-changed): needs per-message delivery + sent-to-identity state. Partially covered today — a resend to a distrusted identity already fails via `message_encrypt`'s `UntrustedIdentity` guard.
- **Dangling-receipt persistence + cleanup loop** (`Clear/DanglingReceipts`): needs a persistent receipt store (schema migration). Largely mitigated by fix #6, which caps mid-drain-disconnect redelivery to one snapshot.
- **Pre-ack of offline `notification`/`receipt` stanzas** (`Offline/ResumePreAckHandler`) and the **ordered ack-level helper** (`Ack/Level`) — small, but no consumer wired yet; land with the offline follow-up.
- Retry `should_include_keys` alignment — **resolved by fix #5**: marking removes the double-offer, so the earlier key inclusion is a retained, now-safe optimization (no separate work).

## Low value — already at parity for the default, or flag-gated off by default

- **Adaptive offline batch-size ladder** (`Offline/Handler` 200→100→50→10): gated behind `isOfflineDynamicBatchSizeEnabled`, which is **off by default**. `offline_resume.rs` already mirrors WA Web's default non-adaptive fixed-200 path, so we are at parity for the shipped behavior; implementing the ladder would be dead-by-default code.
- **Group presence 30s re-subscription poll** (`Group/PresencePoller`): flag-gated, large-groups-only; niche.
- **Independent 20s dead-socket watchdog**: the current keepalive already uses the same 20s threshold; a separate send-armed/receive-reset timer is a concurrency change with marginal benefit.

## Confirmed at parity — no action (documented so effort isn't re-spent)

Sender-key rotation on explicit removal, session window limits (unused-keys 2000 / recv-chains 5 / prev-sessions 40), delivery-receipt aggregation + 256 cap, Fibonacci backoff params / keepalive 15–30s/20s / connect 20s / stream "recycle", retry cap 5 + force-fresh-session + media retry, `AutoAcknowledgeStaleSessions` (flag off upstream; rust already more eager).