### PR TITLE
feat(history-sync): learn PN-LID mappings from phoneNumberToLidMappings

### DIFF
--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -211,6 +211,30 @@ impl Client {
                 self.store_history_sync_msg_secrets(sync_result.msg_secret_records)
                     .await;
 
+                // PN-LID mappings the server ships with the history (field 15):
+                // the bulk identity seed. Same source whatsmeow harvests in
+                // storeHistoricalPNLIDMappings; without it a freshly paired
+                // client only learns peers' LID-PN pairs one by one from live
+                // traffic. Persist and migrations run detached, like the other
+                // batch learn paths.
+                if !sync_result.lid_mappings.is_empty() {
+                    let pairs: Vec<(String, String)> = sync_result
+                        .lid_mappings
+                        .into_iter()
+                        .map(|m| (m.lid, m.phone_number))
+                        .collect();
+                    log::info!(
+                        "History sync provided {} PN-LID mappings; learning",
+                        pairs.len()
+                    );
+                    self.learn_lid_pn_mappings_batch(
+                        pairs,
+                        crate::lid_pn_cache::LearningSource::MigrationSyncLatest,
+                        false,
+                    )
+                    .await;
+                }
+
                 // No interest pre-check: dispatch() evaluates handler interest
                 // against a single bus snapshot (and skips materializing the
                 // Arc when nobody listens), so deferring to it removes the
@@ -547,6 +571,42 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(got, Some(secret));
+    }
+
+    #[tokio::test]
+    async fn process_history_sync_task_learns_lid_mappings() {
+        let client = crate::test_utils::create_test_client_with_name("history_lid_mappings").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let history_sync = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            phone_number_to_lid_mappings: vec![wa::PhoneNumberToLIDMapping {
+                pn_jid: Some("5511777776666@s.whatsapp.net".to_string()),
+                lid_jid: Some("111222333444555@lid".to_string()),
+            }],
+            ..Default::default()
+        };
+        let compressed = compress_history_sync(&history_sync);
+        let notification = HistorySyncNotification {
+            file_length: Some(compressed.len() as u64),
+            sync_type: Some(wa::message::HistorySyncType::INITIAL_BOOTSTRAP),
+            initial_hist_bootstrap_inline_payload: Some(compressed),
+            ..Default::default()
+        };
+
+        client
+            .process_history_sync_task("HIST_SYNC_LID".to_string(), notification)
+            .await;
+
+        assert_eq!(
+            client
+                .lid_pn_cache
+                .get_current_lid("5511777776666")
+                .await
+                .as_deref(),
+            Some("111222333444555"),
+            "history-sync mapping must be learned into the LID-PN cache"
+        );
     }
 
     #[tokio::test]

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -211,12 +211,8 @@ impl Client {
                 self.store_history_sync_msg_secrets(sync_result.msg_secret_records)
                     .await;
 
-                // PN-LID mappings the server ships with the history (field 15):
-                // the bulk identity seed. Same source whatsmeow harvests in
-                // storeHistoricalPNLIDMappings; without it a freshly paired
-                // client only learns peers' LID-PN pairs one by one from live
-                // traffic. Persist and migrations run detached, like the other
-                // batch learn paths.
+                // Bulk PN-LID identity seed from field 15; persist and migrations
+                // run detached, like the other batch learn paths.
                 if !sync_result.lid_mappings.is_empty() {
                     let pairs: Vec<(String, String)> = sync_result
                         .lid_mappings

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -39,6 +39,10 @@ pub struct HistorySyncResult {
     /// Tctoken candidates extracted from 1:1 conversations during streaming.
     pub tc_token_candidates: Vec<TcTokenCandidate>,
     pub msg_secret_records: Vec<HistoryMsgSecretRecord>,
+    /// PN↔LID pairs from `HistorySync.phoneNumberToLidMappings` (field 15) —
+    /// the bulk identity seed the server sends alongside the chats. Same
+    /// source whatsmeow harvests in `storeHistoricalPNLIDMappings`.
+    pub lid_mappings: Vec<HistoryLidMapping>,
     /// The original zlib-compressed input, handed back (moved, never copied or
     /// re-inflated) only when event listeners exist. Wrapped in
     /// `LazyHistorySync` for on-demand consumption.
@@ -277,6 +281,7 @@ fn process_history_sync_streaming(
         // holding only the secret-record subset (over-allocating, ~2.5% of
         // the decode).
         msg_secret_records: Vec::new(),
+        lid_mappings: Vec::new(),
         compressed_bytes: None,
         decompressed_size: 0,
     };
@@ -334,6 +339,12 @@ fn process_history_sync_streaming(
             }
             tags::history_sync::NCT_SALT if !value.is_empty() => {
                 result.nct_salt = Some(value.to_vec());
+            }
+            // phoneNumberToLidMappings (repeated)
+            tags::history_sync::PHONE_NUMBER_TO_LID_MAPPINGS => {
+                if let Some(mapping) = extract_lid_mapping(value) {
+                    result.lid_mappings.push(mapping);
+                }
             }
             _ => {}
         }
@@ -602,11 +613,77 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
     if id_match { pushname } else { None }
 }
 
+/// One PN↔LID pair from `HistorySync.phoneNumberToLidMappings`, reduced to
+/// bare user parts (no server, no device).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryLidMapping {
+    pub phone_number: String,
+    pub lid: String,
+}
+
+// Best-effort: a malformed mapping entry (optional metadata) must not abort
+// the sync, mirroring the pushname extractor above.
+fn extract_lid_mapping(data: &[u8]) -> Option<HistoryLidMapping> {
+    use wacore_binary::{Jid, Server};
+
+    let mut pn_raw: Option<&str> = None;
+    let mut lid_raw: Option<&str> = None;
+    let mut pos = 0;
+
+    while pos < data.len() {
+        let (tag, bytes_read) = read_varint(data.get(pos..)?)?;
+        pos += bytes_read;
+        let field_number = (tag >> 3) as u32;
+        let wt = (tag & 0x7) as u32;
+
+        match field_number {
+            tags::phone_number_to_lid_mapping::PN_JID if wt == wire_type::LENGTH_DELIMITED => {
+                let (len, vlen) = read_varint(data.get(pos..)?)?;
+                pos += vlen;
+                let len = usize::try_from(len).ok()?;
+                let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
+                pn_raw = smoothutf8::from_utf8(data.get(pos..end)?);
+                pos = end;
+            }
+            tags::phone_number_to_lid_mapping::LID_JID if wt == wire_type::LENGTH_DELIMITED => {
+                let (len, vlen) = read_varint(data.get(pos..)?)?;
+                pos += vlen;
+                let len = usize::try_from(len).ok()?;
+                let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
+                lid_raw = smoothutf8::from_utf8(data.get(pos..end)?);
+                pos = end;
+            }
+            _ => {
+                pos = skip_field(wt, data, pos).ok()?;
+            }
+        }
+    }
+
+    let pn: Jid = pn_raw?.parse().ok()?;
+    let lid: Jid = lid_raw?.parse().ok()?;
+    // Legacy `@c.us` is the PN namespace under its old name (whatsmeow maps it
+    // to `@s.whatsapp.net` the same way); the user part is the phone either way.
+    if !(pn.is_pn() || pn.server == Server::Legacy) || !lid.is_lid() {
+        return None;
+    }
+    if pn.user_base().is_empty() || lid.user_base().is_empty() {
+        return None;
+    }
+    Some(HistoryLidMapping {
+        phone_number: pn.user_base().to_string(),
+        lid: lid.user_base().to_string(),
+    })
+}
+
 // Schema pinning: assert that the tags::* constants used by fast_extract and
 // extract_conversation_fields match the generated proto field numbers. If
 // whatsapp.proto renumbers a field, compilation fails here instead of the
 // fast-path silently reading the wrong wire field.
 const _: () = {
+    assert!(tags::history_sync::PHONE_NUMBER_TO_LID_MAPPINGS == 15);
+    assert!(tags::phone_number_to_lid_mapping::PN_JID == 1);
+    assert!(tags::phone_number_to_lid_mapping::LID_JID == 2);
+
     assert!(tags::history_sync_msg::MESSAGE == 1);
 
     assert!(tags::web_message_info::KEY == 1);
@@ -1669,6 +1746,59 @@ mod tests {
         let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(&proto_bytes).unwrap();
         encoder.finish().unwrap()
+    }
+
+    /// `phoneNumberToLidMappings` (field 15) is the bulk PN-LID identity seed;
+    /// valid pairs (including legacy `@c.us` phones and device-suffixed users)
+    /// are extracted, wrong namespaces and incomplete entries are skipped
+    /// without aborting the sync.
+    #[test]
+    fn test_lid_mappings_extracted_and_invalid_skipped() {
+        let mapping = |pn: &str, lid: &str| wa::PhoneNumberToLIDMapping {
+            pn_jid: Some(pn.to_string()),
+            lid_jid: Some(lid.to_string()),
+        };
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            phone_number_to_lid_mappings: vec![
+                mapping("5511777776666@s.whatsapp.net", "111222333444555@lid"),
+                // Legacy PN namespace, still a phone.
+                mapping("15550001111@c.us", "222333444555666@lid"),
+                // Device suffix reduces to the bare user.
+                mapping("5511222223333:2@s.whatsapp.net", "333444555666777@lid"),
+                // Wrong namespaces: skipped.
+                mapping("999888777666555@lid", "111222333444555@lid"),
+                mapping(
+                    "5511777776666@s.whatsapp.net",
+                    "5511777776666@s.whatsapp.net",
+                ),
+                // Incomplete: skipped.
+                wa::PhoneNumberToLIDMapping {
+                    pn_jid: Some("5511000000000@s.whatsapp.net".to_string()),
+                    lid_jid: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(
+            result.lid_mappings,
+            vec![
+                HistoryLidMapping {
+                    phone_number: "5511777776666".to_string(),
+                    lid: "111222333444555".to_string(),
+                },
+                HistoryLidMapping {
+                    phone_number: "15550001111".to_string(),
+                    lid: "222333444555666".to_string(),
+                },
+                HistoryLidMapping {
+                    phone_number: "5511222223333".to_string(),
+                    lid: "333444555666777".to_string(),
+                },
+            ]
+        );
     }
 
     /// Prost-only oracle: what the pre-fast-path pipeline produced for one
@@ -2839,6 +2969,7 @@ mod tests {
             conversations_processed: 0,
             tc_token_candidates: Vec::new(),
             msg_secret_records: Vec::new(),
+            lid_mappings: Vec::new(),
             compressed_bytes: None,
             decompressed_size: decompressed.len(),
         };

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -340,7 +340,6 @@ fn process_history_sync_streaming(
             tags::history_sync::NCT_SALT if !value.is_empty() => {
                 result.nct_salt = Some(value.to_vec());
             }
-            // phoneNumberToLidMappings (repeated)
             tags::history_sync::PHONE_NUMBER_TO_LID_MAPPINGS => {
                 if let Some(mapping) = extract_lid_mapping(value) {
                     result.lid_mappings.push(mapping);
@@ -621,6 +620,17 @@ pub struct HistoryLidMapping {
     pub lid: String,
 }
 
+/// Read one length-delimited UTF-8 string field, advancing `pos` past it.
+fn read_str_field<'a>(data: &'a [u8], pos: &mut usize) -> Option<&'a str> {
+    let (len, vlen) = read_varint(data.get(*pos..)?)?;
+    *pos += vlen;
+    let len = usize::try_from(len).ok()?;
+    let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
+    let value = smoothutf8::from_utf8(data.get(*pos..end)?)?;
+    *pos = end;
+    Some(value)
+}
+
 // Best-effort: a malformed mapping entry (optional metadata) must not abort
 // the sync, mirroring the pushname extractor above.
 fn extract_lid_mapping(data: &[u8]) -> Option<HistoryLidMapping> {
@@ -638,20 +648,10 @@ fn extract_lid_mapping(data: &[u8]) -> Option<HistoryLidMapping> {
 
         match field_number {
             tags::phone_number_to_lid_mapping::PN_JID if wt == wire_type::LENGTH_DELIMITED => {
-                let (len, vlen) = read_varint(data.get(pos..)?)?;
-                pos += vlen;
-                let len = usize::try_from(len).ok()?;
-                let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
-                pn_raw = smoothutf8::from_utf8(data.get(pos..end)?);
-                pos = end;
+                pn_raw = Some(read_str_field(data, &mut pos)?);
             }
             tags::phone_number_to_lid_mapping::LID_JID if wt == wire_type::LENGTH_DELIMITED => {
-                let (len, vlen) = read_varint(data.get(pos..)?)?;
-                pos += vlen;
-                let len = usize::try_from(len).ok()?;
-                let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
-                lid_raw = smoothutf8::from_utf8(data.get(pos..end)?);
-                pos = end;
+                lid_raw = Some(read_str_field(data, &mut pos)?);
             }
             _ => {
                 pos = skip_field(wt, data, pos).ok()?;
@@ -3018,6 +3018,17 @@ mod tests {
                     }
                     pos = end;
                 }
+                tags::history_sync::PHONE_NUMBER_TO_LID_MAPPINGS
+                    if wt == wire_type::LENGTH_DELIMITED =>
+                {
+                    let (len, vlen) = read_varint(&decompressed[pos..]).unwrap();
+                    pos += vlen;
+                    let end = checked_end(pos, len, decompressed.len()).unwrap();
+                    if let Some(mapping) = extract_lid_mapping(&decompressed[pos..end]) {
+                        result.lid_mappings.push(mapping);
+                    }
+                    pos = end;
+                }
                 _ => {
                     pos = skip_field(wt, decompressed, pos).unwrap();
                 }
@@ -3087,6 +3098,17 @@ mod tests {
                 pushname: Some("Me".into()),
             }],
             nct_salt: Some(vec![0x01, 0x02, 0x03, 0x04]),
+            phone_number_to_lid_mappings: vec![
+                wa::PhoneNumberToLIDMapping {
+                    pn_jid: Some("5511777776666@s.whatsapp.net".to_string()),
+                    lid_jid: Some("111222333444555@lid".to_string()),
+                },
+                // Wrong namespace: both walks must skip it identically.
+                wa::PhoneNumberToLIDMapping {
+                    pn_jid: Some("999888777666555@lid".to_string()),
+                    lid_jid: Some("111222333444555@lid".to_string()),
+                },
+            ],
             ..Default::default()
         }
     }
@@ -3133,6 +3155,15 @@ mod tests {
             );
             assert_eq!(result.msg_secret_records, reference.msg_secret_records);
             assert_eq!(result.msg_secret_records.len(), 1500 + 1);
+            assert_eq!(result.lid_mappings, reference.lid_mappings);
+            assert_eq!(
+                result.lid_mappings,
+                vec![HistoryLidMapping {
+                    phone_number: "5511777776666".to_string(),
+                    lid: "111222333444555".to_string(),
+                }],
+                "valid mapping extracted, wrong-namespace entry skipped"
+            );
         }
     }
 


### PR DESCRIPTION
## Motivation

`HistorySync` ships a bulk PN↔LID identity table alongside the chats — field 15, `phoneNumberToLidMappings` — but the streaming extractor currently drops it. A freshly paired client therefore only learns peers' LID↔PN pairs one at a time from live traffic (message `sender_alt`, usync responses, notifications), and LID-addressed chats imported from history stay unresolvable until each peer happens to show up live.

whatsmeow harvests exactly this field on every history-sync chunk (`storeHistoricalPNLIDMappings`, message.go); this PR brings the same behavior here.

## What it does

- `wacore`: the streaming walk in `process_history_sync_streaming` extracts each `PhoneNumberToLIDMapping` into `HistorySyncResult.lid_mappings` (new `HistoryLidMapping { phone_number, lid }`, bare user parts). Same best-effort leniency as the pushname extractor: malformed entries are skipped, never fatal. Legacy `@c.us` phones are accepted as PN (whatsmeow normalizes them the same way); wrong namespaces and incomplete entries are rejected. Tag constants are pinned in the existing const-assert block.
- `whatsapp-rust`: after a successful parse, `process_history_sync_task` feeds the pairs to `learn_lid_pn_mappings_batch` (`LearningSource::MigrationSyncLatest`), so cache, store, and session/registry migrations follow the same path as the other batch learns (persist + migrations detached).

## Notes for review

- **LearningSource**: I reused `MigrationSyncLatest` — its doc comment ("learned from latest history sync migration") finally matches a real history-sync writer. Happy to add a dedicated `HistorySync` variant instead if you prefer.
- **Migration timing**: whatsmeow's history-sync harvest is store-only and lets Signal sessions migrate lazily on the next live message/send. `learn_lid_pn_mappings_batch` additionally runs the registry/session migrations on its detached task; if you'd rather match whatsmeow strictly for large histories, I can switch to the store-only half.

## Tests

- `wacore`: extraction test covering valid pairs, legacy `@c.us`, device-suffixed users, wrong namespaces, and incomplete entries.
- `whatsapp-rust`: end-to-end `process_history_sync_task` test asserting the pair lands in the LID-PN cache.
- `cargo fmt --check` and `cargo clippy` clean; full `history_sync` + `lid_pn` test modules pass.