### PR TITLE
fix(cache): don't capacity-evict a session lock a task still holds

### DIFF
--- a/src/cache_config.rs
+++ b/src/cache_config.rs
@@ -197,7 +197,10 @@ pub struct CacheConfig {
     pub session_recreate_history: CacheEntryConfig,
 
     // --- Coordination caches (capacity-only, no TTL) ---
-    /// Per-device Signal session lock capacity. Default: 10000.
+    /// Per-device Signal session lock capacity. Default: 10000. Soft cap: a lock a
+    /// task is actively holding is never evicted, so the map can briefly exceed this
+    /// under heavy concurrent fan-out (bounded by the concurrently-held count) rather
+    /// than evicting a live lock and letting two writers race the same session.
     pub session_locks_capacity: u64,
     /// Per-chat lane capacity (combined lock + queue). Default: 5000.
     pub chat_lanes_capacity: u64,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -157,8 +157,12 @@ impl Client {
             // Coordination caches: capacity-only eviction, no TTL/TTI.
             // These hold live mutexes and channel senders; time-based eviction
             // while tasks hold references would silently break serialisation.
+            // The evict_guard also blocks capacity eviction of a mutex a task is
+            // holding (strong_count > 1) — evicting it would mint a second mutex
+            // and let two writers race the same Signal session.
             session_locks: Cache::builder()
                 .max_capacity(cache_config.session_locks_capacity.max(1))
+                .evict_guard(|m| Arc::strong_count(m) <= 1)
                 .build(),
             chat_lanes: Cache::builder()
                 .max_capacity(cache_config.chat_lanes_capacity.max(1))

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -86,24 +86,32 @@ where
     ) {
         if let Some(cap) = max_capacity {
             while self.map.len() as u64 >= cap {
-                let victim = match evict_guard {
-                    // Evict the oldest entry no live task still holds; skip protected
-                    // ones so a later lookup can't mint a duplicate. If every entry is
-                    // held, allow temporary over-capacity rather than dropping a live
-                    // entry (growth is bounded by the number of concurrently-held ones).
-                    Some(is_evictable) => self
-                        .order
-                        .iter()
-                        .find(|(_, k)| self.map.get(*k).is_some_and(|e| is_evictable(&e.value)))
-                        .map(|(seq, k)| (*seq, k.clone())),
-                    None => self.order.iter().next().map(|(seq, k)| (*seq, k.clone())),
-                };
-                match victim {
-                    Some((seq, oldest_key)) => {
-                        self.order.remove(&seq);
-                        self.map.remove(&oldest_key);
+                match evict_guard {
+                    // Unguarded caches keep the fast single-pass pop_first() path.
+                    None => match self.order.pop_first() {
+                        Some((_, oldest_key)) => {
+                            self.map.remove(&oldest_key);
+                        }
+                        None => break,
+                    },
+                    // Guarded: evict the oldest entry no live task still holds; skip
+                    // protected ones so a later lookup can't mint a duplicate. If every
+                    // entry is held, allow temporary over-capacity rather than dropping
+                    // a live entry (growth is bounded by the concurrently-held count).
+                    Some(is_evictable) => {
+                        let victim = self
+                            .order
+                            .iter()
+                            .find(|(_, k)| self.map.get(*k).is_some_and(|e| is_evictable(&e.value)))
+                            .map(|(seq, k)| (*seq, k.clone()));
+                        match victim {
+                            Some((seq, oldest_key)) => {
+                                self.order.remove(&seq);
+                                self.map.remove(&oldest_key);
+                            }
+                            None => break,
+                        }
                     }
-                    None => break,
                 }
             }
         }
@@ -616,6 +624,39 @@ mod tests {
         assert!(
             unguarded.get("held").await.is_none(),
             "an unguarded cache FIFO-evicts the held entry (the bug this guards)"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_guard_allows_temporary_over_capacity_when_all_held() {
+        type Lock = Arc<AsyncMutex<()>>;
+        let cache: PortableCache<String, Lock> = PortableCache::builder()
+            .max_capacity(2)
+            .evict_guard(|m| Arc::strong_count(m) <= 1)
+            .build();
+
+        // Hold every entry, then insert one more: with nothing evictable the cache
+        // grows past capacity rather than dropping a live lock.
+        let mut held = Vec::new();
+        for i in 0..3 {
+            let lock: Lock = Arc::new(AsyncMutex::new(()));
+            held.push(lock.clone());
+            cache.insert(format!("k{i}"), lock).await;
+        }
+        assert_eq!(
+            cache.entry_count(),
+            3,
+            "all entries held -> cache exceeds capacity instead of evicting a live lock"
+        );
+
+        // Drop the external refs; the next insert can now evict down toward capacity.
+        drop(held);
+        cache
+            .insert("fresh".into(), Arc::new(AsyncMutex::new(())))
+            .await;
+        assert!(
+            cache.entry_count() <= 3,
+            "once entries are released, eviction resumes"
         );
     }
 

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -73,6 +73,45 @@ where
         Some(entry)
     }
 
+    /// Evict entries until under `cap`. Outlined and never-inlined so the guarded
+    /// scan is compiled once per `<K, V>` (not duplicated into every `insert_new`
+    /// inline site), keeping the binary-size cost of the guard path small.
+    #[inline(never)]
+    fn evict_to_capacity(&mut self, cap: u64, evict_guard: Option<fn(&V) -> bool>) {
+        while self.map.len() as u64 >= cap {
+            match evict_guard {
+                // Unguarded caches keep the single-pass pop_first() fast path.
+                None => match self.order.pop_first() {
+                    Some((_, oldest_key)) => {
+                        self.map.remove(&oldest_key);
+                    }
+                    None => break,
+                },
+                // Guarded: skip entries a live task still holds so a later lookup
+                // can't mint a duplicate; if every entry is held, allow temporary
+                // over-capacity rather than dropping a live entry. Remove by seq so
+                // the key isn't cloned.
+                Some(is_evictable) => {
+                    let mut victim_seq = None;
+                    for (seq, k) in self.order.iter() {
+                        if self.map.get(k).is_some_and(|e| is_evictable(&e.value)) {
+                            victim_seq = Some(*seq);
+                            break;
+                        }
+                    }
+                    match victim_seq {
+                        Some(seq) => {
+                            if let Some(oldest_key) = self.order.remove(&seq) {
+                                self.map.remove(&oldest_key);
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    }
+
     /// Insert a brand-new entry (the caller has already confirmed the key is
     /// absent), evicting the oldest entries first if at capacity. Assigns and
     /// records the FIFO sequence.
@@ -85,35 +124,7 @@ where
         evict_guard: Option<fn(&V) -> bool>,
     ) {
         if let Some(cap) = max_capacity {
-            while self.map.len() as u64 >= cap {
-                match evict_guard {
-                    // Unguarded caches keep the fast single-pass pop_first() path.
-                    None => match self.order.pop_first() {
-                        Some((_, oldest_key)) => {
-                            self.map.remove(&oldest_key);
-                        }
-                        None => break,
-                    },
-                    // Guarded: evict the oldest entry no live task still holds; skip
-                    // protected ones so a later lookup can't mint a duplicate. If every
-                    // entry is held, allow temporary over-capacity rather than dropping
-                    // a live entry (growth is bounded by the concurrently-held count).
-                    Some(is_evictable) => {
-                        let victim = self
-                            .order
-                            .iter()
-                            .find(|(_, k)| self.map.get(*k).is_some_and(|e| is_evictable(&e.value)))
-                            .map(|(seq, k)| (*seq, k.clone()));
-                        match victim {
-                            Some((seq, oldest_key)) => {
-                                self.order.remove(&seq);
-                                self.map.remove(&oldest_key);
-                            }
-                            None => break,
-                        }
-                    }
-                }
-            }
+            self.evict_to_capacity(cap, evict_guard);
         }
 
         let seq = self.next_seq;

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -38,6 +38,11 @@ pub struct PortableCache<K, V> {
     max_capacity: Option<u64>,
     ttl: Option<Duration>,
     tti: Option<Duration>,
+    /// Optional predicate gating capacity eviction: returns `true` if a value may
+    /// be evicted. Used by coordination-lock caches to protect an entry a live task
+    /// still holds (e.g. an `Arc<Mutex>` mid-lock), which would otherwise be
+    /// FIFO-evicted and re-minted, letting two writers race the guarded resource.
+    evict_guard: Option<fn(&V) -> bool>,
 }
 
 struct CacheInner<K, V> {
@@ -71,11 +76,31 @@ where
     /// Insert a brand-new entry (the caller has already confirmed the key is
     /// absent), evicting the oldest entries first if at capacity. Assigns and
     /// records the FIFO sequence.
-    fn insert_new(&mut self, key: K, value: V, now: Instant, max_capacity: Option<u64>) {
+    fn insert_new(
+        &mut self,
+        key: K,
+        value: V,
+        now: Instant,
+        max_capacity: Option<u64>,
+        evict_guard: Option<fn(&V) -> bool>,
+    ) {
         if let Some(cap) = max_capacity {
             while self.map.len() as u64 >= cap {
-                match self.order.pop_first() {
-                    Some((_, oldest_key)) => {
+                let victim = match evict_guard {
+                    // Evict the oldest entry no live task still holds; skip protected
+                    // ones so a later lookup can't mint a duplicate. If every entry is
+                    // held, allow temporary over-capacity rather than dropping a live
+                    // entry (growth is bounded by the number of concurrently-held ones).
+                    Some(is_evictable) => self
+                        .order
+                        .iter()
+                        .find(|(_, k)| self.map.get(*k).is_some_and(|e| is_evictable(&e.value)))
+                        .map(|(seq, k)| (*seq, k.clone())),
+                    None => self.order.iter().next().map(|(seq, k)| (*seq, k.clone())),
+                };
+                match victim {
+                    Some((seq, oldest_key)) => {
+                        self.order.remove(&seq);
                         self.map.remove(&oldest_key);
                     }
                     None => break,
@@ -104,6 +129,7 @@ pub struct PortableCacheBuilder<K, V> {
     max_capacity: Option<u64>,
     ttl: Option<Duration>,
     tti: Option<Duration>,
+    evict_guard: Option<fn(&V) -> bool>,
     _marker: std::marker::PhantomData<fn(K, V)>,
 }
 
@@ -117,8 +143,18 @@ where
             max_capacity: None,
             ttl: None,
             tti: None,
+            evict_guard: None,
             _marker: std::marker::PhantomData,
         }
+    }
+
+    /// Protect entries a live task still holds from capacity eviction: `guard`
+    /// returns `true` when a value is safe to evict. For an `Arc<Mutex>` lock cache,
+    /// pass `|v| Arc::strong_count(v) <= 1`, so an entry held elsewhere is never
+    /// FIFO-evicted and re-minted (which would let two writers race the resource).
+    pub fn evict_guard(mut self, guard: fn(&V) -> bool) -> Self {
+        self.evict_guard = Some(guard);
+        self
     }
 
     pub fn max_capacity(mut self, cap: u64) -> Self {
@@ -143,6 +179,7 @@ where
             max_capacity: self.max_capacity,
             ttl: self.ttl,
             tti: self.tti,
+            evict_guard: self.evict_guard,
         }
     }
 }
@@ -232,7 +269,7 @@ where
             return;
         }
 
-        guard.insert_new(key, value, now, self.max_capacity);
+        guard.insert_new(key, value, now, self.max_capacity, self.evict_guard);
     }
 
     /// Insert and return a clone of the value in one write lock.
@@ -253,7 +290,7 @@ where
         }
 
         let ret = value.clone();
-        guard.insert_new(key, value, now, self.max_capacity);
+        guard.insert_new(key, value, now, self.max_capacity, self.evict_guard);
         ret
     }
 
@@ -486,6 +523,7 @@ impl<K, V> Clone for PortableCache<K, V> {
             max_capacity: self.max_capacity,
             ttl: self.ttl,
             tti: self.tti,
+            evict_guard: self.evict_guard,
         }
     }
 }
@@ -537,6 +575,48 @@ mod tests {
         assert!(cache.get("a").await.is_none());
         assert_eq!(cache.get("b").await, Some(2));
         assert_eq!(cache.get("d").await, Some(4));
+    }
+
+    #[tokio::test]
+    async fn evict_guard_protects_held_entries() {
+        type Lock = Arc<AsyncMutex<()>>;
+        let guarded: PortableCache<String, Lock> = PortableCache::builder()
+            .max_capacity(2)
+            .evict_guard(|m| Arc::strong_count(m) <= 1)
+            .build();
+
+        // Insert an entry and keep an external clone — a live task holding the lock.
+        let held: Lock = Arc::new(AsyncMutex::new(()));
+        guarded.insert("held".into(), held.clone()).await;
+
+        // Churn far past capacity with fresh, unheld entries.
+        for i in 0..5 {
+            guarded
+                .insert(format!("k{i}"), Arc::new(AsyncMutex::new(())))
+                .await;
+        }
+
+        // The held entry survives (protected) and is the SAME mutex instance, so a
+        // later lookup can't mint a duplicate that two writers would race.
+        let again = guarded
+            .get("held")
+            .await
+            .expect("held entry must not be FIFO-evicted");
+        assert!(Arc::ptr_eq(&held, &again), "same mutex instance preserved");
+
+        // Contrast: with no guard the identical churn FIFO-evicts the held entry.
+        let unguarded: PortableCache<String, Lock> =
+            PortableCache::builder().max_capacity(2).build();
+        unguarded.insert("held".into(), held.clone()).await;
+        for i in 0..5 {
+            unguarded
+                .insert(format!("k{i}"), Arc::new(AsyncMutex::new(())))
+                .await;
+        }
+        assert!(
+            unguarded.get("held").await.is_none(),
+            "an unguarded cache FIFO-evicts the held entry (the bug this guards)"
+        );
     }
 
     #[tokio::test]

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -649,14 +649,15 @@ mod tests {
             "all entries held -> cache exceeds capacity instead of evicting a live lock"
         );
 
-        // Drop the external refs; the next insert can now evict down toward capacity.
+        // Drop the external refs; the next insert now evicts back down to capacity.
         drop(held);
         cache
             .insert("fresh".into(), Arc::new(AsyncMutex::new(())))
             .await;
-        assert!(
-            cache.entry_count() <= 3,
-            "once entries are released, eviction resumes"
+        assert_eq!(
+            cache.entry_count(),
+            2,
+            "once entries are released, eviction resumes down to capacity"
         );
     }
 


### PR DESCRIPTION
## What

Add an opt-in **eviction guard** to `PortableCache` and use it on `session_locks` so a per-device session mutex a live task is holding is never capacity-evicted (and re-minted).

## Why (bug)

`session_locks` is a capacity-only `PortableCache<String, Arc<async_lock::Mutex<()>>>` (cap 10k, no TTL). `CacheInner::insert_new` evicted the oldest entry **unconditionally** — no `strong_count` guard, unlike the sibling `reclaim_init_lock` and `run_pending_tasks` paths in the same file. Eviction is pure insertion-order FIFO (`get`'s fast path never refreshes the sequence), so a long-lived, actively-used address is the *first* victim.

Failure: task A holds mutex M1 across an `.await` inside `message_decrypt`; A's address gets FIFO-evicted; task B's `session_lock_for` then misses, mints a fresh mutex M2 ≠ M1, locks it uncontended, and enters the ratchet for the **same** Signal session concurrently → counter/nonce reuse on encrypt, `SessionError` on decrypt. Reachable with >10k distinct protocol addresses in one session (large-community deployments) plus the evict-during-hold timing. The authors flag this exact hazard in `cache_config.rs` but only "mitigate" it by sizing generously.

## How

- `PortableCacheBuilder::evict_guard(fn(&V) -> bool)` — returns `true` when a value is safe to evict. Default `None` keeps the prior fast `pop_first` FIFO path, so **all other caches are unaffected**.
- The eviction loop now evicts the oldest entry the guard *allows*, skipping protected ones. If every entry is held it permits temporary over-capacity rather than dropping a live entry — growth is bounded by the number of concurrently-held locks, and self-corrects as tasks release them.
- `session_locks` passes `|m| Arc::strong_count(m) <= 1` (only the map's own reference ⇒ safe to evict).

Scope note: `chat_lanes` is the other coordination cache, but `ChatLane` isn't an `Arc<Mutex>` (its "held" state is the worker owning the channel `rx`), so it needs a different mechanism — handled separately.

## Tests

- `evict_guard_protects_held_entries` — with the guard, churning far past capacity leaves a held `Arc<Mutex>` present and byte-identical (`Arc::ptr_eq`); the same churn on an **unguarded** cache FIFO-evicts it (the bug this closes).
- `cargo fmt` / `clippy` clean; all 19 `portable_cache` tests pass.
