### PR TITLE
fix(recv): retry (not NACK) InvalidSignedPreKeyId on the 1:1 decrypt path

### DIFF
--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1102,6 +1102,32 @@ impl Client {
                             )
                             .await;
                         continue;
+                    } else if matches!(e, SignalProtocolError::InvalidSignedPreKeyId) {
+                        // A PreKeySignalMessage naming a signed prekey we've
+                        // rotated past SIGNED_PRE_KEY_RETENTION yields
+                        // InvalidSignedPreKeyId. WA Web classifies it as
+                        // SignalRetryable -> retry receipt (carrying our live
+                        // bundle so the peer rebuilds against the current signed
+                        // prekey). The catch-all nack would instead drop the
+                        // stanza from the offline queue -> permanent 1:1 loss;
+                        // the sibling InvalidPreKeyId arm already retries.
+                        log::debug!(
+                            "[msg:{}] Decryption failed for {} message from {} due to InvalidSignedPreKeyId. \
+                             Sender used a signed prekey we've rotated out. Sending retry receipt with fresh prekeys.",
+                            info.id,
+                            enc_type,
+                            info.source.sender.observe()
+                        );
+
+                        outcome.had_failure = true;
+                        outcome.undecryptable |= self
+                            .handle_decrypt_failure(
+                                info,
+                                RetryReason::InvalidKeyId,
+                                decrypt_fail_mode,
+                            )
+                            .await;
+                        continue;
                     } else {
                         // Catch-all → WA Web's UnhandledError nack (500).
                         log::error!(

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1103,14 +1103,9 @@ impl Client {
                             .await;
                         continue;
                     } else if matches!(e, SignalProtocolError::InvalidSignedPreKeyId) {
-                        // A PreKeySignalMessage naming a signed prekey we've
-                        // rotated past SIGNED_PRE_KEY_RETENTION yields
-                        // InvalidSignedPreKeyId. WA Web classifies it as
-                        // SignalRetryable -> retry receipt (carrying our live
-                        // bundle so the peer rebuilds against the current signed
-                        // prekey). The catch-all nack would instead drop the
-                        // stanza from the offline queue -> permanent 1:1 loss;
-                        // the sibling InvalidPreKeyId arm already retries.
+                        // WA Web classifies this as SignalRetryable; the catch-all
+                        // nack would permanently drop the stanza from the offline
+                        // queue. Mirrors the sibling InvalidPreKeyId arm.
                         log::debug!(
                             "[msg:{}] Decryption failed for {} message from {} due to InvalidSignedPreKeyId. \
                              Sender used a signed prekey we've rotated out. Sending retry receipt with fresh prekeys.",

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -759,6 +759,15 @@ async fn ensure_bob_paired(client: &Arc<Client>) {
 /// keys back to the sender — assembled through the same
 /// `SignalProtocolStoreAdapter` traits production uses.
 async fn bobs_prekey_bundle(client: &Arc<Client>) -> (PreKeyBundle, Jid) {
+    bobs_prekey_bundle_with_spk_id(client, 1).await
+}
+
+/// Like [`bobs_prekey_bundle`] but advertises `spk_id` as the bundle's signed
+/// prekey id while still signing with the real record (#1). The signed-prekey
+/// signature covers only the public key, not the id, so an id the client never
+/// provisioned still yields a bundle Alice accepts — and a resulting
+/// PreKeySignalMessage whose decrypt hits `InvalidSignedPreKeyId` on Bob.
+async fn bobs_prekey_bundle_with_spk_id(client: &Arc<Client>, spk_id: u32) -> (PreKeyBundle, Jid) {
     use wacore::libsignal::protocol::GenericSignedPreKey;
     ensure_bob_paired(client).await;
     let snapshot = client.persistence_manager.get_device_snapshot();
@@ -799,7 +808,7 @@ async fn bobs_prekey_bundle(client: &Arc<Client>) -> (PreKeyBundle, Jid) {
         reg_id,
         u32::from(own_device_jid.device).into(),
         Some((pk_id_u32.into(), pk_pair.public_key)),
-        1.into(),
+        spk_id.into(),
         spk_pub,
         spk_sig_vec,
         IdentityKey::new(identity_kp.public_key),
@@ -10449,4 +10458,70 @@ fn test_group_decrypt_retry_reason_classification() {
         group_decrypt_retry_reason(&SignalProtocolError::InvalidProtobufEncoding),
         None
     );
+}
+
+/// F4: a PreKeySignalMessage naming a signed prekey we've rotated past
+/// SIGNED_PRE_KEY_RETENTION surfaces `InvalidSignedPreKeyId`. WA Web classifies
+/// this as `SignalRetryable`, so it must send a retry receipt (carrying our live
+/// bundle) rather than a terminal NACK that drops the 1:1 message. The sibling
+/// `InvalidPreKeyId` arm already retries; this locks the same for signed prekeys.
+#[tokio::test]
+async fn test_invalid_signed_prekey_id_sends_retry_receipt() {
+    let client = crate::test_utils::create_test_client_with_name("invalid_spk_id").await;
+
+    // Bundle advertises a signed-prekey id the client never provisioned, so
+    // Bob's decrypt hits InvalidSignedPreKeyId (as a rotated-out signed prekey
+    // would). Alice still accepts the bundle because the id is not signed.
+    let (bundle, bob_jid) = bobs_prekey_bundle_with_spk_id(&client, 4242).await;
+    let bob_addr = bob_jid.to_protocol_address();
+
+    let mut alice = AlicePeer::new("15550002002@s.whatsapp.net").await;
+    alice.install_bob_session(&bob_addr, &bundle).await;
+    let pkmsg = alice
+        .encrypt_text(&bob_addr, "signed prekey rotated out")
+        .await;
+    assert!(
+        matches!(pkmsg, CiphertextMessage::PreKeySignalMessage(_)),
+        "must be a pkmsg so decrypt looks up the signed prekey"
+    );
+
+    let bytes = match &pkmsg {
+        CiphertextMessage::PreKeySignalMessage(m) => m.serialized().to_vec(),
+        _ => unreachable!(),
+    };
+    let enc_node = NodeBuilder::new("enc")
+        .attr("type", "pkmsg")
+        .bytes(bytes)
+        .build();
+    let enc_ref = enc_node.as_node_ref();
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref).unwrap()];
+    let info = Arc::new(MessageInfo {
+        id: "INVALID_SPK_ID_MSG".to_string(),
+        source: crate::types::message::MessageSource {
+            sender: alice.jid.clone(),
+            chat: alice.jid.clone(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let outcome = client
+        .clone()
+        .process_session_enc_batch(
+            &payloads,
+            &info,
+            &alice.jid,
+            crate::types::events::DecryptFailMode::Show,
+        )
+        .await;
+    assert!(
+        !outcome.decrypted,
+        "must not decrypt with a missing signed prekey"
+    );
+    assert!(outcome.had_failure, "must record a decrypt failure");
+
+    // The fix routes InvalidSignedPreKeyId to handle_decrypt_failure -> retry
+    // receipt with RetryReason::InvalidKeyId. Pre-fix this took the terminal
+    // NACK path, which never bumps the retry caches.
+    await_retry_receipt(&client, &info, 1, RetryReason::InvalidKeyId).await;
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -762,11 +762,9 @@ async fn bobs_prekey_bundle(client: &Arc<Client>) -> (PreKeyBundle, Jid) {
     bobs_prekey_bundle_with_spk_id(client, 1).await
 }
 
-/// Like [`bobs_prekey_bundle`] but advertises `spk_id` as the bundle's signed
-/// prekey id while still signing with the real record (#1). The signed-prekey
-/// signature covers only the public key, not the id, so an id the client never
-/// provisioned still yields a bundle Alice accepts — and a resulting
-/// PreKeySignalMessage whose decrypt hits `InvalidSignedPreKeyId` on Bob.
+/// Like [`bobs_prekey_bundle`] but advertises an arbitrary `spk_id` so callers
+/// can trigger `InvalidSignedPreKeyId` on Bob's decrypt path (the signed-prekey
+/// signature covers only the public key, so an unprovisioned id still verifies).
 async fn bobs_prekey_bundle_with_spk_id(client: &Arc<Client>, spk_id: u32) -> (PreKeyBundle, Jid) {
     use wacore::libsignal::protocol::GenericSignedPreKey;
     ensure_bob_paired(client).await;


### PR DESCRIPTION
## What

Handle `SignalProtocolError::InvalidSignedPreKeyId` on the session (pkmsg/msg) decrypt path by sending a **retry receipt** (`RetryReason::InvalidKeyId`) instead of letting it fall to the catch-all `500` NACK.

## Why (bug)

When a `PreKeySignalMessage` names a signed prekey we've rotated **past** `SIGNED_PRE_KEY_RETENTION` (`src/features/rotate_key.rs`), `SignedPreKeyAdapter::get_signed_pre_key` returns `InvalidSignedPreKeyId`. The session-decrypt match in `src/message/receive.rs` handled `SessionNotFound`, `BadMac`/`InvalidMessage`, `InvalidPreKeyId`, `UntrustedIdentity`, `DuplicatedMessage` — but **not** `InvalidSignedPreKeyId`, so it hit the `else` catch-all → `spawn_nack(UnhandledError)`. A `500` NACK clears the stanza from the offline queue → **permanent, silent 1:1 message loss**.

WhatsApp Web classifies this as a `SignalDecryptionError` → `SignalRetryable` → retry receipt (`WAWeb/Msg/ProcessingDecryptionHandler.js`); the receipt carries our live bundle so the peer rebuilds against the current signed prekey. The **sibling** `InvalidPreKeyId` arm already retries — this was an inconsistent drop for the signed-prekey case.

## How

- Add an `else if matches!(e, InvalidSignedPreKeyId)` arm before the catch-all that routes to the existing `handle_decrypt_failure(RetryReason::InvalidKeyId, …)`, mirroring the adjacent `InvalidPreKeyId` arm. The catch-all `500` NACK is preserved for genuinely non-Signal errors.

## Tests

- `test_invalid_signed_prekey_id_sends_retry_receipt` — builds a bundle whose signed-prekey id the client never provisioned (the id is not signed, so the bundle is still accepted), so decrypt hits `InvalidSignedPreKeyId`; asserts a retry receipt with `RetryReason::InvalidKeyId` is emitted (pre-fix this took the terminal NACK path, which never bumps the retry caches).
- Refactors the shared `bobs_prekey_bundle` test helper into `bobs_prekey_bundle_with_spk_id(client, spk_id)`; the original delegates with `spk_id = 1` (no behavior change for existing callers).
- `cargo fmt`, `cargo clippy -p whatsapp-rust --lib --tests` clean; new test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1geaAZffSxDhP7dpNrbbt)_