### PR TITLE
feat(stats): attribute per-session resources beyond the Client

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -85,6 +85,68 @@ awaiting `send_message`) belongs to the caller — instrument that side
 yourself if you need it. The `voip` feature's media tasks (call driver,
 relay I/O) currently spawn directly on Tokio and are not instrumented.
 
+## `Client::resource_report()` — out-of-client resource attribution (on demand)
+
+`memory_report()` accounts only for the **client's own** in-process
+collections (tens of KiB). Profiling a many-session process shows the real
+per-session ~1 MiB is dominated by memory that lives **outside** the `Client`:
+the storage backend's SQLite page cache (the single largest chunk), transport
+buffers + TLS/noise state, the HTTP pool, and transient heap. `resource_report()`
+(`ResourceReport`) composes all of these into one estimate. Same design rules:
+runtime/platform-agnostic, zero cost when unused (LTO drops it), no PII.
+
+The pieces (each an `Option`-only struct in `wacore::stats`, filled only with
+what a component can introspect — absent means "not reported", not zero):
+
+- **Storage** — `DeviceStore::resource_report() -> StorageResourceReport`. A
+  **defaulted method on the existing `DeviceStore` sub-trait** (next to
+  `snapshot_db`), NOT a new `Backend` supertrait: `Backend` is blanket-impl'd,
+  so a new supertrait would force every backend (incl. external) to add an impl,
+  and an inherent method wouldn't compose through the `Arc<dyn Backend>` the
+  client holds. A default on an already-implemented sub-trait gives both —
+  composable *and* non-breaking. SQLite reports `min(cache cap, db size)` (an
+  upper bound on the page cache; Diesel doesn't expose the raw handle needed for
+  `sqlite3_db_status`), plus the DB page count. Remote backends report
+  `memory_bytes: Some(0)`.
+- **Transport** — `Transport::resource_report() -> Option<TransportResourceReport>`,
+  a defaulted method (clean here — `Transport` isn't blanket-impl'd). The Tokio
+  WebSocket transport fills best-effort static estimates (tokio-websockets and
+  rustls don't surface live buffer sizes).
+- **HTTP** — `HttpClient::resource_report() -> Option<HttpResourceReport>`,
+  defaulted. The `ureq` client reports its idle-pool buffer estimate (`None`
+  when built from a custom agent whose config is opaque).
+- **Alloc churn** — an `AllocSnapshot` from an `AllocMeter` (below), when one is
+  installed.
+
+`ResourceReport::total_estimated_bytes()` sums the **retained** components
+(client + storage + transport + HTTP) and is documented as a **lower bound**;
+`alloc` is churn, not residency, and is excluded. The future is `Send` (compile
+guard in `accessors.rs`, per #964) so multi-session consumers can await it off a
+worker.
+
+### `AllocMeter` — per-client allocation attribution (opt-in)
+
+`wacore::stats::AllocMeter` is a first-class `TaskInstrument` (sibling of
+`CpuMeter`) that attributes bytes allocated/freed to a client — the churn
+counterpart to the point-in-time retained reports. The host installs a
+`#[global_allocator]` that calls `AllocMeter::on_alloc`/`on_dealloc`; the meter,
+installed via `BotBuilder::with_alloc_meter` (or `with_task_instrument`), marks
+per thread which client's poll is running so the charge lands correctly.
+`examples/alloc_tracking.rs` is the ~20-line reference.
+
+Attribution boundary (documented honestly on the type): only allocations inside
+instrumented polls/tasks are counted (the run loop is covered since #963; work
+spawned raw on the runtime — some voip/media paths — is not). Deallocations are
+charged to whichever meter is active at free time, so `allocated` (churn) is the
+reliable signal and `freed`/`net` drift for buffers that outlive their poll.
+
+### `SqliteStoreConfig::mmap_size` — page-cache tuning knob
+
+`mmap_size` (new optional field, default `None` = current behavior; builder
+`with_mmap_size`) emits `PRAGMA mmap_size`, moving reads to reclaimable,
+file-backed pages — useful for a process holding many small per-session DBs. WAL
+caveat: mmap covers reads of the main DB file; writes still go through the WAL.
+
 ## Relation to the `metrics`/`tracing` features
 
 `wacore::telemetry` (cargo feature `metrics`) emits process-global counters

--- a/examples/alloc_tracking.rs
+++ b/examples/alloc_tracking.rs
@@ -1,4 +1,4 @@
-//! Per-session ALLOCATOR attribution through the `TaskInstrument` hook.
+//! Per-session ALLOCATOR attribution with the built-in [`AllocMeter`].
 //!
 //! Run with:
 //!     cargo run --example alloc_tracking
@@ -6,99 +6,50 @@
 //! [`Client::memory_report`] answers "how many bytes do this session's
 //! structures retain right now". This example answers the complementary
 //! question — "how many bytes does this session's work allocate, including
-//! transients" — by combining:
+//! transients" — using [`AllocMeter`], the first-class helper that attributes
+//! allocations to a client through the `TaskInstrument` hook.
 //!
-//! 1. a hand-rolled counting global allocator (no external crates), and
-//! 2. a [`TaskInstrument`] that marks, per thread, which session's task is
-//!    currently being polled, so the allocator knows whom to charge.
+//! The library still knows nothing about allocators. The host provides:
 //!
-//! The library knows nothing about allocators: the hook is just enter/exit
-//! around every poll of a client's internal tasks. The same pattern plugs in
-//! `tracking-allocator`, dhat, or ESP-IDF `heap_caps` sampling instead of
-//! this toy allocator. Expect a measurable overhead while enabled (Vector
-//! reports ~10-20% for the equivalent design); it is a diagnostics tool, not
-//! an always-on meter. Allocations outside instrumented tasks (your own
-//! caller-side code, other libraries) land in the "untracked" bucket.
+//! 1. a global allocator that calls `AllocMeter::on_alloc` / `on_dealloc` on
+//!    every (de)allocation (below — no external crates), and
+//! 2. the meter itself, installed with `with_alloc_meter`, which marks per
+//!    thread *which* client's task is being polled so the charge lands on it.
+//!
+//! Everything else — the thread-local routing, the nesting-safe stack — lives
+//! in `AllocMeter`. Compare the ~20 lines here to hand-rolling the bucket
+//! logic. The same allocator pattern plugs in `tracking-allocator`, dhat, or
+//! ESP-IDF `heap_caps` sampling. Expect a measurable overhead while enabled; it
+//! is a diagnostics tool, not an always-on meter. Allocations outside
+//! instrumented tasks (your caller-side code, other libraries) are uncounted.
 
-use portable_atomic::{AtomicI64, Ordering};
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::Cell;
 use std::sync::Arc;
 use std::time::Duration;
 
 use log::{error, info};
-use wacore::stats::TaskInstrument;
+use wacore::stats::AllocMeter;
 use whatsapp_rust::prelude::*;
 
-/// Live allocation counters for one attribution bucket.
-#[derive(Default)]
-struct Bucket {
-    current_bytes: AtomicI64,
-    total_allocs: AtomicI64,
-}
-
-static SESSION_A: Bucket = Bucket {
-    current_bytes: AtomicI64::new(0),
-    total_allocs: AtomicI64::new(0),
-};
-static UNTRACKED: Bucket = Bucket {
-    current_bytes: AtomicI64::new(0),
-    total_allocs: AtomicI64::new(0),
-};
-
-thread_local! {
-    /// Which bucket the currently-polled task belongs to. `None` = untracked.
-    static CURRENT: Cell<Option<&'static Bucket>> = const { Cell::new(None) };
-}
-
+/// A global allocator that forwards every (de)allocation size to whichever
+/// `AllocMeter` is active on the current thread. `AllocMeter::on_alloc` is
+/// allocation-free, so this does not recurse.
 struct AttributingAllocator;
 
-impl AttributingAllocator {
-    fn bucket() -> &'static Bucket {
-        CURRENT
-            .try_with(|c| c.get())
-            .ok()
-            .flatten()
-            .unwrap_or(&UNTRACKED)
-    }
-}
-
-// SAFETY-adjacent caveat: deallocations are charged to the CURRENT bucket,
-// not the allocating one, so a buffer allocated inside session A but freed
-// elsewhere skews both buckets. Fine for a demo; real deployments use a
-// tracker that stores the group per allocation (e.g. tracking-allocator).
 unsafe impl GlobalAlloc for AttributingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let bucket = Self::bucket();
-        bucket
-            .current_bytes
-            .fetch_add(layout.size() as i64, Ordering::Relaxed);
-        bucket.total_allocs.fetch_add(1, Ordering::Relaxed);
+        AllocMeter::on_alloc(layout.size());
         unsafe { System.alloc(layout) }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        Self::bucket()
-            .current_bytes
-            .fetch_sub(layout.size() as i64, Ordering::Relaxed);
+        AllocMeter::on_dealloc(layout.size());
         unsafe { System.dealloc(ptr, layout) }
     }
 }
 
 #[global_allocator]
 static GLOBAL: AttributingAllocator = AttributingAllocator;
-
-/// TaskInstrument that scopes the thread to a bucket for the poll's duration.
-struct SessionAllocScope(&'static Bucket);
-
-impl TaskInstrument for SessionAllocScope {
-    fn on_poll_start(&self) {
-        CURRENT.with(|c| c.set(Some(self.0)));
-    }
-    fn on_poll_end(&self) {
-        CURRENT.with(|c| c.set(None));
-    }
-}
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -117,9 +68,14 @@ fn main() {
             }
         };
 
+        // One meter per session. `with_alloc_meter` installs it as the task
+        // instrument AND keeps a handle so `client.resource_report()` folds in
+        // its snapshot; we keep our own clone to read it directly here.
+        let meter = Arc::new(AllocMeter::new());
+
         let bot = Bot::builder()
             .with_backend(store)
-            .with_task_instrument(Arc::new(SessionAllocScope(&SESSION_A)))
+            .with_alloc_meter(meter.clone())
             .on_qr_code(|code, timeout| async move {
                 info!("QR code (valid {}s):\n{code}", timeout.as_secs());
             })
@@ -141,12 +97,14 @@ fn main() {
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
+                    let snap = meter.snapshot();
                     info!(
-                        "session A: {}B live across {} allocs | untracked: {}B live",
-                        SESSION_A.current_bytes.load(Ordering::Relaxed),
-                        SESSION_A.total_allocs.load(Ordering::Relaxed),
-                        UNTRACKED.current_bytes.load(Ordering::Relaxed),
+                        "session A alloc churn: {}B allocated / {}B freed across {} allocs (net {}B)",
+                        snap.allocated_bytes, snap.freed_bytes, snap.allocations, snap.net_bytes(),
                     );
+                    // The unified view: client collections + storage + transport
+                    // + http + this alloc snapshot, in one report.
+                    info!("\n{}", client.resource_report().await);
                 }
                 _ = tokio::signal::ctrl_c() => {
                     info!("Shutting down...");

--- a/examples/alloc_tracking.rs
+++ b/examples/alloc_tracking.rs
@@ -38,8 +38,13 @@ struct AttributingAllocator;
 
 unsafe impl GlobalAlloc for AttributingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        AllocMeter::on_alloc(layout.size());
-        unsafe { System.alloc(layout) }
+        // Count only a successful allocation, so an OOM null return doesn't
+        // inflate the counter with bytes that were never allocated.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            AllocMeter::on_alloc(layout.size());
+        }
+        ptr
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -5,10 +5,18 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use wacore::net::{HttpClient, HttpRequest, HttpResponse, StreamingHttpResponse, UploadBody};
+use wacore::stats::HttpResourceReport;
 
 /// Matches `MAX_FILE_SIZE_BYTES` in `WAWebServerPropConstants` (2 GiB).
 /// Overrides ureq's 10 MiB default on `read_to_vec()`.
 pub const DEFAULT_MAX_BODY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Per-buffer size for the default agent (16 KiB vs ureq's 128 KiB default):
+/// WA API payloads are small JSON; media uses streaming I/O.
+const INPUT_BUFFER_BYTES: u64 = 16 * 1024;
+const OUTPUT_BUFFER_BYTES: u64 = 16 * 1024;
+/// Idle connections the default agent's pool may retain.
+const MAX_IDLE_CONNECTIONS: u64 = 3;
 
 /// HTTP client implementation using `ureq` for synchronous HTTP requests.
 /// Since `ureq` is blocking, all requests are wrapped in `tokio::task::spawn_blocking`.
@@ -18,6 +26,20 @@ pub struct UreqHttpClient {
     /// Cap for [`UreqHttpClient::execute`]. Streaming is unbounded — the
     /// caller owns the sink.
     max_body_bytes: u64,
+    /// Best-effort pool footprint for `resource_report`. `None` when a custom
+    /// agent is supplied (its buffer/pool config is opaque to us).
+    pool_report: Option<HttpResourceReport>,
+}
+
+/// Pool footprint of the default agent: each idle connection keeps an input and
+/// an output buffer. ureq exposes neither the live pool size nor in-flight
+/// buffering, so this is an upper-bound estimate, not a measurement.
+fn default_pool_report() -> HttpResourceReport {
+    HttpResourceReport {
+        pool_connections: Some(MAX_IDLE_CONNECTIONS),
+        pool_buffer_bytes: Some(MAX_IDLE_CONNECTIONS * (INPUT_BUFFER_BYTES + OUTPUT_BUFFER_BYTES)),
+        inflight_bytes: None,
+    }
 }
 
 impl UreqHttpClient {
@@ -25,6 +47,7 @@ impl UreqHttpClient {
         Self {
             agent: build_agent(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            pool_report: Some(default_pool_report()),
         }
     }
 
@@ -36,6 +59,8 @@ impl UreqHttpClient {
         Self {
             agent,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            // A custom agent's buffer/pool sizes are opaque — don't guess.
+            pool_report: None,
         }
     }
 
@@ -60,9 +85,9 @@ fn build_agent() -> ureq::Agent {
     let mut builder = Config::builder()
         // 16 KB per buffer instead of the 128 KB default.
         // WA API payloads are small JSON; media uses streaming I/O.
-        .input_buffer_size(16 * 1024)
-        .output_buffer_size(16 * 1024)
-        .max_idle_connections(3)
+        .input_buffer_size(INPUT_BUFFER_BYTES as usize)
+        .output_buffer_size(OUTPUT_BUFFER_BYTES as usize)
+        .max_idle_connections(MAX_IDLE_CONNECTIONS as usize)
         .max_idle_connections_per_host(2);
 
     #[cfg(feature = "danger-skip-tls-verify")]
@@ -196,6 +221,10 @@ impl HttpClient for UreqHttpClient {
             status_code,
             body: body_bytes,
         })
+    }
+
+    fn resource_report(&self) -> Option<HttpResourceReport> {
+        self.pool_report
     }
 }
 
@@ -392,6 +421,38 @@ mod tests {
             .expect("server should capture the request");
         assert_eq!(parsed_content_length(&headers), Some(payload.len()));
         assert_eq!(body, payload);
+    }
+
+    /// Workstream D: the default agent reports its idle-pool buffer estimate;
+    /// a custom agent (opaque config) reports nothing.
+    #[test]
+    fn resource_report_estimates_default_pool() {
+        let report = UreqHttpClient::new()
+            .resource_report()
+            .expect("default agent reports a pool estimate");
+        assert_eq!(report.pool_connections, Some(MAX_IDLE_CONNECTIONS));
+        assert_eq!(
+            report.pool_buffer_bytes,
+            Some(MAX_IDLE_CONNECTIONS * (INPUT_BUFFER_BYTES + OUTPUT_BUFFER_BYTES))
+        );
+        assert_eq!(report.inflight_bytes, None);
+        assert!(report.total_bytes() > 0);
+
+        // A custom agent's buffer/pool config is opaque — don't guess.
+        assert!(
+            UreqHttpClient::with_agent(build_agent())
+                .resource_report()
+                .is_none(),
+            "custom-agent client reports no estimate"
+        );
+
+        // with_max_body_bytes preserves the pool estimate.
+        assert!(
+            UreqHttpClient::new()
+                .with_max_body_bytes(1024)
+                .resource_report()
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -707,6 +707,10 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         instrument: Arc<dyn wacore::stats::TaskInstrument>,
     ) -> Self {
         self.task_instrument = Some(instrument);
+        // Clear any alloc-meter handle: only the last instrument set is driven by
+        // the poll hooks, so a stale handle would make resource_report() report a
+        // never-updated all-zero snapshot instead of `None`.
+        self.alloc_meter = None;
         self
     }
 
@@ -1232,6 +1236,45 @@ mod tests {
                 .await
                 .expect("Failed to create test SqliteStore"),
         ) as Arc<dyn Backend>
+    }
+
+    /// Regression: a `with_task_instrument` after `with_alloc_meter` must drop
+    /// the alloc-meter handle, so `resource_report()` doesn't report a
+    /// never-driven all-zero snapshot as if the meter were active.
+    #[tokio::test]
+    async fn task_instrument_after_alloc_meter_clears_stale_handle() {
+        use wacore::stats::{AllocMeter, CpuMeter};
+
+        let bot = Bot::builder()
+            .with_backend_arc(create_test_sqlite_backend().await)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .with_alloc_meter(Arc::new(AllocMeter::new()))
+            .with_task_instrument(Arc::new(CpuMeter::new()))
+            .build()
+            .await
+            .expect("build");
+        assert!(
+            bot.client().resource_report().await.alloc.is_none(),
+            "a later with_task_instrument must drop the alloc-meter handle"
+        );
+
+        // Reverse order: with_alloc_meter is last, so its snapshot is present.
+        let bot = Bot::builder()
+            .with_backend_arc(create_test_sqlite_backend().await)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .with_task_instrument(Arc::new(CpuMeter::new()))
+            .with_alloc_meter(Arc::new(AllocMeter::new()))
+            .build()
+            .await
+            .expect("build");
+        assert!(
+            bot.client().resource_report().await.alloc.is_some(),
+            "with_alloc_meter installs the handle when it is the last setter"
+        );
     }
 
     #[tokio::test]

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -566,6 +566,7 @@ pub struct BotBuilder<
     wanted_pre_key_count: Option<usize>,
     resend_rate_limit: Option<(u32, u32)>,
     task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
+    alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
     _marker: PhantomData<(B, T, H, R)>,
 }
 
@@ -589,6 +590,7 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             wanted_pre_key_count: None,
             resend_rate_limit: None,
             task_instrument: None,
+            alloc_meter: None,
             _marker: PhantomData,
         }
     }
@@ -616,6 +618,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             wanted_pre_key_count: self.wanted_pre_key_count,
             resend_rate_limit: self.resend_rate_limit,
             task_instrument: self.task_instrument,
+            alloc_meter: self.alloc_meter,
             _marker: PhantomData,
         }
     }
@@ -704,6 +707,24 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         instrument: Arc<dyn wacore::stats::TaskInstrument>,
     ) -> Self {
         self.task_instrument = Some(instrument);
+        self
+    }
+
+    /// Install an [`AllocMeter`](wacore::stats::AllocMeter) as this client's
+    /// task instrument and keep a typed handle so [`Client::resource_report`]
+    /// folds in its allocation-churn snapshot.
+    ///
+    /// Sugar over [`with_task_instrument`](Self::with_task_instrument): it
+    /// occupies the single instrument slot (so it's mutually exclusive with a
+    /// `CpuMeter` or another hook — last setter wins). The host still installs a
+    /// `#[global_allocator]` that calls [`AllocMeter::on_alloc`] /
+    /// [`AllocMeter::on_dealloc`]; see `examples/alloc_tracking.rs`.
+    ///
+    /// [`AllocMeter::on_alloc`]: wacore::stats::AllocMeter::on_alloc
+    /// [`AllocMeter::on_dealloc`]: wacore::stats::AllocMeter::on_dealloc
+    pub fn with_alloc_meter(mut self, meter: Arc<wacore::stats::AllocMeter>) -> Self {
+        self.task_instrument = Some(meter.clone());
+        self.alloc_meter = Some(meter);
         self
     }
 
@@ -1073,6 +1094,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         // Default (None): the original runtime is used untouched. The Bot
         // keeps its own copy for the `run()` path (see the field doc).
         let task_instrument = self.task_instrument;
+        let alloc_meter = self.alloc_meter;
         let runtime: Arc<dyn Runtime> = match task_instrument.clone() {
             Some(instrument) => {
                 Arc::new(wacore::stats::InstrumentedRuntime::new(runtime, instrument))
@@ -1120,6 +1142,12 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         // Bot keeps periodic persistence alive. Client::drop on the last Arc
         // drops the AbortHandle and aborts the task.
         let _ = client.saver_handle.set(saver_handle);
+
+        // Typed alloc-meter handle for resource_report (its poll hooks are
+        // already wired via task_instrument above).
+        if let Some(meter) = alloc_meter {
+            let _ = client.alloc_meter.set(meter);
+        }
 
         // Register custom enc handlers. Immutable after build, so set the whole
         // map once; the receive hot path then reads it lock-free.

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -689,6 +689,12 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// allocator-attribution or platform samplers to this client's work.
     /// Default: no hook — the runtime is used untouched.
     ///
+    /// Occupies the same single-instrument slot as
+    /// [`with_alloc_meter`](Self::with_alloc_meter) (last setter wins): calling
+    /// this after `with_alloc_meter` drops the typed alloc-meter handle, so
+    /// [`Client::resource_report`](crate::Client::resource_report)'s `alloc`
+    /// field reverts to `None`.
+    ///
     /// # Example
     /// ```rust,ignore
     /// use std::sync::Arc;

--- a/src/client.rs
+++ b/src/client.rs
@@ -358,10 +358,13 @@ impl ResourceReport {
     /// - components reporting `None` contribute 0 (absent, not zero);
     /// - `alloc` (churn, not residency) is excluded.
     pub fn total_estimated_bytes(&self) -> u64 {
-        self.client.total_estimated_bytes()
-            + self.storage.total_bytes()
-            + self.transport.map_or(0, |t| t.total_bytes())
-            + self.http.map_or(0, |h| h.total_bytes())
+        // Saturating: a caller-built or backend-supplied component could carry a
+        // large value; the total must stay conservative, never wrap.
+        self.client
+            .total_estimated_bytes()
+            .saturating_add(self.storage.total_bytes())
+            .saturating_add(self.transport.map_or(0, |t| t.total_bytes()))
+            .saturating_add(self.http.map_or(0, |h| h.total_bytes()))
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -173,7 +173,10 @@ const APP_STATE_RETRY_MAX_ATTEMPTS: u32 = 6;
 /// DGW `connectTimeoutMs` defaults to `20000ms`.
 const TRANSPORT_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
 
-pub use wacore::stats::{CollectionStats, StatsSnapshot};
+pub use wacore::stats::{
+    AllocSnapshot, CollectionStats, HttpResourceReport, StatsSnapshot, StorageResourceReport,
+    TransportResourceReport,
+};
 
 /// On-demand report of the client's internal collections: entry counts plus
 /// estimated retained heap bytes for the memory-dominant caches.
@@ -309,6 +312,93 @@ impl std::fmt::Display for MemoryReport {
         writeln!(
             f,
             "  total estimated:        {} B",
+            self.total_estimated_bytes()
+        )?;
+        Ok(())
+    }
+}
+
+/// Unified per-session resource estimate: the client's own collections plus the
+/// components that live *outside* the `Client` and dominate real per-session
+/// RAM — the storage backend, transport, and HTTP client — and an optional
+/// allocation-churn snapshot.
+///
+/// Obtain one from [`Client::resource_report`]. Each out-of-client component
+/// fills only what it can introspect (see the per-field types), so absent
+/// figures mean "not reported", not "zero".
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ResourceReport {
+    /// The client's own in-process collections — identical to
+    /// [`Client::memory_report`].
+    pub client: MemoryReport,
+    /// Storage-backend footprint (SQLite page cache, etc.). All-`None` for
+    /// backends that don't report.
+    pub storage: StorageResourceReport,
+    /// Transport buffers + TLS/noise state, if the transport reports them.
+    pub transport: Option<TransportResourceReport>,
+    /// HTTP connection-pool + in-flight footprint, if the client reports it.
+    pub http: Option<HttpResourceReport>,
+    /// Allocation churn attributed to this client's instrumented work, present
+    /// only when an [`AllocMeter`](wacore::stats::AllocMeter) was installed via
+    /// `BotBuilder::with_alloc_meter`. It is a churn/attribution signal, not a
+    /// retained figure, so it is deliberately excluded from
+    /// [`Self::total_estimated_bytes`].
+    pub alloc: Option<AllocSnapshot>,
+}
+
+impl ResourceReport {
+    /// Best-effort sum of **retained** bytes across the present point-in-time
+    /// components (client collections + storage + transport + HTTP).
+    ///
+    /// Exactness varies by component and this is a **lower bound** overall:
+    /// - client collections and transport/HTTP buffers are honest estimates;
+    /// - storage `memory_bytes` is an upper bound on the SQLite page cache
+    ///   (`min(cache cap, db size)`), 0 for remote backends;
+    /// - components reporting `None` contribute 0 (absent, not zero);
+    /// - `alloc` (churn, not residency) is excluded.
+    pub fn total_estimated_bytes(&self) -> u64 {
+        self.client.total_estimated_bytes()
+            + self.storage.total_bytes()
+            + self.transport.map_or(0, |t| t.total_bytes())
+            + self.http.map_or(0, |h| h.total_bytes())
+    }
+}
+
+impl std::fmt::Display for ResourceReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "=== Resource Report ===")?;
+        writeln!(
+            f,
+            "  client collections:     {:>10} B",
+            self.client.total_estimated_bytes()
+        )?;
+        writeln!(
+            f,
+            "  storage backend:        {:>10} B (pages: {:?})",
+            self.storage.total_bytes(),
+            self.storage.pages
+        )?;
+        writeln!(
+            f,
+            "  transport:              {:>10} B",
+            self.transport.map_or(0, |t| t.total_bytes())
+        )?;
+        writeln!(
+            f,
+            "  http client:            {:>10} B",
+            self.http.map_or(0, |h| h.total_bytes())
+        )?;
+        if let Some(alloc) = self.alloc {
+            writeln!(
+                f,
+                "  alloc churn:            {:>10} B allocated / {:>10} B freed ({} allocs)",
+                alloc.allocated_bytes, alloc.freed_bytes, alloc.allocations
+            )?;
+        }
+        writeln!(
+            f,
+            "  total retained (lower bound): {} B",
             self.total_estimated_bytes()
         )?;
         Ok(())
@@ -702,6 +792,11 @@ pub struct Client {
     /// `Bot::build`; on Client drop (last Arc), the handle drops and the saver
     /// is aborted.
     pub(crate) saver_handle: std::sync::OnceLock<wacore::runtime::AbortHandle>,
+
+    /// Typed handle to an [`AllocMeter`](wacore::stats::AllocMeter) installed via
+    /// `BotBuilder::with_alloc_meter`, so [`Client::resource_report`] can fold in
+    /// its allocation-churn snapshot. Unset unless that builder method was used.
+    pub(crate) alloc_meter: std::sync::OnceLock<Arc<wacore::stats::AllocMeter>>,
 
     /// When true, emit `Event::RawNode` for every decoded stanza before router dispatch.
     /// Default false — only enable when external consumers need raw protocol access.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -175,6 +175,36 @@ impl Client {
         }
     }
 
+    /// Unified per-session resource estimate: the client's own collections
+    /// ([`Client::memory_report`]) **plus** the components that live outside the
+    /// `Client` and dominate real per-session RAM — the storage backend's page
+    /// cache, the transport's buffers + TLS/noise state, the HTTP client's pool
+    /// — and, when a [`AllocMeter`](wacore::stats::AllocMeter) is installed
+    /// (`with_alloc_meter`), an allocation-churn snapshot.
+    ///
+    /// On-demand only, no hot-path cost. Each out-of-client figure is best
+    /// effort: a component reports only what it can introspect, so
+    /// [`ResourceReport::total_estimated_bytes`] is a **lower bound** (see its
+    /// docs for which parts are exact vs. estimated). No PII — sizes and counts
+    /// only. `Send`, so multi-session consumers can await it off a worker.
+    pub async fn resource_report(&self) -> ResourceReport {
+        let client = self.memory_report().await;
+        let storage = self.persistence_manager.backend().resource_report().await;
+        let transport = {
+            let guard = self.transport.lock().await;
+            guard.as_ref().and_then(|t| t.resource_report())
+        };
+        let http = self.http_client.resource_report();
+        let alloc = self.alloc_meter.get().map(|m| m.snapshot());
+        ResourceReport {
+            client,
+            storage,
+            transport,
+            http,
+            alloc,
+        }
+    }
+
     /// Get access to the PersistenceManager for this client.
     /// This is useful for multi-account scenarios to get the device ID.
     pub fn persistence_manager(&self) -> Arc<PersistenceManager> {
@@ -445,12 +475,21 @@ impl Client {
 
 #[cfg(test)]
 mod send_checks {
+    fn assert_send<T: Send>(_: &T) {}
+
     /// Compile-time guard that `memory_report()` stays `Send`: a `!Send` value held
     /// across an `.await` (e.g. a raw-pointer dedup set) would silently break
     /// `tokio::spawn` / axum callers. Built for its type only, never polled.
     #[allow(dead_code)]
     fn memory_report_future_is_send(c: &super::Client) {
-        fn assert_send<T: Send>(_: &T) {}
         assert_send(&c.memory_report());
+    }
+
+    /// Same guard for `resource_report()` — it awaits the backend's async report
+    /// and locks the transport, so a `!Send` future here would break the same
+    /// multi-threaded consumers (per #964).
+    #[allow(dead_code)]
+    fn resource_report_future_is_send(c: &super::Client) {
+        assert_send(&c.resource_report());
     }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -265,6 +265,7 @@ impl Client {
             cache_config,
             self_weak: std::sync::OnceLock::new(),
             saver_handle: std::sync::OnceLock::new(),
+            alloc_meter: std::sync::OnceLock::new(),
             raw_node_forwarding: AtomicBool::new(false),
             #[cfg(feature = "voip")]
             call_registry: std::sync::Arc::new(wacore::voip::CallRegistry::new()),

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2954,6 +2954,57 @@ async fn memory_report_on_fresh_client() {
     let _ = report.to_string();
 }
 
+/// resource_report (workstream F) composes the client's own memory_report with
+/// the out-of-client components, folds in an AllocMeter snapshot when installed,
+/// and is Display-able.
+#[tokio::test]
+async fn resource_report_composes_client_and_out_of_client_components() {
+    use wacore::stats::{AllocMeter, TaskInstrument};
+
+    let client = crate::test_utils::create_test_client().await;
+
+    let report = client.resource_report().await;
+
+    // The client sub-report equals memory_report's total.
+    let mem = client.memory_report().await;
+    assert_eq!(
+        report.client.total_estimated_bytes(),
+        mem.total_estimated_bytes()
+    );
+
+    // The SQLite backend reports its page-cache estimate — proving the storage
+    // report (workstream A) composes through `dyn Backend`.
+    assert!(
+        report.storage.memory_bytes.is_some(),
+        "SQLite backend reports storage memory"
+    );
+    assert!(report.storage.pages.is_some());
+
+    // No transport is connected and the mock HTTP client reports nothing.
+    assert!(report.transport.is_none());
+    assert!(report.http.is_none());
+    assert!(report.alloc.is_none(), "no alloc meter installed yet");
+
+    // The total includes the storage estimate on top of client collections.
+    assert!(report.total_estimated_bytes() >= report.storage.total_bytes());
+    let _ = report.to_string();
+
+    // Install an alloc meter and charge a known allocation inside a poll scope;
+    // the next report folds in its snapshot.
+    let meter = std::sync::Arc::new(AllocMeter::new());
+    meter.on_poll_start();
+    AllocMeter::on_alloc(4096);
+    meter.on_poll_end();
+    let _ = client.alloc_meter.set(meter);
+
+    let report = client.resource_report().await;
+    let alloc = report
+        .alloc
+        .expect("alloc snapshot folded in once installed");
+    assert_eq!(alloc.allocated_bytes, 4096);
+    assert_eq!(alloc.allocations, 1);
+}
+
 /// InstrumentedRuntime must invoke the TaskInstrument around polls of spawned
 /// futures and blocking closures, and CpuMeter must accumulate them.
 #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,11 @@ pub use client::Client;
 /// types embed it.
 pub use client::ClientError;
 pub use client::NodeFilter;
+pub use client::{
+    AllocSnapshot, CollectionStats, HttpResourceReport, MemoryReport, ResourceReport,
+    StatsSnapshot, StorageResourceReport, TransportResourceReport,
+};
 pub use client::{CallError, Voip};
-pub use client::{CollectionStats, MemoryReport, StatsSnapshot};
 pub use types::durability_hook::InboundDurabilityHook;
 pub mod download;
 pub mod handlers;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -3481,32 +3481,55 @@ impl DeviceStore for SqliteStore {
     ///
     /// SQLite's exact cache-in-use (`sqlite3_db_status(SQLITE_DBSTATUS_CACHE_USED)`)
     /// needs the raw `sqlite3*` handle, which Diesel does not expose through a
-    /// safe API. Instead we bound it with PRAGMAs: the page cache never holds
-    /// more than the database's own pages, nor more than the configured cap, so
-    /// `memory_bytes = min(cache cap, db size)` is a tight upper bound for the
-    /// target workload — a fresh per-session DB whose file is far smaller than
-    /// the 512 KiB cap. `pages` is the database page count (a size indicator).
+    /// safe API. Instead we bound it with PRAGMAs: a connection's page cache
+    /// never holds more than the database's own pages, nor more than the
+    /// configured cap, so `min(cache cap, db size)` is a tight per-connection
+    /// upper bound for the target workload (a fresh per-session DB far smaller
+    /// than the 512 KiB cap). Each pooled connection keeps its OWN cache (no
+    /// shared cache), so the figure is scaled by the number of open connections
+    /// — a no-op for the default single-connection store. `pages` is the
+    /// database page count (a size indicator, shared across connections).
+    ///
+    /// Caveat: this does not account for [`SqliteStoreConfig::mmap_size`]. With
+    /// mmap enabled, some reads bypass the heap page cache via an OS-reclaimable
+    /// file mapping, so the estimate can overstate actual process-heap residency
+    /// for that session.
     async fn resource_report(&self) -> wacore::stats::StorageResourceReport {
         let pool = self.pool.clone();
         tokio::task::spawn_blocking(move || {
-            let mut conn = match pool.get() {
-                Ok(conn) => conn,
-                // Best-effort: a report is never load-bearing, so a pool hiccup
-                // yields "not reported" rather than an error.
-                Err(_) => return wacore::stats::StorageResourceReport::default(),
+            // Non-blocking checkout: this report is best-effort, so contention
+            // (e.g. a long write holding the only connection) degrades to "not
+            // reported" immediately instead of blocking up to r2d2's connection
+            // timeout.
+            let Some(mut conn) = pool.try_get() else {
+                return wacore::stats::StorageResourceReport::default();
             };
-            let page_size = pragma_i64(&mut conn, "page_size").unwrap_or(0).max(0) as u64;
-            let page_count = pragma_i64(&mut conn, "page_count").unwrap_or(0).max(0) as u64;
+            // A failed PRAGMA read means "unavailable", not "zero": fall back to
+            // the all-`None` default so the report never asserts zero usage it
+            // couldn't actually confirm (Some(0) is a positive claim).
+            let (Some(page_size), Some(page_count), Some(cache_size)) = (
+                pragma_i64(&mut conn, "page_size"),
+                pragma_i64(&mut conn, "page_count"),
+                pragma_i64(&mut conn, "cache_size"),
+            ) else {
+                return wacore::stats::StorageResourceReport::default();
+            };
+            let page_size = page_size.max(0) as u64;
+            let page_count = page_count.max(0) as u64;
             // `PRAGMA cache_size`: negative = KiB, positive = pages.
-            let cache_size = pragma_i64(&mut conn, "cache_size").unwrap_or(0);
             let cache_cap_bytes = if cache_size < 0 {
-                cache_size.unsigned_abs() * 1024
+                cache_size.unsigned_abs().saturating_mul(1024)
             } else {
-                cache_size as u64 * page_size
+                (cache_size as u64).saturating_mul(page_size)
             };
-            let db_bytes = page_count * page_size;
+            let db_bytes = page_count.saturating_mul(page_size);
+            let per_conn_cache = cache_cap_bytes.min(db_bytes);
+            // Open connections (idle + the one just checked out), each with its
+            // own independent page cache. Defaults to 1 for the single-connection
+            // store, so this only widens the bound when pool_size > 1.
+            let open_connections = pool.state().connections.max(1) as u64;
             wacore::stats::StorageResourceReport {
-                memory_bytes: Some(cache_cap_bytes.min(db_bytes)),
+                memory_bytes: Some(per_conn_cache.saturating_mul(open_connections)),
                 pages: Some(page_count),
                 ..Default::default()
             }
@@ -3516,9 +3539,21 @@ impl DeviceStore for SqliteStore {
     }
 }
 
-/// Read a single-integer `PRAGMA` off a connection. Returns `None` on any
+/// Read a single-integer `PRAGMA` off a connection. `pragma` MUST be a bare
+/// identifier (all current callers pass string literals). Returns `None` on any
 /// error so callers degrade to "not reported" instead of failing.
 fn pragma_i64(conn: &mut SqliteConnection, pragma: &str) -> Option<i64> {
+    // The name is interpolated into SQL below, so reject anything that isn't a
+    // bare identifier — defense-in-depth against a future caller passing
+    // non-constant input. Constant callers always pass this.
+    if pragma.is_empty()
+        || !pragma
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        debug_assert!(false, "pragma_i64 requires an identifier, got {pragma:?}");
+        return None;
+    }
     #[derive(diesel::QueryableByName)]
     struct Row {
         #[diesel(sql_type = diesel::sql_types::BigInt)]

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -132,6 +132,16 @@ pub struct SqliteStoreConfig {
     pub pool_size: u32,
     /// `PRAGMA cache_size`, in KiB per connection.
     pub cache_size_kib: u32,
+    /// `PRAGMA mmap_size`, in bytes. `None` (default) leaves mmap off — the
+    /// current behavior. When set, pages are read through a reclaimable,
+    /// file-backed memory map instead of the heap page cache, which helps a
+    /// process holding many small per-session DBs (the mapped pages are
+    /// OS-reclaimable, unlike heap cache bytes).
+    ///
+    /// Caveat: mmap I/O covers *reads* of the main database file; in WAL mode
+    /// (this store's default) writes still go through the WAL, and a checkpoint
+    /// briefly falls back to non-mmap I/O. `0` disables mmap the same as `None`.
+    pub mmap_size: Option<u64>,
     /// `PRAGMA busy_timeout`.
     pub busy_timeout: Duration,
     /// `PRAGMA synchronous`.
@@ -146,6 +156,7 @@ impl Default for SqliteStoreConfig {
         Self {
             pool_size: 1,
             cache_size_kib: 512,
+            mmap_size: None,
             busy_timeout: Duration::from_secs(30),
             synchronous: Synchronous::Normal,
             thread_pool: None,
@@ -153,9 +164,20 @@ impl Default for SqliteStoreConfig {
     }
 }
 
+impl SqliteStoreConfig {
+    /// Set `PRAGMA mmap_size` (bytes), enabling file-backed memory-mapped reads.
+    /// Builder-style so new optional knobs don't force struct-literal churn;
+    /// pass `0` to keep mmap off. See the [`SqliteStoreConfig::mmap_size`] caveat.
+    pub fn with_mmap_size(mut self, bytes: u64) -> Self {
+        self.mmap_size = Some(bytes);
+        self
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ConnectionOptions {
     cache_size_kib: u32,
+    mmap_size: Option<u64>,
     busy_timeout_ms: u64,
     synchronous: Synchronous,
 }
@@ -169,13 +191,19 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
     ) -> std::result::Result<(), diesel::r2d2::Error> {
         // cache_size negative = KiB (page-size independent). temp_store/foreign_keys are
         // fixed: they guard correctness, not memory, so they're not user-tunable.
-        for pragma in [
+        let mut pragmas = vec![
             format!("PRAGMA busy_timeout = {};", self.busy_timeout_ms),
             format!("PRAGMA synchronous = {};", self.synchronous.as_pragma()),
             format!("PRAGMA cache_size = -{};", self.cache_size_kib),
             "PRAGMA temp_store = memory;".to_string(),
             "PRAGMA foreign_keys = ON;".to_string(),
-        ] {
+        ];
+        // Opt-in: emit mmap_size only for a non-zero value, so the default keeps
+        // SQLite's mmap off (current behavior).
+        if let Some(mmap_size) = self.mmap_size.filter(|&n| n > 0) {
+            pragmas.push(format!("PRAGMA mmap_size = {mmap_size};"));
+        }
+        for pragma in pragmas {
             diesel::sql_query(pragma)
                 .execute(conn)
                 .map_err(diesel::r2d2::Error::QueryError)?;
@@ -275,6 +303,7 @@ impl SqliteStore {
 
         let options = ConnectionOptions {
             cache_size_kib: config.cache_size_kib,
+            mmap_size: config.mmap_size,
             // Clamp a non-zero timeout up to >=1ms (and to SQLite's signed-int ms range):
             // as_millis() would truncate a sub-millisecond Duration to 0, which disables the
             // busy handler instead of keeping a short timeout.
@@ -3446,6 +3475,62 @@ impl DeviceStore for SqliteStore {
 
         Ok(())
     }
+
+    /// Per-session storage memory, the largest per-session chunk in the
+    /// profiling that motivated this (the default 512 KiB page cache).
+    ///
+    /// SQLite's exact cache-in-use (`sqlite3_db_status(SQLITE_DBSTATUS_CACHE_USED)`)
+    /// needs the raw `sqlite3*` handle, which Diesel does not expose through a
+    /// safe API. Instead we bound it with PRAGMAs: the page cache never holds
+    /// more than the database's own pages, nor more than the configured cap, so
+    /// `memory_bytes = min(cache cap, db size)` is a tight upper bound for the
+    /// target workload — a fresh per-session DB whose file is far smaller than
+    /// the 512 KiB cap. `pages` is the database page count (a size indicator).
+    async fn resource_report(&self) -> wacore::stats::StorageResourceReport {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = match pool.get() {
+                Ok(conn) => conn,
+                // Best-effort: a report is never load-bearing, so a pool hiccup
+                // yields "not reported" rather than an error.
+                Err(_) => return wacore::stats::StorageResourceReport::default(),
+            };
+            let page_size = pragma_i64(&mut conn, "page_size").unwrap_or(0).max(0) as u64;
+            let page_count = pragma_i64(&mut conn, "page_count").unwrap_or(0).max(0) as u64;
+            // `PRAGMA cache_size`: negative = KiB, positive = pages.
+            let cache_size = pragma_i64(&mut conn, "cache_size").unwrap_or(0);
+            let cache_cap_bytes = if cache_size < 0 {
+                cache_size.unsigned_abs() * 1024
+            } else {
+                cache_size as u64 * page_size
+            };
+            let db_bytes = page_count * page_size;
+            wacore::stats::StorageResourceReport {
+                memory_bytes: Some(cache_cap_bytes.min(db_bytes)),
+                pages: Some(page_count),
+                ..Default::default()
+            }
+        })
+        .await
+        .unwrap_or_default()
+    }
+}
+
+/// Read a single-integer `PRAGMA` off a connection. Returns `None` on any
+/// error so callers degrade to "not reported" instead of failing.
+fn pragma_i64(conn: &mut SqliteConnection, pragma: &str) -> Option<i64> {
+    #[derive(diesel::QueryableByName)]
+    struct Row {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        value: i64,
+    }
+    // The table-valued `pragma_*` function exposes the value in a column named
+    // after the pragma; alias it to a stable name so one struct maps them all.
+    let sql = format!("SELECT {pragma} AS value FROM pragma_{pragma}()");
+    diesel::sql_query(sql)
+        .get_result::<Row>(conn)
+        .ok()
+        .map(|r| r.value)
 }
 
 #[cfg(test)]
@@ -3489,6 +3574,7 @@ mod tests {
         let config = SqliteStoreConfig {
             pool_size: 2,
             cache_size_kib: 4096,
+            mmap_size: None,
             busy_timeout: Duration::from_secs(7),
             synchronous: Synchronous::Full,
             thread_pool: Some(Arc::new(
@@ -4846,5 +4932,127 @@ mod tests {
             vec![7u8; 32],
             "device_a still sees its own write"
         );
+    }
+
+    /// Workstream A: the storage report bounds the page cache by the actual DB
+    /// size and never exceeds the configured cap.
+    #[tokio::test]
+    async fn resource_report_bounds_cache_by_db_size_and_cap() {
+        let store = create_test_store().await; // default: 512 KiB cache cap
+        let device_id = 1;
+
+        // Seed enough rows to grow the DB past its bare schema pages.
+        let macs: Vec<AppStateMutationMAC> = (0..500u32)
+            .map(|i| {
+                let mut index_mac = vec![0u8; 32];
+                index_mac[..4].copy_from_slice(&i.to_le_bytes());
+                AppStateMutationMAC {
+                    index_mac,
+                    value_mac: vec![(i % 251) as u8; 32],
+                }
+            })
+            .collect();
+        store
+            .put_app_state_mutation_macs_for_device("coll", 1, &macs, device_id)
+            .await
+            .unwrap();
+
+        let report = store.resource_report().await;
+
+        let pages = report.pages.expect("SQLite reports a page count");
+        assert!(pages > 0, "a migrated + seeded DB has pages");
+
+        let mem = report
+            .memory_bytes
+            .expect("SQLite reports a cache estimate");
+        assert!(mem > 0, "cache-in-use estimate is non-zero for a seeded DB");
+        // memory_bytes = min(cache cap, db size); the seeded DB is far under the
+        // 512 KiB cap, so the estimate tracks the DB size and stays under the cap.
+        assert!(
+            mem <= 512 * 1024,
+            "estimate never exceeds the configured 512 KiB cap, got {mem}"
+        );
+        assert_eq!(report.total_bytes(), mem, "total_bytes == memory_bytes");
+        // I/O counters aren't tracked by this backend.
+        assert_eq!(report.io_read_bytes, None);
+        assert_eq!(report.io_write_bytes, None);
+    }
+
+    /// Workstream E: `mmap_size` is an opt-in field + builder — the default is
+    /// `None` (no mmap pragma emitted), and setting it wires `PRAGMA mmap_size`
+    /// through to the connection without breaking the store.
+    #[test]
+    fn mmap_size_config_is_opt_in() {
+        assert_eq!(
+            SqliteStoreConfig::default().mmap_size,
+            None,
+            "default leaves mmap off (current behavior)"
+        );
+        assert_eq!(
+            SqliteStoreConfig::default()
+                .with_mmap_size(64 * 1024 * 1024)
+                .mmap_size,
+            Some(64 * 1024 * 1024),
+            "builder sets the field"
+        );
+    }
+
+    #[tokio::test]
+    async fn mmap_size_applies_pragma_and_store_operates() {
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        // A real file DB — memory DBs ignore mmap.
+        let path =
+            std::env::temp_dir().join(format!("wa_mmap_test_{}_{}.db", std::process::id(), id));
+        let url = path.to_str().unwrap().to_string();
+
+        // `PRAGMA mmap_size` statement form: unlike page_count/page_size/cache_size,
+        // SQLite exposes no `pragma_mmap_size()` table-valued function, so read it
+        // directly (its result column is named `mmap_size`).
+        let read_mmap = |store: &SqliteStore| -> i64 {
+            #[derive(diesel::QueryableByName)]
+            struct M {
+                #[diesel(sql_type = diesel::sql_types::BigInt)]
+                mmap_size: i64,
+            }
+            let mut conn = store.pool.get().unwrap();
+            diesel::sql_query("PRAGMA mmap_size")
+                .get_result::<M>(&mut conn)
+                .map(|m| m.mmap_size)
+                .unwrap_or(-1)
+        };
+
+        // Default config emits no mmap pragma, and SQLITE_DEFAULT_MMAP_SIZE is 0,
+        // so mmap reads back off. Deterministic across environments.
+        let def_store = SqliteStore::new(&url).await.expect("default store");
+        assert_eq!(read_mmap(&def_store), 0, "default keeps mmap off");
+        drop(def_store);
+
+        // Opt-in: the store builds with the pragma applied (on_acquire didn't
+        // error) and stays fully operational.
+        const MMAP: u64 = 64 * 1024 * 1024;
+        let cfg = SqliteStoreConfig::default().with_mmap_size(MMAP);
+        let store = SqliteStore::with_config(&url, cfg)
+            .await
+            .expect("mmap store builds");
+        store
+            .put_identity("559980000001@s.whatsapp.net", [9u8; 32])
+            .await
+            .expect("store operates with mmap set");
+        // The read-back is the configured limit where the VFS supports mmap, or
+        // 0 where it doesn't (some container filesystems) — never a wiring error.
+        let applied = read_mmap(&store);
+        assert!(
+            applied == MMAP as i64 || applied == 0,
+            "mmap_size is applied when the VFS supports it, got {applied}"
+        );
+        drop(store);
+
+        // Best-effort cleanup of the DB and its WAL sidecars.
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = std::fs::remove_file(format!("{url}{suffix}"));
+        }
     }
 }

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -19,6 +19,27 @@ pub use tokio_websockets::Connector;
 
 const EVENT_CHANNEL_CAPACITY: usize = 64;
 
+// Best-effort per-session footprint estimates for `Transport::resource_report`.
+// tokio-websockets and rustls don't expose their live buffer sizes, so these
+// are documented static estimates of steady-state cost, not measurements: a
+// WebSocket read + write framing buffer, plus rustls record buffers and key
+// schedule for one TLS session. They exist to give a consumer a realistic
+// order-of-magnitude for the transport's ~tens-of-KiB-per-session contribution.
+const EST_READ_BUFFER_BYTES: u64 = 16 * 1024;
+const EST_WRITE_BUFFER_BYTES: u64 = 16 * 1024;
+const EST_TLS_STATE_BYTES: u64 = 32 * 1024;
+
+/// The static per-session footprint estimate reported by every WebSocket
+/// transport. Factored out so its numbers are unit-testable without a live
+/// socket.
+fn transport_resource_estimate() -> wacore::stats::TransportResourceReport {
+    wacore::stats::TransportResourceReport {
+        read_buffer_bytes: Some(EST_READ_BUFFER_BYTES),
+        write_buffer_bytes: Some(EST_WRITE_BUFFER_BYTES),
+        tls_state_bytes: Some(EST_TLS_STATE_BYTES),
+    }
+}
+
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
 
 /// Returns the default TLS connector used by [`TokioWebSocketTransportFactory`].
@@ -155,6 +176,12 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send + 'static> Transport for WsTranspo
                 ))
                 .await;
         }
+    }
+
+    fn resource_report(&self) -> Option<wacore::stats::TransportResourceReport> {
+        // Static best-effort estimates (see the constants): tokio-websockets and
+        // rustls don't surface their live buffer sizes.
+        Some(transport_resource_estimate())
     }
 }
 
@@ -307,5 +334,24 @@ impl TransportFactory for TokioWebSocketTransportFactory {
             .map_err(|e| anyhow::anyhow!("WebSocket connect failed: {e}"))?;
 
         Ok(from_websocket(ws))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Workstream C: the transport's reported footprint is the sum of its
+    /// read/write framing buffers and the TLS state estimate.
+    #[test]
+    fn resource_estimate_totals_present_fields() {
+        let report = transport_resource_estimate();
+        assert_eq!(report.read_buffer_bytes, Some(EST_READ_BUFFER_BYTES));
+        assert_eq!(report.write_buffer_bytes, Some(EST_WRITE_BUFFER_BYTES));
+        assert_eq!(report.tls_state_bytes, Some(EST_TLS_STATE_BYTES));
+        assert_eq!(
+            report.total_bytes(),
+            EST_READ_BUFFER_BYTES + EST_WRITE_BUFFER_BYTES + EST_TLS_STATE_BYTES
+        );
     }
 }

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -89,6 +89,15 @@ pub trait Transport: crate::sync_marker::MaybeSendSync {
 
     /// Closes the connection.
     async fn disconnect(&self);
+
+    /// Best-effort per-session footprint of this transport: read/write framing
+    /// buffers plus a TLS/noise session-state estimate. `None` by default;
+    /// concrete transports (e.g. the Tokio WebSocket transport) fill in what
+    /// they can. Not blanket-impl'd, so a defaulted method here is cleanly
+    /// overridable — no `Backend`-style wrinkle.
+    fn resource_report(&self) -> Option<crate::stats::TransportResourceReport> {
+        None
+    }
 }
 
 /// A factory responsible for creating new transport instances.
@@ -203,6 +212,15 @@ pub trait HttpClient: crate::sync_marker::MaybeSendSync {
         Err(anyhow::anyhow!(
             "Upload streaming not supported by this HTTP client"
         ))
+    }
+
+    /// Best-effort per-session footprint of this client: idle connection-pool
+    /// buffers plus any in-flight download/media buffering the impl can see.
+    /// `None` by default; `ureq`/`reqwest`-backed clients report what their
+    /// (limited) introspection allows. Media downloads are a real transient-RAM
+    /// source, so a coarse estimate is still worth reporting.
+    fn resource_report(&self) -> Option<crate::stats::HttpResourceReport> {
+        None
     }
 }
 

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -299,11 +299,13 @@ pub struct TransportResourceReport {
 }
 
 impl TransportResourceReport {
-    /// Sum of the present byte fields.
+    /// Sum of the present byte fields (saturating — `total_bytes` is public, so
+    /// a caller-built report with large values must not wrap).
     pub fn total_bytes(&self) -> u64 {
-        self.read_buffer_bytes.unwrap_or(0)
-            + self.write_buffer_bytes.unwrap_or(0)
-            + self.tls_state_bytes.unwrap_or(0)
+        self.read_buffer_bytes
+            .unwrap_or(0)
+            .saturating_add(self.write_buffer_bytes.unwrap_or(0))
+            .saturating_add(self.tls_state_bytes.unwrap_or(0))
     }
 }
 
@@ -321,9 +323,12 @@ pub struct HttpResourceReport {
 }
 
 impl HttpResourceReport {
-    /// Sum of the present byte fields (excludes the connection count).
+    /// Sum of the present byte fields (excludes the connection count). Saturating
+    /// — `total_bytes` is public, so a caller-built report must not wrap.
     pub fn total_bytes(&self) -> u64 {
-        self.pool_buffer_bytes.unwrap_or(0) + self.inflight_bytes.unwrap_or(0)
+        self.pool_buffer_bytes
+            .unwrap_or(0)
+            .saturating_add(self.inflight_bytes.unwrap_or(0))
     }
 }
 
@@ -441,8 +446,23 @@ std::thread_local! {
     /// `on_poll_end` pops; the host's global allocator charges the innermost.
     /// A stack (not a slot) for the same reason as `POLL_START`: metered poll
     /// scopes nest and several meters can share a thread.
-    static ACTIVE_ALLOC_METER: core::cell::RefCell<Vec<*const AllocMeter>> =
+    ///
+    /// Holds an owned `Arc<AllocMeterInner>`, not a raw pointer: `on_poll_start`
+    /// is a safe public method, so a caller could move or drop a stack-local
+    /// meter before `on_poll_end` — the strong ref here keeps the counters alive
+    /// for the whole scope, so `on_alloc` (driven by the allocator on every
+    /// allocation) can never dereference freed memory.
+    static ACTIVE_ALLOC_METER: core::cell::RefCell<Vec<Arc<AllocMeterInner>>> =
         const { core::cell::RefCell::new(Vec::new()) };
+}
+
+/// Shared counters behind an [`AllocMeter`]. Held by `Arc` so a scope on the
+/// active-meter stack owns the lifetime independently of the `AllocMeter` handle.
+#[derive(Debug, Default)]
+struct AllocMeterInner {
+    allocated: AtomicU64,
+    freed: AtomicU64,
+    allocations: AtomicU64,
 }
 
 /// Built-in [`TaskInstrument`] that attributes heap bytes **allocated and
@@ -472,11 +492,9 @@ std::thread_local! {
 /// [`CpuMeter`]. Expect a measurable overhead while a counting allocator is
 /// installed (~10-20% for this design); it is a diagnostics tool, not an
 /// always-on meter.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AllocMeter {
-    allocated: AtomicU64,
-    freed: AtomicU64,
-    allocations: AtomicU64,
+    inner: Arc<AllocMeterInner>,
 }
 
 /// Point-in-time copy of an [`AllocMeter`]. Counters are cumulative over the
@@ -513,9 +531,9 @@ impl AllocMeter {
     /// inside the allocator without recursing.
     #[inline]
     pub fn on_alloc(bytes: usize) {
-        Self::with_active(|m| {
-            m.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
-            m.allocations.fetch_add(1, Ordering::Relaxed);
+        Self::with_active(|inner| {
+            inner.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
+            inner.allocations.fetch_add(1, Ordering::Relaxed);
         });
     }
 
@@ -523,36 +541,31 @@ impl AllocMeter {
     /// thread, if any. Call from a global allocator's `dealloc`.
     #[inline]
     pub fn on_dealloc(bytes: usize) {
-        Self::with_active(|m| {
-            m.freed.fetch_add(bytes as u64, Ordering::Relaxed);
+        Self::with_active(|inner| {
+            inner.freed.fetch_add(bytes as u64, Ordering::Relaxed);
         });
     }
 
     #[inline]
-    fn with_active(f: impl FnOnce(&AllocMeter)) {
+    fn with_active(f: impl FnOnce(&AllocMeterInner)) {
         // `try_with` guards TLS-destroyed-on-exit; `try_borrow` guards the
         // reentrancy where `on_poll_start`'s own `push` reallocates the stack
         // and lands back here — in that window the borrow fails and we skip
         // (charging that tiny bookkeeping allocation to no one).
         let _ = ACTIVE_ALLOC_METER.try_with(|cell| {
             if let Ok(stack) = cell.try_borrow()
-                && let Some(&ptr) = stack.last()
+                && let Some(inner) = stack.last()
             {
-                // SAFETY: `ptr` was pushed by `on_poll_start` on this thread and
-                // is popped by its matching `on_poll_end` on this same thread
-                // (the `TaskInstrument` contract). Between those calls the meter
-                // is borrowed and thus alive, and allocations only reach here on
-                // that thread within that window, so the pointer is live.
-                f(unsafe { &*ptr });
+                f(inner);
             }
         });
     }
 
     pub fn snapshot(&self) -> AllocSnapshot {
         AllocSnapshot {
-            allocated_bytes: self.allocated.load(Ordering::Relaxed),
-            freed_bytes: self.freed.load(Ordering::Relaxed),
-            allocations: self.allocations.load(Ordering::Relaxed),
+            allocated_bytes: self.inner.allocated.load(Ordering::Relaxed),
+            freed_bytes: self.inner.freed.load(Ordering::Relaxed),
+            allocations: self.inner.allocations.load(Ordering::Relaxed),
         }
     }
 }
@@ -561,13 +574,18 @@ impl TaskInstrument for AllocMeter {
     fn on_poll_start(&self) {
         // `borrow_mut` while pushing: a reentrant `on_alloc` from the push's own
         // reallocation sees the active borrow and skips (see `with_active`).
-        let _ = ACTIVE_ALLOC_METER.try_with(|cell| cell.borrow_mut().push(self as *const Self));
+        let _ = ACTIVE_ALLOC_METER.try_with(|cell| cell.borrow_mut().push(self.inner.clone()));
     }
 
     fn on_poll_end(&self) {
-        let _ = ACTIVE_ALLOC_METER.try_with(|cell| {
-            cell.borrow_mut().pop();
-        });
+        // Pop under the borrow, then drop the popped Arc AFTER the borrow is
+        // released: if it was the last strong ref, its deallocation reenters the
+        // allocator (→ `on_dealloc`), which must not find the stack still borrowed.
+        let popped = ACTIVE_ALLOC_METER
+            .try_with(|cell| cell.borrow_mut().pop())
+            .ok()
+            .flatten();
+        drop(popped);
     }
 }
 
@@ -772,5 +790,37 @@ mod tests {
         }
         // Innermost meter got its own charge; no panic reaching here is the test.
         assert_eq!(meters.last().unwrap().snapshot().allocations, 1);
+    }
+
+    #[test]
+    fn alloc_meter_scope_outlives_a_dropped_handle() {
+        // Regression for the raw-pointer soundness hole: the active-meter scope
+        // owns an `Arc` to the counters, so a charge after the caller's handle is
+        // dropped touches valid memory (with the old `*const AllocMeter` this was
+        // a dangling-pointer deref).
+        let keep = AllocMeter::new();
+        let temp = keep.clone(); // shares the same counters
+        temp.on_poll_start();
+        drop(temp); // handle gone; the scope's Arc keeps the counters alive
+        AllocMeter::on_alloc(128);
+        keep.on_poll_end(); // LIFO pop; any handle pops the top scope
+        assert_eq!(keep.snapshot().allocated_bytes, 128);
+    }
+
+    #[test]
+    fn resource_report_total_bytes_saturate() {
+        let t = TransportResourceReport {
+            read_buffer_bytes: Some(u64::MAX),
+            write_buffer_bytes: Some(10),
+            tls_state_bytes: Some(10),
+        };
+        assert_eq!(t.total_bytes(), u64::MAX, "transport total must not wrap");
+
+        let h = HttpResourceReport {
+            pool_connections: Some(3),
+            pool_buffer_bytes: Some(u64::MAX),
+            inflight_bytes: Some(1),
+        };
+        assert_eq!(h.total_bytes(), u64::MAX, "http total must not wrap");
     }
 }

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -245,6 +245,88 @@ impl CollectionStats {
     }
 }
 
+// ── Out-of-client resource reports ───────────────────────────────────────────
+//
+// `MemoryReport` (in the client crate) accounts only for the client's own
+// in-process collections. The dominant per-session RAM lives *outside* the
+// client — the storage backend's page cache, the transport buffers, the HTTP
+// pool. These small structs let each of those components report what it can
+// introspect, so a consumer can compose a realistic per-session estimate.
+//
+// Every field is `Option`: a component fills only what it knows. All-`None`
+// means "not reported" — distinct from a positive `Some(0)` ("holds none",
+// e.g. a remote/store-backed backend whose data isn't process memory, matching
+// `CollectionStats { bytes: 0 }`). The structs are plain (not `#[non_exhaustive]`)
+// because they are built in the backend/transport/HTTP crates, which need
+// struct-literal construction; add future fields with a `..Default::default()`
+// tail to stay non-breaking.
+
+/// Process-local resource footprint a storage backend attributes to one
+/// session. Returned by `store::traits::DeviceStore::resource_report`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StorageResourceReport {
+    /// Estimated process-local bytes the backend holds for this session (e.g. a
+    /// SQLite page cache). `Some(0)` for backends whose data lives outside this
+    /// process (Redis, other network stores).
+    pub memory_bytes: Option<u64>,
+    /// Pages/entries currently backing the store, when known (SQLite: database
+    /// page count). A size indicator, not part of the memory total.
+    pub pages: Option<u64>,
+    /// Bytes read from the backing store this session, if the backend counts it.
+    pub io_read_bytes: Option<u64>,
+    /// Bytes written to the backing store this session, if the backend counts it.
+    pub io_write_bytes: Option<u64>,
+}
+
+impl StorageResourceReport {
+    /// Retained process memory this backend reports (0 when unknown). Excludes
+    /// the cumulative I/O counters, which are throughput, not residency.
+    pub fn total_bytes(&self) -> u64 {
+        self.memory_bytes.unwrap_or(0)
+    }
+}
+
+/// Per-session footprint of a [`crate::net::Transport`]: read/write framing
+/// buffers plus a best-effort TLS/noise session-state estimate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TransportResourceReport {
+    pub read_buffer_bytes: Option<u64>,
+    pub write_buffer_bytes: Option<u64>,
+    /// Best-effort estimate of TLS/noise session state (record buffers, key
+    /// schedule). Transports that can't introspect their TLS stack leave it
+    /// `None`.
+    pub tls_state_bytes: Option<u64>,
+}
+
+impl TransportResourceReport {
+    /// Sum of the present byte fields.
+    pub fn total_bytes(&self) -> u64 {
+        self.read_buffer_bytes.unwrap_or(0)
+            + self.write_buffer_bytes.unwrap_or(0)
+            + self.tls_state_bytes.unwrap_or(0)
+    }
+}
+
+/// Per-session footprint of a [`crate::net::HttpClient`]: idle connection-pool
+/// buffers plus any in-flight download/media buffering the impl can see.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HttpResourceReport {
+    /// Idle connections the pool may retain (a cap/estimate, not a live count
+    /// when the client can't introspect the pool).
+    pub pool_connections: Option<u64>,
+    /// Bytes held by the pool's per-connection read/write buffers.
+    pub pool_buffer_bytes: Option<u64>,
+    /// Bytes buffered for in-flight requests/responses right now, when known.
+    pub inflight_bytes: Option<u64>,
+}
+
+impl HttpResourceReport {
+    /// Sum of the present byte fields (excludes the connection count).
+    pub fn total_bytes(&self) -> u64 {
+        self.pool_buffer_bytes.unwrap_or(0) + self.inflight_bytes.unwrap_or(0)
+    }
+}
+
 // ── Task instrumentation ─────────────────────────────────────────────────────
 
 /// Runtime-agnostic hook called around every poll of the client's internal
@@ -349,6 +431,143 @@ impl TaskInstrument for CpuMeter {
                 .fetch_add(start.elapsed().as_nanos() as u64, Ordering::Relaxed);
             self.polls.fetch_add(1, Ordering::Relaxed);
         }
+    }
+}
+
+// ── Allocator attribution ────────────────────────────────────────────────────
+
+std::thread_local! {
+    /// Meters active on this thread, innermost last. `on_poll_start` pushes,
+    /// `on_poll_end` pops; the host's global allocator charges the innermost.
+    /// A stack (not a slot) for the same reason as `POLL_START`: metered poll
+    /// scopes nest and several meters can share a thread.
+    static ACTIVE_ALLOC_METER: core::cell::RefCell<Vec<*const AllocMeter>> =
+        const { core::cell::RefCell::new(Vec::new()) };
+}
+
+/// Built-in [`TaskInstrument`] that attributes heap bytes **allocated and
+/// freed** to one client, the churn/transient counterpart to the point-in-time
+/// retained figures in `Client::memory_report`. It captures task futures,
+/// decode arenas and media buffers — anything the client's instrumented tasks
+/// allocate — that no named collection holds.
+///
+/// The library never sees the allocator. The host installs a `#[global_allocator]`
+/// that calls [`AllocMeter::on_alloc`] / [`AllocMeter::on_dealloc`] on every
+/// (de)allocation; this meter — installed via `with_task_instrument` (or the
+/// `with_alloc_meter` convenience) — marks, per thread, *which* client's task is
+/// being polled, so those calls charge the right meter. `examples/alloc_tracking.rs`
+/// shows the ~20 lines of glue.
+///
+/// # Attribution boundary (honest limits)
+/// Only allocations made *inside an instrumented poll or blocking closure* are
+/// counted: every task spawned through the `Runtime` trait, plus the main run
+/// loop (metered since the client meters its own future). Work spawned raw on
+/// the executor — some voip/media paths — and the caller's own
+/// `send_message`-side code are **not** counted. Deallocations are charged to
+/// whichever meter is active when the free happens, not the one that allocated
+/// the block, so `freed` (and `net`) drift when a buffer outlives the poll that
+/// made it; the cumulative `allocated` total is the reliable signal.
+///
+/// Agnostic: the hook is the same wasm/ESP32-safe [`TaskInstrument`] surface as
+/// [`CpuMeter`]. Expect a measurable overhead while a counting allocator is
+/// installed (~10-20% for this design); it is a diagnostics tool, not an
+/// always-on meter.
+#[derive(Debug, Default)]
+pub struct AllocMeter {
+    allocated: AtomicU64,
+    freed: AtomicU64,
+    allocations: AtomicU64,
+}
+
+/// Point-in-time copy of an [`AllocMeter`]. Counters are cumulative over the
+/// meter's lifetime.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AllocSnapshot {
+    /// Total bytes allocated while this meter was the active one.
+    pub allocated_bytes: u64,
+    /// Total bytes freed while this meter was active (see the drift caveat on
+    /// [`AllocMeter`]).
+    pub freed_bytes: u64,
+    /// Number of allocations charged.
+    pub allocations: u64,
+}
+
+impl AllocSnapshot {
+    /// Net bytes still attributed (`allocated - freed`), saturating at 0. A
+    /// lower bound on live churn: blocks freed under a different active meter
+    /// aren't subtracted here.
+    pub fn net_bytes(&self) -> u64 {
+        self.allocated_bytes.saturating_sub(self.freed_bytes)
+    }
+}
+
+impl AllocMeter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Charge `bytes` of allocation to the meter currently active on this
+    /// thread, if any. Call from a global allocator's `alloc`. Allocation-free
+    /// (only a thread-local read + relaxed atomics), so it is safe to call from
+    /// inside the allocator without recursing.
+    #[inline]
+    pub fn on_alloc(bytes: usize) {
+        Self::with_active(|m| {
+            m.allocated.fetch_add(bytes as u64, Ordering::Relaxed);
+            m.allocations.fetch_add(1, Ordering::Relaxed);
+        });
+    }
+
+    /// Charge `bytes` of deallocation to the meter currently active on this
+    /// thread, if any. Call from a global allocator's `dealloc`.
+    #[inline]
+    pub fn on_dealloc(bytes: usize) {
+        Self::with_active(|m| {
+            m.freed.fetch_add(bytes as u64, Ordering::Relaxed);
+        });
+    }
+
+    #[inline]
+    fn with_active(f: impl FnOnce(&AllocMeter)) {
+        // `try_with` guards TLS-destroyed-on-exit; `try_borrow` guards the
+        // reentrancy where `on_poll_start`'s own `push` reallocates the stack
+        // and lands back here — in that window the borrow fails and we skip
+        // (charging that tiny bookkeeping allocation to no one).
+        let _ = ACTIVE_ALLOC_METER.try_with(|cell| {
+            if let Ok(stack) = cell.try_borrow()
+                && let Some(&ptr) = stack.last()
+            {
+                // SAFETY: `ptr` was pushed by `on_poll_start` on this thread and
+                // is popped by its matching `on_poll_end` on this same thread
+                // (the `TaskInstrument` contract). Between those calls the meter
+                // is borrowed and thus alive, and allocations only reach here on
+                // that thread within that window, so the pointer is live.
+                f(unsafe { &*ptr });
+            }
+        });
+    }
+
+    pub fn snapshot(&self) -> AllocSnapshot {
+        AllocSnapshot {
+            allocated_bytes: self.allocated.load(Ordering::Relaxed),
+            freed_bytes: self.freed.load(Ordering::Relaxed),
+            allocations: self.allocations.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl TaskInstrument for AllocMeter {
+    fn on_poll_start(&self) {
+        // `borrow_mut` while pushing: a reentrant `on_alloc` from the push's own
+        // reallocation sees the active borrow and skips (see `with_active`).
+        let _ = ACTIVE_ALLOC_METER.try_with(|cell| cell.borrow_mut().push(self as *const Self));
+    }
+
+    fn on_poll_end(&self) {
+        let _ = ACTIVE_ALLOC_METER.try_with(|cell| {
+            cell.borrow_mut().pop();
+        });
     }
 }
 
@@ -496,5 +715,62 @@ mod tests {
 
         let snap = meter.snapshot();
         assert_eq!(snap.polls, 1);
+    }
+
+    #[test]
+    fn alloc_meter_charges_only_the_active_scope() {
+        let meter = AllocMeter::new();
+
+        // Outside any poll scope: charged to no one.
+        AllocMeter::on_alloc(9999);
+
+        meter.on_poll_start();
+        AllocMeter::on_alloc(1000);
+        AllocMeter::on_alloc(500);
+        AllocMeter::on_dealloc(200);
+        meter.on_poll_end();
+
+        // After the scope closes: charged to no one again.
+        AllocMeter::on_alloc(7777);
+        AllocMeter::on_dealloc(7777);
+
+        let snap = meter.snapshot();
+        assert_eq!(snap.allocated_bytes, 1500);
+        assert_eq!(snap.freed_bytes, 200);
+        assert_eq!(snap.allocations, 2);
+        assert_eq!(snap.net_bytes(), 1300);
+    }
+
+    #[test]
+    fn alloc_meter_attributes_nested_scopes_to_the_innermost() {
+        let outer = AllocMeter::new();
+        let inner = AllocMeter::new();
+
+        outer.on_poll_start();
+        AllocMeter::on_alloc(100); // -> outer
+        inner.on_poll_start();
+        AllocMeter::on_alloc(30); // -> inner (innermost)
+        inner.on_poll_end();
+        AllocMeter::on_alloc(70); // -> outer again
+        outer.on_poll_end();
+
+        assert_eq!(outer.snapshot().allocated_bytes, 170);
+        assert_eq!(inner.snapshot().allocated_bytes, 30);
+    }
+
+    #[test]
+    fn alloc_meter_survives_realloc_reentrancy_during_poll_start() {
+        // Force the thread-local stack to grow inside `on_poll_start` while its
+        // own `borrow_mut` is held: a reentrant `on_alloc` must skip, not panic.
+        let meters: Vec<AllocMeter> = (0..64).map(|_| AllocMeter::new()).collect();
+        for m in &meters {
+            m.on_poll_start();
+            AllocMeter::on_alloc(1);
+        }
+        for m in meters.iter().rev() {
+            m.on_poll_end();
+        }
+        // Innermost meter got its own charge; no panic reaching here is the test.
+        assert_eq!(meters.last().unwrap().snapshot().allocations, 1);
     }
 }

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -582,6 +582,23 @@ pub trait DeviceStore: Send + Sync {
     async fn snapshot_db(&self, _name: &str, _extra_content: Option<&[u8]>) -> Result<()> {
         Ok(())
     }
+
+    /// Best-effort process-local memory this backend attributes to the session
+    /// (e.g. a SQLite page cache — often the single largest per-session chunk,
+    /// living entirely outside the `Client`). Defaults to an all-`None`
+    /// [`StorageResourceReport`] ("not reported"); backends that can introspect
+    /// their memory override it, and remote/store-backed backends report
+    /// `memory_bytes: Some(0)` (their data isn't process memory).
+    ///
+    /// This is a defaulted method on `DeviceStore` — an already-implemented,
+    /// non-blanket sub-trait of `Backend` — rather than an inherent method
+    /// (which wouldn't compose through the `Arc<dyn Backend>` the client holds)
+    /// or a new `Backend` supertrait (which would force *every* backend,
+    /// including external ones, to add an impl). The default keeps it fully
+    /// non-breaking, exactly like [`Self::snapshot_db`].
+    async fn resource_report(&self) -> crate::stats::StorageResourceReport {
+        crate::stats::StorageResourceReport::default()
+    }
 }
 
 /// Per-outbound-message secret storage for addon-style decryption.


### PR DESCRIPTION
## Summary

`memory_report()` accounts only for the `Client`'s own in-process collections (tens of KiB/session). Profiling a many-session process shows the real ~1 MiB/session is dominated by memory that lives **outside** the `Client` — the storage backend's SQLite page cache, transport buffers + TLS/noise state, the HTTP pool, and transient heap. This extends per-client resource attribution to those components so a downstream consumer can size a realistic per-session estimate.

Extends the observability surface from #962 / #963 / #964. All new reporting is **on-demand, zero-cost when unused, runtime/platform-agnostic (the wasm gate passes), and PII-free** (sizes/counts only).

## Design note — composing storage reporting through `dyn Backend`

`Backend` is a blanket-impl'd marker supertrait, so you can't add an overridable defaulted method directly on it, and a new `Backend` supertrait would force *every* backend (including external ones) to add an impl. An inherent method on the concrete store wouldn't compose through the `Arc<dyn Backend>` the client holds.

The report is instead a **defaulted method on the existing `DeviceStore` sub-trait** (next to `snapshot_db`). That sub-trait is implemented concretely (not blanket), so the method is overridable, composes through `dyn Backend`, and stays fully non-breaking — the same defaulted-method pattern the codebase already uses for `snapshot_db`, `get_group_metadata`, etc.

## What changed

- **Storage** — `DeviceStore::resource_report() -> StorageResourceReport`. SQLite reports `min(cache cap, db size)` via PRAGMAs (a tight upper bound on the page cache for the target workload; Diesel doesn't expose the raw handle `sqlite3_db_status(SQLITE_DBSTATUS_CACHE_USED)` would need — documented) plus the DB page count. Remote/store-backed backends report `memory_bytes: Some(0)`.
- **Alloc churn** — promote `examples/alloc_tracking.rs`'s hand-rolled pattern to a first-class `AllocMeter` `TaskInstrument` (sibling of `CpuMeter`). Opt in via `BotBuilder::with_alloc_meter` / `with_task_instrument`; the host installs a `#[global_allocator]` that calls `AllocMeter::on_alloc`/`on_dealloc`. The attribution boundary is documented honestly (only instrumented polls/tasks; deallocations charge the active meter, so `allocated` is the reliable signal).
- **Transport / HTTP** — defaulted `resource_report()` on the `Transport` and `HttpClient` traits (clean — not blanket-impl'd). The Tokio WebSocket transport and `ureq` client fill best-effort estimates; other impls inherit `None`.
- **mmap knob** — opt-in `SqliteStoreConfig::mmap_size` field + `with_mmap_size` builder emitting `PRAGMA mmap_size` (default `None` = current behavior; WAL caveat documented), moving the page cache to reclaimable file-backed pages for processes holding many small per-session DBs.
- **Unified report** — `Client::resource_report() -> ResourceReport` composes client collections + storage + transport + HTTP + an `AllocMeter` snapshot. `total_estimated_bytes()` sums the retained components and is documented as a **lower bound** (which parts are exact vs. estimated); alloc churn is excluded from it. The future is `Send`-guarded (per #964).

New `Option`-only report shapes (`StorageResourceReport`, `TransportResourceReport`, `HttpResourceReport`, `AllocSnapshot`) live in `wacore::stats`. No new feature flags — dead-code elimination keeps unused report code out of the binary, per #962's design notes. `memory_report()` is unchanged.

## Non-breaking

Every default preserves current behavior; all new config is opt-in. The one internal exhaustive `SqliteStoreConfig { .. }` literal was updated for the added field.

## Testing

- `cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings).
- **wasm gate**: `whatsapp-rust --lib --no-default-features` and `wacore --lib --no-default-features --features "voip,js"` both build on `wasm32-unknown-unknown`.
- A regression test per workstream (SQLite report bounds the cache by DB size & cap; `mmap_size` opt-in wiring; `AllocMeter` counts a known allocation + nesting + reentrancy; transport/HTTP estimates; the unified report composes and folds in the alloc snapshot).
- Compile-time `Send` guards on both `memory_report()` and `resource_report()`.
- Full lib suites green: `wacore` (1045), `sqlite-storage`, `tokio-transport`, `ureq-client`, `whatsapp-rust` (896).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTorqejFxX6pZG9AoaHzjG)_