### PR TITLE
feat(tctoken): attach and issue tctoken on outgoing VoIP call offers

### DIFF
--- a/src/features/tctoken.rs
+++ b/src/features/tctoken.rs
@@ -12,11 +12,12 @@
 //! let count = client.tc_token().prune_expired().await?;
 //! ```
 //!
-//! ## TODO: VoIP call integration
-//! WA Web calls `sendTcToken` for each participant when initiating calls
-//! (WAWeb/Voip/StartCall.js). When a calls/VoIP module is added, it should
-//! call `issue_tc_token_after_send` (or equivalent) for every call participant
-//! — both 1:1 and group calls. This prevents 463 nacks on call offers.
+//! ## VoIP call integration
+//! Outgoing 1:1 call offers attach the callee's stored token to the offer's
+//! `<privacy>` node and issue a fresh token after send (WA Web's `sendTcToken`
+//! in StartCall.js), both driven from `voip::facade::place_call`. Group-call
+//! initiation is not yet implemented; when it is, it should attach/issue per
+//! participant the same way to avoid 463 nacks on call offers.
 
 use crate::client::Client;
 use crate::request::IqError;

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -152,6 +152,21 @@ impl Client {
     pub(crate) async fn should_issue_tc_token(&self, to: &Jid) -> bool {
         use wacore::iq::tctoken::should_send_new_tc_token_with;
 
+        // A self-call must never issue or record a token for our own account
+        // (same guard as maybe_include_tc_token).
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        let is_self = snapshot
+            .pn
+            .as_ref()
+            .is_some_and(|pn| pn.is_same_user_as(to))
+            || snapshot
+                .lid
+                .as_ref()
+                .is_some_and(|lid| lid.is_same_user_as(to));
+        if is_self {
+            return false;
+        }
+
         if to.is_bot() || to.is_status_broadcast() {
             return false;
         }
@@ -483,6 +498,24 @@ mod tests {
         assert!(
             !client.should_issue_tc_token(&jid).await,
             "a fresh issuance in the current bucket must not re-issue"
+        );
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn should_issue_tc_token_false_for_self() {
+        let client = create_test_client().await;
+        let own = Jid::new("999000111", Server::Lid);
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own.clone(),
+            )))
+            .await;
+
+        assert!(
+            !client.should_issue_tc_token(&own).await,
+            "a self-call must never issue a tc token for our own account"
         );
     }
 }

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -120,7 +120,7 @@ impl Client {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.issue_tc_token", level = "debug", skip_all, fields(to = %to.observe())))]
-    pub(super) async fn issue_tc_token_after_send(&self, to: &Jid) {
+    pub(crate) async fn issue_tc_token_after_send(&self, to: &Jid) {
         use wacore::iq::tctoken::IssuePrivacyTokensSpec;
 
         // Bots and status broadcast don't participate in the privacy token system.
@@ -142,6 +142,34 @@ impl Client {
             return;
         }
         self.record_tc_token_sender_timestamp(to).await;
+    }
+
+    /// Whether a fresh tctoken should be issued to `to`, rate-limited by the
+    /// sender bucket. Independent of the 1:1 message AB props — WA Web schedules
+    /// `sendTcToken` on its own cadence (`MsgJob`, `StartCall`) regardless of
+    /// whether a token was attached to the outgoing stanza.
+    ///
+    /// The 1:1 message path inlines this decision in `maybe_include_tc_token`
+    /// (it already reads the entry for the token bytes); this standalone form
+    /// serves the call path, which only needs the issuance decision.
+    #[cfg(feature = "voip")]
+    pub(crate) async fn should_issue_tc_token(&self, to: &Jid) -> bool {
+        use wacore::iq::tctoken::should_send_new_tc_token_with;
+
+        if to.is_bot() || to.is_status_broadcast() {
+            return false;
+        }
+
+        let key = self.resolve_tc_token_key(to).await;
+        let sender_ts = match self.persistence_manager.backend().get_tc_token(&key).await {
+            Ok(entry) => entry.and_then(|e| e.sender_timestamp),
+            Err(e) => {
+                log::warn!(target: "Client/TcToken", "Failed to read tc_token for {}: {e}", to.observe());
+                None
+            }
+        };
+
+        should_send_new_tc_token_with(sender_ts, &self.tc_token_config().await)
     }
 
     /// Persist tokens returned by the explicit `tc_token().issue_tokens()` API.
@@ -423,6 +451,42 @@ mod tests {
         assert!(
             entry.sender_timestamp.is_some(),
             "sender_timestamp is advanced on issuance"
+        );
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn should_issue_tc_token_true_for_unknown_contact() {
+        let client = create_test_client().await;
+        let jid = Jid::new("770000003", Server::Lid);
+        assert!(
+            client.should_issue_tc_token(&jid).await,
+            "a contact with no recorded issuance should get a token"
+        );
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn should_issue_tc_token_false_within_sender_bucket() {
+        let client = create_test_client().await;
+        client
+            .persistence_manager
+            .backend()
+            .put_tc_token(
+                "770000004",
+                &TcTokenEntry {
+                    token: Vec::new(),
+                    token_timestamp: 0,
+                    sender_timestamp: Some(wacore::time::now_secs()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let jid = Jid::new("770000004", Server::Lid);
+        assert!(
+            !client.should_issue_tc_token(&jid).await,
+            "a fresh issuance in the current bucket must not re-issue"
         );
     }
 }

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -1,6 +1,21 @@
 use super::*;
 
 impl Client {
+    /// Whether `jid` is our own account (PN or LID). The privacy-token paths
+    /// never attach to or issue for ourselves; a single source of truth keeps
+    /// the message and call paths from drifting apart.
+    fn is_own_jid(&self, jid: &Jid) -> bool {
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        snapshot
+            .pn
+            .as_ref()
+            .is_some_and(|pn| pn.is_same_user_as(jid))
+            || snapshot
+                .lid
+                .as_ref()
+                .is_some_and(|lid| lid.is_same_user_as(jid))
+    }
+
     /// Look up and include a privacy token in outgoing 1:1 message stanza nodes.
     ///
     /// Follows WA Web's fallback chain (MsgCreateFanoutStanza.js `Re = R(te) ?? D(te, s)`):
@@ -26,16 +41,7 @@ impl Client {
         };
 
         // Skip for own JID — no need to send a privacy token to ourselves.
-        let snapshot = self.persistence_manager.get_device_snapshot();
-        let is_self = snapshot
-            .pn
-            .as_ref()
-            .is_some_and(|pn| pn.is_same_user_as(to))
-            || snapshot
-                .lid
-                .as_ref()
-                .is_some_and(|lid| lid.is_same_user_as(to));
-        if is_self {
+        if self.is_own_jid(to) {
             return false;
         }
 
@@ -79,6 +85,7 @@ impl Client {
             .then_some(entry.token.as_slice())
         });
         // cstoken needs both the NCT salt and a resolved account LID (WA Web `D`).
+        let snapshot = self.persistence_manager.get_device_snapshot();
         let cs_token_inputs: Option<(&[u8], &wacore_binary::CompactString)> =
             match (&snapshot.nct_salt, &resolved_lid) {
                 (Some(salt), Some(lid)) => Some((salt.as_slice(), lid)),
@@ -152,18 +159,8 @@ impl Client {
     pub(crate) async fn should_issue_tc_token(&self, to: &Jid) -> bool {
         use wacore::iq::tctoken::should_send_new_tc_token_with;
 
-        // A self-call must never issue or record a token for our own account
-        // (same guard as maybe_include_tc_token).
-        let snapshot = self.persistence_manager.get_device_snapshot();
-        let is_self = snapshot
-            .pn
-            .as_ref()
-            .is_some_and(|pn| pn.is_same_user_as(to))
-            || snapshot
-                .lid
-                .as_ref()
-                .is_some_and(|lid| lid.is_same_user_as(to));
-        if is_self {
+        // A self-call must never issue or record a token for our own account.
+        if self.is_own_jid(to) {
             return false;
         }
 

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -148,10 +148,6 @@ impl Client {
     /// sender bucket. Independent of the 1:1 message AB props — WA Web schedules
     /// `sendTcToken` on its own cadence (`MsgJob`, `StartCall`) regardless of
     /// whether a token was attached to the outgoing stanza.
-    ///
-    /// The 1:1 message path inlines this decision in `maybe_include_tc_token`
-    /// (it already reads the entry for the token bytes); this standalone form
-    /// serves the call path, which only needs the issuance decision.
     #[cfg(feature = "voip")]
     pub(crate) async fn should_issue_tc_token(&self, to: &Jid) -> bool {
         use wacore::iq::tctoken::should_send_new_tc_token_with;

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -512,9 +512,7 @@ async fn place_call(
         Err(_) => return Err(CallError::MissingDeviceIdentity),
     };
 
-    // Attach the callee's stored trusted-contact token to the offer's `<privacy>` node so a
-    // privacy-restricted callee accepts the offer -- the same token the 1:1 message and presence
-    // paths attach. Absent when we hold no valid token for them.
+    // A privacy-restricted callee rejects the offer unless it carries our stored token for them.
     let privacy_token = client.lookup_tc_token_for_jid(peer).await;
 
     // The offer needs a stanza id so the server can ack-correlate it: the initiator's relay rides
@@ -612,9 +610,7 @@ async fn place_call(
         return Err(e.into());
     }
 
-    // Issue our token to the callee after the offer, mirroring WA Web's `sendTcToken` in
-    // StartCall.js: rate-limited by the sender bucket and fire-and-forget so call setup isn't
-    // blocked on the IQ round-trip. Prevents 463 nacks on later offers to this contact.
+    // Prevents 463 nacks on later offers to this contact (WA Web's post-offer sendTcToken).
     spawn_call_tc_token_issuance(client, peer);
 
     // The relay arrives in the `<ack type=offer>` reply to the offer's stanza id (live-only, needs a
@@ -1914,9 +1910,8 @@ mod tests {
         );
     }
 
-    // A stored, non-expired trusted-contact token for the callee must ride on the offer as the
-    // leading `<privacy>` child (WA Web's tctoken-on-call-offer), so a privacy-restricted callee
-    // accepts it. Without a token the offer carries no `<privacy>` (asserted above).
+    // A stored token must ride on the offer as the leading `<privacy>` child, or a
+    // privacy-restricted callee rejects the call (the no-token case is covered above).
     #[tokio::test]
     async fn place_call_attaches_stored_tctoken_as_privacy_node() {
         use wacore::store::traits::TcTokenEntry;

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -512,6 +512,11 @@ async fn place_call(
         Err(_) => return Err(CallError::MissingDeviceIdentity),
     };
 
+    // Attach the callee's stored trusted-contact token to the offer's `<privacy>` node so a
+    // privacy-restricted callee accepts the offer -- the same token the 1:1 message and presence
+    // paths attach. Absent when we hold no valid token for them.
+    let privacy_token = client.lookup_tc_token_for_jid(peer).await;
+
     // The offer needs a stanza id so the server can ack-correlate it: the initiator's relay rides
     // back on the `<ack type=offer>` reply to THIS id, not on a later <call>.
     let offer_stanza_id = client.generate_request_id();
@@ -520,7 +525,7 @@ async fn place_call(
         to: peer,
         call_creator,
         device_keys: &device_keys,
-        privacy_token: None,
+        privacy_token: privacy_token.as_deref(),
         capability: Some(&CAPABILITY_OFFER),
         device_identity: device_identity.as_deref(),
         id: Some(&offer_stanza_id),
@@ -607,6 +612,11 @@ async fn place_call(
         return Err(e.into());
     }
 
+    // Issue our token to the callee after the offer, mirroring WA Web's `sendTcToken` in
+    // StartCall.js: rate-limited by the sender bucket and fire-and-forget so call setup isn't
+    // blocked on the IQ round-trip. Prevents 463 nacks on later offers to this contact.
+    spawn_call_tc_token_issuance(client, peer);
+
     // The relay arrives in the `<ack type=offer>` reply to the offer's stanza id (live-only, needs a
     // real server). Wait on the ack-waiter with a bounded timeout; attach the engine when the relay
     // lands, else fail the call so a parked wait_ended() resolves.
@@ -692,6 +702,25 @@ fn spawn_outgoing_relay_waiter(
                     );
                     fail_pending_outgoing(&client, &call_id, generation);
                 }
+            }
+        }))
+        .detach();
+}
+
+/// Fire-and-forget issuance of our trusted-contact token to the callee after an outgoing offer,
+/// mirroring WA Web's `sendTcToken` in StartCall.js. Rate-limited by the sender bucket so repeat
+/// calls to the same contact within a window don't re-issue. Best-effort: a failed issuance only
+/// risks a later re-issue, never the call itself.
+fn spawn_call_tc_token_issuance(client: &Client, peer: &Jid) {
+    let Some(client) = client.self_weak.get().and_then(|w| w.upgrade()) else {
+        return;
+    };
+    let runtime = client.runtime.clone();
+    let peer = peer.clone();
+    runtime
+        .spawn(Box::pin(async move {
+            if client.should_issue_tc_token(&peer).await {
+                client.issue_tc_token_after_send(&peer).await;
             }
         }))
         .detach();
@@ -1882,6 +1911,72 @@ mod tests {
         assert!(
             !enc.content_bytes().unwrap_or_default().is_empty(),
             "the per-device <enc> must carry the encrypted callKey"
+        );
+    }
+
+    // A stored, non-expired trusted-contact token for the callee must ride on the offer as the
+    // leading `<privacy>` child (WA Web's tctoken-on-call-offer), so a privacy-restricted callee
+    // accepts it. Without a token the offer carries no `<privacy>` (asserted above).
+    #[tokio::test]
+    async fn place_call_attaches_stored_tctoken_as_privacy_node() {
+        use wacore::store::traits::TcTokenEntry;
+
+        let (client, _sent_count) = make_sending_client().await;
+        let peer_user = Jid::new("333333333333333", Server::Lid);
+        let device = peer_lid();
+        seed_peer_session(&client, &device).await;
+
+        // Keyed by the callee's account LID user (resolve_tc_token_key for a LID peer).
+        client
+            .persistence_manager
+            .backend()
+            .put_tc_token(
+                "333333333333333",
+                &TcTokenEntry {
+                    token: vec![0xAB, 0xCD, 0xEF],
+                    token_timestamp: wacore::time::now_secs(),
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let own_lid = client.get_lid().expect("own lid");
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+
+        place_call(
+            &client,
+            "00abcdef0123456789abcdef01234567".into(),
+            &peer_user,
+            &own_lid,
+            &own_lid,
+            std::slice::from_ref(&device),
+            std::slice::from_ref(&device),
+            Arc::new(mic_rx),
+            Arc::new(spk_tx),
+        )
+        .await
+        .expect("place_call");
+
+        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("offer must be sent")
+            .expect("waiter");
+        let r = node.as_node_ref();
+        let offer = &r.children().unwrap()[0];
+        let children = offer.children().unwrap();
+        // `<privacy>` is the load-bearing first child of the offer.
+        assert_eq!(
+            children[0].tag.as_ref(),
+            "privacy",
+            "the stored tctoken must ride as the leading <privacy> child"
+        );
+        assert_eq!(
+            children[0].content_bytes(),
+            Some([0xAB, 0xCD, 0xEF].as_slice())
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the last documented gap in the trusted-contact token sweep: outgoing VoIP call offers. WhatsApp Web attaches the callee's trusted-contact token to the call offer and issues a fresh token to the callee when starting a call (`sendTcToken` in `StartCall.js`); the offer builder already had a `<privacy>` slot but `place_call` was passing `None`, and no issuance ran on the call path.

## Changes

- **`voip::facade::place_call`** — attaches the callee's stored (non-expired) tctoken to the offer's leading `<privacy>` node via `lookup_tc_token_for_jid`, the same token the 1:1 message and presence-subscribe paths already attach. Absent when we hold no valid token.
- **Post-send issuance** — after a successful offer send, fire-and-forget issues our token to the callee (`spawn_call_tc_token_issuance`), rate-limited by the sender bucket so repeat calls to the same contact within a window don't re-issue. It's detached, so it never blocks call setup on the IQ round-trip. This prevents 463 nacks on later offers to privacy-restricted contacts.
- **`should_issue_tc_token`** — new `Client` helper (voip-gated) exposing just the sender-bucket issuance decision the message path inlines in `maybe_include_tc_token`. `issue_tc_token_after_send` widened from `pub(super)` to `pub(crate)` so the call path can reuse it.
- **Doc** — the stale `TODO: VoIP call integration` note in `features/tctoken.rs` is updated to reflect the wired 1:1 path; group-call initiation isn't implemented yet and should attach/issue per participant the same way when added.

## Scope

`place_call` is the only outgoing offer path (1:1); group calls are inbound-only (`offer_notice` parsing) today, so there is no group initiation site to wire.

## Testing

- `should_issue_tc_token` returns `true` for an unknown contact and `false` within the current sender bucket.
- `place_call_attaches_stored_tctoken_as_privacy_node` seeds a token and asserts it rides as the offer's leading `<privacy>` child; the existing no-token offer test still asserts no `<privacy>` node.
- `cargo fmt`, `cargo clippy --features voip`, default and `--features voip` builds all clean; full `voip::facade` suite (30 tests) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPxq74VYidN8RVWZsVrJK6)_