### PR TITLE
perf(binary): inline the exact-marshal string hint cache

### DIFF
--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -243,13 +243,18 @@ enum StringHint {
 pub(crate) struct StringHintCache {
     // Keys use (ptr, len) identity, so this cache is only valid while encoding
     // the same immutable node/strings it was built from.
-    hints: Vec<(StrKey, StringHint)>,
+    //
+    // Inline capacity covers a typical stanza's distinct strings without a
+    // heap allocation: the exact-marshal two-pass builds one of these per
+    // outgoing stanza, and it lives on the (sync) caller's stack, never in
+    // an async frame. Larger stanzas spill to the heap transparently.
+    hints: smallvec::SmallVec<[(StrKey, StringHint); 32]>,
 }
 
 impl Default for StringHintCache {
     fn default() -> Self {
         Self {
-            hints: Vec::with_capacity(32),
+            hints: smallvec::SmallVec::new(),
         }
     }
 }

--- a/wacore/binary/tests/marshal_exact_hint_alloc.rs
+++ b/wacore/binary/tests/marshal_exact_hint_alloc.rs
@@ -1,0 +1,76 @@
+//! Locks the exact-marshal allocation property: for a typical stanza the
+//! two-pass `marshal_exact` must allocate ONLY the output buffer. The string
+//! hint cache built during the size pass keeps its entries inline (SmallVec);
+//! a heap-backed cache (the regression this guards) paid ~1.3 KiB per
+//! outgoing stanza on the send hot path.
+//!
+//! Single test fn on purpose: the counting allocator is process-global, so a
+//! concurrently running sibling test would bleed its allocations into the
+//! measurement (seen once in CI).
+
+// Host-only allocation-count harness; std's 64-bit atomic is fine (never built
+// for embedded targets).
+#![allow(clippy::disallowed_types)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::marshal::{marshal, marshal_exact};
+
+struct CountingAlloc;
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+#[test]
+fn marshal_exact_allocates_only_the_output_buffer() {
+    // A live delivery-receipt shape: the strings comfortably fit the hint
+    // cache's inline capacity, so the size pass must not touch the heap.
+    let node = NodeBuilder::new("receipt")
+        .attr("to", "5511999990000@s.whatsapp.net")
+        .attr("id", "3EB0A9252A8F12B7E2")
+        .attr("type", "read")
+        .attr("t", "1760000000")
+        .build();
+
+    // Min-delta over many windows: the counter is process-global and harness
+    // threads bleed sporadic allocations, but if the plan pass is truly
+    // alloc-free at least one window lands on exactly the output buffer.
+    let mut min_delta = u64::MAX;
+    for _ in 0..100 {
+        let before = ALLOCS.load(Ordering::Relaxed);
+        let payload = marshal_exact(&node).expect("marshal_exact");
+        let after = ALLOCS.load(Ordering::Relaxed);
+        assert!(!payload.is_empty());
+        min_delta = min_delta.min(after - before);
+    }
+    assert_eq!(
+        min_delta, 1,
+        "marshal_exact of a small stanza must allocate only the output buffer"
+    );
+
+    // Spill correctness: a stanza with more distinct strings than the inline
+    // capacity still encodes byte-identically to the one-pass path.
+    let mut builder = NodeBuilder::new("iq");
+    for i in 0..40 {
+        let key: &'static str = Box::leak(format!("k{i:02}").into_boxed_str());
+        builder = builder.attr(key, format!("value-{i:02}"));
+    }
+    let big = builder.build();
+    assert_eq!(
+        marshal_exact(&big).expect("exact"),
+        marshal(&big).expect("one-pass"),
+        "spilled hint cache must not change the encoding"
+    );
+}


### PR DESCRIPTION
## Summary

- The size pass of `marshal_exact` allocated a 32-entry `Vec` (~1.3 KiB) for its string hint cache on every call — and since #1018 switched `send_node` to exact sizing, that's one heap allocation per outgoing stanza (two per ping-pong cycle: the message and its delivery receipt).
- Back the cache with an inline `SmallVec<[_; 32]>` instead (smallvec is already a wacore-binary dependency, same pattern as `AttrsVec`). `marshal_exact` is a sync fn, so the inline storage lives on the caller's real stack — never in an async frame — and stanzas with more distinct strings spill to the heap transparently.

## Impact

DHAT ping-pong (2000 cycles, connect-subtracted, average of 2 runs, baseline = main @ 61c7c39e): allocation cost per cycle dropped from 33,637.5 to 31,210.6 bytes (**-7.2%**) and from 219.88 to 217.97 blocks (-0.9%). 2000/2000 pongs with 0 lost in both runs, no extra retention at exit.

Cumulative since the start of this allocation series (pre-#1015 baseline of 46,088 B/cycle): **-32.3% bytes per cycle**.

## Validation

- `cargo test -p wacore-binary` (102 unit tests + the marshal round-trip proptest)
- New allocation-counting integration test (same harness pattern as `attrs_inline_alloc`) locking the property: `marshal_exact` of a typical stanza allocates only the output buffer, and a spilled hint cache still encodes byte-identically to the one-pass path
- `cargo test -p whatsapp-rust --lib` (976 passed)
- `cargo clippy -p wacore-binary --tests -- -D warnings`