### PR TITLE
feat(retry): opt-in RetryAdmission hook (compliant supersede of #982)

### DIFF
--- a/examples/retry_quarantine.rs
+++ b/examples/retry_quarantine.rs
@@ -96,17 +96,16 @@ impl RetryQuarantine {
     }
 }
 
-#[whatsapp_rust::async_trait]
 impl RetryAdmission for RetryQuarantine {
-    async fn admit(&self, chat: &Jid, requester: &Jid, _retry_count: u8) -> bool {
+    fn admit(&self, chat: &Jid, requester: &Jid, _retry_count: u8) -> bool {
         if self.burst == 0.0 {
             return true;
         }
         let now = Instant::now();
         let key = (chat.user.to_string(), requester.user.to_string());
 
-        // std Mutex, never held across an await: the critical section is a map
-        // op plus the bucket arithmetic.
+        // Synchronous, so the receive path never awaits a policy: the critical
+        // section is a map lookup plus the bucket arithmetic.
         let mut buckets = self.buckets.lock().expect("quarantine mutex poisoned");
         // Fail open if we would exceed the cap with a brand-new pair, so the
         // guard never blocks repair for a pair it isn't already tracking.
@@ -182,42 +181,42 @@ fn main() {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn bounds_per_pair_and_isolates_pairs() {
+    #[test]
+    fn bounds_per_pair_and_isolates_pairs() {
         // burst 2, refill 0: two attempts, then quarantined.
         let q = RetryQuarantine::new(2, 0, 100);
         let g: Jid = "123-456@g.us".parse().unwrap();
         let a: Jid = "111@lid".parse().unwrap();
         let b: Jid = "222@lid".parse().unwrap();
-        assert!(q.admit(&g, &a, 1).await);
-        assert!(q.admit(&g, &a, 1).await);
-        assert!(!q.admit(&g, &a, 1).await, "third receipt quarantined");
+        assert!(q.admit(&g, &a, 1));
+        assert!(q.admit(&g, &a, 1));
+        assert!(!q.admit(&g, &a, 1), "third receipt quarantined");
         // A different requester in the same chat has its own budget.
-        assert!(q.admit(&g, &b, 1).await);
+        assert!(q.admit(&g, &b, 1));
         assert_eq!(q.quarantined_total(), 1);
     }
 
-    #[tokio::test]
-    async fn burst_zero_disables() {
+    #[test]
+    fn burst_zero_disables() {
         let q = RetryQuarantine::new(0, 0, 100);
         let g: Jid = "123-456@g.us".parse().unwrap();
         let a: Jid = "111@lid".parse().unwrap();
         for _ in 0..10 {
-            assert!(q.admit(&g, &a, 1).await);
+            assert!(q.admit(&g, &a, 1));
         }
         assert_eq!(q.quarantined_total(), 0);
     }
 
-    #[tokio::test]
-    async fn fails_open_past_capacity_for_new_pairs() {
+    #[test]
+    fn fails_open_past_capacity_for_new_pairs() {
         // Cap 1: the first pair is tracked and bounded, a second brand-new pair
         // is admitted rather than evicting/blocking.
         let q = RetryQuarantine::new(1, 0, 1);
         let g: Jid = "123-456@g.us".parse().unwrap();
         let a: Jid = "111@lid".parse().unwrap();
         let b: Jid = "222@lid".parse().unwrap();
-        assert!(q.admit(&g, &a, 1).await);
-        assert!(!q.admit(&g, &a, 1).await, "tracked pair still bounded");
-        assert!(q.admit(&g, &b, 1).await, "new pair fails open past cap");
+        assert!(q.admit(&g, &a, 1));
+        assert!(!q.admit(&g, &a, 1), "tracked pair still bounded");
+        assert!(q.admit(&g, &b, 1), "new pair fails open past cap");
     }
 }

--- a/examples/retry_quarantine.rs
+++ b/examples/retry_quarantine.rs
@@ -180,6 +180,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn bounds_per_pair_and_isolates_pairs() {
@@ -218,5 +219,47 @@ mod tests {
         assert!(q.admit(&g, &a, 1));
         assert!(!q.admit(&g, &a, 1), "tracked pair still bounded");
         assert!(q.admit(&g, &b, 1), "new pair fails open past cap");
+    }
+
+    // The bucket is the seam where time matters; `admit` reads the real clock,
+    // so the refill/clamp claims are driven here with explicit `now` values.
+
+    #[test]
+    fn refill_restores_admission_gradually() {
+        // A quarantined pair must recover, but one token at a time — a refill is
+        // not a reset, so a still-broken member cannot immediately storm again.
+        let t0 = Instant::now();
+        let (burst, refill_per_sec) = (2.0, 1.0); // 1 token/sec
+        let mut b = TokenBucket::new(burst, t0);
+
+        assert!(b.try_take(t0, burst, refill_per_sec));
+        assert!(b.try_take(t0, burst, refill_per_sec));
+        assert!(!b.try_take(t0, burst, refill_per_sec), "burst exhausted");
+
+        // One refill period later exactly one token is back.
+        let t1 = t0 + Duration::from_secs(1);
+        assert!(b.try_take(t1, burst, refill_per_sec), "one token refilled");
+        assert!(
+            !b.try_take(t1, burst, refill_per_sec),
+            "only one token, not a full reset"
+        );
+    }
+
+    #[test]
+    fn idle_does_not_accrue_beyond_burst() {
+        // An idle pair must not bank an unbounded reserve: after a long quiet
+        // spell it still gets only `burst` immediate attempts, so a member that
+        // was silent for hours cannot burst 3600 retries at once.
+        let t0 = Instant::now();
+        let (burst, refill_per_sec) = (2.0, 1.0);
+        let mut b = TokenBucket::new(burst, t0);
+
+        let much_later = t0 + Duration::from_secs(3600);
+        assert!(b.try_take(much_later, burst, refill_per_sec));
+        assert!(b.try_take(much_later, burst, refill_per_sec));
+        assert!(
+            !b.try_take(much_later, burst, refill_per_sec),
+            "tokens clamp at burst regardless of idle time"
+        );
     }
 }

--- a/examples/retry_quarantine.rs
+++ b/examples/retry_quarantine.rs
@@ -1,0 +1,223 @@
+//! Bot-side retry-receipt quarantine, built on the [`RetryAdmission`] hook.
+//!
+//! WhatsApp Web processes every inbound retry receipt (no volume throttle), and
+//! this SDK does the same by default. In a large group a cohort of members
+//! whose sessions never establish can retry on every message, driving the
+//! repair path (markForgetSenderKey, key-bundle processing, resend) at storm
+//! rate. That cost only shows up at bot send volume, so the policy lives here in
+//! the bot rather than in the SDK: the core stays WA Web compliant, and this
+//! opt-in bounds the storm for deployments that want it.
+//!
+//! This mirrors the mechanism proposed in oxidezap/whatsapp-rust#982 by
+//! @Salientekill: a token bucket keyed by (chat user, requester user), burst 2,
+//! refill 2/day. One mark repairs a healthy member (the next send carries the
+//! SKDM), so past the burst further receipts from the same pair are dropped
+//! before any repair work; the refill keeps genuine recovery possible. The
+//! device is excluded from the key on purpose: WA Web re-targets the whole user
+//! when the primary goes cold, so all devices of a broken account share one
+//! budget. Our own companion devices never reach this policy (the SDK exempts
+//! `is_peer`), so their group session can always rebuild.
+//!
+//!   cargo run --example retry_quarantine
+//!
+//! Run with `RUST_LOG=debug` to see the SDK's "dropped by RetryAdmission policy"
+//! line when a pair is quarantined.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::Ordering;
+
+use log::{error, info};
+use portable_atomic::AtomicU64;
+use wacore::time::Instant;
+use whatsapp_rust::RetryAdmission;
+use whatsapp_rust::prelude::*;
+
+/// Lazy monotonic token bucket. Pure given `now`/`burst`/`refill_per_sec`, so a
+/// lowered burst clamps on the next access and an idle pair never accrues an
+/// unbounded reserve.
+struct TokenBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(initial: f64, now: Instant) -> Self {
+        Self {
+            tokens: initial,
+            last_refill: now,
+        }
+    }
+
+    fn try_take(&mut self, now: Instant, burst: f64, refill_per_sec: f64) -> bool {
+        // saturating: two receipts in the same instant give elapsed 0, never a panic.
+        let elapsed = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64();
+        self.tokens = (self.tokens + elapsed * refill_per_sec).min(burst);
+        self.last_refill = now;
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Per-(chat user, requester user) quarantine. A `burst` of 0 disables it.
+struct RetryQuarantine {
+    buckets: Mutex<HashMap<(String, String), TokenBucket>>,
+    burst: f64,
+    refill_per_sec: f64,
+    /// Capacity guard: the keyspace is O(groups x broken members), so bound it.
+    /// A production policy would use an LRU / moka cache here (as #982 does with
+    /// a dedicated capacity); this example just refuses new pairs past the cap,
+    /// which fails open (admits) rather than growing without limit.
+    max_pairs: usize,
+    quarantined_total: AtomicU64,
+}
+
+impl RetryQuarantine {
+    fn new(burst: u32, refill_per_day: u32, max_pairs: usize) -> Self {
+        Self {
+            buckets: Mutex::new(HashMap::new()),
+            burst: burst as f64,
+            refill_per_sec: refill_per_day as f64 / 86_400.0,
+            max_pairs,
+            quarantined_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Receipts dropped since start (your own observability, no SDK coupling).
+    fn quarantined_total(&self) -> u64 {
+        self.quarantined_total.load(Ordering::Relaxed)
+    }
+}
+
+#[whatsapp_rust::async_trait]
+impl RetryAdmission for RetryQuarantine {
+    async fn admit(&self, chat: &Jid, requester: &Jid, _retry_count: u8) -> bool {
+        if self.burst == 0.0 {
+            return true;
+        }
+        let now = Instant::now();
+        let key = (chat.user.to_string(), requester.user.to_string());
+
+        // std Mutex, never held across an await: the critical section is a map
+        // op plus the bucket arithmetic.
+        let mut buckets = self.buckets.lock().expect("quarantine mutex poisoned");
+        // Fail open if we would exceed the cap with a brand-new pair, so the
+        // guard never blocks repair for a pair it isn't already tracking.
+        if !buckets.contains_key(&key) && buckets.len() >= self.max_pairs {
+            return true;
+        }
+        let bucket = buckets
+            .entry(key)
+            .or_insert_with(|| TokenBucket::new(self.burst, now));
+        let allowed = bucket.try_take(now, self.burst, self.refill_per_sec);
+        drop(buckets);
+
+        if !allowed {
+            self.quarantined_total.fetch_add(1, Ordering::Relaxed);
+        }
+        allowed
+    }
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+
+    rt.block_on(async {
+        let store = match SqliteStore::new("whatsapp.db").await {
+            Ok(store) => store,
+            Err(e) => {
+                error!("failed to create SQLite backend: {e}");
+                return;
+            }
+        };
+
+        let bot = match Bot::builder()
+            .with_backend(store)
+            .on_qr_code(|code, _timeout| async move {
+                info!("scan to pair:\n{code}");
+            })
+            .on_connected(|_client| async {
+                info!("connected; inbound group retry receipts now pass through the quarantine");
+            })
+            .build()
+            .await
+        {
+            Ok(bot) => bot,
+            Err(e) => {
+                error!("failed to build bot: {e}");
+                return;
+            }
+        };
+
+        // Opt in before connecting. Without this call the client keeps its
+        // default behavior (every retry receipt admitted, matching WA Web).
+        // burst 2, refill 2/day, up to 32768 tracked pairs.
+        let quarantine = Arc::new(RetryQuarantine::new(2, 2, 32_768));
+        if !bot.client().set_retry_admission(quarantine.clone()) {
+            error!("retry admission policy was already set");
+            return;
+        }
+
+        bot.run().await;
+        info!(
+            "quarantined {} retry receipt(s) this session",
+            quarantine.quarantined_total()
+        );
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bounds_per_pair_and_isolates_pairs() {
+        // burst 2, refill 0: two attempts, then quarantined.
+        let q = RetryQuarantine::new(2, 0, 100);
+        let g: Jid = "123-456@g.us".parse().unwrap();
+        let a: Jid = "111@lid".parse().unwrap();
+        let b: Jid = "222@lid".parse().unwrap();
+        assert!(q.admit(&g, &a, 1).await);
+        assert!(q.admit(&g, &a, 1).await);
+        assert!(!q.admit(&g, &a, 1).await, "third receipt quarantined");
+        // A different requester in the same chat has its own budget.
+        assert!(q.admit(&g, &b, 1).await);
+        assert_eq!(q.quarantined_total(), 1);
+    }
+
+    #[tokio::test]
+    async fn burst_zero_disables() {
+        let q = RetryQuarantine::new(0, 0, 100);
+        let g: Jid = "123-456@g.us".parse().unwrap();
+        let a: Jid = "111@lid".parse().unwrap();
+        for _ in 0..10 {
+            assert!(q.admit(&g, &a, 1).await);
+        }
+        assert_eq!(q.quarantined_total(), 0);
+    }
+
+    #[tokio::test]
+    async fn fails_open_past_capacity_for_new_pairs() {
+        // Cap 1: the first pair is tracked and bounded, a second brand-new pair
+        // is admitted rather than evicting/blocking.
+        let q = RetryQuarantine::new(1, 0, 1);
+        let g: Jid = "123-456@g.us".parse().unwrap();
+        let a: Jid = "111@lid".parse().unwrap();
+        let b: Jid = "222@lid".parse().unwrap();
+        assert!(q.admit(&g, &a, 1).await);
+        assert!(!q.admit(&g, &a, 1).await, "tracked pair still bounded");
+        assert!(q.admit(&g, &b, 1).await, "new pair fails open past cap");
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -724,11 +724,10 @@ pub struct Client {
     pub(crate) inbound_durability_hook:
         std::sync::OnceLock<Arc<dyn crate::types::durability_hook::InboundDurabilityHook>>,
 
-    /// Optional inbound retry-receipt admission policy. When set, a group or
-    /// status retry receipt from another account can be dropped before any
-    /// repair work runs (see [`crate::types::retry_admission::RetryAdmission`]).
-    /// `None` (default) admits every receipt, matching WA Web, and the receive
-    /// path pays only one lock-free `OnceLock::get`.
+    /// Optional retry-receipt admission policy (see
+    /// [`crate::types::retry_admission::RetryAdmission`]): an operator opt-in to
+    /// drop some group/status retries. `None` (default) keeps WA Web behavior
+    /// with a single lock-free `OnceLock::get` on the receive path.
     pub(crate) retry_admission:
         std::sync::OnceLock<Arc<dyn crate::types::retry_admission::RetryAdmission>>,
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -724,6 +724,14 @@ pub struct Client {
     pub(crate) inbound_durability_hook:
         std::sync::OnceLock<Arc<dyn crate::types::durability_hook::InboundDurabilityHook>>,
 
+    /// Optional inbound retry-receipt admission policy. When set, a group or
+    /// status retry receipt from another account can be dropped before any
+    /// repair work runs (see [`crate::types::retry_admission::RetryAdmission`]).
+    /// `None` (default) admits every receipt, matching WA Web, and the receive
+    /// path pays only one lock-free `OnceLock::get`.
+    pub(crate) retry_admission:
+        std::sync::OnceLock<Arc<dyn crate::types::retry_admission::RetryAdmission>>,
+
     /// Chat state (typing indicator) handlers registered by external consumers.
     /// Each handler receives a `ChatStateEvent` describing the chat, optional participant and state.
     pub(crate) chatstate_handlers: Arc<RwLock<Vec<ChatStateHandler>>>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -775,13 +775,16 @@ pub struct Client {
     pub(crate) group_distribution_locks: Cache<Jid, Arc<async_lock::Mutex<()>>>,
 
     /// Last `(devices, sender-key-device map)` Arc pair with an empty `needs_skdm`,
-    /// so a warm repeat send skips `filter_skdm_targets`. `Weak` keeps the pointer
-    /// comparison ABA-safe, matching `GroupDevicesMemo`.
+    /// plus the map's generation at that point, so a warm repeat send skips
+    /// `filter_skdm_targets`. `Weak` keeps the pointer comparison ABA-safe
+    /// (matching `GroupDevicesMemo`); the generation catches an in-place cold
+    /// flip that leaves the `Arc` pointer unchanged.
     pub(crate) skdm_warm_memo: Cache<
         Jid,
         (
             std::sync::Weak<wacore::send::ResolvedGroupDevices>,
             std::sync::Weak<crate::sender_key_device_cache::SenderKeyDeviceMap>,
+            u64,
         ),
     >,
 

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -83,6 +83,24 @@ impl Client {
         self.resend_rate_limiter.set_rate(burst, refill_per_min);
     }
 
+    /// Register a [`RetryAdmission`] policy: an opt-in gate that can drop inbound
+    /// group/status retry receipts from other accounts before any repair work
+    /// runs. Unset (the default) admits every receipt, matching WhatsApp Web,
+    /// with zero overhead on the receive path.
+    ///
+    /// Set once, before connecting; a later call is ignored and returns `false`
+    /// (the already-registered policy stays in effect). Live tuning belongs
+    /// inside the policy itself (e.g. atomics), not in re-registration. See
+    /// `examples/retry_quarantine.rs`.
+    ///
+    /// [`RetryAdmission`]: crate::types::retry_admission::RetryAdmission
+    pub fn set_retry_admission(
+        &self,
+        policy: Arc<dyn crate::types::retry_admission::RetryAdmission>,
+    ) -> bool {
+        self.retry_admission.set(policy).is_ok()
+    }
+
     /// Cumulative wire I/O and activity counters for this client session.
     ///
     /// Always available, no feature gate: recording costs one relaxed atomic

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -237,6 +237,7 @@ impl Client {
             passkey_opening: AtomicBool::new(false),
             custom_enc_handlers: std::sync::OnceLock::new(),
             inbound_durability_hook: std::sync::OnceLock::new(),
+            retry_admission: std::sync::OnceLock::new(),
             chatstate_handlers: Arc::new(RwLock::new(Vec::new())),
             pdo_pending_requests: cache_config.pdo_pending_requests.build_with_ttl(),
             pdo_requested: cache_config.pdo_requested.build_with_ttl(),

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -438,4 +438,92 @@ mod tests {
             "device flipped cold"
         );
     }
+
+    // A retry receipt for a group we're in can name our own device alongside the
+    // broken member. WA Web marks fresh SKDM only for other members
+    // (`!isMeDevice`), so the cold mark must flip the member and never our own
+    // device — otherwise an inbound retry could tear down our own group session.
+    #[tokio::test]
+    async fn cold_mark_excludes_own_devices() {
+        let client = create_test_client().await;
+        let own_lid: Jid = "888000888000888:3@lid".parse().unwrap();
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_lid.clone(),
+            )))
+            .await;
+
+        let group = "120363000000000001@g.us";
+        let map = client
+            .sender_key_device_cache
+            .get_or_init(group, async {
+                Arc::new(SenderKeyDeviceMap::from_db_rows(&[
+                    ("888000888000888:3@lid".to_string(), true), // our own device
+                    ("111000111000111:0@lid".to_string(), true), // broken member
+                ]))
+            })
+            .await;
+        let gen_before = map.generation();
+
+        let member: Jid = "111000111000111:0@lid".parse().unwrap();
+        client
+            .mark_forget_sender_key(group, &[own_lid.clone(), member])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            map.device_has_key("111000111000111", 0),
+            Some(false),
+            "the member device is flipped cold"
+        );
+        assert_eq!(
+            map.device_has_key("888000888000888", 3),
+            Some(true),
+            "our own device is excluded, never marked cold"
+        );
+        assert_ne!(
+            map.generation(),
+            gen_before,
+            "the member flip still advances the generation"
+        );
+    }
+
+    // When every named device is our own, nothing is kept: no DB write, no flip,
+    // and (crucially) no generation bump that would churn the warm memo.
+    #[tokio::test]
+    async fn cold_mark_of_only_own_devices_is_noop() {
+        let client = create_test_client().await;
+        let own_lid: Jid = "888000888000888:3@lid".parse().unwrap();
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_lid.clone(),
+            )))
+            .await;
+
+        let group = "120363000000000001@g.us";
+        let map = client
+            .sender_key_device_cache
+            .get_or_init(group, async {
+                Arc::new(SenderKeyDeviceMap::from_db_rows(&[(
+                    "888000888000888:3@lid".to_string(),
+                    true,
+                )]))
+            })
+            .await;
+        let gen_before = map.generation();
+
+        client
+            .mark_forget_sender_key(group, std::slice::from_ref(&own_lid))
+            .await
+            .unwrap();
+
+        assert_eq!(map.device_has_key("888000888000888", 3), Some(true));
+        assert_eq!(
+            map.generation(),
+            gen_before,
+            "excluding all named devices leaves the map untouched"
+        );
+    }
 }

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -30,28 +30,39 @@ impl Client {
             .and_then(|s| s.pn.as_ref())
             .map(|j| j.user.as_str());
 
-        let device_ids: Vec<String> = device_jids
+        let kept: Vec<&Jid> = device_jids
             .iter()
             .filter(|jid| {
                 !exclude_own_devices
                     || !(own_lid_user.is_some_and(|u| u == jid.user)
                         || own_pn_user.is_some_and(|u| u == jid.user))
             })
-            .map(ToString::to_string)
             .collect();
 
-        if device_ids.is_empty() {
+        if kept.is_empty() {
             return Ok(());
         }
 
-        let entries: Vec<(&str, bool)> = device_ids
-            .iter()
-            .map(|jid| (jid.as_str(), has_key))
-            .collect();
+        let device_ids: Vec<String> = kept.iter().map(|jid| jid.to_string()).collect();
+        let entries: Vec<(&str, bool)> = device_ids.iter().map(|s| (s.as_str(), has_key)).collect();
         self.persistence_manager
             .set_sender_key_status(group_jid, &entries)
             .await?;
-        self.sender_key_device_cache.invalidate(group_jid).await;
+
+        if has_key {
+            // Marking devices warm can introduce (user, device) pairs the cached
+            // map doesn't have yet, so drop it and let the next send rebuild from
+            // the DB write above.
+            self.sender_key_device_cache.invalidate(group_jid).await;
+        } else {
+            // Marking cold only flips existing entries: update them in place so a
+            // retry-receipt storm never forces a whole-group re-read on the next
+            // send. Matches WA Web's per-device markForgetSenderKey.
+            let jids: Vec<Jid> = kept.into_iter().cloned().collect();
+            self.sender_key_device_cache
+                .mark_forgotten(group_jid, &jids)
+                .await;
+        }
         Ok(())
     }
 

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -55,20 +55,16 @@ impl Client {
             // the DB write above.
             self.sender_key_device_cache.invalidate(group_jid).await;
         } else {
-            // Marking cold flips existing entries in place (no whole-group
-            // re-read on the next send), matching WA Web's per-device
-            // markForgetSenderKey. But `skdm_warm_memo` skips filter_skdm_targets
-            // while the cached_map Arc is pointer-identical, and an in-place flip
-            // does not swap that Arc — so drop the memo entry too, or the next
-            // warm send would short-circuit past the now-cold device and never
-            // redistribute its SKDM.
+            // Marking cold flips existing entries in place and bumps the map's
+            // generation (no whole-group re-read on the next send), matching WA
+            // Web's per-device markForgetSenderKey. The generation bump is what
+            // the skdm_warm_memo compares, so a warm send re-runs its target
+            // filter and re-sends the now-cold device's SKDM — no separate memo
+            // invalidation, hence no cross-cache ordering window.
             let jids: Vec<Jid> = kept.into_iter().cloned().collect();
             self.sender_key_device_cache
                 .mark_forgotten(group_jid, &jids)
                 .await;
-            if let Ok(group) = group_jid.parse::<Jid>() {
-                self.skdm_warm_memo.invalidate(&group).await;
-            }
         }
         Ok(())
     }
@@ -389,38 +385,57 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use crate::sender_key_device_cache::SenderKeyDeviceMap;
     use crate::test_utils::create_test_client;
+    use std::sync::Arc;
     use wacore_binary::Jid;
 
-    // A cold mark flips has_key in place without swapping the cached_map Arc.
-    // The skdm_warm_memo short-circuits filter_skdm_targets on Arc pointer
-    // identity, so it must be dropped or the next warm send skips the now-cold
-    // device and never redistributes its SKDM.
+    // A cold mark flips has_key in place, keeping the same cached_map Arc, so the
+    // skdm_warm_memo cannot notice via pointer identity. It bumps the map's
+    // generation instead; this asserts the client cold path advances that
+    // generation (and flips the device) so a warm send re-runs its target filter
+    // and re-sends the now-cold device's SKDM.
     #[tokio::test]
-    async fn cold_mark_invalidates_skdm_warm_memo() {
+    async fn cold_mark_bumps_map_generation() {
         let client = create_test_client().await;
-        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        let group = "120363000000000001@g.us";
 
-        // Seed a warm-memo entry for the group (contents irrelevant to this
-        // test; empty Weaks stand in for the (devices, cached_map) pair).
-        client
-            .skdm_warm_memo
-            .insert(
-                group.clone(),
-                (std::sync::Weak::new(), std::sync::Weak::new()),
-            )
+        let map = client
+            .sender_key_device_cache
+            .get_or_init(group, async {
+                Arc::new(SenderKeyDeviceMap::from_db_rows(&[(
+                    "111:0@lid".to_string(),
+                    true,
+                )]))
+            })
             .await;
-        assert!(client.skdm_warm_memo.get(&group).await.is_some());
+        let gen_before = map.generation();
 
         let device: Jid = "111:0@lid".parse().unwrap();
         client
-            .mark_forget_sender_key(&group.to_string(), std::slice::from_ref(&device))
+            .mark_forget_sender_key(group, std::slice::from_ref(&device))
             .await
             .unwrap();
 
+        // Same Arc (in-place) but a fresh generation, so any memo stamped with
+        // gen_before is now detectably stale.
+        let map_after = client
+            .sender_key_device_cache
+            .get_or_init(group, async { panic!("cache should still hold the group") })
+            .await;
         assert!(
-            client.skdm_warm_memo.get(&group).await.is_none(),
-            "cold mark must invalidate the warm memo so the cold device is re-targeted"
+            Arc::ptr_eq(&map, &map_after),
+            "in-place flip keeps the same Arc"
+        );
+        assert_ne!(
+            map_after.generation(),
+            gen_before,
+            "cold mark must advance the generation"
+        );
+        assert_eq!(
+            map_after.device_has_key("111", 0),
+            Some(false),
+            "device flipped cold"
         );
     }
 }

--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -55,13 +55,20 @@ impl Client {
             // the DB write above.
             self.sender_key_device_cache.invalidate(group_jid).await;
         } else {
-            // Marking cold only flips existing entries: update them in place so a
-            // retry-receipt storm never forces a whole-group re-read on the next
-            // send. Matches WA Web's per-device markForgetSenderKey.
+            // Marking cold flips existing entries in place (no whole-group
+            // re-read on the next send), matching WA Web's per-device
+            // markForgetSenderKey. But `skdm_warm_memo` skips filter_skdm_targets
+            // while the cached_map Arc is pointer-identical, and an in-place flip
+            // does not swap that Arc — so drop the memo entry too, or the next
+            // warm send would short-circuit past the now-cold device and never
+            // redistribute its SKDM.
             let jids: Vec<Jid> = kept.into_iter().cloned().collect();
             self.sender_key_device_cache
                 .mark_forgotten(group_jid, &jids)
                 .await;
+            if let Ok(group) = group_jid.parse::<Jid>() {
+                self.skdm_warm_memo.invalidate(&group).await;
+            }
         }
         Ok(())
     }
@@ -377,5 +384,43 @@ impl Client {
                 log::warn!("Failed to store sent message to DB: {e}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::create_test_client;
+    use wacore_binary::Jid;
+
+    // A cold mark flips has_key in place without swapping the cached_map Arc.
+    // The skdm_warm_memo short-circuits filter_skdm_targets on Arc pointer
+    // identity, so it must be dropped or the next warm send skips the now-cold
+    // device and never redistributes its SKDM.
+    #[tokio::test]
+    async fn cold_mark_invalidates_skdm_warm_memo() {
+        let client = create_test_client().await;
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+
+        // Seed a warm-memo entry for the group (contents irrelevant to this
+        // test; empty Weaks stand in for the (devices, cached_map) pair).
+        client
+            .skdm_warm_memo
+            .insert(
+                group.clone(),
+                (std::sync::Weak::new(), std::sync::Weak::new()),
+            )
+            .await;
+        assert!(client.skdm_warm_memo.get(&group).await.is_some());
+
+        let device: Jid = "111:0@lid".parse().unwrap();
+        client
+            .mark_forget_sender_key(&group.to_string(), std::slice::from_ref(&device))
+            .await
+            .unwrap();
+
+        assert!(
+            client.skdm_warm_memo.get(&group).await.is_none(),
+            "cold mark must invalidate the warm memo so the cold device is re-targeted"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub use client::{
 };
 pub use client::{CallError, Voip};
 pub use types::durability_hook::InboundDurabilityHook;
+pub use types::retry_admission::RetryAdmission;
 pub mod download;
 pub mod handlers;
 pub use handlers::chatstate::ChatStateEvent;

--- a/src/reexports_test.rs
+++ b/src/reexports_test.rs
@@ -56,6 +56,27 @@ fn hook_impl_is_object_safe_and_constructible() {
     let _ = &hook;
 }
 
+// A RetryAdmission policy built purely from re-exports.
+struct AdmitAll;
+
+#[whatsapp_rust::async_trait]
+impl whatsapp_rust::RetryAdmission for AdmitAll {
+    async fn admit(
+        &self,
+        _chat: &whatsapp_rust::Jid,
+        _requester: &whatsapp_rust::Jid,
+        _retry_count: u8,
+    ) -> bool {
+        true
+    }
+}
+
+#[test]
+fn retry_admission_is_object_safe_and_constructible() {
+    let policy: Box<dyn whatsapp_rust::RetryAdmission> = Box::new(AdmitAll);
+    let _ = &policy;
+}
+
 #[test]
 fn bytes_and_chrono_reexports_are_usable() {
     let b = whatsapp_rust::bytes::Bytes::from_static(b"frame");

--- a/src/reexports_test.rs
+++ b/src/reexports_test.rs
@@ -59,9 +59,8 @@ fn hook_impl_is_object_safe_and_constructible() {
 // A RetryAdmission policy built purely from re-exports.
 struct AdmitAll;
 
-#[whatsapp_rust::async_trait]
 impl whatsapp_rust::RetryAdmission for AdmitAll {
-    async fn admit(
+    fn admit(
         &self,
         _chat: &whatsapp_rust::Jid,
         _requester: &whatsapp_rust::Jid,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -331,18 +331,14 @@ impl Client {
                 .as_ref()
                 .is_some_and(|our_lid| info.requester.is_same_user_as(our_lid));
 
-        // Opt-in admission policy (default: none → admit all, matching WA Web,
-        // which never volume-throttles inbound retries). Consulted only for
-        // group/status retries from other accounts; our own companion devices
-        // (`is_peer`) always pass so their group session can rebuild. A `false`
-        // verdict drops the receipt before all repair work — the group-info
-        // fetch, the unknown-device rotateKey block, markForgetSenderKey,
-        // key-bundle processing and the resend — releasing the pending-retry
-        // scopeguard normally on the early return. Unset is one OnceLock read.
+        // Volume-throttling inbound retries diverges from WA Web (which
+        // processes every receipt), so it is an operator opt-in, gated here
+        // before the expensive repair stages below. Own devices (`is_peer`) and
+        // DMs are never gated: dropping their retries has no safe SKDM fallback.
         if is_group_or_status
             && !is_peer
-            && let Some(policy) = self.retry_admission.get().cloned()
-            && !policy.admit(&info.chat, &info.requester, retry_count).await
+            && let Some(policy) = self.retry_admission.get()
+            && !policy.admit(&info.chat, &info.requester, retry_count)
         {
             debug!(
                 "Retry receipt from {} in {} dropped by RetryAdmission policy",

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -165,6 +165,16 @@ fn build_retry_processing_key(chat: &Jid, message_id: &str, participant_jid: &Ji
 }
 
 impl Client {
+    /// Handle an inbound `<receipt type="retry">`.
+    ///
+    /// WA Web authorizes these through `isRetryEligible` (`WAWebApiMessageInfoStore`).
+    /// We enforce the reject reasons that need no per-recipient state:
+    /// `HIGH_RETRY_COUNT` (the `MAX_RETRY_COUNT` refusal), `MESSAGE_EXPIRED` /
+    /// `RECORD_MISSING` (the recent-message cache miss), and `DEVICE_NOT_IN_DATABASE`
+    /// (`should_drop_unknown_device_retry`); identity changes are handled during
+    /// repair (reg-id mismatch + base-key collision in `update_local_signal_session`).
+    /// `ALREADY_DELIVERED` and `DEVICE_NOT_RECIPIENT` need a per-(message, device)
+    /// receipt store we do not keep, so they are a known parity gap, not enforced here.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.handle_receipt", level = "debug", skip_all, fields(chat = %receipt.source.chat.observe(), sender = %receipt.source.sender.observe(), count = tracing::field::Empty), err(Debug)))]
     pub(crate) async fn handle_retry_receipt(
         self: &Arc<Self>,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -331,6 +331,27 @@ impl Client {
                 .as_ref()
                 .is_some_and(|our_lid| info.requester.is_same_user_as(our_lid));
 
+        // Opt-in admission policy (default: none → admit all, matching WA Web,
+        // which never volume-throttles inbound retries). Consulted only for
+        // group/status retries from other accounts; our own companion devices
+        // (`is_peer`) always pass so their group session can rebuild. A `false`
+        // verdict drops the receipt before all repair work — the group-info
+        // fetch, the unknown-device rotateKey block, markForgetSenderKey,
+        // key-bundle processing and the resend — releasing the pending-retry
+        // scopeguard normally on the early return. Unset is one OnceLock read.
+        if is_group_or_status
+            && !is_peer
+            && let Some(policy) = self.retry_admission.get().cloned()
+            && !policy.admit(&info.chat, &info.requester, retry_count).await
+        {
+            debug!(
+                "Retry receipt from {} in {} dropped by RetryAdmission policy",
+                info.requester.observe(),
+                info.chat.observe()
+            );
+            return Ok(());
+        }
+
         // Fetch group info (cache-first, server on miss) — used for SKDM rotation + addressing_mode.
         // Without this, a cold cache would silently default to PN semantics for LID groups.
         let cached_group_info = if info.chat.is_group() {
@@ -620,7 +641,10 @@ impl Client {
                     } else {
                         "group"
                     };
-                    info!(
+                    // debug, not info: one line per retry receipt, and a broken
+                    // cohort in a large group emits tens of thousands per day
+                    // (WA Web logs the same event at its verbose LOG level).
+                    debug!(
                         "Marked {} for fresh SKDM in {} {} due to retry receipt",
                         info.requester.observe(),
                         chat_type,

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1094,19 +1094,26 @@ impl Client {
         own_sending_jid: &Jid,
     ) -> Option<(std::sync::Arc<wacore::send::ResolvedGroupDevices>, Vec<Jid>)> {
         let cached_map = self.skdm_device_map(group_jid).await;
+        // Load BEFORE the filter: a cold flip racing after this stamps the memo
+        // as already stale (its stored generation lags the map's), so the next
+        // read re-runs the filter. Loading after would stamp a racing flip as seen.
+        let cached_map_gen = cached_map.generation();
         match self
             .resolve_group_devices_memoized(group, group_info, own_sending_jid)
             .await
         {
             Ok(all_devices) => {
                 // Skip the O(devices) filter_skdm_targets scan when the same
-                // (devices, sender-key-map) Arc pair was already fully warm. Both
-                // Arcs swap on any warm-state or membership change, so a stale skip
-                // is impossible. Needs the device memo for a stable devices Arc.
+                // (devices, sender-key-map) Arc pair AND generation were already
+                // fully warm. The devices Arc swaps on membership change; the
+                // cached-map Arc swaps on a warm-mark invalidation; the generation
+                // catches an in-place cold flip that keeps the same Arc. So a stale
+                // skip is impossible.
                 if self.group_devices_memo_enabled
-                    && let Some((dw, cw)) = self.skdm_warm_memo.get(group).await
+                    && let Some((dw, cw, memo_gen)) = self.skdm_warm_memo.get(group).await
                     && std::ptr::eq(dw.as_ptr(), std::sync::Arc::as_ptr(&all_devices))
                     && std::ptr::eq(cw.as_ptr(), std::sync::Arc::as_ptr(&cached_map))
+                    && memo_gen == cached_map_gen
                 {
                     return Some((all_devices, Vec::new()));
                 }
@@ -1123,6 +1130,7 @@ impl Client {
                             (
                                 std::sync::Arc::downgrade(&all_devices),
                                 std::sync::Arc::downgrade(&cached_map),
+                                cached_map_gen,
                             ),
                         )
                         .await;

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use portable_atomic::AtomicU64;
+
 use crate::cache::Cache;
 use crate::cache_config::CacheEntryConfig;
 use wacore_binary::Jid;
@@ -14,11 +16,16 @@ use wacore_binary::Jid;
 /// `has_key` is an [`AtomicBool`] so `markForgetSenderKey` can flip one device
 /// cold in place, matching WA Web's per-device participant-record update,
 /// instead of invalidating the whole group and forcing the next send to re-read
-/// and re-parse every row from the DB.
+/// and re-parse every row from the DB. An in-place flip keeps the same `Arc`, so
+/// `generation` is the version stamp the `skdm_warm_memo` compares to notice the
+/// change (pointer identity alone cannot).
 #[derive(Debug)]
 pub(crate) struct SenderKeyDeviceMap {
     /// user → (device_id → has_key)
     devices: HashMap<Arc<str>, HashMap<u16, AtomicBool>>,
+    /// Bumped on every in-place warm-state change. Same freshness contract the
+    /// device-registry generation gives membership.
+    generation: AtomicU64,
 }
 
 impl SenderKeyDeviceMap {
@@ -41,7 +48,18 @@ impl SenderKeyDeviceMap {
             }
         }
 
-        Self { devices }
+        Self {
+            devices,
+            generation: AtomicU64::new(0),
+        }
+    }
+
+    /// Monotonic version stamp for the warm state. The `skdm_warm_memo` records
+    /// this value and rejects its skip once it advances, so an in-place cold
+    /// flip (which does not swap the `Arc`) is still detected. Load this BEFORE
+    /// reading device state, so a racing flip stamps the memo as already stale.
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
     }
 
     #[cfg(test)]
@@ -101,7 +119,8 @@ impl SenderKeyDeviceCache {
     }
 
     /// Flip the given devices to `has_key=false` in place, if this group's map
-    /// is cached. Matches WA Web's per-device `markForgetSenderKey`: no
+    /// is cached, and bump the map's generation so the `skdm_warm_memo` re-runs
+    /// its target filter. Matches WA Web's per-device `markForgetSenderKey`: no
     /// whole-group invalidation, so a storm of retry receipts never forces the
     /// next send to re-read every row. A device absent from the map is already
     /// cold, so it is skipped. The DB write is the source of truth; this only
@@ -111,12 +130,19 @@ impl SenderKeyDeviceCache {
         let Some(map) = self.inner.get(group_jid).await else {
             return;
         };
+        let mut changed = false;
         for jid in devices {
             if let Some(by_device) = map.devices.get(jid.user.as_str())
                 && let Some(flag) = by_device.get(&jid.device)
             {
                 flag.store(false, Ordering::Relaxed);
+                changed = true;
             }
+        }
+        if changed {
+            // Release publishes the flip(s); the memo's Acquire load of the
+            // generation then also observes the cold state.
+            map.generation.fetch_add(1, Ordering::Release);
         }
     }
 
@@ -178,14 +204,16 @@ mod tests {
     async fn mark_forgotten_flips_in_place_without_invalidating() {
         let c = cache();
         let group = "120363000000000001@g.us";
-        c.get_or_init(group, async {
-            Arc::new(SenderKeyDeviceMap::from_db_rows(&[
-                ("111:0@lid".to_string(), true),
-                ("111:5@lid".to_string(), true),
-                ("222:0@lid".to_string(), true),
-            ]))
-        })
-        .await;
+        let map0 = c
+            .get_or_init(group, async {
+                Arc::new(SenderKeyDeviceMap::from_db_rows(&[
+                    ("111:0@lid".to_string(), true),
+                    ("111:5@lid".to_string(), true),
+                    ("222:0@lid".to_string(), true),
+                ]))
+            })
+            .await;
+        let gen_before = map0.generation();
 
         let dev5: Jid = "111:5@lid".parse().unwrap();
         c.mark_forgotten(group, std::slice::from_ref(&dev5)).await;
@@ -202,6 +230,20 @@ mod tests {
         assert_eq!(map.device_has_key("222", 0), Some(true));
         assert!(!map.device_and_primary_warm("111", 5));
         assert!(map.device_and_primary_warm("222", 0));
+        // Same Arc, advanced generation: the warm memo detects the change.
+        assert!(Arc::ptr_eq(&map0, &map));
+        assert_ne!(map.generation(), gen_before);
+
+        // A mark for a device the map doesn't hold changes nothing, so the
+        // generation must not advance (no spurious memo miss).
+        let gen_after = map.generation();
+        let absent: Jid = "999:0@lid".parse().unwrap();
+        c.mark_forgotten(group, std::slice::from_ref(&absent)).await;
+        assert_eq!(
+            map.generation(),
+            gen_after,
+            "no-op mark must not bump generation"
+        );
     }
 
     #[tokio::test]

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -134,8 +134,11 @@ impl SenderKeyDeviceCache {
         for jid in devices {
             if let Some(by_device) = map.devices.get(jid.user.as_str())
                 && let Some(flag) = by_device.get(&jid.device)
+                && flag.swap(false, Ordering::Relaxed)
             {
-                flag.store(false, Ordering::Relaxed);
+                // Only a real high→low transition is a warm-state change; a
+                // device already cold must not advance the generation, or a
+                // retry storm would churn the warm memo with no-op misses.
                 changed = true;
             }
         }
@@ -243,6 +246,15 @@ mod tests {
             map.generation(),
             gen_after,
             "no-op mark must not bump generation"
+        );
+
+        // Re-marking an already-cold device it DOES hold is also a no-op: the
+        // flag is already false, so a retry storm must not churn the generation.
+        c.mark_forgotten(group, std::slice::from_ref(&dev5)).await;
+        assert_eq!(
+            map.generation(),
+            gen_after,
+            "duplicate cold mark must not bump generation"
         );
     }
 

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -3,21 +3,28 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::cache::Cache;
 use crate::cache_config::CacheEntryConfig;
 use wacore_binary::Jid;
 
 /// Pre-parsed, pre-indexed sender key device map for one group.
-#[derive(Clone, Debug)]
+///
+/// `has_key` is an [`AtomicBool`] so `markForgetSenderKey` can flip one device
+/// cold in place, matching WA Web's per-device participant-record update,
+/// instead of invalidating the whole group and forcing the next send to re-read
+/// and re-parse every row from the DB.
+#[derive(Debug)]
 pub(crate) struct SenderKeyDeviceMap {
     /// user → (device_id → has_key)
-    devices: HashMap<Arc<str>, HashMap<u16, bool>>,
+    devices: HashMap<Arc<str>, HashMap<u16, AtomicBool>>,
 }
 
 impl SenderKeyDeviceMap {
     pub fn from_db_rows(rows: &[(String, bool)]) -> Self {
-        let mut devices: HashMap<Arc<str>, HashMap<u16, bool>> = HashMap::with_capacity(rows.len());
+        let mut devices: HashMap<Arc<str>, HashMap<u16, AtomicBool>> =
+            HashMap::with_capacity(rows.len());
 
         for (jid_str, has_key) in rows {
             match jid_str.parse::<Jid>() {
@@ -26,7 +33,7 @@ impl SenderKeyDeviceMap {
                     devices
                         .entry(user)
                         .or_default()
-                        .insert(jid.device, *has_key);
+                        .insert(jid.device, AtomicBool::new(*has_key));
                 }
                 Err(e) => {
                     log::warn!("Skipping malformed device JID '{}': {}", jid_str, e);
@@ -46,19 +53,26 @@ impl SenderKeyDeviceMap {
     /// warm gate; production resolves both lookups via `device_and_primary_warm`.
     #[cfg(test)]
     pub fn device_has_key(&self, user: &str, device: u16) -> Option<bool> {
-        self.devices.get(user)?.get(&device).copied()
+        Some(
+            self.devices
+                .get(user)?
+                .get(&device)?
+                .load(Ordering::Relaxed),
+        )
     }
 
     /// WA Web warm gate (ParticipantStore.js): a device is warm only when it AND
     /// its primary (device 0) hold the key. Resolves the per-user inner map once
     /// so the two device lookups share a single outer (user-string) hash instead
-    /// of re-hashing the user per call. A missing entry counts as cold (`?? false`).
+    /// of re-hashing the user per call. A missing entry counts as cold.
     pub fn device_and_primary_warm(&self, user: &str, device: u16) -> bool {
         let Some(by_device) = self.devices.get(user) else {
             return false;
         };
-        by_device.get(&device).copied().unwrap_or(false)
-            && by_device.get(&0).copied().unwrap_or(false)
+        by_device
+            .get(&device)
+            .is_some_and(|k| k.load(Ordering::Relaxed))
+            && by_device.get(&0).is_some_and(|k| k.load(Ordering::Relaxed))
     }
 }
 
@@ -84,6 +98,26 @@ impl SenderKeyDeviceCache {
 
     pub(crate) async fn invalidate(&self, group_jid: &str) {
         self.inner.invalidate(group_jid).await;
+    }
+
+    /// Flip the given devices to `has_key=false` in place, if this group's map
+    /// is cached. Matches WA Web's per-device `markForgetSenderKey`: no
+    /// whole-group invalidation, so a storm of retry receipts never forces the
+    /// next send to re-read every row. A device absent from the map is already
+    /// cold, so it is skipped. The DB write is the source of truth; this only
+    /// keeps a live cache entry consistent with it. On a cache miss the next
+    /// send rebuilds from the DB, which already carries the write.
+    pub(crate) async fn mark_forgotten(&self, group_jid: &str, devices: &[Jid]) {
+        let Some(map) = self.inner.get(group_jid).await else {
+            return;
+        };
+        for jid in devices {
+            if let Some(by_device) = map.devices.get(jid.user.as_str())
+                && let Some(flag) = by_device.get(&jid.device)
+            {
+                flag.store(false, Ordering::Relaxed);
+            }
+        }
     }
 
     /// Drop cache entries whose map indexes the given (user, device_id). Needed
@@ -117,14 +151,71 @@ impl SenderKeyDeviceCache {
         self.inner
             .memory_stats(|k, v| {
                 k.capacity()
-                    + v.devices.capacity() * std::mem::size_of::<(Arc<str>, HashMap<u16, bool>)>()
+                    + v.devices.capacity()
+                        * std::mem::size_of::<(Arc<str>, HashMap<u16, AtomicBool>)>()
                     + v.devices
                         .iter()
                         .map(|(user, by_device)| {
-                            user.len() + by_device.capacity() * std::mem::size_of::<(u16, bool)>()
+                            user.len()
+                                + by_device.capacity() * std::mem::size_of::<(u16, AtomicBool)>()
                         })
                         .sum::<usize>()
             })
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache_config::CacheEntryConfig;
+
+    fn cache() -> SenderKeyDeviceCache {
+        SenderKeyDeviceCache::new(&CacheEntryConfig::new(None, 100))
+    }
+
+    #[tokio::test]
+    async fn mark_forgotten_flips_in_place_without_invalidating() {
+        let c = cache();
+        let group = "120363000000000001@g.us";
+        c.get_or_init(group, async {
+            Arc::new(SenderKeyDeviceMap::from_db_rows(&[
+                ("111:0@lid".to_string(), true),
+                ("111:5@lid".to_string(), true),
+                ("222:0@lid".to_string(), true),
+            ]))
+        })
+        .await;
+
+        let dev5: Jid = "111:5@lid".parse().unwrap();
+        c.mark_forgotten(group, std::slice::from_ref(&dev5)).await;
+
+        // Still cached (no whole-group invalidation): reading it must not run
+        // the init closure.
+        let map = c
+            .get_or_init(group, async { panic!("group was invalidated") })
+            .await;
+        // The forgotten device is cold; its sibling and the other user are
+        // untouched, which the blunt whole-group invalidate could not preserve.
+        assert_eq!(map.device_has_key("111", 5), Some(false));
+        assert_eq!(map.device_has_key("111", 0), Some(true));
+        assert_eq!(map.device_has_key("222", 0), Some(true));
+        assert!(!map.device_and_primary_warm("111", 5));
+        assert!(map.device_and_primary_warm("222", 0));
+    }
+
+    #[tokio::test]
+    async fn mark_forgotten_is_noop_on_cache_miss() {
+        let c = cache();
+        let dev: Jid = "111:0@lid".parse().unwrap();
+        // No entry for this group: must not panic or create one.
+        c.mark_forgotten("120363000000000009@g.us", std::slice::from_ref(&dev))
+            .await;
+        let map = c
+            .get_or_init("120363000000000009@g.us", async {
+                Arc::new(SenderKeyDeviceMap::from_db_rows(&[]))
+            })
+            .await;
+        assert!(map.is_empty());
     }
 }

--- a/src/sender_key_device_cache.rs
+++ b/src/sender_key_device_cache.rs
@@ -259,6 +259,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mark_forgotten_flips_a_mixed_batch_and_bumps_once() {
+        let c = cache();
+        let group = "120363000000000001@g.us";
+        let map = c
+            .get_or_init(group, async {
+                Arc::new(SenderKeyDeviceMap::from_db_rows(&[
+                    ("111:0@lid".to_string(), true),
+                    ("111:5@lid".to_string(), true),
+                    ("222:0@lid".to_string(), true),
+                ]))
+            })
+            .await;
+        let gen_before = map.generation();
+
+        // One receipt naming two present devices and one the map doesn't hold:
+        // both present flip cold, the absent one is skipped, and the whole batch
+        // advances the generation exactly once (not once per device).
+        let d0: Jid = "111:0@lid".parse().unwrap();
+        let d5: Jid = "111:5@lid".parse().unwrap();
+        let absent: Jid = "333:0@lid".parse().unwrap();
+        c.mark_forgotten(group, &[d0, d5, absent]).await;
+
+        assert_eq!(map.device_has_key("111", 0), Some(false));
+        assert_eq!(map.device_has_key("111", 5), Some(false));
+        assert_eq!(map.device_has_key("222", 0), Some(true));
+        assert_eq!(
+            map.generation(),
+            gen_before + 1,
+            "a batch of flips bumps the generation exactly once"
+        );
+    }
+
+    #[test]
+    fn warm_gate_requires_both_device_and_primary() {
+        // WA Web's ParticipantStore gate: a device is warm only when it AND its
+        // primary (device 0) both hold the key. This is the per-device SKDM
+        // targeting decision, so pin every branch.
+        let m = SenderKeyDeviceMap::from_db_rows(&[
+            ("111:0@lid".to_string(), true),  // primary warm
+            ("111:5@lid".to_string(), true),  // secondary warm
+            ("222:0@lid".to_string(), false), // primary cold
+            ("222:7@lid".to_string(), true),  // secondary warm, primary cold
+            ("333:9@lid".to_string(), true),  // secondary warm, no primary row
+        ]);
+
+        // Device and its primary both warm.
+        assert!(m.device_and_primary_warm("111", 5));
+        assert!(m.device_and_primary_warm("111", 0));
+        // Secondary is warm but the primary is cold: the whole user is cold.
+        assert!(!m.device_and_primary_warm("222", 7));
+        // The primary itself when cold.
+        assert!(!m.device_and_primary_warm("222", 0));
+        // Secondary present but the primary row is absent: absent counts as cold.
+        assert!(!m.device_and_primary_warm("333", 9));
+        // A user the map never saw is cold.
+        assert!(!m.device_and_primary_warm("999", 0));
+    }
+
+    #[test]
+    fn from_db_rows_skips_malformed_and_keeps_valid() {
+        // A corrupt or partially-migrated row must not poison the whole map: bad
+        // JIDs are skipped (logged) and the valid devices still index correctly.
+        let m = SenderKeyDeviceMap::from_db_rows(&[
+            ("111:0@lid".to_string(), true),
+            ("not-a-jid".to_string(), true), // unknown server → skipped
+            ("111:xx@lid".to_string(), true), // non-numeric device → skipped
+            ("222:0@lid".to_string(), false),
+        ]);
+
+        assert_eq!(m.device_has_key("111", 0), Some(true));
+        assert_eq!(m.device_has_key("222", 0), Some(false));
+        // The malformed rows produced no entries at all.
+        assert_eq!(m.device_has_key("not-a-jid", 0), None);
+        assert_eq!(m.device_has_key("111", 1), None);
+    }
+
+    #[tokio::test]
     async fn mark_forgotten_is_noop_on_cache_miss() {
         let c = cache();
         let dev: Jid = "111:0@lid".parse().unwrap();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,3 +4,4 @@ pub use wacore::types::*;
 // Local type definitions
 pub mod durability_hook;
 pub mod enc_handler;
+pub mod retry_admission;

--- a/src/types/retry_admission.rs
+++ b/src/types/retry_admission.rs
@@ -1,0 +1,45 @@
+use wacore_binary::Jid;
+
+/// Opt-in policy that decides whether an inbound group or status retry receipt
+/// enters the repair path, or is dropped before any work runs.
+///
+/// WhatsApp Web has no volume-based throttle on inbound retry receipts: it
+/// serializes them per chat, refuses past `MAX_RETRY`, and otherwise processes
+/// every one (`markForgetSenderKey`, key-bundle processing, resend). This SDK
+/// mirrors that by default. In a large group a cohort of members whose pairwise
+/// sessions never establish can send a retry for every single message, driving
+/// that repair path at storm rate. A single-user WA Web client never sends at
+/// the volume that produces this; a bot does.
+///
+/// A `RetryAdmission` policy is the seam for bot-scale deployments that want to
+/// bound that cost, without the SDK itself diverging from WA Web. Registering a
+/// policy is a deliberate, operator-owned decision to drop some eligible repair
+/// requests; leaving it unset keeps exact WA Web behavior. The check is a single
+/// [`std::sync::OnceLock::get`] on the receive path, so an unset policy costs
+/// nothing.
+///
+/// Scope: the policy is consulted only for group and `status@broadcast` retry
+/// receipts from other accounts. Retries from our own companion devices
+/// (`is_peer`) and all DM retries are always admitted and never reach the
+/// policy, because dropping those has no safe SKDM fallback. When the policy
+/// returns `false`, the receipt is dropped before the group-info fetch, the
+/// unknown-device `rotateKey` block, `markForgetSenderKey`, key-bundle
+/// processing and the resend. A dropped receipt is not queued: the requester
+/// re-requests on its own timer, so a policy should refill over time to keep
+/// genuine recovery possible.
+///
+/// See `examples/retry_quarantine.rs` for a token-bucket implementation keyed by
+/// (chat, requester).
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait RetryAdmission: wacore::sync_marker::MaybeSendSync {
+    /// Return `true` to admit the retry receipt (WA Web behavior), `false` to
+    /// drop it before any repair work runs.
+    ///
+    /// `chat` is the group or `status@broadcast` JID, `requester` the retrying
+    /// participant device, and `retry_count` the receipt's attempt number. The
+    /// device is intentionally part of `requester` but a policy may key on the
+    /// user only: WA Web re-targets a whole user's sender key, so all devices of
+    /// one broken account can share a budget.
+    async fn admit(&self, chat: &Jid, requester: &Jid, retry_count: u8) -> bool;
+}

--- a/src/types/retry_admission.rs
+++ b/src/types/retry_admission.rs
@@ -18,6 +18,12 @@ use wacore_binary::Jid;
 /// [`std::sync::OnceLock::get`] on the receive path, so an unset policy costs
 /// nothing.
 ///
+/// [`admit`](RetryAdmission::admit) is called inline on the receive path, so it
+/// must be a fast, local decision (a token-bucket check, an atomic counter) with
+/// no I/O or blocking. It is deliberately synchronous: an admission verdict that
+/// could `.await` would let a slow policy stall retry processing for the pending
+/// key, and a gate never needs to wait.
+///
 /// Scope: the policy is consulted only for group and `status@broadcast` retry
 /// receipts from other accounts. Retries from our own companion devices
 /// (`is_peer`) and all DM retries are always admitted and never reach the
@@ -30,16 +36,15 @@ use wacore_binary::Jid;
 ///
 /// See `examples/retry_quarantine.rs` for a token-bucket implementation keyed by
 /// (chat, requester).
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait RetryAdmission: wacore::sync_marker::MaybeSendSync {
     /// Return `true` to admit the retry receipt (WA Web behavior), `false` to
-    /// drop it before any repair work runs.
+    /// drop it before any repair work runs. Must return promptly (no I/O, no
+    /// blocking).
     ///
     /// `chat` is the group or `status@broadcast` JID, `requester` the retrying
     /// participant device, and `retry_count` the receipt's attempt number. The
     /// device is intentionally part of `requester` but a policy may key on the
     /// user only: WA Web re-targets a whole user's sender key, so all devices of
     /// one broken account can share a budget.
-    async fn admit(&self, chat: &Jid, requester: &Jid, retry_count: u8) -> bool;
+    fn admit(&self, chat: &Jid, requester: &Jid, retry_count: u8) -> bool;
 }


### PR DESCRIPTION
## Summary

A WA-Web-compliant, decoupled alternative to the inbound retry-receipt quarantine in #982 (thanks @Salientekill for the diagnosis and production data that made this possible), plus the compliant efficiency win that helps every send by default.

Two things:
1. An opt-in `RetryAdmission` hook so a quarantine can live in operator code, keeping the SDK's default path byte-for-byte WA Web.
2. `markForgetSenderKey` now updates the sender-key-device cache in place, per device, matching WA Web, instead of invalidating the whole group. A generation stamp keeps the warm-send memo correct without any cross-cache invalidation.

## Why not land #982 as-is

Cross-checked against the captured WA Web bundle:

- **WA Web has no volume-based throttle on inbound retry receipts.** `WAWebHandleRetryRequest` serializes per chat (`onMessageQueue` + `sendMsgQueueMap`), refuses past `MAX_RETRY`, and otherwise processes **every** receipt. Its only gates are *semantic* (`getMsgIfAuthorized` → `isRetryEligible`: `ALREADY_DELIVERED`, `CHANGED_IDENTITY`, `RECORD_MISSING`, `DEVICE_NOT_RECIPIENT`, `HIGH_RETRY_COUNT`, `MESSAGE_EXPIRED`), never "this member is asking too often."
- The send side is faithful too: `GroupSkmsgJob` marks `markHasSenderKey(x, M)` over the whole `skDistribList` (failed devices included). So the "broken member retries every message" loop is WA Web's own design, and the per-receipt session rebuild is work WA Web does too. WA Web survives it only because a single-user client never sends at bot volume.

A per-(chat, requester) quarantine that drops eligible repair requests is a deliberate divergence, fine for a bot operator but not a default the library should impose.

## 1. `RetryAdmission` hook (opt-in, zero overhead when unused)

- **Trait** (`src/types/retry_admission.rs`) mirroring the existing `InboundDurabilityHook` idiom (`OnceLock`, builder-less `Client::set_retry_admission`). Object-safe, WASM-safe.
- **Synchronous** `admit(chat, requester, retry_count) -> bool`: a gate never needs to wait, and a sync verdict cannot stall retry processing while the `pending_retries` scopeguard is held.
- **Gate in `handle_retry_receipt`**, placed exactly where #982 put its gate (after `is_peer`, before the group-info fetch, the unknown-device `rotateKey` block, `markForgetSenderKey`, key-bundle processing, and the resend). Own companion devices (`is_peer`) and all DMs never reach the policy.
- **Zero overhead when unused:** with no policy registered the check is a single `OnceLock::get()`.
- **Log demotion:** the per-receipt `Marked … for fresh SKDM` line drops from `info` to `debug` (a broken cohort emits tens of thousands/day; WA Web logs it at its verbose level).
- **`examples/retry_quarantine.rs`** — a token-bucket quarantine keyed by (chat, requester), burst 2 / refill 2/day, built on the hook. This is @Salientekill's mechanism from #982, now operator-owned and tunable.

## 2. In-place sender-key-device cache forget (compliant perf win, default)

WA Web's `markForgetSenderKey` flips one device's flag in the participant record in place. Ours invalidated the whole-group `sender_key_device_cache`, forcing the next send to re-read and re-parse every device row from the DB (a 1000+ device map re-materialized per send during a storm).

- `SenderKeyDeviceMap` stores `has_key` as an `AtomicBool` and carries an `AtomicU64` `generation`. `SenderKeyDeviceCache::mark_forgotten` flips only the touched devices cold in a live cache entry (no invalidation, no re-read), and bumps the generation once — only when a flag actually transitions warm→cold (`swap(false)`), so a retry storm of duplicate cold marks never churns it.
- The warm-marking path still invalidates the group, since marking a device warm can introduce (user, device) pairs the cached map doesn't have yet.
- **The warm-send memo stays correct without a second invalidation.** `skdm_warm_memo` lets a warm repeat send skip the O(devices) `filter_skdm_targets` scan; it now stores the map's `generation` alongside the two `Weak` Arcs `(Weak<ResolvedGroupDevices>, Weak<SenderKeyDeviceMap>, u64)`. An in-place cold flip keeps the same `Arc`, so pointer identity alone can't see it — the generation can. The send path loads the generation *before* filtering (Acquire), so a flip racing in after that stamps the memo as already stale and the next send re-runs the filter. A single Acquire/Release generation pair carries the freshness (the same contract the device-registry generation gives membership), so there is no separate memo invalidation and therefore no cross-cache ordering window.
- The DB write stays the source of truth; a cache miss rebuilds from it.

## What stays out of the core (vs #982)

`retry_mark_quarantine_capacity`, the `StatsSnapshot` and `MemoryReport` fields, the lifecycle wiring, and any on-by-default behavior.

## Remaining follow-up (separate PR)

**Close the `isRetryEligible` parity gap** — WA Web tracks per-(message, recipient-device) delivery state and rejects `ALREADY_DELIVERED` / `CHANGED_IDENTITY`. We don't, so we can't. `handle_retry_receipt` now documents which reject reasons we already enforce (`HIGH_RETRY_COUNT`, `MESSAGE_EXPIRED` / `RECORD_MISSING`, `DEVICE_NOT_IN_DATABASE`) and which stay a known gap. Closing the rest needs a per-recipient receipt store (schema + hot-path writes per recipient), which is a substantial standalone feature and out of scope here.

## Tests

Both the happy and the failure/edge paths are covered:

- **Cache generation** — in-place flip advances the generation while keeping the same `Arc`; a duplicate-cold or absent-device mark must *not* advance it; a mixed batch flips every present device and bumps the generation exactly once; a cache miss is a no-op.
- **WA Web warm gate** — a device is warm only when it and its primary (device 0) both hold the key; a cold or absent primary makes the whole user cold.
- **Malformed input** — `from_db_rows` skips corrupt / partially-migrated JID rows without dropping the valid devices around them.
- **Own-device exclusion** — a cold mark that names our own device plus a broken member flips only the member (WA Web `!isMeDevice`), and is a full no-op (no DB write, no generation bump) when every named device is our own.
- **Quarantine example** — per-pair bounding and isolation, `burst = 0` disable, fail-open past capacity, gradual token refill (recovery, not a reset), and the idle clamp that stops an idle pair banking an unbounded reserve.

`cargo fmt --all --check` clean; `cargo clippy -p whatsapp-rust --tests --examples` clean; 942 lib tests pass; `examples/retry_quarantine.rs` builds and its 5 unit tests pass.

@Salientekill — would you try this in your 1000-member group? Register `RetryQuarantine` from the example via `client.set_retry_admission(...)` with burst 2 / refill 2/day and confirm it bounds the storm the way your version did.