### PR TITLE
fix(send): isolate a group device's session-setup failure from the cohort

### DIFF
--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -604,15 +604,10 @@ pub async fn ensure_sessions_for_devices(
                 // identity; notify the client so it can react off-path.
                 Ok(Ok(Some(changed_jid))) => resolver.on_local_identity_change(&changed_jid),
                 Ok(Ok(None)) => {}
-                // Isolate the failure to this device: one participant's session
-                // setup must NOT abort the whole cohort. Aborting here left every
-                // other target — including our own companion devices — without an
-                // SKDM even though their sessions established fine, and the cohort
-                // was then marked has_key=true, permanently orphaning own companions
-                // (their retry path is an own-device no-op). WA Web's
-                // GroupKeyDistributionMsg wraps each device's encrypt in try/catch
-                // and drops only the failing one; the skipped device just stays
-                // sessionless and is skipped by the fan-out below.
+                // Isolate the failure to this device so one participant can't abort
+                // the cohort's SKDM (matching WA Web GroupKeyDistributionMsg's
+                // per-device try/catch). The sessionless device is dropped by the
+                // fan-out below.
                 Ok(Err(e)) => {
                     log::warn!("Group session setup failed for a device, skipping it: {e}");
                 }

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -604,7 +604,18 @@ pub async fn ensure_sessions_for_devices(
                 // identity; notify the client so it can react off-path.
                 Ok(Ok(Some(changed_jid))) => resolver.on_local_identity_change(&changed_jid),
                 Ok(Ok(None)) => {}
-                Ok(Err(e)) => return Err(e),
+                // Isolate the failure to this device: one participant's session
+                // setup must NOT abort the whole cohort. Aborting here left every
+                // other target — including our own companion devices — without an
+                // SKDM even though their sessions established fine, and the cohort
+                // was then marked has_key=true, permanently orphaning own companions
+                // (their retry path is an own-device no-op). WA Web's
+                // GroupKeyDistributionMsg wraps each device's encrypt in try/catch
+                // and drops only the failing one; the skipped device just stays
+                // sessionless and is skipped by the fan-out below.
+                Ok(Err(e)) => {
+                    log::warn!("Group session setup failed for a device, skipping it: {e}");
+                }
                 Err(SpawnCanceled) => {
                     log::warn!(
                         "Session-establishment task did not deliver a result; skipping device."

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3271,6 +3271,105 @@ mod mark_full_distribution_list {
             "B must receive a pairwise SKDM via the pre-established session"
         );
     }
+
+    /// One participant's session-setup failure must NOT abort the SKDM for the
+    /// rest of the cohort: the good device still gets its pairwise SKDM, the bad
+    /// one is dropped. Before the fix, the failing device's process_prekey_bundle
+    /// error nulled the whole session_plan, so no device got an SKDM (and the
+    /// cohort was still marked has_key=true, orphaning own companions).
+    #[tokio::test]
+    async fn group_skdm_setup_failure_is_isolated_to_the_bad_device() {
+        let group: Jid = "120363000000000003@g.us".parse().unwrap();
+        let own_jid: Jid = "559900000001@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "100000000000001@lid".parse().unwrap();
+        // good: valid bundle → session establishes. bad: create_mock_bundle's
+        // zeroed signature fails X3DH inside process_prekey_bundle.
+        let good: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let bad: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut ss = MemSessionStore::default();
+        let mut is = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            reg_id: 7,
+            known: Default::default(),
+        };
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+
+        // Properly-signed bundle for the good device.
+        let receiver = IdentityKeyPair::generate(&mut rng);
+        let spk = KeyPair::generate(&mut rng);
+        let opk = KeyPair::generate(&mut rng);
+        let sig = receiver
+            .private_key()
+            .calculate_signature(&spk.public_key.serialize(), &mut rng)
+            .unwrap();
+        let good_bundle = PreKeyBundle::new(
+            1,
+            1u32.into(),
+            Some((1u32.into(), opk.public_key)),
+            1u32.into(),
+            spk.public_key,
+            sig.to_vec(),
+            *receiver.identity_key(),
+        )
+        .unwrap();
+
+        let resolver = MockSendContextResolver::new()
+            .with_bundle(good.clone(), good_bundle)
+            .with_bundle(bad.clone(), create_mock_bundle());
+        let rt = TokioTestRuntime;
+
+        let group_info = GroupInfo::new(
+            vec![own_jid.to_non_ad(), good.to_non_ad(), bad.to_non_ad()],
+            AddressingMode::Pn,
+        );
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+
+        let prepared = prepare_group_stanza(
+            &rt,
+            &mut stores,
+            &resolver,
+            &group_info,
+            &own_jid,
+            &own_lid,
+            None,
+            group,
+            &msg,
+            "TESTREQID_ISO".into(),
+            false,
+            Some(vec![good.clone(), bad.clone()]),
+            None,
+            None,
+            &[],
+            None,
+        )
+        .await
+        .expect("prepare_group_stanza must succeed despite one device's setup failure");
+
+        let participants = prepared
+            .node
+            .get_optional_child("participants")
+            .expect("the good device's SKDM must still be distributed");
+        assert_eq!(
+            participants.children().map(|c| c.len()).unwrap_or(0),
+            1,
+            "only the good device receives an SKDM; the failed one is skipped, \
+             not aborting the whole cohort"
+        );
+    }
 }
 
 /// Item 3 — phash device-set construction. The set hashed is the full

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -1236,8 +1236,8 @@ fn test_lid_prekey_lookup_normalization() {
 mod group_retry {
     use super::*;
     use crate::libsignal::protocol::{
-        Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore,
-        ProtocolAddress, SessionStore, process_prekey_bundle,
+        Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore, ProtocolAddress,
+        SessionStore, process_prekey_bundle,
     };
     use crate::types::message::AddressingMode;
     use std::collections::HashMap;

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -802,6 +802,30 @@ fn create_mock_bundle() -> PreKeyBundle {
     .expect("Failed to create PreKeyBundle")
 }
 
+/// A bundle whose signed-prekey signature actually verifies, so
+/// `process_prekey_bundle` establishes a session. Contrast `create_mock_bundle`,
+/// whose zeroed signature deliberately fails X3DH (used to exercise the reject path).
+fn signed_prekey_bundle() -> PreKeyBundle {
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let receiver = IdentityKeyPair::generate(&mut rng);
+    let spk = KeyPair::generate(&mut rng);
+    let opk = KeyPair::generate(&mut rng);
+    let sig = receiver
+        .private_key()
+        .calculate_signature(&spk.public_key.serialize(), &mut rng)
+        .unwrap();
+    PreKeyBundle::new(
+        1,
+        1u32.into(),
+        Some((1u32.into(), opk.public_key)),
+        1u32.into(),
+        spk.public_key,
+        sig.to_vec(),
+        *receiver.identity_key(),
+    )
+    .unwrap()
+}
+
 // These tests validate the fix for the LID-PN session mismatch issue.
 // When a message is received with sender_lid, the session is stored under the LID address.
 // When sending a reply using the phone number, we must reuse the existing LID session
@@ -3193,27 +3217,8 @@ mod mark_full_distribution_list {
             signed_prekey_store: &spks,
         };
 
-        // Verifiable bundle (create_mock_bundle's zeroed signature fails X3DH).
-        let receiver = IdentityKeyPair::generate(&mut rng);
-        let spk = KeyPair::generate(&mut rng);
-        let opk = KeyPair::generate(&mut rng);
-        let sig = receiver
-            .private_key()
-            .calculate_signature(&spk.public_key.serialize(), &mut rng)
-            .unwrap();
-        let bundle = PreKeyBundle::new(
-            1,
-            1u32.into(),
-            Some((1u32.into(), opk.public_key)),
-            1u32.into(),
-            spk.public_key,
-            sig.to_vec(),
-            *receiver.identity_key(),
-        )
-        .unwrap();
-
         let resolver = MockSendContextResolver::new()
-            .with_bundle(b.clone(), bundle)
+            .with_bundle(b.clone(), signed_prekey_bundle())
             .with_chain_lock_probe(probe.clone());
         let rt = TokioTestRuntime;
 
@@ -3305,27 +3310,8 @@ mod mark_full_distribution_list {
             signed_prekey_store: &spks,
         };
 
-        // Properly-signed bundle for the good device.
-        let receiver = IdentityKeyPair::generate(&mut rng);
-        let spk = KeyPair::generate(&mut rng);
-        let opk = KeyPair::generate(&mut rng);
-        let sig = receiver
-            .private_key()
-            .calculate_signature(&spk.public_key.serialize(), &mut rng)
-            .unwrap();
-        let good_bundle = PreKeyBundle::new(
-            1,
-            1u32.into(),
-            Some((1u32.into(), opk.public_key)),
-            1u32.into(),
-            spk.public_key,
-            sig.to_vec(),
-            *receiver.identity_key(),
-        )
-        .unwrap();
-
         let resolver = MockSendContextResolver::new()
-            .with_bundle(good.clone(), good_bundle)
+            .with_bundle(good.clone(), signed_prekey_bundle())
             .with_bundle(bad.clone(), create_mock_bundle());
         let rt = TokioTestRuntime;
 

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -1236,8 +1236,8 @@ fn test_lid_prekey_lookup_normalization() {
 mod group_retry {
     use super::*;
     use crate::libsignal::protocol::{
-        Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore, KeyPair,
-        PreKeyBundle, ProtocolAddress, SessionStore, process_prekey_bundle,
+        Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore,
+        ProtocolAddress, SessionStore, process_prekey_bundle,
     };
     use crate::types::message::AddressingMode;
     use std::collections::HashMap;
@@ -1324,23 +1324,7 @@ mod group_retry {
     async fn setup_session() -> (MemSessionStore, MemIdentityStore, Jid) {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let sender = IdentityKeyPair::generate(&mut rng);
-        let receiver = IdentityKeyPair::generate(&mut rng);
-        let spk = KeyPair::generate(&mut rng);
-        let opk = KeyPair::generate(&mut rng);
-        let sig = receiver
-            .private_key()
-            .calculate_signature(&spk.public_key.serialize(), &mut rng)
-            .unwrap();
-        let bundle = PreKeyBundle::new(
-            1,
-            1u32.into(),
-            Some((1u32.into(), opk.public_key)),
-            1u32.into(),
-            spk.public_key,
-            sig.to_vec(),
-            *receiver.identity_key(),
-        )
-        .unwrap();
+        let bundle = signed_prekey_bundle();
         let jid: Jid = "559911112222@s.whatsapp.net".parse().unwrap();
         let addr = jid.to_protocol_address();
         let mut ss = MemSessionStore::new();
@@ -2948,23 +2932,7 @@ mod mark_full_distribution_list {
     async fn established_stores(a: &Jid) -> (MemSessionStore, MemIdentityStore) {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let sender = IdentityKeyPair::generate(&mut rng);
-        let receiver = IdentityKeyPair::generate(&mut rng);
-        let spk = KeyPair::generate(&mut rng);
-        let opk = KeyPair::generate(&mut rng);
-        let sig = receiver
-            .private_key()
-            .calculate_signature(&spk.public_key.serialize(), &mut rng)
-            .unwrap();
-        let bundle = PreKeyBundle::new(
-            1,
-            1u32.into(),
-            Some((1u32.into(), opk.public_key)),
-            1u32.into(),
-            spk.public_key,
-            sig.to_vec(),
-            *receiver.identity_key(),
-        )
-        .unwrap();
+        let bundle = signed_prekey_bundle();
         let mut ss = MemSessionStore::default();
         let mut is = MemIdentityStore {
             pair: sender,


### PR DESCRIPTION
## What

Isolate a single group device's **session-setup** failure so it no longer aborts the SKDM distribution to the whole cohort.

## Why (bug)

`ensure_sessions_for_devices` returned `Err` (`Ok(Err(e)) => return Err(e)`) as soon as **any** device's `process_prekey_bundle` failed. In `prepare_group_stanza` that `Err` nulls `session_plan`, and the entire SKDM fan-out is gated on `if let Some(plan) = session_plan` — so **every other target gets no SKDM** even though its session established fine. The skmsg still ships, the phash covers the full set (server reports no mismatch), and on ACK the full cohort is marked `has_key=true`.

External members recover via a retry receipt (`mark_forget_sender_key`). But an **own companion** hits `mark_forget_sender_key` with `exclude_own_devices=true`, which filters own-user JIDs and returns early with no DB write — so the companion stays `has_key=true` **forever** and can never decrypt our group messages from that device until an unrelated full rotation (participant removal / PN↔LID migration).

WA Web's `GroupKeyDistributionMsg` wraps each device's encrypt in its own try/catch and drops only the failing one (`GroupSkmsgJob` swallows the `ensureE2ESessions` error and continues) — one member's failure never suppresses the rest.

## How

- In the session-setup spawn loop, change `Ok(Err(e)) => return Err(e)` to **log and skip** that one device. The sessionless device is then skipped by the encrypt fan-out (which already skips devices without a session), and every other device is distributed normally. The encrypt fan-out loop and the 406 batch path were already isolated; this brings the setup path in line.

## Tests

- `group_skdm_setup_failure_is_isolated_to_the_bad_device` — a group send with one valid-bundle device and one whose bundle fails X3DH: `prepare_group_stanza` now **succeeds and the good device still receives its pairwise SKDM** (`participants` has exactly one child). Before the fix, the failing device nulled `session_plan`, so there was no `participants` node at all (the `.expect` would panic).
- `cargo fmt` / `clippy` clean; full `wacore` send suite (96) passes.

## Residual (separate follow-up)

The primary harm (an *unrelated* device's failure orphaning own companions) is closed. A narrower window remains: if an own companion's *own* setup fails, it's still marked `has_key=true` from the full-cohort mark. Fully closing that needs the own-device `has_key` mark gated on actual SKDM encryption (`skdm_encrypted_devices`), which I've left as a focused follow-up to keep this send-path change minimal.
