### PR TITLE
feat(chat-store): SQLite-backed chat/message history store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,6 +4383,7 @@ dependencies = [
  "flate2",
  "log",
  "portable-atomic",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "wacore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,6 +4373,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "whatsapp-rust-chat-store"
+version = "0.1.0"
+dependencies = [
+ "buffa",
+ "chrono",
+ "diesel",
+ "diesel_migrations",
+ "flate2",
+ "log",
+ "portable-atomic",
+ "thiserror 2.0.18",
+ "tokio",
+ "wacore",
+ "wacore-binary",
+ "waproto",
+ "whatsapp-rust-sqlite-storage",
+]
+
+[[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     ".",
     "examples/voip-cli",
     "http_clients/ureq-client",
+    "storages/chat-store",
     "storages/sqlite-storage",
     "tests/bench-integration",
     "tests/e2e",
@@ -69,6 +70,8 @@ chrono = { version = "0.4", default-features = false }
 compact_str = { version = "0.9", default-features = false }
 ctr = { version = "0.10", default-features = false }
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
+diesel = { version = "2.3.10", default-features = false, features = ["sqlite", "r2d2", "32-column-tables"] }
+diesel_migrations = { version = "2.3.2", default-features = false, features = ["sqlite"] }
 env_logger = { version = "0.11", default-features = false }
 event-listener = { version = "5", default-features = false }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }

--- a/storages/chat-store/Cargo.toml
+++ b/storages/chat-store/Cargo.toml
@@ -20,6 +20,7 @@ chrono = { workspace = true, features = ["std", "clock"] }
 diesel = { workspace = true }
 diesel_migrations = { workspace = true }
 log = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
 wacore = { workspace = true }

--- a/storages/chat-store/Cargo.toml
+++ b/storages/chat-store/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "whatsapp-rust-chat-store"
+version = "0.1.0"
+edition = "2024"
+authors = ["João Lucas <jlucaso@hotmail.com>"]
+license = "MIT"
+repository = "https://github.com/jlucaso1/whatsapp-rust"
+description = "SQLite-backed chat/message history store for whatsapp-rust"
+
+[features]
+default = []
+# Full-text message search via SQLite FTS5 (virtual table + sync triggers,
+# created lazily at open; requires an FTS5-enabled SQLite, which the bundled
+# build of whatsapp-rust-sqlite-storage provides).
+search = []
+
+[dependencies]
+buffa = { workspace = true }
+chrono = { workspace = true, features = ["std", "clock"] }
+diesel = { workspace = true }
+diesel_migrations = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt", "macros"] }
+wacore = { workspace = true }
+wacore-binary = { workspace = true }
+waproto = { workspace = true }
+whatsapp-rust-sqlite-storage = { path = "../sqlite-storage", version = "0.6.0" }
+
+[dev-dependencies]
+flate2 = { workspace = true }
+portable-atomic = { workspace = true }
+tokio = { workspace = true, features = [
+    "sync",
+    "rt",
+    "rt-multi-thread",
+    "time",
+    "macros",
+] }
+
+[lints]
+workspace = true

--- a/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/down.sql
+++ b/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS media_refs;
+DROP TABLE IF EXISTS message_receipts;
+DROP TABLE IF EXISTS contacts;
+DROP TABLE IF EXISTS reactions;
+DROP TABLE IF EXISTS messages;
+DROP TABLE IF EXISTS chats;

--- a/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
+++ b/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
@@ -15,6 +15,9 @@ CREATE TABLE chats (
     muted_until BIGINT,
     archived BOOLEAN NOT NULL DEFAULT FALSE,
     ephemeral_expiration INTEGER,
+    -- Monotonic self-read cursor (ms): a delayed/stale read-self receipt must
+    -- not re-inflate or re-clear the unread badge.
+    read_boundary_ms BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (device_id, jid)
 );
 

--- a/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
+++ b/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
@@ -15,9 +15,12 @@ CREATE TABLE chats (
     muted_until BIGINT,
     archived BOOLEAN NOT NULL DEFAULT FALSE,
     ephemeral_expiration INTEGER,
-    -- Monotonic self-read cursor (ms): a delayed/stale read-self receipt must
-    -- not re-inflate or re-clear the unread badge.
+    -- Monotonic self-read state: everything at or below the watermark is
+    -- read, plus the JSON id list for boundary-instant/keyed coverage that a
+    -- scalar watermark cannot express. A delayed/stale read event must
+    -- neither re-inflate nor re-clear the unread badge.
     read_boundary_ms BIGINT NOT NULL DEFAULT 0,
+    read_boundary_ids TEXT,
     PRIMARY KEY (device_id, jid)
 );
 

--- a/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
+++ b/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
@@ -1,0 +1,89 @@
+-- Chat/message history tables. They live in the SAME database file as the
+-- whatsapp-rust-sqlite-storage tables (shared pool via SqliteStore::shared());
+-- these table names are reserved by the chat-store crate.
+
+CREATE TABLE chats (
+    device_id INTEGER NOT NULL,
+    jid TEXT NOT NULL,
+    name TEXT,
+    last_message_ts BIGINT NOT NULL DEFAULT 0,
+    last_message_preview TEXT,
+    -- -1 = manually marked unread (WA Web convention)
+    unread_count INTEGER NOT NULL DEFAULT 0,
+    pinned_at BIGINT,
+    muted_until BIGINT,
+    archived BOOLEAN NOT NULL DEFAULT FALSE,
+    ephemeral_expiration INTEGER,
+    PRIMARY KEY (device_id, jid)
+);
+
+CREATE INDEX idx_chats_order ON chats (device_id, archived, last_message_ts DESC);
+
+CREATE TABLE messages (
+    device_id INTEGER NOT NULL,
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    sender_jid TEXT NOT NULL,
+    from_me BOOLEAN NOT NULL DEFAULT FALSE,
+    timestamp_ms BIGINT NOT NULL,
+    kind TEXT NOT NULL,
+    text_content TEXT,
+    -- wa::Message encoded with buffa; NULL for tombstones (revoked) and
+    -- undecryptable placeholders. Source of truth: columns are projections.
+    proto BLOB,
+    -- WebMessageInfo.Status values: 0 error, 1 pending, 2 server ack,
+    -- 3 delivered, 4 read, 5 played.
+    status INTEGER NOT NULL DEFAULT 1,
+    starred BOOLEAN NOT NULL DEFAULT FALSE,
+    edited_at_ms BIGINT,
+    revoked BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (device_id, chat_jid, msg_id)
+);
+
+CREATE INDEX idx_messages_chat_time ON messages (device_id, chat_jid, timestamp_ms DESC, msg_id DESC);
+-- Server acks carry only the message id, not the chat.
+CREATE INDEX idx_messages_by_id ON messages (device_id, msg_id);
+
+CREATE TABLE reactions (
+    device_id INTEGER NOT NULL,
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    sender_jid TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    ts_ms BIGINT NOT NULL,
+    PRIMARY KEY (device_id, chat_jid, msg_id, sender_jid)
+);
+
+CREATE TABLE contacts (
+    device_id INTEGER NOT NULL,
+    jid TEXT NOT NULL,
+    push_name TEXT,
+    full_name TEXT,
+    first_name TEXT,
+    business_name TEXT,
+    PRIMARY KEY (device_id, jid)
+);
+
+-- Per-user delivery/read receipts (group read-by lists).
+CREATE TABLE message_receipts (
+    device_id INTEGER NOT NULL,
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
+    -- Same scale as messages.status: 3 delivered, 4 read, 5 played.
+    receipt_type INTEGER NOT NULL,
+    ts_ms BIGINT NOT NULL,
+    PRIMARY KEY (device_id, chat_jid, msg_id, user_jid)
+);
+
+-- Downloaded-media cache index: content hash -> local file, so media survives
+-- restarts and identical files are stored once.
+CREATE TABLE media_refs (
+    device_id INTEGER NOT NULL,
+    file_sha256 BLOB NOT NULL,
+    file_path TEXT NOT NULL,
+    mime_type TEXT,
+    size_bytes BIGINT,
+    downloaded_at_ms BIGINT NOT NULL,
+    PRIMARY KEY (device_id, file_sha256)
+);

--- a/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
+++ b/storages/chat-store/migrations/2026-07-09-000000_chat_store_initial/up.sql
@@ -8,6 +8,7 @@ CREATE TABLE chats (
     name TEXT,
     last_message_ts BIGINT NOT NULL DEFAULT 0,
     last_message_preview TEXT,
+    last_message_kind TEXT,
     -- -1 = manually marked unread (WA Web convention)
     unread_count INTEGER NOT NULL DEFAULT 0,
     pinned_at BIGINT,

--- a/storages/chat-store/src/error.rs
+++ b/storages/chat-store/src/error.rs
@@ -9,6 +9,12 @@ pub enum ChatStoreError {
 
     #[error("invalid full-text search query")]
     InvalidSearchQuery,
+
+    /// A writer batch rolled back; the writes acknowledged by this `flush`
+    /// were dropped. Carries the underlying error rendered to text (one batch
+    /// outcome fans out to many flush waiters).
+    #[error("write batch failed: {0}")]
+    WriteBatchFailed(String),
 }
 
 pub type Result<T> = std::result::Result<T, ChatStoreError>;

--- a/storages/chat-store/src/error.rs
+++ b/storages/chat-store/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+use wacore::store::error::StoreError;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ChatStoreError {
+    #[error("storage error")]
+    Store(#[from] StoreError),
+
+    #[error("invalid full-text search query")]
+    InvalidSearchQuery,
+}
+
+pub type Result<T> = std::result::Result<T, ChatStoreError>;
+
+pub(crate) fn db_err(e: diesel::result::Error) -> StoreError {
+    StoreError::Database(Box::new(e))
+}

--- a/storages/chat-store/src/fts.rs
+++ b/storages/chat-store/src/fts.rs
@@ -16,6 +16,17 @@ use crate::store::ChatStore;
 use crate::types::StoredMessage;
 
 pub(crate) fn ensure_fts(conn: &mut SqliteConnection) -> QueryResult<()> {
+    #[derive(QueryableByName)]
+    struct CountRow {
+        #[diesel(sql_type = diesel::sql_types::Integer)]
+        n: i32,
+    }
+    let already_exists: bool = diesel::sql_query(
+        "SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'",
+    )
+    .get_result::<CountRow>(conn)?
+    .n > 0;
+
     // Canonical FTS5 external-content recipe: EVERY content row gets exactly
     // one index entry (NULL indexes as empty), and the update trigger pairs
     // delete-then-insert in one body. Anything cuter (WHEN guards, split
@@ -38,6 +49,12 @@ pub(crate) fn ensure_fts(conn: &mut SqliteConnection) -> QueryResult<()> {
              END",
     ] {
         diesel::sql_query(statement).execute(conn)?;
+    }
+    // First enablement on a database that already has messages: the triggers
+    // only cover future writes, so index the existing rows once.
+    if !already_exists {
+        diesel::sql_query("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+            .execute(conn)?;
     }
     Ok(())
 }
@@ -78,6 +95,11 @@ impl ChatStore {
         let Some(match_query) = build_match_query(query) else {
             return Err(ChatStoreError::InvalidSearchQuery);
         };
+        // A negative LIMIT means "unbounded" to SQLite; never let that happen.
+        let limit = limit.max(0);
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let device_id = self.device_id();
         let hits: Vec<FtsRow> = self
             .db()

--- a/storages/chat-store/src/fts.rs
+++ b/storages/chat-store/src/fts.rs
@@ -16,6 +16,13 @@ use crate::store::ChatStore;
 use crate::types::StoredMessage;
 
 pub(crate) fn ensure_fts(conn: &mut SqliteConnection) -> QueryResult<()> {
+    // One transaction for existence-check + DDL + backfill: a partially
+    // created index (table committed, rebuild lost) would pass the existence
+    // gate forever after, leaving pre-existing rows permanently unindexed.
+    conn.transaction(ensure_fts_inner)
+}
+
+fn ensure_fts_inner(conn: &mut SqliteConnection) -> QueryResult<()> {
     #[derive(QueryableByName)]
     struct CountRow {
         #[diesel(sql_type = diesel::sql_types::Integer)]

--- a/storages/chat-store/src/fts.rs
+++ b/storages/chat-store/src/fts.rs
@@ -1,0 +1,134 @@
+//! Full-text message search via SQLite FTS5 (feature `search`).
+//!
+//! External-content index over `messages.text_content`, kept in sync by
+//! triggers so the writer never has to think about it. Created lazily and
+//! idempotently at open instead of in a migration, so builds without the
+//! feature leave no FTS objects behind.
+//!
+//! Caveat: the index maps by implicit rowid; after a manual `VACUUM`, run
+//! `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')`.
+
+use diesel::prelude::*;
+use log::warn;
+
+use crate::error::{ChatStoreError, Result, db_err};
+use crate::store::ChatStore;
+use crate::types::StoredMessage;
+
+pub(crate) fn ensure_fts(conn: &mut SqliteConnection) -> QueryResult<()> {
+    // Canonical FTS5 external-content recipe: EVERY content row gets exactly
+    // one index entry (NULL indexes as empty), and the update trigger pairs
+    // delete-then-insert in one body. Anything cuter (WHEN guards, split
+    // triggers) breaks the symmetry FTS5's shadow bookkeeping relies on and
+    // corrupts rank queries.
+    for statement in [
+        "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+             text_content, content='messages', content_rowid='rowid')",
+        "CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages BEGIN
+             INSERT INTO messages_fts(rowid, text_content) VALUES (new.rowid, new.text_content);
+             END",
+        "CREATE TRIGGER IF NOT EXISTS messages_fts_ad AFTER DELETE ON messages BEGIN
+             INSERT INTO messages_fts(messages_fts, rowid, text_content)
+             VALUES ('delete', old.rowid, old.text_content);
+             END",
+        "CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE OF text_content ON messages BEGIN
+             INSERT INTO messages_fts(messages_fts, rowid, text_content)
+             VALUES ('delete', old.rowid, old.text_content);
+             INSERT INTO messages_fts(rowid, text_content) VALUES (new.rowid, new.text_content);
+             END",
+    ] {
+        diesel::sql_query(statement).execute(conn)?;
+    }
+    Ok(())
+}
+
+/// Turn free text into an FTS5 query: each whitespace token becomes a quoted
+/// prefix term (`"tok"*`), AND-combined. Sidesteps FTS5 operator syntax so
+/// user input can't produce a syntax error.
+fn build_match_query(input: &str) -> Option<String> {
+    let mut query = String::with_capacity(input.len() + 8);
+    for token in input.split_whitespace() {
+        if !query.is_empty() {
+            query.push(' ');
+        }
+        query.push('"');
+        for ch in token.chars() {
+            if ch == '"' {
+                query.push('"');
+            }
+            query.push(ch);
+        }
+        query.push_str("\"*");
+    }
+    (!query.is_empty()).then_some(query)
+}
+
+#[derive(QueryableByName)]
+struct FtsRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    chat_jid: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    msg_id: String,
+}
+
+impl ChatStore {
+    /// Full-text search over message text/captions, best match first. The
+    /// query is plain words (prefix-matched); FTS5 operators are neutralized.
+    pub async fn search_messages(&self, query: &str, limit: i64) -> Result<Vec<StoredMessage>> {
+        let Some(match_query) = build_match_query(query) else {
+            return Err(ChatStoreError::InvalidSearchQuery);
+        };
+        let device_id = self.device_id();
+        let hits: Vec<FtsRow> = self
+            .db()
+            .run(move |conn| {
+                diesel::sql_query(
+                    "SELECT m.chat_jid AS chat_jid, m.msg_id AS msg_id
+                     FROM messages_fts f JOIN messages m ON m.rowid = f.rowid
+                     WHERE messages_fts MATCH ? AND m.device_id = ?
+                     ORDER BY rank LIMIT ?",
+                )
+                .bind::<diesel::sql_types::Text, _>(&match_query)
+                .bind::<diesel::sql_types::Integer, _>(device_id)
+                .bind::<diesel::sql_types::BigInt, _>(limit)
+                .load(conn)
+                .map_err(db_err)
+            })
+            .await?;
+
+        // Hydrate full rows through the regular path (decodes protos, parses
+        // JIDs). One extra point query per hit; hit counts are UI-page sized.
+        let mut results = Vec::with_capacity(hits.len());
+        for hit in hits {
+            match hit.chat_jid.parse() {
+                Ok(chat) => {
+                    if let Some(message) = self.message(&chat, &hit.msg_id).await? {
+                        results.push(message);
+                    }
+                }
+                Err(_) => warn!("chat-store: unparseable chat JID in FTS hit"),
+            }
+        }
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_match_query;
+
+    #[test]
+    fn match_query_neutralizes_operators_and_quotes() {
+        assert_eq!(build_match_query("hello"), Some("\"hello\"*".into()));
+        assert_eq!(
+            build_match_query("hello world"),
+            Some("\"hello\"* \"world\"*".into())
+        );
+        assert_eq!(build_match_query("a\"b"), Some("\"a\"\"b\"*".into()));
+        assert_eq!(
+            build_match_query("NOT OR AND"),
+            Some("\"NOT\"* \"OR\"* \"AND\"*".into())
+        );
+        assert_eq!(build_match_query("   "), None);
+    }
+}

--- a/storages/chat-store/src/lib.rs
+++ b/storages/chat-store/src/lib.rs
@@ -1,0 +1,45 @@
+//! SQLite-backed chat/message history for whatsapp-rust.
+//!
+//! This crate materializes the client's event stream (messages, receipts,
+//! edits, revokes, reactions, history sync, app-state chat updates) into
+//! queryable tables in the SAME database file as the device store, so a UI or
+//! stateful bot survives a restart without re-syncing. It has no UI
+//! dependencies — it is a data layer any consumer can opt into.
+//!
+//! Design:
+//! - **Event-sourced**: register [`ChatStore::handler`] on the client; a
+//!   single writer task applies batched events transactionally, in order.
+//! - **Proto as source of truth**: each message row stores the encoded
+//!   `wa::Message` plus denormalized columns for listing/search — new proto
+//!   fields never require a migration.
+//! - **Query + invalidation**: read via the async query API (keyset
+//!   pagination), subscribe to [`types::StoreChange`] to know when to re-query.
+//!   No second in-memory cache of rows.
+//! - **Shared file, shared pool**: writes go through
+//!   [`SqliteStore::shared`](whatsapp_rust_sqlite_storage::SqliteStore),
+//!   so there is exactly one WAL writer per database file.
+//!
+//! ```ignore
+//! let chat_store = ChatStore::new(&sqlite_store).await?;
+//! client.register_handler(chat_store.handler());
+//!
+//! let chats = chat_store.chats(false, 50).await?;
+//! let page = chat_store.messages(&chats[0].jid, None, 40).await?;
+//! let mut changes = chat_store.subscribe();
+//! ```
+
+mod error;
+#[cfg(feature = "search")]
+mod fts;
+mod materialize;
+mod queries;
+mod schema;
+mod store;
+pub mod types;
+
+pub use error::{ChatStoreError, Result};
+pub use store::ChatStore;
+pub use types::{
+    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageStatus, ReactionEntry, ReceiptEntry,
+    StoreChange, StoredMessage,
+};

--- a/storages/chat-store/src/lib.rs
+++ b/storages/chat-store/src/lib.rs
@@ -40,6 +40,6 @@ pub mod types;
 pub use error::{ChatStoreError, Result};
 pub use store::ChatStore;
 pub use types::{
-    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageStatus, ReactionEntry, ReceiptEntry,
-    StoreChange, StoredMessage,
+    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus, ReactionEntry,
+    ReceiptEntry, StoreChange, StoredMessage,
 };

--- a/storages/chat-store/src/materialize.rs
+++ b/storages/chat-store/src/materialize.rs
@@ -130,21 +130,18 @@ pub(crate) fn extract_text(base: &wa::Message) -> Option<String> {
 
 /// Whether the unwrapped message carries anything a chat log should show.
 /// Guards against storing rows for pure-bookkeeping payloads that classify as
-/// "unknown".
+/// "unknown". Decided structurally: strip the bookkeeping carriers and check
+/// whether ANY other field remains set, so an unclassified-but-real bubble
+/// (e.g. a future WA message type) that also carries `message_context_info`
+/// is still stored.
 fn has_any_content(base: &wa::Message) -> bool {
-    // A message whose ONLY set fields are bookkeeping carriers has no bubble.
-    // buffa keeps unknown fields out of these accessors, so checking the known
-    // bookkeeping set suffices.
-    let only_bookkeeping = base.sender_key_distribution_message.is_set()
-        || base
-            .fast_ratchet_key_sender_key_distribution_message
-            .is_set()
-        || base.message_context_info.is_set();
-    if !only_bookkeeping {
-        return true;
-    }
-    // Any renderable field set alongside the carrier still counts as content.
-    message_kind(base) != "unknown"
+    let mut probe = base.clone();
+    probe.sender_key_distribution_message = Default::default();
+    probe.fast_ratchet_key_sender_key_distribution_message = Default::default();
+    probe.message_context_info = Default::default();
+    // Encoded emptiness, not PartialEq: presence of an empty submessage still
+    // costs wire bytes, while buffa's equality folds it into "absent".
+    !probe.encode_to_vec().is_empty()
 }
 
 #[cfg(test)]
@@ -327,6 +324,31 @@ mod tests {
             ..Default::default()
         };
         assert!(matches!(classify(&key_share), MessageOp::Ignore));
+    }
+
+    #[test]
+    fn unknown_content_with_context_info_is_still_stored() {
+        // A future/unclassified bubble type often carries message_context_info
+        // (msg secrets); that must not demote it to bookkeeping-only.
+        let msg = wa::Message {
+            send_payment_message: MessageField::some(wa::message::SendPaymentMessage::default()),
+            message_context_info: MessageField::some(wa::MessageContextInfo::default()),
+            ..Default::default()
+        };
+        match classify(&msg) {
+            MessageOp::Store { kind, .. } => assert_eq!(kind, "unknown"),
+            other => panic!("expected Store, got {other:?}"),
+        }
+
+        // While a PURE bookkeeping payload still has no bubble.
+        let carrier_only = wa::Message {
+            sender_key_distribution_message: MessageField::some(
+                wa::message::SenderKeyDistributionMessage::default(),
+            ),
+            message_context_info: MessageField::some(wa::MessageContextInfo::default()),
+            ..Default::default()
+        };
+        assert!(matches!(classify(&carrier_only), MessageOp::Ignore));
     }
 
     #[test]

--- a/storages/chat-store/src/materialize.rs
+++ b/storages/chat-store/src/materialize.rs
@@ -1,0 +1,343 @@
+//! Pure event-to-row transforms: what a `wa::Message` means for the tables.
+//! No I/O here so every rule is unit-testable without a database.
+
+use buffa::Message as _;
+use wacore::proto_helpers::MessageExt;
+use waproto::whatsapp as wa;
+
+/// What the writer should do with one inbound message.
+#[derive(Debug)]
+pub(crate) enum MessageOp {
+    /// Regular content: insert (or refresh) a message row.
+    Store {
+        kind: &'static str,
+        text: Option<String>,
+    },
+    /// A reaction to another message. `emoji` empty means "remove my reaction".
+    Reaction { target_id: String, emoji: String },
+    /// An edit of another message: replace its content in place.
+    Edit {
+        target_id: String,
+        new_text: Option<String>,
+        new_kind: &'static str,
+        new_proto: Vec<u8>,
+    },
+    /// A revoke of another message: tombstone it.
+    Revoke { target_id: String },
+    /// Protocol/bookkeeping payloads that don't belong in a chat log.
+    Ignore,
+}
+
+/// UI-facing content class, derived from the unwrapped message. Coarser than
+/// the proto (one label per renderable bubble type), finer than WA's stanza
+/// `type` attribute (which collapses everything to text/media).
+pub(crate) fn message_kind(base: &wa::Message) -> &'static str {
+    if base.conversation.is_some() || base.extended_text_message.is_set() {
+        "text"
+    } else if base.image_message.is_set() {
+        "image"
+    } else if base.ptv_message.is_set() {
+        "ptv"
+    } else if base.video_message.is_set() {
+        "video"
+    } else if let Some(audio) = base.audio_message.as_option() {
+        if audio.ptt.unwrap_or(false) {
+            "ptt"
+        } else {
+            "audio"
+        }
+    } else if base.sticker_message.is_set() || base.lottie_sticker_message.is_set() {
+        "sticker"
+    } else if base.document_message.is_set() {
+        "document"
+    } else if base.contact_message.is_set() || base.contacts_array_message.is_set() {
+        "contact"
+    } else if base.location_message.is_set() || base.live_location_message.is_set() {
+        "location"
+    } else if base.poll_creation_message.is_set()
+        || base.poll_creation_message_v2.is_set()
+        || base.poll_creation_message_v3.is_set()
+    {
+        "poll"
+    } else if base.event_message.is_set() {
+        "event"
+    } else if base.group_invite_message.is_set() {
+        "group_invite"
+    } else {
+        "unknown"
+    }
+}
+
+/// Kind label for a placeholder row of a message we could not decrypt.
+pub(crate) const KIND_UNDECRYPTABLE: &str = "undecryptable";
+
+/// Classify one decrypted message into its materialization op.
+pub(crate) fn classify(msg: &wa::Message) -> MessageOp {
+    let base = msg.get_base_message();
+
+    if let Some(reaction) = base.reaction_message.as_option() {
+        let Some(target_id) = reaction.key.as_option().and_then(|k| k.id.clone()) else {
+            return MessageOp::Ignore;
+        };
+        return MessageOp::Reaction {
+            target_id,
+            emoji: reaction.text.clone().unwrap_or_default(),
+        };
+    }
+
+    if let Some(pm) = base.protocol_message.as_option() {
+        use wa::message::protocol_message::Type as ProtocolType;
+        let target_id = pm.key.as_option().and_then(|k| k.id.clone());
+        match (pm.r#type, target_id) {
+            (Some(ProtocolType::REVOKE), Some(target_id)) => {
+                return MessageOp::Revoke { target_id };
+            }
+            (Some(ProtocolType::MESSAGE_EDIT), Some(target_id)) => {
+                if let Some(edited) = pm.edited_message.as_option() {
+                    let edited_base = edited.get_base_message();
+                    return MessageOp::Edit {
+                        target_id,
+                        new_text: extract_text(edited_base),
+                        new_kind: message_kind(edited_base),
+                        new_proto: edited.encode_to_vec(),
+                    };
+                }
+                return MessageOp::Ignore;
+            }
+            // Key shares, history-sync notifications, peer data requests, ...
+            _ => return MessageOp::Ignore,
+        }
+    }
+
+    let kind = message_kind(base);
+    if kind == "unknown" && !has_any_content(base) {
+        // Bare senderKeyDistribution / messageContextInfo carriers.
+        return MessageOp::Ignore;
+    }
+    MessageOp::Store {
+        kind,
+        text: extract_text(base),
+    }
+}
+
+/// Text projection for list previews and full-text search: body text or media
+/// caption.
+pub(crate) fn extract_text(base: &wa::Message) -> Option<String> {
+    base.text_content()
+        .or_else(|| base.get_caption())
+        .map(str::to_owned)
+}
+
+/// Whether the unwrapped message carries anything a chat log should show.
+/// Guards against storing rows for pure-bookkeeping payloads that classify as
+/// "unknown".
+fn has_any_content(base: &wa::Message) -> bool {
+    // A message whose ONLY set fields are bookkeeping carriers has no bubble.
+    // buffa keeps unknown fields out of these accessors, so checking the known
+    // bookkeeping set suffices.
+    let only_bookkeeping = base.sender_key_distribution_message.is_set()
+        || base
+            .fast_ratchet_key_sender_key_distribution_message
+            .is_set()
+        || base.message_context_info.is_set();
+    if !only_bookkeeping {
+        return true;
+    }
+    // Any renderable field set alongside the carrier still counts as content.
+    message_kind(base) != "unknown"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use buffa::MessageField;
+    use wacore::proto_helpers::MessageBuilderExt;
+
+    fn key_for(id: &str) -> MessageField<wa::MessageKey> {
+        MessageField::some(wa::MessageKey {
+            id: Some(id.into()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn classifies_plain_text() {
+        let msg = wa::Message::text("hello");
+        match classify(&msg) {
+            MessageOp::Store { kind, text } => {
+                assert_eq!(kind, "text");
+                assert_eq!(text.as_deref(), Some("hello"));
+            }
+            other => panic!("expected Store, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifies_ephemeral_wrapped_text() {
+        let msg = wa::Message {
+            ephemeral_message: MessageField::some(wa::message::FutureProofMessage {
+                message: MessageField::from_box(Box::new(wa::Message::text("secret"))),
+            }),
+            ..Default::default()
+        };
+        match classify(&msg) {
+            MessageOp::Store { kind, text } => {
+                assert_eq!(kind, "text");
+                assert_eq!(text.as_deref(), Some("secret"));
+            }
+            other => panic!("expected Store, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifies_image_with_caption() {
+        let msg = wa::Message {
+            image_message: MessageField::some(wa::message::ImageMessage {
+                caption: Some("look".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        match classify(&msg) {
+            MessageOp::Store { kind, text } => {
+                assert_eq!(kind, "image");
+                assert_eq!(text.as_deref(), Some("look"));
+            }
+            other => panic!("expected Store, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ptt_and_audio_are_distinct() {
+        let ptt = wa::Message {
+            audio_message: MessageField::some(wa::message::AudioMessage {
+                ptt: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let audio = wa::Message {
+            audio_message: MessageField::some(wa::message::AudioMessage::default()),
+            ..Default::default()
+        };
+        assert_eq!(message_kind(&ptt), "ptt");
+        assert_eq!(message_kind(&audio), "audio");
+    }
+
+    #[test]
+    fn classifies_reaction_add_and_remove() {
+        let add = wa::Message {
+            reaction_message: MessageField::some(wa::message::ReactionMessage {
+                key: key_for("MSG1"),
+                text: Some("👍".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        match classify(&add) {
+            MessageOp::Reaction { target_id, emoji } => {
+                assert_eq!(target_id, "MSG1");
+                assert_eq!(emoji, "👍");
+            }
+            other => panic!("expected Reaction, got {other:?}"),
+        }
+
+        let remove = wa::Message {
+            reaction_message: MessageField::some(wa::message::ReactionMessage {
+                key: key_for("MSG1"),
+                text: Some(String::new()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        match classify(&remove) {
+            MessageOp::Reaction { emoji, .. } => assert!(emoji.is_empty()),
+            other => panic!("expected Reaction, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reaction_without_target_key_is_ignored() {
+        let msg = wa::Message {
+            reaction_message: MessageField::some(wa::message::ReactionMessage {
+                text: Some("👍".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(classify(&msg), MessageOp::Ignore));
+    }
+
+    #[test]
+    fn classifies_revoke_and_edit() {
+        use wa::message::protocol_message::Type as ProtocolType;
+        let revoke = wa::Message {
+            protocol_message: MessageField::some(wa::message::ProtocolMessage {
+                key: key_for("MSG2"),
+                r#type: Some(ProtocolType::REVOKE),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(
+            classify(&revoke),
+            MessageOp::Revoke { target_id } if target_id == "MSG2"
+        ));
+
+        let edit = wa::Message {
+            protocol_message: MessageField::some(wa::message::ProtocolMessage {
+                key: key_for("MSG3"),
+                r#type: Some(ProtocolType::MESSAGE_EDIT),
+                edited_message: MessageField::from_box(Box::new(wa::Message::text("fixed"))),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        match classify(&edit) {
+            MessageOp::Edit {
+                target_id,
+                new_text,
+                new_kind,
+                new_proto,
+            } => {
+                assert_eq!(target_id, "MSG3");
+                assert_eq!(new_text.as_deref(), Some("fixed"));
+                assert_eq!(new_kind, "text");
+                assert!(!new_proto.is_empty());
+            }
+            other => panic!("expected Edit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bookkeeping_only_messages_are_ignored() {
+        let skdm_only = wa::Message {
+            sender_key_distribution_message: MessageField::some(
+                wa::message::SenderKeyDistributionMessage::default(),
+            ),
+            ..Default::default()
+        };
+        assert!(matches!(classify(&skdm_only), MessageOp::Ignore));
+
+        let key_share = wa::Message {
+            protocol_message: MessageField::some(wa::message::ProtocolMessage {
+                r#type: Some(wa::message::protocol_message::Type::APP_STATE_SYNC_KEY_SHARE),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(matches!(classify(&key_share), MessageOp::Ignore));
+    }
+
+    #[test]
+    fn unclassified_but_present_content_stores_as_unknown() {
+        let msg = wa::Message {
+            send_payment_message: MessageField::some(wa::message::SendPaymentMessage::default()),
+            ..Default::default()
+        };
+        match classify(&msg) {
+            MessageOp::Store { kind, .. } => assert_eq!(kind, "unknown"),
+            other => panic!("expected Store, got {other:?}"),
+        }
+    }
+}

--- a/storages/chat-store/src/materialize.rs
+++ b/storages/chat-store/src/materialize.rs
@@ -22,8 +22,13 @@ pub(crate) enum MessageOp {
         new_kind: &'static str,
         new_proto: Vec<u8>,
     },
-    /// A revoke of another message: tombstone it.
-    Revoke { target_id: String },
+    /// A revoke of another message: tombstone it. `target_from_me` is the
+    /// revoke key's `fromMe` — whether the TARGET message was ours — used when
+    /// the tombstone has to be created before its content arrives.
+    Revoke {
+        target_id: String,
+        target_from_me: bool,
+    },
     /// Protocol/bookkeeping payloads that don't belong in a chat log.
     Ignore,
 }
@@ -91,7 +96,10 @@ pub(crate) fn classify(msg: &wa::Message) -> MessageOp {
         let target_id = pm.key.as_option().and_then(|k| k.id.clone());
         match (pm.r#type, target_id) {
             (Some(ProtocolType::REVOKE), Some(target_id)) => {
-                return MessageOp::Revoke { target_id };
+                return MessageOp::Revoke {
+                    target_id,
+                    target_from_me: pm.key.as_option().and_then(|k| k.from_me).unwrap_or(false),
+                };
             }
             (Some(ProtocolType::MESSAGE_EDIT), Some(target_id)) => {
                 if let Some(edited) = pm.edited_message.as_option() {
@@ -279,7 +287,7 @@ mod tests {
         };
         assert!(matches!(
             classify(&revoke),
-            MessageOp::Revoke { target_id } if target_id == "MSG2"
+            MessageOp::Revoke { target_id, .. } if target_id == "MSG2"
         ));
 
         let edit = wa::Message {

--- a/storages/chat-store/src/materialize.rs
+++ b/storages/chat-store/src/materialize.rs
@@ -28,9 +28,10 @@ pub(crate) enum MessageOp {
     Ignore,
 }
 
-/// UI-facing content class, derived from the unwrapped message. Coarser than
-/// the proto (one label per renderable bubble type), finer than WA's stanza
-/// `type` attribute (which collapses everything to text/media).
+/// Content class of the unwrapped message, as a database label (the typed
+/// read-model view is [`MessageKind`](crate::types::MessageKind)). Coarser
+/// than the proto (one label per renderable bubble type), finer than WA's
+/// stanza `type` attribute (which collapses everything to text/media).
 pub(crate) fn message_kind(base: &wa::Message) -> &'static str {
     if base.conversation.is_some() || base.extended_text_message.is_set() {
         "text"

--- a/storages/chat-store/src/materialize.rs
+++ b/storages/chat-store/src/materialize.rs
@@ -22,12 +22,14 @@ pub(crate) enum MessageOp {
         new_kind: &'static str,
         new_proto: Vec<u8>,
     },
-    /// A revoke of another message: tombstone it. `target_from_me` is the
-    /// revoke key's `fromMe` — whether the TARGET message was ours — used when
+    /// A revoke of another message: tombstone it. `target_from_me`/`target_participant`
+    /// come from the revoke KEY (they identify the target message's owner, not
+    /// the revoker — an admin revoke is authored by someone else), used when
     /// the tombstone has to be created before its content arrives.
     Revoke {
         target_id: String,
         target_from_me: bool,
+        target_participant: Option<String>,
     },
     /// Protocol/bookkeeping payloads that don't belong in a chat log.
     Ignore,
@@ -96,9 +98,11 @@ pub(crate) fn classify(msg: &wa::Message) -> MessageOp {
         let target_id = pm.key.as_option().and_then(|k| k.id.clone());
         match (pm.r#type, target_id) {
             (Some(ProtocolType::REVOKE), Some(target_id)) => {
+                let key = pm.key.as_option();
                 return MessageOp::Revoke {
                     target_id,
-                    target_from_me: pm.key.as_option().and_then(|k| k.from_me).unwrap_or(false),
+                    target_from_me: key.and_then(|k| k.from_me).unwrap_or(false),
+                    target_participant: key.and_then(|k| k.participant.clone()),
                 };
             }
             (Some(ProtocolType::MESSAGE_EDIT), Some(target_id)) => {

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -1,0 +1,399 @@
+//! Read API. Every query runs on the shared pool's blocking thread; results
+//! come back as plain owned values (the SQLite page cache is the cache — no
+//! row caching on this side).
+
+use std::str::FromStr;
+
+use buffa::Message as _;
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use log::warn;
+use wacore_binary::Jid;
+use waproto::whatsapp as wa;
+
+use crate::error::{Result, db_err};
+use crate::schema;
+use crate::store::ChatStore;
+use crate::types::{
+    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageStatus, ReactionEntry, ReceiptEntry,
+    StoredMessage,
+};
+
+fn ms_to_utc(ms: i64) -> Option<DateTime<Utc>> {
+    DateTime::<Utc>::from_timestamp_millis(ms)
+}
+
+type ContactRow = (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+type MediaRefRow = (Vec<u8>, String, Option<String>, Option<i64>, i64);
+
+/// Parse a stored JID column; empty (own history messages with no participant)
+/// maps to the default JID rather than an error.
+fn parse_jid(raw: &str) -> Jid {
+    if raw.is_empty() {
+        return Jid::default();
+    }
+    Jid::from_str(raw).unwrap_or_else(|_| {
+        warn!("chat-store: unparseable JID in database: {raw}");
+        Jid::default()
+    })
+}
+
+#[derive(Queryable)]
+struct ChatRow {
+    #[allow(dead_code)]
+    device_id: i32,
+    jid: String,
+    name: Option<String>,
+    last_message_ts: i64,
+    last_message_preview: Option<String>,
+    unread_count: i32,
+    pinned_at: Option<i64>,
+    muted_until: Option<i64>,
+    archived: bool,
+    ephemeral_expiration: Option<i32>,
+}
+
+impl From<ChatRow> for ChatEntry {
+    fn from(row: ChatRow) -> Self {
+        ChatEntry {
+            jid: parse_jid(&row.jid),
+            name: row.name,
+            last_message_at: (row.last_message_ts > 0)
+                .then(|| ms_to_utc(row.last_message_ts))
+                .flatten(),
+            last_message_preview: row.last_message_preview,
+            unread_count: row.unread_count,
+            pinned_at: row.pinned_at.and_then(ms_to_utc),
+            muted_until: row.muted_until.and_then(ms_to_utc),
+            archived: row.archived,
+            ephemeral_expiration: row.ephemeral_expiration.map(|e| e as u32),
+        }
+    }
+}
+
+#[derive(Queryable)]
+struct MessageRow {
+    #[allow(dead_code)]
+    device_id: i32,
+    chat_jid: String,
+    msg_id: String,
+    sender_jid: String,
+    from_me: bool,
+    timestamp_ms: i64,
+    kind: String,
+    text_content: Option<String>,
+    proto: Option<Vec<u8>>,
+    status: i32,
+    starred: bool,
+    edited_at_ms: Option<i64>,
+    revoked: bool,
+}
+
+impl From<MessageRow> for StoredMessage {
+    fn from(row: MessageRow) -> Self {
+        let message = row.proto.as_deref().and_then(|bytes| {
+            match wa::Message::decode_from_slice(bytes) {
+                Ok(msg) => Some(Box::new(msg)),
+                Err(e) => {
+                    // Denormalized columns still render; only the proto is lost.
+                    warn!(
+                        "chat-store: stored proto for {} undecodable: {e}",
+                        row.msg_id
+                    );
+                    None
+                }
+            }
+        });
+        StoredMessage {
+            chat_jid: parse_jid(&row.chat_jid),
+            id: row.msg_id,
+            sender_jid: parse_jid(&row.sender_jid),
+            from_me: row.from_me,
+            timestamp: ms_to_utc(row.timestamp_ms).unwrap_or_default(),
+            kind: row.kind,
+            text: row.text_content,
+            message,
+            status: MessageStatus::from_raw(row.status),
+            starred: row.starred,
+            edited_at: row.edited_at_ms.and_then(ms_to_utc),
+            revoked: row.revoked,
+        }
+    }
+}
+
+impl ChatStore {
+    /// Chat list in display order: pinned first (most recently pinned on top),
+    /// then by latest activity.
+    pub async fn chats(&self, include_archived: bool, limit: i64) -> Result<Vec<ChatEntry>> {
+        use schema::chats::dsl;
+        let device_id = self.device_id();
+        let rows: Vec<ChatRow> = self
+            .db()
+            .run(move |conn| {
+                let mut query = dsl::chats.filter(dsl::device_id.eq(device_id)).into_boxed();
+                if !include_archived {
+                    query = query.filter(dsl::archived.eq(false));
+                }
+                query
+                    .order((
+                        diesel::dsl::sql::<diesel::sql_types::Bool>("pinned_at IS NULL"),
+                        dsl::pinned_at.desc(),
+                        dsl::last_message_ts.desc(),
+                    ))
+                    .limit(limit)
+                    .load(conn)
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    /// One page of a chat's messages, newest first. Pass the cursor of the
+    /// oldest message you already have to get the page before it.
+    pub async fn messages(
+        &self,
+        chat: &Jid,
+        before: Option<MessageCursor>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>> {
+        use schema::messages::dsl;
+        let device_id = self.device_id();
+        let chat = chat.to_string();
+        let rows: Vec<MessageRow> = self
+            .db()
+            .run(move |conn| {
+                let mut query = dsl::messages
+                    .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(&chat)))
+                    .into_boxed();
+                if let Some(cursor) = &before {
+                    query = query.filter(
+                        dsl::timestamp_ms
+                            .lt(cursor.timestamp_ms)
+                            .or(dsl::timestamp_ms
+                                .eq(cursor.timestamp_ms)
+                                .and(dsl::msg_id.lt(&cursor.msg_id))),
+                    );
+                }
+                query
+                    .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+                    .limit(limit)
+                    .load(conn)
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    pub async fn message(&self, chat: &Jid, msg_id: &str) -> Result<Option<StoredMessage>> {
+        use schema::messages::dsl;
+        let device_id = self.device_id();
+        let chat = chat.to_string();
+        let msg_id = msg_id.to_owned();
+        let row: Option<MessageRow> = self
+            .db()
+            .run(move |conn| {
+                dsl::messages
+                    .filter(
+                        dsl::device_id
+                            .eq(device_id)
+                            .and(dsl::chat_jid.eq(&chat))
+                            .and(dsl::msg_id.eq(&msg_id)),
+                    )
+                    .first(conn)
+                    .optional()
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(row.map(Into::into))
+    }
+
+    pub async fn reactions(&self, chat: &Jid, msg_id: &str) -> Result<Vec<ReactionEntry>> {
+        use schema::reactions::dsl;
+        let device_id = self.device_id();
+        let chat = chat.to_string();
+        let msg_id = msg_id.to_owned();
+        let rows: Vec<(String, String, i64)> = self
+            .db()
+            .run(move |conn| {
+                dsl::reactions
+                    .filter(
+                        dsl::device_id
+                            .eq(device_id)
+                            .and(dsl::chat_jid.eq(&chat))
+                            .and(dsl::msg_id.eq(&msg_id)),
+                    )
+                    .select((dsl::sender_jid, dsl::emoji, dsl::ts_ms))
+                    .order(dsl::ts_ms.asc())
+                    .load(conn)
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(sender, emoji, ts)| ReactionEntry {
+                sender_jid: parse_jid(&sender),
+                emoji,
+                timestamp: ms_to_utc(ts).unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    /// Per-user receipts of one message (group "delivered to"/"read by").
+    pub async fn receipts(&self, chat: &Jid, msg_id: &str) -> Result<Vec<ReceiptEntry>> {
+        use schema::message_receipts::dsl;
+        let device_id = self.device_id();
+        let chat = chat.to_string();
+        let msg_id = msg_id.to_owned();
+        let rows: Vec<(String, i32, i64)> = self
+            .db()
+            .run(move |conn| {
+                dsl::message_receipts
+                    .filter(
+                        dsl::device_id
+                            .eq(device_id)
+                            .and(dsl::chat_jid.eq(&chat))
+                            .and(dsl::msg_id.eq(&msg_id)),
+                    )
+                    .select((dsl::user_jid, dsl::receipt_type, dsl::ts_ms))
+                    .order(dsl::ts_ms.asc())
+                    .load(conn)
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(user, status, ts)| ReceiptEntry {
+                user_jid: parse_jid(&user),
+                status: MessageStatus::from_raw(status),
+                timestamp: ms_to_utc(ts).unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    pub async fn contact(&self, jid: &Jid) -> Result<Option<ContactEntry>> {
+        use schema::contacts::dsl;
+        let device_id = self.device_id();
+        let jid_str = jid.to_string();
+        let row: Option<ContactRow> = self
+            .db()
+            .run(move |conn| {
+                dsl::contacts
+                    .filter(dsl::device_id.eq(device_id).and(dsl::jid.eq(&jid_str)))
+                    .select((
+                        dsl::jid,
+                        dsl::push_name,
+                        dsl::full_name,
+                        dsl::first_name,
+                        dsl::business_name,
+                    ))
+                    .first(conn)
+                    .optional()
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(row.map(
+            |(jid, push_name, full_name, first_name, business_name)| ContactEntry {
+                jid: parse_jid(&jid),
+                push_name,
+                full_name,
+                first_name,
+                business_name,
+            },
+        ))
+    }
+
+    /// Sum of positive unread counters (ignores "marked unread" sentinels).
+    pub async fn unread_total(&self) -> Result<i64> {
+        use schema::chats::dsl;
+        let device_id = self.device_id();
+        let total: Option<i64> = self
+            .db()
+            .run(move |conn| {
+                dsl::chats
+                    .filter(dsl::device_id.eq(device_id).and(dsl::unread_count.gt(0)))
+                    .select(diesel::dsl::sum(dsl::unread_count))
+                    .first(conn)
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(total.unwrap_or(0))
+    }
+
+    /// Record where a downloaded media blob lives locally, keyed by content
+    /// hash so identical files are stored once.
+    pub async fn put_media_ref(
+        &self,
+        file_sha256: Vec<u8>,
+        file_path: String,
+        mime_type: Option<String>,
+        size_bytes: Option<i64>,
+    ) -> Result<()> {
+        use schema::media_refs::dsl;
+        let device_id = self.device_id();
+        let now_ms = wacore::time::now_utc().timestamp_millis();
+        self.db()
+            .run(move |conn| {
+                diesel::insert_into(dsl::media_refs)
+                    .values((
+                        dsl::device_id.eq(device_id),
+                        dsl::file_sha256.eq(&file_sha256),
+                        dsl::file_path.eq(&file_path),
+                        dsl::mime_type.eq(&mime_type),
+                        dsl::size_bytes.eq(size_bytes),
+                        dsl::downloaded_at_ms.eq(now_ms),
+                    ))
+                    .on_conflict((dsl::device_id, dsl::file_sha256))
+                    .do_update()
+                    .set((
+                        dsl::file_path.eq(&file_path),
+                        dsl::mime_type.eq(&mime_type),
+                        dsl::size_bytes.eq(size_bytes),
+                        dsl::downloaded_at_ms.eq(now_ms),
+                    ))
+                    .execute(conn)
+                    .map(|_| ())
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn media_ref(&self, file_sha256: &[u8]) -> Result<Option<MediaRef>> {
+        use schema::media_refs::dsl;
+        let device_id = self.device_id();
+        let sha = file_sha256.to_vec();
+        let row: Option<MediaRefRow> = self
+            .db()
+            .run(move |conn| {
+                dsl::media_refs
+                    .filter(dsl::device_id.eq(device_id).and(dsl::file_sha256.eq(&sha)))
+                    .select((
+                        dsl::file_sha256,
+                        dsl::file_path,
+                        dsl::mime_type,
+                        dsl::size_bytes,
+                        dsl::downloaded_at_ms,
+                    ))
+                    .first(conn)
+                    .optional()
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(row.map(
+            |(file_sha256, file_path, mime_type, size_bytes, downloaded_at_ms)| MediaRef {
+                file_sha256,
+                file_path,
+                mime_type,
+                size_bytes,
+                downloaded_at: ms_to_utc(downloaded_at_ms).unwrap_or_default(),
+            },
+        ))
+    }
+}

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -73,7 +73,16 @@ impl From<ChatRow> for ChatEntry {
             last_message_kind: row.last_message_kind.map(MessageKind::from_db),
             unread_count: row.unread_count,
             pinned_at: row.pinned_at.and_then(ms_to_utc),
-            muted_until: row.muted_until.and_then(ms_to_utc),
+            // The writer stores i64::MAX for "muted forever"; that value is
+            // outside DateTime's range, and silently mapping it to None would
+            // make a forever-muted chat read as unmuted.
+            muted_until: row.muted_until.and_then(|ms| {
+                if ms == i64::MAX {
+                    Some(DateTime::<Utc>::MAX_UTC)
+                } else {
+                    ms_to_utc(ms)
+                }
+            }),
             archived: row.archived,
             ephemeral_expiration: row.ephemeral_expiration.map(|e| e as u32),
         }

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -15,8 +15,8 @@ use crate::error::{Result, db_err};
 use crate::schema;
 use crate::store::ChatStore;
 use crate::types::{
-    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageStatus, ReactionEntry, ReceiptEntry,
-    StoredMessage,
+    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus, ReactionEntry,
+    ReceiptEntry, StoredMessage,
 };
 
 fn ms_to_utc(ms: i64) -> Option<DateTime<Utc>> {
@@ -53,6 +53,7 @@ struct ChatRow {
     name: Option<String>,
     last_message_ts: i64,
     last_message_preview: Option<String>,
+    last_message_kind: Option<String>,
     unread_count: i32,
     pinned_at: Option<i64>,
     muted_until: Option<i64>,
@@ -69,6 +70,7 @@ impl From<ChatRow> for ChatEntry {
                 .then(|| ms_to_utc(row.last_message_ts))
                 .flatten(),
             last_message_preview: row.last_message_preview,
+            last_message_kind: row.last_message_kind.map(MessageKind::from_db),
             unread_count: row.unread_count,
             pinned_at: row.pinned_at.and_then(ms_to_utc),
             muted_until: row.muted_until.and_then(ms_to_utc),
@@ -117,7 +119,7 @@ impl From<MessageRow> for StoredMessage {
             sender_jid: parse_jid(&row.sender_jid),
             from_me: row.from_me,
             timestamp: ms_to_utc(row.timestamp_ms).unwrap_or_default(),
-            kind: row.kind,
+            kind: MessageKind::from_db(row.kind),
             text: row.text_content,
             message,
             status: MessageStatus::from_raw(row.status),
@@ -129,8 +131,10 @@ impl From<MessageRow> for StoredMessage {
 }
 
 impl ChatStore {
-    /// Chat list in display order: pinned first (most recently pinned on top),
-    /// then by latest activity.
+    /// Chat list in a sensible default order (pinned first, then latest
+    /// activity). Purely a default: every ordering input (`pinned_at`,
+    /// `last_message_at`, `archived`, ...) is on [`ChatEntry`], so a frontend
+    /// with different needs re-sorts freely.
     pub async fn chats(&self, include_archived: bool, limit: i64) -> Result<Vec<ChatEntry>> {
         use schema::chats::dsl;
         // A negative LIMIT means "unbounded" to SQLite; never let that happen.

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -59,6 +59,8 @@ struct ChatRow {
     muted_until: Option<i64>,
     archived: bool,
     ephemeral_expiration: Option<i32>,
+    #[allow(dead_code)]
+    read_boundary_ms: i64,
 }
 
 impl From<ChatRow> for ChatEntry {

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -133,6 +133,8 @@ impl ChatStore {
     /// then by latest activity.
     pub async fn chats(&self, include_archived: bool, limit: i64) -> Result<Vec<ChatEntry>> {
         use schema::chats::dsl;
+        // A negative LIMIT means "unbounded" to SQLite; never let that happen.
+        let limit = limit.max(0);
         let device_id = self.device_id();
         let rows: Vec<ChatRow> = self
             .db()
@@ -164,6 +166,7 @@ impl ChatStore {
         limit: i64,
     ) -> Result<Vec<StoredMessage>> {
         use schema::messages::dsl;
+        let limit = limit.max(0);
         let device_id = self.device_id();
         let chat = chat.to_string();
         let rows: Vec<MessageRow> = self

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -61,6 +61,8 @@ struct ChatRow {
     ephemeral_expiration: Option<i32>,
     #[allow(dead_code)]
     read_boundary_ms: i64,
+    #[allow(dead_code)]
+    read_boundary_ids: Option<String>,
 }
 
 impl From<ChatRow> for ChatEntry {

--- a/storages/chat-store/src/schema.rs
+++ b/storages/chat-store/src/schema.rs
@@ -12,6 +12,7 @@ diesel::table! {
         archived -> Bool,
         ephemeral_expiration -> Nullable<Integer>,
         read_boundary_ms -> BigInt,
+        read_boundary_ids -> Nullable<Text>,
     }
 }
 

--- a/storages/chat-store/src/schema.rs
+++ b/storages/chat-store/src/schema.rs
@@ -1,0 +1,84 @@
+diesel::table! {
+    chats (device_id, jid) {
+        device_id -> Integer,
+        jid -> Text,
+        name -> Nullable<Text>,
+        last_message_ts -> BigInt,
+        last_message_preview -> Nullable<Text>,
+        unread_count -> Integer,
+        pinned_at -> Nullable<BigInt>,
+        muted_until -> Nullable<BigInt>,
+        archived -> Bool,
+        ephemeral_expiration -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
+    messages (device_id, chat_jid, msg_id) {
+        device_id -> Integer,
+        chat_jid -> Text,
+        msg_id -> Text,
+        sender_jid -> Text,
+        from_me -> Bool,
+        timestamp_ms -> BigInt,
+        kind -> Text,
+        text_content -> Nullable<Text>,
+        proto -> Nullable<Binary>,
+        status -> Integer,
+        starred -> Bool,
+        edited_at_ms -> Nullable<BigInt>,
+        revoked -> Bool,
+    }
+}
+
+diesel::table! {
+    reactions (device_id, chat_jid, msg_id, sender_jid) {
+        device_id -> Integer,
+        chat_jid -> Text,
+        msg_id -> Text,
+        sender_jid -> Text,
+        emoji -> Text,
+        ts_ms -> BigInt,
+    }
+}
+
+diesel::table! {
+    contacts (device_id, jid) {
+        device_id -> Integer,
+        jid -> Text,
+        push_name -> Nullable<Text>,
+        full_name -> Nullable<Text>,
+        first_name -> Nullable<Text>,
+        business_name -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    message_receipts (device_id, chat_jid, msg_id, user_jid) {
+        device_id -> Integer,
+        chat_jid -> Text,
+        msg_id -> Text,
+        user_jid -> Text,
+        receipt_type -> Integer,
+        ts_ms -> BigInt,
+    }
+}
+
+diesel::table! {
+    media_refs (device_id, file_sha256) {
+        device_id -> Integer,
+        file_sha256 -> Binary,
+        file_path -> Text,
+        mime_type -> Nullable<Text>,
+        size_bytes -> Nullable<BigInt>,
+        downloaded_at_ms -> BigInt,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(
+    chats,
+    messages,
+    reactions,
+    contacts,
+    message_receipts
+);

--- a/storages/chat-store/src/schema.rs
+++ b/storages/chat-store/src/schema.rs
@@ -11,6 +11,7 @@ diesel::table! {
         muted_until -> Nullable<BigInt>,
         archived -> Bool,
         ephemeral_expiration -> Nullable<Integer>,
+        read_boundary_ms -> BigInt,
     }
 }
 

--- a/storages/chat-store/src/schema.rs
+++ b/storages/chat-store/src/schema.rs
@@ -5,6 +5,7 @@ diesel::table! {
         name -> Nullable<Text>,
         last_message_ts -> BigInt,
         last_message_preview -> Nullable<Text>,
+        last_message_kind -> Nullable<Text>,
         unread_count -> Integer,
         pinned_at -> Nullable<BigInt>,
         muted_until -> Nullable<BigInt>,

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -307,6 +307,7 @@ fn apply_writer_msg(
                 &chat_str,
                 *timestamp_ms,
                 text.as_deref(),
+                Some(kind),
                 0,
             )?;
             cs.chats = true;
@@ -358,6 +359,7 @@ fn apply_event(
                 &chat,
                 undec.info.timestamp.timestamp_millis(),
                 None,
+                Some(KIND_UNDECRYPTABLE),
                 i32::from(inserted && !undec.info.source.is_from_me),
             )?;
             cs.chats = true;
@@ -541,7 +543,15 @@ fn apply_inbound(
             // A refreshed row (redelivery, PDO recovery of a placeholder that
             // already counted) must not inflate the unread badge again.
             let unread_delta = i32::from(inserted && !info.source.is_from_me);
-            bump_chat(conn, device_id, &chat, ts_ms, text.as_deref(), unread_delta)?;
+            bump_chat(
+                conn,
+                device_id,
+                &chat,
+                ts_ms,
+                text.as_deref(),
+                Some(kind),
+                unread_delta,
+            )?;
             cs.chats = true;
             cs.message_chats.insert(chat);
         }
@@ -609,7 +619,7 @@ fn apply_edit(
     if updated == 0 {
         return Ok(false);
     }
-    refresh_preview_if_latest(conn, device_id, chat, target_id, new_text)
+    refresh_preview_if_latest(conn, device_id, chat, target_id, new_text, Some(new_kind))
 }
 
 /// Tombstone the target row. A revoke arriving before its content (offline
@@ -647,7 +657,7 @@ fn apply_revoke(
             .execute(conn)?;
         return Ok(false);
     }
-    refresh_preview_if_latest(conn, device_id, chat, target_id, None)
+    refresh_preview_if_latest(conn, device_id, chat, target_id, None, None)
 }
 
 /// When `msg_id` is the chat's most recent message, replace the denormalized
@@ -658,6 +668,7 @@ fn refresh_preview_if_latest(
     chat: &str,
     msg_id: &str,
     preview: Option<&str>,
+    kind: Option<&str>,
 ) -> QueryResult<bool> {
     use schema::messages::dsl;
     let ts: Option<i64> = message_row(device_id, chat, msg_id)
@@ -669,7 +680,10 @@ fn refresh_preview_if_latest(
     };
     let updated =
         diesel::update(chat_row(device_id, chat).filter(schema::chats::last_message_ts.le(ts)))
-            .set(schema::chats::last_message_preview.eq(preview))
+            .set((
+                schema::chats::last_message_preview.eq(preview),
+                schema::chats::last_message_kind.eq(kind),
+            ))
             .execute(conn)?;
     Ok(updated > 0)
 }
@@ -682,14 +696,21 @@ fn recompute_chat_preview(
     chat: &str,
 ) -> QueryResult<()> {
     use schema::messages::dsl;
-    let newest: Option<Option<String>> = dsl::messages
+    let newest: Option<(Option<String>, String)> = dsl::messages
         .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
         .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
-        .select(dsl::text_content)
+        .select((dsl::text_content, dsl::kind))
         .first(conn)
         .optional()?;
+    let (preview, kind) = match newest {
+        Some((text, kind)) => (text, Some(kind)),
+        None => (None, None),
+    };
     diesel::update(chat_row(device_id, chat))
-        .set(schema::chats::last_message_preview.eq(newest.flatten()))
+        .set((
+            schema::chats::last_message_preview.eq(preview),
+            schema::chats::last_message_kind.eq(kind),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -942,6 +963,9 @@ fn apply_history_conversation(
         };
         apply_history_message(conn, device_id, chat, wmi, cs)?;
     }
+    // Backfill the denormalized preview from the newest materialized row, so a
+    // freshly-paired client's chat list isn't blank until live traffic.
+    recompute_chat_preview(conn, device_id, chat)?;
     cs.chats = true;
     cs.message_chats.insert(chat.to_string());
     Ok(())
@@ -1124,6 +1148,7 @@ fn bump_chat(
     chat: &str,
     ts_ms: i64,
     preview: Option<&str>,
+    kind: Option<&str>,
     unread_delta: i32,
 ) -> QueryResult<()> {
     use schema::chats::dsl;
@@ -1132,6 +1157,7 @@ fn bump_chat(
         .set((
             dsl::last_message_ts.eq(ts_ms),
             dsl::last_message_preview.eq(preview),
+            dsl::last_message_kind.eq(kind),
         ))
         .execute(conn)?;
     if unread_delta != 0 {

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -693,11 +693,25 @@ fn apply_event(
                         advance_read_state(conn, device_id, &chat, watermark, &[])?
                     }
                 };
-                if let Some(state) = advanced {
-                    let unread = count_unread(conn, device_id, &chat, &state)?;
-                    diesel::update(chat_row(device_id, &chat))
+                match advanced {
+                    Some(state) => {
+                        let unread = count_unread(conn, device_id, &chat, &state)?;
+                        diesel::update(chat_row(device_id, &chat))
+                            .set(schema::chats::unread_count.eq(unread))
+                            .execute(conn)?;
+                    }
+                    // Cursor didn't move (re-reading an already-read chat),
+                    // but a read still clears a manual-unread marker.
+                    None => {
+                        let state = read_state(conn, device_id, &chat)?;
+                        let unread = count_unread(conn, device_id, &chat, &state)?;
+                        diesel::update(
+                            chat_row(device_id, &chat)
+                                .filter(schema::chats::unread_count.eq(UNREAD_MARKER)),
+                        )
                         .set(schema::chats::unread_count.eq(unread))
                         .execute(conn)?;
+                    }
                 }
             } else {
                 diesel::update(chat_row(device_id, &chat))
@@ -891,6 +905,8 @@ fn apply_inbound(
                 device_id,
                 &chat,
                 &target_id,
+                &sender,
+                info.source.is_from_me,
                 new_text.as_deref(),
                 new_kind,
                 &new_proto,
@@ -924,14 +940,19 @@ fn apply_inbound(
 }
 
 /// Apply an edit to its target row. Monotonic on `edited_at_ms` so a replayed
-/// or stale (e.g. history-sync) edit can't roll back a newer one. Returns
-/// whether the chat-list preview changed.
+/// or stale (e.g. history-sync) edit can't roll back a newer one. An edit
+/// arriving before its target (offline drain reordering) materializes the
+/// edited content up front — `insert_message` skips edited rows, so the
+/// original's later arrival can't show pre-edit text. Returns whether the
+/// chat-list preview changed.
 #[allow(clippy::too_many_arguments)]
 fn apply_edit(
     conn: &mut SqliteConnection,
     device_id: i32,
     chat: &str,
     target_id: &str,
+    sender: &str,
+    from_me: bool,
     new_text: Option<&str>,
     new_kind: &str,
     new_proto: &[u8],
@@ -952,6 +973,46 @@ fn apply_edit(
     ))
     .execute(conn)?;
     if updated == 0 {
+        let inserted = diesel::insert_into(dsl::messages)
+            .values((
+                dsl::device_id.eq(device_id),
+                dsl::chat_jid.eq(chat),
+                dsl::msg_id.eq(target_id),
+                dsl::sender_jid.eq(sender),
+                dsl::from_me.eq(from_me),
+                dsl::timestamp_ms.eq(ts_ms),
+                dsl::kind.eq(new_kind),
+                dsl::text_content.eq(new_text),
+                dsl::proto.eq(Some(new_proto)),
+                dsl::status.eq(if from_me {
+                    wa::web_message_info::Status::SERVER_ACK as i32
+                } else {
+                    wa::web_message_info::Status::DELIVERY_ACK as i32
+                }),
+                dsl::edited_at_ms.eq(Some(ts_ms)),
+            ))
+            // Conflict = the row exists but rejected the edit (revoked, or a
+            // newer edit already applied): stale, nothing to preserve.
+            .on_conflict_do_nothing()
+            .execute(conn)?
+            > 0;
+        if inserted {
+            // The message DID happen — the chat must exist, order by it and
+            // badge it exactly as if the (never-seen) original had landed.
+            bump_chat(
+                conn,
+                device_id,
+                chat,
+                ChatBump {
+                    msg_id: target_id,
+                    ts_ms,
+                    preview: new_text,
+                    kind: Some(new_kind),
+                    unread_delta: i32::from(!from_me),
+                },
+            )?;
+            return Ok(true);
+        }
         return Ok(false);
     }
     refresh_preview_if_latest(conn, device_id, chat, target_id, new_text, Some(new_kind))
@@ -1178,6 +1239,19 @@ fn apply_receipt(
                 &receipt.message_ids,
             )?
             else {
+                // Cursor didn't move (chat re-read on another device), but a
+                // self-read still clears a manual-unread marker.
+                let state = read_state(conn, device_id, &chat)?;
+                let unread = count_unread(conn, device_id, &chat, &state)?;
+                let cleared = diesel::update(
+                    chat_row(device_id, &chat)
+                        .filter(schema::chats::unread_count.eq(UNREAD_MARKER)),
+                )
+                .set(schema::chats::unread_count.eq(unread))
+                .execute(conn)?;
+                if cleared > 0 {
+                    cs.chats = true;
+                }
                 return Ok(());
             };
             let unread = count_unread(conn, device_id, &chat, &state)?;
@@ -1245,21 +1319,38 @@ fn apply_server_ack(
     cs: &mut ChangeSet,
 ) -> QueryResult<()> {
     // Acks cover every stanza class; only message acks map to a stored row.
-    if ack.class.as_deref() != Some("message") || ack.error.is_some() {
+    if ack.class.as_deref() != Some("message") {
         return Ok(());
     }
     use schema::messages::dsl;
-    let updated = diesel::update(
-        dsl::messages.filter(
-            dsl::device_id
-                .eq(device_id)
-                .and(dsl::msg_id.eq(&ack.id))
-                .and(dsl::from_me.eq(true))
-                .and(dsl::status.lt(wa::web_message_info::Status::SERVER_ACK as i32)),
-        ),
-    )
-    .set(dsl::status.eq(wa::web_message_info::Status::SERVER_ACK as i32))
-    .execute(conn)?;
+    let updated = if ack.error.is_some() {
+        // Nack: the server rejected the send. Only undelivered rows fail — a
+        // stray nack must not regress a message a peer already received.
+        diesel::update(
+            dsl::messages.filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::msg_id.eq(&ack.id))
+                    .and(dsl::from_me.eq(true))
+                    .and(dsl::status.lt(wa::web_message_info::Status::DELIVERY_ACK as i32))
+                    .and(dsl::status.ne(wa::web_message_info::Status::ERROR as i32)),
+            ),
+        )
+        .set(dsl::status.eq(wa::web_message_info::Status::ERROR as i32))
+        .execute(conn)?
+    } else {
+        diesel::update(
+            dsl::messages.filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::msg_id.eq(&ack.id))
+                    .and(dsl::from_me.eq(true))
+                    .and(dsl::status.lt(wa::web_message_info::Status::SERVER_ACK as i32)),
+            ),
+        )
+        .set(dsl::status.eq(wa::web_message_info::Status::SERVER_ACK as i32))
+        .execute(conn)?
+    };
     if updated > 0 {
         // Acks usually carry the chat; when they don't, resolve it from the
         // row we just updated so consumers still get invalidated.
@@ -1453,6 +1544,8 @@ fn apply_history_message(
                     device_id,
                     chat,
                     &target_id,
+                    sender,
+                    from_me,
                     new_text.as_deref(),
                     new_kind,
                     &new_proto,

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -16,7 +16,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use wacore::store::error::StoreError;
 use wacore::types::events::{Event, EventHandler, EventInterest, EventKind, InboundMessage};
 use wacore::types::presence::ReceiptType;
-use wacore_binary::Jid;
+use wacore_binary::{Jid, JidExt as _};
 use waproto::whatsapp as wa;
 use whatsapp_rust_sqlite_storage::{SharedSqlite, SqliteStore};
 
@@ -944,10 +944,36 @@ fn apply_receipt(
         ReceiptType::Read => wa::web_message_info::Status::READ as i32,
         ReceiptType::Played => wa::web_message_info::Status::PLAYED as i32,
         ReceiptType::ReadSelf | ReceiptType::PlayedSelf => {
-            // Read on another of our devices: the chat is no longer unread.
+            // Read on another of our devices — up to the covered messages.
+            // WA read state is "read up to X": the boundary is the newest
+            // covered row (falling back to the receipt's own timestamp), and
+            // anything we materialized past it keeps its unread badge (a
+            // delayed offline receipt must not swallow newer messages).
+            use schema::messages::dsl;
+            let covered_max: Option<Option<i64>> = dsl::messages
+                .filter(
+                    dsl::device_id
+                        .eq(device_id)
+                        .and(dsl::chat_jid.eq(&chat))
+                        .and(dsl::msg_id.eq_any(&receipt.message_ids)),
+                )
+                .select(diesel::dsl::max(dsl::timestamp_ms))
+                .first(conn)
+                .optional()?;
+            let boundary_ms = covered_max.flatten().unwrap_or(ts_ms);
+            let unread: i64 = dsl::messages
+                .filter(
+                    dsl::device_id
+                        .eq(device_id)
+                        .and(dsl::chat_jid.eq(&chat))
+                        .and(dsl::from_me.eq(false))
+                        .and(dsl::timestamp_ms.gt(boundary_ms)),
+                )
+                .count()
+                .get_result(conn)?;
             ensure_chat(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
-                .set(schema::chats::unread_count.eq(0))
+                .set(schema::chats::unread_count.eq(unread.min(i32::MAX as i64) as i32))
                 .execute(conn)?;
             cs.chats = true;
             return Ok(());
@@ -969,7 +995,9 @@ fn apply_receipt(
         .set(schema::messages::status.eq(status))
         .execute(conn)?;
 
-        if receipt.source.is_group {
+        // Derived from the JID: the library's receipt parser leaves
+        // `source.is_group` defaulted, so the flag can't be trusted here.
+        if receipt.source.chat.is_group() {
             use schema::message_receipts::dsl;
             diesel::insert_into(dsl::message_receipts)
                 .values((

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1324,16 +1324,16 @@ fn apply_server_ack(
     }
     use schema::messages::dsl;
     let updated = if ack.error.is_some() {
-        // Nack: the server rejected the send. Only undelivered rows fail — a
-        // stray nack must not regress a message a peer already received.
+        // Nack: the server rejected the send. Only a still-pending row fails —
+        // the server emits one ack per stanza, so a row past PENDING already
+        // got its positive answer and a stray nack must not regress it.
         diesel::update(
             dsl::messages.filter(
                 dsl::device_id
                     .eq(device_id)
                     .and(dsl::msg_id.eq(&ack.id))
                     .and(dsl::from_me.eq(true))
-                    .and(dsl::status.lt(wa::web_message_info::Status::DELIVERY_ACK as i32))
-                    .and(dsl::status.ne(wa::web_message_info::Status::ERROR as i32)),
+                    .and(dsl::status.eq(wa::web_message_info::Status::PENDING as i32)),
             ),
         )
         .set(dsl::status.eq(wa::web_message_info::Status::ERROR as i32))

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -946,9 +946,7 @@ fn apply_receipt(
         ReceiptType::ReadSelf | ReceiptType::PlayedSelf => {
             // Read on another of our devices — up to the covered messages.
             // WA read state is "read up to X": the boundary is the newest
-            // covered row (falling back to the receipt's own timestamp), and
-            // anything we materialized past it keeps its unread badge (a
-            // delayed offline receipt must not swallow newer messages).
+            // covered row (falling back to the receipt's own timestamp).
             use schema::messages::dsl;
             let covered_max: Option<Option<i64>> = dsl::messages
                 .filter(
@@ -961,17 +959,36 @@ fn apply_receipt(
                 .first(conn)
                 .optional()?;
             let boundary_ms = covered_max.flatten().unwrap_or(ts_ms);
+            ensure_chat(conn, device_id, &chat)?;
+            // Monotonic cursor: receipts can replay out of order across
+            // offline drains, and a stale one must neither re-inflate nor
+            // re-clear the badge.
+            let advanced = diesel::update(
+                chat_row(device_id, &chat).filter(schema::chats::read_boundary_ms.lt(boundary_ms)),
+            )
+            .set(schema::chats::read_boundary_ms.eq(boundary_ms))
+            .execute(conn)?;
+            if advanced == 0 {
+                return Ok(());
+            }
+            // Uncovered = strictly past the boundary, plus boundary-instant
+            // siblings the receipt does not name (ids are the authoritative
+            // coverage signal; timestamps collide at wire granularity).
             let unread: i64 = dsl::messages
                 .filter(
                     dsl::device_id
                         .eq(device_id)
                         .and(dsl::chat_jid.eq(&chat))
                         .and(dsl::from_me.eq(false))
-                        .and(dsl::timestamp_ms.gt(boundary_ms)),
+                        .and(dsl::timestamp_ms.ge(boundary_ms))
+                        .and(
+                            dsl::timestamp_ms
+                                .gt(boundary_ms)
+                                .or(dsl::msg_id.ne_all(&receipt.message_ids)),
+                        ),
                 )
                 .count()
                 .get_result(conn)?;
-            ensure_chat(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
                 .set(schema::chats::unread_count.eq(unread.min(i32::MAX as i64) as i32))
                 .execute(conn)?;

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -557,8 +557,18 @@ fn apply_event(
                 // can't resurrect the badge.
                 match range_bound(&update.action.message_range) {
                     Some(bound) => {
-                        advance_read_cursor(conn, device_id, &chat, bound.second_end_ms)?;
-                        count_uncovered_incoming(conn, device_id, &chat, &bound)?
+                        // Count against the PREVIOUS cursor, then advance: a
+                        // keyed boundary second can't be expressed by a ms
+                        // cursor, so it only advances past the fully-covered
+                        // region (unlisted same-second siblings stay unread).
+                        let unread = count_uncovered_incoming(conn, device_id, &chat, &bound)?;
+                        let durable = if bound.keys.is_some() {
+                            bound.second_start_ms - 1
+                        } else {
+                            bound.second_end_ms
+                        };
+                        advance_read_cursor(conn, device_id, &chat, durable)?;
+                        unread
                     }
                     None => {
                         use schema::messages::dsl;
@@ -567,9 +577,13 @@ fn apply_event(
                             .select(diesel::dsl::max(dsl::timestamp_ms))
                             .first(conn)
                             .optional()?;
-                        if let Some(newest_ms) = newest.flatten() {
-                            advance_read_cursor(conn, device_id, &chat, newest_ms)?;
-                        }
+                        // Empty chat: the action's own timestamp is the read
+                        // moment — the cursor must still advance, or a later
+                        // stale replay resurrects a badge this read cleared.
+                        let boundary_ms = newest
+                            .flatten()
+                            .unwrap_or_else(|| update.timestamp.timestamp_millis());
+                        advance_read_cursor(conn, device_id, &chat, boundary_ms)?;
                         0
                     }
                 }
@@ -763,13 +777,14 @@ fn apply_inbound(
         MessageOp::Revoke {
             target_id,
             target_from_me,
+            target_participant,
         } => {
             if apply_revoke(
                 conn,
                 device_id,
                 &chat,
                 &target_id,
-                &sender,
+                target_participant.as_deref().unwrap_or(&sender),
                 target_from_me,
                 ts_ms,
             )? {
@@ -1137,11 +1152,20 @@ fn apply_history_sync(
             Ok(Some(conv)) => conv,
             Ok(None) => break,
             Err(e) => {
-                warn!("chat-store: history sync chunk unreadable, skipping: {e}");
+                // Framing/zlib failure: the stream position is gone, the rest
+                // of this chunk is unreadable (per-conversation decode errors
+                // are skipped inside the stream, not surfaced here).
+                warn!("chat-store: history sync chunk framing broken, aborting chunk: {e}");
                 return Ok(());
             }
         };
         apply_history_conversation(conn, device_id, &conv, cs)?;
+    }
+    if stream.skipped_conversations() > 0 {
+        warn!(
+            "chat-store: history sync skipped {} undecodable conversation(s)",
+            stream.skipped_conversations()
+        );
     }
     match stream.remainder() {
         Ok(rest) => {
@@ -1302,13 +1326,14 @@ fn apply_history_message(
             MessageOp::Revoke {
                 target_id,
                 target_from_me,
+                target_participant,
             } => {
                 if apply_revoke(
                     conn,
                     device_id,
                     chat,
                     &target_id,
-                    sender,
+                    target_participant.as_deref().unwrap_or(sender),
                     target_from_me,
                     ts_ms,
                 )? {
@@ -1449,9 +1474,15 @@ fn bump_chat(
     // msg_id) order — a same-millisecond sibling applied later must not win.
     refresh_preview_if_latest(conn, device_id, chat, bump.msg_id, bump.preview, bump.kind)?;
     if bump.unread_delta != 0 {
-        diesel::update(chat_row(device_id, chat).filter(dsl::unread_count.ge(0)))
-            .set(dsl::unread_count.eq(dsl::unread_count + bump.unread_delta))
-            .execute(conn)?;
+        // An old row materialized late (offline drain) that a read already
+        // covered must not badge: only rows past the read cursor count.
+        diesel::update(
+            chat_row(device_id, chat)
+                .filter(dsl::unread_count.ge(0))
+                .filter(dsl::read_boundary_ms.lt(bump.ts_ms)),
+        )
+        .set(dsl::unread_count.eq(dsl::unread_count + bump.unread_delta))
+        .execute(conn)?;
     }
     Ok(())
 }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -169,8 +169,12 @@ impl ChatStore {
     }
 
     /// Wait until every write enqueued before this call is committed. Errors
-    /// with [`ChatStoreError::WriteBatchFailed`] when the batch containing
-    /// those writes rolled back instead.
+    /// with [`ChatStoreError::WriteBatchFailed`] when any batch since the
+    /// previous flush answer rolled back. The contract is TEMPORAL, not
+    /// per-caller: writes enqueued by anyone before this call share its fate,
+    /// so a failure that dropped someone else's earlier writes still reports
+    /// here (conservative: a false failure is possible, a false success is
+    /// not).
     pub async fn flush(&self) -> Result<()> {
         let (tx, rx) = oneshot::channel();
         self.tx
@@ -223,33 +227,126 @@ fn range_bound(
     })
 }
 
-/// The chat's monotonic self-read cursor (0 when the chat row doesn't exist).
-fn read_cursor(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<i64> {
-    Ok(chat_row(device_id, chat)
-        .select(schema::chats::read_boundary_ms)
-        .first(conn)
-        .optional()?
-        .unwrap_or(0))
+/// Extra read-boundary ids kept per chat; overflow drops the oldest entries.
+const READ_EXTRA_IDS_CAP: usize = 256;
+
+/// The chat's materialized self-read state: everything at or below the
+/// watermark is read, plus the explicitly-named ids — boundary-instant/keyed
+/// coverage that a scalar watermark cannot express (both directions of the
+/// same-second ambiguity are lossy without them).
+struct ReadState {
+    watermark_ms: i64,
+    extra_ids: Vec<String>,
 }
 
-/// Advance the self-read cursor (never backwards).
-fn advance_read_cursor(
+impl ReadState {
+    fn covers(&self, ts_ms: i64, msg_id: &str) -> bool {
+        ts_ms <= self.watermark_ms || self.extra_ids.iter().any(|id| id == msg_id)
+    }
+}
+
+fn read_state(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<ReadState> {
+    let row: Option<(i64, Option<String>)> = chat_row(device_id, chat)
+        .select((
+            schema::chats::read_boundary_ms,
+            schema::chats::read_boundary_ids,
+        ))
+        .first(conn)
+        .optional()?;
+    let (watermark_ms, ids_json) = row.unwrap_or((0, None));
+    let extra_ids = ids_json
+        .and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default();
+    Ok(ReadState {
+        watermark_ms,
+        extra_ids,
+    })
+}
+
+/// Fold a read event (watermark + explicitly covered ids) into the chat's
+/// monotonic read state. Ids already implied by the watermark are pruned.
+/// Returns the post-advance state, or `None` when the event brought nothing
+/// new (a stale replay, which must not touch the unread badge).
+fn advance_read_state(
     conn: &mut SqliteConnection,
     device_id: i32,
     chat: &str,
-    boundary_ms: i64,
-) -> QueryResult<usize> {
-    diesel::update(
-        chat_row(device_id, chat).filter(schema::chats::read_boundary_ms.lt(boundary_ms)),
-    )
-    .set(schema::chats::read_boundary_ms.eq(boundary_ms))
-    .execute(conn)
+    watermark_ms: i64,
+    covered_ids: &[String],
+) -> QueryResult<Option<ReadState>> {
+    use schema::messages::dsl;
+    let mut state = read_state(conn, device_id, chat)?;
+    let before = (state.watermark_ms, state.extra_ids.clone());
+    if watermark_ms > state.watermark_ms {
+        state.watermark_ms = watermark_ms;
+    }
+    for id in covered_ids {
+        if !state.extra_ids.iter().any(|existing| existing == id) {
+            state.extra_ids.push(id.clone());
+        }
+    }
+    if !state.extra_ids.is_empty() {
+        let implied: Vec<String> = dsl::messages
+            .filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::chat_jid.eq(chat))
+                    .and(dsl::msg_id.eq_any(&state.extra_ids))
+                    .and(dsl::timestamp_ms.le(state.watermark_ms)),
+            )
+            .select(dsl::msg_id)
+            .load(conn)?;
+        if !implied.is_empty() {
+            state.extra_ids.retain(|id| !implied.contains(id));
+        }
+    }
+    if state.extra_ids.len() > READ_EXTRA_IDS_CAP {
+        let overflow = state.extra_ids.len() - READ_EXTRA_IDS_CAP;
+        state.extra_ids.drain(..overflow);
+    }
+    if (state.watermark_ms, &state.extra_ids) == (before.0, &before.1) {
+        return Ok(None);
+    }
+    let ids_json = (!state.extra_ids.is_empty())
+        .then(|| serde_json::to_string(&state.extra_ids).ok())
+        .flatten();
+    diesel::update(chat_row(device_id, chat))
+        .set((
+            schema::chats::read_boundary_ms.eq(state.watermark_ms),
+            schema::chats::read_boundary_ids.eq(ids_json),
+        ))
+        .execute(conn)?;
+    Ok(Some(state))
+}
+
+/// Incoming rows not covered by the read state.
+fn count_unread(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    state: &ReadState,
+) -> QueryResult<i32> {
+    use schema::messages::dsl;
+    let mut query = dsl::messages
+        .filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::chat_jid.eq(chat))
+                .and(dsl::from_me.eq(false))
+                .and(dsl::timestamp_ms.gt(state.watermark_ms)),
+        )
+        .into_boxed();
+    if !state.extra_ids.is_empty() {
+        query = query.filter(dsl::msg_id.ne_all(&state.extra_ids));
+    }
+    let unread: i64 = query.count().get_result(conn)?;
+    Ok(unread.min(i32::MAX as i64) as i32)
 }
 
 /// Incoming rows NOT covered by `bound`: strictly newer than the boundary
 /// second, plus same-second rows the action's keyed list does not name.
-/// Rows at or before the chat's read cursor are already read — a stale ranged
-/// action replaying after a newer self-read must not resurrect their badge.
+/// Rows the read state already covers don't count — a stale ranged action
+/// replaying after a newer self-read must not resurrect their badge.
 fn count_uncovered_incoming(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -257,14 +354,19 @@ fn count_uncovered_incoming(
     bound: &RangeBound,
 ) -> QueryResult<i32> {
     use schema::messages::dsl;
-    let read_boundary_ms = read_cursor(conn, device_id, chat)?;
-    let base = dsl::messages.filter(
-        dsl::device_id
-            .eq(device_id)
-            .and(dsl::chat_jid.eq(chat))
-            .and(dsl::from_me.eq(false))
-            .and(dsl::timestamp_ms.gt(read_boundary_ms)),
-    );
+    let state = read_state(conn, device_id, chat)?;
+    let mut base = dsl::messages
+        .filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::chat_jid.eq(chat))
+                .and(dsl::from_me.eq(false))
+                .and(dsl::timestamp_ms.gt(state.watermark_ms)),
+        )
+        .into_boxed();
+    if !state.extra_ids.is_empty() {
+        base = base.filter(dsl::msg_id.ne_all(state.extra_ids.clone()));
+    }
     let uncovered: i64 = match &bound.keys {
         None => base
             .filter(dsl::timestamp_ms.gt(bound.second_end_ms))
@@ -275,7 +377,7 @@ fn count_uncovered_incoming(
             .filter(
                 dsl::timestamp_ms
                     .gt(bound.second_end_ms)
-                    .or(dsl::msg_id.ne_all(keys)),
+                    .or(dsl::msg_id.ne_all(keys.clone())),
             )
             .count()
             .get_result(conn)?,
@@ -549,26 +651,24 @@ fn apply_event(
         }
         Event::MarkChatAsReadUpdate(update) => {
             let chat = update.jid.to_string();
-            let unread = if update.action.read.unwrap_or(false) {
-                ensure_chat(conn, device_id, &chat)?;
+            ensure_chat(conn, device_id, &chat)?;
+            if update.action.read.unwrap_or(false) {
                 // A delayed replay only covers messages up to its range;
-                // anything we materialized past it is still unread. Reads also
-                // advance the self-read cursor so later stale actions/receipts
-                // can't resurrect the badge.
-                match range_bound(&update.action.message_range) {
+                // anything we materialized past it is still unread. Reads
+                // fold into the monotonic read state (watermark + keyed
+                // boundary ids), so later stale actions/receipts can't
+                // resurrect the badge — and a stale replay itself changes
+                // nothing.
+                let advanced = match range_bound(&update.action.message_range) {
                     Some(bound) => {
-                        // Count against the PREVIOUS cursor, then advance: a
-                        // keyed boundary second can't be expressed by a ms
-                        // cursor, so it only advances past the fully-covered
-                        // region (unlisted same-second siblings stay unread).
-                        let unread = count_uncovered_incoming(conn, device_id, &chat, &bound)?;
-                        let durable = if bound.keys.is_some() {
-                            bound.second_start_ms - 1
-                        } else {
-                            bound.second_end_ms
+                        // A keyed boundary second can't be expressed by the
+                        // watermark alone: it stops short and the named ids
+                        // ride along in the state.
+                        let (watermark, ids): (i64, &[String]) = match &bound.keys {
+                            Some(keys) => (bound.second_start_ms - 1, keys.as_slice()),
+                            None => (bound.second_end_ms, &[]),
                         };
-                        advance_read_cursor(conn, device_id, &chat, durable)?;
-                        unread
+                        advance_read_state(conn, device_id, &chat, watermark, ids)?
                     }
                     None => {
                         use schema::messages::dsl;
@@ -578,22 +678,25 @@ fn apply_event(
                             .first(conn)
                             .optional()?;
                         // Empty chat: the action's own timestamp is the read
-                        // moment — the cursor must still advance, or a later
+                        // moment — the state must still advance, or a later
                         // stale replay resurrects a badge this read cleared.
-                        let boundary_ms = newest
+                        let watermark = newest
                             .flatten()
                             .unwrap_or_else(|| update.timestamp.timestamp_millis());
-                        advance_read_cursor(conn, device_id, &chat, boundary_ms)?;
-                        0
+                        advance_read_state(conn, device_id, &chat, watermark, &[])?
                     }
+                };
+                if let Some(state) = advanced {
+                    let unread = count_unread(conn, device_id, &chat, &state)?;
+                    diesel::update(chat_row(device_id, &chat))
+                        .set(schema::chats::unread_count.eq(unread))
+                        .execute(conn)?;
                 }
             } else {
-                UNREAD_MARKER
-            };
-            ensure_chat(conn, device_id, &chat)?;
-            diesel::update(chat_row(device_id, &chat))
-                .set(schema::chats::unread_count.eq(unread))
-                .execute(conn)?;
+                diesel::update(chat_row(device_id, &chat))
+                    .set(schema::chats::unread_count.eq(UNREAD_MARKER))
+                    .execute(conn)?;
+            }
             cs.chats = true;
             Ok(())
         }
@@ -658,7 +761,23 @@ fn apply_event(
         }
         Event::DeleteMessageForMeUpdate(update) => {
             let chat = update.chat_jid.to_string();
+            // Capture the victim's read state before it goes: deleting an
+            // unread inbound row must also drop its badge (sentinel -1 and
+            // already-read rows are untouched).
+            let victim: Option<(bool, i64)> = message_row(device_id, &chat, &update.message_id)
+                .select((schema::messages::from_me, schema::messages::timestamp_ms))
+                .first(conn)
+                .optional()?;
             diesel::delete(message_row(device_id, &chat, &update.message_id)).execute(conn)?;
+            if let Some((false, ts_ms)) = victim
+                && !read_state(conn, device_id, &chat)?.covers(ts_ms, &update.message_id)
+            {
+                diesel::update(
+                    chat_row(device_id, &chat).filter(schema::chats::unread_count.gt(0)),
+                )
+                .set(schema::chats::unread_count.eq(schema::chats::unread_count - 1))
+                .execute(conn)?;
+            }
             diesel::delete(
                 schema::reactions::table.filter(
                     schema::reactions::device_id
@@ -1019,32 +1138,25 @@ fn apply_receipt(
                 .optional()?;
             let boundary_ms = covered_max.flatten().unwrap_or(ts_ms);
             ensure_chat(conn, device_id, &chat)?;
-            // Monotonic cursor: receipts can replay out of order across
-            // offline drains, and a stale one must neither re-inflate nor
-            // re-clear the badge.
-            if advance_read_cursor(conn, device_id, &chat, boundary_ms)? == 0 {
+            // Fold into the monotonic read state: the watermark stops SHORT
+            // of the boundary instant (coverage there is keyed by the
+            // receipt's ids — timestamps collide at wire granularity), and
+            // the named ids ride along so a covered row materialized later
+            // stays read while an unlisted same-instant sibling still badges.
+            // A stale replay changes nothing and is skipped outright.
+            let Some(state) = advance_read_state(
+                conn,
+                device_id,
+                &chat,
+                boundary_ms - 1,
+                &receipt.message_ids,
+            )?
+            else {
                 return Ok(());
-            }
-            // Uncovered = strictly past the boundary, plus boundary-instant
-            // siblings the receipt does not name (ids are the authoritative
-            // coverage signal; timestamps collide at wire granularity).
-            let unread: i64 = dsl::messages
-                .filter(
-                    dsl::device_id
-                        .eq(device_id)
-                        .and(dsl::chat_jid.eq(&chat))
-                        .and(dsl::from_me.eq(false))
-                        .and(dsl::timestamp_ms.ge(boundary_ms))
-                        .and(
-                            dsl::timestamp_ms
-                                .gt(boundary_ms)
-                                .or(dsl::msg_id.ne_all(&receipt.message_ids)),
-                        ),
-                )
-                .count()
-                .get_result(conn)?;
+            };
+            let unread = count_unread(conn, device_id, &chat, &state)?;
             diesel::update(chat_row(device_id, &chat))
-                .set(schema::chats::unread_count.eq(unread.min(i32::MAX as i64) as i32))
+                .set(schema::chats::unread_count.eq(unread))
                 .execute(conn)?;
             cs.chats = true;
             return Ok(());
@@ -1431,7 +1543,10 @@ fn insert_message(
         let refreshed = diesel::update(
             message_row(device_id, new.chat_jid, new.msg_id)
                 .filter(dsl::revoked.eq(false))
-                .filter(dsl::sender_jid.eq(new.sender_jid)),
+                .filter(dsl::sender_jid.eq(new.sender_jid))
+                // A redelivery carries the PRE-edit original; an edited row
+                // must keep its newer content.
+                .filter(dsl::edited_at_ms.is_null()),
         )
         .set((
             dsl::kind.eq(new.kind),
@@ -1475,14 +1590,13 @@ fn bump_chat(
     refresh_preview_if_latest(conn, device_id, chat, bump.msg_id, bump.preview, bump.kind)?;
     if bump.unread_delta != 0 {
         // An old row materialized late (offline drain) that a read already
-        // covered must not badge: only rows past the read cursor count.
-        diesel::update(
-            chat_row(device_id, chat)
-                .filter(dsl::unread_count.ge(0))
-                .filter(dsl::read_boundary_ms.lt(bump.ts_ms)),
-        )
-        .set(dsl::unread_count.eq(dsl::unread_count + bump.unread_delta))
-        .execute(conn)?;
+        // covered must not badge.
+        let state = read_state(conn, device_id, chat)?;
+        if !state.covers(bump.ts_ms, bump.msg_id) {
+            diesel::update(chat_row(device_id, chat).filter(dsl::unread_count.ge(0)))
+                .set(dsl::unread_count.eq(dsl::unread_count + bump.unread_delta))
+                .execute(conn)?;
+        }
     }
     Ok(())
 }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1,0 +1,1103 @@
+//! The store itself: a write-behind materializer over the client's event
+//! stream plus the public write API. All writes funnel through one writer task
+//! (one transaction per drained batch), so event order is preserved and fan-in
+//! bursts don't pay per-event commit costs.
+
+use std::collections::BTreeSet;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use buffa::Message as _;
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+use log::warn;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use wacore::store::error::StoreError;
+use wacore::types::events::{Event, EventHandler, EventInterest, EventKind, InboundMessage};
+use wacore::types::presence::ReceiptType;
+use wacore_binary::Jid;
+use waproto::whatsapp as wa;
+use whatsapp_rust_sqlite_storage::{SharedSqlite, SqliteStore};
+
+use crate::error::{ChatStoreError, Result, db_err};
+use crate::materialize::{KIND_UNDECRYPTABLE, MessageOp, classify, extract_text, message_kind};
+use crate::schema;
+use crate::types::StoreChange;
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+/// Max events applied per transaction. Bounds transaction size during
+/// offline-drain bursts; the writer loops immediately for the remainder.
+const BATCH_MAX: usize = 128;
+
+/// Capacity of the invalidation broadcast. Lagging receivers see
+/// `RecvError::Lagged` and should re-query everything they display.
+const CHANGE_CHANNEL_CAPACITY: usize = 256;
+
+/// Manually-marked-unread sentinel for `chats.unread_count` (WA Web convention).
+const UNREAD_MARKER: i32 = -1;
+
+pub(crate) enum WriterMsg {
+    Event(Arc<Event>),
+    Outgoing {
+        chat: Jid,
+        msg_id: String,
+        proto: Vec<u8>,
+        kind: &'static str,
+        text: Option<String>,
+        timestamp_ms: i64,
+    },
+    Flush(oneshot::Sender<()>),
+}
+
+/// SQLite-backed chat/message/contact history, materialized from the client's
+/// event stream into the same database file as the device store.
+///
+/// Wire-up:
+/// ```ignore
+/// let chat_store = ChatStore::new(&sqlite_store).await?;
+/// client.register_handler(chat_store.handler());
+/// let mut changes = chat_store.subscribe();
+/// ```
+pub struct ChatStore {
+    db: SharedSqlite,
+    device_id: i32,
+    tx: mpsc::UnboundedSender<WriterMsg>,
+    changes: broadcast::Sender<StoreChange>,
+}
+
+struct ChatStoreHandler {
+    tx: mpsc::UnboundedSender<WriterMsg>,
+}
+
+impl EventHandler for ChatStoreHandler {
+    fn handle_event(&self, event: Arc<Event>) {
+        // Writer gone (store dropped): nothing to record into, drop silently.
+        let _ = self.tx.send(WriterMsg::Event(event));
+    }
+
+    fn interest(&self) -> EventInterest {
+        EventInterest::of(&[
+            EventKind::Messages,
+            EventKind::Receipt,
+            EventKind::ServerAck,
+            EventKind::UndecryptableMessage,
+            EventKind::HistorySync,
+            EventKind::PushNameUpdate,
+            EventKind::ContactUpdate,
+            EventKind::PinUpdate,
+            EventKind::MuteUpdate,
+            EventKind::ArchiveUpdate,
+            EventKind::StarUpdate,
+            EventKind::MarkChatAsReadUpdate,
+            EventKind::DeleteChatUpdate,
+            EventKind::ClearChatUpdate,
+            EventKind::DeleteMessageForMeUpdate,
+        ])
+    }
+}
+
+impl ChatStore {
+    /// Open (running migrations if needed) on the same database file as
+    /// `store`, bound to its device id, and start the writer task.
+    pub async fn new(store: &SqliteStore) -> Result<Arc<Self>> {
+        let db = store.shared();
+        let device_id = store.device_id();
+
+        db.run(|conn| {
+            conn.run_pending_migrations(MIGRATIONS)
+                .map(|_| ())
+                .map_err(StoreError::Migration)?;
+            #[cfg(feature = "search")]
+            crate::fts::ensure_fts(conn).map_err(db_err)?;
+            Ok(())
+        })
+        .await?;
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (changes, _) = broadcast::channel(CHANGE_CHANNEL_CAPACITY);
+
+        let this = Arc::new(Self {
+            db: db.clone(),
+            device_id,
+            tx,
+            changes: changes.clone(),
+        });
+        tokio::spawn(writer_loop(db, device_id, rx, changes));
+        Ok(this)
+    }
+
+    /// Event handler to register on the client. The store keeps working if the
+    /// handler outlives it (events are then dropped), and vice versa.
+    pub fn handler(&self) -> Arc<dyn EventHandler> {
+        Arc::new(ChatStoreHandler {
+            tx: self.tx.clone(),
+        })
+    }
+
+    /// Subscribe to invalidation signals. Emitted once per committed write
+    /// batch, deduplicated. On `Lagged`, re-query all visible state.
+    pub fn subscribe(&self) -> broadcast::Receiver<StoreChange> {
+        self.changes.subscribe()
+    }
+
+    /// Record a message this client just sent. Goes through the writer queue so
+    /// it cannot race the server ack / receipts that follow it in event order.
+    /// Status starts at [`MessageStatus::Pending`](crate::types::MessageStatus::Pending)
+    /// and is lifted by acks/receipts.
+    pub fn record_outgoing(
+        &self,
+        chat: &Jid,
+        msg_id: impl Into<String>,
+        message: &wa::Message,
+        timestamp: DateTime<Utc>,
+    ) -> Result<()> {
+        let base = wacore::proto_helpers::MessageExt::get_base_message(message);
+        self.tx
+            .send(WriterMsg::Outgoing {
+                chat: chat.clone(),
+                msg_id: msg_id.into(),
+                proto: message.encode_to_vec(),
+                kind: message_kind(base),
+                text: extract_text(base),
+                timestamp_ms: timestamp.timestamp_millis(),
+            })
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+    }
+
+    /// Wait until every write enqueued before this call is committed.
+    pub async fn flush(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(WriterMsg::Flush(tx))
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))?;
+        rx.await
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+    }
+
+    pub fn device_id(&self) -> i32 {
+        self.device_id
+    }
+
+    pub(crate) fn db(&self) -> &SharedSqlite {
+        &self.db
+    }
+}
+
+/// Chats/contacts touched by a batch, accumulated for post-commit invalidation.
+#[derive(Default)]
+struct ChangeSet {
+    chats: bool,
+    contacts: bool,
+    message_chats: BTreeSet<String>,
+}
+
+async fn writer_loop(
+    db: SharedSqlite,
+    device_id: i32,
+    mut rx: mpsc::UnboundedReceiver<WriterMsg>,
+    changes: broadcast::Sender<StoreChange>,
+) {
+    while let Some(first) = rx.recv().await {
+        let mut batch = Vec::with_capacity(8);
+        let mut flushes = Vec::new();
+        let mut queue_msg = |msg: WriterMsg, batch: &mut Vec<WriterMsg>| match msg {
+            WriterMsg::Flush(done) => flushes.push(done),
+            other => batch.push(other),
+        };
+        queue_msg(first, &mut batch);
+        while batch.len() < BATCH_MAX {
+            match rx.try_recv() {
+                Ok(msg) => queue_msg(msg, &mut batch),
+                Err(_) => break,
+            }
+        }
+
+        if !batch.is_empty() {
+            let result = db
+                .run(move |conn| {
+                    conn.transaction(|conn| {
+                        let mut cs = ChangeSet::default();
+                        for msg in &batch {
+                            apply_writer_msg(conn, device_id, msg, &mut cs)?;
+                        }
+                        Ok(cs)
+                    })
+                    .map_err(db_err)
+                })
+                .await;
+            match result {
+                Ok(cs) => emit_changes(&changes, cs),
+                // The batch rolled back; state stays consistent (previous
+                // commit) but this slice of history is lost. Surfacing beats
+                // crashing the writer.
+                Err(e) => warn!("chat-store: dropping write batch: {e}"),
+            }
+        }
+        for done in flushes {
+            let _ = done.send(());
+        }
+    }
+}
+
+fn emit_changes(changes: &broadcast::Sender<StoreChange>, cs: ChangeSet) {
+    if cs.chats {
+        let _ = changes.send(StoreChange::Chats);
+    }
+    if cs.contacts {
+        let _ = changes.send(StoreChange::Contacts);
+    }
+    for chat in cs.message_chats {
+        if let Ok(jid) = Jid::from_str(&chat) {
+            let _ = changes.send(StoreChange::Messages { chat: jid });
+        }
+    }
+}
+
+fn apply_writer_msg(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    msg: &WriterMsg,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    match msg {
+        WriterMsg::Event(event) => apply_event(conn, device_id, event, cs),
+        WriterMsg::Outgoing {
+            chat,
+            msg_id,
+            proto,
+            kind,
+            text,
+            timestamp_ms,
+        } => {
+            let chat_str = chat.to_string();
+            insert_message(
+                conn,
+                device_id,
+                NewMessage {
+                    chat_jid: &chat_str,
+                    msg_id,
+                    sender_jid: "",
+                    from_me: true,
+                    timestamp_ms: *timestamp_ms,
+                    kind,
+                    text: text.as_deref(),
+                    proto: Some(proto),
+                    status: wa::web_message_info::Status::PENDING as i32,
+                    starred: false,
+                    overwrite: true,
+                },
+            )?;
+            bump_chat(
+                conn,
+                device_id,
+                &chat_str,
+                *timestamp_ms,
+                text.as_deref(),
+                0,
+            )?;
+            cs.chats = true;
+            cs.message_chats.insert(chat_str);
+            Ok(())
+        }
+        WriterMsg::Flush(_) => Ok(()),
+    }
+}
+
+fn apply_event(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    event: &Event,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    match event {
+        Event::Messages(batch) => {
+            for inbound in batch.iter() {
+                apply_inbound(conn, device_id, inbound, cs)?;
+            }
+            Ok(())
+        }
+        Event::Receipt(receipt) => apply_receipt(conn, device_id, receipt, cs),
+        Event::ServerAck(ack) => apply_server_ack(conn, device_id, ack, cs),
+        Event::UndecryptableMessage(undec) => {
+            let chat = undec.info.source.chat.to_string();
+            let sender = undec.info.source.sender.to_string();
+            insert_message(
+                conn,
+                device_id,
+                NewMessage {
+                    chat_jid: &chat,
+                    msg_id: &undec.info.id,
+                    sender_jid: &sender,
+                    from_me: undec.info.source.is_from_me,
+                    timestamp_ms: undec.info.timestamp.timestamp_millis(),
+                    kind: KIND_UNDECRYPTABLE,
+                    text: None,
+                    proto: None,
+                    status: wa::web_message_info::Status::DELIVERY_ACK as i32,
+                    starred: false,
+                    overwrite: false,
+                },
+            )?;
+            bump_chat(
+                conn,
+                device_id,
+                &chat,
+                undec.info.timestamp.timestamp_millis(),
+                None,
+                i32::from(!undec.info.source.is_from_me),
+            )?;
+            cs.chats = true;
+            cs.message_chats.insert(chat);
+            Ok(())
+        }
+        Event::HistorySync(lazy) => apply_history_sync(conn, device_id, lazy, cs),
+        Event::PushNameUpdate(update) => {
+            upsert_contact_push_name(
+                conn,
+                device_id,
+                &update.jid.to_string(),
+                &update.new_push_name,
+            )?;
+            cs.contacts = true;
+            Ok(())
+        }
+        Event::ContactUpdate(update) => {
+            upsert_contact_names(
+                conn,
+                device_id,
+                &update.jid.to_string(),
+                update.action.full_name.as_deref(),
+                update.action.first_name.as_deref(),
+            )?;
+            cs.contacts = true;
+            Ok(())
+        }
+        Event::PinUpdate(update) => {
+            let pinned_at = update
+                .action
+                .pinned
+                .unwrap_or(false)
+                .then(|| update.timestamp.timestamp_millis());
+            let chat = update.jid.to_string();
+            ensure_chat(conn, device_id, &chat)?;
+            diesel::update(chat_row(device_id, &chat))
+                .set(schema::chats::pinned_at.eq(pinned_at))
+                .execute(conn)?;
+            cs.chats = true;
+            Ok(())
+        }
+        Event::MuteUpdate(update) => {
+            let muted_until = if update.action.muted.unwrap_or(false) {
+                // No end timestamp = muted forever.
+                Some(update.action.mute_end_timestamp.unwrap_or(i64::MAX))
+            } else {
+                None
+            };
+            let chat = update.jid.to_string();
+            ensure_chat(conn, device_id, &chat)?;
+            diesel::update(chat_row(device_id, &chat))
+                .set(schema::chats::muted_until.eq(muted_until))
+                .execute(conn)?;
+            cs.chats = true;
+            Ok(())
+        }
+        Event::ArchiveUpdate(update) => {
+            let chat = update.jid.to_string();
+            ensure_chat(conn, device_id, &chat)?;
+            diesel::update(chat_row(device_id, &chat))
+                .set(schema::chats::archived.eq(update.action.archived.unwrap_or(false)))
+                .execute(conn)?;
+            cs.chats = true;
+            Ok(())
+        }
+        Event::MarkChatAsReadUpdate(update) => {
+            let unread = if update.action.read.unwrap_or(false) {
+                0
+            } else {
+                UNREAD_MARKER
+            };
+            let chat = update.jid.to_string();
+            ensure_chat(conn, device_id, &chat)?;
+            diesel::update(chat_row(device_id, &chat))
+                .set(schema::chats::unread_count.eq(unread))
+                .execute(conn)?;
+            cs.chats = true;
+            Ok(())
+        }
+        Event::StarUpdate(update) => {
+            let chat = update.chat_jid.to_string();
+            diesel::update(message_row(device_id, &chat, &update.message_id))
+                .set(schema::messages::starred.eq(update.action.starred.unwrap_or(false)))
+                .execute(conn)?;
+            cs.message_chats.insert(chat);
+            Ok(())
+        }
+        Event::DeleteChatUpdate(update) => {
+            let chat = update.jid.to_string();
+            delete_chat_rows(conn, device_id, &chat, true)?;
+            diesel::delete(chat_row(device_id, &chat)).execute(conn)?;
+            cs.chats = true;
+            cs.message_chats.insert(chat);
+            Ok(())
+        }
+        Event::ClearChatUpdate(update) => {
+            let chat = update.jid.to_string();
+            delete_chat_rows(conn, device_id, &chat, update.delete_starred)?;
+            diesel::update(chat_row(device_id, &chat))
+                .set((
+                    schema::chats::last_message_preview.eq(None::<String>),
+                    schema::chats::unread_count.eq(0),
+                ))
+                .execute(conn)?;
+            cs.chats = true;
+            cs.message_chats.insert(chat);
+            Ok(())
+        }
+        Event::DeleteMessageForMeUpdate(update) => {
+            let chat = update.chat_jid.to_string();
+            diesel::delete(message_row(device_id, &chat, &update.message_id)).execute(conn)?;
+            diesel::delete(
+                schema::reactions::table.filter(
+                    schema::reactions::device_id
+                        .eq(device_id)
+                        .and(schema::reactions::chat_jid.eq(&chat))
+                        .and(schema::reactions::msg_id.eq(&update.message_id)),
+                ),
+            )
+            .execute(conn)?;
+            cs.message_chats.insert(chat);
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn apply_inbound(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    inbound: &InboundMessage,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    let info = &inbound.info;
+    let chat = info.source.chat.to_string();
+    let sender = info.source.sender.to_string();
+    let ts_ms = info.timestamp.timestamp_millis();
+
+    // Live push names ride on every message; keep contacts warm from them.
+    if !info.push_name.is_empty() && !info.source.is_from_me {
+        upsert_contact_push_name(conn, device_id, &sender, &info.push_name)?;
+        cs.contacts = true;
+    }
+
+    match classify(&inbound.message) {
+        MessageOp::Store { kind, text } => {
+            insert_message(
+                conn,
+                device_id,
+                NewMessage {
+                    chat_jid: &chat,
+                    msg_id: &info.id,
+                    sender_jid: &sender,
+                    from_me: info.source.is_from_me,
+                    timestamp_ms: ts_ms,
+                    kind,
+                    text: text.as_deref(),
+                    proto: Some(&inbound.message.encode_to_vec()),
+                    status: if info.source.is_from_me {
+                        wa::web_message_info::Status::SERVER_ACK as i32
+                    } else {
+                        wa::web_message_info::Status::DELIVERY_ACK as i32
+                    },
+                    starred: false,
+                    overwrite: true,
+                },
+            )?;
+            bump_chat(
+                conn,
+                device_id,
+                &chat,
+                ts_ms,
+                text.as_deref(),
+                i32::from(!info.source.is_from_me),
+            )?;
+            cs.chats = true;
+            cs.message_chats.insert(chat);
+        }
+        MessageOp::Reaction { target_id, emoji } => {
+            apply_reaction(conn, device_id, &chat, &target_id, &sender, &emoji, ts_ms)?;
+            cs.message_chats.insert(chat);
+        }
+        MessageOp::Edit {
+            target_id,
+            new_text,
+            new_kind,
+            new_proto,
+        } => {
+            diesel::update(message_row(device_id, &chat, &target_id))
+                .set((
+                    schema::messages::text_content.eq(new_text.as_deref()),
+                    schema::messages::kind.eq(new_kind),
+                    schema::messages::proto.eq(Some(new_proto)),
+                    schema::messages::edited_at_ms.eq(Some(ts_ms)),
+                ))
+                .execute(conn)?;
+            cs.message_chats.insert(chat);
+        }
+        MessageOp::Revoke { target_id } => {
+            diesel::update(message_row(device_id, &chat, &target_id))
+                .set((
+                    schema::messages::revoked.eq(true),
+                    schema::messages::text_content.eq(None::<String>),
+                    schema::messages::proto.eq(None::<Vec<u8>>),
+                ))
+                .execute(conn)?;
+            cs.message_chats.insert(chat);
+        }
+        MessageOp::Ignore => {}
+    }
+    Ok(())
+}
+
+fn apply_reaction(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    target_id: &str,
+    sender: &str,
+    emoji: &str,
+    ts_ms: i64,
+) -> QueryResult<()> {
+    use schema::reactions::dsl;
+    if emoji.is_empty() {
+        diesel::delete(
+            dsl::reactions.filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::chat_jid.eq(chat))
+                    .and(dsl::msg_id.eq(target_id))
+                    .and(dsl::sender_jid.eq(sender)),
+            ),
+        )
+        .execute(conn)?;
+    } else {
+        diesel::insert_into(dsl::reactions)
+            .values((
+                dsl::device_id.eq(device_id),
+                dsl::chat_jid.eq(chat),
+                dsl::msg_id.eq(target_id),
+                dsl::sender_jid.eq(sender),
+                dsl::emoji.eq(emoji),
+                dsl::ts_ms.eq(ts_ms),
+            ))
+            .on_conflict((dsl::device_id, dsl::chat_jid, dsl::msg_id, dsl::sender_jid))
+            .do_update()
+            .set((dsl::emoji.eq(emoji), dsl::ts_ms.eq(ts_ms)))
+            .execute(conn)?;
+    }
+    Ok(())
+}
+
+fn apply_receipt(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    receipt: &wacore::types::events::Receipt,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    let chat = receipt.source.chat.to_string();
+    let ts_ms = receipt.timestamp.timestamp_millis();
+
+    let status = match receipt.r#type {
+        ReceiptType::Delivered => wa::web_message_info::Status::DELIVERY_ACK as i32,
+        ReceiptType::Read => wa::web_message_info::Status::READ as i32,
+        ReceiptType::Played => wa::web_message_info::Status::PLAYED as i32,
+        ReceiptType::ReadSelf | ReceiptType::PlayedSelf => {
+            // Read on another of our devices: the chat is no longer unread.
+            ensure_chat(conn, device_id, &chat)?;
+            diesel::update(chat_row(device_id, &chat))
+                .set(schema::chats::unread_count.eq(0))
+                .execute(conn)?;
+            cs.chats = true;
+            return Ok(());
+        }
+        _ => return Ok(()),
+    };
+
+    let user = receipt.source.sender.to_string();
+    for msg_id in &receipt.message_ids {
+        // Peer receipts only ever advance the delivery state of our own
+        // messages, and never backwards.
+        diesel::update(
+            message_row(device_id, &chat, msg_id).filter(
+                schema::messages::from_me
+                    .eq(true)
+                    .and(schema::messages::status.lt(status)),
+            ),
+        )
+        .set(schema::messages::status.eq(status))
+        .execute(conn)?;
+
+        if receipt.source.is_group {
+            use schema::message_receipts::dsl;
+            diesel::insert_into(dsl::message_receipts)
+                .values((
+                    dsl::device_id.eq(device_id),
+                    dsl::chat_jid.eq(&chat),
+                    dsl::msg_id.eq(msg_id),
+                    dsl::user_jid.eq(&user),
+                    dsl::receipt_type.eq(status),
+                    dsl::ts_ms.eq(ts_ms),
+                ))
+                .on_conflict_do_nothing()
+                .execute(conn)?;
+            // Existing row: advance only (a late "delivered" must not undo "read").
+            diesel::update(
+                dsl::message_receipts.filter(
+                    dsl::device_id
+                        .eq(device_id)
+                        .and(dsl::chat_jid.eq(&chat))
+                        .and(dsl::msg_id.eq(msg_id))
+                        .and(dsl::user_jid.eq(&user))
+                        .and(dsl::receipt_type.lt(status)),
+                ),
+            )
+            .set((dsl::receipt_type.eq(status), dsl::ts_ms.eq(ts_ms)))
+            .execute(conn)?;
+        }
+    }
+    cs.message_chats.insert(chat);
+    Ok(())
+}
+
+fn apply_server_ack(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    ack: &wacore::types::events::ServerAck,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    // Acks cover every stanza class; only message acks map to a stored row.
+    if ack.class.as_deref() != Some("message") || ack.error.is_some() {
+        return Ok(());
+    }
+    use schema::messages::dsl;
+    let updated = diesel::update(
+        dsl::messages.filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::msg_id.eq(&ack.id))
+                .and(dsl::from_me.eq(true))
+                .and(dsl::status.lt(wa::web_message_info::Status::SERVER_ACK as i32)),
+        ),
+    )
+    .set(dsl::status.eq(wa::web_message_info::Status::SERVER_ACK as i32))
+    .execute(conn)?;
+    if updated > 0
+        && let Some(from) = &ack.from
+    {
+        cs.message_chats.insert(from.to_string());
+    }
+    Ok(())
+}
+
+fn apply_history_sync(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    lazy: &wacore::types::events::LazyHistorySync,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    let mut stream = lazy.stream();
+    loop {
+        let conv = match stream.next_conversation() {
+            Ok(Some(conv)) => conv,
+            Ok(None) => break,
+            Err(e) => {
+                warn!("chat-store: history sync chunk unreadable, skipping: {e}");
+                return Ok(());
+            }
+        };
+        apply_history_conversation(conn, device_id, &conv, cs)?;
+    }
+    match stream.remainder() {
+        Ok(rest) => {
+            for pushname in &rest.pushnames {
+                if let (Some(jid), Some(name)) = (&pushname.id, &pushname.pushname) {
+                    upsert_contact_push_name(conn, device_id, jid, name)?;
+                    cs.contacts = true;
+                }
+            }
+        }
+        Err(e) => warn!("chat-store: history sync remainder unreadable: {e}"),
+    }
+    Ok(())
+}
+
+fn apply_history_conversation(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    conv: &wa::Conversation,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    let chat = conv.id.as_str();
+    let last_ts_ms = conv
+        .conversation_timestamp
+        .map(|s| (s as i64).saturating_mul(1000))
+        .unwrap_or(0);
+
+    {
+        use schema::chats::dsl;
+        let name = conv.name.as_deref().or(conv.display_name.as_deref());
+        diesel::insert_into(dsl::chats)
+            .values((
+                dsl::device_id.eq(device_id),
+                dsl::jid.eq(chat),
+                dsl::name.eq(name),
+                dsl::last_message_ts.eq(last_ts_ms),
+                dsl::unread_count.eq(conv.unread_count.unwrap_or(0) as i32),
+                dsl::pinned_at.eq(conv.pinned.map(|p| p as i64).filter(|&p| p > 0)),
+                dsl::muted_until.eq(conv.mute_end_time.map(|m| m as i64).filter(|&m| m > 0)),
+                dsl::archived.eq(conv.archived.unwrap_or(false)),
+                dsl::ephemeral_expiration.eq(conv.ephemeral_expiration.map(|e| e as i32)),
+            ))
+            .on_conflict((dsl::device_id, dsl::jid))
+            .do_update()
+            // Live rows already track unread/mute/pin; history only refreshes
+            // identity + activity floor.
+            .set((
+                dsl::name.eq(name),
+                dsl::last_message_ts.eq(diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                    "MAX(last_message_ts, excluded.last_message_ts)",
+                )),
+            ))
+            .execute(conn)?;
+    }
+
+    for hist_msg in &conv.messages {
+        let Some(wmi) = hist_msg.message.as_option() else {
+            continue;
+        };
+        apply_history_message(conn, device_id, chat, wmi, cs)?;
+    }
+    cs.chats = true;
+    cs.message_chats.insert(chat.to_string());
+    Ok(())
+}
+
+fn apply_history_message(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    wmi: &wa::WebMessageInfo,
+    cs: &mut ChangeSet,
+) -> QueryResult<()> {
+    let Some(key) = wmi.key.as_option() else {
+        return Ok(());
+    };
+    let Some(msg_id) = key.id.as_deref() else {
+        return Ok(());
+    };
+    let from_me = key.from_me.unwrap_or(false);
+    let sender = wmi
+        .participant
+        .as_deref()
+        .or(key.participant.as_deref())
+        .unwrap_or(if from_me { "" } else { chat });
+    let ts_ms = wmi
+        .message_timestamp
+        .map(|s| (s as i64).saturating_mul(1000))
+        .unwrap_or(0);
+
+    if let Some(name) = wmi.push_name.as_deref()
+        && !name.is_empty()
+        && !from_me
+        && !sender.is_empty()
+    {
+        upsert_contact_push_name(conn, device_id, sender, name)?;
+        cs.contacts = true;
+    }
+
+    if let Some(message) = wmi.message.as_option() {
+        match classify(message) {
+            MessageOp::Store { kind, text } => {
+                insert_message(
+                    conn,
+                    device_id,
+                    NewMessage {
+                        chat_jid: chat,
+                        msg_id,
+                        sender_jid: sender,
+                        from_me,
+                        timestamp_ms: ts_ms,
+                        kind,
+                        text: text.as_deref(),
+                        proto: Some(&message.encode_to_vec()),
+                        status: wmi
+                            .status
+                            .map(|s| s as i32)
+                            .unwrap_or(wa::web_message_info::Status::PENDING as i32),
+                        starred: wmi.starred.unwrap_or(false),
+                        // History is the stale copy: live rows win.
+                        overwrite: false,
+                    },
+                )?;
+            }
+            MessageOp::Reaction { target_id, emoji } => {
+                apply_reaction(conn, device_id, chat, &target_id, sender, &emoji, ts_ms)?;
+            }
+            MessageOp::Edit {
+                target_id,
+                new_text,
+                new_kind,
+                new_proto,
+            } => {
+                diesel::update(message_row(device_id, chat, &target_id))
+                    .set((
+                        schema::messages::text_content.eq(new_text.as_deref()),
+                        schema::messages::kind.eq(new_kind),
+                        schema::messages::proto.eq(Some(new_proto)),
+                        schema::messages::edited_at_ms.eq(Some(ts_ms)),
+                    ))
+                    .execute(conn)?;
+            }
+            MessageOp::Revoke { target_id } => {
+                diesel::update(message_row(device_id, chat, &target_id))
+                    .set((
+                        schema::messages::revoked.eq(true),
+                        schema::messages::text_content.eq(None::<String>),
+                        schema::messages::proto.eq(None::<Vec<u8>>),
+                    ))
+                    .execute(conn)?;
+            }
+            MessageOp::Ignore => {}
+        }
+    }
+
+    // Reactions the server aggregated onto the target message.
+    for reaction in &wmi.reactions {
+        let Some(text) = reaction.text.as_deref() else {
+            continue;
+        };
+        let reactor = reaction
+            .key
+            .as_option()
+            .and_then(|k| {
+                if k.from_me.unwrap_or(false) {
+                    Some("")
+                } else {
+                    k.participant.as_deref().or(k.remote_jid.as_deref())
+                }
+            })
+            .unwrap_or("");
+        let reaction_ts = reaction.sender_timestamp_ms.unwrap_or(ts_ms);
+        apply_reaction(conn, device_id, chat, msg_id, reactor, text, reaction_ts)?;
+    }
+    Ok(())
+}
+
+struct NewMessage<'a> {
+    chat_jid: &'a str,
+    msg_id: &'a str,
+    sender_jid: &'a str,
+    from_me: bool,
+    timestamp_ms: i64,
+    kind: &'a str,
+    text: Option<&'a str>,
+    proto: Option<&'a [u8]>,
+    status: i32,
+    starred: bool,
+    /// Live redeliveries refresh content in place (PDO recovery replaces an
+    /// `undecryptable` placeholder); history-sync copies never clobber live rows.
+    overwrite: bool,
+}
+
+fn insert_message(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    new: NewMessage<'_>,
+) -> QueryResult<()> {
+    use schema::messages::dsl;
+    let values = (
+        dsl::device_id.eq(device_id),
+        dsl::chat_jid.eq(new.chat_jid),
+        dsl::msg_id.eq(new.msg_id),
+        dsl::sender_jid.eq(new.sender_jid),
+        dsl::from_me.eq(new.from_me),
+        dsl::timestamp_ms.eq(new.timestamp_ms),
+        dsl::kind.eq(new.kind),
+        dsl::text_content.eq(new.text),
+        dsl::proto.eq(new.proto),
+        dsl::status.eq(new.status),
+        dsl::starred.eq(new.starred),
+    );
+    let insert = diesel::insert_into(dsl::messages).values(values);
+    if new.overwrite {
+        insert
+            .on_conflict((dsl::device_id, dsl::chat_jid, dsl::msg_id))
+            .do_update()
+            .set((
+                dsl::kind.eq(new.kind),
+                dsl::text_content.eq(new.text),
+                dsl::proto.eq(new.proto),
+                dsl::revoked.eq(false),
+            ))
+            .execute(conn)?;
+    } else {
+        insert
+            .on_conflict((dsl::device_id, dsl::chat_jid, dsl::msg_id))
+            .do_nothing()
+            .execute(conn)?;
+    }
+    Ok(())
+}
+
+/// Refresh a chat's activity row for a message at `ts_ms`: creates the row if
+/// missing, advances ordering/preview only for newer messages, and bumps the
+/// unread counter by `unread_delta` (unless manually marked unread).
+fn bump_chat(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    ts_ms: i64,
+    preview: Option<&str>,
+    unread_delta: i32,
+) -> QueryResult<()> {
+    use schema::chats::dsl;
+    ensure_chat(conn, device_id, chat)?;
+    diesel::update(chat_row(device_id, chat).filter(dsl::last_message_ts.le(ts_ms)))
+        .set((
+            dsl::last_message_ts.eq(ts_ms),
+            dsl::last_message_preview.eq(preview),
+        ))
+        .execute(conn)?;
+    if unread_delta != 0 {
+        diesel::update(chat_row(device_id, chat).filter(dsl::unread_count.ge(0)))
+            .set(dsl::unread_count.eq(dsl::unread_count + unread_delta))
+            .execute(conn)?;
+    }
+    Ok(())
+}
+
+fn ensure_chat(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<()> {
+    use schema::chats::dsl;
+    diesel::insert_into(dsl::chats)
+        .values((dsl::device_id.eq(device_id), dsl::jid.eq(chat)))
+        .on_conflict_do_nothing()
+        .execute(conn)?;
+    Ok(())
+}
+
+fn upsert_contact_push_name(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    jid: &str,
+    push_name: &str,
+) -> QueryResult<()> {
+    use schema::contacts::dsl;
+    diesel::insert_into(dsl::contacts)
+        .values((
+            dsl::device_id.eq(device_id),
+            dsl::jid.eq(jid),
+            dsl::push_name.eq(push_name),
+        ))
+        .on_conflict((dsl::device_id, dsl::jid))
+        .do_update()
+        .set(dsl::push_name.eq(push_name))
+        .execute(conn)?;
+    Ok(())
+}
+
+fn upsert_contact_names(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    jid: &str,
+    full_name: Option<&str>,
+    first_name: Option<&str>,
+) -> QueryResult<()> {
+    use schema::contacts::dsl;
+    diesel::insert_into(dsl::contacts)
+        .values((
+            dsl::device_id.eq(device_id),
+            dsl::jid.eq(jid),
+            dsl::full_name.eq(full_name),
+            dsl::first_name.eq(first_name),
+        ))
+        .on_conflict((dsl::device_id, dsl::jid))
+        .do_update()
+        .set((dsl::full_name.eq(full_name), dsl::first_name.eq(first_name)))
+        .execute(conn)?;
+    Ok(())
+}
+
+/// Delete a chat's message rows (and their reactions/receipts). With
+/// `delete_starred = false`, starred messages and their satellites survive.
+fn delete_chat_rows(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    delete_starred: bool,
+) -> QueryResult<()> {
+    use schema::messages::dsl as m;
+    let base =
+        diesel::delete(m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))));
+    if delete_starred {
+        base.execute(conn)?;
+    } else {
+        base.filter(m::starred.eq(false)).execute(conn)?;
+    }
+    // Satellites of messages that no longer exist.
+    diesel::sql_query(
+        "DELETE FROM reactions WHERE device_id = ? AND chat_jid = ? AND msg_id NOT IN \
+         (SELECT msg_id FROM messages WHERE device_id = ? AND chat_jid = ?)",
+    )
+    .bind::<diesel::sql_types::Integer, _>(device_id)
+    .bind::<diesel::sql_types::Text, _>(chat)
+    .bind::<diesel::sql_types::Integer, _>(device_id)
+    .bind::<diesel::sql_types::Text, _>(chat)
+    .execute(conn)?;
+    diesel::sql_query(
+        "DELETE FROM message_receipts WHERE device_id = ? AND chat_jid = ? AND msg_id NOT IN \
+         (SELECT msg_id FROM messages WHERE device_id = ? AND chat_jid = ?)",
+    )
+    .bind::<diesel::sql_types::Integer, _>(device_id)
+    .bind::<diesel::sql_types::Text, _>(chat)
+    .bind::<diesel::sql_types::Integer, _>(device_id)
+    .bind::<diesel::sql_types::Text, _>(chat)
+    .execute(conn)?;
+    Ok(())
+}
+
+type ChatRowFilter<'a> = diesel::dsl::Filter<
+    schema::chats::table,
+    diesel::dsl::And<
+        diesel::dsl::Eq<schema::chats::device_id, i32>,
+        diesel::dsl::Eq<schema::chats::jid, &'a str>,
+    >,
+>;
+
+fn chat_row(device_id: i32, chat: &str) -> ChatRowFilter<'_> {
+    schema::chats::table.filter(
+        schema::chats::device_id
+            .eq(device_id)
+            .and(schema::chats::jid.eq(chat)),
+    )
+}
+
+type MessageRowFilter<'a> = diesel::dsl::Filter<
+    schema::messages::table,
+    diesel::dsl::And<
+        diesel::dsl::And<
+            diesel::dsl::Eq<schema::messages::device_id, i32>,
+            diesel::dsl::Eq<schema::messages::chat_jid, &'a str>,
+        >,
+        diesel::dsl::Eq<schema::messages::msg_id, &'a str>,
+    >,
+>;
+
+fn message_row<'a>(device_id: i32, chat: &'a str, msg_id: &'a str) -> MessageRowFilter<'a> {
+    schema::messages::table.filter(
+        schema::messages::device_id
+            .eq(device_id)
+            .and(schema::messages::chat_jid.eq(chat))
+            .and(schema::messages::msg_id.eq(msg_id)),
+    )
+}

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -284,7 +284,7 @@ fn apply_writer_msg(
             timestamp_ms,
         } => {
             let chat_str = chat.to_string();
-            let _ = insert_message(
+            let stored = insert_message(
                 conn,
                 device_id,
                 NewMessage {
@@ -301,16 +301,18 @@ fn apply_writer_msg(
                     overwrite: true,
                 },
             )?;
-            bump_chat(
-                conn,
-                device_id,
-                &chat_str,
-                *timestamp_ms,
-                text.as_deref(),
-                Some(kind),
-                0,
-            )?;
-            cs.chats = true;
+            if stored != StoredRow::Skipped {
+                bump_chat(
+                    conn,
+                    device_id,
+                    &chat_str,
+                    *timestamp_ms,
+                    text.as_deref(),
+                    Some(kind),
+                    0,
+                )?;
+                cs.chats = true;
+            }
             cs.message_chats.insert(chat_str);
             Ok(())
         }
@@ -353,16 +355,20 @@ fn apply_event(
                     overwrite: false,
                 },
             )?;
-            bump_chat(
-                conn,
-                device_id,
-                &chat,
-                undec.info.timestamp.timestamp_millis(),
-                None,
-                Some(KIND_UNDECRYPTABLE),
-                i32::from(inserted && !undec.info.source.is_from_me),
-            )?;
-            cs.chats = true;
+            // A duplicate placeholder (or one for an id that was already
+            // recovered/revoked) must neither recount nor blank the preview.
+            if inserted == StoredRow::Inserted {
+                bump_chat(
+                    conn,
+                    device_id,
+                    &chat,
+                    undec.info.timestamp.timestamp_millis(),
+                    None,
+                    Some(KIND_UNDECRYPTABLE),
+                    i32::from(!undec.info.source.is_from_me),
+                )?;
+                cs.chats = true;
+            }
             cs.message_chats.insert(chat);
             Ok(())
         }
@@ -541,18 +547,23 @@ fn apply_inbound(
                 },
             )?;
             // A refreshed row (redelivery, PDO recovery of a placeholder that
-            // already counted) must not inflate the unread badge again.
-            let unread_delta = i32::from(inserted && !info.source.is_from_me);
-            bump_chat(
-                conn,
-                device_id,
-                &chat,
-                ts_ms,
-                text.as_deref(),
-                Some(kind),
-                unread_delta,
-            )?;
-            cs.chats = true;
+            // already counted) must not inflate the unread badge again — and a
+            // skipped one (revoked tombstone) must not surface its content in
+            // the chat preview at all.
+            let unread_delta =
+                i32::from(inserted == StoredRow::Inserted && !info.source.is_from_me);
+            if inserted != StoredRow::Skipped {
+                bump_chat(
+                    conn,
+                    device_id,
+                    &chat,
+                    ts_ms,
+                    text.as_deref(),
+                    Some(kind),
+                    unread_delta,
+                )?;
+                cs.chats = true;
+            }
             cs.message_chats.insert(chat);
         }
         MessageOp::Reaction { target_id, emoji } => {
@@ -607,6 +618,8 @@ fn apply_edit(
     use schema::messages::dsl;
     let updated = diesel::update(
         message_row(device_id, chat, target_id)
+            // A tombstone absorbs edits too: revoked content must not resurface.
+            .filter(dsl::revoked.eq(false))
             .filter(dsl::edited_at_ms.is_null().or(dsl::edited_at_ms.le(ts_ms))),
     )
     .set((
@@ -662,6 +675,8 @@ fn apply_revoke(
 
 /// When `msg_id` is the chat's most recent message, replace the denormalized
 /// chat-list preview (an edit/revoke of an older message leaves it alone).
+/// "Most recent" uses the same total order as `messages()` — `(timestamp_ms,
+/// msg_id)` — so a same-millisecond sibling can't hijack the preview.
 fn refresh_preview_if_latest(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -671,21 +686,22 @@ fn refresh_preview_if_latest(
     kind: Option<&str>,
 ) -> QueryResult<bool> {
     use schema::messages::dsl;
-    let ts: Option<i64> = message_row(device_id, chat, msg_id)
-        .select(dsl::timestamp_ms)
+    let newest: Option<String> = dsl::messages
+        .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
+        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .select(dsl::msg_id)
         .first(conn)
         .optional()?;
-    let Some(ts) = ts else {
+    if newest.as_deref() != Some(msg_id) {
         return Ok(false);
-    };
-    let updated =
-        diesel::update(chat_row(device_id, chat).filter(schema::chats::last_message_ts.le(ts)))
-            .set((
-                schema::chats::last_message_preview.eq(preview),
-                schema::chats::last_message_kind.eq(kind),
-            ))
-            .execute(conn)?;
-    Ok(updated > 0)
+    }
+    diesel::update(chat_row(device_id, chat))
+        .set((
+            schema::chats::last_message_preview.eq(preview),
+            schema::chats::last_message_kind.eq(kind),
+        ))
+        .execute(conn)?;
+    Ok(true)
 }
 
 /// Re-derive the chat-list preview from the newest remaining message (used
@@ -726,13 +742,16 @@ fn apply_reaction(
 ) -> QueryResult<()> {
     use schema::reactions::dsl;
     if emoji.is_empty() {
+        // Same monotonic rule as the add path: a stale remove (older than the
+        // stored reaction) must not delete a newer live one.
         diesel::delete(
             dsl::reactions.filter(
                 dsl::device_id
                     .eq(device_id)
                     .and(dsl::chat_jid.eq(chat))
                     .and(dsl::msg_id.eq(target_id))
-                    .and(dsl::sender_jid.eq(sender)),
+                    .and(dsl::sender_jid.eq(sender))
+                    .and(dsl::ts_ms.le(ts_ms)),
             ),
         )
         .execute(conn)?;
@@ -1098,14 +1117,26 @@ struct NewMessage<'a> {
     overwrite: bool,
 }
 
-/// Returns whether a NEW row was inserted (`false` = the id already existed;
-/// with `overwrite` its content was refreshed in place). A refresh never
-/// touches `revoked`: a tombstone outranks any stale redelivery.
+/// What actually happened to the row, so callers can gate side effects
+/// (unread counting, chat-preview bumps) on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StoredRow {
+    /// A new row was inserted.
+    Inserted,
+    /// The id existed; its content was refreshed in place (`overwrite`).
+    Refreshed,
+    /// The id existed and was left untouched (history duplicate, or a revoked
+    /// tombstone that a redelivery must not resurrect or re-surface).
+    Skipped,
+}
+
+/// A refresh never touches `revoked`: a tombstone outranks any stale
+/// redelivery — such a write reports [`StoredRow::Skipped`].
 fn insert_message(
     conn: &mut SqliteConnection,
     device_id: i32,
     new: NewMessage<'_>,
-) -> QueryResult<bool> {
+) -> QueryResult<StoredRow> {
     use schema::messages::dsl;
     let values = (
         dsl::device_id.eq(device_id),
@@ -1125,8 +1156,11 @@ fn insert_message(
         .on_conflict_do_nothing()
         .execute(conn)?
         > 0;
-    if !inserted && new.overwrite {
-        diesel::update(
+    if inserted {
+        return Ok(StoredRow::Inserted);
+    }
+    if new.overwrite {
+        let refreshed = diesel::update(
             message_row(device_id, new.chat_jid, new.msg_id).filter(dsl::revoked.eq(false)),
         )
         .set((
@@ -1135,8 +1169,11 @@ fn insert_message(
             dsl::proto.eq(new.proto),
         ))
         .execute(conn)?;
+        if refreshed > 0 {
+            return Ok(StoredRow::Refreshed);
+        }
     }
-    Ok(inserted)
+    Ok(StoredRow::Skipped)
 }
 
 /// Refresh a chat's activity row for a message at `ts_ms`: creates the row if

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -48,7 +48,9 @@ pub(crate) enum WriterMsg {
         text: Option<String>,
         timestamp_ms: i64,
     },
-    Flush(oneshot::Sender<()>),
+    // String, not StoreError: one batch outcome fans out to many waiters and
+    // StoreError is not Clone.
+    Flush(oneshot::Sender<std::result::Result<(), String>>),
 }
 
 /// SQLite-backed chat/message/contact history, materialized from the client's
@@ -166,14 +168,17 @@ impl ChatStore {
             .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
     }
 
-    /// Wait until every write enqueued before this call is committed.
+    /// Wait until every write enqueued before this call is committed. Errors
+    /// with [`ChatStoreError::WriteBatchFailed`] when the batch containing
+    /// those writes rolled back instead.
     pub async fn flush(&self) -> Result<()> {
         let (tx, rx) = oneshot::channel();
         self.tx
             .send(WriterMsg::Flush(tx))
             .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))?;
         rx.await
-            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))?
+            .map_err(ChatStoreError::WriteBatchFailed)
     }
 
     pub fn device_id(&self) -> i32 {
@@ -202,6 +207,7 @@ async fn writer_loop(
     while let Some(first) = rx.recv().await {
         let mut batch = Vec::with_capacity(8);
         let mut flushes = Vec::new();
+        let mut batch_error = None;
         let mut queue_msg = |msg: WriterMsg, batch: &mut Vec<WriterMsg>| match msg {
             WriterMsg::Flush(done) => flushes.push(done),
             other => batch.push(other),
@@ -232,11 +238,17 @@ async fn writer_loop(
                 // The batch rolled back; state stays consistent (previous
                 // commit) but this slice of history is lost. Surfacing beats
                 // crashing the writer.
-                Err(e) => warn!("chat-store: dropping write batch: {e}"),
+                Err(e) => {
+                    warn!("chat-store: dropping write batch: {e}");
+                    batch_error = Some(e.to_string());
+                }
             }
         }
         for done in flushes {
-            let _ = done.send(());
+            let _ = done.send(match &batch_error {
+                Some(e) => Err(e.clone()),
+                None => Ok(()),
+            });
         }
     }
 }
@@ -272,7 +284,7 @@ fn apply_writer_msg(
             timestamp_ms,
         } => {
             let chat_str = chat.to_string();
-            insert_message(
+            let _ = insert_message(
                 conn,
                 device_id,
                 NewMessage {
@@ -323,7 +335,7 @@ fn apply_event(
         Event::UndecryptableMessage(undec) => {
             let chat = undec.info.source.chat.to_string();
             let sender = undec.info.source.sender.to_string();
-            insert_message(
+            let inserted = insert_message(
                 conn,
                 device_id,
                 NewMessage {
@@ -346,7 +358,7 @@ fn apply_event(
                 &chat,
                 undec.info.timestamp.timestamp_millis(),
                 None,
-                i32::from(!undec.info.source.is_from_me),
+                i32::from(inserted && !undec.info.source.is_from_me),
             )?;
             cs.chats = true;
             cs.message_chats.insert(chat);
@@ -467,6 +479,18 @@ fn apply_event(
                 ),
             )
             .execute(conn)?;
+            diesel::delete(
+                schema::message_receipts::table.filter(
+                    schema::message_receipts::device_id
+                        .eq(device_id)
+                        .and(schema::message_receipts::chat_jid.eq(&chat))
+                        .and(schema::message_receipts::msg_id.eq(&update.message_id)),
+                ),
+            )
+            .execute(conn)?;
+            // The deleted row may have been the chat's preview.
+            recompute_chat_preview(conn, device_id, &chat)?;
+            cs.chats = true;
             cs.message_chats.insert(chat);
             Ok(())
         }
@@ -493,7 +517,7 @@ fn apply_inbound(
 
     match classify(&inbound.message) {
         MessageOp::Store { kind, text } => {
-            insert_message(
+            let inserted = insert_message(
                 conn,
                 device_id,
                 NewMessage {
@@ -514,14 +538,10 @@ fn apply_inbound(
                     overwrite: true,
                 },
             )?;
-            bump_chat(
-                conn,
-                device_id,
-                &chat,
-                ts_ms,
-                text.as_deref(),
-                i32::from(!info.source.is_from_me),
-            )?;
+            // A refreshed row (redelivery, PDO recovery of a placeholder that
+            // already counted) must not inflate the unread badge again.
+            let unread_delta = i32::from(inserted && !info.source.is_from_me);
+            bump_chat(conn, device_id, &chat, ts_ms, text.as_deref(), unread_delta)?;
             cs.chats = true;
             cs.message_chats.insert(chat);
         }
@@ -535,28 +555,142 @@ fn apply_inbound(
             new_kind,
             new_proto,
         } => {
-            diesel::update(message_row(device_id, &chat, &target_id))
-                .set((
-                    schema::messages::text_content.eq(new_text.as_deref()),
-                    schema::messages::kind.eq(new_kind),
-                    schema::messages::proto.eq(Some(new_proto)),
-                    schema::messages::edited_at_ms.eq(Some(ts_ms)),
-                ))
-                .execute(conn)?;
+            if apply_edit(
+                conn,
+                device_id,
+                &chat,
+                &target_id,
+                new_text.as_deref(),
+                new_kind,
+                &new_proto,
+                ts_ms,
+            )? {
+                cs.chats = true;
+            }
             cs.message_chats.insert(chat);
         }
         MessageOp::Revoke { target_id } => {
-            diesel::update(message_row(device_id, &chat, &target_id))
-                .set((
-                    schema::messages::revoked.eq(true),
-                    schema::messages::text_content.eq(None::<String>),
-                    schema::messages::proto.eq(None::<Vec<u8>>),
-                ))
-                .execute(conn)?;
+            if apply_revoke(conn, device_id, &chat, &target_id, &sender, ts_ms)? {
+                cs.chats = true;
+            }
             cs.message_chats.insert(chat);
         }
         MessageOp::Ignore => {}
     }
+    Ok(())
+}
+
+/// Apply an edit to its target row. Monotonic on `edited_at_ms` so a replayed
+/// or stale (e.g. history-sync) edit can't roll back a newer one. Returns
+/// whether the chat-list preview changed.
+#[allow(clippy::too_many_arguments)]
+fn apply_edit(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    target_id: &str,
+    new_text: Option<&str>,
+    new_kind: &str,
+    new_proto: &[u8],
+    ts_ms: i64,
+) -> QueryResult<bool> {
+    use schema::messages::dsl;
+    let updated = diesel::update(
+        message_row(device_id, chat, target_id)
+            .filter(dsl::edited_at_ms.is_null().or(dsl::edited_at_ms.le(ts_ms))),
+    )
+    .set((
+        dsl::text_content.eq(new_text),
+        dsl::kind.eq(new_kind),
+        dsl::proto.eq(Some(new_proto)),
+        dsl::edited_at_ms.eq(Some(ts_ms)),
+    ))
+    .execute(conn)?;
+    if updated == 0 {
+        return Ok(false);
+    }
+    refresh_preview_if_latest(conn, device_id, chat, target_id, new_text)
+}
+
+/// Tombstone the target row. A revoke arriving before its content (offline
+/// drain reordering) inserts the tombstone up front, so the content's later
+/// arrival can't resurrect it. Returns whether the chat-list preview changed.
+fn apply_revoke(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    target_id: &str,
+    sender: &str,
+    ts_ms: i64,
+) -> QueryResult<bool> {
+    use schema::messages::dsl;
+    let updated = diesel::update(message_row(device_id, chat, target_id))
+        .set((
+            dsl::revoked.eq(true),
+            dsl::text_content.eq(None::<String>),
+            dsl::proto.eq(None::<Vec<u8>>),
+        ))
+        .execute(conn)?;
+    if updated == 0 {
+        diesel::insert_into(dsl::messages)
+            .values((
+                dsl::device_id.eq(device_id),
+                dsl::chat_jid.eq(chat),
+                dsl::msg_id.eq(target_id),
+                dsl::sender_jid.eq(sender),
+                dsl::from_me.eq(false),
+                dsl::timestamp_ms.eq(ts_ms),
+                dsl::kind.eq("unknown"),
+                dsl::revoked.eq(true),
+            ))
+            .on_conflict_do_nothing()
+            .execute(conn)?;
+        return Ok(false);
+    }
+    refresh_preview_if_latest(conn, device_id, chat, target_id, None)
+}
+
+/// When `msg_id` is the chat's most recent message, replace the denormalized
+/// chat-list preview (an edit/revoke of an older message leaves it alone).
+fn refresh_preview_if_latest(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    msg_id: &str,
+    preview: Option<&str>,
+) -> QueryResult<bool> {
+    use schema::messages::dsl;
+    let ts: Option<i64> = message_row(device_id, chat, msg_id)
+        .select(dsl::timestamp_ms)
+        .first(conn)
+        .optional()?;
+    let Some(ts) = ts else {
+        return Ok(false);
+    };
+    let updated =
+        diesel::update(chat_row(device_id, chat).filter(schema::chats::last_message_ts.le(ts)))
+            .set(schema::chats::last_message_preview.eq(preview))
+            .execute(conn)?;
+    Ok(updated > 0)
+}
+
+/// Re-derive the chat-list preview from the newest remaining message (used
+/// after deletions, where the previewed row may be gone).
+fn recompute_chat_preview(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+) -> QueryResult<()> {
+    use schema::messages::dsl;
+    let newest: Option<Option<String>> = dsl::messages
+        .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
+        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .select(dsl::text_content)
+        .first(conn)
+        .optional()?;
+    diesel::update(chat_row(device_id, chat))
+        .set(schema::chats::last_message_preview.eq(newest.flatten()))
+        .execute(conn)?;
     Ok(())
 }
 
@@ -591,10 +725,22 @@ fn apply_reaction(
                 dsl::emoji.eq(emoji),
                 dsl::ts_ms.eq(ts_ms),
             ))
-            .on_conflict((dsl::device_id, dsl::chat_jid, dsl::msg_id, dsl::sender_jid))
-            .do_update()
-            .set((dsl::emoji.eq(emoji), dsl::ts_ms.eq(ts_ms)))
+            .on_conflict_do_nothing()
             .execute(conn)?;
+        // Latest reaction per sender wins; a stale copy (e.g. from a history
+        // chunk) must not replace a newer live one.
+        diesel::update(
+            dsl::reactions.filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::chat_jid.eq(chat))
+                    .and(dsl::msg_id.eq(target_id))
+                    .and(dsl::sender_jid.eq(sender))
+                    .and(dsl::ts_ms.le(ts_ms)),
+            ),
+        )
+        .set((dsl::emoji.eq(emoji), dsl::ts_ms.eq(ts_ms)))
+        .execute(conn)?;
     }
     Ok(())
 }
@@ -692,10 +838,20 @@ fn apply_server_ack(
     )
     .set(dsl::status.eq(wa::web_message_info::Status::SERVER_ACK as i32))
     .execute(conn)?;
-    if updated > 0
-        && let Some(from) = &ack.from
-    {
-        cs.message_chats.insert(from.to_string());
+    if updated > 0 {
+        // Acks usually carry the chat; when they don't, resolve it from the
+        // row we just updated so consumers still get invalidated.
+        let chat = match &ack.from {
+            Some(from) => Some(from.to_string()),
+            None => dsl::messages
+                .filter(dsl::device_id.eq(device_id).and(dsl::msg_id.eq(&ack.id)))
+                .select(dsl::chat_jid)
+                .first(conn)
+                .optional()?,
+        };
+        if let Some(chat) = chat {
+            cs.message_chats.insert(chat);
+        }
     }
     Ok(())
 }
@@ -754,8 +910,16 @@ fn apply_history_conversation(
                 dsl::name.eq(name),
                 dsl::last_message_ts.eq(last_ts_ms),
                 dsl::unread_count.eq(conv.unread_count.unwrap_or(0) as i32),
-                dsl::pinned_at.eq(conv.pinned.map(|p| p as i64).filter(|&p| p > 0)),
-                dsl::muted_until.eq(conv.mute_end_time.map(|m| m as i64).filter(|&m| m > 0)),
+                // Wire values are unix SECONDS; the columns (and the live
+                // app-state paths) are milliseconds.
+                dsl::pinned_at.eq(conv
+                    .pinned
+                    .map(|p| (p as i64).saturating_mul(1000))
+                    .filter(|&p| p > 0)),
+                dsl::muted_until.eq(conv
+                    .mute_end_time
+                    .map(|m| (m as i64).saturating_mul(1000))
+                    .filter(|&m| m > 0)),
                 dsl::archived.eq(conv.archived.unwrap_or(false)),
                 dsl::ephemeral_expiration.eq(conv.ephemeral_expiration.map(|e| e as i32)),
             ))
@@ -819,7 +983,7 @@ fn apply_history_message(
     if let Some(message) = wmi.message.as_option() {
         match classify(message) {
             MessageOp::Store { kind, text } => {
-                insert_message(
+                let _ = insert_message(
                     conn,
                     device_id,
                     NewMessage {
@@ -850,23 +1014,23 @@ fn apply_history_message(
                 new_kind,
                 new_proto,
             } => {
-                diesel::update(message_row(device_id, chat, &target_id))
-                    .set((
-                        schema::messages::text_content.eq(new_text.as_deref()),
-                        schema::messages::kind.eq(new_kind),
-                        schema::messages::proto.eq(Some(new_proto)),
-                        schema::messages::edited_at_ms.eq(Some(ts_ms)),
-                    ))
-                    .execute(conn)?;
+                if apply_edit(
+                    conn,
+                    device_id,
+                    chat,
+                    &target_id,
+                    new_text.as_deref(),
+                    new_kind,
+                    &new_proto,
+                    ts_ms,
+                )? {
+                    cs.chats = true;
+                }
             }
             MessageOp::Revoke { target_id } => {
-                diesel::update(message_row(device_id, chat, &target_id))
-                    .set((
-                        schema::messages::revoked.eq(true),
-                        schema::messages::text_content.eq(None::<String>),
-                        schema::messages::proto.eq(None::<Vec<u8>>),
-                    ))
-                    .execute(conn)?;
+                if apply_revoke(conn, device_id, chat, &target_id, sender, ts_ms)? {
+                    cs.chats = true;
+                }
             }
             MessageOp::Ignore => {}
         }
@@ -910,11 +1074,14 @@ struct NewMessage<'a> {
     overwrite: bool,
 }
 
+/// Returns whether a NEW row was inserted (`false` = the id already existed;
+/// with `overwrite` its content was refreshed in place). A refresh never
+/// touches `revoked`: a tombstone outranks any stale redelivery.
 fn insert_message(
     conn: &mut SqliteConnection,
     device_id: i32,
     new: NewMessage<'_>,
-) -> QueryResult<()> {
+) -> QueryResult<bool> {
     use schema::messages::dsl;
     let values = (
         dsl::device_id.eq(device_id),
@@ -929,25 +1096,23 @@ fn insert_message(
         dsl::status.eq(new.status),
         dsl::starred.eq(new.starred),
     );
-    let insert = diesel::insert_into(dsl::messages).values(values);
-    if new.overwrite {
-        insert
-            .on_conflict((dsl::device_id, dsl::chat_jid, dsl::msg_id))
-            .do_update()
-            .set((
-                dsl::kind.eq(new.kind),
-                dsl::text_content.eq(new.text),
-                dsl::proto.eq(new.proto),
-                dsl::revoked.eq(false),
-            ))
-            .execute(conn)?;
-    } else {
-        insert
-            .on_conflict((dsl::device_id, dsl::chat_jid, dsl::msg_id))
-            .do_nothing()
-            .execute(conn)?;
+    let inserted = diesel::insert_into(dsl::messages)
+        .values(values)
+        .on_conflict_do_nothing()
+        .execute(conn)?
+        > 0;
+    if !inserted && new.overwrite {
+        diesel::update(
+            message_row(device_id, new.chat_jid, new.msg_id).filter(dsl::revoked.eq(false)),
+        )
+        .set((
+            dsl::kind.eq(new.kind),
+            dsl::text_content.eq(new.text),
+            dsl::proto.eq(new.proto),
+        ))
+        .execute(conn)?;
     }
-    Ok(())
+    Ok(inserted)
 }
 
 /// Refresh a chat's activity row for a message at `ts_ms`: creates the row if

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -190,6 +190,18 @@ impl ChatStore {
     }
 }
 
+/// Upper bound (in ms) of a sync action's message range. The wire value is
+/// unix SECONDS (same clock as conversation timestamps). `None` = unbounded.
+fn range_bound_ms(
+    range: &buffa::MessageField<wa::sync_action_value::SyncActionMessageRange>,
+) -> Option<i64> {
+    range
+        .as_option()
+        .and_then(|r| r.last_message_timestamp)
+        .filter(|&ts| ts > 0)
+        .map(|ts| ts.saturating_mul(1000))
+}
+
 /// Chats/contacts touched by a batch, accumulated for post-commit invalidation.
 #[derive(Default)]
 struct ChangeSet {
@@ -204,10 +216,13 @@ async fn writer_loop(
     mut rx: mpsc::UnboundedReceiver<WriterMsg>,
     changes: broadcast::Sender<StoreChange>,
 ) {
+    // Sticky across iterations: a failed batch with no flush waiter of its
+    // own must still be reported to the NEXT flush (a >BATCH_MAX backlog spans
+    // several transactions). Consumed when delivered.
+    let mut pending_error: Option<String> = None;
     while let Some(first) = rx.recv().await {
         let mut batch = Vec::with_capacity(8);
         let mut flushes = Vec::new();
-        let mut batch_error = None;
         // A Flush is a batch BARRIER: stop draining there, so writes enqueued
         // after a caller's flush() can neither commit ahead of that call's
         // answer nor drag the awaited writes down with a later failure.
@@ -249,15 +264,19 @@ async fn writer_loop(
                 // crashing the writer.
                 Err(e) => {
                     warn!("chat-store: dropping write batch: {e}");
-                    batch_error = Some(e.to_string());
+                    pending_error = Some(e.to_string());
                 }
             }
         }
+        if flushes.is_empty() {
+            continue;
+        }
+        let outcome = match pending_error.take() {
+            Some(e) => Err(e),
+            None => Ok(()),
+        };
         for done in flushes {
-            let _ = done.send(match &batch_error {
-                Some(e) => Err(e.clone()),
-                None => Ok(()),
-            });
+            let _ = done.send(outcome.clone());
         }
     }
 }
@@ -315,10 +334,13 @@ fn apply_writer_msg(
                     conn,
                     device_id,
                     &chat_str,
-                    *timestamp_ms,
-                    text.as_deref(),
-                    Some(kind),
-                    0,
+                    ChatBump {
+                        msg_id,
+                        ts_ms: *timestamp_ms,
+                        preview: text.as_deref(),
+                        kind: Some(kind),
+                        unread_delta: 0,
+                    },
                 )?;
                 cs.chats = true;
             }
@@ -371,10 +393,13 @@ fn apply_event(
                     conn,
                     device_id,
                     &chat,
-                    undec.info.timestamp.timestamp_millis(),
-                    None,
-                    Some(KIND_UNDECRYPTABLE),
-                    i32::from(!undec.info.source.is_from_me),
+                    ChatBump {
+                        msg_id: &undec.info.id,
+                        ts_ms: undec.info.timestamp.timestamp_millis(),
+                        preview: None,
+                        kind: Some(KIND_UNDECRYPTABLE),
+                        unread_delta: i32::from(!undec.info.source.is_from_me),
+                    },
                 )?;
                 cs.chats = true;
             }
@@ -442,12 +467,30 @@ fn apply_event(
             Ok(())
         }
         Event::MarkChatAsReadUpdate(update) => {
+            let chat = update.jid.to_string();
             let unread = if update.action.read.unwrap_or(false) {
-                0
+                // A delayed replay only covers messages up to its range end;
+                // anything we materialized after it is still unread.
+                match range_bound_ms(&update.action.message_range) {
+                    Some(bound_ms) => {
+                        use schema::messages::dsl;
+                        let newer: i64 = dsl::messages
+                            .filter(
+                                dsl::device_id
+                                    .eq(device_id)
+                                    .and(dsl::chat_jid.eq(&chat))
+                                    .and(dsl::from_me.eq(false))
+                                    .and(dsl::timestamp_ms.gt(bound_ms)),
+                            )
+                            .count()
+                            .get_result(conn)?;
+                        newer.min(i32::MAX as i64) as i32
+                    }
+                    None => 0,
+                }
             } else {
                 UNREAD_MARKER
             };
-            let chat = update.jid.to_string();
             ensure_chat(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
                 .set(schema::chats::unread_count.eq(unread))
@@ -465,17 +508,28 @@ fn apply_event(
         }
         Event::DeleteChatUpdate(update) => {
             let chat = update.jid.to_string();
-            delete_chat_rows(conn, device_id, &chat, true)?;
-            diesel::delete(chat_row(device_id, &chat)).execute(conn)?;
+            let bound_ms = range_bound_ms(&update.action.message_range);
+            delete_chat_rows(conn, device_id, &chat, true, bound_ms)?;
+            // A delayed delete only covers up to its range end: when newer
+            // messages were already materialized locally, the chat survives
+            // with them instead of vanishing.
+            let survivors = remaining_messages(conn, device_id, &chat)?;
+            if bound_ms.is_some() && survivors > 0 {
+                recompute_chat_preview(conn, device_id, &chat)?;
+            } else {
+                diesel::delete(chat_row(device_id, &chat)).execute(conn)?;
+            }
             cs.chats = true;
             cs.message_chats.insert(chat);
             Ok(())
         }
         Event::ClearChatUpdate(update) => {
             let chat = update.jid.to_string();
-            delete_chat_rows(conn, device_id, &chat, update.delete_starred)?;
-            // Starred rows may survive the clear: the preview/kind must
-            // reflect the newest survivor, not go blank (or keep stale kind).
+            let bound_ms = range_bound_ms(&update.action.message_range);
+            delete_chat_rows(conn, device_id, &chat, update.delete_starred, bound_ms)?;
+            // Starred rows (and messages newer than the range) may survive the
+            // clear: the preview/kind must reflect the newest survivor, not go
+            // blank (or keep stale kind).
             recompute_chat_preview(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
                 .set(schema::chats::unread_count.eq(0))
@@ -566,10 +620,13 @@ fn apply_inbound(
                     conn,
                     device_id,
                     &chat,
-                    ts_ms,
-                    text.as_deref(),
-                    Some(kind),
-                    unread_delta,
+                    ChatBump {
+                        msg_id: &info.id,
+                        ts_ms,
+                        preview: text.as_deref(),
+                        kind: Some(kind),
+                        unread_delta,
+                    },
                 )?;
                 cs.chats = true;
             }
@@ -599,8 +656,19 @@ fn apply_inbound(
             }
             cs.message_chats.insert(chat);
         }
-        MessageOp::Revoke { target_id } => {
-            if apply_revoke(conn, device_id, &chat, &target_id, &sender, ts_ms)? {
+        MessageOp::Revoke {
+            target_id,
+            target_from_me,
+        } => {
+            if apply_revoke(
+                conn,
+                device_id,
+                &chat,
+                &target_id,
+                &sender,
+                target_from_me,
+                ts_ms,
+            )? {
                 cs.chats = true;
             }
             cs.message_chats.insert(chat);
@@ -653,6 +721,7 @@ fn apply_revoke(
     chat: &str,
     target_id: &str,
     sender: &str,
+    target_from_me: bool,
     ts_ms: i64,
 ) -> QueryResult<bool> {
     use schema::messages::dsl;
@@ -670,7 +739,7 @@ fn apply_revoke(
                 dsl::chat_jid.eq(chat),
                 dsl::msg_id.eq(target_id),
                 dsl::sender_jid.eq(sender),
-                dsl::from_me.eq(false),
+                dsl::from_me.eq(target_from_me),
                 dsl::timestamp_ms.eq(ts_ms),
                 dsl::kind.eq("unknown"),
                 dsl::revoked.eq(true),
@@ -726,15 +795,17 @@ fn recompute_chat_preview(
     chat: &str,
 ) -> QueryResult<()> {
     use schema::messages::dsl;
-    let newest: Option<(Option<String>, String)> = dsl::messages
+    let newest: Option<(Option<String>, String, bool)> = dsl::messages
         .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
         .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
-        .select((dsl::text_content, dsl::kind))
+        .select((dsl::text_content, dsl::kind, dsl::revoked))
         .first(conn)
         .optional()?;
     let (preview, kind) = match newest {
-        Some((text, kind)) => (text, Some(kind)),
-        None => (None, None),
+        // A tombstone previews as nothing at all — its pre-revoke kind must
+        // not leak back (mirrors the revoke path's (None, None)).
+        Some((_, _, true)) | None => (None, None),
+        Some((text, kind, false)) => (text, Some(kind)),
     };
     diesel::update(chat_row(device_id, chat))
         .set((
@@ -1084,8 +1155,19 @@ fn apply_history_message(
                     cs.chats = true;
                 }
             }
-            MessageOp::Revoke { target_id } => {
-                if apply_revoke(conn, device_id, chat, &target_id, sender, ts_ms)? {
+            MessageOp::Revoke {
+                target_id,
+                target_from_me,
+            } => {
+                if apply_revoke(
+                    conn,
+                    device_id,
+                    chat,
+                    &target_id,
+                    sender,
+                    target_from_me,
+                    ts_ms,
+                )? {
                     cs.chats = true;
                 }
             }
@@ -1193,27 +1275,33 @@ fn insert_message(
 /// Refresh a chat's activity row for a message at `ts_ms`: creates the row if
 /// missing, advances ordering/preview only for newer messages, and bumps the
 /// unread counter by `unread_delta` (unless manually marked unread).
+/// One message's contribution to its chat's denormalized row.
+struct ChatBump<'a> {
+    msg_id: &'a str,
+    ts_ms: i64,
+    preview: Option<&'a str>,
+    kind: Option<&'a str>,
+    unread_delta: i32,
+}
+
 fn bump_chat(
     conn: &mut SqliteConnection,
     device_id: i32,
     chat: &str,
-    ts_ms: i64,
-    preview: Option<&str>,
-    kind: Option<&str>,
-    unread_delta: i32,
+    bump: ChatBump<'_>,
 ) -> QueryResult<()> {
     use schema::chats::dsl;
     ensure_chat(conn, device_id, chat)?;
-    diesel::update(chat_row(device_id, chat).filter(dsl::last_message_ts.le(ts_ms)))
-        .set((
-            dsl::last_message_ts.eq(ts_ms),
-            dsl::last_message_preview.eq(preview),
-            dsl::last_message_kind.eq(kind),
-        ))
+    // Ordering timestamp is monotonic on its own...
+    diesel::update(chat_row(device_id, chat).filter(dsl::last_message_ts.le(bump.ts_ms)))
+        .set(dsl::last_message_ts.eq(bump.ts_ms))
         .execute(conn)?;
-    if unread_delta != 0 {
+    // ...but the preview belongs to the newest row by the FULL (timestamp_ms,
+    // msg_id) order — a same-millisecond sibling applied later must not win.
+    refresh_preview_if_latest(conn, device_id, chat, bump.msg_id, bump.preview, bump.kind)?;
+    if bump.unread_delta != 0 {
         diesel::update(chat_row(device_id, chat).filter(dsl::unread_count.ge(0)))
-            .set(dsl::unread_count.eq(dsl::unread_count + unread_delta))
+            .set(dsl::unread_count.eq(dsl::unread_count + bump.unread_delta))
             .execute(conn)?;
     }
     Ok(())
@@ -1277,15 +1365,21 @@ fn delete_chat_rows(
     device_id: i32,
     chat: &str,
     delete_starred: bool,
+    up_to_ts_ms: Option<i64>,
 ) -> QueryResult<()> {
     use schema::messages::dsl as m;
-    let base =
-        diesel::delete(m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))));
-    if delete_starred {
-        base.execute(conn)?;
-    } else {
-        base.filter(m::starred.eq(false)).execute(conn)?;
+    let mut query =
+        diesel::delete(m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))))
+            .into_boxed();
+    if !delete_starred {
+        query = query.filter(m::starred.eq(false));
     }
+    // A ranged action only covers messages up to its boundary; rows we
+    // materialized after it (live/offline traffic) survive.
+    if let Some(bound_ms) = up_to_ts_ms {
+        query = query.filter(m::timestamp_ms.le(bound_ms));
+    }
+    query.execute(conn)?;
     // Satellites of messages that no longer exist.
     diesel::sql_query(
         "DELETE FROM reactions WHERE device_id = ? AND chat_jid = ? AND msg_id NOT IN \
@@ -1306,6 +1400,14 @@ fn delete_chat_rows(
     .bind::<diesel::sql_types::Text, _>(chat)
     .execute(conn)?;
     Ok(())
+}
+
+fn remaining_messages(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<i64> {
+    use schema::messages::dsl;
+    dsl::messages
+        .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
+        .count()
+        .get_result(conn)
 }
 
 type ChatRowFilter<'a> = diesel::dsl::Filter<

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -208,14 +208,23 @@ async fn writer_loop(
         let mut batch = Vec::with_capacity(8);
         let mut flushes = Vec::new();
         let mut batch_error = None;
+        // A Flush is a batch BARRIER: stop draining there, so writes enqueued
+        // after a caller's flush() can neither commit ahead of that call's
+        // answer nor drag the awaited writes down with a later failure.
         let mut queue_msg = |msg: WriterMsg, batch: &mut Vec<WriterMsg>| match msg {
-            WriterMsg::Flush(done) => flushes.push(done),
-            other => batch.push(other),
+            WriterMsg::Flush(done) => {
+                flushes.push(done);
+                true
+            }
+            other => {
+                batch.push(other);
+                false
+            }
         };
-        queue_msg(first, &mut batch);
-        while batch.len() < BATCH_MAX {
+        let mut at_barrier = queue_msg(first, &mut batch);
+        while !at_barrier && batch.len() < BATCH_MAX {
             match rx.try_recv() {
-                Ok(msg) => queue_msg(msg, &mut batch),
+                Ok(msg) => at_barrier = queue_msg(msg, &mut batch),
                 Err(_) => break,
             }
         }
@@ -465,11 +474,11 @@ fn apply_event(
         Event::ClearChatUpdate(update) => {
             let chat = update.jid.to_string();
             delete_chat_rows(conn, device_id, &chat, update.delete_starred)?;
+            // Starred rows may survive the clear: the preview/kind must
+            // reflect the newest survivor, not go blank (or keep stale kind).
+            recompute_chat_preview(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
-                .set((
-                    schema::chats::last_message_preview.eq(None::<String>),
-                    schema::chats::unread_count.eq(0),
-                ))
+                .set(schema::chats::unread_count.eq(0))
                 .execute(conn)?;
             cs.chats = true;
             cs.message_chats.insert(chat);

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -223,8 +223,33 @@ fn range_bound(
     })
 }
 
+/// The chat's monotonic self-read cursor (0 when the chat row doesn't exist).
+fn read_cursor(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<i64> {
+    Ok(chat_row(device_id, chat)
+        .select(schema::chats::read_boundary_ms)
+        .first(conn)
+        .optional()?
+        .unwrap_or(0))
+}
+
+/// Advance the self-read cursor (never backwards).
+fn advance_read_cursor(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    boundary_ms: i64,
+) -> QueryResult<usize> {
+    diesel::update(
+        chat_row(device_id, chat).filter(schema::chats::read_boundary_ms.lt(boundary_ms)),
+    )
+    .set(schema::chats::read_boundary_ms.eq(boundary_ms))
+    .execute(conn)
+}
+
 /// Incoming rows NOT covered by `bound`: strictly newer than the boundary
 /// second, plus same-second rows the action's keyed list does not name.
+/// Rows at or before the chat's read cursor are already read — a stale ranged
+/// action replaying after a newer self-read must not resurrect their badge.
 fn count_uncovered_incoming(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -232,11 +257,13 @@ fn count_uncovered_incoming(
     bound: &RangeBound,
 ) -> QueryResult<i32> {
     use schema::messages::dsl;
+    let read_boundary_ms = read_cursor(conn, device_id, chat)?;
     let base = dsl::messages.filter(
         dsl::device_id
             .eq(device_id)
             .and(dsl::chat_jid.eq(chat))
-            .and(dsl::from_me.eq(false)),
+            .and(dsl::from_me.eq(false))
+            .and(dsl::timestamp_ms.gt(read_boundary_ms)),
     );
     let uncovered: i64 = match &bound.keys {
         None => base
@@ -523,11 +550,28 @@ fn apply_event(
         Event::MarkChatAsReadUpdate(update) => {
             let chat = update.jid.to_string();
             let unread = if update.action.read.unwrap_or(false) {
+                ensure_chat(conn, device_id, &chat)?;
                 // A delayed replay only covers messages up to its range;
-                // anything we materialized past it is still unread.
+                // anything we materialized past it is still unread. Reads also
+                // advance the self-read cursor so later stale actions/receipts
+                // can't resurrect the badge.
                 match range_bound(&update.action.message_range) {
-                    Some(bound) => count_uncovered_incoming(conn, device_id, &chat, &bound)?,
-                    None => 0,
+                    Some(bound) => {
+                        advance_read_cursor(conn, device_id, &chat, bound.second_end_ms)?;
+                        count_uncovered_incoming(conn, device_id, &chat, &bound)?
+                    }
+                    None => {
+                        use schema::messages::dsl;
+                        let newest: Option<Option<i64>> = dsl::messages
+                            .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(&chat)))
+                            .select(diesel::dsl::max(dsl::timestamp_ms))
+                            .first(conn)
+                            .optional()?;
+                        if let Some(newest_ms) = newest.flatten() {
+                            advance_read_cursor(conn, device_id, &chat, newest_ms)?;
+                        }
+                        0
+                    }
                 }
             } else {
                 UNREAD_MARKER
@@ -963,12 +1007,7 @@ fn apply_receipt(
             // Monotonic cursor: receipts can replay out of order across
             // offline drains, and a stale one must neither re-inflate nor
             // re-clear the badge.
-            let advanced = diesel::update(
-                chat_row(device_id, &chat).filter(schema::chats::read_boundary_ms.lt(boundary_ms)),
-            )
-            .set(schema::chats::read_boundary_ms.eq(boundary_ms))
-            .execute(conn)?;
-            if advanced == 0 {
+            if advance_read_cursor(conn, device_id, &chat, boundary_ms)? == 0 {
                 return Ok(());
             }
             // Uncovered = strictly past the boundary, plus boundary-instant
@@ -1331,8 +1370,11 @@ enum StoredRow {
     Skipped,
 }
 
-/// A refresh never touches `revoked`: a tombstone outranks any stale
-/// redelivery — such a write reports [`StoredRow::Skipped`].
+/// A refresh never touches `revoked` (a tombstone outranks any stale
+/// redelivery) and never crosses senders: message ids are SENDER-chosen, so a
+/// same-id row from a different sender must not rewrite the original's content
+/// (adversarial id reuse would otherwise alter someone else's message in the
+/// local history). Both cases report [`StoredRow::Skipped`].
 fn insert_message(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1362,7 +1404,9 @@ fn insert_message(
     }
     if new.overwrite {
         let refreshed = diesel::update(
-            message_row(device_id, new.chat_jid, new.msg_id).filter(dsl::revoked.eq(false)),
+            message_row(device_id, new.chat_jid, new.msg_id)
+                .filter(dsl::revoked.eq(false))
+                .filter(dsl::sender_jid.eq(new.sender_jid)),
         )
         .set((
             dsl::kind.eq(new.kind),

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -627,8 +627,15 @@ fn apply_event(
         }
         Event::MuteUpdate(update) => {
             let muted_until = if update.action.muted.unwrap_or(false) {
-                // No end timestamp = muted forever.
-                Some(update.action.mute_end_timestamp.unwrap_or(i64::MAX))
+                // Absent or non-positive (WA Web sends -1 for indefinite,
+                // this crate's own mute_chat() included) = muted forever.
+                Some(
+                    update
+                        .action
+                        .mute_end_timestamp
+                        .filter(|&ts| ts > 0)
+                        .unwrap_or(i64::MAX),
+                )
             } else {
                 None
             };
@@ -971,7 +978,7 @@ fn apply_revoke(
         ))
         .execute(conn)?;
     if updated == 0 {
-        diesel::insert_into(dsl::messages)
+        let inserted = diesel::insert_into(dsl::messages)
             .values((
                 dsl::device_id.eq(device_id),
                 dsl::chat_jid.eq(chat),
@@ -983,7 +990,26 @@ fn apply_revoke(
                 dsl::revoked.eq(true),
             ))
             .on_conflict_do_nothing()
-            .execute(conn)?;
+            .execute(conn)?
+            > 0;
+        // The tombstone may be the chat's first/newest row: the chat must
+        // exist and order by it (the deleted message DID happen), and an
+        // unseen deletion still counts as unread like WA's own badge does.
+        if inserted {
+            bump_chat(
+                conn,
+                device_id,
+                chat,
+                ChatBump {
+                    msg_id: target_id,
+                    ts_ms,
+                    preview: None,
+                    kind: None,
+                    unread_delta: i32::from(!target_from_me),
+                },
+            )?;
+            return Ok(true);
+        }
         return Ok(false);
     }
     refresh_preview_if_latest(conn, device_id, chat, target_id, None, None)

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -706,6 +706,11 @@ fn refresh_preview_if_latest(
 
 /// Re-derive the chat-list preview from the newest remaining message (used
 /// after deletions, where the previewed row may be gone).
+///
+/// `last_message_ts` is deliberately NOT recomputed: it models the chat's
+/// activity (list position), which WhatsApp keeps in place when the latest
+/// message is deleted-for-me. Newest-row time is derivable via
+/// `messages(chat, None, 1)` if a consumer ever needs it.
 fn recompute_chat_preview(
     conn: &mut SqliteConnection,
     device_id: i32,

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -190,16 +190,70 @@ impl ChatStore {
     }
 }
 
-/// Upper bound (in ms) of a sync action's message range. The wire value is
-/// unix SECONDS (same clock as conversation timestamps). `None` = unbounded.
-fn range_bound_ms(
+/// A sync action's message range. The wire boundary is unix SECONDS while
+/// rows store milliseconds, so the boundary covers its WHOLE second; when the
+/// action lists explicit boundary messages (WA Web fills `messages` exactly to
+/// disambiguate same-second siblings), only the listed ids inside the boundary
+/// second count as covered.
+struct RangeBound {
+    /// First ms of the boundary second.
+    second_start_ms: i64,
+    /// Last ms of the boundary second.
+    second_end_ms: i64,
+    /// Ids the action explicitly covers at the boundary; `None` = the whole
+    /// boundary second is covered (sender did not enumerate).
+    keys: Option<Vec<String>>,
+}
+
+fn range_bound(
     range: &buffa::MessageField<wa::sync_action_value::SyncActionMessageRange>,
-) -> Option<i64> {
-    range
-        .as_option()
-        .and_then(|r| r.last_message_timestamp)
-        .filter(|&ts| ts > 0)
-        .map(|ts| ts.saturating_mul(1000))
+) -> Option<RangeBound> {
+    let range = range.as_option()?;
+    let ts_secs = range.last_message_timestamp.filter(|&ts| ts > 0)?;
+    let second_start_ms = ts_secs.saturating_mul(1000);
+    let keys: Vec<String> = range
+        .messages
+        .iter()
+        .filter_map(|m| m.key.as_option().and_then(|k| k.id.clone()))
+        .collect();
+    Some(RangeBound {
+        second_start_ms,
+        second_end_ms: second_start_ms.saturating_add(999),
+        keys: (!keys.is_empty()).then_some(keys),
+    })
+}
+
+/// Incoming rows NOT covered by `bound`: strictly newer than the boundary
+/// second, plus same-second rows the action's keyed list does not name.
+fn count_uncovered_incoming(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    bound: &RangeBound,
+) -> QueryResult<i32> {
+    use schema::messages::dsl;
+    let base = dsl::messages.filter(
+        dsl::device_id
+            .eq(device_id)
+            .and(dsl::chat_jid.eq(chat))
+            .and(dsl::from_me.eq(false)),
+    );
+    let uncovered: i64 = match &bound.keys {
+        None => base
+            .filter(dsl::timestamp_ms.gt(bound.second_end_ms))
+            .count()
+            .get_result(conn)?,
+        Some(keys) => base
+            .filter(dsl::timestamp_ms.gt(bound.second_start_ms - 1))
+            .filter(
+                dsl::timestamp_ms
+                    .gt(bound.second_end_ms)
+                    .or(dsl::msg_id.ne_all(keys)),
+            )
+            .count()
+            .get_result(conn)?,
+    };
+    Ok(uncovered.min(i32::MAX as i64) as i32)
 }
 
 /// Chats/contacts touched by a batch, accumulated for post-commit invalidation.
@@ -469,23 +523,10 @@ fn apply_event(
         Event::MarkChatAsReadUpdate(update) => {
             let chat = update.jid.to_string();
             let unread = if update.action.read.unwrap_or(false) {
-                // A delayed replay only covers messages up to its range end;
-                // anything we materialized after it is still unread.
-                match range_bound_ms(&update.action.message_range) {
-                    Some(bound_ms) => {
-                        use schema::messages::dsl;
-                        let newer: i64 = dsl::messages
-                            .filter(
-                                dsl::device_id
-                                    .eq(device_id)
-                                    .and(dsl::chat_jid.eq(&chat))
-                                    .and(dsl::from_me.eq(false))
-                                    .and(dsl::timestamp_ms.gt(bound_ms)),
-                            )
-                            .count()
-                            .get_result(conn)?;
-                        newer.min(i32::MAX as i64) as i32
-                    }
+                // A delayed replay only covers messages up to its range;
+                // anything we materialized past it is still unread.
+                match range_bound(&update.action.message_range) {
+                    Some(bound) => count_uncovered_incoming(conn, device_id, &chat, &bound)?,
                     None => 0,
                 }
             } else {
@@ -508,16 +549,23 @@ fn apply_event(
         }
         Event::DeleteChatUpdate(update) => {
             let chat = update.jid.to_string();
-            let bound_ms = range_bound_ms(&update.action.message_range);
-            delete_chat_rows(conn, device_id, &chat, true, bound_ms)?;
-            // A delayed delete only covers up to its range end: when newer
+            let bound = range_bound(&update.action.message_range);
+            delete_chat_rows(conn, device_id, &chat, true, bound.as_ref())?;
+            // A delayed delete only covers up to its range: when newer
             // messages were already materialized locally, the chat survives
             // with them instead of vanishing.
             let survivors = remaining_messages(conn, device_id, &chat)?;
-            if bound_ms.is_some() && survivors > 0 {
-                recompute_chat_preview(conn, device_id, &chat)?;
-            } else {
-                diesel::delete(chat_row(device_id, &chat)).execute(conn)?;
+            match &bound {
+                Some(bound) if survivors > 0 => {
+                    recompute_chat_preview(conn, device_id, &chat)?;
+                    let unread = count_uncovered_incoming(conn, device_id, &chat, bound)?;
+                    diesel::update(chat_row(device_id, &chat))
+                        .set(schema::chats::unread_count.eq(unread))
+                        .execute(conn)?;
+                }
+                _ => {
+                    diesel::delete(chat_row(device_id, &chat)).execute(conn)?;
+                }
             }
             cs.chats = true;
             cs.message_chats.insert(chat);
@@ -525,14 +573,26 @@ fn apply_event(
         }
         Event::ClearChatUpdate(update) => {
             let chat = update.jid.to_string();
-            let bound_ms = range_bound_ms(&update.action.message_range);
-            delete_chat_rows(conn, device_id, &chat, update.delete_starred, bound_ms)?;
+            let bound = range_bound(&update.action.message_range);
+            delete_chat_rows(
+                conn,
+                device_id,
+                &chat,
+                update.delete_starred,
+                bound.as_ref(),
+            )?;
             // Starred rows (and messages newer than the range) may survive the
             // clear: the preview/kind must reflect the newest survivor, not go
             // blank (or keep stale kind).
             recompute_chat_preview(conn, device_id, &chat)?;
+            // Unread survivors past a ranged clear keep their badge; an
+            // unranged clear empties the chat, so zero is exact there.
+            let unread = match &bound {
+                Some(bound) => count_uncovered_incoming(conn, device_id, &chat, bound)?,
+                None => 0,
+            };
             diesel::update(chat_row(device_id, &chat))
-                .set(schema::chats::unread_count.eq(0))
+                .set(schema::chats::unread_count.eq(unread))
                 .execute(conn)?;
             cs.chats = true;
             cs.message_chats.insert(chat);
@@ -1365,21 +1425,56 @@ fn delete_chat_rows(
     device_id: i32,
     chat: &str,
     delete_starred: bool,
-    up_to_ts_ms: Option<i64>,
+    bound: Option<&RangeBound>,
 ) -> QueryResult<()> {
     use schema::messages::dsl as m;
-    let mut query =
-        diesel::delete(m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))))
-            .into_boxed();
-    if !delete_starred {
-        query = query.filter(m::starred.eq(false));
-    }
     // A ranged action only covers messages up to its boundary; rows we
-    // materialized after it (live/offline traffic) survive.
-    if let Some(bound_ms) = up_to_ts_ms {
-        query = query.filter(m::timestamp_ms.le(bound_ms));
+    // materialized after it (live/offline traffic) survive. With a keyed
+    // boundary, same-second siblings the action does not name survive too.
+    match bound {
+        None => {
+            let mut query = diesel::delete(
+                m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))),
+            )
+            .into_boxed();
+            if !delete_starred {
+                query = query.filter(m::starred.eq(false));
+            }
+            query.execute(conn)?;
+        }
+        Some(bound) => {
+            let mut query = diesel::delete(
+                m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))),
+            )
+            .into_boxed();
+            if !delete_starred {
+                query = query.filter(m::starred.eq(false));
+            }
+            match &bound.keys {
+                None => {
+                    query = query.filter(m::timestamp_ms.le(bound.second_end_ms));
+                    query.execute(conn)?;
+                }
+                Some(keys) => {
+                    // Everything strictly before the boundary second...
+                    query = query.filter(m::timestamp_ms.lt(bound.second_start_ms));
+                    query.execute(conn)?;
+                    // ...plus the boundary rows the action names explicitly.
+                    let mut keyed = diesel::delete(
+                        m::messages.filter(m::device_id.eq(device_id).and(m::chat_jid.eq(chat))),
+                    )
+                    .into_boxed();
+                    if !delete_starred {
+                        keyed = keyed.filter(m::starred.eq(false));
+                    }
+                    keyed
+                        .filter(m::timestamp_ms.le(bound.second_end_ms))
+                        .filter(m::msg_id.eq_any(keys))
+                        .execute(conn)?;
+                }
+            }
+        }
     }
-    query.execute(conn)?;
     // Satellites of messages that no longer exist.
     diesel::sql_query(
         "DELETE FROM reactions WHERE device_id = ? AND chat_jid = ? AND msg_id NOT IN \

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -118,6 +118,7 @@ pub struct ChatEntry {
     /// `-1` means "manually marked unread" (WA Web convention).
     pub unread_count: i32,
     pub pinned_at: Option<DateTime<Utc>>,
+    /// `Some(DateTime::MAX_UTC)` = muted forever (no expiry).
     pub muted_until: Option<DateTime<Utc>>,
     pub archived: bool,
     pub ephemeral_expiration: Option<u32>,

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -105,11 +105,12 @@ pub struct ContactEntry {
 }
 
 impl ContactEntry {
-    /// Best display name available, WA Web precedence: address book, then
-    /// push name, then business name.
+    /// Best display name available, WA Web precedence: address book (full,
+    /// then first name), then push name, then business name.
     pub fn display_name(&self) -> Option<&str> {
         self.full_name
             .as_deref()
+            .or(self.first_name.as_deref())
             .or(self.push_name.as_deref())
             .or(self.business_name.as_deref())
     }

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -1,0 +1,138 @@
+use chrono::{DateTime, Utc};
+use wacore_binary::Jid;
+use waproto::whatsapp as wa;
+
+/// Delivery state of a stored message, on the same scale WhatsApp itself uses
+/// (`WebMessageInfo.Status`), so history-sync statuses map through unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(i32)]
+pub enum MessageStatus {
+    Error = 0,
+    Pending = 1,
+    ServerAck = 2,
+    Delivered = 3,
+    Read = 4,
+    Played = 5,
+}
+
+impl MessageStatus {
+    pub fn from_raw(raw: i32) -> Self {
+        match raw {
+            0 => Self::Error,
+            2 => Self::ServerAck,
+            3 => Self::Delivered,
+            4 => Self::Read,
+            5 => Self::Played,
+            _ => Self::Pending,
+        }
+    }
+}
+
+/// One row of the chat list, ordered for display (pinned first, then most
+/// recent activity).
+#[derive(Debug, Clone)]
+pub struct ChatEntry {
+    pub jid: Jid,
+    pub name: Option<String>,
+    pub last_message_at: Option<DateTime<Utc>>,
+    pub last_message_preview: Option<String>,
+    /// `-1` means "manually marked unread" (WA Web convention).
+    pub unread_count: i32,
+    pub pinned_at: Option<DateTime<Utc>>,
+    pub muted_until: Option<DateTime<Utc>>,
+    pub archived: bool,
+    pub ephemeral_expiration: Option<u32>,
+}
+
+/// A stored message. `message` is the decoded proto when the row has one and
+/// it decodes cleanly; the denormalized columns (`kind`, `text`) always work
+/// even when it doesn't.
+#[derive(Debug, Clone)]
+pub struct StoredMessage {
+    pub chat_jid: Jid,
+    pub id: String,
+    pub sender_jid: Jid,
+    pub from_me: bool,
+    pub timestamp: DateTime<Utc>,
+    pub kind: String,
+    pub text: Option<String>,
+    pub message: Option<Box<wa::Message>>,
+    pub status: MessageStatus,
+    pub starred: bool,
+    pub edited_at: Option<DateTime<Utc>>,
+    pub revoked: bool,
+}
+
+/// Keyset-pagination cursor: pass the values of the oldest message you have to
+/// fetch the page before it. Never an OFFSET — stable under concurrent inserts.
+#[derive(Debug, Clone)]
+pub struct MessageCursor {
+    pub timestamp_ms: i64,
+    pub msg_id: String,
+}
+
+impl From<&StoredMessage> for MessageCursor {
+    fn from(m: &StoredMessage) -> Self {
+        Self {
+            timestamp_ms: m.timestamp.timestamp_millis(),
+            msg_id: m.id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReactionEntry {
+    pub sender_jid: Jid,
+    pub emoji: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Per-user delivery/read state of one message (group "read by" lists).
+#[derive(Debug, Clone)]
+pub struct ReceiptEntry {
+    pub user_jid: Jid,
+    pub status: MessageStatus,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContactEntry {
+    pub jid: Jid,
+    pub push_name: Option<String>,
+    pub full_name: Option<String>,
+    pub first_name: Option<String>,
+    pub business_name: Option<String>,
+}
+
+impl ContactEntry {
+    /// Best display name available, WA Web precedence: address book, then
+    /// push name, then business name.
+    pub fn display_name(&self) -> Option<&str> {
+        self.full_name
+            .as_deref()
+            .or(self.push_name.as_deref())
+            .or(self.business_name.as_deref())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MediaRef {
+    pub file_sha256: Vec<u8>,
+    pub file_path: String,
+    pub mime_type: Option<String>,
+    pub size_bytes: Option<i64>,
+    pub downloaded_at: DateTime<Utc>,
+}
+
+/// Invalidation signal emitted after each committed write batch. Consumers
+/// re-run the queries backing their visible state; the store never pushes row
+/// data (query + invalidation, not cache duplication).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreChange {
+    /// Chat-list-level change: ordering, previews, unread counts, membership.
+    Chats,
+    /// The message set of one chat changed (insert/edit/revoke/reaction/status).
+    Messages { chat: Jid },
+    /// Contact naming changed.
+    Contacts,
+}

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -2,6 +2,81 @@ use chrono::{DateTime, Utc};
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
 
+/// Content class of a stored message: one label per renderable bubble type,
+/// shared by every frontend (desktop, TUI, mobile) so none of them hard-codes
+/// label strings. Stored as text in the database; [`Other`](Self::Other)
+/// round-trips labels written by a newer crate version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MessageKind {
+    Text,
+    Image,
+    Video,
+    /// Round video note ("ptv").
+    VideoNote,
+    Audio,
+    /// Push-to-talk voice note ("ptt").
+    VoiceNote,
+    Sticker,
+    Document,
+    Contact,
+    Location,
+    Poll,
+    Event,
+    GroupInvite,
+    /// Placeholder for a message that could not be decrypted (yet).
+    Undecryptable,
+    /// Real content this crate version doesn't classify.
+    Unknown,
+    /// A database label written by a newer crate version.
+    Other(String),
+}
+
+impl MessageKind {
+    /// The database label. Stable: these are on-disk values.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Text => "text",
+            Self::Image => "image",
+            Self::Video => "video",
+            Self::VideoNote => "ptv",
+            Self::Audio => "audio",
+            Self::VoiceNote => "ptt",
+            Self::Sticker => "sticker",
+            Self::Document => "document",
+            Self::Contact => "contact",
+            Self::Location => "location",
+            Self::Poll => "poll",
+            Self::Event => "event",
+            Self::GroupInvite => "group_invite",
+            Self::Undecryptable => "undecryptable",
+            Self::Unknown => "unknown",
+            Self::Other(label) => label,
+        }
+    }
+
+    pub(crate) fn from_db(label: String) -> Self {
+        match label.as_str() {
+            "text" => Self::Text,
+            "image" => Self::Image,
+            "video" => Self::Video,
+            "ptv" => Self::VideoNote,
+            "audio" => Self::Audio,
+            "ptt" => Self::VoiceNote,
+            "sticker" => Self::Sticker,
+            "document" => Self::Document,
+            "contact" => Self::Contact,
+            "location" => Self::Location,
+            "poll" => Self::Poll,
+            "event" => Self::Event,
+            "group_invite" => Self::GroupInvite,
+            "undecryptable" => Self::Undecryptable,
+            "unknown" => Self::Unknown,
+            _ => Self::Other(label),
+        }
+    }
+}
+
 /// Delivery state of a stored message, on the same scale WhatsApp itself uses
 /// (`WebMessageInfo.Status`), so history-sync statuses map through unchanged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -36,6 +111,10 @@ pub struct ChatEntry {
     pub name: Option<String>,
     pub last_message_at: Option<DateTime<Utc>>,
     pub last_message_preview: Option<String>,
+    /// Content class of the latest message, so a media preview can render as
+    /// "[photo]"/"[voice note]" in whatever way (and language) the frontend
+    /// chooses — the store never bakes in presentation strings.
+    pub last_message_kind: Option<MessageKind>,
     /// `-1` means "manually marked unread" (WA Web convention).
     pub unread_count: i32,
     pub pinned_at: Option<DateTime<Utc>>,
@@ -54,7 +133,7 @@ pub struct StoredMessage {
     pub sender_jid: Jid,
     pub from_me: bool,
     pub timestamp: DateTime<Utc>,
-    pub kind: String,
+    pub kind: MessageKind,
     pub text: Option<String>,
     pub message: Option<Box<wa::Message>>,
     pub status: MessageStatus,

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -2269,3 +2269,216 @@ async fn early_tombstone_materializes_and_badges_the_chat() {
     assert!(chats[0].last_message_preview.is_none());
     assert_eq!(chats[0].unread_count, 1);
 }
+
+fn mark_read_event(chat: &str, read: bool, ts_secs: i64) -> Event {
+    Event::MarkChatAsReadUpdate(
+        wacore::types::events::MarkChatAsReadUpdate::builder()
+            .jid(jid(chat))
+            .timestamp(Utc.timestamp_opt(ts_secs, 0).unwrap())
+            .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                read: Some(read),
+                ..Default::default()
+            }))
+            .from_full_sync(false)
+            .build(),
+    )
+}
+
+#[tokio::test]
+async fn noop_mark_read_clears_manual_unread_marker() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("oi"),
+            incoming_info(PEER, PEER, "MSG-MU", 1_700_000_000),
+        )],
+    )
+    .await;
+    feed(&chat_store, [mark_read_event(PEER, true, 1_700_000_010)]).await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    // Manually mark unread, then read the chat again: the cursor can't move
+    // (nothing new arrived), but the marker must still clear.
+    feed(&chat_store, [mark_read_event(PEER, false, 1_700_000_020)]).await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, -1);
+
+    feed(&chat_store, [mark_read_event(PEER, true, 1_700_000_030)]).await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, 0);
+}
+
+#[tokio::test]
+async fn noop_read_self_clears_manual_unread_marker() {
+    let (_store, chat_store) = test_store().await;
+
+    let read_self = |ts: i64| {
+        Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER),
+                    sender: jid(PEER),
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-RS".to_string()])
+                .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(false)
+                .build(),
+        )
+    };
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("oi"),
+            incoming_info(PEER, PEER, "MSG-RS", 1_700_000_000),
+        )],
+    )
+    .await;
+    feed(&chat_store, [read_self(1_700_000_010)]).await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    feed(&chat_store, [mark_read_event(PEER, false, 1_700_000_020)]).await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, -1);
+
+    // Re-reading on the phone re-sends the same boundary: a no-op for the
+    // cursor, but the marker must still clear.
+    feed(&chat_store, [read_self(1_700_000_030)]).await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, 0);
+}
+
+#[tokio::test]
+async fn edit_before_target_materializes_edited_content() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    // Offline drain reordering: the edit is applied before the original.
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-EB".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("fixed"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            edit,
+            incoming_info(PEER, PEER, "MSG-EB2", 1_700_000_050),
+        )],
+    )
+    .await;
+
+    // The edited content materializes up front and badges like the original.
+    let msg = chat_store.message(&chat, "MSG-EB").await.unwrap().unwrap();
+    assert_eq!(msg.text.as_deref(), Some("fixed"));
+    assert!(msg.edited_at.is_some());
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("fixed"));
+    assert_eq!(chats[0].unread_count, 1);
+
+    // The original's late arrival must neither restore pre-edit text nor
+    // count the same message twice.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("typo"),
+            incoming_info(PEER, PEER, "MSG-EB", 1_700_000_000),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "MSG-EB").await.unwrap().unwrap();
+    assert_eq!(msg.text.as_deref(), Some("fixed"));
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("fixed"));
+    assert_eq!(chats[0].unread_count, 1);
+}
+
+#[tokio::test]
+async fn server_nack_marks_outgoing_failed() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-NACK",
+            &wa::Message::text("oi"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-NACK".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .error("479".to_string())
+                .build(),
+        )],
+    )
+    .await;
+    let msg = chat_store
+        .message(&chat, "OUT-NACK")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Error);
+
+    // A stray nack must not regress a message a peer already received.
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-READ",
+            &wa::Message::text("oi2"),
+            Utc.timestamp_opt(1_700_000_200, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    feed(
+        &chat_store,
+        [
+            Event::Receipt(
+                Receipt::builder()
+                    .source(MessageSource {
+                        chat: chat.clone(),
+                        sender: chat.clone(),
+                        ..Default::default()
+                    })
+                    .message_ids(vec!["OUT-READ".to_string()])
+                    .timestamp(Utc.timestamp_opt(1_700_000_300, 0).unwrap())
+                    .r#type(ReceiptType::Read)
+                    .offline(false)
+                    .build(),
+            ),
+            Event::ServerAck(
+                ServerAck::builder()
+                    .id("OUT-READ".to_string())
+                    .class("message".to_string())
+                    .from(chat.clone())
+                    .error("479".to_string())
+                    .build(),
+            ),
+        ],
+    )
+    .await;
+    let msg = chat_store
+        .message(&chat, "OUT-READ")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -2020,3 +2020,185 @@ async fn admin_revoke_tombstone_keeps_target_author() {
     assert!(tombstone.revoked);
     assert_eq!(tombstone.sender_jid, jid(author));
 }
+
+#[tokio::test]
+async fn redelivery_after_edit_keeps_edited_content() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    let original = || {
+        message_event(
+            wa::Message::text("original"),
+            incoming_info(PEER, PEER, "MSG-RED", 1_700_000_000),
+        )
+    };
+    feed(&chat_store, [original()]).await;
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-RED".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("edited"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            edit,
+            incoming_info(PEER, PEER, "MSG-RED2", 1_700_000_100),
+        )],
+    )
+    .await;
+
+    // A duplicate delivery of the PRE-edit original must not roll content back.
+    feed(&chat_store, [original()]).await;
+    let msg = chat_store.message(&chat, "MSG-RED").await.unwrap().unwrap();
+    assert_eq!(msg.text.as_deref(), Some("edited"));
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("edited"));
+}
+
+#[tokio::test]
+async fn late_same_instant_sibling_still_badges_after_read_self() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("named"),
+            incoming_info(PEER, PEER, "MSG-SI1", 1_700_000_000),
+        )],
+    )
+    .await;
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER),
+                    sender: jid(PEER),
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-SI1".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    // An unlisted sibling at the SAME instant materializes later (offline
+    // drain): the receipt didn't cover it, so it must badge.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("same instant, uncovered"),
+            incoming_info(PEER, PEER, "MSG-SI2", 1_700_000_000),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn delete_for_me_drops_the_victims_badge() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("stays unread"),
+                incoming_info(PEER, PEER, "MSG-U1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("deleted while unread"),
+                incoming_info(PEER, PEER, "MSG-U2", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 2);
+
+    feed(
+        &chat_store,
+        [Event::DeleteMessageForMeUpdate(
+            wacore::types::events::DeleteMessageForMeUpdate::builder()
+                .chat_jid(chat.clone())
+                .message_id("MSG-U2".to_string())
+                .from_me(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_200, 0).unwrap())
+                .action(Box::new(
+                    wa::sync_action_value::DeleteMessageForMeAction::default(),
+                ))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn keyed_read_covers_a_message_that_materializes_later() {
+    let (_store, chat_store) = test_store().await;
+
+    // The keyed mark-read arrives BEFORE the message it names (read on
+    // another device, local drain lagging).
+    let range = buffa::MessageField::some(wa::sync_action_value::SyncActionMessageRange {
+        last_message_timestamp: Some(1_700_000_000),
+        messages: vec![wa::sync_action_value::SyncActionMessage {
+            key: buffa::MessageField::some(wa::MessageKey {
+                id: Some("MSG-FUT".into()),
+                remote_jid: Some(PEER.into()),
+                ..Default::default()
+            }),
+            timestamp: Some(1_700_000_000),
+        }],
+        ..Default::default()
+    });
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_001, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    message_range: range,
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    // The named message materializes afterwards: covered, no badge...
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("read elsewhere before arriving"),
+            incoming_info(PEER, PEER, "MSG-FUT", 1_700_000_000),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    // ...while an unnamed same-second sibling still badges.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("uncovered sibling"),
+            incoming_info(PEER, PEER, "MSG-SIB", 1_700_000_000),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use buffa::MessageField;
-use chrono::{TimeZone, Utc};
+use chrono::{Datelike, TimeZone, Utc};
+use diesel::RunQueryDsl;
 use wacore::proto_helpers::MessageBuilderExt;
 use wacore::types::events::{
     BatchOrigin, Event, InboundMessage, LazyHistorySync, MessageBatch, Receipt, ServerAck,
@@ -363,28 +364,44 @@ async fn history_sync_materializes_without_clobbering_live_rows() {
     };
     let history = wa::HistorySync {
         sync_type: wa::history_sync::HistorySyncType::RECENT,
-        conversations: vec![wa::Conversation {
-            id: PEER.to_string(),
-            name: Some("Alice".into()),
-            conversation_timestamp: Some(1_700_000_900),
-            unread_count: Some(0),
-            messages: vec![
-                wa::HistorySyncMsg {
-                    message: MessageField::some(make_wmi(
-                        "MSG-H1",
-                        false,
-                        1_700_000_000,
-                        "stale history copy",
-                    )),
-                    ..Default::default()
-                },
-                wa::HistorySyncMsg {
-                    message: MessageField::some(make_wmi("MSG-H2", true, 1_700_000_900, "sent")),
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        }],
+        conversations: vec![
+            // Fresh chat (no live row): mute/pin land via the INSERT path.
+            // Wire values are unix seconds; the store must convert to ms.
+            wa::Conversation {
+                id: "559900000004@s.whatsapp.net".to_string(),
+                conversation_timestamp: Some(1_700_000_500),
+                mute_end_time: Some(1_800_000_000),
+                pinned: Some(1_700_000_800),
+                ..Default::default()
+            },
+            wa::Conversation {
+                id: PEER.to_string(),
+                name: Some("Alice".into()),
+                conversation_timestamp: Some(1_700_000_900),
+                unread_count: Some(0),
+                messages: vec![
+                    wa::HistorySyncMsg {
+                        message: MessageField::some(make_wmi(
+                            "MSG-H1",
+                            false,
+                            1_700_000_000,
+                            "stale history copy",
+                        )),
+                        ..Default::default()
+                    },
+                    wa::HistorySyncMsg {
+                        message: MessageField::some(make_wmi(
+                            "MSG-H2",
+                            true,
+                            1_700_000_900,
+                            "sent",
+                        )),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        ],
         pushnames: vec![wa::Pushname {
             id: Some("559900000003@s.whatsapp.net".into()),
             pushname: Some("Bob Example".into()),
@@ -415,8 +432,19 @@ async fn history_sync_materializes_without_clobbering_live_rows() {
 
     // Chat identity from history; live message content preserved.
     let chats = chat_store.chats(false, 10).await.unwrap();
-    assert_eq!(chats.len(), 1);
-    assert_eq!(chats[0].name.as_deref(), Some("Alice"));
+    assert_eq!(chats.len(), 2);
+    let alice = chats
+        .iter()
+        .find(|c| c.jid == jid(PEER))
+        .expect("alice chat");
+    assert_eq!(alice.name.as_deref(), Some("Alice"));
+    // Seconds-to-ms conversion: a future mute/pin must not decode as 1970.
+    let muted = chats
+        .iter()
+        .find(|c| c.jid == jid("559900000004@s.whatsapp.net"))
+        .expect("muted chat");
+    assert!(muted.muted_until.unwrap().year() > 2020);
+    assert!(muted.pinned_at.unwrap().year() > 2020);
 
     let live = chat_store.message(&chat, "MSG-H1").await.unwrap().unwrap();
     assert_eq!(live.text.as_deref(), Some("live copy"));
@@ -704,4 +732,324 @@ async fn full_text_search_finds_and_survives_operator_input() {
     let hits = chat_store.search_messages("recuperado", 10).await.unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].id, "MSG-S5");
+}
+
+#[tokio::test]
+async fn revoke_before_content_is_not_resurrected() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    // Offline drain can deliver the revoke before the content it targets.
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-RB".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-RB2", 1_700_000_010),
+        )],
+    )
+    .await;
+    let tombstone = chat_store.message(&chat, "MSG-RB").await.unwrap().unwrap();
+    assert!(tombstone.revoked);
+
+    // The content arriving later (redelivery path, overwrite=true) must not
+    // un-revoke the tombstone.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("too late"),
+            incoming_info(PEER, PEER, "MSG-RB", 1_700_000_000),
+        )],
+    )
+    .await;
+    let still_revoked = chat_store.message(&chat, "MSG-RB").await.unwrap().unwrap();
+    assert!(still_revoked.revoked);
+    assert!(still_revoked.text.is_none());
+}
+
+#[tokio::test]
+async fn pdo_recovery_does_not_double_count_unread() {
+    let (_store, chat_store) = test_store().await;
+
+    let info = incoming_info(PEER, PEER, "MSG-DC", 1_700_000_000);
+    feed(
+        &chat_store,
+        [Event::UndecryptableMessage(
+            wacore::types::events::UndecryptableMessage::builder()
+                .info(Arc::new(info.clone()))
+                .is_unavailable(false)
+                .unavailable_type(wacore::types::events::UnavailableType::Unknown)
+                .decrypt_fail_mode(wacore::types::events::DecryptFailMode::Show)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+
+    // PDO recovery replaces the placeholder under the same id: same message,
+    // must not count twice.
+    feed(
+        &chat_store,
+        [message_event(wa::Message::text("recovered"), info)],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn edit_of_latest_message_refreshes_preview_and_stale_edit_is_ignored() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("original"),
+            incoming_info(PEER, PEER, "MSG-EP", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let edit_with = |text: &str, id: &str, ts: i64| {
+        message_event(
+            wa::Message {
+                protocol_message: MessageField::some(wa::message::ProtocolMessage {
+                    key: MessageField::some(wa::MessageKey {
+                        id: Some("MSG-EP".into()),
+                        ..Default::default()
+                    }),
+                    r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+                    edited_message: MessageField::from_box(Box::new(wa::Message::text(text))),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            incoming_info(PEER, PEER, id, ts),
+        )
+    };
+
+    feed(&chat_store, [edit_with("edited", "E1", 1_700_000_100)]).await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("edited"));
+
+    // A stale edit (older than the applied one) must not roll content back.
+    feed(&chat_store, [edit_with("stale", "E2", 1_700_000_050)]).await;
+    let msg = chat_store.message(&chat, "MSG-EP").await.unwrap().unwrap();
+    assert_eq!(msg.text.as_deref(), Some("edited"));
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("edited"));
+}
+
+#[tokio::test]
+async fn delete_for_me_cleans_satellites_and_recomputes_preview() {
+    let (_store, chat_store) = test_store().await;
+    let group = jid(GROUP);
+    let alice = "559900000002@s.whatsapp.net";
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("keep me"),
+            incoming_info(GROUP, PEER, "MSG-K", 1_700_000_000),
+        )],
+    )
+    .await;
+    chat_store
+        .record_outgoing(
+            &group,
+            "MSG-D",
+            &wa::Message::text("delete me"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: group.clone(),
+                    sender: jid(alice),
+                    is_group: true,
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-D".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_110, 0).unwrap())
+                .r#type(ReceiptType::Read)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.receipts(&group, "MSG-D").await.unwrap().len(), 1);
+
+    feed(
+        &chat_store,
+        [Event::DeleteMessageForMeUpdate(
+            wacore::types::events::DeleteMessageForMeUpdate::builder()
+                .chat_jid(group.clone())
+                .message_id("MSG-D".to_string())
+                .from_me(true)
+                .timestamp(Utc.timestamp_opt(1_700_000_200, 0).unwrap())
+                .action(Box::new(
+                    wa::sync_action_value::DeleteMessageForMeAction::default(),
+                ))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    assert!(chat_store.message(&group, "MSG-D").await.unwrap().is_none());
+    assert!(
+        chat_store
+            .receipts(&group, "MSG-D")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    // The chat-list preview falls back to the newest remaining message.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("keep me"));
+}
+
+#[tokio::test]
+async fn stale_reaction_timestamp_does_not_replace_newer() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("target"),
+            incoming_info(PEER, PEER, "MSG-RT", 1_700_000_000),
+        )],
+    )
+    .await;
+    let react = |emoji: &str, id: &str, ts: i64| {
+        message_event(
+            wa::Message {
+                reaction_message: MessageField::some(wa::message::ReactionMessage {
+                    key: MessageField::some(wa::MessageKey {
+                        id: Some("MSG-RT".into()),
+                        ..Default::default()
+                    }),
+                    text: Some(emoji.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            incoming_info(PEER, PEER, id, ts),
+        )
+    };
+    feed(&chat_store, [react("👍", "R1", 1_700_000_200)]).await;
+    // An older copy (e.g. replayed from a history chunk) must not win.
+    feed(&chat_store, [react("❤️", "R2", 1_700_000_100)]).await;
+    let reactions = chat_store.reactions(&chat, "MSG-RT").await.unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "👍");
+}
+
+#[tokio::test]
+async fn flush_surfaces_a_failed_batch() {
+    let (store, chat_store) = test_store().await;
+
+    // Sabotage the schema so the next batch rolls back.
+    store
+        .shared()
+        .run(|conn| {
+            diesel::sql_query("ALTER TABLE messages RENAME TO messages_gone")
+                .execute(conn)
+                .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    let handler = chat_store.handler();
+    handler.handle_event(Arc::new(message_event(
+        wa::Message::text("will fail"),
+        incoming_info(PEER, PEER, "MSG-F", 1_700_000_000),
+    )));
+    let err = chat_store.flush().await.expect_err("batch must fail");
+    assert!(matches!(
+        err,
+        whatsapp_rust_chat_store::ChatStoreError::WriteBatchFailed(_)
+    ));
+
+    // Restore and confirm the writer survived the failure.
+    store
+        .shared()
+        .run(|conn| {
+            diesel::sql_query("ALTER TABLE messages_gone RENAME TO messages")
+                .execute(conn)
+                .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("works again"),
+            incoming_info(PEER, PEER, "MSG-OK", 1_700_000_010),
+        )],
+    )
+    .await;
+    assert!(
+        chat_store
+            .message(&jid(PEER), "MSG-OK")
+            .await
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn fts_backfills_rows_that_predate_the_index() {
+    let (store, chat_store) = test_store().await;
+
+    // Simulate a database created before the `search` feature existed: drop
+    // the FTS objects, then write rows with no triggers in place.
+    store
+        .shared()
+        .run(|conn| {
+            for stmt in [
+                "DROP TRIGGER IF EXISTS messages_fts_ai",
+                "DROP TRIGGER IF EXISTS messages_fts_ad",
+                "DROP TRIGGER IF EXISTS messages_fts_au",
+                "DROP TABLE IF EXISTS messages_fts",
+            ] {
+                diesel::sql_query(stmt)
+                    .execute(conn)
+                    .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            }
+            Ok(())
+        })
+        .await
+        .unwrap();
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("mensagem antiga indexável"),
+            incoming_info(PEER, PEER, "MSG-BF", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    // A second open on the same file recreates the index and must backfill it.
+    let chat_store2 = ChatStore::new(&store).await.unwrap();
+    let hits = chat_store2.search_messages("antiga", 10).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, "MSG-BF");
 }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1191,3 +1191,91 @@ async fn fts_backfills_rows_that_predate_the_index() {
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].id, "MSG-BF");
 }
+
+#[tokio::test]
+async fn forever_mute_is_not_reported_as_unmuted() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("hi"),
+                incoming_info(PEER, PEER, "MSG-M", 1_700_000_000),
+            ),
+            Event::MuteUpdate(
+                wacore::types::events::MuteUpdate::builder()
+                    .jid(jid(PEER))
+                    .timestamp(Utc.timestamp_opt(1_700_000_100, 0).unwrap())
+                    // muted with no end timestamp = muted forever
+                    .action(Box::new(wa::sync_action_value::MuteAction {
+                        muted: Some(true),
+                        ..Default::default()
+                    }))
+                    .from_full_sync(false)
+                    .build(),
+            ),
+        ],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    let muted_until = chats[0].muted_until.expect("forever mute must be Some");
+    assert!(muted_until > wacore::time::now_utc());
+    assert_eq!(muted_until, chrono::DateTime::<Utc>::MAX_UTC);
+}
+
+#[tokio::test]
+async fn clear_chat_reflects_surviving_starred_messages() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("starred survivor"),
+                incoming_info(PEER, PEER, "MSG-S1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("cleared away"),
+                incoming_info(PEER, PEER, "MSG-S2", 1_700_000_100),
+            ),
+            Event::StarUpdate(
+                wacore::types::events::StarUpdate::builder()
+                    .chat_jid(chat.clone())
+                    .message_id("MSG-S1".to_string())
+                    .from_me(false)
+                    .timestamp(Utc.timestamp_opt(1_700_000_200, 0).unwrap())
+                    .action(Box::new(wa::sync_action_value::StarAction {
+                        starred: Some(true),
+                    }))
+                    .from_full_sync(false)
+                    .build(),
+            ),
+            Event::ClearChatUpdate(
+                wacore::types::events::ClearChatUpdate::builder()
+                    .jid(chat.clone())
+                    .delete_starred(false)
+                    .delete_media(false)
+                    .timestamp(Utc.timestamp_opt(1_700_000_300, 0).unwrap())
+                    .action(Box::new(wa::sync_action_value::ClearChatAction::default()))
+                    .from_full_sync(false)
+                    .build(),
+            ),
+        ],
+    )
+    .await;
+
+    // The starred message survives and becomes the preview (not a blank one
+    // with the deleted message's stale kind).
+    assert!(chat_store.message(&chat, "MSG-S1").await.unwrap().is_some());
+    assert!(chat_store.message(&chat, "MSG-S2").await.unwrap().is_none());
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(
+        chats[0].last_message_preview.as_deref(),
+        Some("starred survivor")
+    );
+    assert_eq!(chats[0].last_message_kind, Some(MessageKind::Text));
+    assert_eq!(chats[0].unread_count, 0);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1,0 +1,707 @@
+//! Integration tests: real SqliteStore (in-memory), real writer task, events
+//! fed through the public handler exactly as the client would.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use buffa::MessageField;
+use chrono::{TimeZone, Utc};
+use wacore::proto_helpers::MessageBuilderExt;
+use wacore::types::events::{
+    BatchOrigin, Event, InboundMessage, LazyHistorySync, MessageBatch, Receipt, ServerAck,
+};
+use wacore::types::message::{MessageInfo, MessageSource};
+use wacore::types::presence::ReceiptType;
+use wacore_binary::Jid;
+use waproto::whatsapp as wa;
+use whatsapp_rust_chat_store::{ChatStore, MessageStatus, StoreChange};
+use whatsapp_rust_sqlite_storage::SqliteStore;
+
+const PEER: &str = "559900000001@s.whatsapp.net";
+const GROUP: &str = "120363000000000001@g.us";
+
+async fn test_store() -> (SqliteStore, Arc<ChatStore>) {
+    use portable_atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let db_name = format!(
+        "file:memdb_chat_store_{}_{}?mode=memory&cache=shared",
+        std::process::id(),
+        id
+    );
+    let store = SqliteStore::new(&db_name).await.expect("create store");
+    let chat_store = ChatStore::new(&store).await.expect("create chat store");
+    (store, chat_store)
+}
+
+fn jid(s: &str) -> Jid {
+    s.parse().expect("valid test JID")
+}
+
+fn incoming_info(chat: &str, sender: &str, id: &str, ts_secs: i64) -> MessageInfo {
+    MessageInfo {
+        source: MessageSource {
+            chat: jid(chat),
+            sender: jid(sender),
+            is_from_me: false,
+            is_group: chat.ends_with("@g.us"),
+            ..Default::default()
+        },
+        id: id.to_string(),
+        timestamp: Utc.timestamp_opt(ts_secs, 0).unwrap(),
+        ..Default::default()
+    }
+}
+
+fn message_event(msg: wa::Message, info: MessageInfo) -> Event {
+    Event::Messages(
+        MessageBatch::builder()
+            .messages(Arc::from([InboundMessage::builder()
+                .message(Arc::new(msg))
+                .info(Arc::new(info))
+                .build()]))
+            .origin(BatchOrigin::Live)
+            .build(),
+    )
+}
+
+async fn feed(chat_store: &ChatStore, events: impl IntoIterator<Item = Event>) {
+    let handler = chat_store.handler();
+    for event in events {
+        handler.handle_event(Arc::new(event));
+    }
+    chat_store.flush().await.expect("flush");
+}
+
+#[tokio::test]
+async fn live_text_message_materializes_chat_and_message() {
+    let (_store, chat_store) = test_store().await;
+
+    let mut info = incoming_info(PEER, PEER, "MSG-1", 1_700_000_000);
+    info.push_name = "Alice Example".into();
+    feed(&chat_store, [message_event(wa::Message::text("olá"), info)]).await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER));
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("olá"));
+    assert_eq!(chats[0].unread_count, 1);
+
+    let messages = chat_store.messages(&jid(PEER), None, 10).await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let msg = &messages[0];
+    assert_eq!(msg.id, "MSG-1");
+    assert_eq!(msg.kind, "text");
+    assert_eq!(msg.text.as_deref(), Some("olá"));
+    assert!(!msg.from_me);
+    // The stored proto round-trips.
+    let proto = msg.message.as_ref().expect("decoded proto");
+    assert_eq!(proto.conversation.as_deref(), Some("olá"));
+
+    // Live push name landed in contacts.
+    let contact = chat_store.contact(&jid(PEER)).await.unwrap().unwrap();
+    assert_eq!(contact.push_name.as_deref(), Some("Alice Example"));
+    assert_eq!(contact.display_name(), Some("Alice Example"));
+}
+
+#[tokio::test]
+async fn outgoing_status_advances_monotonically() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-1",
+            &wa::Message::text("oi"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
+    assert!(msg.from_me);
+    assert_eq!(msg.status, MessageStatus::Pending);
+
+    // Server ack lifts to ServerAck.
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-1".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .build(),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
+    assert_eq!(msg.status, MessageStatus::ServerAck);
+
+    // Read receipt from the peer.
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: chat.clone(),
+                    sender: chat.clone(),
+                    ..Default::default()
+                })
+                .message_ids(vec!["OUT-1".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_200, 0).unwrap())
+                .r#type(ReceiptType::Read)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+
+    // A late Delivered must NOT downgrade Read.
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: chat.clone(),
+                    sender: chat.clone(),
+                    ..Default::default()
+                })
+                .message_ids(vec!["OUT-1".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_300, 0).unwrap())
+                .r#type(ReceiptType::Delivered)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+#[tokio::test]
+async fn edit_updates_and_revoke_tombstones() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("typo"),
+            incoming_info(PEER, PEER, "MSG-E", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    // Edit arrives as protocolMessage MESSAGE_EDIT targeting the original id.
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-E".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("fixed"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            edit,
+            incoming_info(PEER, PEER, "MSG-E2", 1_700_000_050),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "MSG-E").await.unwrap().unwrap();
+    assert_eq!(msg.text.as_deref(), Some("fixed"));
+    assert!(msg.edited_at.is_some());
+    assert!(!msg.revoked);
+    // The edit protocol message itself must not create a bubble row.
+    assert!(chat_store.message(&chat, "MSG-E2").await.unwrap().is_none());
+
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-E".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-E3", 1_700_000_060),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "MSG-E").await.unwrap().unwrap();
+    assert!(msg.revoked);
+    assert!(msg.text.is_none());
+    assert!(msg.message.is_none());
+}
+
+#[tokio::test]
+async fn reactions_add_replace_and_remove() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+    let alice = "559900000002@s.whatsapp.net";
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("target"),
+            incoming_info(GROUP, PEER, "MSG-R", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let react = |emoji: &str, id: &str, ts: i64| {
+        message_event(
+            wa::Message {
+                reaction_message: MessageField::some(wa::message::ReactionMessage {
+                    key: MessageField::some(wa::MessageKey {
+                        id: Some("MSG-R".into()),
+                        ..Default::default()
+                    }),
+                    text: Some(emoji.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            incoming_info(GROUP, alice, id, ts),
+        )
+    };
+
+    feed(&chat_store, [react("👍", "R1", 1_700_000_010)]).await;
+    let reactions = chat_store.reactions(&chat, "MSG-R").await.unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "👍");
+    assert_eq!(reactions[0].sender_jid, jid(alice));
+
+    // Same sender replaces their reaction (PK upsert), doesn't add a second.
+    feed(&chat_store, [react("❤️", "R2", 1_700_000_020)]).await;
+    let reactions = chat_store.reactions(&chat, "MSG-R").await.unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "❤️");
+
+    // Empty text removes it.
+    feed(&chat_store, [react("", "R3", 1_700_000_030)]).await;
+    assert!(
+        chat_store
+            .reactions(&chat, "MSG-R")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn keyset_pagination_covers_all_pages_in_order() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    let events: Vec<Event> = (0..5)
+        .map(|i| {
+            message_event(
+                wa::Message::text(format!("m{i}")),
+                incoming_info(PEER, PEER, &format!("MSG-{i}"), 1_700_000_000 + i),
+            )
+        })
+        .collect();
+    feed(&chat_store, events).await;
+
+    let mut seen = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = chat_store.messages(&chat, cursor.take(), 2).await.unwrap();
+        if page.is_empty() {
+            break;
+        }
+        assert!(page.len() <= 2);
+        cursor = page.last().map(Into::into);
+        seen.extend(page.into_iter().map(|m| m.text.unwrap()));
+    }
+    // Newest first, no duplicates, no gaps.
+    assert_eq!(seen, ["m4", "m3", "m2", "m1", "m0"]);
+}
+
+#[tokio::test]
+async fn history_sync_materializes_without_clobbering_live_rows() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    // A live copy arrives first (e.g. offline drain beat the history chunk).
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("live copy"),
+            incoming_info(PEER, PEER, "MSG-H1", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let make_wmi = |id: &str, from_me: bool, ts: u64, text: &str| wa::WebMessageInfo {
+        key: MessageField::some(wa::MessageKey {
+            remote_jid: Some(PEER.into()),
+            from_me: Some(from_me),
+            id: Some(id.into()),
+            ..Default::default()
+        }),
+        message: MessageField::from_box(Box::new(wa::Message::text(text))),
+        message_timestamp: Some(ts),
+        status: Some(wa::web_message_info::Status::READ),
+        push_name: Some("Alice Example".into()),
+        ..Default::default()
+    };
+    let history = wa::HistorySync {
+        sync_type: wa::history_sync::HistorySyncType::RECENT,
+        conversations: vec![wa::Conversation {
+            id: PEER.to_string(),
+            name: Some("Alice".into()),
+            conversation_timestamp: Some(1_700_000_900),
+            unread_count: Some(0),
+            messages: vec![
+                wa::HistorySyncMsg {
+                    message: MessageField::some(make_wmi(
+                        "MSG-H1",
+                        false,
+                        1_700_000_000,
+                        "stale history copy",
+                    )),
+                    ..Default::default()
+                },
+                wa::HistorySyncMsg {
+                    message: MessageField::some(make_wmi("MSG-H2", true, 1_700_000_900, "sent")),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }],
+        pushnames: vec![wa::Pushname {
+            id: Some("559900000003@s.whatsapp.net".into()),
+            pushname: Some("Bob Example".into()),
+        }],
+        ..Default::default()
+    };
+
+    use buffa::Message as _;
+    let raw = history.encode_to_vec();
+    let compressed = {
+        use flate2::{Compression, write::ZlibEncoder};
+        use std::io::Write;
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(&raw).unwrap();
+        enc.finish().unwrap()
+    };
+    feed(
+        &chat_store,
+        [Event::HistorySync(Box::new(LazyHistorySync::new(
+            compressed.into(),
+            raw.len(),
+            wa::history_sync::HistorySyncType::RECENT as i32,
+            None,
+            None,
+        )))],
+    )
+    .await;
+
+    // Chat identity from history; live message content preserved.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].name.as_deref(), Some("Alice"));
+
+    let live = chat_store.message(&chat, "MSG-H1").await.unwrap().unwrap();
+    assert_eq!(live.text.as_deref(), Some("live copy"));
+
+    let hist = chat_store.message(&chat, "MSG-H2").await.unwrap().unwrap();
+    assert!(hist.from_me);
+    assert_eq!(hist.text.as_deref(), Some("sent"));
+    assert_eq!(hist.status, MessageStatus::Read);
+
+    // Pushnames from the remainder landed.
+    let bob = chat_store
+        .contact(&jid("559900000003@s.whatsapp.net"))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(bob.push_name.as_deref(), Some("Bob Example"));
+}
+
+#[tokio::test]
+async fn undecryptable_placeholder_is_replaced_by_recovery() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    let info = incoming_info(PEER, PEER, "MSG-U", 1_700_000_000);
+    feed(
+        &chat_store,
+        [Event::UndecryptableMessage(
+            wacore::types::events::UndecryptableMessage::builder()
+                .info(Arc::new(info.clone()))
+                .is_unavailable(false)
+                .unavailable_type(wacore::types::events::UnavailableType::Unknown)
+                .decrypt_fail_mode(wacore::types::events::DecryptFailMode::Show)
+                .build(),
+        )],
+    )
+    .await;
+    let placeholder = chat_store.message(&chat, "MSG-U").await.unwrap().unwrap();
+    assert_eq!(placeholder.kind, "undecryptable");
+    assert!(placeholder.message.is_none());
+
+    // PDO/retry later recovers the real content under the same id.
+    feed(
+        &chat_store,
+        [message_event(wa::Message::text("recovered"), info)],
+    )
+    .await;
+    let recovered = chat_store.message(&chat, "MSG-U").await.unwrap().unwrap();
+    assert_eq!(recovered.kind, "text");
+    assert_eq!(recovered.text.as_deref(), Some("recovered"));
+}
+
+#[tokio::test]
+async fn mark_chat_as_read_resets_unread_count() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("a"),
+                incoming_info(PEER, PEER, "MSG-A", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("b"),
+                incoming_info(PEER, PEER, "MSG-B", 1_700_000_001),
+            ),
+        ],
+    )
+    .await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, 2);
+    assert_eq!(chat_store.unread_total().await.unwrap(), 2);
+
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_100, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    ..Default::default()
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, 0);
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn invalidation_broadcast_fires_per_batch() {
+    let (_store, chat_store) = test_store().await;
+    let mut changes = chat_store.subscribe();
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("ping"),
+            incoming_info(PEER, PEER, "MSG-N", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let mut got_chats = false;
+    let mut got_messages = false;
+    // Both signals were sent before flush() returned; drain with a timeout so
+    // a regression fails fast instead of hanging.
+    for _ in 0..3 {
+        match tokio::time::timeout(Duration::from_secs(5), changes.recv()).await {
+            Ok(Ok(StoreChange::Chats)) => got_chats = true,
+            Ok(Ok(StoreChange::Messages { chat })) => {
+                assert_eq!(chat, jid(PEER));
+                got_messages = true;
+            }
+            Ok(Ok(StoreChange::Contacts)) => {}
+            Ok(Err(_)) | Err(_) => break,
+        }
+        if got_chats && got_messages {
+            break;
+        }
+    }
+    assert!(got_chats && got_messages);
+}
+
+#[tokio::test]
+async fn group_receipts_track_per_user_state() {
+    let (_store, chat_store) = test_store().await;
+    let group = jid(GROUP);
+    let alice = "559900000002@s.whatsapp.net";
+
+    chat_store
+        .record_outgoing(
+            &group,
+            "OUT-G",
+            &wa::Message::text("hey group"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: group.clone(),
+                    sender: jid(alice),
+                    is_group: true,
+                    ..Default::default()
+                })
+                .message_ids(vec!["OUT-G".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_010, 0).unwrap())
+                .r#type(ReceiptType::Read)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    let receipts = chat_store.receipts(&group, "OUT-G").await.unwrap();
+    assert_eq!(receipts.len(), 1);
+    assert_eq!(receipts[0].user_jid, jid(alice));
+    assert_eq!(receipts[0].status, MessageStatus::Read);
+}
+
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn full_text_search_finds_and_survives_operator_input() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("reunião amanhã às dez"),
+                incoming_info(PEER, PEER, "MSG-S1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("outra coisa qualquer"),
+                incoming_info(PEER, PEER, "MSG-S2", 1_700_000_001),
+            ),
+        ],
+    )
+    .await;
+
+    let hits = chat_store.search_messages("reunião", 10).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, "MSG-S1");
+
+    // Prefix match on partial words.
+    let hits = chat_store.search_messages("aman", 10).await.unwrap();
+    assert_eq!(hits.len(), 1);
+
+    // FTS5 operator characters must not produce a syntax error.
+    let hits = chat_store
+        .search_messages("reunião AND NOT (\"", 10)
+        .await
+        .unwrap();
+    assert!(hits.len() <= 1);
+
+    // Edited text re-indexes.
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-S2".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("agora relevante"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            edit,
+            incoming_info(PEER, PEER, "MSG-S3", 1_700_000_002),
+        )],
+    )
+    .await;
+    let hits = chat_store.search_messages("relevante", 10).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, "MSG-S2");
+    assert!(
+        chat_store
+            .search_messages("outra", 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    // NULL transitions must keep the index sound: revoke clears text
+    // (text -> NULL) and a recovered placeholder gains text (NULL -> text).
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-S1".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-S4", 1_700_000_003),
+        )],
+    )
+    .await;
+    assert!(
+        chat_store
+            .search_messages("reunião", 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    let info = incoming_info(PEER, PEER, "MSG-S5", 1_700_000_004);
+    feed(
+        &chat_store,
+        [Event::UndecryptableMessage(
+            wacore::types::events::UndecryptableMessage::builder()
+                .info(Arc::new(info.clone()))
+                .is_unavailable(false)
+                .unavailable_type(wacore::types::events::UnavailableType::Unknown)
+                .decrypt_fail_mode(wacore::types::events::DecryptFailMode::Show)
+                .build(),
+        )],
+    )
+    .await;
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("conteúdo recuperado"),
+            info,
+        )],
+    )
+    .await;
+    let hits = chat_store.search_messages("recuperado", 10).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, "MSG-S5");
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -2202,3 +2202,70 @@ async fn keyed_read_covers_a_message_that_materializes_later() {
     .await;
     assert_eq!(chat_store.unread_total().await.unwrap(), 1);
 }
+
+#[tokio::test]
+async fn wire_indefinite_mute_value_reads_as_forever() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("hi"),
+                incoming_info(PEER, PEER, "MSG-IM", 1_700_000_000),
+            ),
+            Event::MuteUpdate(
+                wacore::types::events::MuteUpdate::builder()
+                    .jid(jid(PEER))
+                    .timestamp(Utc.timestamp_opt(1_700_000_100, 0).unwrap())
+                    // The wire's indefinite-mute sentinel (what the library's
+                    // own mute_chat() sends).
+                    .action(Box::new(wa::sync_action_value::MuteAction {
+                        muted: Some(true),
+                        mute_end_timestamp: Some(-1),
+                        ..Default::default()
+                    }))
+                    .from_full_sync(false)
+                    .build(),
+            ),
+        ],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].muted_until, Some(chrono::DateTime::<Utc>::MAX_UTC));
+}
+
+#[tokio::test]
+async fn early_tombstone_materializes_and_badges_the_chat() {
+    let (_store, chat_store) = test_store().await;
+
+    // A revoke for a message we never saw, in a chat we never saw: the chat
+    // must still appear (the deleted message DID happen) and badge.
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-GHOST".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-GHOST2", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER));
+    assert!(chats[0].last_message_at.is_some());
+    assert!(chats[0].last_message_preview.is_none());
+    assert_eq!(chats[0].unread_count, 1);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -594,10 +594,11 @@ async fn group_receipts_track_per_user_state() {
         &chat_store,
         [Event::Receipt(
             Receipt::builder()
+                // Production receipts leave is_group defaulted (false); the
+                // store must derive groupness from the chat JID.
                 .source(MessageSource {
                     chat: group.clone(),
                     sender: jid(alice),
-                    is_group: true,
                     ..Default::default()
                 })
                 .message_ids(vec!["OUT-G".to_string()])
@@ -1332,21 +1333,21 @@ async fn ranged_clear_and_delete_keep_newer_messages() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);
 
-    let seed = |chat_store: &Arc<ChatStore>| {
-        let a = message_event(
-            wa::Message::text("old"),
-            incoming_info(PEER, PEER, "MSG-O", 1_700_000_000),
-        );
-        let b = message_event(
-            wa::Message::text("newer than the action"),
-            incoming_info(PEER, PEER, "MSG-N", 1_700_000_100),
-        );
-        (chat_store.clone(), [a, b])
-    };
-
     // Ranged clear: only rows up to the boundary go away.
-    let (cs, events) = seed(&chat_store);
-    feed(&cs, events).await;
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("old"),
+                incoming_info(PEER, PEER, "MSG-O", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("newer than the action"),
+                incoming_info(PEER, PEER, "MSG-N", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
     feed(
         &chat_store,
         [Event::ClearChatUpdate(
@@ -1666,5 +1667,47 @@ async fn ranged_clear_keeps_unread_survivors_counted() {
 
     // The survivor is still there AND still counted as unread.
     assert!(chat_store.message(&chat, "MSG-UN").await.unwrap().is_some());
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn delayed_read_self_keeps_newer_unread() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("read on the phone"),
+                incoming_info(PEER, PEER, "MSG-RS1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("arrived after the read"),
+                incoming_info(PEER, PEER, "MSG-RS2", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 2);
+
+    // Offline-delayed read-self covering only the FIRST message: the second
+    // one keeps its badge.
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER),
+                    sender: jid(PEER),
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-RS1".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(true)
+                .build(),
+        )],
+    )
+    .await;
     assert_eq!(chat_store.unread_total().await.unwrap(), 1);
 }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1279,3 +1279,252 @@ async fn clear_chat_reflects_surviving_starred_messages() {
     assert_eq!(chats[0].last_message_kind, Some(MessageKind::Text));
     assert_eq!(chats[0].unread_count, 0);
 }
+
+fn range_up_to(ts_secs: i64) -> buffa::MessageField<wa::sync_action_value::SyncActionMessageRange> {
+    buffa::MessageField::some(wa::sync_action_value::SyncActionMessageRange {
+        last_message_timestamp: Some(ts_secs),
+        ..Default::default()
+    })
+}
+
+#[tokio::test]
+async fn mark_read_range_preserves_newer_unread() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("covered"),
+                incoming_info(PEER, PEER, "MSG-C1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("newer than the replayed read"),
+                incoming_info(PEER, PEER, "MSG-C2", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 2);
+
+    // A delayed mark-read whose range ends at the first message must not
+    // swallow the second one's unread state.
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    message_range: range_up_to(1_700_000_000),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn ranged_clear_and_delete_keep_newer_messages() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    let seed = |chat_store: &Arc<ChatStore>| {
+        let a = message_event(
+            wa::Message::text("old"),
+            incoming_info(PEER, PEER, "MSG-O", 1_700_000_000),
+        );
+        let b = message_event(
+            wa::Message::text("newer than the action"),
+            incoming_info(PEER, PEER, "MSG-N", 1_700_000_100),
+        );
+        (chat_store.clone(), [a, b])
+    };
+
+    // Ranged clear: only rows up to the boundary go away.
+    let (cs, events) = seed(&chat_store);
+    feed(&cs, events).await;
+    feed(
+        &chat_store,
+        [Event::ClearChatUpdate(
+            wacore::types::events::ClearChatUpdate::builder()
+                .jid(chat.clone())
+                .delete_starred(true)
+                .delete_media(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::ClearChatAction {
+                    message_range: range_up_to(1_700_000_000),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert!(chat_store.message(&chat, "MSG-O").await.unwrap().is_none());
+    assert!(chat_store.message(&chat, "MSG-N").await.unwrap().is_some());
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(
+        chats[0].last_message_preview.as_deref(),
+        Some("newer than the action")
+    );
+
+    // Ranged delete-chat: newer rows keep the chat alive.
+    feed(
+        &chat_store,
+        [Event::DeleteChatUpdate(
+            wacore::types::events::DeleteChatUpdate::builder()
+                .jid(chat.clone())
+                .delete_media(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_060, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::DeleteChatAction {
+                    message_range: range_up_to(1_700_000_000),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert!(chat_store.message(&chat, "MSG-N").await.unwrap().is_some());
+    assert_eq!(chat_store.chats(false, 10).await.unwrap().len(), 1);
+
+    // Unranged delete-chat: everything goes.
+    feed(
+        &chat_store,
+        [Event::DeleteChatUpdate(
+            wacore::types::events::DeleteChatUpdate::builder()
+                .jid(chat.clone())
+                .delete_media(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_070, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::DeleteChatAction::default()))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert!(chat_store.chats(false, 10).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn revoke_tombstone_keeps_target_from_me() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    // Revoke of OUR OWN message (key.fromMe = true) arriving before the
+    // content: the tombstone must not read as incoming forever.
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-FM".into()),
+                from_me: Some(true),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-FM2", 1_700_000_000),
+        )],
+    )
+    .await;
+    let tombstone = chat_store.message(&chat, "MSG-FM").await.unwrap().unwrap();
+    assert!(tombstone.revoked);
+    assert!(tombstone.from_me);
+}
+
+#[tokio::test]
+async fn recompute_does_not_resurrect_tombstone_kind() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("older"),
+                incoming_info(PEER, PEER, "MSG-T1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("newest, will be revoked"),
+                incoming_info(PEER, PEER, "MSG-T2", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-T2".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-T3", 1_700_000_200),
+        )],
+    )
+    .await;
+
+    // Deleting the OLDER row forces a recompute whose newest row is the
+    // tombstone: neither its text (None already) nor its pre-revoke kind may
+    // come back.
+    feed(
+        &chat_store,
+        [Event::DeleteMessageForMeUpdate(
+            wacore::types::events::DeleteMessageForMeUpdate::builder()
+                .chat_jid(chat.clone())
+                .message_id("MSG-T1".to_string())
+                .from_me(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_300, 0).unwrap())
+                .action(Box::new(
+                    wa::sync_action_value::DeleteMessageForMeAction::default(),
+                ))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert!(chats[0].last_message_preview.is_none());
+    assert!(chats[0].last_message_kind.is_none());
+}
+
+#[tokio::test]
+async fn same_millisecond_insert_order_does_not_hijack_preview() {
+    let (_store, chat_store) = test_store().await;
+
+    // Applied in REVERSE msg_id order within the same millisecond: the row
+    // that is newest by (timestamp_ms, msg_id) must own the preview.
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("newest by id"),
+                incoming_info(PEER, PEER, "MSG-Z9", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("older by id, applied later"),
+                incoming_info(PEER, PEER, "MSG-A1", 1_700_000_000),
+            ),
+        ],
+    )
+    .await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(
+        chats[0].last_message_preview.as_deref(),
+        Some("newest by id")
+    );
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1711,3 +1711,91 @@ async fn delayed_read_self_keeps_newer_unread() {
     .await;
     assert_eq!(chat_store.unread_total().await.unwrap(), 1);
 }
+
+#[tokio::test]
+async fn read_self_spares_unlisted_same_timestamp_siblings() {
+    let (_store, chat_store) = test_store().await;
+
+    // Two incoming rows at the SAME stored timestamp; the receipt names one.
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("named"),
+                incoming_info(PEER, PEER, "MSG-RSA", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("same instant, not named"),
+                incoming_info(PEER, PEER, "MSG-RSB", 1_700_000_000),
+            ),
+        ],
+    )
+    .await;
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER),
+                    sender: jid(PEER),
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-RSA".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn stale_read_self_does_not_reinflate_the_badge() {
+    let (_store, chat_store) = test_store().await;
+
+    let read_self = |ids: Vec<&str>, ts: i64| {
+        Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER),
+                    sender: jid(PEER),
+                    ..Default::default()
+                })
+                .message_ids(ids.into_iter().map(String::from).collect())
+                .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(true)
+                .build(),
+        )
+    };
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("first"),
+                incoming_info(PEER, PEER, "MSG-B1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("second"),
+                incoming_info(PEER, PEER, "MSG-B2", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+
+    // Newest receipt clears everything...
+    feed(
+        &chat_store,
+        [read_self(vec!["MSG-B1", "MSG-B2"], 1_700_000_150)],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    // ...and a stale replay covering only the FIRST message must not
+    // resurrect the badge for the second.
+    feed(&chat_store, [read_self(vec!["MSG-B1"], 1_700_000_050)]).await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1799,3 +1799,93 @@ async fn stale_read_self_does_not_reinflate_the_badge() {
     feed(&chat_store, [read_self(vec!["MSG-B1"], 1_700_000_050)]).await;
     assert_eq!(chat_store.unread_total().await.unwrap(), 0);
 }
+
+#[tokio::test]
+async fn cross_sender_id_reuse_cannot_rewrite_a_message() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+    let mallory = "559900000066@s.whatsapp.net";
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("victim's original words"),
+            incoming_info(GROUP, PEER, "MSG-VIC", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    // Message ids are sender-chosen: a different participant reusing the id
+    // must be deduped, never rewrite the victim's row.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("attacker rewrite"),
+            incoming_info(GROUP, mallory, "MSG-VIC", 1_700_000_100),
+        )],
+    )
+    .await;
+
+    let msg = chat_store.message(&chat, "MSG-VIC").await.unwrap().unwrap();
+    assert_eq!(msg.text.as_deref(), Some("victim's original words"));
+    assert_eq!(msg.sender_jid, jid(PEER));
+}
+
+#[tokio::test]
+async fn stale_ranged_mark_read_respects_the_read_cursor() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("first"),
+                incoming_info(PEER, PEER, "MSG-RC1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("second"),
+                incoming_info(PEER, PEER, "MSG-RC2", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+
+    // A read-self covering everything clears the badge and advances the cursor.
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER),
+                    sender: jid(PEER),
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-RC1".to_string(), "MSG-RC2".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_150, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    // A STALE ranged mark-read (covers only the first message) replays later:
+    // it must not resurrect the second message's badge.
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    message_range: range_up_to(1_700_000_000),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1528,3 +1528,143 @@ async fn same_millisecond_insert_order_does_not_hijack_preview() {
         Some("newest by id")
     );
 }
+
+#[tokio::test]
+async fn range_boundary_covers_the_whole_wire_second() {
+    let (_store, chat_store) = test_store().await;
+
+    // 500 ms into the boundary second: the wire range (whole seconds) covers
+    // it, so a mark-read up to that second must clear it.
+    let mut info = incoming_info(PEER, PEER, "MSG-SUB", 1_700_000_000);
+    info.timestamp = Utc.timestamp_opt(1_700_000_000, 500_000_000).unwrap();
+    feed(
+        &chat_store,
+        [message_event(wa::Message::text("sub-second"), info)],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_001, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    message_range: range_up_to(1_700_000_000),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn keyed_range_spares_unlisted_same_second_siblings() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    // Two messages inside the SAME wire second.
+    for (id, text) in [("MSG-IN", "covered"), ("MSG-OUT", "not in the range")] {
+        feed(
+            &chat_store,
+            [message_event(
+                wa::Message::text(text),
+                incoming_info(PEER, PEER, id, 1_700_000_000),
+            )],
+        )
+        .await;
+    }
+
+    // The action enumerates only MSG-IN at the boundary.
+    let range = buffa::MessageField::some(wa::sync_action_value::SyncActionMessageRange {
+        last_message_timestamp: Some(1_700_000_000),
+        messages: vec![wa::sync_action_value::SyncActionMessage {
+            key: buffa::MessageField::some(wa::MessageKey {
+                id: Some("MSG-IN".into()),
+                remote_jid: Some(PEER.into()),
+                ..Default::default()
+            }),
+            timestamp: Some(1_700_000_000),
+        }],
+        ..Default::default()
+    });
+    feed(
+        &chat_store,
+        [Event::ClearChatUpdate(
+            wacore::types::events::ClearChatUpdate::builder()
+                .jid(chat.clone())
+                .delete_starred(true)
+                .delete_media(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_001, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::ClearChatAction {
+                    message_range: range,
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    // Only the enumerated sibling went away; the other survives, still unread.
+    assert!(chat_store.message(&chat, "MSG-IN").await.unwrap().is_none());
+    assert!(
+        chat_store
+            .message(&chat, "MSG-OUT")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, 1);
+    assert_eq!(
+        chats[0].last_message_preview.as_deref(),
+        Some("not in the range")
+    );
+}
+
+#[tokio::test]
+async fn ranged_clear_keeps_unread_survivors_counted() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("cleared"),
+                incoming_info(PEER, PEER, "MSG-CL", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("unread survivor"),
+                incoming_info(PEER, PEER, "MSG-UN", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 2);
+
+    feed(
+        &chat_store,
+        [Event::ClearChatUpdate(
+            wacore::types::events::ClearChatUpdate::builder()
+                .jid(chat.clone())
+                .delete_starred(true)
+                .delete_media(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::ClearChatAction {
+                    message_range: range_up_to(1_700_000_000),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    // The survivor is still there AND still counted as unread.
+    assert!(chat_store.message(&chat, "MSG-UN").await.unwrap().is_some());
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -15,7 +15,7 @@ use wacore::types::message::{MessageInfo, MessageSource};
 use wacore::types::presence::ReceiptType;
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
-use whatsapp_rust_chat_store::{ChatStore, MessageStatus, StoreChange};
+use whatsapp_rust_chat_store::{ChatStore, MessageKind, MessageStatus, StoreChange};
 use whatsapp_rust_sqlite_storage::SqliteStore;
 
 const PEER: &str = "559900000001@s.whatsapp.net";
@@ -93,7 +93,7 @@ async fn live_text_message_materializes_chat_and_message() {
     assert_eq!(messages.len(), 1);
     let msg = &messages[0];
     assert_eq!(msg.id, "MSG-1");
-    assert_eq!(msg.kind, "text");
+    assert_eq!(msg.kind, MessageKind::Text);
     assert_eq!(msg.text.as_deref(), Some("olá"));
     assert!(!msg.from_me);
     // The stored proto round-trips.
@@ -438,6 +438,9 @@ async fn history_sync_materializes_without_clobbering_live_rows() {
         .find(|c| c.jid == jid(PEER))
         .expect("alice chat");
     assert_eq!(alice.name.as_deref(), Some("Alice"));
+    // History backfills the denormalized preview (newest materialized row).
+    assert_eq!(alice.last_message_preview.as_deref(), Some("sent"));
+    assert_eq!(alice.last_message_kind, Some(MessageKind::Text));
     // Seconds-to-ms conversion: a future mute/pin must not decode as 1970.
     let muted = chats
         .iter()
@@ -482,7 +485,7 @@ async fn undecryptable_placeholder_is_replaced_by_recovery() {
     )
     .await;
     let placeholder = chat_store.message(&chat, "MSG-U").await.unwrap().unwrap();
-    assert_eq!(placeholder.kind, "undecryptable");
+    assert_eq!(placeholder.kind, MessageKind::Undecryptable);
     assert!(placeholder.message.is_none());
 
     // PDO/retry later recovers the real content under the same id.
@@ -492,7 +495,7 @@ async fn undecryptable_placeholder_is_replaced_by_recovery() {
     )
     .await;
     let recovered = chat_store.message(&chat, "MSG-U").await.unwrap().unwrap();
-    assert_eq!(recovered.kind, "text");
+    assert_eq!(recovered.kind, MessageKind::Text);
     assert_eq!(recovered.text.as_deref(), Some("recovered"));
 }
 

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -2399,6 +2399,7 @@ async fn edit_before_target_materializes_edited_content() {
     .await;
     let msg = chat_store.message(&chat, "MSG-EB").await.unwrap().unwrap();
     assert_eq!(msg.text.as_deref(), Some("fixed"));
+    assert!(msg.edited_at.is_some());
     let chats = chat_store.chats(false, 10).await.unwrap();
     assert_eq!(chats[0].last_message_preview.as_deref(), Some("fixed"));
     assert_eq!(chats[0].unread_count, 1);
@@ -2481,4 +2482,43 @@ async fn server_nack_marks_outgoing_failed() {
         .unwrap()
         .unwrap();
     assert_eq!(msg.status, MessageStatus::Read);
+
+    // ...nor one the server already accepted: the positive ack answered the
+    // stanza, so a later nack for the same id is noise.
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-ACKED",
+            &wa::Message::text("oi3"),
+            Utc.timestamp_opt(1_700_000_400, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    feed(
+        &chat_store,
+        [
+            Event::ServerAck(
+                ServerAck::builder()
+                    .id("OUT-ACKED".to_string())
+                    .class("message".to_string())
+                    .from(chat.clone())
+                    .build(),
+            ),
+            Event::ServerAck(
+                ServerAck::builder()
+                    .id("OUT-ACKED".to_string())
+                    .class("message".to_string())
+                    .from(chat.clone())
+                    .error("479".to_string())
+                    .build(),
+            ),
+        ],
+    )
+    .await;
+    let msg = chat_store
+        .message(&chat, "OUT-ACKED")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::ServerAck);
 }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -778,6 +778,126 @@ async fn revoke_before_content_is_not_resurrected() {
     let still_revoked = chat_store.message(&chat, "MSG-RB").await.unwrap().unwrap();
     assert!(still_revoked.revoked);
     assert!(still_revoked.text.is_none());
+    // ...and the skipped redelivery must not surface its content in the
+    // chat-list preview either.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert!(
+        chats
+            .iter()
+            .all(|c| c.last_message_preview.as_deref() != Some("too late"))
+    );
+}
+
+#[tokio::test]
+async fn edit_of_revoked_message_is_a_no_op() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("original"),
+            incoming_info(PEER, PEER, "MSG-ER", 1_700_000_000),
+        )],
+    )
+    .await;
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-ER".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(PEER, PEER, "MSG-ER2", 1_700_000_010),
+        )],
+    )
+    .await;
+
+    // An edit targeting the tombstone must not resurrect content.
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-ER".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("resurrected"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            edit,
+            incoming_info(PEER, PEER, "MSG-ER3", 1_700_000_020),
+        )],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "MSG-ER").await.unwrap().unwrap();
+    assert!(msg.revoked);
+    assert!(msg.text.is_none());
+    assert!(msg.message.is_none());
+}
+
+#[tokio::test]
+async fn same_millisecond_sibling_does_not_hijack_preview() {
+    let (_store, chat_store) = test_store().await;
+
+    // Two messages in the same millisecond; (timestamp, msg_id) ordering makes
+    // MSG-Z2 the latest.
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("first"),
+                incoming_info(PEER, PEER, "MSG-A1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("second"),
+                incoming_info(PEER, PEER, "MSG-Z2", 1_700_000_000),
+            ),
+        ],
+    )
+    .await;
+
+    // Editing the OLDER same-millisecond sibling must not steal the preview.
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-A1".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("hijacked"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            edit,
+            incoming_info(PEER, PEER, "MSG-E1", 1_700_000_100),
+        )],
+    )
+    .await;
+    let msg = chat_store
+        .message(&jid(PEER), "MSG-A1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.text.as_deref(), Some("hijacked"));
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("second"));
 }
 
 #[tokio::test]
@@ -960,6 +1080,21 @@ async fn stale_reaction_timestamp_does_not_replace_newer() {
     let reactions = chat_store.reactions(&chat, "MSG-RT").await.unwrap();
     assert_eq!(reactions.len(), 1);
     assert_eq!(reactions[0].emoji, "👍");
+
+    // Neither must a stale REMOVE delete it...
+    feed(&chat_store, [react("", "R3", 1_700_000_150)]).await;
+    let reactions = chat_store.reactions(&chat, "MSG-RT").await.unwrap();
+    assert_eq!(reactions.len(), 1);
+
+    // ...while a newer remove still works.
+    feed(&chat_store, [react("", "R4", 1_700_000_300)]).await;
+    assert!(
+        chat_store
+            .reactions(&chat, "MSG-RT")
+            .await
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -1889,3 +1889,134 @@ async fn stale_ranged_mark_read_respects_the_read_cursor() {
     .await;
     assert_eq!(chat_store.unread_total().await.unwrap(), 0);
 }
+
+#[tokio::test]
+async fn keyed_mark_read_spares_unlisted_same_second_sibling() {
+    let (_store, chat_store) = test_store().await;
+
+    // Two incoming rows in the SAME wire second; the mark-read names only one.
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("named"),
+                incoming_info(PEER, PEER, "MSG-KA", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("unnamed sibling"),
+                incoming_info(PEER, PEER, "MSG-KB", 1_700_000_000),
+            ),
+        ],
+    )
+    .await;
+
+    let range = buffa::MessageField::some(wa::sync_action_value::SyncActionMessageRange {
+        last_message_timestamp: Some(1_700_000_000),
+        messages: vec![wa::sync_action_value::SyncActionMessage {
+            key: buffa::MessageField::some(wa::MessageKey {
+                id: Some("MSG-KA".into()),
+                remote_jid: Some(PEER.into()),
+                ..Default::default()
+            }),
+            timestamp: Some(1_700_000_000),
+        }],
+        ..Default::default()
+    });
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_001, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    message_range: range,
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn late_materialized_old_message_does_not_badge_after_read() {
+    let (_store, chat_store) = test_store().await;
+
+    // Unranged mark-read on an EMPTY chat: the cursor must advance off the
+    // action's own timestamp.
+    feed(
+        &chat_store,
+        [Event::MarkChatAsReadUpdate(
+            wacore::types::events::MarkChatAsReadUpdate::builder()
+                .jid(jid(PEER))
+                .timestamp(Utc.timestamp_opt(1_700_000_100, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::MarkChatAsReadAction {
+                    read: Some(true),
+                    ..Default::default()
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    // An OLDER message materializes afterwards (offline drain): already read,
+    // must not badge.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("late but old"),
+            incoming_info(PEER, PEER, "MSG-LATE", 1_700_000_000),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 0);
+
+    // While a genuinely NEW message still badges.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("genuinely new"),
+            incoming_info(PEER, PEER, "MSG-NEW", 1_700_000_200),
+        )],
+    )
+    .await;
+    assert_eq!(chat_store.unread_total().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn admin_revoke_tombstone_keeps_target_author() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+    let admin = "559900000077@s.whatsapp.net";
+    let author = "559900000088@s.whatsapp.net";
+
+    // Admin revoke arriving BEFORE the original: the tombstone must attribute
+    // the message to its author (revoke key participant), not to the admin.
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-ADM".into()),
+                from_me: Some(false),
+                participant: Some(author.into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            revoke,
+            incoming_info(GROUP, admin, "MSG-ADM2", 1_700_000_000),
+        )],
+    )
+    .await;
+    let tombstone = chat_store.message(&chat, "MSG-ADM").await.unwrap().unwrap();
+    assert!(tombstone.revoked);
+    assert_eq!(tombstone.sender_jid, jid(author));
+}

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -20,14 +20,8 @@ bundled-sqlite = ["libsqlite3-sys/bundled"]
 async-trait = { workspace = true }
 buffa = { workspace = true }
 bytes = { workspace = true }
-diesel = { version = "2.3.10", default-features = false, features = [
-    "sqlite",
-    "r2d2",
-    "32-column-tables",
-] }
-diesel_migrations = { version = "2.3.2", default-features = false, features = [
-    "sqlite",
-] }
+diesel = { workspace = true }
+diesel_migrations = { workspace = true }
 libsqlite3-sys = { version = "0.37", default-features = false, optional = true }
 log = { workspace = true }
 # Shared across all r2d2 pools so each per-session store doesn't spawn its own pool of

--- a/storages/sqlite-storage/src/lib.rs
+++ b/storages/sqlite-storage/src/lib.rs
@@ -4,7 +4,9 @@
 //! It implements all the required storage traits from wacore::store::traits.
 
 mod schema;
+mod shared;
 mod sqlite_store;
 mod wire;
 
+pub use shared::SharedSqlite;
 pub use sqlite_store::{SqliteStore, SqliteStoreConfig, Synchronous};

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -1,0 +1,139 @@
+//! Cross-crate access to a store's SQLite database file.
+//!
+//! Sibling crates that keep their own tables in the same file (e.g. a chat/message
+//! store) must not open a second connection pool: two pools mean two WAL writers
+//! fighting over the file lock, two page caches, and two busy queues. [`SharedSqlite`]
+//! hands them the store's own pool and write-serialization semaphore instead.
+
+use diesel::sqlite::SqliteConnection;
+use std::sync::Arc;
+use wacore::store::error::{Result, StoreError};
+
+use crate::sqlite_store::{SqlitePool, SqliteStore};
+
+/// Clonable handle onto a [`SqliteStore`]'s connection pool and serialization
+/// semaphore. Obtained via [`SqliteStore::shared`]. Holding one does not keep any
+/// device row alive — it is purely connection plumbing.
+#[derive(Clone)]
+pub struct SharedSqlite {
+    pool: SqlitePool,
+    semaphore: Arc<tokio::sync::Semaphore>,
+}
+
+impl SharedSqlite {
+    /// Run `f` on a pooled connection from a blocking thread, holding one of the
+    /// store's serialization permits for the duration. The closure owns error
+    /// mapping into [`StoreError`] so callers can also run non-query work
+    /// (e.g. their own embedded migrations) through the same choke point.
+    pub async fn run<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let permit = self
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            f(&mut conn)
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))?
+    }
+}
+
+impl SqliteStore {
+    /// Handle for sibling crates to run their own queries and migrations against
+    /// this store's database file through the same pool and semaphore.
+    pub fn shared(&self) -> SharedSqlite {
+        SharedSqlite {
+            pool: self.pool.clone(),
+            semaphore: self.db_semaphore.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel::prelude::*;
+
+    use crate::sqlite_store::SqliteStore;
+    use wacore::store::error::StoreError;
+
+    async fn create_test_store(tag: &str) -> SqliteStore {
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let db_name = format!(
+            "file:memdb_shared_{tag}_{}_{}?mode=memory&cache=shared",
+            std::process::id(),
+            id
+        );
+        SqliteStore::new(&db_name)
+            .await
+            .expect("Failed to create test store")
+    }
+
+    fn db_err(e: diesel::result::Error) -> StoreError {
+        StoreError::Database(Box::new(e))
+    }
+
+    #[tokio::test]
+    async fn shared_handle_sees_the_same_database() {
+        let store = create_test_store("same_db").await;
+        let shared = store.shared();
+
+        shared
+            .run(|conn| {
+                diesel::sql_query("CREATE TABLE sibling_data (k TEXT PRIMARY KEY, v TEXT)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                diesel::sql_query("INSERT INTO sibling_data (k, v) VALUES ('a', 'b')")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("create + insert through shared handle");
+
+        // A second (cloned) handle reads what the first wrote: one pool, one file.
+        #[derive(QueryableByName)]
+        struct Row {
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            v: String,
+        }
+        let rows: Vec<Row> = shared
+            .clone()
+            .run(|conn| {
+                diesel::sql_query("SELECT v FROM sibling_data WHERE k = 'a'")
+                    .load(conn)
+                    .map_err(db_err)
+            })
+            .await
+            .expect("read through cloned handle");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].v, "b");
+    }
+
+    #[tokio::test]
+    async fn shared_handle_propagates_closure_errors() {
+        let store = create_test_store("err").await;
+        let result = store
+            .shared()
+            .run(|conn| {
+                diesel::sql_query("SELECT * FROM does_not_exist")
+                    .execute(conn)
+                    .map_err(db_err)
+            })
+            .await;
+        assert!(matches!(result, Err(StoreError::Database(_))));
+    }
+}

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -51,7 +51,7 @@ fn is_retriable_sqlite_error(error: &DieselError) -> bool {
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
-type SqlitePool = Pool<ConnectionManager<SqliteConnection>>;
+pub(crate) type SqlitePool = Pool<ConnectionManager<SqliteConnection>>;
 
 /// Row representation for the `device` table.
 ///


### PR DESCRIPTION
# chat-store: SQLite-backed chat/message history

New opt-in crate `whatsapp-rust-chat-store`: materializes the client's event stream into queryable tables in the same database file as the device store, so a UI or stateful bot survives a restart without re-syncing. It has no UI dependencies — the desktop app (#218) is just its first consumer.

## Design

- **Event-sourced materializer.** Register `chat_store.handler()` on the client; a single write-behind writer task applies batched events in one transaction per drained batch, preserving event order. Covers messages, receipts, server acks/nacks, edits, revokes, reactions, history sync (via the streaming `HistorySyncStream`, constant memory), app-state chat updates (pin/mute/archive/read/star/delete/clear), push names and contact actions.
- **Proto as source of truth.** Each message row stores the encoded `wa::Message` plus denormalized columns (kind, text, status on the `WebMessageInfo.Status` scale). New proto fields never require a migration; history-sync statuses map through unchanged.
- **Query + invalidation, not a second cache.** Reads are async queries (keyset pagination for message pages — stable under concurrent inserts, never OFFSET); consumers subscribe to a `StoreChange` broadcast and re-query what they display.
- **One file, one WAL writer.** Writes go through the new `SqliteStore::shared()` handle (same pool + serialization semaphore), so the chat tables live in the device store's database file without a second connection pool fighting over the WAL lock. Backup of the full session state stays "copy one file". Multi-account ready (`device_id` in every PK).

## Semantics worth reviewing

- Status transitions are monotonic (a late `delivered` never downgrades `read`), for both per-message status and per-user group receipts. A message-class server nack fails only a still-`pending` row (`Error`); it can never regress an acked/delivered one.
- Self-read state is a monotonic keyed cursor (watermark + boundary message ids), so same-second siblings resolve exactly and stale replayed reads/receipts can't resurrect a badge. A no-op read (cursor unchanged) still clears a manual-unread marker. Unread counters follow WA Web conventions (`-1` = manually marked unread; `ReadSelf` receipts zero the chat).
- Offline drains reorder: a revoke or edit arriving before its target materializes up front (tombstone / edited content), so the original's later arrival can neither resurrect revoked content nor show pre-edit text — and never double-counts unread.
- History sync never clobbers live rows (`ON CONFLICT DO NOTHING`); live redeliveries and PDO recovery replace content in place (an `undecryptable` placeholder becomes the real message under the same id). Content refreshes are sender-scoped: message ids are sender-chosen, so adversarial id reuse can't rewrite someone else's message.
- `record_outgoing` goes through the writer queue, so it cannot race the server ack that follows it in event order.

## Optional FTS5 search (`search` feature)

External-content FTS5 index over message text with prefix matching, kept in sync by triggers using the canonical recipe (every row indexed, delete+insert paired in one trigger body — the cute WHEN-guarded variant corrupts rank queries, which the test suite now pins). User input is neutralized before hitting the FTS5 query parser.

## sqlite-storage changes

- `SqliteStore::shared()` exposes a clonable handle onto the pool + semaphore for sibling crates (tested).
- diesel/diesel_migrations moved to `[workspace.dependencies]`.

## Tests

59 tests: 11 unit (materializer classification) + 48 integration through the real writer/store (in-memory SQLite), including monotonic status flow, server-nack handling, keyset pagination coverage, history-vs-live precedence, PDO placeholder replacement, out-of-order revoke/edit arrival, read-state replay and same-second edge cases, manual-unread marker semantics, cross-sender id reuse, FTS NULL-transition soundness (revoke, undecryptable→recovered) and operator-injection inputs.