### PR TITLE
fix(signal): recover cancelled session checkouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,6 +4057,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "log",
+ "portable-atomic",
  "rand 0.10.2",
  "serde",
  "sha1 0.11.0",

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -5,8 +5,9 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use wacore::libsignal::protocol::{
     Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore, PreKeyId,
-    PreKeyRecord, PreKeyStore, ProtocolAddress, SessionCheckoutStoreResult, SessionRecord,
-    SessionStore, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
+    PreKeyRecord, PreKeyStore, ProtocolAddress, SessionCheckoutKey, SessionCheckoutStoreResult,
+    SessionRecord, SessionStore, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord,
+    SignedPreKeyStore,
 };
 
 use wacore::libsignal::store::record_helpers as wacore_record;
@@ -110,23 +111,24 @@ impl SessionStore for SessionAdapter {
     async fn load_session_for_update(
         &self,
         address: &ProtocolAddress,
-    ) -> Result<(Option<SessionRecord>, Option<u64>), SignalProtocolError> {
+    ) -> Result<(Option<SessionRecord>, Option<SessionCheckoutKey>), SignalProtocolError> {
         let device = self.0.device.read().await;
         self.0
             .cache
             .checkout_session(address, &*device.backend)
             .await
-            .map(|(record, generation)| (record, Some(generation)))
+            .map(|(record, checkout)| (record, Some(checkout)))
             .map_err(signal_err("backend"))
     }
 
     fn try_load_session_for_update(
         &self,
         address: &ProtocolAddress,
-    ) -> Option<Result<(Option<SessionRecord>, Option<u64>), SignalProtocolError>> {
+    ) -> Option<Result<(Option<SessionRecord>, Option<SessionCheckoutKey>), SignalProtocolError>>
+    {
         self.0.cache.try_checkout_session(address).map(|result| {
             result
-                .map(|(record, generation)| (record, Some(generation)))
+                .map(|(record, checkout)| (record, Some(checkout)))
                 .map_err(signal_err("backend"))
         })
     }
@@ -135,20 +137,24 @@ impl SessionStore for SessionAdapter {
         &mut self,
         address: &ProtocolAddress,
         record: SessionRecord,
-        generation: Option<u64>,
+        checkout: Option<SessionCheckoutKey>,
         had_session: bool,
     ) -> SessionCheckoutStoreResult {
-        let Some(generation) = generation else {
+        let Some(checkout) = checkout else {
             return SessionCheckoutStoreResult::Unhandled(record);
         };
         self.0
             .cache
-            .restore_session_from_checkout(address, record, generation, had_session)
+            .restore_session_from_checkout(address, record, checkout, had_session)
     }
 
-    fn cancel_session_checkout(&mut self, address: &ProtocolAddress, generation: Option<u64>) {
-        if let Some(generation) = generation {
-            self.0.cache.cancel_session_checkout(address, generation);
+    fn cancel_session_checkout(
+        &mut self,
+        address: &ProtocolAddress,
+        checkout: Option<SessionCheckoutKey>,
+    ) {
+        if let Some(checkout) = checkout {
+            self.0.cache.cancel_session_checkout(address, checkout);
         }
     }
 

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -106,6 +106,35 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
+    async fn load_session_for_update(
+        &self,
+        address: &ProtocolAddress,
+    ) -> Result<(Option<SessionRecord>, Option<u64>), SignalProtocolError> {
+        let device = self.0.device.read().await;
+        self.0
+            .cache
+            .checkout_session(address, &*device.backend)
+            .await
+            .map(|(record, generation)| (record, Some(generation)))
+            .map_err(signal_err("backend"))
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn try_store_session_from_checkout(
+        &mut self,
+        address: &ProtocolAddress,
+        record: SessionRecord,
+        generation: Option<u64>,
+    ) -> core::result::Result<bool, SessionRecord> {
+        let Some(generation) = generation else {
+            return Err(record);
+        };
+        Ok(self
+            .0
+            .cache
+            .restore_session_from_checkout(address, record, generation))
+    }
+
     // Hand-desugared (see `BoxFut`): a cached answer skips the device lock
     // and returns a ready future.
     fn has_session<'life0, 'life1, 'async_trait>(
@@ -475,6 +504,177 @@ mod tests {
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
         let device = Arc::new(RwLock::new(Device::new(backend)));
         SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
+    }
+
+    struct BlockingIdentityStore {
+        pair: IdentityKeyPair,
+        entered: Arc<async_lock::Barrier>,
+    }
+
+    #[async_trait]
+    impl IdentityKeyStore for BlockingIdentityStore {
+        async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
+            Ok(self.pair.clone())
+        }
+
+        async fn get_local_registration_id(&self) -> Result<u32, SignalProtocolError> {
+            Ok(1)
+        }
+
+        async fn save_identity(
+            &mut self,
+            _address: &ProtocolAddress,
+            _identity: &IdentityKey,
+        ) -> Result<IdentityChange, SignalProtocolError> {
+            Ok(IdentityChange::NewOrUnchanged)
+        }
+
+        async fn is_trusted_identity(
+            &self,
+            _address: &ProtocolAddress,
+            _identity: &IdentityKey,
+            _direction: Direction,
+        ) -> Result<bool, SignalProtocolError> {
+            self.entered.wait().await;
+            futures::future::pending().await
+        }
+
+        async fn get_identity(
+            &self,
+            _address: &ProtocolAddress,
+        ) -> Result<Option<IdentityKey>, SignalProtocolError> {
+            Ok(None)
+        }
+    }
+
+    fn outbound_session() -> (SessionRecord, IdentityKeyPair) {
+        use wacore::libsignal::protocol::{
+            AliceSignalProtocolParameters, KeyPair, UsePQRatchet, initialize_alice_session_record,
+        };
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let local_identity = IdentityKeyPair::generate(&mut rng);
+        let remote_identity = IdentityKeyPair::generate(&mut rng);
+        let remote_signed_prekey = KeyPair::generate(&mut rng);
+        let parameters = AliceSignalProtocolParameters::new(
+            local_identity.clone(),
+            KeyPair::generate(&mut rng),
+            *remote_identity.identity_key(),
+            remote_signed_prekey.public_key,
+            remote_signed_prekey.public_key,
+            UsePQRatchet::No,
+        );
+        (
+            initialize_alice_session_record(&parameters, &mut rng).expect("valid session"),
+            local_identity,
+        )
+    }
+
+    async fn cancel_encrypt_after_checkout(seed_durable: bool) {
+        use wacore::libsignal::protocol::message_encrypt;
+
+        let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
+        let cache = Arc::new(SignalStoreCache::new());
+        let address = ProtocolAddress::new("15550006666".to_string(), 1.into());
+        let (record, identity_pair) = outbound_session();
+        let expected = record.serialize().expect("serialize session");
+        cache.put_session(&address, record).await;
+        if seed_durable {
+            cache.flush(backend.as_ref()).await.expect("seed flush");
+        }
+        assert_eq!(
+            wacore::store::traits::SignalStore::get_session(backend.as_ref(), address.as_str())
+                .await
+                .expect("backend read")
+                .is_some(),
+            seed_durable,
+        );
+
+        let device = Arc::new(RwLock::new(Device::new(backend.clone())));
+        let mut session_store =
+            SignalProtocolStoreAdapter::new(device, cache.clone()).session_store;
+        let entered = Arc::new(async_lock::Barrier::new(2));
+        let mut identity_store = BlockingIdentityStore {
+            pair: identity_pair,
+            entered: entered.clone(),
+        };
+        let task_address = address.clone();
+        let task = tokio::spawn(async move {
+            message_encrypt(
+                b"cancelled ciphertext",
+                &task_address,
+                &mut session_store,
+                &mut identity_store,
+            )
+            .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), entered.wait())
+            .await
+            .expect("encrypt reached identity check");
+        task.abort();
+        assert!(
+            task.await
+                .expect_err("task must be cancelled")
+                .is_cancelled()
+        );
+
+        let recovered = cache
+            .get_session(&address, backend.as_ref())
+            .await
+            .expect("cache read")
+            .expect("cancelled checkout restored");
+        assert_eq!(
+            recovered.serialize().expect("serialize recovered session"),
+            expected
+        );
+        cache.put_session(&address, recovered).await;
+        cache.flush(backend.as_ref()).await.expect("recovery flush");
+        assert!(
+            wacore::store::traits::SignalStore::get_session(backend.as_ref(), address.as_str())
+                .await
+                .expect("backend read")
+                .is_some(),
+            "the recovered checkout must remain durably flushable"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_encrypt_restores_a_clean_checkout() {
+        cancel_encrypt_after_checkout(true).await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_encrypt_preserves_a_new_dirty_session() {
+        cancel_encrypt_after_checkout(false).await;
+    }
+
+    #[tokio::test]
+    async fn checkout_commit_fails_closed_across_a_lossy_clear() {
+        use wacore::libsignal::protocol::SessionCheckout;
+
+        let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
+        let cache = Arc::new(SignalStoreCache::new());
+        let device = Arc::new(RwLock::new(Device::new(backend)));
+        let mut adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
+        let address = ProtocolAddress::new("15550005555".to_string(), 1.into());
+        cache
+            .put_session(&address, SessionRecord::new_fresh())
+            .await;
+
+        let checkout = SessionCheckout::load(&mut adapter.session_store, &address)
+            .await
+            .expect("checkout")
+            .expect("session");
+        cache.clear().await;
+        assert!(matches!(
+            checkout.commit().await,
+            Err(SignalProtocolError::InvalidState(
+                "SessionCheckout::commit",
+                _
+            ))
+        ));
+        assert_eq!(cache.try_has_session(&address), None);
     }
 
     /// The hand-desugared session methods must behave exactly like the trait's

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -120,6 +120,17 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
+    fn try_load_session_for_update(
+        &self,
+        address: &ProtocolAddress,
+    ) -> Option<Result<(Option<SessionRecord>, Option<u64>), SignalProtocolError>> {
+        self.0.cache.try_checkout_session(address).map(|result| {
+            result
+                .map(|(record, generation)| (record, Some(generation)))
+                .map_err(signal_err("backend"))
+        })
+    }
+
     fn try_store_session_from_checkout(
         &mut self,
         address: &ProtocolAddress,

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use wacore::libsignal::protocol::{
     Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore, PreKeyId,
-    PreKeyRecord, PreKeyStore, ProtocolAddress, SessionRecord, SessionStore, SignalProtocolError,
-    SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
+    PreKeyRecord, PreKeyStore, ProtocolAddress, SessionCheckoutStoreResult, SessionRecord,
+    SessionStore, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
 };
 
 use wacore::libsignal::store::record_helpers as wacore_record;
@@ -101,8 +101,9 @@ impl SessionStore for SessionAdapter {
         let device = self.0.device.read().await;
         self.0
             .cache
-            .get_session(address, &*device.backend)
+            .peek_session(address, &*device.backend)
             .await
+            .map(|record| record.map(|record| (*record).clone()))
             .map_err(signal_err("backend"))
     }
 
@@ -119,20 +120,29 @@ impl SessionStore for SessionAdapter {
             .map_err(signal_err("backend"))
     }
 
-    #[allow(clippy::result_large_err)]
     fn try_store_session_from_checkout(
         &mut self,
         address: &ProtocolAddress,
         record: SessionRecord,
         generation: Option<u64>,
-    ) -> core::result::Result<bool, SessionRecord> {
+        had_session: bool,
+    ) -> SessionCheckoutStoreResult {
         let Some(generation) = generation else {
-            return Err(record);
+            return SessionCheckoutStoreResult::Unhandled(record);
         };
-        Ok(self
-            .0
+        self.0
             .cache
-            .restore_session_from_checkout(address, record, generation))
+            .restore_session_from_checkout(address, record, generation, had_session)
+    }
+
+    fn cancel_session_checkout(&mut self, address: &ProtocolAddress, generation: Option<u64>) {
+        if let Some(generation) = generation {
+            self.0.cache.cancel_session_checkout(address, generation);
+        }
+    }
+
+    async fn complete_session_checkout(&mut self) {
+        self.0.cache.complete_session_checkout().await;
     }
 
     // Hand-desugared (see `BoxFut`): a cached answer skips the device lock
@@ -704,6 +714,15 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "stored session must be loadable"
+        );
+        assert!(
+            adapter
+                .session_store
+                .load_session(&addr)
+                .await
+                .unwrap()
+                .is_some(),
+            "plain loads must not consume the cached session"
         );
     }
 

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -25,6 +25,7 @@ hex = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }
 log = { workspace = true }
+portable-atomic = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["alloc"] }
 sha1 = { workspace = true }

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -68,6 +68,7 @@ pub use state::{
 };
 pub use storage::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-    SessionCheckout, SessionCheckoutStoreResult, SessionStore, SignedPreKeyStore,
+    SessionCheckout, SessionCheckoutKey, SessionCheckoutStoreResult, SessionStore,
+    SignedPreKeyStore,
 };
 pub use timestamp::Timestamp;

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -68,6 +68,6 @@ pub use state::{
 };
 pub use storage::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-    SessionStore, SignedPreKeyStore,
+    SessionCheckout, SessionStore, SignedPreKeyStore,
 };
 pub use timestamp::Timestamp;

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -68,6 +68,6 @@ pub use state::{
 };
 pub use storage::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-    SessionCheckout, SessionStore, SignedPreKeyStore,
+    SessionCheckout, SessionCheckoutStoreResult, SessionStore, SignedPreKeyStore,
 };
 pub use timestamp::Timestamp;

--- a/wacore/libsignal/src/protocol/session.rs
+++ b/wacore/libsignal/src/protocol/session.rs
@@ -9,8 +9,8 @@ use crate::protocol::state::GenericSignedPreKey;
 use crate::protocol::{AliceSignalProtocolParameters, BobSignalProtocolParameters};
 use crate::protocol::{
     Direction, IdentityChange, IdentityKey, IdentityKeyStore, KeyPair, PreKeyBundle, PreKeyId,
-    PreKeySignalMessage, PreKeyStore, ProtocolAddress, Result, SessionRecord, SessionStore,
-    SignalProtocolError, SignedPreKeyStore, ratchet,
+    PreKeySignalMessage, PreKeyStore, ProtocolAddress, Result, SessionCheckout, SessionRecord,
+    SessionStore, SignalProtocolError, SignedPreKeyStore, ratchet,
 };
 
 #[derive(Default)]
@@ -172,13 +172,12 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
         return Err(SignalProtocolError::SignatureValidationFailed);
     }
 
-    let existing = session_store.load_session(remote_address).await?;
-    let had_session = existing.is_some();
-    let mut session_record = existing.unwrap_or_else(SessionRecord::new_fresh);
+    let mut session = SessionCheckout::load_or_create(session_store, remote_address).await?;
+    let had_session = session.had_session();
 
     let result = process_prekey_bundle_inner(
         remote_address,
-        &mut session_record,
+        session.record_mut(),
         identity_store,
         bundle,
         their_identity_key,
@@ -188,9 +187,9 @@ pub async fn process_prekey_bundle<R: Rng + CryptoRng>(
     .await;
 
     if had_session || result.is_ok() {
-        session_store
-            .store_session(remote_address, session_record)
-            .await?;
+        session.commit().await?;
+    } else {
+        session.discard();
     }
 
     result

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -77,8 +77,8 @@ use crate::protocol::state::PreKeyId;
 use crate::protocol::state::SessionState;
 use crate::protocol::{
     CiphertextMessage, CiphertextMessageType, Direction, IdentityChange, IdentityKeyStore, KeyPair,
-    PreKeySignalMessage, PreKeyStore, ProtocolAddress, PublicKey, Result, SessionRecord,
-    SessionStore, SignalMessage, SignalProtocolError, SignedPreKeyStore, session,
+    PreKeySignalMessage, PreKeyStore, ProtocolAddress, PublicKey, Result, SessionCheckout,
+    SessionRecord, SessionStore, SignalMessage, SignalProtocolError, SignedPreKeyStore, session,
 };
 
 /// Plaintext plus whether decrypting this message replaced a previously-stored
@@ -104,19 +104,16 @@ pub async fn message_encrypt(
     session_store: &mut dyn SessionStore,
     identity_store: &mut dyn IdentityKeyStore,
 ) -> Result<CiphertextMessage> {
-    let mut session_record = session_store
-        .load_session(remote_address)
+    let mut session = SessionCheckout::load(session_store, remote_address)
         .await?
         .ok_or_else(|| SignalProtocolError::SessionNotFound(remote_address.clone()))?;
 
     let result =
-        message_encrypt_inner(ptext, remote_address, &mut session_record, identity_store).await;
+        message_encrypt_inner(ptext, remote_address, session.record_mut(), identity_store).await;
 
     // Always restore — chain key is only advanced inside the inner
     // function after identity checks pass, so no counters are burned.
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
+    session.commit().await?;
 
     result
 }
@@ -298,20 +295,19 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     csprng: &mut R,
     use_pq_ratchet: UsePQRatchet,
 ) -> Result<DecryptionResult> {
-    let existing = session_store.load_session(remote_address).await?;
-    let had_session = existing.is_some();
+    let mut session = SessionCheckout::load_or_create(session_store, remote_address).await?;
+    let had_session = session.had_session();
     // Snapshot before process_prekey so a BadMac/InvalidMessage at the
     // record-level decrypt doesn't persist the promoted (but unusable)
     // session. Without this, an attacker that crafts a pkmsg with a valid
     // prekey header but tampered payload would replace our current_session
     // with a session only they can write to.
-    let pre_call_snapshot = existing.clone();
-    let mut session_record = existing.unwrap_or_else(SessionRecord::new_fresh);
+    let pre_call_snapshot = had_session.then(|| session.record().clone());
 
     let result = message_decrypt_prekey_inner(
         ciphertext,
         remote_address,
-        &mut session_record,
+        session.record_mut(),
         identity_store,
         pre_key_store,
         signed_pre_key_store,
@@ -326,15 +322,13 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     //     CheckedOut marker is replaced with the original record.
     //   - Err + !had_session: nothing to put back; new_fresh wasn't
     //     persisted before the call and there's no CheckedOut to honor.
-    let store_target = match (&result, pre_call_snapshot) {
-        (Ok(_), _) => Some(session_record),
-        (Err(_), Some(snapshot)) => Some(snapshot),
-        (Err(_), None) => None,
-    };
-    if let Some(record) = store_target
-        && (had_session || record.session_state().is_some())
-    {
-        session_store.store_session(remote_address, record).await?;
+    match (&result, pre_call_snapshot) {
+        (Ok(_), _) => session.commit().await?,
+        (Err(_), Some(snapshot)) => {
+            session.replace(snapshot);
+            session.commit().await?;
+        }
+        (Err(_), None) => session.discard(),
     }
 
     let (plaintext, pre_key_used, identity_change) = result?;
@@ -428,23 +422,20 @@ pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
     identity_store: &mut dyn IdentityKeyStore,
     csprng: &mut R,
 ) -> Result<DecryptionResult> {
-    let mut session_record = session_store
-        .load_session(remote_address)
+    let mut session = SessionCheckout::load(session_store, remote_address)
         .await?
         .ok_or_else(|| SignalProtocolError::SessionNotFound(remote_address.clone()))?;
 
     let result = message_decrypt_signal_inner(
         ciphertext,
         remote_address,
-        &mut session_record,
+        session.record_mut(),
         identity_store,
         csprng,
     )
     .await;
 
-    session_store
-        .store_session(remote_address, session_record)
-        .await?;
+    session.commit().await?;
 
     let (plaintext, identity_change) = result?;
     Ok(DecryptionResult {

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -73,8 +73,7 @@ const fn forward_jump_limit(is_self: bool) -> usize {
 }
 use crate::protocol::ratchet::keys::MessageKeyGenerator;
 use crate::protocol::ratchet::{ChainKey, UsePQRatchet};
-use crate::protocol::state::PreKeyId;
-use crate::protocol::state::SessionState;
+use crate::protocol::state::{DecryptSnapshot, PreKeyId, SessionState};
 use crate::protocol::{
     CiphertextMessage, CiphertextMessageType, Direction, IdentityChange, IdentityKeyStore, KeyPair,
     PreKeySignalMessage, PreKeyStore, ProtocolAddress, PublicKey, Result, SessionCheckout,
@@ -296,13 +295,7 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     use_pq_ratchet: UsePQRatchet,
 ) -> Result<DecryptionResult> {
     let mut session = SessionCheckout::load_or_create(session_store, remote_address).await?;
-    let had_session = session.had_session();
-    // Snapshot before process_prekey so a BadMac/InvalidMessage at the
-    // record-level decrypt doesn't persist the promoted (but unusable)
-    // session. Without this, an attacker that crafts a pkmsg with a valid
-    // prekey header but tampered payload would replace our current_session
-    // with a session only they can write to.
-    let pre_call_snapshot = had_session.then(|| session.record().clone());
+    session.snapshot_for_rollback();
 
     let result = message_decrypt_prekey_inner(
         ciphertext,
@@ -316,19 +309,10 @@ pub async fn message_decrypt_prekey<R: Rng + CryptoRng>(
     )
     .await;
 
-    // Persistence rules:
-    //   - Ok: store the (mutated) record with the promoted session.
-    //   - Err + had_session: restore the pre-call snapshot so the cache's
-    //     CheckedOut marker is replaced with the original record.
-    //   - Err + !had_session: nothing to put back; new_fresh wasn't
-    //     persisted before the call and there's no CheckedOut to honor.
-    match (&result, pre_call_snapshot) {
-        (Ok(_), _) => session.commit().await?,
-        (Err(_), Some(snapshot)) => {
-            session.replace(snapshot);
-            session.commit().await?;
-        }
-        (Err(_), None) => session.discard(),
+    if result.is_ok() {
+        session.commit().await?;
+    } else {
+        session.rollback().await?;
     }
 
     let (plaintext, pre_key_used, identity_change) = result?;
@@ -383,7 +367,7 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
         }
     };
 
-    let decrypt_result = decrypt_message_with_record(
+    let decrypt = decrypt_message_with_record(
         remote_address,
         session_record,
         ciphertext.message(),
@@ -397,6 +381,7 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
             identity_to_save.their_identity_key,
         )
         .await?;
+    let plaintext = decrypt.commit();
 
     // A duplicate/out-of-order pkmsg that matched an existing session carries the
     // identity from when that session was built, not a fresh rotation. Reporting
@@ -408,11 +393,7 @@ async fn message_decrypt_prekey_inner<R: Rng + CryptoRng>(
         saved
     };
 
-    Ok((
-        decrypt_result.plaintext,
-        pre_key_used.pre_key_id,
-        identity_change,
-    ))
+    Ok((plaintext, pre_key_used.pre_key_id, identity_change))
 }
 
 pub async fn message_decrypt_signal<R: Rng + CryptoRng>(
@@ -465,7 +446,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
         return Err(SignalProtocolError::SessionNotFound(remote_address.clone()));
     }
 
-    let decrypt_result = decrypt_message_with_record(
+    let decrypt = decrypt_message_with_record(
         remote_address,
         session_record,
         ciphertext,
@@ -473,10 +454,8 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
         csprng,
     )?;
 
-    // Get the identity key from the (now current) session state
-    let their_identity_key = session_record
-        .session_state()
-        .expect("successfully decrypted; must have a current state")
+    let their_identity_key = decrypt
+        .state()
         .remote_identity_key()
         .expect("successfully decrypted; must have a remote identity key")
         .expect("successfully decrypted; must have a remote identity key");
@@ -491,7 +470,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
     // The previous session gets promoted to current via `promote_old_session`, so we need
     // to save its identity to avoid UntrustedIdentity errors on subsequent messages.
     // This handles out-of-order message delivery after an identity change gracefully.
-    let identity_change = if decrypt_result.used_previous_session {
+    let identity_change = if decrypt.used_previous_session() {
         log::debug!(
             "Saving identity for {} from previous session (skipping trust check)",
             remote_address,
@@ -524,7 +503,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
             .await?
     };
 
-    Ok((decrypt_result.plaintext, identity_change))
+    Ok((decrypt.commit(), identity_change))
 }
 
 fn create_decryption_failure_log(
@@ -618,23 +597,143 @@ fn create_decryption_failure_log(
     Ok(lines.join("\n"))
 }
 
-/// Result of decrypting a message against a session record, including whether a
-/// previous session was used.
-struct RecordDecryptResult {
-    plaintext: Vec<u8>,
-    /// True if the message was decrypted using a previous (archived) session state
-    /// rather than the current session. When true, the identity check should be
-    /// skipped since we already had a valid session with that identity.
-    used_previous_session: bool,
+enum RecordDecryptState {
+    Current(DecryptSnapshot),
+    Previous {
+        state: Box<SessionState>,
+        effect: StateDecryptEffect,
+        index: usize,
+    },
 }
 
-fn decrypt_message_with_record<R: Rng + CryptoRng>(
+struct DeferredCurrentDecrypt<'a> {
+    record: &'a mut SessionRecord,
+    ratchet_key: PublicKey,
+    chain_key: ChainKey,
+    plaintext: Vec<u8>,
+}
+
+enum RecordDecrypt<'a> {
+    Deferred(DeferredCurrentDecrypt<'a>),
+    Transaction(RecordDecryptTransaction<'a>),
+}
+
+impl RecordDecrypt<'_> {
+    fn state(&self) -> &SessionState {
+        match self {
+            Self::Deferred(decrypt) => decrypt
+                .record
+                .session_state()
+                .expect("a deferred decrypt keeps the current state installed"),
+            Self::Transaction(decrypt) => decrypt.state(),
+        }
+    }
+
+    fn used_previous_session(&self) -> bool {
+        match self {
+            Self::Deferred(_) => false,
+            Self::Transaction(decrypt) => decrypt.used_previous_session(),
+        }
+    }
+
+    fn commit(self) -> Vec<u8> {
+        match self {
+            Self::Deferred(mut decrypt) => {
+                let state = decrypt
+                    .record
+                    .session_state_mut()
+                    .expect("a deferred decrypt keeps the current state installed");
+                state
+                    .set_receiver_chain_key(&decrypt.ratchet_key, &decrypt.chain_key)
+                    .expect("the deferred in-order receiver chain remains installed");
+                state.clear_unacknowledged_pre_key_message();
+                std::mem::take(&mut decrypt.plaintext)
+            }
+            Self::Transaction(decrypt) => decrypt.commit(),
+        }
+    }
+}
+
+struct RecordDecryptTransaction<'a> {
+    record: &'a mut SessionRecord,
+    state: Option<RecordDecryptState>,
+    plaintext: Vec<u8>,
+}
+
+impl RecordDecryptTransaction<'_> {
+    fn state(&self) -> &SessionState {
+        match self
+            .state
+            .as_ref()
+            .expect("a live decrypt transaction owns its rollback")
+        {
+            RecordDecryptState::Current(_) => self
+                .record
+                .session_state()
+                .expect("a current decrypt transaction keeps the current state installed"),
+            RecordDecryptState::Previous { state, .. } => state,
+        }
+    }
+
+    fn used_previous_session(&self) -> bool {
+        matches!(self.state, Some(RecordDecryptState::Previous { .. }))
+    }
+
+    fn commit(mut self) -> Vec<u8> {
+        match self
+            .state
+            .take()
+            .expect("a live decrypt transaction owns its rollback")
+        {
+            RecordDecryptState::Current(_) => {
+                let state = self
+                    .record
+                    .session_state_mut()
+                    .expect("a current decrypt transaction keeps the current state installed");
+                state.clear_unacknowledged_pre_key_message();
+            }
+            RecordDecryptState::Previous {
+                mut state, effect, ..
+            } => {
+                effect.commit(&mut state);
+                state.clear_unacknowledged_pre_key_message();
+                self.record.promote_state(*state);
+            }
+        }
+        std::mem::take(&mut self.plaintext)
+    }
+}
+
+impl Drop for RecordDecryptTransaction<'_> {
+    fn drop(&mut self) {
+        let Some(state) = self.state.take() else {
+            return;
+        };
+        match state {
+            RecordDecryptState::Current(snapshot) => self
+                .record
+                .session_state_mut()
+                .expect("a current decrypt transaction keeps the current state installed")
+                .restore_decrypt_snapshot(snapshot),
+            RecordDecryptState::Previous {
+                mut state,
+                effect,
+                index,
+            } => {
+                effect.rollback(&mut state);
+                self.record.restore_previous_session(index, *state);
+            }
+        }
+    }
+}
+
+fn decrypt_message_with_record<'a, R: Rng + CryptoRng>(
     remote_address: &ProtocolAddress,
-    record: &mut SessionRecord,
+    record: &'a mut SessionRecord,
     ciphertext: &SignalMessage,
     original_message_type: CiphertextMessageType,
     csprng: &mut R,
-) -> Result<RecordDecryptResult> {
+) -> Result<RecordDecrypt<'a>> {
     debug_assert!(matches!(
         original_message_type,
         CiphertextMessageType::Whisper | CiphertextMessageType::PreKey
@@ -670,7 +769,7 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
         );
 
         match result {
-            Ok(ptext) => {
+            Ok(result) => {
                 log::debug!(
                     "decrypted {:?} message from {} with current session state (base key {})",
                     original_message_type,
@@ -679,11 +778,25 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
                         .sender_ratchet_key_for_logging()
                         .expect("successful decrypt always has a valid base key"),
                 );
-                record.set_session_state(current_state); // update the state
-                return Ok(RecordDecryptResult {
-                    plaintext: ptext,
-                    used_previous_session: false,
-                });
+                record.set_session_state(current_state);
+                return match result.effect {
+                    StateDecryptEffect::DeferredChainKey {
+                        ratchet_key,
+                        chain_key,
+                    } => Ok(RecordDecrypt::Deferred(DeferredCurrentDecrypt {
+                        record,
+                        ratchet_key,
+                        chain_key,
+                        plaintext: result.plaintext,
+                    })),
+                    StateDecryptEffect::Applied(snapshot) => {
+                        Ok(RecordDecrypt::Transaction(RecordDecryptTransaction {
+                            record,
+                            state: Some(RecordDecryptState::Current(snapshot)),
+                            plaintext: result.plaintext,
+                        }))
+                    }
+                };
             }
             Err(SignalProtocolError::DuplicatedMessage(chain, counter)) => {
                 // Restore state before returning error
@@ -758,7 +871,7 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
         );
 
         match result {
-            Ok(ptext) => {
+            Ok(result) => {
                 log::debug!(
                     "decrypted {:?} message from {} with PREVIOUS session state (base key {})",
                     original_message_type,
@@ -767,12 +880,15 @@ fn decrypt_message_with_record<R: Rng + CryptoRng>(
                         .sender_ratchet_key_for_logging()
                         .expect("successful decrypt always has a valid base key"),
                 );
-                // Promote this session (it's already been removed by take_previous_session)
-                record.promote_state(previous);
-                return Ok(RecordDecryptResult {
-                    plaintext: ptext,
-                    used_previous_session: true,
-                });
+                return Ok(RecordDecrypt::Transaction(RecordDecryptTransaction {
+                    record,
+                    state: Some(RecordDecryptState::Previous {
+                        state: Box::new(previous),
+                        effect: result.effect,
+                        index: idx,
+                    }),
+                    plaintext: result.plaintext,
+                }));
             }
             Err(SignalProtocolError::DuplicatedMessage(chain, counter)) => {
                 // Restore the session before returning error
@@ -845,6 +961,42 @@ impl std::fmt::Display for CurrentOrPrevious {
     }
 }
 
+struct StateDecryptResult {
+    plaintext: Vec<u8>,
+    effect: StateDecryptEffect,
+}
+
+enum StateDecryptEffect {
+    DeferredChainKey {
+        ratchet_key: PublicKey,
+        chain_key: ChainKey,
+    },
+    Applied(DecryptSnapshot),
+}
+
+impl StateDecryptEffect {
+    fn commit(self, state: &mut SessionState) {
+        match self {
+            Self::DeferredChainKey {
+                ratchet_key,
+                chain_key,
+            } => {
+                state
+                    .set_receiver_chain_key(&ratchet_key, &chain_key)
+                    .expect("the deferred in-order receiver chain remains installed");
+            }
+            Self::Applied(_) => {}
+        }
+    }
+
+    fn rollback(self, state: &mut SessionState) {
+        match self {
+            Self::DeferredChainKey { .. } => {}
+            Self::Applied(snapshot) => state.restore_decrypt_snapshot(snapshot),
+        }
+    }
+}
+
 fn decrypt_message_with_state<R: Rng + CryptoRng>(
     current_or_previous: CurrentOrPrevious,
     state: &mut SessionState,
@@ -852,7 +1004,7 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
     original_message_type: CiphertextMessageType,
     remote_address: &ProtocolAddress,
     csprng: &mut R,
-) -> Result<Vec<u8>> {
+) -> Result<StateDecryptResult> {
     // Check for a completely empty or invalid session state before we do anything else.
     let _ = state.root_key().map_err(|_| {
         SignalProtocolError::InvalidMessage(
@@ -871,24 +1023,29 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
     let their_ephemeral = ciphertext.sender_ratchet_key();
     let counter = ciphertext.counter();
 
-    // Transactional decrypt — roll back chain advance / new-chain DH step on any
-    // failure so the next msg derives from an uncorrupted ratchet.
-    //
-    // Fast path for the common in-order message on an existing receiver chain
-    // (counter == the chain's current index): the only mutation is a single
-    // `set_receiver_chain_key` advance — no DH ratchet, no skipped-key caching,
-    // no chain eviction — so saving the old `ChainKey` (a `Copy`) is a complete
-    // rollback and avoids cloning the whole receiver-chain set. Every other case
-    // (new chain, skip-ahead, out-of-order key removal) and any lookup error
-    // falls through to the full `decrypt_snapshot`, unchanged.
-    let fast_rollback: Option<ChainKey> = match state.get_receiver_chain_key(their_ephemeral) {
-        Ok(Some(chain_key)) if chain_key.index() == counter => Some(chain_key),
-        _ => None,
-    };
-    let full_snapshot = match fast_rollback {
-        Some(_) => None,
-        None => Some(state.decrypt_snapshot()),
-    };
+    // Deferring the common in-order advance keeps cancellation rollback free.
+    if let Some(chain_key) = state.get_receiver_chain_key(their_ephemeral)?
+        && chain_key.index() == counter
+    {
+        let (message_key_gen, next_chain) = chain_key.step_with_message_keys()?;
+        let plaintext = decrypt_with_message_keys(
+            current_or_previous,
+            state,
+            ciphertext,
+            original_message_type,
+            remote_address,
+            message_key_gen,
+        )?;
+        return Ok(StateDecryptResult {
+            plaintext,
+            effect: StateDecryptEffect::DeferredChainKey {
+                ratchet_key: *their_ephemeral,
+                chain_key: next_chain,
+            },
+        });
+    }
+
+    let snapshot = state.decrypt_snapshot();
 
     let result = decrypt_with_pending_state(
         current_or_previous,
@@ -901,19 +1058,12 @@ fn decrypt_message_with_state<R: Rng + CryptoRng>(
         counter,
     );
     match result {
-        Ok(ptext) => {
-            drop(full_snapshot);
-            state.clear_unacknowledged_pre_key_message();
-            Ok(ptext)
-        }
+        Ok(plaintext) => Ok(StateDecryptResult {
+            plaintext,
+            effect: StateDecryptEffect::Applied(snapshot),
+        }),
         Err(e) => {
-            if let Some(chain_key) = fast_rollback {
-                // The chain still exists (in-order decrypt never removes it), so
-                // restoring its key cannot fail; keep the original decrypt error.
-                let _ = state.set_receiver_chain_key(their_ephemeral, &chain_key);
-            } else if let Some(snapshot) = full_snapshot {
-                state.restore_decrypt_snapshot(snapshot);
-            }
+            state.restore_decrypt_snapshot(snapshot);
             Err(e)
         }
     }
@@ -941,6 +1091,24 @@ fn decrypt_with_pending_state<R: Rng + CryptoRng>(
         counter,
     )?;
 
+    decrypt_with_message_keys(
+        current_or_previous,
+        state,
+        ciphertext,
+        original_message_type,
+        remote_address,
+        message_key_gen,
+    )
+}
+
+fn decrypt_with_message_keys(
+    current_or_previous: CurrentOrPrevious,
+    state: &SessionState,
+    ciphertext: &SignalMessage,
+    original_message_type: CiphertextMessageType,
+    remote_address: &ProtocolAddress,
+    message_key_gen: MessageKeyGenerator,
+) -> Result<Vec<u8>> {
     let message_keys = message_key_gen.generate_keys();
 
     let their_identity_key =
@@ -1098,6 +1266,11 @@ mod tests {
     use crate::protocol::*;
     use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::future::Future;
+    use std::num::NonZeroU64;
+    use std::sync::Mutex as SyncMutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
 
     #[test]
     fn forward_jump_limit_matches_wa_web_signal_future_messages_max() {
@@ -1122,6 +1295,70 @@ mod tests {
     impl MemSessionStore {
         fn new() -> Self {
             Self(HashMap::new())
+        }
+    }
+
+    struct DestructiveSessionStore(SyncMutex<Option<SessionRecord>>);
+
+    impl DestructiveSessionStore {
+        const CHECKOUT: SessionCheckoutKey = SessionCheckoutKey::new(0, NonZeroU64::MIN);
+
+        fn new(record: Option<SessionRecord>) -> Self {
+            Self(SyncMutex::new(record))
+        }
+
+        fn take(&self) -> Option<SessionRecord> {
+            self.0.lock().expect("test store lock poisoned").take()
+        }
+
+        fn replace(&self, record: SessionRecord) {
+            *self.0.lock().expect("test store lock poisoned") = Some(record);
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl SessionStore for DestructiveSessionStore {
+        async fn load_session(
+            &self,
+            _address: &ProtocolAddress,
+        ) -> error::Result<Option<SessionRecord>> {
+            Ok(self.0.lock().expect("test store lock poisoned").clone())
+        }
+
+        fn try_load_session_for_update(
+            &self,
+            _address: &ProtocolAddress,
+        ) -> Option<error::Result<(Option<SessionRecord>, Option<SessionCheckoutKey>)>> {
+            Some(Ok((self.take(), Some(Self::CHECKOUT))))
+        }
+
+        async fn has_session(&self, _address: &ProtocolAddress) -> error::Result<bool> {
+            Ok(self.0.lock().expect("test store lock poisoned").is_some())
+        }
+
+        async fn store_session(
+            &mut self,
+            _address: &ProtocolAddress,
+            record: SessionRecord,
+        ) -> error::Result<()> {
+            self.replace(record);
+            Ok(())
+        }
+
+        fn try_store_session_from_checkout(
+            &mut self,
+            _address: &ProtocolAddress,
+            record: SessionRecord,
+            checkout: Option<SessionCheckoutKey>,
+            _had_session: bool,
+        ) -> SessionCheckoutStoreResult {
+            if checkout != Some(Self::CHECKOUT)
+                || self.0.lock().expect("test store lock poisoned").is_some()
+            {
+                return SessionCheckoutStoreResult::Rejected;
+            }
+            self.replace(record);
+            SessionCheckoutStoreResult::Stored
         }
     }
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -1149,6 +1386,78 @@ mod tests {
         pair: IdentityKeyPair,
         reg_id: u32,
         known: HashMap<String, IdentityKey>,
+    }
+
+    #[derive(Clone, Copy)]
+    enum PendingIdentityCall {
+        Trust,
+        Save,
+    }
+
+    struct PendingIdentityStore {
+        inner: MemIdentityStore,
+        call: PendingIdentityCall,
+        entered: AtomicBool,
+    }
+
+    impl PendingIdentityStore {
+        fn new(inner: MemIdentityStore, call: PendingIdentityCall) -> Self {
+            Self {
+                inner,
+                call,
+                entered: AtomicBool::new(false),
+            }
+        }
+
+        fn wait_forever<T>(&self) -> impl Future<Output = T> {
+            self.entered.store(true, Ordering::Release);
+            futures::future::pending()
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl IdentityKeyStore for PendingIdentityStore {
+        async fn get_identity_key_pair(&self) -> error::Result<IdentityKeyPair> {
+            self.inner.get_identity_key_pair().await
+        }
+
+        async fn get_local_registration_id(&self) -> error::Result<u32> {
+            self.inner.get_local_registration_id().await
+        }
+
+        async fn save_identity(
+            &mut self,
+            address: &ProtocolAddress,
+            identity: &IdentityKey,
+        ) -> error::Result<IdentityChange> {
+            if matches!(self.call, PendingIdentityCall::Save) {
+                self.wait_forever().await
+            } else {
+                self.inner.save_identity(address, identity).await
+            }
+        }
+
+        async fn is_trusted_identity(
+            &self,
+            address: &ProtocolAddress,
+            identity: &IdentityKey,
+            direction: Direction,
+        ) -> error::Result<bool> {
+            if matches!(self.call, PendingIdentityCall::Trust) {
+                self.wait_forever().await
+            } else {
+                self.inner
+                    .is_trusted_identity(address, identity, direction)
+                    .await
+            }
+        }
+
+        async fn get_identity(
+            &self,
+            address: &ProtocolAddress,
+        ) -> error::Result<Option<IdentityKey>> {
+            self.inner.get_identity(address).await
+        }
     }
     impl MemIdentityStore {
         fn new(pair: IdentityKeyPair, reg_id: u32) -> Self {
@@ -1253,6 +1562,8 @@ mod tests {
         bob_addr: ProtocolAddress,
         bob_sessions: MemSessionStore,
         bob_identity: MemIdentityStore,
+        bob_prekeys: MemPreKeyStore,
+        bob_signed: MemSignedPreKeyStore,
     }
 
     fn setup_established_session() -> TestPair {
@@ -1360,7 +1671,133 @@ mod tests {
             bob_addr,
             bob_sessions,
             bob_identity,
+            bob_prekeys,
+            bob_signed,
         }
+    }
+
+    #[test]
+    fn cancelled_signal_decrypt_restores_the_ratchet_for_retry() {
+        let mut tp = setup_established_session();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let ciphertext = futures::executor::block_on(async {
+            let reply = message_encrypt(
+                b"ack",
+                &tp.alice_addr,
+                &mut tp.bob_sessions,
+                &mut tp.bob_identity,
+            )
+            .await
+            .expect("encrypt reply");
+            let CiphertextMessage::SignalMessage(reply) = reply else {
+                panic!("established reply must be a SignalMessage");
+            };
+            message_decrypt_signal(
+                &reply,
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+                &mut rng,
+            )
+            .await
+            .expect("decrypt reply");
+
+            let message = message_encrypt(
+                b"retry-safe",
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+            )
+            .await
+            .expect("encrypt test message");
+            let CiphertextMessage::SignalMessage(message) = message else {
+                panic!("acknowledged session must emit a SignalMessage");
+            };
+            message
+        });
+
+        let record = tp
+            .bob_sessions
+            .0
+            .remove(tp.alice_addr.as_str())
+            .expect("Bob session");
+        let before = record.serialize().expect("serialize baseline");
+        let mut sessions = DestructiveSessionStore::new(Some(record));
+        let mut identity = PendingIdentityStore::new(tp.bob_identity, PendingIdentityCall::Trust);
+
+        let mut decrypt = Box::pin(message_decrypt_signal(
+            &ciphertext,
+            &tp.alice_addr,
+            &mut sessions,
+            &mut identity,
+            &mut rng,
+        ));
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        assert!(matches!(decrypt.as_mut().poll(&mut context), Poll::Pending));
+        drop(decrypt);
+        assert!(identity.entered.load(Ordering::Acquire));
+
+        let restored = sessions.take().expect("cancelled checkout restored");
+        assert_eq!(restored.serialize().expect("serialize restored"), before);
+        sessions.replace(restored);
+        let retried = futures::executor::block_on(message_decrypt_signal(
+            &ciphertext,
+            &tp.alice_addr,
+            &mut sessions,
+            &mut identity.inner,
+            &mut rng,
+        ))
+        .expect("redelivery must decrypt");
+        assert_eq!(retried.plaintext, b"retry-safe");
+    }
+
+    #[test]
+    fn cancelled_fresh_prekey_decrypt_discards_the_promoted_session() {
+        let mut tp = setup_established_session();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let ciphertext = futures::executor::block_on(message_encrypt(
+            b"fresh-retry",
+            &tp.bob_addr,
+            &mut tp.alice_sessions,
+            &mut tp.alice_identity,
+        ))
+        .expect("encrypt prekey test message");
+        let CiphertextMessage::PreKeySignalMessage(ciphertext) = ciphertext else {
+            panic!("unacknowledged session must emit a PreKeySignalMessage");
+        };
+
+        let mut sessions = DestructiveSessionStore::new(None);
+        let mut identity = PendingIdentityStore::new(tp.bob_identity, PendingIdentityCall::Save);
+        let mut decrypt = Box::pin(message_decrypt_prekey(
+            &ciphertext,
+            &tp.alice_addr,
+            &mut sessions,
+            &mut identity,
+            &mut tp.bob_prekeys,
+            &tp.bob_signed,
+            &mut rng,
+            UsePQRatchet::No,
+        ));
+        let waker = futures::task::noop_waker();
+        let mut context = Context::from_waker(&waker);
+        assert!(matches!(decrypt.as_mut().poll(&mut context), Poll::Pending));
+        drop(decrypt);
+        assert!(identity.entered.load(Ordering::Acquire));
+        assert!(sessions.take().is_none());
+
+        let retried = futures::executor::block_on(message_decrypt_prekey(
+            &ciphertext,
+            &tp.alice_addr,
+            &mut sessions,
+            &mut identity.inner,
+            &mut tp.bob_prekeys,
+            &tp.bob_signed,
+            &mut rng,
+            UsePQRatchet::No,
+        ))
+        .expect("redelivery must establish the session");
+        assert_eq!(retried.plaintext, b"fresh-retry");
     }
 
     /// Builds Bob's prekey stores plus a self-signed `PreKeyBundle`, without

--- a/wacore/libsignal/src/protocol/state/mod.rs
+++ b/wacore/libsignal/src/protocol/state/mod.rs
@@ -8,5 +8,6 @@ mod signed_prekey;
 
 pub use bundle::{PreKeyBundle, PreKeyBundleContent};
 pub use prekey::{PreKeyId, PreKeyRecord};
+pub(crate) use session::DecryptSnapshot;
 pub use session::{InvalidSessionError, SessionRecord, SessionState};
 pub use signed_prekey::{GenericSignedPreKey, SignedPreKeyId, SignedPreKeyRecord};

--- a/wacore/libsignal/src/protocol/storage.rs
+++ b/wacore/libsignal/src/protocol/storage.rs
@@ -11,5 +11,5 @@ mod traits;
 
 pub use traits::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-    SessionStore, SignedPreKeyStore,
+    SessionCheckout, SessionStore, SignedPreKeyStore,
 };

--- a/wacore/libsignal/src/protocol/storage.rs
+++ b/wacore/libsignal/src/protocol/storage.rs
@@ -11,5 +11,6 @@ mod traits;
 
 pub use traits::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-    SessionCheckout, SessionCheckoutStoreResult, SessionStore, SignedPreKeyStore,
+    SessionCheckout, SessionCheckoutKey, SessionCheckoutStoreResult, SessionStore,
+    SignedPreKeyStore,
 };

--- a/wacore/libsignal/src/protocol/storage.rs
+++ b/wacore/libsignal/src/protocol/storage.rs
@@ -11,5 +11,5 @@ mod traits;
 
 pub use traits::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
-    SessionCheckout, SessionStore, SignedPreKeyStore,
+    SessionCheckout, SessionCheckoutStoreResult, SessionStore, SignedPreKeyStore,
 };

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -10,7 +10,7 @@ use crate::protocol::sender_keys::SenderKeyRecord;
 use crate::protocol::state::{
     PreKeyId, PreKeyRecord, SessionRecord, SignedPreKeyId, SignedPreKeyRecord,
 };
-use crate::protocol::{IdentityKey, IdentityKeyPair, ProtocolAddress};
+use crate::protocol::{IdentityKey, IdentityKeyPair, ProtocolAddress, SignalProtocolError};
 use crate::store::sender_key_name::SenderKeyName;
 
 /// Each Signal message can be considered to have exactly two participants, a sender and receiver.
@@ -132,8 +132,19 @@ pub trait SignedPreKeyStore: ThreadSafe {
 pub trait SessionStore: ThreadSafe {
     /// Takes the session for `address`. Implementations with caches should
     /// treat this as a logical checkout; callers must always call
-    /// [`store_session`] to return the record, even on error paths.
+    /// [`store_session`] to return the record, even on error paths. Async
+    /// mutation paths use [`SessionCheckout`] so cancellation also returns it.
     async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
+
+    /// Couples take-style loads to a generation so cancellation cannot restore
+    /// state across a lossy cache reset.
+    #[doc(hidden)]
+    async fn load_session_for_update(
+        &self,
+        address: &ProtocolAddress,
+    ) -> Result<(Option<SessionRecord>, Option<u64>)> {
+        Ok((self.load_session(address).await?, None))
+    }
 
     /// Non-destructive existence check (must not consume the cached entry).
     async fn has_session(&self, address: &ProtocolAddress) -> Result<bool>;
@@ -144,6 +155,122 @@ pub trait SessionStore: ThreadSafe {
         address: &ProtocolAddress,
         record: SessionRecord,
     ) -> Result<()>;
+
+    /// Gives take-style stores a synchronous recovery path before an async
+    /// owner can be cancelled again.
+    #[doc(hidden)]
+    #[allow(clippy::result_large_err)]
+    fn try_store_session_from_checkout(
+        &mut self,
+        _address: &ProtocolAddress,
+        record: SessionRecord,
+        _generation: Option<u64>,
+    ) -> core::result::Result<bool, SessionRecord> {
+        Err(record)
+    }
+}
+
+/// Keeps an owned session recoverable while an async protocol operation can be cancelled.
+pub struct SessionCheckout<'a> {
+    store: &'a mut dyn SessionStore,
+    address: &'a ProtocolAddress,
+    record: Option<SessionRecord>,
+    generation: Option<u64>,
+    had_session: bool,
+}
+
+impl<'a> SessionCheckout<'a> {
+    /// Loads an existing session and arms cancellation recovery.
+    pub async fn load(
+        store: &'a mut dyn SessionStore,
+        address: &'a ProtocolAddress,
+    ) -> Result<Option<Self>> {
+        let (record, generation) = store.load_session_for_update(address).await?;
+        Ok(record.map(|record| Self {
+            store,
+            address,
+            record: Some(record),
+            generation,
+            had_session: true,
+        }))
+    }
+
+    /// Creates an empty working record if the store has no session yet.
+    pub async fn load_or_create(
+        store: &'a mut dyn SessionStore,
+        address: &'a ProtocolAddress,
+    ) -> Result<Self> {
+        let (record, generation) = store.load_session_for_update(address).await?;
+        let had_session = record.is_some();
+        Ok(Self {
+            store,
+            address,
+            record: Some(record.unwrap_or_else(SessionRecord::new_fresh)),
+            generation,
+            had_session,
+        })
+    }
+
+    /// Reports whether the store supplied the working record.
+    pub fn had_session(&self) -> bool {
+        self.had_session
+    }
+
+    /// Borrows the working record.
+    pub fn record(&self) -> &SessionRecord {
+        self.record
+            .as_ref()
+            .expect("a live checkout always owns its record")
+    }
+
+    /// Mutably borrows the working record.
+    pub fn record_mut(&mut self) -> &mut SessionRecord {
+        self.record
+            .as_mut()
+            .expect("a live checkout always owns its record")
+    }
+
+    /// Preserves recovery while replacing a rejected mutation with its snapshot.
+    pub fn replace(&mut self, record: SessionRecord) {
+        self.record = Some(record);
+    }
+
+    /// Prevents a deliberately rejected fresh session from being recovered.
+    pub fn discard(mut self) {
+        self.record.take();
+    }
+
+    /// Returns the record by move without a cancellation gap on take-style stores.
+    pub async fn commit(mut self) -> Result<()> {
+        let record = self
+            .record
+            .take()
+            .expect("a live checkout always owns its record");
+        match self
+            .store
+            .try_store_session_from_checkout(self.address, record, self.generation)
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(SignalProtocolError::InvalidState(
+                "SessionCheckout::commit",
+                "cache reset during session mutation".to_string(),
+            )),
+            Err(record) => self.store.store_session(self.address, record).await,
+        }
+    }
+}
+
+impl Drop for SessionCheckout<'_> {
+    fn drop(&mut self) {
+        let Some(record) = self.record.take() else {
+            return;
+        };
+        if self.had_session || record.session_state().is_some() {
+            let _ =
+                self.store
+                    .try_store_session_from_checkout(self.address, record, self.generation);
+        }
+    }
 }
 
 /// Interface for storing sender key records, allowing multiple keys per user.

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -147,6 +147,15 @@ pub trait SessionStore: ThreadSafe {
         Ok((self.load_session(address).await?, None))
     }
 
+    /// Avoids boxing the async fallback when a destructive store can answer immediately.
+    #[doc(hidden)]
+    fn try_load_session_for_update(
+        &self,
+        _address: &ProtocolAddress,
+    ) -> Option<Result<(Option<SessionRecord>, Option<u64>)>> {
+        None
+    }
+
     /// Non-destructive existence check (must not consume the cached entry).
     async fn has_session(&self, address: &ProtocolAddress) -> Result<bool>;
 
@@ -203,7 +212,10 @@ impl<'a> SessionCheckout<'a> {
         store: &'a mut dyn SessionStore,
         address: &'a ProtocolAddress,
     ) -> Result<Option<Self>> {
-        let (record, generation) = store.load_session_for_update(address).await?;
+        let (record, generation) = match store.try_load_session_for_update(address) {
+            Some(result) => result?,
+            None => store.load_session_for_update(address).await?,
+        };
         let Some(record) = record else {
             store.cancel_session_checkout(address, generation);
             return Ok(None);
@@ -222,7 +234,10 @@ impl<'a> SessionCheckout<'a> {
         store: &'a mut dyn SessionStore,
         address: &'a ProtocolAddress,
     ) -> Result<Self> {
-        let (record, generation) = store.load_session_for_update(address).await?;
+        let (record, generation) = match store.try_load_session_for_update(address) {
+            Some(result) => result?,
+            None => store.load_session_for_update(address).await?,
+        };
         let had_session = record.is_some();
         Ok(Self {
             store,

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -12,6 +12,7 @@ use crate::protocol::state::{
 };
 use crate::protocol::{IdentityKey, IdentityKeyPair, ProtocolAddress, SignalProtocolError};
 use crate::store::sender_key_name::SenderKeyName;
+use core::num::NonZeroU64;
 
 /// Each Signal message can be considered to have exactly two participants, a sender and receiver.
 ///
@@ -143,7 +144,7 @@ pub trait SessionStore: ThreadSafe {
     async fn load_session_for_update(
         &self,
         address: &ProtocolAddress,
-    ) -> Result<(Option<SessionRecord>, Option<u64>)> {
+    ) -> Result<(Option<SessionRecord>, Option<SessionCheckoutKey>)> {
         Ok((self.load_session(address).await?, None))
     }
 
@@ -152,7 +153,7 @@ pub trait SessionStore: ThreadSafe {
     fn try_load_session_for_update(
         &self,
         _address: &ProtocolAddress,
-    ) -> Option<Result<(Option<SessionRecord>, Option<u64>)>> {
+    ) -> Option<Result<(Option<SessionRecord>, Option<SessionCheckoutKey>)>> {
         None
     }
 
@@ -173,7 +174,7 @@ pub trait SessionStore: ThreadSafe {
         &mut self,
         _address: &ProtocolAddress,
         record: SessionRecord,
-        _generation: Option<u64>,
+        _checkout: Option<SessionCheckoutKey>,
         _had_session: bool,
     ) -> SessionCheckoutStoreResult {
         SessionCheckoutStoreResult::Unhandled(record)
@@ -181,7 +182,12 @@ pub trait SessionStore: ThreadSafe {
 
     /// Releases an empty reservation made by a destructive update load.
     #[doc(hidden)]
-    fn cancel_session_checkout(&mut self, _address: &ProtocolAddress, _generation: Option<u64>) {}
+    fn cancel_session_checkout(
+        &mut self,
+        _address: &ProtocolAddress,
+        _checkout: Option<SessionCheckoutKey>,
+    ) {
+    }
 
     /// Drives a queued synchronous return once the contended store is available.
     #[doc(hidden)]
@@ -197,13 +203,42 @@ pub enum SessionCheckoutStoreResult {
     Unhandled(SessionRecord),
 }
 
+/// Identifies one cache checkout within a lossy-reset generation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[doc(hidden)]
+pub struct SessionCheckoutKey {
+    generation: u64,
+    token: NonZeroU64,
+}
+
+impl SessionCheckoutKey {
+    pub const fn new(generation: u64, token: NonZeroU64) -> Self {
+        Self { generation, token }
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    pub const fn token(self) -> NonZeroU64 {
+        self.token
+    }
+}
+
 /// Keeps an owned session recoverable while an async protocol operation can be cancelled.
 pub struct SessionCheckout<'a> {
     store: &'a mut dyn SessionStore,
     address: &'a ProtocolAddress,
     record: Option<SessionRecord>,
-    generation: Option<u64>,
+    checkout: Option<SessionCheckoutKey>,
     had_session: bool,
+    drop_recovery: CheckoutDropRecovery,
+}
+
+enum CheckoutDropRecovery {
+    Working,
+    Restore(Box<SessionRecord>),
+    Discard,
 }
 
 impl<'a> SessionCheckout<'a> {
@@ -212,20 +247,21 @@ impl<'a> SessionCheckout<'a> {
         store: &'a mut dyn SessionStore,
         address: &'a ProtocolAddress,
     ) -> Result<Option<Self>> {
-        let (record, generation) = match store.try_load_session_for_update(address) {
+        let (record, checkout) = match store.try_load_session_for_update(address) {
             Some(result) => result?,
             None => store.load_session_for_update(address).await?,
         };
         let Some(record) = record else {
-            store.cancel_session_checkout(address, generation);
+            store.cancel_session_checkout(address, checkout);
             return Ok(None);
         };
         Ok(Some(Self {
             store,
             address,
             record: Some(record),
-            generation,
+            checkout,
             had_session: true,
+            drop_recovery: CheckoutDropRecovery::Working,
         }))
     }
 
@@ -234,7 +270,7 @@ impl<'a> SessionCheckout<'a> {
         store: &'a mut dyn SessionStore,
         address: &'a ProtocolAddress,
     ) -> Result<Self> {
-        let (record, generation) = match store.try_load_session_for_update(address) {
+        let (record, checkout) = match store.try_load_session_for_update(address) {
             Some(result) => result?,
             None => store.load_session_for_update(address).await?,
         };
@@ -243,8 +279,9 @@ impl<'a> SessionCheckout<'a> {
             store,
             address,
             record: Some(record.unwrap_or_else(SessionRecord::new_fresh)),
-            generation,
+            checkout,
             had_session,
+            drop_recovery: CheckoutDropRecovery::Working,
         })
     }
 
@@ -267,9 +304,30 @@ impl<'a> SessionCheckout<'a> {
             .expect("a live checkout always owns its record")
     }
 
-    /// Preserves recovery while replacing a rejected mutation with its snapshot.
-    pub fn replace(&mut self, record: SessionRecord) {
-        self.record = Some(record);
+    /// A prekey promotion must not survive cancellation before identity persistence.
+    pub(crate) fn snapshot_for_rollback(&mut self) {
+        self.drop_recovery = if self.had_session {
+            CheckoutDropRecovery::Restore(Box::new(self.record().clone()))
+        } else {
+            CheckoutDropRecovery::Discard
+        };
+    }
+
+    /// Restores the snapshot armed by [`Self::snapshot_for_rollback`].
+    pub(crate) async fn rollback(mut self) -> Result<()> {
+        match std::mem::replace(&mut self.drop_recovery, CheckoutDropRecovery::Working) {
+            CheckoutDropRecovery::Restore(snapshot) => {
+                self.record = Some(*snapshot);
+                self.commit().await
+            }
+            CheckoutDropRecovery::Discard => {
+                self.record.take();
+                self.store
+                    .cancel_session_checkout(self.address, self.checkout);
+                Ok(())
+            }
+            CheckoutDropRecovery::Working => self.commit().await,
+        }
     }
 
     /// Prevents a deliberately rejected fresh session from being recovered.
@@ -280,7 +338,7 @@ impl<'a> SessionCheckout<'a> {
         }
         self.record.take();
         self.store
-            .cancel_session_checkout(self.address, self.generation);
+            .cancel_session_checkout(self.address, self.checkout);
     }
 
     /// Returns the record by move without a cancellation gap on take-style stores.
@@ -292,7 +350,7 @@ impl<'a> SessionCheckout<'a> {
         match self.store.try_store_session_from_checkout(
             self.address,
             record,
-            self.generation,
+            self.checkout,
             self.had_session,
         ) {
             SessionCheckoutStoreResult::Stored => Ok(()),
@@ -321,14 +379,23 @@ fn checkout_rejected() -> SignalProtocolError {
 
 impl Drop for SessionCheckout<'_> {
     fn drop(&mut self) {
-        let Some(record) = self.record.take() else {
+        let Some(mut record) = self.record.take() else {
             return;
         };
+        match std::mem::replace(&mut self.drop_recovery, CheckoutDropRecovery::Working) {
+            CheckoutDropRecovery::Working => {}
+            CheckoutDropRecovery::Restore(snapshot) => record = *snapshot,
+            CheckoutDropRecovery::Discard => {
+                self.store
+                    .cancel_session_checkout(self.address, self.checkout);
+                return;
+            }
+        }
         if self.had_session || record.session_state().is_some() {
             match self.store.try_store_session_from_checkout(
                 self.address,
                 record,
-                self.generation,
+                self.checkout,
                 self.had_session,
             ) {
                 SessionCheckoutStoreResult::Stored
@@ -338,7 +405,7 @@ impl Drop for SessionCheckout<'_> {
             }
         } else {
             self.store
-                .cancel_session_checkout(self.address, self.generation);
+                .cancel_session_checkout(self.address, self.checkout);
         }
     }
 }

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -130,14 +130,15 @@ pub trait SignedPreKeyStore: ThreadSafe {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait SessionStore: ThreadSafe {
-    /// Takes the session for `address`. Implementations with caches should
-    /// treat this as a logical checkout; callers must always call
-    /// [`store_session`] to return the record, even on error paths. Async
-    /// mutation paths use [`SessionCheckout`] so cancellation also returns it.
+    /// Loads the session for `address` without removing it from the store.
+    /// Destructive cache checkouts belong in [`load_session_for_update`].
     async fn load_session(&self, address: &ProtocolAddress) -> Result<Option<SessionRecord>>;
 
-    /// Couples take-style loads to a generation so cancellation cannot restore
-    /// state across a lossy cache reset.
+    /// Loads a mutation copy and optionally marks it as destructively checked out.
+    ///
+    /// `None` is an assertion that [`load_session`] was non-destructive. A store
+    /// returning a generation must also implement
+    /// [`try_store_session_from_checkout`] so cancellation can restore the record.
     #[doc(hidden)]
     async fn load_session_for_update(
         &self,
@@ -156,18 +157,35 @@ pub trait SessionStore: ThreadSafe {
         record: SessionRecord,
     ) -> Result<()>;
 
-    /// Gives take-style stores a synchronous recovery path before an async
+    /// Gives destructive stores a synchronous recovery path before an async
     /// owner can be cancelled again.
     #[doc(hidden)]
-    #[allow(clippy::result_large_err)]
     fn try_store_session_from_checkout(
         &mut self,
         _address: &ProtocolAddress,
         record: SessionRecord,
         _generation: Option<u64>,
-    ) -> core::result::Result<bool, SessionRecord> {
-        Err(record)
+        _had_session: bool,
+    ) -> SessionCheckoutStoreResult {
+        SessionCheckoutStoreResult::Unhandled(record)
     }
+
+    /// Releases an empty reservation made by a destructive update load.
+    #[doc(hidden)]
+    fn cancel_session_checkout(&mut self, _address: &ProtocolAddress, _generation: Option<u64>) {}
+
+    /// Drives a queued synchronous return once the contended store is available.
+    #[doc(hidden)]
+    async fn complete_session_checkout(&mut self) {}
+}
+
+/// Result of returning a record from a cancellation-safe checkout.
+#[doc(hidden)]
+pub enum SessionCheckoutStoreResult {
+    Stored,
+    Rejected,
+    Pending(std::sync::Arc<portable_atomic::AtomicBool>),
+    Unhandled(SessionRecord),
 }
 
 /// Keeps an owned session recoverable while an async protocol operation can be cancelled.
@@ -186,7 +204,11 @@ impl<'a> SessionCheckout<'a> {
         address: &'a ProtocolAddress,
     ) -> Result<Option<Self>> {
         let (record, generation) = store.load_session_for_update(address).await?;
-        Ok(record.map(|record| Self {
+        let Some(record) = record else {
+            store.cancel_session_checkout(address, generation);
+            return Ok(None);
+        };
+        Ok(Some(Self {
             store,
             address,
             record: Some(record),
@@ -237,7 +259,13 @@ impl<'a> SessionCheckout<'a> {
 
     /// Prevents a deliberately rejected fresh session from being recovered.
     pub fn discard(mut self) {
+        debug_assert!(!self.had_session, "only a fresh checkout can be discarded");
+        if self.had_session {
+            return;
+        }
         self.record.take();
+        self.store
+            .cancel_session_checkout(self.address, self.generation);
     }
 
     /// Returns the record by move without a cancellation gap on take-style stores.
@@ -246,18 +274,34 @@ impl<'a> SessionCheckout<'a> {
             .record
             .take()
             .expect("a live checkout always owns its record");
-        match self
-            .store
-            .try_store_session_from_checkout(self.address, record, self.generation)
-        {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(SignalProtocolError::InvalidState(
-                "SessionCheckout::commit",
-                "cache reset during session mutation".to_string(),
-            )),
-            Err(record) => self.store.store_session(self.address, record).await,
+        match self.store.try_store_session_from_checkout(
+            self.address,
+            record,
+            self.generation,
+            self.had_session,
+        ) {
+            SessionCheckoutStoreResult::Stored => Ok(()),
+            SessionCheckoutStoreResult::Rejected => Err(checkout_rejected()),
+            SessionCheckoutStoreResult::Pending(completion) => {
+                self.store.complete_session_checkout().await;
+                if completion.load(portable_atomic::Ordering::Acquire) {
+                    Ok(())
+                } else {
+                    Err(checkout_rejected())
+                }
+            }
+            SessionCheckoutStoreResult::Unhandled(record) => {
+                self.store.store_session(self.address, record).await
+            }
         }
     }
+}
+
+fn checkout_rejected() -> SignalProtocolError {
+    SignalProtocolError::InvalidState(
+        "SessionCheckout::commit",
+        "session changed during mutation".to_string(),
+    )
 }
 
 impl Drop for SessionCheckout<'_> {
@@ -266,9 +310,20 @@ impl Drop for SessionCheckout<'_> {
             return;
         };
         if self.had_session || record.session_state().is_some() {
-            let _ =
-                self.store
-                    .try_store_session_from_checkout(self.address, record, self.generation);
+            match self.store.try_store_session_from_checkout(
+                self.address,
+                record,
+                self.generation,
+                self.had_session,
+            ) {
+                SessionCheckoutStoreResult::Stored
+                | SessionCheckoutStoreResult::Rejected
+                | SessionCheckoutStoreResult::Pending(_) => {}
+                SessionCheckoutStoreResult::Unhandled(_) => {}
+            }
+        } else {
+            self.store
+                .cancel_session_checkout(self.address, self.generation);
         }
     }
 }

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -241,8 +241,8 @@ pub async fn prepare_dm_stanza(
 ///
 /// `SessionStore::load_session` is take-semantics in production
 /// (`SessionAdapter` → `SignalStoreCache::get_session` marks the slot
-/// `CheckedOut`); the loaded record is put back via `store_session`
-/// so the subsequent `message_encrypt` finds the slot Present.
+/// `CheckedOut`); the checkout guard keeps cancellation from hiding it from
+/// the subsequent `message_encrypt`.
 pub async fn pkmsg_would_be_emitted<S>(
     session_store: &mut S,
     signal_address: &ProtocolAddress,
@@ -250,12 +250,13 @@ pub async fn pkmsg_would_be_emitted<S>(
 where
     S: crate::libsignal::protocol::SessionStore,
 {
-    let loaded = session_store.load_session(signal_address).await?;
+    let loaded =
+        crate::libsignal::protocol::SessionCheckout::load(session_store, signal_address).await?;
     // Conservative read: treat any failure to interrogate the session as
     // "would be pkmsg" so the caller bails. Silently treating Err as false
     // would let message_encrypt run with a corrupt session and potentially
     // burn the sender chain.
-    let needs_pkmsg = match &loaded {
+    let needs_pkmsg = match loaded.as_ref().map(|session| session.record()) {
         None => true,
         Some(record) => match record.session_state() {
             None => true,
@@ -266,9 +267,9 @@ where
             },
         },
     };
-    if let Some(record) = loaded {
-        session_store
-            .store_session(signal_address, record)
+    if let Some(session) = loaded {
+        session
+            .commit()
             .await
             .map_err(|e| anyhow!("restoring checked-out session after pre-flight: {e}"))?;
     }

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -256,16 +256,13 @@ where
     // "would be pkmsg" so the caller bails. Silently treating Err as false
     // would let message_encrypt run with a corrupt session and potentially
     // burn the sender chain.
-    let needs_pkmsg = match loaded.as_ref().map(|session| session.record()) {
-        None => true,
-        Some(record) => match record.session_state() {
-            None => true,
-            Some(state) => match state.unacknowledged_pre_key_message_items() {
-                Ok(Some(_)) => true,
-                Ok(None) => false,
-                Err(_) => true,
-            },
-        },
+    let needs_pkmsg = if let Some(session) = loaded.as_ref()
+        && let Some(state) = session.record().session_state()
+        && let Ok(None) = state.unacknowledged_pre_key_message_items()
+    {
+        false
+    } else {
+        true
     };
     if let Some(session) = loaded {
         session

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -6,7 +6,9 @@ use async_lock::Mutex;
 use portable_atomic::{AtomicBool, AtomicU64, Ordering};
 use rand::RngExt;
 
-use crate::libsignal::protocol::{ProtocolAddress, SenderKeyRecord, SessionRecord};
+use crate::libsignal::protocol::{
+    ProtocolAddress, SenderKeyRecord, SessionCheckoutStoreResult, SessionRecord,
+};
 use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::store::traits::SignalStore;
 
@@ -109,7 +111,14 @@ enum SessionEntry {
     Present(Arc<SessionRecord>),
     Absent,
     /// Taken by load_session; has_session treats as present, flush/eviction skip.
-    CheckedOut,
+    CheckedOut(bool),
+}
+
+enum CachedSessionCheckout {
+    Missing,
+    Absent,
+    Busy,
+    Present(SessionRecord),
 }
 
 struct SessionStoreState {
@@ -166,6 +175,29 @@ impl SessionStoreState {
         self.deleted.remove(&addr);
     }
 
+    fn checkout(&mut self, address: &str) -> CachedSessionCheckout {
+        let Some(entry) = self.cache.get_mut(address) else {
+            return CachedSessionCheckout::Missing;
+        };
+        match entry {
+            SessionEntry::Present(_) => {
+                let SessionEntry::Present(record) =
+                    std::mem::replace(entry, SessionEntry::CheckedOut(true))
+                else {
+                    unreachable!()
+                };
+                CachedSessionCheckout::Present(
+                    Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone()),
+                )
+            }
+            SessionEntry::Absent => {
+                *entry = SessionEntry::CheckedOut(false);
+                CachedSessionCheckout::Absent
+            }
+            SessionEntry::CheckedOut(_) => CachedSessionCheckout::Busy,
+        }
+    }
+
     fn delete(&mut self, address: &str) {
         let addr = self.key_for(address);
         self.cache.insert(addr.clone(), SessionEntry::Absent);
@@ -200,7 +232,7 @@ impl SessionStoreState {
                 continue;
             }
             match v {
-                SessionEntry::CheckedOut => continue, // never evict checked-out
+                SessionEntry::CheckedOut(_) => continue, // never evict checked-out
                 SessionEntry::Absent => negative.push(k.clone()),
                 SessionEntry::Present(_) => positive.push(k.clone()),
             }
@@ -213,8 +245,10 @@ impl SessionStoreState {
 
 struct PendingSessionRestore {
     address: Arc<str>,
-    record: SessionRecord,
+    record: Option<SessionRecord>,
     generation: u64,
+    had_session: bool,
+    completion: Option<Arc<AtomicBool>>,
 }
 
 // === Sender key object cache (same pattern as sessions) ===
@@ -396,16 +430,28 @@ impl SignalStoreCache {
             address,
             record,
             generation,
+            had_session,
+            completion,
         } in pending.drain(..)
         {
-            if generation != state.checkout_generation {
-                continue;
+            let expected = matches!(
+                state.cache.get(address.as_ref()),
+                Some(SessionEntry::CheckedOut(was_present)) if *was_present == had_session
+            );
+            let restored = generation == state.checkout_generation && expected;
+            if restored && let Some(record) = record {
+                let address = state
+                    .cache
+                    .get_key_value(address.as_ref())
+                    .map_or(address, |(cached, _)| cached.clone());
+                state.put_with_key(address, record);
+            } else if restored {
+                let address = state.key_for(address.as_ref());
+                state.cache.insert(address, SessionEntry::Absent);
             }
-            let address = state
-                .cache
-                .get_key_value(address.as_ref())
-                .map_or(address, |(cached, _)| cached.clone());
-            state.put_with_key(address, record);
+            if let Some(completion) = completion {
+                completion.store(restored, Ordering::Release);
+            }
         }
         self.has_pending_session_restores
             .store(false, Ordering::Release);
@@ -431,28 +477,72 @@ impl SignalStoreCache {
         address: &ProtocolAddress,
         record: SessionRecord,
         generation: u64,
-    ) -> bool {
+        had_session: bool,
+    ) -> SessionCheckoutStoreResult {
         if let Some(mut state) = self.try_lock_sessions() {
-            if generation != state.checkout_generation {
-                return false;
+            let expected = matches!(
+                state.cache.get(address.as_str()),
+                Some(SessionEntry::CheckedOut(was_present)) if *was_present == had_session
+            );
+            if generation != state.checkout_generation || !expected {
+                return SessionCheckoutStoreResult::Rejected;
             }
             state.put(address.as_str(), record);
             state.evict_if_needed(self.max_entries);
-            return true;
+            return SessionCheckoutStoreResult::Stored;
         }
 
         let mut pending = self.pending_session_restores();
         if generation != self.session_recovery_generation.load(Ordering::Acquire) {
-            return false;
+            return SessionCheckoutStoreResult::Rejected;
         }
+        let completion = Arc::new(AtomicBool::new(false));
         pending.push(PendingSessionRestore {
             address: Arc::from(address.as_str()),
-            record,
+            record: Some(record),
             generation,
+            had_session,
+            completion: Some(completion.clone()),
         });
         self.has_pending_session_restores
             .store(true, Ordering::Release);
-        true
+        SessionCheckoutStoreResult::Pending(completion)
+    }
+
+    /// An empty checkout must release its pinned cache slot even when dropped.
+    #[doc(hidden)]
+    pub fn cancel_session_checkout(&self, address: &ProtocolAddress, generation: u64) {
+        let Some(mut state) = self.try_lock_sessions() else {
+            let mut pending = self.pending_session_restores();
+            if generation == self.session_recovery_generation.load(Ordering::Acquire) {
+                pending.push(PendingSessionRestore {
+                    address: Arc::from(address.as_str()),
+                    record: None,
+                    generation,
+                    had_session: false,
+                    completion: None,
+                });
+                self.has_pending_session_restores
+                    .store(true, Ordering::Release);
+            }
+            return;
+        };
+        if generation == state.checkout_generation
+            && matches!(
+                state.cache.get(address.as_str()),
+                Some(SessionEntry::CheckedOut(false))
+            )
+        {
+            let key = state.key_for(address.as_str());
+            state.cache.insert(key, SessionEntry::Absent);
+            state.evict_if_needed(self.max_entries);
+        }
+    }
+
+    /// A queued commit drives its own restore; cancellation may leave it for the next cache access.
+    #[doc(hidden)]
+    pub async fn complete_session_checkout(&self) {
+        drop(self.lock_sessions().await);
     }
 
     /// Whether any session or identity is known for `user` (across device ids),
@@ -490,9 +580,11 @@ impl SignalStoreCache {
         address: &ProtocolAddress,
         backend: &dyn SignalStore,
     ) -> Result<Option<SessionRecord>> {
-        self.checkout_session(address, backend)
-            .await
-            .map(|(record, _)| record)
+        let (record, generation) = self.checkout_session(address, backend).await?;
+        if record.is_none() {
+            self.cancel_session_checkout(address, generation);
+        }
+        Ok(record)
     }
 
     /// The generation prevents a cancelled checkout from surviving a lossy reset.
@@ -506,51 +598,41 @@ impl SignalStoreCache {
         {
             let mut state = self.lock_sessions().await;
             let generation = state.checkout_generation;
-            if let Some(entry) = state.cache.get_mut(key) {
-                if matches!(entry, SessionEntry::Present(_)) {
-                    let SessionEntry::Present(record) =
-                        std::mem::replace(entry, SessionEntry::CheckedOut)
-                    else {
-                        unreachable!()
-                    };
-                    // Unique unless a peek's Arc is still alive (short-lived
-                    // inspection paths), so this is a move, not a clone.
-                    return Ok((
-                        Some(Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone())),
-                        generation,
-                    ));
+            match state.checkout(key) {
+                CachedSessionCheckout::Present(record) => {
+                    return Ok((Some(record), generation));
                 }
-                return Ok((None, generation));
+                CachedSessionCheckout::Absent => return Ok((None, generation)),
+                CachedSessionCheckout::Busy => {
+                    anyhow::bail!("session is already checked out")
+                }
+                CachedSessionCheckout::Missing => {}
             }
         }
         // Backend I/O outside the lock
         let backend_result = backend.get_session(key).await?;
         let mut state = self.lock_sessions().await;
         let generation = state.checkout_generation;
+        match state.checkout(key) {
+            CachedSessionCheckout::Present(record) => return Ok((Some(record), generation)),
+            CachedSessionCheckout::Absent => return Ok((None, generation)),
+            CachedSessionCheckout::Busy => anyhow::bail!("session is already checked out"),
+            CachedSessionCheckout::Missing => {}
+        }
         match backend_result {
             Some(bytes) => {
-                if state.cache.contains_key(key) {
-                    // Another task populated this slot while we were loading;
-                    // defer to whatever they wrote (Present, CheckedOut, etc).
-                    // Deserialize and return without caching to avoid conflict.
-                    return Ok((
-                        Some(SessionRecord::deserialize_for_store(
-                            &bytes,
-                            &state.incarnation,
-                        )?),
-                        generation,
-                    ));
-                }
                 let record = SessionRecord::deserialize_for_store(&bytes, &state.incarnation)?;
-                state.cache.insert(Arc::from(key), SessionEntry::CheckedOut);
+                state
+                    .cache
+                    .insert(Arc::from(key), SessionEntry::CheckedOut(true));
                 state.evict_if_needed(self.max_entries);
                 Ok((Some(record), generation))
             }
             None => {
-                if !state.cache.contains_key(key) {
-                    state.cache.insert(Arc::from(key), SessionEntry::Absent);
-                    state.evict_if_needed(self.max_entries);
-                }
+                state
+                    .cache
+                    .insert(Arc::from(key), SessionEntry::CheckedOut(false));
+                state.evict_if_needed(self.max_entries);
                 Ok((None, generation))
             }
         }
@@ -871,7 +953,7 @@ impl SignalStoreCache {
             for key in &dirty_keys {
                 if !matches!(
                     state.cache.get(key.as_ref()),
-                    Some(SessionEntry::CheckedOut)
+                    Some(SessionEntry::CheckedOut(_))
                 ) {
                     state.dirty.remove(key);
                 }
@@ -906,7 +988,7 @@ impl SignalStoreCache {
                         // borrow is held across the backend roundtrip.
                         let durable = match state.cache.get(addr.as_ref()) {
                             Some(SessionEntry::Present(_)) => Some(true),
-                            Some(SessionEntry::CheckedOut) => Some(false),
+                            Some(SessionEntry::CheckedOut(_)) => Some(false),
                             Some(SessionEntry::Absent) | None => None,
                         };
                         let durable = match durable {
@@ -1044,7 +1126,7 @@ impl SignalStoreCache {
                     keys_len += k.len();
                     match v {
                         SessionEntry::Present(rec) => Some(rec.clone()),
-                        SessionEntry::Absent | SessionEntry::CheckedOut => None,
+                        SessionEntry::Absent | SessionEntry::CheckedOut(_) => None,
                     }
                 })
                 .collect();
@@ -1323,11 +1405,15 @@ mod sender_key_lock_tests {
 
         let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
         let sessions = cache.sessions.lock().await;
-        assert!(cache.restore_session_from_checkout(
+        let SessionCheckoutStoreResult::Pending(completion) = cache.restore_session_from_checkout(
             &addr,
             record.expect("checked-out record"),
             generation,
-        ));
+            true,
+        ) else {
+            panic!("contended restore must be queued")
+        };
+        drop(completion);
         assert_eq!(cache.pending_session_restores().len(), 1);
         drop(sessions);
 
@@ -1350,12 +1436,107 @@ mod sender_key_lock_tests {
         let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
 
         cache.clear().await;
-        assert!(!cache.restore_session_from_checkout(
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &addr,
+                record.expect("checked-out record"),
+                generation,
+                true,
+            ),
+            SessionCheckoutStoreResult::Rejected
+        ));
+        assert!(cache.peek_session(&addr, &backend).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn checkout_rejects_a_competing_owner() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550007770".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+        let error = match cache.checkout_session(&addr, &backend).await {
+            Ok(_) => panic!("a second owner must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("already checked out"));
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &addr,
+                record.expect("first owner"),
+                generation,
+                true,
+            ),
+            SessionCheckoutStoreResult::Stored
+        ));
+    }
+
+    #[tokio::test]
+    async fn restore_does_not_resurrect_a_deleted_slot() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550007771".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+        cache.delete_session(&addr).await;
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &addr,
+                record.expect("checked-out record"),
+                generation,
+                true,
+            ),
+            SessionCheckoutStoreResult::Rejected
+        ));
+        assert!(cache.peek_session(&addr, &backend).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn queued_restore_does_not_overwrite_a_delete() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550007772".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+
+        let mut sessions = cache.sessions.lock().await;
+        sessions.delete(addr.as_str());
+        let SessionCheckoutStoreResult::Pending(completion) = cache.restore_session_from_checkout(
             &addr,
             record.expect("checked-out record"),
             generation,
-        ));
+            true,
+        ) else {
+            panic!("contended restore must be queued")
+        };
+        drop(sessions);
+
+        cache.complete_session_checkout().await;
+        assert!(!completion.load(Ordering::Acquire));
         assert!(cache.peek_session(&addr, &backend).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_checkout_reserves_and_releases_its_slot() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550007773".to_string(), 1.into());
+
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+        assert!(record.is_none());
+        assert!(cache.checkout_session(&addr, &backend).await.is_err());
+        cache.cancel_session_checkout(&addr, generation);
+
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+        assert!(record.is_none());
+        let sessions = cache.sessions.lock().await;
+        cache.cancel_session_checkout(&addr, generation);
+        assert_eq!(cache.pending_session_restores().len(), 1);
+        drop(sessions);
+        cache.complete_session_checkout().await;
+        assert_eq!(cache.try_has_session(&addr), Some(false));
     }
 
     #[tokio::test]
@@ -2232,7 +2413,7 @@ mod eviction_tests {
             let state = cache.sessions.lock().await;
             let entry = state.cache.get(pinned.as_str());
             assert!(
-                matches!(entry, Some(SessionEntry::CheckedOut)),
+                matches!(entry, Some(SessionEntry::CheckedOut(_))),
                 "checked-out session must survive eviction"
             );
             assert!(
@@ -2386,7 +2567,7 @@ mod lease_reload_tests {
             assert!(state.dirty.contains(address.as_str()));
             assert!(matches!(
                 state.cache.get(address.as_str()),
-                Some(SessionEntry::CheckedOut)
+                Some(SessionEntry::CheckedOut(_))
             ));
         }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -645,6 +645,24 @@ impl SignalStoreCache {
         }
     }
 
+    /// A warm checkout avoids the device lock and boxed async store future.
+    #[doc(hidden)]
+    pub fn try_checkout_session(
+        &self,
+        address: &ProtocolAddress,
+    ) -> Option<Result<(Option<SessionRecord>, u64)>> {
+        let mut state = self.try_lock_sessions()?;
+        let generation = state.checkout_generation;
+        match state.checkout(address.as_str()) {
+            CachedSessionCheckout::Present(record) => Some(Ok((Some(record), generation))),
+            CachedSessionCheckout::Absent => Some(Ok((None, generation))),
+            CachedSessionCheckout::Busy => {
+                Some(Err(anyhow::anyhow!("session is already checked out")))
+            }
+            CachedSessionCheckout::Missing => None,
+        }
+    }
+
     /// Non-destructive read. Clones the session without removing it from
     /// cache. Use for inspection-only paths (retry, LID migration checks).
     pub async fn peek_session(
@@ -1387,6 +1405,10 @@ mod sender_key_lock_tests {
             None,
             "held sessions lock must reject try_has_session"
         );
+        assert!(
+            cache.try_checkout_session(&addr).is_none(),
+            "held sessions lock must defer checkout"
+        );
         drop(guard);
 
         assert_eq!(
@@ -1394,6 +1416,7 @@ mod sender_key_lock_tests {
             None,
             "unknown entry must defer to the async path"
         );
+        assert!(cache.try_checkout_session(&addr).is_none());
         assert!(
             cache
                 .try_put_session(&addr, SessionRecord::new_fresh())
@@ -1458,12 +1481,17 @@ mod sender_key_lock_tests {
     #[tokio::test]
     async fn checkout_rejects_a_competing_owner() {
         let cache = SignalStoreCache::new();
-        let backend = crate::store::in_memory::InMemoryBackend::new();
         let addr = ProtocolAddress::new("15550007770".to_string(), 1.into());
         cache.put_session(&addr, SessionRecord::new_fresh()).await;
 
-        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
-        let error = match cache.checkout_session(&addr, &backend).await {
+        let (record, generation) = cache
+            .try_checkout_session(&addr)
+            .expect("warm checkout")
+            .expect("first owner");
+        let error = match cache
+            .try_checkout_session(&addr)
+            .expect("checked-out slots are known")
+        {
             Ok(_) => panic!("a second owner must be rejected"),
             Err(error) => error,
         };

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -246,6 +246,11 @@ impl SessionStoreState {
         self.reservation_pending.clear();
     }
 
+    fn clear_clean_entries(&mut self) {
+        self.cache
+            .retain(|_, entry| matches!(entry, SessionEntry::CheckedOut { .. }));
+    }
+
     fn discard(&mut self, incarnation: StoreIncarnation, generation: u64) {
         self.clear();
         self.incarnation = incarnation;
@@ -1294,7 +1299,7 @@ impl SignalStoreCache {
             && sessions.deleted.is_empty()
             && sessions.reservation_pending.is_empty()
         {
-            sessions.clear();
+            sessions.clear_clean_entries();
             self.removed_prekeys.lock().await.clear();
         }
         drop(sessions);
@@ -2802,6 +2807,38 @@ mod lease_reload_tests {
             .get_sender_chain_key()
             .expect("sender chain")
             .index()
+    }
+
+    #[tokio::test]
+    async fn post_flush_clear_preserves_only_live_checkouts() {
+        let backend = InMemoryBackend::new();
+        let cache = SignalStoreCache::new();
+        let active = ProtocolAddress::new("15550001007".to_string(), 1.into());
+        let idle = ProtocolAddress::new("15550001008".to_string(), 1.into());
+        cache.put_session(&active, leased_session()).await;
+        cache.put_session(&idle, leased_session()).await;
+        cache.flush(&backend).await.expect("flush");
+
+        let (record, checkout) = cache.checkout_session(&active, &backend).await.unwrap();
+        cache.clear_after_flush().await;
+
+        {
+            let state = cache.sessions.lock().await;
+            assert!(matches!(
+                state.cache.get(active.as_str()),
+                Some(SessionEntry::CheckedOut { .. })
+            ));
+            assert!(!state.cache.contains_key(idle.as_str()));
+        }
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &active,
+                record.expect("checked-out record"),
+                checkout,
+                true,
+            ),
+            SessionCheckoutStoreResult::Stored
+        ));
     }
 
     #[tokio::test]

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex as SyncMutex, MutexGuard as SyncMutexGuard};
 
 use anyhow::Result;
@@ -7,7 +8,7 @@ use portable_atomic::{AtomicBool, AtomicU64, Ordering};
 use rand::RngExt;
 
 use crate::libsignal::protocol::{
-    ProtocolAddress, SenderKeyRecord, SessionCheckoutStoreResult, SessionRecord,
+    ProtocolAddress, SenderKeyRecord, SessionCheckoutKey, SessionCheckoutStoreResult, SessionRecord,
 };
 use crate::libsignal::store::sender_key_name::SenderKeyName;
 use crate::store::traits::SignalStore;
@@ -110,20 +111,36 @@ enum SessionEntry {
     // instead of deep-cloning the record (KBs with archived states).
     Present(Arc<SessionRecord>),
     Absent,
-    /// Taken by load_session; has_session treats as present, flush/eviction skip.
-    CheckedOut(bool),
+    CheckedOut {
+        had_session: bool,
+        token: NonZeroU64,
+    },
+}
+
+impl SessionEntry {
+    fn exists(&self) -> bool {
+        matches!(
+            self,
+            Self::Present(_)
+                | Self::CheckedOut {
+                    had_session: true,
+                    ..
+                }
+        )
+    }
 }
 
 enum CachedSessionCheckout {
-    Missing,
-    Absent,
+    Missing(SessionCheckoutKey),
+    Absent(SessionCheckoutKey),
     Busy,
-    Present(SessionRecord),
+    Present(SessionRecord, SessionCheckoutKey),
 }
 
 struct SessionStoreState {
     incarnation: StoreIncarnation,
     checkout_generation: u64,
+    next_checkout_token: u64,
     cache: HashMap<Arc<str>, SessionEntry>,
     dirty: HashSet<Arc<str>>,
     deleted: HashSet<Arc<str>>,
@@ -141,6 +158,7 @@ impl SessionStoreState {
         Self {
             incarnation,
             checkout_generation: 0,
+            next_checkout_token: 1,
             cache: HashMap::new(),
             dirty: HashSet::new(),
             deleted: HashSet::new(),
@@ -176,25 +194,39 @@ impl SessionStoreState {
     }
 
     fn checkout(&mut self, address: &str) -> CachedSessionCheckout {
+        let token = NonZeroU64::new(self.next_checkout_token).unwrap_or(NonZeroU64::MIN);
+        self.next_checkout_token = self.next_checkout_token.wrapping_add(1);
+        if self.next_checkout_token == 0 {
+            self.next_checkout_token = 1;
+        }
+        let checkout = SessionCheckoutKey::new(self.checkout_generation, token);
         let Some(entry) = self.cache.get_mut(address) else {
-            return CachedSessionCheckout::Missing;
+            return CachedSessionCheckout::Missing(checkout);
         };
         match entry {
             SessionEntry::Present(_) => {
-                let SessionEntry::Present(record) =
-                    std::mem::replace(entry, SessionEntry::CheckedOut(true))
-                else {
+                let SessionEntry::Present(record) = std::mem::replace(
+                    entry,
+                    SessionEntry::CheckedOut {
+                        had_session: true,
+                        token,
+                    },
+                ) else {
                     unreachable!()
                 };
                 CachedSessionCheckout::Present(
                     Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone()),
+                    checkout,
                 )
             }
             SessionEntry::Absent => {
-                *entry = SessionEntry::CheckedOut(false);
-                CachedSessionCheckout::Absent
+                *entry = SessionEntry::CheckedOut {
+                    had_session: false,
+                    token,
+                };
+                CachedSessionCheckout::Absent(checkout)
             }
-            SessionEntry::CheckedOut(_) => CachedSessionCheckout::Busy,
+            SessionEntry::CheckedOut { .. } => CachedSessionCheckout::Busy,
         }
     }
 
@@ -232,7 +264,7 @@ impl SessionStoreState {
                 continue;
             }
             match v {
-                SessionEntry::CheckedOut(_) => continue, // never evict checked-out
+                SessionEntry::CheckedOut { .. } => continue, // never evict checked-out
                 SessionEntry::Absent => negative.push(k.clone()),
                 SessionEntry::Present(_) => positive.push(k.clone()),
             }
@@ -246,7 +278,7 @@ impl SessionStoreState {
 struct PendingSessionRestore {
     address: Arc<str>,
     record: Option<SessionRecord>,
-    generation: u64,
+    checkout: SessionCheckoutKey,
     had_session: bool,
     completion: Option<Arc<AtomicBool>>,
 }
@@ -429,15 +461,21 @@ impl SignalStoreCache {
         for PendingSessionRestore {
             address,
             record,
-            generation,
+            checkout,
             had_session,
             completion,
         } in pending.drain(..)
         {
-            let key = if generation == state.checkout_generation
-                && let Some((key, SessionEntry::CheckedOut(was_present))) =
-                    state.cache.get_key_value(address.as_ref())
+            let key = if checkout.generation() == state.checkout_generation
+                && let Some((
+                    key,
+                    SessionEntry::CheckedOut {
+                        had_session: was_present,
+                        token,
+                    },
+                )) = state.cache.get_key_value(address.as_ref())
                 && *was_present == had_session
+                && *token == checkout.token()
             {
                 Some(key.clone())
             } else {
@@ -478,19 +516,29 @@ impl SignalStoreCache {
         &self,
         address: &ProtocolAddress,
         record: SessionRecord,
-        generation: u64,
+        checkout: SessionCheckoutKey,
         had_session: bool,
     ) -> SessionCheckoutStoreResult {
+        if checkout.generation() != self.session_recovery_generation.load(Ordering::Acquire) {
+            return SessionCheckoutStoreResult::Rejected;
+        }
         if let Some(mut state) = self.try_lock_sessions() {
-            if generation != state.checkout_generation {
+            if checkout.generation() != self.session_recovery_generation.load(Ordering::Acquire)
+                || checkout.generation() != state.checkout_generation
+            {
                 return SessionCheckoutStoreResult::Rejected;
             }
-            let Some((key, SessionEntry::CheckedOut(was_present))) =
-                state.cache.get_key_value(address.as_str())
+            let Some((
+                key,
+                SessionEntry::CheckedOut {
+                    had_session: was_present,
+                    token,
+                },
+            )) = state.cache.get_key_value(address.as_str())
             else {
                 return SessionCheckoutStoreResult::Rejected;
             };
-            if *was_present != had_session {
+            if *was_present != had_session || *token != checkout.token() {
                 return SessionCheckoutStoreResult::Rejected;
             }
             let key = key.clone();
@@ -500,14 +548,14 @@ impl SignalStoreCache {
         }
 
         let mut pending = self.pending_session_restores();
-        if generation != self.session_recovery_generation.load(Ordering::Acquire) {
+        if checkout.generation() != self.session_recovery_generation.load(Ordering::Acquire) {
             return SessionCheckoutStoreResult::Rejected;
         }
         let completion = Arc::new(AtomicBool::new(false));
         pending.push(PendingSessionRestore {
             address: Arc::from(address.as_str()),
             record: Some(record),
-            generation,
+            checkout,
             had_session,
             completion: Some(completion.clone()),
         });
@@ -518,14 +566,17 @@ impl SignalStoreCache {
 
     /// An empty checkout must release its pinned cache slot even when dropped.
     #[doc(hidden)]
-    pub fn cancel_session_checkout(&self, address: &ProtocolAddress, generation: u64) {
+    pub fn cancel_session_checkout(&self, address: &ProtocolAddress, checkout: SessionCheckoutKey) {
+        if checkout.generation() != self.session_recovery_generation.load(Ordering::Acquire) {
+            return;
+        }
         let Some(mut state) = self.try_lock_sessions() else {
             let mut pending = self.pending_session_restores();
-            if generation == self.session_recovery_generation.load(Ordering::Acquire) {
+            if checkout.generation() == self.session_recovery_generation.load(Ordering::Acquire) {
                 pending.push(PendingSessionRestore {
                     address: Arc::from(address.as_str()),
                     record: None,
-                    generation,
+                    checkout,
                     had_session: false,
                     completion: None,
                 });
@@ -534,13 +585,23 @@ impl SignalStoreCache {
             }
             return;
         };
-        if generation == state.checkout_generation
-            && matches!(
-                state.cache.get(address.as_str()),
-                Some(SessionEntry::CheckedOut(false))
-            )
+        let key = if checkout.generation()
+            == self.session_recovery_generation.load(Ordering::Acquire)
+            && checkout.generation() == state.checkout_generation
+            && let Some((
+                key,
+                SessionEntry::CheckedOut {
+                    had_session: false,
+                    token,
+                },
+            )) = state.cache.get_key_value(address.as_str())
+            && *token == checkout.token()
         {
-            let key = state.key_for(address.as_str());
+            Some(key.clone())
+        } else {
+            None
+        };
+        if let Some(key) = key {
             state.cache.insert(key, SessionEntry::Absent);
             state.evict_if_needed(self.max_entries);
         }
@@ -587,60 +648,68 @@ impl SignalStoreCache {
         address: &ProtocolAddress,
         backend: &dyn SignalStore,
     ) -> Result<Option<SessionRecord>> {
-        let (record, generation) = self.checkout_session(address, backend).await?;
+        let (record, checkout) = self.checkout_session(address, backend).await?;
         if record.is_none() {
-            self.cancel_session_checkout(address, generation);
+            self.cancel_session_checkout(address, checkout);
         }
         Ok(record)
     }
 
-    /// The generation prevents a cancelled checkout from surviving a lossy reset.
+    /// The checkout key rejects stale owners and owners from before a lossy reset.
     #[doc(hidden)]
     pub async fn checkout_session(
         &self,
         address: &ProtocolAddress,
         backend: &dyn SignalStore,
-    ) -> Result<(Option<SessionRecord>, u64)> {
+    ) -> Result<(Option<SessionRecord>, SessionCheckoutKey)> {
         let key = address.as_str();
         {
             let mut state = self.lock_sessions().await;
-            let generation = state.checkout_generation;
             match state.checkout(key) {
-                CachedSessionCheckout::Present(record) => {
-                    return Ok((Some(record), generation));
+                CachedSessionCheckout::Present(record, checkout) => {
+                    return Ok((Some(record), checkout));
                 }
-                CachedSessionCheckout::Absent => return Ok((None, generation)),
+                CachedSessionCheckout::Absent(checkout) => return Ok((None, checkout)),
                 CachedSessionCheckout::Busy => {
                     anyhow::bail!("session is already checked out")
                 }
-                CachedSessionCheckout::Missing => {}
+                CachedSessionCheckout::Missing(_) => {}
             }
         }
         // Backend I/O outside the lock
         let backend_result = backend.get_session(key).await?;
         let mut state = self.lock_sessions().await;
-        let generation = state.checkout_generation;
-        match state.checkout(key) {
-            CachedSessionCheckout::Present(record) => return Ok((Some(record), generation)),
-            CachedSessionCheckout::Absent => return Ok((None, generation)),
+        let checkout = match state.checkout(key) {
+            CachedSessionCheckout::Present(record, checkout) => {
+                return Ok((Some(record), checkout));
+            }
+            CachedSessionCheckout::Absent(checkout) => return Ok((None, checkout)),
             CachedSessionCheckout::Busy => anyhow::bail!("session is already checked out"),
-            CachedSessionCheckout::Missing => {}
-        }
+            CachedSessionCheckout::Missing(checkout) => checkout,
+        };
         match backend_result {
             Some(bytes) => {
                 let record = SessionRecord::deserialize_for_store(&bytes, &state.incarnation)?;
-                state
-                    .cache
-                    .insert(Arc::from(key), SessionEntry::CheckedOut(true));
+                state.cache.insert(
+                    Arc::from(key),
+                    SessionEntry::CheckedOut {
+                        had_session: true,
+                        token: checkout.token(),
+                    },
+                );
                 state.evict_if_needed(self.max_entries);
-                Ok((Some(record), generation))
+                Ok((Some(record), checkout))
             }
             None => {
-                state
-                    .cache
-                    .insert(Arc::from(key), SessionEntry::CheckedOut(false));
+                state.cache.insert(
+                    Arc::from(key),
+                    SessionEntry::CheckedOut {
+                        had_session: false,
+                        token: checkout.token(),
+                    },
+                );
                 state.evict_if_needed(self.max_entries);
-                Ok((None, generation))
+                Ok((None, checkout))
             }
         }
     }
@@ -650,16 +719,15 @@ impl SignalStoreCache {
     pub fn try_checkout_session(
         &self,
         address: &ProtocolAddress,
-    ) -> Option<Result<(Option<SessionRecord>, u64)>> {
+    ) -> Option<Result<(Option<SessionRecord>, SessionCheckoutKey)>> {
         let mut state = self.try_lock_sessions()?;
-        let generation = state.checkout_generation;
         match state.checkout(address.as_str()) {
-            CachedSessionCheckout::Present(record) => Some(Ok((Some(record), generation))),
-            CachedSessionCheckout::Absent => Some(Ok((None, generation))),
+            CachedSessionCheckout::Present(record, checkout) => Some(Ok((Some(record), checkout))),
+            CachedSessionCheckout::Absent(checkout) => Some(Ok((None, checkout))),
             CachedSessionCheckout::Busy => {
                 Some(Err(anyhow::anyhow!("session is already checked out")))
             }
-            CachedSessionCheckout::Missing => None,
+            CachedSessionCheckout::Missing(_) => None,
         }
     }
 
@@ -683,25 +751,27 @@ impl SignalStoreCache {
         // Backend I/O outside the lock
         let backend_result = backend.get_session(key).await?;
         let mut state = self.lock_sessions().await;
+        if let Some(entry) = state.cache.get(key) {
+            return match entry {
+                SessionEntry::Present(record) => Ok(Some(record.clone())),
+                SessionEntry::Absent | SessionEntry::CheckedOut { .. } => Ok(None),
+            };
+        }
         match backend_result {
             Some(bytes) => {
                 let record = Arc::new(SessionRecord::deserialize_for_store(
                     &bytes,
                     &state.incarnation,
                 )?);
-                if !state.cache.contains_key(key) {
-                    state
-                        .cache
-                        .insert(Arc::from(key), SessionEntry::Present(record.clone()));
-                    state.evict_if_needed(self.max_entries);
-                }
+                state
+                    .cache
+                    .insert(Arc::from(key), SessionEntry::Present(record.clone()));
+                state.evict_if_needed(self.max_entries);
                 Ok(Some(record))
             }
             None => {
-                if !state.cache.contains_key(key) {
-                    state.cache.insert(Arc::from(key), SessionEntry::Absent);
-                    state.evict_if_needed(self.max_entries);
-                }
+                state.cache.insert(Arc::from(key), SessionEntry::Absent);
+                state.evict_if_needed(self.max_entries);
                 Ok(None)
             }
         }
@@ -740,10 +810,7 @@ impl SignalStoreCache {
     /// `None` sends the caller to the async path (backend consult).
     pub fn try_has_session(&self, address: &ProtocolAddress) -> Option<bool> {
         let state = self.try_lock_sessions()?;
-        state
-            .cache
-            .get(address.as_str())
-            .map(|entry| !matches!(entry, SessionEntry::Absent))
+        state.cache.get(address.as_str()).map(SessionEntry::exists)
     }
 
     pub async fn delete_session(&self, address: &ProtocolAddress) {
@@ -751,7 +818,7 @@ impl SignalStoreCache {
         state.delete(address.as_str());
     }
 
-    /// Non-destructive existence check (`CheckedOut` counts as present).
+    /// Non-destructive existence check; an empty checkout remains absent.
     /// Backend misses are negative-cached; hits are not cached to skip
     /// deserialization (the subsequent `get_session` will cache on demand).
     pub async fn has_session(
@@ -763,18 +830,18 @@ impl SignalStoreCache {
         {
             let state = self.lock_sessions().await;
             if let Some(entry) = state.cache.get(key) {
-                return Ok(!matches!(entry, SessionEntry::Absent));
+                return Ok(entry.exists());
             }
         }
         // Backend I/O outside the lock
         let exists = backend.has_session(key).await?;
+        let mut state = self.lock_sessions().await;
+        if let Some(entry) = state.cache.get(key) {
+            return Ok(entry.exists());
+        }
         if !exists {
-            let mut state = self.lock_sessions().await;
-            // Re-check: another task may have populated the cache
-            if !state.cache.contains_key(key) {
-                state.cache.insert(Arc::from(key), SessionEntry::Absent);
-                state.evict_if_needed(self.max_entries);
-            }
+            state.cache.insert(Arc::from(key), SessionEntry::Absent);
+            state.evict_if_needed(self.max_entries);
         }
         Ok(exists)
     }
@@ -978,7 +1045,7 @@ impl SignalStoreCache {
             for key in &dirty_keys {
                 if !matches!(
                     state.cache.get(key.as_ref()),
-                    Some(SessionEntry::CheckedOut(_))
+                    Some(SessionEntry::CheckedOut { .. })
                 ) {
                     state.dirty.remove(key);
                 }
@@ -1013,7 +1080,7 @@ impl SignalStoreCache {
                         // borrow is held across the backend roundtrip.
                         let durable = match state.cache.get(addr.as_ref()) {
                             Some(SessionEntry::Present(_)) => Some(true),
-                            Some(SessionEntry::CheckedOut(_)) => Some(false),
+                            Some(SessionEntry::CheckedOut { .. }) => Some(false),
                             Some(SessionEntry::Absent) | None => None,
                         };
                         let durable = match durable {
@@ -1151,7 +1218,7 @@ impl SignalStoreCache {
                     keys_len += k.len();
                     match v {
                         SessionEntry::Present(rec) => Some(rec.clone()),
-                        SessionEntry::Absent | SessionEntry::CheckedOut(_) => None,
+                        SessionEntry::Absent | SessionEntry::CheckedOut { .. } => None,
                     }
                 })
                 .collect();
@@ -1200,13 +1267,12 @@ impl SignalStoreCache {
     }
 
     async fn clear_with_incarnation(&self, incarnation: StoreIncarnation) {
+        self.session_recovery_generation
+            .fetch_add(1, Ordering::AcqRel);
         {
             let mut sessions = self.sessions.lock().await;
             let mut pending = self.pending_session_restores();
-            let generation = self
-                .session_recovery_generation
-                .fetch_add(1, Ordering::AcqRel)
-                .wrapping_add(1);
+            let generation = self.session_recovery_generation.load(Ordering::Acquire);
             pending.clear();
             self.has_pending_session_restores
                 .store(false, Ordering::Release);
@@ -1250,6 +1316,105 @@ impl SignalStoreCache {
 mod sender_key_lock_tests {
     use super::*;
     use crate::libsignal::store::sender_key_name::SenderKeyName;
+    use crate::store::error::Result as StoreResult;
+    use bytes::Bytes;
+
+    struct BlockingSessionLookup {
+        started: async_lock::Barrier,
+        release: async_lock::Barrier,
+    }
+
+    impl BlockingSessionLookup {
+        fn new() -> Self {
+            Self {
+                started: async_lock::Barrier::new(2),
+                release: async_lock::Barrier::new(2),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SignalStore for BlockingSessionLookup {
+        async fn put_identity(&self, _: &str, _: [u8; 32]) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn load_identity(&self, _: &str) -> StoreResult<Option<[u8; 32]>> {
+            unreachable!()
+        }
+
+        async fn delete_identity(&self, _: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn get_session(&self, _: &str) -> StoreResult<Option<Bytes>> {
+            self.started.wait().await;
+            self.release.wait().await;
+            Ok(None)
+        }
+
+        async fn has_session(&self, _: &str) -> StoreResult<bool> {
+            self.started.wait().await;
+            self.release.wait().await;
+            Ok(false)
+        }
+
+        async fn put_session(&self, _: &str, _: &[u8]) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn delete_session(&self, _: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn store_prekey(&self, _: u32, _: &[u8], _: bool) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn load_prekey(&self, _: u32) -> StoreResult<Option<Bytes>> {
+            unreachable!()
+        }
+
+        async fn mark_prekeys_uploaded(&self, _: &[u32]) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn remove_prekey(&self, _: u32) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn get_max_prekey_id(&self) -> StoreResult<u32> {
+            unreachable!()
+        }
+
+        async fn store_signed_prekey(&self, _: u32, _: &[u8]) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn load_signed_prekey(&self, _: u32) -> StoreResult<Option<Vec<u8>>> {
+            unreachable!()
+        }
+
+        async fn load_all_signed_prekeys(&self) -> StoreResult<Vec<(u32, Vec<u8>)>> {
+            unreachable!()
+        }
+
+        async fn remove_signed_prekey(&self, _: u32) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn put_sender_key(&self, _: &str, _: &[u8]) -> StoreResult<()> {
+            unreachable!()
+        }
+
+        async fn get_sender_key(&self, _: &str) -> StoreResult<Option<Vec<u8>>> {
+            unreachable!()
+        }
+
+        async fn delete_sender_key(&self, _: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+    }
 
     async fn wait_for_lock_waiter(lock: &Arc<Mutex<()>>, baseline: usize) {
         for _ in 0..10_000 {
@@ -1479,6 +1644,81 @@ mod sender_key_lock_tests {
     }
 
     #[tokio::test]
+    async fn lossy_clear_invalidates_checkouts_before_waiting_for_the_cache() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550007776".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+        let (record, checkout) = cache.checkout_session(&addr, &backend).await.unwrap();
+
+        let sessions = cache.sessions.lock().await;
+        let clear = tokio::spawn({
+            let cache = cache.clone();
+            async move { cache.clear().await }
+        });
+        for _ in 0..10_000 {
+            if cache.session_recovery_generation.load(Ordering::Acquire) != checkout.generation() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_ne!(
+            cache.session_recovery_generation.load(Ordering::Acquire),
+            checkout.generation(),
+            "clear must invalidate owners before waiting"
+        );
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &addr,
+                record.expect("checked-out record"),
+                checkout,
+                true,
+            ),
+            SessionCheckoutStoreResult::Rejected
+        ));
+
+        drop(sessions);
+        clear.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stale_checkout_cannot_overwrite_a_new_owner() {
+        let cache = SignalStoreCache::new();
+        let addr = ProtocolAddress::new("15550007775".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+
+        let (old_record, old_checkout) = cache
+            .try_checkout_session(&addr)
+            .expect("warm checkout")
+            .expect("old owner");
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+        let (new_record, new_checkout) = cache
+            .try_checkout_session(&addr)
+            .expect("warm checkout")
+            .expect("new owner");
+        assert_ne!(old_checkout, new_checkout);
+
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &addr,
+                old_record.expect("old record"),
+                old_checkout,
+                true,
+            ),
+            SessionCheckoutStoreResult::Rejected
+        ));
+        assert!(matches!(
+            cache.restore_session_from_checkout(
+                &addr,
+                new_record.expect("new record"),
+                new_checkout,
+                true,
+            ),
+            SessionCheckoutStoreResult::Stored
+        ));
+    }
+
+    #[tokio::test]
     async fn checkout_rejects_a_competing_owner() {
         let cache = SignalStoreCache::new();
         let addr = ProtocolAddress::new("15550007770".to_string(), 1.into());
@@ -1561,6 +1801,8 @@ mod sender_key_lock_tests {
 
         let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
         assert!(record.is_none());
+        assert_eq!(cache.try_has_session(&addr), Some(false));
+        assert!(!cache.has_session(&addr, &backend).await.unwrap());
         assert!(cache.checkout_session(&addr, &backend).await.is_err());
         cache.cancel_session_checkout(&addr, generation);
 
@@ -1572,6 +1814,44 @@ mod sender_key_lock_tests {
         drop(sessions);
         cache.complete_session_checkout().await;
         assert_eq!(cache.try_has_session(&addr), Some(false));
+    }
+
+    #[tokio::test]
+    async fn peek_prefers_a_cache_write_that_wins_the_backend_race() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(BlockingSessionLookup::new());
+        let addr = ProtocolAddress::new("15550007774".to_string(), 1.into());
+
+        let peek = tokio::spawn({
+            let cache = cache.clone();
+            let backend = backend.clone();
+            let addr = addr.clone();
+            async move { cache.peek_session(&addr, backend.as_ref()).await }
+        });
+        backend.started.wait().await;
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+        backend.release.wait().await;
+
+        assert!(peek.await.unwrap().unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn existence_prefers_a_cache_write_that_wins_the_backend_race() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(BlockingSessionLookup::new());
+        let addr = ProtocolAddress::new("15550007772".to_string(), 2.into());
+
+        let exists = tokio::spawn({
+            let cache = cache.clone();
+            let backend = backend.clone();
+            let addr = addr.clone();
+            async move { cache.has_session(&addr, backend.as_ref()).await }
+        });
+        backend.started.wait().await;
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+        backend.release.wait().await;
+
+        assert!(exists.await.unwrap().unwrap());
     }
 
     #[tokio::test]
@@ -2448,7 +2728,7 @@ mod eviction_tests {
             let state = cache.sessions.lock().await;
             let entry = state.cache.get(pinned.as_str());
             assert!(
-                matches!(entry, Some(SessionEntry::CheckedOut(_))),
+                matches!(entry, Some(SessionEntry::CheckedOut { .. })),
                 "checked-out session must survive eviction"
             );
             assert!(
@@ -2602,7 +2882,7 @@ mod lease_reload_tests {
             assert!(state.dirty.contains(address.as_str()));
             assert!(matches!(
                 state.cache.get(address.as_str()),
-                Some(SessionEntry::CheckedOut(_))
+                Some(SessionEntry::CheckedOut { .. })
             ));
         }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -434,20 +434,22 @@ impl SignalStoreCache {
             completion,
         } in pending.drain(..)
         {
-            let expected = matches!(
-                state.cache.get(address.as_ref()),
-                Some(SessionEntry::CheckedOut(was_present)) if *was_present == had_session
-            );
-            let restored = generation == state.checkout_generation && expected;
-            if restored && let Some(record) = record {
-                let address = state
-                    .cache
-                    .get_key_value(address.as_ref())
-                    .map_or(address, |(cached, _)| cached.clone());
-                state.put_with_key(address, record);
-            } else if restored {
-                let address = state.key_for(address.as_ref());
-                state.cache.insert(address, SessionEntry::Absent);
+            let key = if generation == state.checkout_generation
+                && let Some((key, SessionEntry::CheckedOut(was_present))) =
+                    state.cache.get_key_value(address.as_ref())
+                && *was_present == had_session
+            {
+                Some(key.clone())
+            } else {
+                None
+            };
+            let restored = key.is_some();
+            match (key, record) {
+                (Some(key), Some(record)) => state.put_with_key(key, record),
+                (Some(key), None) => {
+                    state.cache.insert(key, SessionEntry::Absent);
+                }
+                (None, _) => {}
             }
             if let Some(completion) = completion {
                 completion.store(restored, Ordering::Release);
@@ -480,14 +482,19 @@ impl SignalStoreCache {
         had_session: bool,
     ) -> SessionCheckoutStoreResult {
         if let Some(mut state) = self.try_lock_sessions() {
-            let expected = matches!(
-                state.cache.get(address.as_str()),
-                Some(SessionEntry::CheckedOut(was_present)) if *was_present == had_session
-            );
-            if generation != state.checkout_generation || !expected {
+            if generation != state.checkout_generation {
                 return SessionCheckoutStoreResult::Rejected;
             }
-            state.put(address.as_str(), record);
+            let Some((key, SessionEntry::CheckedOut(was_present))) =
+                state.cache.get_key_value(address.as_str())
+            else {
+                return SessionCheckoutStoreResult::Rejected;
+            };
+            if *was_present != had_session {
+                return SessionCheckoutStoreResult::Rejected;
+            }
+            let key = key.clone();
+            state.put_with_key(key, record);
             state.evict_if_needed(self.max_entries);
             return SessionCheckoutStoreResult::Stored;
         }

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1300,7 +1300,9 @@ impl SignalStoreCache {
             && sessions.reservation_pending.is_empty()
         {
             sessions.clear_clean_entries();
-            self.removed_prekeys.lock().await.clear();
+            if sessions.cache.is_empty() {
+                self.removed_prekeys.lock().await.clear();
+            }
         }
         drop(sessions);
 
@@ -2820,6 +2822,7 @@ mod lease_reload_tests {
         cache.flush(&backend).await.expect("flush");
 
         let (record, checkout) = cache.checkout_session(&active, &backend).await.unwrap();
+        cache.remove_prekey(7, active.as_str()).await;
         cache.clear_after_flush().await;
 
         {
@@ -2830,6 +2833,7 @@ mod lease_reload_tests {
             ));
             assert!(!state.cache.contains_key(idle.as_str()));
         }
+        assert!(cache.removed_prekeys.lock().await.contains_key(&7));
         assert!(matches!(
             cache.restore_session_from_checkout(
                 &active,

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as SyncMutex, MutexGuard as SyncMutexGuard};
 
 use anyhow::Result;
 use async_lock::Mutex;
+use portable_atomic::{AtomicBool, AtomicU64, Ordering};
 use rand::RngExt;
 
 use crate::libsignal::protocol::{ProtocolAddress, SenderKeyRecord, SessionRecord};
@@ -81,6 +82,9 @@ fn high_watermark(max_entries: usize) -> usize {
 /// back to `max_entries` (amortized O(1) thanks to the slack early-out).
 pub struct SignalStoreCache {
     sessions: Mutex<SessionStoreState>,
+    session_recovery_generation: AtomicU64,
+    has_pending_session_restores: AtomicBool,
+    pending_session_restores: SyncMutex<Vec<PendingSessionRestore>>,
     identities: Mutex<ByteStoreState>,
     sender_keys: Mutex<SenderKeyStoreState>,
     /// Consumed one-time prekeys buffered for durable deletion, keyed by the
@@ -110,6 +114,7 @@ enum SessionEntry {
 
 struct SessionStoreState {
     incarnation: StoreIncarnation,
+    checkout_generation: u64,
     cache: HashMap<Arc<str>, SessionEntry>,
     dirty: HashSet<Arc<str>>,
     deleted: HashSet<Arc<str>>,
@@ -126,6 +131,7 @@ impl SessionStoreState {
     fn new(incarnation: StoreIncarnation) -> Self {
         Self {
             incarnation,
+            checkout_generation: 0,
             cache: HashMap::new(),
             dirty: HashSet::new(),
             deleted: HashSet::new(),
@@ -142,8 +148,12 @@ impl SessionStoreState {
         }
     }
 
-    fn put(&mut self, address: &str, mut record: SessionRecord) {
+    fn put(&mut self, address: &str, record: SessionRecord) {
         let addr = self.key_for(address);
+        self.put_with_key(addr, record);
+    }
+
+    fn put_with_key(&mut self, addr: Arc<str>, mut record: SessionRecord) {
         // Take over the record's wire gate: the address stays pending until a
         // flush persists it, regardless of later checkout/put round trips.
         if record.has_pending_reservation() {
@@ -172,9 +182,10 @@ impl SessionStoreState {
         self.reservation_pending.clear();
     }
 
-    fn discard(&mut self, incarnation: StoreIncarnation) {
+    fn discard(&mut self, incarnation: StoreIncarnation, generation: u64) {
         self.clear();
         self.incarnation = incarnation;
+        self.checkout_generation = generation;
     }
 
     fn evict_if_needed(&mut self, max_entries: usize) {
@@ -198,6 +209,12 @@ impl SessionStoreState {
             self.cache.remove(&key);
         }
     }
+}
+
+struct PendingSessionRestore {
+    address: Arc<str>,
+    record: SessionRecord,
+    generation: u64,
 }
 
 // === Sender key object cache (same pattern as sessions) ===
@@ -353,12 +370,89 @@ impl SignalStoreCache {
     fn with_max_entries_and_incarnation(max_entries: usize, incarnation: StoreIncarnation) -> Self {
         Self {
             sessions: Mutex::new(SessionStoreState::new(incarnation)),
+            session_recovery_generation: AtomicU64::new(0),
+            has_pending_session_restores: AtomicBool::new(false),
+            pending_session_restores: SyncMutex::new(Vec::new()),
             identities: Mutex::new(ByteStoreState::new()),
             sender_keys: Mutex::new(SenderKeyStoreState::new(incarnation)),
             removed_prekeys: Mutex::new(HashMap::new()),
             sender_key_locks: Mutex::new(HashMap::new()),
             max_entries,
         }
+    }
+
+    fn pending_session_restores(&self) -> SyncMutexGuard<'_, Vec<PendingSessionRestore>> {
+        self.pending_session_restores
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn drain_session_restores(&self, state: &mut SessionStoreState) {
+        if !self.has_pending_session_restores.load(Ordering::Acquire) {
+            return;
+        }
+        let mut pending = self.pending_session_restores();
+        for PendingSessionRestore {
+            address,
+            record,
+            generation,
+        } in pending.drain(..)
+        {
+            if generation != state.checkout_generation {
+                continue;
+            }
+            let address = state
+                .cache
+                .get_key_value(address.as_ref())
+                .map_or(address, |(cached, _)| cached.clone());
+            state.put_with_key(address, record);
+        }
+        self.has_pending_session_restores
+            .store(false, Ordering::Release);
+        state.evict_if_needed(self.max_entries);
+    }
+
+    async fn lock_sessions(&self) -> async_lock::MutexGuard<'_, SessionStoreState> {
+        let mut state = self.sessions.lock().await;
+        self.drain_session_restores(&mut state);
+        state
+    }
+
+    fn try_lock_sessions(&self) -> Option<async_lock::MutexGuard<'_, SessionStoreState>> {
+        let mut state = self.sessions.try_lock()?;
+        self.drain_session_restores(&mut state);
+        Some(state)
+    }
+
+    /// A cancelled owner must return its record without awaiting the contested cache lock.
+    #[doc(hidden)]
+    pub fn restore_session_from_checkout(
+        &self,
+        address: &ProtocolAddress,
+        record: SessionRecord,
+        generation: u64,
+    ) -> bool {
+        if let Some(mut state) = self.try_lock_sessions() {
+            if generation != state.checkout_generation {
+                return false;
+            }
+            state.put(address.as_str(), record);
+            state.evict_if_needed(self.max_entries);
+            return true;
+        }
+
+        let mut pending = self.pending_session_restores();
+        if generation != self.session_recovery_generation.load(Ordering::Acquire) {
+            return false;
+        }
+        pending.push(PendingSessionRestore {
+            address: Arc::from(address.as_str()),
+            record,
+            generation,
+        });
+        self.has_pending_session_restores
+            .store(true, Ordering::Release);
+        true
     }
 
     /// Whether any session or identity is known for `user` (across device ids),
@@ -373,7 +467,7 @@ impl SignalStoreCache {
                 .is_some_and(|rest| rest.starts_with('@') || rest.starts_with(':'))
         }
         {
-            let state = self.sessions.lock().await;
+            let state = self.lock_sessions().await;
             if state.cache.keys().any(|k| matches(k, user)) {
                 return Ok(true);
             }
@@ -396,9 +490,22 @@ impl SignalStoreCache {
         address: &ProtocolAddress,
         backend: &dyn SignalStore,
     ) -> Result<Option<SessionRecord>> {
+        self.checkout_session(address, backend)
+            .await
+            .map(|(record, _)| record)
+    }
+
+    /// The generation prevents a cancelled checkout from surviving a lossy reset.
+    #[doc(hidden)]
+    pub async fn checkout_session(
+        &self,
+        address: &ProtocolAddress,
+        backend: &dyn SignalStore,
+    ) -> Result<(Option<SessionRecord>, u64)> {
         let key = address.as_str();
         {
-            let mut state = self.sessions.lock().await;
+            let mut state = self.lock_sessions().await;
+            let generation = state.checkout_generation;
             if let Some(entry) = state.cache.get_mut(key) {
                 if matches!(entry, SessionEntry::Present(_)) {
                     let SessionEntry::Present(record) =
@@ -408,38 +515,43 @@ impl SignalStoreCache {
                     };
                     // Unique unless a peek's Arc is still alive (short-lived
                     // inspection paths), so this is a move, not a clone.
-                    return Ok(Some(
-                        Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone()),
+                    return Ok((
+                        Some(Arc::try_unwrap(record).unwrap_or_else(|arc| (*arc).clone())),
+                        generation,
                     ));
                 }
-                return Ok(None);
+                return Ok((None, generation));
             }
         }
         // Backend I/O outside the lock
         let backend_result = backend.get_session(key).await?;
-        let mut state = self.sessions.lock().await;
+        let mut state = self.lock_sessions().await;
+        let generation = state.checkout_generation;
         match backend_result {
             Some(bytes) => {
                 if state.cache.contains_key(key) {
                     // Another task populated this slot while we were loading;
                     // defer to whatever they wrote (Present, CheckedOut, etc).
                     // Deserialize and return without caching to avoid conflict.
-                    return Ok(Some(SessionRecord::deserialize_for_store(
-                        &bytes,
-                        &state.incarnation,
-                    )?));
+                    return Ok((
+                        Some(SessionRecord::deserialize_for_store(
+                            &bytes,
+                            &state.incarnation,
+                        )?),
+                        generation,
+                    ));
                 }
                 let record = SessionRecord::deserialize_for_store(&bytes, &state.incarnation)?;
                 state.cache.insert(Arc::from(key), SessionEntry::CheckedOut);
                 state.evict_if_needed(self.max_entries);
-                Ok(Some(record))
+                Ok((Some(record), generation))
             }
             None => {
                 if !state.cache.contains_key(key) {
                     state.cache.insert(Arc::from(key), SessionEntry::Absent);
                     state.evict_if_needed(self.max_entries);
                 }
-                Ok(None)
+                Ok((None, generation))
             }
         }
     }
@@ -453,7 +565,7 @@ impl SignalStoreCache {
     ) -> Result<Option<Arc<SessionRecord>>> {
         let key = address.as_str();
         {
-            let state = self.sessions.lock().await;
+            let state = self.lock_sessions().await;
             if let Some(entry) = state.cache.get(key) {
                 return match entry {
                     SessionEntry::Present(record) => Ok(Some(record.clone())),
@@ -463,7 +575,7 @@ impl SignalStoreCache {
         }
         // Backend I/O outside the lock
         let backend_result = backend.get_session(key).await?;
-        let mut state = self.sessions.lock().await;
+        let mut state = self.lock_sessions().await;
         match backend_result {
             Some(bytes) => {
                 let record = Arc::new(SessionRecord::deserialize_for_store(
@@ -489,7 +601,7 @@ impl SignalStoreCache {
     }
 
     pub async fn put_session(&self, address: &ProtocolAddress, record: SessionRecord) {
-        let mut state = self.sessions.lock().await;
+        let mut state = self.lock_sessions().await;
         state.put(address.as_str(), record);
         state.evict_if_needed(self.max_entries);
     }
@@ -506,7 +618,7 @@ impl SignalStoreCache {
         address: &ProtocolAddress,
         record: SessionRecord,
     ) -> core::result::Result<(), SessionRecord> {
-        match self.sessions.try_lock() {
+        match self.try_lock_sessions() {
             Some(mut state) => {
                 state.put(address.as_str(), record);
                 state.evict_if_needed(self.max_entries);
@@ -520,7 +632,7 @@ impl SignalStoreCache {
     /// knows: `Some` only when the lock is free AND the entry is cached;
     /// `None` sends the caller to the async path (backend consult).
     pub fn try_has_session(&self, address: &ProtocolAddress) -> Option<bool> {
-        let state = self.sessions.try_lock()?;
+        let state = self.try_lock_sessions()?;
         state
             .cache
             .get(address.as_str())
@@ -528,7 +640,7 @@ impl SignalStoreCache {
     }
 
     pub async fn delete_session(&self, address: &ProtocolAddress) {
-        let mut state = self.sessions.lock().await;
+        let mut state = self.lock_sessions().await;
         state.delete(address.as_str());
     }
 
@@ -542,7 +654,7 @@ impl SignalStoreCache {
     ) -> Result<bool> {
         let key = address.as_str();
         {
-            let state = self.sessions.lock().await;
+            let state = self.lock_sessions().await;
             if let Some(entry) = state.cache.get(key) {
                 return Ok(!matches!(entry, SessionEntry::Absent));
             }
@@ -550,7 +662,7 @@ impl SignalStoreCache {
         // Backend I/O outside the lock
         let exists = backend.has_session(key).await?;
         if !exists {
-            let mut state = self.sessions.lock().await;
+            let mut state = self.lock_sessions().await;
             // Re-check: another task may have populated the cache
             if !state.cache.contains_key(key) {
                 state.cache.insert(Arc::from(key), SessionEntry::Absent);
@@ -726,7 +838,7 @@ impl SignalStoreCache {
         // Flush sessions: one batched write for all dirty puts instead of one
         // backend call (and one SQLite transaction) per session.
         {
-            let mut state = self.sessions.lock().await;
+            let mut state = self.lock_sessions().await;
             let incarnation = state.incarnation;
             let dirty_keys: Vec<_> = state.dirty.iter().cloned().collect();
             let deleted_keys: Vec<_> = state.deleted.iter().cloned().collect();
@@ -894,7 +1006,7 @@ impl SignalStoreCache {
     /// everything else (decrypt advances, identities) safely rides the
     /// coalesced write-behind.
     pub async fn needs_pre_wire_flush(&self) -> bool {
-        if !self.sessions.lock().await.reservation_pending.is_empty() {
+        if !self.lock_sessions().await.reservation_pending.is_empty() {
             return true;
         }
         !self.sender_keys.lock().await.wire_gate_pending.is_empty()
@@ -923,7 +1035,7 @@ impl SignalStoreCache {
         // run after each guard drops. Identities are raw bytes (len is free)
         // and stay fully under their lock.
         let (session_count, session_keys_len, session_recs): (u64, usize, Vec<_>) = {
-            let s = self.sessions.lock().await;
+            let s = self.lock_sessions().await;
             let mut keys_len = 0usize;
             let recs = s
                 .cache
@@ -981,7 +1093,18 @@ impl SignalStoreCache {
     }
 
     async fn clear_with_incarnation(&self, incarnation: StoreIncarnation) {
-        self.sessions.lock().await.discard(incarnation);
+        {
+            let mut sessions = self.sessions.lock().await;
+            let mut pending = self.pending_session_restores();
+            let generation = self
+                .session_recovery_generation
+                .fetch_add(1, Ordering::AcqRel)
+                .wrapping_add(1);
+            pending.clear();
+            self.has_pending_session_restores
+                .store(false, Ordering::Release);
+            sessions.discard(incarnation, generation);
+        }
         self.identities.lock().await.clear();
         self.sender_keys.lock().await.discard(incarnation);
         // Drop buffered prekey removals together with the volatile sessions they
@@ -993,7 +1116,7 @@ impl SignalStoreCache {
     /// Only a discard can make a post-flush write's stale snapshot reloadable.
     #[doc(hidden)]
     pub async fn clear_after_flush(&self) {
-        let mut sessions = self.sessions.lock().await;
+        let mut sessions = self.lock_sessions().await;
         if sessions.dirty.is_empty()
             && sessions.deleted.is_empty()
             && sessions.reservation_pending.is_empty()
@@ -1189,6 +1312,50 @@ mod sender_key_lock_tests {
             "released lock must accept try_put_session"
         );
         assert_eq!(cache.try_has_session(&addr), Some(true));
+    }
+
+    #[tokio::test]
+    async fn cancelled_checkout_queues_under_contention_and_remains_flushable() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550008888".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+        let sessions = cache.sessions.lock().await;
+        assert!(cache.restore_session_from_checkout(
+            &addr,
+            record.expect("checked-out record"),
+            generation,
+        ));
+        assert_eq!(cache.pending_session_restores().len(), 1);
+        drop(sessions);
+
+        cache.flush(&backend).await.unwrap();
+        assert!(
+            crate::store::traits::SignalStore::get_session(&backend, addr.as_str())
+                .await
+                .unwrap()
+                .is_some(),
+            "a queued cancellation restore must not strand dirty state"
+        );
+    }
+
+    #[tokio::test]
+    async fn lossy_clear_rejects_an_older_checkout_generation() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let addr = ProtocolAddress::new("15550007777".to_string(), 1.into());
+        cache.put_session(&addr, SessionRecord::new_fresh()).await;
+        let (record, generation) = cache.checkout_session(&addr, &backend).await.unwrap();
+
+        cache.clear().await;
+        assert!(!cache.restore_session_from_checkout(
+            &addr,
+            record.expect("checked-out record"),
+            generation,
+        ));
+        assert!(cache.peek_session(&addr, &backend).await.unwrap().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

`SignalStoreCache` temporarily takes ownership of a session while Signal mutates it. Cancellation during that window could leave only a checkout marker behind, strand ratchet state, or persist a decrypt ratchet advance whose matching identity write never completed. A reset or a newer checkout also needed to be able to reject an older owner unambiguously.

## What changed

- Add a `SessionCheckout` guard that returns owned state synchronously when a protocol future is cancelled.
- Give every checkout a generation plus a unique token, so stale owners cannot overwrite a reset cache or a newer checkout.
- Invalidate recovery before a lossy clear waits for the session lock, and queue restoration only on actual lock contention.
- Preserve live checkouts and their buffered PreKey deletions during post-flush eviction while still releasing other clean entries.
- Treat empty checkouts as absent and prefer a concurrent cache write over stale backend lookup results.
- Defer the common in-order decrypt ratchet advance until identity persistence succeeds; roll back slow/archived decrypts and discard cancelled fresh PreKey promotions.
- Route Signal encrypt, decrypt, PreKey setup, and group preflight mutations through the guard.

The warm uncontended checkout and ordinary in-order decrypt paths remain allocation-free. Snapshot allocation is limited to rare PreKey/archived-session recovery paths.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all --tests`
- `cargo test --workspace --exclude e2e-tests --quiet`
- Both release WASM builds from `.github/workflows/wasm.yml`
- Deterministic tests for cancellation, identity-write suspension, stale-owner ABA, backend/cache races, contention, empty reservations, and lossy resets

Performance checks used separately built binaries:

- Six pinned, alternating microbenchmark pairs: common DM decrypt median 1.475 -> 1.466 us (about -0.6%).
- DHAT over 10,000 DMs: about +0.08% allocated bytes, -1.2% allocation blocks, and identical retained heap (26,214 bytes / 83 blocks) versus the previous PR head. The rollback snapshot itself accounted for 2,868 bytes / 56 blocks across the whole run.
- Normal 100,000-message runs held roughly 2,955 msg/s with zero loss; CPU and RSS stayed within run-to-run variance.
- Earlier base-vs-PR runs kept 200-member group throughput unchanged and reduced DM allocation bytes by about 1.8% and blocks by about 2.6%.

Closes #1038
