### PR TITLE
fix(pair-code): correct link_code_pairing_nonce byte and close WA Web stage-2 gaps

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -837,6 +837,28 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
         })
     }
 
+    /// Run `handler` when the server asks the companion to refresh an
+    /// in-progress pairing code ([`Event::PairingCodeRefresh`]). The `bool` is
+    /// `force_manual`. The typical reaction is to request a fresh code via
+    /// [`Client::pair_with_code`] with the same phone number.
+    pub fn on_pair_code_refresh<F, Fut>(self, handler: F) -> Self
+    where
+        F: Fn(bool, Arc<Client>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.on_event_for(&[EventKind::PairingCodeRefresh], move |event, client| {
+            let fut = match &*event {
+                Event::PairingCodeRefresh { force_manual } => Some(handler(*force_manual, client)),
+                _ => None,
+            };
+            async move {
+                if let Some(fut) = fut {
+                    fut.await
+                }
+            }
+        })
+    }
+
     /// Run `handler` once the client is connected and authenticated.
     pub fn on_connected<F, Fut>(self, handler: F) -> Self
     where

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -152,6 +152,11 @@ impl Client {
             phone_number
         );
 
+        // Stamp the validity clock before companion_hello, matching WA Web
+        // (`startAltLinkingFlow` sets codeGenerationTs before sending), so the
+        // ~180s window covers the stage-1 round-trip rather than starting after it.
+        let code_generation_ts = wacore::time::now_secs();
+
         // Generate ephemeral keypair for this pairing session
         let ephemeral_keypair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
 
@@ -226,7 +231,7 @@ impl Client {
             phone_jid: phone_number,
             pair_code: code.clone(),
             ephemeral_keypair: Box::new(ephemeral_keypair),
-            code_generation_ts: wacore::time::now_secs(),
+            code_generation_ts,
             primary_hello_attempt_count: 0,
         };
 
@@ -321,62 +326,67 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
         }
     };
 
-    // Kept (not taken) so the primary can retry: WA Web retains the cached hello.
-    let (pairing_ref, phone_jid, pair_code, ephemeral_keypair) = {
-        let mut state_guard = client.pair_code_state.lock().await;
-        match &mut *state_guard {
-            PairCodeState::WaitingForPhoneConfirmation {
-                pairing_ref,
-                phone_jid,
-                pair_code,
-                ephemeral_keypair,
-                code_generation_ts,
-                primary_hello_attempt_count,
-            } => {
-                // Validate before counting: only a genuine, in-window attempt
-                // (matching ref, unexpired code) may spend a retry slot, so a
-                // stale/foreign or late notification — neither of which triggers
-                // a companion_finish — can't exhaust the budget. WA Web bumps
-                // first and shares that window; we tighten it.
-                if pairing_ref.as_slice() != notif_ref.as_slice() {
-                    warn!(
-                        target: "Client/PairCode",
-                        "primary_hello ref does not match the outstanding request; ignoring"
-                    );
-                    return false;
-                }
-                let age = wacore::time::now_secs() - *code_generation_ts;
-                if age > PairCodeUtils::code_validity().as_secs() as i64 {
-                    warn!(
-                        target: "Client/PairCode",
-                        "primary_hello arrived for an expired code ({age}s old); ignoring"
-                    );
-                    return false;
-                }
-                // Check the cap before bumping so a rejected attempt never
-                // pushes the counter past the limit (keeps it bounded at max).
-                if *primary_hello_attempt_count >= PairCodeUtils::max_primary_hello_attempts() {
-                    warn!(
-                        target: "Client/PairCode",
-                        "Exceeded max primary_hello attempts for this code; abandoning"
-                    );
-                    return false;
-                }
-                *primary_hello_attempt_count += 1;
-                (
-                    pairing_ref.clone(),
-                    phone_jid.clone(),
-                    pair_code.clone(),
-                    (**ephemeral_keypair).clone(),
-                )
-            }
-            _ => {
+    // Serialize the whole of stage 2 under the pair_code_state lock. The
+    // transport dispatches <notification> stanzas on concurrent detached tasks
+    // (see client/node_io.rs), so holding the guard across derive → persist →
+    // send makes two primary_hello for the same code sequential, matching WA
+    // Web's single-threaded model. Without it, both could derive a *different*
+    // random adv_secret and race SetAdvSecretKey (last-write-wins), leaving the
+    // persisted secret out of sync with the companion_finish the server acts on
+    // → pair-success HMAC failure. The state is kept (not taken) so a genuine
+    // retry can reuse it.
+    let mut state_guard = client.pair_code_state.lock().await;
+    let (pairing_ref, phone_jid, pair_code, ephemeral_keypair) = match &mut *state_guard {
+        PairCodeState::WaitingForPhoneConfirmation {
+            pairing_ref,
+            phone_jid,
+            pair_code,
+            ephemeral_keypair,
+            code_generation_ts,
+            primary_hello_attempt_count,
+        } => {
+            // Validate before counting: only a genuine, in-window attempt
+            // (matching ref, unexpired code) may spend a retry slot, so a
+            // stale/foreign or late notification — neither of which triggers
+            // a companion_finish — can't exhaust the budget.
+            if pairing_ref.as_slice() != notif_ref.as_slice() {
                 warn!(
                     target: "Client/PairCode",
-                    "Received primary_hello but not in waiting state"
+                    "primary_hello ref does not match the outstanding request; ignoring"
                 );
                 return false;
             }
+            let age = wacore::time::now_secs() - *code_generation_ts;
+            if age > PairCodeUtils::code_validity().as_secs() as i64 {
+                warn!(
+                    target: "Client/PairCode",
+                    "primary_hello arrived for an expired code ({age}s old); ignoring"
+                );
+                return false;
+            }
+            // Check the cap before bumping so a rejected attempt never pushes the
+            // counter past the limit (keeps it bounded at max).
+            if *primary_hello_attempt_count >= PairCodeUtils::max_primary_hello_attempts() {
+                warn!(
+                    target: "Client/PairCode",
+                    "Exceeded max primary_hello attempts for this code; abandoning"
+                );
+                return false;
+            }
+            *primary_hello_attempt_count += 1;
+            (
+                pairing_ref.clone(),
+                phone_jid.clone(),
+                pair_code.clone(),
+                (**ephemeral_keypair).clone(),
+            )
+        }
+        _ => {
+            warn!(
+                target: "Client/PairCode",
+                "Received primary_hello but not in waiting state"
+            );
+            return false;
         }
     };
 
@@ -456,7 +466,9 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
     );
 
     // State stays WaitingForPhoneConfirmation so a retry can reuse it; only
-    // pair-success (see `crate::pair`) transitions to Completed.
+    // pair-success (see `crate::pair`) transitions to Completed. `state_guard`
+    // (held since the top for serialization) is released here.
+    drop(state_guard);
     true
 }
 
@@ -798,6 +810,33 @@ mod tests {
                 .iter()
                 .any(|e| matches!(&**e, Event::PairingCodeRefresh { force_manual: true })),
             "expected PairingCodeRefresh{{force_manual:true}}, got: {events:?}"
+        );
+    }
+
+    /// An absent `force_manual_refresh` attribute maps to `force_manual: false`
+    /// (WA Web's non-force `refreshAltLinkingCode` branch). Locks down the
+    /// `== "true"` parse against a flip to `!= "false"`.
+    #[tokio::test]
+    async fn refresh_code_without_force_manual_defaults_false() {
+        let client = create_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let pairing_ref = vec![5, 6, 7, 8];
+        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+
+        let notif = refresh_code_notif(&pairing_ref, None);
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(handled, "a matching refresh_code should be handled");
+        assert!(
+            collector.events().iter().any(|e| matches!(
+                &**e,
+                Event::PairingCodeRefresh {
+                    force_manual: false
+                }
+            )),
+            "absent force_manual_refresh must dispatch force_manual: false"
         );
     }
 

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -226,6 +226,8 @@ impl Client {
             phone_jid: phone_number,
             pair_code: code.clone(),
             ephemeral_keypair: Box::new(ephemeral_keypair),
+            code_generation_ts: wacore::time::now_secs(),
+            primary_hello_attempt_count: 0,
         };
 
         // Dispatch event for user to display the code
@@ -238,10 +240,10 @@ impl Client {
     }
 }
 
-/// Handles the `link_code_companion_reg` notification (stage 2 trigger).
-///
-/// This is called when the user enters the code on their phone. The notification
-/// contains the primary device's encrypted ephemeral public key and identity public key.
+/// Handles a `link_code_companion_reg` notification. Dispatches on the child's
+/// `stage` attribute, mirroring WA Web `handleAltDeviceLinkingNotification`:
+/// `primary_hello` completes stage 2; `refresh_code` asks the companion to
+/// regenerate the code it is displaying.
 #[cfg_attr(
     feature = "tracing",
     tracing::instrument(name = "wa.pair.code_notification", level = "debug", skip_all)
@@ -250,11 +252,26 @@ pub(crate) async fn handle_pair_code_notification(
     client: &Arc<Client>,
     node: &NodeRef<'_>,
 ) -> bool {
-    // Check if this is a link_code_companion_reg notification
     let Some(reg_node) = node.get_optional_child_by_tag(&["link_code_companion_reg"]) else {
         return false;
     };
 
+    match reg_node.get_attr("stage").map(|v| v.as_str()).as_deref() {
+        Some("primary_hello") => handle_primary_hello(client, reg_node).await,
+        Some("refresh_code") => handle_refresh_code(client, reg_node).await,
+        other => {
+            warn!(
+                target: "Client/PairCode",
+                "Ignoring link_code_companion_reg notification with stage {other:?}"
+            );
+            false
+        }
+    }
+}
+
+/// Stage 2: the user entered the code on their phone. The notification carries
+/// the primary's encrypted ephemeral public key and identity public key.
+async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> bool {
     // Extract primary's wrapped ephemeral public key (80 bytes: salt + iv + encrypted key)
     let primary_wrapped_ephemeral = match reg_node
         .get_optional_child_by_tag(&["link_code_pairing_wrapped_primary_ephemeral_pub"])
@@ -289,24 +306,72 @@ pub(crate) async fn handle_pair_code_notification(
         }
     };
 
-    // Get current pair code state
-    let mut state_guard = client.pair_code_state.lock().await;
-    let state = std::mem::take(&mut *state_guard);
-    drop(state_guard);
-
-    let (pairing_ref, phone_jid, pair_code, ephemeral_keypair) = match state {
-        PairCodeState::WaitingForPhoneConfirmation {
-            pairing_ref,
-            phone_jid,
-            pair_code,
-            ephemeral_keypair,
-        } => (pairing_ref, phone_jid, pair_code, ephemeral_keypair),
-        _ => {
-            warn!(
-                target: "Client/PairCode",
-                "Received pair code notification but not in waiting state"
-            );
+    // Ref echoed by the primary. WA Web (`InvalidRefError`) rejects a
+    // primary_hello whose ref doesn't match the one from our companion_hello.
+    let notif_ref = match reg_node
+        .get_optional_child_by_tag(&["link_code_pairing_ref"])
+        .and_then(|n| match n.content.as_deref() {
+            Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
+            _ => None,
+        }) {
+        Some(r) => r,
+        None => {
+            warn!(target: "Client/PairCode", "primary_hello missing link_code_pairing_ref");
             return false;
+        }
+    };
+
+    // Validate against the outstanding request and snapshot what stage 2 needs.
+    // Bumps the attempt count (WA Web caps at 3 per code) and — unlike a
+    // consuming take — leaves the state in place so the primary can retry.
+    let (pairing_ref, phone_jid, pair_code, ephemeral_keypair) = {
+        let mut state_guard = client.pair_code_state.lock().await;
+        match &mut *state_guard {
+            PairCodeState::WaitingForPhoneConfirmation {
+                pairing_ref,
+                phone_jid,
+                pair_code,
+                ephemeral_keypair,
+                code_generation_ts,
+                primary_hello_attempt_count,
+            } => {
+                *primary_hello_attempt_count += 1;
+                if *primary_hello_attempt_count > PairCodeUtils::max_primary_hello_attempts() {
+                    warn!(
+                        target: "Client/PairCode",
+                        "Exceeded max primary_hello attempts for this code; abandoning"
+                    );
+                    return false;
+                }
+                if pairing_ref.as_slice() != notif_ref.as_slice() {
+                    warn!(
+                        target: "Client/PairCode",
+                        "primary_hello ref does not match the outstanding request; ignoring"
+                    );
+                    return false;
+                }
+                let age = wacore::time::now_secs() - *code_generation_ts;
+                if age > PairCodeUtils::code_validity().as_secs() as i64 {
+                    warn!(
+                        target: "Client/PairCode",
+                        "primary_hello arrived for an expired code ({age}s old); ignoring"
+                    );
+                    return false;
+                }
+                (
+                    pairing_ref.clone(),
+                    phone_jid.clone(),
+                    pair_code.clone(),
+                    (**ephemeral_keypair).clone(),
+                )
+            }
+            _ => {
+                warn!(
+                    target: "Client/PairCode",
+                    "Received primary_hello but not in waiting state"
+                );
+                return false;
+            }
         }
     };
 
@@ -385,9 +450,62 @@ pub(crate) async fn handle_pair_code_notification(
         "Sent companion_finish, waiting for pair-success"
     );
 
-    // Mark state as completed
-    *client.pair_code_state.lock().await = PairCodeState::Completed;
+    // Deliberately keep the WaitingForPhoneConfirmation state (with the bumped
+    // attempt count): WA Web retains the cached hello so the primary can retry
+    // primary_hello. The terminal transition to Completed happens when the
+    // standard pair-success handler fires (see `crate::pair`).
+    true
+}
 
+/// The server asked us to refresh the code we are displaying (WA Web
+/// `refreshAltLinkingCode` / `forceManualRefresh`). Surfaces a
+/// [`Event::PairingCodeRefresh`] so the consumer re-requests a code, but only
+/// when the notification's ref matches the flow currently in progress.
+async fn handle_refresh_code(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> bool {
+    let notif_ref = match reg_node
+        .get_optional_child_by_tag(&["link_code_pairing_ref"])
+        .and_then(|n| match n.content.as_deref() {
+            Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
+            _ => None,
+        }) {
+        Some(r) => r,
+        None => {
+            warn!(target: "Client/PairCode", "refresh_code missing link_code_pairing_ref");
+            return false;
+        }
+    };
+
+    let force_manual = reg_node
+        .get_attr("force_manual_refresh")
+        .map(|v| v.as_str().as_ref() == "true")
+        .unwrap_or(false);
+
+    // Ignore a refresh whose ref doesn't match the outstanding code — matches
+    // WA Web's `getCurrentRef()` guard.
+    let matches_current = {
+        let state_guard = client.pair_code_state.lock().await;
+        matches!(
+            &*state_guard,
+            PairCodeState::WaitingForPhoneConfirmation { pairing_ref, .. }
+                if pairing_ref.as_slice() == notif_ref.as_slice()
+        )
+    };
+    if !matches_current {
+        warn!(
+            target: "Client/PairCode",
+            "refresh_code ref does not match the outstanding request; ignoring"
+        );
+        return false;
+    }
+
+    info!(
+        target: "Client/PairCode",
+        "Server requested pair-code refresh (force_manual={force_manual})"
+    );
+    client
+        .core
+        .event_bus
+        .dispatch(Event::PairingCodeRefresh { force_manual });
     true
 }
 
@@ -423,5 +541,247 @@ mod tests {
             .downcast_ref::<CurveError>()
             .expect("downcasts to CurveError through transparent wrapper");
         assert!(matches!(curve, CurveError::NoKeyTypeIdentifier));
+    }
+
+    // ── Stage-2 notification handling (WA Web parity guards) ─────────────────
+    //
+    // All tests drive the top-level `handle_pair_code_notification`, so the
+    // `stage` dispatch is exercised end-to-end. The guard-reject paths bail
+    // before any stage-2 crypto, so "the adv secret is unchanged" is a reliable
+    // proxy for "we did not process the notification"; conversely a valid
+    // primary_hello rotates it (via `SetAdvSecretKey`) before the socket send.
+
+    use crate::test_utils::create_test_client;
+    use wacore::libsignal::protocol::KeyPair;
+    use wacore_binary::Node;
+    use wacore_binary::builder::NodeBuilder;
+
+    fn primary_hello_notif(reg_ref: &[u8]) -> Node {
+        NodeBuilder::new("notification")
+            .attr("type", "link_code_companion_reg")
+            .attr("from", "s.whatsapp.net")
+            .children([NodeBuilder::new("link_code_companion_reg")
+                .attr("stage", "primary_hello")
+                .children([
+                    // Non-zero dummy bytes keep the stage-2 DH well-defined.
+                    NodeBuilder::new("link_code_pairing_wrapped_primary_ephemeral_pub")
+                        .bytes(vec![7u8; 80])
+                        .build(),
+                    NodeBuilder::new("primary_identity_pub")
+                        .bytes(vec![9u8; 32])
+                        .build(),
+                    NodeBuilder::new("link_code_pairing_ref")
+                        .bytes(reg_ref.to_vec())
+                        .build(),
+                ])
+                .build()])
+            .build()
+    }
+
+    fn refresh_code_notif(reg_ref: &[u8], force_manual: Option<bool>) -> Node {
+        let mut reg = NodeBuilder::new("link_code_companion_reg").attr("stage", "refresh_code");
+        if let Some(f) = force_manual {
+            reg = reg.attr("force_manual_refresh", if f { "true" } else { "false" });
+        }
+        NodeBuilder::new("notification")
+            .attr("type", "link_code_companion_reg")
+            .attr("from", "s.whatsapp.net")
+            .children([reg
+                .children([NodeBuilder::new("link_code_pairing_ref")
+                    .bytes(reg_ref.to_vec())
+                    .build()])
+                .build()])
+            .build()
+    }
+
+    async fn set_waiting(client: &Arc<Client>, pairing_ref: Vec<u8>, ts: i64, count: u32) {
+        *client.pair_code_state.lock().await = PairCodeState::WaitingForPhoneConfirmation {
+            pairing_ref,
+            phone_jid: "15551234567".to_string(),
+            pair_code: "ABCD1234".to_string(),
+            ephemeral_keypair: Box::new(KeyPair::generate(
+                &mut rand::make_rng::<rand::rngs::StdRng>(),
+            )),
+            code_generation_ts: ts,
+            primary_hello_attempt_count: count,
+        };
+    }
+
+    fn adv(client: &Arc<Client>) -> [u8; 32] {
+        client
+            .persistence_manager
+            .get_device_snapshot()
+            .adv_secret_key
+    }
+
+    async fn is_waiting(client: &Arc<Client>) -> bool {
+        matches!(
+            &*client.pair_code_state.lock().await,
+            PairCodeState::WaitingForPhoneConfirmation { .. }
+        )
+    }
+
+    /// Regression: a `primary_hello` whose ref doesn't match our outstanding
+    /// companion_hello must be rejected (WA Web `InvalidRefError`) without
+    /// running stage 2, and must leave the flow intact for a later valid one.
+    #[tokio::test]
+    async fn primary_hello_rejects_mismatched_ref() {
+        let client = create_test_client().await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        let adv_before = adv(&client);
+
+        let notif = primary_hello_notif(&[9, 9, 9, 9]);
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(!handled, "mismatched ref must be rejected");
+        assert_eq!(
+            adv(&client),
+            adv_before,
+            "no stage-2 crypto on ref mismatch"
+        );
+        assert!(
+            is_waiting(&client).await,
+            "state must be preserved so a later valid primary_hello can complete"
+        );
+    }
+
+    /// Regression: a `primary_hello` for a code older than the ~180s validity
+    /// window must be rejected (WA Web `OldCodeError`).
+    #[tokio::test]
+    async fn primary_hello_rejects_expired_code() {
+        let client = create_test_client().await;
+        let pairing_ref = vec![1, 2, 3, 4];
+        let stale_ts =
+            wacore::time::now_secs() - (PairCodeUtils::code_validity().as_secs() as i64 + 20);
+        set_waiting(&client, pairing_ref.clone(), stale_ts, 0).await;
+        let adv_before = adv(&client);
+
+        let notif = primary_hello_notif(&pairing_ref);
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(
+            !handled,
+            "primary_hello for an expired code must be rejected"
+        );
+        assert_eq!(
+            adv(&client),
+            adv_before,
+            "no stage-2 crypto on an expired code"
+        );
+    }
+
+    /// Regression: at most `max_primary_hello_attempts` (WA Web `T = 3`) are
+    /// processed per code; the next one is dropped (`MaxPrimaryHelloError`).
+    #[tokio::test]
+    async fn primary_hello_rejects_beyond_max_attempts() {
+        let client = create_test_client().await;
+        let pairing_ref = vec![1, 2, 3, 4];
+        set_waiting(
+            &client,
+            pairing_ref.clone(),
+            wacore::time::now_secs(),
+            PairCodeUtils::max_primary_hello_attempts(),
+        )
+        .await;
+        let adv_before = adv(&client);
+
+        let notif = primary_hello_notif(&pairing_ref);
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(!handled, "the attempt past the cap must be rejected");
+        assert_eq!(
+            adv(&client),
+            adv_before,
+            "no stage-2 crypto once the per-code attempt cap is exhausted"
+        );
+    }
+
+    /// The guards must not over-reject: a valid retry (matching ref, fresh code,
+    /// still under the cap) reaches stage 2 and rotates the adv secret. The
+    /// socket send then fails (no transport in tests), so the call returns
+    /// false, but the rotation proves processing happened.
+    #[tokio::test]
+    async fn primary_hello_valid_retry_reaches_stage2() {
+        let client = create_test_client().await;
+        let pairing_ref = vec![1, 2, 3, 4];
+        // count = 2 → this is the 3rd attempt, still within the cap of 3.
+        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 2).await;
+        let adv_before = adv(&client);
+
+        let notif = primary_hello_notif(&pairing_ref);
+        let _ = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert_ne!(
+            adv(&client),
+            adv_before,
+            "a valid in-window retry must reach stage 2 and rotate the adv secret"
+        );
+    }
+
+    /// A `refresh_code` whose ref matches the outstanding flow surfaces a
+    /// `PairingCodeRefresh` event carrying `force_manual`.
+    #[tokio::test]
+    async fn refresh_code_matching_ref_dispatches_event() {
+        let client = create_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        let pairing_ref = vec![5, 6, 7, 8];
+        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+
+        let notif = refresh_code_notif(&pairing_ref, Some(true));
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(handled, "a matching refresh_code should be handled");
+        let events = collector.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeRefresh { force_manual: true })),
+            "expected PairingCodeRefresh{{force_manual:true}}, got: {events:?}"
+        );
+    }
+
+    /// A `refresh_code` for a different ref (or with no flow in progress) is
+    /// ignored — no event, matching WA Web's `getCurrentRef()` guard.
+    #[tokio::test]
+    async fn refresh_code_mismatched_ref_is_ignored() {
+        let client = create_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.register_handler(collector.clone());
+
+        set_waiting(&client, vec![5, 6, 7, 8], wacore::time::now_secs(), 0).await;
+
+        let notif = refresh_code_notif(&[1, 1, 1, 1], None);
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(!handled, "a non-matching refresh_code must be ignored");
+        assert!(
+            collector.events().is_empty(),
+            "no event should fire for a refresh_code with an unknown ref"
+        );
+    }
+
+    /// An unknown `stage` on the notification is ignored without touching the
+    /// in-progress flow.
+    #[tokio::test]
+    async fn unknown_stage_is_ignored_and_preserves_state() {
+        let client = create_test_client().await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+
+        let notif = NodeBuilder::new("notification")
+            .attr("type", "link_code_companion_reg")
+            .attr("from", "s.whatsapp.net")
+            .children([NodeBuilder::new("link_code_companion_reg")
+                .attr("stage", "some_future_stage")
+                .build()])
+            .build();
+        let handled = handle_pair_code_notification(&client, &notif.as_node_ref()).await;
+
+        assert!(!handled, "unknown stage must not be treated as handled");
+        assert!(
+            is_waiting(&client).await,
+            "unknown stage must leave the outstanding flow untouched"
+        );
     }
 }

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -235,10 +235,19 @@ impl Client {
             primary_hello_attempt_count: 0,
         };
 
-        // Dispatch event for user to display the code
+        // Dispatch event for the user to display the code. The validity clock
+        // started at `code_generation_ts` (before stage 1), so advertise the
+        // *remaining* window — otherwise a consumer's countdown would outlast the
+        // server's (and our own `handle_primary_hello`) expiry by the stage-1
+        // elapsed time.
+        let elapsed = wacore::time::now_secs()
+            .saturating_sub(code_generation_ts)
+            .max(0) as u64;
+        let remaining =
+            PairCodeUtils::code_validity().saturating_sub(std::time::Duration::from_secs(elapsed));
         self.core.event_bus.dispatch(Event::PairingCode {
             code: code.clone(),
-            timeout: PairCodeUtils::code_validity(),
+            timeout: remaining,
         });
 
         Ok(code)

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -321,9 +321,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
         }
     };
 
-    // Validate against the outstanding request and snapshot what stage 2 needs.
-    // Bumps the attempt count (WA Web caps at 3 per code) and — unlike a
-    // consuming take — leaves the state in place so the primary can retry.
+    // Kept (not taken) so the primary can retry: WA Web retains the cached hello.
     let (pairing_ref, phone_jid, pair_code, ephemeral_keypair) = {
         let mut state_guard = client.pair_code_state.lock().await;
         match &mut *state_guard {
@@ -335,14 +333,11 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
                 code_generation_ts,
                 primary_hello_attempt_count,
             } => {
-                *primary_hello_attempt_count += 1;
-                if *primary_hello_attempt_count > PairCodeUtils::max_primary_hello_attempts() {
-                    warn!(
-                        target: "Client/PairCode",
-                        "Exceeded max primary_hello attempts for this code; abandoning"
-                    );
-                    return false;
-                }
+                // Validate before counting: only a genuine, in-window attempt
+                // (matching ref, unexpired code) may spend a retry slot, so a
+                // stale/foreign or late notification — neither of which triggers
+                // a companion_finish — can't exhaust the budget. WA Web bumps
+                // first and shares that window; we tighten it.
                 if pairing_ref.as_slice() != notif_ref.as_slice() {
                     warn!(
                         target: "Client/PairCode",
@@ -355,6 +350,14 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
                     warn!(
                         target: "Client/PairCode",
                         "primary_hello arrived for an expired code ({age}s old); ignoring"
+                    );
+                    return false;
+                }
+                *primary_hello_attempt_count += 1;
+                if *primary_hello_attempt_count > PairCodeUtils::max_primary_hello_attempts() {
+                    warn!(
+                        target: "Client/PairCode",
+                        "Exceeded max primary_hello attempts for this code; abandoning"
                     );
                     return false;
                 }
@@ -450,10 +453,8 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
         "Sent companion_finish, waiting for pair-success"
     );
 
-    // Deliberately keep the WaitingForPhoneConfirmation state (with the bumped
-    // attempt count): WA Web retains the cached hello so the primary can retry
-    // primary_hello. The terminal transition to Completed happens when the
-    // standard pair-success handler fires (see `crate::pair`).
+    // State stays WaitingForPhoneConfirmation so a retry can reuse it; only
+    // pair-success (see `crate::pair`) transitions to Completed.
     true
 }
 
@@ -621,9 +622,20 @@ mod tests {
         )
     }
 
+    async fn attempt_count(client: &Arc<Client>) -> Option<u32> {
+        match &*client.pair_code_state.lock().await {
+            PairCodeState::WaitingForPhoneConfirmation {
+                primary_hello_attempt_count,
+                ..
+            } => Some(*primary_hello_attempt_count),
+            _ => None,
+        }
+    }
+
     /// Regression: a `primary_hello` whose ref doesn't match our outstanding
     /// companion_hello must be rejected (WA Web `InvalidRefError`) without
-    /// running stage 2, and must leave the flow intact for a later valid one.
+    /// running stage 2, must leave the flow intact for a later valid one, and
+    /// must NOT consume a retry slot (the ref check precedes the counter bump).
     #[tokio::test]
     async fn primary_hello_rejects_mismatched_ref() {
         let client = create_test_client().await;
@@ -642,6 +654,41 @@ mod tests {
         assert!(
             is_waiting(&client).await,
             "state must be preserved so a later valid primary_hello can complete"
+        );
+        assert_eq!(
+            attempt_count(&client).await,
+            Some(0),
+            "a ref-mismatched notification must not burn a retry slot"
+        );
+    }
+
+    /// Regression: stale/foreign-ref notifications must not exhaust the attempt
+    /// cap. Even after several mismatched hellos, the genuine one still reaches
+    /// stage 2 (adv secret rotates).
+    #[tokio::test]
+    async fn stale_mismatched_hellos_do_not_block_the_valid_one() {
+        let client = create_test_client().await;
+        let pairing_ref = vec![1, 2, 3, 4];
+        set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
+        let adv_before = adv(&client);
+
+        // More mismatched hellos than the cap would allow if they counted.
+        for _ in 0..(PairCodeUtils::max_primary_hello_attempts() + 2) {
+            let bad = primary_hello_notif(&[9, 9, 9, 9]);
+            let _ = handle_pair_code_notification(&client, &bad.as_node_ref()).await;
+        }
+        assert_eq!(
+            attempt_count(&client).await,
+            Some(0),
+            "mismatched hellos must leave the attempt count untouched"
+        );
+
+        let good = primary_hello_notif(&pairing_ref);
+        let _ = handle_pair_code_notification(&client, &good.as_node_ref()).await;
+        assert_ne!(
+            adv(&client),
+            adv_before,
+            "the genuine primary_hello must still reach stage 2 after stale mismatches"
         );
     }
 
@@ -667,6 +714,11 @@ mod tests {
             adv(&client),
             adv_before,
             "no stage-2 crypto on an expired code"
+        );
+        assert_eq!(
+            attempt_count(&client).await,
+            Some(0),
+            "an expired-code notification must not burn a retry slot"
         );
     }
 

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -353,14 +353,16 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
                     );
                     return false;
                 }
-                *primary_hello_attempt_count += 1;
-                if *primary_hello_attempt_count > PairCodeUtils::max_primary_hello_attempts() {
+                // Check the cap before bumping so a rejected attempt never
+                // pushes the counter past the limit (keeps it bounded at max).
+                if *primary_hello_attempt_count >= PairCodeUtils::max_primary_hello_attempts() {
                     warn!(
                         target: "Client/PairCode",
                         "Exceeded max primary_hello attempts for this code; abandoning"
                     );
                     return false;
                 }
+                *primary_hello_attempt_count += 1;
                 (
                     pairing_ref.clone(),
                     phone_jid.clone(),
@@ -745,6 +747,11 @@ mod tests {
             adv(&client),
             adv_before,
             "no stage-2 crypto once the per-code attempt cap is exhausted"
+        );
+        assert_eq!(
+            attempt_count(&client).await,
+            Some(PairCodeUtils::max_primary_hello_attempts()),
+            "a rejected over-cap attempt must not push the counter past the max"
         );
     }
 

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -349,9 +349,8 @@ impl PairCodeUtils {
                 NodeBuilder::new("companion_platform_display")
                     .bytes(platform_display.as_bytes().to_vec())
                     .build(),
-                // Single zero byte. WA Web sends `new Uint8Array(1)` (see
-                // `Alt/DeviceLinkingIq.js`) and whatsmeow sends `[]byte{0}` — i.e.
-                // byte 0x00, NOT the ASCII character '0' (0x30).
+                // 0x00, not ASCII '0' (0x30): matches WA Web `new Uint8Array(1)`
+                // (`Alt/DeviceLinkingIq.js`) / whatsmeow `[]byte{0}`.
                 NodeBuilder::new("link_code_pairing_nonce")
                     .bytes(vec![0u8])
                     .build(),

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -83,6 +83,10 @@ fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u
 /// Validity duration for pair codes (approximately).
 const PAIR_CODE_VALIDITY_SECS: u64 = 180;
 
+/// Max `primary_hello` notifications processed per code before the flow is
+/// abandoned. Matches WA Web `DeviceLinkingApi` (`T = 3`, `MaxPrimaryHelloError`).
+const PAIR_CODE_MAX_PRIMARY_HELLO_ATTEMPTS: u32 = 3;
+
 fn build_id_and_display(
     id: CompanionWebClientType,
     props: &wa::DeviceProps,
@@ -160,6 +164,13 @@ pub enum PairCodeState {
         pair_code: String,
         /// Ephemeral keypair generated for this session.
         ephemeral_keypair: Box<KeyPair>,
+        /// Unix seconds when the code was generated. Enforces the ~180s validity
+        /// window: a `primary_hello` arriving later is rejected (WA Web `OldCodeError`).
+        code_generation_ts: i64,
+        /// Count of `primary_hello` notifications processed for this code. WA Web
+        /// (`DeviceLinkingApi`) caps this at 3 per code (`MaxPrimaryHelloError`);
+        /// the primary may retry, re-deriving fresh key material each time.
+        primary_hello_attempt_count: u32,
     },
     /// Pairing completed (success or failure).
     Completed,
@@ -489,6 +500,11 @@ impl PairCodeUtils {
     /// Returns the pair code validity duration.
     pub fn code_validity() -> std::time::Duration {
         std::time::Duration::from_secs(PAIR_CODE_VALIDITY_SECS)
+    }
+
+    /// Max number of `primary_hello` notifications processed per code (WA Web `T`).
+    pub fn max_primary_hello_attempts() -> u32 {
+        PAIR_CODE_MAX_PRIMARY_HELLO_ATTEMPTS
     }
 }
 

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -338,9 +338,11 @@ impl PairCodeUtils {
                 NodeBuilder::new("companion_platform_display")
                     .bytes(platform_display.as_bytes().to_vec())
                     .build(),
-                // Nonce is sent as string "0" (matching whatsmeow/baileys)
+                // Single zero byte. WA Web sends `new Uint8Array(1)` (see
+                // `Alt/DeviceLinkingIq.js`) and whatsmeow sends `[]byte{0}` — i.e.
+                // byte 0x00, NOT the ASCII character '0' (0x30).
                 NodeBuilder::new("link_code_pairing_nonce")
-                    .bytes(b"0".to_vec())
+                    .bytes(vec![0u8])
                     .build(),
             ])
             .build();
@@ -1072,8 +1074,9 @@ mod tests {
             Some("true")
         );
 
-        // Nonce is the string "0", per whatsmeow/baileys parity.
-        assert_eq!(child_bytes(reg, "link_code_pairing_nonce"), b"0");
+        // Nonce is a single zero byte (0x00), matching WA Web's
+        // `new Uint8Array(1)` and whatsmeow's `[]byte{0}` — not ASCII '0'.
+        assert_eq!(child_bytes(reg, "link_code_pairing_nonce"), &[0u8]);
     }
 
     #[test]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -216,6 +216,7 @@ pub enum EventKind {
     LoggedOut,
     PairingQrCode,
     PairingCode,
+    PairingCodeRefresh,
     QrScannedWithoutMultidevice,
     ClientOutdated,
     Messages,
@@ -621,6 +622,16 @@ pub enum Event {
         /// Approximate validity duration (~180 seconds).
         timeout: std::time::Duration,
     },
+    /// The server asked the companion to refresh an in-progress phone-number
+    /// pairing code (WA Web `refreshAltLinkingCode` / `forceManualRefresh`).
+    /// Only emitted while a pair-code flow is outstanding and the server's ref
+    /// matches it. The consumer should request a fresh code via
+    /// `pair_with_code`; the previous code is no longer guaranteed valid.
+    PairingCodeRefresh {
+        /// `true` when the server set `force_manual_refresh` — the code must be
+        /// re-requested explicitly rather than auto-rotated.
+        force_manual: bool,
+    },
     QrScannedWithoutMultidevice(QrScannedWithoutMultidevice),
     ClientOutdated(ClientOutdated),
 
@@ -783,6 +794,7 @@ impl Event {
             Event::LoggedOut(_) => EventKind::LoggedOut,
             Event::PairingQrCode { .. } => EventKind::PairingQrCode,
             Event::PairingCode { .. } => EventKind::PairingCode,
+            Event::PairingCodeRefresh { .. } => EventKind::PairingCodeRefresh,
             Event::QrScannedWithoutMultidevice(_) => EventKind::QrScannedWithoutMultidevice,
             Event::ClientOutdated(_) => EventKind::ClientOutdated,
             Event::Messages(_) => EventKind::Messages,


### PR DESCRIPTION
## What

Makes phone-number **pair-code** linking (`link_code_companion_reg`) behave against the WhatsApp server, cross-checked against the captured WhatsApp Web bundle (`WAWeb/Alt/DeviceLinking*.js`, `WA/Smax/*CompanionHello/Finish/RefreshCode*.js`).

The full crypto path (PBKDF2 `2<<16`, AES-CTR ephemeral wrap, HKDF arg order for the bundle key + `adv_secret`, GCM tag placement, the pair-success HMAC) was audited against the bundle and already matched WA Web — the changes below cover the deviations and the hardening found in an adversarial review.

## 1. `link_code_pairing_nonce` wire byte

`companion_hello` sent the nonce as `b"0"` (ASCII `0x30`). WA Web's `Alt/DeviceLinkingIq.js` sends `new Uint8Array(1)` — a single **`0x00`** byte — and whatsmeow sends `[]byte{0}`. Now emits the zero byte.

## 2. Stage-2 notification handling

`handle_pair_code_notification` assumed every notification was a `primary_hello` and marked the flow `Completed` after the first. Brought in line with WA Web `DeviceLinkingApi.handlePrimaryHelloInternal` / `handleAltDeviceLinkingNotification`:

| Gap | WA Web ref | Now |
|---|---|---|
| Dispatch by child `stage` | routes on `t[0].attrs.stage` | dispatches `primary_hello` vs `refresh_code` (unknown → ignore) |
| Verify `link_code_pairing_ref` | `InvalidRefError` | rejects a `primary_hello` whose ref ≠ the ref cached from `companion_hello` |
| ~180s code validity | `OldCodeError` (`I=180`) | stamps `code_generation_ts` (before `companion_hello`, matching `startAltLinkingFlow`) and drops an out-of-window `primary_hello` |
| ≤3 attempts per code | `MaxPrimaryHelloError` (`T=3`) | counts only genuine (ref-matching, in-window) attempts, checked before the bump so stale/foreign notifications can't exhaust the budget; state retained for retries |
| `refresh_code` stage | `refreshAltLinkingCode` / `forceManualRefresh` | new `Event::PairingCodeRefresh { force_manual }` (ref-gated) + `Bot::on_pair_code_refresh` helper |

## 3. Concurrency + event hardening (adversarial-review follow-ups)

- **Serialize stage 2.** The transport dispatches `notification` stanzas on concurrent detached tasks, so two `primary_hello` for the same code could each derive a *different* random `adv_secret` and race `SetAdvSecretKey` (last-write-wins), desyncing the persisted secret from the `companion_finish` the server acts on → pair-success HMAC failure. The `pair_code_state` lock is now held across the whole of stage 2 (derive → persist → send), making concurrent notifications sequential — matching WA Web's single-threaded model.
- **Accurate code timeout.** Because `code_generation_ts` now starts before stage 1, the `PairingCode` event advertises the *remaining* window (not the full `code_validity()`), so a consumer's countdown can't outlast the real expiry.

## Testing

- Regression tests driving the top-level `handle_pair_code_notification`: ref mismatch (rejected, no retry slot spent, state preserved), expired code (rejected, no slot), over-cap 4th attempt (rejected, counter bounded at max), a valid in-window retry reaching stage 2, stale mismatches not blocking the valid one, `refresh_code` dispatch/ignore + absent-`force_manual` default, and unknown-stage ignore. The nonce byte is guarded by the wacore `companion_hello_iq_shape` test.
- `cargo test -p whatsapp-rust --lib pair_code` (11) and `cargo test -p wacore --lib pair_code` (40) green; `cargo fmt --all --check` and `cargo clippy -p whatsapp-rust -p wacore --tests` clean.

## Not in scope

No replication of WA Web's QPL markers or telemetry pings; no change to the QR pairing path or the pair-success crypto.