### PR TITLE
perf(signal): sync fast paths for hot store adapter methods

### DIFF
--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -22,6 +22,16 @@ where
     move |e| SignalProtocolError::BackendError(context, e.into())
 }
 
+/// Boxed future with the exact shape `#[async_trait]` expects, so the hot
+/// methods below can be hand-desugared: a cache hit completes synchronously
+/// and boxes only a tiny `Ready` instead of the full async state machine.
+#[cfg(not(target_arch = "wasm32"))]
+type BoxFut<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+#[cfg(target_arch = "wasm32")]
+type BoxFut<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + 'a>>;
+
+use std::future::{Future, ready};
+
 #[derive(Clone)]
 struct SharedDevice {
     device: Arc<RwLock<Device>>,
@@ -96,22 +106,50 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
-    async fn has_session(&self, address: &ProtocolAddress) -> Result<bool, SignalProtocolError> {
-        let device = self.0.device.read().await;
-        self.0
-            .cache
-            .has_session(address, &*device.backend)
-            .await
-            .map_err(signal_err("backend"))
+    // Hand-desugared (see `BoxFut`): a cached answer skips the device lock
+    // and returns a ready future.
+    fn has_session<'life0, 'life1, 'async_trait>(
+        &'life0 self,
+        address: &'life1 ProtocolAddress,
+    ) -> BoxFut<'async_trait, Result<bool, SignalProtocolError>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        if let Some(known) = self.0.cache.try_has_session(address) {
+            return Box::pin(ready(Ok(known)));
+        }
+        Box::pin(async move {
+            let device = self.0.device.read().await;
+            self.0
+                .cache
+                .has_session(address, &*device.backend)
+                .await
+                .map_err(signal_err("backend"))
+        })
     }
 
-    async fn store_session(
-        &mut self,
-        address: &ProtocolAddress,
+    // Hand-desugared (see `BoxFut`): the record moves into the cache before
+    // the future is built, so the hot path never boxes the record-sized
+    // state machine. Contention (a flush commit) falls back to the async put.
+    fn store_session<'life0, 'life1, 'async_trait>(
+        &'life0 mut self,
+        address: &'life1 ProtocolAddress,
         record: SessionRecord,
-    ) -> Result<(), SignalProtocolError> {
-        self.0.cache.put_session(address, record).await;
-        Ok(())
+    ) -> BoxFut<'async_trait, Result<(), SignalProtocolError>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        match self.0.cache.try_put_session(address, record) {
+            Ok(()) => Box::pin(ready(Ok(()))),
+            Err(record) => Box::pin(async move {
+                self.0.cache.put_session(address, record).await;
+                Ok(())
+            }),
+        }
     }
 }
 
@@ -132,27 +170,53 @@ impl IdentityKeyStore for IdentityAdapter {
             .map_err(signal_err("get_local_registration_id"))
     }
 
-    async fn save_identity(
-        &mut self,
-        address: &ProtocolAddress,
-        identity: &IdentityKey,
-    ) -> Result<IdentityChange, SignalProtocolError> {
-        let existing_identity = self.get_identity(address).await?;
-
-        // Cache-first: write to cache only. The cache flushes to the backend
-        // during flush_signal_cache(). This avoids a synchronous backend write
-        // on every encrypt/decrypt. is_trusted_identity always returns true
-        // (matching WA Web), so the Device-level save is redundant.
-        self.0
-            .cache
-            .put_identity(address, identity.public_key().public_key_bytes())
-            .await;
-
-        match existing_identity {
-            None => Ok(IdentityChange::NewOrUnchanged),
-            Some(existing) if &existing == identity => Ok(IdentityChange::NewOrUnchanged),
-            Some(_) => Ok(IdentityChange::ReplacedExisting),
+    // Hand-desugared (see `BoxFut`): with the previous value cached, the
+    // read+compare+write completes synchronously. A parse failure of the
+    // cached bytes errors BEFORE the write, like the async path.
+    fn save_identity<'life0, 'life1, 'life2, 'async_trait>(
+        &'life0 mut self,
+        address: &'life1 ProtocolAddress,
+        identity: &'life2 IdentityKey,
+    ) -> BoxFut<'async_trait, Result<IdentityChange, SignalProtocolError>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        'life2: 'async_trait,
+        Self: 'async_trait,
+    {
+        if let Some(prev) = self.0.cache.try_get_identity(address) {
+            let change = match parse_cached_identity(prev) {
+                Ok(None) => IdentityChange::NewOrUnchanged,
+                Ok(Some(existing)) if &existing == identity => IdentityChange::NewOrUnchanged,
+                Ok(Some(_)) => IdentityChange::ReplacedExisting,
+                Err(e) => return Box::pin(ready(Err(e))),
+            };
+            if self
+                .0
+                .cache
+                .try_put_identity(address, identity.public_key().public_key_bytes())
+            {
+                return Box::pin(ready(Ok(change)));
+            }
         }
+        Box::pin(async move {
+            let existing_identity = self.get_identity(address).await?;
+
+            // Cache-first: write to cache only. The cache flushes to the backend
+            // during flush_signal_cache(). This avoids a synchronous backend write
+            // on every encrypt/decrypt. is_trusted_identity always returns true
+            // (matching WA Web), so the Device-level save is redundant.
+            self.0
+                .cache
+                .put_identity(address, identity.public_key().public_key_bytes())
+                .await;
+
+            match existing_identity {
+                None => Ok(IdentityChange::NewOrUnchanged),
+                Some(existing) if &existing == identity => Ok(IdentityChange::NewOrUnchanged),
+                Some(_) => Ok(IdentityChange::ReplacedExisting),
+            }
+        })
     }
 
     async fn is_trusted_identity(
@@ -169,26 +233,45 @@ impl IdentityKeyStore for IdentityAdapter {
         Ok(true)
     }
 
-    async fn get_identity(
-        &self,
-        address: &ProtocolAddress,
-    ) -> Result<Option<IdentityKey>, SignalProtocolError> {
-        let device = self.0.device.read().await;
-        match self
-            .0
-            .cache
-            .get_identity(address, &*device.backend)
-            .await
-            .map_err(signal_err("get_identity"))?
-        {
-            Some(data) if !data.is_empty() => {
-                // Cache and backend store raw 32-byte DJB public key bytes
-                let public_key =
-                    wacore::libsignal::protocol::PublicKey::from_djb_public_key_bytes(&data)?;
-                Ok(Some(IdentityKey::new(public_key)))
-            }
-            _ => Ok(None),
+    // Hand-desugared (see `BoxFut`): a cached entry (present OR known-absent)
+    // skips the device lock and returns a ready future.
+    fn get_identity<'life0, 'life1, 'async_trait>(
+        &'life0 self,
+        address: &'life1 ProtocolAddress,
+    ) -> BoxFut<'async_trait, Result<Option<IdentityKey>, SignalProtocolError>>
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        if let Some(cached) = self.0.cache.try_get_identity(address) {
+            return Box::pin(ready(parse_cached_identity(cached)));
         }
+        Box::pin(async move {
+            let device = self.0.device.read().await;
+            let data = self
+                .0
+                .cache
+                .get_identity(address, &*device.backend)
+                .await
+                .map_err(signal_err("get_identity"))?;
+            parse_cached_identity(data)
+        })
+    }
+}
+
+/// Decode the cache's raw 32-byte DJB public key bytes; empty/absent = no
+/// identity (mirrors the previous inline match in `get_identity`).
+fn parse_cached_identity(
+    data: Option<std::sync::Arc<[u8]>>,
+) -> Result<Option<IdentityKey>, SignalProtocolError> {
+    match data {
+        Some(data) if !data.is_empty() => {
+            let public_key =
+                wacore::libsignal::protocol::PublicKey::from_djb_public_key_bytes(&data)?;
+            Ok(Some(IdentityKey::new(public_key)))
+        }
+        _ => Ok(None),
     }
 }
 
@@ -385,6 +468,101 @@ mod tests {
         assert!(
             backend.load_prekey(PREKEY_ID).await.unwrap().is_none(),
             "remove_pre_key must delete from the backend immediately"
+        );
+    }
+
+    fn test_adapter() -> SignalProtocolStoreAdapter {
+        let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
+        let device = Arc::new(RwLock::new(Device::new(backend)));
+        SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
+    }
+
+    /// The hand-desugared session methods must behave exactly like the trait's
+    /// async path: store → visible to has/load, both on cold and warm cache.
+    #[tokio::test]
+    async fn session_store_fast_paths_round_trip() {
+        use wacore::libsignal::protocol::SessionStore as _;
+        let mut adapter = test_adapter();
+        let addr = ProtocolAddress::new("15550002222".to_string(), 1.into());
+
+        // Cold cache: goes through the async fallback (backend consult).
+        assert!(!adapter.session_store.has_session(&addr).await.unwrap());
+
+        adapter
+            .session_store
+            .store_session(&addr, SessionRecord::new_fresh())
+            .await
+            .unwrap();
+
+        // Warm cache: answered by the sync fast path.
+        assert!(adapter.session_store.has_session(&addr).await.unwrap());
+        assert!(
+            adapter
+                .session_store
+                .load_session(&addr)
+                .await
+                .unwrap()
+                .is_some(),
+            "stored session must be loadable"
+        );
+    }
+
+    /// The hand-desugared identity methods must keep save_identity's change
+    /// semantics: new → NewOrUnchanged, same key → NewOrUnchanged, different
+    /// key → ReplacedExisting (the last two run on the warm-cache fast path).
+    #[tokio::test]
+    async fn identity_fast_paths_keep_change_semantics() {
+        use wacore::libsignal::protocol::{IdentityKeyPair, IdentityKeyStore as _};
+        let mut adapter = test_adapter();
+        let addr = ProtocolAddress::new("15550003333".to_string(), 1.into());
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let first = *IdentityKeyPair::generate(&mut rng).identity_key();
+        let second = *IdentityKeyPair::generate(&mut rng).identity_key();
+
+        assert!(
+            adapter
+                .identity_store
+                .get_identity(&addr)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            adapter
+                .identity_store
+                .save_identity(&addr, &first)
+                .await
+                .unwrap(),
+            IdentityChange::NewOrUnchanged
+        );
+        assert_eq!(
+            adapter
+                .identity_store
+                .save_identity(&addr, &first)
+                .await
+                .unwrap(),
+            IdentityChange::NewOrUnchanged,
+            "same key again must be NewOrUnchanged"
+        );
+        assert_eq!(
+            adapter
+                .identity_store
+                .save_identity(&addr, &second)
+                .await
+                .unwrap(),
+            IdentityChange::ReplacedExisting,
+            "a different key must be ReplacedExisting"
+        );
+        assert_eq!(
+            adapter
+                .identity_store
+                .get_identity(&addr)
+                .await
+                .unwrap()
+                .expect("identity must be cached"),
+            second,
+            "get_identity must observe the fast-path write"
         );
     }
 }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -433,6 +433,39 @@ impl SignalStoreCache {
         state.evict_if_needed(self.max_entries);
     }
 
+    /// Non-blocking [`Self::put_session`]: completes synchronously when the
+    /// sessions lock is free. Returns the record back on contention (e.g. a
+    /// flush commit in progress) so the caller can take the async path
+    /// without cloning.
+    // Err carries the record by value on purpose: boxing it would add the
+    // very allocation this fast path exists to avoid.
+    #[allow(clippy::result_large_err)]
+    pub fn try_put_session(
+        &self,
+        address: &ProtocolAddress,
+        record: SessionRecord,
+    ) -> core::result::Result<(), SessionRecord> {
+        match self.sessions.try_lock() {
+            Some(mut state) => {
+                state.put(address.as_str(), record);
+                state.evict_if_needed(self.max_entries);
+                Ok(())
+            }
+            None => Err(record),
+        }
+    }
+
+    /// Non-blocking [`Self::has_session`] restricted to what the cache already
+    /// knows: `Some` only when the lock is free AND the entry is cached;
+    /// `None` sends the caller to the async path (backend consult).
+    pub fn try_has_session(&self, address: &ProtocolAddress) -> Option<bool> {
+        let state = self.sessions.try_lock()?;
+        state
+            .cache
+            .get(address.as_str())
+            .map(|entry| !matches!(entry, SessionEntry::Absent))
+    }
+
     pub async fn delete_session(&self, address: &ProtocolAddress) {
         let mut state = self.sessions.lock().await;
         state.delete(address.as_str());
@@ -499,6 +532,27 @@ impl SignalStoreCache {
         let mut state = self.identities.lock().await;
         state.put_dedup(address.as_str(), data);
         state.evict_if_needed(self.max_entries);
+    }
+
+    /// Non-blocking cached identity read: `Some` only when the lock is free
+    /// AND the entry is cached (`Some(None)` = known-absent); `None` sends
+    /// the caller to the async path.
+    pub fn try_get_identity(&self, address: &ProtocolAddress) -> Option<Option<Arc<[u8]>>> {
+        let state = self.identities.try_lock()?;
+        state.cache.get(address.as_str()).cloned()
+    }
+
+    /// Non-blocking [`Self::put_identity`]; `false` = contended, caller must
+    /// take the async path.
+    pub fn try_put_identity(&self, address: &ProtocolAddress, data: &[u8]) -> bool {
+        match self.identities.try_lock() {
+            Some(mut state) => {
+                state.put_dedup(address.as_str(), data);
+                state.evict_if_needed(self.max_entries);
+                true
+            }
+            None => false,
+        }
     }
 
     pub async fn delete_identity(&self, address: &ProtocolAddress) {
@@ -900,6 +954,109 @@ mod sender_key_lock_tests {
         // A warm sender-key hit returns a refcount bump of the same allocation,
         // not a deep copy of the message-key backlog.
         assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    /// The sync fast path must be indistinguishable from `put_session`:
+    /// visible to reads AND marked dirty so the flush persists it.
+    #[tokio::test]
+    async fn try_put_session_marks_dirty_and_flushes() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550009999".to_string(), 1.into());
+
+        assert!(
+            cache
+                .try_put_session(&addr, SessionRecord::new_fresh())
+                .is_ok(),
+            "uncontended try_put_session must succeed"
+        );
+
+        assert_eq!(cache.try_has_session(&addr), Some(true));
+        cache.flush(&backend).await.unwrap();
+        assert!(
+            crate::store::traits::SignalStore::get_session(&backend, addr.as_str())
+                .await
+                .unwrap()
+                .is_some(),
+            "flush must persist a session stored via the fast path"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_session_paths_fall_back_under_contention() {
+        let cache = SignalStoreCache::new();
+        let addr = ProtocolAddress::new("15550009999".to_string(), 1.into());
+
+        let guard = cache.sessions.lock().await;
+        assert!(
+            cache
+                .try_put_session(&addr, SessionRecord::new_fresh())
+                .is_err(),
+            "held sessions lock must reject try_put_session"
+        );
+        assert_eq!(
+            cache.try_has_session(&addr),
+            None,
+            "held sessions lock must reject try_has_session"
+        );
+        drop(guard);
+
+        assert_eq!(
+            cache.try_has_session(&addr),
+            None,
+            "unknown entry must defer to the async path"
+        );
+        assert!(
+            cache
+                .try_put_session(&addr, SessionRecord::new_fresh())
+                .is_ok(),
+            "released lock must accept try_put_session"
+        );
+        assert_eq!(cache.try_has_session(&addr), Some(true));
+    }
+
+    #[tokio::test]
+    async fn try_has_session_reports_known_absent() {
+        let cache = SignalStoreCache::new();
+        let addr = ProtocolAddress::new("15550009999".to_string(), 1.into());
+
+        cache.delete_session(&addr).await;
+        assert_eq!(
+            cache.try_has_session(&addr),
+            Some(false),
+            "negative-cached entry must answer synchronously"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_identity_paths_cover_hit_miss_and_contention() {
+        let cache = SignalStoreCache::new();
+        let addr = ProtocolAddress::new("15550009999".to_string(), 1.into());
+        let key_bytes = [7u8; 32];
+
+        assert_eq!(
+            cache.try_get_identity(&addr),
+            None,
+            "unknown entry must defer to the async path"
+        );
+
+        assert!(cache.try_put_identity(&addr, &key_bytes));
+        match cache.try_get_identity(&addr) {
+            Some(Some(bytes)) => assert_eq!(bytes.as_ref(), &key_bytes),
+            other => panic!("expected cached identity, got {other:?}"),
+        }
+
+        let guard = cache.identities.lock().await;
+        assert_eq!(cache.try_get_identity(&addr), None);
+        assert!(!cache.try_put_identity(&addr, &key_bytes));
+        drop(guard);
+
+        cache.delete_identity(&addr).await;
+        assert_eq!(
+            cache.try_get_identity(&addr),
+            Some(None),
+            "known-absent identity must answer synchronously"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- hand-desugar the hot `async_trait` methods on `SessionAdapter`/`IdentityAdapter` so a warm-cache call completes synchronously and boxes only a tiny `Ready` future instead of the full async state machine (the `store_session` box alone is 672 B, ~3 calls per ping-pong cycle)
- add non-blocking `try_*` accessors to `SignalStoreCache` that take the same locks without waiting; on contention (e.g. a flush commit holding the sessions lock) the methods fall back to the unchanged async path, so the flush/prekey commit atomicity is untouched
- covers `store_session`, `has_session`, `save_identity` and `get_identity`; `load_session` keeps the macro because a `Ready` future would carry the `SessionRecord` by value and outgrow its current box

## Impact

DHAT ping-pong (2000 cycles, connect-subtracted, average of 2 runs, baseline = main @ 07b271ad): allocation cost per cycle dropped from 40,169.0 to 37,259.5 bytes (-7.2%) and from 227.21 to 224.26 blocks (-1.3%; the `save_identity` fast path also skips its nested boxed `get_identity` call). No extra retention at exit, 2000/2000 pongs with 0 lost in both runs.

## Validation

- `cargo test -p wacore --lib` (1080 passed; new tests: fast-path put is dirty-tracked and flushed, contention falls back, known-absent answers, identity hit/miss/contention)
- `cargo test -p whatsapp-rust --lib` (968 passed; adapter round-trip and `save_identity` change-semantics through the fast paths)
- `cargo clippy -p whatsapp-rust -p wacore --lib --tests -- -D warnings`
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features`