### PR TITLE
fix(recv): retry (not NACK) recoverable group skmsg decrypt failures

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -143,6 +143,23 @@ fn decrypt_fail_log_level(mode: crate::types::events::DecryptFailMode) -> log::L
     }
 }
 
+/// Maps a recoverable group (skmsg) `group_decrypt` error to the retry reason to
+/// send in a retry receipt, or `None` for a genuinely non-recoverable error that
+/// should still be NACKed. WA Web treats every `SignalDecryptionError` as
+/// `SignalRetryable`, so a sender-key desync (rotated/re-registered sender key)
+/// must request a resend rather than tell the server to stop retransmitting.
+/// `NoSenderKeyState`/`DuplicatedMessage` are handled by dedicated match arms and
+/// never reach here.
+fn group_decrypt_retry_reason(e: &SignalProtocolError) -> Option<RetryReason> {
+    match e {
+        SignalProtocolError::SignatureValidationFailed => Some(RetryReason::InvalidSignature),
+        SignalProtocolError::InvalidSenderKeySession => Some(RetryReason::InvalidSession),
+        SignalProtocolError::UnrecognizedMessageVersion(_) => Some(RetryReason::InvalidMessage),
+        SignalProtocolError::InvalidMessage(_, _) => Some(RetryReason::InvalidMessage),
+        _ => None,
+    }
+}
+
 pub(crate) use wacore::protocol::retry::RetryReason;
 
 pub(crate) mod commit_batch;

--- a/src/message.rs
+++ b/src/message.rs
@@ -143,13 +143,9 @@ fn decrypt_fail_log_level(mode: crate::types::events::DecryptFailMode) -> log::L
     }
 }
 
-/// Maps a recoverable group (skmsg) `group_decrypt` error to the retry reason to
-/// send in a retry receipt, or `None` for a genuinely non-recoverable error that
-/// should still be NACKed. WA Web treats every `SignalDecryptionError` as
-/// `SignalRetryable`, so a sender-key desync (rotated/re-registered sender key)
-/// must request a resend rather than tell the server to stop retransmitting.
-/// `NoSenderKeyState`/`DuplicatedMessage` are handled by dedicated match arms and
-/// never reach here.
+/// WA Web treats every `SignalDecryptionError` as `SignalRetryable`, so a
+/// sender-key desync must request a resend rather than NACK (which stops the
+/// server retransmitting). `None` = keep the NACK (genuinely non-Signal error).
 fn group_decrypt_retry_reason(e: &SignalProtocolError) -> Option<RetryReason> {
     match e {
         SignalProtocolError::SignatureValidationFailed => Some(RetryReason::InvalidSignature),

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1286,6 +1286,27 @@ impl Client {
                         continue;
                     }
 
+                    // Recoverable sender-key desync (participant rotated their sender
+                    // key / re-registered). WA Web classifies every SignalDecryptionError
+                    // as SignalRetryable -> retry receipt, which prompts the sender to
+                    // resend the SKDM + message. NACKing (500) instead tells the server
+                    // to stop retransmitting -> permanent, silent group-message loss.
+                    // Mirror the 1:1 path (BadMac/InvalidMessage) and the NoSenderKeyState
+                    // arm above, which already retry.
+                    if let Some(reason) = group_decrypt_retry_reason(&e) {
+                        log::log!(
+                            decrypt_fail_log_level(decrypt_fail_mode),
+                            "Group batch decrypt failed [msg:{}] for group {} sender {}: {:?}. Sending retry receipt.",
+                            info.id,
+                            sender_key_name.group_id(),
+                            sender_key_name.sender_id(),
+                            e
+                        );
+                        self.handle_decrypt_failure(info, reason, decrypt_fail_mode)
+                            .await;
+                        continue;
+                    }
+
                     log::log!(
                         decrypt_fail_log_level(decrypt_fail_mode),
                         "Group batch decrypt failed [msg:{}] for group {} sender {}: {:?}",

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1286,13 +1286,8 @@ impl Client {
                         continue;
                     }
 
-                    // Recoverable sender-key desync (participant rotated their sender
-                    // key / re-registered). WA Web classifies every SignalDecryptionError
-                    // as SignalRetryable -> retry receipt, which prompts the sender to
-                    // resend the SKDM + message. NACKing (500) instead tells the server
-                    // to stop retransmitting -> permanent, silent group-message loss.
-                    // Mirror the 1:1 path (BadMac/InvalidMessage) and the NoSenderKeyState
-                    // arm above, which already retry.
+                    // Recoverable sender-key desync: retry receipt (prompts an SKDM
+                    // resend), not a 500 NACK that would drop the message permanently.
                     if let Some(reason) = group_decrypt_retry_reason(&e) {
                         log::log!(
                             decrypt_fail_log_level(decrypt_fail_mode),

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -10406,3 +10406,47 @@ async fn bench_session_decrypt_throughput() {
         rss1.saturating_sub(rss0)
     );
 }
+
+/// F3: group (skmsg) decrypt failures from a sender-key desync must map to a
+/// retry receipt (WA Web treats every `SignalDecryptionError` as
+/// `SignalRetryable`), not a terminal NACK that drops the message. Locks the
+/// classification in `group_decrypt_retry_reason`.
+#[test]
+fn test_group_decrypt_retry_reason_classification() {
+    use wacore::libsignal::protocol::CiphertextMessageType;
+
+    // Recoverable sender-key errors -> retry receipt.
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::SignatureValidationFailed),
+        Some(RetryReason::InvalidSignature)
+    );
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::InvalidSenderKeySession),
+        Some(RetryReason::InvalidSession)
+    );
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::UnrecognizedMessageVersion(2)),
+        Some(RetryReason::InvalidMessage)
+    );
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::InvalidMessage(
+            CiphertextMessageType::SenderKey,
+            "decryption failed"
+        )),
+        Some(RetryReason::InvalidMessage)
+    );
+
+    // Errors handled by dedicated arms (or genuinely non-Signal) -> keep NACK.
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::NoSenderKeyState("x".into())),
+        None
+    );
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::DuplicatedMessage(1, 1)),
+        None
+    );
+    assert_eq!(
+        group_decrypt_retry_reason(&SignalProtocolError::InvalidProtobufEncoding),
+        None
+    );
+}


### PR DESCRIPTION
## What

On the group receive path, when `group_decrypt` fails with a **recoverable** Signal-crypto error — `SignatureValidationFailed`, `InvalidSenderKeySession`, `UnrecognizedMessageVersion`, or `InvalidMessage(SenderKey, …)` — send a **retry receipt** instead of a terminal NACK (`error=500`).

## Why (bug)

`src/message/receive.rs` handled only `DuplicatedMessage` and `NoSenderKeyState` specially; every other `group_decrypt` error hit the catch-all `Err(e) =>` arm, which for non-status chats calls `spawn_nack(UnhandledError)`. A `500` NACK tells the server to **stop retransmitting**, so the stanza is dropped from the offline queue.

But those four errors are exactly what a benign **sender-key desync** produces — a participant rotated their sender key or re-registered (`wacore/libsignal/src/protocol/group_cipher.rs:206-250`). The result was **permanent, silent group-message loss** until the sender happened to re-distribute an SKDM.

This diverges from WhatsApp Web, which classifies every `SignalDecryptionError` as `SignalRetryable` → retry receipt (`WAWeb/Msg/ProcessingDecryptionHandler.js`); the receipt prompts the sender to resend the SKDM + message. The sibling **1:1 path** already treats `BadMac`/`InvalidMessage` as retryable (`receive.rs:1000-1053`), so only the group path was asymmetric.

## How

- New pure helper `group_decrypt_retry_reason(&SignalProtocolError) -> Option<RetryReason>` maps each recoverable error to a retry reason; `None` = keep the NACK (genuinely non-Signal errors).
- The group catch-all now routes `Some(reason)` through the existing `handle_decrypt_failure` (which dispatches the undecryptable event **and** sends the retry receipt), mirroring the `NoSenderKeyState` arm. `None` keeps the prior dispatch-then-NACK behavior.
- `DuplicatedMessage` / `NoSenderKeyState` still take their dedicated arms and never reach the helper. Expired-status early-return is unchanged.

## Tests

- `test_group_decrypt_retry_reason_classification` — locks the mapping: the four recoverable variants → retry reasons; `NoSenderKeyState` / `DuplicatedMessage` / non-Signal → `None` (NACK preserved).
- `cargo fmt`, `cargo clippy -p whatsapp-rust --lib --tests` clean; full lib test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1geaAZffSxDhP7dpNrbbt)_