### PR TITLE
feat: gate DM read/played receipts on readreceipts privacy

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -849,19 +849,23 @@ impl Client {
                     match r_priv {
                         Ok(settings) => {
                             use wacore::iq::privacy::{PrivacyCategory, PrivacyValue};
-                            // WA Web reads readreceipts from local prefs; we mirror it by
-                            // persisting the fetched value so DM read/played receipts gate to
-                            // `*-self` before the next connect's fetch even runs. This is the
-                            // refresh path: a change on another device is picked up here.
+                            // Persist so the gate is correct on reconnect before the next fetch
+                            // runs; this is also the cross-device refresh path (WA Web reads
+                            // readreceipts from local prefs).
                             let disabled = matches!(
                                 settings.get_value(&PrivacyCategory::ReadReceipts),
                                 Some(PrivacyValue::None)
                             );
-                            if disabled
-                                != bg_client
-                                    .persistence_manager
-                                    .get_device_snapshot()
-                                    .read_receipts_disabled
+                            // Re-check generation: after the fetch's round-trip a superseded
+                            // connection must not persist its now-stale privacy value.
+                            let stale = bg_client.connection_generation.load(Ordering::SeqCst)
+                                != bg_generation;
+                            if !stale
+                                && disabled
+                                    != bg_client
+                                        .persistence_manager
+                                        .get_device_snapshot()
+                                        .read_receipts_disabled
                             {
                                 bg_client
                                     .persistence_manager

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -846,8 +846,39 @@ impl Client {
                     if let Err(e) = r_block {
                         warn!("Background init: Failed to fetch blocklist: {e:?}");
                     }
-                    if let Err(e) = r_priv {
-                        warn!("Background init: Failed to fetch privacy settings: {e:?}");
+                    match r_priv {
+                        Ok(settings) => {
+                            use wacore::iq::privacy::{PrivacyCategory, PrivacyValue};
+                            // WA Web reads readreceipts from local prefs; we mirror it by
+                            // persisting the fetched value so DM read/played receipts gate to
+                            // `*-self` before the next connect's fetch even runs. This is the
+                            // refresh path: a change on another device is picked up here.
+                            let disabled = matches!(
+                                settings.get_value(&PrivacyCategory::ReadReceipts),
+                                Some(PrivacyValue::None)
+                            );
+                            if disabled
+                                != bg_client
+                                    .persistence_manager
+                                    .get_device_snapshot()
+                                    .read_receipts_disabled
+                            {
+                                bg_client
+                                    .persistence_manager
+                                    .process_command(DeviceCommand::SetReadReceiptsDisabled(
+                                        disabled,
+                                    ))
+                                    .await;
+                                if let Err(e) = bg_client.persistence_manager.flush().await {
+                                    warn!(
+                                        "Background init: Failed to persist readreceipts privacy: {e:?}"
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Background init: Failed to fetch privacy settings: {e:?}");
+                        }
                     }
                     if let Err(e) = r_digest {
                         warn!("Background init: Failed to validate digest key: {e:?}");

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -34,9 +34,9 @@ const MAX_RECEIPT_IDS_PER_STANZA: usize = 256;
 /// mirroring WA Web `WAWebSendPlayedReceiptJob`: newsletters use `played-self`,
 /// everything else `played`. The `participant` attr is set only for
 /// group/broadcast chats; in DMs WA Web drops it (`r.isUser() ? null : author`).
-/// `read_receipts_disabled` is the `readreceipts==none` privacy gate: a DM (not
-/// group, not status) then uses `played-self` (does not notify the sender),
-/// matching WA Web `PlayedReceiptJob.js`; groups are exempt.
+/// `read_receipts_disabled` is the `readreceipts==none` privacy gate: only a DM
+/// (not group, status, or broadcast list) then uses `played-self` (does not
+/// notify the sender), matching WA Web `PlayedReceiptJob.js`.
 fn build_played_receipt_node(
     chat: &Jid,
     sender: Option<&Jid>,
@@ -44,7 +44,8 @@ fn build_played_receipt_node(
     timestamp: &str,
     read_receipts_disabled: bool,
 ) -> wacore_binary::Node {
-    let is_private_dm = !chat.is_group() && !chat.is_status_broadcast();
+    let is_private_dm =
+        !chat.is_group() && !chat.is_status_broadcast() && !chat.is_broadcast_list();
     let receipt_type = if chat.is_newsletter() || (read_receipts_disabled && is_private_dm) {
         ReceiptType::PlayedSelf
     } else {
@@ -78,9 +79,9 @@ fn build_played_receipt_node(
 /// `WAWebSendReadReceiptJob` + `sendAggregateReceipts`: newsletters use
 /// `read-self`, everything else `read`; status reads carry `context="status"`
 /// and, for a LID author, `peer_participant_pn` (the resolved LID->PN).
-/// `read_receipts_disabled` is the `readreceipts==none` privacy gate: a DM (not
-/// group, not status) then uses `read-self` (does not notify the sender),
-/// matching WA Web `ReadReceiptJob.js`; groups are exempt.
+/// `read_receipts_disabled` is the `readreceipts==none` privacy gate: only a DM
+/// (not group, status, or broadcast list) then uses `read-self` (does not notify
+/// the sender), matching WA Web `ReadReceiptJob.js`.
 fn build_read_receipt_node(
     chat: &Jid,
     sender: Option<&Jid>,
@@ -89,7 +90,8 @@ fn build_read_receipt_node(
     peer_participant_pn: Option<&Jid>,
     read_receipts_disabled: bool,
 ) -> wacore_binary::Node {
-    let is_private_dm = !chat.is_group() && !chat.is_status_broadcast();
+    let is_private_dm =
+        !chat.is_group() && !chat.is_status_broadcast() && !chat.is_broadcast_list();
     let receipt_type = if chat.is_newsletter() || (read_receipts_disabled && is_private_dm) {
         ReceiptType::ReadSelf
     } else {
@@ -1217,6 +1219,20 @@ mod tests {
     fn group_receipts_ignore_privacy_gate() {
         // Privacy does not apply to groups: still `read`/`played` even when disabled.
         let chat: Jid = "120363021033254949@g.us".parse().expect("group jid");
+        let sender: Jid = "12025550143@s.whatsapp.net".parse().expect("sender jid");
+        let read = build_read_receipt_node(&chat, Some(&sender), &["MID"], "1", None, true);
+        assert_eq!(type_of(&read).as_deref(), Some("read"));
+        let played = build_played_receipt_node(&chat, Some(&sender), &["MID"], "1", true);
+        assert_eq!(type_of(&played).as_deref(), Some("played"));
+    }
+
+    #[test]
+    fn broadcast_list_receipts_ignore_privacy_gate() {
+        // Broadcast lists are group-adjacent (they carry `participant`), so the
+        // privacy gate must not downgrade them to `*-self` — matching WA Web.
+        let chat: Jid = "120363000000000001@broadcast"
+            .parse()
+            .expect("broadcast list jid");
         let sender: Jid = "12025550143@s.whatsapp.net".parse().expect("sender jid");
         let read = build_read_receipt_node(&chat, Some(&sender), &["MID"], "1", None, true);
         assert_eq!(type_of(&read).as_deref(), Some("read"));

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -34,13 +34,18 @@ const MAX_RECEIPT_IDS_PER_STANZA: usize = 256;
 /// mirroring WA Web `WAWebSendPlayedReceiptJob`: newsletters use `played-self`,
 /// everything else `played`. The `participant` attr is set only for
 /// group/broadcast chats; in DMs WA Web drops it (`r.isUser() ? null : author`).
+/// `read_receipts_disabled` is the `readreceipts==none` privacy gate: a DM (not
+/// group, not status) then uses `played-self` (does not notify the sender),
+/// matching WA Web `PlayedReceiptJob.js`; groups are exempt.
 fn build_played_receipt_node(
     chat: &Jid,
     sender: Option<&Jid>,
     message_ids: &[&str],
     timestamp: &str,
+    read_receipts_disabled: bool,
 ) -> wacore_binary::Node {
-    let receipt_type = if chat.is_newsletter() {
+    let is_private_dm = !chat.is_group() && !chat.is_status_broadcast();
+    let receipt_type = if chat.is_newsletter() || (read_receipts_disabled && is_private_dm) {
         ReceiptType::PlayedSelf
     } else {
         ReceiptType::Played
@@ -72,16 +77,20 @@ fn build_played_receipt_node(
 /// Pure builder for the read `<receipt>` node. Mirrors WA Web
 /// `WAWebSendReadReceiptJob` + `sendAggregateReceipts`: newsletters use
 /// `read-self`, everything else `read`; status reads carry `context="status"`
-/// and, for a LID author, `peer_participant_pn` (the resolved LID->PN). The DM
-/// `read`-vs-`read-self` read-receipts-privacy gating is not modeled here.
+/// and, for a LID author, `peer_participant_pn` (the resolved LID->PN).
+/// `read_receipts_disabled` is the `readreceipts==none` privacy gate: a DM (not
+/// group, not status) then uses `read-self` (does not notify the sender),
+/// matching WA Web `ReadReceiptJob.js`; groups are exempt.
 fn build_read_receipt_node(
     chat: &Jid,
     sender: Option<&Jid>,
     message_ids: &[&str],
     timestamp: &str,
     peer_participant_pn: Option<&Jid>,
+    read_receipts_disabled: bool,
 ) -> wacore_binary::Node {
-    let receipt_type = if chat.is_newsletter() {
+    let is_private_dm = !chat.is_group() && !chat.is_status_broadcast();
+    let receipt_type = if chat.is_newsletter() || (read_receipts_disabled && is_private_dm) {
         ReceiptType::ReadSelf
     } else {
         ReceiptType::Read
@@ -728,6 +737,11 @@ impl Client {
 
         debug!(target: "Client/Receipt", "Sending read receipt for {} message(s) to {}", message_ids.len(), chat.observe());
 
+        let read_receipts_disabled = self
+            .persistence_manager
+            .get_device_snapshot()
+            .read_receipts_disabled;
+
         // WA Web's sendAggregateReceipts caps each <receipt> at 256 ids (one <list>
         // per chunk), so a large catch-up read (post-reconnect / history scroll)
         // doesn't emit one oversized stanza the server may reject.
@@ -738,6 +752,7 @@ impl Client {
                 chunk,
                 &timestamp,
                 peer_participant_pn.as_ref(),
+                read_receipts_disabled,
             );
             self.send_node(node)
                 .await
@@ -750,8 +765,8 @@ impl Client {
     ///
     /// Mirrors WA Web `WAWebSendPlayedReceiptJob`. For group/broadcast chats pass
     /// the message sender as `sender` so the receipt carries `participant`; in DMs
-    /// pass `None`. Newsletters emit `played-self`. The DM `played`-vs-`played-self`
-    /// privacy gating (read-receipts off) is not applied here, matching
+    /// pass `None`. Newsletters emit `played-self`. When `readreceipts` privacy is
+    /// `none`, a DM emits `played-self` too (the sender is not notified), matching
     /// [`mark_as_read`](Self::mark_as_read).
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.receipt.mark_as_played", level = "debug", skip_all, fields(chat = %chat.observe()), err(Debug)))]
     pub async fn mark_as_played(
@@ -768,9 +783,15 @@ impl Client {
 
         debug!(target: "Client/Receipt", "Sending played receipt for {} message(s) to {}", message_ids.len(), chat.observe());
 
+        let read_receipts_disabled = self
+            .persistence_manager
+            .get_device_snapshot()
+            .read_receipts_disabled;
+
         // Same 256-id cap per stanza as read receipts (WA Web sendAggregateReceipts).
         for chunk in message_ids.chunks(MAX_RECEIPT_IDS_PER_STANZA) {
-            let node = build_played_receipt_node(chat, sender, chunk, &timestamp);
+            let node =
+                build_played_receipt_node(chat, sender, chunk, &timestamp, read_receipts_disabled);
             self.send_node(node)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to send played receipt: {}", e))?;
@@ -1166,6 +1187,54 @@ mod tests {
             node.attrs.get("context").map(|v| v.as_str()).as_deref(),
             Some("status")
         );
+    }
+
+    // --- read/played receipt privacy gating (readreceipts==none) ---
+
+    fn type_of(node: &wacore_binary::Node) -> Option<String> {
+        node.attrs.get("type").map(|v| v.as_str().to_string())
+    }
+
+    #[test]
+    fn dm_read_receipt_gates_to_read_self_when_disabled() {
+        let chat: Jid = "12025550143@s.whatsapp.net".parse().expect("dm jid");
+        let read = build_read_receipt_node(&chat, None, &["MID"], "1", None, true);
+        assert_eq!(type_of(&read).as_deref(), Some("read-self"));
+        let played = build_played_receipt_node(&chat, None, &["MID"], "1", true);
+        assert_eq!(type_of(&played).as_deref(), Some("played-self"));
+    }
+
+    #[test]
+    fn dm_receipts_stay_plain_when_privacy_enabled() {
+        let chat: Jid = "12025550143@s.whatsapp.net".parse().expect("dm jid");
+        let read = build_read_receipt_node(&chat, None, &["MID"], "1", None, false);
+        assert_eq!(type_of(&read).as_deref(), Some("read"));
+        let played = build_played_receipt_node(&chat, None, &["MID"], "1", false);
+        assert_eq!(type_of(&played).as_deref(), Some("played"));
+    }
+
+    #[test]
+    fn group_receipts_ignore_privacy_gate() {
+        // Privacy does not apply to groups: still `read`/`played` even when disabled.
+        let chat: Jid = "120363021033254949@g.us".parse().expect("group jid");
+        let sender: Jid = "12025550143@s.whatsapp.net".parse().expect("sender jid");
+        let read = build_read_receipt_node(&chat, Some(&sender), &["MID"], "1", None, true);
+        assert_eq!(type_of(&read).as_deref(), Some("read"));
+        let played = build_played_receipt_node(&chat, Some(&sender), &["MID"], "1", true);
+        assert_eq!(type_of(&played).as_deref(), Some("played"));
+    }
+
+    #[test]
+    fn newsletter_receipts_are_self_regardless_of_flag() {
+        let chat: Jid = "120363298765432100@newsletter"
+            .parse()
+            .expect("newsletter jid");
+        for disabled in [false, true] {
+            let read = build_read_receipt_node(&chat, None, &["MID"], "1", None, disabled);
+            assert_eq!(type_of(&read).as_deref(), Some("read-self"));
+            let played = build_played_receipt_node(&chat, None, &["MID"], "1", disabled);
+            assert_eq!(type_of(&played).as_deref(), Some("played-self"));
+        }
     }
 
     fn own_pn() -> Jid {
@@ -2102,6 +2171,7 @@ mod tests {
             Some(&jid("456@s.whatsapp.net")),
             &["M1"],
             "100",
+            false,
         );
         assert_eq!(node.tag, "receipt");
         assert_eq!(
@@ -2120,7 +2190,8 @@ mod tests {
     #[test]
     fn played_receipt_dm_is_played_without_participant() {
         // WA Web drops `participant` in DMs (PlayedReceiptJob `r.isUser() ? null`).
-        let node = build_played_receipt_node(&jid("456@s.whatsapp.net"), None, &["M1"], "100");
+        let node =
+            build_played_receipt_node(&jid("456@s.whatsapp.net"), None, &["M1"], "100", false);
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
             Some("played")
@@ -2130,7 +2201,7 @@ mod tests {
 
     #[test]
     fn played_receipt_newsletter_is_played_self() {
-        let node = build_played_receipt_node(&jid("123@newsletter"), None, &["M1"], "100");
+        let node = build_played_receipt_node(&jid("123@newsletter"), None, &["M1"], "100", false);
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
             Some("played-self")
@@ -2140,8 +2211,13 @@ mod tests {
 
     #[test]
     fn played_receipt_extra_ids_go_into_list() {
-        let node =
-            build_played_receipt_node(&jid("456@s.whatsapp.net"), None, &["M1", "M2", "M3"], "100");
+        let node = build_played_receipt_node(
+            &jid("456@s.whatsapp.net"),
+            None,
+            &["M1", "M2", "M3"],
+            "100",
+            false,
+        );
         assert_eq!(
             node.attrs.get("id").map(|v| v.as_str()).as_deref(),
             Some("M1")
@@ -2159,6 +2235,7 @@ mod tests {
             Some(&jid("456@s.whatsapp.net")),
             &["M1"],
             "100",
+            false,
         );
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
@@ -2180,6 +2257,7 @@ mod tests {
             Some(&jid("456@s.whatsapp.net")),
             &["M1"],
             "100",
+            false,
         );
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
@@ -2196,7 +2274,14 @@ mod tests {
 
     #[test]
     fn read_receipt_dm_is_read_without_context() {
-        let node = build_read_receipt_node(&jid("456@s.whatsapp.net"), None, &["M1"], "100", None);
+        let node = build_read_receipt_node(
+            &jid("456@s.whatsapp.net"),
+            None,
+            &["M1"],
+            "100",
+            None,
+            false,
+        );
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
             Some("read")
@@ -2207,7 +2292,8 @@ mod tests {
 
     #[test]
     fn read_receipt_newsletter_is_read_self() {
-        let node = build_read_receipt_node(&jid("123@newsletter"), None, &["M1"], "100", None);
+        let node =
+            build_read_receipt_node(&jid("123@newsletter"), None, &["M1"], "100", None, false);
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),
             Some("read-self")
@@ -2223,6 +2309,7 @@ mod tests {
             &["M1"],
             "100",
             Some(&pn),
+            false,
         );
         assert_eq!(
             node.attrs.get("type").map(|v| v.as_str()).as_deref(),

--- a/storages/sqlite-storage/migrations/2026-07-03-000001_add_read_receipts_privacy/down.sql
+++ b/storages/sqlite-storage/migrations/2026-07-03-000001_add_read_receipts_privacy/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device DROP COLUMN read_receipts_disabled;

--- a/storages/sqlite-storage/migrations/2026-07-03-000001_add_read_receipts_privacy/up.sql
+++ b/storages/sqlite-storage/migrations/2026-07-03-000001_add_read_receipts_privacy/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device ADD COLUMN read_receipts_disabled BOOLEAN NOT NULL DEFAULT 0;

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -85,6 +85,7 @@ diesel::table! {
         first_unupload_pre_key_id -> Integer,
         lid_migrated -> Bool,
         last_signed_pre_key_rotation_ms -> BigInt,
+        read_receipts_disabled -> Bool,
     }
 }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -88,6 +88,7 @@ struct DeviceRow {
     first_unupload_pre_key_id: i32,
     lid_migrated: bool,
     last_signed_pre_key_rotation_ms: i64,
+    read_receipts_disabled: bool,
 }
 
 /// Max ids per `eq_any` list, under SQLite's default 999 host-parameter limit.
@@ -504,6 +505,7 @@ impl SqliteStore {
         let login_counter = device_data.login_counter;
         let lid_migrated = device_data.lid_migrated;
         let last_signed_pre_key_rotation_ms = device_data.last_signed_pre_key_rotation_ms;
+        let read_receipts_disabled = device_data.read_receipts_disabled;
         let new_lid: Arc<str> = Arc::from(
             device_data
                 .lid
@@ -565,6 +567,7 @@ impl SqliteStore {
                         device::login_counter.eq(login_counter),
                         device::lid_migrated.eq(lid_migrated),
                         device::last_signed_pre_key_rotation_ms.eq(last_signed_pre_key_rotation_ms),
+                        device::read_receipts_disabled.eq(read_receipts_disabled),
                     ))
                     .on_conflict(device::id)
                     .do_update()
@@ -598,6 +601,7 @@ impl SqliteStore {
                         device::lid_migrated.eq(excluded(device::lid_migrated)),
                         device::last_signed_pre_key_rotation_ms
                             .eq(excluded(device::last_signed_pre_key_rotation_ms)),
+                        device::read_receipts_disabled.eq(excluded(device::read_receipts_disabled)),
                     ))
                     .execute(conn)
                     .map(|_| ())
@@ -666,6 +670,7 @@ impl SqliteStore {
                         device::login_counter.eq(0i32),
                         device::lid_migrated.eq(false),
                         device::last_signed_pre_key_rotation_ms.eq(last_signed_pre_key_rotation_ms),
+                        device::read_receipts_disabled.eq(false),
                     ))
                     .execute(conn)
                     .map(|_| device_id)
@@ -797,6 +802,7 @@ impl SqliteStore {
                 login_counter: row.login_counter,
                 lid_migrated: row.lid_migrated,
                 last_signed_pre_key_rotation_ms: row.last_signed_pre_key_rotation_ms,
+                read_receipts_disabled: row.read_receipts_disabled,
             }))
         } else {
             Ok(None)

--- a/wacore/src/store/commands.rs
+++ b/wacore/src/store/commands.rs
@@ -56,6 +56,9 @@ pub enum DeviceCommand {
     /// the first rotation is scheduled a full interval out rather than firing
     /// immediately on the next connect.
     SetSignedPreKeyRotationBaseline(i64),
+    /// Set whether `readreceipts` privacy is `none`. `true` routes DM
+    /// read/played receipts through the `*-self` types.
+    SetReadReceiptsDisabled(bool),
 }
 
 impl std::fmt::Debug for DeviceCommand {
@@ -98,6 +101,9 @@ impl std::fmt::Debug for DeviceCommand {
                 .debug_tuple("SetSignedPreKeyRotationBaseline")
                 .field(v)
                 .finish(),
+            Self::SetReadReceiptsDisabled(v) => {
+                f.debug_tuple("SetReadReceiptsDisabled").field(v).finish()
+            }
         }
     }
 }
@@ -175,6 +181,9 @@ pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
         }
         DeviceCommand::SetSignedPreKeyRotationBaseline(rotation_ms) => {
             device.last_signed_pre_key_rotation_ms = rotation_ms;
+        }
+        DeviceCommand::SetReadReceiptsDisabled(v) => {
+            device.read_receipts_disabled = v;
         }
     }
 }
@@ -370,6 +379,18 @@ mod tests {
         );
         assert_eq!(device.signed_pre_key_id, id_before);
         assert_eq!(device.signed_pre_key_signature, sig_before);
+    }
+
+    #[test]
+    fn set_read_receipts_disabled_flips_field() {
+        let mut device = Device::new();
+        assert!(!device.read_receipts_disabled);
+
+        apply_command_to_device(&mut device, DeviceCommand::SetReadReceiptsDisabled(true));
+        assert!(device.read_receipts_disabled);
+
+        apply_command_to_device(&mut device, DeviceCommand::SetReadReceiptsDisabled(false));
+        assert!(!device.read_receipts_disabled);
     }
 
     #[test]

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -297,6 +297,12 @@ pub struct Device {
     /// rotation path treats as "seed the baseline, don't rotate yet".
     #[serde(default)]
     pub last_signed_pre_key_rotation_ms: i64,
+    /// true means the account's `readreceipts` privacy is `none`, so DM
+    /// read/played receipts go out as `*-self` (which don't notify the sender).
+    /// Persisted so the value is known on reconnect before the privacy fetch
+    /// completes; `false` (WA default `all`) sends plain `read`/`played`.
+    #[serde(default)]
+    pub read_receipts_disabled: bool,
 }
 
 /// Minimal cached form of a Noise certificate. Mirrors the JSON shape WA Web
@@ -395,6 +401,7 @@ impl Device {
             login_counter: 0,
             lid_migrated: false,
             last_signed_pre_key_rotation_ms: crate::time::now_millis(),
+            read_receipts_disabled: false,
         }
     }
 


### PR DESCRIPTION
## What

When the user sets **read receipts to off** (`readreceipts` privacy = `none`), WhatsApp Web sends DM read/played receipts as `read-self`/`played-self` — which mark the message read on your *own* devices but do **not** notify the sender (no blue ticks). The client previously always sent the notifying `read`/`played` form for DMs, **leaking read/played state regardless of the privacy setting**. The setting was already fetched on connect but discarded.

Follow-up from the WA Web parity audit (after #965, #968).

## The gate (grounded in the bundle)

From `WAWeb/Send/ReadReceiptJob.js` / `PlayedReceiptJob.js`, the receipt type is:

| Chat kind | Type |
|---|---|
| Newsletter | `*-self` (unchanged) |
| Status / PSA | current behavior (unchanged) |
| **Group** | `read` / `played` — privacy does **not** apply to groups |
| **DM** | `*-self` when `readreceipts == none`, else `read` / `played` |

The same `readreceipts` setting governs both read and played receipts.

## Implementation

| Piece | Where |
|---|---|
| `read_receipts_disabled` Device field (+ `SetReadReceiptsDisabled` command) | `wacore/src/store/device.rs`, `commands.rs` |
| SQLite column + migration (mirrors `lid_migrated`: `BOOLEAN NOT NULL DEFAULT 0`) | `storages/sqlite-storage/` |
| Populate from the privacy settings fetched on connect (was discarded) | `src/client/node_io.rs` |
| DM gate in `build_read_receipt_node` / `build_played_receipt_node` | `src/receipt.rs` |

**Why persist it** (vs a runtime cache): the value is then known immediately on every reconnect, so there is no leak window while the per-connect privacy fetch is still in flight. It mirrors WA Web, which reads `readreceipts` from persisted local prefs. Existing rows default to `0` (= `all` = send `read`, the WA default). The fetch re-runs each connect, so a change made on another device is picked up on the next connect.

## Validation

- `cargo build --all` ✅, `cargo clippy --all --tests` ✅ clean, `cargo fmt --all`.
- New tests: DM gates to `*-self` when disabled / stays plain when enabled, a group ignores the gate, a newsletter stays `*-self` regardless, plus the `SetReadReceiptsDisabled` apply arm. Receipt suite 86/86, wacore commands 12/12, sqlite-storage 52/52 (migration applies).

## Not in scope

No dedicated readreceipts-change notification handler (there is no clean one; refresh is per-connect). No change to group/newsletter/status receipt behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T53MPuGRg4kvRjRxW6fUvd)_