### PR TITLE
perf(signal): reuse leases across ciphertext APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }
+wacore = { workspace = true, features = ["test-util"] }
 wacore-noise = { path = "./wacore/noise", features = [
     "test-util",
     "danger-skip-cert-chain-verify",

--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -73,8 +73,8 @@ impl Client {
     ///
     /// The live receive path schedules a coalesced flush (see `signal_flush.rs`)
     /// instead of writing through, and lease-covered sends do the same. Only a
-    /// send that raises its counter lease — or advances a group sender-key
-    /// chain, which has no lease — flushes synchronously. On success the
+    /// send that raises a session or sender-key counter lease flushes
+    /// synchronously. On success, the
     /// backend normally trails the cache by about the coalescing window, but
     /// that is not a hard wall-clock bound — the timer can slip under runtime
     /// starvation and the flush can wait on locks or slow/failing storage (a
@@ -164,7 +164,7 @@ impl Client {
 
     /// Pre-wire durability gate for the send path. Flushes synchronously only
     /// when an outbound crypto advance actually demands it — a raised session
-    /// counter lease or a sender-key chain advance not yet persisted (see
+    /// counter lease or a raised sender-key lease not yet persisted (see
     /// `SignalStoreCache::needs_pre_wire_flush`). Otherwise the dirty state is
     /// covered by an existing durable lease, so it only needs to land
     /// eventually: it rides the same coalesced write-behind as the receive

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -210,11 +210,10 @@ impl<'a> Signal<'a> {
         )
         .await?;
 
-        // Chain mutation done; the batch-safe flush acquires the processing
-        // permit, and a permit holder can need this sender-key lock — release
-        // it first.
+        // The durability gate can need the processing permit, whose holder may
+        // need this chain lock.
         drop(_chain_guard);
-        self.client.flush_signal_cache_batch_safe().await?;
+        self.client.persist_signal_state_pre_wire().await?;
 
         Ok((skdm_bytes, ciphertext.into_serialized().into_vec()))
     }
@@ -334,7 +333,7 @@ impl<'a> Signal<'a> {
         .await?;
 
         drop(_session_guards);
-        self.client.flush_signal_cache_batch_safe().await?;
+        self.client.persist_signal_state_pre_wire().await?;
 
         Ok((result.participant_nodes, result.includes_prekey_message))
     }
@@ -355,5 +354,135 @@ impl Client {
     /// Access low-level Signal protocol operations.
     pub fn signal(&self) -> Signal<'_> {
         Signal::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    use wacore::store::in_memory::InMemoryBackend;
+    use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+    use wacore_binary::Server;
+
+    use crate::test_utils::seed_peer_session;
+
+    async fn memory_client() -> (Arc<Client>, Arc<InMemoryBackend>) {
+        let backend = Arc::new(InMemoryBackend::new());
+        let client = crate::test_utils::create_test_client_with_backend(backend.clone()).await;
+        client
+            .persistence_manager
+            .process_command(crate::store::commands::DeviceCommand::SetId(Some(
+                Jid::new("15550001000", Server::Pn),
+            )))
+            .await;
+        (client, backend)
+    }
+
+    #[tokio::test]
+    async fn group_encrypt_flushes_only_at_sender_key_lease_boundaries() {
+        use wacore::libsignal::protocol::consts::SENDER_CHAIN_RESERVATION_BATCH;
+
+        let (client, backend) = memory_client().await;
+        let group = Jid::new("120363000000000000", Server::Group);
+
+        let (skdm, _) = client
+            .signal()
+            .encrypt_group_message(&group, b"first")
+            .await
+            .expect("first group encrypt");
+        assert!(skdm.is_some(), "the first encrypt must create an SKDM");
+        assert_eq!(backend.sender_key_batch_write_count(), 1);
+
+        client
+            .signal_flush_test_block
+            .store(true, Ordering::Release);
+        for _ in 1..SENDER_CHAIN_RESERVATION_BATCH {
+            let (skdm, _) = client
+                .signal()
+                .encrypt_group_message(&group, b"warm")
+                .await
+                .expect("lease-covered group encrypt");
+            assert!(skdm.is_none(), "a warm chain must reuse its SKDM");
+        }
+        assert_eq!(
+            backend.sender_key_batch_write_count(),
+            1,
+            "lease-covered iterations must not flush synchronously"
+        );
+
+        client
+            .signal()
+            .encrypt_group_message(&group, b"boundary")
+            .await
+            .expect("boundary group encrypt");
+        assert_eq!(
+            backend.sender_key_batch_write_count(),
+            2,
+            "raising the next lease must flush before returning ciphertext"
+        );
+        client
+            .signal_flush_test_block
+            .store(false, Ordering::Release);
+    }
+
+    #[tokio::test]
+    async fn participant_fanout_reuses_durable_session_leases() {
+        let (client, backend) = memory_client().await;
+        let recipient = Jid::new("15550002000", Server::Pn);
+        client
+            .update_device_list(DeviceListRecord {
+                user: recipient.user.to_string(),
+                devices: vec![
+                    DeviceInfo {
+                        device_id: 0,
+                        key_index: None,
+                    },
+                    DeviceInfo {
+                        device_id: 1,
+                        key_index: None,
+                    },
+                ],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .expect("device registry");
+
+        let devices = [recipient.with_device(0), recipient.with_device(1)];
+        for device in &devices {
+            seed_peer_session(&client, device).await;
+            client
+                .signal()
+                .encrypt_message(device, b"warm lease")
+                .await
+                .expect("lease warmup");
+        }
+        let writes_before = backend.session_batch_write_count();
+
+        client
+            .signal_flush_test_block
+            .store(true, Ordering::Release);
+        let message = waproto::whatsapp::Message {
+            conversation: Some("fanout".into()),
+            ..Default::default()
+        };
+        let (nodes, _) = client
+            .signal()
+            .create_participant_nodes(std::slice::from_ref(&recipient), &message)
+            .await
+            .expect("participant fanout");
+        assert_eq!(nodes.len(), devices.len());
+        assert_eq!(
+            backend.session_batch_write_count(),
+            writes_before,
+            "a warm fanout must not flush durable leases synchronously"
+        );
+        client
+            .signal_flush_test_block
+            .store(false, Ordering::Release);
     }
 }

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1484,10 +1484,9 @@ impl Client {
         // reusing an outbound counter reuses its message key + IV. Counters are
         // leased in batches (see `SessionRecord::reserve_sender_chain_counters`),
         // so most sends are already covered by a durable lease and only
-        // schedule the coalesced write-behind; a send that raised the lease (or
-        // advanced a sender-key chain) flushes synchronously, and a persistence
-        // failure must abort the send rather than transmit an advance we
-        // couldn't save.
+        // schedule the coalesced write-behind; a send that raised either lease
+        // flushes synchronously, and a persistence failure must abort the send
+        // rather than transmit an advance we couldn't save.
         self.persist_signal_state_pre_wire().await?;
 
         let ack = if let Some(phash) = dm_phash

--- a/src/signal_flush.rs
+++ b/src/signal_flush.rs
@@ -12,9 +12,10 @@
 //!   a consumed one-time prekey stays buffered until its session is durable, so
 //!   a crash inside the window is recoverable. The SEND path coalesces too
 //!   whenever its advance is covered by a durable counter lease (see
-//!   `SessionRecord::reserve_sender_chain_counters` and
-//!   `Client::persist_signal_state_pre_wire`); only a send that raises the
-//!   lease — or advances a group sender-key chain — still flushes
+//!   `SessionRecord::reserve_sender_chain_counters`,
+//!   `SenderKeyRecord::reserve_iterations`, and
+//!   `Client::persist_signal_state_pre_wire`); only a send that raises either
+//!   lease still flushes
 //!   synchronously before the wire, because reusing an outbound counter would
 //!   reuse its message key + IV.
 //! - The offline drain, retry recovery, identity-change recovery and teardown

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::Client;
-use wacore_binary::{Node, OwnedNodeRef};
+use wacore_binary::{Jid, Node, OwnedNodeRef};
 
 /// Marshal a `Node` into an `Arc<OwnedNodeRef>` for use in tests.
 pub fn node_to_owned_ref(node: &Node) -> Arc<OwnedNodeRef> {
@@ -104,6 +104,23 @@ pub async fn create_test_client_with_config(
             .expect("test backend should initialize"),
     ) as Arc<dyn Backend>;
 
+    create_test_client_from_backend(backend, http_client, cache_config).await
+}
+
+pub async fn create_test_client_with_backend(backend: Arc<dyn Backend>) -> Arc<Client> {
+    create_test_client_from_backend(
+        backend,
+        Arc::new(MockHttpClient),
+        crate::cache_config::CacheConfig::default(),
+    )
+    .await
+}
+
+async fn create_test_client_from_backend(
+    backend: Arc<dyn Backend>,
+    http_client: Arc<dyn HttpClient>,
+    cache_config: crate::cache_config::CacheConfig,
+) -> Arc<Client> {
     let pm = Arc::new(
         PersistenceManager::new(backend)
             .await
@@ -127,6 +144,49 @@ pub async fn create_test_client_with_config(
     client.enter_live_mode_for_tests();
 
     client
+}
+
+pub async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
+    use wacore::libsignal::protocol::{
+        IdentityKeyPair, KeyPair, PreKeyBundle, SignalProtocolError, UsePQRatchet,
+        process_prekey_bundle,
+    };
+    use wacore::types::jid::JidExt;
+
+    let bundle = tokio::task::spawn_blocking(|| -> Result<PreKeyBundle, SignalProtocolError> {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let receiver = IdentityKeyPair::generate(&mut rng);
+        let spk = KeyPair::generate(&mut rng);
+        let opk = KeyPair::generate(&mut rng);
+        let signature = receiver
+            .private_key()
+            .calculate_signature(&spk.public_key.serialize(), &mut rng)?;
+        PreKeyBundle::new(
+            1,
+            1u32.into(),
+            Some((1u32.into(), opk.public_key)),
+            1u32.into(),
+            spk.public_key,
+            signature.to_vec(),
+            *receiver.identity_key(),
+        )
+    })
+    .await
+    .expect("bundle task")
+    .expect("bundle");
+
+    let mut adapter = client.signal_adapter().await;
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    process_prekey_bundle(
+        &peer.to_protocol_address(),
+        &mut adapter.session_store,
+        &mut adapter.identity_store,
+        &bundle,
+        &mut rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("peer session");
 }
 
 use std::sync::Mutex;

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -554,7 +554,7 @@ async fn place_call(
         .map_err(|e| CallError::Setup(e.to_string()))?;
         drop(_session_guards);
         client
-            .flush_signal_cache_batch_safe()
+            .persist_signal_state_pre_wire()
             .await
             .map_err(|e| CallError::Setup(e.to_string()))?;
         raw
@@ -1713,7 +1713,8 @@ mod tests {
     use wacore_binary::{Jid, Server};
 
     use crate::store::persistence_manager::PersistenceManager;
-    use crate::test_utils::{MockHttpClient, create_test_backend};
+    use crate::store::traits::Backend;
+    use crate::test_utils::{MockHttpClient, create_test_backend, seed_peer_session};
 
     async fn make_client() -> Arc<Client> {
         let client = crate::test_utils::create_test_client().await;
@@ -2220,8 +2221,15 @@ mod tests {
     async fn make_sending_client_with_failure_after(
         failure_after: Option<usize>,
     ) -> (Arc<Client>, Arc<std::sync::atomic::AtomicUsize>) {
-        use wacore::handshake::NoiseCipher;
         let backend = create_test_backend().await;
+        make_sending_client_with_backend(backend, failure_after).await
+    }
+
+    async fn make_sending_client_with_backend(
+        backend: Arc<dyn Backend>,
+        failure_after: Option<usize>,
+    ) -> (Arc<Client>, Arc<std::sync::atomic::AtomicUsize>) {
+        use wacore::handshake::NoiseCipher;
         let pm = PersistenceManager::new(backend).await.expect("pm");
         // Set our own LID so get_lid() resolves (the send-side participant id).
         pm.process_command(crate::store::commands::DeviceCommand::SetLid(Some(
@@ -2278,50 +2286,6 @@ mod tests {
         *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
         client.set_connected_for_test(true);
         (client, count)
-    }
-
-    /// Seed a Signal session for `peer` so encrypt_message yields a real pkmsg (fresh session).
-    async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
-        use wacore::libsignal::protocol::{
-            IdentityKeyPair, KeyPair, PreKeyBundle, SignalProtocolError, UsePQRatchet,
-            process_prekey_bundle,
-        };
-        let bundle =
-            tokio::task::spawn_blocking(|| -> Result<PreKeyBundle, SignalProtocolError> {
-                let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-                let receiver = IdentityKeyPair::generate(&mut rng);
-                let spk = KeyPair::generate(&mut rng);
-                let opk = KeyPair::generate(&mut rng);
-                let sig = receiver
-                    .private_key()
-                    .calculate_signature(&spk.public_key.serialize(), &mut rng)?;
-                PreKeyBundle::new(
-                    1,
-                    1u32.into(),
-                    Some((1u32.into(), opk.public_key)),
-                    1u32.into(),
-                    spk.public_key,
-                    sig.to_vec(),
-                    *receiver.identity_key(),
-                )
-            })
-            .await
-            .expect("bundle task")
-            .expect("bundle");
-
-        use wacore::types::jid::JidExt;
-        let mut adapter = client.signal_adapter().await;
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        process_prekey_bundle(
-            &peer.to_protocol_address(),
-            &mut adapter.session_store,
-            &mut adapter.identity_store,
-            &bundle,
-            &mut rng,
-            UsePQRatchet::No,
-        )
-        .await
-        .expect("peer session");
     }
 
     // The offer-build path for an outgoing call: a fresh callKey is generated, encrypted per device
@@ -2428,6 +2392,57 @@ mod tests {
             !enc.content_bytes().unwrap_or_default().is_empty(),
             "the per-device <enc> must carry the encrypted callKey"
         );
+    }
+
+    #[tokio::test]
+    async fn warm_call_key_fanout_reuses_durable_session_leases() {
+        use wacore::store::in_memory::InMemoryBackend;
+
+        let backend = Arc::new(InMemoryBackend::new());
+        let (client, _) =
+            make_sending_client_with_backend(backend.clone() as Arc<dyn Backend>, None).await;
+        let peer = Jid::new("333333333333333", Server::Lid);
+        let devices = [peer.clone().with_device(0), peer.clone().with_device(1)];
+
+        for device in &devices {
+            seed_peer_session(&client, device).await;
+            client
+                .signal()
+                .encrypt_message(device, b"warm lease")
+                .await
+                .expect("lease warmup");
+        }
+        let writes_before = backend.session_batch_write_count();
+
+        client
+            .signal_flush_test_block
+            .store(true, Ordering::Release);
+        let own_lid = client.get_lid().expect("own lid");
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+        let _handle = place_call(
+            &client,
+            "001234567890abcdef1234567890abcd".into(),
+            &peer,
+            &own_lid,
+            &own_lid,
+            &devices,
+            &devices,
+            Arc::new(mic_rx),
+            Arc::new(spk_tx),
+            None,
+        )
+        .await
+        .expect("warm multi-device call");
+
+        assert_eq!(
+            backend.session_batch_write_count(),
+            writes_before,
+            "a warm call-key fanout must not flush durable leases synchronously"
+        );
+        client
+            .signal_flush_test_block
+            .store(false, Ordering::Release);
     }
 
     // A stored token must ride on the offer as the leading `<privacy>` child, or a

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -132,13 +132,15 @@ impl InMemoryBackend {
         }
     }
 
-    /// Number of `put_sessions_batch` calls since construction.
+    /// Number of `put_sessions_batch` attempts since construction, including
+    /// injected failures.
     #[cfg(any(test, feature = "test-util"))]
     pub fn session_batch_write_count(&self) -> u32 {
         self.session_batch_writes.load(Ordering::Relaxed)
     }
 
-    /// Number of `put_sender_keys_batch` calls since construction.
+    /// Number of `put_sender_keys_batch` attempts since construction, including
+    /// injected failures.
     #[cfg(any(test, feature = "test-util"))]
     pub fn sender_key_batch_write_count(&self) -> u32 {
         self.sender_key_batch_writes.load(Ordering::Relaxed)

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -99,6 +99,10 @@ pub struct InMemoryBackend {
     /// per-call bookkeeping.
     #[cfg(any(test, feature = "test-util"))]
     session_batch_writes: AtomicU32,
+    /// Count of `put_sender_keys_batch` calls. Test hook for sender-key lease
+    /// boundaries; absent from normal builds.
+    #[cfg(any(test, feature = "test-util"))]
+    sender_key_batch_writes: AtomicU32,
     /// When set, `put_sessions_batch` fails. Test hook (see `test-util`): lets a
     /// harness prove the send path aborts (and never hits the wire) when the
     /// ratchet advance cannot be persisted.
@@ -120,6 +124,8 @@ impl InMemoryBackend {
             #[cfg(any(test, feature = "test-util"))]
             session_batch_writes: AtomicU32::new(0),
             #[cfg(any(test, feature = "test-util"))]
+            sender_key_batch_writes: AtomicU32::new(0),
+            #[cfg(any(test, feature = "test-util"))]
             fail_session_writes: AtomicBool::new(false),
             #[cfg(any(test, feature = "test-util"))]
             fail_sender_key_writes: AtomicBool::new(false),
@@ -130,6 +136,12 @@ impl InMemoryBackend {
     #[cfg(any(test, feature = "test-util"))]
     pub fn session_batch_write_count(&self) -> u32 {
         self.session_batch_writes.load(Ordering::Relaxed)
+    }
+
+    /// Number of `put_sender_keys_batch` calls since construction.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn sender_key_batch_write_count(&self) -> u32 {
+        self.sender_key_batch_writes.load(Ordering::Relaxed)
     }
 
     /// Make every subsequent `put_sessions_batch` fail (or stop failing).
@@ -339,6 +351,31 @@ impl SignalStore for InMemoryBackend {
             .await
             .sender_keys
             .insert(address.to_string(), record.to_vec());
+        Ok(())
+    }
+
+    async fn put_sender_keys_batch(&self, sender_keys: &[(Arc<str>, Bytes)]) -> Result<()> {
+        #[cfg(any(test, feature = "test-util"))]
+        {
+            self.sender_key_batch_writes.fetch_add(1, Ordering::Relaxed);
+            if self.fail_sender_key_writes.load(Ordering::Relaxed) {
+                return Err(crate::store::error::StoreError::Io(std::io::Error::other(
+                    "put_sender_keys_batch failing (test hook)",
+                )));
+            }
+        }
+        let mut state = self.state.lock().await;
+        state.sender_keys.reserve(sender_keys.len());
+        for (address, record) in sender_keys {
+            if let Some(stored) = state.sender_keys.get_mut(address.as_ref()) {
+                stored.clear();
+                stored.extend_from_slice(record);
+            } else {
+                state
+                    .sender_keys
+                    .insert(address.to_string(), record.to_vec());
+            }
+        }
         Ok(())
     }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -297,9 +297,10 @@ struct SenderKeyStoreState {
     // `VecDeque<SenderKeyState>` with up to `MAX_MESSAGE_KEYS` message keys each.
     cache: HashMap<Arc<str>, Option<Arc<SenderKeyRecord>>>,
     dirty: HashSet<Arc<str>>,
-    /// Chains advanced by an outbound encrypt and not yet persisted; the send
-    /// path must flush before the wire while any entry is here. Decrypt-side
-    /// dirtiness deliberately does NOT enter this set (it re-derives forward),
+    /// Chains whose outbound iteration lease was raised but not yet persisted;
+    /// the send path must flush before the wire while any entry is here.
+    /// Decrypt-side dirtiness deliberately does NOT enter this set (it
+    /// re-derives forward),
     /// so unrelated group receives never force a sync flush onto a DM send.
     wire_gate_pending: HashSet<Arc<str>>,
 }
@@ -1179,9 +1180,9 @@ impl SignalStoreCache {
     }
 
     /// Whether an outbound ciphertext produced since the last flush is still
-    /// gated on durability: a session counter lease was raised, or a
-    /// sender-key chain advanced via encrypt, and neither has reached the
-    /// backend. The send path flushes synchronously only while this holds;
+    /// gated on durability because a session or sender-key counter lease was
+    /// raised and has not reached the backend. The send path flushes
+    /// synchronously only while this holds;
     /// everything else (decrypt advances, identities) safely rides the
     /// coalesced write-behind.
     pub async fn needs_pre_wire_flush(&self) -> bool {


### PR DESCRIPTION
## Summary

- Route public group encryption, participant-node fanout, and VoIP call-key fanout through the pre-wire lease gate after releasing their Signal locks.
- Keep lease-boundary writes synchronous and fail closed, while lease-covered advances use the existing coalesced write-behind. Decrypt and explicit durability paths keep their full flushes.
- Add write-count regressions for sender-key boundaries, warm participant fanout, and warm VoIP fanout.

## Safety

A ciphertext at a new counter boundary is still returned only after its raised lease is durable. A covered ciphertext can recover after a crash by skipping to the already-persisted ceiling, so it cannot reuse a message key or IV. Running the gate after the per-session or sender-key locks also preserves the existing lock ordering.

## Measured impact

A/B against `c63d949d` with the same real-SQLite harness and alternating runs:

- Warm group encryption, 1,024 calls/sample (`n=16`): **84.69 ms → 23.98 ms** (**-71.7%**).
- Warm participant fanout, 4 recipients × 256 calls/sample (`n=12`): **49.16 ms → 8.69 ms** (**-82.3%**).
- DHAT group run, 4 × 1,024 calls: allocated bytes **19.63 MB → 10.32 MB** (-47.4%), allocation blocks **214,103 → 80,260** (-62.5%), process CPU **0.90 s → 0.47 s**. Peak live allocation was 0.99 MB → 1.12 MB and end-of-run live allocation 0.03 MB → 0.04 MB, so the win is reduced transaction/allocation churn rather than retained-memory reduction.

The boundary regression observes two sender-key batch writes across 65 encryptions: the initial reservation and the next 64-iteration boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings`
- `cargo test --all` (including the complete mock-server E2E suite)
- `cargo test -p wacore store::signal_cache -- --nocapture`
- VoIP lease regression under `voip tokio-native tokio-transport`
- Both wasm32 release builds from `.github/workflows/wasm.yml`

Closes #1040