### PR TITLE
fix(tctoken): persist issuance timestamp on IQ success and gate cstoken independently

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -254,7 +254,7 @@ mod tests {
         async fn get_all_tc_token_jids(&self) -> StoreResult<Vec<String>> {
             Ok(vec![])
         }
-        async fn delete_expired_tc_tokens(&self, _: i64) -> StoreResult<u32> {
+        async fn delete_expired_tc_tokens(&self, _: i64, _: i64) -> StoreResult<u32> {
             Ok(0)
         }
         async fn store_sent_message(&self, _: &str, _: &str, _: &[u8]) -> StoreResult<()> {

--- a/src/features/tctoken.rs
+++ b/src/features/tctoken.rs
@@ -66,13 +66,22 @@ impl<'a> TcToken<'a> {
 
     /// Prune expired tc tokens from the store.
     ///
-    /// Cutoff is AB-prop-aware via [`Client::tc_token_config()`] — the server
-    /// may override the default 28-day window (e.g. 26 buckets = 182 days).
+    /// Cutoffs are AB-prop-aware via [`Client::tc_token_config()`] — the server
+    /// may override the default 28-day window (e.g. 26 buckets = 182 days). The
+    /// received token and the sender bucket expire on independent windows, so a
+    /// row is dropped only when both are stale.
     pub async fn prune_expired(&self) -> Result<u32, TcTokenError> {
+        use wacore::iq::tctoken::{
+            sender_tc_token_expiration_cutoff_with, tc_token_expiration_cutoff_with,
+        };
+
         let backend = self.client.persistence_manager.backend();
         let tc_config = self.client.tc_token_config().await;
-        let cutoff = wacore::iq::tctoken::tc_token_expiration_cutoff_with(&tc_config);
-        let deleted = backend.delete_expired_tc_tokens(cutoff).await?;
+        let token_cutoff = tc_token_expiration_cutoff_with(&tc_config);
+        let sender_cutoff = sender_tc_token_expiration_cutoff_with(&tc_config);
+        let deleted = backend
+            .delete_expired_tc_tokens(token_cutoff, sender_cutoff)
+            .await?;
 
         if deleted > 0 {
             log::info!(target: "Client/TcToken", "Pruned {} expired tc_tokens", deleted);

--- a/src/handlers/notification/privacy_business.rs
+++ b/src/handlers/notification/privacy_business.rs
@@ -103,8 +103,11 @@ pub(crate) async fn handle_privacy_token_notification(client: &Arc<Client>, node
                     continue;
                 }
 
-                // Timestamp monotonicity guard: only store if incoming >= existing
-                if received.timestamp < existing.token_timestamp {
+                // Timestamp monotonicity guard: only store if incoming >= existing.
+                // A byte-less placeholder (written by sender-side issuance to carry
+                // sender_timestamp) has no real token yet, so always accept the
+                // contact's first real token regardless of its timestamp.
+                if !existing.token.is_empty() && received.timestamp < existing.token_timestamp {
                     debug!(
                         target: "Client/TcToken",
                         "Skipping older token for {} (incoming={}, existing={})",
@@ -230,4 +233,84 @@ pub(crate) async fn handle_business_notification(client: &Arc<Client>, node: &No
     }
 
     client.core.event_bus.dispatch(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::create_test_client;
+    use wacore::store::traits::TcTokenEntry;
+    use wacore_binary::builder::NodeBuilder;
+
+    fn privacy_token_notification(from_lid: &str, t: i64, bytes: Vec<u8>) -> wacore_binary::Node {
+        NodeBuilder::new("notification")
+            .attr("type", "privacy_token")
+            .attr("from", from_lid)
+            .children([NodeBuilder::new("tokens")
+                .children([NodeBuilder::new("token")
+                    .attr("type", "trusted_contact")
+                    .attr("t", t.to_string())
+                    .bytes(bytes)
+                    .build()])
+                .build()])
+            .build()
+    }
+
+    #[tokio::test]
+    async fn stores_new_token_with_no_sender_timestamp() {
+        let client = create_test_client().await;
+        let node = privacy_token_notification("880000001@lid", 1_700_000_000, vec![0xAA, 0xBB]);
+
+        handle_privacy_token_notification(&client, &node.as_node_ref()).await;
+
+        let stored = client
+            .persistence_manager
+            .backend()
+            .get_tc_token("880000001")
+            .await
+            .unwrap()
+            .expect("token should be stored");
+        assert_eq!(stored.token, vec![0xAA, 0xBB]);
+        assert_eq!(stored.token_timestamp, 1_700_000_000);
+        assert_eq!(stored.sender_timestamp, None);
+    }
+
+    #[tokio::test]
+    async fn real_token_replaces_byteless_placeholder_and_keeps_sender_timestamp() {
+        let client = create_test_client().await;
+        let backend = client.persistence_manager.backend();
+
+        // Placeholder written by sender-side issuance: no bytes yet, but a
+        // sender_timestamp that is newer than the contact's incoming token.
+        backend
+            .put_tc_token(
+                "880000002",
+                &TcTokenEntry {
+                    token: Vec::new(),
+                    token_timestamp: 1_700_000_500,
+                    sender_timestamp: Some(1_700_000_500),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Incoming real token has an OLDER timestamp than the placeholder — the
+        // monotonicity guard must not drop it.
+        let node =
+            privacy_token_notification("880000002@lid", 1_700_000_000, vec![0x01, 0x02, 0x03]);
+        handle_privacy_token_notification(&client, &node.as_node_ref()).await;
+
+        let stored = backend.get_tc_token("880000002").await.unwrap().unwrap();
+        assert_eq!(
+            stored.token,
+            vec![0x01, 0x02, 0x03],
+            "real token must replace the placeholder even with an older timestamp"
+        );
+        assert_eq!(stored.token_timestamp, 1_700_000_000);
+        assert_eq!(
+            stored.sender_timestamp,
+            Some(1_700_000_500),
+            "sender_timestamp must survive the first real token"
+        );
+    }
 }

--- a/src/handlers/notification/privacy_business.rs
+++ b/src/handlers/notification/privacy_business.rs
@@ -25,7 +25,6 @@ use wacore_binary::NodeRef;
 )]
 pub(crate) async fn handle_privacy_token_notification(client: &Arc<Client>, node: &NodeRef<'_>) {
     use wacore::iq::tctoken::parse_privacy_token_notification;
-    use wacore::store::traits::TcTokenEntry;
 
     let from_jid = node.attrs().optional_jid("from");
 
@@ -86,68 +85,50 @@ pub(crate) async fn handle_privacy_token_notification(client: &Arc<Client>, node
     let mut token_stored = false;
 
     for received in &received_tokens {
-        match backend.get_tc_token(sender_lid).await {
-            Ok(Some(existing)) => {
-                // Skip if token bytes are identical and timestamp hasn't advanced
-                if existing.token == received.token {
-                    if received.timestamp > existing.token_timestamp {
-                        // Same bytes but newer timestamp — refresh to prevent premature pruning
-                        let refreshed = TcTokenEntry {
-                            token_timestamp: received.timestamp,
-                            ..existing
-                        };
-                        if let Err(e) = backend.put_tc_token(sender_lid, &refreshed).await {
-                            warn!(target: "Client/TcToken", "Failed to refresh tc_token timestamp for {}: {e}", sender_lid);
-                        }
-                    }
-                    continue;
-                }
-
-                // Timestamp monotonicity guard: only store if incoming >= existing.
-                // A byte-less placeholder (written by sender-side issuance to carry
-                // sender_timestamp) has no real token yet, so always accept the
-                // contact's first real token regardless of its timestamp.
-                if !existing.token.is_empty() && received.timestamp < existing.token_timestamp {
-                    debug!(
-                        target: "Client/TcToken",
-                        "Skipping older token for {} (incoming={}, existing={})",
-                        sender_lid, received.timestamp, existing.token_timestamp
-                    );
-                    continue;
-                }
-
-                // Preserve existing sender_timestamp when updating token
-                let entry = TcTokenEntry {
-                    token: received.token.clone(),
-                    token_timestamp: received.timestamp,
-                    sender_timestamp: existing.sender_timestamp,
-                };
-
-                if let Err(e) = backend.put_tc_token(sender_lid, &entry).await {
-                    warn!(target: "Client/TcToken", "Failed to update tc_token for {}: {e}", sender_lid);
-                } else {
-                    debug!(target: "Client/TcToken", "Updated tc_token for {} (t={})", sender_lid, received.timestamp);
-                    token_stored = true;
-                }
-            }
-            Ok(None) => {
-                // New token — no existing entry
-                let entry = TcTokenEntry {
-                    token: received.token.clone(),
-                    token_timestamp: received.timestamp,
-                    sender_timestamp: None,
-                };
-
-                if let Err(e) = backend.put_tc_token(sender_lid, &entry).await {
-                    warn!(target: "Client/TcToken", "Failed to store tc_token for {}: {e}", sender_lid);
-                } else {
-                    debug!(target: "Client/TcToken", "Stored new tc_token for {} (t={})", sender_lid, received.timestamp);
-                    token_stored = true;
-                }
-            }
+        let existing = match backend.get_tc_token(sender_lid).await {
+            Ok(entry) => entry,
             Err(e) => {
                 warn!(target: "Client/TcToken", "Failed to read tc_token for {}: {e}, skipping", sender_lid);
+                continue;
             }
+        };
+
+        if let Some(existing) = &existing {
+            // Same bytes: only advance the timestamp forward.
+            if existing.token == received.token {
+                if received.timestamp > existing.token_timestamp
+                    && let Err(e) = backend
+                        .store_received_tc_token(sender_lid, &received.token, received.timestamp)
+                        .await
+                {
+                    warn!(target: "Client/TcToken", "Failed to refresh tc_token timestamp for {}: {e}", sender_lid);
+                }
+                continue;
+            }
+
+            // Don't replace a real token with an older one. A byte-less
+            // placeholder (written by sender-side issuance) has no real token
+            // yet, so always accept the contact's first real token.
+            if !existing.token.is_empty() && received.timestamp < existing.token_timestamp {
+                debug!(
+                    target: "Client/TcToken",
+                    "Skipping older token for {} (incoming={}, existing={})",
+                    sender_lid, received.timestamp, existing.token_timestamp
+                );
+                continue;
+            }
+        }
+
+        // store_received_tc_token preserves any sender_timestamp written
+        // concurrently by the issuance path.
+        if let Err(e) = backend
+            .store_received_tc_token(sender_lid, &received.token, received.timestamp)
+            .await
+        {
+            warn!(target: "Client/TcToken", "Failed to store tc_token for {}: {e}", sender_lid);
+        } else {
+            debug!(target: "Client/TcToken", "Stored tc_token for {} (t={})", sender_lid, received.timestamp);
+            token_stored = true;
         }
     }
 

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -410,7 +410,12 @@ impl Client {
         // Avoid clobbering a newer local sender_timestamp from post-send issuance
         let incoming_sender_ts = candidate.tc_token_sender_timestamp.map(|ts| ts as i64);
         let merged_sender_ts = if let Ok(Some(existing)) = backend.get_tc_token(token_key).await {
-            if (existing.token_timestamp as u64) > candidate.tc_token_timestamp {
+            // A byte-less placeholder stamps token_timestamp with a sender epoch,
+            // so it must never block a real token from history sync — only skip
+            // when an existing real token is newer.
+            if !existing.token.is_empty()
+                && (existing.token_timestamp as u64) > candidate.tc_token_timestamp
+            {
                 return;
             }
             match (existing.sender_timestamp, incoming_sender_ts) {
@@ -1063,6 +1068,41 @@ mod tests {
                 .unwrap(),
             None,
             "BotOnly must skip a plain group message"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_sync_tctoken_replaces_byteless_placeholder() {
+        let client = crate::test_utils::create_test_client_with_name("history_tctoken_ph").await;
+        let backend = client.persistence_manager.backend();
+
+        // Post-send issuance wrote a placeholder: no bytes, token_timestamp is a
+        // recent sender epoch (newer than the real token minted earlier).
+        backend
+            .touch_tc_token_sender_timestamp("555000999", 2000)
+            .await
+            .unwrap();
+
+        client
+            .store_tc_token_candidate(TcTokenCandidate {
+                id: "555000999@lid".to_string(),
+                tc_token: vec![0xAB, 0xCD],
+                tc_token_timestamp: 1000,
+                tc_token_sender_timestamp: None,
+            })
+            .await;
+
+        let stored = backend.get_tc_token("555000999").await.unwrap().unwrap();
+        assert_eq!(
+            stored.token,
+            vec![0xAB, 0xCD],
+            "history-sync token must replace the placeholder despite its older timestamp"
+        );
+        assert_eq!(stored.token_timestamp, 1000);
+        assert_eq!(
+            stored.sender_timestamp,
+            Some(2000),
+            "the placeholder's sender bucket must be preserved"
         );
     }
 }

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -1,7 +1,7 @@
 use crate::types::events::{Event, LazyHistorySync};
 use std::sync::Arc;
 use wacore::history_sync::{HistoryMsgSecretRecord, TcTokenCandidate, process_history_sync};
-use wacore::store::traits::{MsgSecretEntry, TcTokenEntry};
+use wacore::store::traits::MsgSecretEntry;
 use wacore_binary::{Jid, JidExt as _};
 use waproto::whatsapp::message::HistorySyncNotification;
 
@@ -407,46 +407,37 @@ impl Client {
 
         let backend = self.persistence_manager.backend();
 
-        // Avoid clobbering a newer local sender_timestamp from post-send issuance
-        let incoming_sender_ts = candidate.tc_token_sender_timestamp.map(|ts| ts as i64);
-        let merged_sender_ts = if let Ok(Some(existing)) = backend.get_tc_token(token_key).await {
-            // A byte-less placeholder stamps token_timestamp with a sender epoch,
-            // so it must never block a real token from history sync — only skip
-            // when an existing real token is newer.
-            if !existing.token.is_empty()
-                && (existing.token_timestamp as u64) > candidate.tc_token_timestamp
-            {
-                return;
-            }
-            match (existing.sender_timestamp, incoming_sender_ts) {
-                (Some(e), Some(i)) => Some(e.max(i)),
-                (Some(e), None) => Some(e),
-                (None, i) => i,
-            }
-        } else {
-            incoming_sender_ts
-        };
-
-        let entry = TcTokenEntry {
-            token: candidate.tc_token,
-            token_timestamp: candidate.tc_token_timestamp as i64,
-            sender_timestamp: merged_sender_ts,
-        };
-
-        if let Err(e) = backend.put_tc_token(token_key, &entry).await {
-            log::warn!(
-                target: "Client/TcToken",
-                "Failed to store history sync tctoken for {}: {e}",
-                token_key
-            );
-        } else {
-            log::debug!(
-                target: "Client/TcToken",
-                "Stored tctoken from history sync for {} (t={})",
-                token_key,
-                candidate.tc_token_timestamp
-            );
+        // Skip only when an existing *real* token is newer than this candidate; a
+        // byte-less placeholder stamps token_timestamp with a sender epoch and
+        // must never block the first real token from history sync.
+        if let Ok(Some(existing)) = backend.get_tc_token(token_key).await
+            && !existing.token.is_empty()
+            && (existing.token_timestamp as u64) > candidate.tc_token_timestamp
+        {
+            return;
         }
+
+        // Two atomic upserts — token fields, then the sender bucket (advance-only)
+        // — so a concurrent post-send issuance is never clobbered by this write.
+        if let Err(e) = backend
+            .store_received_tc_token(
+                token_key,
+                &candidate.tc_token,
+                candidate.tc_token_timestamp as i64,
+            )
+            .await
+        {
+            log::warn!(target: "Client/TcToken", "Failed to store history sync tctoken for {}: {e}", jid.observe());
+            return;
+        }
+        if let Some(sender_ts) = candidate.tc_token_sender_timestamp
+            && let Err(e) = backend
+                .touch_tc_token_sender_timestamp(token_key, sender_ts as i64)
+                .await
+        {
+            log::warn!(target: "Client/TcToken", "Failed to record history sync sender_timestamp for {}: {e}", jid.observe());
+        }
+        log::debug!(target: "Client/TcToken", "Stored tctoken from history sync for {} (t={})", jid.observe(), candidate.tc_token_timestamp);
     }
 }
 
@@ -1104,5 +1095,25 @@ mod tests {
             Some(2000),
             "the placeholder's sender bucket must be preserved"
         );
+    }
+
+    #[tokio::test]
+    async fn history_sync_tctoken_seeds_sender_bucket() {
+        let client = crate::test_utils::create_test_client_with_name("history_tctoken_seed").await;
+        let backend = client.persistence_manager.backend();
+
+        // No prior local state — the candidate's own sender timestamp seeds it.
+        client
+            .store_tc_token_candidate(TcTokenCandidate {
+                id: "555000998@lid".to_string(),
+                tc_token: vec![0x01],
+                tc_token_timestamp: 1000,
+                tc_token_sender_timestamp: Some(1500),
+            })
+            .await;
+
+        let stored = backend.get_tc_token("555000998").await.unwrap().unwrap();
+        assert_eq!(stored.token, vec![0x01]);
+        assert_eq!(stored.sender_timestamp, Some(1500));
     }
 }

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -980,9 +980,15 @@ impl Client {
                             }
                         }
 
-                        // Re-issue tctoken so the contact still has a valid token for us
+                        // Re-issue tctoken so the contact still has a valid token for us.
+                        // WA Web ties re-issuance to a primary-device (device 0) identity
+                        // change (sendTcTokenWhenDeviceIdentityChange); companion-device
+                        // changes don't trigger it.
                         let sender_jid = info.source.sender.clone();
-                        if !sender_jid.is_bot() && !sender_jid.is_status_broadcast() {
+                        if sender_jid.device == 0
+                            && !sender_jid.is_bot()
+                            && !sender_jid.is_status_broadcast()
+                        {
                             let client = self.clone();
                             self.runtime
                                 .spawn(Box::pin(async move {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1358,7 +1358,6 @@ impl Client {
         // instead of redoing the full per-member fan-out. None on warm sends.
         let mut distribution_guard: Option<async_lock::MutexGuardArc<()>> = None;
         let mut should_issue_tc_token_after_send = false;
-        let mut used_cached_tc_token_key: Option<String> = None;
         let tc_issue_target = to.clone();
 
         let mut dm_phash: Option<String> = None;
@@ -1821,13 +1820,9 @@ impl Client {
             // tctoken applies to 1:1 chats; status reactions share the fanout
             // path but WA Web does not attach tctokens to them.
             if !to.is_group() && !to.is_newsletter() && !is_status_addon {
-                let (should_issue_after_send, cached_token_key) = self
+                should_issue_tc_token_after_send = self
                     .maybe_include_tc_token(&to, &mut extra_stanza_nodes)
                     .await;
-                should_issue_tc_token_after_send = should_issue_after_send;
-                if should_issue_after_send {
-                    used_cached_tc_token_key = cached_token_key;
-                }
             }
             if should_issue_tc_token_after_send {
                 debug!(target: "Client/TcToken", "Scheduled tc token issuance after send for {}", to.observe());
@@ -1945,13 +1940,9 @@ impl Client {
         if should_issue_tc_token_after_send {
             if let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) {
                 let target = tc_issue_target;
-                let cached_key = used_cached_tc_token_key;
                 self.runtime
                     .spawn(Box::pin(async move {
-                        let issued_ok = client.issue_tc_token_after_send(&target).await;
-                        if issued_ok && let Some(token_key) = cached_key {
-                            client.mark_tc_token_used_after_send(&token_key).await;
-                        }
+                        client.issue_tc_token_after_send(&target).await;
                     }))
                     .detach();
             } else {

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -59,7 +59,7 @@ impl Client {
         let existing = match backend.get_tc_token(token_key).await {
             Ok(entry) => entry,
             Err(e) => {
-                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_key);
+                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", to.observe());
                 None
             }
         };
@@ -71,11 +71,19 @@ impl Client {
             &tc_config,
         );
 
-        let has_valid_tc_token = existing.as_ref().is_some_and(|entry| {
-            !entry.token.is_empty() && !is_tc_token_expired_with(entry.token_timestamp, &tc_config)
+        // Bind the token payloads up front so the match arms encode the choice
+        // without re-checking invariants that choose_privacy_token already proved.
+        let valid_tc_token: Option<&[u8]> = existing.as_ref().and_then(|entry| {
+            (!entry.token.is_empty()
+                && !is_tc_token_expired_with(entry.token_timestamp, &tc_config))
+            .then_some(entry.token.as_slice())
         });
         // cstoken needs both the NCT salt and a resolved account LID (WA Web `D`).
-        let can_build_cs_token = snapshot.nct_salt.is_some() && resolved_lid.is_some();
+        let cs_token_inputs: Option<(&[u8], &wacore_binary::CompactString)> =
+            match (&snapshot.nct_salt, &resolved_lid) {
+                (Some(salt), Some(lid)) => Some((salt.as_slice(), lid)),
+                _ => None,
+            };
 
         let tc_send_enabled = self
             .ab_props
@@ -86,45 +94,38 @@ impl Client {
             .is_enabled(web::WA_NCT_TOKEN_SEND_ENABLED)
             .await;
 
-        match choose_privacy_token(
+        let choice = choose_privacy_token(
             tc_send_enabled,
             nct_send_enabled,
-            has_valid_tc_token,
-            can_build_cs_token,
-        ) {
+            valid_tc_token.is_some(),
+            cs_token_inputs.is_some(),
+        );
+        match choice {
             PrivacyTokenChoice::TcToken => {
-                // `has_valid_tc_token` guarantees a non-empty, non-expired entry.
-                if let Some(entry) = &existing {
-                    extra_nodes.push(build_tc_token_node(&entry.token));
-                }
+                extra_nodes.extend(valid_tc_token.map(build_tc_token_node))
             }
             PrivacyTokenChoice::CsToken => {
-                if let (Some(salt), Some(lid_user)) = (&snapshot.nct_salt, &resolved_lid) {
+                extra_nodes.extend(cs_token_inputs.map(|(salt, lid_user)| {
                     // HMAC input is "user@lid" (account LID without device suffix),
                     // matching WA Web's accountLid.toString().
-                    let recipient_lid =
-                        wacore_binary::Jid::new(lid_user.as_str(), Server::Lid).to_string();
-                    let cs_token = compute_cs_token(salt, &recipient_lid);
-                    extra_nodes.push(build_cs_token_node(&cs_token));
-                    log::debug!(target: "Client/CsToken", "Attached cstoken for {} (NCT fallback)", to.observe());
-                }
+                    let recipient_lid = Jid::new(lid_user.as_str(), Server::Lid).to_string();
+                    build_cs_token_node(&compute_cs_token(salt, &recipient_lid))
+                }));
             }
-            PrivacyTokenChoice::None => {
-                log::debug!(target: "Client/CsToken", "No tctoken or NCT cstoken available for {}", to.observe());
-            }
+            PrivacyTokenChoice::None => {}
         }
+        log::debug!(target: "Client/TcToken", "privacy token for {}: {choice:?}", to.observe());
 
         should_issue_after_send
     }
 
-    /// Returns `true` if the issuance IQ succeeded.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.issue_tc_token", level = "debug", skip_all, fields(to = %to.observe())))]
-    pub(super) async fn issue_tc_token_after_send(&self, to: &Jid) -> bool {
+    pub(super) async fn issue_tc_token_after_send(&self, to: &Jid) {
         use wacore::iq::tctoken::IssuePrivacyTokensSpec;
 
         // Bots and status broadcast don't participate in the privacy token system.
         if to.is_bot() || to.is_status_broadcast() {
-            return false;
+            return;
         }
 
         let issuance_jid = self.resolve_issuance_jid(to).await;
@@ -135,17 +136,14 @@ impl Client {
             .await
         else {
             log::debug!(target: "Client/TcToken", "Failed to issue tc_token for {}", issuance_jid.observe());
-            return false;
+            return;
         };
 
         // Persist any echoed tokens (forward-compatible; the real `set privacy`
         // response carries none — WA Web ingests tokens only from the
         // privacy_token notification).
         self.store_issued_tc_tokens(&response.tokens).await;
-        // Advance the issuance rate-limit on IQ success regardless of echoed
-        // tokens — WA Web's sendTcToken persists tcTokenSenderTimestamp here.
         self.record_tc_token_sender_timestamp(to).await;
-        true
     }
 
     /// Returns true if at least one token was persisted.
@@ -208,37 +206,25 @@ impl Client {
         }
     }
 
-    /// Record that we issued a trusted-contact token to `to` at the current time.
+    /// Advance the issuance rate-limit on IQ success, independent of any tokens
+    /// echoed in the response.
     ///
-    /// WA Web's `sendTcToken` persists `tcTokenSenderTimestamp` on IQ success,
-    /// independent of any token echoed in the response — the real `set privacy`
-    /// response carries no token bytes. Deriving this update from echoed tokens
-    /// would leave the sender bucket permanently unset and re-issue a privacy IQ
-    /// on every 1:1 message. When no token is stored yet, a byte-less placeholder
-    /// carries the timestamp until the contact's token arrives via notification.
+    /// WA Web's `sendTcToken` persists `tcTokenSenderTimestamp` unconditionally
+    /// on success; the real `set privacy` response echoes no bytes, so deriving
+    /// the update from it would leave the sender bucket unset and re-issue on
+    /// every 1:1 message — hence the byte-less placeholder when no entry exists.
     async fn record_tc_token_sender_timestamp(&self, to: &Jid) {
-        use wacore::store::traits::TcTokenEntry;
-
         let key = self.resolve_tc_token_key(to).await;
-        let backend = self.persistence_manager.backend();
         let now = wacore::time::now_secs();
-        let entry = match backend.get_tc_token(&key).await {
-            Ok(Some(existing)) => TcTokenEntry {
-                sender_timestamp: Some(now),
-                ..existing
-            },
-            Ok(None) => TcTokenEntry {
-                token: Vec::new(),
-                token_timestamp: now,
-                sender_timestamp: Some(now),
-            },
-            Err(e) => {
-                log::warn!(target: "Client/TcToken", "Failed to load tc_token for {key}: {e}");
-                return;
-            }
-        };
-        if let Err(e) = backend.put_tc_token(&key, &entry).await {
-            log::warn!(target: "Client/TcToken", "Failed to record tc_token sender_timestamp for {key}: {e}");
+        // Atomic merge so a concurrent privacy_token notification writing the real
+        // token isn't clobbered by this placeholder's read-modify-write.
+        if let Err(e) = self
+            .persistence_manager
+            .backend()
+            .touch_tc_token_sender_timestamp(&key, now)
+            .await
+        {
+            log::warn!(target: "Client/TcToken", "Failed to record tc_token sender_timestamp for {}: {e}", to.observe());
         }
     }
 
@@ -321,7 +307,7 @@ impl Client {
             }
             Ok(_) => None,
             Err(e) => {
-                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_key);
+                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", jid.observe());
                 None
             }
         }

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -129,37 +129,30 @@ impl Client {
         }
 
         let issuance_jid = self.resolve_issuance_jid(to).await;
-        let Ok(response) = self
+        // WA Web's sendTcToken ignores the response body — the echoed token, if
+        // any, is not the one we attach (that comes from the privacy_token
+        // notification). Only the sender-side timestamp is recorded on success.
+        if let Err(e) = self
             .execute(IssuePrivacyTokensSpec::new(std::slice::from_ref(
                 &issuance_jid,
             )))
             .await
-        else {
-            log::debug!(target: "Client/TcToken", "Failed to issue tc_token for {}", issuance_jid.observe());
+        {
+            log::debug!(target: "Client/TcToken", "Failed to issue tc_token for {}: {e}", issuance_jid.observe());
             return;
-        };
-
-        // Persist any echoed tokens (forward-compatible; the real `set privacy`
-        // response carries none — WA Web ingests tokens only from the
-        // privacy_token notification).
-        self.store_issued_tc_tokens(&response.tokens).await;
+        }
         self.record_tc_token_sender_timestamp(to).await;
     }
 
-    /// Returns true if at least one token was persisted.
+    /// Persist tokens returned by the explicit `tc_token().issue_tokens()` API.
     pub(crate) async fn store_issued_tc_tokens(
         &self,
         tokens: &[wacore::iq::tctoken::ReceivedTcToken],
-    ) -> bool {
+    ) {
         use wacore::store::traits::TcTokenEntry;
-
-        if tokens.is_empty() {
-            return false;
-        }
 
         let backend = self.persistence_manager.backend();
         let now = wacore::time::now_secs();
-        let mut any_stored = false;
         for received in tokens {
             if received.token.is_empty() {
                 log::warn!(target: "Client/TcToken", "Server returned empty tc_token for {}, skipping", received.jid.observe());
@@ -174,11 +167,8 @@ impl Client {
 
             if let Err(e) = backend.put_tc_token(&received.jid.user, &entry).await {
                 log::warn!(target: "Client/TcToken", "Failed to store issued tc_token: {e}");
-            } else {
-                any_stored = true;
             }
         }
-        any_stored
     }
 
     /// Variant of [`store_issued_tc_tokens`] that preserves the original

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -3,26 +3,29 @@ use super::*;
 impl Client {
     /// Look up and include a privacy token in outgoing 1:1 message stanza nodes.
     ///
-    /// Follows WA Web's fallback chain (MsgCreateFanoutStanza.js):
-    ///   1. tctoken — from stored trusted contact token (if valid, non-expired)
-    ///   2. cstoken — HMAC-SHA256(nct_salt, recipient_lid) fallback for first-contact
-    ///   3. No token — message sent without token (server may return 463)
+    /// Follows WA Web's fallback chain (MsgCreateFanoutStanza.js `Re = R(te) ?? D(te, s)`):
+    ///   1. tctoken — stored trusted contact token, gated on
+    ///      `privacy_token_sending_on_all_1_on_1_messages` (WA Web `R`).
+    ///   2. cstoken — `HMAC-SHA256(nct_salt, recipient_lid)` fallback, gated
+    ///      independently on `wa_nct_token_send_enabled` (WA Web `D`). The cstoken
+    ///      is NOT nested behind the 1:1 prop — WA Web attaches it even when `R`
+    ///      returns null.
+    ///   3. No token — message sent without token (server may return 463).
     ///
-    /// Returns whether we should issue a new tc token after send, and the cache key
-    /// of the attached valid tc token when that token should be marked as used.
+    /// Returns whether a new tc token should be issued after send.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.maybe_tc_token", level = "debug", skip_all, fields(to = %to.observe())))]
     pub(super) async fn maybe_include_tc_token(
         &self,
         to: &Jid,
         extra_nodes: &mut Vec<Node>,
-    ) -> (bool, Option<String>) {
+    ) -> bool {
         use wacore::iq::abprops::web;
         use wacore::iq::tctoken::{
-            build_cs_token_node, build_tc_token_node, compute_cs_token, is_tc_token_expired_with,
-            should_send_new_tc_token_with,
+            PrivacyTokenChoice, build_cs_token_node, build_tc_token_node, choose_privacy_token,
+            compute_cs_token, is_tc_token_expired_with, should_send_new_tc_token_with,
         };
 
-        // Skip for own JID — no need to send privacy token to ourselves
+        // Skip for own JID — no need to send a privacy token to ourselves.
         let snapshot = self.persistence_manager.get_device_snapshot();
         let is_self = snapshot
             .pn
@@ -33,88 +36,85 @@ impl Client {
                 .as_ref()
                 .is_some_and(|lid| lid.is_same_user_as(to));
         if is_self {
-            return (false, None);
+            return false;
         }
 
-        // Bots and status broadcast don't participate in the privacy token system
+        // Bots and status broadcast don't participate in the privacy token system.
         if to.is_bot() || to.is_status_broadcast() {
-            return (false, None);
+            return false;
         }
 
-        // Resolve the destination to a LID user string once — reused for
-        // tctoken lookup, issuance, and cstoken HMAC input.
-        let cached_lid = if to.is_lid() {
-            None
+        // Resolve the destination to an account LID once — reused for the tctoken
+        // lookup key, the cstoken HMAC input, and issuance rate-limiting.
+        let resolved_lid: Option<wacore_binary::CompactString> = if to.is_lid() {
+            Some(to.user.clone())
         } else {
             self.lid_pn_cache.get_current_lid(&to.user).await
         };
-        let resolved_lid_user: Option<&str> = if to.is_lid() {
-            Some(&to.user)
-        } else {
-            cached_lid.as_deref()
-        };
-        let token_jid: &str = resolved_lid_user.unwrap_or(&to.user);
+        let token_key: &str = resolved_lid.as_deref().unwrap_or(&to.user);
 
         let backend = self.persistence_manager.backend();
         let tc_config = self.tc_token_config().await;
 
-        // Look up existing tctoken
-        let existing = match backend.get_tc_token(token_jid).await {
+        let existing = match backend.get_tc_token(token_key).await {
             Ok(entry) => entry,
             Err(e) => {
-                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_jid);
+                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_key);
                 None
             }
         };
 
-        // Issuance scheduling is independent of the AB prop — WA Web's sendTcToken
-        // in MsgJob.js fires regardless of whether a token was attached to the stanza
+        // Issuance scheduling is independent of the AB props — WA Web's sendTcToken
+        // in MsgJob.js fires regardless of whether a token was attached to the stanza.
         let should_issue_after_send = should_send_new_tc_token_with(
             existing.as_ref().and_then(|entry| entry.sender_timestamp),
             &tc_config,
         );
 
-        // AB prop gates stanza inclusion only (not issuance scheduling)
-        let token_send_enabled = self
+        let has_valid_tc_token = existing.as_ref().is_some_and(|entry| {
+            !entry.token.is_empty() && !is_tc_token_expired_with(entry.token_timestamp, &tc_config)
+        });
+        // cstoken needs both the NCT salt and a resolved account LID (WA Web `D`).
+        let can_build_cs_token = snapshot.nct_salt.is_some() && resolved_lid.is_some();
+
+        let tc_send_enabled = self
             .ab_props
             .is_enabled(web::PRIVACY_TOKEN_SENDING_ON_ALL_1_ON_1_MESSAGES)
             .await;
+        let nct_send_enabled = self
+            .ab_props
+            .is_enabled(web::WA_NCT_TOKEN_SEND_ENABLED)
+            .await;
 
-        if token_send_enabled {
-            match existing {
-                Some(ref entry)
-                    if !is_tc_token_expired_with(entry.token_timestamp, &tc_config)
-                        && !entry.token.is_empty() =>
-                {
+        match choose_privacy_token(
+            tc_send_enabled,
+            nct_send_enabled,
+            has_valid_tc_token,
+            can_build_cs_token,
+        ) {
+            PrivacyTokenChoice::TcToken => {
+                // `has_valid_tc_token` guarantees a non-empty, non-expired entry.
+                if let Some(entry) = &existing {
                     extra_nodes.push(build_tc_token_node(&entry.token));
-                    return (should_issue_after_send, Some(token_jid.to_string()));
                 }
-                _ => {
-                    // cstoken fallback — gated by wa_nct_token_send_enabled
-                    let nct_send_enabled = self
-                        .ab_props
-                        .is_enabled(web::WA_NCT_TOKEN_SEND_ENABLED)
-                        .await;
-
-                    if nct_send_enabled
-                        && let Some(salt) = &snapshot.nct_salt
-                        && let Some(lid_user) = &resolved_lid_user
-                    {
-                        // HMAC input is "user@lid" (account LID without device suffix),
-                        // matching WA Web's accountLid.toString()
-                        let recipient_lid =
-                            wacore_binary::Jid::new(*lid_user, Server::Lid).to_string();
-                        let cs_token = compute_cs_token(salt, &recipient_lid);
-                        extra_nodes.push(build_cs_token_node(&cs_token));
-                        log::debug!(target: "Client/CsToken", "Attached cstoken for {} (NCT fallback)", to.observe());
-                    } else {
-                        log::debug!(target: "Client/CsToken", "No tctoken or NCT salt/LID available for {}", to.observe());
-                    }
+            }
+            PrivacyTokenChoice::CsToken => {
+                if let (Some(salt), Some(lid_user)) = (&snapshot.nct_salt, &resolved_lid) {
+                    // HMAC input is "user@lid" (account LID without device suffix),
+                    // matching WA Web's accountLid.toString().
+                    let recipient_lid =
+                        wacore_binary::Jid::new(lid_user.as_str(), Server::Lid).to_string();
+                    let cs_token = compute_cs_token(salt, &recipient_lid);
+                    extra_nodes.push(build_cs_token_node(&cs_token));
+                    log::debug!(target: "Client/CsToken", "Attached cstoken for {} (NCT fallback)", to.observe());
                 }
+            }
+            PrivacyTokenChoice::None => {
+                log::debug!(target: "Client/CsToken", "No tctoken or NCT cstoken available for {}", to.observe());
             }
         }
 
-        (should_issue_after_send, None)
+        should_issue_after_send
     }
 
     /// Returns `true` if the issuance IQ succeeded.
@@ -122,7 +122,7 @@ impl Client {
     pub(super) async fn issue_tc_token_after_send(&self, to: &Jid) -> bool {
         use wacore::iq::tctoken::IssuePrivacyTokensSpec;
 
-        // Bots and status broadcast don't participate in the privacy token system
+        // Bots and status broadcast don't participate in the privacy token system.
         if to.is_bot() || to.is_status_broadcast() {
             return false;
         }
@@ -138,7 +138,14 @@ impl Client {
             return false;
         };
 
-        self.store_issued_tc_tokens(&response.tokens).await
+        // Persist any echoed tokens (forward-compatible; the real `set privacy`
+        // response carries none — WA Web ingests tokens only from the
+        // privacy_token notification).
+        self.store_issued_tc_tokens(&response.tokens).await;
+        // Advance the issuance rate-limit on IQ success regardless of echoed
+        // tokens — WA Web's sendTcToken persists tcTokenSenderTimestamp here.
+        self.record_tc_token_sender_timestamp(to).await;
+        true
     }
 
     /// Returns true if at least one token was persisted.
@@ -201,31 +208,37 @@ impl Client {
         }
     }
 
-    pub(super) async fn mark_tc_token_used_after_send(&self, token_key: &str) {
+    /// Record that we issued a trusted-contact token to `to` at the current time.
+    ///
+    /// WA Web's `sendTcToken` persists `tcTokenSenderTimestamp` on IQ success,
+    /// independent of any token echoed in the response — the real `set privacy`
+    /// response carries no token bytes. Deriving this update from echoed tokens
+    /// would leave the sender bucket permanently unset and re-issue a privacy IQ
+    /// on every 1:1 message. When no token is stored yet, a byte-less placeholder
+    /// carries the timestamp until the contact's token arrives via notification.
+    async fn record_tc_token_sender_timestamp(&self, to: &Jid) {
         use wacore::store::traits::TcTokenEntry;
 
+        let key = self.resolve_tc_token_key(to).await;
         let backend = self.persistence_manager.backend();
-        let existing = match backend.get_tc_token(token_key).await {
-            Ok(entry) => entry,
+        let now = wacore::time::now_secs();
+        let entry = match backend.get_tc_token(&key).await {
+            Ok(Some(existing)) => TcTokenEntry {
+                sender_timestamp: Some(now),
+                ..existing
+            },
+            Ok(None) => TcTokenEntry {
+                token: Vec::new(),
+                token_timestamp: now,
+                sender_timestamp: Some(now),
+            },
             Err(e) => {
-                log::warn!(target: "Client/TcToken", "Failed to reload tc_token for {}: {e}", token_key);
+                log::warn!(target: "Client/TcToken", "Failed to load tc_token for {key}: {e}");
                 return;
             }
         };
-
-        let Some(entry) = existing else {
-            return;
-        };
-        if entry.token.is_empty() {
-            return;
-        }
-
-        let updated_entry = TcTokenEntry {
-            sender_timestamp: Some(wacore::time::now_secs()),
-            ..entry
-        };
-        if let Err(e) = backend.put_tc_token(token_key, &updated_entry).await {
-            log::warn!(target: "Client/TcToken", "Failed to update sender_timestamp for {}: {e}", token_key);
+        if let Err(e) = backend.put_tc_token(&key, &entry).await {
+            log::warn!(target: "Client/TcToken", "Failed to record tc_token sender_timestamp for {key}: {e}");
         }
     }
 
@@ -243,15 +256,10 @@ impl Client {
             return;
         };
 
-        let resolved_lid = if sender.is_lid() {
-            None
-        } else {
-            self.lid_pn_cache.get_current_lid(&sender.user).await
-        };
-        let token_jid: &str = resolved_lid.as_deref().unwrap_or(&sender.user);
+        let token_jid = self.resolve_tc_token_key(sender).await;
 
         let backend = self.persistence_manager.backend();
-        let entry = match backend.get_tc_token(token_jid).await {
+        let entry = match backend.get_tc_token(&token_jid).await {
             Ok(Some(e)) => e,
             _ => return,
         };
@@ -301,16 +309,10 @@ impl Client {
     pub(crate) async fn lookup_tc_token_for_jid(&self, jid: &Jid) -> Option<Vec<u8>> {
         use wacore::iq::tctoken::is_tc_token_expired_with;
 
-        let resolved_lid = if jid.is_lid() {
-            None
-        } else {
-            self.lid_pn_cache.get_current_lid(&jid.user).await
-        };
-        let token_jid: &str = resolved_lid.as_deref().unwrap_or(&jid.user);
-
+        let token_key = self.resolve_tc_token_key(jid).await;
         let tc_config = self.tc_token_config().await;
         let backend = self.persistence_manager.backend();
-        match backend.get_tc_token(token_jid).await {
+        match backend.get_tc_token(&token_key).await {
             Ok(Some(entry))
                 if !entry.token.is_empty()
                     && !is_tc_token_expired_with(entry.token_timestamp, &tc_config) =>
@@ -319,7 +321,7 @@ impl Client {
             }
             Ok(_) => None,
             Err(e) => {
-                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_jid);
+                log::warn!(target: "Client/TcToken", "Failed to get tc_token for {}: {e}", token_key);
                 None
             }
         }
@@ -339,7 +341,21 @@ impl Client {
         .clamped()
     }
 
-    /// Resolve a JID to its LID form for tc_token storage.
+    /// Resolve a JID to the tc_token storage key: the account LID user when
+    /// resolvable, else the bare user. The attachment lookup, issuance
+    /// rate-limiting, and feature-gating helpers all key on this so they stay
+    /// consistent for the same contact.
+    pub(crate) async fn resolve_tc_token_key(&self, jid: &Jid) -> String {
+        if jid.is_lid() {
+            jid.user.to_string()
+        } else if let Some(lid_user) = self.lid_pn_cache.get_current_lid(&jid.user).await {
+            lid_user.to_string()
+        } else {
+            jid.user.to_string()
+        }
+    }
+
+    /// Resolve a JID to its LID form for tc_token issuance targeting.
     async fn resolve_to_lid_jid(&self, jid: &Jid) -> Jid {
         if jid.is_lid() {
             return jid.to_non_ad();
@@ -376,5 +392,61 @@ impl Client {
         };
         // Issuance targets bare account JIDs, not device-scoped ones
         resolved.into_non_ad()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::create_test_client;
+    use wacore::store::traits::TcTokenEntry;
+    use wacore_binary::{Jid, Server};
+
+    #[tokio::test]
+    async fn record_sender_timestamp_creates_byteless_placeholder() {
+        let client = create_test_client().await;
+        let jid = Jid::new("770000001", Server::Lid);
+
+        client.record_tc_token_sender_timestamp(&jid).await;
+
+        let entry = client
+            .persistence_manager
+            .backend()
+            .get_tc_token("770000001")
+            .await
+            .unwrap()
+            .expect("placeholder entry should be created");
+        assert!(entry.token.is_empty(), "placeholder carries no token bytes");
+        assert!(
+            entry.sender_timestamp.is_some(),
+            "placeholder records the issuance timestamp"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_sender_timestamp_preserves_existing_token() {
+        let client = create_test_client().await;
+        let backend = client.persistence_manager.backend();
+        backend
+            .put_tc_token(
+                "770000002",
+                &TcTokenEntry {
+                    token: vec![1, 2, 3],
+                    token_timestamp: 1_700_000_000,
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let jid = Jid::new("770000002", Server::Lid);
+        client.record_tc_token_sender_timestamp(&jid).await;
+
+        let entry = backend.get_tc_token("770000002").await.unwrap().unwrap();
+        assert_eq!(entry.token, vec![1, 2, 3], "received token is preserved");
+        assert_eq!(entry.token_timestamp, 1_700_000_000);
+        assert!(
+            entry.sender_timestamp.is_some(),
+            "sender_timestamp is advanced on issuance"
+        );
     }
 }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -3010,8 +3010,9 @@ impl ProtocolStore for SqliteStore {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            // On conflict touch only sender_timestamp so a concurrently stored
-            // real token (bytes + token_timestamp) is never overwritten.
+            // On conflict touch only sender_timestamp, and only to advance it,
+            // so a concurrently stored real token is never overwritten and the
+            // sender bucket never regresses.
             diesel::insert_into(tc_tokens::table)
                 .values((
                     tc_tokens::jid.eq(&jid),
@@ -3024,7 +3025,18 @@ impl ProtocolStore for SqliteStore {
                 .on_conflict((tc_tokens::jid, tc_tokens::device_id))
                 .do_update()
                 .set((
-                    tc_tokens::sender_timestamp.eq(Some(sender_timestamp)),
+                    // MAX(...) keeps the sender bucket advance-only; there is no
+                    // typed Diesel form for a scalar MAX, and `ON CONFLICT ...
+                    // WHERE` isn't expressible via the query builder.
+                    tc_tokens::sender_timestamp.eq(diesel::dsl::sql::<
+                        diesel::sql_types::Nullable<diesel::sql_types::BigInt>,
+                    >(
+                        "MAX(COALESCE(sender_timestamp, "
+                    )
+                    .bind::<diesel::sql_types::BigInt, _>(sender_timestamp)
+                    .sql("), ")
+                    .bind::<diesel::sql_types::BigInt, _>(sender_timestamp)
+                    .sql(")")),
                     tc_tokens::updated_at.eq(now),
                 ))
                 .execute(&mut conn)
@@ -4115,6 +4127,14 @@ mod tests {
         let b = store.get_tc_token("user@lid").await.unwrap().unwrap();
         assert_eq!(b.token, vec![7, 8, 9], "touch must keep the real token");
         assert_eq!(b.sender_timestamp, Some(6000));
+
+        // An older touch must not regress the sender bucket.
+        store
+            .touch_tc_token_sender_timestamp("user@lid", 1000)
+            .await
+            .unwrap();
+        let c = store.get_tc_token("user@lid").await.unwrap().unwrap();
+        assert_eq!(c.sender_timestamp, Some(6000), "touch is advance-only");
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2929,9 +2929,14 @@ impl ProtocolStore for SqliteStore {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            // Placeholder rows (empty token) carry only a sender_timestamp; their
+            // token_timestamp is a sender epoch, not a receiver one, so the
+            // receiver cutoff must not prune them (matches WA Web never pruning
+            // tcTokenSenderTimestamp).
             let deleted = diesel::delete(
                 tc_tokens::table
                     .filter(tc_tokens::token_timestamp.lt(cutoff_timestamp))
+                    .filter(tc_tokens::token.ne(Vec::<u8>::new()))
                     .filter(tc_tokens::device_id.eq(device_id)),
             )
             .execute(&mut conn)
@@ -2940,6 +2945,48 @@ impl ProtocolStore for SqliteStore {
         })
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))?
+    }
+
+    async fn store_received_tc_token(
+        &self,
+        jid: &str,
+        token: &[u8],
+        token_timestamp: i64,
+    ) -> Result<()> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let jid = jid.to_string();
+        let token = token.to_vec();
+        let now = wacore::time::now_secs();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            // On conflict update only the token fields so a sender_timestamp
+            // written concurrently by the issuance path survives.
+            diesel::insert_into(tc_tokens::table)
+                .values((
+                    tc_tokens::jid.eq(&jid),
+                    tc_tokens::token.eq(&token),
+                    tc_tokens::token_timestamp.eq(token_timestamp),
+                    tc_tokens::sender_timestamp.eq(None::<i64>),
+                    tc_tokens::device_id.eq(device_id),
+                    tc_tokens::updated_at.eq(now),
+                ))
+                .on_conflict((tc_tokens::jid, tc_tokens::device_id))
+                .do_update()
+                .set((
+                    tc_tokens::token.eq(&token),
+                    tc_tokens::token_timestamp.eq(token_timestamp),
+                    tc_tokens::updated_at.eq(now),
+                ))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        Ok(())
     }
 
     async fn touch_tc_token_sender_timestamp(
@@ -4031,6 +4078,66 @@ mod tests {
 
         let result = store.get_tc_token("user@lid").await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_touch_and_store_received_preserve_each_others_field() {
+        let store = create_test_store().await;
+
+        // Issuance writes a placeholder; the notification then stores the real
+        // token. Neither write may clobber the other's field.
+        store
+            .touch_tc_token_sender_timestamp("user@lid", 5000)
+            .await
+            .unwrap();
+        store
+            .store_received_tc_token("user@lid", &[7, 8, 9], 4000)
+            .await
+            .unwrap();
+        let a = store.get_tc_token("user@lid").await.unwrap().unwrap();
+        assert_eq!(a.token, vec![7, 8, 9]);
+        assert_eq!(a.token_timestamp, 4000);
+        assert_eq!(a.sender_timestamp, Some(5000));
+
+        // A later touch advances only the sender bucket.
+        store
+            .touch_tc_token_sender_timestamp("user@lid", 6000)
+            .await
+            .unwrap();
+        let b = store.get_tc_token("user@lid").await.unwrap().unwrap();
+        assert_eq!(b.token, vec![7, 8, 9], "touch must keep the real token");
+        assert_eq!(b.sender_timestamp, Some(6000));
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_keeps_byteless_placeholder() {
+        let store = create_test_store().await;
+        store
+            .touch_tc_token_sender_timestamp("placeholder@lid", 1)
+            .await
+            .unwrap();
+        store
+            .put_tc_token(
+                "real@lid",
+                &TcTokenEntry {
+                    token: vec![1],
+                    token_timestamp: 1,
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let removed = store.delete_expired_tc_tokens(1000).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(
+            store
+                .get_tc_token("placeholder@lid")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(store.get_tc_token("real@lid").await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2922,21 +2922,30 @@ impl ProtocolStore for SqliteStore {
         .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
-    async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32> {
+    async fn delete_expired_tc_tokens(&self, token_cutoff: i64, sender_cutoff: i64) -> Result<u32> {
         let pool = self.pool.clone();
         let device_id = self.device_id;
         tokio::task::spawn_blocking(move || -> Result<u32> {
             let mut conn = pool
                 .get()
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            // Placeholder rows (empty token) carry only a sender_timestamp; their
-            // token_timestamp is a sender epoch, not a receiver one, so the
-            // receiver cutoff must not prune them (matches WA Web never pruning
-            // tcTokenSenderTimestamp).
+            // Remove a row only when its received token is expired-or-absent AND
+            // its sender bucket is expired-or-absent, so recent sender state
+            // survives an expired received token (and vice versa). COALESCE
+            // treats a null sender_timestamp as stale.
             let deleted = diesel::delete(
                 tc_tokens::table
-                    .filter(tc_tokens::token_timestamp.lt(cutoff_timestamp))
-                    .filter(tc_tokens::token.ne(Vec::<u8>::new()))
+                    .filter(
+                        tc_tokens::token
+                            .eq(Vec::<u8>::new())
+                            .or(tc_tokens::token_timestamp.lt(token_cutoff)),
+                    )
+                    .filter(
+                        diesel::dsl::sql::<diesel::sql_types::Bool>(
+                            "COALESCE(sender_timestamp, 0) < ",
+                        )
+                        .bind::<diesel::sql_types::BigInt, _>(sender_cutoff),
+                    )
                     .filter(tc_tokens::device_id.eq(device_id)),
             )
             .execute(&mut conn)
@@ -4110,17 +4119,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_delete_expired_keeps_byteless_placeholder() {
+    async fn test_delete_expired_two_window_pruning() {
         let store = create_test_store().await;
+        // token_cutoff = 1000, sender_cutoff = 2000.
+
+        // Recent placeholder: sender bucket live → kept.
         store
-            .touch_tc_token_sender_timestamp("placeholder@lid", 1)
+            .touch_tc_token_sender_timestamp("recent_ph@lid", 2500)
             .await
             .unwrap();
+        // Stale placeholder: both windows passed → pruned.
+        store
+            .touch_tc_token_sender_timestamp("stale_ph@lid", 100)
+            .await
+            .unwrap();
+        // Expired received token but recent sender bucket → kept.
         store
             .put_tc_token(
-                "real@lid",
+                "expired_live_sender@lid",
                 &TcTokenEntry {
                     token: vec![1],
+                    token_timestamp: 1,
+                    sender_timestamp: Some(2500),
+                },
+            )
+            .await
+            .unwrap();
+        // Expired token, no sender state → pruned.
+        store
+            .put_tc_token(
+                "orphan_expired@lid",
+                &TcTokenEntry {
+                    token: vec![2],
                     token_timestamp: 1,
                     sender_timestamp: None,
                 },
@@ -4128,16 +4158,24 @@ mod tests {
             .await
             .unwrap();
 
-        let removed = store.delete_expired_tc_tokens(1000).await.unwrap();
-        assert_eq!(removed, 1);
+        let removed = store.delete_expired_tc_tokens(1000, 2000).await.unwrap();
+        assert_eq!(removed, 2);
+        assert!(store.get_tc_token("recent_ph@lid").await.unwrap().is_some());
+        assert!(store.get_tc_token("stale_ph@lid").await.unwrap().is_none());
         assert!(
             store
-                .get_tc_token("placeholder@lid")
+                .get_tc_token("expired_live_sender@lid")
                 .await
                 .unwrap()
                 .is_some()
         );
-        assert!(store.get_tc_token("real@lid").await.unwrap().is_none());
+        assert!(
+            store
+                .get_tc_token("orphan_expired@lid")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -4175,7 +4213,8 @@ mod tests {
         store.put_tc_token("old@lid", &old).await.unwrap();
         store.put_tc_token("recent@lid", &recent).await.unwrap();
 
-        let deleted = store.delete_expired_tc_tokens(3000).await.unwrap();
+        // Both lack sender state, so the token window alone decides.
+        let deleted = store.delete_expired_tc_tokens(3000, 3000).await.unwrap();
         assert_eq!(deleted, 1);
 
         assert!(store.get_tc_token("old@lid").await.unwrap().is_none());

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2931,8 +2931,8 @@ impl ProtocolStore for SqliteStore {
                 .map_err(|e| StoreError::Connection(Box::new(e)))?;
             // Remove a row only when its received token is expired-or-absent AND
             // its sender bucket is expired-or-absent, so recent sender state
-            // survives an expired received token (and vice versa). COALESCE
-            // treats a null sender_timestamp as stale.
+            // survives an expired received token (and vice versa). A null
+            // sender_timestamp counts as stale.
             let deleted = diesel::delete(
                 tc_tokens::table
                     .filter(
@@ -2941,10 +2941,9 @@ impl ProtocolStore for SqliteStore {
                             .or(tc_tokens::token_timestamp.lt(token_cutoff)),
                     )
                     .filter(
-                        diesel::dsl::sql::<diesel::sql_types::Bool>(
-                            "COALESCE(sender_timestamp, 0) < ",
-                        )
-                        .bind::<diesel::sql_types::BigInt, _>(sender_cutoff),
+                        tc_tokens::sender_timestamp
+                            .is_null()
+                            .or(tc_tokens::sender_timestamp.lt(sender_cutoff)),
                     )
                     .filter(tc_tokens::device_id.eq(device_id)),
             )

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2942,6 +2942,45 @@ impl ProtocolStore for SqliteStore {
         .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
+    async fn touch_tc_token_sender_timestamp(
+        &self,
+        jid: &str,
+        sender_timestamp: i64,
+    ) -> Result<()> {
+        let pool = self.pool.clone();
+        let device_id = self.device_id;
+        let jid = jid.to_string();
+        let now = wacore::time::now_secs();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            // On conflict touch only sender_timestamp so a concurrently stored
+            // real token (bytes + token_timestamp) is never overwritten.
+            diesel::insert_into(tc_tokens::table)
+                .values((
+                    tc_tokens::jid.eq(&jid),
+                    tc_tokens::token.eq(Vec::<u8>::new()),
+                    tc_tokens::token_timestamp.eq(sender_timestamp),
+                    tc_tokens::sender_timestamp.eq(Some(sender_timestamp)),
+                    tc_tokens::device_id.eq(device_id),
+                    tc_tokens::updated_at.eq(now),
+                ))
+                .on_conflict((tc_tokens::jid, tc_tokens::device_id))
+                .do_update()
+                .set((
+                    tc_tokens::sender_timestamp.eq(Some(sender_timestamp)),
+                    tc_tokens::updated_at.eq(now),
+                ))
+                .execute(&mut conn)
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        Ok(())
+    }
+
     async fn store_sent_message(
         &self,
         chat_jid: &str,

--- a/wacore/src/iq/tctoken.rs
+++ b/wacore/src/iq/tctoken.rs
@@ -182,10 +182,24 @@ pub fn tc_token_expiration_cutoff() -> i64 {
     expiration_cutoff_at(unix_now(), TC_TOKEN_BUCKET_DURATION, TC_TOKEN_NUM_BUCKETS)
 }
 
-/// Compute the expiration cutoff using configurable timing.
+/// Compute the receiver-side expiration cutoff using configurable timing.
 pub fn tc_token_expiration_cutoff_with(config: &TcTokenConfig) -> i64 {
     let cfg = config.clamped();
     expiration_cutoff_at(unix_now(), cfg.bucket_duration, cfg.num_buckets)
+}
+
+/// Compute the sender-side expiration cutoff using configurable timing.
+///
+/// Sender state (issuance rate-limit) lives in a different bucket window than the
+/// received token, so pruning must evaluate it against this cutoff rather than
+/// the receiver one.
+pub fn sender_tc_token_expiration_cutoff_with(config: &TcTokenConfig) -> i64 {
+    let cfg = config.clamped();
+    expiration_cutoff_at(
+        unix_now(),
+        cfg.sender_bucket_duration,
+        cfg.sender_num_buckets,
+    )
 }
 
 /// A token received from the server in an IQ response or notification.

--- a/wacore/src/iq/tctoken.rs
+++ b/wacore/src/iq/tctoken.rs
@@ -388,6 +388,40 @@ pub fn build_tc_token_node_with_timestamp(token: &[u8], timestamp: i64) -> Node 
         .build()
 }
 
+/// Which privacy token (if any) to attach to an outgoing 1:1 message stanza.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivacyTokenChoice {
+    /// Attach the stored trusted-contact token bytes.
+    TcToken,
+    /// Attach an NCT `cstoken` fallback.
+    CsToken,
+    /// Attach nothing.
+    None,
+}
+
+/// Decide which privacy token to attach, mirroring WA Web's
+/// `Re = R(te) ?? D(te, s)` in `MsgCreateFanoutStanza.js`.
+///
+/// `tc_send_enabled` (`privacy_token_sending_on_all_1_on_1_messages`) gates the
+/// tctoken only — WA Web's `R`. The cstoken is gated independently on
+/// `nct_send_enabled` (`wa_nct_token_send_enabled`) — WA Web's `D` — and is NOT
+/// nested behind the 1:1 prop: when `R` yields nothing (prop off, or token
+/// missing/expired), `D` still runs.
+pub fn choose_privacy_token(
+    tc_send_enabled: bool,
+    nct_send_enabled: bool,
+    has_valid_tc_token: bool,
+    can_build_cs_token: bool,
+) -> PrivacyTokenChoice {
+    if tc_send_enabled && has_valid_tc_token {
+        PrivacyTokenChoice::TcToken
+    } else if nct_send_enabled && can_build_cs_token {
+        PrivacyTokenChoice::CsToken
+    } else {
+        PrivacyTokenChoice::None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -711,5 +745,57 @@ mod tests {
             Some(NodeContent::Bytes(data)) => assert_eq!(data, &[0xAA, 0xBB, 0xCC]),
             _ => panic!("Expected binary content"),
         }
+    }
+
+    #[test]
+    fn choose_prefers_valid_tc_token() {
+        assert_eq!(
+            choose_privacy_token(true, true, true, true),
+            PrivacyTokenChoice::TcToken
+        );
+    }
+
+    #[test]
+    fn choose_falls_back_to_cs_token_when_tc_missing() {
+        // tctoken prop on, but no valid token → cstoken fallback runs.
+        assert_eq!(
+            choose_privacy_token(true, true, false, true),
+            PrivacyTokenChoice::CsToken
+        );
+    }
+
+    #[test]
+    fn choose_cs_token_when_tc_send_disabled() {
+        // Regression: the cstoken is gated only on nct_send_enabled and must be
+        // attached even when privacy_token_sending_on_all_1_on_1_messages is off.
+        assert_eq!(
+            choose_privacy_token(false, true, false, true),
+            PrivacyTokenChoice::CsToken
+        );
+        // A valid tc token is ignored while its own prop is off; cstoken still wins.
+        assert_eq!(
+            choose_privacy_token(false, true, true, true),
+            PrivacyTokenChoice::CsToken
+        );
+    }
+
+    #[test]
+    fn choose_none_when_cs_token_unbuildable() {
+        assert_eq!(
+            choose_privacy_token(true, true, false, false),
+            PrivacyTokenChoice::None
+        );
+        assert_eq!(
+            choose_privacy_token(false, true, false, false),
+            PrivacyTokenChoice::None
+        );
+    }
+
+    #[test]
+    fn choose_none_when_all_disabled() {
+        assert_eq!(
+            choose_privacy_token(false, false, true, true),
+            PrivacyTokenChoice::None
+        );
     }
 }

--- a/wacore/src/iq/tctoken.rs
+++ b/wacore/src/iq/tctoken.rs
@@ -380,14 +380,6 @@ pub fn build_tc_token_node(token: &[u8]) -> Node {
     NodeBuilder::new("tctoken").bytes(token.to_vec()).build()
 }
 
-/// Build a `<tctoken>` stanza child with timestamp attribute.
-pub fn build_tc_token_node_with_timestamp(token: &[u8], timestamp: i64) -> Node {
-    NodeBuilder::new("tctoken")
-        .attr("t", timestamp)
-        .bytes(token.to_vec())
-        .build()
-}
-
 /// Which privacy token (if any) to attach to an outgoing 1:1 message stanza.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrivacyTokenChoice {
@@ -661,16 +653,6 @@ mod tests {
             Some(NodeContent::Bytes(data)) => assert_eq!(data, &[0x01, 0x02, 0x03]),
             _ => panic!("Expected binary content"),
         }
-    }
-
-    #[test]
-    fn test_build_tc_token_node_with_timestamp() {
-        let node = build_tc_token_node_with_timestamp(&[0x01], 1707000000);
-        assert_eq!(node.tag, "tctoken");
-        assert_eq!(
-            node.attrs().optional_string("t").as_deref(),
-            Some("1707000000")
-        );
     }
 
     #[test]

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -572,6 +572,28 @@ impl ProtocolStore for InMemoryBackend {
         Ok((before - s.tc_tokens.len()) as u32)
     }
 
+    async fn touch_tc_token_sender_timestamp(
+        &self,
+        jid: &str,
+        sender_timestamp: i64,
+    ) -> Result<()> {
+        let mut s = self.state.lock().await;
+        match s.tc_tokens.get_mut(jid) {
+            Some(entry) => entry.sender_timestamp = Some(sender_timestamp),
+            None => {
+                s.tc_tokens.insert(
+                    jid.to_string(),
+                    TcTokenEntry {
+                        token: Vec::new(),
+                        token_timestamp: sender_timestamp,
+                        sender_timestamp: Some(sender_timestamp),
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+
     // --- Sent Message Store ---
 
     async fn store_sent_message(
@@ -1090,5 +1112,44 @@ mod tests {
             vec![9u8; 32],
             "last write wins for the same composite key"
         );
+    }
+
+    #[tokio::test]
+    async fn touch_tc_token_creates_placeholder_then_preserves_real_token() {
+        let backend = InMemoryBackend::new();
+
+        backend
+            .touch_tc_token_sender_timestamp("u1", 1000)
+            .await
+            .unwrap();
+        let placeholder = backend.get_tc_token("u1").await.unwrap().unwrap();
+        assert!(placeholder.token.is_empty());
+        assert_eq!(placeholder.sender_timestamp, Some(1000));
+
+        // A real token stored by the notification path must survive a later touch.
+        backend
+            .put_tc_token(
+                "u1",
+                &TcTokenEntry {
+                    token: vec![7, 8, 9],
+                    token_timestamp: 2000,
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
+        backend
+            .touch_tc_token_sender_timestamp("u1", 3000)
+            .await
+            .unwrap();
+
+        let merged = backend.get_tc_token("u1").await.unwrap().unwrap();
+        assert_eq!(
+            merged.token,
+            vec![7, 8, 9],
+            "touch must not clobber the real token"
+        );
+        assert_eq!(merged.token_timestamp, 2000);
+        assert_eq!(merged.sender_timestamp, Some(3000));
     }
 }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -564,13 +564,16 @@ impl ProtocolStore for InMemoryBackend {
         Ok(self.state.lock().await.tc_tokens.keys().cloned().collect())
     }
 
-    async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32> {
+    async fn delete_expired_tc_tokens(&self, token_cutoff: i64, sender_cutoff: i64) -> Result<u32> {
         let mut s = self.state.lock().await;
         let before = s.tc_tokens.len();
-        // Keep placeholder rows (empty token): their token_timestamp is a sender
-        // epoch, not a receiver one, so the receiver cutoff must not prune them.
-        s.tc_tokens
-            .retain(|_, entry| entry.token.is_empty() || entry.token_timestamp >= cutoff_timestamp);
+        // Keep a row while either window is still live: the received token or the
+        // sender bucket. A row is dropped only when both are stale.
+        s.tc_tokens.retain(|_, entry| {
+            let token_live = !entry.token.is_empty() && entry.token_timestamp >= token_cutoff;
+            let sender_live = entry.sender_timestamp.is_some_and(|ts| ts >= sender_cutoff);
+            token_live || sender_live
+        });
         Ok((before - s.tc_tokens.len()) as u32)
     }
 
@@ -1216,29 +1219,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prune_keeps_byteless_placeholder() {
+    async fn prune_respects_sender_and_token_windows() {
         let backend = InMemoryBackend::new();
+        // token_cutoff = 1000, sender_cutoff = 2000 (wider sender window).
+
+        // Recent placeholder: sender bucket still live → kept.
         backend
-            .touch_tc_token_sender_timestamp("u4", 1)
+            .touch_tc_token_sender_timestamp("recent_ph", 2500)
             .await
             .unwrap();
+        // Stale placeholder: both windows passed → pruned.
+        backend
+            .touch_tc_token_sender_timestamp("stale_ph", 100)
+            .await
+            .unwrap();
+        // Expired token but recent sender bucket → kept (issuance state survives).
         backend
             .put_tc_token(
-                "u5",
+                "expired_tok_live_sender",
                 &TcTokenEntry {
                     token: vec![1],
+                    token_timestamp: 1,
+                    sender_timestamp: Some(2500),
+                },
+            )
+            .await
+            .unwrap();
+        // Expired token, no sender state → pruned.
+        backend
+            .put_tc_token(
+                "orphan_expired",
+                &TcTokenEntry {
+                    token: vec![2],
                     token_timestamp: 1,
                     sender_timestamp: None,
                 },
             )
             .await
             .unwrap();
+        // Fresh received token → kept.
+        backend
+            .put_tc_token(
+                "fresh_tok",
+                &TcTokenEntry {
+                    token: vec![3],
+                    token_timestamp: 5000,
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
 
-        // Cutoff above both timestamps: the real token is pruned, the placeholder
-        // (empty token) is kept — its token_timestamp is a sender epoch.
-        let removed = backend.delete_expired_tc_tokens(1000).await.unwrap();
-        assert_eq!(removed, 1);
-        assert!(backend.get_tc_token("u4").await.unwrap().is_some());
-        assert!(backend.get_tc_token("u5").await.unwrap().is_none());
+        let removed = backend.delete_expired_tc_tokens(1000, 2000).await.unwrap();
+        assert_eq!(removed, 2, "only fully-stale rows are pruned");
+        assert!(backend.get_tc_token("recent_ph").await.unwrap().is_some());
+        assert!(backend.get_tc_token("stale_ph").await.unwrap().is_none());
+        assert!(
+            backend
+                .get_tc_token("expired_tok_live_sender")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            backend
+                .get_tc_token("orphan_expired")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(backend.get_tc_token("fresh_tok").await.unwrap().is_some());
     }
 }

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -584,7 +584,13 @@ impl ProtocolStore for InMemoryBackend {
     ) -> Result<()> {
         let mut s = self.state.lock().await;
         match s.tc_tokens.get_mut(jid) {
-            Some(entry) => entry.sender_timestamp = Some(sender_timestamp),
+            Some(entry) => {
+                entry.sender_timestamp = Some(
+                    entry
+                        .sender_timestamp
+                        .map_or(sender_timestamp, |e| e.max(sender_timestamp)),
+                );
+            }
             None => {
                 s.tc_tokens.insert(
                     jid.to_string(),
@@ -1183,6 +1189,29 @@ mod tests {
         );
         assert_eq!(merged.token_timestamp, 2000);
         assert_eq!(merged.sender_timestamp, Some(3000));
+    }
+
+    #[tokio::test]
+    async fn touch_sender_timestamp_only_advances() {
+        let backend = InMemoryBackend::new();
+        backend
+            .touch_tc_token_sender_timestamp("uadv", 5000)
+            .await
+            .unwrap();
+        // An older touch (e.g. a stale history-sync sender epoch) must not regress.
+        backend
+            .touch_tc_token_sender_timestamp("uadv", 3000)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend
+                .get_tc_token("uadv")
+                .await
+                .unwrap()
+                .unwrap()
+                .sender_timestamp,
+            Some(5000)
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -567,8 +567,10 @@ impl ProtocolStore for InMemoryBackend {
     async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32> {
         let mut s = self.state.lock().await;
         let before = s.tc_tokens.len();
+        // Keep placeholder rows (empty token): their token_timestamp is a sender
+        // epoch, not a receiver one, so the receiver cutoff must not prune them.
         s.tc_tokens
-            .retain(|_, entry| entry.token_timestamp >= cutoff_timestamp);
+            .retain(|_, entry| entry.token.is_empty() || entry.token_timestamp >= cutoff_timestamp);
         Ok((before - s.tc_tokens.len()) as u32)
     }
 
@@ -587,6 +589,33 @@ impl ProtocolStore for InMemoryBackend {
                         token: Vec::new(),
                         token_timestamp: sender_timestamp,
                         sender_timestamp: Some(sender_timestamp),
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn store_received_tc_token(
+        &self,
+        jid: &str,
+        token: &[u8],
+        token_timestamp: i64,
+    ) -> Result<()> {
+        let mut s = self.state.lock().await;
+        match s.tc_tokens.get_mut(jid) {
+            Some(entry) => {
+                entry.token = token.to_vec();
+                entry.token_timestamp = token_timestamp;
+                // sender_timestamp left untouched
+            }
+            None => {
+                s.tc_tokens.insert(
+                    jid.to_string(),
+                    TcTokenEntry {
+                        token: token.to_vec(),
+                        token_timestamp,
+                        sender_timestamp: None,
                     },
                 );
             }
@@ -1151,5 +1180,65 @@ mod tests {
         );
         assert_eq!(merged.token_timestamp, 2000);
         assert_eq!(merged.sender_timestamp, Some(3000));
+    }
+
+    #[tokio::test]
+    async fn store_received_tc_token_preserves_sender_timestamp() {
+        let backend = InMemoryBackend::new();
+        // Placeholder from the issuance path.
+        backend
+            .touch_tc_token_sender_timestamp("u2", 5000)
+            .await
+            .unwrap();
+
+        // Notification stores the real token; the sender bucket must survive.
+        backend
+            .store_received_tc_token("u2", &[1, 2, 3], 4000)
+            .await
+            .unwrap();
+
+        let entry = backend.get_tc_token("u2").await.unwrap().unwrap();
+        assert_eq!(entry.token, vec![1, 2, 3]);
+        assert_eq!(entry.token_timestamp, 4000);
+        assert_eq!(
+            entry.sender_timestamp,
+            Some(5000),
+            "store_received_tc_token must not drop the sender bucket"
+        );
+
+        // No prior entry: sender_timestamp starts unset.
+        backend
+            .store_received_tc_token("u3", &[9], 4000)
+            .await
+            .unwrap();
+        let fresh = backend.get_tc_token("u3").await.unwrap().unwrap();
+        assert_eq!(fresh.sender_timestamp, None);
+    }
+
+    #[tokio::test]
+    async fn prune_keeps_byteless_placeholder() {
+        let backend = InMemoryBackend::new();
+        backend
+            .touch_tc_token_sender_timestamp("u4", 1)
+            .await
+            .unwrap();
+        backend
+            .put_tc_token(
+                "u5",
+                &TcTokenEntry {
+                    token: vec![1],
+                    token_timestamp: 1,
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Cutoff above both timestamps: the real token is pruned, the placeholder
+        // (empty token) is kept — its token_timestamp is a sender epoch.
+        let removed = backend.delete_expired_tc_tokens(1000).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(backend.get_tc_token("u4").await.unwrap().is_some());
+        assert!(backend.get_tc_token("u5").await.unwrap().is_none());
     }
 }

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -451,8 +451,12 @@ pub trait ProtocolStore: Send + Sync {
     /// Get all JIDs that have stored tc tokens.
     async fn get_all_tc_token_jids(&self) -> Result<Vec<String>>;
 
-    /// Delete tc tokens with token_timestamp older than cutoff. Returns count deleted.
-    async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32>;
+    /// Delete tc tokens that have no live state left. A row is removed only when
+    /// its received token is expired-or-absent (`token_timestamp < token_cutoff`
+    /// or empty) **and** its sender bucket is expired-or-absent
+    /// (`sender_timestamp < sender_cutoff` or null), so recent sender state is
+    /// never dropped just because the received token expired. Returns count deleted.
+    async fn delete_expired_tc_tokens(&self, token_cutoff: i64, sender_cutoff: i64) -> Result<u32>;
 
     /// Set `sender_timestamp` for a contact, inserting a byte-less placeholder
     /// when absent and preserving any existing token bytes.

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -454,6 +454,33 @@ pub trait ProtocolStore: Send + Sync {
     /// Delete tc tokens with token_timestamp older than cutoff. Returns count deleted.
     async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32>;
 
+    /// Set `sender_timestamp` for a contact, inserting a byte-less placeholder
+    /// when absent and preserving any existing token bytes.
+    ///
+    /// Must be atomic w.r.t. [`put_tc_token`](Self::put_tc_token): the sender-side
+    /// issuance path and the notification writer both touch the same row, so a
+    /// non-atomic read-modify-write could drop a real token for a placeholder.
+    /// The default is a read-modify-write for third-party backends; the built-in
+    /// stores override it with a single atomic upsert.
+    async fn touch_tc_token_sender_timestamp(
+        &self,
+        jid: &str,
+        sender_timestamp: i64,
+    ) -> Result<()> {
+        let entry = match self.get_tc_token(jid).await? {
+            Some(existing) => TcTokenEntry {
+                sender_timestamp: Some(sender_timestamp),
+                ..existing
+            },
+            None => TcTokenEntry {
+                token: Vec::new(),
+                token_timestamp: sender_timestamp,
+                sender_timestamp: Some(sender_timestamp),
+            },
+        };
+        self.put_tc_token(jid, &entry).await
+    }
+
     // --- Sent Message Store (retry support, matches WA Web's getMessageTable) ---
 
     /// Store a sent message's serialized payload for retry handling.

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -481,6 +481,33 @@ pub trait ProtocolStore: Send + Sync {
         self.put_tc_token(jid, &entry).await
     }
 
+    /// Store a token received from a contact, preserving any existing
+    /// `sender_timestamp`. The symmetric counterpart of
+    /// [`touch_tc_token_sender_timestamp`](Self::touch_tc_token_sender_timestamp):
+    /// each writer owns its own field, so the notification path never drops a
+    /// sender bucket that the issuance path wrote concurrently. Same atomicity
+    /// requirement — the default read-modify-write is for third-party backends.
+    async fn store_received_tc_token(
+        &self,
+        jid: &str,
+        token: &[u8],
+        token_timestamp: i64,
+    ) -> Result<()> {
+        let sender_timestamp = self
+            .get_tc_token(jid)
+            .await?
+            .and_then(|existing| existing.sender_timestamp);
+        self.put_tc_token(
+            jid,
+            &TcTokenEntry {
+                token: token.to_vec(),
+                token_timestamp,
+                sender_timestamp,
+            },
+        )
+        .await
+    }
+
     // --- Sent Message Store (retry support, matches WA Web's getMessageTable) ---
 
     /// Store a sent message's serialized payload for retry handling.

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -458,8 +458,11 @@ pub trait ProtocolStore: Send + Sync {
     /// never dropped just because the received token expired. Returns count deleted.
     async fn delete_expired_tc_tokens(&self, token_cutoff: i64, sender_cutoff: i64) -> Result<u32>;
 
-    /// Set `sender_timestamp` for a contact, inserting a byte-less placeholder
-    /// when absent and preserving any existing token bytes.
+    /// Advance `sender_timestamp` toward `sender_timestamp` for a contact,
+    /// inserting a byte-less placeholder when absent and preserving any existing
+    /// token bytes. The stored value only ever moves forward (max), so
+    /// concurrent writers (post-send issuance, history sync) converge regardless
+    /// of ordering and never regress the sender bucket.
     ///
     /// Must be atomic w.r.t. [`put_tc_token`](Self::put_tc_token): the sender-side
     /// issuance path and the notification writer both touch the same row, so a
@@ -473,7 +476,11 @@ pub trait ProtocolStore: Send + Sync {
     ) -> Result<()> {
         let entry = match self.get_tc_token(jid).await? {
             Some(existing) => TcTokenEntry {
-                sender_timestamp: Some(sender_timestamp),
+                sender_timestamp: Some(
+                    existing
+                        .sender_timestamp
+                        .map_or(sender_timestamp, |e| e.max(sender_timestamp)),
+                ),
                 ..existing
             },
             None => TcTokenEntry {


### PR DESCRIPTION
## Summary

Closes a set of divergences from WhatsApp Web in the 1:1 privacy-token path (`tctoken` / `cstoken`) that make the client issue far more privacy IQs — and sometimes omit the token entirely — than WA Web does, matching the connection/lockout reports in #944.

Verified against the captured JS (`WAWeb/Send/MsgCreateFanoutStanza.js`, `WAWeb/Trusted/ContactsUtils.js`, `WAWeb/Set/PrivacyTokensJob.js`, `WAWeb/Send/TcTokenChatAction.js`, `WAWeb/Send/TcTokenWhenDeviceIdentityChange.js`).

## 1. `tcTokenSenderTimestamp` never advances against the real server

WA Web's `sendTcToken` persists `tcTokenSenderTimestamp` **on IQ success**, and that timestamp is the only input to `shouldSendNewToken` (issue at most once per bucket, ~7 days by default). The token a client *echoes* comes exclusively from the `privacy_token` **notification**: the `set privacy` IQ request sends `<token jid t type/>` with no bytes, and `setPrivacyTokensParser` reads only the stanza id, so the response carries no tokens.

Our code derived the sender-bucket update from tokens echoed in that response, so against the real server `sender_timestamp` stayed `None`, `should_send_new_tc_token` stayed `true`, and **every 1:1 message re-issued a privacy IQ**. The e2e mock echoes tokens, which hid this.

Fix: `issue_tc_token_after_send` records `sender_timestamp` on IQ success regardless of echoed tokens. When no entry exists yet (first contact), a byte-less placeholder carries the timestamp; the notification handler accepts the contact's first real token over that placeholder regardless of its timestamp.

## 2. `cstoken` (NCT) fallback gated behind the wrong prop

WA Web builds the stanza token as `Re = R(te) ?? D(te, s)`: `R` (tctoken) is gated on `privacy_token_sending_on_all_1_on_1_messages`, but `D` (cstoken) is gated **independently** on `wa_nct_token_send_enabled` and still runs when `R` returns null. Our `cstoken` branch was nested inside the 1:1 prop gate, so when the server enabled NCT but not that prop, first-contact messages went out with **no token** and drew a 463.

Fix: the attach decision is extracted into a pure `choose_privacy_token` in `wacore`, and the cstoken is gated on `wa_nct_token_send_enabled` alone.

## Hardening (from review)

- **Concurrency:** the placeholder write raced the `privacy_token` notification writer and could overwrite a real token with a byte-less placeholder. Replaced the read-modify-write with `Backend::touch_tc_token_sender_timestamp` — an atomic upsert in `SqliteStore` (touches only `sender_timestamp` on conflict) and a single-lock update in `InMemoryBackend` — so a real token is never clobbered.
- **Privacy:** tc-token warning logs now emit the observed JID instead of the raw PN/LID storage key.

## Minor WA Web alignments

- `issue_tc_token_after_send` no longer ingests the `set privacy` response body (WA Web's `sendTcToken` ignores it; the echoed token is not the one we attach). The explicit `tc_token().issue_tokens()` API keeps its own storage.
- The decrypt-retry re-issuance is gated on a primary-device (device 0) identity change, matching `sendTcTokenWhenDeviceIdentityChange`.
- Removed the unused `build_tc_token_node_with_timestamp` — no captured WA Web path attaches a timestamp to `<tctoken>` (`enable_privacy_token_with_timestamp` is registry-only).

## Changes

- `wacore/src/iq/tctoken.rs`: `choose_privacy_token` / `PrivacyTokenChoice`; removed dead timestamp-node builder.
- `wacore/src/store/{traits,in_memory}.rs`, `storages/sqlite-storage/src/sqlite_store.rs`: `touch_tc_token_sender_timestamp` atomic merge.
- `src/send/tctoken_lifecycle.rs`: cstoken gating decoupled; sender-timestamp recorded on IQ success via the atomic merge; shared `resolve_tc_token_key`; PII-safe logs; `mark_tc_token_used_after_send` removed.
- `src/handlers/notification/privacy_business.rs`: accept the first real token over a byte-less placeholder.
- `src/message/receive.rs`: primary-device gate on decrypt-retry re-issuance.
- `src/send/mod.rs`: simplified the fire-and-forget issuance call site.

## Validation

- `cargo clippy -p wacore -p whatsapp-rust -p whatsapp-rust-sqlite-storage --tests` clean; `cargo fmt --all --check` clean.
- New unit tests: `choose_privacy_token` matrix (incl. the tc-off / cstoken-on regression), placeholder record/preserve, notification placeholder replacement over an older real token, and `touch_tc_token_sender_timestamp` not clobbering a real token.
- `cargo test -p wacore --lib` (1047), `cargo test -p whatsapp-rust --lib` (899), `cargo test -p whatsapp-rust-sqlite-storage --lib` (47) green.
- Existing `tests/e2e/tests/privacy_tokens.rs` scenarios remain consistent (cstoken cases provision an NCT salt; no-token cases have none, so `choose_privacy_token` still yields `None`).