### PR TITLE
feat(tctoken): attach tctoken in usync status/about and spam-report IQs

### DIFF
--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -230,7 +230,26 @@ impl<'a> Contacts<'a> {
         debug!("get_user_info: fetching info for {} JIDs", jids.len());
 
         let request_id = self.client.generate_request_id();
-        let spec = UserInfoSpec::new(jids.to_vec(), request_id);
+        let mut spec = UserInfoSpec::new(jids.to_vec(), request_id);
+
+        // Attach per-user tctokens so the status/about of privacy-restricted
+        // contacts is returned, matching WA Web's USyncStatusProtocol.getUserElement.
+        if self
+            .client
+            .ab_props()
+            .is_enabled(wacore::iq::abprops::web::PROFILE_SCRAPING_PRIVACY_TOKEN_IN_ABOUT_USYNC)
+            .await
+        {
+            let mut tc_tokens = std::collections::HashMap::new();
+            for jid in jids {
+                if let Some(token) = self.client.lookup_tc_token_for_jid(jid).await {
+                    tc_tokens.insert(jid.user.to_string(), token);
+                }
+            }
+            if !tc_tokens.is_empty() {
+                spec = spec.with_tc_tokens(tc_tokens);
+            }
+        }
 
         let info = self.client.execute(spec).await?;
         self.persist_lid_mappings(info.values().map(user_info_lid_pair))

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -240,12 +240,17 @@ impl<'a> Contacts<'a> {
             .is_enabled(wacore::iq::abprops::web::PROFILE_SCRAPING_PRIVACY_TOKEN_IN_ABOUT_USYNC)
             .await
         {
-            let mut tc_tokens = std::collections::HashMap::new();
-            for jid in jids {
-                if let Some(token) = self.client.lookup_tc_token_for_jid(jid).await {
-                    tc_tokens.insert(jid.user.to_string(), token);
-                }
-            }
+            let lookups = futures::future::join_all(jids.iter().map(|jid| async move {
+                (
+                    jid.to_non_ad().to_string(),
+                    self.client.lookup_tc_token_for_jid(jid).await,
+                )
+            }))
+            .await;
+            let tc_tokens: HashMap<String, Vec<u8>> = lookups
+                .into_iter()
+                .filter_map(|(key, token)| token.map(|t| (key, t)))
+                .collect();
             if !tc_tokens.is_empty() {
                 spec = spec.with_tc_tokens(tc_tokens);
             }

--- a/src/spam_report.rs
+++ b/src/spam_report.rs
@@ -35,7 +35,22 @@ impl Client {
         &self,
         request: SpamReportRequest,
     ) -> Result<SpamReportResult, IqError> {
-        let spec = SpamReportSpec::new(request);
+        use wacore::iq::abprops::web;
+
+        let mut spec = SpamReportSpec::new(request);
+
+        // Attach the reported contact's tctoken so the report is accepted for a
+        // privacy-restricted account, matching WA Web's OutSpamTCTokenMixin.
+        if self
+            .ab_props()
+            .is_enabled(web::ENABLE_SPAM_REPORT_IQ_WITH_PRIVACY_TOKEN)
+            .await
+            && let Some(reported) = spec.request.from_jid.clone()
+            && let Some(token) = self.lookup_tc_token_for_jid(&reported).await
+        {
+            spec = spec.with_tc_token(token);
+        }
+
         self.execute(spec).await
     }
 }

--- a/wacore/src/iq/spam_report.rs
+++ b/wacore/src/iq/spam_report.rs
@@ -18,10 +18,11 @@
 //! ```
 
 use crate::iq::spec::IqSpec;
+use crate::iq::tctoken::build_tc_token_node;
 use crate::request::InfoQuery;
 use crate::types::spam_report::{SpamReportRequest, SpamReportResult, build_spam_list_node};
 use wacore_binary::{Jid, Server};
-use wacore_binary::{NodeContent, NodeContentRef, NodeRef};
+use wacore_binary::{Node, NodeContent, NodeContentRef, NodeRef};
 
 // Re-export types for convenience
 pub use crate::types::spam_report::{
@@ -32,11 +33,23 @@ pub use crate::types::spam_report::{
 #[derive(Debug, Clone)]
 pub struct SpamReportSpec {
     pub request: SpamReportRequest,
+    /// Optional trusted-contact token for the reported contact, matching WA
+    /// Web's `OutSpamTCTokenMixin` (gated on `enable_spam_report_iq_with_privacy_token`).
+    pub tc_token: Option<Vec<u8>>,
 }
 
 impl SpamReportSpec {
     pub fn new(request: SpamReportRequest) -> Self {
-        Self { request }
+        Self {
+            request,
+            tc_token: None,
+        }
+    }
+
+    /// Include the reported contact's tctoken in the spam report IQ.
+    pub fn with_tc_token(mut self, token: Vec<u8>) -> Self {
+        self.tc_token = Some(token);
+        self
     }
 }
 
@@ -44,12 +57,15 @@ impl IqSpec for SpamReportSpec {
     type Response = SpamReportResult;
 
     fn build_iq(&self) -> InfoQuery<'static> {
-        let spam_list_node = build_spam_list_node(&self.request);
+        let mut children: Vec<Node> = vec![build_spam_list_node(&self.request)];
+        if let Some(token) = &self.tc_token {
+            children.push(build_tc_token_node(token));
+        }
 
         InfoQuery::set(
             "spam",
             Jid::new("", Server::Pn),
-            Some(NodeContent::Nodes(vec![spam_list_node])),
+            Some(NodeContent::Nodes(children)),
         )
     }
 
@@ -98,6 +114,33 @@ mod tests {
             );
         } else {
             panic!("Expected NodeContent::Nodes");
+        }
+    }
+
+    #[test]
+    fn test_spam_report_spec_build_iq_with_tctoken() {
+        let request = SpamReportRequest {
+            message_id: "TEST123".to_string(),
+            message_timestamp: 1234567890,
+            spam_flow: SpamFlow::MessageMenu,
+            ..Default::default()
+        };
+
+        let iq = SpamReportSpec::new(request)
+            .with_tc_token(vec![0xCA, 0xFE])
+            .build_iq();
+
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("Expected NodeContent::Nodes");
+        };
+        assert!(nodes.iter().any(|n| n.tag == "spam_list"));
+        let tctoken = nodes
+            .iter()
+            .find(|n| n.tag == "tctoken")
+            .expect("spam report should carry a tctoken when set");
+        match &tctoken.content {
+            Some(NodeContent::Bytes(b)) => assert_eq!(b, &[0xCA, 0xFE]),
+            _ => panic!("tctoken should carry bytes"),
         }
     }
 

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -501,8 +501,9 @@ impl IqSpec for IsOnWhatsAppSpec {
 pub struct UserInfoSpec {
     pub jids: Vec<Jid>,
     pub sid: String,
-    /// Per-user (bare user string) trusted-contact token, attached to the
-    /// matching `<user>` node for privacy-gated subprotocols (status/about),
+    /// Per-user trusted-contact token, keyed by the query JID's non-ad string
+    /// form (domain-qualified, so PN and LID forms don't collide), attached to
+    /// the matching `<user>` node for privacy-gated subprotocols (status/about),
     /// matching WA Web's `USyncStatusProtocol.getUserElement` /
     /// `USyncUser.withTcToken`.
     pub tc_tokens: HashMap<String, Vec<u8>>,
@@ -517,7 +518,8 @@ impl UserInfoSpec {
         }
     }
 
-    /// Attach per-user trusted-contact tokens keyed by the query JID's user part.
+    /// Attach per-user trusted-contact tokens keyed by the query JID's non-ad
+    /// string form (see [`UserInfoSpec::tc_tokens`]).
     pub fn with_tc_tokens(mut self, tc_tokens: HashMap<String, Vec<u8>>) -> Self {
         self.tc_tokens = tc_tokens;
         self
@@ -544,8 +546,9 @@ impl IqSpec for UserInfoSpec {
             .jids
             .iter()
             .map(|jid| {
-                let mut builder = NodeBuilder::new("user").attr("jid", jid.to_non_ad());
-                if let Some(token) = self.tc_tokens.get(jid.user.as_str()) {
+                let key = jid.to_non_ad().to_string();
+                let mut builder = NodeBuilder::new("user").attr("jid", key.clone());
+                if let Some(token) = self.tc_tokens.get(&key) {
                     builder = builder.children([build_tc_token_node(token)]);
                 }
                 builder.build()
@@ -1374,7 +1377,7 @@ mod tests {
     fn user_info_attaches_per_user_tctoken() {
         let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
         let mut tokens = HashMap::new();
-        tokens.insert("1234567890".to_string(), vec![0xDE, 0xAD]);
+        tokens.insert(jid.to_non_ad().to_string(), vec![0xDE, 0xAD]);
         let spec = UserInfoSpec::new(vec![jid], "sid").with_tc_tokens(tokens);
 
         let iq = spec.build_iq();

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -52,6 +52,7 @@
 
 use crate::WireEnum;
 use crate::iq::spec::IqSpec;
+use crate::iq::tctoken::build_tc_token_node;
 use crate::request::InfoQuery;
 use crate::stanza::business::VerifiedName;
 use anyhow::anyhow;
@@ -500,6 +501,11 @@ impl IqSpec for IsOnWhatsAppSpec {
 pub struct UserInfoSpec {
     pub jids: Vec<Jid>,
     pub sid: String,
+    /// Per-user (bare user string) trusted-contact token, attached to the
+    /// matching `<user>` node for privacy-gated subprotocols (status/about),
+    /// matching WA Web's `USyncStatusProtocol.getUserElement` /
+    /// `USyncUser.withTcToken`.
+    pub tc_tokens: HashMap<String, Vec<u8>>,
 }
 
 impl UserInfoSpec {
@@ -507,7 +513,14 @@ impl UserInfoSpec {
         Self {
             jids,
             sid: sid.into(),
+            tc_tokens: HashMap::new(),
         }
+    }
+
+    /// Attach per-user trusted-contact tokens keyed by the query JID's user part.
+    pub fn with_tc_tokens(mut self, tc_tokens: HashMap<String, Vec<u8>>) -> Self {
+        self.tc_tokens = tc_tokens;
+        self
     }
 }
 
@@ -531,9 +544,11 @@ impl IqSpec for UserInfoSpec {
             .jids
             .iter()
             .map(|jid| {
-                NodeBuilder::new("user")
-                    .attr("jid", jid.to_non_ad())
-                    .build()
+                let mut builder = NodeBuilder::new("user").attr("jid", jid.to_non_ad());
+                if let Some(token) = self.tc_tokens.get(jid.user.as_str()) {
+                    builder = builder.children([build_tc_token_node(token)]);
+                }
+                builder.build()
             })
             .collect();
 
@@ -1353,6 +1368,41 @@ mod tests {
         assert_eq!(info.devices_error.as_ref().unwrap().code, Some(500));
         assert!(!info.is_business);
         assert_eq!(info.business_error.as_ref().unwrap().code, Some(406));
+    }
+
+    #[test]
+    fn user_info_attaches_per_user_tctoken() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let mut tokens = HashMap::new();
+        tokens.insert("1234567890".to_string(), vec![0xDE, 0xAD]);
+        let spec = UserInfoSpec::new(vec![jid], "sid").with_tc_tokens(tokens);
+
+        let iq = spec.build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected usync nodes");
+        };
+        let list = nodes[0].get_children_by_tag("list").next().unwrap();
+        let user = list.get_children_by_tag("user").next().unwrap();
+        let tctoken = user
+            .get_children_by_tag("tctoken")
+            .next()
+            .expect("user node should carry a tctoken");
+        match &tctoken.content {
+            Some(NodeContent::Bytes(b)) => assert_eq!(b, &[0xDE, 0xAD]),
+            _ => panic!("tctoken should carry bytes"),
+        }
+    }
+
+    #[test]
+    fn user_info_without_tctoken_omits_it() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let iq = UserInfoSpec::new(vec![jid], "sid").build_iq();
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected usync nodes");
+        };
+        let list = nodes[0].get_children_by_tag("list").next().unwrap();
+        let user = list.get_children_by_tag("user").next().unwrap();
+        assert!(user.get_children_by_tag("tctoken").next().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A compliance sweep of the captured WA Web JS for every site that attaches a trusted-contact token found two outgoing requests where the lib omitted it, so they fail for privacy-restricted accounts. This closes both, following the same pattern the merged #966 established for 1:1 messages.

Verified against the captured JS: `WA/Smax/OutSpamTCTokenMixin.js`, `WA/Smax/OutSpamIndividualReportRequest.js`, `WAWeb/Usync/Status.js`, `WAWeb/Get/AboutQueryJob.js`, `WAWeb/Usync/User.js`.

## 1. Usync status/about query — missing per-user `<tctoken>`

WA Web's `USyncStatusProtocol.getUserElement` attaches a per-user `<tctoken>` to the usync `<user>` node (gated on `profile_scraping_privacy_token_in_about_usync`); `getAbout` builds the status usync via `USyncUser.withTcToken`. Without it, a restricted contact's status/about comes back empty/`401`.

`UserInfoSpec` now carries `tc_tokens` (keyed by the query JID's user part) and attaches `<tctoken>` to the matching `<user>` node. `get_user_info` populates them from `lookup_tc_token_for_jid`, gated on the same AB prop.

## 2. Spam report IQ — missing `<tctoken>`

WA Web's spam report (`OutSpamIndividualReportRequest`) merges `OutSpamTCTokenMixin` (gated on `enable_spam_report_iq_with_privacy_token`) to attach the reported contact's `<tctoken>`. `SpamReportSpec` now takes an optional tctoken and `send_spam_report` resolves it for `request.from_jid`.

## Already compliant (unchanged)

1:1 messages (tctoken + cstoken), presence subscribe, profile-picture GET, and group create/participant-add already attach the token. The `t` timestamp attribute is intentionally omitted — `tctokenT` is never populated anywhere in the captured bundle.

## Known follow-up (not in this PR)

VoIP call offers: WA Web's `StartCall` calls `sendTcToken` per participant. The VoIP subsystem doesn't yet issue/attach tctokens (already a `TODO` in `wacore/src/iq/tctoken.rs`); left for a dedicated change.

## Changes

- `wacore/src/iq/usync.rs`: `UserInfoSpec::with_tc_tokens`; per-user `<tctoken>` in `build_iq`.
- `wacore/src/iq/spam_report.rs`: `SpamReportSpec::with_tc_token`; `<tctoken>` child in `build_iq`.
- `src/features/contacts.rs`: `get_user_info` resolves per-user tctokens under the usync AB prop.
- `src/spam_report.rs`: `send_spam_report` resolves the reported contact's tctoken under the spam AB prop.

## Validation

- `cargo clippy -p wacore -p whatsapp-rust --tests` clean; `cargo fmt --all --check` clean.
- New unit tests: usync attaches/omits per-user tctoken; spam report attaches tctoken when set.
- `cargo test -p wacore --lib` and `cargo test -p whatsapp-rust --lib` (909) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPxq74VYidN8RVWZsVrJK6)_