### PR TITLE
perf(receipt): persistent worker for live delivery receipts

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -678,6 +678,15 @@ pub struct Client {
     /// so in-flight delivery receipts aren't dropped with `NotConnected`
     /// (issue #571).
     pub(crate) outbound_flush: Arc<crate::flush_scope::FlushScope>,
+    /// Feed of the persistent delivery-receipt worker (spawned on first use).
+    /// Queued items carry a [`crate::flush_scope::FlushGuard`] so `flush()`
+    /// still waits for receipts that are queued but not yet sent.
+    pub(crate) delivery_receipt_queue: std::sync::OnceLock<
+        async_channel::Sender<(
+            Arc<crate::types::message::MessageInfo>,
+            crate::flush_scope::FlushGuard,
+        )>,
+    >,
     /// Contacts with active presence subscriptions that must be re-subscribed on reconnect.
     pub(crate) presence_subscriptions: Arc<async_lock::Mutex<HashSet<Jid>>>,
     /// Metrics for granular offline sync logging

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -230,6 +230,7 @@ impl Client {
             history_sync_tasks_in_flight: Arc::new(AtomicUsize::new(0)),
             history_sync_idle_notifier: Arc::new(event_listener::Event::new()),
             outbound_flush: Arc::new(crate::flush_scope::FlushScope::new()),
+            delivery_receipt_queue: std::sync::OnceLock::new(),
             presence_subscriptions: Arc::new(async_lock::Mutex::new(HashSet::new())),
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2901,15 +2901,22 @@ async fn delivery_receipt_dropped_when_flush_scope_closed() {
         0,
         "closed scope must not track new receipts"
     );
-    let start = wacore::time::Instant::now();
-    client
-        .outbound_flush
-        .flush(&*client.runtime, Duration::from_secs(5))
-        .await;
+    // The drop happens before the queue: with the scope closed nothing may be
+    // enqueued, so the lazy worker queue is never even created.
     assert!(
-        start.elapsed() < Duration::from_millis(200),
-        "flush must return immediately when nothing was queued"
+        client.delivery_receipt_queue.get().is_none(),
+        "a dropped receipt must not reach the worker queue"
     );
+    // Finishing well under the 5s flush timeout proves nothing was tracked;
+    // the generous bound keeps this stable on oversubscribed CI runners.
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .outbound_flush
+            .flush(&*client.runtime, Duration::from_secs(5)),
+    )
+    .await
+    .expect("flush must not wait when nothing was queued");
 }
 
 /// Issue #571 under the worker model: `flush()` must wait for receipts that

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -2814,6 +2814,184 @@ async fn disconnect_does_not_signal_connection_cleanup_before_outbound_flush() {
     );
 }
 
+fn receipt_test_info(id: &str) -> Arc<crate::types::message::MessageInfo> {
+    Arc::new(crate::types::message::MessageInfo {
+        id: id.to_string(),
+        source: crate::types::message::MessageSource {
+            chat: "15550001111@s.whatsapp.net".parse().unwrap(),
+            sender: "15550001111@s.whatsapp.net".parse().unwrap(),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+/// Live delivery receipts flow through the persistent worker: the receipt
+/// reaches the transport and the flush counter returns to zero afterwards.
+#[tokio::test]
+async fn delivery_receipt_worker_sends_and_releases_flush() {
+    use crate::socket::NoiseSocket;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use wacore::handshake::NoiseCipher;
+
+    struct CountingTransport {
+        sends: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl crate::transport::Transport for CountingTransport {
+        async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+            self.sends.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn disconnect(&self) {}
+    }
+
+    let client = crate::test_utils::create_test_client().await;
+    let sends = Arc::new(AtomicUsize::new(0));
+    let transport: Arc<dyn crate::transport::Transport> = Arc::new(CountingTransport {
+        sends: Arc::clone(&sends),
+    });
+    let key = [0u8; 32];
+    let noise_socket = NoiseSocket::new(
+        client.runtime.clone(),
+        Arc::clone(&transport),
+        NoiseCipher::new(&key).expect("valid key"),
+        NoiseCipher::new(&key).expect("valid key"),
+    );
+    *client.transport.lock().await = Some(transport);
+    *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+    client.is_connected.store(true, Ordering::Release);
+
+    client.ack_received_message(&receipt_test_info("RCPT-WORKER-1"));
+
+    let deadline = wacore::time::Instant::now() + Duration::from_secs(2);
+    while sends.load(Ordering::SeqCst) == 0 {
+        assert!(
+            wacore::time::Instant::now() < deadline,
+            "delivery receipt was never sent by the worker"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(sends.load(Ordering::SeqCst), 1);
+
+    client
+        .outbound_flush
+        .flush(&*client.runtime, Duration::from_secs(1))
+        .await;
+    assert_eq!(
+        client.outbound_flush.pending(),
+        0,
+        "worker must release the flush guard after the send"
+    );
+}
+
+/// A closed flush scope (disconnect in progress) drops live receipts without
+/// leaking the flush counter — mirroring the previous spawn-per-receipt path.
+#[tokio::test]
+async fn delivery_receipt_dropped_when_flush_scope_closed() {
+    let client = crate::test_utils::create_test_client().await;
+    client.outbound_flush.close();
+
+    client.ack_received_message(&receipt_test_info("RCPT-CLOSED-1"));
+
+    assert_eq!(
+        client.outbound_flush.pending(),
+        0,
+        "closed scope must not track new receipts"
+    );
+    let start = wacore::time::Instant::now();
+    client
+        .outbound_flush
+        .flush(&*client.runtime, Duration::from_secs(5))
+        .await;
+    assert!(
+        start.elapsed() < Duration::from_millis(200),
+        "flush must return immediately when nothing was queued"
+    );
+}
+
+/// Issue #571 under the worker model: `flush()` must wait for receipts that
+/// are queued to the worker but not yet sent, including one queued behind an
+/// in-flight blocked send.
+#[tokio::test]
+async fn flush_waits_for_queued_delivery_receipts() {
+    use crate::socket::NoiseSocket;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use wacore::handshake::NoiseCipher;
+
+    struct BlockingTransport {
+        send_started: async_channel::Sender<()>,
+        release_send: async_channel::Receiver<()>,
+    }
+
+    #[async_trait]
+    impl crate::transport::Transport for BlockingTransport {
+        async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+            let _ = self.send_started.try_send(());
+            let _ = self.release_send.recv().await;
+            Ok(())
+        }
+        async fn disconnect(&self) {}
+    }
+
+    let client = crate::test_utils::create_test_client().await;
+    let (send_started_tx, send_started_rx) = async_channel::bounded(2);
+    let (release_send_tx, release_send_rx) = async_channel::bounded(2);
+    let transport: Arc<dyn crate::transport::Transport> = Arc::new(BlockingTransport {
+        send_started: send_started_tx,
+        release_send: release_send_rx,
+    });
+    let key = [0u8; 32];
+    let noise_socket = NoiseSocket::new(
+        client.runtime.clone(),
+        Arc::clone(&transport),
+        NoiseCipher::new(&key).expect("valid key"),
+        NoiseCipher::new(&key).expect("valid key"),
+    );
+    *client.transport.lock().await = Some(transport);
+    *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+    client.is_connected.store(true, Ordering::Release);
+
+    client.ack_received_message(&receipt_test_info("RCPT-QUEUE-1"));
+    tokio::time::timeout(Duration::from_secs(1), send_started_rx.recv())
+        .await
+        .expect("first receipt send should start")
+        .expect("send_started sender should stay open");
+
+    // Second receipt queues behind the blocked one and must also be tracked.
+    client.ack_received_message(&receipt_test_info("RCPT-QUEUE-2"));
+    assert_eq!(
+        client.outbound_flush.pending(),
+        2,
+        "both the in-flight and the queued receipt must hold flush guards"
+    );
+
+    let flush_client = Arc::clone(&client);
+    let flush_task = tokio::spawn(async move {
+        flush_client
+            .outbound_flush
+            .flush(&*flush_client.runtime, Duration::from_secs(5))
+            .await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !flush_task.is_finished(),
+        "flush must wait while receipts are queued or in flight"
+    );
+
+    release_send_tx.send(()).await.expect("release first send");
+    release_send_tx.send(()).await.expect("release second send");
+
+    tokio::time::timeout(Duration::from_secs(2), flush_task)
+        .await
+        .expect("flush should finish once the queue drains")
+        .expect("flush task should not panic");
+    assert_eq!(client.outbound_flush.pending(), 0);
+}
+
 /// Verifies that `send_ack_for` returns an error (not silent Ok) when
 /// disconnected. This ensures the caller's `warn!` fires so dropped acks
 /// are visible in logs.

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -40,6 +40,23 @@ impl FlushScope {
         *self.closed.lock().unwrap_or_else(|e| e.into_inner()) = false;
     }
 
+    /// Track a unit of outbound work without spawning a task (e.g. an item
+    /// handed to a persistent worker). Returns `None` when the scope is
+    /// closed — the work must be dropped, mirroring `spawn`. Dropping the
+    /// guard marks the work as finished for `flush`.
+    pub fn try_track(self: &Arc<Self>) -> Option<FlushGuard> {
+        {
+            let closed = self.closed.lock().unwrap_or_else(|e| e.into_inner());
+            if *closed {
+                return None;
+            }
+            self.count.fetch_add(1, Ordering::Relaxed);
+        }
+        Some(FlushGuard {
+            scope: Arc::clone(self),
+        })
+    }
+
     /// Spawn a tracked task. The counter decrements on completion OR if the
     /// future is dropped (e.g. aborted, or dropped before its first poll), so
     /// `flush` can never deadlock waiting on a cancelled task.
@@ -49,22 +66,14 @@ impl FlushScope {
     where
         F: Future<Output = ()> + Spawnable,
     {
-        {
-            let closed = self.closed.lock().unwrap_or_else(|e| e.into_inner());
-            if *closed {
-                return;
-            }
-            self.count.fetch_add(1, Ordering::Relaxed);
-        }
-
         // Construct the guard outside the async block so it's captured as an
         // upvalue. This puts it in the future's state machine BEFORE the first
         // poll, so even if the runtime drops the future without polling it,
         // the guard's Drop runs and decrements the counter. Constructing the
         // guard inside the async body would delay it until the first poll,
         // which leaks the count if the future is dropped earlier.
-        let guard = DecrementOnDrop {
-            scope: Arc::clone(self),
+        let Some(guard) = self.try_track() else {
+            return;
         };
         rt.spawn(Box::pin(async move {
             let _guard = guard;
@@ -106,11 +115,13 @@ impl FlushScope {
     }
 }
 
-struct DecrementOnDrop {
+/// RAII guard for one tracked unit of outbound work. Obtained via
+/// [`FlushScope::try_track`]; `spawn` embeds one in the task it creates.
+pub struct FlushGuard {
     scope: Arc<FlushScope>,
 }
 
-impl Drop for DecrementOnDrop {
+impl Drop for FlushGuard {
     fn drop(&mut self) {
         if self.scope.count.fetch_sub(1, Ordering::Relaxed) == 1 {
             self.scope.idle.notify(usize::MAX);
@@ -207,7 +218,7 @@ mod tests {
 
         let scope_for_fut = Arc::clone(&scope);
         let mut fut: std::pin::Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
-            let _guard = DecrementOnDrop {
+            let _guard = FlushGuard {
                 scope: scope_for_fut,
             };
             futures::future::pending::<()>().await;
@@ -225,7 +236,7 @@ mod tests {
         assert_eq!(
             scope.pending(),
             0,
-            "DecrementOnDrop must fire when the in-flight future is dropped"
+            "FlushGuard must fire when the in-flight future is dropped"
         );
     }
 
@@ -242,7 +253,7 @@ mod tests {
         // so it's in the state machine from construction, not only after the
         // first poll.
         scope.count.fetch_add(1, Ordering::Relaxed);
-        let guard = DecrementOnDrop {
+        let guard = FlushGuard {
             scope: Arc::clone(&scope),
         };
         let never_polled_fut = async move {
@@ -258,6 +269,48 @@ mod tests {
             0,
             "guard must drop with the never-polled future"
         );
+    }
+
+    #[tokio::test]
+    async fn try_track_guard_blocks_flush_until_dropped() {
+        let scope = Arc::new(FlushScope::new());
+        let runtime = rt();
+
+        let guard = scope.try_track().expect("open scope must track");
+        assert_eq!(scope.pending(), 1);
+
+        let flush_scope = Arc::clone(&scope);
+        let flush_runtime = Arc::clone(&runtime);
+        let flush_task = tokio::spawn(async move {
+            flush_scope
+                .flush(&*flush_runtime, Duration::from_secs(5))
+                .await;
+        });
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !flush_task.is_finished(),
+            "flush must wait while a tracked guard is alive"
+        );
+
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), flush_task)
+            .await
+            .expect("flush should finish once the guard drops")
+            .expect("flush task should not panic");
+        assert_eq!(scope.pending(), 0);
+    }
+
+    #[tokio::test]
+    async fn try_track_rejected_when_closed() {
+        let scope = Arc::new(FlushScope::new());
+        scope.close();
+        assert!(scope.try_track().is_none(), "closed scope must not track");
+        assert_eq!(scope.pending(), 0);
+
+        scope.reopen();
+        let guard = scope.try_track();
+        assert!(guard.is_some(), "reopened scope must track again");
+        assert_eq!(scope.pending(), 1);
     }
 
     #[tokio::test]

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -97,7 +97,12 @@ impl Client {
         }
     }
 
-    /// Spawn a delivery receipt, tracked so `disconnect()` can flush it (issue #571).
+    /// Queue a delivery receipt, tracked so `disconnect()` can flush it (issue #571).
+    ///
+    /// Live receipts feed a single persistent worker instead of one spawned
+    /// task each: the per-message cost drops to a channel slot plus a
+    /// [`crate::flush_scope::FlushGuard`], and `flush()` still waits because
+    /// the guard rides the queue until the send completes.
     ///
     /// Offline-drained messages are buffered instead and flushed as aggregate
     /// `<receipt>` stanzas when the offline sync completes, collapsing a
@@ -107,10 +112,39 @@ impl Client {
         if info.is_offline && self.try_buffer_offline_receipt(info) {
             return;
         }
-        let client = self.clone();
-        let info = Arc::clone(info);
-        self.outbound_flush.spawn(&*self.runtime, async move {
-            client.send_delivery_receipt(&info).await;
-        });
+        // A closed scope (disconnect in progress) drops the receipt, exactly
+        // like the previous spawn-per-receipt path.
+        let Some(guard) = self.outbound_flush.try_track() else {
+            return;
+        };
+        let tx = self
+            .delivery_receipt_queue
+            .get_or_init(|| self.start_delivery_receipt_worker());
+        // Only fails if the worker exited (client teardown); dropping the
+        // guard here keeps `flush()` honest.
+        let _ = tx.try_send((Arc::clone(info), guard));
+    }
+
+    /// Worker task shared by every live delivery receipt. Holds only a `Weak`
+    /// so a dropped `Client` closes the channel and ends the task instead of
+    /// keeping the client alive.
+    fn start_delivery_receipt_worker(
+        self: &Arc<Self>,
+    ) -> async_channel::Sender<(Arc<MessageInfo>, crate::flush_scope::FlushGuard)> {
+        let (tx, rx) =
+            async_channel::unbounded::<(Arc<MessageInfo>, crate::flush_scope::FlushGuard)>();
+        let client = Arc::downgrade(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                while let Ok((info, guard)) = rx.recv().await {
+                    let Some(client) = client.upgrade() else {
+                        break;
+                    };
+                    client.send_delivery_receipt(&info).await;
+                    drop(guard);
+                }
+            }))
+            .detach();
+        tx
     }
 }


### PR DESCRIPTION
## Summary

- replace the spawned task per live inbound message with a single persistent worker fed by a channel; each delivery receipt now costs a channel slot plus a `FlushGuard` instead of a Tokio task and its boxed future
- add `FlushScope::try_track()` so queued receipts keep participating in the disconnect flush (#571): the guard rides the queue until the send completes, and `close()` still drops new receipts during disconnect
- the worker holds only a `Weak<Client>`, so dropping the client closes the channel and ends the task

## Impact

DHAT ping-pong (2000 cycles, connect-subtracted, average of 2 runs, baseline = main @ 07b271ad): allocation cost per cycle dropped from 40,169.0 to 38,969.1 bytes (-3.0%) and from 227.21 to 225.23 blocks (-0.9%). No extra retention at exit (t-end identical), 2000/2000 pongs with 0 lost in both runs.

## Validation

- `cargo test -p whatsapp-rust --lib` (971 passed; new tests cover the worker send path, the closed-scope drop, flush waiting on receipts queued behind a blocked transport send, and `try_track` semantics)
- `cargo test -p wacore --lib`
- `cargo clippy -p whatsapp-rust -p wacore --tests -- -D warnings`
- `cargo fmt --all`