### PR TITLE
fix(iq): cancellation-safe IQ response waiters (unblocks try_join!) + named fan-out consts

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -467,6 +467,10 @@ pub(crate) struct OfflineSyncMetrics {
     pub start_time: std::sync::Mutex<Option<wacore::time::Instant>>,
 }
 
+/// Map of pending IQ/ack response waiters, keyed by request id.
+pub(crate) type ResponseWaiterMap =
+    HashMap<String, futures::channel::oneshot::Sender<Arc<wacore_binary::OwnedNodeRef>>>;
+
 pub struct Client {
     pub(crate) runtime: Arc<dyn Runtime>,
     pub(crate) core: wacore::client::CoreClient,
@@ -520,9 +524,13 @@ pub struct Client {
     pub(crate) transport_factory: Arc<dyn crate::transport::TransportFactory>,
     pub(crate) noise_socket: Arc<Mutex<Option<Arc<NoiseSocket>>>>,
 
-    pub(crate) response_waiters: Arc<
-        Mutex<HashMap<String, futures::channel::oneshot::Sender<Arc<wacore_binary::OwnedNodeRef>>>>,
-    >,
+    /// Pending IQ/ack response waiters keyed by request id.
+    ///
+    /// A `std::sync::Mutex` (like the `node_waiters` sibling below): the critical
+    /// section is a trivial map op never held across an `.await`, and a sync lock
+    /// is what lets `ResponseWaiterGuard` remove a cancelled waiter from `Drop`
+    /// (an async lock couldn't). See `send_and_wait_iq`.
+    pub(crate) response_waiters: Arc<std::sync::Mutex<ResponseWaiterMap>>,
 
     /// Generic node waiters for waiting on specific stanzas by tag/attributes.
     /// Uses std::sync::Mutex (not tokio) since the critical section is trivial.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -140,7 +140,11 @@ impl Client {
             .await;
 
         // Each count read into a local so no two guards are ever held at once.
-        let response_waiters = self.response_waiters.lock().await.len();
+        let response_waiters = self
+            .response_waiters
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .len();
         let presence_subscriptions = self.presence_subscriptions.lock().await.len();
         let app_state_key_requests = self.app_state_key_requests.lock().await.len();
         let app_state_syncing = self.app_state_syncing.lock().await.len();

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -140,11 +140,7 @@ impl Client {
             .await;
 
         // Each count read into a local so no two guards are ever held at once.
-        let response_waiters = self
-            .response_waiters
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .len();
+        let response_waiters = self.response_waiters_guard().len();
         let presence_subscriptions = self.presence_subscriptions.lock().await.len();
         let app_state_key_requests = self.app_state_key_requests.lock().await.len();
         let app_state_syncing = self.app_state_syncing.lock().await.len();
@@ -376,6 +372,19 @@ impl Client {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         waiters.push(SentNodeWaiter { filter, tx });
         rx
+    }
+
+    /// Poison-recovering lock of the `response_waiters` map. Centralizes the
+    /// `unwrap_or_else(into_inner)` so no call site reaches for a bare
+    /// `.lock().unwrap()` that would panic if a holder ever paniced. The critical
+    /// section is a trivial map op, never held across an `.await`.
+    #[inline]
+    pub(crate) fn response_waiters_guard(
+        &self,
+    ) -> std::sync::MutexGuard<'_, crate::client::ResponseWaiterMap> {
+        self.response_waiters
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
     }
 
     /// Check pending node waiters against an incoming node.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -376,7 +376,7 @@ impl Client {
 
     /// Poison-recovering lock of the `response_waiters` map. Centralizes the
     /// `unwrap_or_else(into_inner)` so no call site reaches for a bare
-    /// `.lock().unwrap()` that would panic if a holder ever paniced. The critical
+    /// `.lock().unwrap()` that would panic if a holder ever panicked. The critical
     /// section is a trivial map op, never held across an `.await`.
     #[inline]
     pub(crate) fn response_waiters_guard(

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -140,7 +140,7 @@ impl Client {
             transport_factory,
             noise_socket: Arc::new(Mutex::new(None)),
 
-            response_waiters: Arc::new(Mutex::new(HashMap::new())),
+            response_waiters: Arc::new(std::sync::Mutex::new(HashMap::new())),
             node_waiters: std::sync::Mutex::new(Vec::new()),
             node_waiter_count: AtomicUsize::new(0),
             sent_node_waiters: std::sync::Mutex::new(Vec::new()),
@@ -876,12 +876,19 @@ impl Client {
         self.history_sync_idle_notifier.notify(usize::MAX);
         // Drain all pending IQ waiters so they fail fast with InternalChannelClosed
         // instead of hanging until the 75s timeout.
-        let mut waiters_map = self.response_waiters.lock().await;
-        let waiter_count = waiters_map.len();
-        // Replace with new map to release backing storage; old senders drop here,
-        // causing receivers to get RecvError → IqError::InternalChannelClosed
-        *waiters_map = HashMap::new();
-        drop(waiters_map);
+        // Scoped so the sync guard is dropped before the awaits below (a
+        // std::sync::MutexGuard held across an await would make this future !Send).
+        let waiter_count = {
+            let mut waiters_map = self
+                .response_waiters
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let count = waiters_map.len();
+            // Replace with new map to release backing storage; old senders drop
+            // here, causing receivers to get RecvError → InternalChannelClosed.
+            *waiters_map = HashMap::new();
+            count
+        };
         if waiter_count > 0 {
             debug!(
                 "Dropping {} orphaned IQ response waiter(s) on disconnect",

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -879,10 +879,7 @@ impl Client {
         // Scoped so the sync guard is dropped before the awaits below (a
         // std::sync::MutexGuard held across an await would make this future !Send).
         let waiter_count = {
-            let mut waiters_map = self
-                .response_waiters
-                .lock()
-                .unwrap_or_else(|p| p.into_inner());
+            let mut waiters_map = self.response_waiters_guard();
             let count = waiters_map.len();
             // Replace with new map to release backing storage; old senders drop
             // here, causing receivers to get RecvError → InternalChannelClosed.

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -238,7 +238,7 @@ impl Client {
         let (tx, rx) = futures::channel::oneshot::channel();
         self.response_waiters
             .lock()
-            .await
+            .unwrap_or_else(|p| p.into_inner())
             .insert(message_id.to_string(), tx);
         rx
     }

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -237,9 +237,7 @@ impl Client {
         message_id: &str,
     ) -> futures::channel::oneshot::Receiver<std::sync::Arc<wacore_binary::OwnedNodeRef>> {
         let (tx, rx) = futures::channel::oneshot::channel();
-        self.response_waiters
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
+        self.response_waiters_guard()
             .insert(message_id.to_string(), tx);
         rx
     }

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -231,7 +231,8 @@ impl Client {
 
     /// Register a oneshot waiter for a server ack by message ID.
     /// Returns the receiver — caller sends the node separately and awaits this in background.
-    pub(crate) async fn register_ack_waiter(
+    /// Sync: registration is just a `std::sync::Mutex` insert (no await).
+    pub(crate) fn register_ack_waiter(
         &self,
         message_id: &str,
     ) -> futures::channel::oneshot::Receiver<std::sync::Arc<wacore_binary::OwnedNodeRef>> {

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -430,19 +430,12 @@ impl Client {
 
         if nr.tag.as_ref() == "iq"
             && let Some(id) = nr.get_attr("id").map(|v| v.as_str())
+            && let Some(waiter) = self.response_waiters_guard().remove(id.as_ref())
         {
-            // Single lock acquisition: try to remove the waiter directly.
-            let waiter = self
-                .response_waiters
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .remove(id.as_ref());
-            if let Some(waiter) = waiter {
-                if waiter.send(Arc::clone(&node)).is_err() {
-                    warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
-                }
-                return;
+            if waiter.send(Arc::clone(&node)).is_err() {
+                warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
             }
+            return;
         }
 
         // Dispatch to appropriate handler using the router
@@ -1118,11 +1111,7 @@ impl Client {
         }
 
         if let Some(id) = node.get_attr("id").map(|v| v.as_str())
-            && let Some(waiter) = self
-                .response_waiters
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .remove(id.as_ref())
+            && let Some(waiter) = self.response_waiters_guard().remove(id.as_ref())
         {
             // ACK responses are infrequent; re-encode into OwnedNodeRef for the channel.
             // marshal_ref prepends a leading 0x00 format byte; OwnedNodeRef::new expects raw

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -432,7 +432,11 @@ impl Client {
             && let Some(id) = nr.get_attr("id").map(|v| v.as_str())
         {
             // Single lock acquisition: try to remove the waiter directly.
-            let waiter = self.response_waiters.lock().await.remove(id.as_ref());
+            let waiter = self
+                .response_waiters
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .remove(id.as_ref());
             if let Some(waiter) = waiter {
                 if waiter.send(Arc::clone(&node)).is_err() {
                     warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
@@ -1114,7 +1118,11 @@ impl Client {
         }
 
         if let Some(id) = node.get_attr("id").map(|v| v.as_str())
-            && let Some(waiter) = self.response_waiters.lock().await.remove(id.as_ref())
+            && let Some(waiter) = self
+                .response_waiters
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .remove(id.as_ref())
         {
             // ACK responses are infrequent; re-encode into OwnedNodeRef for the channel.
             // marshal_ref prepends a leading 0x00 format byte; OwnedNodeRef::new expects raw

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -298,6 +298,7 @@ impl Client {
         // otherwise serialize the per-device DB reads (warm hits serialize on the
         // cache mutex anyway). Order is irrelevant — misses are chunked for the fetch.
         use futures::StreamExt;
+        const SESSION_PROBE_CONCURRENCY: usize = 16;
         let backend = device_snapshot.backend.clone();
         let jids_needing_sessions: Vec<Jid> = futures::stream::iter(jids)
             .map(|jid| {
@@ -315,7 +316,7 @@ impl Client {
                     }
                 }
             })
-            .buffer_unordered(16)
+            .buffer_unordered(SESSION_PROBE_CONCURRENCY)
             .filter_map(|needed| async move { needed })
             .collect()
             .await;

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -130,17 +130,9 @@ async fn test_ack_waiter_resolves() {
     // 1. Insert a waiter for a specific ID
     let test_id = "ack-test-123".to_string();
     let (tx, rx) = oneshot::channel();
-    client
-        .response_waiters
-        .lock()
-        .unwrap()
-        .insert(test_id.clone(), tx);
+    client.response_waiters_guard().insert(test_id.clone(), tx);
     assert!(
-        client
-            .response_waiters
-            .lock()
-            .unwrap()
-            .contains_key(&test_id),
+        client.response_waiters_guard().contains_key(&test_id),
         "Waiter should be inserted before handling ack"
     );
 
@@ -174,11 +166,7 @@ async fn test_ack_waiter_resolves() {
 
     // 5. Verify the waiter was removed
     assert!(
-        !client
-            .response_waiters
-            .lock()
-            .unwrap()
-            .contains_key(&test_id),
+        !client.response_waiters_guard().contains_key(&test_id),
         "Waiter should be removed after handling"
     );
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -133,10 +133,14 @@ async fn test_ack_waiter_resolves() {
     client
         .response_waiters
         .lock()
-        .await
+        .unwrap()
         .insert(test_id.clone(), tx);
     assert!(
-        client.response_waiters.lock().await.contains_key(&test_id),
+        client
+            .response_waiters
+            .lock()
+            .unwrap()
+            .contains_key(&test_id),
         "Waiter should be inserted before handling ack"
     );
 
@@ -170,7 +174,11 @@ async fn test_ack_waiter_resolves() {
 
     // 5. Verify the waiter was removed
     assert!(
-        !client.response_waiters.lock().await.contains_key(&test_id),
+        !client
+            .response_waiters
+            .lock()
+            .unwrap()
+            .contains_key(&test_id),
         "Waiter should be removed after handling"
     );
 

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -175,14 +175,14 @@ impl<'a> Contacts<'a> {
                     .await
             }
         };
-        // join!, NOT try_join!: a fail-fast try_join! would drop the sibling IQ
-        // future the instant one errored, leaking its `response_waiters` entry —
-        // send_and_wait_iq only removes the waiter on send-failure/timeout/shutdown,
-        // not on cancellation-via-drop, and a lingering waiter suppresses
-        // keepalives. Awaiting both lets each clean up its own waiter.
-        let (pn_results, lid_results) = futures::join!(pn_fut, lid_fut);
-        let mut results = pn_results?;
-        results.extend(lid_results?);
+        // try_join! fails fast: it returns the instant either query errors and
+        // drops the sibling in-flight future. That's now safe — `send_and_wait_iq`
+        // registers a `ResponseWaiterGuard` that removes the waiter on drop, so a
+        // cancelled sibling can't leak its `response_waiters` entry (which would
+        // otherwise suppress keepalives). The old sequential code also failed on
+        // the first error, so fail-fast matches the original latency profile.
+        let (mut results, lid_results) = futures::try_join!(pn_fut, lid_fut)?;
+        results.extend(lid_results);
 
         self.persist_lid_mappings(results.iter().map(forward_lid_pair))
             .await;

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -373,6 +373,7 @@ impl<'a> Groups<'a> {
         // Cache hits are in-memory, but a cold cache falls back to the DB and a
         // large group would otherwise serialize those lookups — bounded fan-out.
         use futures::StreamExt;
+        const LID_PN_RESOLVE_CONCURRENCY: usize = 16;
         let resolved: Vec<(usize, Jid)> = futures::stream::iter(pending)
             .map(|(i, jid)| async move {
                 let pn = self
@@ -384,7 +385,7 @@ impl<'a> Groups<'a> {
                     .map(|e| Jid::pn(&*e.phone_number));
                 (i, pn)
             })
-            .buffer_unordered(16)
+            .buffer_unordered(LID_PN_RESOLVE_CONCURRENCY)
             .filter_map(|(i, pn)| async move { pn.map(|pn| (i, pn)) })
             .collect()
             .await;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -77,7 +77,11 @@ impl Client {
 
         // WA Web: skip ping if there are pending IQs
         // (`activePing || ackHandlers.length || pendingIqs.size`)
-        let has_pending = !self.response_waiters.lock().await.is_empty();
+        let has_pending = !self
+            .response_waiters
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .is_empty();
         if has_pending {
             debug!(target: "Client/Keepalive", "Skipping ping: IQ responses pending");
             return KeepaliveResult::Ok;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -77,11 +77,7 @@ impl Client {
 
         // WA Web: skip ping if there are pending IQs
         // (`activePing || ackHandlers.length || pendingIqs.size`)
-        let has_pending = !self
-            .response_waiters
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .is_empty();
+        let has_pending = !self.response_waiters_guard().is_empty();
         if has_pending {
             debug!(target: "Client/Keepalive", "Skipping ping: IQ responses pending");
             return KeepaliveResult::Ok;

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -181,6 +181,7 @@ impl Client {
         // Fan out the per-companion identity loads (independent cache/DB reads) —
         // the keyless-companion set can be large on a cold group send. Owned Vec so
         // the stream doesn't borrow `jids` through buffer_unordered (Send bound).
+        const COMPANION_IDENTITY_LOAD_CONCURRENCY: usize = 16;
         let companions: Vec<Jid> = jids.iter().filter(|j| j.device != 0).cloned().collect();
         futures::stream::iter(companions)
             .map(|jid| async move {
@@ -188,7 +189,7 @@ impl Client {
                     .await
                     .map(|id| (jid.normalize_for_prekey_bundle(), id))
             })
-            .buffer_unordered(16)
+            .buffer_unordered(COMPANION_IDENTITY_LOAD_CONCURRENCY)
             .filter_map(|entry| async move { entry })
             .collect()
             .await

--- a/src/request.rs
+++ b/src/request.rs
@@ -22,6 +22,29 @@ type IqSendFuture<'a> =
 type IqSendFuture<'a> =
     std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ClientError>> + 'a>>;
 
+/// Removes a pending `response_waiters` entry when dropped.
+///
+/// `send_and_wait_iq` can be cancelled mid-await — e.g. the losing side of a
+/// `futures::try_join!` is dropped the instant its sibling errors. Without this
+/// guard the registered waiter would linger in the map: the explicit cleanups
+/// only fired on the send-fail / timeout / shutdown paths, never on
+/// cancellation-via-drop, and a lingering waiter suppresses keepalives for the
+/// life of the connection. Dropping the guard removes the entry on every exit
+/// path; on success `resolve_waiters` already removed it, so it's a no-op.
+struct ResponseWaiterGuard {
+    waiters: Arc<std::sync::Mutex<crate::client::ResponseWaiterMap>>,
+    req_id: String,
+}
+
+impl Drop for ResponseWaiterGuard {
+    fn drop(&mut self) {
+        self.waiters
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&self.req_id);
+    }
+}
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum IqError {
@@ -281,21 +304,27 @@ impl Client {
         let (tx, rx) = futures::channel::oneshot::channel();
         self.response_waiters
             .lock()
-            .await
+            .unwrap_or_else(|p| p.into_inner())
             .insert(req_id.clone(), tx);
+        // RAII cleanup covers every exit below — including this future being
+        // dropped mid-await (cancellation), which the explicit paths can't
+        // catch. So the send-fail / timeout / shutdown arms no longer remove
+        // the waiter by hand; the guard does it on drop.
+        let _waiter_guard = ResponseWaiterGuard {
+            waiters: self.response_waiters.clone(),
+            req_id,
+        };
 
         // Per-connection: pending IQ requests are bound to the current socket;
         // a reconnect aborts them (sender retries on the new connection).
         let shutdown = wacore::runtime::wait_for_shutdown(&self.connection_shutdown_signal());
 
         if !self.is_running.load(Ordering::Acquire) {
-            self.response_waiters.lock().await.remove(&req_id);
             wacore::telemetry::iq("error");
             return Err(IqError::NotConnected);
         }
 
         if let Err(e) = send_fn.await {
-            self.response_waiters.lock().await.remove(&req_id);
             wacore::telemetry::iq("error");
             return match e {
                 ClientError::Socket(s_err) => Err(IqError::Socket(s_err)),
@@ -317,16 +346,10 @@ impl Client {
                         Err(e) => Err(e.into()),
                     },
                     Ok(Err(_)) => Err(IqError::InternalChannelClosed),
-                    Err(_) => {
-                        self.response_waiters.lock().await.remove(&req_id);
-                        Err(IqError::Timeout)
-                    }
+                    Err(_) => Err(IqError::Timeout),
                 }
             }
-            _ = shutdown.fuse() => {
-                self.response_waiters.lock().await.remove(&req_id);
-                Err(IqError::NotConnected)
-            }
+            _ = shutdown.fuse() => Err(IqError::NotConnected),
         };
         wacore::telemetry::iq(match &result {
             Ok(_) => "ok",
@@ -339,7 +362,9 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use super::IqError;
+    use super::{IqError, ResponseWaiterGuard};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn converts_unexpected_response_type() {
@@ -351,5 +376,44 @@ mod tests {
             IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
             other => panic!("expected UnexpectedResponseType, got {other:?}"),
         }
+    }
+
+    // Cancellation cleanup: dropping a `send_and_wait_iq` future mid-await (e.g.
+    // the loser of a `try_join!`) must remove its still-pending waiter, or a
+    // leaked entry suppresses keepalives for the life of the connection.
+    #[test]
+    fn waiter_guard_removes_pending_entry_on_drop() {
+        let waiters: Arc<Mutex<crate::client::ResponseWaiterMap>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = futures::channel::oneshot::channel();
+        waiters.lock().unwrap().insert("req-1".to_string(), tx);
+        assert!(waiters.lock().unwrap().contains_key("req-1"));
+
+        {
+            let _guard = ResponseWaiterGuard {
+                waiters: waiters.clone(),
+                req_id: "req-1".to_string(),
+            };
+        }
+        assert!(
+            !waiters.lock().unwrap().contains_key("req-1"),
+            "dropping the guard must remove the pending waiter"
+        );
+    }
+
+    // On the success path the resolver already removed the entry before the
+    // guard drops, so the guard's removal must be a harmless no-op.
+    #[test]
+    fn waiter_guard_drop_is_noop_when_already_resolved() {
+        let waiters: Arc<Mutex<crate::client::ResponseWaiterMap>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        // Map empty = resolver already delivered + removed this request's waiter.
+        {
+            let _guard = ResponseWaiterGuard {
+                waiters: waiters.clone(),
+                req_id: "req-1".to_string(),
+            };
+        }
+        assert!(waiters.lock().unwrap().is_empty());
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -302,10 +302,19 @@ impl Client {
         }
 
         let (tx, rx) = futures::channel::oneshot::channel();
-        self.response_waiters
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .insert(req_id.clone(), tx);
+        {
+            let mut waiters = self.response_waiters_guard();
+            // req_ids come from the monotonic generate_request_id(), so a given
+            // id is never in flight twice — the invariant that makes the guard's
+            // remove-by-id unambiguous (an overwrite could otherwise let an older
+            // guard evict a newer waiter). Assert it so a future caller passing a
+            // duplicate id is caught in tests instead of silently.
+            debug_assert!(
+                !waiters.contains_key(&req_id),
+                "duplicate in-flight IQ request id: {req_id}"
+            );
+            waiters.insert(req_id.clone(), tx);
+        }
         // RAII cleanup covers every exit below — including this future being
         // dropped mid-await (cancellation), which the explicit paths can't
         // catch. So the send-fail / timeout / shutdown arms no longer remove

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -914,7 +914,7 @@ impl Client {
             .optional_string("phash")
             .map(|s| s.into_owned())
         {
-            let rx = self.register_ack_waiter(&request_id).await;
+            let rx = self.register_ack_waiter(&request_id);
             Some((rx, phash))
         } else {
             None
@@ -1882,7 +1882,7 @@ impl Client {
                 .optional_string("id")
                 .map(|s| s.into_owned())
         {
-            let rx = self.register_ack_waiter(&msg_id).await;
+            let rx = self.register_ack_waiter(&msg_id);
             Some((rx, phash, msg_id))
         } else {
             None

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -741,10 +741,11 @@ impl Client {
         // Resolve recipient LIDs concurrently (a status audience can be hundreds of
         // contacts, each a cold-cache DB read). Stream over indices and rebuild
         // `resolved` in order — assemble_status_participants is position-sensitive.
+        const STATUS_LID_RESOLVE_CONCURRENCY: usize = 16;
         let resolved_indexed: Vec<(usize, Option<Jid>)> =
             futures::stream::iter(0..recipients.len())
                 .map(|i| async move { (i, self.resolve_recipient_to_lid(&recipients[i]).await) })
-                .buffer_unordered(16)
+                .buffer_unordered(STATUS_LID_RESOLVE_CONCURRENCY)
                 .collect()
                 .await;
         let mut resolved: Vec<Option<Jid>> = vec![None; recipients.len()];
@@ -921,7 +922,10 @@ impl Client {
 
         if let Err(e) = self.send_node(stanza).await {
             if ack.is_some() {
-                self.response_waiters.lock().await.remove(&request_id);
+                self.response_waiters
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .remove(&request_id);
             }
             return Err(e.into());
         }
@@ -1192,7 +1196,11 @@ impl Client {
                     Ok(Ok(node)) => node,
                     _ => {
                         // Remove leaked waiter to prevent keepalive suppression
-                        client.response_waiters.lock().await.remove(&message_id);
+                        client
+                            .response_waiters
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner())
+                            .remove(&message_id);
                         return;
                     }
                 };
@@ -1892,7 +1900,10 @@ impl Client {
 
         if let Err(e) = self.send_node(stanza_to_send).await {
             if let Some((_, _, ref msg_id)) = ack {
-                self.response_waiters.lock().await.remove(msg_id);
+                self.response_waiters
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .remove(msg_id);
             }
             return Err(e.into());
         }

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -922,10 +922,7 @@ impl Client {
 
         if let Err(e) = self.send_node(stanza).await {
             if ack.is_some() {
-                self.response_waiters
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .remove(&request_id);
+                self.response_waiters_guard().remove(&request_id);
             }
             return Err(e.into());
         }
@@ -1196,11 +1193,7 @@ impl Client {
                     Ok(Ok(node)) => node,
                     _ => {
                         // Remove leaked waiter to prevent keepalive suppression
-                        client
-                            .response_waiters
-                            .lock()
-                            .unwrap_or_else(|p| p.into_inner())
-                            .remove(&message_id);
+                        client.response_waiters_guard().remove(&message_id);
                         return;
                     }
                 };
@@ -1900,10 +1893,7 @@ impl Client {
 
         if let Err(e) = self.send_node(stanza_to_send).await {
             if let Some((_, _, ref msg_id)) = ack {
-                self.response_waiters
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .remove(msg_id);
+                self.response_waiters_guard().remove(msg_id);
             }
             return Err(e.into());
         }

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -22,13 +22,15 @@ impl Client {
         // device 0). Materialize to an owned Vec first so the stream doesn't borrow
         // `jids` through buffer_unordered (Send bound).
         use futures::StreamExt;
+        // Bounded fan-out over the independent per-user registry reads.
+        const DEVICE_LIST_RESOLVE_CONCURRENCY: usize = 16;
         let non_ad: Vec<Jid> = jids.iter().map(|j| j.to_non_ad()).collect();
         let resolved: Vec<(Jid, Option<Vec<Jid>>)> = futures::stream::iter(non_ad)
             .map(|jid| async move {
                 let devices = self.get_devices_from_registry(&jid).await;
                 (jid, devices)
             })
-            .buffer_unordered(16)
+            .buffer_unordered(DEVICE_LIST_RESOLVE_CONCURRENCY)
             .collect()
             .await;
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -602,7 +602,7 @@ async fn place_call(
         client
             .response_waiters
             .lock()
-            .await
+            .unwrap_or_else(|p| p.into_inner())
             .remove(&offer_stanza_id);
         if removed.is_some() {
             ended.notify();
@@ -679,7 +679,7 @@ fn spawn_outgoing_relay_waiter(
                         client
                             .response_waiters
                             .lock()
-                            .await
+                            .unwrap_or_else(|p| p.into_inner())
                             .remove(&offer_stanza_id);
                         None
                     }
@@ -2731,7 +2731,7 @@ mod tests {
             client
                 .response_waiters
                 .lock()
-                .await
+                .unwrap()
                 .contains_key(&offer_stanza_id),
             "the ack-waiter must be registered"
         );
@@ -2755,7 +2755,7 @@ mod tests {
             if !client
                 .response_waiters
                 .lock()
-                .await
+                .unwrap()
                 .contains_key(&offer_stanza_id)
             {
                 break;
@@ -2766,7 +2766,7 @@ mod tests {
             !client
                 .response_waiters
                 .lock()
-                .await
+                .unwrap()
                 .contains_key(&offer_stanza_id),
             "a no-ack relay-waiter must drop its response_waiters entry so keepalive isn't suppressed"
         );

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -535,7 +535,7 @@ async fn place_call(
     // Register the ack-waiter for the offer's stanza id BEFORE send_node so a fast server reply can't
     // arrive before we are listening. The ack carries the relay; the spawned task below attaches the
     // engine when it resolves.
-    let ack_rx = client.register_ack_waiter(&offer_stanza_id).await;
+    let ack_rx = client.register_ack_waiter(&offer_stanza_id);
 
     // Register the outgoing call AND park the relay-attach material BEFORE send_node, mirroring the
     // incoming register-before-connect ordering. The handle starts dormant; the ack-waiter task
@@ -2726,7 +2726,7 @@ mod tests {
         let client = make_client().await;
 
         let offer_stanza_id = "OFFER-STANZA-J".to_string();
-        let ack_rx = client.register_ack_waiter(&offer_stanza_id).await;
+        let ack_rx = client.register_ack_waiter(&offer_stanza_id);
         assert!(
             client
                 .response_waiters
@@ -2738,7 +2738,7 @@ mod tests {
         // Drop the sender (re-register a NEW waiter under the same id) so ack_rx closes immediately and
         // the task takes the no-ack closed-channel branch without waiting out the full timeout. The new
         // waiter is what the cleanup must then remove.
-        let _shadow_rx = client.register_ack_waiter(&offer_stanza_id).await;
+        let _shadow_rx = client.register_ack_waiter(&offer_stanza_id);
 
         // No matching pending entry: the task's attach is a harmless no-op, but the response_waiters
         // cleanup must still run.

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -599,11 +599,7 @@ async fn place_call(
         let removed = take_pending_if_current(&client.pending_outgoing_calls, &call_id, generation);
         registry.remove_if_current(&call_id, generation);
         // No ack will ever arrive for the failed offer; drop the waiter so it can't leak.
-        client
-            .response_waiters
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .remove(&offer_stanza_id);
+        client.response_waiters_guard().remove(&offer_stanza_id);
         if removed.is_some() {
             ended.notify();
         }
@@ -676,11 +672,7 @@ fn spawn_outgoing_relay_waiter(
                     // handle_ack_response never ran, so our still-registered waiter entry must be dropped
                     // here or send_keepalive suppresses pings for the life of the connection.
                     Ok(Err(_)) | Err(_) => {
-                        client
-                            .response_waiters
-                            .lock()
-                            .unwrap_or_else(|p| p.into_inner())
-                            .remove(&offer_stanza_id);
+                        client.response_waiters_guard().remove(&offer_stanza_id);
                         None
                     }
                 };
@@ -2729,9 +2721,7 @@ mod tests {
         let ack_rx = client.register_ack_waiter(&offer_stanza_id);
         assert!(
             client
-                .response_waiters
-                .lock()
-                .unwrap()
+                .response_waiters_guard()
                 .contains_key(&offer_stanza_id),
             "the ack-waiter must be registered"
         );
@@ -2753,9 +2743,7 @@ mod tests {
         // The spawned task drops the now-dangling waiter on the no-ack path.
         for _ in 0..200 {
             if !client
-                .response_waiters
-                .lock()
-                .unwrap()
+                .response_waiters_guard()
                 .contains_key(&offer_stanza_id)
             {
                 break;
@@ -2764,9 +2752,7 @@ mod tests {
         }
         assert!(
             !client
-                .response_waiters
-                .lock()
-                .unwrap()
+                .response_waiters_guard()
                 .contains_key(&offer_stanza_id),
             "a no-ack relay-waiter must drop its response_waiters entry so keepalive isn't suppressed"
         );


### PR DESCRIPTION
## Summary

Follow-up to #975, taking two items from that PR's "Declined / follow-up" list as a focused refactor.

### 1. Cancellation-safe IQ response waiters — unblocks `try_join!` (main change)

`send_and_wait_iq` registers an entry in `response_waiters` and only removed it on the send-fail / timeout / shutdown paths — **never when the future itself is dropped mid-await** (cancellation). So a fail-fast `futures::try_join!` over two IQs drops the losing side the instant its sibling errors and **leaks that waiter**; a lingering waiter suppresses keepalives for the life of the connection. That's exactly why #975 had to keep `is_on_whatsapp` on `join!` (await both) instead of the fail-fast `try_join!`.

**Root-cause fix:** an RAII `ResponseWaiterGuard` that removes the entry on `Drop`, covering *every* exit path including cancellation. To remove from `Drop` (which can't `.await`), `response_waiters` moves from an `async_lock::Mutex` to a `std::sync::Mutex` — matching its `node_waiters` sibling (a trivial critical section never held across an await; the one drain site is block-scoped so the guard releases before its awaits). The four hand-rolled `remove()` calls in `send_and_wait_iq` collapse into the guard.

`is_on_whatsapp` now uses `try_join!` (fail-fast) — restoring the original sequential error-latency profile while keeping the two IQs concurrent.

### 2. Name the bounded fan-out concurrency limits (quick win)

The five `buffer_unordered(16)` sites (session probe, device-list resolve, status-LID resolve, companion-identity load, LID→PN resolve) get per-module named consts — matching the existing `HISTORY_SYNC_CONCURRENCY` / `MEDIA_REUPLOAD_CONCURRENCY` / `APPSTATE_BLOB_DOWNLOAD_CONCURRENCY` style so they're greppable and independently tunable.

## Why a sync mutex is safe here

Every `response_waiters` lock site is a single-statement map op (insert / remove / len / is_empty), never held across an `.await`. Access is centralized through a `Client::response_waiters_guard()` helper (poison-recovering, mirroring the `node_waiters` helpers) so no call site reaches for a bare `.lock().unwrap()`; the only direct lock left is `ResponseWaiterGuard::drop`, which owns its `Arc`. The one site that binds the guard (`cleanup_connection_state`'s drain) is block-scoped so it drops before the following awaits. Verified: the spawned client future stays `Send`, and wasm32 `--no-default-features` builds.

## Review follow-ups (applied)

- **de-async `register_ack_waiter`** — its only await was the `response_waiters` lock; now a sync `std::sync::Mutex` insert, so it's a plain `fn` (`.await` dropped at all call sites).
- **`response_waiters_guard()` helper** — centralizes the poison-recovering lock; every `&self`/`&Client` access routed through it.
- **let-chain in `node_io`** — the IQ-response waiter removal is folded into the outer let-chain (matching `handle_ack_response`, per the repo's let-chain guideline).
- **`debug_assert!` on `req_id` uniqueness** — the guard removes by `req_id`; every `send_and_wait_iq` caller derives `req_id` from the monotonic `generate_request_id()` (verified across the codebase, incl. the sole `InfoQuery.id` setter in `pair_code.rs`), so an id is never in flight twice and the remove-by-id is unambiguous. The assert documents/enforces that invariant and catches any future caller that breaks it (a per-waiter token would be dead weight for a structurally-unreachable hazard).

## Deliberately out of scope

- **ACK-waiter & VoIP `place_call` cancellation-safety** — the ack/offer waiters were never cancellation-safe (pre-existing; this PR only migrated the lock syntax there, not the cleanup structure). Those paths also carry pending-call/registry state beyond the waiter, so extending the RAII pattern to them is a separate, larger change — a good follow-up now that the guard exists as a template.
- **history-sync in-flight-counter generation-scoping** — floated as a second quick win but it needs threading `connection_generation` through the task lifecycle; more delicate than quick. The existing `previous <= 1 → store(0)` clamp already prevents the underflow; the remaining premature-idle edge is a separate, careful change.

## Testing

- New unit tests: `ResponseWaiterGuard` removes-on-drop, and is a no-op when the waiter was already resolved.
- Existing coverage exercises the mutex change end-to-end: `test_ack_waiter_resolves` (resolve path), `relay_waiter_no_ack_removes_response_waiter` (voip no-ack cleanup, `--features voip`), the keepalive suite.
- **921 lib tests pass**; `cargo clippy --lib --tests` clean; `cargo fmt --all`; wasm32 `--no-default-features` builds. Binary size ~11 KiB smaller (async→sync mutex + collapsed cleanup).