### PR TITLE
ci: reclaim runner disk before tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Reclaim unused Android SDK space
+        run: |
+          df -h /
+          sudo rm -rf --one-file-system /usr/local/lib/android
+          df -h /
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-06-16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,11 @@ jobs:
     # workspace recompile with voip on, not the deps. The heavy relay e2e tests stay out of `--lib`.
     steps:
       - uses: actions/checkout@v6
+      - name: Reclaim unused Android SDK space
+        run: |
+          df -h /
+          sudo rm -rf --one-file-system /usr/local/lib/android
+          df -h /
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-06-16


### PR DESCRIPTION
Closes #1046.

## Why

Build & Test started running out of disk on the Ubuntu 20260714.240.1 image. Main failed once and PR #1045 failed twice at different rustc targets, always with No space left on device. The previous image completed the same matrix.

## Change

Remove the unused hosted Android SDK at the start of the two disk-heavy Rust jobs and print disk usage before and after. This leaves the Rust target cache, debug information, commands, and coverage unchanged.

## Validation

- Cleanup increased free space from 89 GiB to 99 GiB in about 20 seconds.
- Build & Test passed in 10m17s; Build & Lint all-features passed in 8m41s.
- All 14 executable checks passed, including E2E, WASM, Binary Size, and CodSpeed.
- Binary size and LLVM-lines metrics are unchanged.