### PR TITLE
fix(pair-code): canonicalize companion_platform_display OS to a server-safe set

### DIFF
--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -56,7 +56,7 @@ use wacore::pair_code::{PairCodeState, PairCodeUtils, resolve_companion_platform
 use wacore_binary::Jid;
 use wacore_binary::{NodeContent, NodeContentRef, NodeRef};
 
-pub use wacore::companion_reg::CompanionWebClientType;
+pub use wacore::companion_reg::{CompanionOs, CompanionWebClientType};
 pub use wacore::pair_code::{PairCodeError, PairCodeOptions};
 
 /// Errors raised by the high-level pair-code flow.
@@ -69,6 +69,16 @@ pub enum PairError {
     #[error(transparent)]
     PairCode(#[from] PairCodeError),
 
+    /// The pair-code IQ was rejected by the server.
+    ///
+    /// Note the server returns `bad-request` (400) **both** for genuinely invalid
+    /// content and for **rate-limiting** — it throttles pair-code requests per
+    /// phone number and reuses the same error. So a 400 here is not necessarily a
+    /// permanent/invalid-input failure: back off and retry rather than treating
+    /// every 400 as fatal. (The lib canonicalizes the `companion_platform_display`
+    /// OS, so a display-shaped rejection is already ruled out — see
+    /// [`wacore::companion_reg::CompanionOs`].) Any server `backoff` hint is
+    /// preserved on the wrapped [`IqError`].
     #[error("pair-code IQ request failed")]
     RequestFailed(#[from] IqError),
 }
@@ -89,7 +99,9 @@ impl Client {
     /// # Returns
     ///
     /// * `Ok(String)` - The 8-character pairing code to display
-    /// * `Err` - If validation fails, not connected, or server error
+    /// * `Err` - If validation fails, not connected, or server error. A
+    ///   [`PairError::RequestFailed`] carrying `bad-request` may be **rate-limiting**
+    ///   (throttled per phone number), not invalid input — back off and retry.
     ///
     /// # Example
     ///
@@ -186,6 +198,20 @@ impl Client {
         let (platform_id, platform_display) =
             resolve_companion_platform(&options, &device_snapshot.device_props);
         let platform_id_str = platform_id.to_string();
+
+        // The pair-code server rejects a non-OS `companion_platform_display` with
+        // bad-request (QR pairing never sends this field, so it tolerates arbitrary
+        // branding). If `DeviceProps::os` was a branding string it is coerced to
+        // "Linux"; warn so a consumer sees why their branding didn't ride through.
+        if let Some(os) = device_snapshot.device_props.os.as_deref()
+            && !os.trim().is_empty()
+            && CompanionOs::classify(os).is_none()
+        {
+            warn!(
+                target: "Client/PairCode",
+                "companion_platform_display OS {os:?} is not a recognized OS; coerced to \"Linux\" for pair-code (the server would reject a non-OS display with bad-request)"
+            );
+        }
 
         let req_id = self.generate_request_id();
         let iq_content = PairCodeUtils::build_companion_hello_iq(

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -203,14 +203,20 @@ impl Client {
         // bad-request (QR pairing never sends this field, so it tolerates arbitrary
         // branding). If `DeviceProps::os` was a branding string it is coerced to
         // "Linux"; warn so a consumer sees why their branding didn't ride through.
+        // Gated to fire once per process: a rate-limited caller may retry
+        // pair_with_code repeatedly (see PairError::RequestFailed) with the same
+        // unchanged os, and an identical warning per retry is just noise.
+        static OS_COERCE_WARNED: std::sync::Once = std::sync::Once::new();
         if let Some(os) = device_snapshot.device_props.os.as_deref()
             && !os.trim().is_empty()
             && CompanionOs::classify(os).is_none()
         {
-            warn!(
-                target: "Client/PairCode",
-                "companion_platform_display OS {os:?} is not a recognized OS; coerced to \"Linux\" for pair-code (the server would reject a non-OS display with bad-request)"
-            );
+            OS_COERCE_WARNED.call_once(|| {
+                warn!(
+                    target: "Client/PairCode",
+                    "companion_platform_display OS {os:?} is not a recognized OS; coerced to \"Linux\" for pair-code (the server would reject a non-OS display with bad-request)"
+                );
+            });
         }
 
         let req_id = self.generate_request_id();

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -203,11 +203,17 @@ impl Client {
         // bad-request (QR pairing never sends this field, so it tolerates arbitrary
         // branding). If `DeviceProps::os` was a branding string it is coerced to
         // "Linux"; warn so a consumer sees why their branding didn't ride through.
+        // Skipped when `display_os` overrides the OS (then props.os isn't coerced).
         // Gated to fire once per process: a rate-limited caller may retry
         // pair_with_code repeatedly (see PairError::RequestFailed) with the same
         // unchanged os, and an identical warning per retry is just noise.
         static OS_COERCE_WARNED: std::sync::Once = std::sync::Once::new();
-        if let Some(os) = device_snapshot.device_props.os.as_deref()
+        let os_overridden = options
+            .display_os
+            .as_deref()
+            .is_some_and(|o| !o.trim().is_empty());
+        if !os_overridden
+            && let Some(os) = device_snapshot.device_props.os.as_deref()
             && !os.trim().is_empty()
             && CompanionOs::classify(os).is_none()
         {

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -199,14 +199,11 @@ impl Client {
             resolve_companion_platform(&options, &device_snapshot.device_props);
         let platform_id_str = platform_id.to_string();
 
-        // The pair-code server rejects a non-OS `companion_platform_display` with
-        // bad-request (QR pairing never sends this field, so it tolerates arbitrary
-        // branding). If `DeviceProps::os` was a branding string it is coerced to
-        // "Linux"; warn so a consumer sees why their branding didn't ride through.
-        // Skipped when `display_os` overrides the OS (then props.os isn't coerced).
-        // Gated to fire once per process: a rate-limited caller may retry
-        // pair_with_code repeatedly (see PairError::RequestFailed) with the same
-        // unchanged os, and an identical warning per retry is just noise.
+        // Warn when a branding `DeviceProps::os` gets coerced to "Linux", so a
+        // consumer sees why it didn't ride through (the pair-code server rejects a
+        // non-OS display with bad-request; QR never sends this field). Skipped under
+        // a `display_os` override. Once-per-process: retries (PairError::RequestFailed
+        // is rate-limitable) reuse the same os, so repeating the warning is just noise.
         static OS_COERCE_WARNED: std::sync::Once = std::sync::Once::new();
         let os_overridden = options
             .display_os

--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -122,15 +122,89 @@ pub fn companion_web_client_type_for_props(props: &wa::DeviceProps) -> Companion
         .unwrap_or(CompanionWebClientType::OtherWebClient)
 }
 
-/// `companion_platform_display` body. Server validates only length
-/// 1..=100; there is no browser whitelist. Web variants emit
-/// `<Browser> (<OS>)`, mirroring `WAWebAltDeviceLinkingIq`; Android
-/// variants emit `Android (<OS>)`, matching the official Android client.
-/// Empty OS substitutes `Linux`.
+/// Canonical OS label for the pair-code `companion_platform_display`.
+///
+/// WA Web only ever emits a real OS name from its UA parser
+/// (`WAWebBrowserInfo().os` → `ua-parser-js` `getOS().name`). Unlike QR pairing —
+/// which never sends this field and therefore tolerates an arbitrary branding
+/// string in `DeviceProps::os` — the pair-code `companion_hello` server
+/// **rejects a non-OS display with `bad-request`**. So the OS component must come
+/// from a closed set of real OS names, never the free-form branding string.
+///
+/// The set is deliberately small and conservative: the server is lenient toward
+/// real OS names today (it also accepts `Ubuntu`, `Fedora`, `Mac`, …), but
+/// collapsing everything to a guaranteed-accepted canonical value is robust
+/// against that leniency changing. Anything unrecognized coerces to
+/// [`Self::Linux`] (see [`Self::from_hint`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompanionOs {
+    Windows,
+    MacOs,
+    Linux,
+    Android,
+    Ios,
+}
+
+impl CompanionOs {
+    /// The exact wire string, matching `ua-parser-js` `getOS().name` (what WA Web
+    /// sends) — note the `"Mac OS"` and `"iOS"` spellings.
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Windows => "Windows",
+            Self::MacOs => "Mac OS",
+            Self::Linux => "Linux",
+            Self::Android => "Android",
+            Self::Ios => "iOS",
+        }
+    }
+
+    /// Classify a free-form OS hint into a known canonical OS, or `None` when it
+    /// is not recognizably an OS (empty, or a branding label such as `"Veloz"`).
+    /// Case-insensitive. iPad folds to [`Self::Ios`]: older UA parsers report iPad
+    /// as `"iOS"`, so `"iPadOS"` is not a confirmed server-accepted value. Chrome
+    /// OS and Linux distros fold to [`Self::Linux`].
+    pub fn classify(os: &str) -> Option<Self> {
+        let os = os.trim().to_ascii_lowercase();
+        if os.is_empty() {
+            None
+        } else if os.contains("windows") {
+            Some(Self::Windows)
+        } else if os.contains("mac") || os.contains("osx") || os.contains("darwin") {
+            Some(Self::MacOs)
+        } else if os.contains("ipad") || os.contains("iphone") || os.contains("ios") {
+            Some(Self::Ios)
+        } else if os.contains("android") {
+            Some(Self::Android)
+        } else if os.contains("linux")
+            || os.contains("ubuntu")
+            || os.contains("debian")
+            || os.contains("fedora")
+            || os.contains("arch")
+            || os.contains("chrome os")
+            || os.contains("chromium")
+            || os.contains("cros")
+        {
+            Some(Self::Linux)
+        } else {
+            None
+        }
+    }
+
+    /// Coerce a free-form `DeviceProps::os` into a server-safe canonical OS,
+    /// defaulting an unrecognized/branding value to [`Self::Linux`].
+    pub fn from_hint(os: &str) -> Self {
+        Self::classify(os).unwrap_or(Self::Linux)
+    }
+}
+
+/// `companion_platform_display` body: `<Browser> (<OS>)` (Android client types
+/// emit `Android (<OS>)`), mirroring `WAWebAltDeviceLinkingIq`. The OS is
+/// canonicalized through [`CompanionOs`] because the pair-code server rejects a
+/// non-OS string here with `bad-request`; an unrecognized/branding `os` (or an
+/// empty one) becomes `Linux`.
 pub fn companion_platform_display(ct: CompanionWebClientType, os: &str) -> String {
     use CompanionWebClientType as C;
-    let os = os.trim();
-    let os = if os.is_empty() { "Linux" } else { os };
+    let os = CompanionOs::from_hint(os).wire_str();
     match ct {
         C::AndroidPhone | C::AndroidTablet | C::AndroidAmbiguous => {
             format!("Android ({os})")
@@ -324,9 +398,10 @@ mod tests {
             companion_platform_display(CompanionWebClientType::Chrome, "Linux"),
             "Chrome (Linux)"
         );
+        // "Mac" canonicalizes to the ua-parser name WA Web actually sends.
         assert_eq!(
             companion_platform_display(CompanionWebClientType::Firefox, "Mac"),
-            "Firefox (Mac)"
+            "Firefox (Mac OS)"
         );
     }
 
@@ -350,7 +425,73 @@ mod tests {
         );
         assert_eq!(
             companion_platform_display(CompanionWebClientType::Electron, "Mac"),
-            "Chrome (Mac)"
+            "Chrome (Mac OS)"
         );
+    }
+
+    #[test]
+    fn companion_os_wire_str_matches_ua_parser_names() {
+        assert_eq!(CompanionOs::Windows.wire_str(), "Windows");
+        assert_eq!(CompanionOs::MacOs.wire_str(), "Mac OS");
+        assert_eq!(CompanionOs::Linux.wire_str(), "Linux");
+        assert_eq!(CompanionOs::Android.wire_str(), "Android");
+        assert_eq!(CompanionOs::Ios.wire_str(), "iOS");
+    }
+
+    #[test]
+    fn companion_os_classify_known_aliases() {
+        use CompanionOs as O;
+        for (hint, want) in [
+            ("Windows", O::Windows),
+            ("windows 11", O::Windows),
+            ("Mac", O::MacOs),
+            ("macOS", O::MacOs),
+            ("Mac OS", O::MacOs),
+            ("Mac OS X", O::MacOs),
+            ("darwin", O::MacOs),
+            ("Linux", O::Linux),
+            ("Ubuntu", O::Linux),
+            ("Fedora", O::Linux),
+            ("Arch Linux", O::Linux),
+            ("Chrome OS", O::Linux),
+            ("Chromium OS", O::Linux),
+            ("Android", O::Android),
+            ("android 14", O::Android),
+            ("iOS", O::Ios),
+            ("iPhone", O::Ios),
+            ("iPad", O::Ios),
+            ("iPadOS", O::Ios),
+        ] {
+            assert_eq!(CompanionOs::classify(hint), Some(want), "{hint:?}");
+        }
+    }
+
+    #[test]
+    fn companion_os_branding_and_empty_are_unclassified_and_default_linux() {
+        for hint in ["Veloz", "Foobar123", "", "   "] {
+            assert_eq!(CompanionOs::classify(hint), None, "{hint:?}");
+            assert_eq!(CompanionOs::from_hint(hint), CompanionOs::Linux, "{hint:?}");
+        }
+    }
+
+    /// The regression this whole enum exists for: a branding `os` must never ride
+    /// through to the wire (the pair-code server rejects it with `bad-request`).
+    #[test]
+    fn platform_display_coerces_branding_os_to_linux() {
+        assert_eq!(
+            companion_platform_display(CompanionWebClientType::Chrome, "Veloz"),
+            "Chrome (Linux)"
+        );
+    }
+
+    #[test]
+    fn platform_display_canonicalizes_mac_aliases() {
+        for os in ["Mac", "macOS", "Mac OS", "Mac OS X", "darwin"] {
+            assert_eq!(
+                companion_platform_display(CompanionWebClientType::Chrome, os),
+                "Chrome (Mac OS)",
+                "{os:?}"
+            );
+        }
     }
 }

--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -203,20 +203,29 @@ impl CompanionOs {
     }
 }
 
-/// `companion_platform_display` body: `<Browser> (<OS>)` (Android client types
-/// emit `Android (<OS>)`), mirroring `WAWebAltDeviceLinkingIq`. The OS is
-/// canonicalized through [`CompanionOs`] because the pair-code server rejects a
-/// non-OS string here with `bad-request`; an unrecognized/branding `os` (or an
-/// empty one) becomes `Linux`.
-pub fn companion_platform_display(ct: CompanionWebClientType, os: &str) -> String {
+/// Formats `<Browser> (<os>)` (Android client types → `Android (<os>)`),
+/// mirroring `WAWebAltDeviceLinkingIq`, with `os` used **verbatim** — no
+/// canonicalization. This is the escape hatch for an advanced caller that
+/// overrides the display OS (e.g. to keep a real distro name like `"Ubuntu"`
+/// the server accepts); the server validates the OS, so a non-OS string here is
+/// rejected with `bad-request`. Most callers want [`companion_platform_display`].
+pub fn companion_platform_display_raw(ct: CompanionWebClientType, os: &str) -> String {
     use CompanionWebClientType as C;
-    let os = CompanionOs::from_hint(os).wire_str();
     match ct {
         C::AndroidPhone | C::AndroidTablet | C::AndroidAmbiguous => {
             format!("Android ({os})")
         }
         _ => format!("{} ({})", companion_browser_name(ct), os),
     }
+}
+
+/// `companion_platform_display` body: `<Browser> (<OS>)` (Android client types
+/// emit `Android (<OS>)`), mirroring `WAWebAltDeviceLinkingIq`. The OS is
+/// canonicalized through [`CompanionOs`] because the pair-code server rejects a
+/// non-OS string here with `bad-request`; an unrecognized/branding `os` (or an
+/// empty one) becomes `Linux`.
+pub fn companion_platform_display(ct: CompanionWebClientType, os: &str) -> String {
+    companion_platform_display_raw(ct, CompanionOs::from_hint(os).wire_str())
 }
 
 #[cfg(test)]

--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -184,11 +184,14 @@ impl CompanionOs {
             || os.contains("ubuntu")
             || os.contains("debian")
             || os.contains("fedora")
-            || os.contains("arch")
             || os.contains("chrome os")
             || os.contains("chromeos")
             || os.contains("chromium")
-            || os.contains("cros")
+            // Whole-word for the short ambiguous ones so branding like "March"/
+            // "Search"/"across" doesn't false-match (bare "Arch"/"CrOS" still do;
+            // "Arch Linux"/"archlinux" are caught by the "linux" substring above).
+            || os.split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|tok| tok == "arch" || tok == "cros")
         {
             Some(Self::Linux)
         } else {
@@ -468,6 +471,9 @@ mod tests {
             ("Ubuntu", O::Linux),
             ("Fedora", O::Linux),
             ("Arch Linux", O::Linux),
+            ("Arch", O::Linux),
+            ("archlinux", O::Linux),
+            ("CrOS", O::Linux),
             ("Chrome OS", O::Linux),
             ("ChromeOS", O::Linux),
             ("Chromium OS", O::Linux),
@@ -485,8 +491,19 @@ mod tests {
 
     #[test]
     fn companion_os_branding_and_empty_are_unclassified_and_default_linux() {
-        // "KaiOS" must NOT substring-match "ios" -> it is unrecognized -> Linux.
-        for hint in ["Veloz", "Foobar123", "KaiOS", "", "   "] {
+        // "KaiOS" must NOT substring-match "ios", and branding containing "arch"/
+        // "cros" as a fragment ("March", "Search", "across") must NOT match Linux
+        // -> all unrecognized -> Linux via fallback (not via classify).
+        for hint in [
+            "Veloz",
+            "Foobar123",
+            "KaiOS",
+            "March",
+            "Search",
+            "across",
+            "",
+            "   ",
+        ] {
             assert_eq!(CompanionOs::classify(hint), None, "{hint:?}");
             assert_eq!(CompanionOs::from_hint(hint), CompanionOs::Linux, "{hint:?}");
         }

--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -171,7 +171,12 @@ impl CompanionOs {
             Some(Self::Windows)
         } else if os.contains("mac") || os.contains("osx") || os.contains("darwin") {
             Some(Self::MacOs)
-        } else if os.contains("ipad") || os.contains("iphone") || os.contains("ios") {
+        } else if os.contains("ipad")
+            || os.contains("iphone")
+            // Whole-word "ios" only, so "KaiOS" etc. don't false-match the substring.
+            || os.split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|tok| tok == "ios")
+        {
             Some(Self::Ios)
         } else if os.contains("android") {
             Some(Self::Android)
@@ -460,6 +465,7 @@ mod tests {
             ("Android", O::Android),
             ("android 14", O::Android),
             ("iOS", O::Ios),
+            ("iOS 17", O::Ios),
             ("iPhone", O::Ios),
             ("iPad", O::Ios),
             ("iPadOS", O::Ios),
@@ -470,7 +476,8 @@ mod tests {
 
     #[test]
     fn companion_os_branding_and_empty_are_unclassified_and_default_linux() {
-        for hint in ["Veloz", "Foobar123", "", "   "] {
+        // "KaiOS" must NOT substring-match "ios" -> it is unrecognized -> Linux.
+        for hint in ["Veloz", "Foobar123", "KaiOS", "", "   "] {
             assert_eq!(CompanionOs::classify(hint), None, "{hint:?}");
             assert_eq!(CompanionOs::from_hint(hint), CompanionOs::Linux, "{hint:?}");
         }

--- a/wacore/src/companion_reg.rs
+++ b/wacore/src/companion_reg.rs
@@ -181,6 +181,7 @@ impl CompanionOs {
             || os.contains("fedora")
             || os.contains("arch")
             || os.contains("chrome os")
+            || os.contains("chromeos")
             || os.contains("chromium")
             || os.contains("cros")
         {
@@ -454,6 +455,7 @@ mod tests {
             ("Fedora", O::Linux),
             ("Arch Linux", O::Linux),
             ("Chrome OS", O::Linux),
+            ("ChromeOS", O::Linux),
             ("Chromium OS", O::Linux),
             ("Android", O::Android),
             ("android 14", O::Android),

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -20,7 +20,8 @@
 //! - Bundle encryption: AES-256-GCM after HKDF key derivation
 
 use crate::companion_reg::{
-    CompanionWebClientType, companion_platform_display, companion_web_client_type_for_props,
+    CompanionWebClientType, companion_platform_display, companion_platform_display_raw,
+    companion_web_client_type_for_props,
 };
 use crate::libsignal::crypto::{CryptoProviderError, aes_256_gcm_encrypt};
 use crate::libsignal::protocol::{CurveError, KeyPair, PublicKey};
@@ -102,8 +103,9 @@ pub fn derive_companion_platform(props: &wa::DeviceProps) -> (CompanionWebClient
     build_id_and_display(companion_web_client_type_for_props(props), props)
 }
 
-/// Honours `PairCodeOptions::platform_id` override; display is always
-/// derived (no override — WA Web has none, server rejects arbitrary strings).
+/// Honours `PairCodeOptions::platform_id` (browser) and `display_os` (OS)
+/// overrides. By default the OS is canonicalized from `DeviceProps::os`; a
+/// non-empty `display_os` is sent verbatim instead (advanced — see the field).
 pub fn resolve_companion_platform(
     options: &PairCodeOptions,
     props: &wa::DeviceProps,
@@ -111,7 +113,12 @@ pub fn resolve_companion_platform(
     let id = options
         .platform_id
         .unwrap_or_else(|| companion_web_client_type_for_props(props));
-    build_id_and_display(id, props)
+    let display = match options.display_os.as_deref().map(str::trim) {
+        Some(raw) if !raw.is_empty() => companion_platform_display_raw(id, raw),
+        // None, or an all-whitespace override, falls back to the safe coercion.
+        _ => build_id_and_display(id, props).1,
+    };
+    (id, display)
 }
 
 /// Options for pair code authentication.
@@ -125,6 +132,13 @@ pub struct PairCodeOptions {
     pub custom_code: Option<String>,
     /// `None` auto-derives from `Device.device_props.platform_type`.
     pub platform_id: Option<CompanionWebClientType>,
+    /// Advanced OS override for `companion_platform_display`. `None` (default)
+    /// canonicalizes `DeviceProps::os` to a small server-safe set (branding →
+    /// `Linux`). `Some(os)` sends `os` **verbatim**, bypassing that coercion — use
+    /// it to keep a real OS name the server accepts but our canonical set drops
+    /// (e.g. `"Ubuntu"`, `"Fedora"`). At your own risk: the server rejects a
+    /// non-OS string with `bad-request`. An all-whitespace value is ignored.
+    pub display_os: Option<String>,
 }
 
 impl Default for PairCodeOptions {
@@ -134,6 +148,7 @@ impl Default for PairCodeOptions {
             show_push_notification: true,
             custom_code: None,
             platform_id: None,
+            display_os: None,
         }
     }
 }
@@ -864,6 +879,48 @@ mod tests {
             resolve_companion_platform(&PairCodeOptions::default(), &p),
             (CompanionWebClientType::Edge, "Edge (Linux)".to_string())
         );
+    }
+
+    /// `display_os` sends the OS verbatim (bypassing canonicalization), so an
+    /// advanced caller can keep a real distro name the server accepts.
+    #[test]
+    fn resolve_display_os_override_is_verbatim() {
+        let p = props(Some("Linux"), Some(wa::device_props::PlatformType::CHROME));
+        let opts = PairCodeOptions {
+            display_os: Some("Ubuntu".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_companion_platform(&opts, &p),
+            (
+                CompanionWebClientType::Chrome,
+                "Chrome (Ubuntu)".to_string()
+            )
+        );
+    }
+
+    /// The override wins even over a branding `DeviceProps::os` that would
+    /// otherwise coerce to Linux.
+    #[test]
+    fn resolve_display_os_override_beats_branding_props_os() {
+        let p = props(Some("Veloz"), Some(wa::device_props::PlatformType::CHROME));
+        let opts = PairCodeOptions {
+            display_os: Some("Fedora".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_companion_platform(&opts, &p).1, "Chrome (Fedora)");
+    }
+
+    /// An all-whitespace override is ignored — it falls back to the safe coercion
+    /// (never emits an empty OS, which the server rejects).
+    #[test]
+    fn resolve_display_os_override_whitespace_falls_back_to_coercion() {
+        let p = props(Some("Veloz"), Some(wa::device_props::PlatformType::CHROME));
+        let opts = PairCodeOptions {
+            display_os: Some("   ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(resolve_companion_platform(&opts, &p).1, "Chrome (Linux)");
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes a second, orthogonal blocker for phone-number **pair-code** linking, found by testing live against the WhatsApp server (a pre-auth `companion_hello` probe comparing byte-for-byte with a working WhatsApp Web capture). Follow-up to #976 (the nonce fix).

The pair-code `companion_hello` server **rejects a non-OS `companion_platform_display` with `bad-request`**. The lib derived that field's OS from `DeviceProps::os`, which a consumer may set to an arbitrary branding string — so e.g. `os = "Veloz"` produced `"Chrome (Veloz)"` and pairing failed with a persistent 400. QR pairing is unaffected: it never sends this field, so it tolerates arbitrary branding.

Empirically confirmed: with the #976 nonce fix alone (`os = "Veloz"`) → `bad-request`; changing only the OS to a real value (`"Linux"`) → HTTP 200, code emitted, primary phone received the notification.

## The fix

WA Web only ever emits a real OS name from its UA parser (`WAWebBrowserInfo().os` → `ua-parser-js` `getOS().name`). Model that as a small, closed `CompanionOs` enum in `wacore/src/companion_reg.rs`:

- `wire_str()` → the canonical ua-parser spelling (`"Windows"`, `"Mac OS"`, `"Linux"`, `"Android"`, `"iOS"`).
- `classify()` → fuzzy, case-insensitive parse. Distinctive names match by substring; short ambiguous tokens (`"ios"`, `"arch"`, `"cros"`) match **whole-word** so branding like `"KaiOS"`, `"March"`, `"Search"`, `"across"` doesn't false-match. Chrome OS / distros fold to Linux; `from_hint()` = classify-or-`Linux`.

`companion_platform_display` routes the OS through `CompanionOs::from_hint(os).wire_str()`, so the default path can **never** emit a server-rejected string.

**Kept deliberately conservative.** Live testing showed the server is currently *lenient* (it also accepts `Ubuntu`, `Fedora`, `Mac`, `macOS` verbatim), but collapsing to a small guaranteed-accepted set is robust against that leniency changing. `iPad` folds to `iOS`, since older UA parsers report iPad as `"iOS"` and `"iPadOS"` isn't a confirmed-accepted value.

## Flexibility: opt-in OS override

Because the default coercion drops real-but-non-canonical names the server *does* accept (e.g. `Ubuntu`), there's an escape hatch for advanced callers: `PairCodeOptions::display_os: Option<String>`. When set (non-empty) the OS is sent **verbatim**, bypassing coercion; `None` keeps the safe default. It complements the existing `platform_id` (browser) override, so a caller controls both parts of `Browser (OS)`. Documented as at-the-caller's-risk (a non-OS string is rejected with `bad-request`); an all-whitespace value is ignored so we never emit an empty OS.

## Error-handling + docs (no speculative behavior)

- Corrects the false doc that caused the passthrough (*"Server validates only length; there is no browser whitelist"* — the pair-code server does validate the OS).
- Warns once (process-gated) when a branding `os` is coerced, so a consumer sees why their branding didn't ride through; skipped when `display_os` overrides.
- Documents that a pair-code `bad-request` (400) can be **rate-limiting** (throttled per phone number), not invalid input — indistinguishable in the response, so back off and retry rather than treat every 400 as fatal. No auto-retry and no hardcoded threshold (both server-tunable / unreliable to detect); any server `backoff` hint is preserved on the wrapped `IqError`.

## Scope

Pair-code only. QR pairing does not send `companion_platform_display`, so its branding path (`DeviceProps::os`) is untouched, and QR-only consumers are unaffected.

## Testing

- `CompanionOs`: `wire_str` canonical spellings, a `classify`/`from_hint` alias table (Windows/Mac/darwin/Ubuntu/Fedora/Arch/Chrome OS(+no-space)/CrOS/Android/iOS/iPad…), the `"Veloz"` → `Linux` regression, and the whole-word guards — `"KaiOS"`, `"March"`, `"Search"`, `"across"` all stay unclassified → Linux via fallback (never via a false substring match).
- Override: verbatim `display_os`, override beats a branding `props.os`, all-whitespace falls back to coercion.
- Existing `os = "Mac"` display tests updated to canonical `"Mac OS"`.
- `cargo test -p wacore --lib companion_reg` (22) + `pair_code`, `cargo test -p whatsapp-rust --lib pair_code` green; `cargo fmt --all --check` and `cargo clippy -p wacore -p whatsapp-rust --tests` clean.

## Not in scope

Whether the persistent linked-device name on the phone comes from this field or from post-auth `DeviceProps` (which would decide if a dedicated branding field is worth adding) is left for a follow-up once probed — the coercion + opt-in override is the correct, safe behavior regardless.