### PR TITLE
fix(voip): authenticate WARP MI tag before folding recv ROC state

### DIFF
--- a/wacore/src/voip/e2e_srtp.rs
+++ b/wacore/src/voip/e2e_srtp.rs
@@ -1,6 +1,7 @@
 //! E2E 1:1 SRTP, the primary working path. Keys derive from `callKey` (32B) +
 //! participant LID via HKDF-SHA256, then an AES-CM PRF; payloads use AES-128-CTR
-//! with a 4-byte WARP MESSAGE-INTEGRITY tag (HMAC-SHA1, not verified on recv).
+//! with a 4-byte WARP MESSAGE-INTEGRITY tag (HMAC-SHA1), verified on recv before
+//! the rollover counter is advanced (see `session::unprotect_audio`).
 //!
 //! wacrg spec: srtp-e2e (CRY-05), srtp-master-key (CRY-02), call-key (CRY-01).
 
@@ -294,6 +295,37 @@ mod tests {
             rx.guess_roc(0x0001),
             2,
             "state not corrupted by the late packet"
+        );
+    }
+
+    /// The exact rollover-desync the auth fix prevents. `unprotect_audio` only
+    /// `commit_roc`s after the MI tag verifies, so a rejected (unauthenticated)
+    /// packet stays on the pure `estimate_roc` path and can't fold state — while the
+    /// attacker's 2-packet staircase, if committed, advances the ROC by one.
+    #[test]
+    fn unauthenticated_staircase_cannot_advance_roc_without_commit() {
+        let mut rx = RecvRocTracker::default();
+        rx.guess_roc(0x7FFE); // seed s_l into the high half (the exploit's start)
+        assert_eq!(rx.roc, 0);
+
+        // A rejected packet only reaches estimate_roc (never commit_roc): the
+        // attacker's staircase seqs leave the state untouched.
+        let _ = rx.estimate_roc(0xFFFE);
+        let _ = rx.estimate_roc(0x7FFD);
+        assert_eq!(rx.roc, 0, "estimate alone must not advance the ROC");
+        assert_eq!(
+            rx.estimate_roc(0x7FFF),
+            0,
+            "a legit in-window seq still maps to roc=0"
+        );
+
+        // Contrast: committing that same staircase (the pre-fix path) advances the
+        // ROC by one — the desync authentication now blocks.
+        rx.commit_roc(rx.estimate_roc(0xFFFE), 0xFFFE);
+        rx.commit_roc(rx.estimate_roc(0x7FFD), 0x7FFD);
+        assert_eq!(
+            rx.roc, 1,
+            "committing the staircase advances the ROC (the pre-fix desync)"
         );
     }
 

--- a/wacore/src/voip/e2e_srtp.rs
+++ b/wacore/src/voip/e2e_srtp.rs
@@ -9,7 +9,9 @@ use ctr::Ctr128BE;
 use ctr::cipher::{KeyIvInit, StreamCipher};
 
 use crate::voip::hkdf_sha256;
-pub use crate::voip::warp::{WARP_MI_TAG_LEN, append_warp_mi_tag, compute_warp_mi_tag};
+pub use crate::voip::warp::{
+    WARP_MI_TAG_LEN, append_warp_mi_tag, compute_warp_mi_tag, verify_warp_mi_tag,
+};
 
 type AesCtr = Ctr128BE<Aes128>;
 
@@ -142,16 +144,16 @@ pub(crate) struct RecvRocTracker {
 }
 
 impl RecvRocTracker {
-    /// Guess the ROC for `seq` and fold it into the state. Seeds from the first packet (roc=0).
-    pub fn guess_roc(&mut self, seq: u16) -> u32 {
+    /// Estimate the ROC for `seq` WITHOUT mutating state (RFC 3711 guess-index).
+    /// Use this to build the IV / verify a packet; only [`Self::commit_roc`] after
+    /// the packet authenticates, so an unauthenticated packet can't desync state.
+    pub fn estimate_roc(&self, seq: u16) -> u32 {
         if !self.initialized {
-            self.s_l = seq;
-            self.initialized = true;
             return self.roc;
         }
         // Pick v in {roc-1, roc, roc+1} so 2^16*v+seq is closest to 2^16*roc+s_l. The signed 16-bit
         // gap (not a modular wrapping_sub) is what distinguishes "next-but-reordered" from "wrapped".
-        let v = if self.s_l < 0x8000 {
+        if self.s_l < 0x8000 {
             if (seq as i32 - self.s_l as i32) > 0x8000 {
                 self.roc.wrapping_sub(1) // old packet from before the origin (roc-1)
             } else {
@@ -161,7 +163,18 @@ impl RecvRocTracker {
             self.roc.wrapping_add(1) // forward wrap into roc+1
         } else {
             self.roc
-        };
+        }
+    }
+
+    /// Fold an AUTHENTICATED packet's `(v, seq)` into the state; `v` must come from
+    /// a prior [`Self::estimate_roc`] whose MI tag verified. Seeds from the first
+    /// packet (roc stays 0).
+    pub fn commit_roc(&mut self, v: u32, seq: u16) {
+        if !self.initialized {
+            self.s_l = seq;
+            self.initialized = true;
+            return;
+        }
         if v == self.roc {
             if seq > self.s_l {
                 self.s_l = seq;
@@ -170,7 +183,16 @@ impl RecvRocTracker {
             self.roc = v;
             self.s_l = seq;
         }
-        // v == roc-1 (reordered late packet): return the lower ROC, leave state untouched.
+        // v == roc-1 (reordered late packet): leave state untouched.
+    }
+
+    /// Estimate + commit in one step. Test-only: production authenticates the WARP
+    /// MI tag against `estimate_roc` first and only `commit_roc` on success, so an
+    /// unauthenticated packet can't fold state. Kept for the wrap-tracking tests.
+    #[cfg(test)]
+    pub fn guess_roc(&mut self, seq: u16) -> u32 {
+        let v = self.estimate_roc(seq);
+        self.commit_roc(v, seq);
         v
     }
 }

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -627,18 +627,21 @@ mod tests {
         // Legit frame seeds the recv tracker and decrypts cleanly.
         let f0 = tx.protect_audio(&opus);
         assert_eq!(rx.unprotect_audio(&f0).unwrap().1, opus);
+        let base_seq = u16::from_be_bytes([f0[2], f0[3]]);
 
-        // Forge the next frame by corrupting its MI tag (last byte).
+        // Forge a far-AHEAD packet: rewrite the RTP sequence field (bytes 2..4) to a
+        // forward jump the pre-fix guess_roc would have folded into s_l. The rewrite
+        // also invalidates the MI tag, so authentication rejects the packet.
         let mut forged = tx.protect_audio(&opus);
-        let last = forged.len() - 1;
-        forged[last] ^= 0xFF;
+        forged[2..4].copy_from_slice(&base_seq.wrapping_add(0x4000).to_be_bytes());
         assert!(
             rx.unprotect_audio(&forged).is_none(),
-            "an unauthenticated packet must be rejected, not decrypted"
+            "an unauthenticated far-ahead packet must be rejected, not fold the ROC"
         );
 
-        // The forged packet did not advance the ROC: a subsequent legit frame still
-        // decrypts (pre-fix, guess_roc folded it before any auth and could desync).
+        // The rejected packet left the recv tracker untouched, so a subsequent legit
+        // frame still decrypts. (The exact roc-bump staircase is pinned by
+        // e2e_srtp::unauthenticated_staircase_cannot_advance_roc_without_commit.)
         let f2 = tx.protect_audio(&opus);
         assert_eq!(
             rx.unprotect_audio(&f2).unwrap().1,

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -4,6 +4,7 @@
 
 use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
+    verify_warp_mi_tag,
 };
 use super::rtp::{
     RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, encode_rtp_header_into, parse_rtp_header,
@@ -215,20 +216,38 @@ impl MediaPipeline {
         append_warp_mi_tag(&self.send_keys.auth_key, &packet, roc, self.warp_mi_tag_len)
     }
 
-    /// Inbound: strip the WARP MI tag (not verified), parse the header, decrypt the payload.
+    /// Inbound: verify the WARP MI tag, parse the header, decrypt the payload.
     /// The ROC is derived per-packet from the recv tracker (RFC 3711 guess-index), so the keystream
     /// stays aligned with the sender's across 16-bit seq wraps even under reorder/loss.
+    ///
+    /// The tag is authenticated (constant-time) against the *estimated* ROC BEFORE
+    /// that ROC is committed, so an on-path relay can't fold unauthenticated packets
+    /// into the rollover counter and permanently desync the receiver (RFC 3711
+    /// §3.3.1 requires the index update to follow authentication).
     pub fn unprotect_audio(&mut self, packet: &[u8]) -> Option<(RtpHeader, Vec<u8>)> {
         if packet.len() < RTP_FIXED_HEADER_LEN + self.warp_mi_tag_len {
             return None;
         }
-        let without_tag = &packet[..packet.len() - self.warp_mi_tag_len];
+        let split = packet.len() - self.warp_mi_tag_len;
+        let without_tag = &packet[..split];
+        let received_tag = &packet[split..];
         let header = parse_rtp_header(without_tag)?;
         let header_len = rtp_header_byte_length(without_tag)?;
         if without_tag.len() <= header_len {
             return None;
         }
-        let roc = self.recv_roc.guess_roc(header.sequence_number);
+        let roc = self.recv_roc.estimate_roc(header.sequence_number);
+        if !verify_warp_mi_tag(
+            &self.recv_keys.auth_key,
+            without_tag,
+            roc,
+            self.warp_mi_tag_len,
+            received_tag,
+        ) {
+            return None;
+        }
+        // Authenticated: now it's safe to advance the rollover counter.
+        self.recv_roc.commit_roc(roc, header.sequence_number);
         let cipher = &without_tag[header_len..];
         let plain = crypt_payload(
             &self.recv_keys,
@@ -454,8 +473,10 @@ mod tests {
             warp_mi_tag_len: WARP_MI_TAG_LEN,
         })
         .unwrap();
-        let (_, mis) = us2.unprotect_audio(&wrong).unwrap();
-        assert_ne!(mis, opus, "recv must not recover a self-LID-keyed packet");
+        assert!(
+            us2.unprotect_audio(&wrong).is_none(),
+            "recv must reject a self-LID-keyed packet (its MI tag fails to authenticate)"
+        );
     }
 
     // The recv keystream is HKDF'd over the FULL peer LID INCLUDING the device suffix, so the caller
@@ -484,7 +505,8 @@ mod tests {
         .unwrap();
         let from_answerer = answerer_tx.protect_audio(&opus);
 
-        // BUG: caller keys recv from the dialed BASE LID `:0` -> decrypts to garbage.
+        // Wrong keying: caller keys recv from the dialed BASE LID `:0`. The frame's
+        // MI tag (keyed by the answering device) fails to authenticate, so it's rejected.
         let mut caller_base = MediaPipeline::new(&MediaPipelineParams {
             call_key: &call_key,
             self_lid: caller,
@@ -494,10 +516,9 @@ mod tests {
             warp_mi_tag_len: WARP_MI_TAG_LEN,
         })
         .unwrap();
-        let (_, garbled) = caller_base.unprotect_audio(&from_answerer).unwrap();
-        assert_ne!(
-            garbled, opus,
-            "base-LID recv keys must NOT recover a companion-device-keyed frame (proves the bug)"
+        assert!(
+            caller_base.unprotect_audio(&from_answerer).is_none(),
+            "base-LID recv keys must reject a companion-device-keyed frame"
         );
 
         // FIX: caller keys recv from the ANSWERING device LID `:2` -> recovers cleanly.
@@ -540,7 +561,8 @@ mod tests {
         })
         .unwrap();
 
-        // Caller starts keyed to the dialed BASE LID (the bug state) -> a companion frame is garbage.
+        // Caller starts keyed to the dialed BASE LID (the bug state): the companion
+        // frame's MI tag doesn't authenticate under the base-LID recv keys -> rejected.
         let mut caller_pipe = MediaPipeline::new(&MediaPipelineParams {
             call_key: &call_key,
             self_lid: caller,
@@ -551,10 +573,9 @@ mod tests {
         })
         .unwrap();
         let frame1 = answerer_tx.protect_audio(&opus);
-        let (_, garbled) = caller_pipe.unprotect_audio(&frame1).unwrap();
-        assert_ne!(
-            garbled, opus,
-            "pre-rekey: a companion-keyed frame is garbage"
+        assert!(
+            caller_pipe.unprotect_audio(&frame1).is_none(),
+            "pre-rekey: a companion-keyed frame is rejected"
         );
 
         // Rekey to the answering device; a subsequent frame now recovers cleanly.
@@ -579,6 +600,51 @@ mod tests {
         let ours = caller_pipe.protect_audio(&opus);
         let (_, got) = peer_rx.unprotect_audio(&ours).unwrap();
         assert_eq!(got, opus, "rekey_recv must not disturb send keys");
+    }
+
+    // An unauthenticated packet (bad WARP MI tag — an on-path relay can't forge it
+    // without the SRTP auth key) is rejected and must NOT fold the recv rollover
+    // counter, so a following legit frame still decrypts (RFC 3711 §3.3.1).
+    #[test]
+    fn forged_packet_is_rejected_and_does_not_desync_roc() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let ssrc = 0x0BADF00D;
+        let opus = vec![0x50u8, 1, 2, 3, 4, 5, 6, 7];
+
+        let params = |self_lid, peer_lid| MediaPipelineParams {
+            call_key: &call_key,
+            self_lid,
+            peer_lid,
+            ssrc,
+            samples_per_packet: 960,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        };
+        let mut tx = MediaPipeline::new(&params(a, b)).unwrap();
+        let mut rx = MediaPipeline::new(&params(b, a)).unwrap();
+
+        // Legit frame seeds the recv tracker and decrypts cleanly.
+        let f0 = tx.protect_audio(&opus);
+        assert_eq!(rx.unprotect_audio(&f0).unwrap().1, opus);
+
+        // Forge the next frame by corrupting its MI tag (last byte).
+        let mut forged = tx.protect_audio(&opus);
+        let last = forged.len() - 1;
+        forged[last] ^= 0xFF;
+        assert!(
+            rx.unprotect_audio(&forged).is_none(),
+            "an unauthenticated packet must be rejected, not decrypted"
+        );
+
+        // The forged packet did not advance the ROC: a subsequent legit frame still
+        // decrypts (pre-fix, guess_roc folded it before any auth and could desync).
+        let f2 = tx.protect_audio(&opus);
+        assert_eq!(
+            rx.unprotect_audio(&f2).unwrap().1,
+            opus,
+            "recv keystream survives an injected forged packet"
+        );
     }
 
     // A relay-advertised non-4 WARP MI tag length must round-trip: the tag the sender appends and the

--- a/wacore/src/voip/warp.rs
+++ b/wacore/src/voip/warp.rs
@@ -7,6 +7,7 @@
 
 use hmac::{Hmac, KeyInit, Mac};
 use sha1::Sha1;
+use subtle::ConstantTimeEq;
 
 type HmacSha1 = Hmac<Sha1>;
 
@@ -39,6 +40,21 @@ pub fn compute_warp_mi_tag(
     mac.update(&roc.to_be_bytes());
     let full = mac.finalize().into_bytes();
     full[..tag_len].to_vec()
+}
+
+/// Constant-time-verify a received WARP MI tag against the one we compute for
+/// `roc`. Callers must reject a packet whose tag fails BEFORE folding recv ROC
+/// state, so an unauthenticated packet can't desync the rollover counter
+/// (RFC 3711 §3.3.1: update the index only after authentication).
+pub fn verify_warp_mi_tag(
+    auth_key: &[u8],
+    packet_without_tag: &[u8],
+    roc: u32,
+    tag_len: usize,
+    received_tag: &[u8],
+) -> bool {
+    let expected = compute_warp_mi_tag(auth_key, packet_without_tag, roc, tag_len);
+    expected.ct_eq(received_tag).into()
 }
 
 /// Append the WARP MI tag to a protected packet.


### PR DESCRIPTION
## What

Authenticate the WARP MI tag **before** advancing the receiver's E2E-SRTP rollover counter (ROC), so an on-path relay can't desync it with unauthenticated packets. (Behind the opt-in `voip` feature.)

## Why (security — persistent media DoS)

`unprotect_audio` stripped the WARP MI tag *without verifying it* (the doc even said "not verified") and then called `RecvRocTracker::guess_roc(seq)` — which **mutates** `roc`/`s_l` — before any authentication or decrypt. The only gating on that path is a length check and a parseable RTP header, and the MI tag is keyed by the SRTP auth key the attacker doesn't have but which was never checked.

So an on-path relay (the exact party E2E-SRTP defends against — it holds hop-by-hop keys and terminates DTLS, so it can inject onto the media path) can send a short **staircase of 2 unauthenticated packets per step** to advance the receiver's ROC. Since `guess_roc` self-heals only ±1, any offset ≥2 is **permanent**: every subsequent *legit* frame then builds the wrong CTR IV (`packet_index = roc<<16 | seq`) and decrypts to garbage — a persistent, silent audio DoS from a handful of packets. This violates **RFC 3711 §3.3.1** (update the index only *after* authentication). Availability-only (SFrame/GCM still authenticate content), but a real hardening gap.

## How

- Split `RecvRocTracker::guess_roc` into a **pure** `estimate_roc(&self, seq) -> u32` (no mutation) and a mutating `commit_roc(&mut self, v, seq)`.
- Add `verify_warp_mi_tag(...)` — a **constant-time** (`subtle::ConstantTimeEq`) check of the received tag against the one computed for a candidate ROC.
- In `unprotect_audio`: `estimate_roc` → **verify the MI tag against it** → return `None` on failure → only then `commit_roc` + decrypt. Injected packets never reach `commit_roc`, so they can't fold ROC state.
- `guess_roc` becomes `#[cfg(test)]` (production uses estimate+commit; the wrap-tracking unit tests keep it).

## Tests

- `forged_packet_is_rejected_and_does_not_desync_roc` (**bad path / the fix**) — a frame with a corrupted MI tag is rejected (`None`, not decrypted to garbage), and a subsequent legit frame still decrypts (proves the forged packet didn't advance ROC).
- Three existing round-trip tests that asserted a **mis-keyed** frame "decrypts to garbage" now assert it is **rejected** (`None`) — a strictly better outcome under authentication; the correct-keying assertions are unchanged.
- All 206 `wacore --features voip` tests pass; `cargo fmt` / `clippy` clean; default (non-voip) build unaffected.
