### PR TITLE
fix(binary): bound node-decode recursion depth to reject hostile frames

### DIFF
--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -15,6 +15,12 @@ fn jid_ref_to_compact(j: &JidRef<'_>) -> CompactString {
     s
 }
 
+/// Maximum node-nesting depth accepted while decoding. Real WA stanza trees are
+/// shallow (well under 20 levels); the cap only exists to reject a hostile frame
+/// whose deep `LIST` nesting would otherwise overflow the native stack via
+/// unbounded `read_node_ref` recursion.
+const MAX_NODE_DEPTH: usize = 128;
+
 pub(crate) struct Decoder<'a> {
     data: &'a [u8],
     position: usize,
@@ -455,13 +461,17 @@ impl<'a> Decoder<'a> {
         Ok(AttrsRef::from_vec(v))
     }
 
-    fn read_content(&mut self) -> Result<Option<NodeContentRef<'a>>> {
+    fn read_content(&mut self, depth: usize) -> Result<Option<NodeContentRef<'a>>> {
         let tag = self.read_u8()?;
-        self.read_content_from_tag(tag)
+        self.read_content_from_tag(tag, depth)
     }
 
     #[inline(always)]
-    fn read_content_from_tag(&mut self, tag: u8) -> Result<Option<NodeContentRef<'a>>> {
+    fn read_content_from_tag(
+        &mut self,
+        tag: u8,
+        depth: usize,
+    ) -> Result<Option<NodeContentRef<'a>>> {
         match tag {
             token::LIST_EMPTY => Ok(None),
 
@@ -469,7 +479,7 @@ impl<'a> Decoder<'a> {
                 let size = self.read_list_size(tag)?;
                 let mut nodes = Vec::with_capacity(size);
                 for _ in 0..size {
-                    nodes.push(self.read_node_ref()?);
+                    nodes.push(self.read_node_ref_at(depth + 1)?);
                 }
                 Ok(Some(NodeContentRef::Nodes(nodes.into_boxed_slice())))
             }
@@ -502,6 +512,15 @@ impl<'a> Decoder<'a> {
     }
 
     pub(crate) fn read_node_ref(&mut self) -> Result<NodeRef<'a>> {
+        self.read_node_ref_at(0)
+    }
+
+    fn read_node_ref_at(&mut self, depth: usize) -> Result<NodeRef<'a>> {
+        // Reject before recursing: a hostile frame with deeply nested LISTs would
+        // otherwise blow the native stack (uncatchable abort) rather than error.
+        if depth > MAX_NODE_DEPTH {
+            return Err(BinaryError::MaxDepthExceeded);
+        }
         let tag = self.read_u8()?;
         let list_size = self.read_list_size(tag)?;
         if list_size == 0 {
@@ -517,7 +536,7 @@ impl<'a> Decoder<'a> {
 
         let attrs = self.read_attributes(attr_count)?;
         let content = if has_content {
-            self.read_content()?.map(Box::new)
+            self.read_content(depth)?.map(Box::new)
         } else {
             None
         };
@@ -877,5 +896,43 @@ mod tests {
         // Verify top level tag
         assert_eq!(decoded.tag, "level49");
         Ok(())
+    }
+
+    fn encode_nested(levels: usize) -> Vec<u8> {
+        let mut current = Node::new("leaf", Attrs::new(), None);
+        for i in 0..levels {
+            current = Node::new(
+                format!("l{i}"),
+                Attrs::new(),
+                Some(crate::node::NodeContent::Nodes(vec![current])),
+            );
+        }
+        let mut buffer = Vec::new();
+        {
+            let mut encoder =
+                crate::encoder::Encoder::new(std::io::Cursor::new(&mut buffer)).unwrap();
+            encoder.write_node(&current).unwrap();
+        }
+        buffer
+    }
+
+    /// Deep-but-within-cap nesting decodes normally.
+    #[test]
+    fn deeply_nested_within_cap_decodes() -> TestResult {
+        let buffer = encode_nested(MAX_NODE_DEPTH - 8);
+        let decoded = Decoder::new(&buffer[1..]).read_node_ref()?;
+        assert_eq!(decoded.tag, format!("l{}", MAX_NODE_DEPTH - 9).as_str());
+        Ok(())
+    }
+
+    /// A frame nested far past the cap must return `MaxDepthExceeded`, not overflow
+    /// the native stack (this test completing at all is the assertion against abort).
+    #[test]
+    fn deeply_nested_past_cap_is_rejected() {
+        let buffer = encode_nested(MAX_NODE_DEPTH * 3);
+        let err = Decoder::new(&buffer[1..])
+            .read_node_ref()
+            .expect_err("nesting past the cap must be rejected");
+        assert!(matches!(err, BinaryError::MaxDepthExceeded), "got {err:?}");
     }
 }

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -15,10 +15,8 @@ fn jid_ref_to_compact(j: &JidRef<'_>) -> CompactString {
     s
 }
 
-/// Maximum node-nesting depth accepted while decoding. Real WA stanza trees are
-/// shallow (well under 20 levels); the cap only exists to reject a hostile frame
-/// whose deep `LIST` nesting would otherwise overflow the native stack via
-/// unbounded `read_node_ref` recursion.
+/// Node-nesting cap rejecting deep-`LIST` frames that would overflow the stack via
+/// unbounded `read_node_ref` recursion (real WA trees are well under 20 levels).
 const MAX_NODE_DEPTH: usize = 128;
 
 pub(crate) struct Decoder<'a> {
@@ -516,9 +514,9 @@ impl<'a> Decoder<'a> {
     }
 
     fn read_node_ref_at(&mut self, depth: usize) -> Result<NodeRef<'a>> {
-        // Reject before recursing: a hostile frame with deeply nested LISTs would
-        // otherwise blow the native stack (uncatchable abort) rather than error.
-        if depth > MAX_NODE_DEPTH {
+        // Reject before recursing, so a hostile deep-LIST frame errors instead of
+        // aborting the process on a stack overflow.
+        if depth >= MAX_NODE_DEPTH {
             return Err(BinaryError::MaxDepthExceeded);
         }
         let tag = self.read_u8()?;
@@ -916,23 +914,33 @@ mod tests {
         buffer
     }
 
-    /// Deep-but-within-cap nesting decodes normally.
+    fn is_max_depth_err(buffer: &[u8]) -> bool {
+        matches!(
+            Decoder::new(&buffer[1..]).read_node_ref(),
+            Err(BinaryError::MaxDepthExceeded)
+        )
+    }
+
+    /// The deepest accepted nesting (a leaf at depth `MAX_NODE_DEPTH - 1`) decodes.
+    /// Pins the exact accept side of the cap so a `>`/`>=` flip is caught.
     #[test]
-    fn deeply_nested_within_cap_decodes() -> TestResult {
-        let buffer = encode_nested(MAX_NODE_DEPTH - 8);
+    fn deeply_nested_at_cap_decodes() -> TestResult {
+        let buffer = encode_nested(MAX_NODE_DEPTH - 1);
         let decoded = Decoder::new(&buffer[1..]).read_node_ref()?;
-        assert_eq!(decoded.tag, format!("l{}", MAX_NODE_DEPTH - 9).as_str());
+        assert_eq!(decoded.tag, format!("l{}", MAX_NODE_DEPTH - 2).as_str());
         Ok(())
     }
 
-    /// A frame nested far past the cap must return `MaxDepthExceeded`, not overflow
-    /// the native stack (this test completing at all is the assertion against abort).
+    /// Exactly one level past the accepted range is rejected (pins the reject side).
     #[test]
-    fn deeply_nested_past_cap_is_rejected() {
-        let buffer = encode_nested(MAX_NODE_DEPTH * 3);
-        let err = Decoder::new(&buffer[1..])
-            .read_node_ref()
-            .expect_err("nesting past the cap must be rejected");
-        assert!(matches!(err, BinaryError::MaxDepthExceeded), "got {err:?}");
+    fn deeply_nested_one_past_cap_is_rejected() {
+        assert!(is_max_depth_err(&encode_nested(MAX_NODE_DEPTH)));
+    }
+
+    /// A frame nested far past the cap must return `MaxDepthExceeded`, not overflow
+    /// the native stack — this test completing at all is the assertion against abort.
+    #[test]
+    fn deeply_nested_far_past_cap_is_rejected() {
+        assert!(is_max_depth_err(&encode_nested(MAX_NODE_DEPTH * 3)));
     }
 }

--- a/wacore/binary/src/error.rs
+++ b/wacore/binary/src/error.rs
@@ -17,6 +17,9 @@ pub enum BinaryError {
     EmptyData,
     LeftoverData(usize),
     AttrList(Vec<BinaryError>),
+    /// Node nesting exceeded the recursion cap — a hostile frame trying to
+    /// overflow the native stack, rejected before recursing.
+    MaxDepthExceeded,
 }
 
 impl fmt::Display for BinaryError {
@@ -35,6 +38,7 @@ impl fmt::Display for BinaryError {
             BinaryError::EmptyData => write!(f, "Received empty data where payload was expected"),
             BinaryError::LeftoverData(n) => write!(f, "Leftover data after decoding: {n} bytes"),
             BinaryError::AttrList(list) => write!(f, "Multiple attribute parsing errors: {list:?}"),
+            BinaryError::MaxDepthExceeded => write!(f, "Node nesting exceeded the maximum depth"),
         }
     }
 }
@@ -81,6 +85,7 @@ impl Clone for BinaryError {
             BinaryError::EmptyData => BinaryError::EmptyData,
             BinaryError::LeftoverData(n) => BinaryError::LeftoverData(*n),
             BinaryError::AttrList(list) => BinaryError::AttrList(list.clone()),
+            BinaryError::MaxDepthExceeded => BinaryError::MaxDepthExceeded,
         }
     }
 }


### PR DESCRIPTION
## What

Bound the node-decode recursion depth. `read_node_ref` now returns `BinaryError::MaxDepthExceeded` once nesting passes `MAX_NODE_DEPTH` (128), instead of recursing without limit.

## Why (security / DoS)

`read_node_ref` → `read_content` → `read_content_from_tag` (`LIST_8`/`LIST_16` branch) → `read_node_ref` recursed with **no depth counter anywhere**. A single node with `list_size == 2` (`attr_count = 0`, `has_content = true`) carries exactly one child in ~4 wire bytes, so a hostile inbound frame — post-Noise, optionally zlib-compressed so it's tiny on the wire while its decompressed form stays under the 16 MiB `MAX_DECOMPRESSED_SIZE` cap — can nest tens of thousands of `LIST` levels and **overflow the native stack, aborting the process with an uncatchable SIGSEGV**.

The path is reachable straight from the inbound frame decode (`node_io.rs` `OwnedNodeRef::new` → `unmarshal_ref` → `read_node_ref`), and trivially from the `fuzz_targets/unmarshal_ref.rs` target (which the deep-nesting input would currently crash). WA Web's analog throws a catchable `RangeError`; the Rust port was strictly worse (abort, not error).

## How

- Thread a `depth` counter through `read_node_ref_at` / `read_content` / `read_content_from_tag`; the public `read_node_ref()` entry starts at 0.
- Check `depth > MAX_NODE_DEPTH` at the top of `read_node_ref_at`, **before** recursing, returning the new `BinaryError::MaxDepthExceeded`.
- `MAX_NODE_DEPTH = 128` — real WA stanza trees are well under 20 levels, so this only rejects pathological frames.

## Tests

- `deeply_nested_within_cap_decodes` (**happy**) — a frame nested just under the cap decodes normally.
- `deeply_nested_past_cap_is_rejected` (**bad**) — a frame nested 3× past the cap returns `MaxDepthExceeded`; the test completing at all is the assertion that it no longer overflows the stack / aborts.
- `cargo fmt` / `clippy` clean; all 101 `wacore-binary` tests pass.
