### PR TITLE
VoIP 1:1 video calls

### DIFF
--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -953,6 +953,7 @@ fn spawn_call_event_listener(
     tokio::spawn(async move {
         let mut opus = WaOpusDecoder::new().ok();
         let mut peer_video_receiver_confirmed = false;
+        let mut peer_keyframe_request_logged = false;
         while let Ok(ev) = events.recv().await {
             match ev {
                 CallEvent::RelayAllocated => {
@@ -1026,8 +1027,9 @@ fn spawn_call_event_listener(
                         );
                         peer_video_receiver_confirmed = true;
                     }
-                    if requests_keyframe {
+                    if requests_keyframe && !peer_keyframe_request_logged {
                         info!("🎥 peer requests an outbound keyframe: [{feedback}]");
+                        peer_keyframe_request_logged = true;
                     }
                     debug!(
                         "📊 peer RTCP PT={packet_types:?} sender={sender_ssrc:#010x} refs={referenced_ssrcs:x?} reports_audio={reports_audio} reports_video={reports_video} blocks=[{blocks}] feedback=[{feedback}]"

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -32,7 +32,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use log::{debug, error, info, warn};
 use portable_atomic::AtomicU64;
 use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER};
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
     }
     match command {
         CliCommand::Loopback { video: true } => {
-            video::run_video_loopback(&VideoOpts::from_env()?).await
+            video::run_video_loopback(&VideoOpts::from_env().await?).await
         }
         CliCommand::Loopback { video: false } => run_loopback().await,
         CliCommand::Listen { accept, video } => run_bot(Mode::Listen { accept, video }).await,
@@ -167,8 +167,10 @@ fn video_source_is_ignored(command: &CliCommand, video_input_is_set: bool) -> bo
         && matches!(
             command,
             CliCommand::Loopback { video: false }
-                | CliCommand::Listen { video: false, .. }
-                | CliCommand::Call { video: false, .. }
+                | CliCommand::Listen {
+                    accept: false,
+                    video: false,
+                }
         )
 }
 
@@ -737,26 +739,38 @@ impl CallObserver {
     }
 }
 
+fn lock_call_state(state: &Mutex<CallState>) -> std::sync::MutexGuard<'_, CallState> {
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn begin_call_startup(state: &Arc<Mutex<CallState>>, call_id: &str) {
-    let mut st = state.lock().unwrap();
+    let mut st = lock_call_state(state);
     st.starting.insert(call_id.to_string());
     st.terminated_during_startup.remove(call_id);
 }
 
 fn complete_call_startup(state: &Arc<Mutex<CallState>>, call_id: &str) -> bool {
-    let mut st = state.lock().unwrap();
+    let mut st = lock_call_state(state);
     st.starting.remove(call_id);
     st.terminated_during_startup.remove(call_id)
 }
 
 fn record_peer_terminate(state: &Arc<Mutex<CallState>>, call_id: &str) {
-    let mut st = state.lock().unwrap();
+    let mut st = lock_call_state(state);
     if st.starting.contains(call_id) {
         st.terminated_during_startup.insert(call_id.to_string());
     }
     st.handles.remove(call_id);
     st.video_ui.remove(call_id);
     st.call_order.retain(|id| id != call_id);
+}
+
+fn peer_terminated_during_startup(state: &Arc<Mutex<CallState>>, call_id: &str) -> bool {
+    lock_call_state(state)
+        .terminated_during_startup
+        .contains(call_id)
 }
 
 fn mark_call_most_recent(order: &mut Vec<String>, call_id: &str) {
@@ -773,7 +787,7 @@ async fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc
         return;
     }
     {
-        let mut st = state.lock().unwrap();
+        let mut st = lock_call_state(state);
         st.handles.insert(cid.clone(), handle.clone());
         mark_call_most_recent(&mut st.call_order, &cid);
     }
@@ -781,7 +795,7 @@ async fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc
     tokio::spawn(async move {
         handle.wait_ended().await;
         {
-            let mut st = state.lock().unwrap();
+            let mut st = lock_call_state(&state);
             // Remove only if it is still OUR handle: a same-call-id replacement may now own this slot
             // (its own cleanup will remove it), so we must not delete the live call.
             if st
@@ -827,7 +841,23 @@ impl EventHandler for CallObserver {
                         match start_media(&client, &call, video, &state).await {
                             Ok(handle) => register_handle(&state, cid.clone(), handle).await,
                             Err(e) => {
+                                let peer_ended = peer_terminated_during_startup(&state, &cid);
                                 complete_call_startup(&state, &cid);
+                                if !peer_ended
+                                    && let CallAction::Offer {
+                                        call_id,
+                                        call_creator,
+                                        ..
+                                    } = &call.action
+                                    && let Err(terminate_error) = client
+                                        .voip()
+                                        .terminate(call_id, &call.from, call_creator)
+                                        .await
+                                {
+                                    warn!(
+                                        "failed to terminate incomplete inbound call: {terminate_error}"
+                                    );
+                                }
                                 warn!("inbound media failed: {e}");
                             }
                         }
@@ -860,15 +890,24 @@ async fn start_media(
     let mic = spawn_mic()?;
     let speaker = spawn_speaker()?;
     info!("🔌 connecting media via client.voip().accept(..)…");
-    let voip = client.voip();
-    let mut builder = voip.accept(call).audio(mic, speaker.clone());
-    if video {
-        let opts = VideoOpts::from_env()?;
+    let video_endpoints = if video {
+        let opts = VideoOpts::from_env().await?;
         let cid = call.action.call_id();
-        builder = builder.video(
+        Some((
             video::spawn_video_source(&opts).await?,
             video::spawn_video_sink(&opts, cid).await?,
-        );
+        ))
+    } else {
+        None
+    };
+    if peer_terminated_during_startup(state, call.action.call_id()) {
+        bail!("peer ended the call during media preparation");
+    }
+    send_final_accept(client, call, video).await?;
+    let voip = client.voip();
+    let mut builder = voip.accept(call).audio(mic, speaker.clone());
+    if let Some((source, sink)) = video_endpoints {
+        builder = builder.video(source, sink);
     }
     let handle = builder
         .start()
@@ -903,7 +942,7 @@ async fn place_outgoing_call(
     let voip = client.voip();
     let mut builder = voip.call(peer).audio(mic, speaker.clone());
     if video {
-        let opts = VideoOpts::from_env()?;
+        let opts = VideoOpts::from_env().await?;
         builder = builder.video(
             video::spawn_video_source(&opts).await?,
             video::spawn_video_sink(&opts, "outgoing").await?,
@@ -928,7 +967,7 @@ async fn place_outgoing_call(
 
 /// Update (or clear) the stdin toggle's view of a call's video state.
 fn mark_video(state: &Arc<Mutex<CallState>>, call_id: &str, ui: Option<VideoUi>) {
-    let mut st = state.lock().unwrap();
+    let mut st = lock_call_state(state);
     match ui {
         Some(ui) => {
             st.video_ui.insert(call_id.to_string(), ui);
@@ -1074,7 +1113,7 @@ fn spawn_call_event_listener(
 
 /// Fresh ffmpeg/ffplay endpoints for a mid-call upgrade/accept on `handle`.
 async fn accept_peer_video(handle: &CallHandle) -> Result<()> {
-    let opts = VideoOpts::from_env()?;
+    let opts = VideoOpts::from_env().await?;
     let src = video::spawn_video_source(&opts).await?;
     let sink = video::spawn_video_sink(&opts, handle.call_id()).await?;
     handle
@@ -1109,7 +1148,7 @@ async fn respond_to_offer(
             .map_err(|e| anyhow!("send reject: {e}"))?;
         return Ok(());
     }
-    // Callee flow: preaccept immediately, then accept (signaling).
+    // Callee flow: preaccept immediately; final accept waits for ready media.
     let audio_rates = &["16000"];
     let pre_id = hex::encode(rand::random::<[u8; 8]>());
     client
@@ -1125,6 +1164,19 @@ async fn respond_to_offer(
         ))
         .await
         .map_err(|e| anyhow!("send preaccept: {e}"))?;
+    Ok(())
+}
+
+async fn send_final_accept(client: &Arc<Client>, call: &IncomingCall, video: bool) -> Result<()> {
+    let CallAction::Offer {
+        call_id,
+        call_creator,
+        ..
+    } = &call.action
+    else {
+        return Ok(());
+    };
+    let audio_rates = &["16000"];
     let accept_id = hex::encode(rand::random::<[u8; 8]>());
     let metadata = if video { call.media.as_deref() } else { None };
     let accept_node = stanza::build_accept(&stanza::AcceptParams {
@@ -1179,7 +1231,7 @@ fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
         while let Ok(line) = line_rx.recv().await {
             // The most recent live call is the toggle's target (this demo runs one call at a time).
             let picked = {
-                let st = state.lock().unwrap();
+                let st = lock_call_state(&state);
                 st.call_order.iter().rev().find_map(|cid| {
                     st.handles
                         .get(cid)
@@ -1211,7 +1263,7 @@ fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
                     None => {
                         info!("🎥 requesting video upgrade");
                         let started = async {
-                            let opts = VideoOpts::from_env()?;
+                            let opts = VideoOpts::from_env().await?;
                             let src = video::spawn_video_source(&opts).await?;
                             let sink = video::spawn_video_sink(&opts, &cid).await?;
                             handle
@@ -1323,7 +1375,7 @@ mod tests {
 
     use super::{
         CallState, CliCommand, begin_call_startup, complete_call_startup, mark_call_most_recent,
-        parse_cli, record_peer_terminate, video_source_is_ignored,
+        parse_cli, peer_terminated_during_startup, record_peer_terminate, video_source_is_ignored,
     };
 
     fn argv(parts: &[&str]) -> Vec<String> {
@@ -1404,11 +1456,17 @@ mod tests {
 
     #[test]
     fn warns_when_video_input_cannot_be_used() {
-        let audio_only = parse_cli(&argv(&["listen", "accept"]));
+        let loopback = parse_cli(&argv(&["loopback"]));
+        let rejecting = parse_cli(&argv(&["listen"]));
+        let accepting = parse_cli(&argv(&["listen", "accept"]));
+        let calling = parse_cli(&argv(&["call", "15550001111@lid"]));
         let video = parse_cli(&argv(&["listen", "accept", "--video"]));
 
-        assert!(video_source_is_ignored(&audio_only, true));
-        assert!(!video_source_is_ignored(&audio_only, false));
+        assert!(video_source_is_ignored(&loopback, true));
+        assert!(video_source_is_ignored(&rejecting, true));
+        assert!(!video_source_is_ignored(&accepting, true));
+        assert!(!video_source_is_ignored(&calling, true));
+        assert!(!video_source_is_ignored(&loopback, false));
         assert!(!video_source_is_ignored(&video, true));
         assert!(!video_source_is_ignored(&CliCommand::Usage, true));
     }
@@ -1418,6 +1476,7 @@ mod tests {
         let state = Arc::new(Mutex::new(CallState::default()));
         begin_call_startup(&state, "CALL-ID-STARTING");
         record_peer_terminate(&state, "CALL-ID-STARTING");
+        assert!(peer_terminated_during_startup(&state, "CALL-ID-STARTING"));
         assert!(complete_call_startup(&state, "CALL-ID-STARTING"));
 
         let st = state.lock().unwrap();

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -3,27 +3,35 @@
 //! Audio is bridged to the system through `cpal` (cross-platform; ALSA on Linux,
 //! CoreAudio on macOS, WASAPI on Windows). `cpal` is a dev-dependency, so it is
 //! linked only for this example and never reaches consumers of the library.
+//! VIDEO is bridged through `ffmpeg`/`ffplay` subprocesses (must be on PATH when
+//! `--video` is used): ffmpeg encodes the webcam / a file / a test pattern to H.264
+//! and ffplay renders the peer's stream — the library only transports encoded AUs.
 //!
-//! Subcommands:
-//!   loopback         Mic → Opus → E2E-SRTP protect → unprotect → Opus → speaker.
-//!                    Exercises the whole media stack locally; NO WhatsApp connection.
-//!                    Run it and you should hear yourself, processed by the voip pipeline.
-//!   listen [accept]  Connect to WhatsApp, print incoming calls; reject (default) or accept.
-//!   call <jid>       Connect, discover the peer's devices, encrypt the callKey per device,
-//!                    and send a `<call><offer>`; logs the signaling flow via raw nodes.
+//! Subcommands (all accept a trailing `--video`):
+//!   loopback [--video]  Mic → Opus → E2E-SRTP protect → unprotect → Opus → speaker.
+//!                       Exercises the whole media stack locally; NO WhatsApp connection.
+//!                       With --video: ffmpeg source → AU splitter → ffplay window instead.
+//!   listen [accept] [--video]  Connect, print incoming calls; reject (default) or accept.
+//!                       With --video an accepted call answers with video media too.
+//!   call <jid> [--video]  Place a call; with --video it is a video call from the start.
 //!
-//!   cargo run --example voip --features "voip sqlite-storage tokio-transport ureq-client tokio-native" -- loopback
+//!   cargo run -p whatsapp-rust-voip-cli --release -- loopback
+//!
+//! During a live call, single-key commands on stdin (terminal only): `v` toggles video
+//! (upgrade / accept a pending peer request / downgrade), `q` hangs up.
+//! Env: `WA_VIDEO_INPUT` = `testsrc` | file/URL | webcam device (default: OS webcam);
+//! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`.
 //!
 //! The inbound MEDIA path is the library facade: `client.voip().accept(&call).audio(mic,
 //! speaker).start()` returns a `CallHandle` and the library owns the callKey decrypt, the relay
 //! socket, the sans-IO engine, and the task lifetime. This example only supplies the cpal audio
-//! device and reacts to engine events.
+//! device / ffmpeg pipes and reacts to engine events.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use log::{error, info, warn};
 use portable_atomic::AtomicU64;
 use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER};
@@ -31,9 +39,12 @@ use wacore::types::call::{CallAction, IncomingCall};
 use wacore::types::events::{Event, EventHandler};
 use wacore::voip::CallEvent;
 use whatsapp_rust::prelude::*;
-use whatsapp_rust::voip::CallHandle;
 use whatsapp_rust::voip::audio::{WaOpusDecoder, WaOpusEncoder};
 use whatsapp_rust::voip::session::{MediaPipeline, MediaPipelineParams};
+use whatsapp_rust::voip::{CallHandle, VideoState};
+
+mod video;
+use video::VideoOpts;
 
 const FRAME_SAMPLES: usize = 960; // 60 ms @ 16 kHz
 const WA_RATE: u32 = 16_000;
@@ -87,26 +98,59 @@ async fn main() -> Result<()> {
     );
 
     let args: Vec<String> = std::env::args().collect();
-    match args.get(1).map(String::as_str) {
-        Some("loopback") => run_loopback().await,
-        Some("listen") => {
-            run_bot(Mode::Listen {
-                accept: args.get(2).map(String::as_str) == Some("accept"),
-            })
-            .await
+    match parse_cli(&args) {
+        CliCommand::Loopback { video: true } => {
+            video::run_video_loopback(&VideoOpts::from_env()).await
         }
-        Some("call") => {
-            let jid = args
-                .get(2)
-                .context("usage: voip call <jid>")?
-                .parse::<Jid>()
-                .map_err(|e| anyhow!("bad jid: {e}"))?;
-            run_bot(Mode::Call(jid)).await
+        CliCommand::Loopback { video: false } => run_loopback().await,
+        CliCommand::Listen { accept, video } => run_bot(Mode::Listen { accept, video }).await,
+        CliCommand::Call { jid, video } => {
+            let jid = jid.parse::<Jid>().map_err(|e| anyhow!("bad jid: {e}"))?;
+            run_bot(Mode::Call { jid, video }).await
         }
-        _ => {
-            eprintln!("usage: voip <loopback | listen [accept] | call <jid>>");
+        CliCommand::Usage => {
+            eprintln!("usage: voip <loopback | listen [accept] | call <jid>> [--video]");
             Ok(())
         }
+    }
+}
+
+/// A parsed CLI invocation. Kept separate from `Mode` (and pure) so the argument classification —
+/// including the `--video`-implies-accept rule that bit a real test run — is unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum CliCommand {
+    Loopback { video: bool },
+    Listen { accept: bool, video: bool },
+    Call { jid: String, video: bool },
+    Usage,
+}
+
+/// Classify `argv` (including `argv[0]`). `--video` may appear anywhere. On `listen`, `--video`
+/// IMPLIES `accept`: there is no reason to request video while rejecting every call, so
+/// `listen --video` means "accept video calls" rather than silently rejecting them (the footgun a
+/// user hit: the phone showed "no answer" because the reject went out).
+fn parse_cli(argv: &[String]) -> CliCommand {
+    let video = argv.iter().any(|a| a == "--video");
+    let pos: Vec<&str> = argv
+        .iter()
+        .skip(1)
+        .map(String::as_str)
+        .filter(|a| *a != "--video")
+        .collect();
+    match pos.first().copied() {
+        Some("loopback") => CliCommand::Loopback { video },
+        Some("listen") => CliCommand::Listen {
+            accept: pos.get(1).copied() == Some("accept") || video,
+            video,
+        },
+        Some("call") => match pos.get(1) {
+            Some(jid) => CliCommand::Call {
+                jid: (*jid).to_string(),
+                video,
+            },
+            None => CliCommand::Usage,
+        },
+        _ => CliCommand::Usage,
     }
 }
 
@@ -626,8 +670,8 @@ async fn run_loopback() -> Result<()> {
 // ===================== live call / listen =====================
 
 enum Mode {
-    Listen { accept: bool },
-    Call(Jid),
+    Listen { accept: bool, video: bool },
+    Call { jid: Jid, video: bool },
 }
 
 /// Drives calls off the typed `Event::IncomingCall` (no raw-node forwarding needed): on an offer it
@@ -638,6 +682,8 @@ enum Mode {
 struct CallObserver {
     client: Arc<Client>,
     accept: bool,
+    /// `--video`: start/answer calls with video media and auto-accept peer upgrade requests.
+    video: bool,
     /// Whether this run ever starts a media call (auto-accept inbound OR an outbound `call`), so a
     /// `<terminate>` racing media startup is worth recording. A pure-reject run starts no media, so it
     /// must NOT record (the set would grow unbounded with nothing to consume it).
@@ -655,13 +701,24 @@ struct CallState {
     /// Call-ids that were terminated BEFORE their media handle finished starting, so a late
     /// `start_media()` hangs the call up instead of leaving an orphaned live call.
     terminated: HashSet<String>,
+    /// The stdin `v` toggle's view of each call's video: pending peer request vs our video live.
+    video_ui: HashMap<String, VideoUi>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum VideoUi {
+    /// The peer asked for video (`UpgradeRequestV2`); `v` accepts it.
+    PendingPeerRequest,
+    /// Our video plane is up; `v` downgrades.
+    Active,
 }
 
 impl CallObserver {
-    fn new(client: Arc<Client>, accept: bool, manages_media: bool) -> Self {
+    fn new(client: Arc<Client>, accept: bool, video: bool, manages_media: bool) -> Self {
         Self {
             client,
             accept,
+            video,
             manages_media,
             state: Arc::new(Mutex::new(CallState::default())),
         }
@@ -710,23 +767,27 @@ impl EventHandler for CallObserver {
     fn handle_event(&self, event: Arc<Event>) {
         if let Event::IncomingCall(call) = &*event {
             match &call.action {
-                CallAction::Offer { call_id, .. } => {
+                CallAction::Offer {
+                    call_id, is_video, ..
+                } => {
                     let client = self.client.clone();
                     let call = call.clone();
                     let accept = self.accept;
+                    // Only answer with video when we're allowed to AND the offer is actually a video
+                    // call; advertising `<video>` on an audio offer would be wrong.
+                    let video = self.video && *is_video;
                     let state = self.state.clone();
                     let cid = call_id.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = respond_to_offer(&client, &call, accept).await {
+                        if let Err(e) = respond_to_offer(&client, &call, accept, video).await {
                             error!("call signaling failed: {e}");
                             return;
                         }
                         if !accept {
                             return;
                         }
-                        match start_media(&client, &call).await {
+                        match start_media(&client, &call, video, &state).await {
                             Ok(handle) => {
-                                let handle = Arc::new(handle);
                                 // A <terminate> may have arrived while media was starting; if so, hang
                                 // up now instead of registering an orphaned live call.
                                 if !register_handle(&state, cid.clone(), handle.clone()) {
@@ -773,55 +834,106 @@ impl EventHandler for CallObserver {
     }
 }
 
-/// Drive the inbound MEDIA plane through the library facade: PipeWire mic in, PipeWire speaker out,
-/// the engine/relay/decrypt all internal. Replaces the ~180-line hand-rolled `run_inbound_media`.
-async fn start_media(client: &Arc<Client>, call: &IncomingCall) -> Result<CallHandle> {
+/// Drive the inbound MEDIA plane through the library facade: cpal mic in, cpal speaker out,
+/// the engine/relay/decrypt all internal. With `video`, ffmpeg/ffplay ride along as the codec.
+async fn start_media(
+    client: &Arc<Client>,
+    call: &IncomingCall,
+    video: bool,
+    state: &Arc<Mutex<CallState>>,
+) -> Result<Arc<CallHandle>> {
     let mic = spawn_mic()?;
     let speaker = spawn_speaker()?;
     info!("🔌 connecting media via client.voip().accept(..)…");
-    let handle = client
-        .voip()
-        .accept(call)
-        .audio(mic, speaker.clone())
+    let voip = client.voip();
+    let mut builder = voip.accept(call).audio(mic, speaker.clone());
+    if video {
+        let opts = VideoOpts::from_env();
+        let cid = call.action.call_id();
+        builder = builder.video(
+            video::spawn_video_source(&opts).await?,
+            video::spawn_video_sink(&opts, cid).await?,
+        );
+    }
+    let handle = builder
         .start()
         .await
         .map_err(|e| anyhow!("accept media: {e}"))?;
     info!(
-        "🎙  media flow live for call {} — speak into the mic.",
-        handle.call_id()
+        "🎙  media flow live for call {} — speak into the mic.{}",
+        handle.call_id(),
+        if video { " 🎥 video on." } else { "" }
     );
-    spawn_call_event_listener(&handle, speaker);
+    let handle = Arc::new(handle);
+    if video {
+        mark_video(state, handle.call_id(), Some(VideoUi::Active));
+    }
+    spawn_call_event_listener(handle.clone(), speaker, video, state.clone());
     Ok(handle)
 }
 
-/// Place an outgoing 1:1 call through the library facade: PipeWire mic/speaker, the device discovery,
+/// Place an outgoing 1:1 call through the library facade: cpal mic/speaker, the device discovery,
 /// callKey encrypt, offer send, ack-driven relay connect, engine, and task lifetime all internal. The
 /// returned handle is dormant until the server hands back the relay (live); the facade attaches the
 /// engine then. Mirrors `start_media` for the outbound direction.
-async fn place_outgoing_call(client: &Arc<Client>, peer: &Jid) -> Result<CallHandle> {
+async fn place_outgoing_call(
+    client: &Arc<Client>,
+    peer: &Jid,
+    video: bool,
+    state: &Arc<Mutex<CallState>>,
+) -> Result<Arc<CallHandle>> {
     let mic = spawn_mic()?;
     let speaker = spawn_speaker()?;
     info!("📞 placing call to {peer} via client.voip().call(..)…");
-    let handle = client
-        .voip()
-        .call(peer)
-        .audio(mic, speaker.clone())
+    let voip = client.voip();
+    let mut builder = voip.call(peer).audio(mic, speaker.clone());
+    if video {
+        let opts = VideoOpts::from_env();
+        builder = builder.video(
+            video::spawn_video_source(&opts).await?,
+            video::spawn_video_sink(&opts, "outgoing").await?,
+        );
+    }
+    let handle = builder
         .start()
         .await
         .map_err(|e| anyhow!("place call: {e}"))?;
     info!(
-        "☎  offer sent for call {} — waiting for the peer's relay to connect media.",
-        handle.call_id()
+        "☎  offer sent for call {} — waiting for the peer's relay to connect media.{}",
+        handle.call_id(),
+        if video { " 🎥 video call." } else { "" }
     );
-    spawn_call_event_listener(&handle, speaker);
+    let handle = Arc::new(handle);
+    if video {
+        mark_video(state, handle.call_id(), Some(VideoUi::Active));
+    }
+    spawn_call_event_listener(handle.clone(), speaker, video, state.clone());
     Ok(handle)
 }
 
-/// Surface the call's engine events: log relay-allocate outcomes, and decode any non-MLow (standard
-/// Opus) frame the core hands back and play it. The real peer is MLow-only, so ForeignAudio is a
-/// rare/diagnostic path; MLow audio is decoded inside the engine and arrives as playout on the
-/// speaker channel directly.
-fn spawn_call_event_listener(handle: &CallHandle, speaker: async_channel::Sender<Vec<i16>>) {
+/// Update (or clear) the stdin toggle's view of a call's video state.
+fn mark_video(state: &Arc<Mutex<CallState>>, call_id: &str, ui: Option<VideoUi>) {
+    let mut st = state.lock().unwrap();
+    match ui {
+        Some(ui) => {
+            st.video_ui.insert(call_id.to_string(), ui);
+        }
+        None => {
+            st.video_ui.remove(call_id);
+        }
+    }
+}
+
+/// Surface the call's engine events: log relay-allocate outcomes, decode any non-MLow (standard
+/// Opus) frame the core hands back and play it, and drive the video upgrade handshake (auto-accept
+/// under `--video`, otherwise park it for the stdin `v` toggle). MLow audio is decoded inside the
+/// engine and arrives as playout on the speaker channel directly.
+fn spawn_call_event_listener(
+    handle: Arc<CallHandle>,
+    speaker: async_channel::Sender<Vec<i16>>,
+    auto_video: bool,
+    state: Arc<Mutex<CallState>>,
+) {
     let events = handle.events();
     tokio::spawn(async move {
         let mut opus = WaOpusDecoder::new().ok();
@@ -843,13 +955,51 @@ fn spawn_call_event_listener(handle: &CallHandle, speaker: async_channel::Sender
                         let _ = speaker.try_send(pcm);
                     }
                 }
+                CallEvent::VideoStateChanged { state: vs, .. } => match vs {
+                    VideoState::UpgradeRequest | VideoState::UpgradeRequestV2 => {
+                        if auto_video {
+                            info!("🎥 peer asked for video — auto-accepting (--video)");
+                            if let Err(e) = accept_peer_video(&handle).await {
+                                warn!("accepting peer video failed: {e}");
+                            } else {
+                                mark_video(&state, handle.call_id(), Some(VideoUi::Active));
+                            }
+                        } else {
+                            info!("🎥 peer asked for video — press `v` + Enter to accept");
+                            mark_video(&state, handle.call_id(), Some(VideoUi::PendingPeerRequest));
+                        }
+                    }
+                    VideoState::UpgradeAccept | VideoState::Enabled => {
+                        info!("🎥 peer video {vs:?} — inbound video should start flowing");
+                    }
+                    VideoState::Stopped | VideoState::Disabled => {
+                        info!("🎥 peer stopped its video");
+                    }
+                    other => info!("🎥 peer video state: {other:?}"),
+                },
                 // CallEvent is #[non_exhaustive]: ignore variants newer core versions may add.
                 _ => {}
             }
         }
     });
 }
-async fn respond_to_offer(client: &Arc<Client>, call: &IncomingCall, accept: bool) -> Result<()> {
+
+/// Fresh ffmpeg/ffplay endpoints for a mid-call upgrade/accept on `handle`.
+async fn accept_peer_video(handle: &CallHandle) -> Result<()> {
+    let opts = VideoOpts::from_env();
+    let src = video::spawn_video_source(&opts).await?;
+    let sink = video::spawn_video_sink(&opts, handle.call_id()).await?;
+    handle
+        .accept_video(src, sink)
+        .await
+        .map_err(|e| anyhow!("accept_video: {e}"))
+}
+async fn respond_to_offer(
+    client: &Arc<Client>,
+    call: &IncomingCall,
+    accept: bool,
+    video: bool,
+) -> Result<()> {
     let CallAction::Offer {
         call_id,
         call_creator,
@@ -903,6 +1053,8 @@ async fn respond_to_offer(client: &Arc<Client>, call: &IncomingCall, accept: boo
         rte: None,
         voip_settings: None,
         capability: Some(&CAPABILITY_OFFER),
+        // Advertise video media in the accept when we're answering with video.
+        video,
     });
     client
         .send_node(accept_node)
@@ -911,13 +1063,108 @@ async fn respond_to_offer(client: &Arc<Client>, call: &IncomingCall, accept: boo
     Ok(())
 }
 
+/// Single-key commands on stdin during a live call: `v` toggles video (start an upgrade / accept a
+/// pending peer request / downgrade), `q` hangs up. Skipped when stdin is not a terminal (CI /
+/// piped input would EOF-spin).
+fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        return;
+    }
+    info!("⌨  during a call: `v` + Enter toggles video, `q` + Enter hangs up");
+    // Read stdin on a DETACHED std thread, not `tokio::io::stdin()`: the latter reads via a runtime
+    // blocking thread parked in `read()`, and the runtime drop on Ctrl+C waits for it forever — the
+    // process would never exit. A plain std thread is killed when the process exits, so shutdown
+    // stays clean; lines are forwarded over an async channel the cancellable UI task consumes.
+    let (line_tx, line_rx) = async_channel::unbounded::<String>();
+    std::thread::spawn(move || {
+        use std::io::BufRead;
+        let stdin = std::io::stdin();
+        for line in stdin.lock().lines() {
+            let Ok(line) = line else { break };
+            if line_tx.send_blocking(line).is_err() {
+                break;
+            }
+        }
+    });
+    tokio::spawn(async move {
+        while let Ok(line) = line_rx.recv().await {
+            // The most recent live call is the toggle's target (this demo runs one call at a time).
+            let picked = {
+                let st = state.lock().unwrap();
+                st.handles
+                    .iter()
+                    .next()
+                    .map(|(cid, h)| (cid.clone(), h.clone(), st.video_ui.get(cid).copied()))
+            };
+            let Some((cid, handle, ui)) = picked else {
+                info!("⌨  no live call");
+                continue;
+            };
+            match line.trim() {
+                "v" => match ui {
+                    Some(VideoUi::Active) => {
+                        info!("🎥 stopping video (downgrade to audio)");
+                        if let Err(e) = handle.stop_video().await {
+                            warn!("stop_video failed: {e}");
+                        } else {
+                            mark_video(&state, &cid, None);
+                        }
+                    }
+                    Some(VideoUi::PendingPeerRequest) => {
+                        info!("🎥 accepting the peer's video request");
+                        if let Err(e) = accept_peer_video(&handle).await {
+                            warn!("accept_video failed: {e}");
+                        } else {
+                            mark_video(&state, &cid, Some(VideoUi::Active));
+                        }
+                    }
+                    None => {
+                        info!("🎥 requesting video upgrade");
+                        let started = async {
+                            let opts = VideoOpts::from_env();
+                            let src = video::spawn_video_source(&opts).await?;
+                            let sink = video::spawn_video_sink(&opts, &cid).await?;
+                            handle
+                                .start_video(src, sink)
+                                .await
+                                .map_err(|e| anyhow!("start_video: {e}"))
+                        }
+                        .await;
+                        match started {
+                            Ok(()) => mark_video(&state, &cid, Some(VideoUi::Active)),
+                            Err(e) => warn!("video upgrade failed: {e}"),
+                        }
+                    }
+                },
+                "q" => {
+                    info!("⌨  hanging up {cid}");
+                    // Signal the peer with a <terminate> (which also tears our media down), so it
+                    // sees a normal hangup instead of waiting for the transport to time out. Fall
+                    // back to a local-only hangup if the send fails.
+                    if let Err(e) = client
+                        .voip()
+                        .terminate(&cid, &handle.peer_jid(), handle.call_creator())
+                        .await
+                    {
+                        warn!("⌨  terminate failed ({e}); tearing down locally");
+                        handle.hangup().await;
+                    }
+                }
+                "" => {}
+                other => info!("⌨  unknown command {other:?} — `v` toggles video, `q` hangs up"),
+            }
+        }
+    });
+}
+
 async fn run_bot(mode: Mode) -> Result<()> {
     let store = SqliteStore::new("whatsapp.db")
         .await
         .map_err(|e| anyhow!("sqlite: {e}"))?;
-    let (accept, target) = match mode {
-        Mode::Listen { accept } => (accept, None),
-        Mode::Call(jid) => (false, Some(jid)),
+    let (accept, target, video) = match mode {
+        Mode::Listen { accept, video } => (accept, None, video),
+        Mode::Call { jid, video } => (false, Some(jid), video),
     };
 
     let builder = Bot::builder()
@@ -936,10 +1183,12 @@ async fn run_bot(mode: Mode) -> Result<()> {
     let client = bot.client();
     // The structured `Event::IncomingCall` (which now carries the offer's <enc>/<relay>) drives the
     // accept flow, so the raw-node-forwarding crutch the old hand-rolled inbound path needed is gone.
+    let manages_media = accept || target.is_some();
     let observer = Arc::new(CallObserver::new(
         client.clone(),
         accept,
-        accept || target.is_some(),
+        video,
+        manages_media,
     ));
     client.register_handler(observer.clone());
 
@@ -957,10 +1206,9 @@ async fn run_bot(mode: Mode) -> Result<()> {
                 warn!("not connected within 60s, skipping outgoing call: {e}");
                 return;
             }
-            match place_outgoing_call(&client2, &peer).await {
+            match place_outgoing_call(&client2, &peer, video, &state).await {
                 Ok(handle) => {
                     let cid = handle.call_id().to_string();
-                    let handle = Arc::new(handle);
                     if !register_handle(&state, cid.clone(), handle.clone()) {
                         handle.hangup().await;
                         info!("◾ call {cid} terminated during startup");
@@ -971,9 +1219,14 @@ async fn run_bot(mode: Mode) -> Result<()> {
         });
     } else {
         warn!(
-            "listening for calls ({}). Ctrl+C to exit.",
-            if accept { "auto-accept" } else { "auto-reject" }
+            "listening for calls ({}{}). Ctrl+C to exit.",
+            if accept { "auto-accept" } else { "auto-reject" },
+            if video { ", video" } else { "" }
         );
+    }
+
+    if manages_media {
+        spawn_stdin_ui(client.clone(), observer.state.clone());
     }
 
     tokio::select! {
@@ -982,4 +1235,85 @@ async fn run_bot(mode: Mode) -> Result<()> {
         _ = whatsapp_rust::shutdown_signal() => { info!("shutting down"); }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliCommand, parse_cli};
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        std::iter::once("voip")
+            .chain(parts.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn listen_video_implies_accept() {
+        // The footgun that showed "no answer" on the phone: `listen --video` must ACCEPT (video is
+        // meaningless while rejecting), not silently reject.
+        assert_eq!(
+            parse_cli(&argv(&["listen", "--video"])),
+            CliCommand::Listen {
+                accept: true,
+                video: true
+            }
+        );
+    }
+
+    #[test]
+    fn listen_modes() {
+        assert_eq!(
+            parse_cli(&argv(&["listen"])),
+            CliCommand::Listen {
+                accept: false,
+                video: false
+            }
+        );
+        assert_eq!(
+            parse_cli(&argv(&["listen", "accept"])),
+            CliCommand::Listen {
+                accept: true,
+                video: false
+            }
+        );
+        assert_eq!(
+            parse_cli(&argv(&["listen", "accept", "--video"])),
+            CliCommand::Listen {
+                accept: true,
+                video: true
+            }
+        );
+        // `--video` may appear before the subcommand.
+        assert_eq!(
+            parse_cli(&argv(&["--video", "listen", "accept"])),
+            CliCommand::Listen {
+                accept: true,
+                video: true
+            }
+        );
+    }
+
+    #[test]
+    fn loopback_and_call_and_usage() {
+        assert_eq!(
+            parse_cli(&argv(&["loopback"])),
+            CliCommand::Loopback { video: false }
+        );
+        assert_eq!(
+            parse_cli(&argv(&["loopback", "--video"])),
+            CliCommand::Loopback { video: true }
+        );
+        assert_eq!(
+            parse_cli(&argv(&["call", "123@lid", "--video"])),
+            CliCommand::Call {
+                jid: "123@lid".into(),
+                video: true
+            }
+        );
+        // `call` with no jid, and unknown/empty commands, are usage errors.
+        assert_eq!(parse_cli(&argv(&["call"])), CliCommand::Usage);
+        assert_eq!(parse_cli(&argv(&["bogus"])), CliCommand::Usage);
+        assert_eq!(parse_cli(&argv(&[])), CliCommand::Usage);
+    }
 }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -32,7 +32,7 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use portable_atomic::AtomicU64;
 use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER};
 use wacore::types::call::{CallAction, IncomingCall};
@@ -98,7 +98,14 @@ async fn main() -> Result<()> {
     );
 
     let args: Vec<String> = std::env::args().collect();
-    match parse_cli(&args) {
+    let command = parse_cli(&args);
+    if video_source_is_ignored(&command, std::env::var_os("WA_VIDEO_INPUT").is_some()) {
+        warn!(
+            "WA_VIDEO_INPUT is set, but --video is missing; outbound video is disabled. Keep \
+             --video on the same shell command line."
+        );
+    }
+    match command {
         CliCommand::Loopback { video: true } => {
             video::run_video_loopback(&VideoOpts::from_env()).await
         }
@@ -152,6 +159,16 @@ fn parse_cli(argv: &[String]) -> CliCommand {
         },
         _ => CliCommand::Usage,
     }
+}
+
+fn video_source_is_ignored(command: &CliCommand, video_input_is_set: bool) -> bool {
+    video_input_is_set
+        && matches!(
+            command,
+            CliCommand::Loopback { video: false }
+                | CliCommand::Listen { video: false, .. }
+                | CliCommand::Call { video: false, .. }
+        )
 }
 
 // ===================== cpal audio bridge =====================
@@ -955,6 +972,133 @@ fn spawn_call_event_listener(
                         let _ = speaker.try_send(pcm);
                     }
                 }
+                CallEvent::RtcpReceived {
+                    packet_types,
+                    sender_ssrc,
+                    referenced_ssrcs,
+                    reports_audio,
+                    reports_video,
+                    protection,
+                    srtcp_index,
+                    encrypted,
+                    plain_len,
+                    sdes_cname_lengths,
+                    report_blocks,
+                    feedback,
+                    uses_whatsapp_profile_extension,
+                } => {
+                    let blocks = report_blocks
+                        .iter()
+                        .map(|report| {
+                            format!(
+                                "{:#010x}:loss={}/{} highest={} jitter={} lsr={:#010x} dlsr={} ext={}B",
+                                report.ssrc,
+                                report.fraction_lost,
+                                report.cumulative_lost,
+                                report.extended_highest_sequence,
+                                report.jitter,
+                                report.last_sender_report,
+                                report.delay_since_last_sender_report,
+                                report.profile_extension.len(),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let feedback = feedback
+                        .iter()
+                        .map(|item| {
+                            let kind = match (item.packet_type, item.fmt) {
+                                (205, 1) => "NACK",
+                                (206, 1) => "PLI",
+                                (206, 4) => "FIR",
+                                (206, 15) => "AFB",
+                                _ => "unknown",
+                            };
+                            format!(
+                                "{kind}:sender={:#010x}/media={:#010x}/fci={}B:{}",
+                                item.sender_ssrc,
+                                item.media_ssrc,
+                                item.fci.len(),
+                                hex::encode(&item.fci),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    info!(
+                        "📊 peer RTCP mode={protection:?} PT={packet_types:?} sender={sender_ssrc:#010x} refs={referenced_ssrcs:x?} reports_audio={reports_audio} reports_video={reports_video} index={srtcp_index:?} encrypted={encrypted} plain_bytes={plain_len} wa_profile={uses_whatsapp_profile_extension} blocks=[{blocks}] feedback=[{feedback}] sdes_cname_lens={sdes_cname_lengths:?}"
+                    );
+                }
+                CallEvent::RtcpRejected {
+                    stage,
+                    packet_type,
+                    sender_ssrc,
+                    packet_len,
+                    first_rtcp_len,
+                    plain_len,
+                    candidate_srtcp_index,
+                    candidate_encrypted,
+                    first_header_byte,
+                    plain_sample,
+                } => {
+                    if let Some(sample) = plain_sample {
+                        warn!(
+                            "📊 peer transport RTCP rejected at {stage:?}: PT={packet_type} sender={sender_ssrc:#010x} bytes={packet_len} plain_bytes={plain_len:?} first_header={first_header_byte:#04x} first_rtcp_bytes={first_rtcp_len} candidate_index={candidate_srtcp_index:?} candidate_encrypted={candidate_encrypted} plain_hex={} ",
+                            hex::encode(sample),
+                        );
+                    } else if stage == wacore::voip::RtcpRejectStage::Authentication {
+                        warn!(
+                            "📊 peer transport RTCP rejected at {stage:?}: PT={packet_type} sender={sender_ssrc:#010x} bytes={packet_len} plain_bytes={plain_len:?} first_header={first_header_byte:#04x} first_rtcp_bytes={first_rtcp_len} candidate_index={candidate_srtcp_index:?} candidate_encrypted={candidate_encrypted}"
+                        );
+                    } else {
+                        debug!(
+                            "peer transport RTCP rejected at {stage:?}: PT={packet_type} sender={sender_ssrc:#010x} bytes={packet_len} plain_bytes={plain_len:?} first_header={first_header_byte:#04x} first_rtcp_bytes={first_rtcp_len} candidate_index={candidate_srtcp_index:?} candidate_encrypted={candidate_encrypted}"
+                        );
+                    }
+                }
+                CallEvent::VideoRtpLayoutObserved {
+                    ssrc,
+                    sequence_number,
+                    timestamp,
+                    marker,
+                    header_len,
+                    packet_len,
+                    extension_profile,
+                    extension_data,
+                } => {
+                    let profile = extension_profile
+                        .map(|value| format!("{value:#06x}"))
+                        .unwrap_or_else(|| "none".to_owned());
+                    info!(
+                        "🎥 peer RTP layout: ssrc={ssrc:#010x} seq={sequence_number} ts={timestamp} marker={marker} header_bytes={header_len} packet_bytes={packet_len} ext_profile={profile} ext_data={} ",
+                        hex::encode(extension_data)
+                    );
+                }
+                CallEvent::VideoRtpLayoutSent {
+                    ssrc,
+                    sequence_number,
+                    timestamp,
+                    marker,
+                    header_len,
+                    packet_len,
+                    extension_profile,
+                    extension_data,
+                } => {
+                    let profile = extension_profile
+                        .map(|value| format!("{value:#06x}"))
+                        .unwrap_or_else(|| "none".to_owned());
+                    info!(
+                        "🎥 local RTP layout: ssrc={ssrc:#010x} seq={sequence_number} ts={timestamp} marker={marker} header_bytes={header_len} packet_bytes={packet_len} ext_profile={profile} ext_data={}",
+                        hex::encode(extension_data)
+                    );
+                }
+                CallEvent::OutboundMediaDropped {
+                    video_access_units,
+                    packets,
+                } => {
+                    warn!(
+                        "🎥 relay-send backpressure: dropped {video_access_units} complete video AUs / {packets} packets"
+                    );
+                }
                 CallEvent::VideoStateChanged { state: vs, .. } => match vs {
                     VideoState::UpgradeRequest | VideoState::UpgradeRequestV2 => {
                         if auto_video {
@@ -1039,10 +1183,14 @@ async fn respond_to_offer(
             call_creator,
             &pre_id,
             audio_rates,
+            // Byte-matched to a real from-start video callee: <video dec=H264 screen 0x0> in the
+            // preaccept, with the 0xbb capability (the caller offers 0xfa; the callee preaccepts 0xbb).
+            video,
         ))
         .await
         .map_err(|e| anyhow!("send preaccept: {e}"))?;
     let accept_id = hex::encode(rand::random::<[u8; 8]>());
+    let metadata = if video { call.media.as_deref() } else { None };
     let accept_node = stanza::build_accept(&stanza::AcceptParams {
         call_id,
         to: &call.from,
@@ -1052,9 +1200,13 @@ async fn respond_to_offer(
         relay_te: None,
         rte: None,
         voip_settings: None,
-        capability: Some(&CAPABILITY_OFFER),
-        // Advertise video media in the accept when we're answering with video.
+        // A real from-start video accept carries NO <capability> (just audio/video/net/encopt); the
+        // audio path keeps advertising it.
+        capability: if video { None } else { Some(&CAPABILITY_OFFER) },
         video,
+        peer_abtest_bucket: metadata.and_then(|media| media.peer_abtest_bucket.as_deref()),
+        peer_abtest_bucket_id_list: metadata
+            .and_then(|media| media.peer_abtest_bucket_id_list.as_deref()),
     });
     client
         .send_node(accept_node)
@@ -1239,7 +1391,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CliCommand, parse_cli};
+    use super::{CliCommand, parse_cli, video_source_is_ignored};
 
     fn argv(parts: &[&str]) -> Vec<String> {
         std::iter::once("voip")
@@ -1315,5 +1467,16 @@ mod tests {
         assert_eq!(parse_cli(&argv(&["call"])), CliCommand::Usage);
         assert_eq!(parse_cli(&argv(&["bogus"])), CliCommand::Usage);
         assert_eq!(parse_cli(&argv(&[])), CliCommand::Usage);
+    }
+
+    #[test]
+    fn warns_when_video_input_cannot_be_used() {
+        let audio_only = parse_cli(&argv(&["listen", "accept"]));
+        let video = parse_cli(&argv(&["listen", "accept", "--video"]));
+
+        assert!(video_source_is_ignored(&audio_only, true));
+        assert!(!video_source_is_ignored(&audio_only, false));
+        assert!(!video_source_is_ignored(&video, true));
+        assert!(!video_source_is_ignored(&CliCommand::Usage, true));
     }
 }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -20,14 +20,15 @@
 //! During a live call, single-key commands on stdin (terminal only): `v` toggles video
 //! (upgrade / accept a pending peer request / downgrade), `q` hangs up.
 //! Env: `WA_VIDEO_INPUT` = `testsrc` | file/URL | webcam device (default: OS webcam);
-//! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`.
+//! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`; optional quality overrides:
+//! `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`, `WA_VIDEO_BITRATE_KBPS`, `WA_VIDEO_SINK_FPS`.
 //!
 //! The inbound MEDIA path is the library facade: `client.voip().accept(&call).audio(mic,
 //! speaker).start()` returns a `CallHandle` and the library owns the callKey decrypt, the relay
 //! socket, the sans-IO engine, and the task lifetime. This example only supplies the cpal audio
 //! device / ffmpeg pipes and reacts to engine events.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -107,7 +108,7 @@ async fn main() -> Result<()> {
     }
     match command {
         CliCommand::Loopback { video: true } => {
-            video::run_video_loopback(&VideoOpts::from_env()).await
+            video::run_video_loopback(&VideoOpts::from_env()?).await
         }
         CliCommand::Loopback { video: false } => run_loopback().await,
         CliCommand::Listen { accept, video } => run_bot(Mode::Listen { accept, video }).await,
@@ -693,21 +694,14 @@ enum Mode {
 
 /// Drives calls off the typed `Event::IncomingCall` (no raw-node forwarding needed): on an offer it
 /// answers signaling then hands the MEDIA plane to the library facade
-/// (`client.voip().accept(..).audio(..).start()`), on a terminate it hangs the matching call up. The
-/// facade owns the relay socket, the callKey decrypt, the engine, and the task lifetime; this only
-/// supplies the PipeWire mic/speaker and remembers the `CallHandle` so a `<terminate>` can stop it.
+/// (`client.voip().accept(..).audio(..).start()`). The facade owns the relay socket, callKey decrypt,
+/// engine, and termination; this example supplies the mic/speaker and keeps handles for its UI.
 struct CallObserver {
     client: Arc<Client>,
     accept: bool,
     /// `--video`: start/answer calls with video media and auto-accept peer upgrade requests.
     video: bool,
-    /// Whether this run ever starts a media call (auto-accept inbound OR an outbound `call`), so a
-    /// `<terminate>` racing media startup is worth recording. A pure-reject run starts no media, so it
-    /// must NOT record (the set would grow unbounded with nothing to consume it).
-    manages_media: bool,
-    /// Per-call bookkeeping for the example's terminate-driven hangup. The client's own
-    /// `CallRegistry` already tears every call down on disconnect; this is only so a `<terminate>`
-    /// can stop a specific live call (and so a terminate that races media startup isn't lost).
+    /// Per-call UI bookkeeping. The client's `CallRegistry` owns media termination.
     state: Arc<Mutex<CallState>>,
 }
 
@@ -715,9 +709,6 @@ struct CallObserver {
 struct CallState {
     /// Live calls' handles by call-id.
     handles: HashMap<String, Arc<CallHandle>>,
-    /// Call-ids that were terminated BEFORE their media handle finished starting, so a late
-    /// `start_media()` hangs the call up instead of leaving an orphaned live call.
-    terminated: HashSet<String>,
     /// The stdin `v` toggle's view of each call's video: pending peer request vs our video live.
     video_ui: HashMap<String, VideoUi>,
 }
@@ -731,35 +722,23 @@ enum VideoUi {
 }
 
 impl CallObserver {
-    fn new(client: Arc<Client>, accept: bool, video: bool, manages_media: bool) -> Self {
+    fn new(client: Arc<Client>, accept: bool, video: bool) -> Self {
         Self {
             client,
             accept,
             video,
-            manages_media,
             state: Arc::new(Mutex::new(CallState::default())),
         }
     }
 }
 
-/// Register a freshly-started `CallHandle` for terminate-driven hangup. Returns false (and the caller
-/// should hang up) if a `<terminate>` for this call-id already arrived while media was starting. On
-/// success, spawns the wait_ended cleanup that drops the map entry when the call ends on its own.
-/// Shared by the inbound (accept) and outbound (call) paths.
-fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallHandle>) -> bool {
-    let registered = {
-        let mut st = state.lock().unwrap();
-        if st.terminated.remove(&cid) {
-            false
-        } else {
-            st.handles.insert(cid.clone(), handle.clone());
-            true
-        }
-    };
-    if !registered {
-        return false;
-    }
-    // Drop our map entry once the call ends on its own (no terminate).
+/// Register a handle for UI control and remove it when the library-owned call ends.
+fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallHandle>) {
+    state
+        .lock()
+        .unwrap()
+        .handles
+        .insert(cid.clone(), handle.clone());
     let state = state.clone();
     tokio::spawn(async move {
         handle.wait_ended().await;
@@ -773,11 +752,11 @@ fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallH
                 .is_some_and(|h| Arc::ptr_eq(h, &handle))
             {
                 st.handles.remove(&cid);
+                st.video_ui.remove(&cid);
             }
         }
         info!("◾ call {cid} media ended");
     });
-    true
 }
 
 impl EventHandler for CallObserver {
@@ -804,40 +783,16 @@ impl EventHandler for CallObserver {
                             return;
                         }
                         match start_media(&client, &call, video, &state).await {
-                            Ok(handle) => {
-                                // A <terminate> may have arrived while media was starting; if so, hang
-                                // up now instead of registering an orphaned live call.
-                                if !register_handle(&state, cid.clone(), handle.clone()) {
-                                    handle.hangup().await;
-                                    info!("◾ call {cid} terminated during media startup");
-                                }
-                            }
+                            Ok(handle) => register_handle(&state, cid.clone(), handle),
                             Err(e) => warn!("inbound media failed: {e}"),
                         }
                     });
                 }
                 CallAction::Terminate { call_id, .. } => {
-                    info!("◀ terminate for {call_id} — hanging up");
-                    // If the handle is registered, hang it up. If not, the offer is still starting
-                    // media: record the call-id so that path hangs up on completion (no orphan).
-                    let handle = {
-                        let mut st = self.state.lock().unwrap();
-                        match st.handles.remove(call_id) {
-                            Some(h) => Some(h),
-                            // Only track a pre-registration terminate when this run starts media
-                            // (inbound accept OR an outbound call); otherwise there is no call to
-                            // orphan and the set would grow unbounded.
-                            None => {
-                                if self.manages_media {
-                                    st.terminated.insert(call_id.clone());
-                                }
-                                None
-                            }
-                        }
-                    };
-                    if let Some(handle) = handle {
-                        tokio::spawn(async move { handle.hangup().await });
-                    }
+                    info!("◀ peer ended call {call_id}");
+                    let mut st = self.state.lock().unwrap();
+                    st.handles.remove(call_id);
+                    st.video_ui.remove(call_id);
                 }
                 _ => {}
             }
@@ -865,7 +820,7 @@ async fn start_media(
     let voip = client.voip();
     let mut builder = voip.accept(call).audio(mic, speaker.clone());
     if video {
-        let opts = VideoOpts::from_env();
+        let opts = VideoOpts::from_env()?;
         let cid = call.action.call_id();
         builder = builder.video(
             video::spawn_video_source(&opts).await?,
@@ -905,7 +860,7 @@ async fn place_outgoing_call(
     let voip = client.voip();
     let mut builder = voip.call(peer).audio(mic, speaker.clone());
     if video {
-        let opts = VideoOpts::from_env();
+        let opts = VideoOpts::from_env()?;
         builder = builder.video(
             video::spawn_video_source(&opts).await?,
             video::spawn_video_sink(&opts, "outgoing").await?,
@@ -978,14 +933,8 @@ fn spawn_call_event_listener(
                     referenced_ssrcs,
                     reports_audio,
                     reports_video,
-                    protection,
-                    srtcp_index,
-                    encrypted,
-                    plain_len,
-                    sdes_cname_lengths,
                     report_blocks,
                     feedback,
-                    uses_whatsapp_profile_extension,
                 } => {
                     let blocks = report_blocks
                         .iter()
@@ -1024,71 +973,8 @@ fn spawn_call_event_listener(
                         })
                         .collect::<Vec<_>>()
                         .join(",");
-                    info!(
-                        "📊 peer RTCP mode={protection:?} PT={packet_types:?} sender={sender_ssrc:#010x} refs={referenced_ssrcs:x?} reports_audio={reports_audio} reports_video={reports_video} index={srtcp_index:?} encrypted={encrypted} plain_bytes={plain_len} wa_profile={uses_whatsapp_profile_extension} blocks=[{blocks}] feedback=[{feedback}] sdes_cname_lens={sdes_cname_lengths:?}"
-                    );
-                }
-                CallEvent::RtcpRejected {
-                    stage,
-                    packet_type,
-                    sender_ssrc,
-                    packet_len,
-                    first_rtcp_len,
-                    plain_len,
-                    candidate_srtcp_index,
-                    candidate_encrypted,
-                    first_header_byte,
-                    plain_sample,
-                } => {
-                    if let Some(sample) = plain_sample {
-                        warn!(
-                            "📊 peer transport RTCP rejected at {stage:?}: PT={packet_type} sender={sender_ssrc:#010x} bytes={packet_len} plain_bytes={plain_len:?} first_header={first_header_byte:#04x} first_rtcp_bytes={first_rtcp_len} candidate_index={candidate_srtcp_index:?} candidate_encrypted={candidate_encrypted} plain_hex={} ",
-                            hex::encode(sample),
-                        );
-                    } else if stage == wacore::voip::RtcpRejectStage::Authentication {
-                        warn!(
-                            "📊 peer transport RTCP rejected at {stage:?}: PT={packet_type} sender={sender_ssrc:#010x} bytes={packet_len} plain_bytes={plain_len:?} first_header={first_header_byte:#04x} first_rtcp_bytes={first_rtcp_len} candidate_index={candidate_srtcp_index:?} candidate_encrypted={candidate_encrypted}"
-                        );
-                    } else {
-                        debug!(
-                            "peer transport RTCP rejected at {stage:?}: PT={packet_type} sender={sender_ssrc:#010x} bytes={packet_len} plain_bytes={plain_len:?} first_header={first_header_byte:#04x} first_rtcp_bytes={first_rtcp_len} candidate_index={candidate_srtcp_index:?} candidate_encrypted={candidate_encrypted}"
-                        );
-                    }
-                }
-                CallEvent::VideoRtpLayoutObserved {
-                    ssrc,
-                    sequence_number,
-                    timestamp,
-                    marker,
-                    header_len,
-                    packet_len,
-                    extension_profile,
-                    extension_data,
-                } => {
-                    let profile = extension_profile
-                        .map(|value| format!("{value:#06x}"))
-                        .unwrap_or_else(|| "none".to_owned());
-                    info!(
-                        "🎥 peer RTP layout: ssrc={ssrc:#010x} seq={sequence_number} ts={timestamp} marker={marker} header_bytes={header_len} packet_bytes={packet_len} ext_profile={profile} ext_data={} ",
-                        hex::encode(extension_data)
-                    );
-                }
-                CallEvent::VideoRtpLayoutSent {
-                    ssrc,
-                    sequence_number,
-                    timestamp,
-                    marker,
-                    header_len,
-                    packet_len,
-                    extension_profile,
-                    extension_data,
-                } => {
-                    let profile = extension_profile
-                        .map(|value| format!("{value:#06x}"))
-                        .unwrap_or_else(|| "none".to_owned());
-                    info!(
-                        "🎥 local RTP layout: ssrc={ssrc:#010x} seq={sequence_number} ts={timestamp} marker={marker} header_bytes={header_len} packet_bytes={packet_len} ext_profile={profile} ext_data={}",
-                        hex::encode(extension_data)
+                    debug!(
+                        "📊 peer RTCP PT={packet_types:?} sender={sender_ssrc:#010x} refs={referenced_ssrcs:x?} reports_audio={reports_audio} reports_video={reports_video} blocks=[{blocks}] feedback=[{feedback}]"
                     );
                 }
                 CallEvent::OutboundMediaDropped {
@@ -1130,7 +1016,7 @@ fn spawn_call_event_listener(
 
 /// Fresh ffmpeg/ffplay endpoints for a mid-call upgrade/accept on `handle`.
 async fn accept_peer_video(handle: &CallHandle) -> Result<()> {
-    let opts = VideoOpts::from_env();
+    let opts = VideoOpts::from_env()?;
     let src = video::spawn_video_source(&opts).await?;
     let sink = video::spawn_video_sink(&opts, handle.call_id()).await?;
     handle
@@ -1165,16 +1051,8 @@ async fn respond_to_offer(
             .map_err(|e| anyhow!("send reject: {e}"))?;
         return Ok(());
     }
-    // Callee flow: preaccept immediately, then accept (signaling). Relay/media follow once
-    // the live transport orchestration lands.
-    // Codec-steering experiment: VOIP_FORCE_RFC_8K=1 advertises only 8 kHz, trying to push the
-    // caller off Meta's 16 kHz mlow onto plain RFC Opus NB (which our stock libopus can decode).
-    // Default keeps 16 kHz (mlow, garbled inbound until a real mlow decoder lands).
-    let force_rfc_8k = std::env::var_os("VOIP_FORCE_RFC_8K").is_some();
-    let audio_rates: &[&str] = if force_rfc_8k { &["8000"] } else { &["16000"] };
-    if force_rfc_8k {
-        info!("🧪 VOIP_FORCE_RFC_8K set — advertising only <audio rate=8000> to dodge mlow");
-    }
+    // Callee flow: preaccept immediately, then accept (signaling).
+    let audio_rates = &["16000"];
     let pre_id = hex::encode(rand::random::<[u8; 8]>());
     client
         .send_node(stanza::build_preaccept(
@@ -1274,7 +1152,7 @@ fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
                     None => {
                         info!("🎥 requesting video upgrade");
                         let started = async {
-                            let opts = VideoOpts::from_env();
+                            let opts = VideoOpts::from_env()?;
                             let src = video::spawn_video_source(&opts).await?;
                             let sink = video::spawn_video_sink(&opts, &cid).await?;
                             handle
@@ -1336,18 +1214,12 @@ async fn run_bot(mode: Mode) -> Result<()> {
     // The structured `Event::IncomingCall` (which now carries the offer's <enc>/<relay>) drives the
     // accept flow, so the raw-node-forwarding crutch the old hand-rolled inbound path needed is gone.
     let manages_media = accept || target.is_some();
-    let observer = Arc::new(CallObserver::new(
-        client.clone(),
-        accept,
-        video,
-        manages_media,
-    ));
+    let observer = Arc::new(CallObserver::new(client.clone(), accept, video));
     client.register_handler(observer.clone());
 
     if let Some(peer) = target {
         let client2 = client.clone();
-        // Share the observer's call state so a peer `<terminate>` for our outgoing call can hang it up
-        // (the same bookkeeping the inbound path uses).
+        // Share UI state with the inbound path.
         let state = observer.state.clone();
         tokio::spawn(async move {
             // Wait until the socket is up before placing the call; if it never connects, don't dial.
@@ -1361,10 +1233,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
             match place_outgoing_call(&client2, &peer, video, &state).await {
                 Ok(handle) => {
                     let cid = handle.call_id().to_string();
-                    if !register_handle(&state, cid.clone(), handle.clone()) {
-                        handle.hangup().await;
-                        info!("◾ call {cid} terminated during startup");
-                    }
+                    register_handle(&state, cid, handle);
                 }
                 Err(e) => error!("call failed: {e}"),
             }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -28,7 +28,7 @@
 //! socket, the sans-IO engine, and the task lifetime. This example only supplies the cpal audio
 //! device / ffmpeg pipes and reacts to engine events.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -709,8 +709,13 @@ struct CallObserver {
 struct CallState {
     /// Live calls' handles by call-id.
     handles: HashMap<String, Arc<CallHandle>>,
+    /// Registration order; the last live entry is the stdin UI target.
+    call_order: Vec<String>,
     /// The stdin `v` toggle's view of each call's video: pending peer request vs our video live.
     video_ui: HashMap<String, VideoUi>,
+    starting: HashSet<String>,
+    /// Prevents a late startup from resurrecting media after the peer ended the call.
+    terminated_during_startup: HashSet<String>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -732,13 +737,46 @@ impl CallObserver {
     }
 }
 
+fn begin_call_startup(state: &Arc<Mutex<CallState>>, call_id: &str) {
+    let mut st = state.lock().unwrap();
+    st.starting.insert(call_id.to_string());
+    st.terminated_during_startup.remove(call_id);
+}
+
+fn complete_call_startup(state: &Arc<Mutex<CallState>>, call_id: &str) -> bool {
+    let mut st = state.lock().unwrap();
+    st.starting.remove(call_id);
+    st.terminated_during_startup.remove(call_id)
+}
+
+fn record_peer_terminate(state: &Arc<Mutex<CallState>>, call_id: &str) {
+    let mut st = state.lock().unwrap();
+    if st.starting.contains(call_id) {
+        st.terminated_during_startup.insert(call_id.to_string());
+    }
+    st.handles.remove(call_id);
+    st.video_ui.remove(call_id);
+    st.call_order.retain(|id| id != call_id);
+}
+
+fn mark_call_most_recent(order: &mut Vec<String>, call_id: &str) {
+    order.retain(|id| id != call_id);
+    order.push(call_id.to_string());
+}
+
 /// Register a handle for UI control and remove it when the library-owned call ends.
-fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallHandle>) {
-    state
-        .lock()
-        .unwrap()
-        .handles
-        .insert(cid.clone(), handle.clone());
+async fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallHandle>) {
+    if complete_call_startup(state, &cid) {
+        // The library also sees the terminate, but this closes a handle created after that teardown.
+        handle.hangup().await;
+        info!("◾ discarded media startup for already-ended call {cid}");
+        return;
+    }
+    {
+        let mut st = state.lock().unwrap();
+        st.handles.insert(cid.clone(), handle.clone());
+        mark_call_most_recent(&mut st.call_order, &cid);
+    }
     let state = state.clone();
     tokio::spawn(async move {
         handle.wait_ended().await;
@@ -753,6 +791,7 @@ fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallH
             {
                 st.handles.remove(&cid);
                 st.video_ui.remove(&cid);
+                st.call_order.retain(|id| id != &cid);
             }
         }
         info!("◾ call {cid} media ended");
@@ -774,25 +813,29 @@ impl EventHandler for CallObserver {
                     let video = self.video && *is_video;
                     let state = self.state.clone();
                     let cid = call_id.clone();
+                    begin_call_startup(&state, &cid);
                     tokio::spawn(async move {
                         if let Err(e) = respond_to_offer(&client, &call, accept, video).await {
                             error!("call signaling failed: {e}");
+                            complete_call_startup(&state, &cid);
                             return;
                         }
                         if !accept {
+                            complete_call_startup(&state, &cid);
                             return;
                         }
                         match start_media(&client, &call, video, &state).await {
-                            Ok(handle) => register_handle(&state, cid.clone(), handle),
-                            Err(e) => warn!("inbound media failed: {e}"),
+                            Ok(handle) => register_handle(&state, cid.clone(), handle).await,
+                            Err(e) => {
+                                complete_call_startup(&state, &cid);
+                                warn!("inbound media failed: {e}");
+                            }
                         }
                     });
                 }
                 CallAction::Terminate { call_id, .. } => {
                     info!("◀ peer ended call {call_id}");
-                    let mut st = self.state.lock().unwrap();
-                    st.handles.remove(call_id);
-                    st.video_ui.remove(call_id);
+                    record_peer_terminate(&self.state, call_id);
                 }
                 _ => {}
             }
@@ -909,6 +952,7 @@ fn spawn_call_event_listener(
     let events = handle.events();
     tokio::spawn(async move {
         let mut opus = WaOpusDecoder::new().ok();
+        let mut peer_video_receiver_confirmed = false;
         while let Ok(ev) = events.recv().await {
             match ev {
                 CallEvent::RelayAllocated => {
@@ -936,6 +980,9 @@ fn spawn_call_event_listener(
                     report_blocks,
                     feedback,
                 } => {
+                    let requests_keyframe = feedback
+                        .iter()
+                        .any(|item| item.packet_type == 206 && matches!(item.fmt, 1 | 4));
                     let blocks = report_blocks
                         .iter()
                         .map(|report| {
@@ -973,6 +1020,15 @@ fn spawn_call_event_listener(
                         })
                         .collect::<Vec<_>>()
                         .join(",");
+                    if reports_video && !peer_video_receiver_confirmed {
+                        info!(
+                            "🎥 peer RTCP confirms receipt of our outbound video stream: blocks=[{blocks}] feedback=[{feedback}]"
+                        );
+                        peer_video_receiver_confirmed = true;
+                    }
+                    if requests_keyframe {
+                        info!("🎥 peer requests an outbound keyframe: [{feedback}]");
+                    }
                     debug!(
                         "📊 peer RTCP PT={packet_types:?} sender={sender_ssrc:#010x} refs={referenced_ssrcs:x?} reports_audio={reports_audio} reports_video={reports_video} blocks=[{blocks}] feedback=[{feedback}]"
                     );
@@ -1122,10 +1178,11 @@ fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
             // The most recent live call is the toggle's target (this demo runs one call at a time).
             let picked = {
                 let st = state.lock().unwrap();
-                st.handles
-                    .iter()
-                    .next()
-                    .map(|(cid, h)| (cid.clone(), h.clone(), st.video_ui.get(cid).copied()))
+                st.call_order.iter().rev().find_map(|cid| {
+                    st.handles
+                        .get(cid)
+                        .map(|h| (cid.clone(), h.clone(), st.video_ui.get(cid).copied()))
+                })
             };
             let Some((cid, handle, ui)) = picked else {
                 info!("⌨  no live call");
@@ -1233,7 +1290,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
             match place_outgoing_call(&client2, &peer, video, &state).await {
                 Ok(handle) => {
                     let cid = handle.call_id().to_string();
-                    register_handle(&state, cid, handle);
+                    register_handle(&state, cid, handle).await;
                 }
                 Err(e) => error!("call failed: {e}"),
             }
@@ -1260,7 +1317,12 @@ async fn run_bot(mode: Mode) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CliCommand, parse_cli, video_source_is_ignored};
+    use std::sync::{Arc, Mutex};
+
+    use super::{
+        CallState, CliCommand, begin_call_startup, complete_call_startup, mark_call_most_recent,
+        parse_cli, record_peer_terminate, video_source_is_ignored,
+    };
 
     fn argv(parts: &[&str]) -> Vec<String> {
         std::iter::once("voip")
@@ -1347,5 +1409,26 @@ mod tests {
         assert!(!video_source_is_ignored(&audio_only, false));
         assert!(!video_source_is_ignored(&video, true));
         assert!(!video_source_is_ignored(&CliCommand::Usage, true));
+    }
+
+    #[test]
+    fn peer_terminate_tombstones_in_progress_media_startup() {
+        let state = Arc::new(Mutex::new(CallState::default()));
+        begin_call_startup(&state, "CALL-ID-STARTING");
+        record_peer_terminate(&state, "CALL-ID-STARTING");
+        assert!(complete_call_startup(&state, "CALL-ID-STARTING"));
+
+        let st = state.lock().unwrap();
+        assert!(st.starting.is_empty());
+        assert!(st.terminated_during_startup.is_empty());
+    }
+
+    #[test]
+    fn stdin_ui_order_tracks_the_most_recent_call() {
+        let mut order = Vec::new();
+        mark_call_most_recent(&mut order, "CALL-A");
+        mark_call_most_recent(&mut order, "CALL-B");
+        mark_call_most_recent(&mut order, "CALL-A");
+        assert_eq!(order, ["CALL-B", "CALL-A"]);
     }
 }

--- a/examples/voip-cli/src/video.rs
+++ b/examples/voip-cli/src/video.rs
@@ -1,0 +1,456 @@
+//! Cross-platform video source/sink for the demo, with ffmpeg/ffplay as external codec
+//! subprocesses (no native video deps in the Rust closure — the library only transports
+//! pre-encoded H.264 Annex-B access units).
+//!
+//!   source: webcam (per-OS ffmpeg input) | any file/URL | `testsrc2` synthetic pattern
+//!           -> libx264 (baseline, 640x480@15, ~500kbps, AUD-delimited) -> stdout pipe
+//!           -> `AnnexBAuSplitter` -> one AU per channel item
+//!   sink:   received AUs -> ffplay window (low-latency flags) | raw `.h264` file | discard
+//!
+//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | webcam device override
+//! (absent = default webcam); `WA_VIDEO_SINK` = `window` (default) | `file` | `none`.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use log::{info, warn};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, Command};
+use wacore::voip::h264::{AnnexBAuSplitter, au_has_idr};
+use whatsapp_rust::voip::VideoFrame;
+
+/// Reference encode parameters (H.264 Constrained Baseline, WebCodecs `avc1.42E01F` equivalent).
+const VIDEO_SIZE: &str = "640x480";
+const VIDEO_FPS: u32 = 15;
+const VIDEO_BITRATE: &str = "500k";
+/// Keyframe cadence in frames (2 s at 15 fps): the recovery bound after any dropped AU.
+const GOP_FRAMES: u32 = 30;
+/// Outbound AU backlog before the keyframe-aware dropper kicks in (~2 s of video).
+const SOURCE_CHANNEL_CAP: usize = 30;
+/// stdout pipe read granularity.
+const READ_CHUNK: usize = 32 * 1024;
+/// A sink write slower than this sheds frames instead of stalling the call's forwarder.
+const SINK_WRITE_TIMEOUT: Duration = Duration::from_millis(200);
+
+pub struct VideoOpts {
+    pub input: VideoInput,
+    pub sink: VideoSinkMode,
+}
+
+pub enum VideoInput {
+    /// OS default webcam, or an override device (path on Linux, index/name on macOS/Windows).
+    Webcam(Option<String>),
+    /// Any file or URL ffmpeg can open; looped and rate-limited to realtime.
+    Media(String),
+    /// `lavfi testsrc2` synthetic pattern — no camera needed (CI / second instance).
+    TestSrc,
+}
+
+pub enum VideoSinkMode {
+    /// ffplay window (falls back to `File` when ffplay is missing).
+    Window,
+    /// Raw `.h264` capture, replayable with `ffplay -f h264 <file>`.
+    File,
+    /// Count and discard.
+    None,
+}
+
+impl VideoOpts {
+    pub fn from_env() -> Self {
+        let input = match std::env::var("WA_VIDEO_INPUT") {
+            Ok(v) if v == "testsrc" => VideoInput::TestSrc,
+            // A `/dev/*` node is a webcam override (v4l2 on Linux), NOT a media file — it exists on
+            // disk but must not be opened with `-stream_loop`.
+            Ok(v) if v.starts_with("/dev/") => VideoInput::Webcam(Some(v)),
+            Ok(v) if std::path::Path::new(&v).exists() || v.contains("://") => VideoInput::Media(v),
+            Ok(v) => VideoInput::Webcam(Some(v)),
+            Err(_) => VideoInput::Webcam(None),
+        };
+        let sink = match std::env::var("WA_VIDEO_SINK").as_deref() {
+            Ok("file") => VideoSinkMode::File,
+            Ok("none") => VideoSinkMode::None,
+            _ => VideoSinkMode::Window,
+        };
+        Self { input, sink }
+    }
+}
+
+/// Fail fast with an actionable message when a required tool is not on PATH. Async so the
+/// spawn+wait probe doesn't block a runtime thread (it runs from call-setup and event-task paths).
+async fn ensure_tool(tool: &str) -> Result<()> {
+    match Command::new(tool)
+        .arg("-version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => bail!(
+            "`{tool}` not found on PATH — install ffmpeg (pacman -S ffmpeg | apt install ffmpeg | \
+             brew install ffmpeg | winget install Gyan.FFmpeg) or run without --video"
+        ),
+        Err(e) => Err(e).context(format!("probing `{tool}`")),
+    }
+}
+
+/// The per-input head of the ffmpeg command line.
+fn input_args(input: &VideoInput) -> Result<Vec<String>> {
+    let s = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    let fps = VIDEO_FPS.to_string();
+    Ok(match input {
+        // `-re` paces the synthetic source at realtime; unthrottled, lavfi encodes as fast as the
+        // CPU allows and floods the call's bounded channel with dropped GOPs.
+        VideoInput::TestSrc => s(&[
+            "-re",
+            "-f",
+            "lavfi",
+            "-i",
+            &format!("testsrc2=size={VIDEO_SIZE}:rate={VIDEO_FPS}"),
+        ]),
+        VideoInput::Media(path) => {
+            let mut v = s(&["-re", "-stream_loop", "-1", "-i", path]);
+            // Normalize any input to the call's fixed geometry/rate.
+            v.extend(s(&[
+                "-vf",
+                &format!(
+                    "scale={W}:{H}:force_original_aspect_ratio=decrease,\
+                     pad={W}:{H}:(ow-iw)/2:(oh-ih)/2,fps={VIDEO_FPS}",
+                    W = 640,
+                    H = 480
+                ),
+            ]));
+            v
+        }
+        VideoInput::Webcam(dev) => {
+            if cfg!(target_os = "linux") {
+                let dev = dev.clone().unwrap_or_else(|| "/dev/video0".into());
+                s(&[
+                    "-f",
+                    "v4l2",
+                    "-framerate",
+                    &fps,
+                    "-video_size",
+                    VIDEO_SIZE,
+                    "-i",
+                    &dev,
+                ])
+            } else if cfg!(target_os = "macos") {
+                let dev = dev.clone().unwrap_or_else(|| "0".into());
+                s(&[
+                    "-f",
+                    "avfoundation",
+                    "-framerate",
+                    &fps,
+                    "-video_size",
+                    VIDEO_SIZE,
+                    "-i",
+                    &dev,
+                ])
+            } else if cfg!(target_os = "windows") {
+                let Some(dev) = dev else {
+                    bail!(
+                        "no default webcam name on Windows — list devices with `ffmpeg \
+                         -list_devices true -f dshow -i dummy` and set WA_VIDEO_INPUT=<name>"
+                    );
+                };
+                s(&[
+                    "-f",
+                    "dshow",
+                    "-rtbufsize",
+                    "64M",
+                    "-framerate",
+                    &fps,
+                    "-video_size",
+                    VIDEO_SIZE,
+                    "-i",
+                    &format!("video={dev}"),
+                ])
+            } else {
+                bail!("no webcam input mapping for this OS — use WA_VIDEO_INPUT=testsrc or a file");
+            }
+        }
+    })
+}
+
+fn spawn_ffmpeg_encoder(input: &VideoInput) -> Result<Child> {
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args(["-hide_banner", "-loglevel", "error"]);
+    cmd.args(input_args(input)?);
+    // repeat-headers=1: SPS/PPS ride every IDR, so a peer joining mid-stream (upgrade) or
+    // recovering from a drop can always re-sync. aud=insert: the AU delimiter the splitter cuts on.
+    cmd.args([
+        "-c:v",
+        "libx264",
+        "-profile:v",
+        "baseline",
+        "-level",
+        "3.1",
+        "-pix_fmt",
+        "yuv420p",
+        "-preset",
+        "ultrafast",
+        "-tune",
+        "zerolatency",
+        "-g",
+        &GOP_FRAMES.to_string(),
+        "-keyint_min",
+        &GOP_FRAMES.to_string(),
+        "-sc_threshold",
+        "0",
+        "-b:v",
+        VIDEO_BITRATE,
+        "-maxrate",
+        VIDEO_BITRATE,
+        "-bufsize",
+        "250k",
+        "-x264-params",
+        "repeat-headers=1",
+        "-bsf:v",
+        "h264_metadata=aud=insert",
+        "-an",
+        "-f",
+        "h264",
+        "pipe:1",
+    ]);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        // stderr inherited: encoder errors (missing camera, busy device) reach the user directly.
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true);
+    cmd.spawn().context("spawn ffmpeg")
+}
+
+/// Spawn the ffmpeg encoder and return the channel of complete H.264 AUs. The receiver plugs
+/// straight into the library (`VideoSource` blanket impl on `Receiver<Vec<u8>>`).
+pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Receiver<Vec<u8>>> {
+    ensure_tool("ffmpeg").await?;
+    let mut child = spawn_ffmpeg_encoder(&opts.input)?;
+    let mut stdout = child.stdout.take().context("ffmpeg stdout")?;
+    let (tx, rx) = async_channel::bounded::<Vec<u8>>(SOURCE_CHANNEL_CAP);
+
+    tokio::spawn(async move {
+        // Owning the child keeps kill_on_drop armed for the whole read loop.
+        let _child = &mut child;
+        let mut splitter = AnnexBAuSplitter::default();
+        let mut buf = vec![0u8; READ_CHUNK];
+        let mut aus: Vec<Vec<u8>> = Vec::new();
+        // When the channel backs up we drop AUs — but only from a keyframe boundary, because an
+        // arbitrary dropped AU corrupts the peer's decode until the next IDR anyway. Dropping
+        // *deliberately until* the next IDR turns backpressure into one clean skip.
+        let mut dropping = false;
+        let (mut made, mut dropped) = (0u64, 0u64);
+        loop {
+            match stdout.read(&mut buf).await {
+                Ok(0) => break, // encoder EOF (camera unplugged, file without loop)
+                Ok(n) => {
+                    splitter.push(&buf[..n], &mut aus);
+                    for au in aus.drain(..) {
+                        made += 1;
+                        if dropping {
+                            // Resume only on an IDR (a self-contained restart): resuming on a
+                            // parameter-set-only AU would forward dependent frames the peer can't
+                            // decode until the real keyframe.
+                            if !au_has_idr(&au) {
+                                dropped += 1;
+                                continue;
+                            }
+                            dropping = false;
+                        }
+                        match tx.try_send(au) {
+                            Ok(()) => {}
+                            Err(async_channel::TrySendError::Full(_)) => {
+                                dropped += 1;
+                                dropping = true;
+                            }
+                            // Call ended: stop the encoder.
+                            Err(async_channel::TrySendError::Closed(_)) => return,
+                        }
+                    }
+                    if made.is_multiple_of(300) && dropped > 0 {
+                        info!("🎥 video source: {made} AUs, {dropped} dropped (backpressure)");
+                    }
+                }
+                Err(e) => {
+                    warn!("🎥 video source read failed: {e}");
+                    break;
+                }
+            }
+        }
+        if let Some(last) = splitter.finish() {
+            let _ = tx.try_send(last);
+        }
+        // The call survives a dead source (audio keeps running), same as a muted mic.
+        warn!("🎥 video source ended ({made} AUs, {dropped} dropped)");
+    });
+    Ok(rx)
+}
+
+fn spawn_ffplay(tag: &str) -> Result<Child> {
+    let mut cmd = Command::new("ffplay");
+    cmd.args([
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-fflags",
+        "nobuffer",
+        "-flags",
+        "low_delay",
+        "-probesize",
+        "32",
+        "-analyzeduration",
+        "0",
+        "-framedrop",
+        "-window_title",
+        &format!("WA Video {tag}"),
+        "-f",
+        "h264",
+        "-i",
+        "pipe:0",
+    ]);
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true);
+    cmd.spawn().context("spawn ffplay")
+}
+
+/// Where the sink writer is currently sending frames.
+enum SinkTarget {
+    Window(Child),
+    File(tokio::fs::File, String),
+    None,
+}
+
+/// Spawn the display/record sink and return the channel the library pushes received frames into
+/// (`VideoSink` blanket impl on `Sender<VideoFrame>`). Lazy: the window/file only appears when the
+/// first frame arrives, so a call that never activates video opens nothing.
+pub async fn spawn_video_sink(
+    opts: &VideoOpts,
+    tag: &str,
+) -> Result<async_channel::Sender<VideoFrame>> {
+    let want_window = matches!(opts.sink, VideoSinkMode::Window);
+    let want_file = matches!(opts.sink, VideoSinkMode::File);
+    let use_window = want_window && ensure_tool("ffplay").await.is_ok();
+    if want_window && !use_window {
+        warn!("ffplay not found — recording received video to a .h264 file instead");
+    }
+    let (tx, rx) = async_channel::bounded::<VideoFrame>(SOURCE_CHANNEL_CAP);
+    let tag = tag.to_string();
+
+    tokio::spawn(async move {
+        let mut target: Option<SinkTarget> = None;
+        let mut dropping = false;
+        let mut last_orientation = 0u8;
+        while let Ok(frame) = rx.recv().await {
+            if frame.orientation != last_orientation {
+                last_orientation = frame.orientation;
+                // ffplay can't rotate a live pipe; surface it so the user can tilt their head :)
+                info!(
+                    "🎥 peer rotated its camera: {}°",
+                    frame.orientation as u32 * 90
+                );
+            }
+            // Lazy-open on the first frame.
+            if target.is_none() {
+                target = Some(if use_window {
+                    match spawn_ffplay(&tag) {
+                        Ok(child) => SinkTarget::Window(child),
+                        Err(e) => {
+                            warn!("🎥 ffplay spawn failed ({e}); discarding video");
+                            SinkTarget::None
+                        }
+                    }
+                } else if want_file || want_window {
+                    let path = format!("wa-video-{tag}.h264");
+                    match tokio::fs::File::create(&path).await {
+                        Ok(f) => {
+                            info!(
+                                "🎥 recording received video to {path} (replay: ffplay -f h264 {path})"
+                            );
+                            SinkTarget::File(f, path)
+                        }
+                        Err(e) => {
+                            warn!("🎥 cannot create {path} ({e}); discarding video");
+                            SinkTarget::None
+                        }
+                    }
+                } else {
+                    SinkTarget::None
+                });
+            }
+            // Recover from a skip only on an IDR (a self-contained restart): a mid-GOP resume, or
+            // one on a parameter-set-only AU, shows garbage until the real keyframe.
+            if dropping {
+                if !au_has_idr(&frame.data) {
+                    continue;
+                }
+                dropping = false;
+            }
+            match target.as_mut() {
+                Some(SinkTarget::Window(child)) => {
+                    let Some(stdin) = child.stdin.as_mut() else {
+                        continue;
+                    };
+                    match tokio::time::timeout(SINK_WRITE_TIMEOUT, stdin.write_all(&frame.data))
+                        .await
+                    {
+                        Ok(Ok(())) => {}
+                        // Slow consumer: shed until the next keyframe instead of stalling.
+                        Err(_) => dropping = true,
+                        // Window closed / player died: degrade to discard, keep the call alive.
+                        Ok(Err(e)) => {
+                            warn!("🎥 ffplay pipe failed ({e}); discarding further video");
+                            target = Some(SinkTarget::None);
+                        }
+                    }
+                }
+                Some(SinkTarget::File(f, path)) => {
+                    if let Err(e) = f.write_all(&frame.data).await {
+                        warn!("🎥 write to {path} failed ({e}); discarding further video");
+                        target = Some(SinkTarget::None);
+                    }
+                }
+                Some(SinkTarget::None) | None => {}
+            }
+        }
+        // Channel closed (call ended): dropping `target` kills ffplay via kill_on_drop.
+    });
+    Ok(tx)
+}
+
+/// Local smoke test: ffmpeg source -> AU channel -> sink (ffplay window). Exercises the whole
+/// external-codec plumbing without any WhatsApp connection.
+///
+/// Handles Ctrl+C itself and returns cleanly: without it, the default SIGINT terminates the process
+/// abruptly, so the ffmpeg/ffplay `Child`s never drop and their `kill_on_drop` never fires — the
+/// subprocesses are orphaned and keep spamming broken-pipe errors. Returning from here drops `src`
+/// and `sink`, which ends their reader/writer tasks and kills the subprocesses on drop.
+pub async fn run_video_loopback(opts: &VideoOpts) -> Result<()> {
+    let src = spawn_video_source(opts).await?;
+    let sink = spawn_video_sink(opts, "loopback").await?;
+    info!("🎥 video loopback running — Ctrl+C to stop");
+    let mut n = 0u64;
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                info!("🎥 stopping video loopback (Ctrl+C)");
+                return Ok(());
+            }
+            au = src.recv() => {
+                let Ok(au) = au else {
+                    return Err(anyhow!("video source ended"));
+                };
+                let frame = VideoFrame::new(au);
+                if sink.send(frame).await.is_err() {
+                    return Err(anyhow!("video sink closed"));
+                }
+                n += 1;
+                if n.is_multiple_of(150) {
+                    info!("🎥 {n} AUs piped through the video plumbing ({}s)", n / 15);
+                }
+            }
+        }
+    }
+}

--- a/examples/voip-cli/src/video.rs
+++ b/examples/voip-cli/src/video.rs
@@ -193,14 +193,20 @@ pub enum VideoSinkMode {
 }
 
 impl VideoOpts {
-    pub fn from_env() -> Result<Self> {
+    pub async fn from_env() -> Result<Self> {
         let input = match std::env::var("WA_VIDEO_INPUT") {
             Ok(v) if v == "testsrc" => VideoInput::TestSrc,
             // A `/dev/*` node is a webcam override (v4l2 on Linux), NOT a media file — it exists on
             // disk but must not be opened with `-stream_loop`.
             Ok(v) if v.starts_with("/dev/") => VideoInput::Webcam(Some(v)),
-            Ok(v) if std::path::Path::new(&v).exists() || v.contains("://") => VideoInput::Media(v),
-            Ok(v) => VideoInput::Webcam(Some(v)),
+            Ok(v) if v.contains("://") => VideoInput::Media(v),
+            Ok(v) => {
+                if tokio::fs::try_exists(&v).await.unwrap_or(false) {
+                    VideoInput::Media(v)
+                } else {
+                    VideoInput::Webcam(Some(v))
+                }
+            }
             Err(_) => VideoInput::Webcam(None),
         };
         let sink = match std::env::var("WA_VIDEO_SINK").as_deref() {
@@ -516,6 +522,13 @@ fn spawn_ffmpeg_encoder(
 pub struct FfmpegVideoSource {
     frames: async_channel::Receiver<Vec<u8>>,
     timestamp_stride: u32,
+    task: tokio::task::AbortHandle,
+}
+
+impl Drop for FfmpegVideoSource {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
 }
 
 #[derive(Default)]
@@ -574,7 +587,7 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
     let (tx, rx) = async_channel::bounded::<Vec<u8>>(SOURCE_CHANNEL_CAP);
     let (ready_tx, ready_rx) = async_channel::bounded::<std::result::Result<(), String>>(1);
 
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         // Owning the child keeps kill_on_drop armed for the whole read loop.
         let _child = &mut child;
         let mut splitter = AnnexBAuSplitter::default();
@@ -682,20 +695,25 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
         // The call survives a dead source (audio keeps running), same as a muted mic.
         warn!("🎥 video source ended ({made} AUs, {dropped} dropped)");
     });
-    match tokio::time::timeout(SOURCE_READY_TIMEOUT, ready_rx.recv()).await {
-        Ok(Ok(Ok(()))) => {}
-        Ok(Ok(Err(reason))) => return Err(anyhow!("video source failed before ready: {reason}")),
-        Ok(Err(_)) => return Err(anyhow!("video source ended before its first IDR")),
-        Err(_) => {
-            return Err(anyhow!(
-                "video source produced no IDR within {}s",
-                SOURCE_READY_TIMEOUT.as_secs()
-            ));
-        }
+    let readiness = match tokio::time::timeout(SOURCE_READY_TIMEOUT, ready_rx.recv()).await {
+        Ok(Ok(Ok(()))) => Ok(()),
+        Ok(Ok(Err(reason))) => Err(anyhow!("video source failed before ready: {reason}")),
+        Ok(Err(_)) => Err(anyhow!("video source ended before its first IDR")),
+        Err(_) => Err(anyhow!(
+            "video source produced no IDR within {}s",
+            SOURCE_READY_TIMEOUT.as_secs()
+        )),
+    };
+    if let Err(error) = readiness {
+        task.abort();
+        let _ = task.await;
+        return Err(error);
     }
+    let task = task.abort_handle();
     Ok(FfmpegVideoSource {
         frames: rx,
         timestamp_stride: opts.quality.timestamp_stride(),
+        task,
     })
 }
 

--- a/examples/voip-cli/src/video.rs
+++ b/examples/voip-cli/src/video.rs
@@ -17,10 +17,42 @@ use anyhow::{Context, Result, anyhow, bail};
 use log::{info, warn};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
-use wacore::voip::h264::{AnnexBAuSplitter, au_has_idr};
+use wacore::voip::h264::{AnnexBAuSplitter, au_has_idr, nal_unit_type, split_annexb};
 use whatsapp_rust::voip::VideoFrame;
 
-/// Reference encode parameters (H.264 Constrained Baseline, WebCodecs `avc1.42E01F` equivalent).
+/// The NAL-unit type of each NAL in an Annex-B access unit (5=IDR, 7=SPS, 8=PPS, 1=non-IDR, ...),
+/// for diagnostics comparing our outbound AUs against the decodable inbound ones.
+fn au_nal_types(au: &[u8]) -> Vec<u8> {
+    split_annexb(au).map(nal_unit_type).collect()
+}
+
+fn whatsapp_wire_nal_types(au: &[u8]) -> Vec<u8> {
+    au_nal_types(au)
+        .into_iter()
+        .filter(|nal_type| *nal_type != 9)
+        .collect()
+}
+
+fn parameter_set_summary(au: &[u8]) -> Option<String> {
+    let mut sps = None;
+    let mut pps = None;
+    for nal in split_annexb(au) {
+        match nal_unit_type(nal) {
+            7 => sps.get_or_insert(nal),
+            8 => pps.get_or_insert(nal),
+            _ => continue,
+        };
+    }
+    let sps = sps?;
+    let codec = sps.get(1..4).map(hex::encode).unwrap_or_default();
+    Some(format!(
+        "codec=avc1.{codec} SPS={} PPS={}",
+        hex::encode(sps),
+        pps.map(hex::encode).unwrap_or_default(),
+    ))
+}
+
+/// Reference encode parameters (H.264 Constrained Baseline, Level 3.1).
 const VIDEO_SIZE: &str = "640x480";
 const VIDEO_FPS: u32 = 15;
 const VIDEO_BITRATE: &str = "500k";
@@ -240,7 +272,8 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
         // arbitrary dropped AU corrupts the peer's decode until the next IDR anyway. Dropping
         // *deliberately until* the next IDR turns backpressure into one clean skip.
         let mut dropping = false;
-        let (mut made, mut dropped) = (0u64, 0u64);
+        let (mut made, mut dropped, mut sent) = (0u64, 0u64, 0u64);
+        let mut logged_parameter_sets = false;
         loop {
             match stdout.read(&mut buf).await {
                 Ok(0) => break, // encoder EOF (camera unplugged, file without loop)
@@ -248,6 +281,15 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
                     splitter.push(&buf[..n], &mut aus);
                     for au in aus.drain(..) {
                         made += 1;
+                        if !logged_parameter_sets && let Some(summary) = parameter_set_summary(&au)
+                        {
+                            info!(
+                                "🎥 OUT H.264: {summary} encoder_nals={:?} wire_nals={:?}",
+                                au_nal_types(&au),
+                                whatsapp_wire_nal_types(&au),
+                            );
+                            logged_parameter_sets = true;
+                        }
                         if dropping {
                             // Resume only on an IDR (a self-contained restart): resuming on a
                             // parameter-set-only AU would forward dependent frames the peer can't
@@ -258,8 +300,18 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
                             }
                             dropping = false;
                         }
+                        // Periodic outbound telemetry so a live test shows whether we're actually
+                        // producing (and sending) video AUs, and whether they carry IDR keyframes.
+                        if sent.is_multiple_of(30) {
+                            info!(
+                                "🎥 OUT video: {sent} AUs queued ({dropped} source-dropped) | {}B, NALs {:?}, keyframe={}",
+                                au.len(),
+                                au_nal_types(&au),
+                                au_has_idr(&au)
+                            );
+                        }
                         match tx.try_send(au) {
-                            Ok(()) => {}
+                            Ok(()) => sent += 1,
                             Err(async_channel::TrySendError::Full(_)) => {
                                 dropped += 1;
                                 dropping = true;
@@ -267,9 +319,6 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
                             // Call ended: stop the encoder.
                             Err(async_channel::TrySendError::Closed(_)) => return,
                         }
-                    }
-                    if made.is_multiple_of(300) && dropped > 0 {
-                        info!("🎥 video source: {made} AUs, {dropped} dropped (backpressure)");
                     }
                 }
                 Err(e) => {
@@ -343,7 +392,27 @@ pub async fn spawn_video_sink(
         let mut target: Option<SinkTarget> = None;
         let mut dropping = false;
         let mut last_orientation = 0u8;
+        let mut recv = 0u64;
+        let mut logged_parameter_sets = false;
         while let Ok(frame) = rx.recv().await {
+            if !logged_parameter_sets && let Some(summary) = parameter_set_summary(&frame.data) {
+                info!(
+                    "🎥 IN  H.264: {summary} nals={:?}",
+                    au_nal_types(&frame.data),
+                );
+                logged_parameter_sets = true;
+            }
+            // Inbound telemetry: the peer's AUs DO decode (ffplay shows them), so their shape is the
+            // reference to compare our outbound AUs against.
+            if recv.is_multiple_of(30) {
+                info!(
+                    "🎥 IN  video: {recv} AUs recv | {}B, NALs {:?}, keyframe={}",
+                    frame.data.len(),
+                    au_nal_types(&frame.data),
+                    au_has_idr(&frame.data)
+                );
+            }
+            recv += 1;
             if frame.orientation != last_orientation {
                 last_orientation = frame.orientation;
                 // ffplay can't rotate a live pipe; surface it so the user can tilt their head :)
@@ -452,5 +521,28 @@ pub async fn run_video_loopback(opts: &VideoOpts) -> Result<()> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_nal_diagnostics_match_whatsapp_aud_filter() {
+        let au = [
+            &[0, 0, 0, 1, 0x69, 0xf0][..],
+            &[0, 0, 0, 1, 0x67, 0x42, 0xc0, 0x1f][..],
+            &[0, 0, 0, 1, 0x68, 0xce, 0x06, 0xe2][..],
+            &[0, 0, 0, 1, 0x65, 1, 2, 3][..],
+        ]
+        .concat();
+
+        assert_eq!(au_nal_types(&au), [9, 7, 8, 5]);
+        assert_eq!(whatsapp_wire_nal_types(&au), [7, 8, 5]);
+        assert_eq!(
+            parameter_set_summary(&au).as_deref(),
+            Some("codec=avc1.42c01f SPS=6742c01f PPS=68ce06e2")
+        );
     }
 }

--- a/examples/voip-cli/src/video.rs
+++ b/examples/voip-cli/src/video.rs
@@ -7,7 +7,7 @@
 //!           -> `AnnexBAuSplitter` -> one AU per channel item
 //!   sink:   received AUs -> ffplay window (low-latency flags) | raw `.h264` file | discard
 //!
-//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | `annexb:<path>` | webcam device;
+//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | webcam device;
 //! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`; `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`,
 //! `WA_VIDEO_BITRATE_KBPS`, and `WA_VIDEO_SINK_FPS` override the captured WhatsApp defaults.
 
@@ -179,8 +179,6 @@ pub enum VideoInput {
     Webcam(Option<String>),
     /// Any file or URL ffmpeg can open; looped and rate-limited to realtime.
     Media(String),
-    /// Pre-encoded H.264 Annex-B, paced without changing its encoded access units.
-    AnnexB(String),
     /// `lavfi testsrc2` synthetic pattern — no camera needed (CI / second instance).
     TestSrc,
 }
@@ -198,9 +196,6 @@ impl VideoOpts {
     pub fn from_env() -> Result<Self> {
         let input = match std::env::var("WA_VIDEO_INPUT") {
             Ok(v) if v == "testsrc" => VideoInput::TestSrc,
-            Ok(v) if v.starts_with("annexb:") => {
-                VideoInput::AnnexB(v.trim_start_matches("annexb:").to_string())
-            }
             // A `/dev/*` node is a webcam override (v4l2 on Linux), NOT a media file — it exists on
             // disk but must not be opened with `-stream_loop`.
             Ok(v) if v.starts_with("/dev/") => VideoInput::Webcam(Some(v)),
@@ -394,7 +389,6 @@ fn input_args(
             &format!("testsrc2=size={size}:rate={fps}"),
         ]),
         VideoInput::Media(path) => s(&["-re", "-stream_loop", "-1", "-i", path]),
-        VideoInput::AnnexB(path) => s(&["-re", "-framerate", &fps, "-f", "h264", "-i", path]),
         VideoInput::Webcam(dev) => {
             if cfg!(target_os = "linux") {
                 let dev = dev.clone().unwrap_or_else(|| "/dev/video0".into());
@@ -509,14 +503,8 @@ fn spawn_ffmpeg_encoder(
     let mut cmd = Command::new("ffmpeg");
     cmd.args(["-hide_banner", "-loglevel", "error"]);
     cmd.args(input_args(input, quality, camera_mode)?);
-    if matches!(input, VideoInput::AnnexB(_)) {
-        // Copy mode isolates transport behavior without changing already encoded frames.
-        cmd.args(["-c:v", "copy", "-an", "-f", "h264", "pipe:1"]);
-    } else {
-        // Normalize camera metadata so every encoded source presents one decoder contract.
-        // One slice per frame avoids content-dependent RTP layouts.
-        cmd.args(encoder_args(quality));
-    }
+    // One slice per frame avoids content-dependent RTP layouts.
+    cmd.args(encoder_args(quality));
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         // stderr inherited: encoder errors (missing camera, busy device) reach the user directly.
@@ -643,7 +631,7 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
                         match tx.try_send(au) {
                             Ok(()) => {
                                 if is_idr {
-                                    info!(
+                                    debug!(
                                         "🎥 OUT IDR queued: source AU #{made}, wire AU #{sent}, {au_bytes} bytes"
                                     );
                                 }

--- a/examples/voip-cli/src/video.rs
+++ b/examples/voip-cli/src/video.rs
@@ -3,34 +3,29 @@
 //! pre-encoded H.264 Annex-B access units).
 //!
 //!   source: webcam (per-OS ffmpeg input) | any file/URL | `testsrc2` synthetic pattern
-//!           -> libx264 (baseline, 640x480@15, ~500kbps, AUD-delimited) -> stdout pipe
+//!           -> libx264 (baseline, 1280x720@20, ~1980kbps, AUD-delimited) -> stdout pipe
 //!           -> `AnnexBAuSplitter` -> one AU per channel item
 //!   sink:   received AUs -> ffplay window (low-latency flags) | raw `.h264` file | discard
 //!
-//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | webcam device override
-//! (absent = default webcam); `WA_VIDEO_SINK` = `window` (default) | `file` | `none`.
+//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | webcam device override;
+//! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`; `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`,
+//! `WA_VIDEO_BITRATE_KBPS`, and `WA_VIDEO_SINK_FPS` override the captured WhatsApp defaults.
 
 use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
-use log::{info, warn};
+use log::{debug, info, warn};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use wacore::voip::h264::{AnnexBAuSplitter, au_has_idr, nal_unit_type, split_annexb};
-use whatsapp_rust::voip::VideoFrame;
+use wacore::voip::rtp::VIDEO_CLOCK_RATE;
+use whatsapp_rust::voip::{VideoFrame, VideoSource};
 
 /// The NAL-unit type of each NAL in an Annex-B access unit (5=IDR, 7=SPS, 8=PPS, 1=non-IDR, ...),
 /// for diagnostics comparing our outbound AUs against the decodable inbound ones.
 fn au_nal_types(au: &[u8]) -> Vec<u8> {
     split_annexb(au).map(nal_unit_type).collect()
-}
-
-fn whatsapp_wire_nal_types(au: &[u8]) -> Vec<u8> {
-    au_nal_types(au)
-        .into_iter()
-        .filter(|nal_type| *nal_type != 9)
-        .collect()
 }
 
 fn parameter_set_summary(au: &[u8]) -> Option<String> {
@@ -52,22 +47,106 @@ fn parameter_set_summary(au: &[u8]) -> Option<String> {
     ))
 }
 
-/// Reference encode parameters (H.264 Constrained Baseline, Level 3.1).
-const VIDEO_SIZE: &str = "640x480";
-const VIDEO_FPS: u32 = 15;
-const VIDEO_BITRATE: &str = "500k";
-/// Keyframe cadence in frames (2 s at 15 fps): the recovery bound after any dropped AU.
-const GOP_FRAMES: u32 = 30;
-/// Outbound AU backlog before the keyframe-aware dropper kicks in (~2 s of video).
-const SOURCE_CHANNEL_CAP: usize = 30;
+/// Captured WhatsApp Web high-quality mode (H.264 Constrained Baseline, Level 3.1).
+const DEFAULT_VIDEO_WIDTH: u32 = 1280;
+const DEFAULT_VIDEO_HEIGHT: u32 = 720;
+const DEFAULT_VIDEO_FPS: u32 = 20;
+const DEFAULT_VIDEO_BITRATE_KBPS: u32 = 1980;
+/// Raw-H.264 fallback when the bitstream carries no timing; preview timestamps follow arrival time.
+const DEFAULT_SINK_FPS: u32 = 15;
+const GOP_SECONDS: u32 = 3;
+const H264_LEVEL_31_MAX_FRAME_MBS: u32 = 3600;
+const H264_LEVEL_31_MAX_MBS_PER_SECOND: u32 = 108_000;
+const H264_BASELINE_LEVEL_31_MAX_KBPS: u32 = 14_000;
+/// Keep codec plumbing queues short; stale video is worse than a dropped frame in a call.
+const SOURCE_CHANNEL_CAP: usize = 4;
+const SINK_CHANNEL_CAP: usize = 2;
 /// stdout pipe read granularity.
 const READ_CHUNK: usize = 32 * 1024;
 /// A sink write slower than this sheds frames instead of stalling the call's forwarder.
-const SINK_WRITE_TIMEOUT: Duration = Duration::from_millis(200);
+const SINK_WRITE_TIMEOUT: Duration = Duration::from_millis(75);
 
 pub struct VideoOpts {
     pub input: VideoInput,
     pub sink: VideoSinkMode,
+    quality: VideoQuality,
+    sink_fps: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct VideoQuality {
+    width: u32,
+    height: u32,
+    fps: u32,
+    bitrate_kbps: u32,
+}
+
+impl VideoQuality {
+    fn new(width: u32, height: u32, fps: u32, bitrate_kbps: u32) -> Result<Self> {
+        if width == 0 || height == 0 || !width.is_multiple_of(2) || !height.is_multiple_of(2) {
+            bail!("WA_VIDEO_SIZE must contain positive even dimensions (for yuv420p)");
+        }
+        if fps == 0 || fps > 60 || !VIDEO_CLOCK_RATE.is_multiple_of(fps) {
+            bail!("WA_VIDEO_FPS must be a divisor of 90000 in the range 1..=60");
+        }
+        if !(25..=H264_BASELINE_LEVEL_31_MAX_KBPS).contains(&bitrate_kbps) {
+            bail!("WA_VIDEO_BITRATE_KBPS must be in the range 25..=14000");
+        }
+        let frame_mbs = width.div_ceil(16).saturating_mul(height.div_ceil(16));
+        if frame_mbs > H264_LEVEL_31_MAX_FRAME_MBS
+            || frame_mbs.saturating_mul(fps) > H264_LEVEL_31_MAX_MBS_PER_SECOND
+        {
+            bail!("WA_VIDEO_SIZE/FPS exceeds H.264 Level 3.1 (up to 1280x720@30)");
+        }
+        Ok(Self {
+            width,
+            height,
+            fps,
+            bitrate_kbps,
+        })
+    }
+
+    fn whatsapp_hd() -> Self {
+        Self {
+            width: DEFAULT_VIDEO_WIDTH,
+            height: DEFAULT_VIDEO_HEIGHT,
+            fps: DEFAULT_VIDEO_FPS,
+            bitrate_kbps: DEFAULT_VIDEO_BITRATE_KBPS,
+        }
+    }
+
+    fn size(self) -> String {
+        format!("{}x{}", self.width, self.height)
+    }
+
+    fn timestamp_stride(self) -> u32 {
+        VIDEO_CLOCK_RATE / self.fps
+    }
+}
+
+fn parse_video_size(value: &str) -> Result<(u32, u32)> {
+    let (width, height) = value
+        .split_once('x')
+        .or_else(|| value.split_once('X'))
+        .ok_or_else(|| anyhow!("WA_VIDEO_SIZE must use WIDTHxHEIGHT, for example 1280x720"))?;
+    Ok((
+        width
+            .parse()
+            .context("WA_VIDEO_SIZE width is not an integer")?,
+        height
+            .parse()
+            .context("WA_VIDEO_SIZE height is not an integer")?,
+    ))
+}
+
+fn env_u32(name: &str, default: u32) -> Result<u32> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse()
+            .with_context(|| format!("{name} must be an integer")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(e) => Err(e).with_context(|| format!("reading {name}")),
+    }
 }
 
 pub enum VideoInput {
@@ -89,7 +168,7 @@ pub enum VideoSinkMode {
 }
 
 impl VideoOpts {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Result<Self> {
         let input = match std::env::var("WA_VIDEO_INPUT") {
             Ok(v) if v == "testsrc" => VideoInput::TestSrc,
             // A `/dev/*` node is a webcam override (v4l2 on Linux), NOT a media file — it exists on
@@ -104,7 +183,28 @@ impl VideoOpts {
             Ok("none") => VideoSinkMode::None,
             _ => VideoSinkMode::Window,
         };
-        Self { input, sink }
+        let defaults = VideoQuality::whatsapp_hd();
+        let (width, height) = match std::env::var("WA_VIDEO_SIZE") {
+            Ok(value) => parse_video_size(&value)?,
+            Err(std::env::VarError::NotPresent) => (defaults.width, defaults.height),
+            Err(e) => return Err(e).context("reading WA_VIDEO_SIZE"),
+        };
+        let quality = VideoQuality::new(
+            width,
+            height,
+            env_u32("WA_VIDEO_FPS", defaults.fps)?,
+            env_u32("WA_VIDEO_BITRATE_KBPS", defaults.bitrate_kbps)?,
+        )?;
+        let sink_fps = env_u32("WA_VIDEO_SINK_FPS", DEFAULT_SINK_FPS)?;
+        if sink_fps == 0 || sink_fps > 60 {
+            bail!("WA_VIDEO_SINK_FPS must be in the range 1..=60");
+        }
+        Ok(Self {
+            input,
+            sink,
+            quality,
+            sink_fps,
+        })
     }
 }
 
@@ -128,9 +228,10 @@ async fn ensure_tool(tool: &str) -> Result<()> {
 }
 
 /// The per-input head of the ffmpeg command line.
-fn input_args(input: &VideoInput) -> Result<Vec<String>> {
+fn input_args(input: &VideoInput, quality: VideoQuality) -> Result<Vec<String>> {
     let s = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-    let fps = VIDEO_FPS.to_string();
+    let fps = quality.fps.to_string();
+    let size = quality.size();
     Ok(match input {
         // `-re` paces the synthetic source at realtime; unthrottled, lavfi encodes as fast as the
         // CPU allows and floods the call's bounded channel with dropped GOPs.
@@ -139,7 +240,7 @@ fn input_args(input: &VideoInput) -> Result<Vec<String>> {
             "-f",
             "lavfi",
             "-i",
-            &format!("testsrc2=size={VIDEO_SIZE}:rate={VIDEO_FPS}"),
+            &format!("testsrc2=size={size}:rate={fps}"),
         ]),
         VideoInput::Media(path) => {
             let mut v = s(&["-re", "-stream_loop", "-1", "-i", path]);
@@ -148,9 +249,10 @@ fn input_args(input: &VideoInput) -> Result<Vec<String>> {
                 "-vf",
                 &format!(
                     "scale={W}:{H}:force_original_aspect_ratio=decrease,\
-                     pad={W}:{H}:(ow-iw)/2:(oh-ih)/2,fps={VIDEO_FPS}",
-                    W = 640,
-                    H = 480
+                     pad={W}:{H}:(ow-iw)/2:(oh-ih)/2,fps={FPS}",
+                    W = quality.width,
+                    H = quality.height,
+                    FPS = quality.fps,
                 ),
             ]));
             v
@@ -164,7 +266,7 @@ fn input_args(input: &VideoInput) -> Result<Vec<String>> {
                     "-framerate",
                     &fps,
                     "-video_size",
-                    VIDEO_SIZE,
+                    &size,
                     "-i",
                     &dev,
                 ])
@@ -176,7 +278,7 @@ fn input_args(input: &VideoInput) -> Result<Vec<String>> {
                     "-framerate",
                     &fps,
                     "-video_size",
-                    VIDEO_SIZE,
+                    &size,
                     "-i",
                     &dev,
                 ])
@@ -195,7 +297,7 @@ fn input_args(input: &VideoInput) -> Result<Vec<String>> {
                     "-framerate",
                     &fps,
                     "-video_size",
-                    VIDEO_SIZE,
+                    &size,
                     "-i",
                     &format!("video={dev}"),
                 ])
@@ -206,37 +308,35 @@ fn input_args(input: &VideoInput) -> Result<Vec<String>> {
     })
 }
 
-fn spawn_ffmpeg_encoder(input: &VideoInput) -> Result<Child> {
-    let mut cmd = Command::new("ffmpeg");
-    cmd.args(["-hide_banner", "-loglevel", "error"]);
-    cmd.args(input_args(input)?);
-    // repeat-headers=1: SPS/PPS ride every IDR, so a peer joining mid-stream (upgrade) or
-    // recovering from a drop can always re-sync. aud=insert: the AU delimiter the splitter cuts on.
-    cmd.args([
+fn encoder_args(quality: VideoQuality) -> Vec<String> {
+    let gop = quality.fps.saturating_mul(GOP_SECONDS).to_string();
+    let fps = quality.fps.to_string();
+    let bitrate = format!("{}k", quality.bitrate_kbps);
+    [
+        "-r",
+        &fps,
+        "-fps_mode",
+        "cfr",
         "-c:v",
         "libx264",
         "-profile:v",
         "baseline",
-        "-level",
+        "-level:v",
         "3.1",
         "-pix_fmt",
         "yuv420p",
         "-preset",
-        "ultrafast",
+        "veryfast",
         "-tune",
         "zerolatency",
         "-g",
-        &GOP_FRAMES.to_string(),
+        &gop,
         "-keyint_min",
-        &GOP_FRAMES.to_string(),
+        &gop,
         "-sc_threshold",
         "0",
         "-b:v",
-        VIDEO_BITRATE,
-        "-maxrate",
-        VIDEO_BITRATE,
-        "-bufsize",
-        "250k",
+        &bitrate,
         "-x264-params",
         "repeat-headers=1",
         "-bsf:v",
@@ -245,7 +345,19 @@ fn spawn_ffmpeg_encoder(input: &VideoInput) -> Result<Child> {
         "-f",
         "h264",
         "pipe:1",
-    ]);
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+fn spawn_ffmpeg_encoder(input: &VideoInput, quality: VideoQuality) -> Result<Child> {
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args(["-hide_banner", "-loglevel", "error"]);
+    cmd.args(input_args(input, quality)?);
+    // repeat-headers=1: SPS/PPS ride every IDR, so a peer joining mid-stream (upgrade) or
+    // recovering from a drop can always re-sync. aud=insert: the AU delimiter the splitter cuts on.
+    cmd.args(encoder_args(quality));
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         // stderr inherited: encoder errors (missing camera, busy device) reach the user directly.
@@ -254,11 +366,35 @@ fn spawn_ffmpeg_encoder(input: &VideoInput) -> Result<Child> {
     cmd.spawn().context("spawn ffmpeg")
 }
 
-/// Spawn the ffmpeg encoder and return the channel of complete H.264 AUs. The receiver plugs
-/// straight into the library (`VideoSource` blanket impl on `Receiver<Vec<u8>>`).
-pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Receiver<Vec<u8>>> {
+pub struct FfmpegVideoSource {
+    frames: async_channel::Receiver<Vec<u8>>,
+    timestamp_stride: u32,
+}
+
+impl FfmpegVideoSource {
+    async fn recv(&self) -> std::result::Result<Vec<u8>, async_channel::RecvError> {
+        self.frames.recv().await
+    }
+}
+
+impl VideoSource for FfmpegVideoSource {
+    fn frames(&self) -> async_channel::Receiver<Vec<u8>> {
+        self.frames.clone()
+    }
+
+    fn rtp_timestamp_stride(&self) -> u32 {
+        self.timestamp_stride
+    }
+}
+
+/// Spawn the ffmpeg encoder and return complete H.264 AUs with their RTP cadence.
+pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
     ensure_tool("ffmpeg").await?;
-    let mut child = spawn_ffmpeg_encoder(&opts.input)?;
+    info!(
+        "🎥 encoder: {}x{} @ {} fps, {} kbps average target, H.264 baseline level 3.1",
+        opts.quality.width, opts.quality.height, opts.quality.fps, opts.quality.bitrate_kbps,
+    );
+    let mut child = spawn_ffmpeg_encoder(&opts.input, opts.quality)?;
     let mut stdout = child.stdout.take().context("ffmpeg stdout")?;
     let (tx, rx) = async_channel::bounded::<Vec<u8>>(SOURCE_CHANNEL_CAP);
 
@@ -283,11 +419,7 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
                         made += 1;
                         if !logged_parameter_sets && let Some(summary) = parameter_set_summary(&au)
                         {
-                            info!(
-                                "🎥 OUT H.264: {summary} encoder_nals={:?} wire_nals={:?}",
-                                au_nal_types(&au),
-                                whatsapp_wire_nal_types(&au),
-                            );
+                            info!("🎥 OUT H.264: {summary} NALs={:?}", au_nal_types(&au),);
                             logged_parameter_sets = true;
                         }
                         if dropping {
@@ -303,7 +435,7 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
                         // Periodic outbound telemetry so a live test shows whether we're actually
                         // producing (and sending) video AUs, and whether they carry IDR keyframes.
                         if sent.is_multiple_of(30) {
-                            info!(
+                            debug!(
                                 "🎥 OUT video: {sent} AUs queued ({dropped} source-dropped) | {}B, NALs {:?}, keyframe={}",
                                 au.len(),
                                 au_nal_types(&au),
@@ -333,15 +465,29 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<async_channel::Recei
         // The call survives a dead source (audio keeps running), same as a muted mic.
         warn!("🎥 video source ended ({made} AUs, {dropped} dropped)");
     });
-    Ok(rx)
+    Ok(FfmpegVideoSource {
+        frames: rx,
+        timestamp_stride: opts.quality.timestamp_stride(),
+    })
 }
 
-fn spawn_ffplay(tag: &str) -> Result<Child> {
-    let mut cmd = Command::new("ffplay");
-    cmd.args([
+fn orientation_filter(orientation: u8) -> Option<&'static str> {
+    match orientation & 0x03 {
+        0 => None,
+        1 => Some("transpose=cclock"),
+        2 => Some("hflip,vflip"),
+        3 => Some("transpose=clock"),
+        _ => unreachable!(),
+    }
+}
+
+fn ffplay_args(tag: &str, frame_rate: u32, orientation: u8) -> Vec<String> {
+    let mut args: Vec<String> = [
         "-hide_banner",
         "-loglevel",
         "error",
+        "-avioflags",
+        "direct",
         "-fflags",
         "nobuffer",
         "-flags",
@@ -350,14 +496,33 @@ fn spawn_ffplay(tag: &str) -> Result<Child> {
         "32",
         "-analyzeduration",
         "0",
+        "-fpsprobesize",
+        "0",
+        "-max_delay",
+        "0",
         "-framedrop",
+        "-use_wallclock_as_timestamps",
+        "1",
         "-window_title",
         &format!("WA Video {tag}"),
         "-f",
         "h264",
-        "-i",
-        "pipe:0",
-    ]);
+        "-framerate",
+        &frame_rate.to_string(),
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    if let Some(filter) = orientation_filter(orientation) {
+        args.extend(["-vf".into(), filter.into()]);
+    }
+    args.extend(["-i".into(), "pipe:0".into()]);
+    args
+}
+
+fn spawn_ffplay(tag: &str, frame_rate: u32, orientation: u8) -> Result<Child> {
+    let mut cmd = Command::new("ffplay");
+    cmd.args(ffplay_args(tag, frame_rate, orientation));
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
@@ -385,13 +550,16 @@ pub async fn spawn_video_sink(
     if want_window && !use_window {
         warn!("ffplay not found — recording received video to a .h264 file instead");
     }
-    let (tx, rx) = async_channel::bounded::<VideoFrame>(SOURCE_CHANNEL_CAP);
+    let (tx, rx) = async_channel::bounded::<VideoFrame>(SINK_CHANNEL_CAP);
     let tag = tag.to_string();
+    let sink_fps = opts.sink_fps;
 
     tokio::spawn(async move {
         let mut target: Option<SinkTarget> = None;
         let mut dropping = false;
         let mut last_orientation = 0u8;
+        let mut player_orientation = None;
+        let mut pending_orientation = None;
         let mut recv = 0u64;
         let mut logged_parameter_sets = false;
         while let Ok(frame) = rx.recv().await {
@@ -405,7 +573,7 @@ pub async fn spawn_video_sink(
             // Inbound telemetry: the peer's AUs DO decode (ffplay shows them), so their shape is the
             // reference to compare our outbound AUs against.
             if recv.is_multiple_of(30) {
-                info!(
+                debug!(
                     "🎥 IN  video: {recv} AUs recv | {}B, NALs {:?}, keyframe={}",
                     frame.data.len(),
                     au_nal_types(&frame.data),
@@ -413,19 +581,26 @@ pub async fn spawn_video_sink(
                 );
             }
             recv += 1;
-            if frame.orientation != last_orientation {
-                last_orientation = frame.orientation;
-                // ffplay can't rotate a live pipe; surface it so the user can tilt their head :)
+            let orientation = frame.orientation & 0x03;
+            if orientation != last_orientation {
+                last_orientation = orientation;
                 info!(
-                    "🎥 peer rotated its camera: {}°",
-                    frame.orientation as u32 * 90
+                    "🎥 peer camera orientation changed to {}° — correcting preview",
+                    orientation as u32 * 90
                 );
+                if matches!(target.as_ref(), Some(SinkTarget::Window(_))) {
+                    pending_orientation =
+                        (player_orientation != Some(orientation)).then_some(orientation);
+                }
             }
             // Lazy-open on the first frame.
             if target.is_none() {
                 target = Some(if use_window {
-                    match spawn_ffplay(&tag) {
-                        Ok(child) => SinkTarget::Window(child),
+                    match spawn_ffplay(&tag, sink_fps, orientation) {
+                        Ok(child) => {
+                            player_orientation = Some(orientation);
+                            SinkTarget::Window(child)
+                        }
                         Err(e) => {
                             warn!("🎥 ffplay spawn failed ({e}); discarding video");
                             SinkTarget::None
@@ -448,6 +623,24 @@ pub async fn spawn_video_sink(
                 } else {
                     SinkTarget::None
                 });
+            }
+            // A new filter graph needs a fresh decoder. Switch only when this AU can seed it.
+            if let Some(next_orientation) = pending_orientation
+                && matches!(target.as_ref(), Some(SinkTarget::Window(_)))
+                && au_has_idr(&frame.data)
+            {
+                match spawn_ffplay(&tag, sink_fps, next_orientation) {
+                    Ok(child) => {
+                        target = Some(SinkTarget::Window(child));
+                        player_orientation = Some(next_orientation);
+                        pending_orientation = None;
+                        dropping = false;
+                    }
+                    Err(e) => {
+                        warn!("🎥 cannot rotate ffplay preview ({e}); keeping current window");
+                        pending_orientation = None;
+                    }
+                }
             }
             // Recover from a skip only on an IDR (a self-contained restart): a mid-GOP resume, or
             // one on a parameter-set-only AU, shows garbage until the real keyframe.
@@ -472,6 +665,8 @@ pub async fn spawn_video_sink(
                         Ok(Err(e)) => {
                             warn!("🎥 ffplay pipe failed ({e}); discarding further video");
                             target = Some(SinkTarget::None);
+                            player_orientation = None;
+                            pending_orientation = None;
                         }
                     }
                 }
@@ -516,8 +711,11 @@ pub async fn run_video_loopback(opts: &VideoOpts) -> Result<()> {
                     return Err(anyhow!("video sink closed"));
                 }
                 n += 1;
-                if n.is_multiple_of(150) {
-                    info!("🎥 {n} AUs piped through the video plumbing ({}s)", n / 15);
+                if n.is_multiple_of((opts.quality.fps * 10) as u64) {
+                    info!(
+                        "🎥 {n} AUs piped through the video plumbing ({}s)",
+                        n / opts.quality.fps as u64
+                    );
                 }
             }
         }
@@ -528,8 +726,13 @@ pub async fn run_video_loopback(opts: &VideoOpts) -> Result<()> {
 mod tests {
     use super::*;
 
+    fn value_after<'a>(args: &'a [String], option: &str) -> &'a str {
+        let index = args.iter().position(|arg| arg == option).expect("option");
+        &args[index + 1]
+    }
+
     #[test]
-    fn wire_nal_diagnostics_match_whatsapp_aud_filter() {
+    fn nal_diagnostics_report_parameter_sets() {
         let au = [
             &[0, 0, 0, 1, 0x69, 0xf0][..],
             &[0, 0, 0, 1, 0x67, 0x42, 0xc0, 0x1f][..],
@@ -539,10 +742,93 @@ mod tests {
         .concat();
 
         assert_eq!(au_nal_types(&au), [9, 7, 8, 5]);
-        assert_eq!(whatsapp_wire_nal_types(&au), [7, 8, 5]);
         assert_eq!(
             parameter_set_summary(&au).as_deref(),
             Some("codec=avc1.42c01f SPS=6742c01f PPS=68ce06e2")
         );
+    }
+
+    #[test]
+    fn whatsapp_hd_quality_matches_reference_capture() {
+        let quality = VideoQuality::whatsapp_hd();
+        assert_eq!(
+            quality,
+            VideoQuality {
+                width: 1280,
+                height: 720,
+                fps: 20,
+                bitrate_kbps: 1980,
+            }
+        );
+        assert_eq!(quality.timestamp_stride(), 4500);
+        assert!(VideoQuality::new(1280, 720, 30, 2000).is_ok());
+        assert!(VideoQuality::new(1920, 1080, 20, 2000).is_err());
+        assert!(VideoQuality::new(1280, 720, 29, 2000).is_err());
+        assert!(VideoQuality::new(1279, 720, 20, 2000).is_err());
+    }
+
+    #[test]
+    fn encoder_uses_unbuffered_average_bitrate_with_whatsapp_hd_cadence() {
+        let args = encoder_args(VideoQuality::whatsapp_hd());
+        assert_eq!(value_after(&args, "-profile:v"), "baseline");
+        assert_eq!(value_after(&args, "-level:v"), "3.1");
+        assert_eq!(value_after(&args, "-preset"), "veryfast");
+        assert_eq!(value_after(&args, "-tune"), "zerolatency");
+        assert_eq!(value_after(&args, "-r"), "20");
+        assert_eq!(value_after(&args, "-g"), "60");
+        assert_eq!(value_after(&args, "-b:v"), "1980k");
+        assert!(!args.iter().any(|arg| arg == "-maxrate"));
+        assert!(!args.iter().any(|arg| arg == "-bufsize"));
+    }
+
+    #[test]
+    fn input_geometry_follows_quality() {
+        let quality = VideoQuality::new(640, 360, 20, 750).unwrap();
+        let testsrc = input_args(&VideoInput::TestSrc, quality).unwrap();
+        assert_eq!(value_after(&testsrc, "-i"), "testsrc2=size=640x360:rate=20");
+
+        let media = input_args(&VideoInput::Media("clip.mp4".into()), quality).unwrap();
+        let filter = value_after(&media, "-vf");
+        assert!(filter.contains("scale=640:360"));
+        assert!(filter.contains("fps=20"));
+    }
+
+    #[test]
+    fn ffplay_uses_arrival_timestamps_and_bounded_low_latency_flags() {
+        let args = ffplay_args("test", 15, 0);
+        assert_eq!(value_after(&args, "-framerate"), "15");
+        assert_eq!(value_after(&args, "-use_wallclock_as_timestamps"), "1");
+        assert_eq!(value_after(&args, "-fflags"), "nobuffer");
+        assert_eq!(value_after(&args, "-flags"), "low_delay");
+        assert_eq!(value_after(&args, "-avioflags"), "direct");
+        assert_eq!(value_after(&args, "-max_delay"), "0");
+        assert_eq!(value_after(&args, "-fpsprobesize"), "0");
+        assert!(args.iter().any(|arg| arg == "-framedrop"));
+        assert!(!args.iter().any(|arg| arg == "-infbuf"));
+        assert!(
+            args.iter().position(|arg| arg == "-framerate")
+                < args.iter().position(|arg| arg == "-i")
+        );
+        assert!(!args.iter().any(|arg| arg == "-vf"));
+    }
+
+    #[test]
+    fn ffplay_undoes_whatsapp_device_orientation() {
+        assert_eq!(orientation_filter(0), None);
+        assert_eq!(orientation_filter(1), Some("transpose=cclock"));
+        assert_eq!(orientation_filter(2), Some("hflip,vflip"));
+        assert_eq!(orientation_filter(3), Some("transpose=clock"));
+        assert_eq!(orientation_filter(5), orientation_filter(1));
+
+        let args = ffplay_args("test", 15, 1);
+        assert_eq!(value_after(&args, "-vf"), "transpose=cclock");
+        assert!(args.iter().position(|arg| arg == "-vf") < args.iter().position(|arg| arg == "-i"));
+    }
+
+    #[test]
+    fn parses_case_insensitive_video_size() {
+        assert_eq!(parse_video_size("1280x720").unwrap(), (1280, 720));
+        assert_eq!(parse_video_size("640X480").unwrap(), (640, 480));
+        assert!(parse_video_size("1280:720").is_err());
     }
 }

--- a/examples/voip-cli/src/video.rs
+++ b/examples/voip-cli/src/video.rs
@@ -3,11 +3,11 @@
 //! pre-encoded H.264 Annex-B access units).
 //!
 //!   source: webcam (per-OS ffmpeg input) | any file/URL | `testsrc2` synthetic pattern
-//!           -> libx264 (baseline, 1280x720@20, ~1980kbps, AUD-delimited) -> stdout pipe
+//!           -> normalize -> libx264 (baseline, 1280x720@20, ~1980kbps, AUD-delimited) -> stdout
 //!           -> `AnnexBAuSplitter` -> one AU per channel item
 //!   sink:   received AUs -> ffplay window (low-latency flags) | raw `.h264` file | discard
 //!
-//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | webcam device override;
+//! Env knobs: `WA_VIDEO_INPUT` = `testsrc` | existing path/URL | `annexb:<path>` | webcam device;
 //! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`; `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`,
 //! `WA_VIDEO_BITRATE_KBPS`, and `WA_VIDEO_SINK_FPS` override the captured WhatsApp defaults.
 
@@ -52,6 +52,8 @@ const DEFAULT_VIDEO_WIDTH: u32 = 1280;
 const DEFAULT_VIDEO_HEIGHT: u32 = 720;
 const DEFAULT_VIDEO_FPS: u32 = 20;
 const DEFAULT_VIDEO_BITRATE_KBPS: u32 = 1980;
+/// Bound complex camera keyframes without adding encoder lookahead.
+const VIDEO_VBV_WINDOW_MS: u32 = 250;
 /// Raw-H.264 fallback when the bitstream carries no timing; preview timestamps follow arrival time.
 const DEFAULT_SINK_FPS: u32 = 15;
 const GOP_SECONDS: u32 = 3;
@@ -65,6 +67,9 @@ const SINK_CHANNEL_CAP: usize = 2;
 const READ_CHUNK: usize = 32 * 1024;
 /// A sink write slower than this sheds frames instead of stalling the call's forwarder.
 const SINK_WRITE_TIMEOUT: Duration = Duration::from_millis(75);
+const CAMERA_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+/// A video accept must not outrun a cold camera that has not produced a decodable frame yet.
+const SOURCE_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct VideoOpts {
     pub input: VideoInput,
@@ -79,6 +84,20 @@ struct VideoQuality {
     height: u32,
     fps: u32,
     bitrate_kbps: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CameraMode {
+    input_format: String,
+    width: u32,
+    height: u32,
+    compressed: bool,
+}
+
+impl CameraMode {
+    fn size(&self) -> String {
+        format!("{}x{}", self.width, self.height)
+    }
 }
 
 impl VideoQuality {
@@ -122,6 +141,12 @@ impl VideoQuality {
     fn timestamp_stride(self) -> u32 {
         VIDEO_CLOCK_RATE / self.fps
     }
+
+    fn vbv_buffer_kbits(self) -> u32 {
+        self.bitrate_kbps
+            .saturating_mul(VIDEO_VBV_WINDOW_MS)
+            .div_ceil(1000)
+    }
 }
 
 fn parse_video_size(value: &str) -> Result<(u32, u32)> {
@@ -154,6 +179,8 @@ pub enum VideoInput {
     Webcam(Option<String>),
     /// Any file or URL ffmpeg can open; looped and rate-limited to realtime.
     Media(String),
+    /// Pre-encoded H.264 Annex-B, paced without changing its encoded access units.
+    AnnexB(String),
     /// `lavfi testsrc2` synthetic pattern — no camera needed (CI / second instance).
     TestSrc,
 }
@@ -171,6 +198,9 @@ impl VideoOpts {
     pub fn from_env() -> Result<Self> {
         let input = match std::env::var("WA_VIDEO_INPUT") {
             Ok(v) if v == "testsrc" => VideoInput::TestSrc,
+            Ok(v) if v.starts_with("annexb:") => {
+                VideoInput::AnnexB(v.trim_start_matches("annexb:").to_string())
+            }
             // A `/dev/*` node is a webcam override (v4l2 on Linux), NOT a media file — it exists on
             // disk but must not be opened with `-stream_loop`.
             Ok(v) if v.starts_with("/dev/") => VideoInput::Webcam(Some(v)),
@@ -227,8 +257,129 @@ async fn ensure_tool(tool: &str) -> Result<()> {
     }
 }
 
+fn parse_camera_modes(output: &str) -> Vec<CameraMode> {
+    let mut modes = Vec::new();
+    for line in output.lines() {
+        let Some((kind, rest)) = line.split_once(':') else {
+            continue;
+        };
+        let compressed = kind.contains("Compressed");
+        if !compressed && !kind.contains("Raw") {
+            continue;
+        }
+        let Some((input_format, rest)) = rest.split_once(':') else {
+            continue;
+        };
+        let Some((_, sizes)) = rest.split_once(':') else {
+            continue;
+        };
+        for size in sizes.split_ascii_whitespace() {
+            let Ok((width, height)) = parse_video_size(size) else {
+                continue;
+            };
+            modes.push(CameraMode {
+                input_format: input_format.trim().to_string(),
+                width,
+                height,
+                compressed,
+            });
+        }
+    }
+    modes
+}
+
+fn camera_mode_score(mode: &CameraMode, quality: VideoQuality) -> (u8, u64, u8, u64, u8) {
+    let exact = u8::from(mode.width != quality.width || mode.height != quality.height);
+    let aspect_error = (u64::from(mode.width) * u64::from(quality.height))
+        .abs_diff(u64::from(quality.width) * u64::from(mode.height));
+    let mode_area = u64::from(mode.width) * u64::from(mode.height);
+    let target_area = u64::from(quality.width) * u64::from(quality.height);
+    let needs_upscale = u8::from(mode_area < target_area);
+    let format_rank = match (mode.input_format.as_str(), mode.compressed) {
+        ("mjpeg", _) => 0,
+        ("h264", _) => 1,
+        (_, true) => 2,
+        (_, false) => 3,
+    };
+    (
+        exact,
+        aspect_error,
+        needs_upscale,
+        mode_area.abs_diff(target_area),
+        format_rank,
+    )
+}
+
+fn choose_camera_mode(modes: &[CameraMode], quality: VideoQuality) -> Option<CameraMode> {
+    modes
+        .iter()
+        .min_by_key(|mode| camera_mode_score(mode, quality))
+        .cloned()
+}
+
+async fn probe_linux_camera_mode(device: &str, quality: VideoQuality) -> Option<CameraMode> {
+    let mut cmd = Command::new("ffmpeg");
+    cmd.args([
+        "-hide_banner",
+        "-loglevel",
+        "info",
+        "-f",
+        "v4l2",
+        "-list_formats",
+        "all",
+        "-i",
+        device,
+    ])
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true);
+    let output = match tokio::time::timeout(CAMERA_PROBE_TIMEOUT, cmd.output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => {
+            warn!("🎥 cannot inspect camera {device} ({e}); using driver negotiation");
+            return None;
+        }
+        Err(_) => {
+            warn!("🎥 camera probe timed out for {device}; using driver negotiation");
+            return None;
+        }
+    };
+    let modes = parse_camera_modes(&String::from_utf8_lossy(&output.stderr));
+    let selected = choose_camera_mode(&modes, quality);
+    if let Some(mode) = &selected {
+        info!(
+            "🎥 camera capture: {} {} -> normalized to {} @ {} fps",
+            mode.input_format,
+            mode.size(),
+            quality.size(),
+            quality.fps,
+        );
+    } else {
+        warn!(
+            "🎥 camera {device} reported no usable modes; ffmpeg will negotiate before normalization"
+        );
+    }
+    selected
+}
+
+fn normalization_filter(quality: VideoQuality) -> String {
+    format!(
+        "scale={W}:{H}:force_original_aspect_ratio=decrease:force_divisible_by=2:out_range=tv,\
+         pad={W}:{H}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps={FPS},format=yuv420p,\
+         setparams=range=limited:color_primaries=unknown:color_trc=unknown:colorspace=unknown",
+        W = quality.width,
+        H = quality.height,
+        FPS = quality.fps,
+    )
+}
+
 /// The per-input head of the ffmpeg command line.
-fn input_args(input: &VideoInput, quality: VideoQuality) -> Result<Vec<String>> {
+fn input_args(
+    input: &VideoInput,
+    quality: VideoQuality,
+    camera_mode: Option<&CameraMode>,
+) -> Result<Vec<String>> {
     let s = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
     let fps = quality.fps.to_string();
     let size = quality.size();
@@ -242,34 +393,25 @@ fn input_args(input: &VideoInput, quality: VideoQuality) -> Result<Vec<String>> 
             "-i",
             &format!("testsrc2=size={size}:rate={fps}"),
         ]),
-        VideoInput::Media(path) => {
-            let mut v = s(&["-re", "-stream_loop", "-1", "-i", path]);
-            // Normalize any input to the call's fixed geometry/rate.
-            v.extend(s(&[
-                "-vf",
-                &format!(
-                    "scale={W}:{H}:force_original_aspect_ratio=decrease,\
-                     pad={W}:{H}:(ow-iw)/2:(oh-ih)/2,fps={FPS}",
-                    W = quality.width,
-                    H = quality.height,
-                    FPS = quality.fps,
-                ),
-            ]));
-            v
-        }
+        VideoInput::Media(path) => s(&["-re", "-stream_loop", "-1", "-i", path]),
+        VideoInput::AnnexB(path) => s(&["-re", "-framerate", &fps, "-f", "h264", "-i", path]),
         VideoInput::Webcam(dev) => {
             if cfg!(target_os = "linux") {
                 let dev = dev.clone().unwrap_or_else(|| "/dev/video0".into());
-                s(&[
-                    "-f",
-                    "v4l2",
+                let mut args = s(&["-f", "v4l2"]);
+                if let Some(mode) = camera_mode {
+                    args.extend(s(&["-input_format", &mode.input_format]));
+                }
+                let capture_size = camera_mode.map(CameraMode::size).unwrap_or(size);
+                args.extend(s(&[
                     "-framerate",
                     &fps,
                     "-video_size",
-                    &size,
+                    &capture_size,
                     "-i",
                     &dev,
-                ])
+                ]));
+                args
             } else if cfg!(target_os = "macos") {
                 let dev = dev.clone().unwrap_or_else(|| "0".into());
                 s(&[
@@ -312,7 +454,11 @@ fn encoder_args(quality: VideoQuality) -> Vec<String> {
     let gop = quality.fps.saturating_mul(GOP_SECONDS).to_string();
     let fps = quality.fps.to_string();
     let bitrate = format!("{}k", quality.bitrate_kbps);
+    let vbv_buffer = format!("{}k", quality.vbv_buffer_kbits());
+    let filter = normalization_filter(quality);
     [
+        "-vf",
+        &filter,
         "-r",
         &fps,
         "-fps_mode",
@@ -337,8 +483,12 @@ fn encoder_args(quality: VideoQuality) -> Vec<String> {
         "0",
         "-b:v",
         &bitrate,
+        "-maxrate",
+        &bitrate,
+        "-bufsize",
+        &vbv_buffer,
         "-x264-params",
-        "repeat-headers=1",
+        "repeat-headers=1:sliced-threads=0:threads=1",
         "-bsf:v",
         "h264_metadata=aud=insert",
         "-an",
@@ -351,13 +501,22 @@ fn encoder_args(quality: VideoQuality) -> Vec<String> {
     .collect()
 }
 
-fn spawn_ffmpeg_encoder(input: &VideoInput, quality: VideoQuality) -> Result<Child> {
+fn spawn_ffmpeg_encoder(
+    input: &VideoInput,
+    quality: VideoQuality,
+    camera_mode: Option<&CameraMode>,
+) -> Result<Child> {
     let mut cmd = Command::new("ffmpeg");
     cmd.args(["-hide_banner", "-loglevel", "error"]);
-    cmd.args(input_args(input, quality)?);
-    // repeat-headers=1: SPS/PPS ride every IDR, so a peer joining mid-stream (upgrade) or
-    // recovering from a drop can always re-sync. aud=insert: the AU delimiter the splitter cuts on.
-    cmd.args(encoder_args(quality));
+    cmd.args(input_args(input, quality, camera_mode)?);
+    if matches!(input, VideoInput::AnnexB(_)) {
+        // Copy mode isolates transport behavior without changing already encoded frames.
+        cmd.args(["-c:v", "copy", "-an", "-f", "h264", "pipe:1"]);
+    } else {
+        // Normalize camera metadata so every encoded source presents one decoder contract.
+        // One slice per frame avoids content-dependent RTP layouts.
+        cmd.args(encoder_args(quality));
+    }
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         // stderr inherited: encoder errors (missing camera, busy device) reach the user directly.
@@ -369,6 +528,22 @@ fn spawn_ffmpeg_encoder(input: &VideoInput, quality: VideoQuality) -> Result<Chi
 pub struct FfmpegVideoSource {
     frames: async_channel::Receiver<Vec<u8>>,
     timestamp_stride: u32,
+}
+
+#[derive(Default)]
+struct FirstIdrGate {
+    open: bool,
+}
+
+impl FirstIdrGate {
+    fn admit(&mut self, au: &[u8]) -> bool {
+        self.open |= au_has_idr(au);
+        self.open
+    }
+
+    fn is_open(&self) -> bool {
+        self.open
+    }
 }
 
 impl FfmpegVideoSource {
@@ -390,13 +565,26 @@ impl VideoSource for FfmpegVideoSource {
 /// Spawn the ffmpeg encoder and return complete H.264 AUs with their RTP cadence.
 pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
     ensure_tool("ffmpeg").await?;
+    let camera_mode = if cfg!(target_os = "linux")
+        && let VideoInput::Webcam(dev) = &opts.input
+    {
+        let device = dev.as_deref().unwrap_or("/dev/video0");
+        probe_linux_camera_mode(device, opts.quality).await
+    } else {
+        None
+    };
     info!(
-        "🎥 encoder: {}x{} @ {} fps, {} kbps average target, H.264 baseline level 3.1",
-        opts.quality.width, opts.quality.height, opts.quality.fps, opts.quality.bitrate_kbps,
+        "🎥 encoder output: {}x{} @ {} fps, {} kbps capped, {} ms VBV, H.264 baseline level 3.1",
+        opts.quality.width,
+        opts.quality.height,
+        opts.quality.fps,
+        opts.quality.bitrate_kbps,
+        VIDEO_VBV_WINDOW_MS,
     );
-    let mut child = spawn_ffmpeg_encoder(&opts.input, opts.quality)?;
+    let mut child = spawn_ffmpeg_encoder(&opts.input, opts.quality, camera_mode.as_ref())?;
     let mut stdout = child.stdout.take().context("ffmpeg stdout")?;
     let (tx, rx) = async_channel::bounded::<Vec<u8>>(SOURCE_CHANNEL_CAP);
+    let (ready_tx, ready_rx) = async_channel::bounded::<std::result::Result<(), String>>(1);
 
     tokio::spawn(async move {
         // Owning the child keeps kill_on_drop armed for the whole read loop.
@@ -404,6 +592,8 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
         let mut splitter = AnnexBAuSplitter::default();
         let mut buf = vec![0u8; READ_CHUNK];
         let mut aus: Vec<Vec<u8>> = Vec::new();
+        let mut startup = FirstIdrGate::default();
+        let mut ready_tx = Some(ready_tx);
         // When the channel backs up we drop AUs — but only from a keyframe boundary, because an
         // arbitrary dropped AU corrupts the peer's decode until the next IDR anyway. Dropping
         // *deliberately until* the next IDR turns backpressure into one clean skip.
@@ -417,6 +607,12 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
                     splitter.push(&buf[..n], &mut aus);
                     for au in aus.drain(..) {
                         made += 1;
+                        let was_ready = startup.is_open();
+                        if !startup.admit(&au) {
+                            dropped += 1;
+                            continue;
+                        }
+                        let first_idr = !was_ready;
                         if !logged_parameter_sets && let Some(summary) = parameter_set_summary(&au)
                         {
                             info!("🎥 OUT H.264: {summary} NALs={:?}", au_nal_types(&au),);
@@ -442,8 +638,20 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
                                 au_has_idr(&au)
                             );
                         }
+                        let is_idr = au_has_idr(&au);
+                        let au_bytes = au.len();
                         match tx.try_send(au) {
-                            Ok(()) => sent += 1,
+                            Ok(()) => {
+                                if is_idr {
+                                    info!(
+                                        "🎥 OUT IDR queued: source AU #{made}, wire AU #{sent}, {au_bytes} bytes"
+                                    );
+                                }
+                                sent += 1;
+                                if first_idr && let Some(ready) = ready_tx.take() {
+                                    let _ = ready.try_send(Ok(()));
+                                }
+                            }
                             Err(async_channel::TrySendError::Full(_)) => {
                                 dropped += 1;
                                 dropping = true;
@@ -455,16 +663,48 @@ pub async fn spawn_video_source(opts: &VideoOpts) -> Result<FfmpegVideoSource> {
                 }
                 Err(e) => {
                     warn!("🎥 video source read failed: {e}");
+                    if let Some(ready) = ready_tx.take() {
+                        let _ = ready.try_send(Err(e.to_string()));
+                    }
                     break;
                 }
             }
         }
         if let Some(last) = splitter.finish() {
-            let _ = tx.try_send(last);
+            made += 1;
+            let was_ready = startup.is_open();
+            if startup.admit(&last) {
+                let first_idr = !was_ready;
+                match tx.try_send(last) {
+                    Ok(()) => {
+                        if first_idr && let Some(ready) = ready_tx.take() {
+                            let _ = ready.try_send(Ok(()));
+                        }
+                    }
+                    Err(async_channel::TrySendError::Full(_)) => dropped += 1,
+                    Err(async_channel::TrySendError::Closed(_)) => return,
+                }
+            } else {
+                dropped += 1;
+            }
+        }
+        if let Some(ready) = ready_tx.take() {
+            let _ = ready.try_send(Err("encoder ended before its first IDR".to_string()));
         }
         // The call survives a dead source (audio keeps running), same as a muted mic.
         warn!("🎥 video source ended ({made} AUs, {dropped} dropped)");
     });
+    match tokio::time::timeout(SOURCE_READY_TIMEOUT, ready_rx.recv()).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(reason))) => return Err(anyhow!("video source failed before ready: {reason}")),
+        Ok(Err(_)) => return Err(anyhow!("video source ended before its first IDR")),
+        Err(_) => {
+            return Err(anyhow!(
+                "video source produced no IDR within {}s",
+                SOURCE_READY_TIMEOUT.as_secs()
+            ));
+        }
+    }
     Ok(FfmpegVideoSource {
         frames: rx,
         timestamp_stride: opts.quality.timestamp_stride(),
@@ -749,6 +989,19 @@ mod tests {
     }
 
     #[test]
+    fn video_source_opens_only_on_a_decodable_idr() {
+        let delta = [0, 0, 0, 1, 0x41, 1, 2, 3];
+        let idr = [0, 0, 0, 1, 0x65, 1, 2, 3];
+        let mut gate = FirstIdrGate::default();
+
+        assert!(!gate.admit(&delta));
+        assert!(!gate.is_open());
+        assert!(gate.admit(&idr));
+        assert!(gate.is_open());
+        assert!(gate.admit(&delta));
+    }
+
+    #[test]
     fn whatsapp_hd_quality_matches_reference_capture() {
         let quality = VideoQuality::whatsapp_hd();
         assert_eq!(
@@ -768,8 +1021,17 @@ mod tests {
     }
 
     #[test]
-    fn encoder_uses_unbuffered_average_bitrate_with_whatsapp_hd_cadence() {
+    fn encoder_bounds_camera_bursts_with_whatsapp_hd_cadence() {
         let args = encoder_args(VideoQuality::whatsapp_hd());
+        let filter = value_after(&args, "-vf");
+        assert!(filter.contains("scale=1280:720"));
+        assert!(filter.contains("pad=1280:720"));
+        assert!(filter.contains("setsar=1"));
+        assert!(filter.contains("fps=20"));
+        assert!(filter.contains("format=yuv420p"));
+        assert!(filter.contains("out_range=tv"));
+        assert!(filter.contains("setparams=range=limited"));
+        assert!(filter.contains("color_primaries=unknown"));
         assert_eq!(value_after(&args, "-profile:v"), "baseline");
         assert_eq!(value_after(&args, "-level:v"), "3.1");
         assert_eq!(value_after(&args, "-preset"), "veryfast");
@@ -777,20 +1039,76 @@ mod tests {
         assert_eq!(value_after(&args, "-r"), "20");
         assert_eq!(value_after(&args, "-g"), "60");
         assert_eq!(value_after(&args, "-b:v"), "1980k");
-        assert!(!args.iter().any(|arg| arg == "-maxrate"));
-        assert!(!args.iter().any(|arg| arg == "-bufsize"));
+        assert_eq!(value_after(&args, "-maxrate"), "1980k");
+        assert_eq!(value_after(&args, "-bufsize"), "495k");
+        assert_eq!(
+            value_after(&args, "-x264-params"),
+            "repeat-headers=1:sliced-threads=0:threads=1"
+        );
     }
 
     #[test]
     fn input_geometry_follows_quality() {
         let quality = VideoQuality::new(640, 360, 20, 750).unwrap();
-        let testsrc = input_args(&VideoInput::TestSrc, quality).unwrap();
+        let testsrc = input_args(&VideoInput::TestSrc, quality, None).unwrap();
         assert_eq!(value_after(&testsrc, "-i"), "testsrc2=size=640x360:rate=20");
 
-        let media = input_args(&VideoInput::Media("clip.mp4".into()), quality).unwrap();
-        let filter = value_after(&media, "-vf");
-        assert!(filter.contains("scale=640:360"));
-        assert!(filter.contains("fps=20"));
+        let media = input_args(&VideoInput::Media("clip.mp4".into()), quality, None).unwrap();
+        assert_eq!(value_after(&media, "-i"), "clip.mp4");
+        assert!(!media.iter().any(|arg| arg == "-vf"));
+    }
+
+    #[test]
+    fn parses_and_selects_exact_compressed_camera_mode() {
+        let output = "\
+[in#0] Compressed:       mjpeg :          Motion-JPEG : 1920x1080 1280x720 640x480\n\
+[in#0] Raw       :     yuyv422 :           YUYV 4:2:2 : 640x480 640x360\n";
+        let modes = parse_camera_modes(output);
+        assert_eq!(modes.len(), 5);
+
+        let quality = VideoQuality::whatsapp_hd();
+        let mode = choose_camera_mode(&modes, quality).expect("camera mode");
+        assert_eq!(
+            mode,
+            CameraMode {
+                input_format: "mjpeg".into(),
+                width: 1280,
+                height: 720,
+                compressed: true,
+            }
+        );
+
+        let args = input_args(
+            &VideoInput::Webcam(Some("/dev/video9".into())),
+            quality,
+            Some(&mode),
+        )
+        .unwrap();
+        if cfg!(target_os = "linux") {
+            assert_eq!(value_after(&args, "-input_format"), "mjpeg");
+            assert_eq!(value_after(&args, "-video_size"), "1280x720");
+            assert_eq!(value_after(&args, "-i"), "/dev/video9");
+        }
+    }
+
+    #[test]
+    fn camera_mode_selection_prefers_same_aspect_before_upscaling() {
+        let modes = [
+            CameraMode {
+                input_format: "mjpeg".into(),
+                width: 1920,
+                height: 1080,
+                compressed: true,
+            },
+            CameraMode {
+                input_format: "yuyv422".into(),
+                width: 640,
+                height: 480,
+                compressed: false,
+            },
+        ];
+        let mode = choose_camera_mode(&modes, VideoQuality::whatsapp_hd()).expect("camera mode");
+        assert_eq!((mode.width, mode.height), (1920, 1080));
     }
 
     #[test]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -167,8 +167,8 @@ impl StanzaHandler for CallHandler {
                     }
                     // In-call <video state> signaling: send the TYPED ack (`type="video"`) and
                     // suppress the router's generic one — an untyped ack makes the upgrade
-                    // requester assume failure and revert after ~5s. Reserve event capacity first,
-                    // then publish the state only after that ack commits it.
+                    // requester assume failure and revert after ~5s. Serialize event publication,
+                    // then expose the state only after that ack commits it.
                     #[cfg(feature = "voip")]
                     if let CallAction::VideoState {
                         state, orientation, ..
@@ -182,7 +182,7 @@ impl StanzaHandler for CallHandler {
                                 "call: video state event queue is unavailable; leaving the transition unacknowledged"
                             );
                         }
-                        // A typed ack commits the received transition. Without a reserved event slot,
+                        // A typed ack commits the received transition. Without an event permit,
                         // leave the generic ack in place so the peer reverts instead.
                         let acked = if event_permit.is_some() {
                             match build_call_video_ack(&call) {
@@ -523,12 +523,12 @@ mod tests {
             fake_caller_lid(),
             fake_caller_lid(),
         ));
-        let (event_tx, event_rx) = async_channel::bounded::<CallEvent>(2);
+        let (event_tx, event_rx) = async_channel::bounded::<CallEvent>(1);
         let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
         registry.set_video_channels(
             "CALL-ID-0001",
             generation,
-            event_tx,
+            event_tx.clone(),
             control_tx,
             Box::new(|| {}),
         );
@@ -543,9 +543,12 @@ mod tests {
                 _ = &mut handling => panic!("handler completed before the blocked ack send"),
             }
             assert!(
-                event_rx.try_recv().is_err(),
+                event_rx.is_empty(),
                 "the application must not observe an uncommitted video state"
             );
+            event_tx
+                .try_send(CallEvent::RelayAllocated)
+                .expect("fill the queue while the typed ack is in flight");
 
             release_send.send(()).await.expect("release ack send");
             handling.await
@@ -727,7 +730,7 @@ mod tests {
 
     #[cfg(feature = "voip")]
     #[tokio::test]
-    async fn full_event_queue_leaves_video_transition_uncommitted() {
+    async fn committed_video_state_supersedes_diagnostics_when_event_queue_is_full() {
         use wacore::voip::{CallEvent, VideoControl};
 
         let client = make_sending_client().await;
@@ -737,7 +740,7 @@ mod tests {
             fake_caller_lid(),
             fake_caller_lid(),
         ));
-        let (ev_tx, _ev_rx) = async_channel::bounded::<CallEvent>(1);
+        let (ev_tx, ev_rx) = async_channel::bounded::<CallEvent>(1);
         ev_tx.try_send(CallEvent::RelayAllocated).expect("prefill");
         let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
         registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
@@ -752,9 +755,17 @@ mod tests {
                 )
                 .await
         );
-        assert!(!cancelled, "the router must retain its fallback ack");
-        assert!(!registry.snapshot("CALL-ID-0001").expect("session").is_video);
-        assert!(ctl_rx.try_recv().is_err(), "the plane must not transition");
+        assert!(cancelled, "the typed ack must suppress the generic ack");
+        assert!(registry.snapshot("CALL-ID-0001").expect("session").is_video);
+        assert!(matches!(
+            ev_rx.try_recv(),
+            Ok(CallEvent::VideoStateChanged { .. })
+        ));
+        assert!(
+            std::iter::from_fn(|| ctl_rx.try_recv().ok())
+                .any(|ctl| matches!(ctl, VideoControl::Enable)),
+            "the committed transition must steer the local plane"
+        );
     }
 
     #[tokio::test]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -211,7 +211,7 @@ impl StanzaHandler for CallHandler {
                         } else {
                             false
                         };
-                        let transition_current = acked
+                        let mut transition_current = acked
                             && generation
                                 .is_some_and(|generation| registry.is_current(call_id, generation));
                         dispatch_call = transition_current;
@@ -225,41 +225,6 @@ impl StanzaHandler for CallHandler {
                         }
                         // Only drive our local plane once the peer has been acked; see above.
                         if transition_current && let Some(generation) = generation {
-                            let event_delivered = event_permit.as_ref().is_some_and(|permit| {
-                                permit.send(CallEvent::VideoStateChanged {
-                                    state: *state,
-                                    orientation: *orientation,
-                                })
-                            });
-                            if !event_delivered {
-                                warn!("call: video state event receiver closed after typed ack");
-                            }
-                            if let Some(o) = orientation {
-                                registry.send_video_ctl(
-                                    call_id,
-                                    generation,
-                                    VideoControl::SetOrientation(*o),
-                                );
-                            }
-                            match state {
-                                // The peer's video is (about to be) live; make sure our plane decodes
-                                // it even when the consumer skipped `.video()` and only accepts later
-                                // — decoding costs nothing until packets arrive.
-                                VideoState::UpgradeAccept | VideoState::Enabled => {
-                                    registry.set_is_video(call_id, generation, true);
-                                    registry.send_video_ctl(
-                                        call_id,
-                                        generation,
-                                        VideoControl::Enable,
-                                    );
-                                }
-                                // The peer stopped ITS video; our outbound is the consumer's call
-                                // (stop_video), so only the flag is updated here.
-                                VideoState::Disabled | VideoState::Stopped => {
-                                    registry.set_is_video(call_id, generation, false);
-                                }
-                                _ => {}
-                            }
                             if *state == VideoState::UpgradeAccept
                                 && registry.is_current(call_id, generation)
                             {
@@ -274,9 +239,58 @@ impl StanzaHandler for CallHandler {
                                 });
                                 if let Err(e) = client.send_node(enabled).await {
                                     warn!("call: failed to announce accepted video upgrade: {e}");
+                                    if !registry.run_video_teardown(call_id, generation) {
+                                        registry.send_video_ctl(
+                                            call_id,
+                                            generation,
+                                            VideoControl::Disable,
+                                        );
+                                    }
+                                    registry.set_is_video(call_id, generation, false);
+                                    transition_current = false;
                                 }
                             }
-                            dispatch_call = registry.is_current(call_id, generation);
+                            transition_current &= registry.is_current(call_id, generation);
+                            if transition_current {
+                                let event_delivered = event_permit.as_ref().is_some_and(|permit| {
+                                    permit.send(CallEvent::VideoStateChanged {
+                                        state: *state,
+                                        orientation: *orientation,
+                                    })
+                                });
+                                if !event_delivered {
+                                    warn!(
+                                        "call: video state event receiver closed after typed ack"
+                                    );
+                                }
+                                if let Some(o) = orientation {
+                                    registry.send_video_ctl(
+                                        call_id,
+                                        generation,
+                                        VideoControl::SetOrientation(*o),
+                                    );
+                                }
+                                match state {
+                                    // The peer's video is (about to be) live; make sure our plane decodes
+                                    // it even when the consumer skipped `.video()` and only accepts later
+                                    // — decoding costs nothing until packets arrive.
+                                    VideoState::UpgradeAccept | VideoState::Enabled => {
+                                        registry.set_is_video(call_id, generation, true);
+                                        registry.send_video_ctl(
+                                            call_id,
+                                            generation,
+                                            VideoControl::Enable,
+                                        );
+                                    }
+                                    // The peer stopped ITS video; our outbound is the consumer's call
+                                    // (stop_video), so only the flag is updated here.
+                                    VideoState::Disabled | VideoState::Stopped => {
+                                        registry.set_is_video(call_id, generation, false);
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            dispatch_call = transition_current;
                         }
                         // Keep the transition serialized through every committed side effect.
                         drop(event_permit);
@@ -415,28 +429,47 @@ mod tests {
     /// A client whose sends land on a counting transport (so ack sends succeed and can be counted).
     #[cfg(feature = "voip")]
     async fn make_sending_client() -> Arc<Client> {
+        make_sending_client_with_failure_after(None).await.0
+    }
+
+    #[cfg(feature = "voip")]
+    async fn make_sending_client_with_failure_after(
+        failure_after: Option<usize>,
+    ) -> (Arc<Client>, Arc<std::sync::atomic::AtomicUsize>) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
         use wacore::handshake::NoiseCipher;
 
-        struct NullTransport;
+        struct CountingTransport {
+            sends: Arc<AtomicUsize>,
+            failure_after: Option<usize>,
+        }
         #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
         #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-        impl crate::transport::Transport for NullTransport {
+        impl crate::transport::Transport for CountingTransport {
             async fn send(&self, _data: bytes::Bytes) -> Result<(), anyhow::Error> {
+                let attempt = self.sends.fetch_add(1, Ordering::SeqCst);
+                if self.failure_after.is_some_and(|limit| attempt >= limit) {
+                    return Err(anyhow::anyhow!("injected transport send failure"));
+                }
                 Ok(())
             }
             async fn disconnect(&self) {}
         }
 
         let client = make_client().await;
+        let sends = Arc::new(AtomicUsize::new(0));
         let key = [0u8; 32];
         let noise_socket = crate::socket::NoiseSocket::new(
             Arc::new(crate::runtime_impl::TokioRuntime),
-            Arc::new(NullTransport) as Arc<dyn crate::transport::Transport>,
+            Arc::new(CountingTransport {
+                sends: sends.clone(),
+                failure_after,
+            }) as Arc<dyn crate::transport::Transport>,
             NoiseCipher::new(&key).expect("valid key"),
             NoiseCipher::new(&key).expect("valid key"),
         );
         *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
-        client
+        (client, sends)
     }
 
     #[cfg(feature = "voip")]
@@ -633,6 +666,52 @@ mod tests {
         };
         assert!(handled);
         assert!(cancelled);
+        assert!(registry.reserve_call_event("CALL-ID-0001").is_some());
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn failed_enabled_announcement_rolls_back_the_video_upgrade() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let (client, sends) = make_sending_client_with_failure_after(Some(1)).await;
+        let (global_handler, global_rx) = ChannelEventHandler::new();
+        client.register_handler(global_handler);
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_outgoing(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        assert!(registry.set_is_video("CALL-ID-0001", generation, true));
+        let (event_tx, event_rx) = async_channel::unbounded::<CallEvent>();
+        let (control_tx, control_rx) = async_channel::unbounded::<VideoControl>();
+        let teardown_control = control_tx.clone();
+        let teardowns = Arc::new(AtomicUsize::new(0));
+        registry.set_video_channels("CALL-ID-0001", generation, event_tx, control_tx, {
+            let teardowns = teardowns.clone();
+            Box::new(move || {
+                teardowns.fetch_add(1, Ordering::SeqCst);
+                let _ = teardown_control.force_send(VideoControl::Disable);
+            })
+        });
+
+        let node = node_to_owned_ref(&video_stanza("4"));
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+
+        assert!(
+            cancelled,
+            "the successful typed ack suppresses the generic ack"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 2);
+        assert_eq!(teardowns.load(Ordering::SeqCst), 1);
+        assert!(event_rx.try_recv().is_err());
+        assert_eq!(control_rx.try_recv(), Ok(VideoControl::Disable));
+        assert!(control_rx.try_recv().is_err());
+        assert!(!registry.snapshot("CALL-ID-0001").expect("session").is_video);
+        assert!(global_rx.try_recv().is_err());
         assert!(registry.reserve_call_event("CALL-ID-0001").is_some());
     }
 

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -165,6 +165,10 @@ impl StanzaHandler for CallHandler {
                     ) {
                         crate::voip::facade::terminate_call(&client, call.action.call_id());
                     }
+                    #[cfg(feature = "voip")]
+                    let mut dispatch_call = true;
+                    #[cfg(not(feature = "voip"))]
+                    let dispatch_call = true;
                     // In-call <video state> signaling: send the TYPED ack (`type="video"`) and
                     // suppress the router's generic one — an untyped ack makes the upgrade
                     // requester assume failure and revert after ~5s. Serialize event publication,
@@ -185,7 +189,7 @@ impl StanzaHandler for CallHandler {
                         // A typed ack commits the received transition. Without an event permit,
                         // leave the generic ack in place so the peer reverts instead.
                         let acked = if event_permit.is_some() {
-                            match build_call_video_ack(&call) {
+                            match build_call_video_ack(&call, nr) {
                                 Some(ack) => {
                                     *cancelled = true;
                                     match client.send_node(ack).await {
@@ -206,6 +210,7 @@ impl StanzaHandler for CallHandler {
                         } else {
                             false
                         };
+                        dispatch_call = acked;
                         // Rejection ends our attempted upgrade locally even when its ack cannot get
                         // out; retaining the camera cannot help a negotiation the peer already ended.
                         if matches!(state, VideoState::UpgradeReject | VideoState::UpgradeCancel) {
@@ -257,7 +262,9 @@ impl StanzaHandler for CallHandler {
                             }
                         }
                     }
-                    client.core.event_bus.dispatch(Event::IncomingCall(call));
+                    if dispatch_call {
+                        client.core.event_bus.dispatch(Event::IncomingCall(call));
+                    }
                 }
             }
             Ok(None) => {
@@ -581,6 +588,8 @@ mod tests {
         use wacore::voip::{CallEvent, VideoControl};
 
         let client = make_sending_client().await;
+        let (global_handler, global_rx) = ChannelEventHandler::new();
+        client.register_handler(global_handler);
         let registry = client.call_registry();
         let session = wacore::voip::CallSession::new_incoming(
             "CALL-ID-0001",
@@ -619,6 +628,13 @@ mod tests {
             registry.snapshot("CALL-ID-0001").expect("session").is_video,
             "UpgradeAccept marks the call as video"
         );
+        assert!(matches!(
+            global_rx.try_recv().as_deref(),
+            Ok(Event::IncomingCall(IncomingCall {
+                action: CallAction::VideoState { .. },
+                ..
+            }))
+        ));
         let enabled = tokio::time::timeout(std::time::Duration::from_secs(2), enabled_waiter)
             .await
             .expect("Enabled stanza must be sent")
@@ -726,6 +742,42 @@ mod tests {
         assert!(cancelled, "a built typed ack suppresses the generic ack");
         assert_eq!(torn.load(Ordering::SeqCst), 1);
         assert!(!registry.snapshot("CALL-ID-0001").expect("session").is_video);
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn unacked_video_state_is_not_dispatched_globally() {
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let client = make_client().await;
+        let (global_handler, global_rx) = ChannelEventHandler::new();
+        client.register_handler(global_handler);
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
+        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client,
+                    node_to_owned_ref(&video_stanza("4")),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert!(
+            cancelled,
+            "the attempted typed ack suppresses the generic ack"
+        );
+        assert!(global_rx.try_recv().is_err());
+        assert!(ctl_rx.try_recv().is_err());
     }
 
     #[cfg(feature = "voip")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -180,7 +180,8 @@ impl StanzaHandler for CallHandler {
                     {
                         let call_id = call.action.call_id();
                         let registry = client.call_registry();
-                        let mut event_permit = registry.reserve_call_event(call_id);
+                        let event_permit = registry.reserve_call_event(call_id);
+                        let generation = event_permit.as_ref().map(|permit| permit.generation());
                         if event_permit.is_none() {
                             warn!(
                                 "call: video state event queue is unavailable; leaving the transition unacknowledged"
@@ -210,16 +211,21 @@ impl StanzaHandler for CallHandler {
                         } else {
                             false
                         };
-                        dispatch_call = acked;
+                        let transition_current = acked
+                            && generation
+                                .is_some_and(|generation| registry.is_current(call_id, generation));
+                        dispatch_call = transition_current;
                         // Rejection ends our attempted upgrade locally even when its ack cannot get
                         // out; retaining the camera cannot help a negotiation the peer already ended.
-                        if matches!(state, VideoState::UpgradeReject | VideoState::UpgradeCancel) {
-                            registry.run_video_teardown(call_id);
-                            registry.set_is_video(call_id, false);
+                        if matches!(state, VideoState::UpgradeReject | VideoState::UpgradeCancel)
+                            && let Some(generation) = generation
+                        {
+                            registry.run_video_teardown(call_id, generation);
+                            registry.set_is_video(call_id, generation, false);
                         }
                         // Only drive our local plane once the peer has been acked; see above.
-                        if acked {
-                            let event_delivered = event_permit.take().is_some_and(|permit| {
+                        if transition_current && let Some(generation) = generation {
+                            let event_delivered = event_permit.as_ref().is_some_and(|permit| {
                                 permit.send(CallEvent::VideoStateChanged {
                                     state: *state,
                                     orientation: *orientation,
@@ -229,24 +235,34 @@ impl StanzaHandler for CallHandler {
                                 warn!("call: video state event receiver closed after typed ack");
                             }
                             if let Some(o) = orientation {
-                                registry.send_video_ctl(call_id, VideoControl::SetOrientation(*o));
+                                registry.send_video_ctl(
+                                    call_id,
+                                    generation,
+                                    VideoControl::SetOrientation(*o),
+                                );
                             }
                             match state {
                                 // The peer's video is (about to be) live; make sure our plane decodes
                                 // it even when the consumer skipped `.video()` and only accepts later
                                 // — decoding costs nothing until packets arrive.
                                 VideoState::UpgradeAccept | VideoState::Enabled => {
-                                    registry.set_is_video(call_id, true);
-                                    registry.send_video_ctl(call_id, VideoControl::Enable);
+                                    registry.set_is_video(call_id, generation, true);
+                                    registry.send_video_ctl(
+                                        call_id,
+                                        generation,
+                                        VideoControl::Enable,
+                                    );
                                 }
                                 // The peer stopped ITS video; our outbound is the consumer's call
                                 // (stop_video), so only the flag is updated here.
                                 VideoState::Disabled | VideoState::Stopped => {
-                                    registry.set_is_video(call_id, false);
+                                    registry.set_is_video(call_id, generation, false);
                                 }
                                 _ => {}
                             }
-                            if *state == VideoState::UpgradeAccept {
+                            if *state == VideoState::UpgradeAccept
+                                && registry.is_current(call_id, generation)
+                            {
                                 let enabled = build_video_state(&VideoStateParams {
                                     call_id,
                                     to: &call.from,
@@ -260,7 +276,10 @@ impl StanzaHandler for CallHandler {
                                     warn!("call: failed to announce accepted video upgrade: {e}");
                                 }
                             }
+                            dispatch_call = registry.is_current(call_id, generation);
                         }
+                        // Keep the transition serialized through every committed side effect.
+                        drop(event_permit);
                     }
                     if dispatch_call {
                         client.core.event_bus.dispatch(Event::IncomingCall(call));
@@ -568,6 +587,134 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn video_transition_stays_serialized_through_enabled_announcement() {
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let (client, send_started, release_send) = make_blocking_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        let (event_tx, _event_rx) = async_channel::bounded::<CallEvent>(1);
+        let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels(
+            "CALL-ID-0001",
+            generation,
+            event_tx,
+            control_tx,
+            Box::new(|| {}),
+        );
+
+        let node = node_to_owned_ref(&video_stanza("4"));
+        let mut cancelled = false;
+        let handled = {
+            let handling = CallHandler.handle(client, node, &mut cancelled);
+            tokio::pin!(handling);
+
+            tokio::select! {
+                started = send_started.recv() => started.expect("typed ack send started"),
+                _ = &mut handling => panic!("handler completed before the typed ack send"),
+            }
+            release_send.send(()).await.expect("release typed ack");
+            tokio::select! {
+                started = send_started.recv() => started.expect("Enabled announcement started"),
+                _ = &mut handling => panic!("handler completed before the Enabled send"),
+            }
+            assert!(
+                registry.reserve_call_event("CALL-ID-0001").is_none(),
+                "the next transition must not overtake committed effects"
+            );
+            release_send.send(()).await.expect("release Enabled send");
+            handling.await
+        };
+        assert!(handled);
+        assert!(cancelled);
+        assert!(registry.reserve_call_event("CALL-ID-0001").is_some());
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn video_state_does_not_mutate_a_same_id_replacement_after_ack_await() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let (client, send_started, release_send) = make_blocking_sending_client().await;
+        let (global_handler, global_rx) = ChannelEventHandler::new();
+        client.register_handler(global_handler);
+        let registry = client.call_registry();
+        let stale_generation = registry.insert(wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        let (stale_event_tx, stale_event_rx) = async_channel::unbounded::<CallEvent>();
+        let (stale_control_tx, _stale_control_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels(
+            "CALL-ID-0001",
+            stale_generation,
+            stale_event_tx,
+            stale_control_tx,
+            Box::new(|| {}),
+        );
+
+        let node = node_to_owned_ref(&video_stanza("4"));
+        let mut cancelled = false;
+        let replacement_teardowns = Arc::new(AtomicUsize::new(0));
+        let replacement_control_rx = {
+            let handling = CallHandler.handle(client, node, &mut cancelled);
+            tokio::pin!(handling);
+            tokio::select! {
+                started = send_started.recv() => started.expect("typed ack send started"),
+                _ = &mut handling => panic!("handler completed before the typed ack send"),
+            }
+
+            let replacement = registry.insert(wacore::voip::CallSession::new_incoming(
+                "CALL-ID-0001",
+                fake_caller_lid(),
+                fake_caller_lid(),
+            ));
+            let (replacement_event_tx, _replacement_event_rx) =
+                async_channel::unbounded::<CallEvent>();
+            let (replacement_control_tx, replacement_control_rx) =
+                async_channel::unbounded::<VideoControl>();
+            registry.set_video_channels(
+                "CALL-ID-0001",
+                replacement,
+                replacement_event_tx,
+                replacement_control_tx,
+                {
+                    let replacement_teardowns = replacement_teardowns.clone();
+                    Box::new(move || {
+                        replacement_teardowns.fetch_add(1, Ordering::SeqCst);
+                    })
+                },
+            );
+
+            release_send.send(()).await.expect("release typed ack");
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_secs(2), &mut handling)
+                    .await
+                    .expect("stale handler must not start an Enabled send")
+            );
+            replacement_control_rx
+        };
+        assert!(cancelled);
+        assert!(stale_event_rx.try_recv().is_err());
+        assert!(replacement_control_rx.try_recv().is_err());
+        assert!(
+            !registry
+                .snapshot("CALL-ID-0001")
+                .expect("replacement")
+                .is_video
+        );
+        assert_eq!(replacement_teardowns.load(Ordering::SeqCst), 0);
+        assert!(global_rx.try_recv().is_err());
+    }
+
     // Non-video call actions keep the generic ack: `cancelled` must stay false.
     #[cfg(feature = "voip")]
     #[tokio::test]
@@ -678,7 +825,7 @@ mod tests {
                 fake_caller_lid(),
             );
             let generation = registry.insert(session);
-            registry.set_is_video("CALL-ID-0001", true);
+            registry.set_is_video("CALL-ID-0001", generation, true);
             let torn = Arc::new(AtomicUsize::new(0));
             let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
             let (ctl_tx, _ctl_rx) = async_channel::unbounded::<VideoControl>();
@@ -718,7 +865,7 @@ mod tests {
             fake_caller_lid(),
         );
         let generation = registry.insert(session);
-        registry.set_is_video("CALL-ID-0001", true);
+        registry.set_is_video("CALL-ID-0001", generation, true);
         let torn = Arc::new(AtomicUsize::new(0));
         let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
         let (ctl_tx, _ctl_rx) = async_channel::unbounded::<VideoControl>();

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -174,35 +174,50 @@ impl StanzaHandler for CallHandler {
                         state, orientation, ..
                     } = &call.action
                     {
-                        *cancelled = true;
-                        // The typed ack is what tells the peer we received its state; only COMMIT
-                        // the local plane transition once it is sent. If we can't ack (no stanza id,
-                        // or a send failure — usually a dying socket), the peer will time out and
-                        // revert, so mirroring that here (skip the plane change) keeps the two sides
-                        // consistent instead of driving our plane into a state the peer never
-                        // confirmed. The event is still surfaced for observability.
-                        let acked = match build_call_video_ack(&call) {
-                            Some(ack) => match client.send_node(ack).await {
-                                Ok(()) => true,
-                                Err(e) => {
-                                    warn!("call: failed to send typed video ack: {e}");
-                                    false
-                                }
-                            },
-                            None => {
-                                warn!("call: video stanza has no id; cannot send the typed ack");
-                                false
-                            }
-                        };
                         let call_id = call.action.call_id();
                         let registry = client.call_registry();
-                        registry.send_call_event(
+                        let event_delivered = registry.send_call_event(
                             call_id,
                             CallEvent::VideoStateChanged {
                                 state: *state,
                                 orientation: *orientation,
                             },
                         );
+                        if !event_delivered {
+                            warn!(
+                                "call: video state event queue is unavailable; leaving the transition unacknowledged"
+                            );
+                        }
+                        // A typed ack commits the received transition. If the application cannot
+                        // observe it, leave the generic ack in place so the peer reverts instead.
+                        let acked = if event_delivered {
+                            match build_call_video_ack(&call) {
+                                Some(ack) => {
+                                    *cancelled = true;
+                                    match client.send_node(ack).await {
+                                        Ok(()) => true,
+                                        Err(e) => {
+                                            warn!("call: failed to send typed video ack: {e}");
+                                            false
+                                        }
+                                    }
+                                }
+                                None => {
+                                    warn!(
+                                        "call: video stanza has no id; cannot send the typed ack"
+                                    );
+                                    false
+                                }
+                            }
+                        } else {
+                            false
+                        };
+                        // Rejection ends our attempted upgrade locally even when its ack cannot get
+                        // out; retaining the camera cannot help a negotiation the peer already ended.
+                        if matches!(state, VideoState::UpgradeReject | VideoState::UpgradeCancel) {
+                            registry.run_video_teardown(call_id);
+                            registry.set_is_video(call_id, false);
+                        }
                         // Only drive our local plane once the peer has been acked; see above.
                         if acked {
                             if let Some(o) = orientation {
@@ -215,14 +230,6 @@ impl StanzaHandler for CallHandler {
                                 VideoState::UpgradeAccept | VideoState::Enabled => {
                                     registry.set_is_video(call_id, true);
                                     registry.send_video_ctl(call_id, VideoControl::Enable);
-                                }
-                                // The peer refused an upgrade WE started: our source is already feeding
-                                // a now-dead negotiation, so fully release the local video endpoints
-                                // (stops the camera feed, disables the plane) instead of leaking an
-                                // encode.
-                                VideoState::UpgradeReject | VideoState::UpgradeCancel => {
-                                    registry.run_video_teardown(call_id);
-                                    registry.set_is_video(call_id, false);
                                 }
                                 // The peer stopped ITS video; our outbound is the consumer's call
                                 // (stop_video), so only the flag is updated here.
@@ -409,7 +416,24 @@ mod tests {
     #[cfg(feature = "voip")]
     #[tokio::test]
     async fn video_state_sends_typed_ack_and_cancels_generic() {
+        use wacore::voip::{CallEvent, VideoControl};
+
         let client = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        let (event_tx, _event_rx) = async_channel::unbounded::<CallEvent>();
+        let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels(
+            "CALL-ID-0001",
+            generation,
+            event_tx,
+            control_tx,
+            Box::new(|| {}),
+        );
         let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("ack"));
 
         let node = node_to_owned_ref(&video_stanza("11"));
@@ -545,6 +569,78 @@ mod tests {
                 "state {state}: a refused upgrade must clear the video flag"
             );
         }
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn refused_upgrade_tears_down_when_typed_ack_send_fails() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let client = make_client().await;
+        let registry = client.call_registry();
+        let session = wacore::voip::CallSession::new_outgoing(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        );
+        let generation = registry.insert(session);
+        registry.set_is_video("CALL-ID-0001", true);
+        let torn = Arc::new(AtomicUsize::new(0));
+        let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
+        let (ctl_tx, _ctl_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, {
+            let torn = torn.clone();
+            Box::new(move || {
+                torn.fetch_add(1, Ordering::SeqCst);
+            })
+        });
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client,
+                    node_to_owned_ref(&video_stanza("5")),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert!(cancelled, "a built typed ack suppresses the generic ack");
+        assert_eq!(torn.load(Ordering::SeqCst), 1);
+        assert!(!registry.snapshot("CALL-ID-0001").expect("session").is_video);
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn full_event_queue_leaves_video_transition_uncommitted() {
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let client = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        let (ev_tx, _ev_rx) = async_channel::bounded::<CallEvent>(1);
+        ev_tx.try_send(CallEvent::RelayAllocated).expect("prefill");
+        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client,
+                    node_to_owned_ref(&video_stanza("4")),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert!(!cancelled, "the router must retain its fallback ack");
+        assert!(!registry.snapshot("CALL-ID-0001").expect("session").is_video);
+        assert!(ctl_rx.try_recv().is_err(), "the plane must not transition");
     }
 
     #[tokio::test]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -252,17 +252,6 @@ impl StanzaHandler for CallHandler {
                             }
                             transition_current &= registry.is_current(call_id, generation);
                             if transition_current {
-                                let event_delivered = event_permit.as_ref().is_some_and(|permit| {
-                                    permit.send(CallEvent::VideoStateChanged {
-                                        state: *state,
-                                        orientation: *orientation,
-                                    })
-                                });
-                                if !event_delivered {
-                                    warn!(
-                                        "call: video state event receiver closed after typed ack"
-                                    );
-                                }
                                 if let Some(o) = orientation {
                                     registry.send_video_ctl(
                                         call_id,
@@ -288,6 +277,17 @@ impl StanzaHandler for CallHandler {
                                         registry.set_is_video(call_id, generation, false);
                                     }
                                     _ => {}
+                                }
+                                let event_delivered = event_permit.as_ref().is_some_and(|permit| {
+                                    permit.send(CallEvent::VideoStateChanged {
+                                        state: *state,
+                                        orientation: *orientation,
+                                    })
+                                });
+                                if !event_delivered {
+                                    warn!(
+                                        "call: video state event receiver closed after typed ack"
+                                    );
                                 }
                             }
                             dispatch_call = transition_current;
@@ -399,6 +399,8 @@ mod tests {
     use crate::test_utils::node_to_owned_ref;
     use std::sync::Arc;
     use wacore::types::events::{ChannelEventHandler, Event};
+    #[cfg(feature = "voip")]
+    use wacore::voip::video_control_channel;
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
@@ -532,7 +534,7 @@ mod tests {
     #[cfg(feature = "voip")]
     #[tokio::test]
     async fn video_state_sends_typed_ack_and_cancels_generic() {
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         let client = make_sending_client().await;
         let registry = client.call_registry();
@@ -542,7 +544,7 @@ mod tests {
             fake_caller_lid(),
         ));
         let (event_tx, _event_rx) = async_channel::unbounded::<CallEvent>();
-        let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
+        let (control_tx, _control_rx) = video_control_channel();
         registry.set_video_channels(
             "CALL-ID-0001",
             generation,
@@ -573,7 +575,7 @@ mod tests {
     #[cfg(feature = "voip")]
     #[tokio::test]
     async fn video_state_is_not_visible_before_typed_ack_completes() {
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         let (client, send_started, release_send) = make_blocking_sending_client().await;
         let registry = client.call_registry();
@@ -583,7 +585,7 @@ mod tests {
             fake_caller_lid(),
         ));
         let (event_tx, event_rx) = async_channel::bounded::<CallEvent>(1);
-        let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
+        let (control_tx, _control_rx) = video_control_channel();
         registry.set_video_channels(
             "CALL-ID-0001",
             generation,
@@ -623,7 +625,7 @@ mod tests {
     #[cfg(feature = "voip")]
     #[tokio::test]
     async fn video_transition_stays_serialized_through_enabled_announcement() {
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         let (client, send_started, release_send) = make_blocking_sending_client().await;
         let registry = client.call_registry();
@@ -633,7 +635,7 @@ mod tests {
             fake_caller_lid(),
         ));
         let (event_tx, _event_rx) = async_channel::bounded::<CallEvent>(1);
-        let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
+        let (control_tx, _control_rx) = video_control_channel();
         registry.set_video_channels(
             "CALL-ID-0001",
             generation,
@@ -686,14 +688,14 @@ mod tests {
         ));
         assert!(registry.set_is_video("CALL-ID-0001", generation, true));
         let (event_tx, event_rx) = async_channel::unbounded::<CallEvent>();
-        let (control_tx, control_rx) = async_channel::unbounded::<VideoControl>();
+        let (control_tx, control_rx) = video_control_channel();
         let teardown_control = control_tx.clone();
         let teardowns = Arc::new(AtomicUsize::new(0));
         registry.set_video_channels("CALL-ID-0001", generation, event_tx, control_tx, {
             let teardowns = teardowns.clone();
             Box::new(move || {
                 teardowns.fetch_add(1, Ordering::SeqCst);
-                let _ = teardown_control.force_send(VideoControl::Disable);
+                let _ = teardown_control.send(VideoControl::Disable);
             })
         });
 
@@ -719,7 +721,7 @@ mod tests {
     #[tokio::test]
     async fn video_state_does_not_mutate_a_same_id_replacement_after_ack_await() {
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         let (client, send_started, release_send) = make_blocking_sending_client().await;
         let (global_handler, global_rx) = ChannelEventHandler::new();
@@ -731,7 +733,7 @@ mod tests {
             fake_caller_lid(),
         ));
         let (stale_event_tx, stale_event_rx) = async_channel::unbounded::<CallEvent>();
-        let (stale_control_tx, _stale_control_rx) = async_channel::unbounded::<VideoControl>();
+        let (stale_control_tx, _stale_control_rx) = video_control_channel();
         registry.set_video_channels(
             "CALL-ID-0001",
             stale_generation,
@@ -758,8 +760,7 @@ mod tests {
             ));
             let (replacement_event_tx, _replacement_event_rx) =
                 async_channel::unbounded::<CallEvent>();
-            let (replacement_control_tx, replacement_control_rx) =
-                async_channel::unbounded::<VideoControl>();
+            let (replacement_control_tx, replacement_control_rx) = video_control_channel();
             registry.set_video_channels(
                 "CALL-ID-0001",
                 replacement,
@@ -824,7 +825,7 @@ mod tests {
         );
         let generation = registry.insert(session);
         let (ev_tx, ev_rx) = async_channel::unbounded::<CallEvent>();
-        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (ctl_tx, ctl_rx) = video_control_channel();
         registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
         let enabled_waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
 
@@ -892,7 +893,7 @@ mod tests {
     #[tokio::test]
     async fn refused_upgrade_runs_local_video_teardown() {
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         for state in ["5", "8"] {
             // 5 = UpgradeReject, 8 = UpgradeCancel.
@@ -907,7 +908,7 @@ mod tests {
             registry.set_is_video("CALL-ID-0001", generation, true);
             let torn = Arc::new(AtomicUsize::new(0));
             let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
-            let (ctl_tx, _ctl_rx) = async_channel::unbounded::<VideoControl>();
+            let (ctl_tx, _ctl_rx) = video_control_channel();
             registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, {
                 let torn = torn.clone();
                 Box::new(move || {
@@ -934,7 +935,7 @@ mod tests {
     #[tokio::test]
     async fn refused_upgrade_tears_down_when_typed_ack_send_fails() {
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         let client = make_client().await;
         let registry = client.call_registry();
@@ -947,7 +948,7 @@ mod tests {
         registry.set_is_video("CALL-ID-0001", generation, true);
         let torn = Arc::new(AtomicUsize::new(0));
         let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
-        let (ctl_tx, _ctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (ctl_tx, _ctl_rx) = video_control_channel();
         registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, {
             let torn = torn.clone();
             Box::new(move || {
@@ -973,7 +974,7 @@ mod tests {
     #[cfg(feature = "voip")]
     #[tokio::test]
     async fn unacked_video_state_is_not_dispatched_globally() {
-        use wacore::voip::{CallEvent, VideoControl};
+        use wacore::voip::CallEvent;
 
         let client = make_client().await;
         let (global_handler, global_rx) = ChannelEventHandler::new();
@@ -985,7 +986,7 @@ mod tests {
             fake_caller_lid(),
         ));
         let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
-        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (ctl_tx, ctl_rx) = video_control_channel();
         registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
 
         let mut cancelled = false;
@@ -1020,7 +1021,7 @@ mod tests {
         ));
         let (ev_tx, ev_rx) = async_channel::bounded::<CallEvent>(1);
         ev_tx.try_send(CallEvent::RelayAllocated).expect("prefill");
-        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (ctl_tx, ctl_rx) = video_control_channel();
         registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
 
         let mut cancelled = false;

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -6,13 +6,15 @@ use log::{debug, warn};
 use wacore::stanza::call::{
     TERMINATE_REASON_ACCEPTED_ELSEWHERE, TERMINATE_REASON_GROUP_CALL_ENDED,
     TERMINATE_REASON_REJECTED_ELSEWHERE, TERMINATE_REASON_TIMEOUT, TerminateParams,
-    build_terminate,
+    build_call_video_ack, build_terminate,
 };
 use wacore::stanza::call::{build_offer_ack_receipt, parse_call_stanza};
 use wacore::types::call::{CallAction, IncomingCall, MissedCall, MissedReason};
 #[cfg(feature = "voip")]
-use wacore::types::call::{CallEndedElsewhere, ElsewhereOutcome};
+use wacore::types::call::{CallEndedElsewhere, ElsewhereOutcome, VideoState};
 use wacore::types::events::Event;
+#[cfg(feature = "voip")]
+use wacore::voip::{CallEvent, VideoControl};
 #[cfg(feature = "voip")]
 use wacore_binary::Jid;
 use wacore_binary::{OwnedNodeRef, Server};
@@ -42,8 +44,11 @@ impl StanzaHandler for CallHandler {
         &self,
         client: Arc<Client>,
         node: Arc<OwnedNodeRef>,
-        _cancelled: &mut bool,
+        cancelled: &mut bool,
     ) -> bool {
+        // Silence the unused-parameter warning on the no-voip build (only the video arm cancels).
+        #[cfg(not(feature = "voip"))]
+        let _ = &cancelled;
         let nr = node.get();
         match parse_call_stanza(nr) {
             Ok(Some(call)) => {
@@ -159,6 +164,74 @@ impl StanzaHandler for CallHandler {
                         CallAction::Reject { .. } | CallAction::Terminate { .. }
                     ) {
                         crate::voip::facade::terminate_call(&client, call.action.call_id());
+                    }
+                    // In-call <video state> signaling: send the TYPED ack (`type="video"`) and
+                    // suppress the router's generic one — an untyped ack makes the upgrade
+                    // requester assume failure and revert after ~5s. Then surface the state on the
+                    // call's event stream and steer the live video plane.
+                    #[cfg(feature = "voip")]
+                    if let CallAction::VideoState {
+                        state, orientation, ..
+                    } = &call.action
+                    {
+                        *cancelled = true;
+                        // The typed ack is what tells the peer we received its state; only COMMIT
+                        // the local plane transition once it is sent. If we can't ack (no stanza id,
+                        // or a send failure — usually a dying socket), the peer will time out and
+                        // revert, so mirroring that here (skip the plane change) keeps the two sides
+                        // consistent instead of driving our plane into a state the peer never
+                        // confirmed. The event is still surfaced for observability.
+                        let acked = match build_call_video_ack(&call) {
+                            Some(ack) => match client.send_node(ack).await {
+                                Ok(()) => true,
+                                Err(e) => {
+                                    warn!("call: failed to send typed video ack: {e}");
+                                    false
+                                }
+                            },
+                            None => {
+                                warn!("call: video stanza has no id; cannot send the typed ack");
+                                false
+                            }
+                        };
+                        let call_id = call.action.call_id();
+                        let registry = client.call_registry();
+                        registry.send_call_event(
+                            call_id,
+                            CallEvent::VideoStateChanged {
+                                state: *state,
+                                orientation: *orientation,
+                            },
+                        );
+                        // Only drive our local plane once the peer has been acked; see above.
+                        if acked {
+                            if let Some(o) = orientation {
+                                registry.send_video_ctl(call_id, VideoControl::SetOrientation(*o));
+                            }
+                            match state {
+                                // The peer's video is (about to be) live; make sure our plane decodes
+                                // it even when the consumer skipped `.video()` and only accepts later
+                                // — decoding costs nothing until packets arrive.
+                                VideoState::UpgradeAccept | VideoState::Enabled => {
+                                    registry.set_is_video(call_id, true);
+                                    registry.send_video_ctl(call_id, VideoControl::Enable);
+                                }
+                                // The peer refused an upgrade WE started: our source is already feeding
+                                // a now-dead negotiation, so fully release the local video endpoints
+                                // (stops the camera feed, disables the plane) instead of leaking an
+                                // encode.
+                                VideoState::UpgradeReject | VideoState::UpgradeCancel => {
+                                    registry.run_video_teardown(call_id);
+                                    registry.set_is_video(call_id, false);
+                                }
+                                // The peer stopped ITS video; our outbound is the consumer's call
+                                // (stop_video), so only the flag is updated here.
+                                VideoState::Disabled | VideoState::Stopped => {
+                                    registry.set_is_video(call_id, false);
+                                }
+                                _ => {}
+                            }
+                        }
                     }
                     client.core.event_bus.dispatch(Event::IncomingCall(call));
                 }
@@ -287,6 +360,191 @@ mod tests {
 
     async fn make_client() -> Arc<Client> {
         crate::test_utils::create_test_client().await
+    }
+
+    /// A client whose sends land on a counting transport (so ack sends succeed and can be counted).
+    #[cfg(feature = "voip")]
+    async fn make_sending_client() -> Arc<Client> {
+        use wacore::handshake::NoiseCipher;
+
+        struct NullTransport;
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        impl crate::transport::Transport for NullTransport {
+            async fn send(&self, _data: bytes::Bytes) -> Result<(), anyhow::Error> {
+                Ok(())
+            }
+            async fn disconnect(&self) {}
+        }
+
+        let client = make_client().await;
+        let key = [0u8; 32];
+        let noise_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(NullTransport) as Arc<dyn crate::transport::Transport>,
+            NoiseCipher::new(&key).expect("valid key"),
+            NoiseCipher::new(&key).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+        client
+    }
+
+    #[cfg(feature = "voip")]
+    fn video_stanza(state: &str) -> wacore_binary::Node {
+        NodeBuilder::new("call")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-0002")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("video")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CALL-ID-0001")
+                .attr("state", state.to_string())
+                .attr("device_orientation", "1")
+                .build()])
+            .build()
+    }
+
+    // A <call><video> must be acked with the TYPED <ack class="call" type="video"> and the
+    // generic router ack suppressed — an untyped ack makes the upgrade requester revert ~5s in.
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn video_state_sends_typed_ack_and_cancels_generic() {
+        let client = make_sending_client().await;
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("ack"));
+
+        let node = node_to_owned_ref(&video_stanza("11"));
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+        assert!(cancelled, "the generic (untyped) ack must be suppressed");
+
+        let ack = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("typed ack must be sent")
+            .expect("waiter");
+        let r = ack.as_node_ref();
+        assert_eq!(r.attrs().optional_string("class").as_deref(), Some("call"));
+        assert_eq!(r.attrs().optional_string("type").as_deref(), Some("video"));
+        assert_eq!(
+            r.attrs().optional_string("id").as_deref(),
+            Some("STANZA-ID-0002")
+        );
+    }
+
+    // Non-video call actions keep the generic ack: `cancelled` must stay false.
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn non_video_actions_keep_the_generic_ack() {
+        let client = make_sending_client().await;
+        let node = node_to_owned_ref(&offer_stanza());
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+        assert!(!cancelled, "an offer must not cancel the generic ack");
+    }
+
+    // The video state must reach the call's event stream (via the registry hook) with the
+    // orientation, steer the plane (Enable on accept), and update the session's is_video flag.
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn video_state_forwards_event_and_steers_the_plane() {
+        use wacore::types::call::VideoState;
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let client = make_sending_client().await;
+        let registry = client.call_registry();
+        let session = wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        );
+        let generation = registry.insert(session);
+        let (ev_tx, ev_rx) = async_channel::unbounded::<CallEvent>();
+        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
+
+        let node = node_to_owned_ref(&video_stanza("4")); // UpgradeAccept
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node, &mut cancelled)
+                .await
+        );
+
+        let ev = ev_rx.try_recv().expect("event must be forwarded");
+        assert!(matches!(
+            ev,
+            CallEvent::VideoStateChanged {
+                state: VideoState::UpgradeAccept,
+                orientation: Some(1),
+            }
+        ));
+        let ctls: Vec<VideoControl> = std::iter::from_fn(|| ctl_rx.try_recv().ok()).collect();
+        assert!(ctls.contains(&VideoControl::SetOrientation(1)));
+        assert!(
+            ctls.contains(&VideoControl::Enable),
+            "an accept must enable our plane so the peer's video decodes"
+        );
+        assert!(
+            registry.snapshot("CALL-ID-0001").expect("session").is_video,
+            "UpgradeAccept marks the call as video"
+        );
+
+        // The peer stopping its video clears the flag but does NOT disable our plane.
+        let node = node_to_owned_ref(&video_stanza("6"));
+        let mut cancelled = false;
+        assert!(CallHandler.handle(client, node, &mut cancelled).await);
+        assert!(
+            !registry.snapshot("CALL-ID-0001").expect("session").is_video,
+            "Stopped clears the video flag"
+        );
+        let ctls: Vec<VideoControl> = std::iter::from_fn(|| ctl_rx.try_recv().ok()).collect();
+        assert!(
+            !ctls.contains(&VideoControl::Disable),
+            "the peer stopping ITS video must not tear our plane down"
+        );
+    }
+
+    // A peer that REJECTS or CANCELS an upgrade we started must fully release our local video: the
+    // registered teardown hook runs (so the camera feed stops) and the session flag clears.
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn refused_upgrade_runs_local_video_teardown() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wacore::voip::{CallEvent, VideoControl};
+
+        for state in ["5", "8"] {
+            // 5 = UpgradeReject, 8 = UpgradeCancel.
+            let client = make_sending_client().await;
+            let registry = client.call_registry();
+            let session = wacore::voip::CallSession::new_outgoing(
+                "CALL-ID-0001",
+                fake_caller_lid(),
+                fake_caller_lid(),
+            );
+            let generation = registry.insert(session);
+            registry.set_is_video("CALL-ID-0001", true);
+            let torn = Arc::new(AtomicUsize::new(0));
+            let (ev_tx, _ev_rx) = async_channel::unbounded::<CallEvent>();
+            let (ctl_tx, _ctl_rx) = async_channel::unbounded::<VideoControl>();
+            registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, {
+                let torn = torn.clone();
+                Box::new(move || {
+                    torn.fetch_add(1, Ordering::SeqCst);
+                })
+            });
+
+            let node = node_to_owned_ref(&video_stanza(state));
+            let mut cancelled = false;
+            assert!(CallHandler.handle(client, node, &mut cancelled).await);
+            assert_eq!(
+                torn.load(Ordering::SeqCst),
+                1,
+                "state {state}: a refused upgrade must run the local video teardown"
+            );
+            assert!(
+                !registry.snapshot("CALL-ID-0001").expect("session").is_video,
+                "state {state}: a refused upgrade must clear the video flag"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -6,7 +6,7 @@ use log::{debug, warn};
 use wacore::stanza::call::{
     TERMINATE_REASON_ACCEPTED_ELSEWHERE, TERMINATE_REASON_GROUP_CALL_ENDED,
     TERMINATE_REASON_REJECTED_ELSEWHERE, TERMINATE_REASON_TIMEOUT, TerminateParams,
-    build_call_video_ack, build_terminate,
+    VideoStateParams, build_call_video_ack, build_terminate, build_video_state,
 };
 use wacore::stanza::call::{build_offer_ack_receipt, parse_call_stanza};
 use wacore::types::call::{CallAction, IncomingCall, MissedCall, MissedReason};
@@ -237,6 +237,20 @@ impl StanzaHandler for CallHandler {
                                     registry.set_is_video(call_id, false);
                                 }
                                 _ => {}
+                            }
+                            if *state == VideoState::UpgradeAccept {
+                                let enabled = build_video_state(&VideoStateParams {
+                                    call_id,
+                                    to: &call.from,
+                                    id: &client.generate_request_id(),
+                                    call_creator: call.action.call_creator(),
+                                    state: VideoState::Enabled,
+                                    dec: None,
+                                    device_orientation: None,
+                                });
+                                if let Err(e) = client.send_node(enabled).await {
+                                    warn!("call: failed to announce accepted video upgrade: {e}");
+                                }
                             }
                         }
                     }
@@ -484,6 +498,7 @@ mod tests {
         let (ev_tx, ev_rx) = async_channel::unbounded::<CallEvent>();
         let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
         registry.set_video_channels("CALL-ID-0001", generation, ev_tx, ctl_tx, Box::new(|| {}));
+        let enabled_waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
 
         let node = node_to_owned_ref(&video_stanza("4")); // UpgradeAccept
         let mut cancelled = false;
@@ -511,6 +526,15 @@ mod tests {
             registry.snapshot("CALL-ID-0001").expect("session").is_video,
             "UpgradeAccept marks the call as video"
         );
+        let enabled = tokio::time::timeout(std::time::Duration::from_secs(2), enabled_waiter)
+            .await
+            .expect("Enabled stanza must be sent")
+            .expect("waiter");
+        let enabled_ref = enabled.as_node_ref();
+        let children = enabled_ref.children().expect("video child");
+        let video = &children[0];
+        assert_eq!(video.tag, "video");
+        assert_eq!(video.attrs().optional_string("state").as_deref(), Some("1"));
 
         // The peer stopping its video clears the flag but does NOT disable our plane.
         let node = node_to_owned_ref(&video_stanza("6"));

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -167,8 +167,8 @@ impl StanzaHandler for CallHandler {
                     }
                     // In-call <video state> signaling: send the TYPED ack (`type="video"`) and
                     // suppress the router's generic one — an untyped ack makes the upgrade
-                    // requester assume failure and revert after ~5s. Then surface the state on the
-                    // call's event stream and steer the live video plane.
+                    // requester assume failure and revert after ~5s. Reserve event capacity first,
+                    // then publish the state only after that ack commits it.
                     #[cfg(feature = "voip")]
                     if let CallAction::VideoState {
                         state, orientation, ..
@@ -176,21 +176,15 @@ impl StanzaHandler for CallHandler {
                     {
                         let call_id = call.action.call_id();
                         let registry = client.call_registry();
-                        let event_delivered = registry.send_call_event(
-                            call_id,
-                            CallEvent::VideoStateChanged {
-                                state: *state,
-                                orientation: *orientation,
-                            },
-                        );
-                        if !event_delivered {
+                        let mut event_permit = registry.reserve_call_event(call_id);
+                        if event_permit.is_none() {
                             warn!(
                                 "call: video state event queue is unavailable; leaving the transition unacknowledged"
                             );
                         }
-                        // A typed ack commits the received transition. If the application cannot
-                        // observe it, leave the generic ack in place so the peer reverts instead.
-                        let acked = if event_delivered {
+                        // A typed ack commits the received transition. Without a reserved event slot,
+                        // leave the generic ack in place so the peer reverts instead.
+                        let acked = if event_permit.is_some() {
                             match build_call_video_ack(&call) {
                                 Some(ack) => {
                                     *cancelled = true;
@@ -220,6 +214,15 @@ impl StanzaHandler for CallHandler {
                         }
                         // Only drive our local plane once the peer has been acked; see above.
                         if acked {
+                            let event_delivered = event_permit.take().is_some_and(|permit| {
+                                permit.send(CallEvent::VideoStateChanged {
+                                    state: *state,
+                                    orientation: *orientation,
+                                })
+                            });
+                            if !event_delivered {
+                                warn!("call: video state event receiver closed after typed ack");
+                            }
                             if let Some(o) = orientation {
                                 registry.send_video_ctl(call_id, VideoControl::SetOrientation(*o));
                             }
@@ -411,6 +414,46 @@ mod tests {
     }
 
     #[cfg(feature = "voip")]
+    async fn make_blocking_sending_client() -> (
+        Arc<Client>,
+        async_channel::Receiver<()>,
+        async_channel::Sender<()>,
+    ) {
+        use wacore::handshake::NoiseCipher;
+
+        struct BlockingTransport {
+            started: async_channel::Sender<()>,
+            release: async_channel::Receiver<()>,
+        }
+        #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+        impl crate::transport::Transport for BlockingTransport {
+            async fn send(&self, _data: bytes::Bytes) -> Result<(), anyhow::Error> {
+                let _ = self.started.try_send(());
+                let _ = self.release.recv().await;
+                Ok(())
+            }
+            async fn disconnect(&self) {}
+        }
+
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let client = make_client().await;
+        let key = [0u8; 32];
+        let noise_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(BlockingTransport {
+                started: started_tx,
+                release: release_rx,
+            }) as Arc<dyn crate::transport::Transport>,
+            NoiseCipher::new(&key).expect("valid key"),
+            NoiseCipher::new(&key).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+        (client, started_rx, release_tx)
+    }
+
+    #[cfg(feature = "voip")]
     fn video_stanza(state: &str) -> wacore_binary::Node {
         NodeBuilder::new("call")
             .attr("from", fake_caller_lid())
@@ -466,6 +509,53 @@ mod tests {
             r.attrs().optional_string("id").as_deref(),
             Some("STANZA-ID-0002")
         );
+    }
+
+    #[cfg(feature = "voip")]
+    #[tokio::test]
+    async fn video_state_is_not_visible_before_typed_ack_completes() {
+        use wacore::voip::{CallEvent, VideoControl};
+
+        let (client, send_started, release_send) = make_blocking_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_incoming(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        ));
+        let (event_tx, event_rx) = async_channel::bounded::<CallEvent>(2);
+        let (control_tx, _control_rx) = async_channel::unbounded::<VideoControl>();
+        registry.set_video_channels(
+            "CALL-ID-0001",
+            generation,
+            event_tx,
+            control_tx,
+            Box::new(|| {}),
+        );
+
+        let node = node_to_owned_ref(&video_stanza("11"));
+        let mut cancelled = false;
+        let handled = {
+            let handling = CallHandler.handle(client, node, &mut cancelled);
+            tokio::pin!(handling);
+            tokio::select! {
+                started = send_started.recv() => started.expect("typed ack send started"),
+                _ = &mut handling => panic!("handler completed before the blocked ack send"),
+            }
+            assert!(
+                event_rx.try_recv().is_err(),
+                "the application must not observe an uncommitted video state"
+            );
+
+            release_send.send(()).await.expect("release ack send");
+            handling.await
+        };
+        assert!(handled);
+        assert!(cancelled);
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(CallEvent::VideoStateChanged { .. })
+        ));
     }
 
     // Non-video call actions keep the generic ack: `cancelled` must stay false.

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1246,7 +1246,15 @@ impl VideoShared {
     }
 
     fn send_control(&self, control: VideoControl) {
-        let _ = self.ctl_tx.force_send(control);
+        match control {
+            // Orientation must not evict a negotiated state transition under signaling bursts.
+            VideoControl::SetOrientation(_) => {
+                let _ = self.ctl_tx.try_send(control);
+            }
+            _ => {
+                let _ = self.ctl_tx.force_send(control);
+            }
+        }
     }
 
     /// Attach (or replace) the consumer's endpoints: the sink becomes the forwarder's target and a
@@ -1535,8 +1543,14 @@ impl CallHandle {
                 .and_then(|entry| entry.video.take())
         };
         drop(pending_video);
-        self.video.detach_endpoints();
-        self.client_registry.set_is_video(&self.call_id, false);
+        if !self
+            .client_registry
+            .run_video_teardown(&self.call_id, self.generation)
+        {
+            self.video.detach_endpoints();
+        }
+        self.client_registry
+            .set_is_video(&self.call_id, self.generation, false);
     }
 
     /// Shared upgrade/accept body: attach endpoints, enable the plane, send the handshake stanzas.
@@ -1557,6 +1571,14 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         self.video
             .attach_endpoints(&client, &source, &sink, self.ended.clone());
+        if !self.client_registry.set_video_teardown(
+            &self.call_id,
+            self.generation,
+            video_teardown_hook(&self.video),
+        ) {
+            self.video.detach_endpoints();
+            return Err(CallError::Media("call no longer active"));
+        }
         // The upgrade INITIATOR holds outbound video until the peer accepts (the handler ungates on
         // the peer's UpgradeAccept/Enabled). The acceptor's peer already requested, so it may send
         // immediately.
@@ -1566,7 +1588,8 @@ impl CallHandle {
             VideoControl::Enable
         };
         self.video.send_control(ctl);
-        self.client_registry.set_is_video(&self.call_id, true);
+        self.client_registry
+            .set_is_video(&self.call_id, self.generation, true);
 
         let peer = self.peer_jid();
         let send_state = |state: VideoState, dec: Option<&'static str>| {
@@ -3690,7 +3713,18 @@ mod tests {
                 .is_video,
             "stop_video must clear the session's video flag"
         );
+
+        let (vsrc, vsink) = video_endpoints();
+        handle
+            .start_video(vsrc, vsink)
+            .await
+            .expect("restart_video");
+        assert!(handle.video.sink_slot.lock().unwrap().is_some());
         handle.hangup().await;
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "a restarted video plane must rearm terminal teardown"
+        );
     }
 
     #[tokio::test]
@@ -3780,18 +3814,23 @@ mod tests {
     }
 
     #[test]
-    fn video_control_queue_is_bounded_and_retains_latest_intent() {
+    fn video_control_queue_is_bounded_and_prioritizes_state() {
         let shared = VideoShared::new();
         let (_in_rx, ctl_rx) = shared.take_receivers();
+        shared.send_control(VideoControl::Disable);
         for orientation in 0..100u8 {
             shared.send_control(VideoControl::SetOrientation(orientation % 4));
         }
         assert_eq!(ctl_rx.len(), VIDEO_CONTROL_CHANNEL_CAP);
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
 
-        let mut last = None;
-        while let Ok(control) = ctl_rx.try_recv() {
-            last = Some(control);
+        while ctl_rx.try_recv().is_ok() {}
+        for orientation in 0..VIDEO_CONTROL_CHANNEL_CAP as u8 {
+            shared.send_control(VideoControl::SetOrientation(orientation % 4));
         }
-        assert_eq!(last, Some(VideoControl::SetOrientation(3)));
+        shared.send_control(VideoControl::Enable);
+        let controls: Vec<_> = std::iter::from_fn(|| ctl_rx.try_recv().ok()).collect();
+        assert_eq!(controls.len(), VIDEO_CONTROL_CHANNEL_CAP);
+        assert_eq!(controls.last(), Some(&VideoControl::Enable));
     }
 }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -18,7 +18,10 @@ use wacore::stanza::call::{
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
 use wacore::voip::transport::RelayTransportFactory;
-use wacore::voip::{CallChannels, CallConfig, CallEngine, CallEvent, VideoControl, VideoFrame};
+use wacore::voip::{
+    CallChannels, CallConfig, CallEngine, CallEvent, VideoControl, VideoControlReceiver,
+    VideoControlSender, VideoFrame, video_control_channel,
+};
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
 
@@ -1191,9 +1194,6 @@ async fn attach_engine(
 const VIDEO_IN_CHANNEL_CAP: usize = 4;
 /// Inbound video AU backlog between the drive loop and the sink forwarder.
 const VIDEO_OUT_CHANNEL_CAP: usize = 8;
-/// Keeps hostile signaling bursts bounded while retaining the newest control intent.
-const VIDEO_CONTROL_CHANNEL_CAP: usize = 16;
-
 /// `dec` we advertise on an upgrade request (what we can decode).
 const VIDEO_DEC_REQUEST: &str = "H264";
 /// `dec` WA Web advertises on an UpgradeAccept.
@@ -1204,7 +1204,7 @@ const VIDEO_DEC_ACCEPT: &str = "H264,AV1";
 /// and a mid-call upgrade must not have to rebuild the media task.
 pub(crate) struct VideoShared {
     /// Mid-call video-plane control into the drive loop (Enable/Disable/SetOrientation).
-    ctl_tx: async_channel::Sender<VideoControl>,
+    ctl_tx: VideoControlSender,
     /// Outbound AUs into the drive loop; a `VideoFeed` pumps the attached source into it.
     in_tx: async_channel::Sender<Vec<u8>>,
     /// The CURRENTLY attached sink (swappable: upgrade attaches, downgrade clears). The
@@ -1217,14 +1217,11 @@ pub(crate) struct VideoShared {
 }
 
 /// The drive-loop halves of the video channels: (outbound AUs, plane control).
-type VideoReceivers = (
-    async_channel::Receiver<Vec<u8>>,
-    async_channel::Receiver<VideoControl>,
-);
+type VideoReceivers = (async_channel::Receiver<Vec<u8>>, VideoControlReceiver);
 
 impl VideoShared {
     fn new() -> Self {
-        let (ctl_tx, ctl_rx) = async_channel::bounded::<VideoControl>(VIDEO_CONTROL_CHANNEL_CAP);
+        let (ctl_tx, ctl_rx) = video_control_channel();
         let (in_tx, in_rx) = async_channel::bounded::<Vec<u8>>(VIDEO_IN_CHANNEL_CAP);
         Self {
             ctl_tx,
@@ -1242,19 +1239,14 @@ impl VideoShared {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .take()
-            .unwrap_or_else(|| (async_channel::bounded(1).1, async_channel::bounded(1).1))
+            .unwrap_or_else(|| {
+                let (_ctl_tx, ctl_rx) = video_control_channel();
+                (async_channel::bounded(1).1, ctl_rx)
+            })
     }
 
     fn send_control(&self, control: VideoControl) {
-        match control {
-            // Orientation must not evict a negotiated state transition under signaling bursts.
-            VideoControl::SetOrientation(_) => {
-                let _ = self.ctl_tx.try_send(control);
-            }
-            _ => {
-                let _ = self.ctl_tx.force_send(control);
-            }
-        }
+        let _ = self.ctl_tx.send(control);
     }
 
     /// Attach (or replace) the consumer's endpoints: the sink becomes the forwarder's target and a
@@ -1623,6 +1615,10 @@ impl CallHandle {
                 }
                 if let Err(e) = send_state(VideoState::Enabled, None).await {
                     // The peer times out an incomplete handshake; keep local media aligned with it.
+                    warn!(
+                        "voip: video upgrade handshake failed call_id={} phase=enabled_after_accept error={e}",
+                        self.call_id
+                    );
                     self.teardown_local_video();
                     return Err(e.into());
                 }
@@ -3815,23 +3811,18 @@ mod tests {
     }
 
     #[test]
-    fn video_control_queue_is_bounded_and_prioritizes_state() {
+    fn video_control_queue_preserves_state_and_coalesces_orientation() {
         let shared = VideoShared::new();
         let (_in_rx, ctl_rx) = shared.take_receivers();
         shared.send_control(VideoControl::Disable);
         for orientation in 0..100u8 {
             shared.send_control(VideoControl::SetOrientation(orientation % 4));
         }
-        assert_eq!(ctl_rx.len(), VIDEO_CONTROL_CHANNEL_CAP);
-        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
-
-        while ctl_rx.try_recv().is_ok() {}
-        for orientation in 0..VIDEO_CONTROL_CHANNEL_CAP as u8 {
-            shared.send_control(VideoControl::SetOrientation(orientation % 4));
-        }
         shared.send_control(VideoControl::Enable);
-        let controls: Vec<_> = std::iter::from_fn(|| ctl_rx.try_recv().ok()).collect();
-        assert_eq!(controls.len(), VIDEO_CONTROL_CHANNEL_CAP);
-        assert_eq!(controls.last(), Some(&VideoControl::Enable));
+
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Enable));
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
+        assert_eq!(ctl_rx.try_recv(), Err(async_channel::TryRecvError::Empty));
     }
 }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1265,6 +1265,7 @@ impl VideoShared {
         ));
         *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(sink.playout());
         let feed = VideoFeed {
+            source: source.clone(),
             src: source.frames(),
             out: self.in_tx.clone(),
             ended,
@@ -1291,9 +1292,7 @@ impl VideoShared {
     }
 }
 
-/// A registry teardown hook that fully releases the call's local video endpoints. Invoked when a
-/// caller-initiated upgrade is refused (`<video state=UpgradeReject|UpgradeCancel>`), so the camera
-/// feed doesn't keep encoding into a disabled plane.
+/// A registry teardown hook that releases codec endpoints on refusal or call termination.
 fn video_teardown_hook(video: &Arc<VideoShared>) -> Box<dyn Fn() + Send + Sync> {
     let video = video.clone();
     Box::new(move || video.detach_endpoints())
@@ -1303,6 +1302,7 @@ fn video_teardown_hook(video: &Arc<VideoShared>) -> Box<dyn Fn() + Send + Sync> 
 /// `ended` flag as well as the channels, so a source that stops producing after the call ends
 /// can't park this task on `recv()` forever.
 struct VideoFeed {
+    source: Arc<dyn VideoSource>,
     src: async_channel::Receiver<Vec<u8>>,
     out: async_channel::Sender<Vec<u8>>,
     ended: Arc<EndedFlag>,
@@ -1311,6 +1311,7 @@ struct VideoFeed {
 impl VideoFeed {
     async fn run(self) {
         use futures::FutureExt;
+        let _source = self.source;
         loop {
             let ended = self.ended.wait().fuse();
             let recv = self.src.recv().fuse();
@@ -1490,9 +1491,8 @@ impl CallHandle {
             id: &client.generate_request_id(),
             call_creator: &self.call_creator,
             state: VideoState::Enabled,
-            dec: Some(VIDEO_DEC_REQUEST),
-            upgrade_marker: false,
-            device_orientation: Some(0),
+            dec: None,
+            device_orientation: None,
         });
         client.send_node(stanza).await?;
         Ok(())
@@ -1514,7 +1514,6 @@ impl CallHandle {
             call_creator: &self.call_creator,
             state: VideoState::Stopped,
             dec: None,
-            upgrade_marker: false,
             device_orientation: Some(0),
         });
         client.send_node(stanza).await?;
@@ -1570,7 +1569,7 @@ impl CallHandle {
         self.client_registry.set_is_video(&self.call_id, true);
 
         let peer = self.peer_jid();
-        let send_state = |state: VideoState, dec: Option<&'static str>, marker: bool| {
+        let send_state = |state: VideoState, dec: Option<&'static str>| {
             // Each call stanza gets its own wrapper id so the peer's typed ack correlates.
             let stanza = build_video_state(&VideoStateParams {
                 call_id: &self.call_id,
@@ -1579,7 +1578,6 @@ impl CallHandle {
                 call_creator: &self.call_creator,
                 state,
                 dec,
-                upgrade_marker: marker,
                 device_orientation: None,
             });
             let client = client.clone();
@@ -1588,21 +1586,20 @@ impl CallHandle {
         match role {
             VideoState::UpgradeRequestV2 => {
                 if let Err(e) =
-                    send_state(VideoState::UpgradeRequestV2, Some(VIDEO_DEC_REQUEST), true).await
+                    send_state(VideoState::UpgradeRequestV2, Some(VIDEO_DEC_REQUEST)).await
                 {
                     self.teardown_local_video();
                     return Err(e.into());
                 }
             }
             _ => {
-                if let Err(e) =
-                    send_state(VideoState::UpgradeAccept, Some(VIDEO_DEC_ACCEPT), false).await
+                if let Err(e) = send_state(VideoState::UpgradeAccept, Some(VIDEO_DEC_ACCEPT)).await
                 {
                     self.teardown_local_video();
                     return Err(e.into());
                 }
                 // The accept already committed the peer; a failed follow-up cannot be rolled back.
-                send_state(VideoState::Enabled, None, false).await?;
+                send_state(VideoState::Enabled, None).await?;
             }
         }
         Ok(())

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -11,11 +11,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use log::warn;
 use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
-use wacore::stanza::call::{CAPABILITY_OFFER, OfferDeviceKey, OfferParams, build_offer};
-use wacore::types::call::{CallAction, IncomingCall};
+use wacore::stanza::call::{
+    CAPABILITY_OFFER, OfferDeviceKey, OfferParams, VideoStateParams, build_offer, build_video_state,
+};
+use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
 use wacore::voip::transport::RelayTransportFactory;
-use wacore::voip::{CallChannels, CallConfig, CallEngine, CallEvent};
+use wacore::voip::{CallChannels, CallConfig, CallEngine, CallEvent, VideoControl, VideoFrame};
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
 
@@ -23,6 +25,7 @@ use crate::client::{CallError, Client};
 use crate::voip::audio::{AudioSink, AudioSource, WA_FRAME_SAMPLES};
 use crate::voip::driver::{RandTxIds, run_call_tokio};
 use crate::voip::transport::RelayMediaChannelFactory;
+use crate::voip::video::{VideoSink, VideoSource};
 
 /// Builder returned by [`Voip::accept`](super::super::client::voip::Voip::accept). Holds the offer
 /// and, once [`audio`](Self::audio) is called, the source/sink, then [`start`](Self::start) drives
@@ -32,6 +35,7 @@ pub struct AcceptCall<'a> {
     pub(crate) incoming: &'a IncomingCall,
     source: Option<Arc<dyn AudioSource>>,
     sink: Option<Arc<dyn AudioSink>>,
+    video: Option<VideoEndpoints>,
 }
 
 impl<'a> AcceptCall<'a> {
@@ -41,6 +45,7 @@ impl<'a> AcceptCall<'a> {
             incoming,
             source: None,
             sink: None,
+            video: None,
         }
     }
 
@@ -53,6 +58,21 @@ impl<'a> AcceptCall<'a> {
     {
         self.source = Some(Arc::new(source));
         self.sink = Some(Arc::new(sink));
+        self
+    }
+
+    /// Answer with VIDEO media as well: `source` supplies our encoded H.264 AUs, `sink` receives
+    /// the peer's. Use for a video-from-the-start offer (`CallAction::Offer { is_video: true }`);
+    /// an audio-only call can upgrade later via [`CallHandle::start_video`].
+    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.video = Some(VideoEndpoints {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
         self
     }
 
@@ -75,6 +95,7 @@ impl<'a> AcceptCall<'a> {
         // borrows `&self`, so move the fields before those borrows to avoid a partial-move clash.
         let source = self.source.take().ok_or(CallError::MissingAudio)?;
         let sink = self.sink.take().ok_or(CallError::MissingAudio)?;
+        let video = self.video.take();
         // Answering consumes the ringing flag now, BEFORE the media-setup awaits (callKey decrypt /
         // relay connect): a peer <terminate> racing this window must not record a missed call for a
         // call we are answering. A failed start() leaves it cleared -- an attempted answer reads as
@@ -82,7 +103,7 @@ impl<'a> AcceptCall<'a> {
         self.client
             .call_registry()
             .take_ringing(self.incoming.action.call_id());
-        let (engine, call_id, addr) = self.build_engine().await?;
+        let (engine, call_id, addr) = self.build_engine(video.is_some()).await?;
         // The decrypt above may await on the network (prekey fetch). If the connection dropped
         // meanwhile, cleanup_connection_state already ran with no registry entry to abort, so bail
         // rather than register + connect a relay that would outlive the connection.
@@ -90,11 +111,12 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
         let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
-        let session = wacore::voip::CallSession::new_incoming(
+        let mut session = wacore::voip::CallSession::new_incoming(
             &call_id,
             self.incoming.from.clone(),
             self.incoming.action.call_creator().clone(),
         );
+        session.is_video = video.is_some();
         spawn_call(
             self.client,
             call_id,
@@ -103,6 +125,7 @@ impl<'a> AcceptCall<'a> {
             &factory,
             source,
             sink,
+            video,
         )
         .await
     }
@@ -110,7 +133,10 @@ impl<'a> AcceptCall<'a> {
     /// Build the [`CallEngine`] from the offer: decrypt the callKey over the Signal session, then
     /// assemble the incoming-call config from the parsed relay. No network I/O beyond the Signal
     /// session the decrypt needs.
-    async fn build_engine(&self) -> Result<(CallEngine, String, SocketAddr), CallError> {
+    async fn build_engine(
+        &self,
+        enable_video: bool,
+    ) -> Result<(CallEngine, String, SocketAddr), CallError> {
         let media = self.incoming.media.as_ref().ok_or(CallError::NotAnOffer)?;
         let CallAction::Offer {
             call_id,
@@ -161,8 +187,9 @@ impl<'a> AcceptCall<'a> {
             .as_ref()
             .ok_or(CallError::Media("offer carried no <relay>"))?;
 
-        let config = CallConfig::for_incoming(call_id, &self_lid, &peer_lid, call_key, relay)
+        let mut config = CallConfig::for_incoming(call_id, &self_lid, &peer_lid, call_key, relay)
             .map_err(|e| CallError::Setup(e.to_string()))?;
+        config.enable_video = enable_video;
         // Read the dial addr off the config before CallEngine::new consumes it (no second relay walk).
         let addr = socket_addr_from_config(&config)?;
         let engine = CallEngine::new(config, Box::new(RandTxIds))
@@ -180,6 +207,7 @@ pub struct OutgoingCall<'a> {
     pub(crate) peer: &'a Jid,
     source: Option<Arc<dyn AudioSource>>,
     sink: Option<Arc<dyn AudioSink>>,
+    video: Option<VideoEndpoints>,
 }
 
 impl<'a> OutgoingCall<'a> {
@@ -189,6 +217,7 @@ impl<'a> OutgoingCall<'a> {
             peer,
             source: None,
             sink: None,
+            video: None,
         }
     }
 
@@ -201,6 +230,21 @@ impl<'a> OutgoingCall<'a> {
     {
         self.source = Some(Arc::new(source));
         self.sink = Some(Arc::new(sink));
+        self
+    }
+
+    /// Place a VIDEO call: the offer advertises `<video>` and the media plane carries H.264 both
+    /// ways once the call connects. An audio-only call can upgrade later via
+    /// [`CallHandle::start_video`].
+    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.video = Some(VideoEndpoints {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
         self
     }
 
@@ -249,6 +293,7 @@ impl<'a> OutgoingCall<'a> {
     pub async fn start(mut self) -> Result<CallHandle, CallError> {
         let source = self.source.take().ok_or(CallError::MissingAudio)?;
         let sink = self.sink.take().ok_or(CallError::MissingAudio)?;
+        let video = self.video.take();
 
         // WA Web `_e()`: call-id is "00" + 15 random bytes as lowercase hex (32 hex chars total).
         let call_id = gen_call_id();
@@ -344,9 +389,16 @@ impl<'a> OutgoingCall<'a> {
             &ring_devices,
             source,
             sink,
+            video,
         )
         .await
     }
+}
+
+/// The video source/sink pair a builder's `.video()` provided.
+struct VideoEndpoints {
+    source: Arc<dyn VideoSource>,
+    sink: Arc<dyn VideoSink>,
 }
 
 /// Drop hosted (Cloud-API) companions from the offer's device set: the client never establishes
@@ -408,6 +460,7 @@ async fn place_call(
     ring_devices: &[Jid],
     source: Arc<dyn AudioSource>,
     sink: Arc<dyn AudioSink>,
+    video: Option<VideoEndpoints>,
 ) -> Result<CallHandle, CallError> {
     // The offer keeps the addressed `<destination><to jid>` shape whenever the callee is multi-device
     // (computed before any pkmsg/encrypt filtering), even if one encryptable survivor remains.
@@ -530,6 +583,7 @@ async fn place_call(
         // Keep the addressed `<destination>` shape for a multi-device callee even if encryption
         // failures left a single surviving key, so that key stays tied to its device.
         multi_device,
+        video: video.is_some(),
     });
 
     // Register the ack-waiter for the offer's stanza id BEFORE send_node so a fast server reply can't
@@ -543,6 +597,7 @@ async fn place_call(
     let registry = client.call_registry();
     let mut session =
         wacore::voip::CallSession::new_outgoing(&call_id, peer.clone(), call_creator.clone());
+    session.is_video = video.is_some();
     // The rung device set lives on the session so an inbound <accept>/<reject> from one callee device
     // can dismiss the rest (caller-driven accepted_elsewhere); it is dropped automatically whenever the
     // call deregisters (every end path removes the registry entry). Use the FULL server-rung set, NOT
@@ -571,6 +626,17 @@ async fn place_call(
     let (rekey_tx, rekey_rx) = async_channel::bounded::<String>(1);
     registry.set_rekey_sender(&call_id, generation, rekey_tx);
 
+    // Video plumbing exists for EVERY call (idle channels cost nothing): the signaling handler and
+    // CallHandle::start_video need the senders even when the call starts audio-only.
+    let video_shared = Arc::new(VideoShared::new());
+    registry.set_video_channels(
+        &call_id,
+        generation,
+        ev_tx.clone(),
+        video_shared.ctl_tx.clone(),
+        video_teardown_hook(&video_shared),
+    );
+
     // Park the material needed to spawn the engine once the relay arrives. Keyed by call-id.
     client
         .pending_outgoing_calls
@@ -585,6 +651,8 @@ async fn place_call(
                 call_key: call_key.to_vec(),
                 source,
                 sink,
+                video,
+                video_shared: video_shared.clone(),
                 muted: muted.clone(),
                 ended: ended.clone(),
                 ev_tx,
@@ -621,10 +689,22 @@ async fn place_call(
         call_creator: call_creator.clone(),
         client_registry: registry,
         pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+        client: client_weak(client),
         muted,
+        video: video_shared,
         events: ev_rx,
         ended,
     })
+}
+
+/// The client's own `Weak`, for handles that need to reach back (send a `<video>` stanza) without
+/// keeping the client alive.
+fn client_weak(client: &Client) -> std::sync::Weak<Client> {
+    client
+        .self_weak
+        .get()
+        .cloned()
+        .unwrap_or_else(std::sync::Weak::new)
 }
 
 /// Time to wait for the server's `<ack type=offer>` carrying the relay before giving up.
@@ -768,6 +848,10 @@ pub(crate) struct PendingOutgoing {
     call_key: Vec<u8>,
     source: Arc<dyn AudioSource>,
     sink: Arc<dyn AudioSink>,
+    /// `.video()` endpoints for a video-from-the-start call; `None` for audio-only.
+    video: Option<VideoEndpoints>,
+    /// The handle's video plumbing (created at place time so `start_video` works while dormant).
+    video_shared: Arc<VideoShared>,
     muted: Arc<AtomicBool>,
     ended: Arc<EndedFlag>,
     ev_tx: async_channel::Sender<CallEvent>,
@@ -822,7 +906,7 @@ pub(crate) async fn attach_outgoing_relay(
     // (no pending entry left for a later hangup to drain). Build everything in a fallible block and, on
     // any early-return error in this window, reap the generation and notify `ended` before propagating.
     let build = (|| {
-        let config = CallConfig::for_outgoing(
+        let mut config = CallConfig::for_outgoing(
             call_id,
             &pending.self_lid,
             &pending.peer_lid,
@@ -830,6 +914,7 @@ pub(crate) async fn attach_outgoing_relay(
             relay,
         )
         .map_err(|e| CallError::Setup(e.to_string()))?;
+        config.enable_video = pending.video.is_some();
         // Read the dial addr off the config before CallEngine::new consumes it (no second relay walk).
         let addr = socket_addr_from_config(&config)?;
         let engine = CallEngine::new(config, Box::new(RandTxIds))
@@ -858,6 +943,8 @@ pub(crate) async fn attach_outgoing_relay(
         &factory,
         pending.source,
         pending.sink,
+        pending.video,
+        pending.video_shared,
         pending.muted,
         pending.ended,
         pending.ev_tx,
@@ -872,6 +959,7 @@ pub(crate) async fn attach_outgoing_relay(
 /// Spawn the call driver over `factory` and register it. Generic over the relay factory so a test
 /// can inject an in-memory transport instead of the real DTLS/SCTP dialer. The session is supplied so
 /// both incoming (`new_incoming`) and outgoing (`new_outgoing`) callers register the right direction.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_call(
     client: &Client,
     call_id: String,
@@ -880,6 +968,7 @@ async fn spawn_call(
     factory: &dyn RelayTransportFactory,
     source: Arc<dyn AudioSource>,
     sink: Arc<dyn AudioSink>,
+    video: Option<VideoEndpoints>,
 ) -> Result<CallHandle, CallError> {
     // Register BEFORE connecting so the entry exists before the driver task can self-clean.
     let registry = client.call_registry();
@@ -896,6 +985,14 @@ async fn spawn_call(
         move || ended.notify()
     });
     let (ev_tx, ev_rx) = async_channel::bounded::<CallEvent>(CALL_EVENT_CHANNEL_CAPACITY);
+    let video_shared = Arc::new(VideoShared::new());
+    registry.set_video_channels(
+        &call_id,
+        generation,
+        ev_tx.clone(),
+        video_shared.ctl_tx.clone(),
+        video_teardown_hook(&video_shared),
+    );
     attach_engine(
         client,
         &call_id,
@@ -904,6 +1001,8 @@ async fn spawn_call(
         factory,
         source,
         sink,
+        video,
+        video_shared.clone(),
         muted.clone(),
         ended.clone(),
         ev_tx,
@@ -918,7 +1017,9 @@ async fn spawn_call(
         call_creator,
         client_registry: client.call_registry(),
         pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+        client: client_weak(client),
         muted,
+        video: video_shared,
         events: ev_rx,
         ended,
     })
@@ -936,6 +1037,8 @@ async fn attach_engine(
     factory: &dyn RelayTransportFactory,
     source: Arc<dyn AudioSource>,
     sink: Arc<dyn AudioSink>,
+    video: Option<VideoEndpoints>,
+    video_shared: Arc<VideoShared>,
     muted: Arc<AtomicBool>,
     ended: Arc<EndedFlag>,
     ev_tx: async_channel::Sender<CallEvent>,
@@ -999,11 +1102,37 @@ async fn attach_engine(
     // dies with the call instead of parking on `src.recv()` forever, holding the mic channel open.
     let mic_feed = client.runtime.spawn(Box::pin(mute_feed.run()));
 
+    // Video plumbing: the drive loop always gets the channels; the endpoints attach now (a
+    // `.video()` call) or later (an upgrade via CallHandle::start_video/accept_video).
+    let (video_in_rx, video_ctl_rx) = video_shared.take_receivers();
+    let (video_out_tx, video_out_rx) = async_channel::bounded::<VideoFrame>(VIDEO_OUT_CHANNEL_CAP);
+    // Forwarder from the drive loop to whatever sink is CURRENTLY attached (swappable mid-call).
+    // Ends when the drive loop drops its video_out sender; moved into the media task like mic_feed.
+    let sink_slot = video_shared.sink_slot.clone();
+    let video_out_feed = client.runtime.spawn(Box::pin(async move {
+        while let Ok(frame) = video_out_rx.recv().await {
+            let tx = sink_slot.lock().unwrap_or_else(|e| e.into_inner()).clone();
+            if let Some(tx) = tx {
+                // Loss tolerant, like the speaker: a stalled sink sheds frames.
+                let _ = tx.try_send(frame);
+            }
+        }
+    }));
+    if let Some(v) = &video {
+        video_shared.attach_endpoints(client, &v.source, &v.sink, ended.clone());
+        // From-start video: the engine was built with enable_video, but a same-path Enable is
+        // idempotent and keeps one code path for both entries.
+        let _ = video_shared.ctl_tx.try_send(VideoControl::Enable);
+    }
+
     let channels = CallChannels {
         mic: mic_rx,
         speaker: sink.playout(),
         events: ev_tx,
         rekey: rekey_rx,
+        video_in: video_in_rx,
+        video_out: video_out_tx,
+        video_ctl: video_ctl_rx,
     };
 
     let registry = client.call_registry();
@@ -1017,10 +1146,11 @@ async fn attach_engine(
         e.notify();
     });
     let task = client.runtime.spawn(Box::pin(async move {
-        // Both are captured (moved in), so any teardown -- even an abort before the first poll --
-        // drops them: the mic feed is aborted and `ended` is notified.
+        // All are captured (moved in), so any teardown -- even an abort before the first poll --
+        // drops them: the feeds are aborted and `ended` is notified.
         let _ended_guard = ended_guard;
         let _mic_feed = mic_feed;
+        let _video_out_feed = video_out_feed;
         run_call_tokio(transport, relay_events, channels, engine).await;
         // A locally-ended call gets no <terminate>; drop our own entry so the registry doesn't grow.
         // The call's `ring_devices` live on the session, so this also drops the sibling-dismiss
@@ -1029,6 +1159,150 @@ async fn attach_engine(
     }));
     registry.set_media_task(call_id, generation, task);
     Ok(())
+}
+
+/// Outbound video AU backlog before the source feed back-pressures (AUs are large; keep it short).
+const VIDEO_IN_CHANNEL_CAP: usize = 4;
+/// Inbound video AU backlog between the drive loop and the sink forwarder.
+const VIDEO_OUT_CHANNEL_CAP: usize = 8;
+
+/// `dec` we advertise on an upgrade request (what we can decode).
+const VIDEO_DEC_REQUEST: &str = "H264";
+/// `dec` WA Web advertises on an UpgradeAccept.
+const VIDEO_DEC_ACCEPT: &str = "H264,AV1";
+
+/// Per-call video plumbing shared between the [`CallHandle`], the registry (signaling handler),
+/// and the drive loop. Created for EVERY call at registration time — idle channels cost nothing,
+/// and a mid-call upgrade must not have to rebuild the media task.
+pub(crate) struct VideoShared {
+    /// Mid-call video-plane control into the drive loop (Enable/Disable/SetOrientation).
+    ctl_tx: async_channel::Sender<VideoControl>,
+    /// Outbound AUs into the drive loop; a `VideoFeed` pumps the attached source into it.
+    in_tx: async_channel::Sender<Vec<u8>>,
+    /// The CURRENTLY attached sink (swappable: upgrade attaches, downgrade clears). The
+    /// out-forwarder task reads it per frame.
+    sink_slot: Arc<std::sync::Mutex<Option<async_channel::Sender<VideoFrame>>>>,
+    /// The live source feed, aborted on downgrade/replacement.
+    feed: std::sync::Mutex<Option<wacore::runtime::AbortHandle>>,
+    /// Receiver halves parked until `attach_engine` hands them to the drive loop.
+    receivers: std::sync::Mutex<Option<VideoReceivers>>,
+}
+
+/// The drive-loop halves of the video channels: (outbound AUs, plane control).
+type VideoReceivers = (
+    async_channel::Receiver<Vec<u8>>,
+    async_channel::Receiver<VideoControl>,
+);
+
+impl VideoShared {
+    fn new() -> Self {
+        // Control is unbounded: commands are rare, tiny, and must never be dropped (a lost Enable
+        // strands the upgrade). Media (in_tx) is bounded and back-pressures the feed.
+        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (in_tx, in_rx) = async_channel::bounded::<Vec<u8>>(VIDEO_IN_CHANNEL_CAP);
+        Self {
+            ctl_tx,
+            in_tx,
+            sink_slot: Arc::new(std::sync::Mutex::new(None)),
+            feed: std::sync::Mutex::new(None),
+            receivers: std::sync::Mutex::new(Some((in_rx, ctl_rx))),
+        }
+    }
+
+    /// The drive-loop halves. After the one real take (attach_engine), fresh closed channels are
+    /// returned defensively — their arms disable themselves in the driver.
+    fn take_receivers(&self) -> VideoReceivers {
+        self.receivers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+            .unwrap_or_else(|| (async_channel::bounded(1).1, async_channel::bounded(1).1))
+    }
+
+    /// Attach (or replace) the consumer's endpoints: the sink becomes the forwarder's target and a
+    /// fresh `VideoFeed` pumps the source; a previous feed is aborted (its source is released).
+    fn attach_endpoints(
+        &self,
+        client: &Client,
+        source: &Arc<dyn VideoSource>,
+        sink: &Arc<dyn VideoSink>,
+        ended: Arc<EndedFlag>,
+    ) {
+        *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(sink.playout());
+        let feed = VideoFeed {
+            src: source.frames(),
+            out: self.in_tx.clone(),
+            ended,
+        };
+        let handle = client.runtime.spawn(Box::pin(feed.run()));
+        if let Some(old) = self
+            .feed
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .replace(handle)
+        {
+            old.abort();
+        }
+    }
+
+    /// Release the endpoints (downgrade / refused upgrade): the source feed is aborted, the sink is
+    /// dropped, and the drive loop's video plane is disabled so it stops emitting/decoding video.
+    fn detach_endpoints(&self) {
+        *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        if let Some(feed) = self.feed.lock().unwrap_or_else(|e| e.into_inner()).take() {
+            feed.abort();
+        }
+        let _ = self.ctl_tx.try_send(VideoControl::Disable);
+    }
+}
+
+/// A registry teardown hook that fully releases the call's local video endpoints. Invoked when a
+/// caller-initiated upgrade is refused (`<video state=UpgradeReject|UpgradeCancel>`), so the camera
+/// feed doesn't keep encoding into a disabled plane.
+fn video_teardown_hook(video: &Arc<VideoShared>) -> Box<dyn Fn() + Send + Sync> {
+    let video = video.clone();
+    Box::new(move || video.detach_endpoints())
+}
+
+/// Forwards encoded AUs from the consumer's source into the drive loop. Bounded on the call's
+/// `ended` flag as well as the channels, so a source that stops producing after the call ends
+/// can't park this task on `recv()` forever.
+struct VideoFeed {
+    src: async_channel::Receiver<Vec<u8>>,
+    out: async_channel::Sender<Vec<u8>>,
+    ended: Arc<EndedFlag>,
+}
+
+impl VideoFeed {
+    async fn run(self) {
+        use futures::FutureExt;
+        loop {
+            let ended = self.ended.wait().fuse();
+            let recv = self.src.recv().fuse();
+            futures::pin_mut!(ended, recv);
+            let au = futures::select_biased! {
+                _ = ended => break,
+                au = recv => match au {
+                    Ok(au) => au,
+                    Err(_) => break,
+                },
+            };
+            // Await the send (the bounded channel back-pressures a source that outruns the wire),
+            // but race it against `ended` too: a dormant call whose 4-AU queue filled before
+            // `attach_engine` drained it would otherwise park here forever past teardown.
+            let ended = self.ended.wait().fuse();
+            let send = self.out.send(au).fuse();
+            futures::pin_mut!(ended, send);
+            futures::select_biased! {
+                _ = ended => break,
+                res = send => {
+                    if res.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Forwards mic frames to the engine, zeroing them while muted. Zeroing (vs. dropping) keeps the
@@ -1100,7 +1374,10 @@ pub struct CallHandle {
     /// engine task exists yet to fire the drop-guard.
     pending_outgoing_calls:
         Arc<std::sync::Mutex<std::collections::HashMap<String, PendingOutgoing>>>,
+    /// Weak so a lingering handle can't keep the client alive; upgraded to send `<video>` stanzas.
+    client: std::sync::Weak<Client>,
     muted: Arc<AtomicBool>,
+    video: Arc<VideoShared>,
     events: async_channel::Receiver<CallEvent>,
     ended: Arc<EndedFlag>,
 }
@@ -1135,6 +1412,147 @@ impl CallHandle {
     /// Whether the microphone is currently muted.
     pub fn is_muted(&self) -> bool {
         self.muted.load(Ordering::Relaxed)
+    }
+
+    /// UPGRADE the call to video (we initiate): attaches the endpoints, enables the media plane,
+    /// and sends `<video state=11 dec="H264" voip_settings="video">`. The peer answers with
+    /// `UpgradeAccept`/`Enabled` (surfaced as [`CallEvent::VideoStateChanged`]); media flows as
+    /// soon as both planes are up. Also the way to start media on a `.video()` call whose builder
+    /// endpoints you skipped.
+    pub async fn start_video<S, K>(&self, source: S, sink: K) -> Result<(), CallError>
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.begin_video(
+            Arc::new(source),
+            Arc::new(sink),
+            VideoState::UpgradeRequestV2,
+        )
+        .await
+    }
+
+    /// ACCEPT the peer's video upgrade request (a `VideoStateChanged { state: UpgradeRequestV2 }`
+    /// event): attaches the endpoints, enables the media plane, and answers
+    /// `<video state=4 dec="H264,AV1">` followed by `<video state=1>` (Enabled).
+    pub async fn accept_video<S, K>(&self, source: S, sink: K) -> Result<(), CallError>
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.begin_video(Arc::new(source), Arc::new(sink), VideoState::UpgradeAccept)
+            .await
+    }
+
+    /// DOWNGRADE to audio: sends `<video state=6>` (Stopped, no marker), tears the local video
+    /// plane down, and releases the source/sink. The audio plane is untouched. Idempotent.
+    pub async fn stop_video(&self) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        // Tear local media down FIRST, matching `Voip::terminate`: the app asked to stop video, so
+        // a failed signaling send must NOT leave the camera streaming. If the peer misses the
+        // Stopped it keeps sending video, but our plane is disabled so those PT-97 packets drop.
+        self.teardown_local_video();
+        let stanza = build_video_state(&VideoStateParams {
+            call_id: &self.call_id,
+            to: &self.peer_jid(),
+            id: &client.generate_request_id(),
+            call_creator: &self.call_creator,
+            state: VideoState::Stopped,
+            dec: None,
+            upgrade_marker: false,
+            device_orientation: Some(0),
+        });
+        client.send_node(stanza).await?;
+        Ok(())
+    }
+
+    /// Release the local video plane: detach the endpoints (stops the camera feed, drops the sink,
+    /// disables the drive-loop plane) and clear the session flag. Shared by `stop_video` and the
+    /// `begin_video` rollback.
+    fn teardown_local_video(&self) {
+        self.video.detach_endpoints();
+        self.client_registry.set_is_video(&self.call_id, false);
+    }
+
+    /// Shared upgrade/accept body: attach endpoints, enable the plane, send the handshake stanzas.
+    /// On a signaling send failure the local video setup is rolled back (endpoints detached, plane
+    /// disabled, flag cleared) so a failed upgrade doesn't leave the camera encoding into a call
+    /// the peer never transitioned.
+    async fn begin_video(
+        &self,
+        source: Arc<dyn VideoSource>,
+        sink: Arc<dyn VideoSink>,
+        role: VideoState,
+    ) -> Result<(), CallError> {
+        // A stale handle (superseded by a same-call-id glare/retry) must not attach endpoints or
+        // send `<video>` for a call it no longer owns — that would mutate the replacement's state.
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        self.video
+            .attach_endpoints(&client, &source, &sink, self.ended.clone());
+        // The upgrade INITIATOR holds outbound video until the peer accepts (the handler ungates on
+        // the peer's UpgradeAccept/Enabled). The acceptor's peer already requested, so it may send
+        // immediately.
+        let ctl = if role == VideoState::UpgradeRequestV2 {
+            VideoControl::EnableAwaitingAccept
+        } else {
+            VideoControl::Enable
+        };
+        let _ = self.video.ctl_tx.try_send(ctl);
+        self.client_registry.set_is_video(&self.call_id, true);
+
+        let peer = self.peer_jid();
+        let send_state = |state: VideoState, dec: Option<&'static str>, marker: bool| {
+            // Each call stanza gets its own wrapper id so the peer's typed ack correlates.
+            let stanza = build_video_state(&VideoStateParams {
+                call_id: &self.call_id,
+                to: &peer,
+                id: &client.generate_request_id(),
+                call_creator: &self.call_creator,
+                state,
+                dec,
+                upgrade_marker: marker,
+                device_orientation: None,
+            });
+            let client = client.clone();
+            async move { client.send_node(stanza).await }
+        };
+        let result = match role {
+            VideoState::UpgradeRequestV2 => {
+                // The marker attr is what the server keys the upgrade enrichment on.
+                send_state(VideoState::UpgradeRequestV2, Some(VIDEO_DEC_REQUEST), true).await
+            }
+            _ => {
+                // Acceptor: answer the request, then declare our video enabled (the WA Web order).
+                match send_state(VideoState::UpgradeAccept, Some(VIDEO_DEC_ACCEPT), false).await {
+                    Ok(()) => send_state(VideoState::Enabled, None, false).await,
+                    Err(e) => Err(e),
+                }
+            }
+        };
+        if let Err(e) = result {
+            // The peer never learned of the transition; don't leave the source encoding into it.
+            self.teardown_local_video();
+            return Err(e.into());
+        }
+        Ok(())
+    }
+
+    fn upgrade_client(&self) -> Result<Arc<Client>, CallError> {
+        self.client
+            .upgrade()
+            .ok_or(CallError::Media("client dropped"))
+    }
+
+    /// Reject a video op from a handle that no longer owns its call-id (superseded by a same-call-id
+    /// replacement), so it can't drive the replacement's video state.
+    fn ensure_current(&self) -> Result<(), CallError> {
+        if self.client_registry.generation_of(&self.call_id) == Some(self.generation) {
+            Ok(())
+        } else {
+            Err(CallError::Media("call no longer active"))
+        }
     }
 
     /// Tear the call down: abort the media task (which closes the relay and the audio channels).
@@ -1260,7 +1678,9 @@ mod tests {
             call_creator: caller(),
             client_registry: client.call_registry(),
             pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            client: std::sync::Weak::new(),
             muted: Arc::new(AtomicBool::new(false)),
+            video: Arc::new(VideoShared::new()),
             events: ev_rx,
             ended: Arc::new(EndedFlag::default()),
         };
@@ -1349,6 +1769,7 @@ mod tests {
             &factory,
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("spawn_call");
@@ -1416,6 +1837,7 @@ mod tests {
             &factory,
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("spawn_call");
@@ -1469,6 +1891,7 @@ mod tests {
             &factory,
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("spawn_call");
@@ -1507,6 +1930,7 @@ mod tests {
             &f1,
             mic1,
             spk1,
+            None,
         )
         .await
         .expect("first spawn_call");
@@ -1520,6 +1944,7 @@ mod tests {
             &f2,
             mic2,
             spk2,
+            None,
         )
         .await
         .expect("replacement spawn_call");
@@ -1567,6 +1992,7 @@ mod tests {
             &f1,
             mic1,
             spk1,
+            None,
         )
         .await
         .expect("first spawn_call");
@@ -1579,6 +2005,7 @@ mod tests {
             &f2,
             mic2,
             spk2,
+            None,
         )
         .await
         .expect("replacement spawn_call");
@@ -1613,6 +2040,7 @@ mod tests {
                 &factory,
                 Arc::new(mic_rx),
                 Arc::new(spk_tx),
+                None,
             )
             .await
             .expect("spawn_call"),
@@ -1824,6 +2252,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("place_call");
@@ -1944,6 +2373,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("place_call");
@@ -1997,6 +2427,7 @@ mod tests {
             &[good0.clone(), good1.clone(), bad.clone()],
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("place_call must succeed with surviving devices");
@@ -2069,6 +2500,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await;
         assert!(
@@ -2111,6 +2543,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await
         .expect("place_call");
@@ -2224,6 +2657,7 @@ mod tests {
                     &factory,
                     Arc::new(mic_rx),
                     Arc::new(spk_tx),
+                    None,
                 )
                 .await
             }
@@ -2289,6 +2723,7 @@ mod tests {
             &factory,
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await;
         assert!(
@@ -2332,7 +2767,9 @@ mod tests {
             call_creator: caller(),
             client_registry: client.call_registry(),
             pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            client: std::sync::Weak::new(),
             muted: muted.clone(),
+            video: Arc::new(VideoShared::new()),
             events: ev_rx,
             ended: ended.clone(),
         };
@@ -2350,6 +2787,8 @@ mod tests {
                     &*factory,
                     Arc::new(mic_rx),
                     Arc::new(spk_tx),
+                    None,
+                    Arc::new(VideoShared::new()),
                     muted,
                     ended,
                     ev_tx,
@@ -2426,6 +2865,8 @@ mod tests {
                     &*factory,
                     Arc::new(mic_rx),
                     Arc::new(spk_tx),
+                    None,
+                    Arc::new(VideoShared::new()),
                     muted,
                     ended,
                     ev_tx,
@@ -2496,6 +2937,8 @@ mod tests {
                     &*factory,
                     Arc::new(mic_rx),
                     Arc::new(spk_tx),
+                    None,
+                    Arc::new(VideoShared::new()),
                     muted,
                     ended,
                     ev_tx,
@@ -2565,6 +3008,7 @@ mod tests {
             &FailingFactory,
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await;
         assert!(
@@ -2638,6 +3082,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await;
         assert!(
@@ -2804,6 +3249,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
+            None,
         )
         .await;
         assert!(
@@ -2874,5 +3320,259 @@ mod tests {
         // Every device would be pkmsg: nothing to offer without a <device-identity>.
         let err = keep_non_pkmsg_devices(vec![d0, d1], &[true, true]);
         assert!(matches!(err, Err(CallError::MissingDeviceIdentity)));
+    }
+
+    /// A live handle over a mock relay + a sending client, for the video handshake tests. The
+    /// returned relay sender is a keepalive: dropping it disconnects the relay and ends the call.
+    async fn sending_handle() -> (
+        Arc<Client>,
+        Arc<std::sync::atomic::AtomicUsize>,
+        CallHandle,
+        async_channel::Sender<wacore::voip::transport::RelayTransportEvent>,
+    ) {
+        let (client, sent_count) = make_sending_client().await;
+        let (relay_tx, relay_rx) = async_channel::unbounded();
+        let factory = MockFactory {
+            sent: Arc::new(Mutex::new(Vec::new())),
+            relay_rx: Mutex::new(Some(relay_rx)),
+            connects: Arc::new(AtomicUsize::new(0)),
+        };
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+        let handle = spawn_call(
+            &client,
+            "CID-FACADE".into(),
+            mk_session(),
+            engine(),
+            &factory,
+            Arc::new(mic_rx),
+            Arc::new(spk_tx),
+            None,
+        )
+        .await
+        .expect("spawn_call");
+        (client, sent_count, handle, relay_tx)
+    }
+
+    fn video_endpoints() -> (
+        async_channel::Receiver<Vec<u8>>,
+        async_channel::Sender<VideoFrame>,
+    ) {
+        let (_vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
+        // Keep the unused halves alive long enough for the test by leaking them into the channels'
+        // refcounts via clone-on-return (the closed-channel behavior is covered elsewhere).
+        std::mem::forget(_vin_tx);
+        std::mem::forget(_vout_rx);
+        (vin_rx, vout_tx)
+    }
+
+    /// The action child of a sent `<call>` node.
+    fn call_action_of(node: &wacore_binary::Node) -> wacore_binary::Node {
+        node.as_node_ref().children().unwrap()[0].to_owned()
+    }
+
+    #[tokio::test]
+    async fn start_video_sends_upgrade_request_with_marker() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("upgrade request must be sent")
+            .expect("waiter");
+        let r = node.as_node_ref();
+        assert!(
+            r.attrs()
+                .optional_string("id")
+                .is_some_and(|id| !id.is_empty()),
+            "the <call> wrapper needs an id so the peer's typed video ack correlates"
+        );
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.tag, "video");
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("11"));
+        assert_eq!(ar.attrs().optional_string("dec").as_deref(), Some("H264"));
+        assert_eq!(
+            ar.attrs().optional_string("voip_settings").as_deref(),
+            Some("video"),
+            "the upgrade request must carry the marker attr"
+        );
+        assert!(
+            client
+                .call_registry()
+                .snapshot("CID-FACADE")
+                .expect("session")
+                .is_video,
+            "start_video must mark the session as video"
+        );
+        handle.hangup().await;
+    }
+
+    // A signaling send failure during an upgrade must roll the local video setup back: endpoints
+    // detached and the session flag cleared, so the source isn't left encoding into a call the peer
+    // never transitioned.
+    #[tokio::test]
+    async fn start_video_send_failure_rolls_back_local_setup() {
+        let client = make_failing_send_client().await; // send_node errors (no noise socket)
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let video_shared = Arc::new(VideoShared::new());
+        let (ev_tx, ev_rx) = async_channel::unbounded::<CallEvent>();
+        registry.set_video_channels(
+            "CID-FACADE",
+            generation,
+            ev_tx,
+            video_shared.ctl_tx.clone(),
+            video_teardown_hook(&video_shared),
+        );
+        let handle = CallHandle {
+            call_id: "CID-FACADE".into(),
+            generation,
+            peer_jid: caller(),
+            call_creator: caller(),
+            client_registry: registry.clone(),
+            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            client: Arc::downgrade(&client),
+            muted: Arc::new(AtomicBool::new(false)),
+            video: video_shared.clone(),
+            events: ev_rx,
+            ended: Arc::new(EndedFlag::default()),
+        };
+
+        let (vsrc, vsink) = video_endpoints();
+        let res = handle.start_video(vsrc, vsink).await;
+        assert!(res.is_err(), "a failed upgrade send must surface an error");
+        assert!(
+            video_shared.sink_slot.lock().unwrap().is_none(),
+            "the video endpoints must be detached after a failed upgrade"
+        );
+        assert!(
+            !registry.snapshot("CID-FACADE").expect("session").is_video,
+            "a failed upgrade must clear the video flag"
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_video_sends_accept_then_enabled() {
+        let (client, sent_count, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        let before = sent_count.load(Ordering::SeqCst);
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle
+            .accept_video(vsrc, vsink)
+            .await
+            .expect("accept_video");
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst) - before,
+            2,
+            "accept_video sends UpgradeAccept then Enabled"
+        );
+        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("accept must be sent")
+            .expect("waiter");
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("4"));
+        assert_eq!(
+            ar.attrs().optional_string("dec").as_deref(),
+            Some("H264,AV1")
+        );
+        assert_eq!(
+            ar.attrs().optional_string("voip_settings"),
+            None,
+            "an accept must not carry the upgrade marker"
+        );
+        handle.hangup().await;
+    }
+
+    #[tokio::test]
+    async fn stop_video_sends_stopped_and_releases_endpoints() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_some(),
+            "start_video attaches the sink"
+        );
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.stop_video().await.expect("stop_video");
+        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("downgrade must be sent")
+            .expect("waiter");
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.tag, "video");
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("6"));
+        assert_eq!(
+            ar.attrs().optional_string("voip_settings"),
+            None,
+            "a downgrade must NOT carry the marker (it re-arms the peer's video)"
+        );
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "stop_video releases the sink"
+        );
+        assert!(
+            !client
+                .call_registry()
+                .snapshot("CID-FACADE")
+                .expect("session")
+                .is_video,
+            "stop_video must clear the session's video flag"
+        );
+        handle.hangup().await;
+    }
+
+    // The VideoFeed pumps the consumer's source into the drive loop's channel and dies on the
+    // call's ended flag (not only on channel closure), so a silent source can't park it forever.
+    #[tokio::test]
+    async fn video_feed_forwards_and_stops_on_ended() {
+        let client = make_client().await;
+        let shared = VideoShared::new();
+        let (in_rx, _ctl_rx) = shared.take_receivers();
+        let (src_tx, src_rx) = async_channel::unbounded::<Vec<u8>>();
+        let sink: Arc<dyn VideoSink> = {
+            let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
+            std::mem::forget(_vout_rx);
+            Arc::new(vout_tx)
+        };
+        let source: Arc<dyn VideoSource> = Arc::new(src_rx);
+        let ended = Arc::new(EndedFlag::default());
+        shared.attach_endpoints(&client, &source, &sink, ended.clone());
+
+        src_tx.send(vec![1, 2, 3]).await.expect("feed source");
+        let got = tokio::time::timeout(std::time::Duration::from_secs(2), in_rx.recv())
+            .await
+            .expect("AU must be forwarded")
+            .expect("channel open");
+        assert_eq!(got, vec![1, 2, 3]);
+
+        // Ending the call stops the feed even though the source channel stays open: a later AU
+        // must NOT be forwarded. (The channel itself stays open — VideoShared retains a sender —
+        // so absence of traffic, not closure, is the observable.)
+        ended.notify();
+        tokio::task::yield_now().await;
+        src_tx.send(vec![9, 9, 9]).await.expect("source still open");
+        let after = tokio::time::timeout(std::time::Duration::from_millis(300), in_rx.recv()).await;
+        assert!(
+            after.is_err(),
+            "an AU sent after ended must not be forwarded (feed stopped)"
+        );
+    }
+
+    // A second take is defensive: it must yield closed channels (their driver arms self-disable),
+    // never panic or hand out a duplicate of the live receivers.
+    #[test]
+    fn video_shared_second_take_yields_closed_channels() {
+        let shared = VideoShared::new();
+        let _live = shared.take_receivers();
+        let (in_rx, ctl_rx) = shared.take_receivers();
+        assert!(in_rx.is_closed());
+        assert!(ctl_rx.is_closed());
     }
 }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -12,7 +12,8 @@ use log::warn;
 use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
 use wacore::stanza::call::{
-    CAPABILITY_OFFER, OfferDeviceKey, OfferParams, VideoStateParams, build_offer, build_video_state,
+    CAPABILITY_OFFER, CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, VideoStateParams,
+    build_offer, build_video_state,
 };
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
@@ -442,6 +443,14 @@ fn keep_non_pkmsg_devices(devices: Vec<Jid>, would_pkmsg: &[bool]) -> Result<Vec
     Ok(kept)
 }
 
+fn offer_capability(video: bool) -> &'static [u8] {
+    if video {
+        &CAPABILITY_VIDEO_OFFER
+    } else {
+        &CAPABILITY_OFFER
+    }
+}
+
 /// Drain every dormant outgoing call (relay never arrived) and notify each one's `ended` so any
 /// parked `wait_ended()` resolves. The relay socket and signaling are connection-scoped, so a dormant
 /// outgoing call can't survive a disconnect; the registry's `abort_all` already covers attached calls,
@@ -594,7 +603,7 @@ async fn place_call(
         call_creator,
         device_keys: &device_keys,
         privacy_token: privacy_token.as_deref(),
-        capability: Some(&CAPABILITY_OFFER),
+        capability: Some(offer_capability(video.is_some())),
         device_identity: device_identity.as_deref(),
         id: Some(&offer_stanza_id),
         // Keep the addressed `<destination>` shape for a multi-device callee even if encryption
@@ -1139,7 +1148,7 @@ async fn attach_engine(
         video_shared.attach_endpoints(client, &v.source, &v.sink, ended.clone());
         // From-start video: the engine was built with enable_video, but a same-path Enable is
         // idempotent and keeps one code path for both entries.
-        let _ = video_shared.ctl_tx.try_send(VideoControl::Enable);
+        video_shared.send_control(VideoControl::Enable);
     }
 
     let channels = CallChannels {
@@ -1182,6 +1191,8 @@ async fn attach_engine(
 const VIDEO_IN_CHANNEL_CAP: usize = 4;
 /// Inbound video AU backlog between the drive loop and the sink forwarder.
 const VIDEO_OUT_CHANNEL_CAP: usize = 8;
+/// Keeps hostile signaling bursts bounded while retaining the newest control intent.
+const VIDEO_CONTROL_CHANNEL_CAP: usize = 16;
 
 /// `dec` we advertise on an upgrade request (what we can decode).
 const VIDEO_DEC_REQUEST: &str = "H264";
@@ -1213,9 +1224,7 @@ type VideoReceivers = (
 
 impl VideoShared {
     fn new() -> Self {
-        // Control is unbounded: commands are rare, tiny, and must never be dropped (a lost Enable
-        // strands the upgrade). Media (in_tx) is bounded and back-pressures the feed.
-        let (ctl_tx, ctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (ctl_tx, ctl_rx) = async_channel::bounded::<VideoControl>(VIDEO_CONTROL_CHANNEL_CAP);
         let (in_tx, in_rx) = async_channel::bounded::<Vec<u8>>(VIDEO_IN_CHANNEL_CAP);
         Self {
             ctl_tx,
@@ -1236,6 +1245,10 @@ impl VideoShared {
             .unwrap_or_else(|| (async_channel::bounded(1).1, async_channel::bounded(1).1))
     }
 
+    fn send_control(&self, control: VideoControl) {
+        let _ = self.ctl_tx.force_send(control);
+    }
+
     /// Attach (or replace) the consumer's endpoints: the sink becomes the forwarder's target and a
     /// fresh `VideoFeed` pumps the source; a previous feed is aborted (its source is released).
     fn attach_endpoints(
@@ -1247,7 +1260,7 @@ impl VideoShared {
     ) {
         // Queue timing before the feed can make an AU ready. The driver's control arm is biased
         // ahead of media, so the first RTP timestamp already uses the source's cadence.
-        let _ = self.ctl_tx.try_send(VideoControl::SetTimestampStride(
+        self.send_control(VideoControl::SetTimestampStride(
             source.rtp_timestamp_stride(),
         ));
         *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(sink.playout());
@@ -1274,7 +1287,7 @@ impl VideoShared {
         if let Some(feed) = self.feed.lock().unwrap_or_else(|e| e.into_inner()).take() {
             feed.abort();
         }
-        let _ = self.ctl_tx.try_send(VideoControl::Disable);
+        self.send_control(VideoControl::Disable);
     }
 }
 
@@ -1512,6 +1525,17 @@ impl CallHandle {
     /// disables the drive-loop plane) and clear the session flag. Shared by `stop_video` and the
     /// `begin_video` rollback.
     fn teardown_local_video(&self) {
+        let pending_video = {
+            let mut pending = self
+                .pending_outgoing_calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            pending
+                .get_mut(&self.call_id)
+                .filter(|entry| entry.generation == self.generation)
+                .and_then(|entry| entry.video.take())
+        };
+        drop(pending_video);
         self.video.detach_endpoints();
         self.client_registry.set_is_video(&self.call_id, false);
     }
@@ -1545,7 +1569,7 @@ impl CallHandle {
         } else {
             VideoControl::Enable
         };
-        let _ = self.video.ctl_tx.try_send(ctl);
+        self.video.send_control(ctl);
         self.client_registry.set_is_video(&self.call_id, true);
 
         let peer = self.peer_jid();
@@ -2572,6 +2596,13 @@ mod tests {
     /// Place a dormant outgoing call (offer sent, relay not yet arrived) and return its handle. Shares
     /// the place_call machinery the offer-send test uses; the call lands in pending_outgoing_calls.
     async fn place_dormant_outgoing(client: &Arc<Client>) -> (CallHandle, String) {
+        place_dormant_outgoing_with_video(client, None).await
+    }
+
+    async fn place_dormant_outgoing_with_video(
+        client: &Arc<Client>,
+        video: Option<VideoEndpoints>,
+    ) -> (CallHandle, String) {
         let peer_user = Jid::new("333333333333333", Server::Lid);
         let device = peer_lid();
         seed_peer_session(client, &device).await;
@@ -2589,7 +2620,7 @@ mod tests {
             std::slice::from_ref(&device),
             Arc::new(mic_rx),
             Arc::new(spk_tx),
-            None,
+            video,
         )
         .await
         .expect("place_call");
@@ -3368,6 +3399,13 @@ mod tests {
         assert!(matches!(err, Err(CallError::MissingDeviceIdentity)));
     }
 
+    #[test]
+    fn outgoing_video_offer_uses_video_capability() {
+        assert_eq!(offer_capability(false), CAPABILITY_OFFER);
+        assert_eq!(offer_capability(true), CAPABILITY_VIDEO_OFFER);
+        assert_ne!(offer_capability(false), offer_capability(true));
+    }
+
     /// A live handle over a mock relay + a sending client, for the video handshake tests. The
     /// returned relay sender is a keepalive: dropping it disconnects the relay and ends the call.
     async fn sending_handle() -> (
@@ -3611,6 +3649,36 @@ mod tests {
         handle.hangup().await;
     }
 
+    #[tokio::test]
+    async fn dormant_stop_video_clears_pending_endpoints() {
+        let (client, _sent) = make_sending_client().await;
+        let (source, sink) = video_endpoints();
+        let (handle, call_id) =
+            place_dormant_outgoing_with_video(&client, Some(VideoEndpoints::new(source, sink)))
+                .await;
+        assert!(
+            client
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .get(&call_id)
+                .is_some_and(|pending| pending.video.is_some())
+        );
+
+        handle.stop_video().await.expect("dormant downgrade");
+        assert!(
+            client
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .get(&call_id)
+                .is_some_and(|pending| pending.video.is_none()),
+            "relay attach must not resurrect endpoints removed before its ack"
+        );
+        assert!(!client.call_registry().snapshot(&call_id).unwrap().is_video);
+        handle.hangup().await;
+    }
+
     // The VideoFeed pumps the consumer's source into the drive loop's channel and dies on the
     // call's ended flag (not only on channel closure), so a silent source can't park it forever.
     #[tokio::test]
@@ -3665,5 +3733,21 @@ mod tests {
         let (in_rx, ctl_rx) = shared.take_receivers();
         assert!(in_rx.is_closed());
         assert!(ctl_rx.is_closed());
+    }
+
+    #[test]
+    fn video_control_queue_is_bounded_and_retains_latest_intent() {
+        let shared = VideoShared::new();
+        let (_in_rx, ctl_rx) = shared.take_receivers();
+        for orientation in 0..100u8 {
+            shared.send_control(VideoControl::SetOrientation(orientation % 4));
+        }
+        assert_eq!(ctl_rx.len(), VIDEO_CONTROL_CHANNEL_CAP);
+
+        let mut last = None;
+        while let Ok(control) = ctl_rx.try_recv() {
+            last = Some(control);
+        }
+        assert_eq!(last, Some(VideoControl::SetOrientation(3)));
     }
 }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1444,6 +1444,25 @@ impl CallHandle {
             .await
     }
 
+    /// Send the standalone `<video state=1>` used after a mid-call video upgrade. Captured
+    /// video-from-start callees do not need this extra stanza.
+    pub async fn announce_video_enabled(&self) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        let stanza = build_video_state(&VideoStateParams {
+            call_id: &self.call_id,
+            to: &self.peer_jid(),
+            id: &client.generate_request_id(),
+            call_creator: &self.call_creator,
+            state: VideoState::Enabled,
+            dec: Some(VIDEO_DEC_REQUEST),
+            upgrade_marker: false,
+            device_orientation: Some(0),
+        });
+        client.send_node(stanza).await?;
+        Ok(())
+    }
+
     /// DOWNGRADE to audio: sends `<video state=6>` (Stopped, no marker), tears the local video
     /// plane down, and releases the source/sink. The audio plane is untouched. Idempotent.
     pub async fn stop_video(&self) -> Result<(), CallError> {

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1541,9 +1541,6 @@ impl CallHandle {
     }
 
     /// Shared upgrade/accept body: attach endpoints, enable the plane, send the handshake stanzas.
-    /// On a signaling send failure the local video setup is rolled back (endpoints detached, plane
-    /// disabled, flag cleared) so a failed upgrade doesn't leave the camera encoding into a call
-    /// the peer never transitioned.
     async fn begin_video(
         &self,
         source: Arc<dyn VideoSource>,
@@ -1588,23 +1585,25 @@ impl CallHandle {
             let client = client.clone();
             async move { client.send_node(stanza).await }
         };
-        let result = match role {
+        match role {
             VideoState::UpgradeRequestV2 => {
-                // The marker attr is what the server keys the upgrade enrichment on.
-                send_state(VideoState::UpgradeRequestV2, Some(VIDEO_DEC_REQUEST), true).await
-            }
-            _ => {
-                // Acceptor: answer the request, then declare our video enabled (the WA Web order).
-                match send_state(VideoState::UpgradeAccept, Some(VIDEO_DEC_ACCEPT), false).await {
-                    Ok(()) => send_state(VideoState::Enabled, None, false).await,
-                    Err(e) => Err(e),
+                if let Err(e) =
+                    send_state(VideoState::UpgradeRequestV2, Some(VIDEO_DEC_REQUEST), true).await
+                {
+                    self.teardown_local_video();
+                    return Err(e.into());
                 }
             }
-        };
-        if let Err(e) = result {
-            // The peer never learned of the transition; don't leave the source encoding into it.
-            self.teardown_local_video();
-            return Err(e.into());
+            _ => {
+                if let Err(e) =
+                    send_state(VideoState::UpgradeAccept, Some(VIDEO_DEC_ACCEPT), false).await
+                {
+                    self.teardown_local_video();
+                    return Err(e.into());
+                }
+                // The accept already committed the peer; a failed follow-up cannot be rolled back.
+                send_state(VideoState::Enabled, None, false).await?;
+            }
         }
         Ok(())
     }
@@ -2196,6 +2195,12 @@ mod tests {
     /// A test client with a real NoiseSocket over a counting transport, so the offer send path
     /// (`send_node`) is exercised, plus the own LID set so `place_call` can derive call_creator.
     async fn make_sending_client() -> (Arc<Client>, Arc<std::sync::atomic::AtomicUsize>) {
+        make_sending_client_with_failure_after(None).await
+    }
+
+    async fn make_sending_client_with_failure_after(
+        failure_after: Option<usize>,
+    ) -> (Arc<Client>, Arc<std::sync::atomic::AtomicUsize>) {
         use wacore::handshake::NoiseCipher;
         let backend = create_test_backend().await;
         let pm = PersistenceManager::new(backend).await.expect("pm");
@@ -2227,17 +2232,22 @@ mod tests {
         let count = Arc::new(AtomicUsize::new(0));
         struct CountingTransport {
             count: Arc<AtomicUsize>,
+            failure_after: Option<usize>,
         }
         #[async_trait]
         impl crate::transport::Transport for CountingTransport {
             async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
-                self.count.fetch_add(1, Ordering::SeqCst);
+                let attempt = self.count.fetch_add(1, Ordering::SeqCst);
+                if self.failure_after.is_some_and(|limit| attempt >= limit) {
+                    return Err(anyhow::anyhow!("injected transport send failure"));
+                }
                 Ok(())
             }
             async fn disconnect(&self) {}
         }
         let socket_transport: Arc<dyn crate::transport::Transport> = Arc::new(CountingTransport {
             count: count.clone(),
+            failure_after,
         });
         let key = [0u8; 32];
         let noise_socket = crate::socket::NoiseSocket::new(
@@ -3607,6 +3617,43 @@ mod tests {
             "an accept must not carry the upgrade marker"
         );
         handle.hangup().await;
+    }
+
+    #[tokio::test]
+    async fn accept_video_keeps_local_plane_after_accept_reaches_peer() {
+        let (client, sent) = make_sending_client_with_failure_after(Some(1)).await;
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let video = Arc::new(VideoShared::new());
+        let (event_tx, events) = async_channel::unbounded::<CallEvent>();
+        registry.set_video_channels(
+            "CID-FACADE",
+            generation,
+            event_tx,
+            video.ctl_tx.clone(),
+            video_teardown_hook(&video),
+        );
+        let handle = CallHandle {
+            call_id: "CID-FACADE".into(),
+            generation,
+            peer_jid: caller(),
+            call_creator: caller(),
+            client_registry: registry.clone(),
+            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            client: Arc::downgrade(&client),
+            muted: Arc::new(AtomicBool::new(false)),
+            video: video.clone(),
+            events,
+            ended: Arc::new(EndedFlag::default()),
+        };
+
+        let (source, sink) = video_endpoints();
+        assert!(handle.accept_video(source, sink).await.is_err());
+        assert_eq!(sent.load(Ordering::SeqCst), 2);
+        assert!(video.sink_slot.lock().unwrap().is_some());
+        assert!(registry.snapshot("CID-FACADE").unwrap().is_video);
+
+        handle.teardown_local_video();
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -69,10 +69,7 @@ impl<'a> AcceptCall<'a> {
         S: VideoSource,
         K: VideoSink,
     {
-        self.video = Some(VideoEndpoints {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
+        self.video = Some(VideoEndpoints::new(source, sink));
         self
     }
 
@@ -96,6 +93,11 @@ impl<'a> AcceptCall<'a> {
         let source = self.source.take().ok_or(CallError::MissingAudio)?;
         let sink = self.sink.take().ok_or(CallError::MissingAudio)?;
         let video = self.video.take();
+        if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
+            return Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero",
+            ));
+        }
         // Answering consumes the ringing flag now, BEFORE the media-setup awaits (callKey decrypt /
         // relay connect): a peer <terminate> racing this window must not record a missed call for a
         // call we are answering. A failed start() leaves it cleared -- an attempted answer reads as
@@ -241,10 +243,7 @@ impl<'a> OutgoingCall<'a> {
         S: VideoSource,
         K: VideoSink,
     {
-        self.video = Some(VideoEndpoints {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
+        self.video = Some(VideoEndpoints::new(source, sink));
         self
     }
 
@@ -294,6 +293,11 @@ impl<'a> OutgoingCall<'a> {
         let source = self.source.take().ok_or(CallError::MissingAudio)?;
         let sink = self.sink.take().ok_or(CallError::MissingAudio)?;
         let video = self.video.take();
+        if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
+            return Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero",
+            ));
+        }
 
         // WA Web `_e()`: call-id is "00" + 15 random bytes as lowercase hex (32 hex chars total).
         let call_id = gen_call_id();
@@ -399,6 +403,19 @@ impl<'a> OutgoingCall<'a> {
 struct VideoEndpoints {
     source: Arc<dyn VideoSource>,
     sink: Arc<dyn VideoSink>,
+}
+
+impl VideoEndpoints {
+    fn new<S: VideoSource, K: VideoSink>(source: S, sink: K) -> Self {
+        Self {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        }
+    }
+
+    fn has_valid_timing(&self) -> bool {
+        self.source.rtp_timestamp_stride() != 0
+    }
 }
 
 /// Drop hosted (Cloud-API) companions from the offer's device set: the client never establishes
@@ -1228,6 +1245,11 @@ impl VideoShared {
         sink: &Arc<dyn VideoSink>,
         ended: Arc<EndedFlag>,
     ) {
+        // Queue timing before the feed can make an AU ready. The driver's control arm is biased
+        // ahead of media, so the first RTP timestamp already uses the source's cadence.
+        let _ = self.ctl_tx.try_send(VideoControl::SetTimestampStride(
+            source.rtp_timestamp_stride(),
+        ));
         *self.sink_slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(sink.playout());
         let feed = VideoFeed {
             src: source.frames(),
@@ -1507,6 +1529,11 @@ impl CallHandle {
         // A stale handle (superseded by a same-call-id glare/retry) must not attach endpoints or
         // send `<video>` for a call it no longer owns — that would mutate the replacement's state.
         self.ensure_current()?;
+        if source.rtp_timestamp_stride() == 0 {
+            return Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero",
+            ));
+        }
         let client = self.upgrade_client()?;
         self.video
             .attach_endpoints(&client, &source, &sink, self.ended.clone());
@@ -3386,6 +3413,21 @@ mod tests {
         (vin_rx, vout_tx)
     }
 
+    struct TimedVideoSource {
+        frames: async_channel::Receiver<Vec<u8>>,
+        timestamp_stride: u32,
+    }
+
+    impl VideoSource for TimedVideoSource {
+        fn frames(&self) -> async_channel::Receiver<Vec<u8>> {
+            self.frames.clone()
+        }
+
+        fn rtp_timestamp_stride(&self) -> u32 {
+            self.timestamp_stride
+        }
+    }
+
     /// The action child of a sent `<call>` node.
     fn call_action_of(node: &wacore_binary::Node) -> wacore_binary::Node {
         node.as_node_ref().children().unwrap()[0].to_owned()
@@ -3425,6 +3467,28 @@ mod tests {
                 .expect("session")
                 .is_video,
             "start_video must mark the session as video"
+        );
+        handle.hangup().await;
+    }
+
+    #[tokio::test]
+    async fn start_video_rejects_zero_timestamp_stride() {
+        let (_client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (frames, sink) = video_endpoints();
+        let source = TimedVideoSource {
+            frames,
+            timestamp_stride: 0,
+        };
+
+        assert!(matches!(
+            handle.start_video(source, sink).await,
+            Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero"
+            ))
+        ));
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "invalid timing must not attach endpoints"
         );
         handle.hangup().await;
     }
@@ -3553,16 +3617,24 @@ mod tests {
     async fn video_feed_forwards_and_stops_on_ended() {
         let client = make_client().await;
         let shared = VideoShared::new();
-        let (in_rx, _ctl_rx) = shared.take_receivers();
+        let (in_rx, ctl_rx) = shared.take_receivers();
         let (src_tx, src_rx) = async_channel::unbounded::<Vec<u8>>();
         let sink: Arc<dyn VideoSink> = {
             let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
             std::mem::forget(_vout_rx);
             Arc::new(vout_tx)
         };
-        let source: Arc<dyn VideoSource> = Arc::new(src_rx);
+        let source: Arc<dyn VideoSource> = Arc::new(TimedVideoSource {
+            frames: src_rx,
+            timestamp_stride: 4500,
+        });
         let ended = Arc::new(EndedFlag::default());
         shared.attach_endpoints(&client, &source, &sink, ended.clone());
+
+        assert_eq!(
+            ctl_rx.recv().await.unwrap(),
+            VideoControl::SetTimestampStride(4500)
+        );
 
         src_tx.send(vec![1, 2, 3]).await.expect("feed source");
         let got = tokio::time::timeout(std::time::Duration::from_secs(2), in_rx.recv())

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1621,8 +1621,11 @@ impl CallHandle {
                     self.teardown_local_video();
                     return Err(e.into());
                 }
-                // The accept already committed the peer; a failed follow-up cannot be rolled back.
-                send_state(VideoState::Enabled, None).await?;
+                if let Err(e) = send_state(VideoState::Enabled, None).await {
+                    // The peer times out an incomplete handshake; keep local media aligned with it.
+                    self.teardown_local_video();
+                    return Err(e.into());
+                }
             }
         }
         Ok(())
@@ -3640,7 +3643,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accept_video_keeps_local_plane_after_accept_reaches_peer() {
+    async fn accept_video_enabled_failure_rolls_back_local_plane() {
         let (client, sent) = make_sending_client_with_failure_after(Some(1)).await;
         let registry = client.call_registry();
         let generation = registry.insert(mk_session());
@@ -3670,10 +3673,8 @@ mod tests {
         let (source, sink) = video_endpoints();
         assert!(handle.accept_video(source, sink).await.is_err());
         assert_eq!(sent.load(Ordering::SeqCst), 2);
-        assert!(video.sink_slot.lock().unwrap().is_some());
-        assert!(registry.snapshot("CID-FACADE").unwrap().is_video);
-
-        handle.teardown_local_video();
+        assert!(video.sink_slot.lock().unwrap().is_none());
+        assert!(!registry.snapshot("CID-FACADE").unwrap().is_video);
     }
 
     #[tokio::test]

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -20,8 +20,12 @@ pub mod facade;
 pub mod registry;
 pub mod session;
 pub mod transport;
+pub mod video;
 
 pub use audio::{AudioSink, AudioSource};
 pub use facade::{AcceptCall, CallHandle, OutgoingCall};
+pub use video::{VideoFrame, VideoSink, VideoSource};
 // CallHandle::events() yields these, so surface them next to CallHandle (they live in wacore).
 pub use wacore::voip::CallEvent;
+// `CallEvent::VideoStateChanged` carries this; surface it next to CallEvent (it lives in wacore).
+pub use wacore::types::call::VideoState;

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -573,6 +573,7 @@ mod udp_relay_e2e {
             integrity_key: b"relay-key".to_vec(),
             warp_mi_tag_len: 4,
             enable_media: true,
+            enable_video: false,
             enable_sframe: false,
         }
     }
@@ -737,6 +738,9 @@ mod udp_relay_e2e {
                     speaker: spk_tx,
                     events: ev_tx,
                     rekey: None,
+                    video_in: async_channel::bounded(1).1,
+                    video_out: async_channel::bounded(1).0,
+                    video_ctl: async_channel::bounded(1).1,
                 },
                 eng,
             ));

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -547,7 +547,7 @@ mod udp_relay_e2e {
 
     use wacore::voip::engine::{CallConfig, CallEvent, SequentialTxIds};
     use wacore::voip::session::{CallDirection, MediaPipeline, MediaPipelineParams};
-    use wacore::voip::{CallChannels, CallEngine};
+    use wacore::voip::{CallChannels, CallEngine, video_control_channel};
     use webrtc_dtls::config::Config as DtlsConfig;
     use webrtc_sctp::association::{Association, Config as SctpConfig};
 
@@ -740,7 +740,7 @@ mod udp_relay_e2e {
                     rekey: None,
                     video_in: async_channel::bounded(1).1,
                     video_out: async_channel::bounded(1).0,
-                    video_ctl: async_channel::bounded(1).1,
+                    video_ctl: video_control_channel().1,
                 },
                 eng,
             ));

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -1,7 +1,7 @@
 //! Relay media transport: a pre-negotiated WebRTC DataChannel over SCTP-over-DTLS-over-UDP
 //! to a single WhatsApp relay endpoint. The synthetic-SDP / wrtc dance reduces, at this layer,
 //! to: connect a UDP socket to the relay, DTLS-handshake as the client (self-signed cert,
-//! server-cert verification skipped, since SRTP keys come from callKey/hbh_key, not DTLS),
+//! server-cert verification skipped, since SRTP keys come from callKey, not DTLS),
 //! run an SCTP association over it, and open the pre-negotiated id=0 DataChannel that carries
 //! STUN/RTP/RTCP as binary messages.
 

--- a/src/voip/video.rs
+++ b/src/voip/video.rs
@@ -1,9 +1,9 @@
 //! Video endpoints for WhatsApp calls. The library transports pre-encoded H.264 — it never touches
 //! pixels — so a source hands us complete Annex-B access units (start codes included) and a sink
 //! receives reassembled peer AUs. The codec lives with the consumer (ffmpeg, WebCodecs, a hardware
-//! encoder); reference parameters: H.264 Constrained Baseline (avc1.42E01F), 640x480 @ 15 fps,
-//! ~500 kbps, a keyframe every ~30 frames, SPS/PPS repeated on each IDR (the peer can join
-//! mid-stream on an upgrade).
+//! encoder). WhatsApp uses H.264 Constrained Baseline (avc1.42E01F), repeated SPS/PPS, and adapts
+//! from a low-bandwidth 15 fps mode up to 1280x720 @ 20 fps / ~2 Mbps. A bare channel keeps the
+//! compatibility cadence of 15 fps; custom sources report their RTP stride explicitly.
 
 pub use wacore::voip::VideoFrame;
 
@@ -13,6 +13,12 @@ pub use wacore::voip::VideoFrame;
 pub trait VideoSource: Send + Sync + 'static {
     /// The channel the facade reads encoded AUs from. Called once when video starts.
     fn frames(&self) -> async_channel::Receiver<Vec<u8>>;
+
+    /// RTP clock increment between access units. It must match the source's pacing
+    /// (`90_000 / frames_per_second`) and remain non-zero.
+    fn rtp_timestamp_stride(&self) -> u32 {
+        wacore::voip::rtp::VIDEO_TS_STRIDE_15FPS
+    }
 }
 
 /// A video sink for a call: reassembled peer access units, with keyframe/orientation metadata.

--- a/src/voip/video.rs
+++ b/src/voip/video.rs
@@ -1,0 +1,36 @@
+//! Video endpoints for WhatsApp calls. The library transports pre-encoded H.264 — it never touches
+//! pixels — so a source hands us complete Annex-B access units (start codes included) and a sink
+//! receives reassembled peer AUs. The codec lives with the consumer (ffmpeg, WebCodecs, a hardware
+//! encoder); reference parameters: H.264 Constrained Baseline (avc1.42E01F), 640x480 @ 15 fps,
+//! ~500 kbps, a keyframe every ~30 frames, SPS/PPS repeated on each IDR (the peer can join
+//! mid-stream on an upgrade).
+
+pub use wacore::voip::VideoFrame;
+
+/// A video source for a call: one complete H.264 Annex-B access unit per item. Channel-factory
+/// shaped for the same reasons as [`AudioSource`](crate::voip::audio::AudioSource); a closed
+/// channel (encoder gone) does NOT end the call — audio keeps running.
+pub trait VideoSource: Send + Sync + 'static {
+    /// The channel the facade reads encoded AUs from. Called once when video starts.
+    fn frames(&self) -> async_channel::Receiver<Vec<u8>>;
+}
+
+/// A video sink for a call: reassembled peer access units, with keyframe/orientation metadata.
+/// VoIP is loss tolerant, so the facade drops a frame if the sink can't keep up.
+pub trait VideoSink: Send + Sync + 'static {
+    /// The channel the facade writes received AUs to. Called once when video starts.
+    fn playout(&self) -> async_channel::Sender<VideoFrame>;
+}
+
+/// Blanket impls so a bare `async_channel` endpoint is usable directly, like the audio ones.
+impl VideoSource for async_channel::Receiver<Vec<u8>> {
+    fn frames(&self) -> async_channel::Receiver<Vec<u8>> {
+        self.clone()
+    }
+}
+
+impl VideoSink for async_channel::Sender<VideoFrame> {
+    fn playout(&self) -> async_channel::Sender<VideoFrame> {
+        self.clone()
+    }
+}

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -129,7 +129,7 @@ fn started_engine() -> CallEngine {
 
 fn started_engine_from(cfg: CallConfig) -> CallEngine {
     let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
-    eng.start(0);
+    eng.start(0, 0);
     drain(&mut eng);
     eng
 }
@@ -394,6 +394,7 @@ mod framing {
             timestamp: 0x0009_6000,
             ssrc: 0xDEAD_BEEF,
             extension_word: Some(0x3001_0000),
+            video_extension: None,
         }
     }
 

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -112,6 +112,7 @@ fn config_for(self_lid: &str, peer_lid: &str, ssrc: u32, direction: CallDirectio
         integrity_key: b"relay-key".to_vec(),
         warp_mi_tag_len: 4,
         enable_media: true,
+        enable_video: false,
         enable_sframe: false,
     }
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -316,7 +316,8 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 .ok_or_else(|| anyhow!("<video> missing or non-numeric 'state'"))?;
             let orientation = attrs
                 .optional_string("device_orientation")
-                .and_then(|s| s.parse::<u8>().ok());
+                .and_then(|s| s.parse::<u8>().ok())
+                .filter(|orientation| *orientation <= 3);
             let dec = attrs.optional_string("dec").map(|s| s.into_owned());
             // The upgrade-request marker attr and the server-enriched knobs; consumed (their
             // semantics ride on `state`), plus a possible `<voip_settings>` blob child we ignore.
@@ -1967,6 +1968,16 @@ mod tests {
             }
             other => panic!("expected VideoState, got {other:?}"),
         }
+
+        let malformed = video_call_node(&[("state", "1"), ("device_orientation", "255")]);
+        let call = parse_call_stanza(&as_ref(&malformed)).unwrap().unwrap();
+        assert!(matches!(
+            call.action,
+            CallAction::VideoState {
+                orientation: None,
+                ..
+            }
+        ));
 
         // A future state number parses to Unknown rather than failing the stanza.
         let future = video_call_node(&[("state", "42")]);

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -784,10 +784,6 @@ pub struct VideoStateParams<'a> {
     pub state: VideoState,
     /// `dec` attr: codecs we can decode (`"H264"` on the upgrade request, `"H264,AV1"` on accept).
     pub dec: Option<&'a str>,
-    /// Emit the `voip_settings="video"` marker attr. ONLY the upgrade request carries it: the mock
-    /// server keys its enrichment (and its non-bare ack) on marker+state=11, and stamping it on a
-    /// downgrade re-arms the peer's video (the zombie-stream bug).
-    pub upgrade_marker: bool,
     pub device_orientation: Option<u8>,
 }
 
@@ -801,7 +797,7 @@ pub fn build_video_state(p: &VideoStateParams<'_>) -> Node {
     if let Some(dec) = p.dec {
         action = action.attr("dec", dec.to_string());
     }
-    if p.upgrade_marker {
+    if p.state == VideoState::UpgradeRequestV2 {
         action = action.attr("voip_settings", "video");
     }
     if let Some(o) = p.device_orientation {
@@ -2010,7 +2006,6 @@ mod tests {
             call_creator: &creator,
             state: VideoState::UpgradeRequestV2,
             dec: Some("H264"),
-            upgrade_marker: true,
             device_orientation: None,
         });
         let r = upgrade.as_node_ref();
@@ -2046,7 +2041,6 @@ mod tests {
             call_creator: &creator,
             state: VideoState::Stopped,
             dec: None,
-            upgrade_marker: false,
             device_orientation: Some(0),
         });
         let action = downgrade.as_node_ref().children().unwrap()[0].to_owned();

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -11,7 +11,7 @@ use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeRef};
 
 use crate::time::from_secs;
-use crate::types::call::{CallAction, CallAudioCodec, IncomingCall};
+use crate::types::call::{CallAction, CallAudioCodec, IncomingCall, VideoState};
 
 const KNOWN_ACTIONS: &[&str] = &[
     "offer",
@@ -22,6 +22,7 @@ const KNOWN_ACTIONS: &[&str] = &[
     "terminate",
     "transport",
     "relaylatency",
+    "video",
 ];
 
 pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
@@ -289,6 +290,27 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 call_creator,
             }
         }
+        "video" => {
+            let state_raw = attrs
+                .optional_string("state")
+                .and_then(|s| s.parse::<i32>().ok())
+                .ok_or_else(|| anyhow!("<video> missing or non-numeric 'state'"))?;
+            let orientation = attrs
+                .optional_string("device_orientation")
+                .and_then(|s| s.parse::<u8>().ok());
+            let dec = attrs.optional_string("dec").map(|s| s.into_owned());
+            // The upgrade-request marker attr and the server-enriched knobs; consumed (their
+            // semantics ride on `state`), plus a possible `<voip_settings>` blob child we ignore.
+            let _ = attrs.optional_string("voip_settings");
+            attrs.finish().map_err(|e| anyhow!("<video> attrs: {e}"))?;
+            CallAction::VideoState {
+                call_id,
+                call_creator,
+                state: VideoState::from(state_raw),
+                orientation,
+                dec,
+            }
+        }
         "terminate" => {
             // WA Web gates the call-log outcome on `reason` (missed vs accepted/rejected-elsewhere),
             // so surface it instead of dropping it.
@@ -394,11 +416,15 @@ pub struct OfferParams<'a> {
     /// keep the `<destination><to jid>` shape so the surviving device stays explicitly addressed (a
     /// bare `<enc>` drops its jid and could misroute to the primary device).
     pub multi_device: bool,
+    /// Advertise a `<video>` child: a video-from-the-start call. The node shape and its position
+    /// (after the `<audio>` children) come from a WA Web capture; unvalidated against the real
+    /// server's 439 child-order enforcement.
+    pub video: bool,
 }
 
 /// `<call to=peer><offer call-id call-creator>…</offer></call>` with the mandatory
-/// child order: privacy → audio(8k) → audio(16k) → net → capability → destination|enc →
-/// encopt → device-identity.
+/// child order: privacy → audio(8k) → audio(16k) → [video] → net → capability →
+/// destination|enc → encopt → device-identity.
 pub fn build_offer(p: &OfferParams<'_>) -> Node {
     let mut children: Vec<Node> = Vec::new();
     if let Some(privacy) = p.privacy_token {
@@ -416,6 +442,9 @@ pub fn build_offer(p: &OfferParams<'_>) -> Node {
             .attr("rate", "16000")
             .build(),
     );
+    if p.video {
+        children.push(offer_video_node());
+    }
     children.push(NodeBuilder::new("net").attr("medium", "3").build());
     if let Some(cap) = p.capability {
         children.push(capability_node(cap));
@@ -477,11 +506,20 @@ pub struct AcceptParams<'a> {
     pub rte: Option<&'a [u8]>,
     pub voip_settings: Option<&'a [u8]>,
     pub capability: Option<&'a [u8]>,
+    /// Advertise a `<video>` child: accepting a video-from-the-start call with video media. The node
+    /// mirrors the offer's `<video dec="H264" enc="h.264" …>` (NOT a bare `enc="h264"`, which uses a
+    /// codec token the peer doesn't match). Exact accept format is still a live-validation point —
+    /// the authoritative shape lives in WA Web's WASM, not the captured JS.
+    pub video: bool,
 }
 
-/// `<accept>`: audio → [te priority=2] → net medium=2 → encopt → [capability] → [rte] → [voip_settings].
+/// `<accept>`: audio → [video] → [te priority=2] → net medium=2 → encopt → [capability] → [rte] →
+/// [voip_settings].
 pub fn build_accept(p: &AcceptParams<'_>) -> Node {
     let mut children: Vec<Node> = p.audio_rates.iter().map(|rate| audio_opus(rate)).collect();
+    if p.video {
+        children.push(offer_video_node());
+    }
     if let Some(te) = p.relay_te {
         children.push(
             NodeBuilder::new("te")
@@ -511,6 +549,18 @@ pub fn build_accept(p: &AcceptParams<'_>) -> Node {
         Some(p.id),
         offer_action("accept", p.call_id, p.call_creator, children),
     )
+}
+
+/// The `<video>` advertisement in a video-from-the-start offer, as captured from WA Web:
+/// `<video dec="H264" enc="h.264" device_orientation="0" screen_width="0" screen_height="0"/>`.
+fn offer_video_node() -> Node {
+    NodeBuilder::new("video")
+        .attr("dec", "H264")
+        .attr("enc", "h.264")
+        .attr("device_orientation", "0")
+        .attr("screen_width", "0")
+        .attr("screen_height", "0")
+        .build()
 }
 
 /// One `<audio enc=opus rate=…>` advertisement child.
@@ -654,6 +704,61 @@ pub fn build_terminate(p: &TerminateParams<'_>) -> Node {
         action = action.attr("reason", reason.to_string());
     }
     call_wrap(p.to, p.id, action.build())
+}
+
+pub struct VideoStateParams<'a> {
+    pub call_id: &'a str,
+    pub to: &'a Jid,
+    /// The `<call>` wrapper id. Load-bearing: the peer's typed `<ack type="video">` correlates to
+    /// it, so an idless upgrade request can't be acked and the flow times out and reverts. The pure
+    /// builder takes it; the I/O layer supplies the generated id (mirrors `build_offer`).
+    pub id: &'a str,
+    pub call_creator: &'a Jid,
+    pub state: VideoState,
+    /// `dec` attr: codecs we can decode (`"H264"` on the upgrade request, `"H264,AV1"` on accept).
+    pub dec: Option<&'a str>,
+    /// Emit the `voip_settings="video"` marker attr. ONLY the upgrade request carries it: the mock
+    /// server keys its enrichment (and its non-bare ack) on marker+state=11, and stamping it on a
+    /// downgrade re-arms the peer's video (the zombie-stream bug).
+    pub upgrade_marker: bool,
+    pub device_orientation: Option<u8>,
+}
+
+/// `<call to=peer id=wrapper><video call-id call-creator state=N [dec] [voip_settings="video"]
+/// [device_orientation]/></call>` — the in-call video upgrade/downgrade handshake stanza.
+pub fn build_video_state(p: &VideoStateParams<'_>) -> Node {
+    let mut action = NodeBuilder::new("video")
+        .attr("call-id", p.call_id)
+        .attr("call-creator", p.call_creator)
+        .attr("state", p.state.code().to_string());
+    if let Some(dec) = p.dec {
+        action = action.attr("dec", dec.to_string());
+    }
+    if p.upgrade_marker {
+        action = action.attr("voip_settings", "video");
+    }
+    if let Some(o) = p.device_orientation {
+        action = action.attr("device_orientation", o.to_string());
+    }
+    call_wrap(p.to, Some(p.id), action.build())
+}
+
+/// `<ack class="call" id=stanza_id to=from type="video">` for a received `<call><video>`. The
+/// typed ack is load-bearing: the generic router ack carries no `type` (the `<video>` is a child,
+/// not a `<call>` attr), and an untyped ack makes the upgrade requester assume failure and revert
+/// after ~5s. The handler sends this and cancels the generic ack.
+pub fn build_call_video_ack(call: &IncomingCall) -> Option<Node> {
+    if call.stanza_id.is_empty() {
+        return None;
+    }
+    Some(
+        NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("id", call.stanza_id.as_str())
+            .attr("to", &call.from)
+            .attr("type", "video")
+            .build(),
+    )
 }
 
 pub fn build_mute_v2(call_id: &str, to: &Jid, call_creator: &Jid, mute_state: &str) -> Node {
@@ -1418,6 +1523,7 @@ mod tests {
             device_identity: Some(&[0xcc]),
             id: Some("OFFER-STANZA-ID"),
             multi_device: false,
+            video: false,
         });
         // Single device key → bare <enc> (not <destination>).
         assert_eq!(
@@ -1474,6 +1580,7 @@ mod tests {
             device_identity: None,
             id: None,
             multi_device: false,
+            video: false,
         });
         let tags = child_tags(&call);
         assert!(tags.contains(&"destination".to_string()));
@@ -1501,6 +1608,7 @@ mod tests {
             device_identity: None,
             id: None,
             multi_device: true,
+            video: false,
         });
         let tags = child_tags(&call);
         assert!(tags.contains(&"destination".to_string()));
@@ -1524,6 +1632,7 @@ mod tests {
             rte: None,
             voip_settings: None,
             capability: Some(&CAPABILITY_OFFER),
+            video: false,
         });
         assert_eq!(
             child_tags(&accept),
@@ -1658,5 +1767,270 @@ mod tests {
             action.get_optional_child("destination").is_none(),
             "terminate must not use a <destination> block"
         );
+    }
+
+    #[test]
+    fn video_state_wire_enum_round_trips() {
+        let known = [
+            (0, VideoState::Disabled),
+            (1, VideoState::Enabled),
+            (3, VideoState::UpgradeRequest),
+            (4, VideoState::UpgradeAccept),
+            (5, VideoState::UpgradeReject),
+            (6, VideoState::Stopped),
+            (8, VideoState::UpgradeCancel),
+            (11, VideoState::UpgradeRequestV2),
+        ];
+        for (code, state) in known {
+            assert_eq!(VideoState::from(code), state);
+            assert_eq!(state.code(), code);
+        }
+        // Forward-compat: an unknown state degrades to Unknown, preserving the wire value.
+        assert_eq!(VideoState::from(99), VideoState::Unknown(99));
+        assert_eq!(VideoState::Unknown(99).code(), 99);
+    }
+
+    fn video_call_node(attrs: &[(&'static str, &str)]) -> Node {
+        let mut video = NodeBuilder::new("video")
+            .attr("call-id", "CID")
+            .attr("call-creator", fake_caller_lid());
+        for (k, v) in attrs {
+            video = video.attr(k, v.to_string());
+        }
+        base_call_builder().children([video.build()]).build()
+    }
+
+    #[test]
+    fn parse_video_upgrade_request() {
+        let node = video_call_node(&[("state", "11"), ("dec", "H264"), ("voip_settings", "video")]);
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        match call.action {
+            CallAction::VideoState {
+                state,
+                dec,
+                orientation,
+                ..
+            } => {
+                assert_eq!(state, VideoState::UpgradeRequestV2);
+                assert_eq!(dec.as_deref(), Some("H264"));
+                assert_eq!(orientation, None);
+            }
+            other => panic!("expected VideoState, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_video_accept_downgrade_and_unknown_states() {
+        let accept = video_call_node(&[("state", "4"), ("dec", "H264,AV1")]);
+        let call = parse_call_stanza(&as_ref(&accept)).unwrap().unwrap();
+        assert!(matches!(
+            call.action,
+            CallAction::VideoState {
+                state: VideoState::UpgradeAccept,
+                ..
+            }
+        ));
+
+        let downgrade = video_call_node(&[("state", "6"), ("device_orientation", "2")]);
+        let call = parse_call_stanza(&as_ref(&downgrade)).unwrap().unwrap();
+        match call.action {
+            CallAction::VideoState {
+                state, orientation, ..
+            } => {
+                assert_eq!(state, VideoState::Stopped);
+                assert_eq!(orientation, Some(2));
+            }
+            other => panic!("expected VideoState, got {other:?}"),
+        }
+
+        // A future state number parses to Unknown rather than failing the stanza.
+        let future = video_call_node(&[("state", "42")]);
+        let call = parse_call_stanza(&as_ref(&future)).unwrap().unwrap();
+        assert!(matches!(
+            call.action,
+            CallAction::VideoState {
+                state: VideoState::Unknown(42),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_video_missing_or_garbage_state_errors() {
+        let missing = video_call_node(&[("dec", "H264")]);
+        assert!(parse_call_stanza(&as_ref(&missing)).is_err());
+        let garbage = video_call_node(&[("state", "not-a-number")]);
+        assert!(parse_call_stanza(&as_ref(&garbage)).is_err());
+    }
+
+    #[test]
+    fn build_video_state_upgrade_carries_marker_downgrade_does_not() {
+        let peer = peer();
+        let creator = creator();
+        let upgrade = build_video_state(&VideoStateParams {
+            call_id: "CID",
+            to: &peer,
+            id: "VIDEO-WRAP-ID",
+            call_creator: &creator,
+            state: VideoState::UpgradeRequestV2,
+            dec: Some("H264"),
+            upgrade_marker: true,
+            device_orientation: None,
+        });
+        let r = upgrade.as_node_ref();
+        assert_eq!(
+            r.attrs().optional_string("to").as_deref(),
+            Some(peer.to_string().as_str())
+        );
+        assert_eq!(
+            r.attrs().optional_string("id").as_deref(),
+            Some("VIDEO-WRAP-ID"),
+            "the <call> wrapper must carry the id the peer's typed ack correlates to"
+        );
+        let action = &r.children().unwrap()[0];
+        assert_eq!(action.tag, "video");
+        assert_eq!(
+            action.attrs().optional_string("state").as_deref(),
+            Some("11")
+        );
+        assert_eq!(
+            action.attrs().optional_string("dec").as_deref(),
+            Some("H264")
+        );
+        assert_eq!(
+            action.attrs().optional_string("voip_settings").as_deref(),
+            Some("video"),
+            "the upgrade request must carry the marker attr"
+        );
+
+        let downgrade = build_video_state(&VideoStateParams {
+            call_id: "CID",
+            to: &peer,
+            id: "VIDEO-WRAP-ID-2",
+            call_creator: &creator,
+            state: VideoState::Stopped,
+            dec: None,
+            upgrade_marker: false,
+            device_orientation: Some(0),
+        });
+        let action = downgrade.as_node_ref().children().unwrap()[0].to_owned();
+        let ar = action.as_node_ref();
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("6"));
+        assert_eq!(
+            ar.attrs().optional_string("voip_settings"),
+            None,
+            "a downgrade must NOT carry the marker (it re-arms the peer's video)"
+        );
+        assert_eq!(
+            ar.attrs().optional_string("device_orientation").as_deref(),
+            Some("0")
+        );
+
+        // Round-trip: our own builder output parses back to the same action.
+        let wrapped = base_call_builder()
+            .children([upgrade.as_node_ref().children().unwrap()[0].to_owned()])
+            .build();
+        let call = parse_call_stanza(&as_ref(&wrapped)).unwrap().unwrap();
+        assert!(matches!(
+            call.action,
+            CallAction::VideoState {
+                state: VideoState::UpgradeRequestV2,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn offer_and_accept_video_advertisement() {
+        let peer = peer();
+        let creator = creator();
+        let dk = OfferDeviceKey {
+            device_jid: peer.clone(),
+            ciphertext: vec![1, 2, 3],
+            enc_type: "msg".into(),
+        };
+        let base = OfferParams {
+            call_id: "CID",
+            to: &peer,
+            call_creator: &creator,
+            device_keys: std::slice::from_ref(&dk),
+            privacy_token: None,
+            capability: None,
+            device_identity: None,
+            id: None,
+            multi_device: false,
+            video: true,
+        };
+        let offer = build_offer(&base);
+        // The <video> child sits right after the <audio> children (capture-observed position).
+        assert_eq!(
+            child_tags(&offer),
+            ["audio", "audio", "video", "net", "enc", "encopt"]
+        );
+        // And our own parser reads it back as a video offer.
+        let call = parse_call_stanza(&offer.as_node_ref()).ok().flatten();
+        assert!(
+            call.is_none(),
+            "an outbound offer has no from/t; shape-only check above"
+        );
+
+        let no_video = build_offer(&OfferParams {
+            video: false,
+            ..base
+        });
+        assert!(!child_tags(&no_video).contains(&"video".to_string()));
+
+        let accept = build_accept(&AcceptParams {
+            call_id: "CID",
+            to: &peer,
+            id: "ACCEPT-ID",
+            call_creator: &creator,
+            audio_rates: &["16000"],
+            relay_te: None,
+            rte: None,
+            voip_settings: None,
+            capability: None,
+            video: true,
+        });
+        assert_eq!(child_tags(&accept), ["audio", "video", "net", "encopt"]);
+        // The accept's <video> mirrors the offer's format (dec + enc="h.264"), not a bare enc.
+        let vnode = accept.as_node_ref().children().unwrap()[0]
+            .children()
+            .unwrap()
+            .iter()
+            .find(|c| c.tag == "video")
+            .unwrap()
+            .to_owned();
+        let vr = vnode.as_node_ref();
+        assert_eq!(vr.attrs().optional_string("enc").as_deref(), Some("h.264"));
+        assert_eq!(vr.attrs().optional_string("dec").as_deref(), Some("H264"));
+    }
+
+    #[test]
+    fn video_ack_is_typed_and_requires_a_stanza_id() {
+        let node = video_call_node(&[("state", "11"), ("voip_settings", "video")]);
+        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        let ack = build_call_video_ack(&call).expect("ack for an id-carrying stanza");
+        let r = ack.as_node_ref();
+        assert_eq!(r.tag, "ack");
+        assert_eq!(r.attrs().optional_string("class").as_deref(), Some("call"));
+        assert_eq!(
+            r.attrs().optional_string("type").as_deref(),
+            Some("video"),
+            "the ack must be typed: an untyped ack makes the requester revert the upgrade"
+        );
+        assert_eq!(
+            r.attrs().optional_string("id").as_deref(),
+            Some("STANZA-ID-0001")
+        );
+        assert_eq!(
+            r.attrs().optional_string("to").as_deref(),
+            Some(fake_caller_lid().to_string().as_str())
+        );
+
+        // No stanza id -> nothing to ack-correlate; the builder refuses.
+        let mut idless = call.clone();
+        idless.stanza_id = String::new();
+        assert!(build_call_video_ack(&idless).is_none());
     }
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -806,22 +806,28 @@ pub fn build_video_state(p: &VideoStateParams<'_>) -> Node {
     call_wrap(p.to, Some(p.id), action.build())
 }
 
-/// `<ack class="call" id=stanza_id to=from type="video">` for a received `<call><video>`. The
-/// typed ack is load-bearing: the generic router ack carries no `type` (the `<video>` is a child,
-/// not a `<call>` attr), and an untyped ack makes the upgrade requester assume failure and revert
-/// after ~5s. The handler sends this and cancels the generic ack.
-pub fn build_call_video_ack(call: &IncomingCall) -> Option<Node> {
+/// Typed ack for a received `<call><video>`. The original stanza supplies routing attrs because
+/// suppressing the generic ack must not drop companion routing metadata.
+pub fn build_call_video_ack(call: &IncomingCall, original: &NodeRef<'_>) -> Option<Node> {
     if call.stanza_id.is_empty() {
         return None;
     }
-    Some(
-        NodeBuilder::new("ack")
-            .attr("class", "call")
-            .attr("id", call.stanza_id.as_str())
-            .attr("to", &call.from)
-            .attr("type", "video")
-            .build(),
-    )
+    let mut ack = NodeBuilder::new("ack")
+        .attr("class", "call")
+        .attr("id", call.stanza_id.as_str())
+        .attr("to", &call.from)
+        .attr("type", "video");
+    let from = call.from.to_string();
+    if let Some(participant) = original
+        .get_attr("participant")
+        .filter(|participant| participant.as_str().as_ref() != from)
+    {
+        ack = ack.attr("participant", participant.to_node_value());
+    }
+    if let Some(recipient) = original.get_attr("recipient") {
+        ack = ack.attr("recipient", recipient.to_node_value());
+    }
+    Some(ack.build())
 }
 
 pub fn build_mute_v2(call_id: &str, to: &Jid, call_creator: &Jid, mute_state: &str) -> Node {
@@ -2196,7 +2202,8 @@ mod tests {
     fn video_ack_is_typed_and_requires_a_stanza_id() {
         let node = video_call_node(&[("state", "11"), ("voip_settings", "video")]);
         let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
-        let ack = build_call_video_ack(&call).expect("ack for an id-carrying stanza");
+        let ack =
+            build_call_video_ack(&call, &as_ref(&node)).expect("ack for an id-carrying stanza");
         let r = ack.as_node_ref();
         assert_eq!(r.tag, "ack");
         assert_eq!(r.attrs().optional_string("class").as_deref(), Some("call"));
@@ -2214,9 +2221,32 @@ mod tests {
             Some(fake_caller_lid().to_string().as_str())
         );
 
+        let participant = fake_caller_lid().with_device(3);
+        let recipient = fake_caller_pn();
+        let routed = base_call_builder()
+            .attr("participant", &participant)
+            .attr("recipient", &recipient)
+            .children([NodeBuilder::new("video")
+                .attr("call-id", "CID")
+                .attr("call-creator", fake_caller_lid())
+                .attr("state", "11")
+                .build()])
+            .build();
+        let routed_call = parse_call_stanza(&as_ref(&routed)).unwrap().unwrap();
+        let routed_ack = build_call_video_ack(&routed_call, &as_ref(&routed)).unwrap();
+        let routed_ref = routed_ack.as_node_ref();
+        assert_eq!(
+            routed_ref.attrs().optional_jid("participant"),
+            Some(participant)
+        );
+        assert_eq!(
+            routed_ref.attrs().optional_jid("recipient"),
+            Some(recipient)
+        );
+
         // No stanza id -> nothing to ack-correlate; the builder refuses.
         let mut idless = call.clone();
         idless.stanza_id = String::new();
-        assert!(build_call_video_ack(&idless).is_none());
+        assert!(build_call_video_ack(&idless, &as_ref(&node)).is_none());
     }
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -133,7 +133,26 @@ fn parse_media_offer(
     }
 
     let relay = find_relay(call).and_then(crate::voip::relay_parse::parse_relay_data);
-    Some(MediaOffer { encs, relay })
+    let (peer_abtest_bucket, peer_abtest_bucket_id_list) = offer
+        .get_optional_child("metadata")
+        .map(|metadata| {
+            let mut attrs = metadata.attrs();
+            (
+                attrs
+                    .optional_string("peer_abtest_bucket")
+                    .map(|value| value.into_owned()),
+                attrs
+                    .optional_string("peer_abtest_bucket_id_list")
+                    .map(|value| value.into_owned()),
+            )
+        })
+        .unwrap_or_default();
+    Some(MediaOffer {
+        encs,
+        relay,
+        peer_abtest_bucket,
+        peer_abtest_bucket_id_list,
+    })
 }
 
 /// Parse one `<enc>` node into the ciphertext plus the wire `type`/`v` needed to decrypt the callKey.
@@ -374,10 +393,15 @@ pub fn build_offer_ack_receipt(call: &IncomingCall, own_ad: Option<&Jid>) -> Opt
 // Stanza ids generated from random bytes (heartbeat, preaccept) are passed in so the
 // builders stay pure; the I/O layer supplies them.
 
-/// Capability blob for `<offer>`/`<accept>` (ver=1).
-pub const CAPABILITY_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x13];
-/// Capability blob for `<preaccept>` (ver=1).
-pub const CAPABILITY_PREACCEPT: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x07];
+/// Capability blob for `<offer>`/`<accept>`/video `<preaccept>` (ver=1). Byte 4 is `0xe0`, matching
+/// real WhatsApp captures (an earlier `0xe4` was tolerated for audio but is not what the client sends).
+pub const CAPABILITY_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13];
+/// Capability blob for an audio-only `<preaccept>` (ver=1).
+pub const CAPABILITY_PREACCEPT: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07];
+/// Capability blob a client places in a VIDEO `<offer>`: byte 5 is `0xfa` (video) vs the audio
+/// `0xbb`. Observed in a real from-start video offer. A video CALLEE preaccepts with [`CAPABILITY_OFFER`]
+/// (`0xbb`), not this.
+pub const CAPABILITY_VIDEO_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xfa, 0x13];
 
 /// `<terminate reason>` wire tokens. The caller-driven sibling dismiss SENDS the `*_ELSEWHERE`
 /// ones; the receive path maps every reason to a call-log outcome (see WA Web's
@@ -443,7 +467,7 @@ pub fn build_offer(p: &OfferParams<'_>) -> Node {
             .build(),
     );
     if p.video {
-        children.push(offer_video_node());
+        children.push(video_offer_node());
     }
     children.push(NodeBuilder::new("net").attr("medium", "3").build());
     if let Some(cap) = p.capability {
@@ -506,19 +530,18 @@ pub struct AcceptParams<'a> {
     pub rte: Option<&'a [u8]>,
     pub voip_settings: Option<&'a [u8]>,
     pub capability: Option<&'a [u8]>,
-    /// Advertise a `<video>` child: accepting a video-from-the-start call with video media. The node
-    /// mirrors the offer's `<video dec="H264" enc="h.264" …>` (NOT a bare `enc="h264"`, which uses a
-    /// codec token the peer doesn't match). Exact accept format is still a live-validation point —
-    /// the authoritative shape lives in WA Web's WASM, not the captured JS.
+    /// Include the captured callee-side `<video>` child for a video-from-start accept.
     pub video: bool,
+    pub peer_abtest_bucket: Option<&'a str>,
+    pub peer_abtest_bucket_id_list: Option<&'a str>,
 }
 
-/// `<accept>`: audio → [video] → [te priority=2] → net medium=2 → encopt → [capability] → [rte] →
-/// [voip_settings].
+/// `<accept>`: audio → [video] → [te priority=2] → net medium=2 → encopt → [metadata] →
+/// [capability] → [rte] → [voip_settings].
 pub fn build_accept(p: &AcceptParams<'_>) -> Node {
     let mut children: Vec<Node> = p.audio_rates.iter().map(|rate| audio_opus(rate)).collect();
     if p.video {
-        children.push(offer_video_node());
+        children.push(video_accept_node());
     }
     if let Some(te) = p.relay_te {
         children.push(
@@ -530,6 +553,16 @@ pub fn build_accept(p: &AcceptParams<'_>) -> Node {
     }
     children.push(NodeBuilder::new("net").attr("medium", "2").build());
     children.push(encopt_node());
+    if p.peer_abtest_bucket.is_some() || p.peer_abtest_bucket_id_list.is_some() {
+        let mut metadata = NodeBuilder::new("metadata");
+        if let Some(bucket) = p.peer_abtest_bucket {
+            metadata = metadata.attr("peer_abtest_bucket", bucket.to_string());
+        }
+        if let Some(ids) = p.peer_abtest_bucket_id_list {
+            metadata = metadata.attr("peer_abtest_bucket_id_list", ids.to_string());
+        }
+        children.push(metadata.build());
+    }
     if let Some(cap) = p.capability {
         children.push(capability_node(cap));
     }
@@ -551,12 +584,35 @@ pub fn build_accept(p: &AcceptParams<'_>) -> Node {
     )
 }
 
-/// The `<video>` advertisement in a video-from-the-start offer, as captured from WA Web:
-/// `<video dec="H264" enc="h.264" device_orientation="0" screen_width="0" screen_height="0"/>`.
-fn offer_video_node() -> Node {
+/// Default initiator-side geometry used by the WaCalls reference.
+const VIDEO_SCREEN_WIDTH: &str = "1920";
+const VIDEO_SCREEN_HEIGHT: &str = "1080";
+
+/// `<video>` for an `<offer>`: full decoder + geometry advertisement (the initiator side).
+fn video_offer_node() -> Node {
+    NodeBuilder::new("video")
+        .attr("enc", "h264")
+        .attr("dec", "h264")
+        .attr("orientation", "0")
+        .attr("screen_width", VIDEO_SCREEN_WIDTH)
+        .attr("screen_height", VIDEO_SCREEN_HEIGHT)
+        .attr("device_orientation", "0")
+        .build()
+}
+
+/// `<video>` byte-matching a captured from-start video callee.
+fn video_accept_node() -> Node {
     NodeBuilder::new("video")
         .attr("dec", "H264")
-        .attr("enc", "h.264")
+        .attr("device_orientation", "0")
+        .build()
+}
+
+/// `<video>` for a `<preaccept>`, byte-matching a real from-start video callee: `dec` +
+/// `device_orientation` + `screen_width="0" screen_height="0"` (the real client sends zero here).
+fn video_preaccept_node() -> Node {
+    NodeBuilder::new("video")
+        .attr("dec", "H264")
         .attr("device_orientation", "0")
         .attr("screen_width", "0")
         .attr("screen_height", "0")
@@ -584,17 +640,27 @@ fn capability_node(blob: &[u8]) -> Node {
         .build()
 }
 
-/// `<preaccept>`: audio → encopt → capability(preaccept blob). `id` is the random call-wrapper id.
+/// `<preaccept>`: audio → [video] → encopt → capability. `id` is the random call-wrapper id. A video
+/// callee advertises the `<video>` decoder here; the capability stays the `0xbb` [`CAPABILITY_OFFER`]
+/// blob (byte-matched to a real from-start video callee — the `0xfa` variant is the CALLER's offer).
 pub fn build_preaccept(
     call_id: &str,
     to: &Jid,
     call_creator: &Jid,
     wrapper_id: &str,
     audio_rates: &[&str],
+    video: bool,
 ) -> Node {
     let mut children: Vec<Node> = audio_rates.iter().map(|rate| audio_opus(rate)).collect();
+    if video {
+        children.push(video_preaccept_node());
+    }
     children.push(encopt_node());
-    children.push(capability_node(&CAPABILITY_PREACCEPT));
+    children.push(capability_node(if video {
+        &CAPABILITY_OFFER
+    } else {
+        &CAPABILITY_PREACCEPT
+    }));
     call_wrap(
         to,
         Some(wrapper_id),
@@ -871,11 +937,17 @@ mod tests {
         let node = base_call_builder()
             .children([
                 offer_builder_base()
-                    .children([NodeBuilder::new("enc")
-                        .attr("v", "2")
-                        .attr("type", "pkmsg")
-                        .bytes(vec![1, 2, 3, 4])
-                        .build()])
+                    .children([
+                        NodeBuilder::new("enc")
+                            .attr("v", "2")
+                            .attr("type", "pkmsg")
+                            .bytes(vec![1, 2, 3, 4])
+                            .build(),
+                        NodeBuilder::new("metadata")
+                            .attr("peer_abtest_bucket", "video_interop_holdout")
+                            .attr("peer_abtest_bucket_id_list", "110001,110002")
+                            .build(),
+                    ])
                     .build(),
                 relay,
             ])
@@ -889,6 +961,14 @@ mod tests {
         assert_eq!(enc.enc_type, "pkmsg");
         assert_eq!(enc.version, 2);
         assert_eq!(enc.ciphertext, vec![1, 2, 3, 4]);
+        assert_eq!(
+            media.peer_abtest_bucket.as_deref(),
+            Some("video_interop_holdout")
+        );
+        assert_eq!(
+            media.peer_abtest_bucket_id_list.as_deref(),
+            Some("110001,110002")
+        );
         let rd = media.relay.expect("the <relay> must be parsed");
         assert_eq!(rd.warp_mi_tag_len, Some(4));
         assert_eq!(rd.relay_tokens[0], vec![0xaa, 0xbb]);
@@ -1633,6 +1713,8 @@ mod tests {
             voip_settings: None,
             capability: Some(&CAPABILITY_OFFER),
             video: false,
+            peer_abtest_bucket: None,
+            peer_abtest_bucket_id_list: None,
         });
         assert_eq!(
             child_tags(&accept),
@@ -1649,11 +1731,54 @@ mod tests {
             Some("ACCEPT-STANZA-ID")
         );
 
-        let pre = build_preaccept("CID", &peer, &creator, "abcd1234", &["8000", "16000"]);
+        let pre = build_preaccept(
+            "CID",
+            &peer,
+            &creator,
+            "abcd1234",
+            &["8000", "16000"],
+            false,
+        );
         assert_eq!(child_tags(&pre), ["audio", "audio", "encopt", "capability"]);
         assert_eq!(
             pre.as_node_ref().attrs().optional_string("id").as_deref(),
             Some("abcd1234")
+        );
+    }
+
+    #[test]
+    fn video_preaccept_advertises_video_and_video_capability() {
+        let peer = peer();
+        let creator = creator();
+        let pre = build_preaccept("CID", &peer, &creator, "abcd1234", &["16000"], true);
+        assert_eq!(child_tags(&pre), ["audio", "video", "encopt", "capability"]);
+        let pre_ref = pre.as_node_ref();
+        let action = &pre_ref.children().unwrap()[0];
+        let video = action.get_optional_child("video").unwrap();
+        assert_eq!(
+            video.attrs().optional_string("dec").as_deref(),
+            Some("H264")
+        );
+        // Real from-start video callee sends screen_width/height="0" in the preaccept <video>.
+        assert_eq!(
+            video.attrs().optional_string("screen_width").as_deref(),
+            Some("0")
+        );
+        // A video callee preaccepts with the 0xbb CAPABILITY_OFFER blob, not the 0xfa offer blob.
+        let cap = action.get_optional_child("capability").unwrap();
+        assert_eq!(cap.content_bytes().unwrap(), &CAPABILITY_OFFER);
+
+        // An audio preaccept keeps the audio capability blob.
+        let audio_pre = build_preaccept("CID", &peer, &creator, "id", &["16000"], false);
+        let audio_ref = audio_pre.as_node_ref();
+        let audio_action = &audio_ref.children().unwrap()[0];
+        assert_eq!(
+            audio_action
+                .get_optional_child("capability")
+                .unwrap()
+                .content_bytes()
+                .unwrap(),
+            &CAPABILITY_PREACCEPT
         );
     }
 
@@ -1991,9 +2116,11 @@ mod tests {
             voip_settings: None,
             capability: None,
             video: true,
+            peer_abtest_bucket: None,
+            peer_abtest_bucket_id_list: None,
         });
         assert_eq!(child_tags(&accept), ["audio", "video", "net", "encopt"]);
-        // The accept's <video> mirrors the offer's format (dec + enc="h.264"), not a bare enc.
+        // Captured callee accept: dec + device_orientation, without enc or screen geometry.
         let vnode = accept.as_node_ref().children().unwrap()[0]
             .children()
             .unwrap()
@@ -2002,8 +2129,62 @@ mod tests {
             .unwrap()
             .to_owned();
         let vr = vnode.as_node_ref();
-        assert_eq!(vr.attrs().optional_string("enc").as_deref(), Some("h.264"));
         assert_eq!(vr.attrs().optional_string("dec").as_deref(), Some("H264"));
+        assert_eq!(
+            vr.attrs().optional_string("enc"),
+            None,
+            "accept <video> must not advertise enc"
+        );
+        assert_eq!(vr.attrs().optional_string("screen_width"), None);
+
+        // The offer's <video> carries the decoder/geometry advertisement (WaCalls reference form).
+        let ovnode = offer.as_node_ref().children().unwrap()[0]
+            .children()
+            .unwrap()
+            .iter()
+            .find(|c| c.tag == "video")
+            .unwrap()
+            .to_owned();
+        let ovr = ovnode.as_node_ref();
+        assert_eq!(ovr.attrs().optional_string("enc").as_deref(), Some("h264"));
+        assert_eq!(ovr.attrs().optional_string("dec").as_deref(), Some("h264"));
+
+        let accept = build_accept(&AcceptParams {
+            call_id: "CID",
+            to: &peer,
+            id: "ACCEPT-ID-METADATA",
+            call_creator: &creator,
+            audio_rates: &["16000"],
+            relay_te: None,
+            rte: None,
+            voip_settings: None,
+            capability: None,
+            video: true,
+            peer_abtest_bucket: Some("video_interop_holdout"),
+            peer_abtest_bucket_id_list: Some("110001,110002"),
+        });
+        assert_eq!(
+            child_tags(&accept),
+            ["audio", "video", "net", "encopt", "metadata"]
+        );
+        let accept_ref = accept.as_node_ref();
+        let metadata = accept_ref.children().unwrap()[0]
+            .get_optional_child("metadata")
+            .unwrap();
+        assert_eq!(
+            metadata
+                .attrs()
+                .optional_string("peer_abtest_bucket")
+                .as_deref(),
+            Some("video_interop_holdout")
+        );
+        assert_eq!(
+            metadata
+                .attrs()
+                .optional_string("peer_abtest_bucket_id_list")
+                .as_deref(),
+            Some("110001,110002")
+        );
     }
 
     #[test]

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -65,6 +65,32 @@ pub struct CallAudioCodec {
     pub rate: u32,
 }
 
+/// In-call `<video state=N>` handshake states (audio→video upgrade, video→audio downgrade).
+/// Values verified against WA Web captures relayed by the mock server; unknown future states land
+/// in `Unknown` so a new server value degrades to an observable no-op instead of a parse failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+#[wire(kind = "int")]
+pub enum VideoState {
+    #[wire = 0]
+    Disabled,
+    #[wire = 1]
+    Enabled,
+    #[wire = 3]
+    UpgradeRequest,
+    #[wire = 4]
+    UpgradeAccept,
+    #[wire = 5]
+    UpgradeReject,
+    #[wire = 6]
+    Stopped,
+    #[wire = 8]
+    UpgradeCancel,
+    #[wire = 11]
+    UpgradeRequestV2,
+    #[wire_fallback]
+    Unknown(i32),
+}
+
 /// Fields kept per-variant (not a shared `BasicCallMeta`) so the `serde` shape
 /// mirrors the stanza 1:1 for downstream JS consumers.
 #[derive(Debug, Clone, Serialize)]
@@ -138,6 +164,21 @@ pub enum CallAction {
         call_id: String,
         call_creator: Jid,
     },
+    /// In-call `<video state=N>` signaling: the audio→video upgrade / video→audio downgrade
+    /// handshake. Serde-renamed to the wire tag (`video`), like the other variants.
+    #[serde(rename = "video")]
+    VideoState {
+        call_id: String,
+        call_creator: Jid,
+        state: VideoState,
+        /// `device_orientation` attr (0..3, ×90° rotation of the sender's camera).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        orientation: Option<u8>,
+        /// `dec` attr: the codecs the sender can decode (`"H264"` on an upgrade request,
+        /// `"H264,AV1"` on an accept).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dec: Option<String>,
+    },
 }
 
 impl CallAction {
@@ -150,7 +191,8 @@ impl CallAction {
             | Self::Reject { call_id, .. }
             | Self::Terminate { call_id, .. }
             | Self::Transport { call_id, .. }
-            | Self::RelayLatency { call_id, .. } => call_id,
+            | Self::RelayLatency { call_id, .. }
+            | Self::VideoState { call_id, .. } => call_id,
         }
     }
 
@@ -163,7 +205,8 @@ impl CallAction {
             | Self::Reject { call_creator, .. }
             | Self::Terminate { call_creator, .. }
             | Self::Transport { call_creator, .. }
-            | Self::RelayLatency { call_creator, .. } => call_creator,
+            | Self::RelayLatency { call_creator, .. }
+            | Self::VideoState { call_creator, .. } => call_creator,
         }
     }
 
@@ -178,6 +221,7 @@ impl CallAction {
             Self::Terminate { .. } => "terminate",
             Self::Transport { .. } => "transport",
             Self::RelayLatency { .. } => "relaylatency",
+            Self::VideoState { .. } => "video",
         }
     }
 }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -16,6 +16,9 @@ pub struct MediaOffer {
     pub encs: Vec<OfferRecipientEnc>,
     /// The parsed `<relay>` block (endpoints + crypto material), when the offer carried one.
     pub relay: Option<crate::voip::relay_parse::RelayData>,
+    /// Rollout metadata echoed by official callees in the video accept.
+    pub peer_abtest_bucket: Option<String>,
+    pub peer_abtest_bucket_id_list: Option<String>,
 }
 
 #[cfg(feature = "voip")]

--- a/wacore/src/voip/demux.rs
+++ b/wacore/src/voip/demux.rs
@@ -1,5 +1,8 @@
-//! First-byte demux of packets seen on the relay channel (STUN vs RTP vs RTCP). Pure: the same
+//! Demux of packets seen on the relay channel (STUN vs RTP vs RTCP). Pure: the same
 //! classification the sans-IO engine and the platform driver use to route an inbound relay message.
+
+use super::rtcp::is_rtcp_packet;
+use super::rtp::is_rtp_version2;
 
 /// Classification of a packet seen on the relay channel, by its first byte.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,21 +13,22 @@ pub enum RelayPacketKind {
     Other,
 }
 
-/// First-byte demux: top two bits zero means STUN; 0x80/0x81 means RTCP; 0x90 means RTP
-/// (WARP); anything else is other.
+/// RTP/RTCP mux follows RFC 5761's non-overlapping payload-type range. Looking only at byte 0 loses
+/// feedback packets whose count/FMT changes it and mistakes ordinary X=0 video RTP for RTCP.
 pub fn classify_relay_packet(data: &[u8]) -> RelayPacketKind {
     if data.len() < 2 {
         return RelayPacketKind::Other;
     }
-    let first = data[0];
-    if first & 0xc0 != 0 {
-        return match first {
-            0x80 | 0x81 => RelayPacketKind::Rtcp,
-            0x90 => RelayPacketKind::Rtp,
-            _ => RelayPacketKind::Other,
-        };
+    if data[0] & 0xc0 == 0 {
+        return RelayPacketKind::Stun;
     }
-    RelayPacketKind::Stun
+    if is_rtcp_packet(data) {
+        return RelayPacketKind::Rtcp;
+    }
+    if is_rtp_version2(data) {
+        return RelayPacketKind::Rtp;
+    }
+    RelayPacketKind::Other
 }
 
 #[cfg(test)]
@@ -35,9 +39,24 @@ mod tests {
     fn classify_first_byte() {
         assert_eq!(classify_relay_packet(&[0x00, 0x01]), RelayPacketKind::Stun);
         assert_eq!(classify_relay_packet(&[0x00, 0x03]), RelayPacketKind::Stun);
-        assert_eq!(classify_relay_packet(&[0x80, 0xc8]), RelayPacketKind::Rtcp);
-        assert_eq!(classify_relay_packet(&[0x81, 0xc8]), RelayPacketKind::Rtcp);
-        assert_eq!(classify_relay_packet(&[0x90, 0x78]), RelayPacketKind::Rtp);
+        assert_eq!(
+            classify_relay_packet(&[0x80, 0xc8, 0, 1, 0, 0, 0, 1]),
+            RelayPacketKind::Rtcp
+        );
+        assert_eq!(
+            classify_relay_packet(&[0x8f, 0xce, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2]),
+            RelayPacketKind::Rtcp
+        );
+        let mut video = [0u8; 12];
+        video[0] = 0x80;
+        video[1] = 0x61;
+        assert_eq!(classify_relay_packet(&video), RelayPacketKind::Rtp);
+        video[1] = 0xe1;
+        assert_eq!(classify_relay_packet(&video), RelayPacketKind::Rtp);
+        let mut audio = [0u8; 16];
+        audio[0] = 0x90;
+        audio[1] = 0x78;
+        assert_eq!(classify_relay_packet(&audio), RelayPacketKind::Rtp);
         assert_eq!(classify_relay_packet(&[0xff, 0xff]), RelayPacketKind::Other);
         assert_eq!(classify_relay_packet(&[0x00]), RelayPacketKind::Other);
     }

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -45,6 +45,110 @@ pub enum VideoControl {
     SetOrientation(u8),
 }
 
+/// State changes stay FIFO so `Disable` performs its purge before a later `Enable`; only the latest
+/// orientation matters while the driver is busy.
+#[derive(Clone)]
+pub struct VideoControlSender {
+    state: async_channel::Sender<VideoControl>,
+    orientation: async_channel::Sender<u8>,
+}
+
+/// Receiving half of [`video_control_channel`].
+pub struct VideoControlReceiver {
+    state: async_channel::Receiver<VideoControl>,
+    orientation: async_channel::Receiver<u8>,
+}
+
+/// Build the control mailbox used by one call driver.
+pub fn video_control_channel() -> (VideoControlSender, VideoControlReceiver) {
+    let (state_tx, state_rx) = async_channel::unbounded();
+    let (orientation_tx, orientation_rx) = async_channel::bounded(1);
+    (
+        VideoControlSender {
+            state: state_tx,
+            orientation: orientation_tx,
+        },
+        VideoControlReceiver {
+            state: state_rx,
+            orientation: orientation_rx,
+        },
+    )
+}
+
+impl VideoControlSender {
+    /// Queue a state change, or replace the pending orientation with the newest value.
+    pub fn send(&self, control: VideoControl) -> bool {
+        match control {
+            VideoControl::SetOrientation(orientation) => {
+                self.orientation.force_send(orientation).is_ok()
+            }
+            state => self.state.try_send(state).is_ok(),
+        }
+    }
+}
+
+impl VideoControlReceiver {
+    /// Whether both halves have lost every sender.
+    pub fn is_closed(&self) -> bool {
+        self.state.is_closed() && self.orientation.is_closed()
+    }
+
+    /// Receive a ready state first, otherwise the latest orientation.
+    pub fn try_recv(&self) -> Result<VideoControl, async_channel::TryRecvError> {
+        let state_error = match self.state.try_recv() {
+            Ok(state) => return Ok(state),
+            Err(error) => error,
+        };
+        match self.orientation.try_recv() {
+            Ok(orientation) => Ok(VideoControl::SetOrientation(orientation)),
+            Err(async_channel::TryRecvError::Closed)
+                if state_error == async_channel::TryRecvError::Closed =>
+            {
+                Err(async_channel::TryRecvError::Closed)
+            }
+            Err(_) => Err(async_channel::TryRecvError::Empty),
+        }
+    }
+
+    /// Wait for a state or orientation until every sender is gone.
+    pub async fn recv(&self) -> Result<VideoControl, async_channel::RecvError> {
+        loop {
+            match self.try_recv() {
+                Ok(control) => return Ok(control),
+                Err(async_channel::TryRecvError::Closed) => return self.state.recv().await,
+                Err(async_channel::TryRecvError::Empty) => {}
+            }
+
+            match (self.state.is_closed(), self.orientation.is_closed()) {
+                (false, true) => return self.state.recv().await,
+                (true, false) => {
+                    return self
+                        .orientation
+                        .recv()
+                        .await
+                        .map(VideoControl::SetOrientation);
+                }
+                (true, true) => return self.state.recv().await,
+                (false, false) => {
+                    let state = self.state.recv().fuse();
+                    let orientation = self.orientation.recv().fuse();
+                    futures::pin_mut!(state, orientation);
+                    futures::select_biased! {
+                        state = state => match state {
+                            Ok(state) => return Ok(state),
+                            Err(_) => continue,
+                        },
+                        orientation = orientation => match orientation {
+                            Ok(orientation) => return Ok(VideoControl::SetOrientation(orientation)),
+                            Err(_) => continue,
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// The audio + video + event channels the driver bridges to the platform. Mic frames in, playout
 /// frames out (dropped on speaker overflow since VoIP is loss tolerant), and engine events out
 /// (RelayAllocated, ForeignAudio) for the shell to act on (e.g. decode a non-MLow frame with a
@@ -61,8 +165,8 @@ pub struct CallChannels {
     pub video_in: async_channel::Receiver<Vec<u8>>,
     /// Inbound video: reassembled peer access units (dropped on sink overflow, like the speaker).
     pub video_out: async_channel::Sender<VideoFrame>,
-    /// Mid-call video-plane control (upgrade/downgrade/orientation).
-    pub video_ctl: async_channel::Receiver<VideoControl>,
+    /// Mid-call video-plane control (lossless state, coalesced orientation).
+    pub video_ctl: VideoControlReceiver,
 }
 
 /// Bound slow relay writes without truncating a complete video access unit.
@@ -540,8 +644,8 @@ async fn run_call_with_clock_and_wallclock(
                     break 'drive; // malformed stored call_key (a setup invariant violated)
                 }
             },
-            // Video-plane control before the media arms, so an Enable lands before queued AUs and
-            // a Disable stops decoding queued inbound PT-97 right away.
+            // State control before orientation and media, so a Disable always purges before a later
+            // Enable can admit frames from the replacement source.
             ctl = video_ctl_fut => {
                 match ctl {
                     Ok(VideoControl::SetTimestampStride(ts_stride)) => {
@@ -703,6 +807,21 @@ mod tests {
         async fn disconnect(&self) {}
     }
 
+    #[test]
+    fn video_control_channel_preserves_state_and_coalesces_orientation() {
+        let (tx, rx) = video_control_channel();
+        assert!(tx.send(VideoControl::Disable));
+        for orientation in 0..100u8 {
+            assert!(tx.send(VideoControl::SetOrientation(orientation % 4)));
+        }
+        assert!(tx.send(VideoControl::Enable));
+
+        assert_eq!(rx.try_recv(), Ok(VideoControl::Disable));
+        assert_eq!(rx.try_recv(), Ok(VideoControl::Enable));
+        assert_eq!(rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
+        assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+    }
+
     /// CallChannels with idle video plumbing (senders/receivers dropped immediately), for the
     /// audio-only driver tests: the closed-channel guards must keep those arms inert.
     fn test_channels(
@@ -712,7 +831,7 @@ mod tests {
     ) -> CallChannels {
         let (_vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
         let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
-        let (_vctl_tx, vctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (_vctl_tx, vctl_rx) = video_control_channel();
         CallChannels {
             mic,
             speaker,
@@ -1374,14 +1493,12 @@ mod tests {
         let (ev_tx, _ev_rx) = async_channel::unbounded();
         let (vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
         let (vout_tx, vout_rx) = async_channel::unbounded::<VideoFrame>();
-        let (vctl_tx, vctl_rx) = async_channel::unbounded::<VideoControl>();
+        let (vctl_tx, vctl_rx) = video_control_channel();
 
         // Control drains first (bias), so cadence, Enable, and orientation land before any AU.
-        vctl_tx
-            .try_send(VideoControl::SetTimestampStride(4500))
-            .unwrap();
-        vctl_tx.try_send(VideoControl::Enable).unwrap();
-        vctl_tx.try_send(VideoControl::SetOrientation(1)).unwrap();
+        assert!(vctl_tx.send(VideoControl::SetTimestampStride(4500)));
+        assert!(vctl_tx.send(VideoControl::Enable));
+        assert!(vctl_tx.send(VideoControl::SetOrientation(1)));
         let our_au = make_au(3000);
         vin_tx.try_send(our_au.clone()).unwrap();
         vin_tx.try_send(our_au).unwrap();

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -69,17 +69,6 @@ pub struct CallChannels {
 const SEND_QUEUE_BATCH_CAP: usize = 64;
 const SEND_QUEUE_BYTE_CAP: usize = 2 * 1024 * 1024;
 
-fn try_send_engine_event(events: &async_channel::Sender<CallEvent>, event: CallEvent) {
-    // The last bounded slot belongs to ack-ordered signaling, which cannot be dropped.
-    if events
-        .capacity()
-        .is_some_and(|capacity| events.len() >= capacity.saturating_sub(1))
-    {
-        return;
-    }
-    let _ = events.try_send(event);
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SendBatchKind {
     Control,
@@ -387,13 +376,10 @@ async fn run_call_with_clock_and_wallclock(
                         data,
                     );
                     if dropped.packets != 0 {
-                        try_send_engine_event(
-                            &channels.events,
-                            CallEvent::OutboundMediaDropped {
-                                video_access_units: dropped.video_access_units,
-                                packets: dropped.packets,
-                            },
-                        );
+                        let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                            video_access_units: dropped.video_access_units,
+                            packets: dropped.packets,
+                        });
                     }
                 }
                 // Loss tolerant: drop the frame if the speaker can't keep up.
@@ -405,7 +391,7 @@ async fn run_call_with_clock_and_wallclock(
                     let _ = channels.video_out.try_send(frame);
                 }
                 Output::Event(ev) => {
-                    try_send_engine_event(&channels.events, ev);
+                    let _ = channels.events.try_send(ev);
                 }
                 Output::Timeout(_) => {
                     if !pending_video.is_empty() {
@@ -415,13 +401,10 @@ async fn run_call_with_clock_and_wallclock(
                             SendBatch::video(std::mem::take(&mut pending_video)),
                         );
                         if dropped.packets != 0 {
-                            try_send_engine_event(
-                                &channels.events,
-                                CallEvent::OutboundMediaDropped {
-                                    video_access_units: dropped.video_access_units,
-                                    packets: dropped.packets,
-                                },
-                            );
+                            let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                                video_access_units: dropped.video_access_units,
+                                packets: dropped.packets,
+                            });
                         }
                     }
                     break;
@@ -711,16 +694,6 @@ mod tests {
             video_out: vout_tx,
             video_ctl: vctl_rx,
         }
-    }
-
-    #[test]
-    fn engine_events_leave_one_slot_for_signaling() {
-        let (events, rx) = async_channel::bounded(2);
-        try_send_engine_event(&events, CallEvent::RelayAllocated);
-        try_send_engine_event(&events, CallEvent::RelayAllocateTimedOut);
-
-        assert!(matches!(rx.try_recv(), Ok(CallEvent::RelayAllocated)));
-        assert!(rx.try_recv().is_err(), "the signaling slot stays free");
     }
 
     fn config() -> CallConfig {

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -482,8 +482,8 @@ async fn run_call_with_clock_and_wallclock(
                     Ok(VideoControl::SetOrientation(o)) => eng.set_peer_video_orientation(o),
                     Err(_) => video_ctl_open = false,
                 }
-                // Fire an overdue timer like the other ready arms: video_ctl is unbounded, so a
-                // stream of control messages must not keep this arm hot and defer the keepalive.
+                // Fire an overdue timer like the other ready arms so a stream of control messages
+                // cannot keep this arm hot and defer the keepalive.
                 let now = now_ms();
                 if let Some(at) = eng.poll_timeout()
                     && at != engine::NEVER

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -69,6 +69,17 @@ pub struct CallChannels {
 const SEND_QUEUE_BATCH_CAP: usize = 64;
 const SEND_QUEUE_BYTE_CAP: usize = 2 * 1024 * 1024;
 
+fn try_send_engine_event(events: &async_channel::Sender<CallEvent>, event: CallEvent) {
+    // The last bounded slot belongs to ack-ordered signaling, which cannot be dropped.
+    if events
+        .capacity()
+        .is_some_and(|capacity| events.len() >= capacity.saturating_sub(1))
+    {
+        return;
+    }
+    let _ = events.try_send(event);
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SendBatchKind {
     Control,
@@ -376,10 +387,13 @@ async fn run_call_with_clock_and_wallclock(
                         data,
                     );
                     if dropped.packets != 0 {
-                        let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
-                            video_access_units: dropped.video_access_units,
-                            packets: dropped.packets,
-                        });
+                        try_send_engine_event(
+                            &channels.events,
+                            CallEvent::OutboundMediaDropped {
+                                video_access_units: dropped.video_access_units,
+                                packets: dropped.packets,
+                            },
+                        );
                     }
                 }
                 // Loss tolerant: drop the frame if the speaker can't keep up.
@@ -391,7 +405,7 @@ async fn run_call_with_clock_and_wallclock(
                     let _ = channels.video_out.try_send(frame);
                 }
                 Output::Event(ev) => {
-                    let _ = channels.events.try_send(ev);
+                    try_send_engine_event(&channels.events, ev);
                 }
                 Output::Timeout(_) => {
                     if !pending_video.is_empty() {
@@ -401,10 +415,13 @@ async fn run_call_with_clock_and_wallclock(
                             SendBatch::video(std::mem::take(&mut pending_video)),
                         );
                         if dropped.packets != 0 {
-                            let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
-                                video_access_units: dropped.video_access_units,
-                                packets: dropped.packets,
-                            });
+                            try_send_engine_event(
+                                &channels.events,
+                                CallEvent::OutboundMediaDropped {
+                                    video_access_units: dropped.video_access_units,
+                                    packets: dropped.packets,
+                                },
+                            );
                         }
                     }
                     break;
@@ -694,6 +711,16 @@ mod tests {
             video_out: vout_tx,
             video_ctl: vctl_rx,
         }
+    }
+
+    #[test]
+    fn engine_events_leave_one_slot_for_signaling() {
+        let (events, rx) = async_channel::bounded(2);
+        try_send_engine_event(&events, CallEvent::RelayAllocated);
+        try_send_engine_event(&events, CallEvent::RelayAllocateTimedOut);
+
+        assert!(matches!(rx.try_recv(), Ok(CallEvent::RelayAllocated)));
+        assert!(rx.try_recv().is_err(), "the signaling slot stays free");
     }
 
     fn config() -> CallConfig {

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -131,6 +131,24 @@ fn record_drop(dropped: &mut DroppedMedia, batch: &SendBatch) {
     }
 }
 
+fn purge_unstarted_video(
+    queue: &mut VecDeque<SendBatch>,
+    awaiting_video_keyframe: &mut bool,
+) -> DroppedMedia {
+    let mut dropped = DroppedMedia::default();
+    queue.retain(|batch| {
+        let discard = !batch.started && batch.kind == SendBatchKind::Video;
+        if discard {
+            record_drop(&mut dropped, batch);
+        }
+        !discard
+    });
+    if dropped.video_access_units != 0 {
+        *awaiting_video_keyframe = true;
+    }
+    dropped
+}
+
 fn discard_video_until_keyframe(
     queue: &mut VecDeque<SendBatch>,
     dropped: &mut DroppedMedia,
@@ -539,6 +557,16 @@ async fn run_call_with_clock_and_wallclock(
                     }
                     Ok(VideoControl::Disable) => {
                         eng.disable_video();
+                        let dropped = purge_unstarted_video(
+                            &mut send_queue,
+                            &mut awaiting_video_keyframe,
+                        );
+                        if dropped.packets != 0 {
+                            let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                                video_access_units: dropped.video_access_units,
+                                packets: dropped.packets,
+                            });
+                        }
                         // Discard any AUs still queued from the (now-detached) source, so a quick
                         // re-Enable can't transmit stale frames from the previous session under the
                         // new negotiation. Drained after the select block (the futures borrow the
@@ -1499,6 +1527,37 @@ mod tests {
         assert_eq!(dropped.packets, 40);
         assert!(queue.is_empty(), "no partial AU may remain queued");
         assert!(awaiting_keyframe);
+    }
+
+    #[test]
+    fn disabling_purges_only_video_batches_that_have_not_started() {
+        let mut started = SendBatch::video(vec![
+            Bytes::from_static(b"started-1"),
+            Bytes::from_static(b"started-2"),
+        ]);
+        started.started = true;
+        let mut queue = VecDeque::from([
+            SendBatch::packet(Bytes::from_static(&[0x90, 0x01])),
+            started,
+            SendBatch::video(vec![Bytes::from_static(b"stale")]),
+            SendBatch::packet(Bytes::from_static(&[0x00, 0x01])),
+        ]);
+        let mut awaiting_keyframe = false;
+
+        let dropped = purge_unstarted_video(&mut queue, &mut awaiting_keyframe);
+
+        assert_eq!(dropped.video_access_units, 1);
+        assert_eq!(dropped.packets, 1);
+        assert!(awaiting_keyframe);
+        assert_eq!(queue.len(), 3);
+        assert!(queue.iter().any(|batch| {
+            batch.kind == SendBatchKind::Video && batch.started && batch.packets.len() == 2
+        }));
+        assert!(
+            queue
+                .iter()
+                .all(|batch| batch.kind != SendBatchKind::Video || batch.started)
+        );
     }
 
     #[test]

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -30,6 +30,9 @@ use crate::voip::transport::{RelayTransport, RelayTransportEvent};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum VideoControl {
+    /// RTP clock increment for each access unit. Sent before attaching a source whose cadence is
+    /// different from the 15 fps compatibility default.
+    SetTimestampStride(u32),
     /// Bring the video plane up with outbound video ALLOWED (a from-start call, an accept, or the
     /// initiator once the peer accepted the upgrade).
     Enable,
@@ -62,7 +65,7 @@ pub struct CallChannels {
     pub video_ctl: async_channel::Receiver<VideoControl>,
 }
 
-/// About two seconds of mixed audio/video at the example's 15 fps, bounded by bytes as well.
+/// Bound slow relay writes without truncating a complete video access unit.
 const SEND_QUEUE_BATCH_CAP: usize = 64;
 const SEND_QUEUE_BYTE_CAP: usize = 2 * 1024 * 1024;
 
@@ -457,6 +460,9 @@ async fn run_call_with_clock_and_wallclock(
             // a Disable stops decoding queued inbound PT-97 right away.
             ctl = video_ctl_fut => {
                 match ctl {
+                    Ok(VideoControl::SetTimestampStride(ts_stride)) => {
+                        let _ = eng.set_video_timestamp_stride(ts_stride);
+                    }
                     Ok(VideoControl::Enable) => {
                         // False only for a control-only engine or a malformed stored callKey; the
                         // audio plane already validated the key, so treat it as a no-op not fatal.
@@ -1276,10 +1282,14 @@ mod tests {
         let (vout_tx, vout_rx) = async_channel::unbounded::<VideoFrame>();
         let (vctl_tx, vctl_rx) = async_channel::unbounded::<VideoControl>();
 
-        // Control drains first (bias), so Enable + orientation land before any packet or AU.
+        // Control drains first (bias), so cadence, Enable, and orientation land before any AU.
+        vctl_tx
+            .try_send(VideoControl::SetTimestampStride(4500))
+            .unwrap();
         vctl_tx.try_send(VideoControl::Enable).unwrap();
         vctl_tx.try_send(VideoControl::SetOrientation(1)).unwrap();
         let our_au = make_au(3000);
+        vin_tx.try_send(our_au.clone()).unwrap();
         vin_tx.try_send(our_au).unwrap();
 
         let eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
@@ -1309,15 +1319,23 @@ mod tests {
             "SetOrientation must apply before the inbound AU reassembles"
         );
 
-        // Outbound: the 3KB AU fans out to ceil(3000/798) = 4 FU-A packets, all PT 97.
+        // Outbound: each 3KB AU fans out to four PT-97 packets and the 20 fps stride applies.
         let sent = transport.sent.lock().unwrap();
-        let pt97 = sent
+        let video_headers = sent
             .iter()
-            .filter(|b| {
-                parse_rtp_header(b).is_some_and(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264)
+            .filter_map(|packet| {
+                parse_rtp_header(packet).filter(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264)
             })
-            .count();
-        assert_eq!(pt97, 4, "one 3KB AU must fan out to 4 PT-97 packets");
+            .collect::<Vec<_>>();
+        assert_eq!(video_headers.len(), 8);
+        assert_eq!(
+            video_headers
+                .iter()
+                .filter(|header| header.marker)
+                .map(|header| header.timestamp)
+                .collect::<Vec<_>>(),
+            [0, 4500]
+        );
     }
 
     // A relay stall backs the queue up past cap: the overflow policy must shed media, never the STUN

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -22,6 +22,7 @@ use crate::time::Instant;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
 use crate::voip::h264::VideoFrame;
+use crate::voip::rtp::{RTP_PAYLOAD_TYPE_H264, parse_rtp_header};
 use crate::voip::transport::{RelayTransport, RelayTransportEvent};
 
 /// Mid-call video-plane commands from the shell (upgrade / downgrade / peer orientation). Kept out
@@ -61,24 +62,134 @@ pub struct CallChannels {
     pub video_ctl: async_channel::Receiver<VideoControl>,
 }
 
-/// Depth of the outbound send queue between the drive loop and the concurrent send task. ~2s of RTP
-/// at one 60ms frame per slot; on overflow the oldest is dropped (loss-tolerant), bounding latency.
-const SEND_QUEUE_CAP: usize = 32;
+/// About two seconds of mixed audio/video at the example's 15 fps, bounded by bytes as well.
+const SEND_QUEUE_BATCH_CAP: usize = 64;
+const SEND_QUEUE_BYTE_CAP: usize = 2 * 1024 * 1024;
 
-/// Enforce [`SEND_QUEUE_CAP`] on the outbound queue when a relay write stalls. Media is loss
-/// tolerant, but relay control is not: STUN keepalives and the consent Binding Success replies
-/// share this queue, and shedding one under media backpressure fails relay consent (RFC 7675) and
-/// tears down a still recoverable call. So evict the oldest *media* packet, sparing control; only
-/// if the queue is somehow all control do we drop the oldest to keep the bound.
-fn shed_to_cap(queue: &mut VecDeque<Bytes>) {
-    if queue.len() <= SEND_QUEUE_CAP {
-        return;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SendBatchKind {
+    Control,
+    Media,
+    Video,
+}
+
+struct SendBatch {
+    packets: VecDeque<Bytes>,
+    bytes: usize,
+    kind: SendBatchKind,
+    started: bool,
+}
+
+impl SendBatch {
+    fn packet(data: Bytes) -> Self {
+        let kind = if classify_relay_packet(&data) == RelayPacketKind::Stun {
+            SendBatchKind::Control
+        } else {
+            SendBatchKind::Media
+        };
+        Self {
+            bytes: data.len(),
+            packets: VecDeque::from([data]),
+            kind,
+            started: false,
+        }
     }
-    let victim = queue
+
+    fn video(packets: Vec<Bytes>) -> Self {
+        Self {
+            bytes: packets.iter().map(Bytes::len).sum(),
+            packets: packets.into(),
+            kind: SendBatchKind::Video,
+            started: false,
+        }
+    }
+}
+
+#[derive(Default)]
+struct DroppedMedia {
+    video_access_units: u32,
+    packets: u32,
+}
+
+fn shed_to_cap(queue: &mut VecDeque<SendBatch>) -> DroppedMedia {
+    let mut dropped = DroppedMedia::default();
+    loop {
+        let bytes: usize = queue.iter().map(|batch| batch.bytes).sum();
+        if queue.len() <= SEND_QUEUE_BATCH_CAP && bytes <= SEND_QUEUE_BYTE_CAP {
+            break;
+        }
+        // Never cut an AU after one of its fragments has entered the transport.
+        let victim = queue
+            .iter()
+            .position(|batch| !batch.started && batch.kind == SendBatchKind::Video)
+            .or_else(|| {
+                queue
+                    .iter()
+                    .position(|batch| !batch.started && batch.kind == SendBatchKind::Media)
+            })
+            .or_else(|| queue.iter().position(|batch| !batch.started));
+        let Some(victim) = victim else {
+            break;
+        };
+        let Some(batch) = queue.remove(victim) else {
+            break;
+        };
+        dropped.packets = dropped
+            .packets
+            .saturating_add(batch.packets.len().try_into().unwrap_or(u32::MAX));
+        if batch.kind == SendBatchKind::Video {
+            dropped.video_access_units = dropped.video_access_units.saturating_add(1);
+        }
+    }
+    dropped
+}
+
+fn enqueue_batch(queue: &mut VecDeque<SendBatch>, batch: SendBatch) -> DroppedMedia {
+    queue.push_back(batch);
+    shed_to_cap(queue)
+}
+
+/// Coalesce every PT-97 packet through the marker into one queue unit, so backpressure keeps or
+/// drops a complete H.264 access unit instead of silently truncating an IDR.
+fn queue_transmit(
+    queue: &mut VecDeque<SendBatch>,
+    pending_video: &mut Vec<Bytes>,
+    data: Bytes,
+) -> DroppedMedia {
+    if let Some(header) = parse_rtp_header(&data)
+        && header.payload_type == RTP_PAYLOAD_TYPE_H264
+    {
+        pending_video.push(data);
+        if header.marker {
+            return enqueue_batch(queue, SendBatch::video(std::mem::take(pending_video)));
+        }
+        return DroppedMedia::default();
+    }
+    let mut dropped = DroppedMedia::default();
+    if !pending_video.is_empty() {
+        dropped = enqueue_batch(queue, SendBatch::video(std::mem::take(pending_video)));
+    }
+    let more = enqueue_batch(queue, SendBatch::packet(data));
+    dropped.video_access_units = dropped
+        .video_access_units
+        .saturating_add(more.video_access_units);
+    dropped.packets = dropped.packets.saturating_add(more.packets);
+    dropped
+}
+
+fn pop_next_packet(queue: &mut VecDeque<SendBatch>) -> Option<Bytes> {
+    let index = queue
         .iter()
-        .position(|p| classify_relay_packet(p) != RelayPacketKind::Stun)
+        .position(|batch| batch.kind == SendBatchKind::Control)
         .unwrap_or(0);
-    queue.remove(victim);
+    let batch = queue.get_mut(index)?;
+    batch.started = true;
+    let packet = batch.packets.pop_front()?;
+    batch.bytes = batch.bytes.saturating_sub(packet.len());
+    if batch.packets.is_empty() {
+        queue.remove(index);
+    }
+    Some(packet)
 }
 
 /// Drive one call to completion: returns when the relay channel disconnects, a send fails, or the
@@ -95,9 +206,16 @@ pub async fn run_call(
     eng: CallEngine,
 ) {
     let epoch = Instant::now();
-    run_call_with_clock(rt, transport, relay_events, channels, eng, move || {
-        epoch.elapsed().as_millis() as u64
-    })
+    let wallclock_ms = crate::time::now_millis().max(0) as u64;
+    run_call_with_clock_and_wallclock(
+        rt,
+        transport,
+        relay_events,
+        channels,
+        eng,
+        move || epoch.elapsed().as_millis() as u64,
+        wallclock_ms,
+    )
     .await;
 }
 
@@ -114,15 +232,37 @@ pub async fn run_call(
         fields(call_id = %eng.call_id())
     )
 )]
+#[cfg(test)]
 async fn run_call_with_clock(
+    rt: Arc<dyn Runtime>,
+    transport: Arc<dyn RelayTransport>,
+    relay_events: async_channel::Receiver<RelayTransportEvent>,
+    channels: CallChannels,
+    eng: CallEngine,
+    now_ms: impl Fn() -> engine::Millis,
+) {
+    run_call_with_clock_and_wallclock(
+        rt,
+        transport,
+        relay_events,
+        channels,
+        eng,
+        now_ms,
+        1_700_000_000_000,
+    )
+    .await;
+}
+
+async fn run_call_with_clock_and_wallclock(
     rt: Arc<dyn Runtime>,
     transport: Arc<dyn RelayTransport>,
     relay_events: async_channel::Receiver<RelayTransportEvent>,
     channels: CallChannels,
     mut eng: CallEngine,
     now_ms: impl Fn() -> engine::Millis,
+    wallclock_ms: u64,
 ) {
-    eng.start(now_ms());
+    eng.start(now_ms(), wallclock_ms);
 
     #[cfg(feature = "tracing")]
     let call_id = eng.call_id().to_string();
@@ -151,9 +291,8 @@ async fn run_call_with_clock(
     // the two: a slow send parked the loop, inbound packets queued then arrived in a burst, and the
     // playout tick fired late -- so the jitter buffer overflowed then underran (audible glitching,
     // worst whatsapp-rust<->whatsapp-rust where both ends stalled; the official client decouples them).
-    // The queue is bounded and drops the OLDEST packet on overflow: outbound media is loss tolerant, so
-    // when the link can't keep up, shedding the stalest frame (lowest latency) is correct.
-    let mut send_queue: VecDeque<Bytes> = VecDeque::new();
+    // Video is queued per access unit so overload never leaves half an IDR on the wire.
+    let mut send_queue: VecDeque<SendBatch> = VecDeque::new();
     // Idle sentinel: a terminated `Fuse` is safe to re-select every iteration and never fires until a
     // real send replaces it; on completion it terminates itself, so no manual reset / re-poll hazard.
     // `BoxFuture` is `Send` natively but `?Send` on wasm (the transport is single-threaded there).
@@ -161,12 +300,18 @@ async fn run_call_with_clock(
 
     'drive: loop {
         // Drain every intent the last mutation produced; stop at the terminal Timeout.
+        let mut pending_video = Vec::new();
         loop {
             match eng.poll_output() {
                 // Queue for the in-flight send arm; never await the write in this loop.
                 Output::Transmit(data) => {
-                    send_queue.push_back(data);
-                    shed_to_cap(&mut send_queue);
+                    let dropped = queue_transmit(&mut send_queue, &mut pending_video, data);
+                    if dropped.packets != 0 {
+                        let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                            video_access_units: dropped.video_access_units,
+                            packets: dropped.packets,
+                        });
+                    }
                 }
                 // Loss tolerant: drop the frame if the speaker can't keep up.
                 Output::Playout(pcm) => {
@@ -179,7 +324,21 @@ async fn run_call_with_clock(
                 Output::Event(ev) => {
                     let _ = channels.events.try_send(ev);
                 }
-                Output::Timeout(_) => break,
+                Output::Timeout(_) => {
+                    if !pending_video.is_empty() {
+                        let dropped = enqueue_batch(
+                            &mut send_queue,
+                            SendBatch::video(std::mem::take(&mut pending_video)),
+                        );
+                        if dropped.packets != 0 {
+                            let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
+                                video_access_units: dropped.video_access_units,
+                                packets: dropped.packets,
+                            });
+                        }
+                    }
+                    break;
+                }
             }
         }
 
@@ -192,7 +351,7 @@ async fn run_call_with_clock(
         // Start the next queued send when none is in flight. The future owns an Arc clone, so it is
         // `'static` (no borrow of the loop's `transport`).
         if sending.is_terminated()
-            && let Some(data) = send_queue.pop_front()
+            && let Some(data) = pop_next_packet(&mut send_queue)
         {
             let t = transport.clone();
             let fut: BoxFuture<'static, anyhow::Result<()>> =
@@ -1170,36 +1329,77 @@ mod tests {
         // Top two bits zero -> STUN control.
         let control = || Bytes::from(vec![0x00, 0x01]);
 
-        let mut q: VecDeque<Bytes> = VecDeque::new();
-        q.push_back(control()); // oldest, must survive
-        for n in 0..SEND_QUEUE_CAP as u8 {
-            q.push_back(media(n));
-            shed_to_cap(&mut q);
+        let mut q: VecDeque<SendBatch> = VecDeque::new();
+        q.push_back(SendBatch::packet(control())); // oldest, must survive
+        for n in 0..SEND_QUEUE_BATCH_CAP as u8 {
+            q.push_back(SendBatch::packet(media(n)));
+            let _ = shed_to_cap(&mut q);
         }
 
-        assert_eq!(q.len(), SEND_QUEUE_CAP);
+        assert_eq!(q.len(), SEND_QUEUE_BATCH_CAP);
         assert_eq!(
-            classify_relay_packet(&q[0]),
-            RelayPacketKind::Stun,
+            q[0].kind,
+            SendBatchKind::Control,
             "the queued control packet must not be evicted by media backpressure"
         );
         // The oldest media (seq 0) is the one shed, not the control at the front.
-        assert_eq!(&q[1][..], &[0x90, 1]);
+        assert_eq!(&q[1].packets[0][..], &[0x90, 1]);
     }
 
     // Pathological: an all-control queue still has to honor the bound, so it falls back to dropping
     // the oldest.
     #[test]
     fn overflow_all_control_drops_oldest() {
-        let mut q: VecDeque<Bytes> = (0..=SEND_QUEUE_CAP as u8)
-            .map(|n| Bytes::from(vec![0x00, n]))
+        let mut q: VecDeque<SendBatch> = (0..=SEND_QUEUE_BATCH_CAP as u8)
+            .map(|n| SendBatch::packet(Bytes::from(vec![0x00, n])))
             .collect();
-        shed_to_cap(&mut q);
-        assert_eq!(q.len(), SEND_QUEUE_CAP);
+        let _ = shed_to_cap(&mut q);
+        assert_eq!(q.len(), SEND_QUEUE_BATCH_CAP);
         assert_eq!(
-            &q[0][..],
+            &q[0].packets[0][..],
             &[0x00, 1],
             "oldest control dropped to keep bound"
         );
+    }
+
+    #[test]
+    fn large_video_au_is_queued_atomically() {
+        fn video_packet(seq: u16, marker: bool) -> Bytes {
+            let mut packet = vec![0u8; 16];
+            packet[0] = 0x90; // V=2, X=1
+            packet[1] = ((marker as u8) << 7) | RTP_PAYLOAD_TYPE_H264;
+            packet[2..4].copy_from_slice(&seq.to_be_bytes());
+            packet[12..14].copy_from_slice(&0xdebeu16.to_be_bytes());
+            Bytes::from(packet)
+        }
+
+        // The old 32-datagram queue truncated this AU before its marker.
+        let mut queue = VecDeque::new();
+        let mut pending = Vec::new();
+        for seq in 0..40u16 {
+            let dropped = queue_transmit(&mut queue, &mut pending, video_packet(seq, seq == 39));
+            assert_eq!(dropped.packets, 0);
+        }
+        assert!(pending.is_empty());
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].kind, SendBatchKind::Video);
+        assert_eq!(queue[0].packets.len(), 40);
+
+        let sent: Vec<u16> = std::iter::from_fn(|| pop_next_packet(&mut queue))
+            .map(|packet| parse_rtp_header(&packet).unwrap().sequence_number)
+            .collect();
+        assert_eq!(sent, (0..40u16).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn oversized_video_is_dropped_as_a_whole_au() {
+        let packets = (0..40)
+            .map(|_| Bytes::from(vec![0x90; 64 * 1024]))
+            .collect();
+        let mut queue = VecDeque::new();
+        let dropped = enqueue_batch(&mut queue, SendBatch::video(packets));
+        assert_eq!(dropped.video_access_units, 1);
+        assert_eq!(dropped.packets, 40);
+        assert!(queue.is_empty(), "no partial AU may remain queued");
     }
 }

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -22,7 +22,7 @@ use crate::time::Instant;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
 use crate::voip::h264::VideoFrame;
-use crate::voip::rtp::{RTP_PAYLOAD_TYPE_H264, parse_rtp_header};
+use crate::voip::rtp::{RTP_PAYLOAD_TYPE_H264, VIDEO_MEDIA_FRAME_INFO_IDR, parse_rtp_header};
 use crate::voip::transport::{RelayTransport, RelayTransportEvent};
 
 /// Mid-call video-plane commands from the shell (upgrade / downgrade / peer orientation). Kept out
@@ -81,6 +81,7 @@ struct SendBatch {
     bytes: usize,
     kind: SendBatchKind,
     started: bool,
+    video_keyframe: bool,
 }
 
 impl SendBatch {
@@ -95,15 +96,22 @@ impl SendBatch {
             packets: VecDeque::from([data]),
             kind,
             started: false,
+            video_keyframe: false,
         }
     }
 
     fn video(packets: Vec<Bytes>) -> Self {
+        let video_keyframe = packets
+            .first()
+            .and_then(|packet| parse_rtp_header(packet))
+            .and_then(|header| header.video_extension)
+            .is_some_and(|extension| extension.media_frame_info == VIDEO_MEDIA_FRAME_INFO_IDR);
         Self {
             bytes: packets.iter().map(Bytes::len).sum(),
             packets: packets.into(),
             kind: SendBatchKind::Video,
             started: false,
+            video_keyframe,
         }
     }
 }
@@ -114,7 +122,39 @@ struct DroppedMedia {
     packets: u32,
 }
 
-fn shed_to_cap(queue: &mut VecDeque<SendBatch>) -> DroppedMedia {
+fn record_drop(dropped: &mut DroppedMedia, batch: &SendBatch) {
+    dropped.packets = dropped
+        .packets
+        .saturating_add(batch.packets.len().try_into().unwrap_or(u32::MAX));
+    if batch.kind == SendBatchKind::Video {
+        dropped.video_access_units = dropped.video_access_units.saturating_add(1);
+    }
+}
+
+fn discard_video_until_keyframe(
+    queue: &mut VecDeque<SendBatch>,
+    dropped: &mut DroppedMedia,
+) -> bool {
+    loop {
+        let Some(index) = queue
+            .iter()
+            .position(|batch| !batch.started && batch.kind == SendBatchKind::Video)
+        else {
+            return true;
+        };
+        if queue[index].video_keyframe {
+            return false;
+        }
+        if let Some(batch) = queue.remove(index) {
+            record_drop(dropped, &batch);
+        }
+    }
+}
+
+fn shed_to_cap(
+    queue: &mut VecDeque<SendBatch>,
+    awaiting_video_keyframe: &mut bool,
+) -> DroppedMedia {
     let mut dropped = DroppedMedia::default();
     loop {
         let bytes: usize = queue.iter().map(|batch| batch.bytes).sum();
@@ -137,19 +177,30 @@ fn shed_to_cap(queue: &mut VecDeque<SendBatch>) -> DroppedMedia {
         let Some(batch) = queue.remove(victim) else {
             break;
         };
-        dropped.packets = dropped
-            .packets
-            .saturating_add(batch.packets.len().try_into().unwrap_or(u32::MAX));
-        if batch.kind == SendBatchKind::Video {
-            dropped.video_access_units = dropped.video_access_units.saturating_add(1);
+        let dropped_video = batch.kind == SendBatchKind::Video;
+        record_drop(&mut dropped, &batch);
+        if dropped_video {
+            *awaiting_video_keyframe = discard_video_until_keyframe(queue, &mut dropped);
         }
     }
     dropped
 }
 
-fn enqueue_batch(queue: &mut VecDeque<SendBatch>, batch: SendBatch) -> DroppedMedia {
+fn enqueue_batch(
+    queue: &mut VecDeque<SendBatch>,
+    awaiting_video_keyframe: &mut bool,
+    batch: SendBatch,
+) -> DroppedMedia {
+    if batch.kind == SendBatchKind::Video && *awaiting_video_keyframe {
+        if !batch.video_keyframe {
+            let mut dropped = DroppedMedia::default();
+            record_drop(&mut dropped, &batch);
+            return dropped;
+        }
+        *awaiting_video_keyframe = false;
+    }
     queue.push_back(batch);
-    shed_to_cap(queue)
+    shed_to_cap(queue, awaiting_video_keyframe)
 }
 
 /// Coalesce every PT-97 packet through the marker into one queue unit, so backpressure keeps or
@@ -157,6 +208,7 @@ fn enqueue_batch(queue: &mut VecDeque<SendBatch>, batch: SendBatch) -> DroppedMe
 fn queue_transmit(
     queue: &mut VecDeque<SendBatch>,
     pending_video: &mut Vec<Bytes>,
+    awaiting_video_keyframe: &mut bool,
     data: Bytes,
 ) -> DroppedMedia {
     if let Some(header) = parse_rtp_header(&data)
@@ -164,15 +216,23 @@ fn queue_transmit(
     {
         pending_video.push(data);
         if header.marker {
-            return enqueue_batch(queue, SendBatch::video(std::mem::take(pending_video)));
+            return enqueue_batch(
+                queue,
+                awaiting_video_keyframe,
+                SendBatch::video(std::mem::take(pending_video)),
+            );
         }
         return DroppedMedia::default();
     }
     let mut dropped = DroppedMedia::default();
     if !pending_video.is_empty() {
-        dropped = enqueue_batch(queue, SendBatch::video(std::mem::take(pending_video)));
+        dropped = enqueue_batch(
+            queue,
+            awaiting_video_keyframe,
+            SendBatch::video(std::mem::take(pending_video)),
+        );
     }
-    let more = enqueue_batch(queue, SendBatch::packet(data));
+    let more = enqueue_batch(queue, awaiting_video_keyframe, SendBatch::packet(data));
     dropped.video_access_units = dropped
         .video_access_units
         .saturating_add(more.video_access_units);
@@ -296,6 +356,7 @@ async fn run_call_with_clock_and_wallclock(
     // worst whatsapp-rust<->whatsapp-rust where both ends stalled; the official client decouples them).
     // Video is queued per access unit so overload never leaves half an IDR on the wire.
     let mut send_queue: VecDeque<SendBatch> = VecDeque::new();
+    let mut awaiting_video_keyframe = false;
     // Idle sentinel: a terminated `Fuse` is safe to re-select every iteration and never fires until a
     // real send replaces it; on completion it terminates itself, so no manual reset / re-poll hazard.
     // `BoxFuture` is `Send` natively but `?Send` on wasm (the transport is single-threaded there).
@@ -308,7 +369,12 @@ async fn run_call_with_clock_and_wallclock(
             match eng.poll_output() {
                 // Queue for the in-flight send arm; never await the write in this loop.
                 Output::Transmit(data) => {
-                    let dropped = queue_transmit(&mut send_queue, &mut pending_video, data);
+                    let dropped = queue_transmit(
+                        &mut send_queue,
+                        &mut pending_video,
+                        &mut awaiting_video_keyframe,
+                        data,
+                    );
                     if dropped.packets != 0 {
                         let _ = channels.events.try_send(CallEvent::OutboundMediaDropped {
                             video_access_units: dropped.video_access_units,
@@ -331,6 +397,7 @@ async fn run_call_with_clock_and_wallclock(
                     if !pending_video.is_empty() {
                         let dropped = enqueue_batch(
                             &mut send_queue,
+                            &mut awaiting_video_keyframe,
                             SendBatch::video(std::mem::take(&mut pending_video)),
                         );
                         if dropped.packets != 0 {
@@ -345,8 +412,7 @@ async fn run_call_with_clock_and_wallclock(
             }
         }
 
-        // A terminal relay-allocate failure went out via the drain above; tear the call down rather
-        // than keepalive a dead relay (transport.disconnect runs on the exit path below).
+        // The terminal event above must reach the consumer before transport teardown.
         if eng.is_terminated() {
             break 'drive;
         }
@@ -1348,10 +1414,11 @@ mod tests {
         let control = || Bytes::from(vec![0x00, 0x01]);
 
         let mut q: VecDeque<SendBatch> = VecDeque::new();
+        let mut awaiting_keyframe = false;
         q.push_back(SendBatch::packet(control())); // oldest, must survive
         for n in 0..SEND_QUEUE_BATCH_CAP as u8 {
             q.push_back(SendBatch::packet(media(n)));
-            let _ = shed_to_cap(&mut q);
+            let _ = shed_to_cap(&mut q, &mut awaiting_keyframe);
         }
 
         assert_eq!(q.len(), SEND_QUEUE_BATCH_CAP);
@@ -1371,7 +1438,8 @@ mod tests {
         let mut q: VecDeque<SendBatch> = (0..=SEND_QUEUE_BATCH_CAP as u8)
             .map(|n| SendBatch::packet(Bytes::from(vec![0x00, n])))
             .collect();
-        let _ = shed_to_cap(&mut q);
+        let mut awaiting_keyframe = false;
+        let _ = shed_to_cap(&mut q, &mut awaiting_keyframe);
         assert_eq!(q.len(), SEND_QUEUE_BATCH_CAP);
         assert_eq!(
             &q[0].packets[0][..],
@@ -1394,8 +1462,14 @@ mod tests {
         // The old 32-datagram queue truncated this AU before its marker.
         let mut queue = VecDeque::new();
         let mut pending = Vec::new();
+        let mut awaiting_keyframe = false;
         for seq in 0..40u16 {
-            let dropped = queue_transmit(&mut queue, &mut pending, video_packet(seq, seq == 39));
+            let dropped = queue_transmit(
+                &mut queue,
+                &mut pending,
+                &mut awaiting_keyframe,
+                video_packet(seq, seq == 39),
+            );
             assert_eq!(dropped.packets, 0);
         }
         assert!(pending.is_empty());
@@ -1415,9 +1489,82 @@ mod tests {
             .map(|_| Bytes::from(vec![0x90; 64 * 1024]))
             .collect();
         let mut queue = VecDeque::new();
-        let dropped = enqueue_batch(&mut queue, SendBatch::video(packets));
+        let mut awaiting_keyframe = false;
+        let dropped = enqueue_batch(
+            &mut queue,
+            &mut awaiting_keyframe,
+            SendBatch::video(packets),
+        );
         assert_eq!(dropped.video_access_units, 1);
         assert_eq!(dropped.packets, 40);
         assert!(queue.is_empty(), "no partial AU may remain queued");
+        assert!(awaiting_keyframe);
+    }
+
+    #[test]
+    fn video_backpressure_recovers_at_the_next_keyframe() {
+        fn video_packet(seq: u16, keyframe: bool) -> Bytes {
+            let mut packet = Vec::new();
+            crate::voip::rtp::encode_rtp_header_into(
+                &crate::voip::rtp::RtpHeader {
+                    marker: true,
+                    payload_type: RTP_PAYLOAD_TYPE_H264,
+                    sequence_number: seq,
+                    timestamp: u32::from(seq) * 4500,
+                    ssrc: 0x1122_3344,
+                    extension_word: None,
+                    video_extension: Some(crate::voip::rtp::VideoRtpExtension {
+                        media_frame_info: if keyframe {
+                            VIDEO_MEDIA_FRAME_INFO_IDR
+                        } else {
+                            crate::voip::rtp::VIDEO_MEDIA_FRAME_INFO_DELTA
+                        },
+                        initial_bandwidth: 20_000,
+                        short_offset: 0,
+                        transport_sequence: seq,
+                    }),
+                },
+                &mut packet,
+            );
+            Bytes::from(packet)
+        }
+
+        let mut queue = VecDeque::new();
+        let mut awaiting_keyframe = true;
+
+        let dropped = enqueue_batch(
+            &mut queue,
+            &mut awaiting_keyframe,
+            SendBatch::video(vec![video_packet(1, false)]),
+        );
+        assert_eq!(dropped.video_access_units, 1);
+        assert!(queue.is_empty());
+
+        let dropped = enqueue_batch(
+            &mut queue,
+            &mut awaiting_keyframe,
+            SendBatch::video(vec![video_packet(2, true)]),
+        );
+        assert_eq!(dropped.video_access_units, 0);
+        assert!(!awaiting_keyframe);
+
+        let dropped = enqueue_batch(
+            &mut queue,
+            &mut awaiting_keyframe,
+            SendBatch::video(vec![video_packet(3, false)]),
+        );
+        assert_eq!(dropped.video_access_units, 0);
+        assert_eq!(queue.len(), 2);
+        assert!(queue[0].video_keyframe);
+        assert!(!queue[1].video_keyframe);
+
+        let mut queued: VecDeque<_> = (0..=SEND_QUEUE_BATCH_CAP as u16)
+            .map(|seq| SendBatch::video(vec![video_packet(seq, seq == 10)]))
+            .collect();
+        let mut awaiting_keyframe = false;
+        let dropped = shed_to_cap(&mut queued, &mut awaiting_keyframe);
+        assert_eq!(dropped.video_access_units, 10);
+        assert!(queued.front().is_some_and(|batch| batch.video_keyframe));
+        assert!(!awaiting_keyframe, "a queued IDR is a valid recovery point");
     }
 }

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -21,11 +21,31 @@ use crate::runtime::{BoxFuture, Runtime};
 use crate::time::Instant;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
+use crate::voip::h264::VideoFrame;
 use crate::voip::transport::{RelayTransport, RelayTransportEvent};
 
-/// The audio + event channels the driver bridges to the platform. Mic frames in, playout frames out
-/// (dropped on speaker overflow since VoIP is loss tolerant), and engine events out (RelayAllocated,
-/// ForeignAudio) for the shell to act on (e.g. decode a non-MLow frame with a platform codec).
+/// Mid-call video-plane commands from the shell (upgrade / downgrade / peer orientation). Kept out
+/// of the engine so it stays sans-IO; the drive loop translates each into an engine method call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum VideoControl {
+    /// Bring the video plane up with outbound video ALLOWED (a from-start call, an accept, or the
+    /// initiator once the peer accepted the upgrade).
+    Enable,
+    /// Bring the video plane up but hold outbound video off the wire until the peer accepts (the
+    /// initiator of an upgrade). Inbound still decodes. A later `Enable` ungates it.
+    EnableAwaitingAccept,
+    /// Tear the video plane down (downgrade to audio).
+    Disable,
+    /// The peer's device orientation (0..3, ×90°) from a `<video>` stanza.
+    SetOrientation(u8),
+}
+
+/// The audio + video + event channels the driver bridges to the platform. Mic frames in, playout
+/// frames out (dropped on speaker overflow since VoIP is loss tolerant), and engine events out
+/// (RelayAllocated, ForeignAudio) for the shell to act on (e.g. decode a non-MLow frame with a
+/// platform codec). The video channels are always present — a call that never negotiates video
+/// simply leaves them idle (the engine drops AUs while its video plane is off).
 pub struct CallChannels {
     pub mic: async_channel::Receiver<Vec<i16>>,
     pub speaker: async_channel::Sender<Vec<i16>>,
@@ -33,6 +53,12 @@ pub struct CallChannels {
     /// Caller-only: the answering device's LID, delivered once the callee's `<accept>` is received so
     /// the drive loop can rekey the recv path before media flows. `None` on the callee side and esp32.
     pub rekey: Option<async_channel::Receiver<String>>,
+    /// Outbound video: one pre-encoded H.264 Annex-B access unit per item.
+    pub video_in: async_channel::Receiver<Vec<u8>>,
+    /// Inbound video: reassembled peer access units (dropped on sink overflow, like the speaker).
+    pub video_out: async_channel::Sender<VideoFrame>,
+    /// Mid-call video-plane control (upgrade/downgrade/orientation).
+    pub video_ctl: async_channel::Receiver<VideoControl>,
 }
 
 /// Depth of the outbound send queue between the drive loop and the concurrent send task. ~2s of RTP
@@ -110,6 +136,14 @@ async fn run_call_with_clock(
     // always-ready `Err` doesn't busy-spin the select (the mic arm has the same guard).
     let mut rekey_open = true;
 
+    // Same closed-channel guards for the video arms: a call that never wires a video source/control
+    // sender must not busy-spin on their always-ready `Err`.
+    let mut video_in_open = true;
+    let mut video_ctl_open = true;
+    // Set by a `Disable` to drain the video input queue after the select block (it can't be drained
+    // inside, where the arm futures borrow the channel).
+    let mut drain_video_in = false;
+
     // Decouple sending from receive/playout. Outbound packets are queued and the in-flight send is
     // polled as one arm of the select, CONCURRENTLY with the relay/mic/timer arms -- so a slow or
     // stalled relay write (SCTP cwnd, a congested link, a loaded host) is simply pending here and never
@@ -137,6 +171,10 @@ async fn run_call_with_clock(
                 // Loss tolerant: drop the frame if the speaker can't keep up.
                 Output::Playout(pcm) => {
                     let _ = channels.speaker.try_send(pcm);
+                }
+                // Same policy for video: a stalled sink sheds frames, never the drive loop.
+                Output::VideoPlayout(frame) => {
+                    let _ = channels.video_out.try_send(frame);
                 }
                 Output::Event(ev) => {
                     let _ = channels.events.try_send(ev);
@@ -207,6 +245,30 @@ async fn run_call_with_clock(
         .fuse();
         futures::pin_mut!(rekey_fut);
 
+        // Video source and control arms, guarded like the mic: a closed channel disables the arm
+        // (a video source EOF must not end the call — audio keeps running after a downgrade).
+        let video_in = &channels.video_in;
+        let video_in_fut = async move {
+            if video_in_open {
+                video_in.recv().await
+            } else {
+                std::future::pending().await
+            }
+        }
+        .fuse();
+        futures::pin_mut!(video_in_fut);
+
+        let video_ctl = &channels.video_ctl;
+        let video_ctl_fut = async move {
+            if video_ctl_open {
+                video_ctl.recv().await
+            } else {
+                std::future::pending().await
+            }
+        }
+        .fuse();
+        futures::pin_mut!(video_ctl_fut);
+
         // Wait for exactly one input, then apply it. A dropped (unready) recv future loses nothing:
         // async_channel only dequeues on a ready poll.
         // Biased: the in-flight send first so it always makes progress (drain the queue, surface a send
@@ -230,6 +292,39 @@ async fn run_call_with_clock(
                     && !eng.rekey_recv(&lid)
                 {
                     break 'drive; // malformed stored call_key (a setup invariant violated)
+                }
+            },
+            // Video-plane control before the media arms, so an Enable lands before queued AUs and
+            // a Disable stops decoding queued inbound PT-97 right away.
+            ctl = video_ctl_fut => {
+                match ctl {
+                    Ok(VideoControl::Enable) => {
+                        // False only for a control-only engine or a malformed stored callKey; the
+                        // audio plane already validated the key, so treat it as a no-op not fatal.
+                        let _ = eng.enable_video();
+                    }
+                    Ok(VideoControl::EnableAwaitingAccept) => {
+                        let _ = eng.enable_video_gated();
+                    }
+                    Ok(VideoControl::Disable) => {
+                        eng.disable_video();
+                        // Discard any AUs still queued from the (now-detached) source, so a quick
+                        // re-Enable can't transmit stale frames from the previous session under the
+                        // new negotiation. Drained after the select block (the futures borrow the
+                        // channel).
+                        drain_video_in = true;
+                    }
+                    Ok(VideoControl::SetOrientation(o)) => eng.set_peer_video_orientation(o),
+                    Err(_) => video_ctl_open = false,
+                }
+                // Fire an overdue timer like the other ready arms: video_ctl is unbounded, so a
+                // stream of control messages must not keep this arm hot and defer the keepalive.
+                let now = now_ms();
+                if let Some(at) = eng.poll_timeout()
+                    && at != engine::NEVER
+                    && now >= at
+                {
+                    eng.handle_input(now, Input::Timeout);
                 }
             },
             ev = relay_events.recv().fuse() => match ev {
@@ -262,7 +357,29 @@ async fn run_call_with_clock(
                 // alive: muting the mic must not hang up the call (see the comment above).
                 Err(_) => mic_open = false,
             },
+            au = video_in_fut => match au {
+                Ok(au) => {
+                    eng.handle_input(now_ms(), Input::VideoFrame(&au));
+                    let now = now_ms();
+                    if let Some(at) = eng.poll_timeout()
+                        && at != engine::NEVER
+                        && now >= at
+                    {
+                        eng.handle_input(now, Input::Timeout);
+                    }
+                }
+                // Video source gone (encoder EOF / downgrade released it): disable the arm but keep
+                // the call alive, exactly like the mic.
+                Err(_) => video_in_open = false,
+            },
             _ = timer => eng.handle_input(now_ms(), Input::Timeout),
+        }
+
+        // Post-select: the arm futures (which borrow the channels) have been dropped, so it is now
+        // safe to drain the video input queue requested by a Disable above.
+        if drain_video_in {
+            drain_video_in = false;
+            while channels.video_in.try_recv().is_ok() {}
         }
     }
 
@@ -327,6 +444,27 @@ mod tests {
         async fn disconnect(&self) {}
     }
 
+    /// CallChannels with idle video plumbing (senders/receivers dropped immediately), for the
+    /// audio-only driver tests: the closed-channel guards must keep those arms inert.
+    fn test_channels(
+        mic: async_channel::Receiver<Vec<i16>>,
+        speaker: async_channel::Sender<Vec<i16>>,
+        events: async_channel::Sender<CallEvent>,
+    ) -> CallChannels {
+        let (_vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
+        let (_vctl_tx, vctl_rx) = async_channel::unbounded::<VideoControl>();
+        CallChannels {
+            mic,
+            speaker,
+            events,
+            rekey: None,
+            video_in: vin_rx,
+            video_out: vout_tx,
+            video_ctl: vctl_rx,
+        }
+    }
+
     fn config() -> CallConfig {
         CallConfig {
             call_id: "CID".into(),
@@ -342,6 +480,7 @@ mod tests {
             integrity_key: b"relay-key".to_vec(),
             warp_mi_tag_len: 4,
             enable_media: true,
+            enable_video: false,
             enable_sframe: false,
         }
     }
@@ -373,12 +512,7 @@ mod tests {
             rt,
             transport.clone() as Arc<dyn RelayTransport>,
             relay_rx,
-            CallChannels {
-                mic: mic_rx,
-                speaker: spk_tx,
-                events: ev_tx,
-                rekey: None,
-            },
+            test_channels(mic_rx, spk_tx, ev_tx),
             eng,
         ));
 
@@ -452,12 +586,7 @@ mod tests {
             rt,
             transport.clone() as Arc<dyn RelayTransport>,
             relay_rx,
-            CallChannels {
-                mic: mic_rx,
-                speaker: spk_tx,
-                events: ev_tx,
-                rekey: None,
-            },
+            test_channels(mic_rx, spk_tx, ev_tx),
             eng,
         ));
 
@@ -510,12 +639,7 @@ mod tests {
             rt,
             transport.clone() as Arc<dyn RelayTransport>,
             relay_rx,
-            CallChannels {
-                mic: mic_rx,
-                speaker: spk_tx,
-                events: ev_tx,
-                rekey: None,
-            },
+            test_channels(mic_rx, spk_tx, ev_tx),
             eng,
             move || clk.fetch_add(1000, Ordering::Relaxed),
         ));
@@ -583,12 +707,7 @@ mod tests {
             rt,
             transport.clone() as Arc<dyn RelayTransport>,
             relay_rx,
-            CallChannels {
-                mic: mic_rx,
-                speaker: spk_tx,
-                events: ev_tx,
-                rekey: None,
-            },
+            test_channels(mic_rx, spk_tx, ev_tx),
             eng,
             move || clk.fetch_add(1000, Ordering::Relaxed),
         ));
@@ -627,12 +746,7 @@ mod tests {
             rt,
             transport.clone() as Arc<dyn RelayTransport>,
             relay_rx,
-            CallChannels {
-                mic: mic_rx,
-                speaker: spk_tx,
-                events: ev_tx,
-                rekey: None,
-            },
+            test_channels(mic_rx, spk_tx, ev_tx),
             eng,
         ));
 
@@ -778,12 +892,7 @@ mod tests {
             rt,
             relay.clone() as Arc<dyn RelayTransport>,
             relay_rx,
-            CallChannels {
-                mic: mic_rx,
-                speaker: spk_tx,
-                events: ev_tx,
-                rekey: None,
-            },
+            test_channels(mic_rx, spk_tx, ev_tx),
             eng,
             move || clk.load(Ordering::Relaxed),
         ));
@@ -931,12 +1040,7 @@ mod tests {
                 rt,
                 Arc::new(WedgedSend) as Arc<dyn RelayTransport>,
                 relay_rx,
-                CallChannels {
-                    mic: mic_rx,
-                    speaker: spk_tx,
-                    events: ev_tx,
-                    rekey: None,
-                },
+                test_channels(mic_rx, spk_tx, ev_tx),
                 eng,
                 move || clk.load(Ordering::Relaxed),
             ));
@@ -957,6 +1061,104 @@ mod tests {
             peak > 0,
             "inbound audio must play out while transport.send() is wedged (send/receive decoupled)"
         );
+    }
+
+    // Video through the real drive loop: Enable + orientation via video_ctl (biased ahead of the
+    // media arms), mirrored peer video packets via the relay (reassemble to video_out with the
+    // orientation stamped), one of our own AUs via video_in (fans out to PT-97 FU-A transmits).
+    // Deterministic: queues drain by bias order, then the first timer arm closes the relay.
+    #[test]
+    fn drive_loop_routes_video_both_ways() {
+        use crate::voip::rtp::{RTP_PAYLOAD_TYPE_H264, VIDEO_TS_STRIDE_15FPS, parse_rtp_header};
+        use crate::voip::session::{VideoPipeline, VideoPipelineParams};
+        use crate::voip::ssrc;
+
+        let sleeps = Arc::new(AtomicUsize::new(0));
+        let (relay_tx, relay_rx) = async_channel::unbounded();
+        // The timer arm is only polled once every queue is idle; its first sleep closes the relay,
+        // ending the loop deterministically after all the video work is done.
+        let rt: Arc<dyn Runtime> = Arc::new(CloseRelayOnSleepRuntime {
+            sleeps,
+            relay_tx: relay_tx.clone(),
+            close_after: 1,
+        });
+        let transport = Arc::new(RecordingTransport::default());
+        let cfg = config();
+
+        // Mirrored peer video pipe (its self LID = our peer LID).
+        let mut peer_video = VideoPipeline::new(&VideoPipelineParams {
+            call_key: &cfg.call_key,
+            self_lid: &cfg.peer_lid,
+            peer_lid: &cfg.self_lid,
+            ssrc: ssrc::derive_video_participant_ssrc(
+                &cfg.call_id,
+                &ssrc::format_e2e_srtp_participant_id(&cfg.peer_lid),
+            ),
+            ts_stride: VIDEO_TS_STRIDE_15FPS,
+            warp_mi_tag_len: cfg.warp_mi_tag_len,
+        })
+        .unwrap();
+        let make_au = |len: usize| -> Vec<u8> {
+            let mut au = vec![0, 0, 0, 1, 0x65];
+            au.extend((0..len).map(|i| (i % 251) as u8));
+            au
+        };
+        let peer_au = make_au(2000);
+        for p in peer_video.protect_video(&peer_au) {
+            relay_tx
+                .try_send(RelayTransportEvent::PacketReceived(Bytes::from(p)))
+                .unwrap();
+        }
+
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, _ev_rx) = async_channel::unbounded();
+        let (vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (vout_tx, vout_rx) = async_channel::unbounded::<VideoFrame>();
+        let (vctl_tx, vctl_rx) = async_channel::unbounded::<VideoControl>();
+
+        // Control drains first (bias), so Enable + orientation land before any packet or AU.
+        vctl_tx.try_send(VideoControl::Enable).unwrap();
+        vctl_tx.try_send(VideoControl::SetOrientation(1)).unwrap();
+        let our_au = make_au(3000);
+        vin_tx.try_send(our_au).unwrap();
+
+        let eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        futures::executor::block_on(run_call(
+            rt,
+            transport.clone() as Arc<dyn RelayTransport>,
+            relay_rx,
+            CallChannels {
+                mic: mic_rx,
+                speaker: spk_tx,
+                events: ev_tx,
+                rekey: None,
+                video_in: vin_rx,
+                video_out: vout_tx,
+                video_ctl: vctl_rx,
+            },
+            eng,
+        ));
+
+        // Inbound: the peer AU reassembled to the sink, orientation stamped from the control arm.
+        let frames: Vec<VideoFrame> = std::iter::from_fn(|| vout_rx.try_recv().ok()).collect();
+        assert_eq!(frames.len(), 1, "peer AU must reach video_out exactly once");
+        assert_eq!(frames[0].data, peer_au);
+        assert!(frames[0].keyframe);
+        assert_eq!(
+            frames[0].orientation, 1,
+            "SetOrientation must apply before the inbound AU reassembles"
+        );
+
+        // Outbound: the 3KB AU fans out to ceil(3000/798) = 4 FU-A packets, all PT 97.
+        let sent = transport.sent.lock().unwrap();
+        let pt97 = sent
+            .iter()
+            .filter(|b| {
+                parse_rtp_header(b).is_some_and(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264)
+            })
+            .count();
+        assert_eq!(pt97, 4, "one 3KB AU must fan out to 4 PT-97 packets");
     }
 
     // A relay stall backs the queue up past cap: the overflow policy must shed media, never the STUN

--- a/wacore/src/voip/e2e_srtp.rs
+++ b/wacore/src/voip/e2e_srtp.rs
@@ -173,9 +173,13 @@ pub fn protect_srtcp(keys: &E2eSrtpKeys, sender_ssrc: u32, index: u32, rtcp: &[u
     out
 }
 
-/// Inverse of [`protect_srtcp`]: verify the tag, then decrypt the body. `None` on a bad tag or a
-/// too-short packet. Used by the round-trip test and any future inbound-RTCP handling.
-pub fn unprotect_srtcp(keys: &E2eSrtpKeys, sender_ssrc: u32, packet: &[u8]) -> Option<Vec<u8>> {
+/// Inverse of [`protect_srtcp`]: verify the tag, then decrypt the body and return its authenticated
+/// 31-bit index. `None` on a bad tag or a too-short packet.
+pub fn unprotect_srtcp(
+    keys: &E2eSrtpKeys,
+    sender_ssrc: u32,
+    packet: &[u8],
+) -> Option<(Vec<u8>, u32)> {
     if packet.len() < RTCP_HEADER_LEN + 4 + SRTCP_AUTH_TAG_LEN {
         return None;
     }
@@ -200,7 +204,7 @@ pub fn unprotect_srtcp(keys: &E2eSrtpKeys, sender_ssrc: u32, packet: &[u8]) -> O
     let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
     cipher.apply_keystream(&mut body);
     out.extend_from_slice(&body);
-    Some(out)
+    Some((out, index))
 }
 
 /// Send-side ROC tracker for monotonic 16-bit sequence numbers.
@@ -341,10 +345,9 @@ mod tests {
             0x80
         );
 
-        assert_eq!(
-            unprotect_srtcp(&srtcp, ssrc, &protected).as_deref(),
-            Some(&sr[..])
-        );
+        let (plain, index) = unprotect_srtcp(&srtcp, ssrc, &protected).unwrap();
+        assert_eq!(plain, sr);
+        assert_eq!(index, 0);
         // A flipped tag byte must fail authentication.
         let mut forged = protected.clone();
         *forged.last_mut().unwrap() ^= 1;
@@ -356,7 +359,9 @@ mod tests {
             p1[8..28],
             "a new index must change the ciphertext"
         );
-        assert_eq!(unprotect_srtcp(&srtcp, ssrc, &p1).as_deref(), Some(&sr[..]));
+        let (plain, index) = unprotect_srtcp(&srtcp, ssrc, &p1).unwrap();
+        assert_eq!(plain, sr);
+        assert_eq!(index, 1);
     }
 
     #[test]

--- a/wacore/src/voip/e2e_srtp.rs
+++ b/wacore/src/voip/e2e_srtp.rs
@@ -110,6 +110,99 @@ pub fn crypt_payload(keys: &E2eSrtpKeys, ssrc: u32, seq: u16, roc: u32, payload:
     out
 }
 
+/// SRTCP auth-tag length (HMAC-SHA1-80). With the 4-byte E-flag+index word this is the 14-byte
+/// SRTCP trailer.
+pub const SRTCP_AUTH_TAG_LEN: usize = 10;
+/// First 8 bytes of an RTCP packet (V/P/RC, PT, length, sender SSRC) are left in the clear; only the
+/// body is encrypted (RFC 3711 §3.4).
+const RTCP_HEADER_LEN: usize = 8;
+
+fn hmac_sha1_20(key: &[u8], data: &[u8]) -> [u8; 20] {
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha1::Sha1;
+    let mut mac = Hmac::<Sha1>::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    let mut tag = [0u8; 20];
+    tag.copy_from_slice(&mac.finalize().into_bytes());
+    tag
+}
+
+/// SRTCP session keys derived with the RFC 3711 labels used by the native client.
+#[doc(hidden)]
+pub fn derive_srtcp_keys(call_key: &[u8], participant_lid: &str) -> Option<E2eSrtpKeys> {
+    if call_key.len() < 32 {
+        return None;
+    }
+    let master = hkdf_sha256(&[0u8; 32], &call_key[..32], participant_lid.as_bytes(), 46);
+    let master_key = &master[0..16];
+    let master_salt = &master[16..30];
+    let mut keys = E2eSrtpKeys {
+        cipher_key: [0u8; 16],
+        salt: [0u8; 14],
+        auth_key: [0u8; 20],
+    };
+    keys.cipher_key
+        .copy_from_slice(&aes_cm_kdf(master_key, master_salt, 0x03, 16));
+    keys.auth_key
+        .copy_from_slice(&aes_cm_kdf(master_key, master_salt, 0x04, 20));
+    keys.salt
+        .copy_from_slice(&aes_cm_kdf(master_key, master_salt, 0x05, 14));
+    Some(keys)
+}
+
+/// Protect one RTCP packet as SRTCP (RFC 3711 §3.4): AES-CTR the body, append the 4-byte
+/// E-flag+index word, then an HMAC-SHA1-80 tag over the whole thing. `sender_ssrc` is the SR's
+/// own SSRC (bytes 4..8) and `index` the per-SSRC SRTCP counter.
+pub fn protect_srtcp(keys: &E2eSrtpKeys, sender_ssrc: u32, index: u32, rtcp: &[u8]) -> Vec<u8> {
+    let split = rtcp.len().min(RTCP_HEADER_LEN);
+    let iv = build_e2e_rtp_iv(
+        &keys.salt,
+        sender_ssrc,
+        index >> 16,
+        (index & 0xffff) as u16,
+    );
+    let mut out = Vec::with_capacity(rtcp.len() + 4 + SRTCP_AUTH_TAG_LEN);
+    out.extend_from_slice(&rtcp[..split]);
+    let mut body = rtcp[split..].to_vec();
+    let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
+    cipher.apply_keystream(&mut body);
+    out.extend_from_slice(&body);
+    out.extend_from_slice(&(0x8000_0000u32 | (index & 0x7fff_ffff)).to_be_bytes());
+    let tag = hmac_sha1_20(&keys.auth_key, &out);
+    out.extend_from_slice(&tag[..SRTCP_AUTH_TAG_LEN]);
+    out
+}
+
+/// Inverse of [`protect_srtcp`]: verify the tag, then decrypt the body. `None` on a bad tag or a
+/// too-short packet. Used by the round-trip test and any future inbound-RTCP handling.
+pub fn unprotect_srtcp(keys: &E2eSrtpKeys, sender_ssrc: u32, packet: &[u8]) -> Option<Vec<u8>> {
+    if packet.len() < RTCP_HEADER_LEN + 4 + SRTCP_AUTH_TAG_LEN {
+        return None;
+    }
+    let tag_start = packet.len() - SRTCP_AUTH_TAG_LEN;
+    let expected = hmac_sha1_20(&keys.auth_key, &packet[..tag_start]);
+    if !bool::from(subtle::ConstantTimeEq::ct_eq(
+        &packet[tag_start..],
+        &expected[..SRTCP_AUTH_TAG_LEN],
+    )) {
+        return None;
+    }
+    let idx_start = tag_start - 4;
+    let index = u32::from_be_bytes(packet[idx_start..tag_start].try_into().ok()?) & 0x7fff_ffff;
+    let iv = build_e2e_rtp_iv(
+        &keys.salt,
+        sender_ssrc,
+        index >> 16,
+        (index & 0xffff) as u16,
+    );
+    let mut out = packet[..RTCP_HEADER_LEN].to_vec();
+    let mut body = packet[RTCP_HEADER_LEN..idx_start].to_vec();
+    let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
+    cipher.apply_keystream(&mut body);
+    out.extend_from_slice(&body);
+    Some(out)
+}
+
 /// Send-side ROC tracker for monotonic 16-bit sequence numbers.
 #[derive(Default)]
 pub(crate) struct RocTracker {
@@ -216,6 +309,54 @@ mod tests {
         keys.auth_key
             .copy_from_slice(&hexd(k, &["e2e_srtp", &format!("{who}_authKey")]));
         keys
+    }
+
+    #[test]
+    fn srtcp_round_trips_and_authenticates() {
+        // SRTCP keys must be distinct from the SRTP keys (different KDF labels).
+        let call_key: Vec<u8> = (0u8..40).collect();
+        let lid = "12345:0@lid";
+        let srtp = derive_e2e_keys(&call_key, lid).unwrap();
+        let srtcp = derive_srtcp_keys(&call_key, lid).unwrap();
+        assert_ne!(
+            srtp.cipher_key, srtcp.cipher_key,
+            "SRTCP must use its own key"
+        );
+        assert_ne!(srtp.salt, srtcp.salt);
+
+        // A 28-byte Sender Report (header 8 + body 20).
+        let ssrc: u32 = 0x0a0b_0c0d;
+        let mut sr = vec![0x80, 200, 0x00, 0x06];
+        sr.extend_from_slice(&ssrc.to_be_bytes());
+        sr.extend_from_slice(&[0x11; 20]);
+
+        let protected = protect_srtcp(&srtcp, ssrc, 0, &sr);
+        // header stays clear, body is encrypted, +4 index +10 tag.
+        assert_eq!(protected.len(), sr.len() + 4 + SRTCP_AUTH_TAG_LEN);
+        assert_eq!(&protected[..8], &sr[..8], "header/SSRC left in the clear");
+        assert_ne!(&protected[8..28], &sr[8..28], "body must be encrypted");
+        // E-flag set on the index word.
+        assert_eq!(
+            protected[protected.len() - SRTCP_AUTH_TAG_LEN - 4] & 0x80,
+            0x80
+        );
+
+        assert_eq!(
+            unprotect_srtcp(&srtcp, ssrc, &protected).as_deref(),
+            Some(&sr[..])
+        );
+        // A flipped tag byte must fail authentication.
+        let mut forged = protected.clone();
+        *forged.last_mut().unwrap() ^= 1;
+        assert_eq!(unprotect_srtcp(&srtcp, ssrc, &forged), None);
+        // The index increments per packet, changing the keystream.
+        let p1 = protect_srtcp(&srtcp, ssrc, 1, &sr);
+        assert_ne!(
+            protected[8..28],
+            p1[8..28],
+            "a new index must change the ciphertext"
+        );
+        assert_eq!(unprotect_srtcp(&srtcp, ssrc, &p1).as_deref(), Some(&sr[..]));
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -17,9 +17,13 @@ use std::collections::VecDeque;
 use bytes::Bytes;
 
 use super::demux::{RelayPacketKind, classify_relay_packet};
-use super::session::{CallDirection, MediaPipeline, MediaPipelineParams};
+use super::h264::{VideoFrame, au_is_keyframe};
+use super::rtp::{RTP_PAYLOAD_TYPE_H264, VIDEO_TS_STRIDE_15FPS, parse_rtp_header};
+use super::session::{
+    CallDirection, MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
+};
 use super::sframe::{SframeIn, SframeSession};
-use super::{is_standard_opus_frame, mlow, stun};
+use super::{is_standard_opus_frame, mlow, ssrc, stun};
 
 /// Monotonic milliseconds. The shell supplies it; the engine never reads a clock.
 pub type Millis = u64;
@@ -115,6 +119,9 @@ pub struct CallConfig {
     pub warp_mi_tag_len: usize,
     /// Run the media plane (MLow + playout). Off for the esp32 control plane.
     pub enable_media: bool,
+    /// Build the video plane at engine construction (a video-from-the-start call). An audio call
+    /// upgrades later via [`CallEngine::enable_video`]; both paths build the same pipeline.
+    pub enable_video: bool,
     /// Decrypt inbound SFrame, with a plaintext fallback (the Android peer may GCM-wrap its
     /// Opus/MLow). Recv-side only by design: outbound stays plain codec inside WAHKDF SRTP, which
     /// the peer accepts, matching the pre-refactor pipeline (`MediaPipeline`: "SFrame is omitted,
@@ -141,6 +148,7 @@ impl core::fmt::Debug for CallConfig {
             .field("integrity_key", &"[redacted]")
             .field("warp_mi_tag_len", &self.warp_mi_tag_len)
             .field("enable_media", &self.enable_media)
+            .field("enable_video", &self.enable_video)
             .field("enable_sframe", &self.enable_sframe)
             .finish()
     }
@@ -243,6 +251,7 @@ impl CallConfig {
             integrity_key,
             warp_mi_tag_len,
             enable_media: true,
+            enable_video: false,
             enable_sframe: true,
         })
     }
@@ -292,6 +301,9 @@ pub enum Input<'a> {
     /// A 60ms PCM frame captured from the local mic (16kHz mono). Must be exactly 960 samples (the
     /// MLow frame size); a wrong-length frame is silently dropped by the encoder (no RTP sent).
     MicFrame(&'a [i16]),
+    /// One pre-encoded H.264 Annex-B access unit to send. Dropped while the video plane is off
+    /// (audio-only call, or after a downgrade).
+    VideoFrame(&'a [u8]),
     /// The deadline that `poll_output`/`poll_timeout` last reported has fired.
     Timeout,
 }
@@ -304,6 +316,9 @@ pub enum Output {
     Transmit(Bytes),
     /// Decoded PCM for the speaker (16kHz mono).
     Playout(Vec<i16>),
+    /// A reassembled peer access unit for the video sink. Dedicated output (not a CallEvent) for
+    /// the same reason audio uses `Playout`: the event channel sheds on overflow, media must not.
+    VideoPlayout(VideoFrame),
     /// A call lifecycle / diagnostic event.
     Event(CallEvent),
     /// Drained: arm a timer for this monotonic-ms deadline ([`NEVER`] = no timer).
@@ -323,6 +338,14 @@ pub enum CallEvent {
     RelayAllocateFailed(u16),
     /// The relay never acked the allocate within the deadline (wedged relay). Terminal.
     RelayAllocateTimedOut,
+    /// The peer's `<video state=N>` signaling arrived (upgrade requested/accepted, stopped, ...).
+    /// Pushed by the signaling handler, not the engine; surfaced here so one event stream carries
+    /// the whole call. `UpgradeRequestV2` is the peer asking for video — answer with
+    /// `accept_video` or ignore to decline.
+    VideoStateChanged {
+        state: crate::types::call::VideoState,
+        orientation: Option<u8>,
+    },
 }
 
 /// The optional media plane: the SRTP pipeline, the MLow codec, an optional SFrame session, and
@@ -333,6 +356,16 @@ struct MediaState {
     /// Retained so the caller can re-derive the recv keys once the answering device is known (the
     /// callee's `<accept>` carries its device LID). See [`CallEngine::rekey_recv`].
     call_key: Vec<u8>,
+    /// Retained for a mid-call [`CallEngine::enable_video`]: the video pipeline derives its own
+    /// SSRC and send keys from these on demand.
+    self_lid: String,
+    /// The peer LID the recv keys are CURRENTLY derived from — starts as the dialed base LID and
+    /// moves to the answering device on [`CallEngine::rekey_recv`]. A video plane enabled after
+    /// that rekey must key its recv path from this, not the stale config LID.
+    recv_peer_lid: String,
+    warp_mi_tag_len: usize,
+    /// The video plane, present while video is enabled (from the start or via upgrade).
+    video: Option<VideoPlaneState>,
     sframe: Option<SframeSession>,
     encoder: mlow::MlowEncoder,
     decoder: mlow::MlowDecoder,
@@ -347,6 +380,50 @@ struct MediaState {
     /// Consecutive playout ticks spent priming; bounds the wait so a partial buffer (the peer sent one
     /// frame then went DTX) is flushed after `MAX_PRIME_TICKS` instead of being held silent forever.
     priming_ticks: u32,
+}
+
+/// The video half of the media plane. No jitter buffer or playout tick: an AU is handed to the
+/// sink the moment its marker packet reassembles it (the consumer's decoder does its own pacing).
+///
+/// The pipeline is built once per call and OUTLIVES a downgrade: `active` gates transmit/decode
+/// while the pipe (its SRTP send seq + ROC) is preserved. Rebuilding it on a re-upgrade would reset
+/// the packet index to zero under the same key+SSRC and repeat the AES-CTR keystream (a two-time
+/// pad), so a downgrade must not drop it.
+struct VideoPlaneState {
+    pipe: VideoPipeline,
+    active: bool,
+    /// When set, inbound video still decodes but OUTBOUND AUs are dropped: the initiator of an
+    /// upgrade holds its camera off the wire until the peer accepts (a `<video>` request the peer
+    /// ignores must not leak our video). Cleared on the peer's UpgradeAccept/Enabled.
+    send_gated: bool,
+}
+
+/// Build the video pipeline for `self_lid` sending / `recv_peer_lid` receiving. `None` on a
+/// malformed callKey (a setup invariant the audio plane already validated).
+fn make_video_plane(
+    call_id: &str,
+    call_key: &[u8],
+    self_lid: &str,
+    recv_peer_lid: &str,
+    warp_mi_tag_len: usize,
+) -> Option<VideoPlaneState> {
+    let video_ssrc = ssrc::derive_video_participant_ssrc(
+        call_id,
+        &ssrc::format_e2e_srtp_participant_id(self_lid),
+    );
+    let pipe = VideoPipeline::new(&VideoPipelineParams {
+        call_key,
+        self_lid,
+        peer_lid: recv_peer_lid,
+        ssrc: video_ssrc,
+        ts_stride: VIDEO_TS_STRIDE_15FPS,
+        warp_mi_tag_len,
+    })?;
+    Some(VideoPlaneState {
+        pipe,
+        active: true,
+        send_gated: false,
+    })
 }
 
 /// The sans-IO call engine. See the module docs for the drive contract.
@@ -370,6 +447,9 @@ pub struct CallEngine {
     terminated: bool,
     // Media plane (None = control plane only, e.g. esp32).
     media: Option<MediaState>,
+    /// Peer device orientation (0..3, ×90°) from the last `<video device_orientation>`; stamped on
+    /// every reassembled inbound AU so the sink can rotate.
+    peer_video_orientation: u8,
     outbox: VecDeque<Output>,
 }
 
@@ -408,9 +488,27 @@ impl CallEngine {
             } else {
                 None
             };
+            let video = if config.enable_video {
+                Some(
+                    make_video_plane(
+                        &config.call_id,
+                        &config.call_key,
+                        &config.self_lid,
+                        &config.peer_lid,
+                        config.warp_mi_tag_len,
+                    )
+                    .ok_or(EngineError::BadCallKey)?,
+                )
+            } else {
+                None
+            };
             Some(MediaState {
                 pipe,
                 call_key: config.call_key.clone(),
+                self_lid: config.self_lid.clone(),
+                recv_peer_lid: config.peer_lid.clone(),
+                warp_mi_tag_len: config.warp_mi_tag_len,
+                video,
                 sframe,
                 encoder: mlow::MlowEncoder::new(),
                 decoder: mlow::MlowDecoder::new(),
@@ -438,6 +536,7 @@ impl CallEngine {
             started: false,
             terminated: false,
             media,
+            peer_video_orientation: 0,
             outbox: VecDeque::new(),
         })
     }
@@ -469,7 +568,80 @@ impl CallEngine {
         let Some(m) = self.media.as_mut() else {
             return true;
         };
-        m.pipe.rekey_recv(&m.call_key, answering_peer_lid)
+        if !m.pipe.rekey_recv(&m.call_key, answering_peer_lid) {
+            return false;
+        }
+        // The video recv keys derive from the same participant id and go stale together with the
+        // audio ones; a video plane enabled after this rekey must also start from the new LID.
+        m.recv_peer_lid = answering_peer_lid.to_string();
+        if let Some(v) = m.video.as_mut() {
+            return v.pipe.rekey_recv(&m.call_key, answering_peer_lid);
+        }
+        true
+    }
+
+    /// Whether the video plane is currently up (sending is possible, inbound PT-97 decodes).
+    pub fn is_video_enabled(&self) -> bool {
+        self.media
+            .as_ref()
+            .and_then(|m| m.video.as_ref())
+            .is_some_and(|v| v.active)
+    }
+
+    /// Bring the video plane up (from-start call, or an accepted upgrade) with OUTBOUND allowed.
+    /// Idempotent; also ungates a previously send-gated plane. See [`enable_video_gated`].
+    pub fn enable_video(&mut self) -> bool {
+        self.enable_video_inner(false)
+    }
+
+    /// Bring the video plane up but hold OUTBOUND video off the wire (the initiator of an upgrade,
+    /// before the peer accepts). Inbound still decodes. [`enable_video`] later ungates it.
+    pub fn enable_video_gated(&mut self) -> bool {
+        self.enable_video_inner(true)
+    }
+
+    /// `false` when there is no media plane (control-only engine) or the stored callKey is malformed.
+    /// A plane built by an earlier upgrade is REACTIVATED, not rebuilt, so its SRTP send seq/ROC
+    /// continue (rebuilding would repeat the keystream under the same key+SSRC).
+    fn enable_video_inner(&mut self, send_gated: bool) -> bool {
+        let call_id = &self.call_id;
+        let Some(m) = self.media.as_mut() else {
+            return false;
+        };
+        if let Some(v) = m.video.as_mut() {
+            v.active = true;
+            v.send_gated = send_gated;
+            return true;
+        }
+        match make_video_plane(
+            call_id,
+            &m.call_key,
+            &m.self_lid,
+            &m.recv_peer_lid,
+            m.warp_mi_tag_len,
+        ) {
+            Some(mut v) => {
+                v.send_gated = send_gated;
+                m.video = Some(v);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Deactivate the video plane (downgrade): outbound AUs drop, inbound PT-97 is ignored. The
+    /// pipeline (and its SRTP send seq/ROC) is PRESERVED so a later re-upgrade continues the
+    /// keystream instead of resetting the packet index. The audio plane is untouched. Idempotent.
+    pub fn disable_video(&mut self) {
+        if let Some(v) = self.media.as_mut().and_then(|m| m.video.as_mut()) {
+            v.active = false;
+        }
+    }
+
+    /// Record the peer's device orientation (0..3, ×90°) from a `<video>` stanza; stamped on every
+    /// subsequently reassembled inbound AU.
+    pub fn set_peer_video_orientation(&mut self, orientation: u8) {
+        self.peer_video_orientation = orientation & 0x03;
     }
 
     /// Begin the media session: build and emit the initial STUN allocate and arm the keepalive
@@ -507,6 +679,7 @@ impl CallEngine {
             Input::Timeout => self.on_timeout(now),
             Input::RelayPacket(pkt) => self.on_packet(pkt),
             Input::MicFrame(pcm) => self.on_mic(pcm),
+            Input::VideoFrame(au) => self.on_video(au),
         }
     }
 
@@ -633,6 +806,25 @@ impl CallEngine {
         let Some(m) = self.media.as_mut() else {
             return;
         };
+        // Demux by payload type BEFORE unprotect: audio and video share E2E keys but have
+        // distinct SSRCs/ROC trackers, so feeding a video packet through the audio pipeline
+        // would fail its MI tag at best and desync at worst.
+        if parse_rtp_header(pkt).is_some_and(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264) {
+            // A PT-97 packet with no ACTIVE video plane (not negotiated, or after a downgrade) is
+            // dropped. The pipe still advances its recv ROC on drop-free packets it never sees, but
+            // an inactive plane simply ignores them.
+            if let Some(v) = m.video.as_mut().filter(|v| v.active)
+                && let Some(au) = v.pipe.unprotect_video(pkt)
+            {
+                let keyframe = au_is_keyframe(&au);
+                self.outbox.push_back(Output::VideoPlayout(VideoFrame {
+                    data: au,
+                    keyframe,
+                    orientation: self.peer_video_orientation,
+                }));
+            }
+            return;
+        }
         let Some((_, payload)) = m.pipe.unprotect_audio(pkt) else {
             return;
         };
@@ -690,6 +882,23 @@ impl CallEngine {
         // pre-refactor send path; send-side SFrame is intentionally not wired.
         let packet = m.pipe.protect_audio(&coded);
         self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+    }
+
+    fn on_video(&mut self, au: &[u8]) {
+        // Drop unless the plane is active AND ungated: an inactive plane (audio-only / post-
+        // downgrade) or a send-gated one (upgrade requested but not yet accepted) must not put video
+        // on the wire. Either way the pipe's send seq/ROC stay frozen for a later resume.
+        let Some(v) = self
+            .media
+            .as_mut()
+            .and_then(|m| m.video.as_mut())
+            .filter(|v| v.active && !v.send_gated)
+        else {
+            return;
+        };
+        for packet in v.pipe.protect_video(au) {
+            self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+        }
     }
 }
 
@@ -775,6 +984,7 @@ mod tests {
             integrity_key: b"relay-key".to_vec(),
             warp_mi_tag_len: 4,
             enable_media,
+            enable_video: false,
             enable_sframe: false,
         }
     }
@@ -1612,6 +1822,343 @@ mod tests {
         assert!(
             f.iter().any(|&s| s != 0),
             "at the target playout starts real audio"
+        );
+    }
+
+    /// A mirrored peer engine's video plane (its self LID = our peer LID), used to craft real
+    /// inbound video packets for demux tests.
+    fn peer_video_pipe() -> crate::voip::session::VideoPipeline {
+        use crate::voip::session::{VideoPipeline, VideoPipelineParams};
+        let call_key: Vec<u8> = (0u8..32).collect();
+        VideoPipeline::new(&VideoPipelineParams {
+            call_key: &call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: ssrc::derive_video_participant_ssrc(
+                "CID",
+                &ssrc::format_e2e_srtp_participant_id(PEER_LID),
+            ),
+            ts_stride: VIDEO_TS_STRIDE_15FPS,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap()
+    }
+
+    /// A synthetic Annex-B AU with one large IDR NAL (forces FU-A fragmentation).
+    fn video_au(nal_len: usize) -> Vec<u8> {
+        let mut au = vec![0, 0, 0, 1, 0x65];
+        au.extend((0..nal_len).map(|i| (i % 251) as u8));
+        au
+    }
+
+    #[test]
+    fn video_frame_dropped_when_video_disabled() {
+        let mut eng = engine(true); // enable_video: false
+        eng.start(0);
+        let _ = drain(&mut eng);
+        assert!(!eng.is_video_enabled());
+        eng.handle_input(1, Input::VideoFrame(&video_au(100)));
+        let (outs, _) = drain(&mut eng);
+        assert_eq!(
+            count_transmits(&outs),
+            0,
+            "an AU with video off must not transmit"
+        );
+    }
+
+    #[test]
+    fn video_from_start_transmits_pt97_packets() {
+        let mut cfg = config(true);
+        cfg.enable_video = true;
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        assert!(eng.is_video_enabled());
+        eng.start(0);
+        let _ = drain(&mut eng);
+        eng.handle_input(1, Input::VideoFrame(&video_au(3000)));
+        let (outs, _) = drain(&mut eng);
+        let transmits: Vec<&Bytes> = outs
+            .iter()
+            .filter_map(|o| match o {
+                Output::Transmit(b) => Some(b),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            transmits.len() >= 4,
+            "a 3KB AU must fan out into FU-A packets"
+        );
+        for b in &transmits {
+            let h = parse_rtp_header(b).expect("valid RTP header");
+            assert_eq!(h.payload_type, RTP_PAYLOAD_TYPE_H264);
+        }
+    }
+
+    #[test]
+    fn enable_video_mid_call_then_disable() {
+        let mut eng = engine(true);
+        eng.start(0);
+        let _ = drain(&mut eng);
+        let au = video_au(200);
+        // Off: dropped.
+        eng.handle_input(1, Input::VideoFrame(&au));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 0);
+        // Upgrade: transmits.
+        assert!(eng.enable_video());
+        assert!(eng.enable_video(), "enable_video must be idempotent");
+        eng.handle_input(2, Input::VideoFrame(&au));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 1);
+        // Downgrade: dropped again, audio untouched.
+        eng.disable_video();
+        assert!(!eng.is_video_enabled());
+        eng.handle_input(3, Input::VideoFrame(&au));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 0);
+        eng.handle_input(4, Input::MicFrame(&[0i16; SAMPLES as usize]));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "audio DTX must survive a video downgrade"
+        );
+    }
+
+    // SECURITY: a downgrade must PRESERVE the video SRTP send state, so a re-upgrade never repeats
+    // an (SSRC, ROC, seq) triple under the same key — that would repeat the AES-CTR keystream (a
+    // two-time pad). Pin it by checking the RTP sequence number strictly increases across the
+    // disable→enable cycle instead of resetting to 0.
+    #[test]
+    fn re_enabling_video_does_not_reset_the_srtp_packet_index() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.start(0);
+        let _ = drain(&mut eng);
+
+        let seq_of = |outs: &[Output]| -> Vec<u16> {
+            outs.iter()
+                .filter_map(|o| match o {
+                    Output::Transmit(b) => parse_rtp_header(b)
+                        .filter(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264)
+                        .map(|h| h.sequence_number),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // First video AU: single NAL -> one packet at seq 0.
+        eng.handle_input(1, Input::VideoFrame(&video_au(100)));
+        let first = seq_of(&drain(&mut eng).0);
+        assert_eq!(first, vec![0]);
+
+        // Downgrade then re-upgrade: the plane is preserved, so the next packet's seq CONTINUES.
+        eng.disable_video();
+        assert!(!eng.is_video_enabled());
+        eng.handle_input(2, Input::VideoFrame(&video_au(100))); // dropped while inactive
+        assert!(seq_of(&drain(&mut eng).0).is_empty());
+        assert!(eng.enable_video());
+        eng.handle_input(3, Input::VideoFrame(&video_au(100)));
+        let after = seq_of(&drain(&mut eng).0);
+        assert_eq!(
+            after,
+            vec![1],
+            "re-enabled video must continue the sequence, not reset to 0 (keystream reuse)"
+        );
+    }
+
+    // The upgrade initiator holds outbound video until the peer accepts: a send-gated plane decodes
+    // inbound but transmits nothing, and a later ungating `enable_video` starts transmission.
+    #[test]
+    fn send_gated_video_plane_holds_outbound_until_ungated() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video_gated());
+        assert!(eng.is_video_enabled(), "a gated plane is still 'enabled'");
+        eng.start(0);
+        let _ = drain(&mut eng);
+
+        // Gated: local AUs are dropped (no PT-97 on the wire).
+        eng.handle_input(1, Input::VideoFrame(&video_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "a send-gated plane must not transmit our video"
+        );
+        // Inbound still decodes while gated.
+        let mut peer = peer_video_pipe();
+        for p in peer.protect_video(&video_au(120)) {
+            eng.handle_input(1, Input::RelayPacket(&p));
+        }
+        assert!(
+            drain(&mut eng)
+                .0
+                .iter()
+                .any(|o| matches!(o, Output::VideoPlayout(_))),
+            "a gated plane must still decode inbound video"
+        );
+
+        // Peer accepted -> ungate -> our video flows.
+        assert!(eng.enable_video());
+        eng.handle_input(2, Input::VideoFrame(&video_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "ungating must let our video onto the wire"
+        );
+    }
+
+    #[test]
+    fn enable_video_fails_without_media_plane() {
+        let mut eng = engine(false); // control-plane only
+        assert!(!eng.enable_video(), "no media plane -> no video plane");
+        assert!(!eng.is_video_enabled());
+    }
+
+    #[test]
+    fn inbound_video_reassembles_into_video_playout() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.start(0);
+        let _ = drain(&mut eng);
+        eng.set_peer_video_orientation(2);
+
+        let mut peer = peer_video_pipe();
+        let au = video_au(3000);
+        let packets = peer.protect_video(&au);
+        assert!(packets.len() >= 4);
+        let mut frames = Vec::new();
+        for p in &packets {
+            eng.handle_input(1, Input::RelayPacket(p));
+            let (outs, _) = drain(&mut eng);
+            frames.extend(outs.into_iter().filter_map(|o| match o {
+                Output::VideoPlayout(f) => Some(f),
+                _ => None,
+            }));
+        }
+        assert_eq!(frames.len(), 1, "N packets must reassemble into 1 AU");
+        assert_eq!(frames[0].data, au);
+        assert!(frames[0].keyframe, "IDR AU must be flagged as keyframe");
+        assert_eq!(frames[0].orientation, 2);
+        assert_eq!(
+            eng.jitter_len(),
+            0,
+            "video must not leak into the audio jitter buffer"
+        );
+    }
+
+    #[test]
+    fn inbound_video_dropped_when_video_disabled_and_audio_unaffected() {
+        let mut eng = engine(true); // video off
+        eng.start(0);
+        let _ = drain(&mut eng);
+        let mut peer = peer_video_pipe();
+        for p in peer.protect_video(&video_au(500)) {
+            eng.handle_input(1, Input::RelayPacket(&p));
+        }
+        let (outs, _) = drain(&mut eng);
+        assert!(
+            !outs
+                .iter()
+                .any(|o| matches!(o, Output::VideoPlayout(_) | Output::Event(_))),
+            "PT-97 with video off must be silently dropped"
+        );
+        // Audio still decodes (demux must not eat Opus packets).
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut peer_audio = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: SSRC,
+            samples_per_packet: SAMPLES,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap();
+        let mut enc = MlowEncoder::new();
+        let tone: Vec<f32> = (0..SAMPLES as usize)
+            .map(|i| 0.3 * (i as f32 * 0.07).sin())
+            .collect();
+        for _ in 0..2 {
+            let pkt = peer_audio.protect_audio(&enc.encode(&tone).unwrap());
+            eng.handle_input(2, Input::RelayPacket(&pkt));
+        }
+        let _ = drain(&mut eng);
+        assert!(eng.jitter_len() > 0, "audio path must keep decoding");
+    }
+
+    #[test]
+    fn rekey_recv_also_rekeys_the_video_plane() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.start(0);
+        let _ = drain(&mut eng);
+
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let answering = "222222222222222:2@lid";
+        let mut answerer =
+            crate::voip::session::VideoPipeline::new(&crate::voip::session::VideoPipelineParams {
+                call_key: &call_key,
+                self_lid: answering,
+                peer_lid: SELF_LID,
+                ssrc: ssrc::derive_video_participant_ssrc(
+                    "CID",
+                    &ssrc::format_e2e_srtp_participant_id(answering),
+                ),
+                ts_stride: VIDEO_TS_STRIDE_15FPS,
+                warp_mi_tag_len: WARP_MI_TAG_LEN,
+            })
+            .unwrap();
+
+        let au = video_au(120);
+        for p in answerer.protect_video(&au) {
+            eng.handle_input(1, Input::RelayPacket(&p));
+        }
+        let (outs, _) = drain(&mut eng);
+        assert!(
+            !outs.iter().any(|o| matches!(o, Output::VideoPlayout(_))),
+            "pre-rekey: companion-keyed video must not decode"
+        );
+
+        assert!(eng.rekey_recv(answering));
+        for p in answerer.protect_video(&au) {
+            eng.handle_input(2, Input::RelayPacket(&p));
+        }
+        let (outs, _) = drain(&mut eng);
+        assert!(
+            outs.iter()
+                .any(|o| matches!(o, Output::VideoPlayout(f) if f.data == au)),
+            "post-rekey: the answering device's video must decode"
+        );
+    }
+
+    #[test]
+    fn video_enabled_after_rekey_keys_recv_from_answering_device() {
+        // Upgrade AFTER the answering device is known: the late-built video pipeline must key its
+        // recv path from the CURRENT (rekeyed) peer LID, not the stale dialed base.
+        let mut eng = engine(true);
+        eng.start(0);
+        let _ = drain(&mut eng);
+        let answering = "222222222222222:2@lid";
+        assert!(eng.rekey_recv(answering));
+        assert!(eng.enable_video(), "upgrade after rekey");
+
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut answerer =
+            crate::voip::session::VideoPipeline::new(&crate::voip::session::VideoPipelineParams {
+                call_key: &call_key,
+                self_lid: answering,
+                peer_lid: SELF_LID,
+                ssrc: ssrc::derive_video_participant_ssrc(
+                    "CID",
+                    &ssrc::format_e2e_srtp_participant_id(answering),
+                ),
+                ts_stride: VIDEO_TS_STRIDE_15FPS,
+                warp_mi_tag_len: WARP_MI_TAG_LEN,
+            })
+            .unwrap();
+        let au = video_au(80);
+        for p in answerer.protect_video(&au) {
+            eng.handle_input(1, Input::RelayPacket(&p));
+        }
+        let (outs, _) = drain(&mut eng);
+        assert!(
+            outs.iter()
+                .any(|o| matches!(o, Output::VideoPlayout(f) if f.data == au)),
+            "a video plane built after rekey must decode the answering device"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -17,9 +17,9 @@ use std::collections::VecDeque;
 use bytes::Bytes;
 
 use super::demux::{RelayPacketKind, classify_relay_packet};
-use super::h264::{VideoFrame, au_is_keyframe};
+use super::h264::{VideoFrame, au_has_idr, au_is_keyframe};
 use super::rtcp::{
-    RtcpFeedback, RtcpReportBlock, RtpReceptionStats, build_whatsapp_rtcp_cname,
+    RTCP_PT_PSFB, RtcpFeedback, RtcpReportBlock, RtpReceptionStats, build_whatsapp_rtcp_cname,
     parse_sender_report_timing, summarize_rtcp,
 };
 use super::rtp::{
@@ -424,6 +424,28 @@ struct VideoPlaneState {
     /// upgrade holds its camera off the wire until the peer accepts (a `<video>` request the peer
     /// ignores must not leak our video). Cleared on the peer's UpgradeAccept/Enabled.
     send_gated: bool,
+    /// PLI/FIR means dependent frames only prolong the peer's undecodable jitter-buffer state.
+    keyframe_required: bool,
+}
+
+fn requests_keyframe(feedback: &[RtcpFeedback], video_ssrc: u32) -> bool {
+    let target = video_ssrc.to_be_bytes();
+    feedback.iter().any(|item| {
+        if item.packet_type != RTCP_PT_PSFB {
+            return false;
+        }
+        match item.fmt {
+            1 => item.media_ssrc == video_ssrc,
+            4 => {
+                item.media_ssrc == video_ssrc
+                    || item
+                        .fci
+                        .chunks_exact(8)
+                        .any(|row| row.get(..4) == Some(target.as_slice()))
+            }
+            _ => false,
+        }
+    })
 }
 
 /// Build the video pipeline for `self_lid` sending / `recv_peer_lid` receiving. `None` on a
@@ -457,6 +479,7 @@ fn make_video_plane(
         reception: RtpReceptionStats::default(),
         active: true,
         send_gated: false,
+        keyframe_required: false,
     })
 }
 
@@ -891,6 +914,12 @@ impl CallEngine {
             let Some(summary) = summarize_rtcp(&plain) else {
                 return;
             };
+            if let Some(video_ssrc) = video_ssrc
+                && requests_keyframe(&summary.feedback, video_ssrc)
+                && let Some(video) = m.video.as_mut()
+            {
+                video.keyframe_required = true;
+            }
             if let Some((sender, ntp_seconds, ntp_fraction)) = parse_sender_report_timing(&plain) {
                 m.audio_reception
                     .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
@@ -1070,6 +1099,12 @@ impl CallEngine {
         else {
             return;
         };
+        if v.keyframe_required {
+            if !au_has_idr(au) {
+                return;
+            }
+            v.keyframe_required = false;
+        }
         for packet in v.pipe.protect_video(au) {
             self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
         }
@@ -2120,9 +2155,22 @@ mod tests {
                     && item.fci.is_empty())
         )));
 
+        eng.handle_input(2, Input::VideoFrame(&video_delta_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "PLI must suppress dependent AUs until recovery"
+        );
+        eng.handle_input(3, Input::VideoFrame(&video_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "the next IDR must recover transmission"
+        );
+
         let mut forged = protected;
         *forged.last_mut().unwrap() ^= 1;
-        eng.handle_input(2, Input::RelayPacket(&forged));
+        eng.handle_input(4, Input::RelayPacket(&forged));
         let (outs, _) = drain(&mut eng);
         assert!(
             !outs
@@ -2130,6 +2178,49 @@ mod tests {
                 .any(|output| matches!(output, Output::Event(CallEvent::RtcpReceived { .. }))),
             "forged SRTCP must be dropped"
         );
+        eng.handle_input(5, Input::VideoFrame(&video_delta_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "forged feedback must not re-arm keyframe recovery"
+        );
+    }
+
+    #[test]
+    fn keyframe_feedback_must_target_the_local_video_ssrc() {
+        let video_ssrc = 0x1122_3344;
+        let other_ssrc = 0x5566_7788;
+        let feedback = |packet_type, fmt, media_ssrc, fci| RtcpFeedback {
+            packet_type,
+            fmt,
+            sender_ssrc: 0x99aa_bbcc,
+            media_ssrc,
+            fci,
+        };
+
+        assert!(requests_keyframe(
+            &[feedback(RTCP_PT_PSFB, 1, video_ssrc, Vec::new())],
+            video_ssrc
+        ));
+        assert!(!requests_keyframe(
+            &[feedback(RTCP_PT_PSFB, 1, other_ssrc, Vec::new())],
+            video_ssrc
+        ));
+        assert!(!requests_keyframe(
+            &[feedback(205, 1, video_ssrc, Vec::new())],
+            video_ssrc
+        ));
+
+        let fir = [video_ssrc.to_be_bytes().as_slice(), &[7, 0, 0, 0]].concat();
+        assert!(requests_keyframe(
+            &[feedback(RTCP_PT_PSFB, 4, 0, fir)],
+            video_ssrc
+        ));
+        let other_fir = [other_ssrc.to_be_bytes().as_slice(), &[8, 0, 0, 0]].concat();
+        assert!(!requests_keyframe(
+            &[feedback(RTCP_PT_PSFB, 4, 0, other_fir)],
+            video_ssrc
+        ));
     }
 
     #[test]
@@ -2359,6 +2450,12 @@ mod tests {
     /// A synthetic Annex-B AU with one large IDR NAL (forces FU-A fragmentation).
     fn video_au(nal_len: usize) -> Vec<u8> {
         let mut au = vec![0, 0, 0, 1, 0x65];
+        au.extend((0..nal_len).map(|i| (i % 251) as u8));
+        au
+    }
+
+    fn video_delta_au(nal_len: usize) -> Vec<u8> {
+        let mut au = vec![0, 0, 0, 1, 0x41];
         au.extend((0..nal_len).map(|i| (i % 251) as u8));
         au
     }

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -20,11 +20,10 @@ use super::demux::{RelayPacketKind, classify_relay_packet};
 use super::h264::{VideoFrame, au_is_keyframe};
 use super::rtcp::{
     RtcpFeedback, RtcpReportBlock, RtpReceptionStats, build_whatsapp_rtcp_cname,
-    parse_rtcp_sender_ssrc, parse_sender_report_timing, rtcp_payload_type, summarize_rtcp,
+    parse_sender_report_timing, summarize_rtcp,
 };
 use super::rtp::{
     RTP_PAYLOAD_TYPE_H264, VIDEO_CLOCK_RATE, VIDEO_TS_STRIDE_15FPS, parse_rtp_header,
-    rtp_extension_profile_and_data, rtp_header_byte_length,
 };
 use super::session::{
     CallDirection, MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
@@ -335,18 +334,6 @@ pub enum Output {
     Timeout(Millis),
 }
 
-/// Lifecycle / diagnostic events the shell may act on or surface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RtcpProtection {
-    Transport,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RtcpRejectStage {
-    Authentication,
-    Parsing,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CallEvent {
@@ -375,51 +362,8 @@ pub enum CallEvent {
         referenced_ssrcs: Vec<u32>,
         reports_audio: bool,
         reports_video: bool,
-        protection: RtcpProtection,
-        srtcp_index: Option<u32>,
-        encrypted: bool,
-        plain_len: usize,
-        sdes_cname_lengths: Vec<usize>,
         report_blocks: Vec<RtcpReportBlock>,
         feedback: Vec<RtcpFeedback>,
-        uses_whatsapp_profile_extension: bool,
-    },
-    /// An RTCP-shaped datagram failed SRTCP authentication or plaintext parsing.
-    RtcpRejected {
-        stage: RtcpRejectStage,
-        packet_type: u8,
-        sender_ssrc: u32,
-        packet_len: usize,
-        first_rtcp_len: usize,
-        plain_len: Option<usize>,
-        /// Standard SRTCP index inferred from the word before the 10-byte auth tag.
-        candidate_srtcp_index: Option<u32>,
-        candidate_encrypted: bool,
-        first_header_byte: u8,
-        /// First authenticated sample for this sender/layout, capped at 256 bytes.
-        plain_sample: Option<Vec<u8>>,
-    },
-    /// First authenticated inbound video packet's RTP extension layout.
-    VideoRtpLayoutObserved {
-        ssrc: u32,
-        sequence_number: u16,
-        timestamp: u32,
-        marker: bool,
-        header_len: usize,
-        packet_len: usize,
-        extension_profile: Option<u16>,
-        extension_data: Vec<u8>,
-    },
-    /// First outbound video packet's RTP extension layout, before relay transmission.
-    VideoRtpLayoutSent {
-        ssrc: u32,
-        sequence_number: u16,
-        timestamp: u32,
-        marker: bool,
-        header_len: usize,
-        packet_len: usize,
-        extension_profile: Option<u16>,
-        extension_data: Vec<u8>,
     },
     /// Relay-send backpressure discarded complete media units before transmission.
     OutboundMediaDropped {
@@ -445,10 +389,10 @@ struct MediaState {
     /// that rekey must key its recv path from this, not the stale config LID.
     recv_peer_lid: String,
     warp_mi_tag_len: usize,
+    video_ts_stride: u32,
     /// The video plane, present while video is enabled (from the start or via upgrade).
     video: Option<VideoPlaneState>,
     audio_rtcp_announced: bool,
-    rtcp_parse_samples: Vec<(u32, usize, u8)>,
     sframe: Option<SframeSession>,
     encoder: mlow::MlowEncoder,
     decoder: mlow::MlowDecoder,
@@ -476,8 +420,6 @@ struct VideoPlaneState {
     pipe: VideoPipeline,
     reception: RtpReceptionStats,
     active: bool,
-    peer_layout_reported: bool,
-    local_layout_reported: bool,
     /// When set, inbound video still decodes but OUTBOUND AUs are dropped: the initiator of an
     /// upgrade holds its camera off the wire until the peer accepts (a `<video>` request the peer
     /// ignores must not leak our video). Cleared on the peer's UpgradeAccept/Enabled.
@@ -492,6 +434,7 @@ fn make_video_plane(
     self_lid: &str,
     recv_peer_lid: &str,
     warp_mi_tag_len: usize,
+    ts_stride: u32,
     rtcp_cname: [u8; super::rtcp::WHATSAPP_RTCP_CNAME_LEN],
 ) -> Option<VideoPlaneState> {
     let video_ssrc = ssrc::derive_video_participant_ssrc(
@@ -504,7 +447,7 @@ fn make_video_plane(
             self_lid,
             peer_lid: recv_peer_lid,
             ssrc: video_ssrc,
-            ts_stride: VIDEO_TS_STRIDE_15FPS,
+            ts_stride,
             warp_mi_tag_len,
         },
         rtcp_cname,
@@ -513,8 +456,6 @@ fn make_video_plane(
         pipe,
         reception: RtpReceptionStats::default(),
         active: true,
-        peer_layout_reported: false,
-        local_layout_reported: false,
         send_gated: false,
     })
 }
@@ -602,6 +543,7 @@ impl CallEngine {
                         &config.self_lid,
                         &config.peer_lid,
                         config.warp_mi_tag_len,
+                        VIDEO_TS_STRIDE_15FPS,
                         video_rtcp_cname,
                     )
                     .ok_or(EngineError::BadCallKey)?,
@@ -616,9 +558,9 @@ impl CallEngine {
                 self_lid: config.self_lid.clone(),
                 recv_peer_lid: config.peer_lid.clone(),
                 warp_mi_tag_len: config.warp_mi_tag_len,
+                video_ts_stride: VIDEO_TS_STRIDE_15FPS,
                 video,
                 audio_rtcp_announced: false,
-                rtcp_parse_samples: Vec::new(),
                 sframe,
                 encoder: mlow::MlowEncoder::new(),
                 decoder: mlow::MlowDecoder::new(),
@@ -702,6 +644,22 @@ impl CallEngine {
             .is_some_and(|v| v.active)
     }
 
+    /// Set the nominal RTP cadence for subsequent video access units. The source must pace access
+    /// units at the same rate; changing this never resets the SRTP or RTP sequence state.
+    pub fn set_video_timestamp_stride(&mut self, ts_stride: u32) -> bool {
+        if ts_stride == 0 {
+            return false;
+        }
+        let Some(media) = self.media.as_mut() else {
+            return false;
+        };
+        media.video_ts_stride = ts_stride;
+        if let Some(video) = media.video.as_mut() {
+            video.pipe.set_timestamp_stride(ts_stride);
+        }
+        true
+    }
+
     /// Bring the video plane up (from-start call, or an accepted upgrade) with OUTBOUND allowed.
     /// Idempotent; also ungates a previously send-gated plane. See [`enable_video_gated`].
     pub fn enable_video(&mut self) -> bool {
@@ -734,6 +692,7 @@ impl CallEngine {
             &m.self_lid,
             &m.recv_peer_lid,
             m.warp_mi_tag_len,
+            m.video_ts_stride,
             rtcp_cname,
         ) {
             Some(mut v) => {
@@ -920,30 +879,6 @@ impl CallEngine {
     }
 
     fn on_rtcp(&mut self, now: Millis, pkt: &[u8]) {
-        let (Some(packet_type), Some(sender_ssrc)) =
-            (rtcp_payload_type(pkt), parse_rtcp_sender_ssrc(pkt))
-        else {
-            return;
-        };
-        let trailer_word = pkt
-            .len()
-            .checked_sub(14)
-            .and_then(|offset| pkt.get(offset..offset + 4));
-        let candidate_srtcp_index = trailer_word
-            .map(|word| u32::from_be_bytes([word[0], word[1], word[2], word[3]]) & 0x7fff_ffff);
-        let candidate_encrypted = trailer_word.is_some_and(|word| word[0] & 0x80 != 0);
-        let rejected = |stage, plain_len, plain_sample| CallEvent::RtcpRejected {
-            stage,
-            packet_type,
-            sender_ssrc,
-            packet_len: pkt.len(),
-            first_rtcp_len: u16::from_be_bytes([pkt[2], pkt[3]]) as usize * 4 + 4,
-            plain_len,
-            candidate_srtcp_index,
-            candidate_encrypted,
-            first_header_byte: pkt[0],
-            plain_sample,
-        };
         let event = {
             let Some(m) = self.media.as_mut() else {
                 return;
@@ -951,61 +886,28 @@ impl CallEngine {
             let audio_ssrc = m.pipe.send_ssrc();
             let video_ssrc = m.video.as_ref().map(|v| v.pipe.send_ssrc());
             let Some(plain) = m.pipe.unprotect_rtcp(pkt) else {
-                self.outbox.push_back(Output::Event(rejected(
-                    RtcpRejectStage::Authentication,
-                    None,
-                    None,
-                )));
                 return;
             };
-            let plain_len = plain.len();
-            match summarize_rtcp(&plain) {
-                Some(summary) => {
-                    if let Some((sender, ntp_seconds, ntp_fraction)) =
-                        parse_sender_report_timing(&plain)
-                    {
-                        m.audio_reception.observe_sender_report(
-                            sender,
-                            ntp_seconds,
-                            ntp_fraction,
-                            now,
-                        );
-                        if let Some(v) = m.video.as_mut() {
-                            v.reception.observe_sender_report(
-                                sender,
-                                ntp_seconds,
-                                ntp_fraction,
-                                now,
-                            );
-                        }
-                    }
-                    CallEvent::RtcpReceived {
-                        reports_audio: summary.referenced_ssrcs.contains(&audio_ssrc),
-                        reports_video: video_ssrc
-                            .is_some_and(|ssrc| summary.referenced_ssrcs.contains(&ssrc)),
-                        packet_types: summary.packet_types,
-                        sender_ssrc: summary.sender_ssrc,
-                        referenced_ssrcs: summary.referenced_ssrcs,
-                        protection: RtcpProtection::Transport,
-                        srtcp_index: candidate_srtcp_index,
-                        encrypted: candidate_encrypted,
-                        plain_len,
-                        sdes_cname_lengths: summary.sdes_cname_lengths,
-                        report_blocks: summary.report_blocks,
-                        feedback: summary.feedback,
-                        uses_whatsapp_profile_extension: summary.uses_whatsapp_profile_extension,
-                    }
+            let Some(summary) = summarize_rtcp(&plain) else {
+                return;
+            };
+            if let Some((sender, ntp_seconds, ntp_fraction)) = parse_sender_report_timing(&plain) {
+                m.audio_reception
+                    .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
+                if let Some(v) = m.video.as_mut() {
+                    v.reception
+                        .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
                 }
-                None => {
-                    let layout = (sender_ssrc, plain_len, plain[0]);
-                    let plain_sample = if m.rtcp_parse_samples.contains(&layout) {
-                        None
-                    } else {
-                        m.rtcp_parse_samples.push(layout);
-                        Some(plain.into_iter().take(256).collect())
-                    };
-                    rejected(RtcpRejectStage::Parsing, Some(plain_len), plain_sample)
-                }
+            }
+            CallEvent::RtcpReceived {
+                reports_audio: summary.referenced_ssrcs.contains(&audio_ssrc),
+                reports_video: video_ssrc
+                    .is_some_and(|ssrc| summary.referenced_ssrcs.contains(&ssrc)),
+                packet_types: summary.packet_types,
+                sender_ssrc: summary.sender_ssrc,
+                referenced_ssrcs: summary.referenced_ssrcs,
+                report_blocks: summary.report_blocks,
+                feedback: summary.feedback,
             }
         };
         self.outbox.push_back(Output::Event(event));
@@ -1079,23 +981,6 @@ impl CallEngine {
                     now,
                     VIDEO_CLOCK_RATE,
                 );
-                if !v.peer_layout_reported
-                    && let Some((extension_profile, extension_data)) =
-                        rtp_extension_profile_and_data(pkt)
-                {
-                    v.peer_layout_reported = true;
-                    self.outbox
-                        .push_back(Output::Event(CallEvent::VideoRtpLayoutObserved {
-                            ssrc: header.ssrc,
-                            sequence_number: header.sequence_number,
-                            timestamp: header.timestamp,
-                            marker: header.marker,
-                            header_len: rtp_header_byte_length(pkt).unwrap_or_default(),
-                            packet_len: pkt.len(),
-                            extension_profile,
-                            extension_data: extension_data.to_vec(),
-                        }));
-                }
                 if let Some(au) = au {
                     let keyframe = au_is_keyframe(&au);
                     self.outbox.push_back(Output::VideoPlayout(VideoFrame {
@@ -1185,30 +1070,7 @@ impl CallEngine {
         else {
             return;
         };
-        let packets = v.pipe.protect_video(au);
-        let report_layout = !v.local_layout_reported && !packets.is_empty();
-        if report_layout {
-            v.local_layout_reported = true;
-        }
-        for (index, packet) in packets.into_iter().enumerate() {
-            if report_layout
-                && index == 0
-                && let Some(header) = parse_rtp_header(&packet)
-                && let Some((extension_profile, extension_data)) =
-                    rtp_extension_profile_and_data(&packet)
-            {
-                self.outbox
-                    .push_back(Output::Event(CallEvent::VideoRtpLayoutSent {
-                        ssrc: header.ssrc,
-                        sequence_number: header.sequence_number,
-                        timestamp: header.timestamp,
-                        marker: header.marker,
-                        header_len: rtp_header_byte_length(&packet).unwrap_or_default(),
-                        packet_len: packet.len(),
-                        extension_profile,
-                        extension_data: extension_data.to_vec(),
-                    }));
-            }
+        for packet in v.pipe.protect_video(au) {
             self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
         }
     }
@@ -1275,6 +1137,7 @@ mod tests {
     use super::*;
     use crate::voip::e2e_srtp::SRTCP_AUTH_TAG_LEN;
     use crate::voip::mlow::MlowEncoder;
+    use crate::voip::rtcp::parse_rtcp_sender_ssrc;
     use crate::voip::warp::WARP_MI_TAG_LEN;
 
     const SELF_LID: &str = "111111111111111:0@lid";
@@ -2246,7 +2109,6 @@ mod tests {
                 feedback,
                 reports_audio: true,
                 reports_video: true,
-                protection: RtcpProtection::Transport,
                 ..
             }) if packet_types == &[RTCP_PT_RR, crate::voip::rtcp::RTCP_PT_PSFB]
                 && *sender_ssrc == peer_ssrc
@@ -2262,21 +2124,16 @@ mod tests {
         *forged.last_mut().unwrap() ^= 1;
         eng.handle_input(2, Input::RelayPacket(&forged));
         let (outs, _) = drain(&mut eng);
-        assert!(outs.iter().any(|output| matches!(
-            output,
-            Output::Event(CallEvent::RtcpRejected {
-                stage: RtcpRejectStage::Authentication,
-                packet_type: RTCP_PT_RR,
-                sender_ssrc,
-                candidate_srtcp_index: Some(0),
-                candidate_encrypted: true,
-                ..
-            }) if *sender_ssrc == peer_ssrc
-        )));
+        assert!(
+            !outs
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RtcpReceived { .. }))),
+            "forged SRTCP must be dropped"
+        );
     }
 
     #[test]
-    fn authenticated_malformed_rtcp_is_reported_as_a_parse_rejection() {
+    fn authenticated_malformed_rtcp_is_dropped() {
         use crate::voip::e2e_srtp::{derive_srtcp_keys, protect_srtcp};
         use crate::voip::rtcp::RTCP_PT_SDES;
 
@@ -2298,23 +2155,12 @@ mod tests {
         let _ = drain(&mut eng);
         eng.handle_input(1, Input::RelayPacket(&protected));
         let (outs, _) = drain(&mut eng);
-        assert!(outs.iter().any(|output| matches!(
-            output,
-            Output::Event(CallEvent::RtcpRejected {
-                stage: RtcpRejectStage::Parsing,
-                packet_type: RTCP_PT_SDES,
-                sender_ssrc,
-                packet_len,
-                first_rtcp_len: 12,
-                plain_len: Some(12),
-                candidate_srtcp_index: Some(3),
-                candidate_encrypted: true,
-                first_header_byte: 0x81,
-                plain_sample: Some(sample),
-            }) if *sender_ssrc == peer_ssrc
-                && *packet_len == protected.len()
-                && sample == &malformed
-        )));
+        assert!(
+            !outs
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RtcpReceived { .. }))),
+            "malformed RTCP must not surface as authenticated feedback"
+        );
     }
 
     #[test]
@@ -2613,17 +2459,6 @@ mod tests {
         let (outputs, _) = drain(&mut eng);
         let first = seq_of(&outputs);
         assert_eq!(first, vec![0]);
-        assert!(outputs.iter().any(|output| matches!(
-            output,
-            Output::Event(CallEvent::VideoRtpLayoutSent {
-                sequence_number: 0,
-                marker: true,
-                header_len: 28,
-                extension_profile: Some(0xdebe),
-                extension_data,
-                ..
-            }) if extension_data == &[0x30, 0x09, 0x51, 0, 0, 0x61, 0, 0, 0x91, 0, 0, 0]
-        )));
 
         // Downgrade then re-upgrade: the plane is preserved, so the next packet's seq CONTINUES.
         eng.disable_video();
@@ -2720,7 +2555,7 @@ mod tests {
     }
 
     #[test]
-    fn inbound_video_reports_authenticated_rtp_layout_once() {
+    fn inbound_video_rejects_forged_warp_tag() {
         let mut eng = engine(true);
         assert!(eng.enable_video());
         eng.start(0, 0);
@@ -2731,71 +2566,25 @@ mod tests {
             .protect_video(&video_au(100))
             .pop()
             .expect("single-packet video AU");
-        let expected = parse_rtp_header(&packet).expect("valid peer RTP");
 
         let mut forged = packet.clone();
         *forged.last_mut().expect("WARP tag") ^= 1;
         eng.handle_input(1, Input::RelayPacket(&forged));
         assert!(
-            !drain(&mut eng).0.iter().any(|output| matches!(
-                output,
-                Output::Event(CallEvent::VideoRtpLayoutObserved { .. })
-            )),
-            "unauthenticated RTP must not surface diagnostic bytes"
+            !drain(&mut eng)
+                .0
+                .iter()
+                .any(|output| matches!(output, Output::VideoPlayout(_))),
+            "unauthenticated RTP must not reach playout"
         );
 
         eng.handle_input(2, Input::RelayPacket(&packet));
-        let (outputs, _) = drain(&mut eng);
-        let layouts: Vec<_> = outputs
-            .iter()
-            .filter_map(|output| match output {
-                Output::Event(CallEvent::VideoRtpLayoutObserved {
-                    ssrc,
-                    sequence_number,
-                    timestamp,
-                    marker,
-                    header_len,
-                    packet_len,
-                    extension_profile,
-                    extension_data,
-                }) => Some((
-                    *ssrc,
-                    *sequence_number,
-                    *timestamp,
-                    *marker,
-                    *header_len,
-                    *packet_len,
-                    *extension_profile,
-                    extension_data.as_slice(),
-                )),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            layouts,
-            vec![(
-                expected.ssrc,
-                expected.sequence_number,
-                expected.timestamp,
-                expected.marker,
-                28,
-                packet.len(),
-                Some(0xdebe),
-                &[0x30, 0x09, 0x51, 0, 0, 0x61, 0, 0, 0x91, 0, 0, 0][..],
-            )]
-        );
-
-        let next = peer
-            .protect_video(&video_au(100))
-            .pop()
-            .expect("second single-packet video AU");
-        eng.handle_input(3, Input::RelayPacket(&next));
         assert!(
-            !drain(&mut eng).0.iter().any(|output| matches!(
-                output,
-                Output::Event(CallEvent::VideoRtpLayoutObserved { .. })
-            )),
-            "the stable RTP layout only needs one event"
+            drain(&mut eng)
+                .0
+                .iter()
+                .any(|output| matches!(output, Output::VideoPlayout(_))),
+            "authenticated RTP must reach playout"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -703,8 +703,10 @@ impl CallEngine {
             return false;
         };
         if let Some(v) = m.video.as_mut() {
+            let resuming_after_gate = v.send_gated && !send_gated;
             v.active = true;
             v.send_gated = send_gated;
+            v.keyframe_required |= resuming_after_gate;
             return true;
         }
         let rtcp_cname = build_whatsapp_rtcp_cname(&self.tx_ids.next_tx_id());
@@ -1001,7 +1003,7 @@ impl CallEngine {
             // dropped. The pipe still advances its recv ROC on drop-free packets it never sees, but
             // an inactive plane simply ignores them.
             if let Some(v) = m.video.as_mut().filter(|v| v.active)
-                && let Some((header, au)) = v.pipe.unprotect_video_packet(pkt)
+                && let Some((header, completed)) = v.pipe.unprotect_video_packet(pkt)
             {
                 v.reception.observe(
                     header.ssrc,
@@ -1010,7 +1012,7 @@ impl CallEngine {
                     now,
                     VIDEO_CLOCK_RATE,
                 );
-                if let Some(au) = au {
+                for au in completed {
                     let keyframe = au_is_keyframe(&au);
                     self.outbox.push_back(Output::VideoPlayout(VideoFrame {
                         data: au,
@@ -1946,7 +1948,7 @@ mod tests {
         assert_eq!(parse_rtcp_sender_ssrc(rtcp[0]), Some(audio_ssrc));
         assert_eq!(rtcp[0].len(), 32 + 4 + SRTCP_AUTH_TAG_LEN);
         let transport = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
-        let plain = unprotect_srtcp(&transport, audio_ssrc, rtcp[0]).unwrap();
+        let (plain, _) = unprotect_srtcp(&transport, audio_ssrc, rtcp[0]).unwrap();
         let summary = summarize_rtcp(&plain).unwrap();
         assert_eq!(summary.packet_types, [RTCP_PT_SDES]);
         assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
@@ -1976,7 +1978,7 @@ mod tests {
             let index = u32::from_be_bytes(packet[index_at..index_at + 4].try_into().unwrap())
                 & 0x7fff_ffff;
             assert_eq!(index, expected_index);
-            let plain = unprotect_srtcp(&transport, ssrc, packet).unwrap();
+            let (plain, _) = unprotect_srtcp(&transport, ssrc, packet).unwrap();
             let summary = summarize_rtcp(&plain).unwrap();
             assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
             assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
@@ -2049,7 +2051,7 @@ mod tests {
 
         assert_eq!(protected.len(), 76 + 32 + 4 + SRTCP_AUTH_TAG_LEN);
         let transport = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
-        let plain = unprotect_srtcp(&transport, local_video_ssrc, protected).unwrap();
+        let (plain, _) = unprotect_srtcp(&transport, local_video_ssrc, protected).unwrap();
         assert_eq!(&plain[..4], &[0x91, RTCP_PT_SR, 0, 18]);
         assert_eq!(&plain[28..32], &peer_video_ssrc.to_be_bytes());
         assert_eq!(&plain[52..76], &[0; 24]);
@@ -2090,7 +2092,7 @@ mod tests {
             .expect("RTCP tick emits an audio Sender Report");
         let sender_ssrc = parse_rtcp_sender_ssrc(protected).unwrap();
         let keys = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
-        let plain = unprotect_srtcp(&keys, sender_ssrc, protected).unwrap();
+        let (plain, _) = unprotect_srtcp(&keys, sender_ssrc, protected).unwrap();
         let ntp_seconds = u32::from_be_bytes(plain[8..12].try_into().unwrap());
         assert_eq!(
             ntp_seconds,
@@ -2602,13 +2604,19 @@ mod tests {
             "a gated plane must still decode inbound video"
         );
 
-        // Peer accepted -> ungate -> our video flows.
+        // Peer accepted -> deltas remain withheld until a decoder-safe IDR.
         assert!(eng.enable_video());
-        eng.handle_input(2, Input::VideoFrame(&video_au(200)));
+        eng.handle_input(2, Input::VideoFrame(&video_delta_au(200)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "ungating must not start with a delta whose references were gated"
+        );
+        eng.handle_input(3, Input::VideoFrame(&video_au(200)));
         assert_eq!(
             count_transmits(&drain(&mut eng).0),
             1,
-            "ungating must let our video onto the wire"
+            "the next IDR resumes outbound video"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -479,7 +479,7 @@ fn make_video_plane(
         reception: RtpReceptionStats::default(),
         active: true,
         send_gated: false,
-        keyframe_required: false,
+        keyframe_required: true,
     })
 }
 
@@ -703,10 +703,10 @@ impl CallEngine {
             return false;
         };
         if let Some(v) = m.video.as_mut() {
-            let resuming_after_gate = v.send_gated && !send_gated;
+            let needs_recovery = !v.active || (v.send_gated && !send_gated);
             v.active = true;
             v.send_gated = send_gated;
-            v.keyframe_required |= resuming_after_gate;
+            v.keyframe_required |= needs_recovery;
             return true;
         }
         let rtcp_cname = build_whatsapp_rtcp_cname(&self.tx_ids.next_tx_id());
@@ -1101,13 +1101,15 @@ impl CallEngine {
         else {
             return;
         };
-        if v.keyframe_required {
-            if !au_has_idr(au) {
-                return;
-            }
-            v.keyframe_required = false;
+        if v.keyframe_required && !au_has_idr(au) {
+            return;
         }
-        for packet in v.pipe.protect_video(au) {
+        let packets = v.pipe.protect_video(au);
+        if packets.is_empty() {
+            return;
+        }
+        v.keyframe_required = false;
+        for packet in packets {
             self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
         }
     }
@@ -2485,6 +2487,12 @@ mod tests {
         assert!(eng.is_video_enabled());
         eng.start(0, 0);
         let _ = drain(&mut eng);
+        eng.handle_input(1, Input::VideoFrame(&video_delta_au(300)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "from-start video must wait for a decoder-safe IDR"
+        );
         eng.handle_input(1, Input::VideoFrame(&video_au(3000)));
         let (outs, _) = drain(&mut eng);
         let transmits: Vec<&Bytes> = outs
@@ -2513,9 +2521,11 @@ mod tests {
         // Off: dropped.
         eng.handle_input(1, Input::VideoFrame(&au));
         assert_eq!(count_transmits(&drain(&mut eng).0), 0);
-        // Upgrade: transmits.
+        // Upgrade: dependent frames wait for the first IDR.
         assert!(eng.enable_video());
         assert!(eng.enable_video(), "enable_video must be idempotent");
+        eng.handle_input(2, Input::VideoFrame(&video_delta_au(200)));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 0);
         eng.handle_input(2, Input::VideoFrame(&au));
         assert_eq!(count_transmits(&drain(&mut eng).0), 1);
         // Downgrade: dropped again, audio untouched.
@@ -2565,6 +2575,8 @@ mod tests {
         eng.handle_input(2, Input::VideoFrame(&video_au(100))); // dropped while inactive
         assert!(seq_of(&drain(&mut eng).0).is_empty());
         assert!(eng.enable_video());
+        eng.handle_input(3, Input::VideoFrame(&video_delta_au(100)));
+        assert!(seq_of(&drain(&mut eng).0).is_empty());
         eng.handle_input(3, Input::VideoFrame(&video_au(100)));
         let after = seq_of(&drain(&mut eng).0);
         assert_eq!(
@@ -2572,6 +2584,28 @@ mod tests {
             vec![1],
             "re-enabled video must continue the sequence, not reset to 0 (keystream reuse)"
         );
+    }
+
+    #[test]
+    fn rejected_idr_packetization_keeps_the_recovery_gate_armed() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+
+        let oversized = video_au(crate::voip::h264::H264_MAX_AU_BYTES);
+        eng.handle_input(1, Input::VideoFrame(&oversized));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 0);
+
+        eng.handle_input(2, Input::VideoFrame(&video_delta_au(100)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "a rejected IDR must not admit dependent frames"
+        );
+
+        eng.handle_input(3, Input::VideoFrame(&video_au(100)));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 1);
     }
 
     // The upgrade initiator holds outbound video until the peer accepts: a send-gated plane decodes

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -18,7 +18,14 @@ use bytes::Bytes;
 
 use super::demux::{RelayPacketKind, classify_relay_packet};
 use super::h264::{VideoFrame, au_is_keyframe};
-use super::rtp::{RTP_PAYLOAD_TYPE_H264, VIDEO_TS_STRIDE_15FPS, parse_rtp_header};
+use super::rtcp::{
+    RtcpFeedback, RtcpReportBlock, RtpReceptionStats, build_whatsapp_rtcp_cname,
+    parse_rtcp_sender_ssrc, parse_sender_report_timing, rtcp_payload_type, summarize_rtcp,
+};
+use super::rtp::{
+    RTP_PAYLOAD_TYPE_H264, VIDEO_CLOCK_RATE, VIDEO_TS_STRIDE_15FPS, parse_rtp_header,
+    rtp_extension_profile_and_data, rtp_header_byte_length,
+};
 use super::session::{
     CallDirection, MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
 };
@@ -34,6 +41,8 @@ pub const NEVER: Millis = u64::MAX;
 /// Relay consent-freshness cadence: re-send the STUN allocate + a WA ping every second. The relay
 /// drops the client after ~4s without traffic, which is what makes the peer reconnect/terminate.
 const KEEPALIVE_MS: Millis = 1000;
+/// RTCP Sender-Report cadence. WhatsApp's `voip_settings` advertises `rtcp_interval_ms=1500`.
+const RTCP_MS: Millis = 1500;
 /// Deadline for the relay to ack the allocate. Past this with no success the relay is wedged
 /// (silently dropping the allocate), so surface a terminal timeout instead of keepaliving forever.
 const ALLOCATE_TIMEOUT_MS: Millis = 10_000;
@@ -60,6 +69,7 @@ const MLOW_DTX_CNG: [u8; 1] = [0x90];
 /// One 60ms MLow frame at 16kHz. `Input::MicFrame` must carry exactly this; a wrong-length buffer is
 /// dropped (the encoder requires it), never sent.
 const MIC_FRAME_SAMPLES: usize = 960;
+const AUDIO_CLOCK_RATE: u32 = 16_000;
 
 /// Supplies STUN transaction ids. Injected so the core stays RNG-free and deterministically
 /// testable. Production shells MUST back this with a real RNG (the ids gate consent freshness);
@@ -326,6 +336,17 @@ pub enum Output {
 }
 
 /// Lifecycle / diagnostic events the shell may act on or surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RtcpProtection {
+    Transport,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RtcpRejectStage {
+    Authentication,
+    Parsing,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CallEvent {
@@ -346,6 +367,65 @@ pub enum CallEvent {
         state: crate::types::call::VideoState,
         orientation: Option<u8>,
     },
+    /// Authenticated peer RTCP. A referenced local video SSRC proves the peer built a receiver for
+    /// our outbound stream; RR, NACK, PLI and FIR are all represented here.
+    RtcpReceived {
+        packet_types: Vec<u8>,
+        sender_ssrc: u32,
+        referenced_ssrcs: Vec<u32>,
+        reports_audio: bool,
+        reports_video: bool,
+        protection: RtcpProtection,
+        srtcp_index: Option<u32>,
+        encrypted: bool,
+        plain_len: usize,
+        sdes_cname_lengths: Vec<usize>,
+        report_blocks: Vec<RtcpReportBlock>,
+        feedback: Vec<RtcpFeedback>,
+        uses_whatsapp_profile_extension: bool,
+    },
+    /// An RTCP-shaped datagram failed SRTCP authentication or plaintext parsing.
+    RtcpRejected {
+        stage: RtcpRejectStage,
+        packet_type: u8,
+        sender_ssrc: u32,
+        packet_len: usize,
+        first_rtcp_len: usize,
+        plain_len: Option<usize>,
+        /// Standard SRTCP index inferred from the word before the 10-byte auth tag.
+        candidate_srtcp_index: Option<u32>,
+        candidate_encrypted: bool,
+        first_header_byte: u8,
+        /// First authenticated sample for this sender/layout, capped at 256 bytes.
+        plain_sample: Option<Vec<u8>>,
+    },
+    /// First authenticated inbound video packet's RTP extension layout.
+    VideoRtpLayoutObserved {
+        ssrc: u32,
+        sequence_number: u16,
+        timestamp: u32,
+        marker: bool,
+        header_len: usize,
+        packet_len: usize,
+        extension_profile: Option<u16>,
+        extension_data: Vec<u8>,
+    },
+    /// First outbound video packet's RTP extension layout, before relay transmission.
+    VideoRtpLayoutSent {
+        ssrc: u32,
+        sequence_number: u16,
+        timestamp: u32,
+        marker: bool,
+        header_len: usize,
+        packet_len: usize,
+        extension_profile: Option<u16>,
+        extension_data: Vec<u8>,
+    },
+    /// Relay-send backpressure discarded complete media units before transmission.
+    OutboundMediaDropped {
+        video_access_units: u32,
+        packets: u32,
+    },
 }
 
 /// The optional media plane: the SRTP pipeline, the MLow codec, an optional SFrame session, and
@@ -353,6 +433,7 @@ pub enum CallEvent {
 /// keys/ROC/RTP state, unprotect its recv keys/ROC, and those fields are disjoint.
 struct MediaState {
     pipe: MediaPipeline,
+    audio_reception: RtpReceptionStats,
     /// Retained so the caller can re-derive the recv keys once the answering device is known (the
     /// callee's `<accept>` carries its device LID). See [`CallEngine::rekey_recv`].
     call_key: Vec<u8>,
@@ -366,6 +447,8 @@ struct MediaState {
     warp_mi_tag_len: usize,
     /// The video plane, present while video is enabled (from the start or via upgrade).
     video: Option<VideoPlaneState>,
+    audio_rtcp_announced: bool,
+    rtcp_parse_samples: Vec<(u32, usize, u8)>,
     sframe: Option<SframeSession>,
     encoder: mlow::MlowEncoder,
     decoder: mlow::MlowDecoder,
@@ -391,7 +474,10 @@ struct MediaState {
 /// pad), so a downgrade must not drop it.
 struct VideoPlaneState {
     pipe: VideoPipeline,
+    reception: RtpReceptionStats,
     active: bool,
+    peer_layout_reported: bool,
+    local_layout_reported: bool,
     /// When set, inbound video still decodes but OUTBOUND AUs are dropped: the initiator of an
     /// upgrade holds its camera off the wire until the peer accepts (a `<video>` request the peer
     /// ignores must not leak our video). Cleared on the peer's UpgradeAccept/Enabled.
@@ -406,22 +492,29 @@ fn make_video_plane(
     self_lid: &str,
     recv_peer_lid: &str,
     warp_mi_tag_len: usize,
+    rtcp_cname: [u8; super::rtcp::WHATSAPP_RTCP_CNAME_LEN],
 ) -> Option<VideoPlaneState> {
     let video_ssrc = ssrc::derive_video_participant_ssrc(
         call_id,
         &ssrc::format_e2e_srtp_participant_id(self_lid),
     );
-    let pipe = VideoPipeline::new(&VideoPipelineParams {
-        call_key,
-        self_lid,
-        peer_lid: recv_peer_lid,
-        ssrc: video_ssrc,
-        ts_stride: VIDEO_TS_STRIDE_15FPS,
-        warp_mi_tag_len,
-    })?;
+    let pipe = VideoPipeline::new_with_rtcp_cname(
+        &VideoPipelineParams {
+            call_key,
+            self_lid,
+            peer_lid: recv_peer_lid,
+            ssrc: video_ssrc,
+            ts_stride: VIDEO_TS_STRIDE_15FPS,
+            warp_mi_tag_len,
+        },
+        rtcp_cname,
+    )?;
     Some(VideoPlaneState {
         pipe,
+        reception: RtpReceptionStats::default(),
         active: true,
+        peer_layout_reported: false,
+        local_layout_reported: false,
         send_gated: false,
     })
 }
@@ -437,6 +530,11 @@ pub struct CallEngine {
     allocate: Bytes,
     tx_ids: Box<dyn TxIdSource>,
     keepalive_deadline: Millis,
+    /// Next RTCP Sender-Report tick (NEVER until the relay allocates).
+    rtcp_deadline: Millis,
+    /// Mapping injected at start so SR NTP timestamps use wall time while scheduling stays monotonic.
+    rtcp_monotonic_origin: Millis,
+    rtcp_wallclock_origin_ms: u64,
     /// Deadline by which the allocate must be acked; NEVER once it is (or after firing the timeout).
     allocate_deadline: Millis,
     allocated: bool,
@@ -445,6 +543,9 @@ pub struct CallEngine {
     /// timer, no further transmits) so the driver tears the call down instead of keepaliving a
     /// dead relay forever.
     terminated: bool,
+    /// Our SRTP participant id (LID normalized to `<user>:<device>@lid`), the HKDF input for every
+    /// stream SSRC. Retained so the STUN allocate announces this call's live SSRCs.
+    self_participant_id: String,
     // Media plane (None = control plane only, e.g. esp32).
     media: Option<MediaState>,
     /// Peer device orientation (0..3, ×90°) from the last `<video device_orientation>`; stamped on
@@ -469,19 +570,23 @@ impl CallEngine {
             err(Debug)
         )
     )]
-    pub fn new(config: CallConfig, tx_ids: Box<dyn TxIdSource>) -> Result<Self, EngineError> {
+    pub fn new(config: CallConfig, mut tx_ids: Box<dyn TxIdSource>) -> Result<Self, EngineError> {
         let endpoint_xor = stun::encode_xor_relay_endpoint(&config.relay_ip, config.relay_port)
             .ok_or(EngineError::BadEndpoint)?;
 
         let media = if config.enable_media {
-            let pipe = MediaPipeline::new(&MediaPipelineParams {
-                call_key: &config.call_key,
-                self_lid: &config.self_lid,
-                peer_lid: &config.peer_lid,
-                ssrc: config.ssrc,
-                samples_per_packet: config.samples_per_packet,
-                warp_mi_tag_len: config.warp_mi_tag_len,
-            })
+            let audio_rtcp_cname = build_whatsapp_rtcp_cname(&tx_ids.next_tx_id());
+            let pipe = MediaPipeline::new_with_rtcp_cname(
+                &MediaPipelineParams {
+                    call_key: &config.call_key,
+                    self_lid: &config.self_lid,
+                    peer_lid: &config.peer_lid,
+                    ssrc: config.ssrc,
+                    samples_per_packet: config.samples_per_packet,
+                    warp_mi_tag_len: config.warp_mi_tag_len,
+                },
+                audio_rtcp_cname,
+            )
             .ok_or(EngineError::BadCallKey)?;
             let sframe = if config.enable_sframe {
                 SframeSession::new(&config.call_key, &config.self_lid, &config.peer_lid)
@@ -489,6 +594,7 @@ impl CallEngine {
                 None
             };
             let video = if config.enable_video {
+                let video_rtcp_cname = build_whatsapp_rtcp_cname(&tx_ids.next_tx_id());
                 Some(
                     make_video_plane(
                         &config.call_id,
@@ -496,6 +602,7 @@ impl CallEngine {
                         &config.self_lid,
                         &config.peer_lid,
                         config.warp_mi_tag_len,
+                        video_rtcp_cname,
                     )
                     .ok_or(EngineError::BadCallKey)?,
                 )
@@ -504,11 +611,14 @@ impl CallEngine {
             };
             Some(MediaState {
                 pipe,
+                audio_reception: RtpReceptionStats::default(),
                 call_key: config.call_key.clone(),
                 self_lid: config.self_lid.clone(),
                 recv_peer_lid: config.peer_lid.clone(),
                 warp_mi_tag_len: config.warp_mi_tag_len,
                 video,
+                audio_rtcp_announced: false,
+                rtcp_parse_samples: Vec::new(),
                 sframe,
                 encoder: mlow::MlowEncoder::new(),
                 decoder: mlow::MlowDecoder::new(),
@@ -531,10 +641,14 @@ impl CallEngine {
             allocate: Bytes::new(),
             tx_ids,
             keepalive_deadline: 0,
+            rtcp_deadline: NEVER,
+            rtcp_monotonic_origin: 0,
+            rtcp_wallclock_origin_ms: 0,
             allocate_deadline: 0,
             allocated: false,
             started: false,
             terminated: false,
+            self_participant_id: ssrc::format_e2e_srtp_participant_id(&config.self_lid),
             media,
             peer_video_orientation: 0,
             outbox: VecDeque::new(),
@@ -604,7 +718,6 @@ impl CallEngine {
     /// A plane built by an earlier upgrade is REACTIVATED, not rebuilt, so its SRTP send seq/ROC
     /// continue (rebuilding would repeat the keystream under the same key+SSRC).
     fn enable_video_inner(&mut self, send_gated: bool) -> bool {
-        let call_id = &self.call_id;
         let Some(m) = self.media.as_mut() else {
             return false;
         };
@@ -613,12 +726,15 @@ impl CallEngine {
             v.send_gated = send_gated;
             return true;
         }
+        let rtcp_cname = build_whatsapp_rtcp_cname(&self.tx_ids.next_tx_id());
+        let call_id = &self.call_id;
         match make_video_plane(
             call_id,
             &m.call_key,
             &m.self_lid,
             &m.recv_peer_lid,
             m.warp_mi_tag_len,
+            rtcp_cname,
         ) {
             Some(mut v) => {
                 v.send_gated = send_gated;
@@ -644,13 +760,15 @@ impl CallEngine {
         self.peer_video_orientation = orientation & 0x03;
     }
 
-    /// Begin the media session: build and emit the initial STUN allocate and arm the keepalive
-    /// (and playout, if media is enabled) timers. Idempotent.
-    pub fn start(&mut self, now: Millis) {
+    /// Begin the media session with separate monotonic and Unix clocks. RTCP scheduling must not
+    /// leak wall-clock jumps, while Sender Reports require a real NTP epoch. Idempotent.
+    pub fn start(&mut self, now: Millis, wallclock_ms: u64) {
         if self.started {
             return;
         }
         self.started = true;
+        self.rtcp_monotonic_origin = now;
+        self.rtcp_wallclock_origin_ms = wallclock_ms;
         let tx = self.tx_ids.next_tx_id();
         // Built once here; the 1s keepalive re-sends it, so store it as Bytes and refcount-clone
         // rather than re-allocating the buffer every tick.
@@ -659,6 +777,8 @@ impl CallEngine {
             &self.relay_token,
             &self.endpoint_xor,
             &self.integrity_key,
+            &self.call_id,
+            &self.self_participant_id,
         ));
         self.outbox
             .push_back(Output::Transmit(self.allocate.clone()));
@@ -677,7 +797,7 @@ impl CallEngine {
         }
         match input {
             Input::Timeout => self.on_timeout(now),
-            Input::RelayPacket(pkt) => self.on_packet(pkt),
+            Input::RelayPacket(pkt) => self.on_packet(now, pkt),
             Input::MicFrame(pcm) => self.on_mic(pcm),
             Input::VideoFrame(au) => self.on_video(au),
         }
@@ -704,6 +824,7 @@ impl CallEngine {
         }
         if let Some(m) = &self.media {
             next = next.min(m.playout_deadline);
+            next = next.min(self.rtcp_deadline);
         }
         Some(next)
     }
@@ -748,18 +869,149 @@ impl CallEngine {
             m.playout_deadline = next_tick(m.playout_deadline, now, PLAYOUT_MS);
             self.outbox.push_back(Output::Playout(frame));
         }
-    }
-
-    fn on_packet(&mut self, pkt: &[u8]) {
-        match classify_relay_packet(pkt) {
-            RelayPacketKind::Stun => self.on_stun(pkt),
-            RelayPacketKind::Rtp => self.on_rtp(pkt),
-            // RTCP / other: no behavior yet (stats are a later concern).
-            RelayPacketKind::Rtcp | RelayPacketKind::Other => {}
+        if self.started && self.allocated && self.media.is_some() && now >= self.rtcp_deadline {
+            self.emit_sender_reports(now, self.rtcp_wallclock_at(now));
+            self.rtcp_deadline = next_tick(self.rtcp_deadline, now, RTCP_MS);
         }
     }
 
-    fn on_stun(&mut self, pkt: &[u8]) {
+    fn rtcp_wallclock_at(&self, monotonic_now: Millis) -> u64 {
+        self.rtcp_wallclock_origin_ms
+            .saturating_add(monotonic_now.saturating_sub(self.rtcp_monotonic_origin))
+    }
+
+    fn announce_audio_rtcp_session(&mut self) {
+        let Some(m) = self.media.as_mut().filter(|m| !m.audio_rtcp_announced) else {
+            return;
+        };
+        let packet = m.pipe.audio_source_description();
+        m.audio_rtcp_announced = true;
+        self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+    }
+
+    /// Audio and video share one wall-clock sample for lip sync.
+    fn emit_sender_reports(&mut self, monotonic_ms: Millis, wallclock_ms: u64) {
+        let Some(m) = self.media.as_mut() else {
+            return;
+        };
+        let audio_report = m.audio_reception.report(monotonic_ms);
+        let audio_sr = m
+            .pipe
+            .audio_sender_report(wallclock_ms, audio_report.as_ref());
+        self.outbox
+            .push_back(Output::Transmit(Bytes::from(audio_sr)));
+        if let Some(v) = m.video.as_mut().filter(|v| v.active && !v.send_gated) {
+            let video_report = v.reception.report(monotonic_ms);
+            let video_sr = v
+                .pipe
+                .video_sender_report(wallclock_ms, video_report.as_ref());
+            self.outbox
+                .push_back(Output::Transmit(Bytes::from(video_sr)));
+        }
+    }
+
+    fn on_packet(&mut self, now: Millis, pkt: &[u8]) {
+        match classify_relay_packet(pkt) {
+            RelayPacketKind::Stun => self.on_stun(now, pkt),
+            RelayPacketKind::Rtp => self.on_rtp(now, pkt),
+            RelayPacketKind::Rtcp => self.on_rtcp(now, pkt),
+            RelayPacketKind::Other => {}
+        }
+    }
+
+    fn on_rtcp(&mut self, now: Millis, pkt: &[u8]) {
+        let (Some(packet_type), Some(sender_ssrc)) =
+            (rtcp_payload_type(pkt), parse_rtcp_sender_ssrc(pkt))
+        else {
+            return;
+        };
+        let trailer_word = pkt
+            .len()
+            .checked_sub(14)
+            .and_then(|offset| pkt.get(offset..offset + 4));
+        let candidate_srtcp_index = trailer_word
+            .map(|word| u32::from_be_bytes([word[0], word[1], word[2], word[3]]) & 0x7fff_ffff);
+        let candidate_encrypted = trailer_word.is_some_and(|word| word[0] & 0x80 != 0);
+        let rejected = |stage, plain_len, plain_sample| CallEvent::RtcpRejected {
+            stage,
+            packet_type,
+            sender_ssrc,
+            packet_len: pkt.len(),
+            first_rtcp_len: u16::from_be_bytes([pkt[2], pkt[3]]) as usize * 4 + 4,
+            plain_len,
+            candidate_srtcp_index,
+            candidate_encrypted,
+            first_header_byte: pkt[0],
+            plain_sample,
+        };
+        let event = {
+            let Some(m) = self.media.as_mut() else {
+                return;
+            };
+            let audio_ssrc = m.pipe.send_ssrc();
+            let video_ssrc = m.video.as_ref().map(|v| v.pipe.send_ssrc());
+            let Some(plain) = m.pipe.unprotect_rtcp(pkt) else {
+                self.outbox.push_back(Output::Event(rejected(
+                    RtcpRejectStage::Authentication,
+                    None,
+                    None,
+                )));
+                return;
+            };
+            let plain_len = plain.len();
+            match summarize_rtcp(&plain) {
+                Some(summary) => {
+                    if let Some((sender, ntp_seconds, ntp_fraction)) =
+                        parse_sender_report_timing(&plain)
+                    {
+                        m.audio_reception.observe_sender_report(
+                            sender,
+                            ntp_seconds,
+                            ntp_fraction,
+                            now,
+                        );
+                        if let Some(v) = m.video.as_mut() {
+                            v.reception.observe_sender_report(
+                                sender,
+                                ntp_seconds,
+                                ntp_fraction,
+                                now,
+                            );
+                        }
+                    }
+                    CallEvent::RtcpReceived {
+                        reports_audio: summary.referenced_ssrcs.contains(&audio_ssrc),
+                        reports_video: video_ssrc
+                            .is_some_and(|ssrc| summary.referenced_ssrcs.contains(&ssrc)),
+                        packet_types: summary.packet_types,
+                        sender_ssrc: summary.sender_ssrc,
+                        referenced_ssrcs: summary.referenced_ssrcs,
+                        protection: RtcpProtection::Transport,
+                        srtcp_index: candidate_srtcp_index,
+                        encrypted: candidate_encrypted,
+                        plain_len,
+                        sdes_cname_lengths: summary.sdes_cname_lengths,
+                        report_blocks: summary.report_blocks,
+                        feedback: summary.feedback,
+                        uses_whatsapp_profile_extension: summary.uses_whatsapp_profile_extension,
+                    }
+                }
+                None => {
+                    let layout = (sender_ssrc, plain_len, plain[0]);
+                    let plain_sample = if m.rtcp_parse_samples.contains(&layout) {
+                        None
+                    } else {
+                        m.rtcp_parse_samples.push(layout);
+                        Some(plain.into_iter().take(256).collect())
+                    };
+                    rejected(RtcpRejectStage::Parsing, Some(plain_len), plain_sample)
+                }
+            }
+        };
+        self.outbox.push_back(Output::Event(event));
+    }
+
+    fn on_stun(&mut self, now: Millis, pkt: &[u8]) {
         // Consent freshness (RFC 7675): answer a binding request with a binding success.
         if stun::stun_message_type(pkt) == Some(stun::MSG_BINDING_REQUEST)
             && let Some(req_tx) = stun::stun_transaction_id(pkt)
@@ -784,6 +1036,10 @@ impl CallEngine {
             tracing::debug!(call_id = %self.call_id, "voip relay allocated");
             self.outbox
                 .push_back(Output::Event(CallEvent::RelayAllocated));
+            if self.media.is_some() {
+                self.rtcp_deadline = now + RTCP_MS;
+                self.announce_audio_rtcp_session();
+            }
             return;
         }
         // A complete allocate-error (a parsed ERROR-CODE) terminates the call; STUN-typed garbage
@@ -802,7 +1058,7 @@ impl CallEngine {
         }
     }
 
-    fn on_rtp(&mut self, pkt: &[u8]) {
+    fn on_rtp(&mut self, now: Millis, pkt: &[u8]) {
         let Some(m) = self.media.as_mut() else {
             return;
         };
@@ -814,20 +1070,53 @@ impl CallEngine {
             // dropped. The pipe still advances its recv ROC on drop-free packets it never sees, but
             // an inactive plane simply ignores them.
             if let Some(v) = m.video.as_mut().filter(|v| v.active)
-                && let Some(au) = v.pipe.unprotect_video(pkt)
+                && let Some((header, au)) = v.pipe.unprotect_video_packet(pkt)
             {
-                let keyframe = au_is_keyframe(&au);
-                self.outbox.push_back(Output::VideoPlayout(VideoFrame {
-                    data: au,
-                    keyframe,
-                    orientation: self.peer_video_orientation,
-                }));
+                v.reception.observe(
+                    header.ssrc,
+                    header.sequence_number,
+                    header.timestamp,
+                    now,
+                    VIDEO_CLOCK_RATE,
+                );
+                if !v.peer_layout_reported
+                    && let Some((extension_profile, extension_data)) =
+                        rtp_extension_profile_and_data(pkt)
+                {
+                    v.peer_layout_reported = true;
+                    self.outbox
+                        .push_back(Output::Event(CallEvent::VideoRtpLayoutObserved {
+                            ssrc: header.ssrc,
+                            sequence_number: header.sequence_number,
+                            timestamp: header.timestamp,
+                            marker: header.marker,
+                            header_len: rtp_header_byte_length(pkt).unwrap_or_default(),
+                            packet_len: pkt.len(),
+                            extension_profile,
+                            extension_data: extension_data.to_vec(),
+                        }));
+                }
+                if let Some(au) = au {
+                    let keyframe = au_is_keyframe(&au);
+                    self.outbox.push_back(Output::VideoPlayout(VideoFrame {
+                        data: au,
+                        keyframe,
+                        orientation: self.peer_video_orientation,
+                    }));
+                }
             }
             return;
         }
-        let Some((_, payload)) = m.pipe.unprotect_audio(pkt) else {
+        let Some((header, payload)) = m.pipe.unprotect_audio(pkt) else {
             return;
         };
+        m.audio_reception.observe(
+            header.ssrc,
+            header.sequence_number,
+            header.timestamp,
+            now,
+            AUDIO_CLOCK_RATE,
+        );
         // SFrame on: use the GCM-decrypted bytes; otherwise the SRTP payload is already plain Opus.
         let opus = match m.sframe.as_ref().map(|s| s.decrypt(&payload)) {
             Some(SframeIn::Decrypted(plain)) => plain,
@@ -896,7 +1185,30 @@ impl CallEngine {
         else {
             return;
         };
-        for packet in v.pipe.protect_video(au) {
+        let packets = v.pipe.protect_video(au);
+        let report_layout = !v.local_layout_reported && !packets.is_empty();
+        if report_layout {
+            v.local_layout_reported = true;
+        }
+        for (index, packet) in packets.into_iter().enumerate() {
+            if report_layout
+                && index == 0
+                && let Some(header) = parse_rtp_header(&packet)
+                && let Some((extension_profile, extension_data)) =
+                    rtp_extension_profile_and_data(&packet)
+            {
+                self.outbox
+                    .push_back(Output::Event(CallEvent::VideoRtpLayoutSent {
+                        ssrc: header.ssrc,
+                        sequence_number: header.sequence_number,
+                        timestamp: header.timestamp,
+                        marker: header.marker,
+                        header_len: rtp_header_byte_length(&packet).unwrap_or_default(),
+                        packet_len: packet.len(),
+                        extension_profile,
+                        extension_data: extension_data.to_vec(),
+                    }));
+            }
             self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
         }
     }
@@ -961,6 +1273,7 @@ fn drain_playout(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::voip::e2e_srtp::SRTCP_AUTH_TAG_LEN;
     use crate::voip::mlow::MlowEncoder;
     use crate::voip::warp::WARP_MI_TAG_LEN;
 
@@ -993,7 +1306,8 @@ mod tests {
     // redaction on the sibling key structs. Pins the manual Debug against a `#[derive(Debug)]` regression.
     #[test]
     fn call_config_debug_redacts_key_material() {
-        let dbg = format!("{:?}", config(true));
+        let cfg = config(true);
+        let dbg = format!("{cfg:?}");
         assert!(
             dbg.contains("call_key: \"[redacted]\""),
             "callKey not redacted"
@@ -1272,7 +1586,7 @@ mod tests {
     fn start_emits_allocate_and_arms_playout_first() {
         let mut eng = engine(true);
         assert_eq!(eng.poll_timeout(), None);
-        eng.start(0);
+        eng.start(0, 0);
         let (outs, deadline) = drain(&mut eng);
         // The initial allocate is the only transmit; playout (20ms) is the nearer deadline.
         assert_eq!(count_transmits(&outs), 1);
@@ -1285,7 +1599,7 @@ mod tests {
     fn control_plane_only_arms_keepalive_no_playout() {
         // esp32-style: no media. The only deadline is the 1s keepalive, and mic frames are ignored.
         let mut eng = engine(false);
-        eng.start(0);
+        eng.start(0, 0);
         let (outs, deadline) = drain(&mut eng);
         assert_eq!(count_transmits(&outs), 1); // allocate
         assert_eq!(deadline, KEEPALIVE_MS);
@@ -1298,7 +1612,7 @@ mod tests {
     #[test]
     fn keepalive_fires_allocate_and_ping() {
         let mut eng = engine(false);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(KEEPALIVE_MS, Input::Timeout);
         let (outs, deadline) = drain(&mut eng);
@@ -1310,7 +1624,7 @@ mod tests {
     #[test]
     fn playout_emits_silence_every_tick() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(PLAYOUT_MS, Input::Timeout);
         let (outs, deadline) = drain(&mut eng);
@@ -1327,7 +1641,7 @@ mod tests {
     #[test]
     fn binding_request_gets_binding_success() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let req =
             stun::encode_stun_request(stun::MSG_BINDING_REQUEST, &[7u8; 12], &[], None, false);
@@ -1346,7 +1660,7 @@ mod tests {
     #[test]
     fn allocate_success_emits_event_once() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let ok =
             stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
@@ -1373,7 +1687,7 @@ mod tests {
     #[test]
     fn mic_drops_wrong_length_frames() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         // A wrong-length all-zero buffer must not reach the DTX fast-path: it is dropped, not sent.
         eng.handle_input(1, Input::MicFrame(&[0i16; 480]));
@@ -1399,7 +1713,7 @@ mod tests {
     #[test]
     fn mic_mute_emits_dtx_keepalive_not_a_gap() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         // OS mute delivers exact-zero frames; each must still transmit a DTX comfort-noise frame so
         // the peer's media-liveness timer stays fed (a gap makes the peer re-negotiate the transport).
@@ -1452,7 +1766,7 @@ mod tests {
         // must SRTP-decrypt, MLow-decode, and drain them to the speaker as non-silent audio. Two
         // frames are sent so the playout prebuffer reaches PLAYOUT_TARGET and starts draining.
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
 
         let call_key: Vec<u8> = (0u8..32).collect();
@@ -1494,7 +1808,7 @@ mod tests {
     #[test]
     fn rekey_recv_switches_inbound_to_answering_device() {
         let mut eng = engine(true); // recv keyed to PEER_LID = "222...:0@lid" (the dialed base)
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
 
         let call_key: Vec<u8> = (0u8..32).collect();
@@ -1549,7 +1863,7 @@ mod tests {
     #[test]
     fn merged_deadline_is_the_nearer_of_keepalive_and_playout() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         // Playout (20) is nearer than keepalive (1000) right after start.
         assert_eq!(eng.poll_timeout(), Some(PLAYOUT_MS));
@@ -1561,7 +1875,7 @@ mod tests {
     #[test]
     fn inbound_burst_keeps_jitter_bounded() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let call_key: Vec<u8> = (0u8..32).collect();
         let mut peer_tx = MediaPipeline::new(&MediaPipelineParams {
@@ -1595,7 +1909,7 @@ mod tests {
     #[test]
     fn standard_opus_payload_routes_to_foreign_audio() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let call_key: Vec<u8> = (0u8..32).collect();
         let mut peer_tx = MediaPipeline::new(&MediaPipelineParams {
@@ -1632,7 +1946,7 @@ mod tests {
         let mut cfg = config(true);
         cfg.enable_sframe = true;
         let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let call_key: Vec<u8> = (0u8..32).collect();
         let mut peer_tx = MediaPipeline::new(&MediaPipelineParams {
@@ -1672,12 +1986,11 @@ mod tests {
         );
     }
 
-    // At t = 1000 the 1s keepalive and the 20ms playout deadlines coincide; one on_timeout must fire
-    // BOTH: the keepalive transmits (allocate + ping) and exactly one playout frame.
+    // At t = 1000 the keepalive and playout deadlines coincide; one timeout must fire both.
     #[test]
     fn coincident_keepalive_and_playout_both_fire() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(KEEPALIVE_MS, Input::Timeout);
         let (outs, _) = drain(&mut eng);
@@ -1691,12 +2004,365 @@ mod tests {
         );
     }
 
+    // Native parity: audio announces SDES once after transport association; video has no initial
+    // packet. The first periodic tick then sends independent audio/video SR+SDES compounds.
+    #[test]
+    fn rtcp_sender_reports_emitted_for_audio_and_video() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys, unprotect_srtcp};
+        use crate::voip::rtcp::{RTCP_PT_SDES, RTCP_PT_SR, WHATSAPP_RTCP_CNAME_LEN};
+
+        let mut cfg = config(true);
+        cfg.enable_video = true;
+        let call_key = cfg.call_key.clone();
+        let audio_ssrc = cfg.ssrc;
+        let video_ssrc = ssrc::derive_video_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.self_lid),
+        );
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+
+        // RTCP cannot precede a usable transport.
+        eng.handle_input(RTCP_MS, Input::Timeout);
+        let (outs, _) = drain(&mut eng);
+        assert!(outs.iter().all(|output| !matches!(
+            output,
+            Output::Transmit(packet)
+                if classify_relay_packet(packet) == RelayPacketKind::Rtcp
+        )));
+
+        let allocate =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocated_at = RTCP_MS + 1;
+        eng.handle_input(allocated_at, Input::RelayPacket(&allocate));
+        let (outs, _) = drain(&mut eng);
+        let rtcp: Vec<&Bytes> = outs
+            .iter()
+            .filter_map(|o| match o {
+                Output::Transmit(b) if classify_relay_packet(b) == RelayPacketKind::Rtcp => Some(b),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rtcp.len(), 1, "only audio sends an initial SDES");
+        assert_eq!(parse_rtcp_sender_ssrc(rtcp[0]), Some(audio_ssrc));
+        assert_eq!(rtcp[0].len(), 32 + 4 + SRTCP_AUTH_TAG_LEN);
+        let transport = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
+        let plain = unprotect_srtcp(&transport, audio_ssrc, rtcp[0]).unwrap();
+        let summary = summarize_rtcp(&plain).unwrap();
+        assert_eq!(summary.packet_types, [RTCP_PT_SDES]);
+        assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
+
+        eng.handle_input(allocated_at + RTCP_MS, Input::Timeout);
+        let (outs, _) = drain(&mut eng);
+        let rtcp: Vec<&Bytes> = outs
+            .iter()
+            .filter_map(|output| match output {
+                Output::Transmit(packet)
+                    if classify_relay_packet(packet) == RelayPacketKind::Rtcp =>
+                {
+                    Some(packet)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rtcp.len(), 2, "one periodic compound per active stream");
+        for (ssrc, expected_index) in [(audio_ssrc, 2), (video_ssrc, 1)] {
+            let packet = rtcp
+                .iter()
+                .copied()
+                .find(|packet| parse_rtcp_sender_ssrc(packet) == Some(ssrc))
+                .expect("stream RTCP packet");
+            assert_eq!(packet.len(), 60 + 4 + SRTCP_AUTH_TAG_LEN);
+            let index_at = packet.len() - SRTCP_AUTH_TAG_LEN - 4;
+            let index = u32::from_be_bytes(packet[index_at..index_at + 4].try_into().unwrap())
+                & 0x7fff_ffff;
+            assert_eq!(index, expected_index);
+            let plain = unprotect_srtcp(&transport, ssrc, packet).unwrap();
+            let summary = summarize_rtcp(&plain).unwrap();
+            assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
+            assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
+        }
+    }
+
+    #[test]
+    fn video_sender_report_carries_native_video_reception_block() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys, unprotect_srtcp};
+        use crate::voip::rtcp::{RTCP_PT_SDES, RTCP_PT_SR};
+
+        let mut cfg = config(true);
+        cfg.enable_video = true;
+        let call_key = cfg.call_key.clone();
+        let local_video_ssrc = ssrc::derive_video_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.self_lid),
+        );
+        let peer_audio_ssrc = ssrc::derive_wasm_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.peer_lid),
+            0,
+        );
+        let peer_video_ssrc = ssrc::derive_video_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.peer_lid),
+        );
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 1_700_000_000_000);
+        let _ = drain(&mut eng);
+        let allocate =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        eng.handle_input(1, Input::RelayPacket(&allocate));
+        let _ = drain(&mut eng);
+
+        let mut peer_audio = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: peer_audio_ssrc,
+            samples_per_packet: SAMPLES,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap();
+        let audio = peer_audio.protect_audio(&[0xf8, 0xff, 0xfe]);
+        eng.handle_input(100, Input::RelayPacket(&audio));
+        let _ = drain(&mut eng);
+
+        let mut peer_video = peer_video_pipe();
+        let video = peer_video
+            .protect_video(&video_au(100))
+            .pop()
+            .expect("one-packet video AU");
+        eng.handle_input(101, Input::RelayPacket(&video));
+        let _ = drain(&mut eng);
+
+        eng.handle_input(1 + RTCP_MS, Input::Timeout);
+        let (outs, _) = drain(&mut eng);
+        let protected = outs
+            .iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet)
+                    if parse_rtcp_sender_ssrc(packet) == Some(local_video_ssrc) =>
+                {
+                    Some(packet)
+                }
+                _ => None,
+            })
+            .expect("video Sender Report");
+
+        assert_eq!(protected.len(), 76 + 32 + 4 + SRTCP_AUTH_TAG_LEN);
+        let transport = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
+        let plain = unprotect_srtcp(&transport, local_video_ssrc, protected).unwrap();
+        assert_eq!(&plain[..4], &[0x91, RTCP_PT_SR, 0, 18]);
+        assert_eq!(&plain[28..32], &peer_video_ssrc.to_be_bytes());
+        assert_eq!(&plain[52..76], &[0; 24]);
+        assert_eq!(&plain[76..80], &[0x91, RTCP_PT_SDES, 0, 7]);
+        let summary = summarize_rtcp(&plain).unwrap();
+        assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
+        assert_eq!(summary.referenced_ssrcs, [peer_video_ssrc]);
+        assert_eq!(summary.report_blocks.len(), 1);
+        assert_eq!(summary.report_blocks[0].profile_extension, [0; 24]);
+        assert!(summary.uses_whatsapp_profile_extension);
+    }
+
+    #[test]
+    fn sender_report_uses_unix_wallclock_not_monotonic_time() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys, unprotect_srtcp};
+
+        const UNIX_START_MS: u64 = 1_700_000_000_250;
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut eng = engine(true);
+        eng.start(100, UNIX_START_MS);
+        let _ = drain(&mut eng);
+        let allocate =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        eng.handle_input(100, Input::RelayPacket(&allocate));
+        let _ = drain(&mut eng);
+        eng.handle_input(100 + RTCP_MS, Input::Timeout);
+        let (outs, _) = drain(&mut eng);
+        let protected = outs
+            .iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet)
+                    if classify_relay_packet(packet) == RelayPacketKind::Rtcp =>
+                {
+                    Some(packet)
+                }
+                _ => None,
+            })
+            .expect("RTCP tick emits an audio Sender Report");
+        let sender_ssrc = parse_rtcp_sender_ssrc(protected).unwrap();
+        let keys = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
+        let plain = unprotect_srtcp(&keys, sender_ssrc, protected).unwrap();
+        let ntp_seconds = u32::from_be_bytes(plain[8..12].try_into().unwrap());
+        assert_eq!(
+            ntp_seconds,
+            (2_208_988_800 + (UNIX_START_MS + RTCP_MS) / 1000) as u32
+        );
+    }
+
+    #[test]
+    fn authenticated_receiver_report_identifies_local_video_ssrc() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys, protect_srtcp};
+        use crate::voip::rtcp::RTCP_PT_RR;
+
+        let mut cfg = config(true);
+        cfg.enable_video = true;
+        let call_key = cfg.call_key.clone();
+        let audio_ssrc = cfg.ssrc;
+        let video_ssrc = ssrc::derive_video_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.self_lid),
+        );
+        let peer_ssrc = ssrc::derive_wasm_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.peer_lid),
+            0,
+        );
+
+        // Receiver Report with one block for audio and one for video, followed by a video PLI.
+        let mut rr = vec![0x82, RTCP_PT_RR, 0, 13];
+        rr.extend_from_slice(&peer_ssrc.to_be_bytes());
+        for reported in [audio_ssrc, video_ssrc] {
+            rr.extend_from_slice(&reported.to_be_bytes());
+            rr.extend_from_slice(&[0; 20]);
+        }
+        rr.extend_from_slice(&[0x81, crate::voip::rtcp::RTCP_PT_PSFB, 0, 2]);
+        rr.extend_from_slice(&peer_ssrc.to_be_bytes());
+        rr.extend_from_slice(&video_ssrc.to_be_bytes());
+        let peer_keys = derive_srtcp_keys(&call_key, PEER_LID).unwrap();
+        let protected = protect_srtcp(&peer_keys, peer_ssrc, 0, &rr);
+
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+        eng.handle_input(1, Input::RelayPacket(&protected));
+        let (outs, _) = drain(&mut eng);
+        assert!(outs.iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::RtcpReceived {
+                packet_types,
+                sender_ssrc,
+                referenced_ssrcs,
+                feedback,
+                reports_audio: true,
+                reports_video: true,
+                protection: RtcpProtection::Transport,
+                ..
+            }) if packet_types == &[RTCP_PT_RR, crate::voip::rtcp::RTCP_PT_PSFB]
+                && *sender_ssrc == peer_ssrc
+                && referenced_ssrcs.contains(&audio_ssrc)
+                && referenced_ssrcs.contains(&video_ssrc)
+                && feedback.iter().any(|item| item.packet_type == crate::voip::rtcp::RTCP_PT_PSFB
+                    && item.fmt == 1
+                    && item.media_ssrc == video_ssrc
+                    && item.fci.is_empty())
+        )));
+
+        let mut forged = protected;
+        *forged.last_mut().unwrap() ^= 1;
+        eng.handle_input(2, Input::RelayPacket(&forged));
+        let (outs, _) = drain(&mut eng);
+        assert!(outs.iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::RtcpRejected {
+                stage: RtcpRejectStage::Authentication,
+                packet_type: RTCP_PT_RR,
+                sender_ssrc,
+                candidate_srtcp_index: Some(0),
+                candidate_encrypted: true,
+                ..
+            }) if *sender_ssrc == peer_ssrc
+        )));
+    }
+
+    #[test]
+    fn authenticated_malformed_rtcp_is_reported_as_a_parse_rejection() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys, protect_srtcp};
+        use crate::voip::rtcp::RTCP_PT_SDES;
+
+        let cfg = config(true);
+        let call_key = cfg.call_key.clone();
+        let peer_ssrc = ssrc::derive_wasm_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.peer_lid),
+            0,
+        );
+        let mut malformed = vec![0x81, RTCP_PT_SDES, 0, 2];
+        malformed.extend_from_slice(&peer_ssrc.to_be_bytes());
+        malformed.extend_from_slice(&[1, 18, 0, 0]);
+        let peer_keys = derive_srtcp_keys(&call_key, PEER_LID).unwrap();
+        let protected = protect_srtcp(&peer_keys, peer_ssrc, 3, &malformed);
+
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+        eng.handle_input(1, Input::RelayPacket(&protected));
+        let (outs, _) = drain(&mut eng);
+        assert!(outs.iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::RtcpRejected {
+                stage: RtcpRejectStage::Parsing,
+                packet_type: RTCP_PT_SDES,
+                sender_ssrc,
+                packet_len,
+                first_rtcp_len: 12,
+                plain_len: Some(12),
+                candidate_srtcp_index: Some(3),
+                candidate_encrypted: true,
+                first_header_byte: 0x81,
+                plain_sample: Some(sample),
+            }) if *sender_ssrc == peer_ssrc
+                && *packet_len == protected.len()
+                && sample == &malformed
+        )));
+    }
+
+    #[test]
+    fn sender_reports_use_transport_srtcp_for_audio_and_video() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys, unprotect_srtcp};
+
+        let mut cfg = config(true);
+        cfg.enable_video = true;
+        let call_key = cfg.call_key.clone();
+        let audio_ssrc = cfg.ssrc;
+        let video_ssrc = ssrc::derive_video_participant_ssrc(
+            &cfg.call_id,
+            &ssrc::format_e2e_srtp_participant_id(&cfg.self_lid),
+        );
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 1_700_000_000_000);
+        let _ = drain(&mut eng);
+        let allocate =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        eng.handle_input(0, Input::RelayPacket(&allocate));
+        let _ = drain(&mut eng);
+        eng.handle_input(1, Input::VideoFrame(&video_au(200)));
+        let _ = drain(&mut eng);
+        eng.handle_input(RTCP_MS, Input::Timeout);
+        let (outs, _) = drain(&mut eng);
+
+        let find_sr = |ssrc| {
+            outs.iter().find_map(|output| match output {
+                Output::Transmit(packet) if parse_rtcp_sender_ssrc(packet) == Some(ssrc) => {
+                    Some(packet)
+                }
+                _ => None,
+            })
+        };
+        let audio = find_sr(audio_ssrc).expect("audio SR");
+        let video = find_sr(video_ssrc).expect("video SR");
+        let transport = derive_srtcp_keys(&call_key, SELF_LID).unwrap();
+
+        assert!(unprotect_srtcp(&transport, audio_ssrc, audio).is_some());
+        assert!(unprotect_srtcp(&transport, video_ssrc, video).is_some());
+    }
+
     // The MLow encoder requires exactly 960 samples; a wrong-length mic frame is dropped (no RTP,
     // no panic), not partially sent. Pins the samples_per_packet contract (see CallConfig doc).
     #[test]
     fn wrong_length_mic_frame_is_dropped() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let short: Vec<i16> = (0..480i32).map(|i| (i % 50) as i16 + 1).collect();
         eng.handle_input(1, Input::MicFrame(&short));
@@ -1713,7 +2379,7 @@ mod tests {
     #[test]
     fn early_timeout_is_a_noop() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         assert_eq!(eng.poll_timeout(), Some(PLAYOUT_MS));
         eng.handle_input(5, Input::Timeout); // before the 20ms playout deadline
@@ -1854,7 +2520,7 @@ mod tests {
     #[test]
     fn video_frame_dropped_when_video_disabled() {
         let mut eng = engine(true); // enable_video: false
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         assert!(!eng.is_video_enabled());
         eng.handle_input(1, Input::VideoFrame(&video_au(100)));
@@ -1872,7 +2538,7 @@ mod tests {
         cfg.enable_video = true;
         let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
         assert!(eng.is_video_enabled());
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(1, Input::VideoFrame(&video_au(3000)));
         let (outs, _) = drain(&mut eng);
@@ -1896,7 +2562,7 @@ mod tests {
     #[test]
     fn enable_video_mid_call_then_disable() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let au = video_au(200);
         // Off: dropped.
@@ -1928,7 +2594,7 @@ mod tests {
     fn re_enabling_video_does_not_reset_the_srtp_packet_index() {
         let mut eng = engine(true);
         assert!(eng.enable_video());
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
 
         let seq_of = |outs: &[Output]| -> Vec<u16> {
@@ -1944,8 +2610,20 @@ mod tests {
 
         // First video AU: single NAL -> one packet at seq 0.
         eng.handle_input(1, Input::VideoFrame(&video_au(100)));
-        let first = seq_of(&drain(&mut eng).0);
+        let (outputs, _) = drain(&mut eng);
+        let first = seq_of(&outputs);
         assert_eq!(first, vec![0]);
+        assert!(outputs.iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::VideoRtpLayoutSent {
+                sequence_number: 0,
+                marker: true,
+                header_len: 28,
+                extension_profile: Some(0xdebe),
+                extension_data,
+                ..
+            }) if extension_data == &[0x30, 0x09, 0x51, 0, 0, 0x61, 0, 0, 0x91, 0, 0, 0]
+        )));
 
         // Downgrade then re-upgrade: the plane is preserved, so the next packet's seq CONTINUES.
         eng.disable_video();
@@ -1969,7 +2647,7 @@ mod tests {
         let mut eng = engine(true);
         assert!(eng.enable_video_gated());
         assert!(eng.is_video_enabled(), "a gated plane is still 'enabled'");
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
 
         // Gated: local AUs are dropped (no PT-97 on the wire).
@@ -2013,7 +2691,7 @@ mod tests {
     fn inbound_video_reassembles_into_video_playout() {
         let mut eng = engine(true);
         assert!(eng.enable_video());
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.set_peer_video_orientation(2);
 
@@ -2042,9 +2720,89 @@ mod tests {
     }
 
     #[test]
+    fn inbound_video_reports_authenticated_rtp_layout_once() {
+        let mut eng = engine(true);
+        assert!(eng.enable_video());
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+
+        let mut peer = peer_video_pipe();
+        let packet = peer
+            .protect_video(&video_au(100))
+            .pop()
+            .expect("single-packet video AU");
+        let expected = parse_rtp_header(&packet).expect("valid peer RTP");
+
+        let mut forged = packet.clone();
+        *forged.last_mut().expect("WARP tag") ^= 1;
+        eng.handle_input(1, Input::RelayPacket(&forged));
+        assert!(
+            !drain(&mut eng).0.iter().any(|output| matches!(
+                output,
+                Output::Event(CallEvent::VideoRtpLayoutObserved { .. })
+            )),
+            "unauthenticated RTP must not surface diagnostic bytes"
+        );
+
+        eng.handle_input(2, Input::RelayPacket(&packet));
+        let (outputs, _) = drain(&mut eng);
+        let layouts: Vec<_> = outputs
+            .iter()
+            .filter_map(|output| match output {
+                Output::Event(CallEvent::VideoRtpLayoutObserved {
+                    ssrc,
+                    sequence_number,
+                    timestamp,
+                    marker,
+                    header_len,
+                    packet_len,
+                    extension_profile,
+                    extension_data,
+                }) => Some((
+                    *ssrc,
+                    *sequence_number,
+                    *timestamp,
+                    *marker,
+                    *header_len,
+                    *packet_len,
+                    *extension_profile,
+                    extension_data.as_slice(),
+                )),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            layouts,
+            vec![(
+                expected.ssrc,
+                expected.sequence_number,
+                expected.timestamp,
+                expected.marker,
+                28,
+                packet.len(),
+                Some(0xdebe),
+                &[0x30, 0x09, 0x51, 0, 0, 0x61, 0, 0, 0x91, 0, 0, 0][..],
+            )]
+        );
+
+        let next = peer
+            .protect_video(&video_au(100))
+            .pop()
+            .expect("second single-packet video AU");
+        eng.handle_input(3, Input::RelayPacket(&next));
+        assert!(
+            !drain(&mut eng).0.iter().any(|output| matches!(
+                output,
+                Output::Event(CallEvent::VideoRtpLayoutObserved { .. })
+            )),
+            "the stable RTP layout only needs one event"
+        );
+    }
+
+    #[test]
     fn inbound_video_dropped_when_video_disabled_and_audio_unaffected() {
         let mut eng = engine(true); // video off
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let mut peer = peer_video_pipe();
         for p in peer.protect_video(&video_au(500)) {
@@ -2084,7 +2842,7 @@ mod tests {
     fn rekey_recv_also_rekeys_the_video_plane() {
         let mut eng = engine(true);
         assert!(eng.enable_video());
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
 
         let call_key: Vec<u8> = (0u8..32).collect();
@@ -2130,7 +2888,7 @@ mod tests {
         // Upgrade AFTER the answering device is known: the late-built video pipeline must key its
         // recv path from the CURRENT (rekeyed) peer LID, not the stale dialed base.
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let answering = "222222222222222:2@lid";
         assert!(eng.rekey_recv(answering));
@@ -2167,7 +2925,7 @@ mod tests {
     #[test]
     fn allocate_error_emits_failed_event_with_code() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let err = allocate_error(486); // class 4, number 86
         eng.handle_input(1, Input::RelayPacket(&err));
@@ -2188,7 +2946,7 @@ mod tests {
     #[test]
     fn malformed_stun_success_does_not_cancel_the_allocate_timeout() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         // A success-typed packet without the STUN magic cookie must not mark us allocated or cancel
         // the allocate timeout, else a garbage packet keeps a wedged relay in indefinite keepalive.
@@ -2220,7 +2978,7 @@ mod tests {
     #[test]
     fn garbage_stun_does_not_terminate_the_call() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         // Dropping the ERROR-CODE TLV leaves the body-length header still claiming the full body, so
         // the packet is rejected as INCOMPLETE (fails is_complete_stun), not as a parseable error. A
@@ -2244,7 +3002,7 @@ mod tests {
     #[test]
     fn allocate_error_terminates_and_stops_keepalive() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(1, Input::RelayPacket(&allocate_error(486)));
         let _ = drain(&mut eng);
@@ -2265,7 +3023,7 @@ mod tests {
     #[test]
     fn allocate_timeout_terminates_and_stops_keepalive() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(ALLOCATE_TIMEOUT_MS, Input::Timeout);
         let (outs, _) = drain(&mut eng);
@@ -2292,7 +3050,7 @@ mod tests {
     #[test]
     fn allocate_timeout_fires_exactly_once() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         eng.handle_input(ALLOCATE_TIMEOUT_MS, Input::Timeout);
         let (outs, _) = drain(&mut eng);
@@ -2320,7 +3078,7 @@ mod tests {
     #[test]
     fn allocate_success_cancels_the_timeout() {
         let mut eng = engine(true);
-        eng.start(0);
+        eng.start(0, 0);
         let _ = drain(&mut eng);
         let ok =
             stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -1,0 +1,763 @@
+//! H.264 Annex-B handling for the video media plane: NAL splitting, RFC 6184
+//! packetization (single NAL / FU-A out, single NAL / STAP-A / FU-A in), and an
+//! access-unit splitter for byte streams delimited by AUD NALs.
+//!
+//! The library never encodes or decodes pixels — callers hand us pre-encoded
+//! Annex-B access units and receive reassembled ones. Pure, no-Tokio, wasm-safe.
+
+/// Largest RTP payload we emit before fragmenting a NAL into FU-A units.
+/// Mirrors the reference implementation's relay MTU budget; unvalidated live.
+pub const H264_SINGLE_NAL_MAX: usize = 800;
+/// FU-A fragment body size: `H264_SINGLE_NAL_MAX` minus indicator + FU header.
+const H264_FUA_FRAG_SIZE: usize = H264_SINGLE_NAL_MAX - 2;
+/// Reassembly cap: a "NAL" that grows past this is garbage or an attack, not video.
+pub const H264_MAX_AU_BYTES: usize = 4 * 1024 * 1024;
+
+const NAL_TYPE_IDR: u8 = 5;
+const NAL_TYPE_SPS: u8 = 7;
+const NAL_TYPE_PPS: u8 = 8;
+const NAL_TYPE_AUD: u8 = 9;
+const NAL_TYPE_STAP_A: u8 = 24;
+const NAL_TYPE_FU_A: u8 = 28;
+
+const START_CODE: [u8; 4] = [0, 0, 0, 1];
+
+/// One received access unit, reassembled back into Annex-B form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VideoFrame {
+    /// Annex-B access unit (`00 00 00 01` start codes included).
+    pub data: Vec<u8>,
+    /// The AU carries an IDR/SPS/PPS NAL — safe point to (re)start a decoder.
+    pub keyframe: bool,
+    /// Peer device orientation in 90° steps (0..3), from `<video device_orientation>`.
+    pub orientation: u8,
+}
+
+impl VideoFrame {
+    pub fn new(data: Vec<u8>) -> Self {
+        let keyframe = au_is_keyframe(&data);
+        Self {
+            data,
+            keyframe,
+            orientation: 0,
+        }
+    }
+}
+
+pub fn nal_unit_type(nal: &[u8]) -> u8 {
+    nal.first().map(|b| b & 0x1f).unwrap_or(0)
+}
+
+/// Iterate the NAL units of an Annex-B buffer (start codes stripped, empty NALs skipped).
+pub fn split_annexb(data: &[u8]) -> impl Iterator<Item = &[u8]> {
+    SplitAnnexB { data, pos: 0 }
+}
+
+struct SplitAnnexB<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Iterator for SplitAnnexB<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<&'a [u8]> {
+        loop {
+            let start = find_start_code(self.data, self.pos)?;
+            let nal_begin = start.end;
+            let nal_end = match find_start_code(self.data, nal_begin) {
+                Some(next) => next.begin,
+                None => self.data.len(),
+            };
+            self.pos = nal_end;
+            let nal = &self.data[nal_begin..nal_end];
+            if !nal.is_empty() {
+                return Some(nal);
+            }
+        }
+    }
+}
+
+struct StartCode {
+    /// Index of the first byte of the start code (including a leading zero of
+    /// the 4-byte form).
+    begin: usize,
+    /// Index of the first NAL byte after the start code.
+    end: usize,
+}
+
+fn find_start_code(data: &[u8], from: usize) -> Option<StartCode> {
+    let hay = data.get(from..)?;
+    let mut i = 0;
+    while i + 3 <= hay.len() {
+        if hay[i] == 0 && hay[i + 1] == 0 {
+            if hay[i + 2] == 1 {
+                // Fold a preceding zero into the start code so AU slicing keeps
+                // the conventional 4-byte form intact.
+                let begin = if i > 0 && hay[i - 1] == 0 { i - 1 } else { i };
+                return Some(StartCode {
+                    begin: from + begin,
+                    end: from + i + 3,
+                });
+            }
+            if hay[i + 2] == 0 {
+                i += 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// True when the AU contains an IDR slice or parameter set — the points a
+/// decoder can (re)sync from. Use [`au_has_idr`] instead to gate a *resume*
+/// after loss: a parameter-set-only AU is a sync marker but not a decodable
+/// restart on its own.
+pub fn au_is_keyframe(au: &[u8]) -> bool {
+    split_annexb(au).any(|nal| {
+        matches!(
+            nal_unit_type(nal),
+            NAL_TYPE_IDR | NAL_TYPE_SPS | NAL_TYPE_PPS
+        )
+    })
+}
+
+/// True when the AU carries an IDR slice — a self-contained decodable restart
+/// point. Resuming a dropped stream here (rather than on any parameter set)
+/// avoids handing the decoder dependent frames it can't decode yet.
+pub fn au_has_idr(au: &[u8]) -> bool {
+    split_annexb(au).any(|nal| nal_unit_type(nal) == NAL_TYPE_IDR)
+}
+
+/// Packetize one Annex-B access unit into RTP payloads (no RTP headers): each
+/// NAL goes out as a single-NAL payload when it fits, or a run of FU-A
+/// fragments otherwise. `out` is cleared and refilled so the send path can
+/// reuse one buffer per AU.
+pub fn packetize_au(au: &[u8], out: &mut Vec<Vec<u8>>) {
+    out.clear();
+    for nal in split_annexb(au) {
+        if nal.len() <= H264_SINGLE_NAL_MAX {
+            out.push(nal.to_vec());
+            continue;
+        }
+        let indicator = (nal[0] & 0xe0) | NAL_TYPE_FU_A;
+        let orig_type = nal[0] & 0x1f;
+        let body = &nal[1..];
+        let n_frags = body.len().div_ceil(H264_FUA_FRAG_SIZE);
+        for (i, chunk) in body.chunks(H264_FUA_FRAG_SIZE).enumerate() {
+            let mut fu_header = orig_type;
+            if i == 0 {
+                fu_header |= 0x80; // S
+            }
+            if i == n_frags - 1 {
+                fu_header |= 0x40; // E
+            }
+            let mut pkt = Vec::with_capacity(2 + chunk.len());
+            pkt.push(indicator);
+            pkt.push(fu_header);
+            pkt.extend_from_slice(chunk);
+            out.push(pkt);
+        }
+    }
+}
+
+/// Access units completed but not yet returned can briefly exceed one when a
+/// timestamp boundary and a marker land in the same packet; cap the backlog so
+/// pathological loss can't grow it without bound.
+const H264_MAX_READY_AUS: usize = 4;
+
+/// Reassemble RTP payloads back into Annex-B access units. Feed each payload
+/// with its RTP sequence number, timestamp, and marker bit; a completed AU is
+/// returned when its marker arrives OR when a new RTP timestamp begins the next
+/// AU (so a lost marker packet doesn't merge two frames). Malformed or
+/// partially-lost input degrades to dropped NALs, never a panic.
+#[derive(Default)]
+pub struct H264Depacketizer {
+    au_buf: Vec<u8>,
+    fu_buf: Vec<u8>,
+    fu_active: bool,
+    /// The sequence number the NEXT fragment of the in-progress FU must carry.
+    /// FU-A fragments of one NAL are consecutive packets (RFC 6184 §5.8), so a
+    /// gap means a lost fragment: the partial NAL is dropped rather than
+    /// emitted truncated (silent corruption until the next keyframe).
+    fu_next_seq: u16,
+    /// RTP timestamp of the AU currently in `au_buf`. All packets of one AU share
+    /// it (RFC 3550), so a change marks a new AU even if the previous marker was
+    /// lost.
+    au_timestamp: Option<u32>,
+    /// AUs completed this or a prior push but not yet handed back (drained one per
+    /// `push`), so a timestamp boundary coinciding with a marker never drops one.
+    ready: std::collections::VecDeque<Vec<u8>>,
+}
+
+impl H264Depacketizer {
+    pub fn reset(&mut self) {
+        self.au_buf.clear();
+        self.fu_buf.clear();
+        self.fu_active = false;
+        self.au_timestamp = None;
+        self.ready.clear();
+    }
+
+    fn queue_ready(&mut self, au: Vec<u8>) {
+        if self.ready.len() >= H264_MAX_READY_AUS {
+            self.ready.pop_front();
+        }
+        self.ready.push_back(au);
+    }
+
+    /// A lost end-fragment leaves a stale partial NAL; drop it rather than
+    /// splice its bytes into the next NAL.
+    fn drop_partial_fu(&mut self) {
+        self.fu_buf.clear();
+        self.fu_active = false;
+    }
+
+    fn append_nal(&mut self, nal: &[u8]) {
+        if nal.is_empty() || self.au_buf.len() + START_CODE.len() + nal.len() > H264_MAX_AU_BYTES {
+            return;
+        }
+        self.au_buf.extend_from_slice(&START_CODE);
+        self.au_buf.extend_from_slice(nal);
+    }
+
+    pub fn push(
+        &mut self,
+        seq: u16,
+        timestamp: u32,
+        payload: &[u8],
+        marker: bool,
+    ) -> Option<Vec<u8>> {
+        if let Some(cur) = self.au_timestamp {
+            if timestamp != cur {
+                // Signed wrap-aware compare (RFC 3550): a FORWARD jump begins a new AU, so flush the
+                // buffered one even if its marker was lost (two frames must not merge). A BACKWARD one
+                // is a reordered packet from an already-past AU — discard it rather than flush the
+                // current partial as complete, which would corrupt video on normal reordering.
+                if (timestamp.wrapping_sub(cur) as i32) > 0 {
+                    if !self.au_buf.is_empty() {
+                        self.drop_partial_fu();
+                        let au = std::mem::take(&mut self.au_buf);
+                        self.queue_ready(au);
+                    }
+                    self.au_timestamp = Some(timestamp);
+                } else {
+                    return self.ready.pop_front();
+                }
+            }
+        } else {
+            self.au_timestamp = Some(timestamp);
+        }
+        match nal_unit_type(payload) {
+            NAL_TYPE_STAP_A => {
+                self.drop_partial_fu();
+                let mut rest = &payload[1..];
+                while rest.len() >= 2 {
+                    let len = u16::from_be_bytes([rest[0], rest[1]]) as usize;
+                    rest = &rest[2..];
+                    if len == 0 || len > rest.len() {
+                        break;
+                    }
+                    let (nal, tail) = rest.split_at(len);
+                    self.append_nal(nal);
+                    rest = tail;
+                }
+            }
+            NAL_TYPE_FU_A if payload.len() >= 2 => {
+                let fu_header = payload[1];
+                let start = fu_header & 0x80 != 0;
+                let end = fu_header & 0x40 != 0;
+                if start {
+                    self.drop_partial_fu();
+                    self.fu_active = true;
+                    self.fu_buf.push((payload[0] & 0xe0) | (fu_header & 0x1f));
+                } else if self.fu_active && seq != self.fu_next_seq {
+                    // A lost (or reordered) fragment: the bytes on hand no longer
+                    // form a prefix of the NAL, so emitting them would hand the
+                    // decoder a truncated slice. Drop the partial instead.
+                    self.drop_partial_fu();
+                }
+                if self.fu_active {
+                    self.fu_next_seq = seq.wrapping_add(1);
+                    if self.fu_buf.len() + payload.len() > H264_MAX_AU_BYTES {
+                        self.drop_partial_fu();
+                    } else {
+                        self.fu_buf.extend_from_slice(&payload[2..]);
+                        if end {
+                            let nal = std::mem::take(&mut self.fu_buf);
+                            self.fu_active = false;
+                            self.append_nal(&nal);
+                            self.fu_buf = nal; // reuse the allocation
+                            self.fu_buf.clear();
+                        }
+                    }
+                }
+                // A middle fragment with no start on record means the start was
+                // lost: ignore it and wait for the next start bit.
+            }
+            t if (1..=23).contains(&t) => {
+                self.drop_partial_fu();
+                self.append_nal(payload);
+            }
+            // Type 0 (empty/garbage) and unsupported aggregation types are ignored.
+            _ => {}
+        }
+        if let Some(au) = self.flush_on(marker) {
+            self.queue_ready(au);
+        }
+        // Drain one completed AU per push; any second (a timestamp boundary that coincided with a
+        // marker) surfaces on the next call, adding at most one packet of latency.
+        self.ready.pop_front()
+    }
+
+    fn flush_on(&mut self, marker: bool) -> Option<Vec<u8>> {
+        if !marker {
+            return None;
+        }
+        self.drop_partial_fu();
+        // The next packet after a marker begins a fresh AU; forget this AU's timestamp so an
+        // identical-timestamp reuse (wrap or a stale value) doesn't suppress the boundary check.
+        self.au_timestamp = None;
+        if self.au_buf.is_empty() {
+            return None;
+        }
+        Some(std::mem::take(&mut self.au_buf))
+    }
+}
+
+/// Split a raw Annex-B byte stream (e.g. an encoder's stdout) into access
+/// units, cutting at AUD NALs (type 9). Feed arbitrary chunks; complete AUs
+/// come back as they close. Requires the producer to emit AUDs (ffmpeg:
+/// `-bsf:v h264_metadata=aud=insert`).
+#[derive(Default)]
+pub struct AnnexBAuSplitter {
+    buf: Vec<u8>,
+    /// Scan resume point: everything before it was already searched for an AUD.
+    scan_pos: usize,
+}
+
+impl AnnexBAuSplitter {
+    pub fn push(&mut self, data: &[u8], out: &mut Vec<Vec<u8>>) {
+        self.buf.extend_from_slice(data);
+        loop {
+            let Some(sc) = find_start_code(&self.buf, self.scan_pos) else {
+                // No start code found. A stream that never yields one (garbage, or a producer
+                // emitting no AUDs) would otherwise grow `buf` unbounded across pushes, so cap it
+                // here too — keep only the last few bytes so a start code split across chunks still
+                // reassembles.
+                if self.buf.len() > H264_MAX_AU_BYTES {
+                    self.buf.clear();
+                }
+                self.scan_pos = self.buf.len().saturating_sub(3);
+                break;
+            };
+            let Some(&nal_byte) = self.buf.get(sc.end) else {
+                // Start code at the buffer edge: wait for the NAL type byte.
+                self.scan_pos = sc.begin;
+                break;
+            };
+            if nal_byte & 0x1f == NAL_TYPE_AUD && sc.begin > 0 {
+                let rest = self.buf.split_off(sc.begin);
+                let au = std::mem::replace(&mut self.buf, rest);
+                out.push(au);
+                self.scan_pos = 0;
+            } else {
+                self.scan_pos = sc.end;
+            }
+            if self.buf.len() > H264_MAX_AU_BYTES {
+                // Runaway buffer means the stream has no AUDs; dropping is
+                // safer than emitting a cut mid-NAL.
+                self.buf.clear();
+                self.scan_pos = 0;
+            }
+        }
+    }
+
+    /// Flush the trailing AU on end-of-stream.
+    pub fn finish(&mut self) -> Option<Vec<u8>> {
+        self.scan_pos = 0;
+        if self.buf.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut self.buf))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nal(t: u8, len: usize) -> Vec<u8> {
+        let mut n = vec![0x60 | t];
+        n.extend((0..len.saturating_sub(1)).map(|i| (i % 251) as u8));
+        n
+    }
+
+    fn au_from_nals(nals: &[Vec<u8>]) -> Vec<u8> {
+        let mut au = Vec::new();
+        for n in nals {
+            au.extend_from_slice(&START_CODE);
+            au.extend_from_slice(n);
+        }
+        au
+    }
+
+    /// Drive the depacketizer with consecutive sequence numbers (the on-wire
+    /// order the sender emits), returning the last AU produced.
+    fn depacketize_all(payloads: &[Vec<u8>]) -> Option<Vec<u8>> {
+        let mut d = H264Depacketizer::default();
+        let last = payloads.len() - 1;
+        let mut au = None;
+        // All packets of one AU share a timestamp.
+        for (i, p) in payloads.iter().enumerate() {
+            if let Some(got) = d.push(i as u16, 9000, p, i == last) {
+                au = Some(got);
+            }
+        }
+        au
+    }
+
+    #[test]
+    fn split_annexb_handles_3_and_4_byte_start_codes() {
+        let mut data = vec![0, 0, 1];
+        data.extend_from_slice(&nal(1, 4));
+        data.extend_from_slice(&START_CODE);
+        data.extend_from_slice(&nal(5, 6));
+        let nals: Vec<_> = split_annexb(&data).collect();
+        assert_eq!(nals.len(), 2);
+        assert_eq!(nal_unit_type(nals[0]), 1);
+        assert_eq!(nal_unit_type(nals[1]), 5);
+    }
+
+    #[test]
+    fn split_annexb_skips_empty_nals_and_garbage_prefix() {
+        // Garbage before the first start code, and back-to-back start codes.
+        let mut data = vec![0xaa, 0xbb];
+        data.extend_from_slice(&START_CODE);
+        data.extend_from_slice(&START_CODE);
+        data.extend_from_slice(&nal(1, 3));
+        let nals: Vec<_> = split_annexb(&data).collect();
+        assert_eq!(nals.len(), 1);
+        assert!(split_annexb(&[]).next().is_none());
+        assert!(split_annexb(&[0, 0]).next().is_none());
+    }
+
+    #[test]
+    fn keyframe_detection() {
+        assert!(au_is_keyframe(&au_from_nals(&[
+            nal(7, 4),
+            nal(8, 4),
+            nal(5, 100)
+        ])));
+        assert!(au_is_keyframe(&au_from_nals(&[nal(9, 2), nal(5, 10)])));
+        assert!(!au_is_keyframe(&au_from_nals(&[nal(9, 2), nal(1, 100)])));
+        assert!(!au_is_keyframe(&[]));
+    }
+
+    #[test]
+    fn single_nal_round_trips() {
+        let au = au_from_nals(&[nal(9, 2), nal(1, 100)]);
+        let mut payloads = Vec::new();
+        packetize_au(&au, &mut payloads);
+        assert_eq!(payloads.len(), 2);
+        assert!(payloads.iter().all(|p| p.len() <= H264_SINGLE_NAL_MAX));
+        assert_eq!(depacketize_all(&payloads), Some(au));
+    }
+
+    #[test]
+    fn boundary_800_stays_single_and_801_fragments() {
+        let au = au_from_nals(&[nal(1, H264_SINGLE_NAL_MAX)]);
+        let mut payloads = Vec::new();
+        packetize_au(&au, &mut payloads);
+        assert_eq!(payloads.len(), 1, "800-byte NAL must not fragment");
+
+        let au = au_from_nals(&[nal(1, H264_SINGLE_NAL_MAX + 1)]);
+        packetize_au(&au, &mut payloads);
+        assert_eq!(payloads.len(), 2, "801-byte NAL must fragment");
+        assert_eq!(nal_unit_type(&payloads[0]), NAL_TYPE_FU_A);
+        assert_eq!(payloads[0][1] & 0x80, 0x80, "first fragment sets S");
+        assert_eq!(payloads[1][1] & 0x40, 0x40, "last fragment sets E");
+        assert_eq!(depacketize_all(&payloads), Some(au));
+    }
+
+    #[test]
+    fn large_idr_round_trips_via_fua() {
+        let au = au_from_nals(&[nal(7, 20), nal(8, 8), nal(5, 3000)]);
+        let mut payloads = Vec::new();
+        packetize_au(&au, &mut payloads);
+        assert!(payloads.len() >= 5);
+        let got = depacketize_all(&payloads).expect("AU must reassemble");
+        assert_eq!(got, au);
+        assert!(au_is_keyframe(&got));
+    }
+
+    #[test]
+    fn stap_a_unpacks_both_nals() {
+        let a = nal(7, 5);
+        let b = nal(8, 3);
+        let mut stap = vec![0x60 | NAL_TYPE_STAP_A];
+        for n in [&a, &b] {
+            stap.extend_from_slice(&(n.len() as u16).to_be_bytes());
+            stap.extend_from_slice(n);
+        }
+        let got = depacketize_all(&[stap]).expect("STAP-A must unpack");
+        assert_eq!(got, au_from_nals(&[a, b]));
+    }
+
+    // A lost middle fragment leaves the sequence gapped, so the truncated NAL
+    // must be DROPPED (not emitted truncated, which would corrupt the decode
+    // until the next keyframe), and a following AU with contiguous seqs decodes.
+    #[test]
+    fn lost_middle_fragment_drops_the_truncated_nal() {
+        let au = au_from_nals(&[nal(5, 3000)]);
+        let mut payloads = Vec::new();
+        packetize_au(&au, &mut payloads);
+        assert!(payloads.len() >= 3);
+        let mut d = H264Depacketizer::default();
+        // seq 0 = start; seq 1 is LOST; seq 2.. arrive, so the E fragment lands
+        // on a gapped sequence and the partial NAL is discarded.
+        let mut seq = 0u16;
+        for (i, p) in payloads.iter().enumerate() {
+            if i == 1 {
+                seq = seq.wrapping_add(1); // the lost fragment still consumed a seq
+                continue;
+            }
+            let marker = i == payloads.len() - 1;
+            let out = d.push(seq, 7000, p, marker);
+            if marker {
+                assert_eq!(
+                    out, None,
+                    "a NAL with a lost interior fragment must be dropped, not emitted truncated"
+                );
+            }
+            seq = seq.wrapping_add(1);
+        }
+        // A subsequent complete AU (contiguous seqs) still reassembles.
+        let au2 = au_from_nals(&[nal(1, 50)]);
+        let mut p2 = Vec::new();
+        packetize_au(&au2, &mut p2);
+        assert_eq!(depacketize_all(&p2), Some(au2));
+    }
+
+    // A reordered fragment (seq jumps) is treated the same as loss: the partial
+    // NAL is dropped rather than spliced out of order.
+    #[test]
+    fn reordered_fu_fragment_drops_the_partial() {
+        let au = au_from_nals(&[nal(5, 2500)]);
+        let mut payloads = Vec::new();
+        packetize_au(&au, &mut payloads);
+        let mut d = H264Depacketizer::default();
+        // Feed start at seq 0, then jump the next fragment's seq forward.
+        assert_eq!(d.push(0, 7000, &payloads[0], false), None);
+        let out = d.push(5, 7000, &payloads[1], false); // gap: 1..5 missing
+        assert_eq!(
+            out, None,
+            "a gapped fragment must not extend the partial NAL"
+        );
+    }
+
+    #[test]
+    fn lost_end_fragment_discards_partial_and_keeps_next_nal() {
+        let au = au_from_nals(&[nal(5, 2000)]);
+        let mut payloads = Vec::new();
+        packetize_au(&au, &mut payloads);
+        payloads.pop(); // lose the E fragment
+        let mut d = H264Depacketizer::default();
+        for (i, p) in payloads.iter().enumerate() {
+            assert_eq!(d.push(i as u16, 7000, p, false), None);
+        }
+        // Next single NAL arrives with the marker: partial FU is dropped, the
+        // fresh NAL survives alone.
+        let tail = nal(1, 40);
+        let got = d
+            .push(100, 13000, &tail, true)
+            .expect("fresh NAL must flush");
+        assert_eq!(got, au_from_nals(&[tail]));
+    }
+
+    #[test]
+    fn depacketizer_survives_garbage() {
+        let bufs: Vec<Vec<u8>> = vec![
+            vec![],
+            vec![0x7c],                   // FU-A indicator with no header
+            vec![0x7c, 0x00],             // FU-A middle with no start seen
+            vec![0x7c, 0xc0],             // FU-A with S and E, empty body
+            vec![0x78, 0x00, 0xff, 0xaa], // STAP-A with lying length
+            vec![0x78],                   // STAP-A with no body
+            vec![0x1f; 3],                // reserved type 31
+            vec![0x00; 8],                // type 0
+            vec![0xff; 900],
+        ];
+        let mut d = H264Depacketizer::default();
+        for (i, b) in bufs.iter().enumerate() {
+            let _ = d.push(i as u16, i as u32, b, false);
+            let _ = d.push(i as u16, i as u32, b, true);
+        }
+        // Still functional afterwards.
+        let au = au_from_nals(&[nal(1, 10)]);
+        let mut p = Vec::new();
+        packetize_au(&au, &mut p);
+        assert_eq!(depacketize_all(&p), Some(au));
+    }
+
+    // A lost marker packet must not merge two AUs: the next AU's new RTP timestamp flushes the
+    // buffered one, so each frame comes back separately (the first missing only its lost NAL).
+    #[test]
+    fn lost_marker_does_not_merge_frames_across_a_timestamp_change() {
+        let mut d = H264Depacketizer::default();
+        // AU1 @ ts 1000: two single-NAL packets, but the SECOND (its marker) is "lost".
+        let a1 = nal(1, 40);
+        assert_eq!(d.push(0, 1000, &a1, false), None);
+        // (the marker packet of AU1 never arrives)
+
+        // AU2 @ ts 2000 begins: its first packet's new timestamp flushes AU1.
+        let b1 = nal(1, 50);
+        let flushed = d
+            .push(2, 2000, &b1, false)
+            .expect("a new timestamp must flush the previous AU whose marker was lost");
+        assert_eq!(
+            flushed,
+            au_from_nals(&[a1]),
+            "the flushed AU is the buffered first frame, not a merge of both"
+        );
+        // AU2 completes normally on its marker.
+        let b2 = nal(5, 30);
+        let au2 = d
+            .push(3, 2000, &b2, true)
+            .expect("AU2 completes on its marker");
+        assert_eq!(au2, au_from_nals(&[b1, b2]));
+    }
+
+    // A reordered packet from an OLDER timestamp must not flush the current AU as complete: it is
+    // discarded, and the in-progress AU keeps accumulating and completes normally.
+    #[test]
+    fn reordered_older_timestamp_packet_is_discarded_not_flushed() {
+        let mut d = H264Depacketizer::default();
+        // AU1 @ ts 1000 completes cleanly.
+        let a1 = nal(1, 20);
+        let want_a1 = au_from_nals(std::slice::from_ref(&a1));
+        assert_eq!(d.push(0, 1000, &a1, true), Some(want_a1));
+        // AU2 @ ts 2000 starts (first of two packets, no marker yet).
+        let b1 = nal(1, 30);
+        assert_eq!(d.push(1, 2000, &b1, false), None);
+        // A LATE reordered packet from ts 1000 arrives — it must be discarded, NOT flush the partial
+        // AU2 as if complete.
+        let stale = nal(1, 10);
+        assert_eq!(
+            d.push(2, 1000, &stale, false),
+            None,
+            "a stale reordered packet must not flush the in-progress AU"
+        );
+        // AU2 completes normally on its marker, intact.
+        let b2 = nal(5, 25);
+        assert_eq!(
+            d.push(3, 2000, &b2, true),
+            Some(au_from_nals(&[b1, b2])),
+            "the in-progress AU survives the reordered packet and completes on its marker"
+        );
+    }
+
+    // The rare case where a timestamp boundary AND a marker fire for the same push: both AUs must
+    // surface (the second one push later), not be dropped.
+    #[test]
+    fn boundary_and_marker_in_one_push_surface_both_aus() {
+        let mut d = H264Depacketizer::default();
+        // AU1 @ ts 1000 buffered, marker lost.
+        let a1 = nal(1, 20);
+        assert_eq!(d.push(0, 1000, &a1, false), None);
+        // AU2 @ ts 2000 is a single-packet AU WITH a marker: boundary flushes AU1, marker completes AU2.
+        let b1 = nal(5, 25);
+        let first = d
+            .push(1, 2000, &b1, true)
+            .expect("boundary flush returns AU1");
+        assert_eq!(first, au_from_nals(&[a1]));
+        // AU2 surfaces on the next push (drained one-per-call). Use a fresh AU3 packet to pump it.
+        let c1 = nal(1, 15);
+        let second = d
+            .push(2, 3000, &c1, false)
+            .expect("the second completed AU surfaces on the next push");
+        assert_eq!(second, au_from_nals(&[b1]));
+    }
+
+    #[test]
+    fn empty_au_yields_no_payloads_and_marker_alone_yields_none() {
+        let mut payloads = vec![vec![1u8]];
+        packetize_au(&[], &mut payloads);
+        assert!(payloads.is_empty(), "packetize_au must clear stale output");
+        let mut d = H264Depacketizer::default();
+        assert_eq!(d.push(0, 0, &[], true), None);
+    }
+
+    #[test]
+    fn au_splitter_cuts_on_aud() {
+        let au1 = au_from_nals(&[nal(9, 2), nal(7, 4), nal(5, 60)]);
+        let au2 = au_from_nals(&[nal(9, 2), nal(1, 40)]);
+        let mut stream = au1.clone();
+        stream.extend_from_slice(&au2);
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        s.push(&stream, &mut out);
+        assert_eq!(out, vec![au1]);
+        assert_eq!(s.finish(), Some(au2));
+        assert_eq!(s.finish(), None);
+    }
+
+    #[test]
+    fn au_splitter_handles_start_code_split_across_chunks() {
+        let au1 = au_from_nals(&[nal(9, 2), nal(1, 30)]);
+        let au2 = au_from_nals(&[nal(9, 2), nal(1, 20)]);
+        let mut stream = au1.clone();
+        stream.extend_from_slice(&au2);
+        // Feed byte by byte: start codes and the AUD type byte land on every
+        // possible chunk boundary.
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        for b in &stream {
+            s.push(std::slice::from_ref(b), &mut out);
+        }
+        assert_eq!(out, vec![au1]);
+        assert_eq!(s.finish(), Some(au2));
+    }
+
+    #[test]
+    fn au_splitter_without_aud_does_not_grow_unbounded() {
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        let chunk = au_from_nals(&[nal(1, 64 * 1024)]);
+        for _ in 0..80 {
+            s.push(&chunk, &mut out);
+        }
+        assert!(out.is_empty());
+        // Internal buffer was capped, not grown to ~5 MiB.
+        assert!(s.buf.len() <= H264_MAX_AU_BYTES);
+    }
+
+    #[test]
+    fn au_splitter_pure_garbage_no_start_code_is_capped() {
+        // A stream that never yields a start code must not grow the buffer without bound.
+        let mut s = AnnexBAuSplitter::default();
+        let mut out = Vec::new();
+        let chunk = vec![0xabu8; 64 * 1024];
+        for _ in 0..80 {
+            s.push(&chunk, &mut out);
+        }
+        assert!(out.is_empty());
+        assert!(
+            s.buf.len() <= H264_MAX_AU_BYTES,
+            "no-start-code stream must be capped, got {}",
+            s.buf.len()
+        );
+    }
+
+    #[test]
+    fn video_frame_new_detects_keyframe() {
+        let f = VideoFrame::new(au_from_nals(&[nal(5, 30)]));
+        assert!(f.keyframe);
+        assert_eq!(f.orientation, 0);
+        let f = VideoFrame::new(au_from_nals(&[nal(1, 30)]));
+        assert!(!f.keyframe);
+    }
+}

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -6,7 +6,7 @@
 //! Annex-B access units and receive reassembled ones. Pure, no-Tokio, wasm-safe.
 
 /// Largest RTP payload we emit before fragmenting a NAL into FU-A units.
-/// Mirrors the reference implementation's relay MTU budget; unvalidated live.
+/// Matches the reference relay MTU budget used by live WhatsApp interop.
 pub const H264_SINGLE_NAL_MAX: usize = 800;
 /// FU-A fragment body size: `H264_SINGLE_NAL_MAX` minus indicator + FU header.
 const H264_FUA_FRAG_SIZE: usize = H264_SINGLE_NAL_MAX - 2;

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -191,6 +191,8 @@ pub struct H264Depacketizer {
     /// it (RFC 3550), so a change marks a new AU even if the previous marker was
     /// lost.
     au_timestamp: Option<u32>,
+    /// Keeps a marker-completed AU closed when one of its packets arrives late.
+    last_completed_timestamp: Option<u32>,
     /// AUs completed this or a prior push but not yet handed back (drained one per
     /// `push`), so a timestamp boundary coinciding with a marker never drops one.
     ready: std::collections::VecDeque<Vec<u8>>,
@@ -202,6 +204,7 @@ impl H264Depacketizer {
         self.fu_buf.clear();
         self.fu_active = false;
         self.au_timestamp = None;
+        self.last_completed_timestamp = None;
         self.ready.clear();
     }
 
@@ -246,12 +249,18 @@ impl H264Depacketizer {
                         let au = std::mem::take(&mut self.au_buf);
                         self.queue_ready(au);
                     }
+                    self.last_completed_timestamp = Some(cur);
                     self.au_timestamp = Some(timestamp);
                 } else {
                     return self.ready.pop_front();
                 }
             }
         } else {
+            if let Some(completed) = self.last_completed_timestamp
+                && (timestamp.wrapping_sub(completed) as i32) <= 0
+            {
+                return self.ready.pop_front();
+            }
             self.au_timestamp = Some(timestamp);
         }
         match nal_unit_type(payload) {
@@ -321,9 +330,7 @@ impl H264Depacketizer {
             return None;
         }
         self.drop_partial_fu();
-        // The next packet after a marker begins a fresh AU; forget this AU's timestamp so an
-        // identical-timestamp reuse (wrap or a stale value) doesn't suppress the boundary check.
-        self.au_timestamp = None;
+        self.last_completed_timestamp = self.au_timestamp.take();
         if self.au_buf.is_empty() {
             return None;
         }
@@ -691,6 +698,25 @@ mod tests {
             d.push(3, 2000, &b2, true),
             Some(au_from_nals(&[b1, b2])),
             "the in-progress AU survives the reordered packet and completes on its marker"
+        );
+    }
+
+    #[test]
+    fn late_packet_after_marker_cannot_seed_a_stale_au() {
+        let mut d = H264Depacketizer::default();
+        let completed = nal(5, 20);
+        assert_eq!(
+            d.push(10, 1000, &completed, true),
+            Some(au_from_nals(std::slice::from_ref(&completed)))
+        );
+
+        let late = nal(1, 15);
+        assert_eq!(d.push(9, 1000, &late, false), None);
+        let next = nal(1, 25);
+        assert_eq!(
+            d.push(11, 2000, &next, true),
+            Some(au_from_nals(std::slice::from_ref(&next))),
+            "a late packet from the completed timestamp must not leak into the next AU"
         );
     }
 

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -215,6 +215,11 @@ impl H264Depacketizer {
         self.ready.push_back(au);
     }
 
+    /// Take another AU completed by the previous [`push`](Self::push).
+    pub fn pop_ready(&mut self) -> Option<Vec<u8>> {
+        self.ready.pop_front()
+    }
+
     /// A lost end-fragment leaves a stale partial NAL; drop it rather than
     /// splice its bytes into the next NAL.
     fn drop_partial_fu(&mut self) {
@@ -320,8 +325,8 @@ impl H264Depacketizer {
         if let Some(au) = self.flush_on(marker) {
             self.queue_ready(au);
         }
-        // Drain one completed AU per push; any second (a timestamp boundary that coincided with a
-        // marker) surfaces on the next call, adding at most one packet of latency.
+        // The caller must drain `pop_ready` immediately: a timestamp boundary and marker can finish
+        // two access units in one push.
         self.ready.pop_front()
     }
 
@@ -721,7 +726,7 @@ mod tests {
     }
 
     // The rare case where a timestamp boundary AND a marker fire for the same push: both AUs must
-    // surface (the second one push later), not be dropped.
+    // surface immediately, even if no later packet arrives.
     #[test]
     fn boundary_and_marker_in_one_push_surface_both_aus() {
         let mut d = H264Depacketizer::default();
@@ -734,12 +739,11 @@ mod tests {
             .push(1, 2000, &b1, true)
             .expect("boundary flush returns AU1");
         assert_eq!(first, au_from_nals(&[a1]));
-        // AU2 surfaces on the next push (drained one-per-call). Use a fresh AU3 packet to pump it.
-        let c1 = nal(1, 15);
         let second = d
-            .push(2, 3000, &c1, false)
-            .expect("the second completed AU surfaces on the next push");
+            .pop_ready()
+            .expect("the second completed AU is ready without another packet");
         assert_eq!(second, au_from_nals(&[b1]));
+        assert_eq!(d.pop_ready(), None);
     }
 
     #[test]

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -131,13 +131,17 @@ pub fn au_has_idr(au: &[u8]) -> bool {
     split_annexb(au).any(|nal| nal_unit_type(nal) == NAL_TYPE_IDR)
 }
 
-/// Packetize one Annex-B access unit into RTP payloads (no RTP headers): each
-/// NAL goes out as a single-NAL payload when it fits, or a run of FU-A
-/// fragments otherwise. `out` is cleared and refilled so the send path can
-/// reuse one buffer per AU.
+/// Packetize one Annex-B access unit into WhatsApp RTP payloads (no RTP headers): each
+/// media NAL goes out as a single-NAL payload when it fits, or a run of FU-A
+/// fragments otherwise. Encoder-only AUDs are omitted because WhatsApp's H.264
+/// decoder requires SPS/PPS to lead an IDR frame. `out` is cleared and refilled
+/// so the send path can reuse one buffer per AU.
 pub fn packetize_au(au: &[u8], out: &mut Vec<Vec<u8>>) {
     out.clear();
     for nal in split_annexb(au) {
+        if nal_unit_type(nal) == NAL_TYPE_AUD {
+            continue;
+        }
         if nal.len() <= H264_SINGLE_NAL_MAX {
             out.push(nal.to_vec());
             continue;
@@ -459,12 +463,42 @@ mod tests {
 
     #[test]
     fn single_nal_round_trips() {
-        let au = au_from_nals(&[nal(9, 2), nal(1, 100)]);
+        let au = au_from_nals(&[nal(1, 100)]);
         let mut payloads = Vec::new();
         packetize_au(&au, &mut payloads);
-        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads.len(), 1);
         assert!(payloads.iter().all(|p| p.len() <= H264_SINGLE_NAL_MAX));
         assert_eq!(depacketize_all(&payloads), Some(au));
+    }
+
+    #[test]
+    fn whatsapp_packetization_omits_aud_before_parameter_sets() {
+        let sps = nal(7, 20);
+        let pps = nal(8, 8);
+        let idr = nal(5, 100);
+        let au = au_from_nals(&[nal(9, 2), sps.clone(), pps.clone(), idr.clone()]);
+        let mut payloads = Vec::new();
+
+        packetize_au(&au, &mut payloads);
+
+        assert_eq!(
+            payloads
+                .iter()
+                .map(|nal| nal_unit_type(nal))
+                .collect::<Vec<_>>(),
+            [NAL_TYPE_SPS, NAL_TYPE_PPS, NAL_TYPE_IDR]
+        );
+        assert_eq!(
+            depacketize_all(&payloads),
+            Some(au_from_nals(&[sps, pps, idr]))
+        );
+    }
+
+    #[test]
+    fn aud_only_access_unit_produces_no_rtp_payload() {
+        let mut payloads = vec![vec![1]];
+        packetize_au(&au_from_nals(&[nal(9, 2)]), &mut payloads);
+        assert!(payloads.is_empty());
     }
 
     #[test]

--- a/wacore/src/voip/hbh_srtp.rs
+++ b/wacore/src/voip/hbh_srtp.rs
@@ -420,10 +420,9 @@ mod tests {
             1_718_000_000_000,
         );
         let protected = protect_srtcp(&uplink, ssrc, 7, &plain);
-        assert_eq!(
-            unprotect_srtcp(&uplink, ssrc, &protected).as_deref(),
-            Some(plain.as_slice())
-        );
+        let (unprotected, index) = unprotect_srtcp(&uplink, ssrc, &protected).unwrap();
+        assert_eq!(unprotected, plain);
+        assert_eq!(index, 7);
         assert!(unprotect_srtcp(&downlink, ssrc, &protected).is_none());
 
         for mode in HBH_SRTCP_MODES {

--- a/wacore/src/voip/hbh_srtp.rs
+++ b/wacore/src/voip/hbh_srtp.rs
@@ -1,33 +1,49 @@
-//! HBH (hop-by-hop) SRTP: legacy/fallback path keyed from the signaling `hbh_key`
-//! (30B) via HKDF-SHA256 (label as `info`), then the libsrtp AES-ICM session-key expansion.
+//! HBH (hop-by-hop) SRTP/SRTCP keyed from the signaling `hbh_key` via WhatsApp's
+//! two-stage SFU HKDF, then the libsrtp AES-ICM session-key expansion.
 //!
 //! The counter here is libsrtp's AES-ICM with a 2-byte carry (bytes 15 then 14),
 //! NOT a full 128-bit CTR; it only diverges past ~1 MiB/packet (impossible for
 //! audio), but is reproduced faithfully so vectors match.
 //!
-//! wacrg spec: srtp-hop-by-hop (CRY-03). Note: the spec says HBH skips the WAHKDF
-//! layer, but the KAT-pinned implementation applies a labeled HKDF-SHA256 step here
-//! (the spec entry is `status: draft`; the code reflects the captured vectors).
+//! wacrg spec: srtp-hop-by-hop (CRY-03).
 
 use aes::Aes128;
 use aes::cipher::{Block, BlockCipherEncrypt, KeyInit};
 
+use crate::voip::e2e_srtp::E2eSrtpKeys;
 use crate::voip::hkdf_sha256;
 
 const NULL_SALT_32: [u8; 32] = [0u8; 32];
 
-/// Relay-supplied hop-by-hop keying material: 16B master key followed by a 14B master salt.
+/// Relay-supplied SFU seed: 14B salt material followed by 16B key material.
 pub(crate) const HBH_KEY_LEN: usize = 30;
+const HBH_SALT_SEED_LEN: usize = 14;
 
 /// HKDF `info` labels for the WA SFU HBH SRTCP key derivation (KAT-pinned wire values).
 const HBH_UPLINK_SALT_LABEL: &str = "uplink hbh srtcp salt";
 const HBH_UPLINK_KEY_LABEL: &str = "uplink hbh srtcp key";
 const HBH_DOWNLINK_SALT_LABEL: &str = "downlink hbh srtcp salt";
 const HBH_DOWNLINK_KEY_LABEL: &str = "downlink hbh srtcp key";
+const HBH_SHARED_SRTCP_SALT_LABEL: &str = "hbh srtcp salt";
+const HBH_SHARED_SRTCP_KEY_LABEL: &str = "hbh srtcp key";
+const HBH_SHARED_SRTP_SALT_LABEL: &str = "hbh srtp salt";
+const HBH_SHARED_SRTP_KEY_LABEL: &str = "hbh srtp key";
 
 const LABEL_RTP_ENCRYPTION: u8 = 0x00;
 const LABEL_RTP_AUTH: u8 = 0x01;
 const LABEL_RTP_SALT: u8 = 0x02;
+const LABEL_RTCP_ENCRYPTION: u8 = 0x03;
+const LABEL_RTCP_AUTH: u8 = 0x04;
+const LABEL_RTCP_SALT: u8 = 0x05;
+
+/// HBH SRTCP layouts selected by WhatsApp's transport rollout flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HbhSrtcpMode {
+    Directional,
+    Shared,
+}
+
+pub const HBH_SRTCP_MODES: [HbhSrtcpMode; 2] = [HbhSrtcpMode::Directional, HbhSrtcpMode::Shared];
 
 /// 16B master key + 14B master salt.
 #[derive(Clone)]
@@ -67,9 +83,9 @@ fn keying_from_crypto_key(crypto_key: &[u8]) -> SrtpKeyingMaterial {
     m
 }
 
-/// mbedtls/Android hbh_key split: 16B master_key + 14B master_salt, two-stage KDF.
+/// Android copies the wire seed as 14B salt material followed by 16B key material.
 /// Returns `None` on malformed relay input (the only valid `hbh_key` is exactly 30 bytes).
-fn derive_hbh_srtp_key_with_labels(
+fn derive_hbh_key_with_labels(
     hbh_key: &[u8],
     salt_label: &str,
     key_label: &str,
@@ -77,34 +93,61 @@ fn derive_hbh_srtp_key_with_labels(
     if hbh_key.len() != HBH_KEY_LEN {
         return None;
     }
-    let master_key = &hbh_key[0..16];
-    let master_salt = &hbh_key[16..HBH_KEY_LEN];
-    // WA SFU KDF == HKDF-SHA256 with the literal UTF-8 label as `info`.
-    let srtcp_salt = hkdf_sha256(&NULL_SALT_32, master_salt, salt_label.as_bytes(), 32);
+    let salt_seed = &hbh_key[..HBH_SALT_SEED_LEN];
+    let key_seed = &hbh_key[HBH_SALT_SEED_LEN..];
+    let derived_salt = hkdf_sha256(&NULL_SALT_32, salt_seed, salt_label.as_bytes(), 32);
     Some(hkdf_sha256(
-        &srtcp_salt,
-        master_key,
+        &derived_salt,
+        key_seed,
         key_label.as_bytes(),
         HBH_KEY_LEN,
     ))
 }
 
-pub fn derive_hbh_srtp_key_uplink(hbh_key: &[u8]) -> Option<Vec<u8>> {
-    derive_hbh_srtp_key_with_labels(hbh_key, HBH_UPLINK_SALT_LABEL, HBH_UPLINK_KEY_LABEL)
+pub fn derive_hbh_srtcp_key_uplink(hbh_key: &[u8]) -> Option<Vec<u8>> {
+    derive_hbh_key_with_labels(hbh_key, HBH_UPLINK_SALT_LABEL, HBH_UPLINK_KEY_LABEL)
 }
 
-pub fn derive_hbh_srtp_key_downlink(hbh_key: &[u8]) -> Option<Vec<u8>> {
-    derive_hbh_srtp_key_with_labels(hbh_key, HBH_DOWNLINK_SALT_LABEL, HBH_DOWNLINK_KEY_LABEL)
+pub fn derive_hbh_srtcp_key_downlink(hbh_key: &[u8]) -> Option<Vec<u8>> {
+    derive_hbh_key_with_labels(hbh_key, HBH_DOWNLINK_SALT_LABEL, HBH_DOWNLINK_KEY_LABEL)
 }
 
-pub fn keying_from_hbh_key_uplink(hbh_key: &[u8]) -> Option<SrtpKeyingMaterial> {
-    Some(keying_from_crypto_key(&derive_hbh_srtp_key_uplink(
+pub fn derive_hbh_srtp_key_shared(hbh_key: &[u8]) -> Option<Vec<u8>> {
+    derive_hbh_key_with_labels(
+        hbh_key,
+        HBH_SHARED_SRTP_SALT_LABEL,
+        HBH_SHARED_SRTP_KEY_LABEL,
+    )
+}
+
+pub fn derive_hbh_srtcp_key_shared(hbh_key: &[u8]) -> Option<Vec<u8>> {
+    derive_hbh_key_with_labels(
+        hbh_key,
+        HBH_SHARED_SRTCP_SALT_LABEL,
+        HBH_SHARED_SRTCP_KEY_LABEL,
+    )
+}
+
+pub fn keying_from_hbh_srtcp_key_uplink(hbh_key: &[u8]) -> Option<SrtpKeyingMaterial> {
+    Some(keying_from_crypto_key(&derive_hbh_srtcp_key_uplink(
         hbh_key,
     )?))
 }
 
-pub fn keying_from_hbh_key_downlink(hbh_key: &[u8]) -> Option<SrtpKeyingMaterial> {
-    Some(keying_from_crypto_key(&derive_hbh_srtp_key_downlink(
+pub fn keying_from_hbh_srtcp_key_downlink(hbh_key: &[u8]) -> Option<SrtpKeyingMaterial> {
+    Some(keying_from_crypto_key(&derive_hbh_srtcp_key_downlink(
+        hbh_key,
+    )?))
+}
+
+pub fn keying_from_hbh_srtcp_key_shared(hbh_key: &[u8]) -> Option<SrtpKeyingMaterial> {
+    Some(keying_from_crypto_key(&derive_hbh_srtcp_key_shared(
+        hbh_key,
+    )?))
+}
+
+pub fn keying_from_hbh_srtp_key_shared(hbh_key: &[u8]) -> Option<SrtpKeyingMaterial> {
+    Some(keying_from_crypto_key(&derive_hbh_srtp_key_shared(
         hbh_key,
     )?))
 }
@@ -184,6 +227,78 @@ pub fn expand_libsrtp_session_keys(keying: &SrtpKeyingMaterial) -> LibsrtpSessio
     out
 }
 
+/// Expand a dedicated HBH-SRTCP master key through the RTCP labels used by libsrtp.
+pub fn expand_libsrtcp_session_keys(keying: &SrtpKeyingMaterial) -> LibsrtpSessionKeys {
+    let mut out = LibsrtpSessionKeys {
+        session_key: [0u8; 16],
+        session_salt: [0u8; 14],
+        auth_key: [0u8; 20],
+    };
+    out.session_key.copy_from_slice(&derive_session_bytes(
+        &keying.master_key,
+        &keying.master_salt,
+        LABEL_RTCP_ENCRYPTION,
+        16,
+    ));
+    out.session_salt.copy_from_slice(&derive_session_bytes(
+        &keying.master_key,
+        &keying.master_salt,
+        LABEL_RTCP_SALT,
+        14,
+    ));
+    out.auth_key.copy_from_slice(&derive_session_bytes(
+        &keying.master_key,
+        &keying.master_salt,
+        LABEL_RTCP_AUTH,
+        20,
+    ));
+    out
+}
+
+fn as_srtcp_keys(session: LibsrtpSessionKeys) -> E2eSrtpKeys {
+    E2eSrtpKeys {
+        cipher_key: session.session_key,
+        salt: session.session_salt,
+        auth_key: session.auth_key,
+    }
+}
+
+fn expand_srtcp(keying: &SrtpKeyingMaterial) -> E2eSrtpKeys {
+    as_srtcp_keys(expand_libsrtcp_session_keys(keying))
+}
+
+pub fn derive_hbh_srtcp_keys_uplink_for_mode(
+    hbh_key: &[u8],
+    mode: HbhSrtcpMode,
+) -> Option<E2eSrtpKeys> {
+    let keying = match mode {
+        HbhSrtcpMode::Directional => keying_from_hbh_srtcp_key_uplink(hbh_key)?,
+        HbhSrtcpMode::Shared => keying_from_hbh_srtcp_key_shared(hbh_key)?,
+    };
+    Some(expand_srtcp(&keying))
+}
+
+pub fn derive_hbh_srtcp_keys_downlink_for_mode(
+    hbh_key: &[u8],
+    mode: HbhSrtcpMode,
+) -> Option<E2eSrtpKeys> {
+    let keying = match mode {
+        HbhSrtcpMode::Directional => keying_from_hbh_srtcp_key_downlink(hbh_key)?,
+        HbhSrtcpMode::Shared => keying_from_hbh_srtcp_key_shared(hbh_key)?,
+    };
+    Some(expand_srtcp(&keying))
+}
+
+/// Session keys for RTCP sent from this client to the relay.
+pub fn derive_hbh_srtcp_keys_uplink(hbh_key: &[u8]) -> Option<E2eSrtpKeys> {
+    derive_hbh_srtcp_keys_uplink_for_mode(hbh_key, HbhSrtcpMode::Directional)
+}
+
+/// Session keys for RTCP received from the relay.
+pub fn derive_hbh_srtcp_keys_downlink(hbh_key: &[u8]) -> Option<E2eSrtpKeys> {
+    derive_hbh_srtcp_keys_downlink_for_mode(hbh_key, HbhSrtcpMode::Directional)
+}
+
 /// RTP AES-ICM nonce: zero, SSRC at bytes 4-7 (BE), (packet_index << 16) at bytes 8-15 (BE).
 pub fn build_rtp_icm_nonce(ssrc: u32, packet_index: u64) -> [u8; 16] {
     let mut iv = [0u8; 16];
@@ -210,16 +325,38 @@ mod tests {
     use crate::voip::testkat::{hexd, kats};
 
     #[test]
-    fn hbh_uplink_derivation_matches_kat() {
+    fn hbh_sfu_derivation_matches_native_kat() {
         let k = kats();
         let hbh = hexd(&k, &["inputs", "hbhKey"]);
-        let uplink = derive_hbh_srtp_key_uplink(&hbh).unwrap();
+        let uplink_salt = hkdf_sha256(
+            &NULL_SALT_32,
+            &hbh[..HBH_SALT_SEED_LEN],
+            HBH_UPLINK_SALT_LABEL.as_bytes(),
+            32,
+        );
+        assert_eq!(
+            hex::encode(uplink_salt),
+            k["hbh_srtp"]["uplinkSalt32"].as_str().unwrap()
+        );
+        let uplink = derive_hbh_srtcp_key_uplink(&hbh).unwrap();
         assert_eq!(
             hex::encode(&uplink),
             k["hbh_srtp"]["uplinkKey30"].as_str().unwrap()
         );
+        assert_eq!(
+            hex::encode(derive_hbh_srtp_key_shared(&hbh).unwrap()),
+            k["hbh_srtp"]["sharedSrtpKey30"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(derive_hbh_srtcp_key_shared(&hbh).unwrap()),
+            k["hbh_srtp"]["sharedSrtcpKey30"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(derive_hbh_srtcp_key_downlink(&hbh).unwrap()),
+            k["hbh_srtp"]["downlinkKey30"].as_str().unwrap()
+        );
 
-        let keying = keying_from_hbh_key_uplink(&hbh).unwrap();
+        let keying = keying_from_hbh_srtcp_key_uplink(&hbh).unwrap();
         assert_eq!(
             hex::encode(keying.master_key),
             k["hbh_srtp"]["masterKey"].as_str().unwrap()
@@ -242,13 +379,86 @@ mod tests {
             hex::encode(session.auth_key),
             k["hbh_srtp"]["authKey"].as_str().unwrap()
         );
+
+        let srtcp = expand_libsrtcp_session_keys(&keying);
+        assert_eq!(
+            hex::encode(srtcp.session_key),
+            k["hbh_srtp"]["srtcpSessionKey"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(srtcp.session_salt),
+            k["hbh_srtp"]["srtcpSessionSalt"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(srtcp.auth_key),
+            k["hbh_srtp"]["srtcpAuthKey"].as_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn hbh_srtcp_direction_and_labels_are_isolated() {
+        use crate::voip::e2e_srtp::{protect_srtcp, unprotect_srtcp};
+        use crate::voip::rtcp::{RtcpSenderStats, build_sender_report};
+
+        let k = kats();
+        let hbh = hexd(&k, &["inputs", "hbhKey"]);
+        let uplink = derive_hbh_srtcp_keys_uplink(&hbh).unwrap();
+        let downlink = derive_hbh_srtcp_keys_downlink(&hbh).unwrap();
+        let rtp = expand_libsrtp_session_keys(&keying_from_hbh_srtcp_key_uplink(&hbh).unwrap());
+        assert_ne!(uplink.cipher_key, rtp.session_key);
+        assert_ne!(uplink.auth_key, rtp.auth_key);
+        assert_ne!(uplink.cipher_key, downlink.cipher_key);
+
+        let ssrc = 0x1234_5678;
+        let plain = build_sender_report(
+            ssrc,
+            &RtcpSenderStats {
+                packets_sent: 3,
+                octets_sent: 900,
+                rtp_timestamp: 18_000,
+            },
+            1_718_000_000_000,
+        );
+        let protected = protect_srtcp(&uplink, ssrc, 7, &plain);
+        assert_eq!(
+            unprotect_srtcp(&uplink, ssrc, &protected).as_deref(),
+            Some(plain.as_slice())
+        );
+        assert!(unprotect_srtcp(&downlink, ssrc, &protected).is_none());
+
+        for mode in HBH_SRTCP_MODES {
+            let uplink = derive_hbh_srtcp_keys_uplink_for_mode(&hbh, mode).unwrap();
+            let downlink = derive_hbh_srtcp_keys_downlink_for_mode(&hbh, mode).unwrap();
+            if mode == HbhSrtcpMode::Directional {
+                assert_ne!(uplink.auth_key, downlink.auth_key);
+            } else {
+                assert_eq!(uplink.auth_key, downlink.auth_key);
+            }
+        }
+    }
+
+    #[test]
+    fn hbh_srtcp_packet_matches_libsrtp() {
+        use crate::voip::e2e_srtp::protect_srtcp;
+
+        let k = kats();
+        let hbh = hexd(&k, &["inputs", "hbhKey"]);
+        let plain = hexd(&k, &["rtcp", "senderReport"]);
+        let keys = derive_hbh_srtcp_keys_uplink(&hbh).unwrap();
+        let protected = protect_srtcp(&keys, 0x1234_5678, 1, &plain);
+
+        // Pinned independently with libSRTP 2.8's first srtp_protect_rtcp call.
+        assert_eq!(
+            hex::encode(protected),
+            k["hbh_srtp"]["srtcpProtectedSrIndex1"].as_str().unwrap()
+        );
     }
 
     #[test]
     fn hbh_icm_nonce_and_cipher_match_kat() {
         let k = kats();
         let hbh = hexd(&k, &["inputs", "hbhKey"]);
-        let session = expand_libsrtp_session_keys(&keying_from_hbh_key_uplink(&hbh).unwrap());
+        let session = expand_libsrtp_session_keys(&keying_from_hbh_srtcp_key_uplink(&hbh).unwrap());
         let ssrc = k["inputs"]["ssrc"].as_u64().unwrap() as u32;
         let seq = k["inputs"]["seq"].as_u64().unwrap();
         let roc = k["inputs"]["roc"].as_u64().unwrap();

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -33,8 +33,8 @@ pub mod warp;
 pub use demux::{RelayPacketKind, classify_relay_packet};
 pub use driver::{CallChannels, VideoControl, run_call};
 pub use engine::{
-    CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, SetupError,
-    TxIdSource,
+    CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, RtcpProtection,
+    RtcpRejectStage, SetupError, TxIdSource,
 };
 pub use h264::{AnnexBAuSplitter, VideoFrame};
 pub use mlow::{MlowDecoder, MlowEncoder};

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -33,8 +33,8 @@ pub mod warp;
 pub use demux::{RelayPacketKind, classify_relay_packet};
 pub use driver::{CallChannels, VideoControl, run_call};
 pub use engine::{
-    CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, RtcpProtection,
-    RtcpRejectStage, SetupError, TxIdSource,
+    CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, SetupError,
+    TxIdSource,
 };
 pub use h264::{AnnexBAuSplitter, VideoFrame};
 pub use mlow::{MlowDecoder, MlowEncoder};

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -9,6 +9,7 @@ pub mod demux;
 pub mod driver;
 pub mod e2e_srtp;
 pub mod engine;
+pub mod h264;
 pub mod hbh_srtp;
 pub mod mlow;
 pub mod registry;
@@ -30,16 +31,20 @@ pub mod warp;
 // The sub-modules stay `pub` for fine-grained wire helpers (parsers, attr builders), but
 // these are the ones worth surfacing by name.
 pub use demux::{RelayPacketKind, classify_relay_packet};
-pub use driver::{CallChannels, run_call};
+pub use driver::{CallChannels, VideoControl, run_call};
 pub use engine::{
     CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, SetupError,
     TxIdSource,
 };
+pub use h264::{AnnexBAuSplitter, VideoFrame};
 pub use mlow::{MlowDecoder, MlowEncoder};
 // Internal: the inbound router's standard-Opus vs mlow discriminator (engine reaches it via `super`).
 pub(crate) use mlow::is_standard_opus_frame;
 pub use registry::CallRegistry;
-pub use session::{CallDirection, CallPhase, CallSession, MediaPipeline, MediaPipelineParams};
+pub use session::{
+    CallDirection, CallPhase, CallSession, MediaPipeline, MediaPipelineParams, VideoPipeline,
+    VideoPipelineParams,
+};
 pub use transport::{
     RelayDisconnectReason, RelayTransport, RelayTransportEvent, RelayTransportFactory,
 };

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -31,7 +31,10 @@ pub mod warp;
 // The sub-modules stay `pub` for fine-grained wire helpers (parsers, attr builders), but
 // these are the ones worth surfacing by name.
 pub use demux::{RelayPacketKind, classify_relay_packet};
-pub use driver::{CallChannels, VideoControl, run_call};
+pub use driver::{
+    CallChannels, VideoControl, VideoControlReceiver, VideoControlSender, run_call,
+    video_control_channel,
+};
 pub use engine::{
     CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, SetupError,
     TxIdSource,

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -50,7 +50,7 @@ struct CallEntry {
     video_ctl_tx: Option<async_channel::Sender<VideoControl>>,
     /// Fully release the local video endpoints. Stored here so refusal and terminal paths share the
     /// same teardown without keeping codec resources alive through lingering handles.
-    video_teardown: Option<Arc<dyn Fn() + Send + Sync>>,
+    video_teardown: Option<Box<dyn Fn() + Send + Sync>>,
     /// Prevents concurrent video transitions from overtaking each other while an ack is in flight.
     event_publication_reserved: Arc<AtomicBool>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
@@ -62,10 +62,15 @@ struct CallEntry {
 pub struct CallEventPermit {
     tx: async_channel::Sender<CallEvent>,
     reserved: Arc<AtomicBool>,
+    generation: u64,
 }
 
 impl CallEventPermit {
-    pub fn send(self, event: CallEvent) -> bool {
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn send(&self, event: CallEvent) -> bool {
         // The latest committed state must remain observable even when its consumer is behind.
         self.tx.force_send(event).is_ok()
     }
@@ -220,33 +225,55 @@ impl CallRegistry {
         {
             entry.event_tx = Some(event_tx);
             entry.video_ctl_tx = Some(video_ctl_tx);
-            entry.video_teardown = Some(video_teardown.into());
+            entry.video_teardown = Some(video_teardown);
         }
     }
 
-    /// Release the local video endpoints for `call_id` (a refused upgrade). Best-effort: a no-op if
-    /// the call is unknown or has no teardown hook registered.
-    pub fn run_video_teardown(&self, call_id: &str) {
+    /// Replace the one-shot endpoint teardown for the current call generation.
+    pub fn set_video_teardown(
+        &self,
+        call_id: &str,
+        generation: u64,
+        video_teardown: Box<dyn Fn() + Send + Sync>,
+    ) -> bool {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        entry.video_teardown = Some(video_teardown);
+        true
+    }
+
+    /// Release the local video endpoints once for the current call generation.
+    pub fn run_video_teardown(&self, call_id: &str, generation: u64) -> bool {
         let hook = self
             .inner
             .lock()
             .expect("registry lock poisoned")
-            .get(call_id)
-            .and_then(|entry| entry.video_teardown.clone());
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.video_teardown.take());
         if let Some(hook) = hook {
             hook();
+            true
+        } else {
+            false
         }
     }
 
     /// Serialize an actionable signaling event across its typed ack. The permit force-inserts the
     /// committed transition, so queue pressure cannot hide peer-visible state from the consumer.
     pub fn reserve_call_event(&self, call_id: &str) -> Option<CallEventPermit> {
-        let (tx, reserved) = {
+        let (tx, reserved, generation) = {
             let map = self.inner.lock().expect("registry lock poisoned");
             let entry = map.get(call_id)?;
             (
                 entry.event_tx.clone()?,
                 entry.event_publication_reserved.clone(),
+                entry.generation,
             )
         };
         if tx.is_closed()
@@ -256,33 +283,58 @@ impl CallRegistry {
         {
             return None;
         }
-        Some(CallEventPermit { tx, reserved })
+        Some(CallEventPermit {
+            tx,
+            reserved,
+            generation,
+        })
     }
 
-    /// Send a mid-call video-plane command to the drive loop (best-effort).
-    pub fn send_video_ctl(&self, call_id: &str, ctl: VideoControl) {
+    /// Send a mid-call video-plane command to the current drive loop (best-effort).
+    pub fn send_video_ctl(&self, call_id: &str, generation: u64, ctl: VideoControl) {
         let tx = self
             .inner
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
+            .filter(|entry| entry.generation == generation)
             .and_then(|e| e.video_ctl_tx.clone());
         if let Some(tx) = tx {
-            let _ = tx.force_send(ctl);
+            match ctl {
+                // Orientation is advisory and must not evict a negotiated state transition.
+                VideoControl::SetOrientation(_) => {
+                    let _ = tx.try_send(ctl);
+                }
+                _ => {
+                    let _ = tx.force_send(ctl);
+                }
+            }
         }
     }
 
     /// Track whether the call currently has video negotiated (offer `<video>`, upgrade accepted, or
     /// downgraded back). No-op for an unknown call.
-    pub fn set_is_video(&self, call_id: &str, is_video: bool) {
+    pub fn set_is_video(&self, call_id: &str, generation: u64, is_video: bool) -> bool {
         if let Some(entry) = self
             .inner
             .lock()
             .expect("registry lock poisoned")
             .get_mut(call_id)
+            && entry.generation == generation
         {
             entry.session.is_video = is_video;
+            true
+        } else {
+            false
         }
+    }
+
+    pub fn is_current(&self, call_id: &str, generation: u64) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .is_some_and(|entry| entry.generation == generation)
     }
 
     /// Caller side: rekey recv to the device that answered. One-shot — the sender is TAKEN, so a
@@ -522,6 +574,11 @@ mod tests {
             event_rx.try_recv(),
             Ok(CallEvent::VideoStateChanged { .. })
         ));
+        assert!(
+            reg.reserve_call_event("CID").is_none(),
+            "publishing must not release the transition before its effects finish"
+        );
+        drop(permit);
         assert!(reg.reserve_call_event("CID").is_some());
         assert!(reg.reserve_call_event("UNKNOWN").is_none());
     }
@@ -541,8 +598,68 @@ mod tests {
             })
         });
 
-        reg.run_video_teardown("CID");
+        assert!(reg.run_video_teardown("CID", generation));
         assert!(lock_was_free.load(Ordering::SeqCst));
+        assert!(!reg.run_video_teardown("CID", generation));
+    }
+
+    #[test]
+    fn video_teardown_is_one_shot_until_rearmed() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        let (event_tx, _event_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = async_channel::bounded(1);
+        let calls = Arc::new(AtomicU64::new(0));
+        let hook = |calls: &Arc<AtomicU64>| {
+            let calls = calls.clone();
+            Box::new(move || {
+                calls.fetch_add(1, Ordering::SeqCst);
+            }) as Box<dyn Fn() + Send + Sync>
+        };
+        reg.set_video_channels("CID", generation, event_tx, ctl_tx, hook(&calls));
+
+        assert!(reg.run_video_teardown("CID", generation));
+        assert!(!reg.run_video_teardown("CID", generation));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        assert!(reg.set_video_teardown("CID", generation, hook(&calls)));
+        assert!(reg.run_video_teardown("CID", generation));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(reg.remove_if_current("CID", generation));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn video_mutations_are_generation_guarded_and_orientation_is_advisory() {
+        let reg = CallRegistry::new();
+        let stale = reg.insert(session("CID"));
+        let current = reg.insert(session("CID"));
+        let (event_tx, _event_rx) = async_channel::bounded(1);
+        let (ctl_tx, ctl_rx) = async_channel::bounded(1);
+        let teardown_calls = Arc::new(AtomicU64::new(0));
+        reg.set_video_channels("CID", current, event_tx, ctl_tx, {
+            let teardown_calls = teardown_calls.clone();
+            Box::new(move || {
+                teardown_calls.fetch_add(1, Ordering::SeqCst);
+            })
+        });
+
+        assert!(reg.set_is_video("CID", current, true));
+        assert!(!reg.set_is_video("CID", stale, false));
+        assert!(reg.snapshot("CID").expect("session").is_video);
+        assert!(!reg.run_video_teardown("CID", stale));
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 0);
+
+        reg.send_video_ctl("CID", current, VideoControl::Disable);
+        reg.send_video_ctl("CID", current, VideoControl::SetOrientation(1));
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
+
+        reg.send_video_ctl("CID", current, VideoControl::SetOrientation(2));
+        reg.send_video_ctl("CID", current, VideoControl::Enable);
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Enable));
+
+        reg.send_video_ctl("CID", stale, VideoControl::Disable);
+        assert!(ctl_rx.try_recv().is_err());
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -48,14 +48,20 @@ struct CallEntry {
     event_tx: Option<async_channel::Sender<CallEvent>>,
     /// Mid-call video-plane control into the drive loop (enable/disable/orientation).
     video_ctl_tx: Option<async_channel::Sender<VideoControl>>,
-    /// Fully release the local video endpoints (stop the camera feed, drop the sink). Runs when a
-    /// negotiation the caller started is refused (`<video state=UpgradeReject|UpgradeCancel>`), so a
-    /// dead upgrade doesn't leave the source encoding into a disabled plane. Built in the root crate
-    /// (it owns the endpoints), stored here so the wacore-side signaling handler can invoke it.
+    /// Fully release the local video endpoints. Stored here so refusal and terminal paths share the
+    /// same teardown without keeping codec resources alive through lingering handles.
     video_teardown: Option<Arc<dyn Fn() + Send + Sync>>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
+}
+
+impl Drop for CallEntry {
+    fn drop(&mut self) {
+        if let Some(teardown) = self.video_teardown.take() {
+            teardown();
+        }
+    }
 }
 
 /// Thread-safe map of active calls keyed by call-id.
@@ -497,6 +503,26 @@ mod tests {
 
         reg.run_video_teardown("CID");
         assert!(lock_was_free.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn removal_releases_video_endpoints_after_registry_unlock() {
+        let reg = Arc::new(CallRegistry::new());
+        let generation = reg.insert(session("CID"));
+        let (event_tx, _event_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = async_channel::bounded(1);
+        let calls = Arc::new(AtomicU64::new(0));
+        reg.set_video_channels("CID", generation, event_tx, ctl_tx, {
+            let reg = reg.clone();
+            let calls = calls.clone();
+            Box::new(move || {
+                assert!(reg.inner.try_lock().is_ok());
+                calls.fetch_add(1, Ordering::SeqCst);
+            })
+        });
+
+        assert!(reg.remove_if_current("CID", generation));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use portable_atomic::{AtomicBool, AtomicU64};
 
 use crate::runtime::AbortHandle;
-use crate::voip::driver::VideoControl;
+use crate::voip::driver::{VideoControl, VideoControlSender};
 use crate::voip::engine::CallEvent;
 use crate::voip::session::{CallPhase, CallSession};
 use wacore_binary::Jid;
@@ -47,7 +47,7 @@ struct CallEntry {
     /// SIGNALING handler can surface `<video state>` changes next to the engine's events.
     event_tx: Option<async_channel::Sender<CallEvent>>,
     /// Mid-call video-plane control into the drive loop (enable/disable/orientation).
-    video_ctl_tx: Option<async_channel::Sender<VideoControl>>,
+    video_ctl_tx: Option<VideoControlSender>,
     /// Fully release the local video endpoints. Stored here so refusal and terminal paths share the
     /// same teardown without keeping codec resources alive through lingering handles.
     video_teardown: Option<Box<dyn Fn() + Send + Sync>>,
@@ -213,7 +213,7 @@ impl CallRegistry {
         call_id: &str,
         generation: u64,
         event_tx: async_channel::Sender<CallEvent>,
-        video_ctl_tx: async_channel::Sender<VideoControl>,
+        video_ctl_tx: VideoControlSender,
         video_teardown: Box<dyn Fn() + Send + Sync>,
     ) {
         if let Some(entry) = self
@@ -290,7 +290,7 @@ impl CallRegistry {
         })
     }
 
-    /// Send a mid-call video-plane command to the current drive loop (best-effort).
+    /// Send a mid-call video-plane command to the current drive loop.
     pub fn send_video_ctl(&self, call_id: &str, generation: u64, ctl: VideoControl) {
         let tx = self
             .inner
@@ -300,15 +300,7 @@ impl CallRegistry {
             .filter(|entry| entry.generation == generation)
             .and_then(|e| e.video_ctl_tx.clone());
         if let Some(tx) = tx {
-            match ctl {
-                // Orientation is advisory and must not evict a negotiated state transition.
-                VideoControl::SetOrientation(_) => {
-                    let _ = tx.try_send(ctl);
-                }
-                _ => {
-                    let _ = tx.force_send(ctl);
-                }
-            }
+            let _ = tx.send(ctl);
         }
     }
 
@@ -505,6 +497,7 @@ impl CallRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::voip::driver::video_control_channel;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use wacore_binary::{Jid, Server};
@@ -550,7 +543,7 @@ mod tests {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("CID"));
         let (event_tx, event_rx) = async_channel::bounded(1);
-        let (ctl_tx, _ctl_rx) = async_channel::unbounded();
+        let (ctl_tx, _ctl_rx) = video_control_channel();
         reg.set_video_channels("CID", generation, event_tx.clone(), ctl_tx, Box::new(|| {}));
 
         let event = || CallEvent::VideoStateChanged {
@@ -588,7 +581,7 @@ mod tests {
         let reg = Arc::new(CallRegistry::new());
         let generation = reg.insert(session("CID"));
         let (event_tx, _event_rx) = async_channel::bounded(1);
-        let (ctl_tx, _ctl_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = video_control_channel();
         let lock_was_free = Arc::new(AtomicBool::new(false));
         reg.set_video_channels("CID", generation, event_tx, ctl_tx, {
             let reg = reg.clone();
@@ -608,7 +601,7 @@ mod tests {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("CID"));
         let (event_tx, _event_rx) = async_channel::bounded(1);
-        let (ctl_tx, _ctl_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = video_control_channel();
         let calls = Arc::new(AtomicU64::new(0));
         let hook = |calls: &Arc<AtomicU64>| {
             let calls = calls.clone();
@@ -635,7 +628,7 @@ mod tests {
         let stale = reg.insert(session("CID"));
         let current = reg.insert(session("CID"));
         let (event_tx, _event_rx) = async_channel::bounded(1);
-        let (ctl_tx, ctl_rx) = async_channel::bounded(1);
+        let (ctl_tx, ctl_rx) = video_control_channel();
         let teardown_calls = Arc::new(AtomicU64::new(0));
         reg.set_video_channels("CID", current, event_tx, ctl_tx, {
             let teardown_calls = teardown_calls.clone();
@@ -651,12 +644,17 @@ mod tests {
         assert_eq!(teardown_calls.load(Ordering::SeqCst), 0);
 
         reg.send_video_ctl("CID", current, VideoControl::Disable);
-        reg.send_video_ctl("CID", current, VideoControl::SetOrientation(1));
-        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
-
-        reg.send_video_ctl("CID", current, VideoControl::SetOrientation(2));
+        for orientation in 0..100u8 {
+            reg.send_video_ctl(
+                "CID",
+                current,
+                VideoControl::SetOrientation(orientation % 4),
+            );
+        }
         reg.send_video_ctl("CID", current, VideoControl::Enable);
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
         assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Enable));
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
 
         reg.send_video_ctl("CID", stale, VideoControl::Disable);
         assert!(ctl_rx.try_recv().is_err());
@@ -667,7 +665,7 @@ mod tests {
         let reg = Arc::new(CallRegistry::new());
         let generation = reg.insert(session("CID"));
         let (event_tx, _event_rx) = async_channel::bounded(1);
-        let (ctl_tx, _ctl_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = video_control_channel();
         let calls = Arc::new(AtomicU64::new(0));
         reg.set_video_channels("CID", generation, event_tx, ctl_tx, {
             let reg = reg.clone();

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
-use portable_atomic::AtomicU64;
+use portable_atomic::{AtomicBool, AtomicU64};
 
 use crate::runtime::AbortHandle;
 use crate::voip::driver::VideoControl;
@@ -51,9 +51,29 @@ struct CallEntry {
     /// Fully release the local video endpoints. Stored here so refusal and terminal paths share the
     /// same teardown without keeping codec resources alive through lingering handles.
     video_teardown: Option<Arc<dyn Fn() + Send + Sync>>,
+    /// Serializes the signaling event slot across an async typed-ack send.
+    event_slot_reserved: Arc<AtomicBool>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
+}
+
+/// Capacity reserved for one actionable signaling event while its typed ack is in flight.
+pub struct CallEventPermit {
+    tx: async_channel::Sender<CallEvent>,
+    reserved: Arc<AtomicBool>,
+}
+
+impl CallEventPermit {
+    pub fn send(self, event: CallEvent) -> bool {
+        self.tx.try_send(event).is_ok()
+    }
+}
+
+impl Drop for CallEventPermit {
+    fn drop(&mut self) {
+        self.reserved.store(false, Ordering::Release);
+    }
 }
 
 impl Drop for CallEntry {
@@ -104,6 +124,7 @@ impl CallRegistry {
                     event_tx: None,
                     video_ctl_tx: None,
                     video_teardown: None,
+                    event_slot_reserved: Arc::new(AtomicBool::new(false)),
                     on_terminal: None,
                 },
             )
@@ -216,16 +237,26 @@ impl CallRegistry {
         }
     }
 
-    /// Surface signaling on the consumer's event queue. The result lets the handler withhold its
-    /// protocol acknowledgement instead of accepting a transition the application never received.
-    pub fn send_call_event(&self, call_id: &str, event: CallEvent) -> bool {
-        let tx = self
-            .inner
-            .lock()
-            .expect("registry lock poisoned")
-            .get(call_id)
-            .and_then(|e| e.event_tx.clone());
-        tx.is_some_and(|tx| tx.try_send(event).is_ok())
+    /// Reserve the queue's signaling slot before sending the typed ack. Engine diagnostics leave
+    /// this last slot unused, so the event can only become visible after the ack succeeds.
+    pub fn reserve_call_event(&self, call_id: &str) -> Option<CallEventPermit> {
+        let (tx, reserved) = {
+            let map = self.inner.lock().expect("registry lock poisoned");
+            let entry = map.get(call_id)?;
+            (entry.event_tx.clone()?, entry.event_slot_reserved.clone())
+        };
+        if tx.is_closed()
+            || reserved
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+        {
+            return None;
+        }
+        if tx.is_full() {
+            reserved.store(false, Ordering::Release);
+            return None;
+        }
+        Some(CallEventPermit { tx, reserved })
     }
 
     /// Send a mid-call video-plane command to the drive loop (best-effort).
@@ -463,10 +494,10 @@ mod tests {
     }
 
     #[test]
-    fn signaling_event_reports_queue_backpressure() {
+    fn signaling_event_reserves_capacity_until_commit() {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("CID"));
-        let (event_tx, event_rx) = async_channel::bounded(1);
+        let (event_tx, event_rx) = async_channel::bounded(2);
         let (ctl_tx, _ctl_rx) = async_channel::unbounded();
         reg.set_video_channels("CID", generation, event_tx, ctl_tx, Box::new(|| {}));
 
@@ -474,16 +505,36 @@ mod tests {
             state: crate::types::call::VideoState::Enabled,
             orientation: None,
         };
-        assert!(reg.send_call_event("CID", event()));
+        let permit = reg.reserve_call_event("CID").expect("first reservation");
         assert!(
-            !reg.send_call_event("CID", event()),
-            "a full queue must be visible to the signaling handler"
+            reg.reserve_call_event("CID").is_none(),
+            "only one typed ack may own the signaling slot"
         );
+        assert!(
+            event_rx.is_empty(),
+            "reservation must not publish the event"
+        );
+        assert!(permit.send(event()));
         assert!(matches!(
             event_rx.try_recv(),
             Ok(CallEvent::VideoStateChanged { .. })
         ));
-        assert!(!reg.send_call_event("UNKNOWN", event()));
+        assert!(reg.reserve_call_event("CID").is_some());
+        assert!(reg.reserve_call_event("UNKNOWN").is_none());
+
+        let (full_tx, _full_rx) = async_channel::bounded(1);
+        full_tx.try_send(CallEvent::RelayAllocated).unwrap();
+        reg.set_video_channels(
+            "CID",
+            generation,
+            full_tx,
+            async_channel::unbounded().0,
+            Box::new(|| {}),
+        );
+        assert!(
+            reg.reserve_call_event("CID").is_none(),
+            "a pre-existing full queue cannot reserve the ack-ordered slot"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -51,14 +51,14 @@ struct CallEntry {
     /// Fully release the local video endpoints. Stored here so refusal and terminal paths share the
     /// same teardown without keeping codec resources alive through lingering handles.
     video_teardown: Option<Arc<dyn Fn() + Send + Sync>>,
-    /// Serializes the signaling event slot across an async typed-ack send.
-    event_slot_reserved: Arc<AtomicBool>,
+    /// Prevents concurrent video transitions from overtaking each other while an ack is in flight.
+    event_publication_reserved: Arc<AtomicBool>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
 }
 
-/// Capacity reserved for one actionable signaling event while its typed ack is in flight.
+/// Exclusive publication right for an actionable signaling event awaiting its typed ack.
 pub struct CallEventPermit {
     tx: async_channel::Sender<CallEvent>,
     reserved: Arc<AtomicBool>,
@@ -66,7 +66,8 @@ pub struct CallEventPermit {
 
 impl CallEventPermit {
     pub fn send(self, event: CallEvent) -> bool {
-        self.tx.try_send(event).is_ok()
+        // The latest committed state must remain observable even when its consumer is behind.
+        self.tx.force_send(event).is_ok()
     }
 }
 
@@ -124,7 +125,7 @@ impl CallRegistry {
                     event_tx: None,
                     video_ctl_tx: None,
                     video_teardown: None,
-                    event_slot_reserved: Arc::new(AtomicBool::new(false)),
+                    event_publication_reserved: Arc::new(AtomicBool::new(false)),
                     on_terminal: None,
                 },
             )
@@ -237,23 +238,22 @@ impl CallRegistry {
         }
     }
 
-    /// Reserve the queue's signaling slot before sending the typed ack. Engine diagnostics leave
-    /// this last slot unused, so the event can only become visible after the ack succeeds.
+    /// Serialize an actionable signaling event across its typed ack. The permit force-inserts the
+    /// committed transition, so queue pressure cannot hide peer-visible state from the consumer.
     pub fn reserve_call_event(&self, call_id: &str) -> Option<CallEventPermit> {
         let (tx, reserved) = {
             let map = self.inner.lock().expect("registry lock poisoned");
             let entry = map.get(call_id)?;
-            (entry.event_tx.clone()?, entry.event_slot_reserved.clone())
+            (
+                entry.event_tx.clone()?,
+                entry.event_publication_reserved.clone(),
+            )
         };
         if tx.is_closed()
             || reserved
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                 .is_err()
         {
-            return None;
-        }
-        if tx.is_full() {
-            reserved.store(false, Ordering::Release);
             return None;
         }
         Some(CallEventPermit { tx, reserved })
@@ -494,12 +494,12 @@ mod tests {
     }
 
     #[test]
-    fn signaling_event_reserves_capacity_until_commit() {
+    fn signaling_event_commit_survives_queue_backpressure() {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("CID"));
-        let (event_tx, event_rx) = async_channel::bounded(2);
+        let (event_tx, event_rx) = async_channel::bounded(1);
         let (ctl_tx, _ctl_rx) = async_channel::unbounded();
-        reg.set_video_channels("CID", generation, event_tx, ctl_tx, Box::new(|| {}));
+        reg.set_video_channels("CID", generation, event_tx.clone(), ctl_tx, Box::new(|| {}));
 
         let event = || CallEvent::VideoStateChanged {
             state: crate::types::call::VideoState::Enabled,
@@ -514,6 +514,9 @@ mod tests {
             event_rx.is_empty(),
             "reservation must not publish the event"
         );
+        event_tx
+            .try_send(CallEvent::RelayAllocated)
+            .expect("fill the queue while the typed ack is in flight");
         assert!(permit.send(event()));
         assert!(matches!(
             event_rx.try_recv(),
@@ -521,20 +524,6 @@ mod tests {
         ));
         assert!(reg.reserve_call_event("CID").is_some());
         assert!(reg.reserve_call_event("UNKNOWN").is_none());
-
-        let (full_tx, _full_rx) = async_channel::bounded(1);
-        full_tx.try_send(CallEvent::RelayAllocated).unwrap();
-        reg.set_video_channels(
-            "CID",
-            generation,
-            full_tx,
-            async_channel::unbounded().0,
-            Box::new(|| {}),
-        );
-        assert!(
-            reg.reserve_call_event("CID").is_none(),
-            "a pre-existing full queue cannot reserve the ack-ordered slot"
-        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -8,8 +8,8 @@
 //! the portable core to a specific executor.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 
 use portable_atomic::AtomicU64;
 
@@ -52,7 +52,7 @@ struct CallEntry {
     /// negotiation the caller started is refused (`<video state=UpgradeReject|UpgradeCancel>`), so a
     /// dead upgrade doesn't leave the source encoding into a disabled plane. Built in the root crate
     /// (it owns the endpoints), stored here so the wacore-side signaling handler can invoke it.
-    video_teardown: Option<Box<dyn Fn() + Send + Sync>>,
+    video_teardown: Option<Arc<dyn Fn() + Send + Sync>>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
@@ -192,38 +192,37 @@ impl CallRegistry {
         {
             entry.event_tx = Some(event_tx);
             entry.video_ctl_tx = Some(video_ctl_tx);
-            entry.video_teardown = Some(video_teardown);
+            entry.video_teardown = Some(video_teardown.into());
         }
     }
 
     /// Release the local video endpoints for `call_id` (a refused upgrade). Best-effort: a no-op if
     /// the call is unknown or has no teardown hook registered.
     pub fn run_video_teardown(&self, call_id: &str) {
-        let map = self.inner.lock().expect("registry lock poisoned");
-        // Invoke under the lock: the boxed Fn stays owned by the live entry. It only flips the
-        // root-crate VideoShared flags / aborts a feed — no re-entry into the registry — so this
-        // is safe.
-        if let Some(hook) = map.get(call_id).and_then(|e| e.video_teardown.as_ref()) {
+        let hook = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|entry| entry.video_teardown.clone());
+        if let Some(hook) = hook {
             hook();
         }
     }
 
-    /// Surface a call event on the consumer's event queue (best-effort: dropped when the queue is
-    /// full or the call is unknown, same loss policy as the driver's event posts).
-    pub fn send_call_event(&self, call_id: &str, event: CallEvent) {
+    /// Surface signaling on the consumer's event queue. The result lets the handler withhold its
+    /// protocol acknowledgement instead of accepting a transition the application never received.
+    pub fn send_call_event(&self, call_id: &str, event: CallEvent) -> bool {
         let tx = self
             .inner
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
             .and_then(|e| e.event_tx.clone());
-        if let Some(tx) = tx {
-            let _ = tx.try_send(event);
-        }
+        tx.is_some_and(|tx| tx.try_send(event).is_ok())
     }
 
-    /// Send a mid-call video-plane command to the drive loop. Best-effort like
-    /// [`send_call_event`](Self::send_call_event).
+    /// Send a mid-call video-plane command to the drive loop (best-effort).
     pub fn send_video_ctl(&self, call_id: &str, ctl: VideoControl) {
         let tx = self
             .inner
@@ -232,7 +231,7 @@ impl CallRegistry {
             .get(call_id)
             .and_then(|e| e.video_ctl_tx.clone());
         if let Some(tx) = tx {
-            let _ = tx.try_send(ctl);
+            let _ = tx.force_send(ctl);
         }
     }
 
@@ -455,6 +454,49 @@ mod tests {
             "a stale generation must not read the replacement's device"
         );
         assert_eq!(reg.answering_device_if_current("CID", g2), None);
+    }
+
+    #[test]
+    fn signaling_event_reports_queue_backpressure() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("CID"));
+        let (event_tx, event_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = async_channel::unbounded();
+        reg.set_video_channels("CID", generation, event_tx, ctl_tx, Box::new(|| {}));
+
+        let event = || CallEvent::VideoStateChanged {
+            state: crate::types::call::VideoState::Enabled,
+            orientation: None,
+        };
+        assert!(reg.send_call_event("CID", event()));
+        assert!(
+            !reg.send_call_event("CID", event()),
+            "a full queue must be visible to the signaling handler"
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(CallEvent::VideoStateChanged { .. })
+        ));
+        assert!(!reg.send_call_event("UNKNOWN", event()));
+    }
+
+    #[test]
+    fn video_teardown_runs_after_registry_unlock() {
+        let reg = Arc::new(CallRegistry::new());
+        let generation = reg.insert(session("CID"));
+        let (event_tx, _event_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = async_channel::bounded(1);
+        let lock_was_free = Arc::new(AtomicBool::new(false));
+        reg.set_video_channels("CID", generation, event_tx, ctl_tx, {
+            let reg = reg.clone();
+            let lock_was_free = lock_was_free.clone();
+            Box::new(move || {
+                lock_was_free.store(reg.inner.try_lock().is_ok(), Ordering::SeqCst);
+            })
+        });
+
+        reg.run_video_teardown("CID");
+        assert!(lock_was_free.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -14,6 +14,8 @@ use std::sync::atomic::Ordering;
 use portable_atomic::AtomicU64;
 
 use crate::runtime::AbortHandle;
+use crate::voip::driver::VideoControl;
+use crate::voip::engine::CallEvent;
 use crate::voip::session::{CallPhase, CallSession};
 use wacore_binary::Jid;
 
@@ -41,6 +43,16 @@ struct CallEntry {
     /// Caller-only, one-shot: delivers the answering device LID to the drive loop so it can rekey
     /// recv. Taken on first use (a duplicate `<accept>` finds `None`); dropped with the entry.
     rekey_tx: Option<async_channel::Sender<String>>,
+    /// The call's consumer-facing event queue (same channel `CallHandle::events()` reads), so the
+    /// SIGNALING handler can surface `<video state>` changes next to the engine's events.
+    event_tx: Option<async_channel::Sender<CallEvent>>,
+    /// Mid-call video-plane control into the drive loop (enable/disable/orientation).
+    video_ctl_tx: Option<async_channel::Sender<VideoControl>>,
+    /// Fully release the local video endpoints (stop the camera feed, drop the sink). Runs when a
+    /// negotiation the caller started is refused (`<video state=UpgradeReject|UpgradeCancel>`), so a
+    /// dead upgrade doesn't leave the source encoding into a disabled plane. Built in the root crate
+    /// (it owns the endpoints), stored here so the wacore-side signaling handler can invoke it.
+    video_teardown: Option<Box<dyn Fn() + Send + Sync>>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
@@ -83,6 +95,9 @@ impl CallRegistry {
                     media_task: None,
                     generation,
                     rekey_tx: None,
+                    event_tx: None,
+                    video_ctl_tx: None,
+                    video_teardown: None,
                     on_terminal: None,
                 },
             )
@@ -153,6 +168,84 @@ impl CallRegistry {
             && entry.generation == generation
         {
             entry.rekey_tx = Some(tx);
+        }
+    }
+
+    /// Store the call's consumer-facing event sender, video-control sender, and the local-video
+    /// teardown hook, so the signaling handler can surface `<video state>` changes, steer the video
+    /// plane mid-call, and fully release the endpoints on a refused upgrade. Generation-guarded like
+    /// the rekey sender.
+    pub fn set_video_channels(
+        &self,
+        call_id: &str,
+        generation: u64,
+        event_tx: async_channel::Sender<CallEvent>,
+        video_ctl_tx: async_channel::Sender<VideoControl>,
+        video_teardown: Box<dyn Fn() + Send + Sync>,
+    ) {
+        if let Some(entry) = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            && entry.generation == generation
+        {
+            entry.event_tx = Some(event_tx);
+            entry.video_ctl_tx = Some(video_ctl_tx);
+            entry.video_teardown = Some(video_teardown);
+        }
+    }
+
+    /// Release the local video endpoints for `call_id` (a refused upgrade). Best-effort: a no-op if
+    /// the call is unknown or has no teardown hook registered.
+    pub fn run_video_teardown(&self, call_id: &str) {
+        let map = self.inner.lock().expect("registry lock poisoned");
+        // Invoke under the lock: the boxed Fn stays owned by the live entry. It only flips the
+        // root-crate VideoShared flags / aborts a feed — no re-entry into the registry — so this
+        // is safe.
+        if let Some(hook) = map.get(call_id).and_then(|e| e.video_teardown.as_ref()) {
+            hook();
+        }
+    }
+
+    /// Surface a call event on the consumer's event queue (best-effort: dropped when the queue is
+    /// full or the call is unknown, same loss policy as the driver's event posts).
+    pub fn send_call_event(&self, call_id: &str, event: CallEvent) {
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|e| e.event_tx.clone());
+        if let Some(tx) = tx {
+            let _ = tx.try_send(event);
+        }
+    }
+
+    /// Send a mid-call video-plane command to the drive loop. Best-effort like
+    /// [`send_call_event`](Self::send_call_event).
+    pub fn send_video_ctl(&self, call_id: &str, ctl: VideoControl) {
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|e| e.video_ctl_tx.clone());
+        if let Some(tx) = tx {
+            let _ = tx.try_send(ctl);
+        }
+    }
+
+    /// Track whether the call currently has video negotiated (offer `<video>`, upgrade accepted, or
+    /// downgraded back). No-op for an unknown call.
+    pub fn set_is_video(&self, call_id: &str, is_video: bool) {
+        if let Some(entry) = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+        {
+            entry.session.is_video = is_video;
         }
     }
 

--- a/wacore/src/voip/relay_parse.rs
+++ b/wacore/src/voip/relay_parse.rs
@@ -104,7 +104,7 @@ fn node_content_bytes(node: &NodeRef<'_>) -> Option<Vec<u8>> {
     node.content_str().map(|s| s.as_bytes().to_vec())
 }
 
-/// Decode `<hbh_key>` to 30 bytes (16B master_key + 14B master_salt); handles double-base64.
+/// Decode `<hbh_key>` to its 14B salt seed + 16B key seed; handles double-base64.
 pub fn decode_hbh_key(bytes: &[u8]) -> Option<Vec<u8>> {
     if bytes.is_empty() {
         return None;

--- a/wacore/src/voip/rtcp.rs
+++ b/wacore/src/voip/rtcp.rs
@@ -1,30 +1,23 @@
-//! RTCP: WhatsApp compact reports (PT 208/209) and a Sender Report (PT 200).
+//! RTCP: standard sender/source reports and WhatsApp compact reports (PT 208/209).
 //! The SR's NTP timestamp is taken as a `now_ms` argument so this stays
 //! pure/no-clock (caller passes `wacore::time`).
 
-use crate::voip::rtp::RTP_PAYLOAD_TYPE_OPUS;
-
 pub const RTCP_PT_SR: u8 = 200;
+pub const RTCP_PT_RR: u8 = 201;
+pub const RTCP_PT_SDES: u8 = 202;
+pub const RTCP_PT_RTPFB: u8 = 205;
+pub const RTCP_PT_PSFB: u8 = 206;
 pub const RTCP_PT_WA_COMPACT: u8 = 208;
 pub const RTCP_PT_WA_COMPACT2: u8 = 209;
 pub const RTCP_HEADER_LEN: usize = 8;
 pub const SRTCP_TRAILER_LEN: usize = 14;
+pub const WHATSAPP_RTCP_CNAME_LEN: usize = 18;
 
 /// NTP epoch offset (seconds between 1900-01-01 and 1970-01-01).
 const NTP_UNIX_OFFSET_SECS: u64 = 2_208_988_800;
 
 pub fn is_rtcp_packet(data: &[u8]) -> bool {
-    if data.len() < RTCP_HEADER_LEN + SRTCP_TRAILER_LEN {
-        return false;
-    }
-    if (data[0] >> 6) & 0x03 != 2 {
-        return false;
-    }
-    // WhatsApp RTP uses X=1 (byte0 0x90) and a 7-bit PT in byte1; RTCP uses the full byte1 as PT.
-    if data[0] & 0x10 != 0 && data[1] & 0x7f == RTP_PAYLOAD_TYPE_OPUS {
-        return false;
-    }
-    data[1] >= 64
+    data.len() >= RTCP_HEADER_LEN && (data[0] >> 6) & 0x03 == 2 && (192..=223).contains(&data[1])
 }
 
 pub fn rtcp_payload_type(data: &[u8]) -> Option<u8> {
@@ -32,10 +25,218 @@ pub fn rtcp_payload_type(data: &[u8]) -> Option<u8> {
 }
 
 pub fn parse_rtcp_sender_ssrc(data: &[u8]) -> Option<u32> {
-    if data.len() < 8 || (data[0] >> 6) & 0x03 != 2 {
+    if !is_rtcp_packet(data) {
         return None;
     }
     Some(u32::from_be_bytes([data[4], data[5], data[6], data[7]]))
+}
+
+/// Fields useful for proving whether the peer reports or requests one of our streams.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtcpSummary {
+    pub packet_types: Vec<u8>,
+    pub sender_ssrc: u32,
+    pub referenced_ssrcs: Vec<u32>,
+    pub report_blocks: Vec<RtcpReportBlock>,
+    pub feedback: Vec<RtcpFeedback>,
+    pub sdes_cname_lengths: Vec<usize>,
+    /// The native video profile sets bit 4 separately from the four-bit report count.
+    pub uses_whatsapp_profile_extension: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtcpFeedback {
+    pub packet_type: u8,
+    pub fmt: u8,
+    pub sender_ssrc: u32,
+    pub media_ssrc: u32,
+    pub fci: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RtcpReportBlock {
+    pub ssrc: u32,
+    pub fraction_lost: u8,
+    pub cumulative_lost: i32,
+    pub extended_highest_sequence: u32,
+    pub jitter: u32,
+    pub last_sender_report: u32,
+    pub delay_since_last_sender_report: u32,
+    /// WhatsApp appends per-stream fields after the RFC 3550 block.
+    pub profile_extension: Vec<u8>,
+}
+
+fn parse_sdes_cname_lengths(packet: &[u8], source_count: usize) -> Option<Vec<usize>> {
+    let mut cursor = 4usize;
+    let mut cname_lengths = Vec::new();
+    for _ in 0..source_count {
+        cursor = cursor.checked_add(4)?;
+        packet.get(cursor - 4..cursor)?;
+        loop {
+            let item_type = *packet.get(cursor)?;
+            cursor += 1;
+            if item_type == 0 {
+                while cursor & 3 != 0 {
+                    if *packet.get(cursor)? != 0 {
+                        return None;
+                    }
+                    cursor += 1;
+                }
+                break;
+            }
+            let item_len = *packet.get(cursor)? as usize;
+            cursor += 1;
+            packet.get(cursor..cursor.checked_add(item_len)?)?;
+            if item_type == 1 {
+                cname_lengths.push(item_len);
+            }
+            cursor += item_len;
+        }
+    }
+    (cursor == packet.len()).then_some(cname_lengths)
+}
+
+fn parse_report_blocks(
+    packet: &[u8],
+    start: usize,
+    raw_count: usize,
+) -> Option<(Vec<RtcpReportBlock>, bool)> {
+    let available = packet.len().checked_sub(start)?;
+    let mut report_count = raw_count;
+    let mut uses_whatsapp_profile_extension = false;
+    if available < report_count.checked_mul(24)? && raw_count & 0x10 != 0 {
+        report_count = raw_count & 0x0f;
+        uses_whatsapp_profile_extension = true;
+    }
+    if report_count == 0 {
+        return (available == 0).then_some((Vec::new(), uses_whatsapp_profile_extension));
+    }
+    if available < report_count.checked_mul(24)? {
+        return None;
+    }
+
+    let stride = if available % report_count == 0 {
+        available / report_count
+    } else {
+        24
+    };
+    if stride < 24 {
+        return None;
+    }
+
+    let mut reports = Vec::with_capacity(report_count);
+    for index in 0..report_count {
+        let at = start.checked_add(index.checked_mul(stride)?)?;
+        let block = packet.get(at..at.checked_add(stride)?)?;
+        let cumulative_raw = u32::from_be_bytes([0, block[5], block[6], block[7]]) as i32;
+        let cumulative_lost = if cumulative_raw & 0x80_0000 != 0 {
+            cumulative_raw | !0x00ff_ffff
+        } else {
+            cumulative_raw
+        };
+        reports.push(RtcpReportBlock {
+            ssrc: u32::from_be_bytes(block[0..4].try_into().ok()?),
+            fraction_lost: block[4],
+            cumulative_lost,
+            extended_highest_sequence: u32::from_be_bytes(block[8..12].try_into().ok()?),
+            jitter: u32::from_be_bytes(block[12..16].try_into().ok()?),
+            last_sender_report: u32::from_be_bytes(block[16..20].try_into().ok()?),
+            delay_since_last_sender_report: u32::from_be_bytes(block[20..24].try_into().ok()?),
+            profile_extension: block[24..].to_vec(),
+        });
+    }
+    Some((reports, uses_whatsapp_profile_extension))
+}
+
+/// Parse a decrypted RTCP compound packet. Referenced SSRCs include SR/RR report blocks and the
+/// media targets of transport/payload feedback (NACK, PLI, FIR).
+pub fn summarize_rtcp(data: &[u8]) -> Option<RtcpSummary> {
+    let mut offset = 0usize;
+    let mut packet_types = Vec::new();
+    let mut referenced_ssrcs = Vec::new();
+    let mut report_blocks = Vec::new();
+    let mut feedback = Vec::new();
+    let mut sdes_cname_lengths = Vec::new();
+    let mut sender_ssrc = None;
+    let mut uses_whatsapp_profile_extension = false;
+
+    while offset < data.len() {
+        let header = data.get(offset..offset + 4)?;
+        if (header[0] >> 6) & 0x03 != 2 || !(192..=223).contains(&header[1]) {
+            return None;
+        }
+        let words = u16::from_be_bytes([header[2], header[3]]) as usize + 1;
+        let packet_len = words.checked_mul(4)?;
+        let packet = data.get(offset..offset.checked_add(packet_len)?)?;
+        if packet.len() < RTCP_HEADER_LEN {
+            return None;
+        }
+
+        let packet_type = packet[1];
+        let raw_count = (packet[0] & 0x1f) as usize;
+        let this_sender = u32::from_be_bytes(packet[4..8].try_into().ok()?);
+        sender_ssrc.get_or_insert(this_sender);
+        packet_types.push(packet_type);
+
+        let report_start = match packet_type {
+            RTCP_PT_SR => Some(28),
+            RTCP_PT_RR => Some(8),
+            _ => None,
+        };
+        if let Some(start) = report_start {
+            let (mut parsed, uses_profile) = parse_report_blocks(packet, start, raw_count)?;
+            uses_whatsapp_profile_extension |= uses_profile;
+            referenced_ssrcs.extend(parsed.iter().map(|report| report.ssrc));
+            report_blocks.append(&mut parsed);
+        }
+
+        if matches!(packet_type, RTCP_PT_RTPFB | RTCP_PT_PSFB) && packet.len() >= 12 {
+            let media_ssrc = u32::from_be_bytes(packet[8..12].try_into().ok()?);
+            feedback.push(RtcpFeedback {
+                packet_type,
+                fmt: raw_count as u8,
+                sender_ssrc: this_sender,
+                media_ssrc,
+                fci: packet[12..].to_vec(),
+            });
+            if media_ssrc != 0 {
+                referenced_ssrcs.push(media_ssrc);
+            }
+            // FIR commonly leaves the media-source field zero and names targets in 8-byte FCI rows.
+            if packet_type == RTCP_PT_PSFB && raw_count == 4 {
+                for fci in packet[12..].chunks_exact(8) {
+                    referenced_ssrcs.push(u32::from_be_bytes(fci[..4].try_into().ok()?));
+                }
+            }
+        } else if packet_type == RTCP_PT_WA_COMPACT && packet.len() >= 12 {
+            referenced_ssrcs.push(u32::from_be_bytes(packet[8..12].try_into().ok()?));
+        } else if packet_type == RTCP_PT_SDES {
+            let (parsed, uses_profile) =
+                if let Some(parsed) = parse_sdes_cname_lengths(packet, raw_count) {
+                    (parsed, false)
+                } else if raw_count & 0x10 != 0 {
+                    (parse_sdes_cname_lengths(packet, raw_count & 0x0f)?, true)
+                } else {
+                    return None;
+                };
+            uses_whatsapp_profile_extension |= uses_profile;
+            sdes_cname_lengths.extend(parsed);
+        }
+
+        offset += packet_len;
+    }
+
+    referenced_ssrcs.sort_unstable();
+    referenced_ssrcs.dedup();
+    Some(RtcpSummary {
+        packet_types,
+        sender_ssrc: sender_ssrc?,
+        referenced_ssrcs,
+        report_blocks,
+        feedback,
+        sdes_cname_lengths,
+        uses_whatsapp_profile_extension,
+    })
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -43,6 +244,169 @@ pub struct RtcpSenderStats {
     pub packets_sent: u32,
     pub octets_sent: u32,
     pub rtp_timestamp: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RtcpReceptionReport {
+    pub ssrc: u32,
+    pub fraction_lost: u8,
+    pub cumulative_lost: i32,
+    pub extended_highest_sequence: u32,
+    pub jitter: u32,
+    pub last_sender_report: u32,
+    pub delay_since_last_sender_report: u32,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RtpReceptionStats {
+    ssrc: Option<u32>,
+    base_sequence: u16,
+    max_sequence: u16,
+    sequence_cycles: u32,
+    received: u32,
+    expected_prior: u32,
+    received_prior: u32,
+    transit: Option<u32>,
+    jitter_q4: u64,
+    last_sender_report: u32,
+    last_sender_report_at_ms: Option<u64>,
+}
+
+impl RtpReceptionStats {
+    pub(crate) fn observe(
+        &mut self,
+        ssrc: u32,
+        sequence: u16,
+        rtp_timestamp: u32,
+        arrival_ms: u64,
+        clock_rate: u32,
+    ) {
+        if self.ssrc != Some(ssrc) {
+            *self = Self {
+                ssrc: Some(ssrc),
+                base_sequence: sequence,
+                max_sequence: sequence,
+                received: 1,
+                ..Self::default()
+            };
+        } else {
+            let delta = sequence.wrapping_sub(self.max_sequence);
+            if delta != 0 && delta < 0x8000 {
+                if sequence < self.max_sequence {
+                    self.sequence_cycles = self.sequence_cycles.wrapping_add(1 << 16);
+                }
+                self.max_sequence = sequence;
+            }
+            self.received = self.received.wrapping_add(1);
+        }
+
+        let arrival_rtp = ((arrival_ms as u128 * clock_rate as u128) / 1000) as u32;
+        let transit = arrival_rtp.wrapping_sub(rtp_timestamp);
+        if let Some(previous) = self.transit {
+            let delta = transit.wrapping_sub(previous) as i32;
+            let distance = (delta as i64).unsigned_abs();
+            let decay = (self.jitter_q4 + 8) >> 4;
+            self.jitter_q4 = self
+                .jitter_q4
+                .saturating_add(distance)
+                .saturating_sub(decay);
+        }
+        self.transit = Some(transit);
+    }
+
+    pub(crate) fn observe_sender_report(
+        &mut self,
+        sender_ssrc: u32,
+        ntp_seconds: u32,
+        ntp_fraction: u32,
+        arrival_ms: u64,
+    ) {
+        if self.ssrc != Some(sender_ssrc) {
+            return;
+        }
+        self.last_sender_report = (ntp_seconds << 16) | (ntp_fraction >> 16);
+        self.last_sender_report_at_ms = Some(arrival_ms);
+    }
+
+    pub(crate) fn report(&mut self, now_ms: u64) -> Option<RtcpReceptionReport> {
+        let ssrc = self.ssrc?;
+        let expected = self
+            .sequence_cycles
+            .wrapping_add(self.max_sequence as u32)
+            .wrapping_sub(self.base_sequence as u32)
+            .wrapping_add(1);
+        let expected_interval = expected.wrapping_sub(self.expected_prior);
+        let received_interval = self.received.wrapping_sub(self.received_prior);
+        let lost_interval = expected_interval as i64 - received_interval as i64;
+        let fraction_lost = if expected_interval == 0 || lost_interval <= 0 {
+            0
+        } else {
+            ((lost_interval * 256) / expected_interval as i64).min(255) as u8
+        };
+        self.expected_prior = expected;
+        self.received_prior = self.received;
+
+        let cumulative_lost =
+            (expected as i64 - self.received as i64).clamp(-0x80_0000, 0x7f_ffff) as i32;
+        let delay_since_last_sender_report = self
+            .last_sender_report_at_ms
+            .map(|at| {
+                let elapsed = now_ms.saturating_sub(at);
+                ((elapsed as u128 * 65_536) / 1000).min(u32::MAX as u128) as u32
+            })
+            .unwrap_or(0);
+
+        Some(RtcpReceptionReport {
+            ssrc,
+            fraction_lost,
+            cumulative_lost,
+            extended_highest_sequence: self.sequence_cycles | self.max_sequence as u32,
+            jitter: (self.jitter_q4 >> 4).min(u32::MAX as u64) as u32,
+            last_sender_report: self.last_sender_report,
+            delay_since_last_sender_report,
+        })
+    }
+}
+
+pub(crate) fn parse_sender_report_timing(data: &[u8]) -> Option<(u32, u32, u32)> {
+    let mut offset = 0usize;
+    while offset < data.len() {
+        let header = data.get(offset..offset + 4)?;
+        let packet_len =
+            (u16::from_be_bytes([header[2], header[3]]) as usize + 1).checked_mul(4)?;
+        let packet = data.get(offset..offset.checked_add(packet_len)?)?;
+        if header[1] == RTCP_PT_SR && packet.len() >= 28 {
+            return Some((
+                u32::from_be_bytes(packet[4..8].try_into().ok()?),
+                u32::from_be_bytes(packet[8..12].try_into().ok()?),
+                u32::from_be_bytes(packet[12..16].try_into().ok()?),
+            ));
+        }
+        offset += packet_len;
+    }
+    None
+}
+
+/// Native WhatsApp streams use eleven random lowercase hex nibbles around a fixed `@pj...org`
+/// suffix. Production entropy comes from the engine's injected random source.
+pub fn build_whatsapp_rtcp_cname(entropy: &[u8; 12]) -> [u8; WHATSAPP_RTCP_CNAME_LEN] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut random_hex = [0u8; 11];
+    for (nibble, out) in random_hex.iter_mut().enumerate() {
+        let byte = entropy[6 + nibble / 2];
+        let value = if nibble & 1 == 0 {
+            byte >> 4
+        } else {
+            byte & 0x0f
+        };
+        *out = HEX[value as usize];
+    }
+    let mut cname = [0u8; WHATSAPP_RTCP_CNAME_LEN];
+    cname[..5].copy_from_slice(&random_hex[..5]);
+    cname[5..8].copy_from_slice(b"@pj");
+    cname[8..14].copy_from_slice(&random_hex[5..]);
+    cname[14..].copy_from_slice(b".org");
+    cname
 }
 
 /// 12-byte compact RTCP (PT 208, RC=1); 26 bytes on the wire with the SRTCP trailer.
@@ -88,6 +452,131 @@ pub fn build_sender_report(local_ssrc: u32, stats: &RtcpSenderStats, now_ms: u64
     buf
 }
 
+fn encode_reception_report(report: &RtcpReceptionReport, out: &mut Vec<u8>) {
+    out.extend_from_slice(&report.ssrc.to_be_bytes());
+    out.push(report.fraction_lost);
+    let lost = report.cumulative_lost as u32;
+    out.extend_from_slice(&lost.to_be_bytes()[1..]);
+    out.extend_from_slice(&report.extended_highest_sequence.to_be_bytes());
+    out.extend_from_slice(&report.jitter.to_be_bytes());
+    out.extend_from_slice(&report.last_sender_report.to_be_bytes());
+    out.extend_from_slice(&report.delay_since_last_sender_report.to_be_bytes());
+}
+
+const WHATSAPP_RECEPTION_REPORT_EXTENSION_LEN: usize = 24;
+
+fn encode_whatsapp_reception_report(report: &RtcpReceptionReport, out: &mut Vec<u8>) {
+    encode_reception_report(report, out);
+    // These are optional transport/BWE statistics in the native 1:1 report. Zero is the
+    // native unavailable value; the RFC fields above remain authoritative.
+    out.resize(out.len() + WHATSAPP_RECEPTION_REPORT_EXTENSION_LEN, 0);
+}
+
+fn build_sender_report_with_reports(
+    local_ssrc: u32,
+    stats: &RtcpSenderStats,
+    now_ms: u64,
+    reports: &[RtcpReceptionReport],
+) -> Vec<u8> {
+    let reports = &reports[..reports.len().min(31)];
+    let mut packet = build_sender_report(local_ssrc, stats, now_ms).to_vec();
+    packet[0] |= reports.len() as u8;
+    for report in reports {
+        encode_reception_report(report, &mut packet);
+    }
+    let words = packet.len() / 4 - 1;
+    packet[2..4].copy_from_slice(&(words as u16).to_be_bytes());
+    packet
+}
+
+/// Native WhatsApp's 32-byte SDES packet: one chunk, its 18-byte CNAME, END, and padding.
+pub fn build_source_description(
+    local_ssrc: u32,
+    cname: &[u8; WHATSAPP_RTCP_CNAME_LEN],
+) -> [u8; 32] {
+    let mut packet = [0u8; 32];
+    packet[0] = 0x81;
+    packet[1] = RTCP_PT_SDES;
+    packet[2..4].copy_from_slice(&7u16.to_be_bytes());
+    packet[4..8].copy_from_slice(&local_ssrc.to_be_bytes());
+    packet[8] = 1;
+    packet[9] = WHATSAPP_RTCP_CNAME_LEN as u8;
+    packet[10..28].copy_from_slice(cname);
+    packet
+}
+
+pub(crate) fn build_whatsapp_source_description(
+    local_ssrc: u32,
+    cname: &[u8; WHATSAPP_RTCP_CNAME_LEN],
+    profile_extension: bool,
+) -> [u8; 32] {
+    let mut packet = build_source_description(local_ssrc, cname);
+    if profile_extension {
+        packet[0] |= 0x10;
+    }
+    packet
+}
+
+/// Native RTCP sessions without a CNAME still send an empty 12-byte SDES chunk.
+pub fn build_empty_source_description(local_ssrc: u32) -> [u8; 12] {
+    let mut packet = [0u8; 12];
+    packet[0] = 0x81;
+    packet[1] = RTCP_PT_SDES;
+    packet[2..4].copy_from_slice(&2u16.to_be_bytes());
+    packet[4..8].copy_from_slice(&local_ssrc.to_be_bytes());
+    packet
+}
+
+/// WhatsApp's periodic sender report is a compound `SR + SDES` datagram.
+pub fn build_sender_report_with_sdes(
+    local_ssrc: u32,
+    stats: &RtcpSenderStats,
+    now_ms: u64,
+    cname: &[u8; WHATSAPP_RTCP_CNAME_LEN],
+) -> Vec<u8> {
+    build_sender_report_with_sdes_and_reports(local_ssrc, stats, now_ms, cname, &[])
+}
+
+pub(crate) fn build_sender_report_with_sdes_and_reports(
+    local_ssrc: u32,
+    stats: &RtcpSenderStats,
+    now_ms: u64,
+    cname: &[u8; WHATSAPP_RTCP_CNAME_LEN],
+    reports: &[RtcpReceptionReport],
+) -> Vec<u8> {
+    let sdes = build_source_description(local_ssrc, cname);
+    let sender_report = build_sender_report_with_reports(local_ssrc, stats, now_ms, reports);
+    let mut compound = Vec::with_capacity(sender_report.len() + sdes.len());
+    compound.extend_from_slice(&sender_report);
+    compound.extend_from_slice(&sdes);
+    compound
+}
+
+/// The native 1:1 path associates one receive stream with each RTCP sender. Its report block is
+/// the RFC 3550 block followed by 24 bytes of WhatsApp transport/BWE statistics.
+pub(crate) fn build_whatsapp_sender_report_with_sdes(
+    local_ssrc: u32,
+    stats: &RtcpSenderStats,
+    now_ms: u64,
+    cname: &[u8; WHATSAPP_RTCP_CNAME_LEN],
+    report: Option<&RtcpReceptionReport>,
+    profile_extension: bool,
+) -> Vec<u8> {
+    let mut sender_report = build_sender_report(local_ssrc, stats, now_ms).to_vec();
+    if profile_extension {
+        sender_report[0] |= 0x10;
+    }
+    if let Some(report) = report {
+        sender_report[0] |= 1;
+        encode_whatsapp_reception_report(report, &mut sender_report);
+        let words = sender_report.len() / 4 - 1;
+        sender_report[2..4].copy_from_slice(&(words as u16).to_be_bytes());
+    }
+    let sdes = build_whatsapp_source_description(local_ssrc, cname, profile_extension);
+    sender_report.extend_from_slice(&sdes);
+    sender_report
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,16 +614,307 @@ mod tests {
     }
 
     #[test]
+    fn native_cname_and_sdes_match_wire_layout() {
+        let entropy = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+        ];
+        let cname = build_whatsapp_rtcp_cname(&entropy);
+        assert_eq!(&cname, b"66778@pj899aab.org");
+
+        let sdes = build_source_description(0x1234_5678, &cname);
+        assert_eq!(
+            hex::encode(sdes),
+            "81ca0007123456780112363637373840706a3839396161622e6f726700000000"
+        );
+        let summary = summarize_rtcp(&sdes).unwrap();
+        assert_eq!(summary.packet_types, [RTCP_PT_SDES]);
+        assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
+    }
+
+    #[test]
+    fn empty_sdes_is_one_padded_chunk() {
+        let sdes = build_empty_source_description(0x1234_5678);
+        assert_eq!(hex::encode(sdes), "81ca00021234567800000000");
+        let summary = summarize_rtcp(&sdes).unwrap();
+        assert!(summary.sdes_cname_lengths.is_empty());
+    }
+
+    #[test]
+    fn sender_report_compound_includes_sdes() {
+        let stats = RtcpSenderStats {
+            packets_sent: 5,
+            octets_sent: 600,
+            rtp_timestamp: 1600,
+        };
+        let cname = *b"66778@pj899aab.org";
+        let compound =
+            build_sender_report_with_sdes(0x1234_5678, &stats, 1_718_000_000_000, &cname);
+        let summary = summarize_rtcp(&compound).unwrap();
+        assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
+        assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
+    }
+
+    #[test]
+    fn standard_sender_report_encodes_two_report_blocks() {
+        let stats = RtcpSenderStats {
+            packets_sent: 9,
+            octets_sent: 4_096,
+            rtp_timestamp: 90_000,
+        };
+        let reports = [
+            RtcpReceptionReport {
+                ssrc: 0x1111_2222,
+                fraction_lost: 0x40,
+                cumulative_lost: 2,
+                extended_highest_sequence: 0x0001_0002,
+                jitter: 123,
+                last_sender_report: 0x3344_5566,
+                delay_since_last_sender_report: 0x7788_99aa,
+            },
+            RtcpReceptionReport {
+                ssrc: 0x3333_4444,
+                fraction_lost: 0,
+                cumulative_lost: -1,
+                extended_highest_sequence: 7,
+                jitter: 8,
+                last_sender_report: 0,
+                delay_since_last_sender_report: 0,
+            },
+        ];
+        let compound = build_sender_report_with_sdes_and_reports(
+            0x5555_6666,
+            &stats,
+            1_700_000_000_000,
+            b"00000@pj000000.org",
+            &reports,
+        );
+
+        assert_eq!(compound.len(), 76 + 32);
+        assert_eq!(&compound[..4], &[0x82, RTCP_PT_SR, 0, 18]);
+        assert_eq!(&compound[28..32], &reports[0].ssrc.to_be_bytes());
+        assert_eq!(&compound[32..36], &[0x40, 0, 0, 2]);
+        assert_eq!(&compound[52..56], &reports[1].ssrc.to_be_bytes());
+        assert_eq!(&compound[56..60], &[0, 0xff, 0xff, 0xff]);
+        assert_eq!(&compound[76..80], &[0x81, RTCP_PT_SDES, 0, 7]);
+
+        let summary = summarize_rtcp(&compound).expect("valid SR+SDES compound");
+        assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
+        assert_eq!(summary.referenced_ssrcs, [reports[0].ssrc, reports[1].ssrc]);
+    }
+
+    #[test]
+    fn parses_native_video_profile_report_and_sdes_layouts() {
+        let sender = 0x1111_2222u32;
+        let target = 0x3333_4444u32;
+        let mut sender_report = vec![0x91, RTCP_PT_SR, 0, 18];
+        sender_report.extend_from_slice(&sender.to_be_bytes());
+        sender_report.extend_from_slice(&[0; 20]);
+        sender_report.extend_from_slice(&target.to_be_bytes());
+        sender_report.extend_from_slice(&[0x20, 0xff, 0xff, 0xfe]);
+        sender_report.extend_from_slice(&0x0001_2345u32.to_be_bytes());
+        sender_report.extend_from_slice(&77u32.to_be_bytes());
+        sender_report.extend_from_slice(&0x5566_7788u32.to_be_bytes());
+        sender_report.extend_from_slice(&0x0000_8000u32.to_be_bytes());
+        let extension: Vec<u8> = (0..WHATSAPP_RECEPTION_REPORT_EXTENSION_LEN as u8).collect();
+        sender_report.extend_from_slice(&extension);
+        assert_eq!(sender_report.len(), 76);
+
+        let mut full_sdes = build_source_description(sender, b"00000@pj000000.org");
+        full_sdes[0] = 0x91;
+        let mut full_compound = sender_report.clone();
+        full_compound.extend_from_slice(&full_sdes);
+        assert_eq!(full_compound.len(), 108);
+
+        let summary = summarize_rtcp(&full_compound).expect("native full-SDES compound");
+        assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
+        assert_eq!(summary.referenced_ssrcs, [target]);
+        assert!(summary.uses_whatsapp_profile_extension);
+        assert_eq!(summary.sdes_cname_lengths, [WHATSAPP_RTCP_CNAME_LEN]);
+        assert_eq!(
+            summary.report_blocks,
+            [RtcpReportBlock {
+                ssrc: target,
+                fraction_lost: 0x20,
+                cumulative_lost: -2,
+                extended_highest_sequence: 0x0001_2345,
+                jitter: 77,
+                last_sender_report: 0x5566_7788,
+                delay_since_last_sender_report: 0x0000_8000,
+                profile_extension: extension,
+            }]
+        );
+
+        let mut empty_sdes = build_empty_source_description(sender);
+        empty_sdes[0] = 0x91;
+        let mut empty_compound = sender_report;
+        empty_compound.extend_from_slice(&empty_sdes);
+        assert_eq!(empty_compound.len(), 88);
+        let summary = summarize_rtcp(&empty_compound).expect("native empty-SDES compound");
+        assert_eq!(summary.packet_types, [RTCP_PT_SR, RTCP_PT_SDES]);
+        assert!(summary.sdes_cname_lengths.is_empty());
+        assert!(summary.uses_whatsapp_profile_extension);
+    }
+
+    #[test]
+    fn native_video_sender_report_matches_profile_structure() {
+        let report = RtcpReceptionReport {
+            ssrc: 0x3333_4444,
+            fraction_lost: 5,
+            cumulative_lost: 2,
+            extended_highest_sequence: 91,
+            jitter: 7,
+            last_sender_report: 8,
+            delay_since_last_sender_report: 9,
+        };
+        let compound = build_whatsapp_sender_report_with_sdes(
+            0x1111_2222,
+            &RtcpSenderStats {
+                packets_sent: 3,
+                octets_sent: 400,
+                rtp_timestamp: 90_000,
+            },
+            1_700_000_000_000,
+            b"00000@pj000000.org",
+            Some(&report),
+            true,
+        );
+
+        assert_eq!(compound.len(), 108);
+        assert_eq!(&compound[..4], &[0x91, RTCP_PT_SR, 0, 18]);
+        assert_eq!(&compound[28..32], &report.ssrc.to_be_bytes());
+        assert_eq!(&compound[52..76], &[0; 24]);
+        assert_eq!(&compound[76..80], &[0x91, RTCP_PT_SDES, 0, 7]);
+        let summary = summarize_rtcp(&compound).expect("native video compound");
+        assert_eq!(summary.referenced_ssrcs, [report.ssrc]);
+        assert_eq!(summary.report_blocks[0].profile_extension, [0; 24]);
+        assert!(summary.uses_whatsapp_profile_extension);
+    }
+
+    #[test]
+    fn reception_stats_track_loss_wrap_lsr_and_dlsr() {
+        let mut reception = RtpReceptionStats::default();
+        reception.observe(0x1234_5678, 65_534, 90_000, 1_000, 90_000);
+        reception.observe(0x1234_5678, 65_535, 95_400, 1_060, 90_000);
+        // Sequence zero is deliberately lost; sequence one proves the rollover.
+        reception.observe(0x1234_5678, 1, 106_200, 1_180, 90_000);
+        reception.observe_sender_report(0x1234_5678, 0x0102_0304, 0x5060_7080, 1_180);
+
+        let report = reception.report(1_680).expect("observed RTP source");
+        assert_eq!(report.ssrc, 0x1234_5678);
+        assert_eq!(report.fraction_lost, 64);
+        assert_eq!(report.cumulative_lost, 1);
+        assert_eq!(report.extended_highest_sequence, 0x0001_0001);
+        assert_eq!(report.jitter, 0);
+        assert_eq!(report.last_sender_report, 0x0304_5060);
+        assert_eq!(report.delay_since_last_sender_report, 32_768);
+
+        let next = reception.report(1_680).expect("source remains active");
+        assert_eq!(next.fraction_lost, 0);
+        assert_eq!(next.cumulative_lost, 1);
+    }
+
+    #[test]
+    fn parses_sender_report_ntp_timing_from_compound() {
+        let report = build_sender_report(
+            0x1234_5678,
+            &RtcpSenderStats {
+                packets_sent: 0,
+                octets_sent: 0,
+                rtp_timestamp: 0,
+            },
+            1_700_000_000_250,
+        );
+        assert_eq!(
+            parse_sender_report_timing(&report),
+            Some((
+                0x1234_5678,
+                (NTP_UNIX_OFFSET_SECS + 1_700_000_000) as u32,
+                1 << 30,
+            ))
+        );
+    }
+
+    #[test]
     fn rtcp_classification() {
         let k = kats();
         let sr = hex::decode(k["rtcp"]["senderReport"].as_str().unwrap()).unwrap();
-        // SR alone is 28 bytes (>= 8+14), V=2, PT=200 >= 64.
         assert!(is_rtcp_packet(&sr));
         assert_eq!(rtcp_payload_type(&sr), Some(200));
-        // An RTP speech header (X=1, PT=120) must NOT be classified as RTCP.
+        // RTP uses a 7-bit PT. Marker+H264 is 0xe1, outside RTCP's mux range.
+        let video = [0x80, 0xe1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1];
+        assert!(!is_rtcp_packet(&video));
         let rtp = hex::decode(k["rtp"]["speechHeader16"].as_str().unwrap()).unwrap();
-        let mut padded = rtp.clone();
-        padded.resize(40, 0);
-        assert!(!is_rtcp_packet(&padded));
+        assert!(!is_rtcp_packet(&rtp));
+    }
+
+    #[test]
+    fn summarizes_rr_and_feedback_targets() {
+        let sender = 0x1111_2222u32;
+        let audio = 0x3333_4444u32;
+        let video = 0x5555_6666u32;
+
+        // RR with one 24-byte report block.
+        let mut compound = vec![0x81, RTCP_PT_RR, 0, 7];
+        compound.extend_from_slice(&sender.to_be_bytes());
+        compound.extend_from_slice(&audio.to_be_bytes());
+        compound.extend_from_slice(&[0; 20]);
+        // PLI for the video SSRC.
+        compound.extend_from_slice(&[0x81, RTCP_PT_PSFB, 0, 2]);
+        compound.extend_from_slice(&sender.to_be_bytes());
+        compound.extend_from_slice(&video.to_be_bytes());
+
+        let summary = summarize_rtcp(&compound).expect("valid compound RTCP");
+        assert_eq!(summary.packet_types, [RTCP_PT_RR, RTCP_PT_PSFB]);
+        assert_eq!(summary.sender_ssrc, sender);
+        assert_eq!(summary.referenced_ssrcs, [audio, video]);
+        assert_eq!(
+            summary.feedback,
+            [RtcpFeedback {
+                packet_type: RTCP_PT_PSFB,
+                fmt: 1,
+                sender_ssrc: sender,
+                media_ssrc: video,
+                fci: Vec::new(),
+            }]
+        );
+        assert!(summary.sdes_cname_lengths.is_empty());
+    }
+
+    #[test]
+    fn summarizes_fir_target_from_feedback_control_information() {
+        let sender = 0x1111_2222u32;
+        let video = 0x5555_6666u32;
+        let mut fir = vec![0x84, RTCP_PT_PSFB, 0, 4];
+        fir.extend_from_slice(&sender.to_be_bytes());
+        fir.extend_from_slice(&0u32.to_be_bytes());
+        fir.extend_from_slice(&video.to_be_bytes());
+        fir.extend_from_slice(&[7, 0, 0, 0]);
+
+        let summary = summarize_rtcp(&fir).expect("valid FIR");
+
+        assert_eq!(summary.referenced_ssrcs, [video]);
+        assert_eq!(
+            summary.feedback,
+            [RtcpFeedback {
+                packet_type: RTCP_PT_PSFB,
+                fmt: 4,
+                sender_ssrc: sender,
+                media_ssrc: 0,
+                fci: [video.to_be_bytes().as_slice(), &[7, 0, 0, 0]].concat(),
+            }]
+        );
+    }
+
+    #[test]
+    fn malformed_compound_rtcp_is_rejected() {
+        // Claims 32 bytes but only carries the common header.
+        assert!(summarize_rtcp(&[0x80, RTCP_PT_RR, 0, 7, 0, 0, 0, 1]).is_none());
+    }
+
+    #[test]
+    fn malformed_sdes_is_rejected() {
+        let mut sdes = build_source_description(1, b"00000@pj000000.org");
+        *sdes.last_mut().unwrap() = 1;
+        assert!(summarize_rtcp(&sdes).is_none());
     }
 }

--- a/wacore/src/voip/rtcp.rs
+++ b/wacore/src/voip/rtcp.rs
@@ -191,10 +191,16 @@ pub fn summarize_rtcp(data: &[u8]) -> Option<RtcpSummary> {
         }
 
         if matches!(packet_type, RTCP_PT_RTPFB | RTCP_PT_PSFB) && packet.len() >= 12 {
+            let fmt = if raw_count & 0x10 != 0 {
+                uses_whatsapp_profile_extension = true;
+                raw_count & 0x0f
+            } else {
+                raw_count
+            };
             let media_ssrc = u32::from_be_bytes(packet[8..12].try_into().ok()?);
             feedback.push(RtcpFeedback {
                 packet_type,
-                fmt: raw_count as u8,
+                fmt: fmt as u8,
                 sender_ssrc: this_sender,
                 media_ssrc,
                 fci: packet[12..].to_vec(),
@@ -203,7 +209,7 @@ pub fn summarize_rtcp(data: &[u8]) -> Option<RtcpSummary> {
                 referenced_ssrcs.push(media_ssrc);
             }
             // FIR commonly leaves the media-source field zero and names targets in 8-byte FCI rows.
-            if packet_type == RTCP_PT_PSFB && raw_count == 4 {
+            if packet_type == RTCP_PT_PSFB && fmt == 4 {
                 for fci in packet[12..].chunks_exact(8) {
                     referenced_ssrcs.push(u32::from_be_bytes(fci[..4].try_into().ok()?));
                 }
@@ -878,6 +884,20 @@ mod tests {
             }]
         );
         assert!(summary.sdes_cname_lengths.is_empty());
+    }
+
+    #[test]
+    fn whatsapp_feedback_profile_bit_is_not_part_of_fmt() {
+        let sender = 0x1111_2222u32;
+        let video = 0x5555_6666u32;
+        let mut pli = vec![0x91, RTCP_PT_PSFB, 0, 2];
+        pli.extend_from_slice(&sender.to_be_bytes());
+        pli.extend_from_slice(&video.to_be_bytes());
+
+        let summary = summarize_rtcp(&pli).expect("WhatsApp-profile PLI");
+        assert!(summary.uses_whatsapp_profile_extension);
+        assert_eq!(summary.feedback[0].fmt, 1);
+        assert_eq!(summary.referenced_ssrcs, [video]);
     }
 
     #[test]

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -4,6 +4,13 @@
 use crate::voip::warp::audio_piggyback_extension_for;
 
 pub const RTP_PAYLOAD_TYPE_OPUS: u8 = 120;
+/// H.264 video payload type. Taken from the WaCalls/meowcaller reference,
+/// never validated against a live capture.
+pub const RTP_PAYLOAD_TYPE_H264: u8 = 97;
+/// Video RTP timestamp clock.
+pub const VIDEO_CLOCK_RATE: u32 = 90_000;
+/// Timestamp stride per access unit at the reference 15 fps (90000 / 15).
+pub const VIDEO_TS_STRIDE_15FPS: u32 = VIDEO_CLOCK_RATE / 15;
 pub const WHATSAPP_RTP_EXTENSION_PROFILE: u16 = 0xdebe;
 /// RFC 3550 fixed RTP header length, before any CSRC list or extension block.
 pub const RTP_FIXED_HEADER_LEN: usize = 12;
@@ -266,6 +273,46 @@ impl RtpStream {
     }
 }
 
+/// Send-side sequencer for the video stream: one header per RTP packet of an
+/// access unit, the timestamp is shared by every packet of the AU and advances
+/// by `ts_stride` only when the AU closes (marker packet). Plain 16-byte
+/// header — no WARP extension, no DTX, no speech latch.
+pub struct VideoRtpStream {
+    pub ssrc: u32,
+    seq: u16,
+    timestamp: u32,
+    ts_stride: u32,
+}
+
+impl VideoRtpStream {
+    pub fn new(ssrc: u32, ts_stride: u32) -> Self {
+        Self {
+            ssrc,
+            seq: 0,
+            timestamp: 0,
+            ts_stride,
+        }
+    }
+
+    /// Header for the next packet of the current AU; `last_in_au` sets the
+    /// marker and moves the timestamp to the next AU.
+    pub fn next_video_packet(&mut self, last_in_au: bool) -> RtpHeader {
+        let header = RtpHeader {
+            marker: last_in_au,
+            payload_type: RTP_PAYLOAD_TYPE_H264,
+            sequence_number: self.seq,
+            timestamp: self.timestamp,
+            ssrc: self.ssrc,
+            extension_word: None,
+        };
+        self.seq = self.seq.wrapping_add(1);
+        if last_in_au {
+            self.timestamp = self.timestamp.wrapping_add(self.ts_stride);
+        }
+        header
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,6 +394,52 @@ mod tests {
         assert!(is_whatsapp_opus_rtp_payload(120));
         assert!(is_whatsapp_opus_rtp_payload(121));
         assert!(!is_whatsapp_opus_rtp_payload(96));
+    }
+
+    #[test]
+    fn video_stream_marker_and_timestamp_advance_per_au() {
+        let mut s = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
+        // 3-packet AU: ts shared, marker only on the last.
+        let p0 = s.next_video_packet(false);
+        let p1 = s.next_video_packet(false);
+        let p2 = s.next_video_packet(true);
+        assert_eq!(
+            (p0.sequence_number, p1.sequence_number, p2.sequence_number),
+            (0, 1, 2)
+        );
+        assert_eq!((p0.timestamp, p1.timestamp, p2.timestamp), (0, 0, 0));
+        assert_eq!((p0.marker, p1.marker, p2.marker), (false, false, true));
+        // Next AU: timestamp advanced by one stride.
+        let p3 = s.next_video_packet(true);
+        assert_eq!(p3.timestamp, VIDEO_TS_STRIDE_15FPS);
+        assert_eq!(p3.sequence_number, 3);
+        for p in [p0, p1, p2, p3] {
+            assert_eq!(p.payload_type, RTP_PAYLOAD_TYPE_H264);
+            assert_eq!(p.extension_word, None);
+            assert_eq!(p.byte_size(), WHATSAPP_RTP_HEADER_SIZE);
+        }
+    }
+
+    #[test]
+    fn video_header_round_trips_through_parse() {
+        let mut s = VideoRtpStream::new(0xdead_beef, VIDEO_TS_STRIDE_15FPS);
+        s.next_video_packet(true);
+        let h = s.next_video_packet(true);
+        let bytes = encode_rtp_header(&h);
+        assert_eq!(rtp_header_byte_length(&bytes), Some(16));
+        assert_eq!(parse_rtp_header(&bytes), Some(h));
+    }
+
+    #[test]
+    fn video_stream_wraps_seq_and_timestamp() {
+        let mut s = VideoRtpStream::new(1, u32::MAX);
+        s.seq = u16::MAX;
+        s.timestamp = u32::MAX;
+        let p = s.next_video_packet(true);
+        assert_eq!(p.sequence_number, u16::MAX);
+        let p = s.next_video_packet(false);
+        assert_eq!(p.sequence_number, 0, "seq must wrap, not panic");
+        assert_eq!(p.timestamp, u32::MAX - 1, "timestamp must wrap, not panic");
     }
 
     #[test]

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -404,15 +404,18 @@ pub struct VideoRtpStream {
 }
 
 impl VideoRtpStream {
-    pub fn new(ssrc: u32, ts_stride: u32) -> Self {
-        Self {
+    pub fn new(ssrc: u32, ts_stride: u32) -> Option<Self> {
+        if ts_stride == 0 {
+            return None;
+        }
+        Some(Self {
             ssrc,
             seq: 0,
             timestamp: 0,
             last_sent_timestamp: None,
             ts_stride,
             transport_sequence: 0,
-        }
+        })
     }
 
     /// The current send timestamp (last emitted), for an RTCP Sender Report.
@@ -548,7 +551,7 @@ mod tests {
 
     #[test]
     fn video_stream_marker_and_timestamp_advance_per_au() {
-        let mut s = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
+        let mut s = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS).unwrap();
         // 3-packet AU: ts shared, marker only on the last.
         let p0 = s.next_video_packet(false, VIDEO_MEDIA_FRAME_INFO_IDR);
         let p1 = s.next_video_packet(false, VIDEO_MEDIA_FRAME_INFO_IDR);
@@ -587,7 +590,7 @@ mod tests {
 
     #[test]
     fn video_stream_changes_cadence_without_resetting_timestamp() {
-        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
+        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS).unwrap();
         let first = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
         assert_eq!(first.timestamp, 0);
 
@@ -600,11 +603,12 @@ mod tests {
             VIDEO_TS_STRIDE_15FPS + VIDEO_TS_STRIDE_20FPS
         );
         assert!(!stream.set_timestamp_stride(0));
+        assert!(VideoRtpStream::new(0x1122_3344, 0).is_none());
     }
 
     #[test]
     fn video_header_round_trips_through_parse() {
-        let mut s = VideoRtpStream::new(0xdead_beef, VIDEO_TS_STRIDE_15FPS);
+        let mut s = VideoRtpStream::new(0xdead_beef, VIDEO_TS_STRIDE_15FPS).unwrap();
         s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);
         let h = s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
         let bytes = encode_rtp_header(&h);
@@ -614,7 +618,7 @@ mod tests {
 
     #[test]
     fn video_header_uses_wasm_extension_layout() {
-        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
+        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS).unwrap();
         let header = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);
         assert_eq!(
             encode_rtp_header(&header),
@@ -717,7 +721,7 @@ mod tests {
 
     #[test]
     fn video_stream_wraps_seq_and_timestamp() {
-        let mut s = VideoRtpStream::new(1, u32::MAX);
+        let mut s = VideoRtpStream::new(1, u32::MAX).unwrap();
         s.seq = u16::MAX;
         s.timestamp = u32::MAX;
         let p = s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -4,22 +4,60 @@
 use crate::voip::warp::audio_piggyback_extension_for;
 
 pub const RTP_PAYLOAD_TYPE_OPUS: u8 = 120;
-/// H.264 video payload type. Taken from the WaCalls/meowcaller reference,
-/// never validated against a live capture.
+/// H.264 video payload type used by captured Android video RTP.
 pub const RTP_PAYLOAD_TYPE_H264: u8 = 97;
 /// Video RTP timestamp clock.
 pub const VIDEO_CLOCK_RATE: u32 = 90_000;
 /// Timestamp stride per access unit at the reference 15 fps (90000 / 15).
 pub const VIDEO_TS_STRIDE_15FPS: u32 = VIDEO_CLOCK_RATE / 15;
 pub const WHATSAPP_RTP_EXTENSION_PROFILE: u16 = 0xdebe;
+
 /// RFC 3550 fixed RTP header length, before any CSRC list or extension block.
 pub const RTP_FIXED_HEADER_LEN: usize = 12;
 pub const WHATSAPP_RTP_HEADER_SIZE: usize = 16;
 pub const WHATSAPP_RTP_HEADER_DTX_SIZE: usize = 20;
+pub const WHATSAPP_VIDEO_RTP_HEADER_SIZE: usize = 28;
+/// WhatsApp frame-present and keyframe flags carried by an IDR access unit.
+pub const VIDEO_MEDIA_FRAME_INFO_IDR: u8 = 0x09;
+/// WhatsApp frame-present flag carried by a dependent H.264 access unit.
+pub const VIDEO_MEDIA_FRAME_INFO_DELTA: u8 = 0x01;
 pub const WHATSAPP_RTP_EXTENSION_DTX_WORD: u32 = 0x3001_0000;
 const RTP_VERSION: u8 = 2;
 const SRTP_AUTH_TAG_LEN: usize = 10;
 const SRTP_AUTH_TAG_LEN_SHORT: usize = 4;
+
+/// The four one-byte-header extensions emitted by WhatsApp's video sender.
+/// IDs and ordering are pinned by the Android packet captured in
+/// `video_header_matches_android_capture` and the corresponding WASM extenders.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VideoRtpExtension {
+    pub media_frame_info: u8,
+    pub initial_bandwidth: u16,
+    pub short_offset: i16,
+    pub transport_sequence: u16,
+}
+
+impl VideoRtpExtension {
+    fn encode_into(self, out: &mut [u8; 12]) {
+        let initial_bandwidth = self.initial_bandwidth.to_be_bytes();
+        let short_offset = self.short_offset.to_be_bytes();
+        let transport_sequence = self.transport_sequence.to_be_bytes();
+        *out = [
+            0x30,
+            self.media_frame_info,
+            0x51,
+            initial_bandwidth[0],
+            initial_bandwidth[1],
+            0x61,
+            short_offset[0],
+            short_offset[1],
+            0x91,
+            transport_sequence[0],
+            transport_sequence[1],
+            0,
+        ];
+    }
+}
 
 /// Android first priming frame (18 bytes).
 pub const OPUS_PRIMING_FRAME_1: [u8; 18] = [
@@ -95,11 +133,15 @@ pub struct RtpHeader {
     pub ssrc: u32,
     /// When set, the header carries one 0xdebe extension word (DTX/piggyback).
     pub extension_word: Option<u32>,
+    /// WhatsApp video metadata, encoded as the captured 12-byte 0xdebe block.
+    pub video_extension: Option<VideoRtpExtension>,
 }
 
 impl RtpHeader {
     pub fn byte_size(&self) -> usize {
-        if self.extension_word.is_some() {
+        if self.video_extension.is_some() {
+            WHATSAPP_VIDEO_RTP_HEADER_SIZE
+        } else if self.extension_word.is_some() {
             WHATSAPP_RTP_HEADER_DTX_SIZE
         } else {
             WHATSAPP_RTP_HEADER_SIZE
@@ -134,6 +176,59 @@ pub fn rtp_header_byte_length(data: &[u8]) -> Option<usize> {
     Some(header_len)
 }
 
+/// Extension profile and its word-aligned payload. A valid RTP packet without X returns
+/// `(None, &[])` so callers can distinguish it from malformed input.
+pub fn rtp_extension_profile_and_data(data: &[u8]) -> Option<(Option<u16>, &[u8])> {
+    if data.len() < RTP_FIXED_HEADER_LEN || (data[0] >> 6) & 0x03 != RTP_VERSION {
+        return None;
+    }
+    let extension_offset = RTP_FIXED_HEADER_LEN + (data[0] & 0x0f) as usize * 4;
+    if data.len() < extension_offset {
+        return None;
+    }
+    if data[0] & 0x10 == 0 {
+        return Some((None, &[]));
+    }
+    if data.len() < extension_offset + 4 {
+        return None;
+    }
+    let words =
+        u16::from_be_bytes([data[extension_offset + 2], data[extension_offset + 3]]) as usize;
+    let data_start = extension_offset + 4;
+    let data_end = data_start.checked_add(words.checked_mul(4)?)?;
+    Some((
+        Some(u16::from_be_bytes([
+            data[extension_offset],
+            data[extension_offset + 1],
+        ])),
+        data.get(data_start..data_end)?,
+    ))
+}
+
+/// Decode the exact WhatsApp video extension set. Other 0xdebe layouts, including audio
+/// piggyback, deliberately return `None`.
+pub fn parse_whatsapp_video_extension(data: &[u8]) -> Option<VideoRtpExtension> {
+    let (Some(profile), extension) = rtp_extension_profile_and_data(data)? else {
+        return None;
+    };
+    if profile != WHATSAPP_RTP_EXTENSION_PROFILE
+        || extension.len() != 12
+        || extension[0] != 0x30
+        || extension[2] != 0x51
+        || extension[5] != 0x61
+        || extension[8] != 0x91
+        || extension[11] != 0
+    {
+        return None;
+    }
+    Some(VideoRtpExtension {
+        media_frame_info: extension[1],
+        initial_bandwidth: u16::from_be_bytes([extension[3], extension[4]]),
+        short_offset: i16::from_be_bytes([extension[6], extension[7]]),
+        transport_sequence: u16::from_be_bytes([extension[9], extension[10]]),
+    })
+}
+
 pub fn is_rtp_version2(data: &[u8]) -> bool {
     data.len() >= RTP_FIXED_HEADER_LEN && (data[0] >> 6) & 0x03 == RTP_VERSION
 }
@@ -163,6 +258,7 @@ pub fn parse_rtp_header(data: &[u8]) -> Option<RtpHeader> {
         timestamp: h.timestamp.get(),
         ssrc: h.ssrc.get(),
         extension_word: None,
+        video_extension: parse_whatsapp_video_extension(data),
     })
 }
 
@@ -172,7 +268,8 @@ pub fn parse_rtp_header(data: &[u8]) -> Option<RtpHeader> {
 /// header.
 pub fn encode_rtp_header_into(header: &RtpHeader, out: &mut Vec<u8>) {
     let size = header.byte_size();
-    let mut b = [0u8; WHATSAPP_RTP_HEADER_DTX_SIZE];
+    debug_assert!(header.extension_word.is_none() || header.video_extension.is_none());
+    let mut b = [0u8; WHATSAPP_VIDEO_RTP_HEADER_SIZE];
     b[0] = RTP_VERSION << 6;
     if size > RTP_FIXED_HEADER_LEN {
         b[0] |= 0x10; // X=1 (WhatsApp 0xdebe extension)
@@ -183,10 +280,18 @@ pub fn encode_rtp_header_into(header: &RtpHeader, out: &mut Vec<u8>) {
     b[8..12].copy_from_slice(&header.ssrc.to_be_bytes());
     if size >= 16 {
         b[12..14].copy_from_slice(&WHATSAPP_RTP_EXTENSION_PROFILE.to_be_bytes());
-        // Extension length in 32-bit words (0 or 1): high byte (b[14]) stays 0.
-        b[15] = header.extension_word.is_some() as u8;
+        // High byte stays zero: current extension blocks are at most three words.
+        b[15] = if header.video_extension.is_some() {
+            3
+        } else {
+            header.extension_word.is_some() as u8
+        };
     }
-    if size >= 20
+    if let Some(extension) = header.video_extension {
+        let mut encoded = [0u8; 12];
+        extension.encode_into(&mut encoded);
+        b[16..28].copy_from_slice(&encoded);
+    } else if size >= 20
         && let Some(w) = header.extension_word
     {
         b[16..20].copy_from_slice(&w.to_be_bytes());
@@ -205,6 +310,7 @@ pub struct RtpStream {
     pub ssrc: u32,
     seq: u16,
     timestamp: u32,
+    last_sent_timestamp: Option<u32>,
     samples_per_packet: u32,
     speech_started: bool,
     audio_packet_index: usize,
@@ -217,11 +323,17 @@ impl RtpStream {
             ssrc,
             seq: 1,
             timestamp: 0,
+            last_sent_timestamp: None,
             samples_per_packet,
             speech_started: false,
             audio_packet_index: 0,
             warp_piggyback,
         }
+    }
+
+    /// The current send timestamp (last emitted), for an RTCP Sender Report.
+    pub fn rtp_timestamp(&self) -> u32 {
+        self.last_sent_timestamp.unwrap_or(self.timestamp)
     }
 
     fn resolve_warp_extension(&mut self, dtx: bool) -> Option<u32> {
@@ -251,7 +363,9 @@ impl RtpStream {
             timestamp: self.timestamp,
             ssrc: self.ssrc,
             extension_word: self.resolve_warp_extension(dtx),
+            video_extension: None,
         };
+        self.last_sent_timestamp = Some(header.timestamp);
         self.seq = self.seq.wrapping_add(1);
         self.timestamp = self.timestamp.wrapping_add(self.samples_per_packet);
         header
@@ -266,7 +380,9 @@ impl RtpStream {
             timestamp: self.timestamp,
             ssrc: self.ssrc,
             extension_word: self.resolve_warp_extension(false),
+            video_extension: None,
         };
+        self.last_sent_timestamp = Some(header.timestamp);
         self.seq = self.seq.wrapping_add(1);
         self.timestamp = self.timestamp.wrapping_add(self.samples_per_packet);
         header
@@ -275,13 +391,14 @@ impl RtpStream {
 
 /// Send-side sequencer for the video stream: one header per RTP packet of an
 /// access unit, the timestamp is shared by every packet of the AU and advances
-/// by `ts_stride` only when the AU closes (marker packet). Plain 16-byte
-/// header — no WARP extension, no DTX, no speech latch.
+/// by `ts_stride` only when the AU closes (marker packet).
 pub struct VideoRtpStream {
     pub ssrc: u32,
     seq: u16,
     timestamp: u32,
+    last_sent_timestamp: Option<u32>,
     ts_stride: u32,
+    transport_sequence: u16,
 }
 
 impl VideoRtpStream {
@@ -290,13 +407,21 @@ impl VideoRtpStream {
             ssrc,
             seq: 0,
             timestamp: 0,
+            last_sent_timestamp: None,
             ts_stride,
+            transport_sequence: 0,
         }
     }
 
+    /// The current send timestamp (last emitted), for an RTCP Sender Report.
+    pub fn rtp_timestamp(&self) -> u32 {
+        self.last_sent_timestamp.unwrap_or(self.timestamp)
+    }
+
     /// Header for the next packet of the current AU; `last_in_au` sets the
-    /// marker and moves the timestamp to the next AU.
-    pub fn next_video_packet(&mut self, last_in_au: bool) -> RtpHeader {
+    /// marker and moves the timestamp to the next AU. `media_frame_info` is an
+    /// encoded-frame property and must be identical on every fragment of the AU.
+    pub fn next_video_packet(&mut self, last_in_au: bool, media_frame_info: u8) -> RtpHeader {
         let header = RtpHeader {
             marker: last_in_au,
             payload_type: RTP_PAYLOAD_TYPE_H264,
@@ -304,8 +429,18 @@ impl VideoRtpStream {
             timestamp: self.timestamp,
             ssrc: self.ssrc,
             extension_word: None,
+            video_extension: Some(VideoRtpExtension {
+                media_frame_info,
+                initial_bandwidth: 0,
+                // The real sender reported 29 ticks (~0.3 ms). Zero is the truthful value when
+                // the API has no capture-time origin to subtract from the RTP timestamp.
+                short_offset: 0,
+                transport_sequence: self.transport_sequence,
+            }),
         };
+        self.last_sent_timestamp = Some(header.timestamp);
         self.seq = self.seq.wrapping_add(1);
+        self.transport_sequence = self.transport_sequence.wrapping_add(1);
         if last_in_au {
             self.timestamp = self.timestamp.wrapping_add(self.ts_stride);
         }
@@ -329,6 +464,7 @@ mod tests {
             timestamp: 0,
             ssrc,
             extension_word: None,
+            video_extension: None,
         };
         assert_eq!(
             hex::encode(encode_rtp_header(&speech)),
@@ -341,6 +477,7 @@ mod tests {
             timestamp: 320,
             ssrc,
             extension_word: Some(0x3001_0000),
+            video_extension: None,
         };
         assert_eq!(
             hex::encode(encode_rtp_header(&dtx)),
@@ -357,6 +494,7 @@ mod tests {
             timestamp: 0xdead_beef,
             ssrc: 0x0102_0304,
             extension_word: None,
+            video_extension: None,
         };
         let bytes = encode_rtp_header(&h);
         assert_eq!(rtp_header_byte_length(&bytes), Some(16));
@@ -400,34 +538,152 @@ mod tests {
     fn video_stream_marker_and_timestamp_advance_per_au() {
         let mut s = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
         // 3-packet AU: ts shared, marker only on the last.
-        let p0 = s.next_video_packet(false);
-        let p1 = s.next_video_packet(false);
-        let p2 = s.next_video_packet(true);
+        let p0 = s.next_video_packet(false, VIDEO_MEDIA_FRAME_INFO_IDR);
+        let p1 = s.next_video_packet(false, VIDEO_MEDIA_FRAME_INFO_IDR);
+        let p2 = s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);
         assert_eq!(
             (p0.sequence_number, p1.sequence_number, p2.sequence_number),
             (0, 1, 2)
         );
         assert_eq!((p0.timestamp, p1.timestamp, p2.timestamp), (0, 0, 0));
         assert_eq!((p0.marker, p1.marker, p2.marker), (false, false, true));
+        assert_eq!(s.rtp_timestamp(), 0, "SR maps to the emitted AU timestamp");
+        assert_eq!(
+            [p0, p1, p2].map(|packet| packet.video_extension.unwrap().media_frame_info),
+            [VIDEO_MEDIA_FRAME_INFO_IDR; 3]
+        );
+        assert_eq!(
+            [p0, p1, p2].map(|packet| packet.video_extension.unwrap().transport_sequence),
+            [0, 1, 2]
+        );
         // Next AU: timestamp advanced by one stride.
-        let p3 = s.next_video_packet(true);
+        let p3 = s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
         assert_eq!(p3.timestamp, VIDEO_TS_STRIDE_15FPS);
         assert_eq!(p3.sequence_number, 3);
+        assert_eq!(s.rtp_timestamp(), VIDEO_TS_STRIDE_15FPS);
+        assert_eq!(
+            p3.video_extension.unwrap().media_frame_info,
+            VIDEO_MEDIA_FRAME_INFO_DELTA
+        );
+        assert_eq!(p3.video_extension.unwrap().transport_sequence, 3);
         for p in [p0, p1, p2, p3] {
             assert_eq!(p.payload_type, RTP_PAYLOAD_TYPE_H264);
             assert_eq!(p.extension_word, None);
-            assert_eq!(p.byte_size(), WHATSAPP_RTP_HEADER_SIZE);
+            assert_eq!(p.byte_size(), WHATSAPP_VIDEO_RTP_HEADER_SIZE);
         }
     }
 
     #[test]
     fn video_header_round_trips_through_parse() {
         let mut s = VideoRtpStream::new(0xdead_beef, VIDEO_TS_STRIDE_15FPS);
-        s.next_video_packet(true);
-        let h = s.next_video_packet(true);
+        s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);
+        let h = s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
         let bytes = encode_rtp_header(&h);
-        assert_eq!(rtp_header_byte_length(&bytes), Some(16));
+        assert_eq!(rtp_header_byte_length(&bytes), Some(28));
         assert_eq!(parse_rtp_header(&bytes), Some(h));
+    }
+
+    #[test]
+    fn video_header_uses_wasm_extension_layout() {
+        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
+        let header = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);
+        assert_eq!(
+            encode_rtp_header(&header),
+            [
+                0x90, 0xe1, // V=2, X=1, marker, PT=97
+                0x00, 0x00, // sequence
+                0x00, 0x00, 0x00, 0x00, // timestamp
+                0x11, 0x22, 0x33, 0x44, // SSRC
+                0xde, 0xbe, 0x00, 0x03, // WARP profile, three words
+                0x30, 0x09, // ID 3: one-byte encoded-frame flags (keyframe | IDR)
+                0x51, 0x00, 0x00, // ID 5: two-byte initial bandwidth
+                0x61, 0x00, 0x00, // ID 6: two-byte short timestamp offset
+                0x91, 0x00, 0x00, // ID 9: two-byte transport sequence
+                0x00, // word alignment
+            ]
+        );
+        let encoded = encode_rtp_header(&header);
+        assert_eq!(
+            rtp_extension_profile_and_data(&encoded),
+            Some((Some(WHATSAPP_RTP_EXTENSION_PROFILE), &encoded[16..28]))
+        );
+    }
+
+    #[test]
+    fn video_header_matches_android_capture() {
+        let k = kats();
+        let captured = hex::decode(k["rtp"]["androidVideoHeader28"].as_str().unwrap()).unwrap();
+        assert_eq!(rtp_header_byte_length(&captured), Some(28));
+        assert_eq!(
+            hex::encode(rtp_extension_profile_and_data(&captured).unwrap().1),
+            k["rtp"]["androidVideoExtension12"].as_str().unwrap()
+        );
+        assert_eq!(
+            parse_rtp_header(&captured),
+            Some(RtpHeader {
+                marker: true,
+                payload_type: RTP_PAYLOAD_TYPE_H264,
+                sequence_number: 1,
+                timestamp: 114_120,
+                ssrc: 0x49c5_fb8c,
+                extension_word: None,
+                video_extension: Some(VideoRtpExtension {
+                    media_frame_info: 0x09,
+                    initial_bandwidth: 0,
+                    short_offset: 29,
+                    transport_sequence: 0x0c3f,
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn delta_video_header_matches_android_capture() {
+        let k = kats();
+        let captured =
+            hex::decode(k["rtp"]["androidVideoDeltaHeader28"].as_str().unwrap()).unwrap();
+        assert_eq!(rtp_header_byte_length(&captured), Some(28));
+        assert_eq!(
+            hex::encode(rtp_extension_profile_and_data(&captured).unwrap().1),
+            k["rtp"]["androidVideoDeltaExtension12"].as_str().unwrap()
+        );
+        assert_eq!(
+            parse_rtp_header(&captured),
+            Some(RtpHeader {
+                marker: true,
+                payload_type: RTP_PAYLOAD_TYPE_H264,
+                sequence_number: 7,
+                timestamp: 143_010,
+                ssrc: 0x9b19_59f0,
+                extension_word: None,
+                video_extension: Some(VideoRtpExtension {
+                    media_frame_info: VIDEO_MEDIA_FRAME_INFO_DELTA,
+                    initial_bandwidth: 0,
+                    short_offset: 36,
+                    transport_sequence: 0x0a6a,
+                }),
+            })
+        );
+        assert_eq!(
+            VIDEO_MEDIA_FRAME_INFO_IDR,
+            VIDEO_MEDIA_FRAME_INFO_DELTA | 0x08
+        );
+    }
+
+    #[test]
+    fn extension_view_handles_one_byte_profile_and_malformed_lengths() {
+        let packet = [
+            0x90, 97, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0xbe, 0xde, 0, 1, 0x31, 1, 2, 3, 0x65,
+        ];
+        assert_eq!(
+            rtp_extension_profile_and_data(&packet),
+            Some((Some(0xbede), &packet[16..20]))
+        );
+        assert_eq!(rtp_header_byte_length(&packet), Some(20));
+
+        let mut malformed = packet;
+        malformed[15] = 2;
+        assert_eq!(rtp_extension_profile_and_data(&malformed), None);
     }
 
     #[test]
@@ -435,9 +691,9 @@ mod tests {
         let mut s = VideoRtpStream::new(1, u32::MAX);
         s.seq = u16::MAX;
         s.timestamp = u32::MAX;
-        let p = s.next_video_packet(true);
+        let p = s.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_IDR);
         assert_eq!(p.sequence_number, u16::MAX);
-        let p = s.next_video_packet(false);
+        let p = s.next_video_packet(false, VIDEO_MEDIA_FRAME_INFO_DELTA);
         assert_eq!(p.sequence_number, 0, "seq must wrap, not panic");
         assert_eq!(p.timestamp, u32::MAX - 1, "timestamp must wrap, not panic");
     }
@@ -454,12 +710,14 @@ mod tests {
             (2, 320, false)
         );
         assert_eq!(d1.extension_word, Some(WHATSAPP_RTP_EXTENSION_DTX_WORD));
+        assert_eq!(s.rtp_timestamp(), 320);
         // First speech frame latches the marker.
         let sp = s.next_packet(&[0x48; 40], false);
         assert_eq!(
             (sp.sequence_number, sp.timestamp, sp.marker),
             (3, 640, true)
         );
+        assert_eq!(s.rtp_timestamp(), 640);
         // Subsequent speech has no marker.
         let sp2 = s.next_packet(&[0x48; 40], false);
         assert!(!sp2.marker);

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -10,6 +10,8 @@ pub const RTP_PAYLOAD_TYPE_H264: u8 = 97;
 pub const VIDEO_CLOCK_RATE: u32 = 90_000;
 /// Timestamp stride per access unit at the reference 15 fps (90000 / 15).
 pub const VIDEO_TS_STRIDE_15FPS: u32 = VIDEO_CLOCK_RATE / 15;
+/// Timestamp stride used by WhatsApp's 720p / 20 fps mode.
+pub const VIDEO_TS_STRIDE_20FPS: u32 = VIDEO_CLOCK_RATE / 20;
 pub const WHATSAPP_RTP_EXTENSION_PROFILE: u16 = 0xdebe;
 
 /// RFC 3550 fixed RTP header length, before any CSRC list or extension block.
@@ -418,6 +420,16 @@ impl VideoRtpStream {
         self.last_sent_timestamp.unwrap_or(self.timestamp)
     }
 
+    /// Change the cadence used after the current access unit. This keeps sequence numbers and the
+    /// RTP clock continuous when an encoder changes frame rate.
+    pub fn set_timestamp_stride(&mut self, ts_stride: u32) -> bool {
+        if ts_stride == 0 {
+            return false;
+        }
+        self.ts_stride = ts_stride;
+        true
+    }
+
     /// Header for the next packet of the current AU; `last_in_au` sets the
     /// marker and moves the timestamp to the next AU. `media_frame_info` is an
     /// encoded-frame property and must be identical on every fragment of the AU.
@@ -571,6 +583,23 @@ mod tests {
             assert_eq!(p.extension_word, None);
             assert_eq!(p.byte_size(), WHATSAPP_VIDEO_RTP_HEADER_SIZE);
         }
+    }
+
+    #[test]
+    fn video_stream_changes_cadence_without_resetting_timestamp() {
+        let mut stream = VideoRtpStream::new(0x1122_3344, VIDEO_TS_STRIDE_15FPS);
+        let first = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
+        assert_eq!(first.timestamp, 0);
+
+        assert!(stream.set_timestamp_stride(VIDEO_TS_STRIDE_20FPS));
+        let second = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
+        let third = stream.next_video_packet(true, VIDEO_MEDIA_FRAME_INFO_DELTA);
+        assert_eq!(second.timestamp, VIDEO_TS_STRIDE_15FPS);
+        assert_eq!(
+            third.timestamp,
+            VIDEO_TS_STRIDE_15FPS + VIDEO_TS_STRIDE_20FPS
+        );
+        assert!(!stream.set_timestamp_stride(0));
     }
 
     #[test]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -4,12 +4,18 @@
 
 use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
-    verify_warp_mi_tag,
+    derive_srtcp_keys, protect_srtcp, unprotect_srtcp, verify_warp_mi_tag,
 };
-use super::h264::{H264Depacketizer, packetize_au};
+use super::h264::{H264Depacketizer, au_has_idr, packetize_au};
+use super::rtcp::{
+    RtcpReceptionReport, RtcpSenderStats, WHATSAPP_RTCP_CNAME_LEN, build_whatsapp_rtcp_cname,
+    build_whatsapp_sender_report_with_sdes, build_whatsapp_source_description,
+    parse_rtcp_sender_ssrc,
+};
 use super::rtp::{
-    RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, VideoRtpStream, encode_rtp_header_into,
-    parse_rtp_header, rtp_header_byte_length,
+    RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, VIDEO_MEDIA_FRAME_INFO_DELTA,
+    VIDEO_MEDIA_FRAME_INFO_IDR, VideoRtpStream, encode_rtp_header_into, parse_rtp_header,
+    rtp_header_byte_length,
 };
 use super::ssrc::format_e2e_srtp_participant_id;
 use wacore_binary::Jid;
@@ -133,6 +139,89 @@ fn phase_rank(p: CallPhase) -> u8 {
     }
 }
 
+/// Per-stream RTCP Sender-Report state.
+struct SrtcpSender {
+    keys: E2eSrtpKeys,
+    cname: [u8; WHATSAPP_RTCP_CNAME_LEN],
+    index: u32,
+    packets_sent: u32,
+    octets_sent: u32,
+    profile_extension: bool,
+}
+
+impl SrtcpSender {
+    fn new(
+        call_key: &[u8],
+        self_lid: &str,
+        cname: [u8; WHATSAPP_RTCP_CNAME_LEN],
+        profile_extension: bool,
+    ) -> Option<Self> {
+        Some(Self::from_keys(
+            derive_srtcp_keys(call_key, &format_e2e_srtp_participant_id(self_lid))?,
+            cname,
+            profile_extension,
+        ))
+    }
+
+    fn from_keys(
+        keys: E2eSrtpKeys,
+        cname: [u8; WHATSAPP_RTCP_CNAME_LEN],
+        profile_extension: bool,
+    ) -> Self {
+        Self {
+            keys,
+            cname,
+            // libSRTP increments its SRTCP sender index before protecting the first packet.
+            index: 1,
+            packets_sent: 0,
+            octets_sent: 0,
+            profile_extension,
+        }
+    }
+
+    fn record(&mut self, packets: u32, octets: usize) {
+        self.packets_sent = self.packets_sent.wrapping_add(packets);
+        self.octets_sent = self.octets_sent.wrapping_add(octets as u32);
+    }
+
+    fn protect(&mut self, ssrc: u32, plain: &[u8]) -> Vec<u8> {
+        let out = protect_srtcp(&self.keys, ssrc, self.index, plain);
+        self.index = self.index.wrapping_add(1);
+        out
+    }
+
+    fn source_description(&mut self, ssrc: u32) -> Vec<u8> {
+        self.protect(
+            ssrc,
+            &build_whatsapp_source_description(ssrc, &self.cname, self.profile_extension),
+        )
+    }
+
+    /// Build and SRTCP-protect a Sender Report for `ssrc` at wall-clock `now_ms`.
+    fn sender_report(
+        &mut self,
+        ssrc: u32,
+        rtp_timestamp: u32,
+        now_ms: u64,
+        report: Option<&RtcpReceptionReport>,
+    ) -> Vec<u8> {
+        let stats = RtcpSenderStats {
+            packets_sent: self.packets_sent,
+            octets_sent: self.octets_sent,
+            rtp_timestamp,
+        };
+        let plain = build_whatsapp_sender_report_with_sdes(
+            ssrc,
+            &stats,
+            now_ms,
+            &self.cname,
+            report,
+            self.profile_extension,
+        );
+        self.protect(ssrc, &plain)
+    }
+}
+
 /// Composes the outbound (protect) and inbound (unprotect) media pipeline for E2E 1:1.
 /// SFrame is omitted (default-off on send; plain Opus inside WAHKDF SRTP).
 pub struct MediaPipeline {
@@ -142,6 +231,8 @@ pub struct MediaPipeline {
     rtp: RtpStream,
     send_roc: RocTracker,
     recv_roc: RecvRocTracker,
+    srtcp: SrtcpSender,
+    recv_srtcp_keys: E2eSrtpKeys,
 }
 
 /// Borrowed inputs for [`MediaPipeline::new`]. `self_lid`/`peer_lid` are the E2E-SRTP
@@ -164,6 +255,18 @@ impl MediaPipeline {
     /// must match the form the peer derives our SSRC from.
     /// Returns `None` when `call_key` is shorter than 32 bytes (a malformed peer callKey).
     pub fn new(p: &MediaPipelineParams<'_>) -> Option<Self> {
+        let mut entropy = [0u8; 12];
+        entropy[6..10].copy_from_slice(&p.ssrc.to_be_bytes());
+        if let Some(call_prefix) = p.call_key.get(..2) {
+            entropy[10..].copy_from_slice(call_prefix);
+        }
+        Self::new_with_rtcp_cname(p, build_whatsapp_rtcp_cname(&entropy))
+    }
+
+    pub(crate) fn new_with_rtcp_cname(
+        p: &MediaPipelineParams<'_>,
+        rtcp_cname: [u8; WHATSAPP_RTCP_CNAME_LEN],
+    ) -> Option<Self> {
         // The WARP MI tag is sliced from the 20-byte HMAC-SHA1 digest; a relay-advertised length
         // above 20 (or zero) would panic on the first packet, so reject it at setup instead.
         if !(1..=20).contains(&p.warp_mi_tag_len) {
@@ -176,7 +279,32 @@ impl MediaPipeline {
             rtp: RtpStream::new(p.ssrc, p.samples_per_packet, false),
             send_roc: RocTracker::default(),
             recv_roc: RecvRocTracker::default(),
+            srtcp: SrtcpSender::new(p.call_key, p.self_lid, rtcp_cname, false)?,
+            recv_srtcp_keys: derive_srtcp_keys(
+                p.call_key,
+                &format_e2e_srtp_participant_id(p.peer_lid),
+            )?,
         })
+    }
+
+    pub fn send_ssrc(&self) -> u32 {
+        self.rtp.ssrc
+    }
+
+    /// An SRTCP-protected Sender Report for the audio stream (our send SSRC), or the accumulated
+    /// packet/octet totals since the call began. Emitted periodically by the engine.
+    pub(crate) fn audio_sender_report(
+        &mut self,
+        now_ms: u64,
+        report: Option<&RtcpReceptionReport>,
+    ) -> Vec<u8> {
+        self.srtcp
+            .sender_report(self.rtp.ssrc, self.rtp.rtp_timestamp(), now_ms, report)
+    }
+
+    /// The native client sends this once when the audio RTCP session is associated.
+    pub fn audio_source_description(&mut self) -> Vec<u8> {
+        self.srtcp.source_description(self.rtp.ssrc)
     }
 
     /// Caller-side: re-derive the recv keys for the device that actually answered. We dial the base
@@ -186,13 +314,15 @@ impl MediaPipeline {
     /// stream is fresh, so a stale `s_l` would mis-guess the index of its first packets. Returns
     /// `false` only on a malformed `call_key` (a setup invariant already checked in [`new`](Self::new)).
     pub fn rekey_recv(&mut self, call_key: &[u8], answering_peer_lid: &str) -> bool {
-        let Some(keys) = derive_e2e_keys(
-            call_key,
-            &format_e2e_srtp_participant_id(answering_peer_lid),
-        ) else {
+        let participant_id = format_e2e_srtp_participant_id(answering_peer_lid);
+        let Some(keys) = derive_e2e_keys(call_key, &participant_id) else {
+            return false;
+        };
+        let Some(srtcp_keys) = derive_srtcp_keys(call_key, &participant_id) else {
             return false;
         };
         self.recv_keys = keys;
+        self.recv_srtcp_keys = srtcp_keys;
         self.recv_roc = RecvRocTracker::default();
         true
     }
@@ -214,6 +344,7 @@ impl MediaPipeline {
         let mut packet = Vec::with_capacity(header.byte_size() + encrypted.len());
         encode_rtp_header_into(&header, &mut packet);
         packet.extend_from_slice(&encrypted);
+        self.srtcp.record(1, opus_payload.len());
         append_warp_mi_tag(&self.send_keys.auth_key, &packet, roc, self.warp_mi_tag_len)
     }
 
@@ -232,6 +363,12 @@ impl MediaPipeline {
             self.warp_mi_tag_len,
             packet,
         )
+    }
+
+    /// Authenticate and decrypt peer SRTCP using the sender SSRC left clear on the wire.
+    pub fn unprotect_rtcp(&self, packet: &[u8]) -> Option<Vec<u8>> {
+        let sender_ssrc = parse_rtcp_sender_ssrc(packet)?;
+        unprotect_srtcp(&self.recv_srtcp_keys, sender_ssrc, packet)
     }
 }
 
@@ -287,6 +424,7 @@ pub struct VideoPipeline {
     recv_roc: RecvRocTracker,
     depacketizer: H264Depacketizer,
     pkt_scratch: Vec<Vec<u8>>,
+    srtcp: SrtcpSender,
 }
 
 /// Borrowed inputs for [`VideoPipeline::new`]. No `samples_per_packet`: the
@@ -303,6 +441,18 @@ pub struct VideoPipelineParams<'a> {
 
 impl VideoPipeline {
     pub fn new(p: &VideoPipelineParams<'_>) -> Option<Self> {
+        let mut entropy = [0u8; 12];
+        entropy[6..10].copy_from_slice(&p.ssrc.to_be_bytes());
+        if let Some(call_prefix) = p.call_key.get(..2) {
+            entropy[10..].copy_from_slice(call_prefix);
+        }
+        Self::new_with_rtcp_cname(p, build_whatsapp_rtcp_cname(&entropy))
+    }
+
+    pub(crate) fn new_with_rtcp_cname(
+        p: &VideoPipelineParams<'_>,
+        rtcp_cname: [u8; WHATSAPP_RTCP_CNAME_LEN],
+    ) -> Option<Self> {
         // A zero stride would leave every AU at timestamp 0 (an unusable stream); reject it at
         // setup rather than emit a frozen clock.
         if !(1..=20).contains(&p.warp_mi_tag_len) || p.ts_stride == 0 {
@@ -317,7 +467,22 @@ impl VideoPipeline {
             recv_roc: RecvRocTracker::default(),
             depacketizer: H264Depacketizer::default(),
             pkt_scratch: Vec::new(),
+            srtcp: SrtcpSender::new(p.call_key, p.self_lid, rtcp_cname, true)?,
         })
+    }
+
+    /// An SRTCP-protected Sender Report for the video stream.
+    pub(crate) fn video_sender_report(
+        &mut self,
+        now_ms: u64,
+        report: Option<&RtcpReceptionReport>,
+    ) -> Vec<u8> {
+        self.srtcp
+            .sender_report(self.rtp.ssrc, self.rtp.rtp_timestamp(), now_ms, report)
+    }
+
+    pub fn send_ssrc(&self) -> u32 {
+        self.rtp.ssrc
     }
 
     /// Same answering-device rekey as [`MediaPipeline::rekey_recv`]; the video
@@ -341,10 +506,15 @@ impl VideoPipeline {
     pub fn protect_video(&mut self, au: &[u8]) -> Vec<Vec<u8>> {
         let mut payloads = std::mem::take(&mut self.pkt_scratch);
         packetize_au(au, &mut payloads);
+        let media_frame_info = if au_has_idr(au) {
+            VIDEO_MEDIA_FRAME_INFO_IDR
+        } else {
+            VIDEO_MEDIA_FRAME_INFO_DELTA
+        };
         let mut packets = Vec::with_capacity(payloads.len());
         let last = payloads.len().saturating_sub(1);
         for (i, payload) in payloads.iter().enumerate() {
-            let header = self.rtp.next_video_packet(i == last);
+            let header = self.rtp.next_video_packet(i == last, media_frame_info);
             let roc = self.send_roc.advance(header.sequence_number);
             let encrypted = crypt_payload(
                 &self.send_keys,
@@ -356,6 +526,7 @@ impl VideoPipeline {
             let mut packet = Vec::with_capacity(header.byte_size() + encrypted.len());
             encode_rtp_header_into(&header, &mut packet);
             packet.extend_from_slice(&encrypted);
+            self.srtcp.record(1, payload.len());
             packets.push(append_warp_mi_tag(
                 &self.send_keys.auth_key,
                 &packet,
@@ -370,18 +541,26 @@ impl VideoPipeline {
     /// Inbound: authenticate+decrypt one RTP packet and feed the depacketizer;
     /// the reassembled access unit is returned on the AU's marker packet.
     pub fn unprotect_video(&mut self, packet: &[u8]) -> Option<Vec<u8>> {
+        self.unprotect_video_packet(packet)?.1
+    }
+
+    pub(crate) fn unprotect_video_packet(
+        &mut self,
+        packet: &[u8],
+    ) -> Option<(RtpHeader, Option<Vec<u8>>)> {
         let (header, payload) = unprotect_srtp_packet(
             &self.recv_keys,
             &mut self.recv_roc,
             self.warp_mi_tag_len,
             packet,
         )?;
-        self.depacketizer.push(
+        let au = self.depacketizer.push(
             header.sequence_number,
             header.timestamp,
             &payload,
             header.marker,
-        )
+        );
+        Some((header, au))
     }
 }
 
@@ -846,6 +1025,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn srtcp_recv_rekeys_to_the_answering_device() {
+        use crate::voip::rtcp::build_compact_rtcp_208;
+
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let caller = "111111111111111:0@lid";
+        let callee_base = "222222222222222:0@lid";
+        let callee_answering = "222222222222222:2@lid";
+        let params = MediaPipelineParams {
+            call_key: &call_key,
+            self_lid: caller,
+            peer_lid: callee_base,
+            ssrc: 0x0102_0304,
+            samples_per_packet: 960,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        };
+        let mut caller_rx = MediaPipeline::new(&params).unwrap();
+        let peer_ssrc = 0x1122_3344;
+        let plain = build_compact_rtcp_208(peer_ssrc, params.ssrc);
+        let peer_keys = derive_srtcp_keys(&call_key, callee_answering).unwrap();
+        let protected = protect_srtcp(&peer_keys, peer_ssrc, 0, &plain);
+
+        assert!(caller_rx.unprotect_rtcp(&protected).is_none());
+        assert!(caller_rx.rekey_recv(&call_key, callee_answering));
+        assert_eq!(
+            caller_rx.unprotect_rtcp(&protected).as_deref(),
+            Some(plain.as_slice())
+        );
+    }
+
     fn video_params<'a>(
         call_key: &'a [u8],
         self_lid: &'a str,
@@ -898,6 +1107,38 @@ mod tests {
     }
 
     #[test]
+    fn video_pipeline_keeps_parameter_sets_first_on_the_wire() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&call_key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&call_key, b, a)).unwrap();
+        let au = [
+            &[0, 0, 0, 1, 0x69, 0xf0][..],
+            &[0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1f][..],
+            &[0, 0, 0, 1, 0x68, 0xce, 0x06, 0xe2][..],
+            &[0, 0, 0, 1, 0x65, 1, 2, 3][..],
+        ]
+        .concat();
+
+        let packets = tx.protect_video(&au);
+        let mut received = None;
+        for packet in &packets {
+            if let Some(frame) = rx.unprotect_video(packet) {
+                received = Some(frame);
+            }
+        }
+
+        let received = received.expect("marker packet completes the access unit");
+        assert_eq!(
+            crate::voip::h264::split_annexb(&received)
+                .map(crate::voip::h264::nal_unit_type)
+                .collect::<Vec<_>>(),
+            [7, 8, 5]
+        );
+    }
+
+    #[test]
     fn video_protect_uses_self_lid_and_video_headers() {
         let call_key: Vec<u8> = (0u8..32).collect();
         let self_lid = "111111111111111:0@lid";
@@ -912,6 +1153,11 @@ mod tests {
         assert_eq!(header.payload_type, crate::voip::rtp::RTP_PAYLOAD_TYPE_H264);
         assert!(header.marker, "single-packet AU carries the marker");
         assert_eq!(header.sequence_number, 0, "video seq starts at 0");
+        assert_eq!(
+            header.video_extension.unwrap().media_frame_info,
+            VIDEO_MEDIA_FRAME_INFO_IDR,
+            "an IDR AU carries WhatsApp's keyframe and IDR bits"
+        );
 
         // Pin the send keystream to the SELF lid (same inversion guard as audio).
         let header_len = rtp_header_byte_length(without_tag).unwrap();
@@ -925,6 +1171,36 @@ mod tests {
             nal,
         );
         assert_eq!(body, expect.as_slice(), "video send must key on self LID");
+    }
+
+    #[test]
+    fn video_frame_info_is_constant_across_every_au_fragment() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut pipe = VideoPipeline::new(&video_params(
+            &call_key,
+            "111111111111111:0@lid",
+            "222222222222222:0@lid",
+        ))
+        .unwrap();
+
+        let idr = video_au(3_000);
+        let idr_packets = pipe.protect_video(&idr);
+        assert!(idr_packets.len() > 1);
+        assert!(idr_packets.iter().all(|packet| {
+            parse_rtp_header(packet)
+                .and_then(|header| header.video_extension)
+                .is_some_and(|extension| extension.media_frame_info == VIDEO_MEDIA_FRAME_INFO_IDR)
+        }));
+
+        let mut delta = vec![0, 0, 0, 1, 0x41];
+        delta.extend((0..3_000).map(|i| (i % 251) as u8));
+        let delta_packets = pipe.protect_video(&delta);
+        assert!(delta_packets.len() > 1);
+        assert!(delta_packets.iter().all(|packet| {
+            parse_rtp_header(packet)
+                .and_then(|header| header.video_extension)
+                .is_some_and(|extension| extension.media_frame_info == VIDEO_MEDIA_FRAME_INFO_DELTA)
+        }));
     }
 
     #[test]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -6,9 +6,10 @@ use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
     verify_warp_mi_tag,
 };
+use super::h264::{H264Depacketizer, packetize_au};
 use super::rtp::{
-    RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, encode_rtp_header_into, parse_rtp_header,
-    rtp_header_byte_length,
+    RTP_FIXED_HEADER_LEN, RtpHeader, RtpStream, VideoRtpStream, encode_rtp_header_into,
+    parse_rtp_header, rtp_header_byte_length,
 };
 use super::ssrc::format_e2e_srtp_participant_id;
 use wacore_binary::Jid;
@@ -225,38 +226,162 @@ impl MediaPipeline {
     /// into the rollover counter and permanently desync the receiver (RFC 3711
     /// §3.3.1 requires the index update to follow authentication).
     pub fn unprotect_audio(&mut self, packet: &[u8]) -> Option<(RtpHeader, Vec<u8>)> {
-        if packet.len() < RTP_FIXED_HEADER_LEN + self.warp_mi_tag_len {
-            return None;
-        }
-        let split = packet.len() - self.warp_mi_tag_len;
-        let without_tag = &packet[..split];
-        let received_tag = &packet[split..];
-        let header = parse_rtp_header(without_tag)?;
-        let header_len = rtp_header_byte_length(without_tag)?;
-        if without_tag.len() <= header_len {
-            return None;
-        }
-        let roc = self.recv_roc.estimate_roc(header.sequence_number);
-        if !verify_warp_mi_tag(
-            &self.recv_keys.auth_key,
-            without_tag,
-            roc,
-            self.warp_mi_tag_len,
-            received_tag,
-        ) {
-            return None;
-        }
-        // Authenticated: now it's safe to advance the rollover counter.
-        self.recv_roc.commit_roc(roc, header.sequence_number);
-        let cipher = &without_tag[header_len..];
-        let plain = crypt_payload(
+        unprotect_srtp_packet(
             &self.recv_keys,
-            header.ssrc,
+            &mut self.recv_roc,
+            self.warp_mi_tag_len,
+            packet,
+        )
+    }
+}
+
+/// Shared inbound SRTP step for the audio and video pipelines: verify the WARP
+/// MI tag against the *estimated* ROC BEFORE committing it, then decrypt. The
+/// order is load-bearing (RFC 3711 §3.3.1): an on-path relay must not be able
+/// to fold unauthenticated packets into the rollover counter and permanently
+/// desync the receiver.
+fn unprotect_srtp_packet(
+    recv_keys: &E2eSrtpKeys,
+    recv_roc: &mut RecvRocTracker,
+    warp_mi_tag_len: usize,
+    packet: &[u8],
+) -> Option<(RtpHeader, Vec<u8>)> {
+    if packet.len() < RTP_FIXED_HEADER_LEN + warp_mi_tag_len {
+        return None;
+    }
+    let split = packet.len() - warp_mi_tag_len;
+    let without_tag = &packet[..split];
+    let received_tag = &packet[split..];
+    let header = parse_rtp_header(without_tag)?;
+    let header_len = rtp_header_byte_length(without_tag)?;
+    if without_tag.len() <= header_len {
+        return None;
+    }
+    let roc = recv_roc.estimate_roc(header.sequence_number);
+    if !verify_warp_mi_tag(
+        &recv_keys.auth_key,
+        without_tag,
+        roc,
+        warp_mi_tag_len,
+        received_tag,
+    ) {
+        return None;
+    }
+    // Authenticated: now it's safe to advance the rollover counter.
+    recv_roc.commit_roc(roc, header.sequence_number);
+    let cipher = &without_tag[header_len..];
+    let plain = crypt_payload(recv_keys, header.ssrc, header.sequence_number, roc, cipher);
+    Some((header, plain))
+}
+
+/// Video sibling of [`MediaPipeline`]: same E2E-SRTP keys (per participant, not
+/// per media type) and WARP MI tag, but H.264 packetization on top and its own
+/// SSRC/sequencer. One access unit fans out to N RTP packets on send and is
+/// reassembled from them on receive.
+pub struct VideoPipeline {
+    send_keys: E2eSrtpKeys,
+    recv_keys: E2eSrtpKeys,
+    warp_mi_tag_len: usize,
+    rtp: VideoRtpStream,
+    send_roc: RocTracker,
+    recv_roc: RecvRocTracker,
+    depacketizer: H264Depacketizer,
+    pkt_scratch: Vec<Vec<u8>>,
+}
+
+/// Borrowed inputs for [`VideoPipeline::new`]. No `samples_per_packet`: the
+/// video timestamp advances by a fixed per-AU stride instead.
+#[derive(Clone, Copy)]
+pub struct VideoPipelineParams<'a> {
+    pub call_key: &'a [u8],
+    pub self_lid: &'a str,
+    pub peer_lid: &'a str,
+    pub ssrc: u32,
+    pub ts_stride: u32,
+    pub warp_mi_tag_len: usize,
+}
+
+impl VideoPipeline {
+    pub fn new(p: &VideoPipelineParams<'_>) -> Option<Self> {
+        // A zero stride would leave every AU at timestamp 0 (an unusable stream); reject it at
+        // setup rather than emit a frozen clock.
+        if !(1..=20).contains(&p.warp_mi_tag_len) || p.ts_stride == 0 {
+            return None;
+        }
+        Some(Self {
+            send_keys: derive_e2e_keys(p.call_key, &format_e2e_srtp_participant_id(p.self_lid))?,
+            recv_keys: derive_e2e_keys(p.call_key, &format_e2e_srtp_participant_id(p.peer_lid))?,
+            warp_mi_tag_len: p.warp_mi_tag_len,
+            rtp: VideoRtpStream::new(p.ssrc, p.ts_stride),
+            send_roc: RocTracker::default(),
+            recv_roc: RecvRocTracker::default(),
+            depacketizer: H264Depacketizer::default(),
+            pkt_scratch: Vec::new(),
+        })
+    }
+
+    /// Same answering-device rekey as [`MediaPipeline::rekey_recv`]; the video
+    /// recv keys are derived from the identical participant id, so they go
+    /// stale together with the audio ones. The in-flight reassembly state is
+    /// dropped: pre-rekey fragments decrypted to garbage anyway.
+    pub fn rekey_recv(&mut self, call_key: &[u8], answering_peer_lid: &str) -> bool {
+        let Some(keys) = derive_e2e_keys(
+            call_key,
+            &format_e2e_srtp_participant_id(answering_peer_lid),
+        ) else {
+            return false;
+        };
+        self.recv_keys = keys;
+        self.recv_roc = RecvRocTracker::default();
+        self.depacketizer.reset();
+        true
+    }
+
+    /// Outbound: packetize one Annex-B access unit and protect each RTP packet.
+    pub fn protect_video(&mut self, au: &[u8]) -> Vec<Vec<u8>> {
+        let mut payloads = std::mem::take(&mut self.pkt_scratch);
+        packetize_au(au, &mut payloads);
+        let mut packets = Vec::with_capacity(payloads.len());
+        let last = payloads.len().saturating_sub(1);
+        for (i, payload) in payloads.iter().enumerate() {
+            let header = self.rtp.next_video_packet(i == last);
+            let roc = self.send_roc.advance(header.sequence_number);
+            let encrypted = crypt_payload(
+                &self.send_keys,
+                header.ssrc,
+                header.sequence_number,
+                roc,
+                payload,
+            );
+            let mut packet = Vec::with_capacity(header.byte_size() + encrypted.len());
+            encode_rtp_header_into(&header, &mut packet);
+            packet.extend_from_slice(&encrypted);
+            packets.push(append_warp_mi_tag(
+                &self.send_keys.auth_key,
+                &packet,
+                roc,
+                self.warp_mi_tag_len,
+            ));
+        }
+        self.pkt_scratch = payloads;
+        packets
+    }
+
+    /// Inbound: authenticate+decrypt one RTP packet and feed the depacketizer;
+    /// the reassembled access unit is returned on the AU's marker packet.
+    pub fn unprotect_video(&mut self, packet: &[u8]) -> Option<Vec<u8>> {
+        let (header, payload) = unprotect_srtp_packet(
+            &self.recv_keys,
+            &mut self.recv_roc,
+            self.warp_mi_tag_len,
+            packet,
+        )?;
+        self.depacketizer.push(
             header.sequence_number,
-            roc,
-            cipher,
-        );
-        Some((header, plain))
+            header.timestamp,
+            &payload,
+            header.marker,
+        )
     }
 }
 
@@ -719,6 +844,165 @@ mod tests {
             Some(opus.as_slice()),
             "a recv/send tag-length mismatch must NOT recover the payload"
         );
+    }
+
+    fn video_params<'a>(
+        call_key: &'a [u8],
+        self_lid: &'a str,
+        peer_lid: &'a str,
+    ) -> VideoPipelineParams<'a> {
+        VideoPipelineParams {
+            call_key,
+            self_lid,
+            peer_lid,
+            ssrc: 0x0055_AA33,
+            ts_stride: crate::voip::rtp::VIDEO_TS_STRIDE_15FPS,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        }
+    }
+
+    /// A synthetic Annex-B AU big enough to force FU-A fragmentation.
+    fn video_au(nal_len: usize) -> Vec<u8> {
+        let mut au = vec![0, 0, 0, 1, 0x65];
+        au.extend((0..nal_len).map(|i| (i % 251) as u8));
+        au
+    }
+
+    #[test]
+    fn video_pipeline_round_trips_multi_packet_au() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&call_key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&call_key, b, a)).unwrap();
+
+        let au = video_au(3000);
+        let packets = tx.protect_video(&au);
+        assert!(packets.len() >= 4, "3KB AU must fragment into FU-A packets");
+        let mut got = None;
+        for (i, p) in packets.iter().enumerate() {
+            let out = rx.unprotect_video(p);
+            if i < packets.len() - 1 {
+                assert!(out.is_none(), "AU must only complete on the marker packet");
+            } else {
+                got = out;
+            }
+        }
+        assert_eq!(got, Some(au), "AU must reassemble byte-identical");
+
+        // Second AU keeps flowing (sequencer + ROC state stay consistent).
+        let au2 = video_au(100);
+        let packets2 = tx.protect_video(&au2);
+        assert_eq!(packets2.len(), 1);
+        assert_eq!(rx.unprotect_video(&packets2[0]), Some(au2));
+    }
+
+    #[test]
+    fn video_protect_uses_self_lid_and_video_headers() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let self_lid = "111111111111111:0@lid";
+        let peer_lid = "222222222222222:0@lid";
+        let mut pipe = VideoPipeline::new(&video_params(&call_key, self_lid, peer_lid)).unwrap();
+        let au = video_au(10);
+        let packets = pipe.protect_video(&au);
+        assert_eq!(packets.len(), 1);
+        let packet = &packets[0];
+        let without_tag = &packet[..packet.len() - WARP_MI_TAG_LEN];
+        let header = parse_rtp_header(without_tag).unwrap();
+        assert_eq!(header.payload_type, crate::voip::rtp::RTP_PAYLOAD_TYPE_H264);
+        assert!(header.marker, "single-packet AU carries the marker");
+        assert_eq!(header.sequence_number, 0, "video seq starts at 0");
+
+        // Pin the send keystream to the SELF lid (same inversion guard as audio).
+        let header_len = rtp_header_byte_length(without_tag).unwrap();
+        let body = &without_tag[header_len..];
+        let nal = &au[4..];
+        let expect = crypt_payload(
+            &derive_e2e_keys(&call_key, self_lid).unwrap(),
+            header.ssrc,
+            0,
+            0,
+            nal,
+        );
+        assert_eq!(body, expect.as_slice(), "video send must key on self LID");
+    }
+
+    #[test]
+    fn video_forged_tag_rejected_and_stream_survives() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let a = "111111111111111:0@lid";
+        let b = "222222222222222:0@lid";
+        let mut tx = VideoPipeline::new(&video_params(&call_key, a, b)).unwrap();
+        let mut rx = VideoPipeline::new(&video_params(&call_key, b, a)).unwrap();
+
+        let au = video_au(50);
+        let packets = tx.protect_video(&au);
+        let mut forged = packets[0].clone();
+        let seq = u16::from_be_bytes([forged[2], forged[3]]);
+        forged[2..4].copy_from_slice(&seq.wrapping_add(0x4000).to_be_bytes());
+        assert!(
+            rx.unprotect_video(&forged).is_none(),
+            "tampered video packet must fail authentication"
+        );
+        assert_eq!(
+            rx.unprotect_video(&packets[0]),
+            Some(au),
+            "legit packet still decrypts after the forgery"
+        );
+        // Garbage never panics.
+        assert!(rx.unprotect_video(&[]).is_none());
+        assert!(rx.unprotect_video(&[0xff; 9]).is_none());
+    }
+
+    #[test]
+    fn video_rekey_recv_switches_to_answering_device() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let caller = "111111111111111:0@lid";
+        let callee_base = "222222222222222:0@lid";
+        let callee_answering = "222222222222222:2@lid";
+
+        let mut answerer_tx =
+            VideoPipeline::new(&video_params(&call_key, callee_answering, caller)).unwrap();
+        let mut caller_rx =
+            VideoPipeline::new(&video_params(&call_key, caller, callee_base)).unwrap();
+
+        let au = video_au(60);
+        let f1 = answerer_tx.protect_video(&au);
+        assert!(
+            caller_rx.unprotect_video(&f1[0]).is_none(),
+            "base-LID keys must reject the companion's video"
+        );
+        assert!(caller_rx.rekey_recv(&call_key, callee_answering));
+        let f2 = answerer_tx.protect_video(&au);
+        assert_eq!(caller_rx.unprotect_video(&f2[0]), Some(au));
+        // Malformed key refuses without clobbering state.
+        assert!(!caller_rx.rekey_recv(&[0u8; 4], callee_answering));
+    }
+
+    #[test]
+    fn video_pipeline_rejects_bad_setup() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let lid = "222222222222222:0@lid";
+        let mut p = video_params(&call_key, lid, lid);
+        p.warp_mi_tag_len = 0;
+        assert!(VideoPipeline::new(&p).is_none());
+        p.warp_mi_tag_len = 21;
+        assert!(VideoPipeline::new(&p).is_none());
+        let mut zero_stride = video_params(&call_key, lid, lid);
+        zero_stride.ts_stride = 0;
+        assert!(
+            VideoPipeline::new(&zero_stride).is_none(),
+            "a zero timestamp stride must be rejected"
+        );
+        let mut short = video_params(&[0u8; 8], lid, lid);
+        short.warp_mi_tag_len = WARP_MI_TAG_LEN;
+        assert!(
+            VideoPipeline::new(&short).is_none(),
+            "short callKey must be rejected"
+        );
+        // Empty AU produces no packets rather than a marker-only ghost.
+        let mut ok = VideoPipeline::new(&video_params(&call_key, lid, lid)).unwrap();
+        assert!(ok.protect_video(&[]).is_empty());
     }
 
     // The esp32 control/crypto plane. An embedded consumer with no UDP, no codec, and no audio

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -6,7 +6,7 @@ use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
     derive_srtcp_keys, protect_srtcp, unprotect_srtcp, verify_warp_mi_tag,
 };
-use super::h264::{H264Depacketizer, au_has_idr, packetize_au};
+use super::h264::{H264_MAX_AU_BYTES, H264Depacketizer, au_has_idr, packetize_au};
 use super::rtcp::{
     RtcpReceptionReport, RtcpSenderStats, WHATSAPP_RTCP_CNAME_LEN, build_whatsapp_rtcp_cname,
     build_whatsapp_sender_report_with_sdes, build_whatsapp_source_description,
@@ -508,6 +508,9 @@ impl VideoPipeline {
 
     /// Outbound: packetize one Annex-B access unit and protect each RTP packet.
     pub fn protect_video(&mut self, au: &[u8]) -> Vec<Vec<u8>> {
+        if au.len() > H264_MAX_AU_BYTES {
+            return Vec::new();
+        }
         let mut payloads = std::mem::take(&mut self.pkt_scratch);
         packetize_au(au, &mut payloads);
         let media_frame_info = if au_has_idr(au) {
@@ -1108,6 +1111,22 @@ mod tests {
         let packets2 = tx.protect_video(&au2);
         assert_eq!(packets2.len(), 1);
         assert_eq!(rx.unprotect_video(&packets2[0]), Some(au2));
+    }
+
+    #[test]
+    fn video_pipeline_rejects_oversized_au_before_packetization() {
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut pipe = VideoPipeline::new(&video_params(
+            &call_key,
+            "111111111111111:0@lid",
+            "222222222222222:0@lid",
+        ))
+        .unwrap();
+        let oversized = vec![0u8; H264_MAX_AU_BYTES + 1];
+        assert!(pipe.protect_video(&oversized).is_empty());
+
+        let packet = pipe.protect_video(&video_au(10)).pop().unwrap();
+        assert_eq!(parse_rtp_header(&packet).unwrap().sequence_number, 0);
     }
 
     #[test]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -139,6 +139,75 @@ fn phase_rank(p: CallPhase) -> u8 {
     }
 }
 
+const SRTCP_INDEX_MASK: u32 = 0x7fff_ffff;
+const SRTCP_INDEX_HALF_RANGE: u32 = 1 << 30;
+const SRTCP_REPLAY_WINDOW_BITS: u32 = 64;
+const SRTCP_REPLAY_STREAM_CAP: usize = 16;
+
+#[derive(Default)]
+struct SrtcpReplayWindow {
+    highest: Option<u32>,
+    seen: u64,
+}
+
+impl SrtcpReplayWindow {
+    fn accept(&mut self, index: u32) -> bool {
+        let index = index & SRTCP_INDEX_MASK;
+        let Some(highest) = self.highest else {
+            self.highest = Some(index);
+            self.seen = 1;
+            return true;
+        };
+        let forward = index.wrapping_sub(highest) & SRTCP_INDEX_MASK;
+        if forward == 0 {
+            return false;
+        }
+        if forward < SRTCP_INDEX_HALF_RANGE {
+            self.seen = if forward >= SRTCP_REPLAY_WINDOW_BITS {
+                1
+            } else {
+                (self.seen << forward) | 1
+            };
+            self.highest = Some(index);
+            return true;
+        }
+        let behind = highest.wrapping_sub(index) & SRTCP_INDEX_MASK;
+        if behind >= SRTCP_REPLAY_WINDOW_BITS {
+            return false;
+        }
+        let bit = 1u64 << behind;
+        if self.seen & bit != 0 {
+            return false;
+        }
+        self.seen |= bit;
+        true
+    }
+}
+
+#[derive(Default)]
+struct SrtcpReplayState {
+    streams: Vec<(u32, SrtcpReplayWindow)>,
+}
+
+impl SrtcpReplayState {
+    fn accept(&mut self, sender_ssrc: u32, index: u32) -> bool {
+        if let Some((_, window)) = self
+            .streams
+            .iter_mut()
+            .find(|(ssrc, _)| *ssrc == sender_ssrc)
+        {
+            return window.accept(index);
+        }
+        if self.streams.len() >= SRTCP_REPLAY_STREAM_CAP {
+            return false;
+        }
+        let mut window = SrtcpReplayWindow::default();
+        let accepted = window.accept(index);
+        self.streams.push((sender_ssrc, window));
+        accepted
+    }
+}
+
 /// Per-stream RTCP Sender-Report state.
 struct SrtcpSender {
     keys: E2eSrtpKeys,
@@ -233,6 +302,7 @@ pub struct MediaPipeline {
     recv_roc: RecvRocTracker,
     srtcp: SrtcpSender,
     recv_srtcp_keys: E2eSrtpKeys,
+    recv_srtcp_replay: SrtcpReplayState,
 }
 
 /// Borrowed inputs for [`MediaPipeline::new`]. `self_lid`/`peer_lid` are the E2E-SRTP
@@ -284,6 +354,7 @@ impl MediaPipeline {
                 p.call_key,
                 &format_e2e_srtp_participant_id(p.peer_lid),
             )?,
+            recv_srtcp_replay: SrtcpReplayState::default(),
         })
     }
 
@@ -324,6 +395,7 @@ impl MediaPipeline {
         self.recv_keys = keys;
         self.recv_srtcp_keys = srtcp_keys;
         self.recv_roc = RecvRocTracker::default();
+        self.recv_srtcp_replay = SrtcpReplayState::default();
         true
     }
 
@@ -366,9 +438,12 @@ impl MediaPipeline {
     }
 
     /// Authenticate and decrypt peer SRTCP using the sender SSRC left clear on the wire.
-    pub fn unprotect_rtcp(&self, packet: &[u8]) -> Option<Vec<u8>> {
+    pub fn unprotect_rtcp(&mut self, packet: &[u8]) -> Option<Vec<u8>> {
         let sender_ssrc = parse_rtcp_sender_ssrc(packet)?;
-        unprotect_srtcp(&self.recv_srtcp_keys, sender_ssrc, packet)
+        let (plain, index) = unprotect_srtcp(&self.recv_srtcp_keys, sender_ssrc, packet)?;
+        self.recv_srtcp_replay
+            .accept(sender_ssrc, index)
+            .then_some(plain)
     }
 }
 
@@ -462,7 +537,7 @@ impl VideoPipeline {
             send_keys: derive_e2e_keys(p.call_key, &format_e2e_srtp_participant_id(p.self_lid))?,
             recv_keys: derive_e2e_keys(p.call_key, &format_e2e_srtp_participant_id(p.peer_lid))?,
             warp_mi_tag_len: p.warp_mi_tag_len,
-            rtp: VideoRtpStream::new(p.ssrc, p.ts_stride),
+            rtp: VideoRtpStream::new(p.ssrc, p.ts_stride)?,
             send_roc: RocTracker::default(),
             recv_roc: RecvRocTracker::default(),
             depacketizer: H264Depacketizer::default(),
@@ -547,27 +622,35 @@ impl VideoPipeline {
 
     /// Inbound: authenticate+decrypt one RTP packet and feed the depacketizer;
     /// the reassembled access unit is returned on the AU's marker packet.
-    pub fn unprotect_video(&mut self, packet: &[u8]) -> Option<Vec<u8>> {
-        self.unprotect_video_packet(packet)?.1
+    pub fn unprotect_video(&mut self, packet: &[u8]) -> Option<Vec<Vec<u8>>> {
+        let completed = self.unprotect_video_packet(packet)?.1;
+        (!completed.is_empty()).then_some(completed)
     }
 
     pub(crate) fn unprotect_video_packet(
         &mut self,
         packet: &[u8],
-    ) -> Option<(RtpHeader, Option<Vec<u8>>)> {
+    ) -> Option<(RtpHeader, Vec<Vec<u8>>)> {
         let (header, payload) = unprotect_srtp_packet(
             &self.recv_keys,
             &mut self.recv_roc,
             self.warp_mi_tag_len,
             packet,
         )?;
-        let au = self.depacketizer.push(
+        let first = self.depacketizer.push(
             header.sequence_number,
             header.timestamp,
             &payload,
             header.marker,
         );
-        Some((header, au))
+        let mut completed = Vec::with_capacity(if first.is_some() { 2 } else { 0 });
+        if let Some(au) = first {
+            completed.push(au);
+        }
+        while let Some(au) = self.depacketizer.pop_ready() {
+            completed.push(au);
+        }
+        Some((header, completed))
     }
 }
 
@@ -1062,6 +1145,91 @@ mod tests {
         );
     }
 
+    #[test]
+    fn srtcp_replay_window_handles_reorder_and_index_wrap() {
+        let mut window = SrtcpReplayWindow::default();
+        assert!(window.accept(100));
+        assert!(window.accept(102));
+        assert!(window.accept(101));
+        assert!(
+            !window.accept(101),
+            "a reordered packet is accepted only once"
+        );
+        assert!(window.accept(40), "the oldest in-window packet is accepted");
+        assert!(
+            !window.accept(38),
+            "packets outside the 64-index window are stale"
+        );
+
+        let mut wrapping = SrtcpReplayWindow::default();
+        assert!(wrapping.accept(0x7fff_fffe));
+        assert!(wrapping.accept(0x7fff_ffff));
+        assert!(wrapping.accept(0));
+        assert!(wrapping.accept(1));
+        assert!(!wrapping.accept(0x7fff_ffff));
+    }
+
+    #[test]
+    fn srtcp_replay_is_rejected_only_after_authentication() {
+        use crate::voip::rtcp::build_compact_rtcp_208;
+
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let caller = "111111111111111:0@lid";
+        let peer = "222222222222222:0@lid";
+        let params = MediaPipelineParams {
+            call_key: &call_key,
+            self_lid: caller,
+            peer_lid: peer,
+            ssrc: 0x0102_0304,
+            samples_per_packet: 960,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        };
+        let mut receiver = MediaPipeline::new(&params).unwrap();
+        let peer_keys = derive_srtcp_keys(&call_key, peer).unwrap();
+        let sender = 0x1122_3344;
+        let plain = build_compact_rtcp_208(sender, params.ssrc);
+        let packet = |index| protect_srtcp(&peer_keys, sender, index, &plain);
+
+        assert_eq!(
+            receiver.unprotect_rtcp(&packet(5)).as_deref(),
+            Some(&plain[..])
+        );
+        assert!(receiver.unprotect_rtcp(&packet(5)).is_none());
+
+        let mut forged = packet(6);
+        *forged.last_mut().unwrap() ^= 1;
+        assert!(receiver.unprotect_rtcp(&forged).is_none());
+        assert_eq!(
+            receiver.unprotect_rtcp(&packet(6)).as_deref(),
+            Some(&plain[..]),
+            "a forged packet must not consume the authenticated index"
+        );
+
+        assert_eq!(
+            receiver.unprotect_rtcp(&packet(8)).as_deref(),
+            Some(&plain[..])
+        );
+        assert_eq!(
+            receiver.unprotect_rtcp(&packet(7)).as_deref(),
+            Some(&plain[..])
+        );
+        assert!(receiver.unprotect_rtcp(&packet(7)).is_none());
+        assert_eq!(
+            receiver.unprotect_rtcp(&packet(80)).as_deref(),
+            Some(&plain[..])
+        );
+        assert!(receiver.unprotect_rtcp(&packet(10)).is_none());
+
+        let other_sender = 0x5566_7788;
+        let other_plain = build_compact_rtcp_208(other_sender, params.ssrc);
+        let other = protect_srtcp(&peer_keys, other_sender, 5, &other_plain);
+        assert_eq!(
+            receiver.unprotect_rtcp(&other).as_deref(),
+            Some(&other_plain[..]),
+            "replay state is independent per sender SSRC"
+        );
+    }
+
     fn video_params<'a>(
         call_key: &'a [u8],
         self_lid: &'a str,
@@ -1104,13 +1272,13 @@ mod tests {
                 got = out;
             }
         }
-        assert_eq!(got, Some(au), "AU must reassemble byte-identical");
+        assert_eq!(got, Some(vec![au]), "AU must reassemble byte-identical");
 
         // Second AU keeps flowing (sequencer + ROC state stay consistent).
         let au2 = video_au(100);
         let packets2 = tx.protect_video(&au2);
         assert_eq!(packets2.len(), 1);
-        assert_eq!(rx.unprotect_video(&packets2[0]), Some(au2));
+        assert_eq!(rx.unprotect_video(&packets2[0]), Some(vec![au2]));
     }
 
     #[test]
@@ -1152,7 +1320,9 @@ mod tests {
             }
         }
 
-        let received = received.expect("marker packet completes the access unit");
+        let mut received = received.expect("marker packet completes the access unit");
+        assert_eq!(received.len(), 1);
+        let received = received.remove(0);
         assert_eq!(
             crate::voip::h264::split_annexb(&received)
                 .map(crate::voip::h264::nal_unit_type)
@@ -1245,7 +1415,7 @@ mod tests {
         );
         assert_eq!(
             rx.unprotect_video(&packets[0]),
-            Some(au),
+            Some(vec![au]),
             "legit packet still decrypts after the forgery"
         );
         // Garbage never panics.
@@ -1273,7 +1443,7 @@ mod tests {
         );
         assert!(caller_rx.rekey_recv(&call_key, callee_answering));
         let f2 = answerer_tx.protect_video(&au);
-        assert_eq!(caller_rx.unprotect_video(&f2[0]), Some(au));
+        assert_eq!(caller_rx.unprotect_video(&f2[0]), Some(vec![au]));
         // Malformed key refuses without clobbering state.
         assert!(!caller_rx.rekey_recv(&[0u8; 4], callee_answering));
     }

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -485,6 +485,10 @@ impl VideoPipeline {
         self.rtp.ssrc
     }
 
+    pub(crate) fn set_timestamp_stride(&mut self, ts_stride: u32) -> bool {
+        self.rtp.set_timestamp_stride(ts_stride)
+    }
+
     /// Same answering-device rekey as [`MediaPipeline::rekey_recv`]; the video
     /// recv keys are derived from the identical participant id, so they go
     /// stale together with the audio ones. The in-flight reassembly state is

--- a/wacore/src/voip/ssrc.rs
+++ b/wacore/src/voip/ssrc.rs
@@ -13,10 +13,7 @@ pub fn derive_wasm_participant_ssrc(call_id: &str, lid: &str, slot_word: u32) ->
     u32::from_le_bytes(okm)
 }
 
-/// Relay stream slot used to derive the VIDEO SSRC. Taken from the
-/// WaCalls/meowcaller reference (audio is slot 0); our KATs only pin slots 0/1,
-/// so this value is unvalidated against a live capture — if interop shows the
-/// peer deriving a different video SSRC, this single constant is the fix.
+/// Relay stream slot used to derive the VIDEO SSRC, pinned to the WhatsApp WASM slot grid.
 pub const VIDEO_SSRC_SLOT_WORD: u32 = 2;
 
 /// Video-stream SSRC for a participant: same HKDF as audio, video slot word.
@@ -59,11 +56,7 @@ mod tests {
         let audio = derive_wasm_participant_ssrc("CALL-ID-0001", "12345:0@lid", 0);
         let video = derive_video_participant_ssrc("CALL-ID-0001", "12345:0@lid");
         assert_ne!(audio, video);
-        assert_eq!(
-            video,
-            derive_wasm_participant_ssrc("CALL-ID-0001", "12345:0@lid", VIDEO_SSRC_SLOT_WORD),
-            "helper must be the slot-word derivation, nothing extra"
-        );
+        assert_eq!(video, 0xf8d7_0484, "WhatsApp WASM video-slot KAT");
     }
 
     #[test]

--- a/wacore/src/voip/ssrc.rs
+++ b/wacore/src/voip/ssrc.rs
@@ -13,6 +13,17 @@ pub fn derive_wasm_participant_ssrc(call_id: &str, lid: &str, slot_word: u32) ->
     u32::from_le_bytes(okm)
 }
 
+/// Relay stream slot used to derive the VIDEO SSRC. Taken from the
+/// WaCalls/meowcaller reference (audio is slot 0); our KATs only pin slots 0/1,
+/// so this value is unvalidated against a live capture — if interop shows the
+/// peer deriving a different video SSRC, this single constant is the fix.
+pub const VIDEO_SSRC_SLOT_WORD: u32 = 2;
+
+/// Video-stream SSRC for a participant: same HKDF as audio, video slot word.
+pub fn derive_video_participant_ssrc(call_id: &str, lid: &str) -> u32 {
+    derive_wasm_participant_ssrc(call_id, lid, VIDEO_SSRC_SLOT_WORD)
+}
+
 /// Device-qualified LID for E2E SRTP HKDF `info`: keep an existing `:N@lid`,
 /// bare `@lid` becomes `:0@lid`, everything else passes through. Intentionally a separate protocol
 /// surface from SFrame's variant; they coincide today, so both delegate to one helper. Un-shim here
@@ -38,6 +49,20 @@ mod tests {
         assert_eq!(
             derive_wasm_participant_ssrc(call_id, lid, 1) as u64,
             k["voip_crypto"]["ssrc_slot1"].as_u64().unwrap()
+        );
+    }
+
+    #[test]
+    fn video_ssrc_differs_from_audio_ssrc() {
+        // Same call/participant must yield distinct per-stream SSRCs, or the
+        // engine's demux would collapse audio and video into one stream.
+        let audio = derive_wasm_participant_ssrc("CALL-ID-0001", "12345:0@lid", 0);
+        let video = derive_video_participant_ssrc("CALL-ID-0001", "12345:0@lid");
+        assert_ne!(audio, video);
+        assert_eq!(
+            video,
+            derive_wasm_participant_ssrc("CALL-ID-0001", "12345:0@lid", VIDEO_SSRC_SLOT_WORD),
+            "helper must be the slot-word derivation, nothing extra"
         );
     }
 

--- a/wacore/src/voip/stun.rs
+++ b/wacore/src/voip/stun.rs
@@ -34,16 +34,6 @@ pub const MSG_ALLOCATE_ERROR: u16 = 0x0113;
 pub const MSG_WHATSAPP_PING: u16 = 0x0801;
 pub const MSG_WHATSAPP_PONG: u16 = 0x0802;
 
-/// WASM/Web StreamDescriptors template (attr 0x4024): auxiliary stream SSRCs.
-const WASM_STREAM_DESCRIPTORS_TEMPLATE: &[u8] = &[
-    0x0a, 0x06, 0x18, 0xca, 0xbc, 0x85, 0xae, 0x04, 0x0a, 0x08, 0x10, 0x01, 0x18, 0xa5, 0xac, 0xaf,
-    0xae, 0x0a, 0x0a, 0x08, 0x10, 0x02, 0x18, 0xd6, 0xa4, 0xe6, 0xf9, 0x0f, 0x0a, 0x08, 0x08, 0x01,
-    0x18, 0xf7, 0xdd, 0x9e, 0xb6, 0x0a, 0x0a, 0x0a, 0x08, 0x01, 0x10, 0x01, 0x18, 0xab, 0xcc, 0xb1,
-    0xf3, 0x0d, 0x0a, 0x0a, 0x08, 0x01, 0x10, 0x02, 0x18, 0xda, 0xda, 0xef, 0x8a, 0x05, 0x0a, 0x08,
-    0x08, 0x02, 0x18, 0xc5, 0xe9, 0xec, 0x8e, 0x0b, 0x0a, 0x0a, 0x08, 0x02, 0x10, 0x01, 0x18, 0xfd,
-    0xc2, 0xb1, 0xb6, 0x0f, 0x0a, 0x0a, 0x08, 0x02, 0x10, 0x02, 0x18, 0xb0, 0x97, 0xf7, 0xb2, 0x09,
-];
-
 fn pad4(n: usize) -> usize {
     (4 - (n % 4)) % 4
 }
@@ -154,17 +144,56 @@ fn create_wasm_relay_endpoint_attr(endpoint_xor: &[u8; 6]) -> [u8; 8] {
     buf
 }
 
+/// `(stream_index, sub_type, slot_word)` in WASM wire order. Stream indices are audio/video0/video1;
+/// sub-types are media/FEC/NACK.
+const WASM_STREAM_SLOTS: [(u32, u32, u32); 9] = [
+    (0, 0, 0),
+    (0, 1, 1),
+    (0, 2, 4),
+    (1, 0, 2),
+    (1, 1, 3),
+    (1, 2, 5),
+    (2, 0, 7),
+    (2, 1, 8),
+    (2, 2, 6),
+];
+
+/// Build call-specific WASM `StreamDescriptors` (0x4024).
+pub fn create_wasm_stream_descriptors(call_id: &str, self_participant_id: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    for &(stream_index, sub_type, slot) in &WASM_STREAM_SLOTS {
+        let ssrc =
+            crate::voip::ssrc::derive_wasm_participant_ssrc(call_id, self_participant_id, slot);
+        let mut d = Vec::new();
+        if stream_index != 0 {
+            pb_tag(&mut d, 1, 0);
+            pb_varint(&mut d, stream_index as u64);
+        }
+        if sub_type != 0 {
+            pb_tag(&mut d, 2, 0);
+            pb_varint(&mut d, sub_type as u64);
+        }
+        pb_tag(&mut d, 3, 0);
+        pb_varint(&mut d, ssrc as u64);
+        pb_len_delim(&mut out, 1, &d);
+    }
+    out
+}
+
 /// WASM/Web DataChannel Allocate: 0x4000 token + 0x4024 stream desc + 0x0016 endpoint + MI, no FP.
+/// Descriptors must carry this call's derived SSRCs rather than values captured from another call.
 pub fn build_wasm_stun_allocate_request(
     transaction_id: &[u8; 12],
     relay_token: &[u8],
     endpoint_xor: &[u8; 6],
     integrity_key: &[u8],
+    call_id: &str,
+    self_participant_id: &str,
 ) -> Vec<u8> {
     let mut attrs = stun_attr(ATTR_RELAY_TOKEN, relay_token);
     attrs.extend_from_slice(&stun_attr(
         STUN_ATTR_STREAM_DESCRIPTORS,
-        WASM_STREAM_DESCRIPTORS_TEMPLATE,
+        &create_wasm_stream_descriptors(call_id, self_participant_id),
     ));
     attrs.extend_from_slice(&stun_attr(
         STUN_ATTR_WASM_RELAY_ENDPOINT,
@@ -507,22 +536,105 @@ mod tests {
         assert!(!is_allocate_or_binding_success(&pkt));
     }
 
+    fn dv(b: &[u8], i: &mut usize) -> u64 {
+        let (mut val, mut shift) = (0u64, 0u32);
+        loop {
+            let byte = b[*i];
+            *i += 1;
+            val |= ((byte & 0x7f) as u64) << shift;
+            if byte & 0x80 == 0 {
+                return val;
+            }
+            shift += 7;
+        }
+    }
+
+    /// Decode the WASM StreamDescriptors protobuf into `(stream_index, sub_type) -> ssrc`.
+    fn decode_stream_descriptors(buf: &[u8]) -> std::collections::HashMap<(u32, u32), u32> {
+        let mut out = std::collections::HashMap::new();
+        let mut i = 0;
+        while i < buf.len() {
+            assert_eq!(dv(buf, &mut i), (1 << 3) | 2, "top-level repeated field 1");
+            let end = i + dv(buf, &mut i) as usize;
+            let (mut sidx, mut sub, mut ssrc) = (0u32, 0u32, None);
+            while i < end {
+                let field = dv(buf, &mut i) >> 3;
+                match field {
+                    1 => sidx = dv(buf, &mut i) as u32,
+                    2 => sub = dv(buf, &mut i) as u32,
+                    3 => ssrc = Some(dv(buf, &mut i) as u32),
+                    other => panic!("unexpected descriptor field {other}"),
+                }
+            }
+            out.insert((sidx, sub), ssrc.expect("descriptor carries an ssrc"));
+        }
+        out
+    }
+
     #[test]
-    fn wasm_allocate_and_ping_match_kat() {
+    fn wasm_allocate_carries_dynamic_stream_descriptors() {
         let k = kats();
         let tx = tx12(&k);
         let token = hexd(&k, &["stun", "relayToken"]);
         let mi_key = hexd(&k, &["stun", "miKey"]);
         let ep = encode_xor_relay_endpoint("157.240.226.133", 3478).unwrap();
-        let alloc = build_wasm_stun_allocate_request(&tx, &token, &ep, &mi_key);
+        let call_id = "CALL-ID-0001";
+        let participant = crate::voip::ssrc::format_e2e_srtp_participant_id("12345:0@lid");
+        let alloc =
+            build_wasm_stun_allocate_request(&tx, &token, &ep, &mi_key, call_id, &participant);
+
+        let attrs = parse_stun_attributes(&alloc);
+        assert_eq!(attrs[0].attr_type, ATTR_RELAY_TOKEN);
+        let sd = attrs
+            .iter()
+            .find(|a| a.attr_type == STUN_ATTR_STREAM_DESCRIPTORS)
+            .expect("stream descriptors attr present");
         assert_eq!(
-            hex::encode(&alloc),
-            k["stun"]["wasmAllocate"].as_str().unwrap()
+            sd.value,
+            create_wasm_stream_descriptors(call_id, &participant)
         );
+        assert!(
+            attrs
+                .iter()
+                .any(|a| a.attr_type == STUN_ATTR_WASM_RELAY_ENDPOINT)
+        );
+        let mi = attrs
+            .iter()
+            .find(|a| a.attr_type == ATTR_MESSAGE_INTEGRITY)
+            .expect("message integrity present");
+        assert_eq!(mi.value.len(), 20);
+
         assert_eq!(
             hex::encode(build_whatsapp_ping(&tx)),
             k["stun"]["ping"].as_str().unwrap()
         );
+    }
+
+    #[test]
+    fn stream_descriptors_announce_the_live_media_ssrcs() {
+        let call_id = "CALL-ID-0001";
+        let participant = crate::voip::ssrc::format_e2e_srtp_participant_id("12345:0@lid");
+        let entries =
+            decode_stream_descriptors(&create_wasm_stream_descriptors(call_id, &participant));
+
+        // The video0 media descriptor must name the VideoPipeline SSRC.
+        assert_eq!(
+            entries.get(&(1, 0)).copied(),
+            Some(crate::voip::ssrc::derive_video_participant_ssrc(
+                call_id,
+                &participant
+            ))
+        );
+        assert_eq!(
+            entries.get(&(0, 0)).copied(),
+            Some(crate::voip::ssrc::derive_wasm_participant_ssrc(
+                call_id,
+                &participant,
+                0
+            ))
+        );
+        // audio + video0 + video1, each with media/FEC/NACK.
+        assert_eq!(entries.len(), 9);
     }
 
     #[test]

--- a/wacore/src/voip/testdata/kats.json
+++ b/wacore/src/voip/testdata/kats.json
@@ -38,15 +38,23 @@
     "masterSalt": "749ee99101a47c82bb5dacec40cf"
   },
   "hbh_srtp": {
-    "uplinkKey30": "d7c293861dccfc246ce7c66b498e7d50e92424ae12c54f79c9131eac0a94",
-    "masterKey": "d7c293861dccfc246ce7c66b498e7d50",
-    "masterSalt": "e92424ae12c54f79c9131eac0a94",
-    "sessionKey": "8586b2992b154e6531606e8b7ceeb782",
-    "sessionSalt": "e14ea5189ca6f303f3697237cf04",
-    "authKey": "1caf9c0b1f0c08fad93a41f7d6897ba12eaf100f",
-    "icmKey30": "8586b2992b154e6531606e8b7ceeb782e14ea5189ca6f303f3697237cf04",
+    "uplinkSalt32": "501238bf8f996669b5172c9aa47338eb7de4d12ddba98eea1e531a694f894129",
+    "uplinkKey30": "f77854760b4340f0eabbe93930eafe0310c8f699d1ebaf1f609a1781f3fc",
+    "sharedSrtpKey30": "693a8070145a5d26d39183593d1b648e895a8a3f2354ab38e718cbd93822",
+    "sharedSrtcpKey30": "4ad41608b1fe681b56e8230ba5fea1060de1e767fb1275d4dcf85ce3cea9",
+    "downlinkKey30": "707aad5216a25868eea63a32403b9d0c643644f691145e02b6d7d3776301",
+    "masterKey": "f77854760b4340f0eabbe93930eafe03",
+    "masterSalt": "10c8f699d1ebaf1f609a1781f3fc",
+    "sessionKey": "cf8c0c31437c9a5ab292cbdaa533c2c0",
+    "sessionSalt": "30879d9e6a76f04e7349f40066a7",
+    "authKey": "b012d6003068b460da0121866712a335987d72b8",
+    "srtcpSessionKey": "f065528cfce4757f444bb8b5892aad7c",
+    "srtcpSessionSalt": "54bc95ca04c05be16456f0f12dc0",
+    "srtcpAuthKey": "6e6b37a126a522302a578c9713d38e85606048eb",
+    "srtcpProtectedSrIndex1": "80c80006123456787d74643dbb62b23f5005bf9b4296de885c3ff6e280000001cc486281b0510f8b2a83",
+    "icmKey30": "cf8c0c31437c9a5ab292cbdaa533c2c030879d9e6a76f04e7349f40066a7",
     "rtpIcmNonce": "00000000123456780000000000070000",
-    "cipher_out": "eacd64249a77b5270140c634"
+    "cipher_out": "363ea223cb020f6d58cea9ee"
   },
   "voip_crypto": {
     "ssrc_slot0": 1805509457,
@@ -55,6 +63,10 @@
   "rtp": {
     "speechHeader16": "90f800010000000012345678debe0000",
     "dtxHeader20": "907800020000014012345678debe000130010000",
+    "androidVideoHeader28": "90e100010001bdc849c5fb8cdebe0003300951000061001d910c3f00",
+    "androidVideoExtension12": "300951000061001d910c3f00",
+    "androidVideoDeltaHeader28": "90e1000700022ea29b1959f0debe00033001510000610024910a6a00",
+    "androidVideoDeltaExtension12": "3001510000610024910a6a00",
     "estimateSpeech12": 32,
     "estimateDtx1": 25,
     "estimatePriming2": 25


### PR DESCRIPTION
## Summary

Adds interoperable **1:1 video calls** to the existing VoIP implementation. Calls can start with video, upgrade from audio to video, return to audio, and accept the same transitions initiated by an official WhatsApp client.

The library remains codec-neutral: consumers provide and receive complete H.264 Annex-B access units through `VideoSource` / `VideoSink`. Encoding, decoding, capture, and display stay outside the core crates; the CLI example uses `ffmpeg` and `ffplay` without adding codec dependencies to the library.

This is additive to the existing 1:1 voice path. Bidirectional audio continues over its established pipeline while video is independently signaled, demultiplexed, encrypted, paced, and recovered.

## WhatsApp interoperability

The implementation covers the media and signaling profile verified against WhatsApp Web/Android captures and live Android calls:

- WhatsApp SSRC derivation, including the video participant slot and dynamic STUN `StreamDescriptors` for live audio/video SSRCs;
- PT-97 RTP with the captured extension layout, marker/timestamp behavior, WARP authentication, E2E-SRTP, and answering-device rekeying;
- directional/shared relay SRTCP derivation, native RTCP CNAME/SDES, and periodic Sender Reports at the advertised 1.5 s cadence using NTP wall time and actual sender/reception statistics;
- authenticated peer SR/RR, compact reports, NACK, PLI, and FIR parsing, including WhatsApp's feedback profile bit;
- per-sender SRTCP replay windows that reject duplicate/stale authenticated indices, accept bounded reordering and 31-bit wrap, and never commit state for forged packets;
- offer, preaccept, accept, typed video acknowledgements, orientation, upgrade/downgrade, and the standalone `Enabled` transition used to complete accepted upgrades.

The Android peer reports reception of the Rust participant's video SSRC and renders outbound video from both synthetic input and a real V4L2 webcam.

## Empirically confirmed webcam recovery

The webcam-only failure was isolated by replaying the exact captured webcam Annex-B stream and inspecting authenticated peer RTCP. The H.264 was valid and reached Android, but Android repeatedly sent PLI for the local video SSRC. Continuing to send dependent frames before the next IDR kept the official decoder outside a valid recovery point.

The engine now treats authenticated PLI/FIR as a decoder resynchronization boundary: dependent access units are withheld without consuming RTP/SRTP sequence state until the next IDR, then normal transmission resumes. The live V4L2 test changed from PLI every ~440 ms with no picture to one recovery request followed by continuous rendered webcam video.

The same invariant protects from-start video, reactivation, upgrade ungating, and relay backpressure. The recovery gate clears only after an IDR packetizes successfully. Disable purges queued, unstarted video access units while preserving any batch already on the transport, so reactivation resumes at a complete IDR without truncating an in-flight frame; audio and control traffic stay live.

## API and lifecycle

```rust
let handle = client
    .voip()
    .call(peer)
    .audio(mic, speaker)
    .video(h264_source, h264_sink)
    .start()
    .await?;

handle.start_video(new_source, new_sink).await?;
handle.stop_video().await?;
```

- `VideoSource` exposes its RTP timestamp stride, so 15 fps, 20 fps, 30 fps, and other valid 90 kHz cadences do not drift; zero stride is rejected at construction.
- Upgrade video remains send-gated until peer acceptance. Downgrade drains stale source access units without resetting RTP/SRTP state.
- Accepted peer upgrades become locally visible and ungate media only after the standalone `Enabled` send succeeds. A failed second handshake send emits phase-tagged diagnostics, tears down endpoints, and clears local video state in both initiator and acceptor paths, leaving the official peer to perform its normal incomplete-upgrade timeout.
- Incoming video-state events preserve routed `participant`/`recipient` metadata in typed acknowledgements, bind transitions to the call generation, and hold serialization through every post-ack effect and accepted-upgrade `Enabled` send. Unacknowledged or stale same-ID transitions cannot mutate a replacement call, and a committed state supersedes an older queued event under backpressure.
- Signaling state derives its wire markers from `VideoState`, preventing invalid marker/state combinations.
- Failed setup before a peer-visible transition rolls back endpoints and explicitly terminates an already-preaccepted call. Final accept is sent only after camera/ffmpeg has produced a decodable SPS/PPS/IDR.
- ffmpeg reader tasks are cancelled on readiness failure, timeout, source replacement, terminal call removal, and source drop. Video feeds retain source ownership for exactly the call lifetime.
- Peer termination during media preparation is tombstoned so a dead call cannot finish startup later.
- Video teardown hooks are generation-bound, consumed exactly once off-lock, and rearmed on every activation; stop/restart and all terminal paths release the correct endpoints without touching a same-call-id replacement.
- Video state and cadence controls use a lossless FIFO, so a `Disable` purge always precedes a later `Enable`; orientation is isolated in a one-slot latest-value mailbox and cannot evict negotiated transitions.

## H.264 media plane

- Single-NAL and FU-A packetization; single-NAL, STAP-A, and FU-A reassembly.
- SPS/PPS/IDR ordering compatible with the official receiver; encoder-only AUDs are omitted from RTP.
- Timestamp-boundary recovery when markers are lost, sequence-aware fragment-loss handling, allocation caps, forged-tag rejection, and immediate ordered draining when one packet completes multiple access units.
- Complete access units are the backpressure unit, so overload cannot leave half an IDR on the wire.
- From-start video, upgrades/downgrades, receiver rekey, RTP/RTCP wrap, malformed input, authenticated feedback, replay rejection, and keyframe recovery have deterministic tests/KATs.

## CLI example

Every call/listen mode accepts `--video`; `v` toggles video during a call and `q` performs a signaled hangup. Sources can be an OS webcam, a file/URL, or `WA_VIDEO_INPUT=testsrc`; sinks can be an `ffplay` window, raw `.h264`, or discard mode.

The example asynchronously classifies input paths, probes V4L2 capabilities, selects an exact supported capture mode, normalizes pixel format/geometry, and waits for a decodable SPS/PPS/IDR before accepting the call. Its default encoder contract matches the captured WhatsApp Web high-quality tier: H.264 Constrained Baseline Level 3.1, 1280×720 at 20 fps, about 1.98 Mbps, one slice per frame, repeated SPS/PPS, and a 60-frame GOP. `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`, and `WA_VIDEO_BITRATE_KBPS` remain explicit overrides.

The preview uses arrival-time timestamps, bounded low-latency queues, and inverse `device_orientation` correction. This prevents long-run delay accumulation and correctly displays Android portrait video. Official clients still adapt quality dynamically; the example matches a captured high-quality tier but does not claim to implement WhatsApp's full bandwidth estimator.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests -- -D warnings`
- `cargo test --workspace --exclude e2e-tests`
  - `wacore`: 1,403 passed, 1 ignored
  - `whatsapp-rust`: 1,068 passed, 1 ignored
  - `whatsapp-rust-voip-cli`: 16 passed
- `cargo test -p wacore --features voip voip::`: 297 passed, 1 diagnostic ignored
- `cargo test -p whatsapp-rust --features voip voip::`: 53 passed
- `cargo test -p whatsapp-rust --features voip handlers::call::tests::`: 24 passed
- `cargo build -p whatsapp-rust-voip-cli --release`
- live Android interoperability: stable bidirectional audio, inbound video decode, outbound synthetic and V4L2 webcam video rendered on the phone, portrait correction on desktop, and sustained low-latency preview

`cargo test --all` additionally requires the documented E2E mock server; GitHub Actions supplies that environment.

## Scope

- 1:1 calls only; group video is not part of this PR.
- H.264 Annex-B transport only; pixel formats and codec implementations remain consumer-owned.
- VoIP feature scope only, with no new runtime codec dependency in `wacore` or `whatsapp-rust`.