### PR TITLE
fix(passkey): don't skip the verification-code UX on a fresh link

### DIFF
--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -521,16 +521,22 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
 }
 
 async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
-    // Handoff key from the current secret proves continuity to the server; presence
-    // of a key marks this as a re-link. The rotated secret itself is generated
-    // per-attempt in the session.
-    let adv_secret = client
-        .persistence_manager
-        .get_device_snapshot()
-        .adv_secret_key;
-    let handoff_key = ShortcakeUtils::derive_pairing_handoff_hmac_key(&adv_secret)
-        .inspect_err(|e| warn!("failed to derive pairing-handoff key: {e}"))
-        .ok();
+    // The handoff key proves ADV-secret continuity to the server and suppresses the
+    // verification-code UX — that is a RE-LINK signal. adv_secret_key is present even
+    // on a brand-new device, so gating on it alone makes skip_handoff_ux structurally
+    // always true and disables the fresh-link code check. Only derive it when a prior
+    // linked identity exists; a fresh device leaves it None so the human code-compare
+    // still defends the (server-supplied) primary ephemeral identity.
+    let snapshot = client.persistence_manager.get_device_snapshot();
+    let previously_linked =
+        snapshot.account.is_some() || snapshot.pn.is_some() || snapshot.lid.is_some();
+    let handoff_key = if previously_linked {
+        ShortcakeUtils::derive_pairing_handoff_hmac_key(&snapshot.adv_secret_key)
+            .inspect_err(|e| warn!("failed to derive pairing-handoff key: {e}"))
+            .ok()
+    } else {
+        None
+    };
     client.passkey_state.lock().await.handoff_key = handoff_key;
 
     client
@@ -1020,6 +1026,35 @@ mod tests {
                 .as_node_ref()
                 .get_optional_child(TAG_PAIRING_HANDOFF_PROOF)
                 .is_none()
+        );
+    }
+
+    /// A fresh device (never linked) must NOT derive a handoff key, so
+    /// skip_handoff_ux stays false and the verification-code check runs.
+    #[tokio::test]
+    async fn fresh_link_does_not_derive_a_handoff_key() {
+        let client = create_test_client().await;
+        drive_passkey_request(&client, "{}".to_string()).await;
+        assert!(
+            client.passkey_state.lock().await.handoff_key.is_none(),
+            "a fresh link must leave handoff_key None (verification-code UX stays on)"
+        );
+    }
+
+    /// A re-link (a prior identity is present) derives the handoff key, which is
+    /// what legitimately lets the server skip the verification-code UX.
+    #[tokio::test]
+    async fn relink_derives_a_handoff_key() {
+        let client = create_test_client().await;
+        let pn: Jid = "15551230000:1@s.whatsapp.net".parse().unwrap();
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetId(Some(pn)))
+            .await;
+        drive_passkey_request(&client, "{}".to_string()).await;
+        assert!(
+            client.passkey_state.lock().await.handoff_key.is_some(),
+            "a re-link with a prior identity must derive the handoff key"
         );
     }
 }

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -521,12 +521,9 @@ pub(crate) async fn handle_passkey_notification(client: &Arc<Client>, node: Arc<
 }
 
 async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
-    // The handoff key proves ADV-secret continuity to the server and suppresses the
-    // verification-code UX — that is a RE-LINK signal. adv_secret_key is present even
-    // on a brand-new device, so gating on it alone makes skip_handoff_ux structurally
-    // always true and disables the fresh-link code check. Only derive it when a prior
-    // linked identity exists; a fresh device leaves it None so the human code-compare
-    // still defends the (server-supplied) primary ephemeral identity.
+    // The handoff key suppresses the verification-code UX, so it must be a RE-LINK
+    // signal only: adv_secret_key alone is present on a fresh device too, which would
+    // disable the code check on a first link. Gate on a prior linked identity.
     let snapshot = client.persistence_manager.get_device_snapshot();
     let previously_linked =
         snapshot.account.is_some() || snapshot.pn.is_some() || snapshot.lid.is_some();


### PR DESCRIPTION
## What

Only derive the passkey **handoff key** (which suppresses the verification-code UX) when the device has a **prior linked identity** — so a fresh, first-time link keeps the human code check.

## Why (security)

`drive_passkey_request` derived `handoff_key` unconditionally from `adv_secret_key`, which is random-filled at device creation (`store/device.rs`) and therefore **always present**, with no gate on `account`/`pn`/`lid`. So `skip_handoff_ux = handoff_proof.is_some()` (`flow.rs:120-122`) was **structurally always true**, and the "fresh link ⇒ show `XXXX-XXXX` code" branch was dead.

The handoff proof is meant to prove **ADV-secret continuity for a re-link** (the code's own docs: `shortcake.rs`, `flow.rs:524-525` — "presence of a key marks this as a re-link"). On a **fresh** device there is no continuity to prove, yet the code auto-attached one. When a continuation arrives from `SERVER_JID` carrying an attacker-chosen `primary_ephemeral_identity`, `drive_continuation` auto-fires `send_passkey_confirmation` — encrypting the rotated `new_adv_secret` under `ECDH(companion_eph, attacker_primary_pub)` and committing the rotation — with **no human code compare**. The verification code is exactly the defense-in-depth control against a compromised/MITM server on that exchange, and it was disabled on every fresh link.

## How

- Gate `handoff_key` derivation on `snapshot.account.is_some() || snapshot.pn.is_some() || snapshot.lid.is_some()`. A fresh device (all three `None`, populated only at pairing) leaves it `None` ⇒ `skip_handoff_ux` is false ⇒ the code UX runs and `drive_continuation` won't auto-confirm. Re-links keep the skip.

## Tests

- `fresh_link_does_not_derive_a_handoff_key` (**bad-path fixed**) — a fresh client leaves `handoff_key` `None`.
- `relink_derives_a_handoff_key` (**happy**) — after a prior identity is set (`SetId`), `handoff_key` is `Some`.
- `cargo fmt` / `clippy` clean; full passkey suite (19) passes.
