### PR TITLE
refactor(events): model ServerAck.class as Option, document payload stability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ cargo test -p e2e-tests          # requires mock server running
 - **Protocol**: Cross-reference **whatsmeow**, **Baileys**, and captured WhatsApp Web JS (`docs/captured-js/`) to verify implementations.
 - **IQ Requests**: Use `client.execute(Spec::new(&jid)).await?` pattern. IqSpec constructors take `&Jid` not `Jid`.
 - **New features**: Expose via `src/features/mod.rs`, re-export in `src/lib.rs`.
+- **Event payloads**: Model a maybe-absent field as `Option<T>`, never an empty-string/zero sentinel. Pre-1.0 the payload structs stay constructible (not `#[non_exhaustive]`), so consumers read the fields they need instead of destructuring exhaustively; see the `Event` doc in `wacore/src/types/events.rs` for the full stability policy.
 - **Wire-tagged enums**: Every protocol enum uses `#[derive(WireEnum)]`. The `#[wire = "..."]` (or `#[wire = NUM]` for int mode) attribute is the SINGLE source of truth for each variant's wire value. Do NOT also derive `serde::Serialize`/`Deserialize` or add `#[serde(rename_all)]` — the derive owns both. Three modes: unit-string (default), tagged-with-payload (`#[wire(tag = "type")]` on the enum, optional `#[wire_alias = "..."]` and `#[wire(skip)]` on fields, `#[wire_fallback]` for catch-all), and int (`#[wire(kind = "int")]`). In tagged mode the derive auto-generates a sibling `<Name>Tag` enum; parsers must dispatch via `<Name>Tag::try_from(node.tag.as_ref())` instead of matching string literals, so renaming a wire tag stays a single-attribute change.
 
 ## Detailed Docs

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1149,10 +1149,7 @@ impl Client {
         {
             let ack = wacore::types::events::ServerAck {
                 id: id.as_str().to_string(),
-                class: node
-                    .get_attr("class")
-                    .map(|v| v.as_str().to_string())
-                    .unwrap_or_default(),
+                class: node.get_attr("class").map(|v| v.as_str().to_string()),
                 from: node.get_attr("from").and_then(|v| v.as_str().parse().ok()),
                 timestamp: node
                     .get_attr("t")

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -235,7 +235,7 @@ async fn test_ack_dispatches_server_ack_event() {
             e.as_ref(),
             Event::ServerAck(ack)
                 if ack.id == "ack-evt-1"
-                    && ack.class == "message"
+                    && ack.class.as_deref() == Some("message")
                     && ack.from.as_ref().is_some_and(|j| j.to_string() == "123456789@s.whatsapp.net")
                     && ack.timestamp.is_some_and(|t| t.timestamp() == 1_720_000_000)
                     && ack.error.is_none()
@@ -243,7 +243,7 @@ async fn test_ack_dispatches_server_ack_event() {
         "server <ack> should dispatch Event::ServerAck with class/from/t"
     );
 
-    // Nack: the error code rides along; absent class/t stay empty/None.
+    // Nack: the error code rides along; absent class/t stay None.
     let nack_node = NodeBuilder::new("ack")
         .attr("id", "ack-evt-2")
         .attr("error", "479")
@@ -255,7 +255,7 @@ async fn test_ack_dispatches_server_ack_event() {
             e.as_ref(),
             Event::ServerAck(ack)
                 if ack.id == "ack-evt-2"
-                    && ack.class.is_empty()
+                    && ack.class.is_none()
                     && ack.timestamp.is_none()
                     && ack.error.as_deref() == Some("479")
         )),

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -603,6 +603,17 @@ pub struct DisappearingModeChanged {
     pub setting_timestamp: DateTime<Utc>,
 }
 
+/// An event dispatched by the client to registered handlers.
+///
+/// # Stability (pre-1.0)
+///
+/// The enum is `#[non_exhaustive]`, so match arms must keep a `_` catch-all.
+/// The payload structs are *not* sealed: while the crate is `0.x`, an existing
+/// payload may gain new fields in a minor release, so read the fields you need
+/// (`ack.class`) or keep a `..` rest when destructuring, rather than binding
+/// every field. A maybe-absent field is always modeled as `Option<T>`, never
+/// an empty-string / zero sentinel. Sealing the payloads behind
+/// `#[non_exhaustive]` + constructors is deferred to the 1.0 API freeze.
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub enum Event {
@@ -1195,8 +1206,8 @@ pub struct ServerAck {
     /// Id of the acked stanza (for a sent message, its message id).
     pub id: String,
     /// Stanza class the ack refers to (`"message"`, `"receipt"`,
-    /// `"notification"`, `"call"`, …). Empty when the server omits it.
-    pub class: String,
+    /// `"notification"`, `"call"`, …). `None` when the server omits it.
+    pub class: Option<String>,
     /// Chat/entity the ack refers to, when present and parseable.
     pub from: Option<Jid>,
     /// Server timestamp from the ack's `t` attribute, when present. For a


### PR DESCRIPTION
## What

Follow-up to #989. Two small, related cleanups on the event API surface while the crate is still pre-1.0 and breaking changes are cheap.

### 1. `ServerAck.class`: plain `String` becomes an `Option`

`ServerAck.class` used an empty-string sentinel (`unwrap_or_default()`) when the server ack omits the `class` attribute. Every other payload in `events.rs` models a maybe-absent field as an `Option`, so this was the lone exception. Now a missing class is `None` instead of `""`, and the parser drops the `unwrap_or_default()`.

### 2. Document the pre-1.0 event stability policy

Added a stability note to the `Event` enum doc (and a pointer in `AGENTS.md`):

- the enum is `#[non_exhaustive]`, so match arms keep a `_` catch-all;
- payload structs stay constructible (not `#[non_exhaustive]`) so the crate can build them across the `wacore` / `whatsapp-rust` boundary without constructors;
- consumers should read the fields they need or keep a `..` rest when destructuring, since a payload may gain fields in a `0.x` minor;
- a maybe-absent field is always an `Option`, never a sentinel;
- sealing payloads behind `#[non_exhaustive]` + constructors is deferred to the 1.0 API freeze.

## Why not seal the payloads now

`#[non_exhaustive]` on a `wacore` payload struct blocks struct-literal construction from `whatsapp-rust` (a separate crate), which would force a constructor for every event payload. Pre-1.0 that cost buys little, since fields can still be added with a minor bump. The policy records the decision instead.

## Breaking

`ServerAck.class` is now an `Option`. Consumers match `Some("message")` instead of `"message"`. Only landed in #989, so nothing released depends on the old shape.

## Verification

- `cargo fmt --check` and `cargo clippy -p whatsapp-rust -p wacore --tests` clean.
- `test_ack_dispatches_server_ack_event` updated for the `Option` shape and green.
- `ack_miss_path_does_not_heap_allocate` green — the change stays inside the interest-gated block, so the #827 allocation-free miss path is untouched.