### PR TITLE
fix(waproto): stop the build script recompiling on every run

### DIFF
--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -171,15 +171,11 @@ fn snake_case_descriptor_fields(input: &str, output: &std::path::Path) -> std::i
     write_if_changed(output, &fds.encode_to_vec())
 }
 
-/// Write `contents` to `path` only when they differ from what is already there.
+/// Skip the write when bytes are unchanged, to keep the file's mtime stable.
 ///
-/// buffa_build::compile() emits a `cargo:rerun-if-changed` for the descriptor it
-/// is handed, which lives in OUT_DIR. Rewriting that file every run bumps its
-/// mtime past the build-script `output` stamp, so cargo marks the build script
-/// stale and recompiles waproto (and everything above it) on every `cargo run`
-/// even with no source change. The transform is a deterministic function of the
-/// committed descriptor, so skipping the write when bytes are unchanged keeps
-/// the mtime stable and breaks that self-invalidation loop.
+/// buffa_build emits a `cargo:rerun-if-changed` for this OUT_DIR descriptor, so
+/// rewriting it every run would re-invalidate the build script and force a full
+/// waproto rebuild on every `cargo run`.
 fn write_if_changed(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
     if let Ok(existing) = std::fs::read(path)
         && existing == contents

--- a/waproto/build.rs
+++ b/waproto/build.rs
@@ -168,7 +168,25 @@ fn snake_case_descriptor_fields(input: &str, output: &std::path::Path) -> std::i
             snake_case_message_fields(message);
         }
     }
-    std::fs::write(output, fds.encode_to_vec())
+    write_if_changed(output, &fds.encode_to_vec())
+}
+
+/// Write `contents` to `path` only when they differ from what is already there.
+///
+/// buffa_build::compile() emits a `cargo:rerun-if-changed` for the descriptor it
+/// is handed, which lives in OUT_DIR. Rewriting that file every run bumps its
+/// mtime past the build-script `output` stamp, so cargo marks the build script
+/// stale and recompiles waproto (and everything above it) on every `cargo run`
+/// even with no source change. The transform is a deterministic function of the
+/// committed descriptor, so skipping the write when bytes are unchanged keeps
+/// the mtime stable and breaks that self-invalidation loop.
+fn write_if_changed(path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    if let Ok(existing) = std::fs::read(path)
+        && existing == contents
+    {
+        return Ok(());
+    }
+    std::fs::write(path, contents)
 }
 
 fn snake_case_message_fields(message: &mut DescriptorProto) {


### PR DESCRIPTION
## What

`waproto` (and, in cascade, `wacore`, `whatsapp-rust`, the transports and the example being run) recompiled on **every** `cargo run` / `cargo build`, even with no source change. This makes the build script idempotent so a no-op `cargo run --example demo` drops from a full `waproto` rebuild to **~0.2s**.

## Why

`build.rs` rewrites the committed camelCase descriptor into a snake-cased copy and hands that copy — living in `OUT_DIR` — to `buffa_build`. Like prost-build, `buffa_build::compile()` emits a `cargo:rerun-if-changed` for the descriptor it is given:

```
cargo:rerun-if-changed=.../waproto-<hash>/out/whatsapp.snake.desc
```

That file was regenerated with `std::fs::write` on every build script run, so its mtime always ended up **newer** than the build-script `output` stamp cargo compares against:

```
output               ...51.085   ← build-script stamp
whatsapp.snake.desc  ...51.185   ← rewritten every run, always newer
```

Cargo's rule is "is any rerun-if-changed path newer than `output`?" — the answer was always yes, so it re-ran the build script, which rewrote the file, which made it stale again. A textbook build-script self-invalidation loop, confirmed with `CARGO_LOG=cargo::core::compiler::fingerprint=info`:

```
dirty: FsStatusOutdated(StaleItem(ChangedFile {
  reference: ".../out/whatsapp.snake.desc", stale_mtime > output }))
```

## How

The snake-case transform is a deterministic function of the committed `whatsapp.desc`, so the generated bytes are identical across runs. A small `write_if_changed` helper writes the `OUT_DIR` copy **only when its bytes actually differ**, so its mtime stays stable and no longer overtakes `output`. The loop breaks after one healing rebuild; subsequent no-op builds are `Fresh`.

The other three build scripts (`wacore` voip tables, `sqlite-storage` wire, `wacore/binary` tokens) were checked and are **not** affected — they feed `buffa_build` committed descriptor paths (or emit rerun-if-changed only on committed sources), so their rerun-if-changed targets never churn.

## Testing

- `cargo build --example demo`, then two more with no changes → `Finished ... in 0.21s`, zero `Compiling` lines. The fingerprint log reports nothing stale for the `waproto` build script.
- `cargo build` twice back-to-back → `0.17s` no-op (the earlier full-workspace recompile was feature-thrashing from alternating `cargo build` with `cargo build --example demo`, not this loop).
- `cargo fmt --all --check` clean; `cargo test -p waproto` green (generated code round-trips unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY9J7APbS2a9gWY49tSemn)_