### PR TITLE
fix(send): lock per-device sessions across the group SKDM fan-out

### DIFF
--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -59,4 +59,24 @@ impl SendContextResolver for Client {
     fn on_local_identity_change(&self, jid: &Jid) {
         self.react_to_local_identity_change(jid);
     }
+
+    async fn lock_device_sessions(
+        &self,
+        device_jids: &[Jid],
+    ) -> wacore::client::context::SessionLockGuard {
+        use wacore::client::context::SessionLockGuard;
+        if device_jids.is_empty() {
+            return SessionLockGuard::none();
+        }
+        // Reuse the DM send path's key derivation + ordering (resolve_encryption_jid
+        // keys, sorted by cmp_for_lock_order) so both paths serialize on the identical
+        // per-device mutexes.
+        let keys = self.build_session_lock_keys(device_jids).await;
+        let mutexes = self.session_mutexes_for(&keys).await;
+        let mut guards = Vec::with_capacity(mutexes.len());
+        for mutex in &mutexes {
+            guards.push(mutex.lock_arc().await);
+        }
+        SessionLockGuard::hold(Box::new(guards))
+    }
 }

--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -68,9 +68,7 @@ impl SendContextResolver for Client {
         if device_jids.is_empty() {
             return SessionLockGuard::none();
         }
-        // Reuse the DM send path's key derivation + ordering (resolve_encryption_jid
-        // keys, sorted by cmp_for_lock_order) so both paths serialize on the identical
-        // per-device mutexes.
+        // Reuse the DM path's helpers so both lock the identical per-device mutexes.
         let keys = self.build_session_lock_keys(device_jids).await;
         let mutexes = self.session_mutexes_for(&keys).await;
         let mut guards = Vec::with_capacity(mutexes.len());

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -2136,6 +2136,43 @@ mod tests {
         assert!(out.participants.iter().any(|p| p.is_same_user_as(&own)));
     }
 
+    // The group SKDM pairwise fan-out must hold the SAME per-device session mutex
+    // the DM path locks, so the two can't advance a shared device's ratchet at
+    // once. Acquiring the group lock must block the DM per-device lock.
+    #[tokio::test]
+    async fn group_skdm_lock_shares_dm_per_device_session_mutex() {
+        use wacore::client::context::SendContextResolver;
+
+        let client = crate::test_utils::create_test_client().await;
+        let device: Jid = "15551234567:3@s.whatsapp.net".parse().unwrap();
+
+        // The exact mutex the DM send path would lock for this device.
+        let keys = client
+            .build_session_lock_keys(std::slice::from_ref(&device))
+            .await;
+        let dm_mutexes = client.session_mutexes_for(&keys).await;
+        assert_eq!(dm_mutexes.len(), 1);
+        assert!(
+            dm_mutexes[0].try_lock().is_some(),
+            "uncontended before the group lock"
+        );
+
+        // Hold the group SKDM lock for the same device.
+        let guard = client
+            .lock_device_sessions(std::slice::from_ref(&device))
+            .await;
+        assert!(
+            dm_mutexes[0].try_lock().is_none(),
+            "group SKDM fan-out must block the DM per-device session lock"
+        );
+
+        drop(guard);
+        assert!(
+            dm_mutexes[0].try_lock().is_some(),
+            "the per-device session lock releases when the group guard drops"
+        );
+    }
+
     #[tokio::test]
     async fn send_message_to_status_without_reaction_errors() {
         let client = crate::test_utils::create_test_client().await;

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -188,6 +188,28 @@ impl crate::stats::HeapSize for GroupInfo {
     }
 }
 
+/// Opaque RAII holder for the per-device pairwise session locks a
+/// [`SendContextResolver`] acquires around the group SKDM fan-out. Wacore holds it
+/// across the fan-out and drops it to release; the concrete guard type lives in the
+/// platform crate, since the per-address lock cache is not part of the portable core.
+#[must_use = "the session locks release the moment this guard is dropped"]
+pub struct SessionLockGuard(
+    // Held purely for its `Drop` (releases the locks); never read.
+    #[allow(dead_code)] Option<Box<dyn crate::sync_marker::MaybeSendSync>>,
+);
+
+impl SessionLockGuard {
+    /// No locks held — the default resolver behavior (tests/benches don't race).
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    /// Hold `guards` until this value is dropped.
+    pub fn hold(guards: Box<dyn crate::sync_marker::MaybeSendSync>) -> Self {
+        Self(Some(guards))
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {
@@ -224,6 +246,17 @@ pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {
     /// back to the client available inside `encrypt_for_devices`.
     fn on_local_identity_change(&self, jid: &Jid) {
         let _ = jid;
+    }
+
+    /// Acquire the per-device pairwise session locks for the SKDM fan-out targets,
+    /// in the same deadlock-free order the DM send path uses, so a group send and a
+    /// concurrent DM (or another group send) sharing a device can't advance that
+    /// device's pairwise ratchet at once and drop a chain step. The `sender_key_lock`
+    /// only serializes the sender-key chain, not these pairwise sessions. Default:
+    /// no-op — tests and benches don't race concurrent sends.
+    async fn lock_device_sessions(&self, device_jids: &[Jid]) -> SessionLockGuard {
+        let _ = device_jids;
+        SessionLockGuard::none()
     }
 }
 

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -423,17 +423,24 @@ pub async fn prepare_group_stanza(
             // `decrypt-fail="hide"` but the payload does not (e.g. AdminRevoke), recipients
             // without a sender key never decrypt the skmsg and the revoke is silently dropped.
             let skdm_hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit.as_ref(), message);
-            match encrypt_for_devices_with_sessions(
-                runtime,
-                stores,
-                distribution_list,
-                &skdm_plaintext_to_encrypt,
-                skdm_hide_decrypt_fail,
-                None,
-                plan,
-            )
-            .await
-            {
+            // The fan-out mutates each target's pairwise Signal session; the chain
+            // lock above only covers the sender-key chain. Hold the same per-device
+            // session locks the DM path uses so a concurrent DM / group send can't
+            // race the ratchet and drop an advance (lost SKDM -> undecryptable skmsg).
+            let skdm_result = {
+                let _session_guard = resolver.lock_device_sessions(distribution_list).await;
+                encrypt_for_devices_with_sessions(
+                    runtime,
+                    stores,
+                    distribution_list,
+                    &skdm_plaintext_to_encrypt,
+                    skdm_hide_decrypt_fail,
+                    None,
+                    plan,
+                )
+                .await
+            };
+            match skdm_result {
                 Ok(result) => {
                     includes_prekey_message =
                         includes_prekey_message || result.includes_prekey_message;

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -341,6 +341,16 @@ pub async fn prepare_group_stanza(
 
     let sender_key_name = make_sender_key_name(&to_jid, &own_sending_jid.to_protocol_address());
 
+    // Hold the per-device session locks the DM path uses across BOTH the X3DH setup
+    // and the SKDM fan-out below, so a concurrent DM or group send sharing a device
+    // can't race that device's pairwise session (create or ratchet-advance). The DM
+    // path holds the same locks across all of prepare_dm_stanza; sender_key_lock only
+    // serializes the sender-key chain. Acquired before sender_key_lock so the whole
+    // send path takes session -> sender-key order (no other path takes the reverse).
+    let session_guard = resolver
+        .lock_device_sessions(distribution_list.as_deref().unwrap_or(&[]))
+        .await;
+
     // Establish missing pairwise sessions (prekey fetch + X3DH) for the SKDM
     // targets before taking the chain lock, so the chain critical section
     // below never spans a network RTT — concurrent sends to the same group
@@ -385,11 +395,9 @@ pub async fn prepare_group_stanza(
 
     // The lock spans SKDM creation, the pairwise SKDM fan-out, and the skmsg
     // encrypt. Creating the SKDM snapshots the sender key and the skmsg uses it,
-    // so those must be atomic. The fan-out also mutates the shared per-device
-    // Signal sessions, which the group path (unlike the DM path) does not lock,
-    // so it has to stay serialized here too or concurrent same-group sends race
-    // those sessions. Dropped after the encrypt so only the stanza build runs
-    // off the serialization point.
+    // so those must be atomic. Per-device pairwise sessions are guarded separately
+    // by `session_guard` above. Dropped after the encrypt so only the stanza build
+    // runs off the serialization point.
     let chain_lock = stores
         .sender_key_store
         .sender_key_lock(&sender_key_name)
@@ -423,24 +431,17 @@ pub async fn prepare_group_stanza(
             // `decrypt-fail="hide"` but the payload does not (e.g. AdminRevoke), recipients
             // without a sender key never decrypt the skmsg and the revoke is silently dropped.
             let skdm_hide_decrypt_fail = should_hide_decrypt_fail_for_send(edit.as_ref(), message);
-            // The fan-out mutates each target's pairwise Signal session; the chain
-            // lock above only covers the sender-key chain. Hold the same per-device
-            // session locks the DM path uses so a concurrent DM / group send can't
-            // race the ratchet and drop an advance (lost SKDM -> undecryptable skmsg).
-            let skdm_result = {
-                let _session_guard = resolver.lock_device_sessions(distribution_list).await;
-                encrypt_for_devices_with_sessions(
-                    runtime,
-                    stores,
-                    distribution_list,
-                    &skdm_plaintext_to_encrypt,
-                    skdm_hide_decrypt_fail,
-                    None,
-                    plan,
-                )
-                .await
-            };
-            match skdm_result {
+            match encrypt_for_devices_with_sessions(
+                runtime,
+                stores,
+                distribution_list,
+                &skdm_plaintext_to_encrypt,
+                skdm_hide_decrypt_fail,
+                None,
+                plan,
+            )
+            .await
+            {
                 Ok(result) => {
                     includes_prekey_message =
                         includes_prekey_message || result.includes_prekey_message;
@@ -493,6 +494,7 @@ pub async fn prepare_group_stanza(
 
     // Release before the chain-independent stanza build.
     drop(chain_guard);
+    drop(session_guard);
 
     let skmsg_ciphertext = skmsg.into_serialized();
 

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -484,6 +484,11 @@ pub async fn prepare_group_stanza(
         }
     }
 
+    // The skmsg encrypt only advances the sender-key chain, not any pairwise
+    // session, so release the per-device locks now instead of holding them across
+    // it (avoids head-of-line blocking a concurrent DM to a shared device).
+    drop(session_guard);
+
     let skmsg = encrypt_group_message(
         stores.sender_key_store,
         &sender_key_name,
@@ -494,7 +499,6 @@ pub async fn prepare_group_stanza(
 
     // Release before the chain-independent stanza build.
     drop(chain_guard);
-    drop(session_guard);
 
     let skmsg_ciphertext = skmsg.into_serialized();
 


### PR DESCRIPTION
## What

Hold the same per-device pairwise **session locks** the DM send path uses across the group **SKDM fan-out**, so a group send and a concurrent DM (or another group send) sharing a device can't advance that device's Signal ratchet at once.

## Why (bug)

`prepare_group_stanza`'s SKDM pairwise fan-out (`encrypt_for_devices_with_sessions`) mutates each target device's **pairwise** Signal session (load → advance chain → store, non-atomic). But it ran under only `sender_key_lock(group + sender)` — the per-(group,sender) chain lock. The DM path guards those *same* sessions with a **disjoint** mutex: `session_lock_for(<device protocol addr>)` (`build_session_lock_keys` / `session_mutexes_for`).

Two different lock keys ⇒ no mutual exclusion. Group sends aren't per-chat locked (matches WA Web), so a concurrent group send + DM — or two cold group sends sharing a recipient/own-companion device — could both read chain index `N` and both store `N+1`, dropping one advance. If the lost output was the **SKDM**, that member never receives the sender key and **every subsequent skmsg to the group is undecryptable** until a retry re-distributes. (Gated on a cold/evicted-session window; the warm cache path self-heals.)

## How

- New `SendContextResolver::lock_device_sessions(&[Jid]) -> SessionLockGuard` hook, default **no-op** (tests/benches don't race). `SessionLockGuard` is an opaque RAII holder in wacore; the concrete guards live in the platform crate (the per-address lock cache isn't part of the portable core).
- `Client` implements it by **reusing** `build_session_lock_keys` + `session_mutexes_for` — the *exact same* key derivation (`resolve_encryption_jid`, sorted by `cmp_for_lock_order`) and ordering the DM path uses, so both serialize on the identical mutexes. Consistent global lock order ⇒ no deadlock; the group path acquires `sender_key_lock` → session locks, and no path acquires the reverse.
- `prepare_group_stanza` holds the guard across the fan-out only; the `sender_key_lock` still covers the sender-key chain itself. Zero overhead on warm sends (no SKDM targets ⇒ hook not reached).

## Tests

- `group_skdm_lock_shares_dm_per_device_session_mutex` — acquiring the group SKDM lock for a device makes the DM path's per-device mutex (`session_mutexes_for`) contended, and it releases when the guard drops. Proves both paths share the same mutex.
- `cargo fmt` / `clippy` clean; full `wacore` send suite (95) + main-crate send tests (89) pass.
