### PR TITLE
refactor(events): seal notification, sync event payloads (non_exhaustive + bon builder)

### DIFF
--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -323,11 +323,11 @@ impl Client {
             .await;
 
         self.core.event_bus.dispatch(Event::SelfPushNameUpdated(
-            crate::types::events::SelfPushNameUpdated {
-                from_server: true,
-                old_name,
-                new_name: new_name.clone(),
-            },
+            crate::types::events::SelfPushNameUpdated::builder()
+                .from_server(true)
+                .old_name(old_name)
+                .new_name(new_name.clone())
+                .build(),
         ));
 
         let client_clone = self.clone();

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -875,11 +875,11 @@ impl Client {
                     .process_command(DeviceCommand::SetPushName(new_name.clone()))
                     .await;
                 bus.dispatch(Event::SelfPushNameUpdated(
-                    crate::types::events::SelfPushNameUpdated {
-                        from_server: true,
-                        old_name: old.clone(),
-                        new_name: new_name.clone(),
-                    },
+                    crate::types::events::SelfPushNameUpdated::builder()
+                        .from_server(true)
+                        .old_name(old.clone())
+                        .new_name(new_name.clone())
+                        .build(),
                 ));
 
                 // WhatsApp Web sends presence immediately when receiving pushname

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -331,10 +331,9 @@ impl Client {
             ReceivedChatState::Idle => (ChatPresence::Paused, ChatPresenceMedia::Text),
         };
 
-        self.core
-            .event_bus
-            .dispatch(Event::ChatPresence(ChatPresenceUpdate {
-                source: MessageSource {
+        self.core.event_bus.dispatch(Event::ChatPresence(
+            ChatPresenceUpdate::builder()
+                .source(MessageSource {
                     chat,
                     sender,
                     is_from_me: false,
@@ -344,10 +343,11 @@ impl Client {
                     recipient_alt: None,
                     broadcast_list_owner: None,
                     recipient: None,
-                },
-                state,
-                media,
-            }));
+                })
+                .state(state)
+                .media(media)
+                .build(),
+        ));
 
         // Invoke legacy callback handlers
         let event = ChatStateEvent::from_stanza(stanza);

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -130,12 +130,14 @@ pub(crate) fn dispatch_chat_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.mute_action.as_option()
             {
-                event_bus.dispatch(Event::MuteUpdate(MuteUpdate {
-                    jid,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::MuteUpdate(
+                    MuteUpdate::builder()
+                        .jid(jid)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -143,12 +145,14 @@ pub(crate) fn dispatch_chat_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.pin_action.as_option()
             {
-                event_bus.dispatch(Event::PinUpdate(PinUpdate {
-                    jid,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::PinUpdate(
+                    PinUpdate::builder()
+                        .jid(jid)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -156,12 +160,14 @@ pub(crate) fn dispatch_chat_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.archive_chat_action.as_option()
             {
-                event_bus.dispatch(Event::ArchiveUpdate(ArchiveUpdate {
-                    jid,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::ArchiveUpdate(
+                    ArchiveUpdate::builder()
+                        .jid(jid)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -171,15 +177,17 @@ pub(crate) fn dispatch_chat_mutation(
                 && let Some((message_id, from_me, participant_jid)) =
                     parse_message_key_fields(kind, &m.index)
             {
-                event_bus.dispatch(Event::StarUpdate(StarUpdate {
-                    chat_jid: jid,
-                    participant_jid,
-                    message_id,
-                    from_me,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::StarUpdate(
+                    StarUpdate::builder()
+                        .chat_jid(jid)
+                        .maybe_participant_jid(participant_jid)
+                        .message_id(message_id)
+                        .from_me(from_me)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -187,12 +195,14 @@ pub(crate) fn dispatch_chat_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.contact_action.as_option()
             {
-                event_bus.dispatch(Event::ContactUpdate(ContactUpdate {
-                    jid,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::ContactUpdate(
+                    ContactUpdate::builder()
+                        .jid(jid)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -200,12 +210,14 @@ pub(crate) fn dispatch_chat_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.mark_chat_as_read_action.as_option()
             {
-                event_bus.dispatch(Event::MarkChatAsReadUpdate(MarkChatAsReadUpdate {
-                    jid,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::MarkChatAsReadUpdate(
+                    MarkChatAsReadUpdate::builder()
+                        .jid(jid)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -215,13 +227,15 @@ pub(crate) fn dispatch_chat_mutation(
             {
                 // delete_media is in index[2], not in the proto (which only has messageRange)
                 let delete_media = m.index.get(2).is_none_or(|v| v != "0");
-                event_bus.dispatch(Event::DeleteChatUpdate(DeleteChatUpdate {
-                    jid,
-                    delete_media,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::DeleteChatUpdate(
+                    DeleteChatUpdate::builder()
+                        .jid(jid)
+                        .delete_media(delete_media)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -234,14 +248,16 @@ pub(crate) fn dispatch_chat_mutation(
                 // builder encodes both as "1"/"0".
                 let delete_starred = m.index.get(2).is_some_and(|v| v == "1");
                 let delete_media = m.index.get(3).is_some_and(|v| v == "1");
-                event_bus.dispatch(Event::ClearChatUpdate(ClearChatUpdate {
-                    jid,
-                    delete_starred,
-                    delete_media,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::ClearChatUpdate(
+                    ClearChatUpdate::builder()
+                        .jid(jid)
+                        .delete_starred(delete_starred)
+                        .delete_media(delete_media)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -249,13 +265,15 @@ pub(crate) fn dispatch_chat_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.user_status_mute_action.as_option()
             {
-                event_bus.dispatch(Event::UserStatusMuteUpdate(UserStatusMuteUpdate {
-                    jid,
-                    muted: act.muted.unwrap_or(false),
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::UserStatusMuteUpdate(
+                    UserStatusMuteUpdate::builder()
+                        .jid(jid)
+                        .muted(act.muted.unwrap_or(false))
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -265,15 +283,17 @@ pub(crate) fn dispatch_chat_mutation(
                 && let Some((message_id, from_me, participant_jid)) =
                     parse_message_key_fields(kind, &m.index)
             {
-                event_bus.dispatch(Event::DeleteMessageForMeUpdate(DeleteMessageForMeUpdate {
-                    chat_jid: jid,
-                    participant_jid,
-                    message_id,
-                    from_me,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::DeleteMessageForMeUpdate(
+                    DeleteMessageForMeUpdate::builder()
+                        .chat_jid(jid)
+                        .maybe_participant_jid(participant_jid)
+                        .message_id(message_id)
+                        .from_me(from_me)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -50,12 +50,14 @@ pub(crate) fn dispatch_label_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.label_edit_action.as_option()
             {
-                event_bus.dispatch(Event::LabelEditUpdate(LabelEditUpdate {
-                    label_id,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::LabelEditUpdate(
+                    LabelEditUpdate::builder()
+                        .label_id(label_id)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }
@@ -76,13 +78,15 @@ pub(crate) fn dispatch_label_mutation(
             if let Some(val) = &m.action_value
                 && let Some(act) = val.label_association_action.as_option()
             {
-                event_bus.dispatch(Event::LabelAssociationUpdate(LabelAssociationUpdate {
-                    label_id,
-                    chat_jid,
-                    timestamp: time,
-                    action: Box::new(act.clone()),
-                    from_full_sync: full_sync,
-                }));
+                event_bus.dispatch(Event::LabelAssociationUpdate(
+                    LabelAssociationUpdate::builder()
+                        .label_id(label_id)
+                        .chat_jid(chat_jid)
+                        .timestamp(time)
+                        .action(Box::new(act.clone()))
+                        .from_full_sync(full_sync)
+                        .build(),
+                ));
             }
             true
         }

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -241,17 +241,16 @@ pub(crate) async fn handle_group_notification(client: &Arc<Client>, node: Arc<Ow
             notification.group_jid.observe(), action.tag_name()
         );
 
-        client
-            .core
-            .event_bus
-            .dispatch(Event::GroupUpdate(GroupUpdate {
-                group_jid: notification.group_jid.clone(),
-                participant: notification.participant.clone(),
-                participant_pn: notification.participant_pn.clone(),
-                timestamp,
-                is_lid_addressing_mode: notification.is_lid_addressing_mode,
-                action,
-            }));
+        client.core.event_bus.dispatch(Event::GroupUpdate(
+            GroupUpdate::builder()
+                .group_jid(notification.group_jid.clone())
+                .maybe_participant(notification.participant.clone())
+                .maybe_participant_pn(notification.participant_pn.clone())
+                .timestamp(timestamp)
+                .is_lid_addressing_mode(notification.is_lid_addressing_mode)
+                .action(action)
+                .build(),
+        ));
     }
 
     // Also dispatch legacy generic notification for backward compatibility

--- a/src/handlers/notification/profile.rs
+++ b/src/handlers/notification/profile.rs
@@ -95,13 +95,15 @@ pub(crate) fn handle_picture_notification(client: &Arc<Client>, node: &NodeRef<'
         jid.observe(), author, picture_id
     );
 
-    let event = Event::PictureUpdate(PictureUpdate {
-        jid,
-        author,
-        timestamp,
-        removed,
-        picture_id,
-    });
+    let event = Event::PictureUpdate(
+        PictureUpdate::builder()
+            .jid(jid)
+            .maybe_author(author)
+            .timestamp(timestamp)
+            .removed(removed)
+            .maybe_picture_id(picture_id)
+            .build(),
+    );
     client.core.event_bus.dispatch(event);
 }
 
@@ -136,11 +138,13 @@ pub(crate) fn handle_status_notification(client: &Arc<Client>, node: &NodeRef<'_
             "Status update from {} (length={})", from.observe(), status_text.len()
         );
 
-        let event = Event::UserAboutUpdate(UserAboutUpdate {
-            jid: from,
-            status: status_text,
-            timestamp,
-        });
+        let event = Event::UserAboutUpdate(
+            UserAboutUpdate::builder()
+                .jid(from)
+                .status(status_text)
+                .timestamp(timestamp)
+                .build(),
+        );
         client.core.event_bus.dispatch(event);
     } else {
         debug!(
@@ -232,10 +236,12 @@ pub(crate) async fn handle_contacts_notification(client: &Arc<Client>, node: &No
             };
 
             debug!(target: "Client/Contacts", "Contact updated for {}", jid.observe());
-            client
-                .core
-                .event_bus
-                .dispatch(Event::ContactUpdated(ContactUpdated { jid, timestamp }));
+            client.core.event_bus.dispatch(Event::ContactUpdated(
+                ContactUpdated::builder()
+                    .jid(jid)
+                    .timestamp(timestamp)
+                    .build(),
+            ));
         }
         "modify" => {
             // WA Web: old/new are PN JIDs, old_lid/new_lid are optional LID JIDs.
@@ -265,16 +271,15 @@ pub(crate) async fn handle_contacts_notification(client: &Arc<Client>, node: &No
                 "Contact number changed: {} -> {} (old_lid={:?}, new_lid={:?})",
                 old_jid.observe(), new_jid.observe(), old_lid, new_lid
             );
-            client
-                .core
-                .event_bus
-                .dispatch(Event::ContactNumberChanged(ContactNumberChanged {
-                    old_jid,
-                    new_jid,
-                    old_lid,
-                    new_lid,
-                    timestamp,
-                }));
+            client.core.event_bus.dispatch(Event::ContactNumberChanged(
+                ContactNumberChanged::builder()
+                    .old_jid(old_jid)
+                    .new_jid(new_jid)
+                    .maybe_old_lid(old_lid)
+                    .maybe_new_lid(new_lid)
+                    .timestamp(timestamp)
+                    .build(),
+            ));
         }
         "sync" => {
             let after = child
@@ -287,13 +292,12 @@ pub(crate) async fn handle_contacts_notification(client: &Arc<Client>, node: &No
                 "Contact sync requested after {:?}",
                 after
             );
-            client
-                .core
-                .event_bus
-                .dispatch(Event::ContactSyncRequested(ContactSyncRequested {
-                    after,
-                    timestamp,
-                }));
+            client.core.event_bus.dispatch(Event::ContactSyncRequested(
+                ContactSyncRequested::builder()
+                    .maybe_after(after)
+                    .timestamp(timestamp)
+                    .build(),
+            ));
         }
         "add" | "remove" => {
             debug!(

--- a/src/handlers/presence.rs
+++ b/src/handlers/presence.rs
@@ -56,14 +56,13 @@ impl StanzaHandler for PresenceHandler {
             from_jid.observe(), unavailable
         );
 
-        client
-            .core
-            .event_bus
-            .dispatch(Event::Presence(PresenceUpdate {
-                from: from_jid,
-                unavailable,
-                last_seen,
-            }));
+        client.core.event_bus.dispatch(Event::Presence(
+            PresenceUpdate::builder()
+                .from(from_jid)
+                .unavailable(unavailable)
+                .maybe_last_seen(last_seen)
+                .build(),
+        ));
 
         true
     }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -439,7 +439,8 @@ impl CoreEventBus {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct SelfPushNameUpdated {
     pub from_server: bool,
     pub old_name: String,
@@ -1222,14 +1223,16 @@ pub struct ServerAck {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ChatPresenceUpdate {
     pub source: crate::types::message::MessageSource,
     pub state: ChatPresence,
     pub media: ChatPresenceMedia,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct PresenceUpdate {
     /// The contact whose presence changed.
     pub from: Jid,
@@ -1237,7 +1240,8 @@ pub struct PresenceUpdate {
     pub last_seen: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct PictureUpdate {
     /// The JID whose picture changed (user or group).
     pub jid: Jid,
@@ -1253,7 +1257,8 @@ pub struct PictureUpdate {
     pub picture_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct UserAboutUpdate {
     /// The contact whose about text changed.
     pub jid: Jid,
@@ -1269,7 +1274,8 @@ pub struct UserAboutUpdate {
 ///
 /// Not to be confused with [`ContactUpdate`] which comes from app-state
 /// sync mutations (different source, different payload).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ContactUpdated {
     /// The contact whose profile was updated.
     pub jid: Jid,
@@ -1287,7 +1293,8 @@ pub struct ContactUpdated {
 /// sessions intact). Group participant updates arrive via separate
 /// `w:gp2` notifications, so per-group caches are not touched here.
 /// Consumers can subscribe and refresh their own caches if needed.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ContactNumberChanged {
     /// Old phone number JID.
     pub old_jid: Jid,
@@ -1305,7 +1312,8 @@ pub struct ContactNumberChanged {
 /// Server requests a full contact re-sync.
 ///
 /// Emitted from `<notification type="contacts"><sync after="..."/>`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ContactSyncRequested {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<DateTime<Utc>>,
@@ -1316,7 +1324,8 @@ pub struct ContactSyncRequested {
 ///
 /// Emitted for each action in a `<notification type="w:gp2">` stanza.
 /// A single notification may produce multiple `GroupUpdate` events (one per action).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct GroupUpdate {
     /// The group this update applies to
     pub group_jid: Jid,
@@ -1334,7 +1343,8 @@ pub struct GroupUpdate {
     pub action: crate::stanza::groups::GroupNotificationAction,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ContactUpdate {
     /// The chat/contact this sync action applies to.
     pub jid: Jid,
@@ -1343,7 +1353,8 @@ pub struct ContactUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct PushNameUpdate {
     /// The contact who changed their push name.
     pub jid: Jid,
@@ -1352,7 +1363,8 @@ pub struct PushNameUpdate {
     pub new_push_name: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct PinUpdate {
     /// The chat being pinned or unpinned.
     pub jid: Jid,
@@ -1361,7 +1373,8 @@ pub struct PinUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct MuteUpdate {
     /// The chat being muted or unmuted.
     pub jid: Jid,
@@ -1370,7 +1383,8 @@ pub struct MuteUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ArchiveUpdate {
     /// The chat being archived or unarchived.
     pub jid: Jid,
@@ -1379,7 +1393,8 @@ pub struct ArchiveUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct StarUpdate {
     /// The chat containing the starred or unstarred message.
     pub chat_jid: Jid,
@@ -1393,7 +1408,8 @@ pub struct StarUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct MarkChatAsReadUpdate {
     /// The chat being marked as read or unread.
     pub jid: Jid,
@@ -1402,7 +1418,8 @@ pub struct MarkChatAsReadUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct DeleteChatUpdate {
     /// The chat being deleted.
     pub jid: Jid,
@@ -1414,7 +1431,8 @@ pub struct DeleteChatUpdate {
 }
 
 /// A chat's messages were cleared (kept) on a linked device.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct ClearChatUpdate {
     /// The chat being cleared.
     pub jid: Jid,
@@ -1428,7 +1446,8 @@ pub struct ClearChatUpdate {
 }
 
 /// A contact/group/newsletter's status updates were muted/unmuted on a linked device.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct UserStatusMuteUpdate {
     /// The entity whose status was (un)muted.
     pub jid: Jid,
@@ -1439,7 +1458,8 @@ pub struct UserStatusMuteUpdate {
     pub from_full_sync: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct DeleteMessageForMeUpdate {
     /// The chat containing the deleted message.
     pub chat_jid: Jid,
@@ -1453,7 +1473,8 @@ pub struct DeleteMessageForMeUpdate {
 
 /// A label was created, renamed/recolored, or deleted on a linked device.
 /// `action.deleted == Some(true)` means the label was removed.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct LabelEditUpdate {
     /// The label identifier (the index key, not a JID).
     pub label_id: String,
@@ -1464,7 +1485,8 @@ pub struct LabelEditUpdate {
 
 /// A label was associated with or removed from a chat on a linked device.
 /// `action.labeled == Some(true)` means the label was added to the chat.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
 pub struct LabelAssociationUpdate {
     /// The label identifier.
     pub label_id: String,


### PR DESCRIPTION
## What

Second tranche of the pre-1.0 event-payload API freeze, after `ServerAck` in #1002. It applies the same seal to the notification and app-state-sync payload family, so these payloads can gain fields later without breaking consumers:

`#[non_exhaustive]` + `#[derive(bon::Builder)]`

## Structs sealed (22)

- **App-state sync mutations (12):** `ContactUpdate`, `PinUpdate`, `MuteUpdate`, `ArchiveUpdate`, `StarUpdate`, `MarkChatAsReadUpdate`, `DeleteChatUpdate`, `ClearChatUpdate`, `UserStatusMuteUpdate`, `DeleteMessageForMeUpdate`, `LabelEditUpdate`, `LabelAssociationUpdate`.
- **Notification / contact / presence / group (10):** `ChatPresenceUpdate`, `PresenceUpdate`, `PictureUpdate`, `UserAboutUpdate`, `ContactUpdated`, `ContactNumberChanged`, `ContactSyncRequested`, `GroupUpdate`, `PushNameUpdate`, `SelfPushNameUpdated`.

## Construction sites

The 22 cross-crate construction sites move from struct literals to the generated builder, with `Option` attributes passed through `maybe_*` setters. This is behavior-preserving: same values, same order, no logic change. Spread across `chat_actions.rs` (10), `notification/profile.rs` (5), `labels.rs` (2), and one each in `accessors.rs`, `app_state.rs`, `messaging.rs`, `notification/groups.rs`, `presence.rs`.

## Safety

The migration is compiler-enforced end to end:

- `#[non_exhaustive]` makes every missed struct literal a hard `E0639` error, so no construction site can be silently left behind.
- `bon`'s typestate `build()` rejects a missing required field at compile time, so no required field can be dropped in the conversion.
- Every `Option` field was checked against the struct definition and routed through its `maybe_*` setter, preserving the original value.

## Verification

- `cargo build -p whatsapp-rust` clean.
- `cargo clippy -p whatsapp-rust -p wacore --tests` clean.
- `cargo fmt --all --check` clean.
- `cargo test -p whatsapp-rust --lib` → 954 passed, 0 failed.

## Follow-ups (not in this PR)

- The message/newsletter payloads (`Receipt`, `MessageBatch`, `InboundMessage`, `UndecryptableMessage`, newsletter events).
- The pairing payloads and the three inline `Event` variants (`PairingQrCode` / `PairingCode` / `PairingCodeRefresh`) converted to newtypes.
- The unit-struct markers (`Connected`, `Disconnected`, etc.) — decide per case whether an empty sealed struct is worth it.
- A `trybuild` compile-fail test to lock the seal permanently.
- Optionally migrate `EventInterest` off `u64`.