### PR TITLE
feat(voip): add encoded audio pipeline and native Opus negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,6 +4449,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-channel",
+ "bytes",
  "cpal",
  "env_logger",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,10 +140,8 @@ tokio-runtime = ["dep:tokio"]
 signal = ["tokio-runtime", "tokio/signal"]
 sqlite-storage = ["whatsapp-rust-sqlite-storage"]
 tokio-native = ["tokio-runtime", "tokio/rt-multi-thread"]
-# VoIP calls media plane (opt-in, NOT default): pulls wacore's voip crypto plus the
-# DTLS/SCTP/DataChannel transport (webrtc-rs) and libopus FFI. Not buildable on wasm32/esp32
-# (a compile_error in src/voip/mod.rs enforces this); use wacore's `voip` feature there.
-voip = [
+# Shared native VoIP runtime. Public profiles below select which codec implementation is linked.
+voip-runtime = [
     "wacore/voip",
     "tokio-runtime",
     "tokio/net",
@@ -152,9 +150,16 @@ voip = [
     "dep:webrtc-data",
     "dep:webrtc-util",
     "dep:webrtc-util-011",
-    "dep:opus",
     "dep:rustls",
 ]
+# Backwards-compatible full profile: preserves both codec adapters from the former single feature.
+voip = ["voip-mlow", "voip-libopus"]
+# Codec-bypass profile: raw MLOW/Opus payloads supplied by the application, no codec linked.
+voip-encoded = ["voip-runtime"]
+# Explicit spelling for consumers that assemble feature sets instead of using `voip`.
+voip-mlow = ["voip-runtime", "wacore/voip-mlow"]
+# Optional PCM adapter for standard Opus. Encoded Opus I/O does not need libopus.
+voip-libopus = ["voip-encoded", "dep:opus"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ voip = ["voip-mlow", "voip-libopus"]
 voip-encoded = ["voip-runtime"]
 # Explicit spelling for consumers that assemble feature sets instead of using `voip`.
 voip-mlow = ["voip-runtime", "wacore/voip-mlow"]
-# Optional PCM adapter for standard Opus. Encoded Opus I/O does not need libopus.
+# Optional PCM adapter for standard Opus, including MLOW's CELT escape. Encoded I/O needs no libopus.
 voip-libopus = ["voip-encoded", "dep:opus"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A high-performance, async Rust library for the WhatsApp Web API. Inspired by [wh
 - **Authentication** — QR code pairing, pair code linking, persistent sessions
 - **Messaging** — E2E encrypted (Signal Protocol), 1-on-1 and group chats, editing, reactions, quoting, receipts
 - **Media** — Upload/download images, videos, documents, GIFs, audio with automatic encryption
-- **Voice calls** — 1:1 VoIP audio calls (incoming and outgoing) behind the optional `voip` feature
+- **Voice calls** — 1:1 VoIP audio calls with built-in MLOW or external encoded Opus/MLOW; see the
+  [codec boundary and production profiles](agent_docs/voip_audio_codecs.md)
 - **Groups & Communities** — Create, manage, invite, membership approval, subgroup linking
 - **Newsletters** — Create, join, send messages, reactions
 - **Status** — Text, image, and video status posts with privacy controls

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -17,29 +17,62 @@ built-in MLOW adapter          EncodedAudioSource / Sink
                  WhatsApp relay
 ```
 
-The encoded boundary does not inspect codec bytes. Codec selection still is not arbitrary: the
-selected `AudioFormat` fixes the signaling profile, RTP payload type, RTP clock, and packet cadence
-for the whole call. A format cannot change in the middle of a call.
+The encoded boundary does not transcode codec bytes. It only validates and classifies the MLOW
+profile's standard-Opus escape. Codec selection still is not arbitrary: the selected `AudioFormat`
+fixes the signaling rate, RTP profile, payload type, clock, and packet cadence for the whole call.
+A format cannot change in the middle of a call.
 
 ## Supported profiles
 
-| Format | `<audio rate>` | Codec PCM | Frame | RTP clock | Timestamp step | RTP PT |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `MLOW_16KHZ_60MS` | 16000 | 16 kHz mono | 960 samples / 60 ms | 16 kHz | 960 | 120 |
-| `OPUS_16KHZ_60MS` | 8000 | 16 kHz mono | 960 samples / 60 ms | 48 kHz | 2880 | 111 |
-| `OPUS_RFC7587_48KHZ_60MS` | 8000 | 48 kHz mono | 2880 samples / 60 ms | 48 kHz | 2880 | 111 |
+| Format | RTP profile | `<audio rate>` | Codec PCM | Frame | RTP clock | Step | PT |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `MLOW_16KHZ_60MS` | MLOW | 16000 | 16 kHz mono | 960 / 60 ms | 16 kHz | 960 | 120 |
+| `OPUS_MLOW_16KHZ_60MS` | MLOW escape | 16000 | 16 kHz mono | 960 / 60 ms | 16 kHz | 960 | 120 |
+| `OPUS_16KHZ_60MS` | native Opus | 16000 | 16 kHz mono | 960 / 60 ms | 16 kHz | 960 | 120 |
+| `OPUS_RFC7587_16KHZ_60MS` | RFC 7587 Opus | 16000 | 16 kHz mono | 960 / 60 ms | 48 kHz | 2880 | 111 |
+| `OPUS_RFC7587_48KHZ_60MS` | RFC 7587 Opus | 16000 | 48 kHz mono | 2880 / 60 ms | 48 kHz | 2880 | 111 |
 
-The Opus signaling `rate=8000` is a WhatsApp media-profile selector. It is not the PCM sample rate
-and does not change RFC 7587's 48 kHz RTP clock. MLOW redundancy packets use PT 121; encoded MLOW
-sinks receive the actual PT in `EncodedAudioFrame` so they can distinguish primary and redundant
-payloads.
+`<audio enc="opus">` names the codec family, not the RTP payload profile. The signaling rate also
+does not determine that profile by itself. Capability v1 index 31 gates the codec the peer sends:
+advertising it keeps MLOW available, while omitting it selects the standard-Opus fallback. The
+answer's directional `voip_settings.encode.use_mlow_codec_v1` selects the decoder for media sent by
+the answerer; both sides must agree for full-duplex native Opus. A separate
+`options.enable_48khz_rtp_clock` value selects PT 111 with a 48 kHz RTP clock. When false, both MLOW
+and native Opus use PT 120 with a 16 kHz clock. The serialized capability is
+`version-count | mask-length | mask`, so disabling MLOW changes only bit `0x80` in byte 5 of the
+captured seven-byte blob. MLOW redundancy packets use PT 121. Encoded sinks receive both the actual
+PT and the classified per-packet codec in
+`EncodedAudioFrame`, because a MLOW-profile peer may send proprietary MLOW while our source sends
+standard Opus through its escape.
+
+The server-forwarded 1:1 offer can carry a large `<voip_settings uncompressed="1">` JSON object.
+The Android receive path first loads its local defaults and then overlays only fields present in the
+peer's answer. A native-Opus accept therefore sends a minimal, static settings object containing
+`encode.use_mlow_codec_v1` and `options.enable_48khz_rtp_clock`; copying and reparsing the peer's
+rollout settings is unnecessary. The native parser rejects compressed VoIP settings on this path,
+so the answer explicitly marks this small JSON as uncompressed.
 
 Outgoing calls advertise exactly the selected rate. Incoming calls can select only a rate present
 in the offer. A peer that later preaccepts or accepts with a different rate produces
 `CallEvent::AudioFormatMismatch` and the call is terminated instead of decoding with the wrong
-codec. Payload bytes are deliberately not used to select the call profile because valid Opus and
-MLOW TOCs overlap. After MLOW has been negotiated, its own standard-Opus escape remains supported;
-the PCM path surfaces those packets as `CallEvent::ForeignAudio` for an optional Opus decoder.
+codec. Payload bytes are not used to select the call profile. Once MLOW is negotiated, PT 120 bytes
+starting with `0b11` are its standard-Opus/CELT escape; PT 121 remains MLOW RED even when its RED
+header starts with the same bits. The PCM path surfaces escaped packets as `CallEvent::ForeignAudio`
+for an optional Opus decoder.
+
+For the escape, the source must produce CELT-only Opus. MLOW uses its own CELT TOC rather than the
+RFC Opus TOC; `packetize_opus_for_mlow` rewrites it without transcoding and without allocating for
+the common one-frame and arbitrary-frame packet forms. The inverse `depacketize_opus_from_mlow`
+prepares an inbound escape for a stock Opus decoder. The included libopus adapter does both and uses
+16 kHz wideband restricted-low-delay mode, avoiding an otherwise unnecessary 16→48 kHz resample.
+
+DTX is part of that profile boundary. Stock libopus may represent a 60 ms DTX interval as the
+two-byte RFC packet `BB 03`; sending only a rewritten CELT TOC would set MLOW's VAD bit and make the
+receiver consume the RTP speech marker while the payload still contains silence. The packetizer
+therefore maps libopus DTX packets of at most two bytes to MLOW's one-byte SID `90`. The RTP stream
+re-arms its speech latch on SID/DTX, so the first subsequent coded voice packet carries the marker.
+An external Opus producer should enable DTX; passing every packet through
+`packetize_opus_for_mlow` applies the same mapping.
 
 ## Cargo profiles
 
@@ -73,7 +106,7 @@ let (playout_tx, playout_rx) = async_channel::bounded::<EncodedAudioFrame>(3);
 let call = client
     .voip()
     .call(&peer)
-    .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, encoded_rx, playout_tx)
+    .encoded_audio(AudioFormat::OPUS_MLOW_16KHZ_60MS, encoded_rx, playout_tx)
     .start()
     .await?;
 
@@ -92,24 +125,26 @@ FFmpeg can be used without linking a Rust codec library, but its output framing 
   `encoded_audio`.
 - An FFmpeg RTP output already contains RTP headers. The application must parse it and extract each
   raw Opus payload because this core creates the WhatsApp RTP/SRTP packet itself.
-- A libavcodec integration can read each encoded `AVPacket` directly and pass its payload as one
-  `Bytes` item.
+- A libavcodec integration can read each encoded `AVPacket` directly. For
+  `OPUS_MLOW_16KHZ_60MS`, configure 16 kHz mono CELT/WB with 60 ms packets, call
+  `packetize_opus_for_mlow` on each packet, then pass it as `Bytes`.
 - A child-process adapter can define a small length-prefixed IPC protocol around raw packets. This
   avoids a linked codec dependency but adds process supervision, IPC copies, and another failure
   boundary.
 - For the built-in MLOW path, FFmpeg can decode or resample input to signed 16-bit, mono, 16 kHz PCM;
   the application chunks exactly 960 samples and sends those frames through `audio(...)`.
 
-Opus cannot be transformed into MLOW by rewriting a header. They are different codecs. Conversion
-must decode Opus to PCM and encode that PCM as MLOW:
+Compatible CELT Opus needs only the reversible MLOW packet-header rewrite. Arbitrary Opus cannot be
+made compatible that way. A SILK/Hybrid packet must be decoded and re-encoded as CELT, or
+transcoded all the way to proprietary MLOW:
 
 ```text
 raw Opus → Opus decoder → 16 kHz mono PCM → MLOW encoder → raw MLOW
 ```
 
-That conversion costs CPU, adds latency, and introduces another lossy generation. Prefer negotiating
-the codec already produced by the source. FFmpeg has standard Opus support but no MLOW codec, so the
-last step requires this project's MLOW encoder or another compatible implementation.
+That conversion costs CPU, adds latency, and introduces another lossy generation. Prefer producing
+compatible CELT at the source. FFmpeg has standard Opus support but no MLOW codec, so the last step
+requires this project's MLOW encoder or another compatible implementation.
 
 ## Interoperability evidence
 
@@ -117,18 +152,36 @@ The profile mapping was checked against the locally decompiled Android media spl
 artifacts, without copying proprietary implementation code:
 
 - The Android media registration path distinguishes `use_mlow_codec` from RTP clock selection.
-- The MLOW profile registers PT 120 and normally uses a 16 kHz RTP clock; an experiment flag can
-  select a 48 kHz clock.
-- The standard Opus profile registers PT 111 and uses a 48 kHz RTP clock.
+- Codec registration and RTP-clock selection are independent: disabling MLOW can produce native
+  Opus on PT 120 with a 16 kHz clock.
+- `enable_48khz_rtp_clock` switches the native Opus path to PT 111 with a 48 kHz RTP clock; the
+  server-provided setting was false in the live Android negotiation.
 - PT 121 is registered as `mlow-red-1`.
 - Audio capability intersection is performed before preaccept/accept, confirming that the signaling
   rate must be preserved rather than discarded.
+- Capability v1 index 31 controls `use_mlow_codec`: the official peer clears that media parameter
+  when the bit is absent and recreates the audio stream if the effective value changes.
+- The current Android `accept` handler stores an incoming settings object before intersecting device
+  capabilities, then reapplies the selected VoIP parameters and recreates transport/media state.
+- The current Android NetEQ registration chooses `mlow-1` or `opus` directly from the effective
+  `use_mlow_codec` value; payload inspection is not the negotiation mechanism.
 - Android/Web artifacts contain separate MLOW and standard Opus decoder paths, which confirms that a
   payload-content heuristic is not a valid negotiation mechanism.
+- The current Android APK's Ghidra project confirms that MLOW mode selects `mlow_packet_parse`, sets
+  the MLOW control on both libopus encoder and decoder, and still decodes escaped packets through
+  `opus_decode`.
+- The negotiated settings request one-byte DTX frames and a speech-resume RTP marker. The WebAssembly
+  receiver independently contains marker-controlled DTX-exit state, matching the SID/marker behavior
+  above.
+- A live Android call answered with `rate=8000` tore down its audio devices before sending RTP.
+  With `rate=16000` and MLOW capability 31 cleared, media remained connected and the peer sent PT
+  120. This confirms the native Opus/PT 120 combination selected by the decompiled media path.
+- In that connected call the Android RTCP receiver reports acknowledged the outbound audio SSRC
+  without loss while playout stayed silent. Together with the decoder-selection path above, this
+  distinguishes a directional negotiation mismatch from RTP, SRTP, relay, volume, or routing loss.
 
-The corresponding local research points are in
-`wa-apk-re/decompiled-split-v2/04_wa_media.c`, `09_handlers.c`, and the captured WebAssembly/JavaScript
-artifacts under the sibling reverse-engineering projects.
+The corresponding local research points are in the current `wa-apk-re/ghidra-project` and the
+captured WebAssembly/JavaScript artifacts under the sibling reverse-engineering projects.
 
 ## MLOW versus Opus
 
@@ -136,11 +189,18 @@ MLOW keeps the entire PCM codec path pure Rust and matches the newer WhatsApp-sp
 has no external runtime dependency, but it contributes substantially more code and its
 analysis-by-synthesis encoder is CPU/allocation heavy.
 
-Standard Opus has a mature tool ecosystem and lets the Rust core omit both codecs when another
-component already produces packets. Linking `voip-libopus` is convenient, while an FFmpeg process
-keeps the Rust dependency graph smaller at the cost of operational complexity. The `rate=8000`/PT
-111 path is supported by the official artifacts, but it should still be canaried against the current
-Android/iOS population before becoming the default.
+Standard Opus has a mature tool ecosystem and lets the Rust core omit the outbound codec when
+another component already produces compatible packets. Linking `voip-libopus` is convenient, while
+an FFmpeg process keeps the Rust dependency graph smaller at the cost of operational complexity.
+Clearing MLOW capability 31 selects the native Opus codec; it does not itself select PT 111. The
+default observed path remains PT 120/16 kHz, while the independent 48 kHz-clock setting selects the
+RFC 7587 PT 111 variant. The bundled libopus adapter follows the observed 60 ms, 24 kbps, DTX, and
+complexity-5 configuration so its CPU cost and packet behavior track the official sender more
+closely.
+
+The escape is asymmetric: a peer that negotiated the MLOW profile can still send proprietary MLOW
+inbound. An Opus-only binary keeps the call alive and exposes those packets, but needs an external
+MLOW decoder for full-duplex playout.
 
 Transcoding Opus to MLOW combines the disadvantages of both paths and should be a compatibility
 fallback, not the normal architecture.
@@ -161,6 +221,8 @@ The VoIP CLI can switch codecs without changing the call flow:
 # One binary containing both variants
 WA_AUDIO_CODEC=mlow cargo run -p whatsapp-rust-voip-cli --release -- listen accept
 WA_AUDIO_CODEC=opus cargo run -p whatsapp-rust-voip-cli --release -- listen accept
+WA_AUDIO_CODEC=opus WA_AUDIO_PROFILE=mlow \
+  cargo run -p whatsapp-rust-voip-cli --release -- listen accept # MLOW escape diagnostic
 
 # Binaries proving that the unused codec is absent
 WA_AUDIO_CODEC=mlow cargo run -p whatsapp-rust-voip-cli --release \

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -1,0 +1,182 @@
+# VoIP audio codec boundary
+
+The VoIP media core owns call signaling, RTP timing, SRTP/WARP protection, relay transport, and
+receive statistics. Codec work is optional. An application can either use the built-in PCM/MLOW
+path or exchange complete encoded payloads through `encoded_audio`.
+
+```text
+PCM application                 Encoded application
+     │                                  │ raw codec packet
+     ▼                                  ▼
+built-in MLOW adapter          EncodedAudioSource / Sink
+     │                                  │
+     └──────── codec payload ────────────┘
+                        │
+                  RTP + SRTP/WARP
+                        │
+                 WhatsApp relay
+```
+
+The encoded boundary does not inspect codec bytes. Codec selection still is not arbitrary: the
+selected `AudioFormat` fixes the signaling profile, RTP payload type, RTP clock, and packet cadence
+for the whole call. A format cannot change in the middle of a call.
+
+## Supported profiles
+
+| Format | `<audio rate>` | Codec PCM | Frame | RTP clock | Timestamp step | RTP PT |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `MLOW_16KHZ_60MS` | 16000 | 16 kHz mono | 960 samples / 60 ms | 16 kHz | 960 | 120 |
+| `OPUS_16KHZ_60MS` | 8000 | 16 kHz mono | 960 samples / 60 ms | 48 kHz | 2880 | 111 |
+| `OPUS_RFC7587_48KHZ_60MS` | 8000 | 48 kHz mono | 2880 samples / 60 ms | 48 kHz | 2880 | 111 |
+
+The Opus signaling `rate=8000` is a WhatsApp media-profile selector. It is not the PCM sample rate
+and does not change RFC 7587's 48 kHz RTP clock. MLOW redundancy packets use PT 121; encoded MLOW
+sinks receive the actual PT in `EncodedAudioFrame` so they can distinguish primary and redundant
+payloads.
+
+Outgoing calls advertise exactly the selected rate. Incoming calls can select only a rate present
+in the offer. A peer that later preaccepts or accepts with a different rate produces
+`CallEvent::AudioFormatMismatch` and the call is terminated instead of decoding with the wrong
+codec. Payload bytes are deliberately not used to select the call profile because valid Opus and
+MLOW TOCs overlap. After MLOW has been negotiated, its own standard-Opus escape remains supported;
+the PCM path surfaces those packets as `CallEvent::ForeignAudio` for an optional Opus decoder.
+
+## Cargo profiles
+
+The former `voip` feature remains the compatibility profile and includes the native runtime, MLOW,
+and the optional libopus helpers. Smaller deployments can select only what they use:
+
+| Feature | Contents |
+| --- | --- |
+| `voip-encoded` | Native relay/runtime and raw encoded I/O; no audio codec implementation |
+| `voip-mlow` | Native relay/runtime plus the pure-Rust PCM/MLOW adapter |
+| `voip-libopus` | Encoded runtime plus `WaOpusEncoder`/`WaOpusDecoder` backed by libopus |
+| `voip` | Compatibility aggregate: `voip-mlow` + `voip-libopus` |
+| `wacore/voip` | Runtime-agnostic media crypto, RTP, engine, and encoded I/O |
+| `wacore/voip-mlow` | `wacore/voip` plus the pure-Rust MLOW codec |
+
+An application that already has Opus packets needs only `voip-encoded`; it does not need libopus or
+the MLOW implementation in its dependency graph.
+
+## Encoded API
+
+The source sends one complete raw codec packet per item, paced at the format's 60 ms cadence. The
+sink receives one decrypted packet plus its RTP metadata.
+
+```rust,ignore
+use bytes::Bytes;
+use whatsapp_rust::voip::{AudioFormat, EncodedAudioFrame};
+
+let (encoded_tx, encoded_rx) = async_channel::bounded::<Bytes>(3);
+let (playout_tx, playout_rx) = async_channel::bounded::<EncodedAudioFrame>(3);
+
+let call = client
+    .voip()
+    .call(&peer)
+    .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, encoded_rx, playout_tx)
+    .start()
+    .await?;
+
+// Producer: encode one PCM frame, then send Bytes containing only the Opus packet.
+// Consumer: decode frame.data; frame.timestamp/PT remain available for diagnostics.
+```
+
+`Bytes` avoids another copy when ownership crosses the application/core boundary. RTP/SRTP output
+still requires a protected packet buffer.
+
+## FFmpeg and external converters
+
+FFmpeg can be used without linking a Rust codec library, but its output framing matters:
+
+- `ffmpeg ... -f opus pipe:1` emits an Ogg Opus stream. Ogg pages must not be sent to
+  `encoded_audio`.
+- An FFmpeg RTP output already contains RTP headers. The application must parse it and extract each
+  raw Opus payload because this core creates the WhatsApp RTP/SRTP packet itself.
+- A libavcodec integration can read each encoded `AVPacket` directly and pass its payload as one
+  `Bytes` item.
+- A child-process adapter can define a small length-prefixed IPC protocol around raw packets. This
+  avoids a linked codec dependency but adds process supervision, IPC copies, and another failure
+  boundary.
+- For the built-in MLOW path, FFmpeg can decode or resample input to signed 16-bit, mono, 16 kHz PCM;
+  the application chunks exactly 960 samples and sends those frames through `audio(...)`.
+
+Opus cannot be transformed into MLOW by rewriting a header. They are different codecs. Conversion
+must decode Opus to PCM and encode that PCM as MLOW:
+
+```text
+raw Opus → Opus decoder → 16 kHz mono PCM → MLOW encoder → raw MLOW
+```
+
+That conversion costs CPU, adds latency, and introduces another lossy generation. Prefer negotiating
+the codec already produced by the source. FFmpeg has standard Opus support but no MLOW codec, so the
+last step requires this project's MLOW encoder or another compatible implementation.
+
+## Interoperability evidence
+
+The profile mapping was checked against the locally decompiled Android media split and captured Web
+artifacts, without copying proprietary implementation code:
+
+- The Android media registration path distinguishes `use_mlow_codec` from RTP clock selection.
+- The MLOW profile registers PT 120 and normally uses a 16 kHz RTP clock; an experiment flag can
+  select a 48 kHz clock.
+- The standard Opus profile registers PT 111 and uses a 48 kHz RTP clock.
+- PT 121 is registered as `mlow-red-1`.
+- Audio capability intersection is performed before preaccept/accept, confirming that the signaling
+  rate must be preserved rather than discarded.
+- Android/Web artifacts contain separate MLOW and standard Opus decoder paths, which confirms that a
+  payload-content heuristic is not a valid negotiation mechanism.
+
+The corresponding local research points are in
+`wa-apk-re/decompiled-split-v2/04_wa_media.c`, `09_handlers.c`, and the captured WebAssembly/JavaScript
+artifacts under the sibling reverse-engineering projects.
+
+## MLOW versus Opus
+
+MLOW keeps the entire PCM codec path pure Rust and matches the newer WhatsApp-specific profile. It
+has no external runtime dependency, but it contributes substantially more code and its
+analysis-by-synthesis encoder is CPU/allocation heavy.
+
+Standard Opus has a mature tool ecosystem and lets the Rust core omit both codecs when another
+component already produces packets. Linking `voip-libopus` is convenient, while an FFmpeg process
+keeps the Rust dependency graph smaller at the cost of operational complexity. The `rate=8000`/PT
+111 path is supported by the official artifacts, but it should still be canaried against the current
+Android/iOS population before becoming the default.
+
+Transcoding Opus to MLOW combines the disadvantages of both paths and should be a compatibility
+fallback, not the normal architecture.
+
+## Video scope
+
+Video already accepts externally encoded access units, so encoding can live in FFmpeg or another
+process. It is not codec-agnostic on the wire yet: signaling, packetization, depacketization, and PT
+97 currently target H.264 Annex-B. Supporting another video codec requires a negotiated
+`VideoFormat` plus a packetizer/depacketizer for that codec; swapping only the external encoder is
+not sufficient.
+
+## Production comparison
+
+The VoIP CLI can switch codecs without changing the call flow:
+
+```bash
+# One binary containing both variants
+WA_AUDIO_CODEC=mlow cargo run -p whatsapp-rust-voip-cli --release -- listen accept
+WA_AUDIO_CODEC=opus cargo run -p whatsapp-rust-voip-cli --release -- listen accept
+
+# Binaries proving that the unused codec is absent
+WA_AUDIO_CODEC=mlow cargo run -p whatsapp-rust-voip-cli --release \
+  --no-default-features --features voip-mlow -- listen accept
+WA_AUDIO_CODEC=opus cargo run -p whatsapp-rust-voip-cli --release \
+  --no-default-features --features voip-opus -- listen accept
+```
+
+Compare at least call-setup success, format mismatches, first-audio latency, CPU time, peak RSS,
+microphone drops, playout underruns, RTP loss/jitter, and subjective quality. Keep the codec fixed for
+the call; if a cohort fails, roll back on the next call rather than attempting an in-call format
+switch.
+
+The MLOW realtime path reuses its sanitization, range-coder, encoded-output, VAD, and history
+buffers. The pitch estimator also avoids short-lived per-subframe arrays. The allocation benchmark
+for the varied voiced stream moved from 673 allocations / about 494.7 KB per encode to 627
+allocations / about 456.5 KB on the engine-style reused-output path. Continue treating CPU numbers
+as benchmark-host-specific; the byte-exact and reverse-engineering ground-truth tests guard codec
+behavior.

--- a/agent_docs/voip_audio_codecs.md
+++ b/agent_docs/voip_audio_codecs.md
@@ -1,100 +1,71 @@
-# VoIP audio codec boundary
+# VoIP audio codecs
 
-The VoIP media core owns call signaling, RTP timing, SRTP/WARP protection, relay transport, and
-receive statistics. Codec work is optional. An application can either use the built-in PCM/MLOW
-path or exchange complete encoded payloads through `encoded_audio`.
+The media core owns signaling, RTP timing, SRTP/WARP, relay transport, and receive statistics.
+Applications may use the built-in PCM/MLOW path or exchange complete codec packets through
+`encoded_audio`.
 
 ```text
-PCM application                 Encoded application
-     │                                  │ raw codec packet
-     ▼                                  ▼
-built-in MLOW adapter          EncodedAudioSource / Sink
-     │                                  │
-     └──────── codec payload ────────────┘
-                        │
-                  RTP + SRTP/WARP
-                        │
-                 WhatsApp relay
+PCM source ── MLOW adapter ──┐
+                             ├── RTP + SRTP/WARP ── WhatsApp relay
+encoded source/sink ─────────┘
 ```
 
-The encoded boundary does not transcode codec bytes. It only validates and classifies the MLOW
-profile's standard-Opus escape. Codec selection still is not arbitrary: the selected `AudioFormat`
-fixes the signaling rate, RTP profile, payload type, clock, and packet cadence for the whole call.
-A format cannot change in the middle of a call.
+The encoded boundary does not transcode. `AudioFormat` fixes the codec profile, payload type, RTP
+clock, and 60 ms packet cadence for the call.
 
-## Supported profiles
+## Profiles
 
-| Format | RTP profile | `<audio rate>` | Codec PCM | Frame | RTP clock | Step | PT |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `MLOW_16KHZ_60MS` | MLOW | 16000 | 16 kHz mono | 960 / 60 ms | 16 kHz | 960 | 120 |
-| `OPUS_MLOW_16KHZ_60MS` | MLOW escape | 16000 | 16 kHz mono | 960 / 60 ms | 16 kHz | 960 | 120 |
-| `OPUS_16KHZ_60MS` | native Opus | 16000 | 16 kHz mono | 960 / 60 ms | 16 kHz | 960 | 120 |
-| `OPUS_RFC7587_16KHZ_60MS` | RFC 7587 Opus | 16000 | 16 kHz mono | 960 / 60 ms | 48 kHz | 2880 | 111 |
-| `OPUS_RFC7587_48KHZ_60MS` | RFC 7587 Opus | 16000 | 48 kHz mono | 2880 / 60 ms | 48 kHz | 2880 | 111 |
+| Format | Profile | PCM | RTP clock / step | PT |
+| --- | --- | ---: | ---: | ---: |
+| `MLOW_16KHZ_60MS` | MLOW | 16 kHz mono | 16 kHz / 960 | 120 |
+| `OPUS_MLOW_16KHZ_60MS` | Opus CELT in MLOW | 16 kHz mono | 16 kHz / 960 | 120 |
+| `OPUS_16KHZ_60MS` | Native Opus | 16 kHz mono | 16 kHz / 960 | 120 |
+| `OPUS_RFC7587_16KHZ_60MS` | Native Opus | 16 kHz mono | 48 kHz / 2880 | 111 |
+| `OPUS_RFC7587_48KHZ_60MS` | Native Opus | 48 kHz mono | 48 kHz / 2880 | 111 |
 
-`<audio enc="opus">` names the codec family, not the RTP payload profile. The signaling rate also
-does not determine that profile by itself. Capability v1 index 31 gates the codec the peer sends:
-advertising it keeps MLOW available, while omitting it selects the standard-Opus fallback. The
-answer's directional `voip_settings.encode.use_mlow_codec_v1` selects the decoder for media sent by
-the answerer; both sides must agree for full-duplex native Opus. A separate
-`options.enable_48khz_rtp_clock` value selects PT 111 with a 48 kHz RTP clock. When false, both MLOW
-and native Opus use PT 120 with a 16 kHz clock. The serialized capability is
-`version-count | mask-length | mask`, so disabling MLOW changes only bit `0x80` in byte 5 of the
-captured seven-byte blob. MLOW redundancy packets use PT 121. Encoded sinks receive both the actual
-PT and the classified per-packet codec in
-`EncodedAudioFrame`, because a MLOW-profile peer may send proprietary MLOW while our source sends
-standard Opus through its escape.
+All current profiles signal `<audio enc="opus" rate="16000">`. The rate alone does not select the
+RTP profile.
 
-The server-forwarded 1:1 offer can carry a large `<voip_settings uncompressed="1">` JSON object.
-The Android receive path first loads its local defaults and then overlays only fields present in the
-peer's answer. A native-Opus accept therefore sends a minimal, static settings object containing
-`encode.use_mlow_codec_v1` and `options.enable_48khz_rtp_clock`; copying and reparsing the peer's
-rollout settings is unnecessary. The native parser rejects compressed VoIP settings on this path,
-so the answer explicitly marks this small JSON as uncompressed.
+## Negotiation
 
-Outgoing calls advertise exactly the selected rate. Incoming calls can select only a rate present
-in the offer. A peer that later preaccepts or accepts with a different rate produces
-`CallEvent::AudioFormatMismatch` and the call is terminated instead of decoding with the wrong
-codec. Payload bytes are not used to select the call profile. Once MLOW is negotiated, PT 120 bytes
-starting with `0b11` are its standard-Opus/CELT escape; PT 121 remains MLOW RED even when its RED
-header starts with the same bits. The PCM path surfaces escaped packets as `CallEvent::ForeignAudio`
-for an optional Opus decoder.
+MLOW capability index 31 controls the codec sent by the peer. Native Opus clears that bit and sends
+this minimal uncompressed settings overlay in the answer:
 
-For the escape, the source must produce CELT-only Opus. MLOW uses its own CELT TOC rather than the
-RFC Opus TOC; `packetize_opus_for_mlow` rewrites it without transcoding and without allocating for
-the common one-frame and arbitrary-frame packet forms. The inverse `depacketize_opus_from_mlow`
-prepares an inbound escape for a stock Opus decoder. The included libopus adapter does both and uses
-16 kHz wideband restricted-low-delay mode, avoiding an otherwise unnecessary 16→48 kHz resample.
+```json
+{
+  "encode": { "use_mlow_codec_v1": "false" },
+  "options": { "enable_48khz_rtp_clock": "false" }
+}
+```
 
-DTX is part of that profile boundary. Stock libopus may represent a 60 ms DTX interval as the
-two-byte RFC packet `BB 03`; sending only a rewritten CELT TOC would set MLOW's VAD bit and make the
-receiver consume the RTP speech marker while the payload still contains silence. The packetizer
-therefore maps libopus DTX packets of at most two bytes to MLOW's one-byte SID `90`. The RTP stream
-re-arms its speech latch on SID/DTX, so the first subsequent coded voice packet carries the marker.
-An external Opus producer should enable DTX; passing every packet through
-`packetize_opus_for_mlow` applies the same mapping.
+The capability selects the peer's encoder; `use_mlow_codec_v1` selects its decoder for the reverse
+direction. Both are required for full-duplex native Opus. `enable_48khz_rtp_clock=true` independently
+selects PT 111 and the 48 kHz RTP clock; the production default is PT 120 at 16 kHz.
 
-## Cargo profiles
+Incoming calls reject a locally selected rate absent from the offer. A later incompatible
+preaccept/accept emits `CallEvent::AudioFormatMismatch` and terminates the call. Codec detection never
+overrides the negotiated RTP profile.
 
-The former `voip` feature remains the compatibility profile and includes the native runtime, MLOW,
-and the optional libopus helpers. Smaller deployments can select only what they use:
+The PT120 native-Opus path was verified against Android/Web implementations and with a live
+full-duplex Android call. MLOW remains the compatibility default.
+
+## Cargo features
 
 | Feature | Contents |
 | --- | --- |
-| `voip-encoded` | Native relay/runtime and raw encoded I/O; no audio codec implementation |
-| `voip-mlow` | Native relay/runtime plus the pure-Rust PCM/MLOW adapter |
-| `voip-libopus` | Encoded runtime plus `WaOpusEncoder`/`WaOpusDecoder` backed by libopus |
-| `voip` | Compatibility aggregate: `voip-mlow` + `voip-libopus` |
-| `wacore/voip` | Runtime-agnostic media crypto, RTP, engine, and encoded I/O |
-| `wacore/voip-mlow` | `wacore/voip` plus the pure-Rust MLOW codec |
+| `voip-encoded` | Native relay/runtime and encoded I/O; no audio codec |
+| `voip-mlow` | Runtime plus the pure-Rust PCM/MLOW adapter |
+| `voip-libopus` | Encoded runtime plus the optional libopus adapter |
+| `voip` | Compatibility aggregate: MLOW + libopus |
+| `wacore/voip` | Runtime-agnostic media engine and encoded I/O |
+| `wacore/voip-mlow` | Core media engine plus MLOW |
 
-An application that already has Opus packets needs only `voip-encoded`; it does not need libopus or
-the MLOW implementation in its dependency graph.
+An application that already produces raw Opus packets needs only `voip-encoded`.
 
 ## Encoded API
 
-The source sends one complete raw codec packet per item, paced at the format's 60 ms cadence. The
-sink receives one decrypted packet plus its RTP metadata.
+The source sends one complete raw codec packet per `Bytes`, paced every 60 ms. The sink receives the
+decrypted packet and its RTP metadata.
 
 ```rust,ignore
 use bytes::Bytes;
@@ -106,139 +77,49 @@ let (playout_tx, playout_rx) = async_channel::bounded::<EncodedAudioFrame>(3);
 let call = client
     .voip()
     .call(&peer)
-    .encoded_audio(AudioFormat::OPUS_MLOW_16KHZ_60MS, encoded_rx, playout_tx)
+    .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, encoded_rx, playout_tx)
     .start()
     .await?;
-
-// Producer: encode one PCM frame, then send Bytes containing only the Opus packet.
-// Consumer: decode frame.data; frame.timestamp/PT remain available for diagnostics.
 ```
 
-`Bytes` avoids another copy when ownership crosses the application/core boundary. RTP/SRTP output
-still requires a protected packet buffer.
+Container data is not accepted. Ogg pages from `ffmpeg -f opus` must be demuxed; FFmpeg RTP output
+must have its RTP header removed because this core creates and protects the WhatsApp RTP packet.
+libavcodec integrations can pass each raw `AVPacket` directly.
 
-## FFmpeg and external converters
+`OPUS_MLOW_16KHZ_60MS` requires CELT-only Opus. Run each packet through
+`packetize_opus_for_mlow`; the reverse path uses `depacketize_opus_from_mlow`. These helpers rewrite
+only the packet header. SILK/Hybrid Opus requires decode/re-encode, and arbitrary Opus-to-MLOW
+conversion requires full transcoding.
 
-FFmpeg can be used without linking a Rust codec library, but its output framing matters:
+The libopus adapter uses the observed 16 kHz mono, 60 ms, 24 kbps, complexity-5, DTX configuration.
+It maps short Opus DTX packets to MLOW SID when the escape profile is selected.
 
-- `ffmpeg ... -f opus pipe:1` emits an Ogg Opus stream. Ogg pages must not be sent to
-  `encoded_audio`.
-- An FFmpeg RTP output already contains RTP headers. The application must parse it and extract each
-  raw Opus payload because this core creates the WhatsApp RTP/SRTP packet itself.
-- A libavcodec integration can read each encoded `AVPacket` directly. For
-  `OPUS_MLOW_16KHZ_60MS`, configure 16 kHz mono CELT/WB with 60 ms packets, call
-  `packetize_opus_for_mlow` on each packet, then pass it as `Bytes`.
-- A child-process adapter can define a small length-prefixed IPC protocol around raw packets. This
-  avoids a linked codec dependency but adds process supervision, IPC copies, and another failure
-  boundary.
-- For the built-in MLOW path, FFmpeg can decode or resample input to signed 16-bit, mono, 16 kHz PCM;
-  the application chunks exactly 960 samples and sends those frames through `audio(...)`.
+## Tradeoffs
 
-Compatible CELT Opus needs only the reversible MLOW packet-header rewrite. Arbitrary Opus cannot be
-made compatible that way. A SILK/Hybrid packet must be decoded and re-encoded as CELT, or
-transcoded all the way to proprietary MLOW:
+- MLOW is pure Rust and broadly compatible, but its analysis-by-synthesis encoder costs more CPU.
+- Native Opus avoids MLOW transcoding and works with FFmpeg/libopus or another packet producer.
+- The MLOW Opus escape is asymmetric: a peer may still send proprietary MLOW, so an Opus-only
+  application needs an external MLOW decoder for that fallback.
 
-```text
-raw Opus → Opus decoder → 16 kHz mono PCM → MLOW encoder → raw MLOW
-```
+The MLOW hot path reuses VAD, history, range-coder, pitch, and output buffers. The encoded path
+preserves `Bytes` ownership until RTP/SRTP framing.
 
-That conversion costs CPU, adds latency, and introduces another lossy generation. Prefer producing
-compatible CELT at the source. FFmpeg has standard Opus support but no MLOW codec, so the last step
-requires this project's MLOW encoder or another compatible implementation.
-
-## Interoperability evidence
-
-The profile mapping was checked against the locally decompiled Android media split and captured Web
-artifacts, without copying proprietary implementation code:
-
-- The Android media registration path distinguishes `use_mlow_codec` from RTP clock selection.
-- Codec registration and RTP-clock selection are independent: disabling MLOW can produce native
-  Opus on PT 120 with a 16 kHz clock.
-- `enable_48khz_rtp_clock` switches the native Opus path to PT 111 with a 48 kHz RTP clock; the
-  server-provided setting was false in the live Android negotiation.
-- PT 121 is registered as `mlow-red-1`.
-- Audio capability intersection is performed before preaccept/accept, confirming that the signaling
-  rate must be preserved rather than discarded.
-- Capability v1 index 31 controls `use_mlow_codec`: the official peer clears that media parameter
-  when the bit is absent and recreates the audio stream if the effective value changes.
-- The current Android `accept` handler stores an incoming settings object before intersecting device
-  capabilities, then reapplies the selected VoIP parameters and recreates transport/media state.
-- The current Android NetEQ registration chooses `mlow-1` or `opus` directly from the effective
-  `use_mlow_codec` value; payload inspection is not the negotiation mechanism.
-- Android/Web artifacts contain separate MLOW and standard Opus decoder paths, which confirms that a
-  payload-content heuristic is not a valid negotiation mechanism.
-- The current Android APK's Ghidra project confirms that MLOW mode selects `mlow_packet_parse`, sets
-  the MLOW control on both libopus encoder and decoder, and still decodes escaped packets through
-  `opus_decode`.
-- The negotiated settings request one-byte DTX frames and a speech-resume RTP marker. The WebAssembly
-  receiver independently contains marker-controlled DTX-exit state, matching the SID/marker behavior
-  above.
-- A live Android call answered with `rate=8000` tore down its audio devices before sending RTP.
-  With `rate=16000` and MLOW capability 31 cleared, media remained connected and the peer sent PT
-  120. This confirms the native Opus/PT 120 combination selected by the decompiled media path.
-- In that connected call the Android RTCP receiver reports acknowledged the outbound audio SSRC
-  without loss while playout stayed silent. Together with the decoder-selection path above, this
-  distinguishes a directional negotiation mismatch from RTP, SRTP, relay, volume, or routing loss.
-
-The corresponding local research points are in the current `wa-apk-re/ghidra-project` and the
-captured WebAssembly/JavaScript artifacts under the sibling reverse-engineering projects.
-
-## MLOW versus Opus
-
-MLOW keeps the entire PCM codec path pure Rust and matches the newer WhatsApp-specific profile. It
-has no external runtime dependency, but it contributes substantially more code and its
-analysis-by-synthesis encoder is CPU/allocation heavy.
-
-Standard Opus has a mature tool ecosystem and lets the Rust core omit the outbound codec when
-another component already produces compatible packets. Linking `voip-libopus` is convenient, while
-an FFmpeg process keeps the Rust dependency graph smaller at the cost of operational complexity.
-Clearing MLOW capability 31 selects the native Opus codec; it does not itself select PT 111. The
-default observed path remains PT 120/16 kHz, while the independent 48 kHz-clock setting selects the
-RFC 7587 PT 111 variant. The bundled libopus adapter follows the observed 60 ms, 24 kbps, DTX, and
-complexity-5 configuration so its CPU cost and packet behavior track the official sender more
-closely.
-
-The escape is asymmetric: a peer that negotiated the MLOW profile can still send proprietary MLOW
-inbound. An Opus-only binary keeps the call alive and exposes those packets, but needs an external
-MLOW decoder for full-duplex playout.
-
-Transcoding Opus to MLOW combines the disadvantages of both paths and should be a compatibility
-fallback, not the normal architecture.
-
-## Video scope
-
-Video already accepts externally encoded access units, so encoding can live in FFmpeg or another
-process. It is not codec-agnostic on the wire yet: signaling, packetization, depacketization, and PT
-97 currently target H.264 Annex-B. Supporting another video codec requires a negotiated
-`VideoFormat` plus a packetizer/depacketizer for that codec; swapping only the external encoder is
-not sufficient.
-
-## Production comparison
-
-The VoIP CLI can switch codecs without changing the call flow:
+## CLI validation
 
 ```bash
-# One binary containing both variants
 WA_AUDIO_CODEC=mlow cargo run -p whatsapp-rust-voip-cli --release -- listen accept
 WA_AUDIO_CODEC=opus cargo run -p whatsapp-rust-voip-cli --release -- listen accept
-WA_AUDIO_CODEC=opus WA_AUDIO_PROFILE=mlow \
-  cargo run -p whatsapp-rust-voip-cli --release -- listen accept # MLOW escape diagnostic
 
-# Binaries proving that the unused codec is absent
 WA_AUDIO_CODEC=mlow cargo run -p whatsapp-rust-voip-cli --release \
   --no-default-features --features voip-mlow -- listen accept
 WA_AUDIO_CODEC=opus cargo run -p whatsapp-rust-voip-cli --release \
   --no-default-features --features voip-opus -- listen accept
 ```
 
-Compare at least call-setup success, format mismatches, first-audio latency, CPU time, peak RSS,
-microphone drops, playout underruns, RTP loss/jitter, and subjective quality. Keep the codec fixed for
-the call; if a cohort fails, roll back on the next call rather than attempting an in-call format
-switch.
+`WA_AUDIO_CODEC=opus` selects native PT120 Opus. `WA_AUDIO_PROFILE=pt111` selects the 48 kHz RTP
+variant; `WA_AUDIO_PROFILE=mlow` selects the CELT escape.
 
-The MLOW realtime path reuses its sanitization, range-coder, encoded-output, VAD, and history
-buffers. The pitch estimator also avoids short-lived per-subframe arrays. The allocation benchmark
-for the varied voiced stream moved from 673 allocations / about 494.7 KB per encode to 627
-allocations / about 456.5 KB on the engine-style reused-output path. Continue treating CPU numbers
-as benchmark-host-specific; the byte-exact and reverse-engineering ground-truth tests guard codec
-behavior.
+## Video
+
+Video already accepts external H.264 Annex-B access units. It is not wire-codec-agnostic: signaling,
+packetization, and PT 97 currently target H.264.

--- a/examples/voip-cli/Cargo.toml
+++ b/examples/voip-cli/Cargo.toml
@@ -10,9 +10,15 @@ edition = "2024"
 license = "MIT"
 publish = false
 
+[features]
+default = ["voip-mlow", "voip-opus"]
+voip-mlow = ["whatsapp-rust/voip-mlow"]
+voip-opus = ["whatsapp-rust/voip-encoded", "whatsapp-rust/voip-libopus"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-channel = { workspace = true }
+bytes = { workspace = true }
 cpal = "0.18"
 env_logger = { workspace = true }
 hex = { workspace = true }
@@ -23,7 +29,6 @@ ringbuf = "0.5"
 tokio = { workspace = true, features = ["full"] }
 wacore = { path = "../../wacore", features = ["voip"] }
 whatsapp-rust = { path = "../..", features = [
-    "voip",
     "sqlite-storage",
     "tokio-transport",
     "ureq-client",

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -22,6 +22,7 @@
 //! Env: `WA_VIDEO_INPUT` = `testsrc` | file/URL | webcam device (default: OS webcam);
 //! `WA_VIDEO_SINK` = `window` (default) | `file` | `none`; optional quality overrides:
 //! `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`, `WA_VIDEO_BITRATE_KBPS`, `WA_VIDEO_SINK_FPS`.
+//! `WA_AUDIO_CODEC` = `mlow` (default when available) | `opus`.
 //!
 //! The inbound MEDIA path is the library facade: `client.voip().accept(&call).audio(mic,
 //! speaker).start()` returns a `CallHandle` and the library owns the callKey decrypt, the relay
@@ -33,6 +34,8 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow, bail};
+#[cfg(feature = "voip-opus")]
+use bytes::Bytes;
 use log::{debug, error, info, warn};
 use portable_atomic::AtomicU64;
 use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER};
@@ -40,8 +43,12 @@ use wacore::types::call::{CallAction, IncomingCall};
 use wacore::types::events::{Event, EventHandler};
 use wacore::voip::CallEvent;
 use whatsapp_rust::prelude::*;
+#[cfg(feature = "voip-opus")]
 use whatsapp_rust::voip::audio::{WaOpusDecoder, WaOpusEncoder};
+#[cfg(feature = "voip-opus")]
 use whatsapp_rust::voip::session::{MediaPipeline, MediaPipelineParams};
+#[cfg(feature = "voip-opus")]
+use whatsapp_rust::voip::{AudioFormat, EncodedAudioFrame};
 use whatsapp_rust::voip::{CallHandle, VideoState};
 
 mod video;
@@ -49,7 +56,68 @@ use video::VideoOpts;
 
 const FRAME_SAMPLES: usize = 960; // 60 ms @ 16 kHz
 const WA_RATE: u32 = 16_000;
+#[cfg(feature = "voip-opus")]
 const SSRC: u32 = 0x5741_0001;
+
+#[cfg(not(any(feature = "voip-mlow", feature = "voip-opus")))]
+compile_error!("enable at least one of voip-mlow or voip-opus");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AudioMode {
+    #[cfg(feature = "voip-mlow")]
+    Mlow,
+    #[cfg(feature = "voip-opus")]
+    Opus,
+}
+
+impl AudioMode {
+    fn from_env() -> Result<Self> {
+        let configured = std::env::var("WA_AUDIO_CODEC").ok();
+        match configured
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            #[cfg(feature = "voip-mlow")]
+            None | Some("mlow") => Ok(Self::Mlow),
+            #[cfg(all(not(feature = "voip-mlow"), feature = "voip-opus"))]
+            None => Ok(Self::Opus),
+            #[cfg(feature = "voip-opus")]
+            Some("opus") => Ok(Self::Opus),
+            Some(other) => bail!(
+                "WA_AUDIO_CODEC={other:?} is unavailable in this build; compile the matching \
+                 voip-mlow/voip-opus feature"
+            ),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            #[cfg(feature = "voip-mlow")]
+            Self::Mlow => "mlow",
+            #[cfg(feature = "voip-opus")]
+            Self::Opus => "opus",
+        }
+    }
+
+    fn signaling_rate(self) -> u32 {
+        match self {
+            #[cfg(feature = "voip-mlow")]
+            Self::Mlow => 16_000,
+            #[cfg(feature = "voip-opus")]
+            Self::Opus => 8_000,
+        }
+    }
+
+    fn signaling_rate_wire(self) -> &'static str {
+        match self {
+            #[cfg(feature = "voip-mlow")]
+            Self::Mlow => "16000",
+            #[cfg(feature = "voip-opus")]
+            Self::Opus => "8000",
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -89,13 +157,11 @@ async fn main() -> Result<()> {
         }
     }
 
-    // The realtime media path encodes one mlow frame every 60 ms; a debug build makes that encode
-    // ~7-10x slower (measured ~19 ms avg / ~49 ms peak vs ~2.5 ms release), and on a slower machine it
-    // overruns the 60 ms budget so frames back up and the far end breaks up. Run calls in release.
+    // Codec work in a debug build can overrun the 60 ms frame budget on slower machines.
     #[cfg(debug_assertions)]
     warn!(
-        "⚠ debug build: mlow encode is much slower than release and may not keep up with realtime \
-         audio (choppy/inaudible far-end voice). Run VoIP with `cargo run --release` for clean audio."
+        "⚠ debug build: audio encoding may not keep up with realtime. Run VoIP with \
+         `cargo run --release` for clean audio."
     );
 
     let args: Vec<String> = std::env::args().collect();
@@ -287,7 +353,7 @@ fn spawn_mic() -> Result<async_channel::Receiver<Vec<i16>>> {
             .unwrap_or_else(|_| "?".into())
     );
 
-    let (tx, rx) = async_channel::bounded::<Vec<i16>>(8);
+    let (tx, rx) = async_channel::bounded::<Vec<i16>>(3);
 
     // ~1 s of native-rate mono headroom: absorbs the callback's bursty deliveries so the drain (and
     // the channel) see a steady 60 ms cadence.
@@ -642,6 +708,7 @@ where
 
 // ===================== loopback (no WhatsApp) =====================
 
+#[cfg(feature = "voip-opus")]
 async fn run_loopback() -> Result<()> {
     info!(
         "voip loopback: mic → Opus → E2E-SRTP protect/unprotect → Opus → speaker. Ctrl+C to stop."
@@ -687,7 +754,54 @@ async fn run_loopback() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "voip-opus"))]
+async fn run_loopback() -> Result<()> {
+    bail!("loopback requires the voip-opus feature")
+}
+
 // ===================== live call / listen =====================
+
+#[cfg(feature = "voip-opus")]
+fn spawn_opus_bridge(
+    mic: async_channel::Receiver<Vec<i16>>,
+    speaker: async_channel::Sender<Vec<i16>>,
+) -> Result<(
+    async_channel::Receiver<Bytes>,
+    async_channel::Sender<EncodedAudioFrame>,
+)> {
+    let mut encoder = WaOpusEncoder::new()?;
+    let mut decoder = WaOpusDecoder::new()?;
+    let (encoded_tx, encoded_rx) = async_channel::bounded::<Bytes>(3);
+    let (playout_tx, playout_rx) = async_channel::bounded::<EncodedAudioFrame>(3);
+
+    tokio::spawn(async move {
+        while let Ok(pcm) = mic.recv().await {
+            match encoder.encode(&pcm) {
+                Ok(payload) => {
+                    if encoded_tx.send(Bytes::from(payload)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    warn!("Opus encode failed: {error}");
+                    break;
+                }
+            }
+        }
+    });
+    tokio::spawn(async move {
+        while let Ok(frame) = playout_rx.recv().await {
+            match decoder.decode(&frame.data) {
+                Ok(pcm) => {
+                    let _ = speaker.try_send(pcm);
+                }
+                Err(error) => warn!("Opus decode failed: {error}"),
+            }
+        }
+    });
+
+    Ok((encoded_rx, playout_tx))
+}
 
 enum Mode {
     Listen { accept: bool, video: bool },
@@ -701,6 +815,7 @@ enum Mode {
 struct CallObserver {
     client: Arc<Client>,
     accept: bool,
+    audio: AudioMode,
     /// `--video`: start/answer calls with video media and auto-accept peer upgrade requests.
     video: bool,
     /// Per-call UI bookkeeping. The client's `CallRegistry` owns media termination.
@@ -729,10 +844,11 @@ enum VideoUi {
 }
 
 impl CallObserver {
-    fn new(client: Arc<Client>, accept: bool, video: bool) -> Self {
+    fn new(client: Arc<Client>, accept: bool, video: bool, audio: AudioMode) -> Self {
         Self {
             client,
             accept,
+            audio,
             video,
             state: Arc::new(Mutex::new(CallState::default())),
         }
@@ -822,6 +938,7 @@ impl EventHandler for CallObserver {
                     let client = self.client.clone();
                     let call = call.clone();
                     let accept = self.accept;
+                    let audio = self.audio;
                     // Only answer with video when we're allowed to AND the offer is actually a video
                     // call; advertising `<video>` on an audio offer would be wrong.
                     let video = self.video && *is_video;
@@ -829,7 +946,8 @@ impl EventHandler for CallObserver {
                     let cid = call_id.clone();
                     begin_call_startup(&state, &cid);
                     tokio::spawn(async move {
-                        if let Err(e) = respond_to_offer(&client, &call, accept, video).await {
+                        if let Err(e) = respond_to_offer(&client, &call, accept, video, audio).await
+                        {
                             error!("call signaling failed: {e}");
                             complete_call_startup(&state, &cid);
                             return;
@@ -838,7 +956,7 @@ impl EventHandler for CallObserver {
                             complete_call_startup(&state, &cid);
                             return;
                         }
-                        match start_media(&client, &call, video, &state).await {
+                        match start_media(&client, &call, video, audio, &state).await {
                             Ok(handle) => register_handle(&state, cid.clone(), handle).await,
                             Err(e) => {
                                 let peer_ended = peer_terminated_during_startup(&state, &cid);
@@ -885,10 +1003,12 @@ async fn start_media(
     client: &Arc<Client>,
     call: &IncomingCall,
     video: bool,
+    audio: AudioMode,
     state: &Arc<Mutex<CallState>>,
 ) -> Result<Arc<CallHandle>> {
     let mic = spawn_mic()?;
     let speaker = spawn_speaker()?;
+    let event_speaker = speaker.clone();
     info!("🔌 connecting media via client.voip().accept(..)…");
     let video_endpoints = if video {
         let opts = VideoOpts::from_env().await?;
@@ -903,9 +1023,18 @@ async fn start_media(
     if peer_terminated_during_startup(state, call.action.call_id()) {
         bail!("peer ended the call during media preparation");
     }
-    send_final_accept(client, call, video).await?;
+    send_final_accept(client, call, video, audio).await?;
     let voip = client.voip();
-    let mut builder = voip.accept(call).audio(mic, speaker.clone());
+    let mut builder = match audio {
+        #[cfg(feature = "voip-mlow")]
+        AudioMode::Mlow => voip.accept(call).audio(mic, speaker),
+        #[cfg(feature = "voip-opus")]
+        AudioMode::Opus => {
+            let (source, sink) = spawn_opus_bridge(mic, speaker)?;
+            voip.accept(call)
+                .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, source, sink)
+        }
+    };
     if let Some((source, sink)) = video_endpoints {
         builder = builder.video(source, sink);
     }
@@ -914,7 +1043,8 @@ async fn start_media(
         .await
         .map_err(|e| anyhow!("accept media: {e}"))?;
     info!(
-        "🎙  media flow live for call {} — speak into the mic.{}",
+        "🎙  {} media flow live for call {} — speak into the mic.{}",
+        audio.name(),
         handle.call_id(),
         if video { " 🎥 video on." } else { "" }
     );
@@ -922,7 +1052,7 @@ async fn start_media(
     if video {
         mark_video(state, handle.call_id(), Some(VideoUi::Active));
     }
-    spawn_call_event_listener(handle.clone(), speaker, video, state.clone());
+    spawn_call_event_listener(handle.clone(), event_speaker, video, state.clone());
     Ok(handle)
 }
 
@@ -934,13 +1064,24 @@ async fn place_outgoing_call(
     client: &Arc<Client>,
     peer: &Jid,
     video: bool,
+    audio: AudioMode,
     state: &Arc<Mutex<CallState>>,
 ) -> Result<Arc<CallHandle>> {
     let mic = spawn_mic()?;
     let speaker = spawn_speaker()?;
+    let event_speaker = speaker.clone();
     info!("📞 placing call to {peer} via client.voip().call(..)…");
     let voip = client.voip();
-    let mut builder = voip.call(peer).audio(mic, speaker.clone());
+    let mut builder = match audio {
+        #[cfg(feature = "voip-mlow")]
+        AudioMode::Mlow => voip.call(peer).audio(mic, speaker),
+        #[cfg(feature = "voip-opus")]
+        AudioMode::Opus => {
+            let (source, sink) = spawn_opus_bridge(mic, speaker)?;
+            voip.call(peer)
+                .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, source, sink)
+        }
+    };
     if video {
         let opts = VideoOpts::from_env().await?;
         builder = builder.video(
@@ -953,7 +1094,8 @@ async fn place_outgoing_call(
         .await
         .map_err(|e| anyhow!("place call: {e}"))?;
     info!(
-        "☎  offer sent for call {} — waiting for the peer's relay to connect media.{}",
+        "☎  {} offer sent for call {} — waiting for the peer's relay to connect media.{}",
+        audio.name(),
         handle.call_id(),
         if video { " 🎥 video call." } else { "" }
     );
@@ -961,7 +1103,7 @@ async fn place_outgoing_call(
     if video {
         mark_video(state, handle.call_id(), Some(VideoUi::Active));
     }
-    spawn_call_event_listener(handle.clone(), speaker, video, state.clone());
+    spawn_call_event_listener(handle.clone(), event_speaker, video, state.clone());
     Ok(handle)
 }
 
@@ -978,10 +1120,7 @@ fn mark_video(state: &Arc<Mutex<CallState>>, call_id: &str, ui: Option<VideoUi>)
     }
 }
 
-/// Surface the call's engine events: log relay-allocate outcomes, decode any non-MLow (standard
-/// Opus) frame the core hands back and play it, and drive the video upgrade handshake (auto-accept
-/// under `--video`, otherwise park it for the stdin `v` toggle). MLow audio is decoded inside the
-/// engine and arrives as playout on the speaker channel directly.
+/// Surface call diagnostics and drive the video upgrade handshake.
 fn spawn_call_event_listener(
     handle: Arc<CallHandle>,
     speaker: async_channel::Sender<Vec<i16>>,
@@ -990,7 +1129,10 @@ fn spawn_call_event_listener(
 ) {
     let events = handle.events();
     tokio::spawn(async move {
-        let mut opus = WaOpusDecoder::new().ok();
+        #[cfg(feature = "voip-opus")]
+        let mut fallback_opus = WaOpusDecoder::new().ok();
+        #[cfg(not(feature = "voip-opus"))]
+        let mut fallback_warning_logged = false;
         let mut peer_video_receiver_confirmed = false;
         let mut peer_keyframe_request_logged = false;
         while let Ok(ev) = events.recv().await {
@@ -1005,11 +1147,31 @@ fn spawn_call_event_listener(
                     warn!("relay never acked the allocate (wedged relay) — media never came up")
                 }
                 CallEvent::ForeignAudio(payload) => {
-                    if let Some(dec) = opus.as_mut()
-                        && let Ok(pcm) = dec.decode(&payload)
+                    #[cfg(feature = "voip-opus")]
+                    if let Some(decoder) = fallback_opus.as_mut()
+                        && let Ok(pcm) = decoder.decode(&payload)
                     {
                         let _ = speaker.try_send(pcm);
                     }
+                    #[cfg(not(feature = "voip-opus"))]
+                    if !fallback_warning_logged {
+                        warn!(
+                            "peer sent a {}-byte MLOW embedded Opus fallback, but this binary has \
+                             no Opus decoder",
+                            payload.len()
+                        );
+                        let _ = &speaker;
+                        fallback_warning_logged = true;
+                    }
+                }
+                CallEvent::AudioFormatMismatch {
+                    expected_rate,
+                    received_rates,
+                } => {
+                    error!(
+                        "peer selected incompatible audio rates {received_rates:?}; expected \
+                         {expected_rate}"
+                    );
                 }
                 CallEvent::RtcpReceived {
                     packet_types,
@@ -1126,10 +1288,12 @@ async fn respond_to_offer(
     call: &IncomingCall,
     accept: bool,
     video: bool,
+    audio: AudioMode,
 ) -> Result<()> {
     let CallAction::Offer {
         call_id,
         call_creator,
+        audio: offered_audio,
         ..
     } = &call.action
     else {
@@ -1148,8 +1312,24 @@ async fn respond_to_offer(
             .map_err(|e| anyhow!("send reject: {e}"))?;
         return Ok(());
     }
+    if !offered_audio.is_empty()
+        && !offered_audio.iter().any(|codec| {
+            codec.enc.eq_ignore_ascii_case("opus") && codec.rate == audio.signaling_rate()
+        })
+    {
+        client
+            .voip()
+            .reject(call)
+            .await
+            .map_err(|e| anyhow!("reject incompatible audio offer: {e}"))?;
+        bail!(
+            "peer did not offer {} signaling rate {}",
+            audio.name(),
+            audio.signaling_rate()
+        );
+    }
     // Callee flow: preaccept immediately; final accept waits for ready media.
-    let audio_rates = &["16000"];
+    let audio_rates = &[audio.signaling_rate_wire()];
     let pre_id = hex::encode(rand::random::<[u8; 8]>());
     client
         .send_node(stanza::build_preaccept(
@@ -1167,7 +1347,12 @@ async fn respond_to_offer(
     Ok(())
 }
 
-async fn send_final_accept(client: &Arc<Client>, call: &IncomingCall, video: bool) -> Result<()> {
+async fn send_final_accept(
+    client: &Arc<Client>,
+    call: &IncomingCall,
+    video: bool,
+    audio: AudioMode,
+) -> Result<()> {
     let CallAction::Offer {
         call_id,
         call_creator,
@@ -1176,7 +1361,7 @@ async fn send_final_accept(client: &Arc<Client>, call: &IncomingCall, video: boo
     else {
         return Ok(());
     };
-    let audio_rates = &["16000"];
+    let audio_rates = &[audio.signaling_rate_wire()];
     let accept_id = hex::encode(rand::random::<[u8; 8]>());
     let metadata = if video { call.media.as_deref() } else { None };
     let accept_node = stanza::build_accept(&stanza::AcceptParams {
@@ -1300,6 +1485,12 @@ fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
 }
 
 async fn run_bot(mode: Mode) -> Result<()> {
+    let audio = AudioMode::from_env()?;
+    info!(
+        "🔊 selected {} audio (signaling rate {})",
+        audio.name(),
+        audio.signaling_rate()
+    );
     let store = SqliteStore::new("whatsapp.db")
         .await
         .map_err(|e| anyhow!("sqlite: {e}"))?;
@@ -1325,7 +1516,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
     // The structured `Event::IncomingCall` (which now carries the offer's <enc>/<relay>) drives the
     // accept flow, so the raw-node-forwarding crutch the old hand-rolled inbound path needed is gone.
     let manages_media = accept || target.is_some();
-    let observer = Arc::new(CallObserver::new(client.clone(), accept, video));
+    let observer = Arc::new(CallObserver::new(client.clone(), accept, video, audio));
     client.register_handler(observer.clone());
 
     if let Some(peer) = target {
@@ -1341,7 +1532,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
                 warn!("not connected within 60s, skipping outgoing call: {e}");
                 return;
             }
-            match place_outgoing_call(&client2, &peer, video, &state).await {
+            match place_outgoing_call(&client2, &peer, video, audio, &state).await {
                 Ok(handle) => {
                     let cid = handle.call_id().to_string();
                     register_handle(&state, cid, handle).await;
@@ -1351,8 +1542,9 @@ async fn run_bot(mode: Mode) -> Result<()> {
         });
     } else {
         warn!(
-            "listening for calls ({}{}). Ctrl+C to exit.",
+            "listening for calls ({}, {}{}). Ctrl+C to exit.",
             if accept { "auto-accept" } else { "auto-reject" },
+            audio.name(),
             if video { ", video" } else { "" }
         );
     }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -917,6 +917,22 @@ fn spawn_opus_bridge(
     Ok((encoded_rx, playout_tx))
 }
 
+#[cfg(feature = "voip-opus")]
+fn spawn_fallback_opus_decoder(
+    speaker: async_channel::Sender<Vec<i16>>,
+) -> Option<async_channel::Sender<Bytes>> {
+    let mut decoder = WaOpusDecoder::new().ok()?;
+    let (payload_tx, payload_rx) = async_channel::bounded::<Bytes>(3);
+    tokio::task::spawn_blocking(move || {
+        while let Ok(payload) = payload_rx.recv_blocking() {
+            if let Ok(pcm) = decoder.decode_mlow_escape(&payload) {
+                let _ = speaker.try_send(pcm.to_vec());
+            }
+        }
+    });
+    Some(payload_tx)
+}
+
 enum Mode {
     Listen { accept: bool, video: bool },
     Call { jid: Jid, video: bool },
@@ -1241,9 +1257,9 @@ fn spawn_call_event_listener(
     state: Arc<Mutex<CallState>>,
 ) {
     let events = handle.events();
+    #[cfg(feature = "voip-opus")]
+    let fallback_opus_tx = spawn_fallback_opus_decoder(speaker.clone());
     tokio::spawn(async move {
-        #[cfg(feature = "voip-opus")]
-        let mut fallback_opus = WaOpusDecoder::new().ok();
         #[cfg(not(feature = "voip-opus"))]
         let mut fallback_warning_logged = false;
         let mut peer_video_receiver_confirmed = false;
@@ -1261,10 +1277,8 @@ fn spawn_call_event_listener(
                 }
                 CallEvent::ForeignAudio(payload) => {
                     #[cfg(feature = "voip-opus")]
-                    if let Some(decoder) = fallback_opus.as_mut()
-                        && let Ok(pcm) = decoder.decode_mlow_escape(&payload)
-                    {
-                        let _ = speaker.try_send(pcm.to_vec());
+                    if let Some(fallback_opus_tx) = &fallback_opus_tx {
+                        let _ = fallback_opus_tx.try_send(payload);
                     }
                     #[cfg(not(feature = "voip-opus"))]
                     if !fallback_warning_logged {
@@ -1686,7 +1700,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     #[cfg(feature = "voip-opus")]
-    use super::{AudioMode, FRAME_SAMPLES, spawn_opus_bridge};
+    use super::{
+        AudioMode, FRAME_SAMPLES, WaOpusEncoder, spawn_fallback_opus_decoder, spawn_opus_bridge,
+    };
     use super::{
         CallState, CliCommand, begin_call_startup, complete_call_startup, mark_call_most_recent,
         parse_cli, peer_terminated_during_startup, record_peer_terminate, video_source_is_ignored,
@@ -1851,5 +1867,28 @@ mod tests {
             .expect("encoder worker must continue")
             .unwrap();
         assert!(!payload.is_empty());
+    }
+
+    #[cfg(feature = "voip-opus")]
+    #[tokio::test]
+    async fn fallback_opus_decoder_delivers_pcm() {
+        let mut encoder = WaOpusEncoder::new_mlow_escape().unwrap();
+        let voice = (0..FRAME_SAMPLES)
+            .map(|i| {
+                let t = i as f32 / 16_000.0;
+                (16_000.0 * (2.0 * std::f32::consts::PI * 440.0 * t).sin()) as i16
+            })
+            .collect::<Vec<_>>();
+        let payload = bytes::Bytes::from(encoder.encode(&voice).unwrap());
+        let (speaker_tx, speaker_rx) = async_channel::bounded(2);
+        let fallback_tx = spawn_fallback_opus_decoder(speaker_tx).unwrap();
+
+        fallback_tx.send(payload).await.unwrap();
+
+        let pcm = tokio::time::timeout(std::time::Duration::from_secs(2), speaker_rx.recv())
+            .await
+            .expect("decoder worker must respond")
+            .unwrap();
+        assert_eq!(pcm.len(), FRAME_SAMPLES);
     }
 }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -1686,6 +1686,8 @@ async fn run_bot(mode: Mode) -> Result<()> {
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "voip-opus")]
+    use super::AudioMode;
     use super::{
         CallState, CliCommand, begin_call_startup, complete_call_startup, mark_call_most_recent,
         parse_cli, peer_terminated_during_startup, record_peer_terminate, video_source_is_ignored,
@@ -1804,5 +1806,33 @@ mod tests {
         mark_call_most_recent(&mut order, "CALL-B");
         mark_call_most_recent(&mut order, "CALL-A");
         assert_eq!(order, ["CALL-B", "CALL-A"]);
+    }
+
+    #[cfg(feature = "voip-opus")]
+    #[test]
+    fn native_opus_mode_keeps_codec_and_clock_negotiation_aligned() {
+        use wacore::stanza::call::{
+            CAPABILITY_STANDARD_OPUS_OFFER, CAPABILITY_STANDARD_OPUS_PREACCEPT,
+        };
+        use wacore::voip::rtp::{RTP_PAYLOAD_TYPE_OPUS, RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO};
+
+        let native = AudioMode::OpusNative;
+        assert_eq!(
+            native.format().rtp_payload_type,
+            RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO
+        );
+        assert_eq!(native.format().rtp_clock_rate, 16_000);
+        assert_eq!(
+            native.preaccept_capability(false),
+            &CAPABILITY_STANDARD_OPUS_PREACCEPT
+        );
+        assert_eq!(native.accept_capability(), &CAPABILITY_STANDARD_OPUS_OFFER);
+        assert!(native.uses_standard_opus());
+        assert!(!native.uses_48khz_rtp_clock());
+
+        let rfc7587 = AudioMode::OpusRfc7587;
+        assert_eq!(rfc7587.format().rtp_payload_type, RTP_PAYLOAD_TYPE_OPUS);
+        assert_eq!(rfc7587.format().rtp_clock_rate, 48_000);
+        assert!(rfc7587.uses_48khz_rtp_clock());
     }
 }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -921,12 +921,21 @@ fn spawn_opus_bridge(
 fn spawn_fallback_opus_decoder(
     speaker: async_channel::Sender<Vec<i16>>,
 ) -> Option<async_channel::Sender<Bytes>> {
-    let mut decoder = WaOpusDecoder::new().ok()?;
+    let mut decoder = match WaOpusDecoder::new() {
+        Ok(decoder) => decoder,
+        Err(error) => {
+            error!("failed to initialize fallback Opus decoder: {error}");
+            return None;
+        }
+    };
     let (payload_tx, payload_rx) = async_channel::bounded::<Bytes>(3);
     tokio::task::spawn_blocking(move || {
         while let Ok(payload) = payload_rx.recv_blocking() {
-            if let Ok(pcm) = decoder.decode_mlow_escape(&payload) {
-                let _ = speaker.try_send(pcm.to_vec());
+            match decoder.decode_mlow_escape(&payload) {
+                Ok(pcm) => {
+                    let _ = speaker.try_send(pcm.to_vec());
+                }
+                Err(error) => debug!("failed to decode MLOW escape payload: {error}"),
             }
         }
     });

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -818,7 +818,7 @@ async fn run_loopback() -> Result<()> {
         // The recv tracker derives the ROC per packet, so this stays correct past a 16-bit wrap.
         if let Some((_, opus_out)) = recv.unprotect_audio(&packet) {
             let out = dec.decode(&opus_out)?;
-            let _ = speaker.send(out).await;
+            let _ = speaker.send(out.to_vec()).await;
         }
         frames += 1;
         if frames.is_multiple_of(100) {
@@ -857,27 +857,26 @@ fn spawn_opus_bridge(
     let (encoded_tx, encoded_rx) = async_channel::bounded::<Bytes>(3);
     let (playout_tx, playout_rx) = async_channel::bounded::<EncodedAudioFrame>(3);
 
-    tokio::spawn(async move {
-        while let Ok(pcm) = mic.recv().await {
+    tokio::task::spawn_blocking(move || {
+        while let Ok(pcm) = mic.recv_blocking() {
             match encoder.encode(&pcm).map(Bytes::from) {
                 Ok(payload) => {
-                    if encoded_tx.send(payload).await.is_err() {
+                    if encoded_tx.send_blocking(payload).is_err() {
                         break;
                     }
                 }
                 Err(error) => {
                     warn!("Opus encode failed: {error}");
-                    break;
                 }
             }
         }
     });
-    tokio::spawn(async move {
+    tokio::task::spawn_blocking(move || {
         #[cfg(feature = "voip-mlow")]
         let mut mlow_decoder = MlowDecoder::new();
         #[cfg(not(feature = "voip-mlow"))]
         let mut mlow_warning_logged = false;
-        while let Ok(frame) = playout_rx.recv().await {
+        while let Ok(frame) = playout_rx.recv_blocking() {
             match frame.codec {
                 AudioCodec::Opus => match if mlow_escape {
                     decoder.decode_mlow_escape(&frame.data)
@@ -885,7 +884,7 @@ fn spawn_opus_bridge(
                     decoder.decode(&frame.data)
                 } {
                     Ok(pcm) => {
-                        let _ = speaker.try_send(pcm);
+                        let _ = speaker.try_send(pcm.to_vec());
                     }
                     Err(error) => warn!("Opus decode failed: {error}"),
                 },
@@ -1265,7 +1264,7 @@ fn spawn_call_event_listener(
                     if let Some(decoder) = fallback_opus.as_mut()
                         && let Ok(pcm) = decoder.decode_mlow_escape(&payload)
                     {
-                        let _ = speaker.try_send(pcm);
+                        let _ = speaker.try_send(pcm.to_vec());
                     }
                     #[cfg(not(feature = "voip-opus"))]
                     if !fallback_warning_logged {
@@ -1687,7 +1686,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     #[cfg(feature = "voip-opus")]
-    use super::AudioMode;
+    use super::{AudioMode, FRAME_SAMPLES, spawn_opus_bridge};
     use super::{
         CallState, CliCommand, begin_call_startup, complete_call_startup, mark_call_most_recent,
         parse_cli, peer_terminated_during_startup, record_peer_terminate, video_source_is_ignored,
@@ -1834,5 +1833,23 @@ mod tests {
         assert_eq!(rfc7587.format().rtp_payload_type, RTP_PAYLOAD_TYPE_OPUS);
         assert_eq!(rfc7587.format().rtp_clock_rate, 48_000);
         assert!(rfc7587.uses_48khz_rtp_clock());
+    }
+
+    #[cfg(feature = "voip-opus")]
+    #[tokio::test]
+    async fn opus_bridge_recovers_after_bad_input_frame() {
+        let (mic_tx, mic_rx) = async_channel::bounded(2);
+        let (speaker_tx, _speaker_rx) = async_channel::bounded(2);
+        let (encoded_rx, _playout_tx) =
+            spawn_opus_bridge(mic_rx, speaker_tx, AudioMode::OpusNative).unwrap();
+
+        mic_tx.send(vec![0; FRAME_SAMPLES - 1]).await.unwrap();
+        mic_tx.send(vec![0; FRAME_SAMPLES]).await.unwrap();
+
+        let payload = tokio::time::timeout(std::time::Duration::from_secs(2), encoded_rx.recv())
+            .await
+            .expect("encoder worker must continue")
+            .unwrap();
+        assert!(!payload.is_empty());
     }
 }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -38,18 +38,24 @@ use anyhow::{Result, anyhow, bail};
 use bytes::Bytes;
 use log::{debug, error, info, warn};
 use portable_atomic::AtomicU64;
-use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER};
+use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER, CAPABILITY_PREACCEPT};
+#[cfg(feature = "voip-opus")]
+use wacore::stanza::call::{CAPABILITY_STANDARD_OPUS_OFFER, CAPABILITY_STANDARD_OPUS_PREACCEPT};
 use wacore::types::call::{CallAction, IncomingCall};
 use wacore::types::events::{Event, EventHandler};
 use wacore::voip::CallEvent;
+#[cfg(all(feature = "voip-opus", feature = "voip-mlow"))]
+use wacore::voip::MlowDecoder;
+#[cfg(all(feature = "voip-opus", feature = "voip-mlow"))]
+use wacore::voip::rtp::RTP_PAYLOAD_TYPE_MLOW_RED;
 use whatsapp_rust::prelude::*;
 #[cfg(feature = "voip-opus")]
 use whatsapp_rust::voip::audio::{WaOpusDecoder, WaOpusEncoder};
 #[cfg(feature = "voip-opus")]
 use whatsapp_rust::voip::session::{MediaPipeline, MediaPipelineParams};
 #[cfg(feature = "voip-opus")]
-use whatsapp_rust::voip::{AudioFormat, EncodedAudioFrame};
-use whatsapp_rust::voip::{CallHandle, VideoState};
+use whatsapp_rust::voip::{AudioCodec, EncodedAudioFrame};
+use whatsapp_rust::voip::{AudioFormat, CallHandle, VideoState};
 
 mod video;
 use video::VideoOpts;
@@ -67,7 +73,11 @@ enum AudioMode {
     #[cfg(feature = "voip-mlow")]
     Mlow,
     #[cfg(feature = "voip-opus")]
-    Opus,
+    OpusMlow,
+    #[cfg(feature = "voip-opus")]
+    OpusNative,
+    #[cfg(feature = "voip-opus")]
+    OpusRfc7587,
 }
 
 impl AudioMode {
@@ -81,13 +91,34 @@ impl AudioMode {
             #[cfg(feature = "voip-mlow")]
             None | Some("mlow") => Ok(Self::Mlow),
             #[cfg(all(not(feature = "voip-mlow"), feature = "voip-opus"))]
-            None => Ok(Self::Opus),
+            None => Self::opus_from_env(),
             #[cfg(feature = "voip-opus")]
-            Some("opus") => Ok(Self::Opus),
+            Some("opus") => Self::opus_from_env(),
+            #[cfg(feature = "voip-opus")]
+            Some("opus-pt111") => Ok(Self::OpusRfc7587),
             Some(other) => bail!(
                 "WA_AUDIO_CODEC={other:?} is unavailable in this build; compile the matching \
                  voip-mlow/voip-opus feature"
             ),
+        }
+    }
+
+    #[cfg(feature = "voip-opus")]
+    fn opus_from_env() -> Result<Self> {
+        match std::env::var("WA_AUDIO_PROFILE")
+            .ok()
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            None | Some("native") | Some("standard") | Some("pt120") => Ok(Self::OpusNative),
+            Some("rfc7587") | Some("pt111") => Ok(Self::OpusRfc7587),
+            Some("mlow") | Some("mlow-escape") => Ok(Self::OpusMlow),
+            Some(other) => {
+                bail!(
+                    "unknown WA_AUDIO_PROFILE={other:?}; expected native (default), rfc7587, or mlow"
+                )
+            }
         }
     }
 
@@ -96,25 +127,71 @@ impl AudioMode {
             #[cfg(feature = "voip-mlow")]
             Self::Mlow => "mlow",
             #[cfg(feature = "voip-opus")]
-            Self::Opus => "opus",
+            Self::OpusMlow => "opus/mlow-escape",
+            #[cfg(feature = "voip-opus")]
+            Self::OpusNative => "opus-native/pt120",
+            #[cfg(feature = "voip-opus")]
+            Self::OpusRfc7587 => "opus-rfc7587/pt111",
+        }
+    }
+
+    fn format(self) -> AudioFormat {
+        match self {
+            #[cfg(feature = "voip-mlow")]
+            Self::Mlow => AudioFormat::MLOW_16KHZ_60MS,
+            #[cfg(feature = "voip-opus")]
+            Self::OpusMlow => AudioFormat::OPUS_MLOW_16KHZ_60MS,
+            #[cfg(feature = "voip-opus")]
+            Self::OpusNative => AudioFormat::OPUS_16KHZ_60MS,
+            #[cfg(feature = "voip-opus")]
+            Self::OpusRfc7587 => AudioFormat::OPUS_RFC7587_16KHZ_60MS,
         }
     }
 
     fn signaling_rate(self) -> u32 {
-        match self {
-            #[cfg(feature = "voip-mlow")]
-            Self::Mlow => 16_000,
-            #[cfg(feature = "voip-opus")]
-            Self::Opus => 8_000,
-        }
+        self.format().signaling_rate
     }
 
     fn signaling_rate_wire(self) -> &'static str {
-        match self {
-            #[cfg(feature = "voip-mlow")]
-            Self::Mlow => "16000",
+        match self.signaling_rate() {
+            16_000 => "16000",
+            8_000 => "8000",
+            _ => unreachable!("built-in audio formats use known signaling rates"),
+        }
+    }
+
+    fn preaccept_capability(self, video: bool) -> &'static [u8] {
+        match (self, video) {
             #[cfg(feature = "voip-opus")]
-            Self::Opus => "8000",
+            (Self::OpusNative | Self::OpusRfc7587, true) => &CAPABILITY_STANDARD_OPUS_OFFER,
+            #[cfg(feature = "voip-opus")]
+            (Self::OpusNative | Self::OpusRfc7587, false) => &CAPABILITY_STANDARD_OPUS_PREACCEPT,
+            (_, true) => &CAPABILITY_OFFER,
+            (_, false) => &CAPABILITY_PREACCEPT,
+        }
+    }
+
+    fn accept_capability(self) -> &'static [u8] {
+        match self {
+            #[cfg(feature = "voip-opus")]
+            Self::OpusNative | Self::OpusRfc7587 => &CAPABILITY_STANDARD_OPUS_OFFER,
+            _ => &CAPABILITY_OFFER,
+        }
+    }
+
+    fn uses_standard_opus(self) -> bool {
+        match self {
+            #[cfg(feature = "voip-opus")]
+            Self::OpusNative | Self::OpusRfc7587 => true,
+            _ => false,
+        }
+    }
+
+    fn uses_48khz_rtp_clock(self) -> bool {
+        match self {
+            #[cfg(feature = "voip-opus")]
+            Self::OpusRfc7587 => true,
+            _ => false,
         }
     }
 }
@@ -765,20 +842,26 @@ async fn run_loopback() -> Result<()> {
 fn spawn_opus_bridge(
     mic: async_channel::Receiver<Vec<i16>>,
     speaker: async_channel::Sender<Vec<i16>>,
+    audio: AudioMode,
 ) -> Result<(
     async_channel::Receiver<Bytes>,
     async_channel::Sender<EncodedAudioFrame>,
 )> {
-    let mut encoder = WaOpusEncoder::new()?;
+    let mlow_escape = audio == AudioMode::OpusMlow;
+    let mut encoder = if mlow_escape {
+        WaOpusEncoder::new_mlow_escape()?
+    } else {
+        WaOpusEncoder::new()?
+    };
     let mut decoder = WaOpusDecoder::new()?;
     let (encoded_tx, encoded_rx) = async_channel::bounded::<Bytes>(3);
     let (playout_tx, playout_rx) = async_channel::bounded::<EncodedAudioFrame>(3);
 
     tokio::spawn(async move {
         while let Ok(pcm) = mic.recv().await {
-            match encoder.encode(&pcm) {
+            match encoder.encode(&pcm).map(Bytes::from) {
                 Ok(payload) => {
-                    if encoded_tx.send(Bytes::from(payload)).await.is_err() {
+                    if encoded_tx.send(payload).await.is_err() {
                         break;
                     }
                 }
@@ -790,12 +873,44 @@ fn spawn_opus_bridge(
         }
     });
     tokio::spawn(async move {
+        #[cfg(feature = "voip-mlow")]
+        let mut mlow_decoder = MlowDecoder::new();
+        #[cfg(not(feature = "voip-mlow"))]
+        let mut mlow_warning_logged = false;
         while let Ok(frame) = playout_rx.recv().await {
-            match decoder.decode(&frame.data) {
-                Ok(pcm) => {
-                    let _ = speaker.try_send(pcm);
+            match frame.codec {
+                AudioCodec::Opus => match if mlow_escape {
+                    decoder.decode_mlow_escape(&frame.data)
+                } else {
+                    decoder.decode(&frame.data)
+                } {
+                    Ok(pcm) => {
+                        let _ = speaker.try_send(pcm);
+                    }
+                    Err(error) => warn!("Opus decode failed: {error}"),
+                },
+                AudioCodec::Mlow => {
+                    #[cfg(feature = "voip-mlow")]
+                    {
+                        mlow_decoder.set_redundancy(i32::from(
+                            frame.payload_type == RTP_PAYLOAD_TYPE_MLOW_RED,
+                        ));
+                        let pcm = mlow_decoder
+                            .decode(&frame.data)
+                            .into_iter()
+                            .map(|sample| (sample * 32767.0).clamp(-32768.0, 32767.0) as i16)
+                            .collect();
+                        let _ = speaker.try_send(pcm);
+                    }
+                    #[cfg(not(feature = "voip-mlow"))]
+                    if !mlow_warning_logged {
+                        warn!(
+                            "peer selected MLOW inbound audio; this Opus-only binary will keep the call but cannot play it"
+                        );
+                        mlow_warning_logged = true;
+                    }
                 }
-                Err(error) => warn!("Opus decode failed: {error}"),
+                _ => {}
             }
         }
     });
@@ -1029,10 +1144,10 @@ async fn start_media(
         #[cfg(feature = "voip-mlow")]
         AudioMode::Mlow => voip.accept(call).audio(mic, speaker),
         #[cfg(feature = "voip-opus")]
-        AudioMode::Opus => {
-            let (source, sink) = spawn_opus_bridge(mic, speaker)?;
+        AudioMode::OpusMlow | AudioMode::OpusNative | AudioMode::OpusRfc7587 => {
+            let (source, sink) = spawn_opus_bridge(mic, speaker, audio)?;
             voip.accept(call)
-                .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, source, sink)
+                .encoded_audio(audio.format(), source, sink)
         }
     };
     if let Some((source, sink)) = video_endpoints {
@@ -1076,10 +1191,9 @@ async fn place_outgoing_call(
         #[cfg(feature = "voip-mlow")]
         AudioMode::Mlow => voip.call(peer).audio(mic, speaker),
         #[cfg(feature = "voip-opus")]
-        AudioMode::Opus => {
-            let (source, sink) = spawn_opus_bridge(mic, speaker)?;
-            voip.call(peer)
-                .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, source, sink)
+        AudioMode::OpusMlow | AudioMode::OpusNative | AudioMode::OpusRfc7587 => {
+            let (source, sink) = spawn_opus_bridge(mic, speaker, audio)?;
+            voip.call(peer).encoded_audio(audio.format(), source, sink)
         }
     };
     if video {
@@ -1149,7 +1263,7 @@ fn spawn_call_event_listener(
                 CallEvent::ForeignAudio(payload) => {
                     #[cfg(feature = "voip-opus")]
                     if let Some(decoder) = fallback_opus.as_mut()
-                        && let Ok(pcm) = decoder.decode(&payload)
+                        && let Ok(pcm) = decoder.decode_mlow_escape(&payload)
                     {
                         let _ = speaker.try_send(pcm);
                     }
@@ -1332,14 +1446,14 @@ async fn respond_to_offer(
     let audio_rates = &[audio.signaling_rate_wire()];
     let pre_id = hex::encode(rand::random::<[u8; 8]>());
     client
-        .send_node(stanza::build_preaccept(
+        .send_node(stanza::build_preaccept_with_capability(
             call_id,
             &call.from,
             call_creator,
             &pre_id,
             audio_rates,
-            // Byte-matched to a real from-start video callee: <video dec=H264 screen 0x0> in the
-            // preaccept, with the 0xbb capability (the caller offers 0xfa; the callee preaccepts 0xbb).
+            audio.preaccept_capability(video),
+            // The video node is capture-matched; standard Opus only clears the MLOW capability bit.
             video,
         ))
         .await
@@ -1364,6 +1478,9 @@ async fn send_final_accept(
     let audio_rates = &[audio.signaling_rate_wire()];
     let accept_id = hex::encode(rand::random::<[u8; 8]>());
     let metadata = if video { call.media.as_deref() } else { None };
+    let voip_settings = audio
+        .uses_standard_opus()
+        .then(|| stanza::standard_opus_voip_settings(audio.uses_48khz_rtp_clock()));
     let accept_node = stanza::build_accept(&stanza::AcceptParams {
         call_id,
         to: &call.from,
@@ -1372,10 +1489,14 @@ async fn send_final_accept(
         audio_rates,
         relay_te: None,
         rte: None,
-        voip_settings: None,
+        voip_settings,
         // A real from-start video accept carries NO <capability> (just audio/video/net/encopt); the
         // audio path keeps advertising it.
-        capability: if video { None } else { Some(&CAPABILITY_OFFER) },
+        capability: if video {
+            None
+        } else {
+            Some(audio.accept_capability())
+        },
         video,
         peer_abtest_bucket: metadata.and_then(|media| media.peer_abtest_bucket.as_deref()),
         peer_abtest_bucket_id_list: metadata

--- a/src/client.rs
+++ b/src/client.rs
@@ -910,14 +910,14 @@ pub struct Client {
     /// Active VoIP calls and their media-task abort handles. `abort_all` runs from the
     /// connection-cleanup path so a disconnect/reconnect tears down every in-flight call. Behind the
     /// `voip` feature: it is populated only by the `voip` media facade.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub(crate) call_registry: Arc<wacore::voip::CallRegistry>,
 
     /// Outgoing calls awaiting their relay. The initiator's relay is not in the offer; it arrives
     /// from the server AFTER the offer (live-only), so each `voip().call()` parks the material needed
     /// to spawn the engine here, keyed by call-id, until a `<call>` carrying a `<relay>` for that id
     /// arrives. Behind the `voip` feature; populated only by the media facade.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub(crate) pending_outgoing_calls: Arc<
         std::sync::Mutex<std::collections::HashMap<String, crate::voip::facade::PendingOutgoing>>,
     >,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -287,9 +287,9 @@ impl Client {
             saver_handle: std::sync::OnceLock::new(),
             alloc_meter: std::sync::OnceLock::new(),
             raw_node_forwarding: AtomicBool::new(false),
-            #[cfg(feature = "voip")]
+            #[cfg(feature = "voip-runtime")]
             call_registry: std::sync::Arc::new(wacore::voip::CallRegistry::new()),
-            #[cfg(feature = "voip")]
+            #[cfg(feature = "voip-runtime")]
             pending_outgoing_calls: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::HashMap::new(),
             )),
@@ -789,7 +789,7 @@ impl Client {
         self.is_connected.store(false, Ordering::Release);
         // Tear down every in-flight VoIP call: the relay socket and signaling are connection-scoped,
         // so a call can't survive a disconnect/reconnect. Aborts each media task and clears the map.
-        #[cfg(feature = "voip")]
+        #[cfg(feature = "voip-runtime")]
         {
             self.call_registry.abort_all();
             // Dormant outgoing calls (relay never arrived) live in pending_outgoing_calls, not the
@@ -992,7 +992,7 @@ impl Client {
 
     /// Force the connected flag (tests only): the facade's connect path now gates on `is_connected`,
     /// so a unit test driving `spawn_call`/`place_call` must mark the client connected first.
-    #[cfg(all(test, feature = "voip"))]
+    #[cfg(all(test, feature = "voip-runtime"))]
     pub(crate) fn set_connected_for_test(&self, connected: bool) {
         self.is_connected.store(connected, Ordering::Release);
     }

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -488,7 +488,7 @@ impl Client {
     /// session with an un-acked pre-key still pending). Reuses the send path's
     /// pre-flight so the voip offer treats a session-present-but-unacked device as
     /// pkmsg too, not as plain msg.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub(crate) async fn would_emit_pkmsg(&self, jid: &Jid) -> Result<bool, anyhow::Error> {
         let device_store = self.persistence_manager.get_device_arc().await;
         let mut adapter = self.signal_adapter_from(device_store);

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -101,7 +101,8 @@ impl Voip<'_> {
     /// Begin answering an incoming call's MEDIA plane: returns a builder; call
     /// `.audio(source, sink)` then `.start().await` to decrypt the callKey, connect the relay, and
     /// drive the call, yielding a [`CallHandle`](crate::voip::CallHandle). Signaling (preaccept /
-    /// accept) is the consumer's concern; this drives only media. Requires the `voip` feature.
+    /// accept) is the consumer's concern; this drives only media. Requires `voip-runtime` or a
+    /// profile that enables it: `voip`, `voip-encoded`, `voip-mlow`, or `voip-libopus`.
     #[cfg(feature = "voip-runtime")]
     pub fn accept<'b>(&'b self, incoming: &'b IncomingCall) -> crate::voip::AcceptCall<'b> {
         crate::voip::facade::AcceptCall::new(self.client, incoming)
@@ -111,7 +112,8 @@ impl Voip<'_> {
     /// then `.start().await` to generate the callKey, encrypt it per peer device, send the `<offer>`,
     /// and register the call, yielding a [`CallHandle`](crate::voip::CallHandle). The media engine
     /// only attaches once the server hands back the relay for our call-id (live), so the returned
-    /// handle is dormant until then. Requires the `voip` feature.
+    /// handle is dormant until then. Requires `voip-runtime` or a profile that enables it: `voip`,
+    /// `voip-encoded`, `voip-mlow`, or `voip-libopus`.
     #[cfg(feature = "voip-runtime")]
     pub fn call<'b>(&'b self, peer: &'b Jid) -> crate::voip::OutgoingCall<'b> {
         crate::voip::facade::OutgoingCall::new(self.client, peer)

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1,7 +1,7 @@
 //! Call-control accessor. Signaling (reject/terminate) is always available since
 //! the stanza builders live in core; media (call/accept) needs the `voip` feature.
 
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 use std::sync::Arc;
 
 use wacore::stanza::call::{TerminateParams, build_reject, build_terminate};
@@ -25,7 +25,7 @@ impl Client {
 
     /// The per-call media registry the `voip` facade registers active calls in. `pub(crate)` so the
     /// facade and the connection-cleanup teardown share one instance.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub(crate) fn call_registry(&self) -> Arc<wacore::voip::CallRegistry> {
         self.call_registry.clone()
     }
@@ -41,37 +41,41 @@ pub enum CallError {
     #[error("call_id cannot be empty")]
     EmptyCallId,
     /// `accept` was called with an `IncomingCall` that is not an `<offer>` (nothing to answer).
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("not an incoming call offer")]
     NotAnOffer,
-    /// `accept().start()` was called without `audio(source, sink)`.
-    #[cfg(feature = "voip")]
-    #[error("accept() requires audio(source, sink) before start()")]
+    /// `accept().start()` was called without PCM or encoded audio endpoints.
+    #[cfg(feature = "voip-runtime")]
+    #[error("accept() requires audio(...) or encoded_audio(...) before start()")]
     MissingAudio,
+    /// The selected media profile was not present in the incoming offer.
+    #[cfg(feature = "voip-runtime")]
+    #[error("incoming offer does not advertise the selected audio rate {0}")]
+    AudioFormatNotOffered(u32),
     /// Decrypting the offer's encrypted callKey failed.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("callKey decrypt failed: {0}")]
     Decrypt(String),
     /// Assembling the call config from the offer's relay block failed.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("call setup failed: {0}")]
     Setup(String),
     /// Connecting the relay media transport (UDP/DTLS/SCTP) failed.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("relay connect failed: {0}")]
     Connect(String),
     /// The offer was missing media material (no `<enc>`/`<relay>`, no callKey, no own LID, etc.).
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("media offer error: {0}")]
     Media(&'static str),
     /// `call(peer)` resolved zero devices for the peer (nothing to address an offer to).
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("peer has no resolvable devices")]
     NoDevices,
     /// An outgoing offer would emit a pkmsg `<enc>` but we hold no ADV account, so the peer could
     /// not validate the pre-key message. Refused before send to avoid advancing the sender chain
     /// (mirrors the peer-send path's `<device-identity>` requirement).
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[error("offer pkmsg requires <device-identity> (account is None)")]
     MissingDeviceIdentity,
 }
@@ -88,7 +92,7 @@ impl Voip<'_> {
         // Consume the ringing flag BEFORE the async send: a caller <terminate> processed while we await
         // the send would otherwise hit take_ringing first and surface a phantom missed call for a call
         // we already declined (WA Web deletes it from _ringingCalls on reject). No-op if never ringing.
-        #[cfg(feature = "voip")]
+        #[cfg(feature = "voip-runtime")]
         self.client.call_registry().take_ringing(call_id);
         self.client.send_node(stanza).await?;
         Ok(())
@@ -98,7 +102,7 @@ impl Voip<'_> {
     /// `.audio(source, sink)` then `.start().await` to decrypt the callKey, connect the relay, and
     /// drive the call, yielding a [`CallHandle`](crate::voip::CallHandle). Signaling (preaccept /
     /// accept) is the consumer's concern; this drives only media. Requires the `voip` feature.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub fn accept<'b>(&'b self, incoming: &'b IncomingCall) -> crate::voip::AcceptCall<'b> {
         crate::voip::facade::AcceptCall::new(self.client, incoming)
     }
@@ -108,7 +112,7 @@ impl Voip<'_> {
     /// and register the call, yielding a [`CallHandle`](crate::voip::CallHandle). The media engine
     /// only attaches once the server hands back the relay for our call-id (live), so the returned
     /// handle is dormant until then. Requires the `voip` feature.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub fn call<'b>(&'b self, peer: &'b Jid) -> crate::voip::OutgoingCall<'b> {
         crate::voip::facade::OutgoingCall::new(self.client, peer)
     }
@@ -136,7 +140,7 @@ impl Voip<'_> {
         // hang up, and a failed signaling send must not leave the media task capturing/sending (or a
         // dormant outgoing call free to attach on a late relay ack). Reuse the same teardown the peer's
         // `<terminate>` triggers so the public hangup actually ends our side too.
-        #[cfg(feature = "voip")]
+        #[cfg(feature = "voip-runtime")]
         crate::voip::facade::terminate_call(self.client, call_id);
         sent?;
         Ok(())
@@ -188,10 +192,10 @@ mod tests {
         (client, count)
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     struct FailingTransport;
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl crate::transport::Transport for FailingTransport {
@@ -201,7 +205,7 @@ mod tests {
         async fn disconnect(&self) {}
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     async fn make_client_failing() -> Arc<Client> {
         let client = crate::test_utils::create_test_client().await;
         let socket_transport: Arc<dyn crate::transport::Transport> = Arc::new(FailingTransport);
@@ -261,7 +265,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 1);
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn terminate_aborts_the_local_call() {
         use wacore::voip::CallSession;
@@ -285,7 +289,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn terminate_tears_down_local_even_when_send_fails() {
         use wacore::voip::CallSession;

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -113,6 +113,7 @@ impl StanzaHandler for CallHandler {
                             "call: peer selected audio rates {received_rates:?}, expected {}",
                             expected.signaling_rate
                         );
+                        dismiss_outgoing_siblings(&client, &call).await;
                         client.call_registry().send_call_event(
                             call.action.call_id(),
                             CallEvent::AudioFormatMismatch {
@@ -588,6 +589,7 @@ mod tests {
     #[cfg(feature = "voip-runtime")]
     fn register_native_opus_call(
         client: &Client,
+        ring_devices: Vec<Jid>,
     ) -> async_channel::Receiver<wacore::voip::CallEvent> {
         use wacore::voip::{AudioFormat, CallEvent};
 
@@ -598,6 +600,7 @@ mod tests {
             fake_caller_lid(),
         );
         session.audio_format = Some(AudioFormat::OPUS_16KHZ_60MS);
+        session.ring_devices = ring_devices;
         let generation = registry.insert(session);
         let (event_tx, event_rx) = async_channel::unbounded::<CallEvent>();
         let (control_tx, _control_rx) = video_control_channel();
@@ -616,9 +619,10 @@ mod tests {
     async fn incompatible_audio_selection_emits_event_and_terminates_call() {
         use wacore::voip::CallEvent;
 
-        let client = make_sending_client().await;
-        let event_rx = register_native_opus_call(&client);
-        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let (client, sends) = make_sending_client_with_failure_after(None).await;
+        let accepting = fake_caller_lid();
+        let event_rx =
+            register_native_opus_call(&client, vec![accepting.clone(), accepting.with_device(1)]);
 
         let mut cancelled = false;
         assert!(
@@ -638,14 +642,7 @@ mod tests {
                 received_rates: vec![8_000],
             })
         );
-        let terminate = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
-            .await
-            .expect("terminate must be sent")
-            .expect("waiter");
-        assert_eq!(
-            terminate.as_node_ref().children().unwrap()[0].tag,
-            "terminate"
-        );
+        assert_eq!(sends.load(std::sync::atomic::Ordering::SeqCst), 2);
         assert!(client.call_registry().snapshot("CALL-ID-0001").is_none());
         assert!(!cancelled);
     }
@@ -654,7 +651,7 @@ mod tests {
     #[tokio::test]
     async fn compatible_audio_selection_keeps_call_active() {
         let (client, sends) = make_sending_client_with_failure_after(None).await;
-        let event_rx = register_native_opus_call(&client);
+        let event_rx = register_native_opus_call(&client, Vec::new());
         let (handler, global_rx) = ChannelEventHandler::new();
         client.register_handler(handler);
 

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -568,6 +568,120 @@ mod tests {
             .build()
     }
 
+    #[cfg(feature = "voip-runtime")]
+    fn audio_selection_stanza(rate: &str) -> wacore_binary::Node {
+        NodeBuilder::new("call")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-AUDIO")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("accept")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CALL-ID-0001")
+                .children([NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", rate.to_string())
+                    .build()])
+                .build()])
+            .build()
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn register_native_opus_call(
+        client: &Client,
+    ) -> async_channel::Receiver<wacore::voip::CallEvent> {
+        use wacore::voip::{AudioFormat, CallEvent};
+
+        let registry = client.call_registry();
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            "CALL-ID-0001",
+            fake_caller_lid(),
+            fake_caller_lid(),
+        );
+        session.audio_format = Some(AudioFormat::OPUS_16KHZ_60MS);
+        let generation = registry.insert(session);
+        let (event_tx, event_rx) = async_channel::unbounded::<CallEvent>();
+        let (control_tx, _control_rx) = video_control_channel();
+        registry.set_video_channels(
+            "CALL-ID-0001",
+            generation,
+            event_tx,
+            control_tx,
+            Box::new(|| {}),
+        );
+        event_rx
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn incompatible_audio_selection_emits_event_and_terminates_call() {
+        use wacore::voip::CallEvent;
+
+        let client = make_sending_client().await;
+        let event_rx = register_native_opus_call(&client);
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&audio_selection_stanza("8000")),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        assert_eq!(
+            event_rx.try_recv(),
+            Ok(CallEvent::AudioFormatMismatch {
+                expected_rate: 16_000,
+                received_rates: vec![8_000],
+            })
+        );
+        let terminate = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("terminate must be sent")
+            .expect("waiter");
+        assert_eq!(
+            terminate.as_node_ref().children().unwrap()[0].tag,
+            "terminate"
+        );
+        assert!(client.call_registry().snapshot("CALL-ID-0001").is_none());
+        assert!(!cancelled);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn compatible_audio_selection_keeps_call_active() {
+        let (client, sends) = make_sending_client_with_failure_after(None).await;
+        let event_rx = register_native_opus_call(&client);
+        let (handler, global_rx) = ChannelEventHandler::new();
+        client.register_handler(handler);
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&audio_selection_stanza("16000")),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        assert!(event_rx.try_recv().is_err());
+        assert!(client.call_registry().snapshot("CALL-ID-0001").is_some());
+        assert_eq!(sends.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(matches!(
+            global_rx.try_recv().as_deref(),
+            Ok(Event::IncomingCall(IncomingCall {
+                action: CallAction::Accept { .. },
+                ..
+            }))
+        ));
+        assert!(!cancelled);
+    }
+
     // A <call><video> must be acked with the TYPED <ack class="call" type="video"> and the
     // generic router ack suppressed — an untyped ack makes the upgrade requester revert ~5s in.
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::{debug, warn};
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 use wacore::stanza::call::{
     TERMINATE_REASON_ACCEPTED_ELSEWHERE, TERMINATE_REASON_GROUP_CALL_ENDED,
     TERMINATE_REASON_REJECTED_ELSEWHERE, TERMINATE_REASON_TIMEOUT, TerminateParams,
@@ -10,12 +10,12 @@ use wacore::stanza::call::{
 };
 use wacore::stanza::call::{build_offer_ack_receipt, parse_call_stanza};
 use wacore::types::call::{CallAction, IncomingCall, MissedCall, MissedReason};
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 use wacore::types::call::{CallEndedElsewhere, ElsewhereOutcome, VideoState};
 use wacore::types::events::Event;
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 use wacore::voip::{CallEvent, VideoControl};
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 use wacore_binary::Jid;
 use wacore_binary::{OwnedNodeRef, Server};
 
@@ -47,7 +47,7 @@ impl StanzaHandler for CallHandler {
         cancelled: &mut bool,
     ) -> bool {
         // Silence the unused-parameter warning on the no-voip build (only the video arm cancels).
-        #[cfg(not(feature = "voip"))]
+        #[cfg(not(feature = "voip-runtime"))]
         let _ = &cancelled;
         let nr = node.get();
         match parse_call_stanza(nr) {
@@ -85,7 +85,7 @@ impl StanzaHandler for CallHandler {
                     // offer-ack await: <call> stanzas are processed concurrently, so a fast <terminate>
                     // for this offer racing the await must see the ringing flag (else its missed-call
                     // is lost and we'd set a stale flag after the call already ended).
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     if is_offer {
                         client
                             .call_registry()
@@ -94,11 +94,50 @@ impl StanzaHandler for CallHandler {
                     if is_offer && let Err(e) = send_offer_ack_receipt(&client, &call).await {
                         warn!("call: failed to send offer ack receipt: {e}");
                     }
+                    #[cfg(feature = "voip-runtime")]
+                    if let CallAction::PreAccept { audio, .. } | CallAction::Accept { audio, .. } =
+                        &call.action
+                        && !audio.is_empty()
+                        && let Some(expected) = client
+                            .call_registry()
+                            .snapshot(call.action.call_id())
+                            .and_then(|session| session.audio_format)
+                        && !audio.iter().any(|codec| {
+                            codec.enc.eq_ignore_ascii_case("opus")
+                                && codec.rate == expected.signaling_rate
+                        })
+                    {
+                        let received_rates =
+                            audio.iter().map(|codec| codec.rate).collect::<Vec<_>>();
+                        warn!(
+                            "call: peer selected audio rates {received_rates:?}, expected {}",
+                            expected.signaling_rate
+                        );
+                        client.call_registry().send_call_event(
+                            call.action.call_id(),
+                            CallEvent::AudioFormatMismatch {
+                                expected_rate: expected.signaling_rate,
+                                received_rates,
+                            },
+                        );
+                        if let Err(e) = client
+                            .voip()
+                            .terminate(
+                                call.action.call_id(),
+                                &call.from,
+                                call.action.call_creator(),
+                            )
+                            .await
+                        {
+                            warn!("call: failed to terminate incompatible audio profile: {e}");
+                        }
+                        return true;
+                    }
                     // Caller-side: key our recv path to the device that actually answered. We dial the
                     // base callee LID, but a companion answers from `:N` and encrypts under its own
                     // device id; without this every inbound frame decrypts to garbage. One-shot, and a
                     // no-op for an incoming call or a call we aren't the caller of (no sender registered).
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     if let CallAction::Accept { .. } = &call.action {
                         // Record the device that answered so a later <terminate> targets it (call
                         // signaling is addressed per device, not to the bare peer the offer rang).
@@ -111,7 +150,7 @@ impl StanzaHandler for CallHandler {
                     }
                     // Caller-side multi-device dismiss: when one of the callee's devices accepts or
                     // rejects an outbound call of ours, tell the rest to stop ringing.
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     dismiss_outgoing_siblings(&client, &call).await;
                     // A <terminate> for a call that was still ringing (an incoming offer we never
                     // answered) gets a terminal outcome. We mirror WA Web's
@@ -122,7 +161,7 @@ impl StanzaHandler for CallHandler {
                     // answered, outgoing, or already-terminated call, so we never misfire for our own
                     // outgoing call or a duplicate terminate; it still consumes the flag on any reason.
                     // Decided BEFORE terminate_call below.
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     if let CallAction::Terminate { reason, .. } = &call.action
                         && client.call_registry().take_ringing(call.action.call_id())
                     {
@@ -158,22 +197,22 @@ impl StanzaHandler for CallHandler {
                             client.core.event_bus.dispatch(outcome);
                         }
                     }
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     if matches!(
                         &call.action,
                         CallAction::Reject { .. } | CallAction::Terminate { .. }
                     ) {
                         crate::voip::facade::terminate_call(&client, call.action.call_id());
                     }
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     let mut dispatch_call = true;
-                    #[cfg(not(feature = "voip"))]
+                    #[cfg(not(feature = "voip-runtime"))]
                     let dispatch_call = true;
                     // In-call <video state> signaling: send the TYPED ack (`type="video"`) and
                     // suppress the router's generic one — an untyped ack makes the upgrade
                     // requester assume failure and revert after ~5s. Serialize event publication,
                     // then expose the state only after that ack commits it.
-                    #[cfg(feature = "voip")]
+                    #[cfg(feature = "voip-runtime")]
                     if let CallAction::VideoState {
                         state, orientation, ..
                     } = &call.action
@@ -332,7 +371,7 @@ async fn send_offer_ack_receipt(client: &Client, call: &IncomingCall) -> anyhow:
 /// duplicate accept/reject can't re-dismiss. No-op for any other action, or a call we aren't the
 /// caller of (inbound call, single-device callee, or one already dismissed). A `Terminate` needs no
 /// handling here: the call ends, its registry entry (and the device set with it) goes away.
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 async fn dismiss_outgoing_siblings(client: &Client, call: &IncomingCall) {
     let reason = match &call.action {
         CallAction::Accept { .. } => TERMINATE_REASON_ACCEPTED_ELSEWHERE,
@@ -388,7 +427,7 @@ async fn dismiss_outgoing_siblings(client: &Client, call: &IncomingCall) {
 
 /// Whether two JIDs name the same device: user + server + device id. Excludes `agent`/`integrator`,
 /// representation details that can differ between the usync device-list and a stanza's `from`.
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 fn same_device(a: &Jid, b: &Jid) -> bool {
     a.user == b.user && a.server == b.server && a.device == b.device
 }
@@ -399,7 +438,7 @@ mod tests {
     use crate::test_utils::node_to_owned_ref;
     use std::sync::Arc;
     use wacore::types::events::{ChannelEventHandler, Event};
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     use wacore::voip::video_control_channel;
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
@@ -429,12 +468,12 @@ mod tests {
     }
 
     /// A client whose sends land on a counting transport (so ack sends succeed and can be counted).
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     async fn make_sending_client() -> Arc<Client> {
         make_sending_client_with_failure_after(None).await.0
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     async fn make_sending_client_with_failure_after(
         failure_after: Option<usize>,
     ) -> (Arc<Client>, Arc<std::sync::atomic::AtomicUsize>) {
@@ -474,7 +513,7 @@ mod tests {
         (client, sends)
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     async fn make_blocking_sending_client() -> (
         Arc<Client>,
         async_channel::Receiver<()>,
@@ -514,7 +553,7 @@ mod tests {
         (client, started_rx, release_tx)
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     fn video_stanza(state: &str) -> wacore_binary::Node {
         NodeBuilder::new("call")
             .attr("from", fake_caller_lid())
@@ -531,7 +570,7 @@ mod tests {
 
     // A <call><video> must be acked with the TYPED <ack class="call" type="video"> and the
     // generic router ack suppressed — an untyped ack makes the upgrade requester revert ~5s in.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn video_state_sends_typed_ack_and_cancels_generic() {
         use wacore::voip::CallEvent;
@@ -572,7 +611,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn video_state_is_not_visible_before_typed_ack_completes() {
         use wacore::voip::CallEvent;
@@ -622,7 +661,7 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn video_transition_stays_serialized_through_enabled_announcement() {
         use wacore::voip::CallEvent;
@@ -671,7 +710,7 @@ mod tests {
         assert!(registry.reserve_call_event("CALL-ID-0001").is_some());
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn failed_enabled_announcement_rolls_back_the_video_upgrade() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -717,7 +756,7 @@ mod tests {
         assert!(registry.reserve_call_event("CALL-ID-0001").is_some());
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn video_state_does_not_mutate_a_same_id_replacement_after_ack_await() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -796,7 +835,7 @@ mod tests {
     }
 
     // Non-video call actions keep the generic ack: `cancelled` must stay false.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn non_video_actions_keep_the_generic_ack() {
         let client = make_sending_client().await;
@@ -808,7 +847,7 @@ mod tests {
 
     // The video state must reach the call's event stream (via the registry hook) with the
     // orientation, steer the plane (Enable on accept), and update the session's is_video flag.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn video_state_forwards_event_and_steers_the_plane() {
         use wacore::types::call::VideoState;
@@ -889,7 +928,7 @@ mod tests {
 
     // A peer that REJECTS or CANCELS an upgrade we started must fully release our local video: the
     // registered teardown hook runs (so the camera feed stops) and the session flag clears.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn refused_upgrade_runs_local_video_teardown() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -931,7 +970,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn refused_upgrade_tears_down_when_typed_ack_send_fails() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -971,7 +1010,7 @@ mod tests {
         assert!(!registry.snapshot("CALL-ID-0001").expect("session").is_video);
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn unacked_video_state_is_not_dispatched_globally() {
         use wacore::voip::CallEvent;
@@ -1007,7 +1046,7 @@ mod tests {
         assert!(ctl_rx.try_recv().is_err());
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn committed_video_state_supersedes_diagnostics_when_event_queue_is_full() {
         use wacore::voip::{CallEvent, VideoControl};
@@ -1169,7 +1208,7 @@ mod tests {
     // device gets a per-device `<call to=DEVICE_JID id=..><terminate reason="accepted_elsewhere">`
     // (no <destination> block), and the rung set is consumed one-shot. A two-device callee keeps the
     // assertion to a single dismiss stanza the waiter can capture in full.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn accept_dismisses_other_callee_device() {
         let client = make_client().await;
@@ -1234,7 +1273,7 @@ mod tests {
 
     // A peer <terminate> for our call tears it down: the registry entry (and with it the media task)
     // is removed so CallHandle::wait_ended() resolves, instead of leaking until a relay timeout.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn terminate_tears_down_the_call() {
         let client = make_client().await;
@@ -1281,12 +1320,12 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     fn terminate_stanza(from: Jid, call_creator: Jid, call_id: &str) -> wacore_binary::Node {
         terminate_stanza_reason(from, call_creator, call_id, None)
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     fn terminate_stanza_reason(
         from: Jid,
         call_creator: Jid,
@@ -1307,7 +1346,7 @@ mod tests {
             .build()
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     fn count_missed(rx: &async_channel::Receiver<Arc<Event>>, call_id: &str) -> usize {
         let mut n = 0;
         while let Ok(ev) = rx.try_recv() {
@@ -1324,7 +1363,7 @@ mod tests {
     // An incoming offer that rings and is never answered, then a peer <terminate>, surfaces exactly
     // one MissedCall(Remote) -- WA Web's missed-call outcome. The offer is what marks the call ringing;
     // a terminate with no preceding offer is an ended call, not a missed one.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn unanswered_incoming_terminate_surfaces_missed_call() {
         let client = make_client().await;
@@ -1362,7 +1401,7 @@ mod tests {
 
     // A duplicate <terminate> for the same unanswered call must NOT re-fire a missed call: the ringing
     // flag is consumed one-shot by the first terminate.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn duplicate_terminate_does_not_refire_missed_call() {
         let client = make_client().await;
@@ -1401,7 +1440,7 @@ mod tests {
     // A <terminate> for an OUTGOING call we placed must NOT surface a missed call: we never rang for
     // it, so it is an ended call, not a missed one. This is the regression the registry-absence gate
     // produced -- our own call's teardown looked identical to an unanswered incoming call.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn outgoing_call_terminate_does_not_surface_missed_call() {
         let client = make_client().await;
@@ -1443,7 +1482,7 @@ mod tests {
     // outcome: accepted_elsewhere -> AcceptedElsewhere and rejected_elsewhere -> Rejected, meaning
     // another of our devices took the call. A companion device that rang then receives the caller's
     // elsewhere-dismiss must surface CallEndedElsewhere with the matching outcome, NOT a MissedCall.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn elsewhere_terminate_surfaces_call_ended_elsewhere_not_missed() {
         for (reason, expected) in [
@@ -1505,7 +1544,7 @@ mod tests {
 
     // A reason that IS a missed outcome (timeout) on a still-ringing call surfaces the missed call,
     // confirming the reason gate excludes only the elsewhere outcomes, not every reason.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn timeout_terminate_surfaces_missed_call() {
         let client = make_client().await;
@@ -1546,7 +1585,7 @@ mod tests {
 
     // A call we locally declined must not later be recorded as missed: reject() consumes the ringing
     // flag, so a caller <terminate> that follows our <reject> reads as ended, not missed.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn local_reject_then_caller_terminate_is_not_missed() {
         use async_trait::async_trait;
@@ -1621,7 +1660,7 @@ mod tests {
     // A call we answered must not later be recorded as missed: accepting registers the call (as
     // accept().start() -> spawn_call -> registry.insert does), which consumes the ringing flag, so a
     // caller <terminate> after we picked up reads as ended, not missed.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn answered_call_then_caller_terminate_is_not_missed() {
         let client = make_client().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub mod socket;
 pub mod store;
 pub mod transport;
 pub mod upload;
-#[cfg(feature = "voip")]
+#[cfg(feature = "voip-runtime")]
 pub mod voip;
 pub use upload::UploadOptions;
 

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -155,7 +155,7 @@ impl Client {
     /// sender bucket. Independent of the 1:1 message AB props — WA Web schedules
     /// `sendTcToken` on its own cadence (`MsgJob`, `StartCall`) regardless of
     /// whether a token was attached to the outgoing stanza.
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     pub(crate) async fn should_issue_tc_token(&self, to: &Jid) -> bool {
         use wacore::iq::tctoken::should_send_new_tc_token_with;
 
@@ -462,7 +462,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn should_issue_tc_token_true_for_unknown_contact() {
         let client = create_test_client().await;
@@ -473,7 +473,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn should_issue_tc_token_false_within_sender_bucket() {
         let client = create_test_client().await;
@@ -498,7 +498,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "voip")]
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn should_issue_tc_token_false_for_self() {
         let client = create_test_client().await;

--- a/src/voip/audio.rs
+++ b/src/voip/audio.rs
@@ -151,6 +151,7 @@ impl WaOpusEncoder {
 #[cfg(feature = "voip-libopus")]
 pub struct WaOpusDecoder {
     dec: Decoder,
+    packet_scratch: Vec<u8>,
 }
 
 #[cfg(feature = "voip-libopus")]
@@ -158,14 +159,20 @@ impl WaOpusDecoder {
     pub fn new() -> Result<Self> {
         let dec = Decoder::new(WA_SAMPLE_RATE, Channels::Mono)
             .map_err(|e| anyhow!("opus decoder init: {e}"))?;
-        Ok(Self { dec })
+        Ok(Self {
+            dec,
+            packet_scratch: Vec::with_capacity(OPUS_MAX_PACKET_BYTES),
+        })
     }
 
     /// Decode one Opus frame to mono 16-bit PCM, returning the decoded samples.
     pub fn decode(&mut self, opus: &[u8]) -> Result<Vec<i16>> {
+        Self::decode_packet(&mut self.dec, opus)
+    }
+
+    fn decode_packet(dec: &mut Decoder, opus: &[u8]) -> Result<Vec<i16>> {
         let mut out = vec![0i16; WA_DECODE_MAX_SAMPLES];
-        let n = self
-            .dec
+        let n = dec
             .decode(opus, &mut out, false)
             .map_err(|e| anyhow!("opus decode: {e}"))?;
         out.truncate(n);
@@ -174,10 +181,11 @@ impl WaOpusDecoder {
 
     /// Restore MLOW's CELT TOC and decode with stock libopus.
     pub fn decode_mlow_escape(&mut self, opus: &[u8]) -> Result<Vec<i16>> {
-        let mut packet = opus.to_vec();
-        depacketize_opus_from_mlow(&mut packet)
+        self.packet_scratch.clear();
+        self.packet_scratch.extend_from_slice(opus);
+        depacketize_opus_from_mlow(&mut self.packet_scratch)
             .map_err(|e| anyhow!("depacketize Opus from MLOW: {e}"))?;
-        self.decode(&packet)
+        Self::decode_packet(&mut self.dec, &self.packet_scratch)
     }
 }
 

--- a/src/voip/audio.rs
+++ b/src/voip/audio.rs
@@ -152,6 +152,7 @@ impl WaOpusEncoder {
 pub struct WaOpusDecoder {
     dec: Decoder,
     packet_scratch: Vec<u8>,
+    pcm_scratch: Vec<i16>,
 }
 
 #[cfg(feature = "voip-libopus")]
@@ -162,30 +163,35 @@ impl WaOpusDecoder {
         Ok(Self {
             dec,
             packet_scratch: Vec::with_capacity(OPUS_MAX_PACKET_BYTES),
+            pcm_scratch: vec![0; WA_DECODE_MAX_SAMPLES],
         })
     }
 
-    /// Decode one Opus frame to mono 16-bit PCM, returning the decoded samples.
-    pub fn decode(&mut self, opus: &[u8]) -> Result<Vec<i16>> {
-        Self::decode_packet(&mut self.dec, opus)
+    /// Decode one Opus frame to mono 16-bit PCM. The returned view is valid until the next decode.
+    pub fn decode(&mut self, opus: &[u8]) -> Result<&[i16]> {
+        Self::decode_packet(&mut self.dec, &mut self.pcm_scratch, opus)
     }
 
-    fn decode_packet(dec: &mut Decoder, opus: &[u8]) -> Result<Vec<i16>> {
-        let mut out = vec![0i16; WA_DECODE_MAX_SAMPLES];
+    fn decode_packet<'a>(
+        dec: &mut Decoder,
+        pcm_scratch: &'a mut Vec<i16>,
+        opus: &[u8],
+    ) -> Result<&'a [i16]> {
+        pcm_scratch.resize(WA_DECODE_MAX_SAMPLES, 0);
         let n = dec
-            .decode(opus, &mut out, false)
+            .decode(opus, pcm_scratch, false)
             .map_err(|e| anyhow!("opus decode: {e}"))?;
-        out.truncate(n);
-        Ok(out)
+        pcm_scratch.truncate(n);
+        Ok(pcm_scratch)
     }
 
     /// Restore MLOW's CELT TOC and decode with stock libopus.
-    pub fn decode_mlow_escape(&mut self, opus: &[u8]) -> Result<Vec<i16>> {
+    pub fn decode_mlow_escape(&mut self, opus: &[u8]) -> Result<&[i16]> {
         self.packet_scratch.clear();
         self.packet_scratch.extend_from_slice(opus);
         depacketize_opus_from_mlow(&mut self.packet_scratch)
             .map_err(|e| anyhow!("depacketize Opus from MLOW: {e}"))?;
-        Self::decode_packet(&mut self.dec, &self.packet_scratch)
+        Self::decode_packet(&mut self.dec, &mut self.pcm_scratch, &self.packet_scratch)
     }
 }
 
@@ -223,6 +229,18 @@ mod tests {
         let encoded = enc.encode(&silence).unwrap();
         let decoded = dec.decode(&encoded).unwrap();
         assert_eq!(decoded.len(), WA_FRAME_SAMPLES);
+    }
+
+    #[test]
+    fn decoder_reuses_pcm_scratch() {
+        let mut enc = WaOpusEncoder::new().unwrap();
+        let mut dec = WaOpusDecoder::new().unwrap();
+        let encoded = enc.encode(&sine_frame()).unwrap();
+
+        let first = dec.decode(&encoded).unwrap().as_ptr();
+        let second = dec.decode(&encoded).unwrap().as_ptr();
+
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/src/voip/audio.rs
+++ b/src/voip/audio.rs
@@ -1,11 +1,13 @@
 //! PCM and encoded-audio endpoints for WhatsApp calls.
 
 #[cfg(feature = "voip-libopus")]
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, ensure};
 use bytes::Bytes;
 #[cfg(feature = "voip-libopus")]
-use opus::{Application, Bitrate, Channels, Decoder, Encoder};
+use opus::{Application, Bandwidth, Bitrate, Channels, Decoder, Encoder};
 use wacore::voip::EncodedAudioFrame;
+#[cfg(feature = "voip-libopus")]
+use wacore::voip::{depacketize_opus_from_mlow, packetize_opus_for_mlow};
 
 /// A microphone source for a call: 60 ms / 960-sample mono i16 frames at 16 kHz. The media facade
 /// pulls frames from the returned channel and feeds them to the engine; a closed channel (e.g. the
@@ -42,8 +44,9 @@ impl AudioSink for async_channel::Sender<Vec<i16>> {
     }
 }
 
-/// A source of complete codec payloads. Each item must be one raw MLOW or Opus packet; container
-/// framing such as Ogg pages is not accepted. The engine adds RTP/SRTP framing without transcoding.
+/// A source of complete codec payloads. Each item must be one raw MLOW or profile-compatible Opus
+/// packet; container framing such as Ogg pages is not accepted. The engine adds RTP/SRTP framing
+/// without transcoding.
 pub trait EncodedAudioSource: Send + Sync + 'static {
     fn frames(&self) -> async_channel::Receiver<Bytes>;
 }
@@ -68,17 +71,21 @@ impl EncodedAudioSink for async_channel::Sender<EncodedAudioFrame> {
 pub const WA_SAMPLE_RATE: u32 = 16_000;
 /// 60 ms @ 16 kHz.
 pub const WA_FRAME_SAMPLES: usize = 960;
-/// Max decode frame (60 ms @ 48 kHz headroom).
-pub const WA_DECODE_MAX_SAMPLES: usize = 2880;
+/// Opus permits at most 120 ms in one packet; the decoder emits 16 kHz PCM.
+pub const WA_DECODE_MAX_SAMPLES: usize = 1_920;
 #[cfg(feature = "voip-libopus")]
-const WA_BITRATE: i32 = 25_000;
+const WA_BITRATE: i32 = 24_000;
 #[cfg(feature = "voip-libopus")]
-const WA_COMPLEXITY: i32 = 9;
+const WA_COMPLEXITY: i32 = 5;
+#[cfg(feature = "voip-libopus")]
+const OPUS_MAX_PACKET_BYTES: usize = 1_275;
 
-/// Opus encoder configured to match the WhatsApp call encoder (minus the mlow layers).
+/// Opus encoder with constructors for standard RTP and MLOW's compatible CELT escape.
 #[cfg(feature = "voip-libopus")]
 pub struct WaOpusEncoder {
     enc: Encoder,
+    frame_samples: usize,
+    require_mlow_escape: bool,
 }
 
 #[cfg(feature = "voip-libopus")]
@@ -86,23 +93,57 @@ impl WaOpusEncoder {
     pub fn new() -> Result<Self> {
         let mut enc = Encoder::new(WA_SAMPLE_RATE, Channels::Mono, Application::Voip)
             .map_err(|e| anyhow!("opus encoder init: {e}"))?;
+        Self::finish_init(&mut enc)?;
+        Ok(Self {
+            enc,
+            frame_samples: WA_FRAME_SAMPLES,
+            require_mlow_escape: false,
+        })
+    }
+
+    /// Configure libopus for the standard-Opus escape inside WhatsApp's MLOW RTP profile.
+    pub fn new_mlow_escape() -> Result<Self> {
+        let mut enc = Encoder::new(WA_SAMPLE_RATE, Channels::Mono, Application::LowDelay)
+            .map_err(|e| anyhow!("opus MLOW-escape encoder init: {e}"))?;
+        Self::finish_init(&mut enc)?;
+        enc.set_max_bandwidth(Bandwidth::Wideband)
+            .map_err(|e| anyhow!("opus set_max_bandwidth: {e}"))?;
+        enc.set_bandwidth(Bandwidth::Wideband)
+            .map_err(|e| anyhow!("opus set_bandwidth: {e}"))?;
+        Ok(Self {
+            enc,
+            frame_samples: WA_FRAME_SAMPLES,
+            require_mlow_escape: true,
+        })
+    }
+
+    fn finish_init(enc: &mut Encoder) -> Result<()> {
         enc.set_bitrate(Bitrate::Bits(WA_BITRATE))
             .map_err(|e| anyhow!("opus set_bitrate: {e}"))?;
         enc.set_complexity(WA_COMPLEXITY)
             .map_err(|e| anyhow!("opus set_complexity: {e}"))?;
-        Ok(Self { enc })
+        enc.set_dtx(true)
+            .map_err(|e| anyhow!("opus set_dtx: {e}"))?;
+        Ok(())
     }
 
-    /// Encode one mono frame of `WA_FRAME_SAMPLES` 16-bit samples to Opus.
+    /// Encode one mono frame at the rate selected by the constructor.
     pub fn encode(&mut self, pcm: &[i16]) -> Result<Vec<u8>> {
-        debug_assert_eq!(
-            pcm.len(),
-            WA_FRAME_SAMPLES,
-            "WaOpusEncoder expects exactly one {WA_FRAME_SAMPLES}-sample frame"
+        ensure!(
+            pcm.len() == self.frame_samples,
+            "WaOpusEncoder expects exactly {} samples, got {}",
+            self.frame_samples,
+            pcm.len()
         );
-        self.enc
-            .encode_vec(pcm, pcm.len() * 2 + 64)
-            .map_err(|e| anyhow!("opus encode: {e}"))
+        let mut payload = self
+            .enc
+            .encode_vec(pcm, OPUS_MAX_PACKET_BYTES)
+            .map_err(|e| anyhow!("opus encode: {e}"))?;
+        if self.require_mlow_escape {
+            packetize_opus_for_mlow(&mut payload)
+                .map_err(|e| anyhow!("packetize Opus for MLOW: {e}"))?;
+        }
+        Ok(payload)
     }
 }
 
@@ -129,6 +170,14 @@ impl WaOpusDecoder {
             .map_err(|e| anyhow!("opus decode: {e}"))?;
         out.truncate(n);
         Ok(out)
+    }
+
+    /// Restore MLOW's CELT TOC and decode with stock libopus.
+    pub fn decode_mlow_escape(&mut self, opus: &[u8]) -> Result<Vec<i16>> {
+        let mut packet = opus.to_vec();
+        depacketize_opus_from_mlow(&mut packet)
+            .map_err(|e| anyhow!("depacketize Opus from MLOW: {e}"))?;
+        self.decode(&packet)
     }
 }
 
@@ -166,5 +215,43 @@ mod tests {
         let encoded = enc.encode(&silence).unwrap();
         let decoded = dec.decode(&encoded).unwrap();
         assert_eq!(decoded.len(), WA_FRAME_SAMPLES);
+    }
+
+    #[test]
+    fn mlow_escape_encoder_emits_celt_toc_and_60ms_packet() {
+        let mut enc = WaOpusEncoder::new_mlow_escape().unwrap();
+        let mut dec = WaOpusDecoder::new().unwrap();
+        let pcm = sine_frame();
+        let encoded = enc.encode(&pcm).unwrap();
+
+        assert_eq!(encoded[0], 0xDD);
+        assert_eq!(encoded[1] & 0x3F, 3);
+        assert_eq!(
+            dec.decode_mlow_escape(&encoded).unwrap().len(),
+            WA_FRAME_SAMPLES
+        );
+    }
+
+    #[test]
+    fn mlow_escape_encoder_maps_opus_dtx_to_mlow_sid() {
+        let mut enc = WaOpusEncoder::new_mlow_escape().unwrap();
+        let silence = vec![0i16; WA_FRAME_SAMPLES];
+
+        let encoded = (0..20)
+            .map(|_| enc.encode(&silence).unwrap())
+            .find(|packet| packet.as_slice() == [0x90]);
+
+        assert!(
+            encoded.is_some(),
+            "Opus did not enter DTX within 1.2 seconds"
+        );
+    }
+
+    #[test]
+    fn mlow_escape_encoder_maps_initial_silence_to_mlow_sid() {
+        let mut enc = WaOpusEncoder::new_mlow_escape().unwrap();
+        let silence = vec![0i16; WA_FRAME_SAMPLES];
+
+        assert_eq!(enc.encode(&silence).unwrap(), [0x90]);
     }
 }

--- a/src/voip/audio.rs
+++ b/src/voip/audio.rs
@@ -1,9 +1,11 @@
-//! Opus audio for WhatsApp calls. Standard libopus (the proprietary "mlow" encode is not
-//! portable) at 16 kHz mono, Voip mode, 60 ms frames, which the peer accepts. Priming frames
-//! are hardcoded constants (see `wacore::voip::rtp`) and bypass the encoder.
+//! PCM and encoded-audio endpoints for WhatsApp calls.
 
+#[cfg(feature = "voip-libopus")]
 use anyhow::{Result, anyhow};
+use bytes::Bytes;
+#[cfg(feature = "voip-libopus")]
 use opus::{Application, Bitrate, Channels, Decoder, Encoder};
+use wacore::voip::EncodedAudioFrame;
 
 /// A microphone source for a call: 60 ms / 960-sample mono i16 frames at 16 kHz. The media facade
 /// pulls frames from the returned channel and feeds them to the engine; a closed channel (e.g. the
@@ -40,19 +42,46 @@ impl AudioSink for async_channel::Sender<Vec<i16>> {
     }
 }
 
+/// A source of complete codec payloads. Each item must be one raw MLOW or Opus packet; container
+/// framing such as Ogg pages is not accepted. The engine adds RTP/SRTP framing without transcoding.
+pub trait EncodedAudioSource: Send + Sync + 'static {
+    fn frames(&self) -> async_channel::Receiver<Bytes>;
+}
+
+/// A sink for decrypted codec payloads with their original RTP metadata.
+pub trait EncodedAudioSink: Send + Sync + 'static {
+    fn frames(&self) -> async_channel::Sender<EncodedAudioFrame>;
+}
+
+impl EncodedAudioSource for async_channel::Receiver<Bytes> {
+    fn frames(&self) -> async_channel::Receiver<Bytes> {
+        self.clone()
+    }
+}
+
+impl EncodedAudioSink for async_channel::Sender<EncodedAudioFrame> {
+    fn frames(&self) -> async_channel::Sender<EncodedAudioFrame> {
+        self.clone()
+    }
+}
+
 pub const WA_SAMPLE_RATE: u32 = 16_000;
 /// 60 ms @ 16 kHz.
 pub const WA_FRAME_SAMPLES: usize = 960;
 /// Max decode frame (60 ms @ 48 kHz headroom).
 pub const WA_DECODE_MAX_SAMPLES: usize = 2880;
+#[cfg(feature = "voip-libopus")]
 const WA_BITRATE: i32 = 25_000;
+#[cfg(feature = "voip-libopus")]
 const WA_COMPLEXITY: i32 = 9;
 
 /// Opus encoder configured to match the WhatsApp call encoder (minus the mlow layers).
+#[cfg(feature = "voip-libopus")]
 pub struct WaOpusEncoder {
     enc: Encoder,
 }
 
+#[cfg(feature = "voip-libopus")]
 impl WaOpusEncoder {
     pub fn new() -> Result<Self> {
         let mut enc = Encoder::new(WA_SAMPLE_RATE, Channels::Mono, Application::Voip)
@@ -78,10 +107,12 @@ impl WaOpusEncoder {
 }
 
 /// Opus decoder (mono, 16 kHz).
+#[cfg(feature = "voip-libopus")]
 pub struct WaOpusDecoder {
     dec: Decoder,
 }
 
+#[cfg(feature = "voip-libopus")]
 impl WaOpusDecoder {
     pub fn new() -> Result<Self> {
         let dec = Decoder::new(WA_SAMPLE_RATE, Channels::Mono)
@@ -101,7 +132,7 @@ impl WaOpusDecoder {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "voip-libopus"))]
 mod tests {
     use super::*;
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -613,6 +613,7 @@ async fn place_call(
         // failures left a single surviving key, so that key stays tied to its device.
         multi_device,
         video: video.is_some(),
+        audio_rates: wacore::stanza::call::DEFAULT_AUDIO_RATES,
     });
 
     // Register the ack-waiter for the offer's stanza id BEFORE send_node so a fast server reply can't

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use bytes::Bytes;
 use log::warn;
 use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
@@ -19,17 +20,44 @@ use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
 use wacore::voip::transport::RelayTransportFactory;
 use wacore::voip::{
-    CallChannels, CallConfig, CallEngine, CallEvent, VideoControl, VideoControlReceiver,
-    VideoControlSender, VideoFrame, video_control_channel,
+    AudioConfig, AudioFormat, CallChannels, CallConfig, CallEngine, CallEvent, EncodedAudioFrame,
+    VideoControl, VideoControlReceiver, VideoControlSender, VideoFrame, video_control_channel,
 };
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
 
 use crate::client::{CallError, Client};
-use crate::voip::audio::{AudioSink, AudioSource, WA_FRAME_SAMPLES};
+use crate::voip::audio::{
+    AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource, WA_FRAME_SAMPLES,
+};
 use crate::voip::driver::{RandTxIds, run_call_tokio};
 use crate::voip::transport::RelayMediaChannelFactory;
 use crate::voip::video::{VideoSink, VideoSource};
+
+enum AudioEndpoints {
+    Pcm {
+        source: Arc<dyn AudioSource>,
+        sink: Arc<dyn AudioSink>,
+    },
+    Encoded {
+        format: AudioFormat,
+        source: Arc<dyn EncodedAudioSource>,
+        sink: Arc<dyn EncodedAudioSink>,
+    },
+}
+
+impl AudioEndpoints {
+    fn config(&self) -> AudioConfig {
+        match self {
+            Self::Pcm { .. } => AudioConfig::MLOW_PCM,
+            Self::Encoded { format, .. } => AudioConfig::encoded(*format),
+        }
+    }
+
+    fn signaling_rate(&self) -> u32 {
+        self.config().format.signaling_rate
+    }
+}
 
 /// Builder returned by [`Voip::accept`](super::super::client::voip::Voip::accept). Holds the offer
 /// and, once [`audio`](Self::audio) is called, the source/sink, then [`start`](Self::start) drives
@@ -37,8 +65,7 @@ use crate::voip::video::{VideoSink, VideoSource};
 pub struct AcceptCall<'a> {
     pub(crate) client: &'a Client,
     pub(crate) incoming: &'a IncomingCall,
-    source: Option<Arc<dyn AudioSource>>,
-    sink: Option<Arc<dyn AudioSink>>,
+    audio: Option<AudioEndpoints>,
     video: Option<VideoEndpoints>,
 }
 
@@ -47,8 +74,7 @@ impl<'a> AcceptCall<'a> {
         Self {
             client,
             incoming,
-            source: None,
-            sink: None,
+            audio: None,
             video: None,
         }
     }
@@ -60,8 +86,25 @@ impl<'a> AcceptCall<'a> {
         S: AudioSource,
         K: AudioSink,
     {
-        self.source = Some(Arc::new(source));
-        self.sink = Some(Arc::new(sink));
+        self.audio = Some(AudioEndpoints::Pcm {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    /// Use complete codec payloads instead of the built-in PCM/MLOW adapter. `Bytes` ownership is
+    /// preserved at the external Opus or MLOW boundary; the engine only adds media framing.
+    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
+    where
+        S: EncodedAudioSource,
+        K: EncodedAudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Encoded {
+            format,
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
         self
     }
 
@@ -94,8 +137,19 @@ impl<'a> AcceptCall<'a> {
     pub async fn start(mut self) -> Result<CallHandle, CallError> {
         // Take the audio endpoints out first; the offline setup (decrypt + config + addr) only
         // borrows `&self`, so move the fields before those borrows to avoid a partial-move clash.
-        let source = self.source.take().ok_or(CallError::MissingAudio)?;
-        let sink = self.sink.take().ok_or(CallError::MissingAudio)?;
+        let audio = self.audio.take().ok_or(CallError::MissingAudio)?;
+        let audio_config = audio.config();
+        if let CallAction::Offer { audio, .. } = &self.incoming.action
+            && !audio.is_empty()
+            && !audio.iter().any(|codec| {
+                codec.enc.eq_ignore_ascii_case("opus")
+                    && codec.rate == audio_config.format.signaling_rate
+            })
+        {
+            return Err(CallError::AudioFormatNotOffered(
+                audio_config.format.signaling_rate,
+            ));
+        }
         let video = self.video.take();
         if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
             return Err(CallError::Media(
@@ -109,7 +163,7 @@ impl<'a> AcceptCall<'a> {
         self.client
             .call_registry()
             .take_ringing(self.incoming.action.call_id());
-        let (engine, call_id, addr) = self.build_engine(video.is_some()).await?;
+        let (engine, call_id, addr) = self.build_engine(video.is_some(), audio_config).await?;
         // The decrypt above may await on the network (prekey fetch). If the connection dropped
         // meanwhile, cleanup_connection_state already ran with no registry entry to abort, so bail
         // rather than register + connect a relay that would outlive the connection.
@@ -122,6 +176,7 @@ impl<'a> AcceptCall<'a> {
             self.incoming.from.clone(),
             self.incoming.action.call_creator().clone(),
         );
+        session.audio_format = Some(audio_config.format);
         session.is_video = video.is_some();
         spawn_call(
             self.client,
@@ -129,8 +184,7 @@ impl<'a> AcceptCall<'a> {
             session,
             engine,
             &factory,
-            source,
-            sink,
+            audio,
             video,
         )
         .await
@@ -142,6 +196,7 @@ impl<'a> AcceptCall<'a> {
     async fn build_engine(
         &self,
         enable_video: bool,
+        audio: AudioConfig,
     ) -> Result<(CallEngine, String, SocketAddr), CallError> {
         let media = self.incoming.media.as_ref().ok_or(CallError::NotAnOffer)?;
         let CallAction::Offer {
@@ -195,6 +250,7 @@ impl<'a> AcceptCall<'a> {
 
         let mut config = CallConfig::for_incoming(call_id, &self_lid, &peer_lid, call_key, relay)
             .map_err(|e| CallError::Setup(e.to_string()))?;
+        config.audio = audio;
         config.enable_video = enable_video;
         // Read the dial addr off the config before CallEngine::new consumes it (no second relay walk).
         let addr = socket_addr_from_config(&config)?;
@@ -211,8 +267,7 @@ impl<'a> AcceptCall<'a> {
 pub struct OutgoingCall<'a> {
     pub(crate) client: &'a Client,
     pub(crate) peer: &'a Jid,
-    source: Option<Arc<dyn AudioSource>>,
-    sink: Option<Arc<dyn AudioSink>>,
+    audio: Option<AudioEndpoints>,
     video: Option<VideoEndpoints>,
 }
 
@@ -221,8 +276,7 @@ impl<'a> OutgoingCall<'a> {
         Self {
             client,
             peer,
-            source: None,
-            sink: None,
+            audio: None,
             video: None,
         }
     }
@@ -234,8 +288,25 @@ impl<'a> OutgoingCall<'a> {
         S: AudioSource,
         K: AudioSink,
     {
-        self.source = Some(Arc::new(source));
-        self.sink = Some(Arc::new(sink));
+        self.audio = Some(AudioEndpoints::Pcm {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    /// Send and receive complete codec payloads. The selected format also controls the outgoing
+    /// offer's single audio rate and the engine's RTP payload type/clock.
+    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
+    where
+        S: EncodedAudioSource,
+        K: EncodedAudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Encoded {
+            format,
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
         self
     }
 
@@ -294,8 +365,7 @@ impl<'a> OutgoingCall<'a> {
         )
     )]
     pub async fn start(mut self) -> Result<CallHandle, CallError> {
-        let source = self.source.take().ok_or(CallError::MissingAudio)?;
-        let sink = self.sink.take().ok_or(CallError::MissingAudio)?;
+        let audio = self.audio.take().ok_or(CallError::MissingAudio)?;
         let video = self.video.take();
         if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
             return Err(CallError::Media(
@@ -395,8 +465,7 @@ impl<'a> OutgoingCall<'a> {
             &own_lid,
             &devices,
             &ring_devices,
-            source,
-            sink,
+            audio,
             video,
         )
         .await
@@ -487,8 +556,7 @@ async fn place_call(
     // The FULL callee device set the server rings (a superset of `devices` -- it includes devices we
     // can't encrypt for). Drives the sibling-dismiss target set and the addressed offer shape.
     ring_devices: &[Jid],
-    source: Arc<dyn AudioSource>,
-    sink: Arc<dyn AudioSink>,
+    audio: AudioEndpoints,
     video: Option<VideoEndpoints>,
 ) -> Result<CallHandle, CallError> {
     // The offer keeps the addressed `<destination><to jid>` shape whenever the callee is multi-device
@@ -600,6 +668,8 @@ async fn place_call(
     // The offer needs a stanza id so the server can ack-correlate it: the initiator's relay rides
     // back on the `<ack type=offer>` reply to THIS id, not on a later <call>.
     let offer_stanza_id = client.generate_request_id();
+    let audio_rate = audio.signaling_rate().to_string();
+    let audio_rates = [audio_rate.as_str()];
     let offer = build_offer(&OfferParams {
         call_id: &call_id,
         to: peer,
@@ -613,7 +683,7 @@ async fn place_call(
         // failures left a single surviving key, so that key stays tied to its device.
         multi_device,
         video: video.is_some(),
-        audio_rates: wacore::stanza::call::DEFAULT_AUDIO_RATES,
+        audio_rates: &audio_rates,
     });
 
     // Register the ack-waiter for the offer's stanza id BEFORE send_node so a fast server reply can't
@@ -627,6 +697,7 @@ async fn place_call(
     let registry = client.call_registry();
     let mut session =
         wacore::voip::CallSession::new_outgoing(&call_id, peer.clone(), call_creator.clone());
+    session.audio_format = Some(audio.config().format);
     session.is_video = video.is_some();
     // The rung device set lives on the session so an inbound <accept>/<reject> from one callee device
     // can dismiss the rest (caller-driven accepted_elsewhere); it is dropped automatically whenever the
@@ -679,8 +750,7 @@ async fn place_call(
                 self_lid: own_lid.to_string(),
                 peer_lid: peer.to_string(),
                 call_key: call_key.to_vec(),
-                source,
-                sink,
+                audio,
                 video,
                 video_shared: video_shared.clone(),
                 muted: muted.clone(),
@@ -740,12 +810,12 @@ fn client_weak(client: &Client) -> std::sync::Weak<Client> {
 /// Time to wait for the server's `<ack type=offer>` carrying the relay before giving up.
 const OFFER_ACK_RELAY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
-/// Pre-encode mic-frame backlog before the channel back-pressures the source (8 × 20 ms = 160 ms).
-const MIC_CHANNEL_CAPACITY: usize = 8;
+/// Three 60 ms frames absorb scheduling jitter without building a long capture delay.
+const MIC_CHANNEL_CAPACITY: usize = 3;
 
 /// Bound on the consumer-facing `CallEvent` queue. The driver posts with `try_send`, so once a slow
-/// or absent consumer lets it fill, further events drop instead of growing without bound: an
-/// authenticated peer streaming `ForeignAudio` frames can't drive an OOM. Lifecycle events
+/// or absent consumer lets it fill, further diagnostics drop instead of growing without bound.
+/// Lifecycle events
 /// (RelayAllocated/Failed/TimedOut) are emitted before any media flows, so they are never dropped,
 /// and call teardown is driven by the `ended` flag, not this channel.
 const CALL_EVENT_CHANNEL_CAPACITY: usize = 64;
@@ -876,8 +946,7 @@ pub(crate) struct PendingOutgoing {
     self_lid: String,
     peer_lid: String,
     call_key: Vec<u8>,
-    source: Arc<dyn AudioSource>,
-    sink: Arc<dyn AudioSink>,
+    audio: AudioEndpoints,
     /// `.video()` endpoints for a video-from-the-start call; `None` for audio-only.
     video: Option<VideoEndpoints>,
     /// The handle's video plumbing (created at place time so `start_video` works while dormant).
@@ -944,6 +1013,7 @@ pub(crate) async fn attach_outgoing_relay(
             relay,
         )
         .map_err(|e| CallError::Setup(e.to_string()))?;
+        config.audio = pending.audio.config();
         config.enable_video = pending.video.is_some();
         // Read the dial addr off the config before CallEngine::new consumes it (no second relay walk).
         let addr = socket_addr_from_config(&config)?;
@@ -971,8 +1041,7 @@ pub(crate) async fn attach_outgoing_relay(
         pending.generation,
         engine,
         &factory,
-        pending.source,
-        pending.sink,
+        pending.audio,
         pending.video,
         pending.video_shared,
         pending.muted,
@@ -996,8 +1065,7 @@ async fn spawn_call(
     session: wacore::voip::CallSession,
     engine: CallEngine,
     factory: &dyn RelayTransportFactory,
-    source: Arc<dyn AudioSource>,
-    sink: Arc<dyn AudioSink>,
+    audio: AudioEndpoints,
     video: Option<VideoEndpoints>,
 ) -> Result<CallHandle, CallError> {
     // Register BEFORE connecting so the entry exists before the driver task can self-clean.
@@ -1029,8 +1097,7 @@ async fn spawn_call(
         generation,
         engine,
         factory,
-        source,
-        sink,
+        audio,
         video,
         video_shared.clone(),
         muted.clone(),
@@ -1065,8 +1132,7 @@ async fn attach_engine(
     generation: u64,
     engine: CallEngine,
     factory: &dyn RelayTransportFactory,
-    source: Arc<dyn AudioSource>,
-    sink: Arc<dyn AudioSink>,
+    audio: AudioEndpoints,
     video: Option<VideoEndpoints>,
     video_shared: Arc<VideoShared>,
     muted: Arc<AtomicBool>,
@@ -1120,17 +1186,33 @@ async fn attach_engine(
             }
         };
 
-    // The shared mute flag the mic feed checks: muted frames become exact-zero (the engine sends a
-    // cheap DTX comfort-noise frame for an all-zero frame, so the relay stream never gaps).
-    let (mic_tx, mic_rx) = async_channel::bounded::<Vec<i16>>(MIC_CHANNEL_CAPACITY);
-    let mute_feed = MuteFeed {
-        src: source.frames(),
-        out: mic_tx,
-        muted,
+    // Only the selected I/O pair stays open. Closed inactive channels make their driver select arms
+    // retire immediately without per-frame branching or idle tasks.
+    let (mic_rx, speaker, encoded_audio_in, encoded_audio_out, audio_feed) = match audio {
+        AudioEndpoints::Pcm { source, sink } => {
+            let (mic_tx, mic_rx) = async_channel::bounded::<Vec<i16>>(MIC_CHANNEL_CAPACITY);
+            let mute_feed = MuteFeed {
+                src: source.frames(),
+                out: mic_tx,
+                muted,
+            };
+            let feed = client.runtime.spawn(Box::pin(mute_feed.run()));
+            let (_encoded_tx, encoded_audio_in) = async_channel::bounded::<Bytes>(1);
+            let (encoded_audio_out, _encoded_rx) = async_channel::bounded::<EncodedAudioFrame>(1);
+            (
+                mic_rx,
+                sink.playout(),
+                encoded_audio_in,
+                encoded_audio_out,
+                Some(feed),
+            )
+        }
+        AudioEndpoints::Encoded { source, sink, .. } => {
+            let (_mic_tx, mic_rx) = async_channel::bounded::<Vec<i16>>(1);
+            let (speaker, _speaker_rx) = async_channel::bounded::<Vec<i16>>(1);
+            (mic_rx, speaker, source.frames(), sink.frames(), None)
+        }
     };
-    // Keep the feed's AbortHandle (don't detach): it moves into the driver task below so the feed
-    // dies with the call instead of parking on `src.recv()` forever, holding the mic channel open.
-    let mic_feed = client.runtime.spawn(Box::pin(mute_feed.run()));
 
     // Video plumbing: the drive loop always gets the channels; the endpoints attach now (a
     // `.video()` call) or later (an upgrade via CallHandle::start_video/accept_video).
@@ -1157,7 +1239,9 @@ async fn attach_engine(
 
     let channels = CallChannels {
         mic: mic_rx,
-        speaker: sink.playout(),
+        speaker,
+        encoded_audio_in,
+        encoded_audio_out,
         events: ev_tx,
         rekey: rekey_rx,
         video_in: video_in_rx,
@@ -1179,7 +1263,7 @@ async fn attach_engine(
         // All are captured (moved in), so any teardown -- even an abort before the first poll --
         // drops them: the feeds are aborted and `ended` is notified.
         let _ended_guard = ended_guard;
-        let _mic_feed = mic_feed;
+        let _audio_feed = audio_feed;
         let _video_out_feed = video_out_feed;
         run_call_tokio(transport, relay_events, channels, engine).await;
         // A locally-ended call gets no <terminate>; drop our own entry so the registry doesn't grow.
@@ -1684,7 +1768,7 @@ impl CallHandle {
         }
     }
 
-    /// Subscribe to the call's engine events (relay allocate, foreign-audio, allocate failures).
+    /// Subscribe to call lifecycle and media diagnostics.
     ///
     /// All receivers returned here (and across cloned handles) share ONE queue: each event is
     /// delivered to exactly one receiver, competitively. Drive a single consumer loop per call;
@@ -1752,6 +1836,58 @@ mod tests {
 
     fn mk_session() -> wacore::voip::CallSession {
         wacore::voip::CallSession::new_incoming("CID-FACADE", caller(), caller())
+    }
+
+    fn pcm_audio(source: Arc<dyn AudioSource>, sink: Arc<dyn AudioSink>) -> AudioEndpoints {
+        AudioEndpoints::Pcm { source, sink }
+    }
+
+    fn encoded_audio(format: AudioFormat) -> AudioEndpoints {
+        let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+        AudioEndpoints::Encoded {
+            format,
+            source: Arc::new(source_rx),
+            sink: Arc::new(sink_tx),
+        }
+    }
+
+    #[tokio::test]
+    async fn accept_rejects_an_audio_profile_the_peer_did_not_offer() {
+        let client = make_client().await;
+        let incoming = IncomingCall::new_for_test(
+            caller(),
+            "STANZA-AUDIO-MISMATCH".into(),
+            wacore::time::from_secs(1_700_000_000).expect("timestamp"),
+            CallAction::Offer {
+                call_id: "CALL-AUDIO-MISMATCH".into(),
+                call_creator: caller(),
+                caller_pn: None,
+                caller_country_code: None,
+                device_class: None,
+                joinable: false,
+                is_video: false,
+                audio: vec![wacore::types::call::CallAudioCodec {
+                    enc: "opus".into(),
+                    rate: 16_000,
+                }],
+                group_jid: None,
+            },
+        );
+        let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+
+        let result = client
+            .voip()
+            .accept(&incoming)
+            .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, source_rx, sink_tx)
+            .start()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CallError::AudioFormatNotOffered(8_000))
+        ));
     }
 
     // peer_jid() is the <terminate> target: the bare peer until an <accept> records the answering
@@ -1857,8 +1993,7 @@ mod tests {
             mk_session(),
             engine(),
             &factory,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -1925,8 +2060,7 @@ mod tests {
             session,
             engine(),
             &factory,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -1979,8 +2113,7 @@ mod tests {
             mk_session(),
             engine(),
             &factory,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -2018,8 +2151,7 @@ mod tests {
             mk_session(),
             engine(),
             &f1,
-            mic1,
-            spk1,
+            pcm_audio(mic1, spk1),
             None,
         )
         .await
@@ -2032,8 +2164,7 @@ mod tests {
             mk_session(),
             engine(),
             &f2,
-            mic2,
-            spk2,
+            pcm_audio(mic2, spk2),
             None,
         )
         .await
@@ -2080,8 +2211,7 @@ mod tests {
             mk_session(),
             engine(),
             &f1,
-            mic1,
-            spk1,
+            pcm_audio(mic1, spk1),
             None,
         )
         .await
@@ -2093,8 +2223,7 @@ mod tests {
             mk_session(),
             engine(),
             &f2,
-            mic2,
-            spk2,
+            pcm_audio(mic2, spk2),
             None,
         )
         .await
@@ -2128,8 +2257,7 @@ mod tests {
                 mk_session(),
                 engine(),
                 &factory,
-                Arc::new(mic_rx),
-                Arc::new(spk_tx),
+                pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
                 None,
             )
             .await
@@ -2314,8 +2442,7 @@ mod tests {
             &own_lid,
             std::slice::from_ref(&device),
             std::slice::from_ref(&device),
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -2376,7 +2503,6 @@ mod tests {
             tags,
             [
                 "audio",
-                "audio",
                 "net",
                 "capability",
                 "enc",
@@ -2385,6 +2511,13 @@ mod tests {
             ]
         );
         let enc = offer.get_optional_child("enc").unwrap();
+        assert_eq!(
+            offer
+                .get_optional_child("audio")
+                .and_then(|audio| audio.attrs().optional_string("rate"))
+                .as_deref(),
+            Some("16000")
+        );
         assert_eq!(
             enc.attrs().optional_string("type").as_deref(),
             Some("pkmsg")
@@ -2429,8 +2562,7 @@ mod tests {
             &own_lid,
             &devices,
             &devices,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -2444,6 +2576,55 @@ mod tests {
         client
             .signal_flush_test_block
             .store(false, Ordering::Release);
+    }
+
+    #[tokio::test]
+    async fn encoded_opus_offer_advertises_only_its_selected_profile() {
+        let (client, _sent_count) = make_sending_client().await;
+        let peer_user = Jid::new("333333333333333", Server::Lid);
+        let device = peer_lid();
+        seed_peer_session(&client, &device).await;
+        let own_lid = client.get_lid().expect("own lid");
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+
+        let handle = place_call(
+            &client,
+            "00abcdef0123456789abcdef00c0dec0".into(),
+            &peer_user,
+            &own_lid,
+            &own_lid,
+            std::slice::from_ref(&device),
+            std::slice::from_ref(&device),
+            encoded_audio(AudioFormat::OPUS_16KHZ_60MS),
+            None,
+        )
+        .await
+        .expect("place encoded call");
+
+        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("offer must be sent")
+            .expect("waiter");
+        let node_ref = node.as_node_ref();
+        let offer = &node_ref.children().unwrap()[0];
+        let audio = offer
+            .children()
+            .unwrap()
+            .iter()
+            .filter(|child| child.tag.as_ref() == "audio")
+            .collect::<Vec<_>>();
+        assert_eq!(audio.len(), 1);
+        assert_eq!(
+            audio[0].attrs().optional_string("rate").as_deref(),
+            Some("8000")
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .snapshot(handle.call_id())
+                .and_then(|session| session.audio_format),
+            Some(AudioFormat::OPUS_16KHZ_60MS)
+        );
     }
 
     // A stored token must ride on the offer as the leading `<privacy>` child, or a
@@ -2486,8 +2667,7 @@ mod tests {
             &own_lid,
             std::slice::from_ref(&device),
             std::slice::from_ref(&device),
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -2540,8 +2720,7 @@ mod tests {
             &own_lid,
             &[good0.clone(), good1.clone(), bad.clone()],
             &[good0.clone(), good1.clone(), bad.clone()],
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await
@@ -2613,8 +2792,7 @@ mod tests {
             &own_lid,
             std::slice::from_ref(&device),
             std::slice::from_ref(&device),
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await;
@@ -2663,8 +2841,7 @@ mod tests {
             &own_lid,
             std::slice::from_ref(&device),
             std::slice::from_ref(&device),
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             video,
         )
         .await
@@ -2777,8 +2954,7 @@ mod tests {
                     mk_session(),
                     engine(),
                     &factory,
-                    Arc::new(mic_rx),
-                    Arc::new(spk_tx),
+                    pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
                     None,
                 )
                 .await
@@ -2843,8 +3019,7 @@ mod tests {
             mk_session(),
             engine(),
             &factory,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await;
@@ -2907,8 +3082,7 @@ mod tests {
                     generation,
                     engine(),
                     &*factory,
-                    Arc::new(mic_rx),
-                    Arc::new(spk_tx),
+                    pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
                     None,
                     Arc::new(VideoShared::new()),
                     muted,
@@ -2985,8 +3159,7 @@ mod tests {
                     generation,
                     engine(),
                     &*factory,
-                    Arc::new(mic_rx),
-                    Arc::new(spk_tx),
+                    pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
                     None,
                     Arc::new(VideoShared::new()),
                     muted,
@@ -3057,8 +3230,7 @@ mod tests {
                     generation,
                     engine(),
                     &*factory,
-                    Arc::new(mic_rx),
-                    Arc::new(spk_tx),
+                    pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
                     None,
                     Arc::new(VideoShared::new()),
                     muted,
@@ -3128,8 +3300,7 @@ mod tests {
             mk_session(),
             engine(),
             &FailingFactory,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await;
@@ -3202,8 +3373,7 @@ mod tests {
             &own_lid,
             std::slice::from_ref(&device),
             std::slice::from_ref(&device),
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await;
@@ -3369,8 +3539,7 @@ mod tests {
             &own_lid,
             std::slice::from_ref(&device),
             std::slice::from_ref(&device),
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await;
@@ -3474,8 +3643,7 @@ mod tests {
             mk_session(),
             engine(),
             &factory,
-            Arc::new(mic_rx),
-            Arc::new(spk_tx),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
             None,
         )
         .await

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -13,15 +13,17 @@ use log::warn;
 use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
 use wacore::stanza::call::{
-    CAPABILITY_OFFER, CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, VideoStateParams,
-    build_offer, build_video_state,
+    CAPABILITY_OFFER, CAPABILITY_STANDARD_OPUS_OFFER, CAPABILITY_STANDARD_OPUS_VIDEO_OFFER,
+    CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, VideoStateParams, build_offer,
+    build_video_state,
 };
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
 use wacore::voip::transport::RelayTransportFactory;
 use wacore::voip::{
-    AudioConfig, AudioFormat, CallChannels, CallConfig, CallEngine, CallEvent, EncodedAudioFrame,
-    VideoControl, VideoControlReceiver, VideoControlSender, VideoFrame, video_control_channel,
+    AudioConfig, AudioFormat, AudioRtpProfile, CallChannels, CallConfig, CallEngine, CallEvent,
+    EncodedAudioFrame, VideoControl, VideoControlReceiver, VideoControlSender, VideoFrame,
+    video_control_channel,
 };
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
@@ -515,11 +517,13 @@ fn keep_non_pkmsg_devices(devices: Vec<Jid>, would_pkmsg: &[bool]) -> Result<Vec
     Ok(kept)
 }
 
-fn offer_capability(video: bool) -> &'static [u8] {
-    if video {
-        &CAPABILITY_VIDEO_OFFER
-    } else {
-        &CAPABILITY_OFFER
+fn offer_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
+    let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
+    match (video, standard_opus) {
+        (true, true) => &CAPABILITY_STANDARD_OPUS_VIDEO_OFFER,
+        (false, true) => &CAPABILITY_STANDARD_OPUS_OFFER,
+        (true, false) => &CAPABILITY_VIDEO_OFFER,
+        (false, false) => &CAPABILITY_OFFER,
     }
 }
 
@@ -676,7 +680,7 @@ async fn place_call(
         call_creator,
         device_keys: &device_keys,
         privacy_token: privacy_token.as_deref(),
-        capability: Some(offer_capability(video.is_some())),
+        capability: Some(offer_capability(video.is_some(), audio.config().format)),
         device_identity: device_identity.as_deref(),
         id: Some(&offer_stanza_id),
         // Keep the addressed `<destination>` shape for a multi-device callee even if encryption
@@ -1869,7 +1873,7 @@ mod tests {
                 is_video: false,
                 audio: vec![wacore::types::call::CallAudioCodec {
                     enc: "opus".into(),
-                    rate: 16_000,
+                    rate: 8_000,
                 }],
                 group_jid: None,
             },
@@ -1886,7 +1890,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(CallError::AudioFormatNotOffered(8_000))
+            Err(CallError::AudioFormatNotOffered(16_000))
         ));
     }
 
@@ -2616,7 +2620,7 @@ mod tests {
         assert_eq!(audio.len(), 1);
         assert_eq!(
             audio[0].attrs().optional_string("rate").as_deref(),
-            Some("8000")
+            Some("16000")
         );
         assert_eq!(
             client
@@ -3614,10 +3618,23 @@ mod tests {
     }
 
     #[test]
-    fn outgoing_video_offer_uses_video_capability() {
-        assert_eq!(offer_capability(false), CAPABILITY_OFFER);
-        assert_eq!(offer_capability(true), CAPABILITY_VIDEO_OFFER);
-        assert_ne!(offer_capability(false), offer_capability(true));
+    fn outgoing_offer_capability_matches_audio_profile() {
+        assert_eq!(
+            offer_capability(false, AudioFormat::MLOW_16KHZ_60MS),
+            CAPABILITY_OFFER
+        );
+        assert_eq!(
+            offer_capability(true, AudioFormat::MLOW_16KHZ_60MS),
+            CAPABILITY_VIDEO_OFFER
+        );
+        assert_eq!(
+            offer_capability(false, AudioFormat::OPUS_16KHZ_60MS),
+            CAPABILITY_STANDARD_OPUS_OFFER
+        );
+        assert_eq!(
+            offer_capability(true, AudioFormat::OPUS_16KHZ_60MS),
+            CAPABILITY_STANDARD_OPUS_VIDEO_OFFER
+        );
     }
 
     /// A live handle over a mock relay + a sending client, for the video handshake tests. The

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -819,9 +819,8 @@ const MIC_CHANNEL_CAPACITY: usize = 3;
 
 /// Bound on the consumer-facing `CallEvent` queue. The driver posts with `try_send`, so once a slow
 /// or absent consumer lets it fill, further diagnostics drop instead of growing without bound.
-/// Lifecycle events
-/// (RelayAllocated/Failed/TimedOut) are emitted before any media flows, so they are never dropped,
-/// and call teardown is driven by the `ended` flag, not this channel.
+/// Lifecycle events (RelayAllocated/Failed/TimedOut) are emitted before media flows, so they are
+/// never dropped, and call teardown is driven by the `ended` flag, not this channel.
 const CALL_EVENT_CHANNEL_CAPACITY: usize = 64;
 
 /// Returned by `CallError::Connect` when the socket drops mid-setup, before the engine is attached.
@@ -1530,6 +1529,7 @@ impl CallHandle {
 
     /// Mute or unmute the local microphone. While muted the engine sends DTX comfort-noise (the
     /// stream stays fed); it does not gap, so the peer doesn't re-negotiate the transport.
+    /// This affects PCM audio only; encoded-audio callers must mute their external source.
     pub fn set_muted(&self, muted: bool) {
         self.muted.store(muted, Ordering::Relaxed);
     }

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -1,17 +1,20 @@
 //! VoIP calls media plane (Tokio runtime side): the DTLS/SCTP DataChannel transport
-//! over the WhatsApp relay, Opus audio, the call state machine, and the media pipeline.
+//! over the WhatsApp relay, encoded audio, the call state machine, and the media pipeline.
 //! Pure protocol/crypto lives in `wacore::voip`.
 //!
-//! This module pulls webrtc-rs (DTLS/SCTP) and the libopus FFI, neither of which builds on
-//! wasm32 or espidf. The wasm/esp32-safe subset is `wacore`'s `voip` feature (pure-Rust crypto
-//! + the MLow codec), which has no FFI and stays buildable on those targets.
+//! This module pulls webrtc-rs, which does not build on wasm32 or espidf. The wasm/esp32-safe
+//! subset is `wacore`'s `voip` feature (pure-Rust crypto and encoded transport); add
+//! `wacore/voip-mlow` for its pure-Rust MLOW codec.
 
-// Fail fast with an actionable message instead of a confusing webrtc/opus FFI link error.
-#[cfg(all(feature = "voip", any(target_arch = "wasm32", target_os = "espidf")))]
+// Fail fast with an actionable message instead of a confusing webrtc link error.
+#[cfg(all(
+    feature = "voip-runtime",
+    any(target_arch = "wasm32", target_os = "espidf")
+))]
 compile_error!(
-    "the `voip` feature of `whatsapp-rust` pulls webrtc-rs + libopus FFI and does not build on \
-     wasm32/espidf. For those targets enable only `wacore`'s `voip` feature (pure-Rust crypto + \
-     the MLow codec)."
+    "the native VoIP features of `whatsapp-rust` pull webrtc-rs and do not build on \
+     wasm32/espidf. For those targets use `wacore/voip` for crypto/encoded transport and \
+     optionally `wacore/voip-mlow` for the pure-Rust MLOW codec."
 );
 
 pub mod audio;
@@ -22,10 +25,11 @@ pub mod session;
 pub mod transport;
 pub mod video;
 
-pub use audio::{AudioSink, AudioSource};
+pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};
 pub use facade::{AcceptCall, CallHandle, OutgoingCall};
 pub use video::{VideoFrame, VideoSink, VideoSource};
 // CallHandle::events() yields these, so surface them next to CallHandle (they live in wacore).
 pub use wacore::voip::CallEvent;
+pub use wacore::voip::{AudioCodec, AudioConfig, AudioFormat, AudioIo, EncodedAudioFrame};
 // `CallEvent::VideoStateChanged` carries this; surface it next to CallEvent (it lives in wacore).
 pub use wacore::types::call::VideoState;

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -30,6 +30,9 @@ pub use facade::{AcceptCall, CallHandle, OutgoingCall};
 pub use video::{VideoFrame, VideoSink, VideoSource};
 // CallHandle::events() yields these, so surface them next to CallHandle (they live in wacore).
 pub use wacore::voip::CallEvent;
-pub use wacore::voip::{AudioCodec, AudioConfig, AudioFormat, AudioIo, EncodedAudioFrame};
+pub use wacore::voip::{
+    AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,
+    OpusMlowPacketError, depacketize_opus_from_mlow, packetize_opus_for_mlow,
+};
 // `CallEvent::VideoStateChanged` carries this; surface it next to CallEvent (it lives in wacore).
 pub use wacore::types::call::VideoState;

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -566,7 +566,7 @@ mod udp_relay_e2e {
             peer_lid: PEER_LID.into(),
             call_key: (0u8..32).collect(),
             ssrc: SSRC,
-            samples_per_packet: SAMPLES,
+            audio: wacore::voip::AudioConfig::MLOW_PCM,
             relay_token: vec![0xAB; 16],
             relay_ip: relay_addr.ip().to_string(),
             relay_port: relay_addr.port(),
@@ -736,6 +736,8 @@ mod udp_relay_e2e {
                 CallChannels {
                     mic: mic_rx,
                     speaker: spk_tx,
+                    encoded_audio_in: async_channel::bounded(1).1,
+                    encoded_audio_out: async_channel::bounded(1).0,
                     events: ev_tx,
                     rekey: None,
                     video_in: async_channel::bounded(1).1,

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -540,7 +540,7 @@ mod tests {
 /// by `run_call_tokio` exchanges packets with it. This is the one place CI exercises the native
 /// transport's I/O (the rest of the suite mocks the socket), closing the `connect_relay_media is not
 /// exercised in CI` gap in the module header.
-#[cfg(test)]
+#[cfg(all(test, feature = "voip-mlow"))]
 mod udp_relay_e2e {
     use super::*;
     use std::time::Duration;

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -35,10 +35,10 @@ danger-skip-cert-chain-verify = ["wacore-noise/danger-skip-cert-chain-verify"]
 # Enable JS-based random number generation for wasm32 targets.
 # Activates getrandom's wasm_js backend so rand works in the browser.
 js = ["getrandom/wasm_js"]
-# VoIP/calls media crypto (SRTP, SFrame, WAHKDF). Pure, no-Tokio. Off by default:
-# the media plane is opt-in and pulls aes-gcm into the non-dev build. The MLow codec's
-# runtime constant tables are zlib-compressed protobuf (buffa, see tables.proto).
+# VoIP/calls media crypto (SRTP, SFrame, WAHKDF). Pure, no-Tokio. Off by default.
 voip = ["dep:aes-gcm", "dep:zerocopy"]
+# Built-in PCM/MLOW adapter. Encoded audio transport needs only `voip`.
+voip-mlow = ["voip"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
 # Dev/profiling only; off by default and not pulled into normal builds.
 dhat-heap = ["dep:dhat"]
@@ -126,11 +126,11 @@ harness = false
 [[bench]]
 name = "voip_benchmark"
 harness = false
-required-features = ["voip"]
+required-features = ["voip-mlow"]
 
 [[example]]
 name = "voip_profile"
-required-features = ["voip"]
+required-features = ["voip-mlow"]
 
 [lints]
 workspace = true

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -1,4 +1,4 @@
-//! VoIP media-plane hot paths: the per-packet work a live 1:1 call pays 50x/second each way.
+//! VoIP media-plane hot paths: the per-packet work a live 1:1 call pays every 60 ms each way.
 //! Two layers are benched so a regression can be localized: the raw primitives (MLow encode/decode,
 //! E2E-SRTP protect/unprotect, the AES-CTR payload cipher, SFrame) and the full engine inputs that
 //! compose them (`on_mic`, `on_rtp`). `divan::AllocProfiler` is wired as the global allocator so each
@@ -105,7 +105,7 @@ fn config_for(self_lid: &str, peer_lid: &str, ssrc: u32, direction: CallDirectio
         peer_lid: peer_lid.into(),
         call_key: call_key(),
         ssrc,
-        samples_per_packet: SAMPLES as u32,
+        audio: wacore::voip::AudioConfig::MLOW_PCM,
         relay_token: vec![0xAB; 16],
         relay_ip: "203.0.113.7".into(),
         relay_port: 3478,
@@ -161,6 +161,22 @@ fn mlow_encode(bencher: Bencher) {
             let f = &frames[*i % frames.len()];
             *i += 1;
             black_box(enc.encode(black_box(f.as_slice())).unwrap())
+        });
+}
+
+/// The engine path keeps the encoded output allocation for the lifetime of the call.
+#[divan::bench]
+fn mlow_encode_reused_output(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            let frames: Vec<Vec<f32>> = (0..STREAM).map(|i| tone_f32(i * SAMPLES)).collect();
+            (primed_encoder(), frames, 0usize, Vec::with_capacity(2048))
+        })
+        .bench_refs(|(enc, frames, i, output)| {
+            let f = &frames[*i % frames.len()];
+            *i += 1;
+            enc.encode_into(black_box(f.as_slice()), output).unwrap();
+            black_box(output.len())
         });
 }
 

--- a/wacore/examples/voip_profile.rs
+++ b/wacore/examples/voip_profile.rs
@@ -1,5 +1,5 @@
 //! Minimal MLow codec hot-loop driver for an unbiased profiler pass (callgrind for CPU + malloc
-//! attribution). Not a benchmark -- no timing, no sampling: it just runs `encode` or `decode` N
+//! attribution). Not a benchmark -- no timing, no sampling: it runs `encode`, `encode-into`, or `decode` N
 //! times over a small stream so an external profiler can attribute instructions and allocations to
 //! the real per-stage functions.
 //!
@@ -34,6 +34,16 @@ fn hot_encode(enc: &mut MlowEncoder, frames: &[Vec<f32>], n: usize) {
 }
 
 #[inline(never)]
+fn hot_encode_into(enc: &mut MlowEncoder, frames: &[Vec<f32>], n: usize) {
+    let mut output = Vec::with_capacity(2048);
+    for k in 0..n {
+        enc.encode_into(black_box(&frames[k % frames.len()]), &mut output)
+            .unwrap();
+        black_box(output.as_slice());
+    }
+}
+
+#[inline(never)]
 fn hot_decode(dec: &mut MlowDecoder, packets: &[Vec<u8>], n: usize) {
     for k in 0..n {
         black_box(dec.decode(black_box(&packets[k % packets.len()])));
@@ -55,6 +65,11 @@ fn main() {
             let _ = enc.encode(&frames[0]); // prime past the first-frame path
             hot_encode(&mut enc, &frames, n);
         }
+        "encode-into" => {
+            let mut enc = MlowEncoder::new();
+            let _ = enc.encode(&frames[0]);
+            hot_encode_into(&mut enc, &frames, n);
+        }
         "decode" => {
             let mut enc = MlowEncoder::new();
             let _ = enc.encode(&frames[0]);
@@ -63,6 +78,6 @@ fn main() {
             let _ = dec.decode(&packets[0]); // prime
             hot_decode(&mut dec, &packets, n);
         }
-        other => eprintln!("usage: voip_profile <encode|decode> <n>; got {other:?}"),
+        other => eprintln!("usage: voip_profile <encode|encode-into|decode> <n>; got {other:?}"),
     }
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -422,6 +422,21 @@ pub const DEFAULT_AUDIO_RATES: &[&str] = &["8000", "16000"];
 /// (`0xbb`), not this.
 pub const CAPABILITY_VIDEO_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xfa, 0x13];
 
+const fn without_mlow_capability(mut capability: [u8; 7]) -> [u8; 7] {
+    // Capability 31 is the peer gate for `use_mlow_codec_v1`.
+    capability[5] &= 0x7f;
+    capability
+}
+
+/// Audio offer/accept capability selecting WhatsApp's standard Opus fallback instead of MLOW.
+pub const CAPABILITY_STANDARD_OPUS_OFFER: [u8; 7] = without_mlow_capability(CAPABILITY_OFFER);
+/// Audio-only preaccept capability selecting WhatsApp's standard Opus fallback instead of MLOW.
+pub const CAPABILITY_STANDARD_OPUS_PREACCEPT: [u8; 7] =
+    without_mlow_capability(CAPABILITY_PREACCEPT);
+/// Video offer capability selecting standard Opus for its audio stream instead of MLOW.
+pub const CAPABILITY_STANDARD_OPUS_VIDEO_OFFER: [u8; 7] =
+    without_mlow_capability(CAPABILITY_VIDEO_OFFER);
+
 /// `<terminate reason>` wire tokens. The caller-driven sibling dismiss SENDS the `*_ELSEWHERE`
 /// ones; the receive path maps every reason to a call-log outcome (see WA Web's
 /// `ActionWebHandleIncomingSignalingMessage`): `TIMEOUT`/`GROUP_CALL_ENDED`/absent -> missed.
@@ -527,6 +542,21 @@ fn enc_node(dk: &OfferDeviceKey) -> Node {
         .build()
 }
 
+const STANDARD_OPUS_PT120_SETTINGS: &[u8] =
+    br#"{"encode":{"use_mlow_codec_v1":"false"},"options":{"enable_48khz_rtp_clock":"false"}}"#;
+const STANDARD_OPUS_PT111_SETTINGS: &[u8] =
+    br#"{"encode":{"use_mlow_codec_v1":"false"},"options":{"enable_48khz_rtp_clock":"true"}}"#;
+
+/// Directional decoder selection for a standard-Opus answer. Android overlays these fields on its
+/// local defaults, so copying the peer's large rollout settings is unnecessary and can be harmful.
+pub fn standard_opus_voip_settings(enable_48khz_rtp_clock: bool) -> &'static [u8] {
+    if enable_48khz_rtp_clock {
+        STANDARD_OPUS_PT111_SETTINGS
+    } else {
+        STANDARD_OPUS_PT120_SETTINGS
+    }
+}
+
 pub struct AcceptParams<'a> {
     pub call_id: &'a str,
     pub to: &'a Jid,
@@ -535,8 +565,8 @@ pub struct AcceptParams<'a> {
     /// caller (which then never marks the call accepted, leaving siblings ringing and timing it out).
     pub id: &'a str,
     pub call_creator: &'a Jid,
-    /// Advertised `<audio enc=opus rate=…>` formats, in preference order. Selecting only `8000`
-    /// is the lever to steer the caller off Meta's 16 kHz mlow codec onto RFC Opus NB.
+    /// Advertised `<audio enc=opus rate=…>` formats, in preference order. The MLOW selection in
+    /// `voip_settings` is independent, so a rate alone must not be treated as an RTP profile.
     pub audio_rates: &'a [&'a str],
     pub relay_te: Option<&'a [u8]>,
     pub rte: Option<&'a [u8]>,
@@ -653,8 +683,8 @@ fn capability_node(blob: &[u8]) -> Node {
 }
 
 /// `<preaccept>`: audio → [video] → encopt → capability. `id` is the random call-wrapper id. A video
-/// callee advertises the `<video>` decoder here; the capability stays the `0xbb` [`CAPABILITY_OFFER`]
-/// blob (byte-matched to a real from-start video callee — the `0xfa` variant is the CALLER's offer).
+/// callee advertises the `<video>` decoder here; the default capability stays the `0xbb`
+/// [`CAPABILITY_OFFER`] blob (the `0xfa` variant is the caller's offer).
 pub fn build_preaccept(
     call_id: &str,
     to: &Jid,
@@ -663,16 +693,37 @@ pub fn build_preaccept(
     audio_rates: &[&str],
     video: bool,
 ) -> Node {
+    build_preaccept_with_capability(
+        call_id,
+        to,
+        call_creator,
+        wrapper_id,
+        audio_rates,
+        if video {
+            &CAPABILITY_OFFER
+        } else {
+            &CAPABILITY_PREACCEPT
+        },
+        video,
+    )
+}
+
+/// Build a preaccept with an explicit media capability blob.
+pub fn build_preaccept_with_capability(
+    call_id: &str,
+    to: &Jid,
+    call_creator: &Jid,
+    wrapper_id: &str,
+    audio_rates: &[&str],
+    capability: &[u8],
+    video: bool,
+) -> Node {
     let mut children: Vec<Node> = audio_rates.iter().map(|rate| audio_opus(rate)).collect();
     if video {
         children.push(video_preaccept_node());
     }
     children.push(encopt_node());
-    children.push(capability_node(if video {
-        &CAPABILITY_OFFER
-    } else {
-        &CAPABILITY_PREACCEPT
-    }));
+    children.push(capability_node(capability));
     call_wrap(
         to,
         Some(wrapper_id),
@@ -1602,6 +1653,62 @@ mod tests {
 
     // --- Outbound signaling builder tests ---
 
+    #[test]
+    fn audio_voip_settings_select_native_opus_pt120() {
+        let settings: serde_json::Value =
+            serde_json::from_slice(standard_opus_voip_settings(false)).unwrap();
+
+        assert_eq!(settings["encode"]["use_mlow_codec_v1"], "false");
+        assert_eq!(settings["options"]["enable_48khz_rtp_clock"], "false");
+    }
+
+    #[test]
+    fn audio_voip_settings_select_rfc7587_pt111() {
+        let settings: serde_json::Value =
+            serde_json::from_slice(standard_opus_voip_settings(true)).unwrap();
+
+        assert_eq!(settings["encode"]["use_mlow_codec_v1"], "false");
+        assert_eq!(settings["options"]["enable_48khz_rtp_clock"], "true");
+    }
+
+    #[test]
+    fn native_opus_accept_carries_directional_settings() {
+        let peer = peer();
+        let creator = creator();
+        let settings = standard_opus_voip_settings(false);
+        let accept = build_accept(&AcceptParams {
+            call_id: "CID",
+            to: &peer,
+            id: "ACCEPT-ID",
+            call_creator: &creator,
+            audio_rates: &["16000"],
+            relay_te: None,
+            rte: None,
+            voip_settings: Some(settings),
+            capability: Some(&CAPABILITY_STANDARD_OPUS_OFFER),
+            video: false,
+            peer_abtest_bucket: None,
+            peer_abtest_bucket_id_list: None,
+        });
+
+        assert_eq!(
+            child_tags(&accept),
+            ["audio", "net", "encopt", "capability", "voip_settings"]
+        );
+        let accept_ref = accept.as_node_ref();
+        let voip_settings = accept_ref.children().unwrap()[0]
+            .get_optional_child("voip_settings")
+            .unwrap();
+        assert_eq!(
+            voip_settings
+                .attrs()
+                .optional_string("uncompressed")
+                .as_deref(),
+            Some("1")
+        );
+        assert_eq!(voip_settings.content_bytes(), Some(settings));
+    }
+
     fn peer() -> Jid {
         Jid::new("111111111111111", Server::Lid)
     }
@@ -1820,6 +1927,32 @@ mod tests {
         assert_eq!(
             pre.as_node_ref().attrs().optional_string("id").as_deref(),
             Some("abcd1234")
+        );
+
+        let standard_opus = build_preaccept_with_capability(
+            "CID",
+            &peer,
+            &creator,
+            "abcd1234",
+            &["8000"],
+            &CAPABILITY_STANDARD_OPUS_PREACCEPT,
+            false,
+        );
+        let standard_ref = standard_opus.as_node_ref();
+        let action = &standard_ref.children().unwrap()[0];
+        let capability = action
+            .children()
+            .unwrap()
+            .iter()
+            .find(|child| child.tag == "capability")
+            .unwrap();
+        assert_eq!(
+            capability.content_bytes().unwrap(),
+            &CAPABILITY_STANDARD_OPUS_PREACCEPT
+        );
+        assert_eq!(
+            CAPABILITY_OFFER[5] ^ CAPABILITY_STANDARD_OPUS_OFFER[5],
+            0x80
         );
     }
 

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -1696,9 +1696,13 @@ mod tests {
             ["audio", "net", "encopt", "capability", "voip_settings"]
         );
         let accept_ref = accept.as_node_ref();
-        let voip_settings = accept_ref.children().unwrap()[0]
-            .get_optional_child("voip_settings")
-            .unwrap();
+        let action = &accept_ref.children().unwrap()[0];
+        let capability = action.get_optional_child("capability").unwrap();
+        assert_eq!(
+            capability.content_bytes(),
+            Some(CAPABILITY_STANDARD_OPUS_OFFER.as_slice())
+        );
+        let voip_settings = action.get_optional_child("voip_settings").unwrap();
         assert_eq!(
             voip_settings
                 .attrs()

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -264,9 +264,17 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
             attrs
                 .finish()
                 .map_err(|e| anyhow!("<preaccept> attrs: {e}"))?;
+            let audio = node
+                .children()
+                .unwrap_or_default()
+                .iter()
+                .filter(|child| child.tag == "audio")
+                .map(parse_audio_codec)
+                .collect::<Result<Vec<_>>>()?;
             CallAction::PreAccept {
                 call_id,
                 call_creator,
+                audio,
             }
         }
         "transport" => {
@@ -297,9 +305,17 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
         }
         "accept" => {
             attrs.finish().map_err(|e| anyhow!("<accept> attrs: {e}"))?;
+            let audio = node
+                .children()
+                .unwrap_or_default()
+                .iter()
+                .filter(|child| child.tag == "audio")
+                .map(parse_audio_codec)
+                .collect::<Result<Vec<_>>>()?;
             CallAction::Accept {
                 call_id,
                 call_creator,
+                audio,
             }
         }
         "reject" => {
@@ -399,6 +415,8 @@ pub fn build_offer_ack_receipt(call: &IncomingCall, own_ad: Option<&Jid>) -> Opt
 pub const CAPABILITY_OFFER: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13];
 /// Capability blob for an audio-only `<preaccept>` (ver=1).
 pub const CAPABILITY_PREACCEPT: [u8; 7] = [0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07];
+/// Legacy offer order observed on WhatsApp Web.
+pub const DEFAULT_AUDIO_RATES: &[&str] = &["8000", "16000"];
 /// Capability blob a client places in a VIDEO `<offer>`: byte 5 is `0xfa` (video) vs the audio
 /// `0xbb`. Observed in a real from-start video offer. A video CALLEE preaccepts with [`CAPABILITY_OFFER`]
 /// (`0xbb`), not this.
@@ -445,6 +463,10 @@ pub struct OfferParams<'a> {
     /// (after the `<audio>` children) come from a WA Web capture; unvalidated against the real
     /// server's 439 child-order enforcement.
     pub video: bool,
+    /// Advertised `<audio enc=opus rate=…>` formats, in preference order. WhatsApp uses the
+    /// signaling rate to select its audio path; callers that need the legacy behavior pass
+    /// `["8000", "16000"]`.
+    pub audio_rates: &'a [&'a str],
 }
 
 /// `<call to=peer><offer call-id call-creator>…</offer></call>` with the mandatory
@@ -455,18 +477,7 @@ pub fn build_offer(p: &OfferParams<'_>) -> Node {
     if let Some(privacy) = p.privacy_token {
         children.push(NodeBuilder::new("privacy").bytes(privacy.to_vec()).build());
     }
-    children.push(
-        NodeBuilder::new("audio")
-            .attr("enc", "opus")
-            .attr("rate", "8000")
-            .build(),
-    );
-    children.push(
-        NodeBuilder::new("audio")
-            .attr("enc", "opus")
-            .attr("rate", "16000")
-            .build(),
-    );
+    children.extend(p.audio_rates.iter().map(|rate| audio_opus(rate)));
     if p.video {
         children.push(video_offer_node());
     }
@@ -1306,6 +1317,32 @@ mod tests {
     }
 
     #[test]
+    fn preaccept_and_accept_preserve_audio_selection() {
+        for tag in ["preaccept", "accept"] {
+            let node = base_call_builder()
+                .children([NodeBuilder::new(tag)
+                    .attr("call-creator", fake_caller_lid())
+                    .attr("call-id", "CID")
+                    .children([audio_opus("8000")])
+                    .build()])
+                .build();
+
+            let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+            let audio = match call.action {
+                CallAction::PreAccept { audio, .. } | CallAction::Accept { audio, .. } => audio,
+                other => panic!("expected {tag}, got {other:?}"),
+            };
+            assert_eq!(
+                audio,
+                [CallAudioCodec {
+                    enc: "opus".to_string(),
+                    rate: 8_000,
+                }]
+            );
+        }
+    }
+
+    #[test]
     fn terminate_with_duration() {
         let node = base_call_builder()
             .children([NodeBuilder::new("terminate")
@@ -1607,6 +1644,7 @@ mod tests {
             id: Some("OFFER-STANZA-ID"),
             multi_device: false,
             video: false,
+            audio_rates: DEFAULT_AUDIO_RATES,
         });
         // Single device key → bare <enc> (not <destination>).
         assert_eq!(
@@ -1664,10 +1702,45 @@ mod tests {
             id: None,
             multi_device: false,
             video: false,
+            audio_rates: DEFAULT_AUDIO_RATES,
         });
         let tags = child_tags(&call);
         assert!(tags.contains(&"destination".to_string()));
         assert!(!tags.contains(&"enc".to_string()));
+    }
+
+    #[test]
+    fn offer_audio_rates_are_configurable() {
+        let peer = peer();
+        let creator = creator();
+        let dk = OfferDeviceKey {
+            device_jid: peer.clone(),
+            ciphertext: vec![1],
+            enc_type: "msg".into(),
+        };
+        let call = build_offer(&OfferParams {
+            call_id: "CID",
+            to: &peer,
+            call_creator: &creator,
+            device_keys: std::slice::from_ref(&dk),
+            privacy_token: None,
+            capability: None,
+            device_identity: None,
+            id: None,
+            multi_device: false,
+            video: false,
+            audio_rates: &["8000"],
+        });
+        let call_ref = call.as_node_ref();
+        let offer = &call_ref.children().unwrap()[0];
+        let rates: Vec<_> = offer
+            .children()
+            .unwrap()
+            .iter()
+            .filter(|child| child.tag == "audio")
+            .map(|child| child.attrs().optional_u64("rate"))
+            .collect();
+        assert_eq!(rates, [Some(8_000)]);
     }
 
     // A multi-device callee whose encryption left a single survivor must keep the addressed
@@ -1692,6 +1765,7 @@ mod tests {
             id: None,
             multi_device: true,
             video: false,
+            audio_rates: DEFAULT_AUDIO_RATES,
         });
         let tags = child_tags(&call);
         assert!(tags.contains(&"destination".to_string()));
@@ -2096,6 +2170,7 @@ mod tests {
             id: None,
             multi_device: false,
             video: true,
+            audio_rates: DEFAULT_AUDIO_RATES,
         };
         let offer = build_offer(&base);
         // The <video> child sits right after the <audio> children (capture-observed position).

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -62,7 +62,7 @@ pub struct OfferEnc {
     pub ciphertext: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CallAudioCodec {
     pub enc: String,
     pub rate: u32,
@@ -130,10 +130,12 @@ pub enum CallAction {
     PreAccept {
         call_id: String,
         call_creator: Jid,
+        audio: Vec<CallAudioCodec>,
     },
     Accept {
         call_id: String,
         call_creator: Jid,
+        audio: Vec<CallAudioCodec>,
     },
     Reject {
         call_id: String,

--- a/wacore/src/voip/audio.rs
+++ b/wacore/src/voip/audio.rs
@@ -1,0 +1,146 @@
+//! Audio format and I/O contracts shared by the sans-I/O engine and platform drivers.
+
+use bytes::Bytes;
+
+use super::rtp::{RTP_PAYLOAD_TYPE_MLOW, RTP_PAYLOAD_TYPE_MLOW_RED, RTP_PAYLOAD_TYPE_OPUS};
+
+/// Codec carried inside WhatsApp's audio RTP payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AudioCodec {
+    Mlow,
+    Opus,
+}
+
+/// Where encoding and decoding happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AudioIo {
+    /// The core converts 16-bit PCM using its built-in codec.
+    Pcm,
+    /// The application supplies and consumes complete codec payloads.
+    Encoded,
+}
+
+/// Fixed audio timing for one call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AudioFormat {
+    pub codec: AudioCodec,
+    /// `<audio rate=…>` value used by call signaling.
+    pub signaling_rate: u32,
+    /// PCM rate expected by a codec adapter, when one is used.
+    pub sample_rate: u32,
+    pub channels: u8,
+    /// PCM samples represented by one encoded payload, per channel.
+    pub samples_per_frame: u32,
+    /// RTP clock used for reception statistics.
+    pub rtp_clock_rate: u32,
+    /// RTP timestamp increment after each encoded payload.
+    pub rtp_timestamp_step: u32,
+    /// RTP payload type advertised by the selected WhatsApp media profile.
+    pub rtp_payload_type: u8,
+}
+
+impl AudioFormat {
+    /// The implemented MLOW operating point: mono, 16 kHz, 60 ms.
+    pub const MLOW_16KHZ_60MS: Self = Self {
+        codec: AudioCodec::Mlow,
+        signaling_rate: 16_000,
+        sample_rate: 16_000,
+        channels: 1,
+        samples_per_frame: 960,
+        rtp_clock_rate: 16_000,
+        rtp_timestamp_step: 960,
+        rtp_payload_type: RTP_PAYLOAD_TYPE_MLOW,
+    };
+
+    /// Standard Opus with a 16 kHz codec adapter and RFC 7587's 48 kHz RTP clock.
+    pub const OPUS_16KHZ_60MS: Self = Self {
+        codec: AudioCodec::Opus,
+        signaling_rate: 8_000,
+        sample_rate: 16_000,
+        channels: 1,
+        samples_per_frame: 960,
+        rtp_clock_rate: 48_000,
+        rtp_timestamp_step: 2_880,
+        rtp_payload_type: RTP_PAYLOAD_TYPE_OPUS,
+    };
+
+    /// RFC 7587 Opus timing. Useful for interop experiments with external RTP-aware codecs.
+    pub const OPUS_RFC7587_48KHZ_60MS: Self = Self {
+        codec: AudioCodec::Opus,
+        signaling_rate: 8_000,
+        sample_rate: 48_000,
+        channels: 1,
+        samples_per_frame: 2_880,
+        rtp_clock_rate: 48_000,
+        rtp_timestamp_step: 2_880,
+        rtp_payload_type: RTP_PAYLOAD_TYPE_OPUS,
+    };
+
+    /// WhatsApp's signaling rate selects a media profile rather than the Opus PCM rate.
+    pub const fn from_signaling_rate(rate: u32) -> Option<Self> {
+        match rate {
+            16_000 => Some(Self::MLOW_16KHZ_60MS),
+            8_000 => Some(Self::OPUS_16KHZ_60MS),
+            _ => None,
+        }
+    }
+
+    pub const fn accepts_rtp_payload_type(self, payload_type: u8) -> bool {
+        payload_type == self.rtp_payload_type
+            || matches!(self.codec, AudioCodec::Mlow) && payload_type == RTP_PAYLOAD_TYPE_MLOW_RED
+    }
+
+    pub(crate) fn is_valid(self) -> bool {
+        self.signaling_rate != 0
+            && self.sample_rate != 0
+            && self.channels != 0
+            && self.samples_per_frame != 0
+            && self.rtp_clock_rate != 0
+            && self.rtp_timestamp_step != 0
+            && self.rtp_payload_type <= 127
+    }
+}
+
+/// Audio configuration owned by a call engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AudioConfig {
+    pub format: AudioFormat,
+    pub io: AudioIo,
+}
+
+impl AudioConfig {
+    pub const MLOW_PCM: Self = Self {
+        format: AudioFormat::MLOW_16KHZ_60MS,
+        io: AudioIo::Pcm,
+    };
+
+    pub const fn encoded(format: AudioFormat) -> Self {
+        Self {
+            format,
+            io: AudioIo::Encoded,
+        }
+    }
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Self::MLOW_PCM
+    }
+}
+
+/// One decrypted codec payload received from the peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EncodedAudioFrame {
+    pub format: AudioFormat,
+    pub data: Bytes,
+    /// Actual RTP payload type. MLOW redundancy uses PT 121 while the primary format uses PT 120.
+    pub payload_type: u8,
+    pub sequence_number: u16,
+    pub timestamp: u32,
+    pub marker: bool,
+}

--- a/wacore/src/voip/audio.rs
+++ b/wacore/src/voip/audio.rs
@@ -2,7 +2,10 @@
 
 use bytes::Bytes;
 
-use super::rtp::{RTP_PAYLOAD_TYPE_MLOW, RTP_PAYLOAD_TYPE_MLOW_RED, RTP_PAYLOAD_TYPE_OPUS};
+use super::rtp::{
+    RTP_PAYLOAD_TYPE_MLOW, RTP_PAYLOAD_TYPE_MLOW_RED, RTP_PAYLOAD_TYPE_OPUS,
+    RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO,
+};
 
 /// Codec carried inside WhatsApp's audio RTP payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,6 +13,16 @@ use super::rtp::{RTP_PAYLOAD_TYPE_MLOW, RTP_PAYLOAD_TYPE_MLOW_RED, RTP_PAYLOAD_T
 pub enum AudioCodec {
     Mlow,
     Opus,
+}
+
+/// RTP payload family selected for the call independently from the encoded bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AudioRtpProfile {
+    /// WhatsApp MLOW framing: PT 120/121 with the in-profile Opus escape.
+    Mlow,
+    /// Native Opus bytes. Payload type and clock remain independently negotiated.
+    StandardOpus,
 }
 
 /// Where encoding and decoding happen.
@@ -26,7 +39,10 @@ pub enum AudioIo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct AudioFormat {
+    /// Codec bytes supplied by the encoded source.
     pub codec: AudioCodec,
+    /// RTP family negotiated with the peer. This is not implied by [`Self::codec`].
+    pub rtp_profile: AudioRtpProfile,
     /// `<audio rate=…>` value used by call signaling.
     pub signaling_rate: u32,
     /// PCM rate expected by a codec adapter, when one is used.
@@ -46,6 +62,7 @@ impl AudioFormat {
     /// The implemented MLOW operating point: mono, 16 kHz, 60 ms.
     pub const MLOW_16KHZ_60MS: Self = Self {
         codec: AudioCodec::Mlow,
+        rtp_profile: AudioRtpProfile::Mlow,
         signaling_rate: 16_000,
         sample_rate: 16_000,
         channels: 1,
@@ -55,10 +72,42 @@ impl AudioFormat {
         rtp_payload_type: RTP_PAYLOAD_TYPE_MLOW,
     };
 
-    /// Standard Opus with a 16 kHz codec adapter and RFC 7587's 48 kHz RTP clock.
+    /// Standard Opus/CELT carried through MLOW's native escape.
+    ///
+    /// The Opus packet must be CELT-only and use MLOW's rewritten TOC. The RTP clock remains the
+    /// negotiated MLOW clock.
+    pub const OPUS_MLOW_16KHZ_60MS: Self = Self {
+        codec: AudioCodec::Opus,
+        rtp_profile: AudioRtpProfile::Mlow,
+        signaling_rate: 16_000,
+        sample_rate: 16_000,
+        channels: 1,
+        samples_per_frame: 960,
+        rtp_clock_rate: 16_000,
+        rtp_timestamp_step: 960,
+        rtp_payload_type: RTP_PAYLOAD_TYPE_MLOW,
+    };
+
+    /// Native Opus using WhatsApp's default PT 120 and 16 kHz RTP clock.
+    ///
+    /// Capability v1 index 31 disables MLOW decoding independently from PT and clock selection.
     pub const OPUS_16KHZ_60MS: Self = Self {
         codec: AudioCodec::Opus,
-        signaling_rate: 8_000,
+        rtp_profile: AudioRtpProfile::StandardOpus,
+        signaling_rate: 16_000,
+        sample_rate: 16_000,
+        channels: 1,
+        samples_per_frame: 960,
+        rtp_clock_rate: 16_000,
+        rtp_timestamp_step: 960,
+        rtp_payload_type: RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO,
+    };
+
+    /// Native Opus with a 16 kHz codec adapter and RFC 7587's 48 kHz RTP clock.
+    pub const OPUS_RFC7587_16KHZ_60MS: Self = Self {
+        codec: AudioCodec::Opus,
+        rtp_profile: AudioRtpProfile::StandardOpus,
+        signaling_rate: 16_000,
         sample_rate: 16_000,
         channels: 1,
         samples_per_frame: 960,
@@ -70,7 +119,8 @@ impl AudioFormat {
     /// RFC 7587 Opus timing. Useful for interop experiments with external RTP-aware codecs.
     pub const OPUS_RFC7587_48KHZ_60MS: Self = Self {
         codec: AudioCodec::Opus,
-        signaling_rate: 8_000,
+        rtp_profile: AudioRtpProfile::StandardOpus,
+        signaling_rate: 16_000,
         sample_rate: 48_000,
         channels: 1,
         samples_per_frame: 2_880,
@@ -79,18 +129,33 @@ impl AudioFormat {
         rtp_payload_type: RTP_PAYLOAD_TYPE_OPUS,
     };
 
-    /// WhatsApp's signaling rate selects a media profile rather than the Opus PCM rate.
-    pub const fn from_signaling_rate(rate: u32) -> Option<Self> {
-        match rate {
-            16_000 => Some(Self::MLOW_16KHZ_60MS),
-            8_000 => Some(Self::OPUS_16KHZ_60MS),
-            _ => None,
+    pub const fn accepts_rtp_payload_type(self, payload_type: u8) -> bool {
+        payload_type == self.rtp_payload_type
+            || matches!(self.rtp_profile, AudioRtpProfile::Mlow)
+                && payload_type == RTP_PAYLOAD_TYPE_MLOW_RED
+    }
+
+    /// Identify the actual inbound codec after the negotiated RTP profile is known.
+    pub fn inbound_codec(self, payload_type: u8, payload: &[u8]) -> AudioCodec {
+        match self.rtp_profile {
+            AudioRtpProfile::StandardOpus => AudioCodec::Opus,
+            AudioRtpProfile::Mlow
+                if payload_type != RTP_PAYLOAD_TYPE_MLOW_RED && is_mlow_embedded_opus(payload) =>
+            {
+                AudioCodec::Opus
+            }
+            AudioRtpProfile::Mlow => AudioCodec::Mlow,
         }
     }
 
-    pub const fn accepts_rtp_payload_type(self, payload_type: u8) -> bool {
-        payload_type == self.rtp_payload_type
-            || matches!(self.codec, AudioCodec::Mlow) && payload_type == RTP_PAYLOAD_TYPE_MLOW_RED
+    /// Reject raw Opus that the MLOW receiver would parse as proprietary codec data.
+    pub fn accepts_encoded_payload(self, payload: &[u8]) -> bool {
+        !payload.is_empty()
+            && (!matches!(
+                (self.codec, self.rtp_profile),
+                (AudioCodec::Opus, AudioRtpProfile::Mlow)
+            ) || is_mlow_embedded_opus(payload)
+                || payload == [0x90])
     }
 
     pub(crate) fn is_valid(self) -> bool {
@@ -101,6 +166,235 @@ impl AudioFormat {
             && self.rtp_clock_rate != 0
             && self.rtp_timestamp_step != 0
             && self.rtp_payload_type <= 127
+    }
+}
+
+fn is_mlow_embedded_opus(payload: &[u8]) -> bool {
+    payload.first().is_some_and(|byte| byte & 0xC0 == 0xC0)
+}
+
+/// Failure while translating between RFC Opus and MLOW's CELT packet header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum OpusMlowPacketError {
+    #[error("empty Opus packet")]
+    Empty,
+    #[error("Opus config {0} is not CELT-only")]
+    NotCelt(u8),
+    #[error("invalid Opus frame packing")]
+    InvalidFramePacking,
+    #[error("packet is not an MLOW CELT escape")]
+    NotMlowEscape,
+}
+
+/// Rewrite one RFC Opus CELT packet for MLOW's in-profile escape.
+///
+/// Code-0 and code-3 packets are changed in place without allocation. The two-frame RFC shorthand
+/// forms need one inserted descriptor byte. Codec payload bytes are never transcoded.
+pub fn packetize_opus_for_mlow(packet: &mut Vec<u8>) -> Result<(), OpusMlowPacketError> {
+    let Some(&toc) = packet.first() else {
+        return Err(OpusMlowPacketError::Empty);
+    };
+    // libopus uses packets of at most two bytes for DTX, including a repacketized 60 ms frame.
+    // MLOW needs its SID token so the peer does not consume the speech-resume RTP marker.
+    if packet.len() <= 2 {
+        packet[0] = 0x90;
+        packet.truncate(1);
+        return Ok(());
+    }
+    let config = toc >> 3;
+    if config < 16 {
+        return Err(OpusMlowPacketError::NotCelt(config));
+    }
+    // General Opus DTX has a hangover. Its canonical CELT silence frames still carry the MLOW VAD
+    // bit after a TOC rewrite, which can consume the receiver's speech-resume marker before speech.
+    if opus_celt_packet_is_silence(packet) {
+        packet.clear();
+        packet.push(0x90);
+        return Ok(());
+    }
+
+    let packing = toc & 0x03;
+    match packing {
+        0 => {}
+        1 => {
+            let body_len = packet.len() - 1;
+            if body_len == 0 || !body_len.is_multiple_of(2) {
+                return Err(OpusMlowPacketError::InvalidFramePacking);
+            }
+            packet.insert(1, 2);
+        }
+        2 => {
+            if !valid_two_frame_vbr_body(&packet[1..]) {
+                return Err(OpusMlowPacketError::InvalidFramePacking);
+            }
+            packet.insert(1, 0x82);
+        }
+        3 => {
+            if packet.get(1).is_none_or(|descriptor| {
+                let frame_count = descriptor & 0x3F;
+                frame_count == 0 || frame_count > 48
+            }) {
+                return Err(OpusMlowPacketError::InvalidFramePacking);
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    let mode = config - 16;
+    let stereo = (toc >> 2) & 1;
+    packet[0] = 0xC0 | mode << 2 | stereo << 1 | u8::from(packing != 0);
+    Ok(())
+}
+
+/// Restore the RFC Opus TOC before passing an escaped MLOW payload to a stock Opus decoder.
+pub fn depacketize_opus_from_mlow(packet: &mut [u8]) -> Result<(), OpusMlowPacketError> {
+    let Some(&toc) = packet.first() else {
+        return Err(OpusMlowPacketError::Empty);
+    };
+    if toc & 0xC0 != 0xC0 {
+        return Err(OpusMlowPacketError::NotMlowEscape);
+    }
+    let multiple = toc & 1 != 0;
+    if multiple
+        && packet.get(1).is_none_or(|descriptor| {
+            let frame_count = descriptor & 0x3F;
+            frame_count == 0 || frame_count > 48
+        })
+    {
+        return Err(OpusMlowPacketError::InvalidFramePacking);
+    }
+
+    let config = 16 + ((toc >> 2) & 0x0F);
+    let stereo = (toc >> 1) & 1;
+    packet[0] = config << 3 | stereo << 2 | if multiple { 3 } else { 0 };
+    Ok(())
+}
+
+fn valid_two_frame_vbr_body(body: &[u8]) -> bool {
+    let Some(&first) = body.first() else {
+        return false;
+    };
+    let (size, field_len) = if first < 252 {
+        (usize::from(first), 1)
+    } else {
+        let Some(&second) = body.get(1) else {
+            return false;
+        };
+        (usize::from(first) + 4 * usize::from(second), 2)
+    };
+    size > 0 && body.len().saturating_sub(field_len + size) > 0
+}
+
+fn opus_celt_packet_is_silence(packet: &[u8]) -> bool {
+    fn frame_is_silence(frame: &[u8]) -> bool {
+        frame.is_empty() || frame == [0xFF, 0xFE]
+    }
+
+    fn parse_size(packet: &[u8], offset: &mut usize) -> Option<usize> {
+        let first = *packet.get(*offset)?;
+        *offset += 1;
+        if first < 252 {
+            return Some(usize::from(first));
+        }
+        let second = *packet.get(*offset)?;
+        *offset += 1;
+        Some(usize::from(first) + 4 * usize::from(second))
+    }
+
+    let Some(&toc) = packet.first() else {
+        return false;
+    };
+    match toc & 0x03 {
+        0 => frame_is_silence(&packet[1..]),
+        1 => {
+            let body = &packet[1..];
+            body.len().is_multiple_of(2)
+                && frame_is_silence(&body[..body.len() / 2])
+                && frame_is_silence(&body[body.len() / 2..])
+        }
+        2 => {
+            let mut offset = 1;
+            let Some(first_len) = parse_size(packet, &mut offset) else {
+                return false;
+            };
+            let Some(split) = offset.checked_add(first_len) else {
+                return false;
+            };
+            split <= packet.len()
+                && frame_is_silence(&packet[offset..split])
+                && frame_is_silence(&packet[split..])
+        }
+        3 => {
+            let Some(&descriptor) = packet.get(1) else {
+                return false;
+            };
+            let frame_count = usize::from(descriptor & 0x3F);
+            if frame_count == 0 || frame_count > 48 {
+                return false;
+            }
+            let mut offset = 2;
+            let mut padding = 0usize;
+            if descriptor & 0x40 != 0 {
+                loop {
+                    let Some(&byte) = packet.get(offset) else {
+                        return false;
+                    };
+                    offset += 1;
+                    let added = if byte == 255 { 254 } else { usize::from(byte) };
+                    let Some(total) = padding.checked_add(added) else {
+                        return false;
+                    };
+                    padding = total;
+                    if byte != 255 {
+                        break;
+                    }
+                }
+            }
+            let Some(payload_end) = packet.len().checked_sub(padding) else {
+                return false;
+            };
+            if offset > payload_end {
+                return false;
+            }
+            if descriptor & 0x80 == 0 {
+                let body = &packet[offset..payload_end];
+                if !body.len().is_multiple_of(frame_count) {
+                    return false;
+                }
+                let frame_len = body.len() / frame_count;
+                return frame_len == 0 || body.chunks(frame_len).all(frame_is_silence);
+            }
+
+            let mut lengths = [0usize; 48];
+            let mut encoded_len = 0usize;
+            for length in &mut lengths[..frame_count - 1] {
+                let Some(parsed) = parse_size(packet, &mut offset) else {
+                    return false;
+                };
+                let Some(total) = encoded_len.checked_add(parsed) else {
+                    return false;
+                };
+                encoded_len = total;
+                *length = parsed;
+            }
+            let Some(last_len) = payload_end
+                .checked_sub(offset)
+                .and_then(|remaining| remaining.checked_sub(encoded_len))
+            else {
+                return false;
+            };
+            lengths[frame_count - 1] = last_len;
+            lengths[..frame_count].iter().all(|&length| {
+                let Some(end) = offset.checked_add(length) else {
+                    return false;
+                };
+                let silence = end <= payload_end && frame_is_silence(&packet[offset..end]);
+                offset = end;
+                silence
+            }) && offset == payload_end
+        }
+        _ => unreachable!(),
     }
 }
 
@@ -137,10 +431,141 @@ impl Default for AudioConfig {
 #[non_exhaustive]
 pub struct EncodedAudioFrame {
     pub format: AudioFormat,
+    /// Codec detected within the negotiated RTP profile for this packet.
+    pub codec: AudioCodec,
     pub data: Bytes,
     /// Actual RTP payload type. MLOW redundancy uses PT 121 while the primary format uses PT 120.
     pub payload_type: u8,
     pub sequence_number: u16,
     pub timestamp: u32,
     pub marker: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_opus_codec_selection_is_independent_from_rtp_clock_profile() {
+        let native = AudioFormat::OPUS_16KHZ_60MS;
+        assert_eq!(native.rtp_profile, AudioRtpProfile::StandardOpus);
+        assert_eq!(native.rtp_payload_type, RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO);
+        assert_eq!(native.rtp_clock_rate, 16_000);
+        assert_eq!(native.rtp_timestamp_step, 960);
+
+        let rfc7587 = AudioFormat::OPUS_RFC7587_16KHZ_60MS;
+        assert_eq!(rfc7587.rtp_profile, AudioRtpProfile::StandardOpus);
+        assert_eq!(rfc7587.rtp_payload_type, RTP_PAYLOAD_TYPE_OPUS);
+        assert_eq!(rfc7587.rtp_clock_rate, 48_000);
+        assert_eq!(rfc7587.rtp_timestamp_step, 2_880);
+    }
+
+    #[test]
+    fn mlow_profile_accepts_primary_and_redundancy_payload_types() {
+        assert!(AudioFormat::OPUS_MLOW_16KHZ_60MS.accepts_rtp_payload_type(RTP_PAYLOAD_TYPE_MLOW));
+        assert!(
+            AudioFormat::OPUS_MLOW_16KHZ_60MS.accepts_rtp_payload_type(RTP_PAYLOAD_TYPE_MLOW_RED)
+        );
+        assert!(!AudioFormat::OPUS_MLOW_16KHZ_60MS.accepts_rtp_payload_type(RTP_PAYLOAD_TYPE_OPUS));
+    }
+
+    #[test]
+    fn mlow_profile_classifies_embedded_opus_only_on_primary_pt() {
+        let format = AudioFormat::OPUS_MLOW_16KHZ_60MS;
+        assert_eq!(
+            format.inbound_codec(RTP_PAYLOAD_TYPE_MLOW, &[0xF8, 1, 2]),
+            AudioCodec::Opus
+        );
+        assert_eq!(
+            format.inbound_codec(RTP_PAYLOAD_TYPE_MLOW, &[0x50, 1, 2]),
+            AudioCodec::Mlow
+        );
+        assert_eq!(
+            format.inbound_codec(RTP_PAYLOAD_TYPE_MLOW_RED, &[0xC0, 1, 2]),
+            AudioCodec::Mlow
+        );
+    }
+
+    #[test]
+    fn opus_in_mlow_requires_the_escape_toc() {
+        let format = AudioFormat::OPUS_MLOW_16KHZ_60MS;
+        assert!(format.accepts_encoded_payload(&[0xF8, 1, 2]));
+        assert!(format.accepts_encoded_payload(&[0x90]));
+        assert!(!format.accepts_encoded_payload(&[0x08, 1, 2]));
+        assert!(!format.accepts_encoded_payload(&[]));
+    }
+
+    #[test]
+    fn opus_celt_packet_round_trips_through_mlow_toc() {
+        // RFC Opus: CELT-WB 20 ms, mono, arbitrary three-frame packet.
+        let original = vec![0xBB, 0x03, 1, 2, 3, 4, 5, 6];
+        let mut packet = original.clone();
+
+        packetize_opus_for_mlow(&mut packet).unwrap();
+        assert_eq!(packet[0], 0xDD);
+        assert_eq!(&packet[1..], &original[1..]);
+        depacketize_opus_from_mlow(&mut packet).unwrap();
+        assert_eq!(packet, original);
+    }
+
+    #[test]
+    fn two_frame_opus_shorthand_gets_an_explicit_descriptor() {
+        let mut cbr = vec![0xB9, 1, 2, 3, 4];
+        packetize_opus_for_mlow(&mut cbr).unwrap();
+        assert_eq!(&cbr[..2], &[0xDD, 2]);
+
+        let mut vbr = vec![0xBA, 2, 1, 2, 3];
+        packetize_opus_for_mlow(&mut vbr).unwrap();
+        assert_eq!(&vbr[..3], &[0xDD, 0x82, 2]);
+    }
+
+    #[test]
+    fn opus_dtx_maps_to_mlow_sid() {
+        let mut packet = vec![0xB8];
+        packetize_opus_for_mlow(&mut packet).unwrap();
+        assert_eq!(packet, [0x90]);
+
+        let mut repacketized_60_ms = vec![0xBB, 0x03];
+        packetize_opus_for_mlow(&mut repacketized_60_ms).unwrap();
+        assert_eq!(repacketized_60_ms, [0x90]);
+    }
+
+    #[test]
+    fn opus_celt_hangover_silence_maps_to_mlow_sid() {
+        let mut cbr = vec![0xBB, 0x03, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE];
+        packetize_opus_for_mlow(&mut cbr).unwrap();
+        assert_eq!(cbr, [0x90]);
+
+        let mut vbr_refresh = vec![0xBB, 0x83, 0x02, 0x00, 0xFF, 0xFE];
+        packetize_opus_for_mlow(&mut vbr_refresh).unwrap();
+        assert_eq!(vbr_refresh, [0x90]);
+
+        let mut active = vec![0xBB, 0x03, 0xFF, 0xFD, 0xFF, 0xFE, 0xFF, 0xFE];
+        packetize_opus_for_mlow(&mut active).unwrap();
+        assert_eq!(active[0], 0xDD);
+    }
+
+    #[test]
+    fn silk_opus_cannot_use_mlow_celt_escape() {
+        let mut silk = vec![0x08, 1, 2, 3];
+        assert_eq!(
+            packetize_opus_for_mlow(&mut silk),
+            Err(OpusMlowPacketError::NotCelt(1))
+        );
+    }
+
+    #[test]
+    fn opus_escape_rejects_more_than_48_frames() {
+        let mut packet = vec![0xBB, 49, 1, 2, 3];
+        assert_eq!(
+            packetize_opus_for_mlow(&mut packet),
+            Err(OpusMlowPacketError::InvalidFramePacking)
+        );
+
+        let mut escaped = [0xDD, 49, 1, 2, 3];
+        assert_eq!(
+            depacketize_opus_from_mlow(&mut escaped),
+            Err(OpusMlowPacketError::InvalidFramePacking)
+        );
+    }
 }

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -19,6 +19,7 @@ use futures::future::{Fuse, FusedFuture};
 
 use crate::runtime::{BoxFuture, Runtime};
 use crate::time::Instant;
+use crate::voip::audio::EncodedAudioFrame;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
 use crate::voip::h264::VideoFrame;
@@ -149,14 +150,14 @@ impl VideoControlReceiver {
     }
 }
 
-/// The audio + video + event channels the driver bridges to the platform. Mic frames in, playout
-/// frames out (dropped on speaker overflow since VoIP is loss tolerant), and engine events out
-/// (RelayAllocated, ForeignAudio) for the shell to act on (e.g. decode a non-MLow frame with a
-/// platform codec). The video channels are always present — a call that never negotiates video
-/// simply leaves them idle (the engine drops AUs while its video plane is off).
+/// The audio + video + event channels the driver bridges to the platform. PCM and encoded audio
+/// channels are both present; the call's [`super::audio::AudioIo`] selects which pair is active.
+/// Media outputs shed frames on sink overflow, while lifecycle events use their own bounded queue.
 pub struct CallChannels {
     pub mic: async_channel::Receiver<Vec<i16>>,
     pub speaker: async_channel::Sender<Vec<i16>>,
+    pub encoded_audio_in: async_channel::Receiver<Bytes>,
+    pub encoded_audio_out: async_channel::Sender<EncodedAudioFrame>,
     pub events: async_channel::Sender<CallEvent>,
     /// Caller-only: the answering device's LID, delivered once the callee's `<accept>` is received so
     /// the drive loop can rekey the recv path before media flows. `None` on the callee side and esp32.
@@ -417,7 +418,7 @@ pub async fn run_call(
         fields(call_id = %eng.call_id())
     )
 )]
-#[cfg(test)]
+#[cfg(all(test, feature = "voip-mlow"))]
 async fn run_call_with_clock(
     rt: Arc<dyn Runtime>,
     transport: Arc<dyn RelayTransport>,
@@ -455,6 +456,7 @@ async fn run_call_with_clock_and_wallclock(
     // The mic feeds outgoing audio only; its liveness must not gate the call. Flipped false when the
     // mic channel closes so we stop polling it without tearing the call down (see the mic arm).
     let mut mic_open = true;
+    let mut encoded_audio_open = true;
 
     // The recv-rekey is one-shot (the first callee `<accept>` picks the answering device). Flipped
     // false after the first event -- a rekey or the sender closing -- so the closed channel's
@@ -507,6 +509,9 @@ async fn run_call_with_clock_and_wallclock(
                 // Loss tolerant: drop the frame if the speaker can't keep up.
                 Output::Playout(pcm) => {
                     let _ = channels.speaker.try_send(pcm);
+                }
+                Output::EncodedAudio(frame) => {
+                    let _ = channels.encoded_audio_out.try_send(frame);
                 }
                 // Same policy for video: a stalled sink sheds frames, never the drive loop.
                 Output::VideoPlayout(frame) => {
@@ -580,6 +585,17 @@ async fn run_call_with_clock_and_wallclock(
         }
         .fuse();
         futures::pin_mut!(mic_fut);
+
+        let encoded_audio = &channels.encoded_audio_in;
+        let encoded_audio_fut = async move {
+            if encoded_audio_open {
+                encoded_audio.recv().await
+            } else {
+                std::future::pending().await
+            }
+        }
+        .fuse();
+        futures::pin_mut!(encoded_audio_fut);
 
         // Caller-only recv-rekey: the answering device's LID. Parked (pending) when there is no rekey
         // channel (callee/esp32) or once consumed, mirroring the mic arm so a closed channel can't spin.
@@ -720,6 +736,19 @@ async fn run_call_with_clock_and_wallclock(
                 // alive: muting the mic must not hang up the call (see the comment above).
                 Err(_) => mic_open = false,
             },
+            frame = encoded_audio_fut => match frame {
+                Ok(encoded) => {
+                    eng.handle_input(now_ms(), Input::EncodedAudio(&encoded));
+                    let now = now_ms();
+                    if let Some(at) = eng.poll_timeout()
+                        && at != engine::NEVER
+                        && now >= at
+                    {
+                        eng.handle_input(now, Input::Timeout);
+                    }
+                }
+                Err(_) => encoded_audio_open = false,
+            },
             au = video_in_fut => match au {
                 Ok(au) => {
                     eng.handle_input(now_ms(), Input::VideoFrame(&au));
@@ -754,7 +783,7 @@ async fn run_call_with_clock_and_wallclock(
     transport.disconnect().await;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "voip-mlow"))]
 mod tests {
     use super::*;
     use crate::runtime::AbortHandle;
@@ -832,9 +861,13 @@ mod tests {
         let (_vin_tx, vin_rx) = async_channel::unbounded::<Vec<u8>>();
         let (vout_tx, _vout_rx) = async_channel::unbounded::<VideoFrame>();
         let (_vctl_tx, vctl_rx) = video_control_channel();
+        let (_encoded_tx, encoded_rx) = async_channel::unbounded::<Bytes>();
+        let (encoded_out_tx, _encoded_out_rx) = async_channel::unbounded::<EncodedAudioFrame>();
         CallChannels {
             mic,
             speaker,
+            encoded_audio_in: encoded_rx,
+            encoded_audio_out: encoded_out_tx,
             events,
             rekey: None,
             video_in: vin_rx,
@@ -851,7 +884,7 @@ mod tests {
             peer_lid: "222222222222222:0@lid".into(),
             call_key: (0u8..32).collect(),
             ssrc: 0x5741_0001,
-            samples_per_packet: 960,
+            audio: crate::voip::AudioConfig::MLOW_PCM,
             relay_token: vec![0xAB; 16],
             relay_ip: "203.0.113.7".into(),
             relay_port: 3478,
@@ -1241,7 +1274,7 @@ mod tests {
             self_lid: &cfg.peer_lid,
             peer_lid: &cfg.self_lid,
             ssrc: cfg.ssrc,
-            samples_per_packet: cfg.samples_per_packet,
+            samples_per_packet: cfg.audio.format.rtp_timestamp_step,
             warp_mi_tag_len: cfg.warp_mi_tag_len,
         })
         .unwrap();
@@ -1257,7 +1290,7 @@ mod tests {
         });
 
         let (mic_tx, mic_rx) = async_channel::unbounded();
-        let tone: Vec<i16> = (0..cfg.samples_per_packet as usize)
+        let tone: Vec<i16> = (0..cfg.audio.format.samples_per_frame as usize)
             .map(|i| (8000.0 * (i as f32 * 0.1).sin()) as i16)
             .collect();
         mic_tx.try_send(tone).unwrap();
@@ -1376,7 +1409,7 @@ mod tests {
             self_lid: &cfg.peer_lid,
             peer_lid: &cfg.self_lid,
             ssrc: cfg.ssrc,
-            samples_per_packet: cfg.samples_per_packet,
+            samples_per_packet: cfg.audio.format.rtp_timestamp_step,
             warp_mi_tag_len: cfg.warp_mi_tag_len,
         })
         .unwrap();
@@ -1511,6 +1544,8 @@ mod tests {
             CallChannels {
                 mic: mic_rx,
                 speaker: spk_tx,
+                encoded_audio_in: async_channel::unbounded::<Bytes>().1,
+                encoded_audio_out: async_channel::unbounded::<EncodedAudioFrame>().0,
                 events: ev_tx,
                 rekey: None,
                 video_in: vin_rx,

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1,6 +1,6 @@
 //! The sans-IO call engine: a str0m-shaped state machine that owns the relay control plane (STUN
-//! allocate, 1s keepalive, consent-freshness replies) and, optionally, the media plane (MLow
-//! encode/decode + E2E-SRTP + SFrame + a 20ms playout jitter buffer). It owns no socket, no clock,
+//! allocate, 1s keepalive, consent-freshness replies) and, optionally, the media plane (encoded
+//! audio or PCM MLOW + E2E-SRTP + SFrame + a playout jitter buffer). It owns no socket, no clock,
 //! and no thread. The shell performs a single mutation (`handle_input`), drains `poll_output()`
 //! until it yields `Output::Timeout`, executes each intent, and arms one timer for that deadline.
 //!
@@ -16,12 +16,17 @@ use std::collections::VecDeque;
 
 use bytes::Bytes;
 
+use super::audio::{AudioCodec, AudioConfig, AudioFormat, AudioIo, EncodedAudioFrame};
 use super::demux::{RelayPacketKind, classify_relay_packet};
 use super::h264::{VideoFrame, au_has_idr, au_is_keyframe};
+#[cfg(feature = "voip-mlow")]
+use super::mlow;
 use super::rtcp::{
     RTCP_PT_PSFB, RtcpFeedback, RtcpReportBlock, RtpReceptionStats, build_whatsapp_rtcp_cname,
     parse_sender_report_timing, summarize_rtcp,
 };
+#[cfg(feature = "voip-mlow")]
+use super::rtp::RTP_PAYLOAD_TYPE_MLOW_RED;
 use super::rtp::{
     RTP_PAYLOAD_TYPE_H264, VIDEO_CLOCK_RATE, VIDEO_TS_STRIDE_15FPS, parse_rtp_header,
 };
@@ -29,7 +34,7 @@ use super::session::{
     CallDirection, MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
 };
 use super::sframe::{SframeIn, SframeSession};
-use super::{is_standard_opus_frame, mlow, ssrc, stun};
+use super::{ssrc, stun};
 
 /// Monotonic milliseconds. The shell supplies it; the engine never reads a clock.
 pub type Millis = u64;
@@ -48,27 +53,34 @@ const ALLOCATE_TIMEOUT_MS: Millis = 10_000;
 /// Playout drain cadence: hand the speaker a fixed slice every 20ms so it stays fed at 16kHz.
 const PLAYOUT_MS: Millis = 20;
 /// 20ms @ 16kHz: samples drained to the speaker per playout tick.
+#[cfg(feature = "voip-mlow")]
 const PLAYOUT_DRAIN: usize = 320;
 /// ~150ms latency ceiling; a burst past this resyncs (drops oldest) instead of lagging.
+#[cfg(feature = "voip-mlow")]
 const PLAYOUT_CAP: usize = 2400;
 /// Prebuffer target: prime playout until the jitter buffer holds two 60ms peer frames, so the
 /// steady-state buffer never drains below one frame (a 60ms cushion that absorbs the relay's
 /// inter-arrival jitter). Priming to a single frame is a zero cushion: that one frame drains away
 /// over its own 60ms cycle, so the buffer returns to empty before the next packet and any late
 /// arrival underruns. The cushion has to be one frame above what the per-cycle drain consumes.
+#[cfg(feature = "voip-mlow")]
 const PLAYOUT_TARGET: usize = 1920;
 /// Bound on how long playout primes before flushing a partial buffer: if the peer sends one frame
 /// then goes DTX the jitter buffer never reaches `PLAYOUT_TARGET`, so after this many 20ms ticks
 /// (~200ms) drain whatever is queued instead of holding it (silent) forever. Comfortably above the
 /// few ticks a normal jittered second-frame arrival takes, so it never trips in steady operation.
+#[cfg(feature = "voip-mlow")]
 const MAX_PRIME_TICKS: u32 = 10;
 /// One-byte mlow DTX comfort-noise token sent on a muted (exact-zero) mic frame so the media stream
 /// never gaps; protect_audio frames it with the DTX RTP header and the peer decodes it to silence.
+#[cfg(feature = "voip-mlow")]
 const MLOW_DTX_CNG: [u8; 1] = [0x90];
 /// One 60ms MLow frame at 16kHz. `Input::MicFrame` must carry exactly this; a wrong-length buffer is
 /// dropped (the encoder requires it), never sent.
+#[cfg(feature = "voip-mlow")]
 const MIC_FRAME_SAMPLES: usize = 960;
-const AUDIO_CLOCK_RATE: u32 = 16_000;
+#[cfg(feature = "voip-mlow")]
+const MLOW_ENCODED_CAPACITY: usize = 513;
 
 /// Supplies STUN transaction ids. Injected so the core stays RNG-free and deterministically
 /// testable. Production shells MUST back this with a real RNG (the ids gate consent freshness);
@@ -114,10 +126,8 @@ pub struct CallConfig {
     /// The 32-byte callKey.
     pub call_key: Vec<u8>,
     pub ssrc: u32,
-    /// RTP timestamp stride per packet. NOTE: the MLow encoder requires exactly 960-sample (60ms @
-    /// 16kHz) frames, so `Input::MicFrame` must carry 960 samples regardless of this value (a
-    /// wrong-length frame is dropped, no RTP sent). Set to 960 unless the codec changes.
-    pub samples_per_packet: u32,
+    /// Codec, timing, and whether the engine sees PCM or complete encoded payloads.
+    pub audio: AudioConfig,
     /// Relay endpoint allocate inputs.
     pub relay_token: Vec<u8>,
     pub relay_ip: String,
@@ -150,7 +160,7 @@ impl core::fmt::Debug for CallConfig {
             .field("peer_lid", &self.peer_lid)
             .field("call_key", &"[redacted]")
             .field("ssrc", &self.ssrc)
-            .field("samples_per_packet", &self.samples_per_packet)
+            .field("audio", &self.audio)
             .field("relay_token", &"[redacted]")
             .field("relay_ip", &self.relay_ip)
             .field("relay_port", &self.relay_port)
@@ -171,6 +181,12 @@ pub enum EngineError {
     BadCallKey,
     #[error("relay endpoint is not a valid IPv4 address")]
     BadEndpoint,
+    #[error("audio format contains a zero timing or channel value")]
+    BadAudioFormat,
+    #[error("PCM audio is currently supported only for mono 16 kHz / 60 ms MLOW")]
+    UnsupportedPcmAudio,
+    #[error("PCM MLOW audio requires the `voip-mlow` feature")]
+    MlowUnavailable,
 }
 
 /// Why an incoming call's [`CallConfig`] could not be assembled from the offer's relay block.
@@ -252,8 +268,7 @@ impl CallConfig {
             peer_lid: peer_lid.to_string(),
             call_key,
             ssrc: our_ssrc,
-            // The MLow encoder requires exactly 960-sample frames.
-            samples_per_packet: 960,
+            audio: AudioConfig::MLOW_PCM,
             relay_token,
             relay_ip,
             relay_port,
@@ -310,6 +325,9 @@ pub enum Input<'a> {
     /// A 60ms PCM frame captured from the local mic (16kHz mono). Must be exactly 960 samples (the
     /// MLow frame size); a wrong-length frame is silently dropped by the encoder (no RTP sent).
     MicFrame(&'a [i16]),
+    /// One complete payload produced by the codec selected in [`CallConfig::audio`]. The engine
+    /// adds RTP, SRTP, and WARP framing without inspecting or transcoding it.
+    EncodedAudio(&'a [u8]),
     /// One pre-encoded H.264 Annex-B access unit to send. Dropped while the video plane is off
     /// (audio-only call, or after a downgrade).
     VideoFrame(&'a [u8]),
@@ -325,6 +343,8 @@ pub enum Output {
     Transmit(Bytes),
     /// Decoded PCM for the speaker (16kHz mono).
     Playout(Vec<i16>),
+    /// A decrypted codec payload for an encoded audio sink.
+    EncodedAudio(EncodedAudioFrame),
     /// A reassembled peer access unit for the video sink. Dedicated output (not a CallEvent) for
     /// the same reason audio uses `Playout`: the event channel sheds on overflow, media must not.
     VideoPlayout(VideoFrame),
@@ -339,9 +359,14 @@ pub enum Output {
 pub enum CallEvent {
     /// The relay accepted our allocate (an allocate/binding success arrived); media path is live.
     RelayAllocated,
-    /// An inbound audio payload the core won't decode itself (a standard-Opus frame, not MLow).
-    /// The shell may decode it with a platform codec (libopus). Carries the decrypted payload.
+    /// A standard Opus packet carried through MLOW's in-profile escape while PCM/MLOW I/O is
+    /// selected. Shells with an Opus decoder can play it; codec selection still follows signaling.
     ForeignAudio(Bytes),
+    /// The peer selected signaling rates incompatible with the single profile offered locally.
+    AudioFormatMismatch {
+        expected_rate: u32,
+        received_rates: Vec<u32>,
+    },
     /// The relay rejected our allocate. Terminal; carries the STUN error code (class*100 + number).
     RelayAllocateFailed(u16),
     /// The relay never acked the allocate within the deadline (wedged relay). Terminal.
@@ -372,11 +397,12 @@ pub enum CallEvent {
     },
 }
 
-/// The optional media plane: the SRTP pipeline, the MLow codec, an optional SFrame session, and
-/// the playout jitter buffer. One `MediaPipeline` serves both directions: protect uses its send
+/// The optional media plane: the SRTP pipeline, selected audio mode, an optional SFrame session,
+/// and the PCM playout jitter buffer. One `MediaPipeline` serves both directions: protect uses its send
 /// keys/ROC/RTP state, unprotect its recv keys/ROC, and those fields are disjoint.
 struct MediaState {
     pipe: MediaPipeline,
+    audio: AudioConfig,
     audio_reception: RtpReceptionStats,
     /// Retained so the caller can re-derive the recv keys once the answering device is known (the
     /// callee's `<accept>` carries its device LID). See [`CallEngine::rekey_recv`].
@@ -394,13 +420,22 @@ struct MediaState {
     video: Option<VideoPlaneState>,
     audio_rtcp_announced: bool,
     sframe: Option<SframeSession>,
+    #[cfg(feature = "voip-mlow")]
+    pcm: Option<PcmAudioState>,
+    /// `NEVER` for encoded I/O, which has no core-side playout timer.
+    playout_deadline: Millis,
+}
+
+#[cfg(feature = "voip-mlow")]
+struct PcmAudioState {
     encoder: mlow::MlowEncoder,
     decoder: mlow::MlowDecoder,
     /// Reused per outbound frame to hold the i16->f32 conversion, so the encode hot path doesn't
     /// allocate a fresh Vec each frame.
     scratch: Vec<f32>,
+    /// Reused codec output before SRTP copies it into the protected packet.
+    encoded: Vec<u8>,
     jitter: VecDeque<i16>,
-    playout_deadline: Millis,
     /// Playout emits silence (without draining) while the jitter buffer fills to `PLAYOUT_TARGET`, so
     /// a late packet costs one re-prime instead of a silence gap every 20ms tick. Re-armed on underrun.
     priming: bool,
@@ -535,23 +570,43 @@ impl CallEngine {
         )
     )]
     pub fn new(config: CallConfig, mut tx_ids: Box<dyn TxIdSource>) -> Result<Self, EngineError> {
+        if config.enable_media && !config.audio.format.is_valid() {
+            return Err(EngineError::BadAudioFormat);
+        }
+        if config.enable_media
+            && config.audio.io == AudioIo::Pcm
+            && config.audio
+                != (AudioConfig {
+                    format: AudioFormat::MLOW_16KHZ_60MS,
+                    io: AudioIo::Pcm,
+                })
+        {
+            return Err(EngineError::UnsupportedPcmAudio);
+        }
+        #[cfg(not(feature = "voip-mlow"))]
+        if config.enable_media && config.audio.io == AudioIo::Pcm {
+            return Err(EngineError::MlowUnavailable);
+        }
         let endpoint_xor = stun::encode_xor_relay_endpoint(&config.relay_ip, config.relay_port)
             .ok_or(EngineError::BadEndpoint)?;
 
         let media = if config.enable_media {
             let audio_rtcp_cname = build_whatsapp_rtcp_cname(&tx_ids.next_tx_id());
-            let pipe = MediaPipeline::new_with_rtcp_cname(
+            let mut pipe = MediaPipeline::new_with_rtcp_cname(
                 &MediaPipelineParams {
                     call_key: &config.call_key,
                     self_lid: &config.self_lid,
                     peer_lid: &config.peer_lid,
                     ssrc: config.ssrc,
-                    samples_per_packet: config.samples_per_packet,
+                    samples_per_packet: config.audio.format.rtp_timestamp_step,
                     warp_mi_tag_len: config.warp_mi_tag_len,
                 },
                 audio_rtcp_cname,
             )
             .ok_or(EngineError::BadCallKey)?;
+            if !pipe.set_audio_payload_type(config.audio.format.rtp_payload_type) {
+                return Err(EngineError::BadAudioFormat);
+            }
             let sframe = if config.enable_sframe {
                 SframeSession::new(&config.call_key, &config.self_lid, &config.peer_lid)
             } else {
@@ -576,6 +631,7 @@ impl CallEngine {
             };
             Some(MediaState {
                 pipe,
+                audio: config.audio,
                 audio_reception: RtpReceptionStats::default(),
                 call_key: config.call_key.clone(),
                 self_lid: config.self_lid.clone(),
@@ -585,13 +641,17 @@ impl CallEngine {
                 video,
                 audio_rtcp_announced: false,
                 sframe,
-                encoder: mlow::MlowEncoder::new(),
-                decoder: mlow::MlowDecoder::new(),
-                scratch: Vec::with_capacity(config.samples_per_packet as usize),
-                jitter: VecDeque::new(),
-                playout_deadline: 0,
-                priming: true,
-                priming_ticks: 0,
+                #[cfg(feature = "voip-mlow")]
+                pcm: (config.audio.io == AudioIo::Pcm).then(|| PcmAudioState {
+                    encoder: mlow::MlowEncoder::new(),
+                    decoder: mlow::MlowDecoder::new(),
+                    scratch: Vec::with_capacity(config.audio.format.samples_per_frame as usize),
+                    encoded: Vec::with_capacity(MLOW_ENCODED_CAPACITY),
+                    jitter: VecDeque::new(),
+                    priming: true,
+                    priming_ticks: 0,
+                }),
+                playout_deadline: NEVER,
             })
         } else {
             None
@@ -768,7 +828,9 @@ impl CallEngine {
             .push_back(Output::Transmit(self.allocate.clone()));
         self.keepalive_deadline = now + KEEPALIVE_MS;
         self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
-        if let Some(m) = &mut self.media {
+        if let Some(m) = &mut self.media
+            && m.audio.io == AudioIo::Pcm
+        {
             m.playout_deadline = now + PLAYOUT_MS;
         }
     }
@@ -783,6 +845,7 @@ impl CallEngine {
             Input::Timeout => self.on_timeout(now),
             Input::RelayPacket(pkt) => self.on_packet(now, pkt),
             Input::MicFrame(pcm) => self.on_mic(pcm),
+            Input::EncodedAudio(payload) => self.on_encoded_audio(payload),
             Input::VideoFrame(au) => self.on_video(au),
         }
     }
@@ -815,9 +878,12 @@ impl CallEngine {
 
     /// Current playout jitter-buffer depth in samples. Test-only: lets coverage assert the
     /// feed-side bound without exposing the media plane.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "voip-mlow"))]
     pub(crate) fn jitter_len(&self) -> usize {
-        self.media.as_ref().map_or(0, |m| m.jitter.len())
+        self.media
+            .as_ref()
+            .and_then(|m| m.pcm.as_ref())
+            .map_or(0, |pcm| pcm.jitter.len())
     }
 
     fn on_timeout(&mut self, now: Millis) {
@@ -847,11 +913,16 @@ impl CallEngine {
         }
         if let Some(m) = self.media.as_mut()
             && self.started
+            && m.audio.io == AudioIo::Pcm
             && now >= m.playout_deadline
         {
-            let frame = drain_playout(&mut m.jitter, &mut m.priming, &mut m.priming_ticks);
-            m.playout_deadline = next_tick(m.playout_deadline, now, PLAYOUT_MS);
-            self.outbox.push_back(Output::Playout(frame));
+            #[cfg(feature = "voip-mlow")]
+            if let Some(pcm) = m.pcm.as_mut() {
+                let frame =
+                    drain_playout(&mut pcm.jitter, &mut pcm.priming, &mut pcm.priming_ticks);
+                m.playout_deadline = next_tick(m.playout_deadline, now, PLAYOUT_MS);
+                self.outbox.push_back(Output::Playout(frame));
+            }
         }
         if self.started && self.allocated && self.media.is_some() && now >= self.rtcp_deadline {
             self.emit_sender_reports(now, self.rtcp_wallclock_at(now));
@@ -998,7 +1069,10 @@ impl CallEngine {
         // Demux by payload type BEFORE unprotect: audio and video share E2E keys but have
         // distinct SSRCs/ROC trackers, so feeding a video packet through the audio pipeline
         // would fail its MI tag at best and desync at worst.
-        if parse_rtp_header(pkt).is_some_and(|h| h.payload_type == RTP_PAYLOAD_TYPE_H264) {
+        let Some(wire_header) = parse_rtp_header(pkt) else {
+            return;
+        };
+        if wire_header.payload_type == RTP_PAYLOAD_TYPE_H264 {
             // A PT-97 packet with no ACTIVE video plane (not negotiated, or after a downgrade) is
             // dropped. The pipe still advances its recv ROC on drop-free packets it never sees, but
             // an inactive plane simply ignores them.
@@ -1023,6 +1097,13 @@ impl CallEngine {
             }
             return;
         }
+        if !m
+            .audio
+            .format
+            .accepts_rtp_payload_type(wire_header.payload_type)
+        {
+            return;
+        }
         let Some((header, payload)) = m.pipe.unprotect_audio(pkt) else {
             return;
         };
@@ -1031,36 +1112,70 @@ impl CallEngine {
             header.sequence_number,
             header.timestamp,
             now,
-            AUDIO_CLOCK_RATE,
+            m.audio.format.rtp_clock_rate,
         );
-        // SFrame on: use the GCM-decrypted bytes; otherwise the SRTP payload is already plain Opus.
-        let opus = match m.sframe.as_ref().map(|s| s.decrypt(&payload)) {
+        // SFrame on: use the GCM-decrypted bytes; otherwise the SRTP payload is already plain codec.
+        let encoded = match m.sframe.as_ref().map(|s| s.decrypt(&payload)) {
             Some(SframeIn::Decrypted(plain)) => plain,
             _ => payload,
         };
-        let first = opus.first().copied().unwrap_or(0);
-        if is_standard_opus_frame(first) {
-            // Not portably decodable (libopus is FFI); hand it to the shell.
+        #[cfg(feature = "voip-mlow")]
+        if m.audio.io == AudioIo::Pcm
+            && m.audio.format.codec == AudioCodec::Mlow
+            && header.payload_type != RTP_PAYLOAD_TYPE_MLOW_RED
+            && mlow::is_embedded_opus(&encoded)
+        {
             self.outbox
-                .push_back(Output::Event(CallEvent::ForeignAudio(Bytes::from(opus))));
+                .push_back(Output::Event(CallEvent::ForeignAudio(Bytes::from(encoded))));
             return;
         }
+        if m.audio.io == AudioIo::Encoded {
+            self.outbox
+                .push_back(Output::EncodedAudio(EncodedAudioFrame {
+                    format: m.audio.format,
+                    data: Bytes::from(encoded),
+                    payload_type: header.payload_type,
+                    sequence_number: header.sequence_number,
+                    timestamp: header.timestamp,
+                    marker: header.marker,
+                }));
+            return;
+        }
+        debug_assert_eq!(m.audio.format.codec, AudioCodec::Mlow);
+        #[cfg(feature = "voip-mlow")]
+        let Some(pcm) = m.pcm.as_mut() else {
+            return;
+        };
+        #[cfg(not(feature = "voip-mlow"))]
+        return;
         // MLow decode (f32 [-1,1]) -> i16, appended to the playout buffer.
-        for s in m.decoder.decode(&opus) {
-            m.jitter
+        #[cfg(feature = "voip-mlow")]
+        pcm.decoder
+            .set_redundancy(i32::from(header.payload_type == RTP_PAYLOAD_TYPE_MLOW_RED));
+        #[cfg(feature = "voip-mlow")]
+        for s in pcm.decoder.decode(&encoded) {
+            pcm.jitter
                 .push_back((s * 32767.0).clamp(-32768.0, 32767.0) as i16);
         }
         // Bound the buffer on the feed side too: a burst of inbound packets arriving between two 20ms
         // playout ticks must not grow `jitter` without limit (drain_playout's cap only runs on a
         // tick). Drop oldest past the same ceiling the drain path uses.
-        if m.jitter.len() > PLAYOUT_CAP {
-            let drop_n = m.jitter.len() - PLAYOUT_CAP;
-            m.jitter.drain(..drop_n);
+        #[cfg(feature = "voip-mlow")]
+        if pcm.jitter.len() > PLAYOUT_CAP {
+            let drop_n = pcm.jitter.len() - PLAYOUT_CAP;
+            pcm.jitter.drain(..drop_n);
         }
     }
 
+    #[cfg(feature = "voip-mlow")]
     fn on_mic(&mut self, pcm: &[i16]) {
         let Some(m) = self.media.as_mut() else {
+            return;
+        };
+        if m.audio.io != AudioIo::Pcm || m.audio.format.codec != AudioCodec::Mlow {
+            return;
+        }
+        let Some(pcm_state) = m.pcm.as_mut() else {
             return;
         };
         // Drop a wrong-length frame before any send: the encoder needs exactly one 60ms frame, and a
@@ -1076,16 +1191,37 @@ impl CallEngine {
             self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
             return;
         }
-        m.scratch.clear();
-        m.scratch.extend(pcm.iter().map(|&s| s as f32 / 32768.0));
+        pcm_state.scratch.clear();
+        pcm_state
+            .scratch
+            .extend(pcm.iter().map(|&s| s as f32 / 32768.0));
         // A transient encode failure drops just this frame; the next one resyncs.
-        let Ok(coded) = m.encoder.encode(&m.scratch) else {
+        if pcm_state
+            .encoder
+            .encode_into(&pcm_state.scratch, &mut pcm_state.encoded)
+            .is_err()
+        {
             return;
-        };
+        }
         // No SFrame on send by design: the encoded frame goes plain into WAHKDF SRTP, which the peer
         // accepts. `enable_sframe` is recv-decrypt-only (see CallConfig). This matches the
         // pre-refactor send path; send-side SFrame is intentionally not wired.
-        let packet = m.pipe.protect_audio(&coded);
+        let packet = m.pipe.protect_audio(&pcm_state.encoded);
+        self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+    }
+
+    #[cfg(not(feature = "voip-mlow"))]
+    fn on_mic(&mut self, _pcm: &[i16]) {}
+
+    fn on_encoded_audio(&mut self, payload: &[u8]) {
+        let Some(m) = self
+            .media
+            .as_mut()
+            .filter(|media| media.audio.io == AudioIo::Encoded)
+        else {
+            return;
+        };
+        let packet = m.pipe.protect_audio(payload);
         self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
     }
 
@@ -1132,6 +1268,7 @@ fn next_tick(deadline: Millis, now: Millis, interval: Millis) -> Millis {
 /// re-prime rather than a silence pad every tick. Priming also gives up after `MAX_PRIME_TICKS` if
 /// the buffer holds some audio but never reaches the target (the peer sent one frame then went DTX),
 /// flushing it instead of stalling silent forever.
+#[cfg(feature = "voip-mlow")]
 fn drain_playout(
     jitter: &mut VecDeque<i16>,
     priming: &mut bool,
@@ -1172,6 +1309,93 @@ fn drain_playout(
 }
 
 #[cfg(test)]
+mod encoded_tests {
+    use super::*;
+
+    const SELF_LID: &str = "15550001111:0@lid";
+    const PEER_LID: &str = "15550002222:0@lid";
+
+    fn config() -> CallConfig {
+        CallConfig {
+            call_id: "ENCODED-AUDIO-TEST".into(),
+            direction: CallDirection::Incoming,
+            self_lid: SELF_LID.into(),
+            peer_lid: PEER_LID.into(),
+            call_key: (0u8..32).collect(),
+            ssrc: 0x5741_0001,
+            audio: AudioConfig::encoded(AudioFormat::OPUS_16KHZ_60MS),
+            relay_token: vec![0xAB; 16],
+            relay_ip: "203.0.113.7".into(),
+            relay_port: 3478,
+            integrity_key: b"relay-key".to_vec(),
+            warp_mi_tag_len: 4,
+            enable_media: true,
+            enable_video: false,
+            enable_sframe: false,
+        }
+    }
+
+    fn drain(engine: &mut CallEngine) -> Vec<Output> {
+        let mut outputs = Vec::new();
+        loop {
+            match engine.poll_output() {
+                Output::Timeout(_) => return outputs,
+                output => outputs.push(output),
+            }
+        }
+    }
+
+    #[test]
+    fn encoded_opus_round_trips_without_a_core_codec() {
+        let cfg = config();
+        let mut engine =
+            CallEngine::new(cfg.clone(), Box::new(SequentialTxIds::new())).expect("engine");
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        let mut peer = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &cfg.call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: cfg.ssrc,
+            samples_per_packet: AudioFormat::OPUS_16KHZ_60MS.rtp_timestamp_step,
+            warp_mi_tag_len: cfg.warp_mi_tag_len,
+        })
+        .expect("peer pipeline");
+        assert!(peer.set_audio_payload_type(AudioFormat::OPUS_16KHZ_60MS.rtp_payload_type));
+
+        let outbound = [0x08, 0x11, 0x22, 0x33];
+        engine.handle_input(1, Input::EncodedAudio(&outbound));
+        let protected = drain(&mut engine)
+            .into_iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet) => Some(packet),
+                _ => None,
+            })
+            .expect("protected audio");
+        let (header, recovered) = peer
+            .unprotect_audio(&protected)
+            .expect("peer decrypts outbound audio");
+        assert_eq!(header.payload_type, 111);
+        assert_eq!(recovered, outbound);
+
+        let inbound = [0x08, 0x44, 0x55, 0x66];
+        let protected = peer.protect_audio(&inbound);
+        engine.handle_input(2, Input::RelayPacket(&protected));
+        let frame = drain(&mut engine)
+            .into_iter()
+            .find_map(|output| match output {
+                Output::EncodedAudio(frame) => Some(frame),
+                _ => None,
+            })
+            .expect("encoded output");
+        assert_eq!(frame.data.as_ref(), inbound);
+        assert_eq!(frame.payload_type, 111);
+        assert_eq!(frame.format, AudioFormat::OPUS_16KHZ_60MS);
+    }
+}
+
+#[cfg(all(test, feature = "voip-mlow"))]
 mod tests {
     use super::*;
     use crate::voip::e2e_srtp::SRTCP_AUTH_TAG_LEN;
@@ -1192,7 +1416,7 @@ mod tests {
             peer_lid: PEER_LID.into(),
             call_key: (0u8..32).collect(),
             ssrc: SSRC,
-            samples_per_packet: SAMPLES,
+            audio: AudioConfig::MLOW_PCM,
             relay_token: vec![0xAB; 16],
             relay_ip: "203.0.113.7".into(),
             relay_port: 3478,
@@ -1806,10 +2030,48 @@ mod tests {
         );
     }
 
-    // A decrypted payload whose first byte marks standard Opus/CELT ((b & 0xC0) == 0xC0) is surfaced
-    // as CallEvent::ForeignAudio for the shell to decode, NOT pushed into the MLow playout buffer.
+    // Encoded routing follows negotiation, not an ambiguous TOC-byte heuristic.
     #[test]
-    fn standard_opus_payload_routes_to_foreign_audio() {
+    fn negotiated_opus_payload_routes_to_encoded_output() {
+        let mut cfg = config(true);
+        cfg.audio = AudioConfig::encoded(AudioFormat::OPUS_16KHZ_60MS);
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut peer_tx = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: SSRC,
+            samples_per_packet: SAMPLES,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap();
+        assert!(peer_tx.set_audio_payload_type(AudioFormat::OPUS_16KHZ_60MS.rtp_payload_type));
+        let encoded = [0x08u8, 1, 2, 3, 4, 5];
+        let packet = peer_tx.protect_audio(&encoded);
+        eng.handle_input(1, Input::RelayPacket(&packet));
+        let (outs, _) = drain(&mut eng);
+        let frames: Vec<_> = outs
+            .iter()
+            .filter_map(|output| match output {
+                Output::EncodedAudio(frame) => Some(frame),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].data.as_ref(), encoded);
+        assert_eq!(frames[0].format, AudioFormat::OPUS_16KHZ_60MS);
+        assert_eq!(
+            eng.jitter_len(),
+            0,
+            "encoded audio must not enter the PCM playout buffer"
+        );
+    }
+
+    #[test]
+    fn negotiated_mlow_surfaces_its_embedded_opus_escape() {
         let mut eng = engine(true);
         eng.start(0, 0);
         let _ = drain(&mut eng);
@@ -1823,21 +2085,51 @@ mod tests {
             warp_mi_tag_len: WARP_MI_TAG_LEN,
         })
         .unwrap();
-        let packet = peer_tx.protect_audio(&[0xC8u8, 1, 2, 3, 4, 5]); // 0xC8 & 0xC0 == 0xC0
+        let embedded_opus = [0xF8u8, 0xFF, 0xFE];
+        let packet = peer_tx.protect_audio(&embedded_opus);
         eng.handle_input(1, Input::RelayPacket(&packet));
-        let (outs, _) = drain(&mut eng);
-        assert_eq!(
-            outs.iter()
-                .filter(|o| matches!(o, Output::Event(CallEvent::ForeignAudio(_))))
-                .count(),
-            1,
-            "standard-Opus payload must surface exactly one ForeignAudio event"
+        let (outputs, _) = drain(&mut eng);
+
+        assert!(outputs.iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::ForeignAudio(payload)) if payload.as_ref() == embedded_opus
+        )));
+        assert_eq!(eng.jitter_len(), 0);
+    }
+
+    #[test]
+    fn mlow_red_payload_type_is_depacketized_before_toc_dispatch() {
+        let mut eng = engine(true);
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+        let call_key: Vec<u8> = (0u8..32).collect();
+        let mut peer_tx = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: SSRC,
+            samples_per_packet: SAMPLES,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap();
+        assert!(peer_tx.set_audio_payload_type(RTP_PAYLOAD_TYPE_MLOW_RED));
+        let tone = (0..SAMPLES as usize)
+            .map(|sample| 0.3 * (sample as f32 * 0.05).sin())
+            .collect::<Vec<_>>();
+        let main = MlowEncoder::new().encode(&tone).expect("MLOW frame");
+        // 0xC0 is a RED header here, not MLOW's embedded-Opus escape.
+        let mut red = vec![0xC0, 1, 0, 0x90];
+        red.extend_from_slice(&main);
+        let packet = peer_tx.protect_audio(&red);
+        eng.handle_input(1, Input::RelayPacket(&packet));
+        let (outputs, _) = drain(&mut eng);
+
+        assert!(
+            outputs
+                .iter()
+                .all(|output| !matches!(output, Output::Event(CallEvent::ForeignAudio(_))))
         );
-        assert_eq!(
-            eng.jitter_len(),
-            0,
-            "foreign audio must not enter the MLow playout buffer"
-        );
+        assert_eq!(eng.jitter_len(), SAMPLES as usize);
     }
 
     // The inbound SFrame decrypt branch end-to-end: a mirrored peer GCM-wraps an MLow frame (its

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -16,7 +16,9 @@ use std::collections::VecDeque;
 
 use bytes::Bytes;
 
-use super::audio::{AudioCodec, AudioConfig, AudioFormat, AudioIo, EncodedAudioFrame};
+use super::audio::{
+    AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,
+};
 use super::demux::{RelayPacketKind, classify_relay_packet};
 use super::h264::{VideoFrame, au_has_idr, au_is_keyframe};
 #[cfg(feature = "voip-mlow")]
@@ -75,6 +77,7 @@ const MAX_PRIME_TICKS: u32 = 10;
 /// never gaps; protect_audio frames it with the DTX RTP header and the peer decodes it to silence.
 #[cfg(feature = "voip-mlow")]
 const MLOW_DTX_CNG: [u8; 1] = [0x90];
+
 /// One 60ms MLow frame at 16kHz. `Input::MicFrame` must carry exactly this; a wrong-length buffer is
 /// dropped (the encoder requires it), never sent.
 #[cfg(feature = "voip-mlow")]
@@ -419,6 +422,7 @@ struct MediaState {
     /// The video plane, present while video is enabled (from the start or via upgrade).
     video: Option<VideoPlaneState>,
     audio_rtcp_announced: bool,
+    audio_tx_invalid_logged: bool,
     sframe: Option<SframeSession>,
     #[cfg(feature = "voip-mlow")]
     pcm: Option<PcmAudioState>,
@@ -607,6 +611,10 @@ impl CallEngine {
             if !pipe.set_audio_payload_type(config.audio.format.rtp_payload_type) {
                 return Err(EngineError::BadAudioFormat);
             }
+            pipe.set_audio_speech_start_markers(matches!(
+                config.audio.format.rtp_profile,
+                AudioRtpProfile::Mlow
+            ));
             let sframe = if config.enable_sframe {
                 SframeSession::new(&config.call_key, &config.self_lid, &config.peer_lid)
             } else {
@@ -640,6 +648,7 @@ impl CallEngine {
                 video_ts_stride: VIDEO_TS_STRIDE_15FPS,
                 video,
                 audio_rtcp_announced: false,
+                audio_tx_invalid_logged: false,
                 sframe,
                 #[cfg(feature = "voip-mlow")]
                 pcm: (config.audio.io == AudioIo::Pcm).then(|| PcmAudioState {
@@ -1119,12 +1128,9 @@ impl CallEngine {
             Some(SframeIn::Decrypted(plain)) => plain,
             _ => payload,
         };
+        let codec = m.audio.format.inbound_codec(header.payload_type, &encoded);
         #[cfg(feature = "voip-mlow")]
-        if m.audio.io == AudioIo::Pcm
-            && m.audio.format.codec == AudioCodec::Mlow
-            && header.payload_type != RTP_PAYLOAD_TYPE_MLOW_RED
-            && mlow::is_embedded_opus(&encoded)
-        {
+        if m.audio.io == AudioIo::Pcm && codec == AudioCodec::Opus {
             self.outbox
                 .push_back(Output::Event(CallEvent::ForeignAudio(Bytes::from(encoded))));
             return;
@@ -1133,6 +1139,7 @@ impl CallEngine {
             self.outbox
                 .push_back(Output::EncodedAudio(EncodedAudioFrame {
                     format: m.audio.format,
+                    codec,
                     data: Bytes::from(encoded),
                     payload_type: header.payload_type,
                     sequence_number: header.sequence_number,
@@ -1221,6 +1228,20 @@ impl CallEngine {
         else {
             return;
         };
+        if !m.audio.format.accepts_encoded_payload(payload) {
+            if !m.audio_tx_invalid_logged {
+                log::warn!(
+                    "voip dropping encoded audio incompatible with the negotiated RTP profile call_id={} codec={:?} profile={:?} payload_len={} toc={:?}",
+                    self.call_id,
+                    m.audio.format.codec,
+                    m.audio.format.rtp_profile,
+                    payload.len(),
+                    payload.first().copied(),
+                );
+                m.audio_tx_invalid_logged = true;
+            }
+            return;
+        }
         let packet = m.pipe.protect_audio(payload);
         self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
     }
@@ -1376,7 +1397,8 @@ mod encoded_tests {
         let (header, recovered) = peer
             .unprotect_audio(&protected)
             .expect("peer decrypts outbound audio");
-        assert_eq!(header.payload_type, 111);
+        assert_eq!(header.payload_type, 120);
+        assert!(!header.marker);
         assert_eq!(recovered, outbound);
 
         let inbound = [0x08, 0x44, 0x55, 0x66];
@@ -1390,8 +1412,73 @@ mod encoded_tests {
             })
             .expect("encoded output");
         assert_eq!(frame.data.as_ref(), inbound);
-        assert_eq!(frame.payload_type, 111);
+        assert_eq!(frame.payload_type, 120);
+        assert_eq!(frame.codec, AudioCodec::Opus);
         assert_eq!(frame.format, AudioFormat::OPUS_16KHZ_60MS);
+    }
+
+    #[test]
+    fn opus_mlow_escape_uses_pt120_and_rejects_ambiguous_toc() {
+        let mut cfg = config();
+        cfg.audio = AudioConfig::encoded(AudioFormat::OPUS_MLOW_16KHZ_60MS);
+        let mut engine =
+            CallEngine::new(cfg.clone(), Box::new(SequentialTxIds::new())).expect("engine");
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        engine.handle_input(1, Input::EncodedAudio(&[0x08, 1, 2]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Transmit(_)))
+        );
+
+        let mut peer = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &cfg.call_key,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: cfg.ssrc,
+            samples_per_packet: AudioFormat::OPUS_MLOW_16KHZ_60MS.rtp_timestamp_step,
+            warp_mi_tag_len: cfg.warp_mi_tag_len,
+        })
+        .expect("peer pipeline");
+        assert!(peer.set_audio_payload_type(AudioFormat::OPUS_MLOW_16KHZ_60MS.rtp_payload_type));
+
+        let outbound = [0xDD, 0x03, 0x11, 0x22, 0x33];
+        engine.handle_input(2, Input::EncodedAudio(&outbound));
+        let protected: Vec<_> = drain(&mut engine)
+            .into_iter()
+            .filter_map(|output| match output {
+                Output::Transmit(packet) => Some(packet),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(protected.len(), 1);
+        let (header, payload) = peer
+            .unprotect_audio(&protected[0])
+            .expect("peer decrypts initial outbound audio");
+        assert_eq!(
+            header.payload_type,
+            AudioFormat::OPUS_MLOW_16KHZ_60MS.rtp_payload_type
+        );
+        assert_eq!(payload, outbound);
+        assert_eq!(
+            (header.sequence_number, header.timestamp, header.marker),
+            (1, 0, true)
+        );
+
+        let inbound_mlow = [0x50, 0x44, 0x55, 0x66];
+        let protected = peer.protect_audio(&inbound_mlow);
+        engine.handle_input(3, Input::RelayPacket(&protected));
+        let frame = drain(&mut engine)
+            .into_iter()
+            .find_map(|output| match output {
+                Output::EncodedAudio(frame) => Some(frame),
+                _ => None,
+            })
+            .expect("encoded output");
+        assert_eq!(frame.codec, AudioCodec::Mlow);
+        assert_eq!(frame.data.as_ref(), inbound_mlow);
     }
 }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -84,6 +84,7 @@ const MLOW_DTX_CNG: [u8; 1] = [0x90];
 const MIC_FRAME_SAMPLES: usize = 960;
 #[cfg(feature = "voip-mlow")]
 const MLOW_ENCODED_CAPACITY: usize = 513;
+const MAX_INVALID_AUDIO_WARNINGS: u8 = 3;
 
 /// Supplies STUN transaction ids. Injected so the core stays RNG-free and deterministically
 /// testable. Production shells MUST back this with a real RNG (the ids gate consent freshness);
@@ -422,7 +423,7 @@ struct MediaState {
     /// The video plane, present while video is enabled (from the start or via upgrade).
     video: Option<VideoPlaneState>,
     audio_rtcp_announced: bool,
-    audio_tx_invalid_logged: bool,
+    audio_tx_invalid_streak: u8,
     sframe: Option<SframeSession>,
     #[cfg(feature = "voip-mlow")]
     pcm: Option<PcmAudioState>,
@@ -611,7 +612,7 @@ impl CallEngine {
             if !pipe.set_audio_payload_type(config.audio.format.rtp_payload_type) {
                 return Err(EngineError::BadAudioFormat);
             }
-            pipe.set_audio_speech_start_markers(matches!(
+            pipe.set_audio_mlow_profile(matches!(
                 config.audio.format.rtp_profile,
                 AudioRtpProfile::Mlow
             ));
@@ -648,7 +649,7 @@ impl CallEngine {
                 video_ts_stride: VIDEO_TS_STRIDE_15FPS,
                 video,
                 audio_rtcp_announced: false,
-                audio_tx_invalid_logged: false,
+                audio_tx_invalid_streak: 0,
                 sframe,
                 #[cfg(feature = "voip-mlow")]
                 pcm: (config.audio.io == AudioIo::Pcm).then(|| PcmAudioState {
@@ -1229,7 +1230,7 @@ impl CallEngine {
             return;
         };
         if !m.audio.format.accepts_encoded_payload(payload) {
-            if !m.audio_tx_invalid_logged {
+            if m.audio_tx_invalid_streak < MAX_INVALID_AUDIO_WARNINGS {
                 log::warn!(
                     "voip dropping encoded audio incompatible with the negotiated RTP profile call_id={} codec={:?} profile={:?} payload_len={} toc={:?}",
                     self.call_id,
@@ -1238,10 +1239,11 @@ impl CallEngine {
                     payload.len(),
                     payload.first().copied(),
                 );
-                m.audio_tx_invalid_logged = true;
+                m.audio_tx_invalid_streak += 1;
             }
             return;
         }
+        m.audio_tx_invalid_streak = 0;
         let packet = m.pipe.protect_audio(payload);
         self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
     }

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -52,6 +52,11 @@ pub(crate) struct SmplEncoderState {
     hist: Vec<f64>,
     /// Reused because VAD runs for every packet on the realtime encode path.
     vad_pcm: Vec<i16>,
+    /// Reused to avoid four packet-sized allocations on the realtime encode path.
+    hp: Vec<f32>,
+    x: Vec<f64>,
+    xn: Vec<f32>,
+    hp_full: Vec<f32>,
     /// Input high-pass (ARMA2, fcorner 35 Hz) coefficients + carried state, matching the real encoder.
     hp_coefs: Option<([f32; 3], [f32; 3])>,
     hp_state: [f32; 4],
@@ -201,16 +206,25 @@ pub(crate) fn smpl_analyze_frame_st(
     let (hp_ma, hp_ar) = *es
         .hp_coefs
         .get_or_insert_with(|| smpl_get_hp_coefs(SMPL_ENC_HP_FCORNER_HZ));
-    let mut hp = vec![0f32; need];
-    smpl_filt_arma2(&pcm[..need], need, hp_ma, hp_ar, &mut es.hp_state, &mut hp);
+    es.hp.resize(need, 0.0);
+    es.hp.fill(0.0);
+    smpl_filt_arma2(
+        &pcm[..need],
+        need,
+        hp_ma,
+        hp_ar,
+        &mut es.hp_state,
+        &mut es.hp,
+    );
 
     // int16-scaled input with smplOrder lead samples of history.
-    let mut x = vec![0f64; SMPL_ORDER + need];
+    es.x.resize(SMPL_ORDER + need, 0.0);
+    es.x.fill(0.0);
     if es.hist.len() >= SMPL_ORDER {
-        x[..SMPL_ORDER].copy_from_slice(&es.hist[es.hist.len() - SMPL_ORDER..]);
+        es.x[..SMPL_ORDER].copy_from_slice(&es.hist[es.hist.len() - SMPL_ORDER..]);
     }
     for i in 0..need {
-        x[SMPL_ORDER + i] = hp[i] as f64 * 32768.0;
+        es.x[SMPL_ORDER + i] = es.hp[i] as f64 * 32768.0;
     }
 
     let mut shadow = SmplFrameSynth::default();
@@ -241,21 +255,29 @@ pub(crate) fn smpl_analyze_frame_st(
     // xhp_packet_buf + SMPL_LPC_BUF_MEM_LEN + SMPL_WINNEXT_WB_LEN), so the excitation it codes leads
     // the input by 32 samples. Carry SMPL_ORDER + 32 lead so the residual can read that far back.
     let res_lead: usize = SMPL_ORDER + SMPL_WINNEXT_WB_LEN;
-    let mut xn = vec![0f32; res_lead + need];
+    es.xn.resize(res_lead + need, 0.0);
+    es.xn.fill(0.0);
     if es.hist.len() >= res_lead {
         for i in 0..res_lead {
-            xn[i] = (es.hist[es.hist.len() - res_lead + i] / 32768.0) as f32;
+            es.xn[i] = (es.hist[es.hist.len() - res_lead + i] / 32768.0) as f32;
         }
     }
-    xn[res_lead..res_lead + need].copy_from_slice(&hp[..need]);
+    es.xn[res_lead..res_lead + need].copy_from_slice(&es.hp[..need]);
 
     // Full HP-domain buffer that `lpcbuf` indexes: [history(144)] ++ [current 960 HP] ++ [32 zeros].
     // The 32-sample lookahead tail is zero at 16 kHz (no band split), per the buffer layout.
-    let mut hp_full = vec![0f32; SMPL_LPC_HIST_LEN + need + SMPL_WINNEXT_WB_LEN];
+    es.hp_full
+        .resize(SMPL_LPC_HIST_LEN + need + SMPL_WINNEXT_WB_LEN, 0.0);
+    es.hp_full.fill(0.0);
     if es.lpc_hist.len() == SMPL_LPC_HIST_LEN {
-        hp_full[..SMPL_LPC_HIST_LEN].copy_from_slice(&es.lpc_hist);
+        es.hp_full[..SMPL_LPC_HIST_LEN].copy_from_slice(&es.lpc_hist);
     }
-    hp_full[SMPL_LPC_HIST_LEN..SMPL_LPC_HIST_LEN + need].copy_from_slice(&hp[..need]);
+    es.hp_full[SMPL_LPC_HIST_LEN..SMPL_LPC_HIST_LEN + need].copy_from_slice(&es.hp[..need]);
+
+    let hp = es.hp.as_slice();
+    let x = es.x.as_slice();
+    let xn = es.xn.as_slice();
+    let hp_full = es.hp_full.as_slice();
 
     // Snapshot the previous packet's HP tail (pitch history for this packet's intf=0), then refresh it
     // from this packet's tail for the next call.
@@ -304,7 +326,7 @@ pub(crate) fn smpl_analyze_frame_st(
             perc,
             perc_prev: &mut es.perc_prev,
             bitrate,
-            hp_n: &hp,
+            hp_n: hp,
             intf: f,
             sp_act_prob: sp_act_prob[f],
             coded_as_active_voice,

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -50,6 +50,8 @@ const SMPL_LSF_RDW_ADJ: f32 = 1.1952286;
 #[derive(Default)]
 pub(crate) struct SmplEncoderState {
     hist: Vec<f64>,
+    /// Reused because VAD runs for every packet on the realtime encode path.
+    vad_pcm: Vec<i16>,
     /// Input high-pass (ARMA2, fcorner 35 Hz) coefficients + carried state, matching the real encoder.
     hp_coefs: Option<([f32; 3], [f32; 3])>,
     hp_state: [f32; 4],
@@ -180,14 +182,16 @@ pub(crate) fn smpl_analyze_frame_st(
 
     // SILK VAD on the int16 input PCM (runs on the raw API samples, before the encoder HP). Produces
     // the per-internal-frame speech-activity probability + the packet coded_as_active_voice.
-    let pcm_i16: Vec<i16> = pcm[..need]
-        .iter()
-        .map(|&s| (s * 32768.0).round().clamp(-32768.0, 32767.0) as i16)
-        .collect();
+    es.vad_pcm.clear();
+    es.vad_pcm.extend(
+        pcm[..need]
+            .iter()
+            .map(|&s| (s * 32768.0).round().clamp(-32768.0, 32767.0) as i16),
+    );
     let vad = es
         .vad
         .get_or_insert_with(super::smpl_vad::SmplVadState::new)
-        .process_packet(&pcm_i16, SMPL_INTF_LEN);
+        .process_packet(&es.vad_pcm, SMPL_INTF_LEN);
     let sp_act_prob = vad.vad_results;
     let coded_as_active_voice = vad.coded_as_active_voice;
 
@@ -197,9 +201,8 @@ pub(crate) fn smpl_analyze_frame_st(
     let (hp_ma, hp_ar) = *es
         .hp_coefs
         .get_or_insert_with(|| smpl_get_hp_coefs(SMPL_ENC_HP_FCORNER_HZ));
-    let pcm_in: Vec<f32> = pcm[..need].to_vec();
     let mut hp = vec![0f32; need];
-    smpl_filt_arma2(&pcm_in, need, hp_ma, hp_ar, &mut es.hp_state, &mut hp);
+    smpl_filt_arma2(&pcm[..need], need, hp_ma, hp_ar, &mut es.hp_state, &mut hp);
 
     // int16-scaled input with smplOrder lead samples of history.
     let mut x = vec![0f64; SMPL_ORDER + need];
@@ -256,11 +259,10 @@ pub(crate) fn smpl_analyze_frame_st(
 
     // Snapshot the previous packet's HP tail (pitch history for this packet's intf=0), then refresh it
     // from this packet's tail for the next call.
-    let mut hp_pitch_hist = vec![0f32; SMPL_PITCH_LAG_MAX];
-    if es.hp_pitch_hist.len() == SMPL_PITCH_LAG_MAX {
-        hp_pitch_hist.copy_from_slice(&es.hp_pitch_hist);
+    let mut hp_pitch_hist = std::mem::take(&mut es.hp_pitch_hist);
+    if hp_pitch_hist.len() != SMPL_PITCH_LAG_MAX {
+        hp_pitch_hist.resize(SMPL_PITCH_LAG_MAX, 0.0);
     }
-    es.hp_pitch_hist = hp[need - SMPL_PITCH_LAG_MAX..need].to_vec();
 
     // Lazily size the persistent perceptually-weighted speech buffer (`ltp_buf`).
     if es.ltp_buf.len() != super::smpl_pitch_enc::MAX_LTP_BUF_LEN {
@@ -273,7 +275,7 @@ pub(crate) fn smpl_analyze_frame_st(
     let ltp_buf = &mut es.ltp_buf;
     let pitch_est = &mut es.pitch_est;
 
-    let mut prev_lsfq = es.prev_lsfq.clone();
+    let mut prev_lsfq = std::mem::take(&mut es.prev_lsfq);
     let mut prev_voiced = es.prev_voiced;
 
     let mut internal: [SmplInternalParams; 3] = Default::default();
@@ -345,9 +347,15 @@ pub(crate) fn smpl_analyze_frame_st(
     }
 
     // Carry SMPL_ORDER + SMPL_WINNEXT_WB_LEN history so the next packet's residual lead is filled.
-    es.hist = x[x.len() - (SMPL_ORDER + SMPL_WINNEXT_WB_LEN)..].to_vec();
+    es.hist.clear();
+    es.hist
+        .extend_from_slice(&x[x.len() - (SMPL_ORDER + SMPL_WINNEXT_WB_LEN)..]);
     // Carry the last 144 HP samples as next packet's LPC window history (mirrors `lpc_buf_mem`).
-    es.lpc_hist = hp[need - SMPL_LPC_HIST_LEN..need].to_vec();
+    es.lpc_hist.clear();
+    es.lpc_hist
+        .extend_from_slice(&hp[need - SMPL_LPC_HIST_LEN..need]);
+    hp_pitch_hist.copy_from_slice(&hp[need - SMPL_PITCH_LAG_MAX..need]);
+    es.hp_pitch_hist = hp_pitch_hist;
     es.prev_lsfq = prev_lsfq;
     es.prev_voiced = prev_voiced;
     super::params::SmplFrameParams {

--- a/wacore/src/voip/mlow/encode.rs
+++ b/wacore/src/voip/mlow/encode.rs
@@ -36,6 +36,8 @@ pub enum MlowError {
 /// per internal frame via analysis-by-synthesis.
 pub struct MlowEncoder {
     state: SmplEncoderState,
+    clean: Vec<f32>,
+    range: RangeEncoder,
 }
 
 impl Default for MlowEncoder {
@@ -48,16 +50,27 @@ impl MlowEncoder {
     pub fn new() -> Self {
         MlowEncoder {
             state: SmplEncoderState::default(),
+            clean: Vec::with_capacity(OPUS_FRAME_SAMPS),
+            range: RangeEncoder::new(1 + SMPL_ENCODE_BUF_BYTES),
         }
     }
 
     /// Clear the cross-frame analysis history (call at a stream discontinuity).
     pub fn reset(&mut self) {
         self.state = SmplEncoderState::default();
+        self.clean.clear();
+        self.range.reset();
     }
 
     /// Encode one 60 ms frame. Expects exactly 960 samples.
     pub fn encode(&mut self, pcm: &[f32]) -> Result<Vec<u8>, MlowError> {
+        let mut output = Vec::with_capacity(1 + SMPL_ENCODE_BUF_BYTES);
+        self.encode_into(pcm, &mut output)?;
+        Ok(output)
+    }
+
+    /// Encode into a caller-owned buffer so a realtime stream can reuse its allocation.
+    pub fn encode_into(&mut self, pcm: &[f32], output: &mut Vec<u8>) -> Result<(), MlowError> {
         if pcm.len() != OPUS_FRAME_SAMPS {
             return Err(MlowError::FrameLength {
                 expected: OPUS_FRAME_SAMPS,
@@ -65,32 +78,36 @@ impl MlowEncoder {
             });
         }
         // Sanitize: NaN → 0, clamp to [-1,1] (the LPC analysis degenerates on non-finite input).
-        let clean: Vec<f32> = pcm
-            .iter()
-            .map(|&s| if s.is_nan() { 0.0 } else { s.clamp(-1.0, 1.0) })
-            .collect();
-        let fp = smpl_analyze_frame_st(&mut self.state, &clean);
-        encode_smpl_frame(&fp)
+        self.clean.clear();
+        self.clean.extend(
+            pcm.iter()
+                .map(|&s| if s.is_nan() { 0.0 } else { s.clamp(-1.0, 1.0) }),
+        );
+        let fp = smpl_analyze_frame_st(&mut self.state, &self.clean);
+        encode_smpl_frame_into(&fp, &mut self.range, output)
     }
 }
 
-/// Encode one 60 ms MLow frame from its parameters → `[TOC || range-coded body]`.
-pub(crate) fn encode_smpl_frame(fp: &SmplFrameParams) -> Result<Vec<u8>, MlowError> {
+fn encode_smpl_frame_into(
+    fp: &SmplFrameParams,
+    enc: &mut RangeEncoder,
+    output: &mut Vec<u8>,
+) -> Result<(), MlowError> {
     let (p2, p3, p4) = (320i32, 4i32, 1i32);
     let p6 = fp.config as i32;
     let tbl = load_smpl_tables();
     let mem = load_smpl_mem();
     let cc = load_cc_tables();
-    let mut enc = RangeEncoder::new(1 + SMPL_ENCODE_BUF_BYTES);
+    enc.reset();
     let mut st = SmplLsfState::default();
     for f in 0..3 {
         let ip = &fp.internal[f];
-        encode_smpl_lsf(&mut enc, tbl, &mut st, fp.config, f, &ip.lsf);
-        encode_smpl_pulses(&mut enc, cc, p2, p3, p4, p6, ip.lsf.stage1, &ip.pulses);
+        encode_smpl_lsf(enc, tbl, &mut st, fp.config, f, &ip.lsf);
+        encode_smpl_pulses(enc, cc, p2, p3, p4, p6, ip.lsf.stage1, &ip.pulses);
         // Voiced internal frames emit a pitch block; unvoiced emit a gains block (never both).
         if ip.lsf.stage1 == 1 {
             encode_smpl_pitch(
-                &mut enc,
+                enc,
                 mem,
                 cc,
                 &mut st,
@@ -101,7 +118,7 @@ pub(crate) fn encode_smpl_frame(fp: &SmplFrameParams) -> Result<Vec<u8>, MlowErr
                 &ip.pitch,
             );
         } else {
-            encode_smpl_gains(&mut enc, cc, p3, ip.pulses.subfr, &ip.gains);
+            encode_smpl_gains(enc, cc, p3, ip.pulses.subfr, &ip.gains);
         }
     }
     enc.done();
@@ -110,10 +127,11 @@ pub(crate) fn encode_smpl_frame(fp: &SmplFrameParams) -> Result<Vec<u8>, MlowErr
     }
     let n = enc.consumed_len();
     let body = enc.bytes();
-    let mut out = Vec::with_capacity(1 + n);
-    out.push(fp.toc);
-    out.extend_from_slice(&body[..n]);
-    Ok(out)
+    output.clear();
+    output.reserve(1 + n);
+    output.push(fp.toc);
+    output.extend_from_slice(&body[..n]);
+    Ok(())
 }
 
 /// Inverse of `decode_smpl_lsf`: mirror the selector/grid/16-residual/extra reads, mutating `st`.
@@ -595,19 +613,13 @@ mod tests {
         );
     }
 
-    // R9: the encoder is config-0 / no-DTX, so every emitted frame is an active mlow TOC (0x50) and
-    // never a standard Opus/CELT TOC. Makes the implicit contract explicit; a future DTX/SID path
-    // would trip this.
+    // R9: the encoder is config-0 / no-DTX, so every emitted frame has the active MLOW TOC. Codec
+    // routing comes from negotiation, not from interpreting this byte.
     #[test]
     fn encoder_emits_only_active_mlow_toc() {
-        use super::super::is_standard_opus_frame;
         let input = synth_input();
         for frame in encode_all(&mut MlowEncoder::new(), &input) {
             let toc = frame[0];
-            assert!(
-                !is_standard_opus_frame(toc),
-                "encoder emitted a standard-opus TOC 0x{toc:02x}"
-            );
             assert_eq!(toc, 0x50, "encoder emitted non-config-0 TOC 0x{toc:02x}");
         }
     }

--- a/wacore/src/voip/mlow/mod.rs
+++ b/wacore/src/voip/mlow/mod.rs
@@ -2,11 +2,10 @@
 //! split-band CELP codec WhatsApp 1:1 calls use by default. Pinned against captured WASM decode
 //! vectors (provenance in `testdata/PROVENANCE.md`).
 //!
-//! Both directions are implemented: the DECODER (inbound peer audio is mlow; stock Opus
-//! mis-decodes it into energy-correct noise) and the ENCODER (outbound must be mlow too, since the
-//! peer won't play standard Opus). The encoder analyzes PCM into voiced (LTP) or unvoiced frames and
-//! entropy-encodes them. Every layer is validated byte-for-byte against captured vectors, the only
-//! real guard since a wrong-but-consistent codec would otherwise pass round-trips.
+//! Both proprietary directions are implemented: the DECODER (stock Opus mis-decodes MLOW into
+//! energy-correct noise) and the ENCODER. Compatible standard Opus/CELT can instead use MLOW's
+//! in-profile escape. Every layer is validated byte-for-byte against captured vectors, the only real
+//! guard since a wrong-but-consistent codec would otherwise pass round-trips.
 //!
 mod analysis;
 mod decoder;
@@ -44,9 +43,3 @@ mod toc;
 
 pub use decoder::MlowDecoder;
 pub use encode::{MlowEncoder, MlowError};
-
-/// MLOW's in-profile escape for a standard Opus/CELT packet. This is meaningful only after call
-/// negotiation selected MLOW; it must never be used to choose the call's media profile.
-pub(crate) fn is_embedded_opus(payload: &[u8]) -> bool {
-    payload.first().is_some_and(|byte| byte & 0xC0 == 0xC0)
-}

--- a/wacore/src/voip/mlow/mod.rs
+++ b/wacore/src/voip/mlow/mod.rs
@@ -45,30 +45,8 @@ mod toc;
 pub use decoder::MlowDecoder;
 pub use encode::{MlowEncoder, MlowError};
 
-/// Whether the first payload byte is a STANDARD Opus/CELT TOC (`(b & 0xC0) == 0xC0`) rather than a
-/// Meta mlow "smpl" TOC. The inbound path routes standard-Opus frames to stock Opus and mlow
-/// frames to [`MlowDecoder`].
-pub(crate) fn is_standard_opus_frame(first_byte: u8) -> bool {
-    first_byte & 0xC0 == 0xC0
-}
-
-#[cfg(test)]
-mod tests {
-    use super::is_standard_opus_frame;
-
-    // The inbound router splits on exactly bit-pattern 0xC0: every 0xC0..=0xFF byte is stock
-    // Opus/CELT, and the mlow "smpl" TOCs we actually emit/receive (0x10, 0x12, 0x50) are not. This
-    // pins the boundary so a router-predicate edit can't silently send mlow to stock Opus.
-    #[test]
-    fn opus_split_boundary_table() {
-        for b in 0xC0u8..=0xFF {
-            assert!(is_standard_opus_frame(b), "0x{b:02x} must be standard opus");
-        }
-        for &mlow_toc in &[0x10u8, 0x12, 0x50] {
-            assert!(
-                !is_standard_opus_frame(mlow_toc),
-                "mlow TOC 0x{mlow_toc:02x} must not route to stock Opus"
-            );
-        }
-    }
+/// MLOW's in-profile escape for a standard Opus/CELT packet. This is meaningful only after call
+/// negotiation selected MLOW; it must never be used to choose the call's media profile.
+pub(crate) fn is_embedded_opus(payload: &[u8]) -> bool {
+    payload.first().is_some_and(|byte| byte & 0xC0 == 0xC0)
 }

--- a/wacore/src/voip/mlow/quality_tests.rs
+++ b/wacore/src/voip/mlow/quality_tests.rs
@@ -731,20 +731,11 @@ fn voiced_harmonic_multiple_frames_no_panic() {
 // The encoder's voiced/unvoiced decision is pitch/VAD-driven, so there is no byte-exact-encoder gate
 // here: the wire format stays pinned by the byte-exact decoder round-trip vectors and the golden test.
 
-/// Inbound-routing regression: an mlow stream (`inbound_capture_frames.json`) must decode to clean,
-/// voice-level audio through `MlowDecoder`, and EVERY frame must be classified as mlow
-/// (`!is_standard_opus_frame`) so the inbound router never hands one to the standard Opus decoder.
-///
-/// This guards the bug where the inbound path defaulted to the standard Opus decoder, which
-/// mis-decodes mlow into energy-correct clipping noise (and rejects the config-2 TOC-0x12 frames
-/// outright). Routing by the TOC byte to `MlowDecoder` instead yields voice-level audio with no
-/// clipping. The stream is a captured-encoder fixture (see PROVENANCE.md): not Rust-reproducible
-/// because we ship no encoder matching the peer's exact wire bytes, so it is committed and pinned by
-/// the tripwire test below.
+/// A captured, negotiated MLOW stream must decode to clean, voice-level audio. The stream is a
+/// captured-encoder fixture (see PROVENANCE.md): not Rust-reproducible because our encoder does not
+/// match the peer's exact wire bytes, so it is committed and pinned by the tripwire test below.
 #[test]
-fn captured_inbound_routes_to_mlow_and_decodes_clean() {
-    use super::is_standard_opus_frame;
-
+fn captured_inbound_mlow_decodes_clean() {
     let frames: Vec<String> =
         serde_json::from_str(include_str!("testdata/inbound_capture_frames.json"))
             .expect("inbound_capture_frames.json");
@@ -752,15 +743,10 @@ fn captured_inbound_routes_to_mlow_and_decodes_clean() {
 
     let mut dec = MlowDecoder::new();
     let mut all: Vec<f32> = Vec::new();
-    let mut std_opus_frames = 0usize;
     let mut active_frames = 0usize;
 
     for hex_frame in &frames {
         let frame = hex::decode(hex_frame).unwrap();
-        let toc = frame.first().copied().unwrap_or(0);
-        if is_standard_opus_frame(toc) {
-            std_opus_frames += 1;
-        }
         let pcm = dec.decode(&frame);
         // `decode` is total: even a TOC the standard Opus decoder would reject yields valid PCM.
         // Active frames are 960 samples (60 ms); DTX/CN frames return a shorter block, never empty.
@@ -771,12 +757,7 @@ fn captured_inbound_routes_to_mlow_and_decodes_clean() {
         all.extend_from_slice(&pcm);
     }
 
-    assert_eq!(
-        std_opus_frames, 0,
-        "inbound stream is all mlow; routing any of it to the standard Opus decoder garbles it"
-    );
-
-    // Clean decode is voice-level and never saturates; the mis-routed path would clip heavily.
+    // Clean decode is voice-level and never saturates.
     let overall_rms = rms(&all);
     let peak = all.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
     let clip = all.iter().filter(|&&x| x.abs() >= 0.999).count();

--- a/wacore/src/voip/mlow/rangecoder.rs
+++ b/wacore/src/voip/mlow/rangecoder.rs
@@ -375,6 +375,20 @@ impl RangeEncoder {
         }
     }
 
+    /// Start a new stream while retaining the fixed output allocation.
+    pub(crate) fn reset(&mut self) {
+        self.end_offs = 0;
+        self.end_window = 0;
+        self.nend_bits = 0;
+        self.nbits_total = EC_CODE_BITS as i32 + 1;
+        self.offs = 0;
+        self.rng = EC_CODE_TOP;
+        self.val = 0;
+        self.ext = 0;
+        self.rem = -1;
+        self.err = 0;
+    }
+
     pub(crate) fn err(&self) -> i32 {
         self.err
     }

--- a/wacore/src/voip/mlow/smpl_pitch_enc.rs
+++ b/wacore/src/voip/mlow/smpl_pitch_enc.rs
@@ -731,7 +731,7 @@ pub(crate) fn smpl_pitch(
     pitch_hp_filter(ltp_buf, &mut stage1[offset..offset + l]);
     // ltp_buf_hp = stage1[offset .. offset + (L - look)]
     let hp_len = l - look;
-    let ltp_buf_hp: Vec<f32> = stage1[offset..offset + hp_len].to_vec();
+    let ltp_buf_hp = &stage1[offset..offset + hp_len];
 
     // Downsample stage1[0 .. L+offset] -> stage1_ds. We keep the HP signal already copied out, so a
     // separate output buffer is equivalent to the reference in-place write.
@@ -749,7 +749,7 @@ pub(crate) fn smpl_pitch(
         MAXPITCH_STAGE1,
         LAG_SUBFRLEN_STAGE1 as usize,
     );
-    let mut e2 = vec![0.0f32; numsubfrs];
+    let mut e2 = [0.0f32; NUM_SUBFRAMES];
     // C / E arrays are over-allocated: the upsample stages expand them in place to full-res widths.
     let cap = (2 * FS_KHZ / STAGE1_FS_KHZ) as usize * NUM_LAGS_STAGE1 * numsubfrs + 64;
     let mut c = vec![0.0f32; cap];
@@ -761,13 +761,10 @@ pub(crate) fn smpl_pitch(
     // E from sqrt-energy blend (stage 1).
     let numlags = numlags0;
     for sf in 0..numsubfrs {
-        let mut sqrt_e1 = vec![0.0f32; numlags];
-        for i in 0..numlags {
-            sqrt_e1[i] = (e1[sf * numlags + i] + 1e-30).sqrt();
-        }
         let sqrt_e2 = (e2[sf] + 1e-30).sqrt();
         for i in 0..numlags {
-            let tmp = 0.5 * (sqrt_e1[i] + sqrt_e2);
+            let sqrt_e1 = (e1[sf * numlags + i] + 1e-30).sqrt();
+            let tmp = 0.5 * (sqrt_e1 + sqrt_e2);
             e[sf * numlags + i] = tmp * tmp;
         }
     }
@@ -850,7 +847,7 @@ pub(crate) fn smpl_pitch(
     let mut e1_fs = vec![0.0f32; numlags_e * numsubfrs + 16];
     calc_e1(
         &mut e1_fs,
-        &ltp_buf_hp,
+        ltp_buf_hp,
         l - look,
         numsubfrs,
         minpitch_e,
@@ -953,7 +950,7 @@ pub(crate) fn smpl_pitch(
     // Fine search: per survivor, per blockseg, per block: combine H over the seg's subframes, argmax.
     let mut laginds_surv: Vec<[i32; NUM_SUBFRAMES]> = Vec::new();
     let mut blocksegs_ix_list: Vec<usize> = Vec::new();
-    let mut h_comb = vec![0.0f32; 2 * PITCHBLOCK];
+    let mut h_comb = [0.0f32; 2 * PITCHBLOCK];
     let mut lagind_cache: std::collections::HashMap<i32, i32> = std::collections::HashMap::new();
     for &idx in &track_idx {
         let range = tab.blocksegs_ix[idx];
@@ -997,7 +994,7 @@ pub(crate) fn smpl_pitch(
     let pitch_ratewght = if LOW_RATE { 0.028 } else { RATEWGHT_HR };
     let f2w = build_f2w(f2);
     let max_ix = get_maxi(&sf_wght[..numsubfrs]);
-    let mut spectral_harm_cache = vec![0.0f32; 50];
+    let mut spectral_harm_cache = [0.0f32; 50];
 
     let mut best_util = 0.0f32;
     let mut best_pitchcorr = 0.0f32;

--- a/wacore/src/voip/mlow/toc.rs
+++ b/wacore/src/voip/mlow/toc.rs
@@ -1,6 +1,6 @@
-//! MLow "smpl_toc": the first byte of a bare MLow frame. The smpl TOC is only valid when
-//! `(b & 0xC0) != 0xC0`; `(b & 0xC0) == 0xC0` marks a STANDARD Opus/CELT TOC instead, which is
-//! routed to stock Opus.
+//! MLOW "smpl_toc": the first byte of a payload after negotiation selected the MLOW profile.
+//! `(b & 0xC0) == 0xC0` is its in-profile standard Opus/CELT escape; it is not a global codec
+//! discriminator.
 //!
 //! Bit layout (LSB = bit0): bit7=SID(DTX/CNG), bit6=VAD, bit5=internal rate(0->16k,1->32k),
 //! bits4:3->frame size index into {10,20,60,120}ms, bit2=flag2, bit1=voiced-enable, bit0=flag0.
@@ -38,8 +38,7 @@ fn standard_opus_frame_ms(b: u8) -> i32 {
     }
 }
 
-/// Parse the smpl TOC byte. Emits a per-frame `trace!` so production logs can show the routing of
-/// every inbound frame (this parse is not yet prod-validated, so keep it instrumented).
+/// Parse the smpl TOC byte. Emits a per-frame `trace!` while this parse is production-validated.
 pub(crate) fn parse_mlow_toc(b: u8) -> MlowToc {
     if b & 0xC0 == 0xC0 {
         let toc = MlowToc {

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -5,12 +5,14 @@
 //! tests pass even when both directions are wrong identically, so known-answer vectors are
 //! the only real guard.
 
+pub mod audio;
 pub mod demux;
 pub mod driver;
 pub mod e2e_srtp;
 pub mod engine;
 pub mod h264;
 pub mod hbh_srtp;
+#[cfg(feature = "voip-mlow")]
 pub mod mlow;
 pub mod registry;
 pub mod relay_parse;
@@ -30,6 +32,7 @@ pub mod warp;
 // Curated facade: the headline entry points a consumer reaches for, hoisted to `voip::`.
 // The sub-modules stay `pub` for fine-grained wire helpers (parsers, attr builders), but
 // these are the ones worth surfacing by name.
+pub use audio::{AudioCodec, AudioConfig, AudioFormat, AudioIo, EncodedAudioFrame};
 pub use demux::{RelayPacketKind, classify_relay_packet};
 pub use driver::{
     CallChannels, VideoControl, VideoControlReceiver, VideoControlSender, run_call,
@@ -40,9 +43,8 @@ pub use engine::{
     TxIdSource,
 };
 pub use h264::{AnnexBAuSplitter, VideoFrame};
+#[cfg(feature = "voip-mlow")]
 pub use mlow::{MlowDecoder, MlowEncoder};
-// Internal: the inbound router's standard-Opus vs mlow discriminator (engine reaches it via `super`).
-pub(crate) use mlow::is_standard_opus_frame;
 pub use registry::CallRegistry;
 pub use session::{
     CallDirection, CallPhase, CallSession, MediaPipeline, MediaPipelineParams, VideoPipeline,

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -32,7 +32,10 @@ pub mod warp;
 // Curated facade: the headline entry points a consumer reaches for, hoisted to `voip::`.
 // The sub-modules stay `pub` for fine-grained wire helpers (parsers, attr builders), but
 // these are the ones worth surfacing by name.
-pub use audio::{AudioCodec, AudioConfig, AudioFormat, AudioIo, EncodedAudioFrame};
+pub use audio::{
+    AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,
+    OpusMlowPacketError, depacketize_opus_from_mlow, packetize_opus_for_mlow,
+};
 pub use demux::{RelayPacketKind, classify_relay_packet};
 pub use driver::{
     CallChannels, VideoControl, VideoControlReceiver, VideoControlSender, run_call,

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -107,6 +107,17 @@ impl CallRegistry {
         Self::default()
     }
 
+    /// Deliver a terminal/signaling diagnostic through the call's existing consumer queue.
+    pub fn send_call_event(&self, call_id: &str, event: CallEvent) -> bool {
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|entry| entry.event_tx.clone());
+        tx.is_some_and(|tx| tx.force_send(event).is_ok())
+    }
+
     /// Register a call, returning its generation token. A same-call-id re-offer (retry/glare)
     /// REPLACES the prior registration, aborting its media task; the returned generation
     /// distinguishes the new call from the old. Pass it to [`set_media_task`](Self::set_media_task)

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -107,7 +107,7 @@ impl CallRegistry {
         Self::default()
     }
 
-    /// Deliver a terminal/signaling diagnostic through the call's existing consumer queue.
+    /// Deliver a signaling event through the call's consumer queue.
     pub fn send_call_event(&self, call_id: &str, event: CallEvent) -> bool {
         let tx = self
             .inner

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -3,7 +3,12 @@
 
 use crate::voip::warp::audio_piggyback_extension_for;
 
-pub const RTP_PAYLOAD_TYPE_OPUS: u8 = 120;
+/// Standard Opus payload type in the current native media profile.
+pub const RTP_PAYLOAD_TYPE_OPUS: u8 = 111;
+/// MLOW payload type in captured native and Web media.
+pub const RTP_PAYLOAD_TYPE_MLOW: u8 = 120;
+/// MLOW SplitRed redundancy payload type (`mlow-red-1`).
+pub const RTP_PAYLOAD_TYPE_MLOW_RED: u8 = 121;
 /// H.264 video payload type used by captured Android video RTP.
 pub const RTP_PAYLOAD_TYPE_H264: u8 = 97;
 /// Video RTP timestamp clock.
@@ -75,7 +80,10 @@ pub const OPUS_PRIMING_FRAME_1_WASM: [u8; 24] = [
 pub const OPUS_PRIMING_FRAME_2: [u8; 5] = [0x90, 0xb8, 0x14, 0x14, 0xc4];
 
 pub fn is_whatsapp_opus_rtp_payload(payload_type: u8) -> bool {
-    payload_type == RTP_PAYLOAD_TYPE_OPUS || payload_type == 121
+    matches!(
+        payload_type,
+        RTP_PAYLOAD_TYPE_OPUS | RTP_PAYLOAD_TYPE_MLOW | RTP_PAYLOAD_TYPE_MLOW_RED
+    )
 }
 
 /// DTX / comfort-noise: RFC `0x10`, mlow `0x90`, and short warmup silence frames.
@@ -317,6 +325,7 @@ pub struct RtpStream {
     speech_started: bool,
     audio_packet_index: usize,
     warp_piggyback: bool,
+    payload_type: u8,
 }
 
 impl RtpStream {
@@ -330,7 +339,16 @@ impl RtpStream {
             speech_started: false,
             audio_packet_index: 0,
             warp_piggyback,
+            payload_type: RTP_PAYLOAD_TYPE_MLOW,
         }
+    }
+
+    pub fn set_payload_type(&mut self, payload_type: u8) -> bool {
+        if payload_type > 127 {
+            return false;
+        }
+        self.payload_type = payload_type;
+        true
     }
 
     /// The current send timestamp (last emitted), for an RTCP Sender Report.
@@ -360,7 +378,7 @@ impl RtpStream {
         }
         let header = RtpHeader {
             marker: use_marker,
-            payload_type: RTP_PAYLOAD_TYPE_OPUS,
+            payload_type: self.payload_type,
             sequence_number: self.seq,
             timestamp: self.timestamp,
             ssrc: self.ssrc,
@@ -377,7 +395,7 @@ impl RtpStream {
     pub fn next_pre_speech_packet(&mut self) -> RtpHeader {
         let header = RtpHeader {
             marker: false,
-            payload_type: RTP_PAYLOAD_TYPE_OPUS,
+            payload_type: self.payload_type,
             sequence_number: self.seq,
             timestamp: self.timestamp,
             ssrc: self.ssrc,
@@ -544,9 +562,25 @@ mod tests {
         assert!(!is_opus_priming_payload(&[0x12, 0x36]));
         assert!(is_opus_mlow_speech_payload(&[0x48; 20]));
         assert!(!is_opus_mlow_speech_payload(&[0x48; 4]));
+        assert!(is_whatsapp_opus_rtp_payload(111));
         assert!(is_whatsapp_opus_rtp_payload(120));
         assert!(is_whatsapp_opus_rtp_payload(121));
         assert!(!is_whatsapp_opus_rtp_payload(96));
+    }
+
+    #[test]
+    fn audio_stream_payload_type_is_configurable_without_resetting_timing() {
+        let mut stream = RtpStream::new(0x1122_3344, 2_880, false);
+        let first = stream.next_packet(&[0x48; 20], false);
+        assert_eq!(first.payload_type, RTP_PAYLOAD_TYPE_MLOW);
+        assert_eq!(first.timestamp, 0);
+
+        assert!(stream.set_payload_type(RTP_PAYLOAD_TYPE_OPUS));
+        let second = stream.next_packet(&[0x48; 20], false);
+        assert_eq!(second.payload_type, RTP_PAYLOAD_TYPE_OPUS);
+        assert_eq!(second.sequence_number, 2);
+        assert_eq!(second.timestamp, 2_880);
+        assert!(!stream.set_payload_type(128));
     }
 
     #[test]

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -107,9 +107,7 @@ pub fn is_opus_dtx_payload(payload: &[u8]) -> bool {
 }
 
 fn is_mlow_dtx_payload(payload: &[u8]) -> bool {
-    payload
-        .first()
-        .is_some_and(|byte| byte & 0xC0 != 0xC0 && byte & 0x80 != 0)
+    payload.first().is_some_and(|byte| byte & 0xC0 == 0x80)
 }
 
 /// mlow speech frame (20 ms `0x48..0x4f` or 60 ms `0x50..0x57`).

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -89,7 +89,7 @@ pub fn is_whatsapp_opus_rtp_payload(payload_type: u8) -> bool {
     )
 }
 
-/// DTX / comfort-noise: RFC `0x10`, mlow `0x90`, and short warmup silence frames.
+/// Standard Opus DTX / comfort-noise and short warmup silence frames.
 pub fn is_opus_dtx_payload(payload: &[u8]) -> bool {
     match payload.len() {
         0 => false,
@@ -104,6 +104,12 @@ pub fn is_opus_dtx_payload(payload: &[u8]) -> bool {
         }
         _ => false,
     }
+}
+
+fn is_mlow_dtx_payload(payload: &[u8]) -> bool {
+    payload
+        .first()
+        .is_some_and(|byte| byte & 0xC0 != 0xC0 && byte & 0x80 != 0)
 }
 
 /// mlow speech frame (20 ms `0x48..0x4f` or 60 ms `0x50..0x57`).
@@ -328,6 +334,7 @@ pub struct RtpStream {
     samples_per_packet: u32,
     speech_started: bool,
     speech_start_markers: bool,
+    mlow_profile: bool,
     audio_packet_index: usize,
     warp_piggyback: bool,
     payload_type: u8,
@@ -343,6 +350,7 @@ impl RtpStream {
             samples_per_packet,
             speech_started: false,
             speech_start_markers: true,
+            mlow_profile: true,
             audio_packet_index: 0,
             warp_piggyback,
             payload_type: RTP_PAYLOAD_TYPE_MLOW,
@@ -357,7 +365,8 @@ impl RtpStream {
         true
     }
 
-    pub fn set_speech_start_markers(&mut self, enabled: bool) {
+    pub fn set_mlow_profile(&mut self, enabled: bool) {
+        self.mlow_profile = enabled;
         self.speech_start_markers = enabled;
     }
 
@@ -379,7 +388,11 @@ impl RtpStream {
     }
 
     pub fn next_packet(&mut self, payload: &[u8], marker: bool) -> RtpHeader {
-        let dtx = is_opus_dtx_payload(payload);
+        let dtx = if self.mlow_profile {
+            is_mlow_dtx_payload(payload)
+        } else {
+            is_opus_dtx_payload(payload)
+        };
         let priming = is_opus_priming_payload(payload);
         let speech = !dtx && !priming;
         let use_marker = marker || (self.speech_start_markers && speech && !self.speech_started);
@@ -570,6 +583,8 @@ mod tests {
         assert!(is_opus_dtx_payload(&[0x90]));
         assert!(is_opus_dtx_payload(&[0xBB, 0x03]));
         assert!(!is_opus_dtx_payload(&[]));
+        assert!(is_mlow_dtx_payload(&[0x90]));
+        assert!(!is_mlow_dtx_payload(&[0x48, 0x00]));
         assert!(is_opus_priming_payload(&OPUS_PRIMING_FRAME_1));
         assert!(is_opus_priming_payload(&OPUS_PRIMING_FRAME_2));
         assert!(!is_opus_priming_payload(&[0x12, 0x36]));
@@ -784,7 +799,7 @@ mod tests {
         // Priming/DTX before speech: no marker, no speech latch.
         let p0 = s.next_packet(&OPUS_PRIMING_FRAME_2, false);
         assert_eq!((p0.sequence_number, p0.timestamp, p0.marker), (1, 0, false));
-        let d1 = s.next_packet(&[0x10], false);
+        let d1 = s.next_packet(&[0x90], false);
         assert_eq!(
             (d1.sequence_number, d1.timestamp, d1.marker),
             (2, 320, false)
@@ -811,10 +826,21 @@ mod tests {
     #[test]
     fn native_opus_can_disable_mlow_speech_markers() {
         let mut stream = RtpStream::new(0xabcd, 960, false);
-        stream.set_speech_start_markers(false);
+        stream.set_mlow_profile(false);
 
         assert!(!stream.next_packet(&[0x58; 80], false).marker);
         let _ = stream.next_packet(&[0x10], false);
         assert!(!stream.next_packet(&[0x58; 80], false).marker);
+    }
+
+    #[test]
+    fn short_mlow_speech_is_not_classified_as_dtx() {
+        let mut stream = RtpStream::new(0xabcd, 960, false);
+
+        assert!(stream.next_packet(&[0x48, 0x00], false).marker);
+        let next = stream.next_packet(&[0x48, 0x00], false);
+
+        assert!(!next.marker);
+        assert_eq!(next.extension_word, None);
     }
 }

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -3,10 +3,13 @@
 
 use crate::voip::warp::audio_piggyback_extension_for;
 
-/// Standard Opus payload type in the current native media profile.
+/// RFC 7587 Opus payload type used when the 48 kHz RTP-clock setting is enabled.
 pub const RTP_PAYLOAD_TYPE_OPUS: u8 = 111;
-/// MLOW payload type in captured native and Web media.
-pub const RTP_PAYLOAD_TYPE_MLOW: u8 = 120;
+/// Default WhatsApp audio payload type; the negotiated codec decides whether its bytes are MLOW or
+/// native Opus.
+pub const RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO: u8 = 120;
+/// MLOW name for the shared default WhatsApp audio payload type.
+pub const RTP_PAYLOAD_TYPE_MLOW: u8 = RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO;
 /// MLOW SplitRed redundancy payload type (`mlow-red-1`).
 pub const RTP_PAYLOAD_TYPE_MLOW_RED: u8 = 121;
 /// H.264 video payload type used by captured Android video RTP.
@@ -90,7 +93,8 @@ pub fn is_whatsapp_opus_rtp_payload(payload_type: u8) -> bool {
 pub fn is_opus_dtx_payload(payload: &[u8]) -> bool {
     match payload.len() {
         0 => false,
-        1 => matches!(payload[0], 0x10 | 0x88 | 0x90),
+        // libopus defines packets up to two bytes as DTX. This also covers MLOW's one-byte SID.
+        1..=2 => true,
         n if n <= 15 => {
             let b0 = payload[0];
             if (b0 & 0xf8) == 0x08 || b0 == 0x0a {
@@ -323,6 +327,7 @@ pub struct RtpStream {
     last_sent_timestamp: Option<u32>,
     samples_per_packet: u32,
     speech_started: bool,
+    speech_start_markers: bool,
     audio_packet_index: usize,
     warp_piggyback: bool,
     payload_type: u8,
@@ -337,6 +342,7 @@ impl RtpStream {
             last_sent_timestamp: None,
             samples_per_packet,
             speech_started: false,
+            speech_start_markers: true,
             audio_packet_index: 0,
             warp_piggyback,
             payload_type: RTP_PAYLOAD_TYPE_MLOW,
@@ -349,6 +355,10 @@ impl RtpStream {
         }
         self.payload_type = payload_type;
         true
+    }
+
+    pub fn set_speech_start_markers(&mut self, enabled: bool) {
+        self.speech_start_markers = enabled;
     }
 
     /// The current send timestamp (last emitted), for an RTCP Sender Report.
@@ -372,8 +382,10 @@ impl RtpStream {
         let dtx = is_opus_dtx_payload(payload);
         let priming = is_opus_priming_payload(payload);
         let speech = !dtx && !priming;
-        let use_marker = marker || (speech && !self.speech_started);
-        if speech {
+        let use_marker = marker || (self.speech_start_markers && speech && !self.speech_started);
+        if dtx {
+            self.speech_started = false;
+        } else if speech {
             self.speech_started = true;
         }
         let header = RtpHeader {
@@ -556,6 +568,7 @@ mod tests {
     fn classifiers() {
         assert!(is_opus_dtx_payload(&[0x10]));
         assert!(is_opus_dtx_payload(&[0x90]));
+        assert!(is_opus_dtx_payload(&[0xBB, 0x03]));
         assert!(!is_opus_dtx_payload(&[]));
         assert!(is_opus_priming_payload(&OPUS_PRIMING_FRAME_1));
         assert!(is_opus_priming_payload(&OPUS_PRIMING_FRAME_2));
@@ -788,5 +801,20 @@ mod tests {
         // Subsequent speech has no marker.
         let sp2 = s.next_packet(&[0x48; 40], false);
         assert!(!sp2.marker);
+
+        let d2 = s.next_packet(&[0x90], false);
+        assert!(!d2.marker);
+        let resumed = s.next_packet(&[0x48; 40], false);
+        assert!(resumed.marker, "speech after DTX must re-arm the marker");
+    }
+
+    #[test]
+    fn native_opus_can_disable_mlow_speech_markers() {
+        let mut stream = RtpStream::new(0xabcd, 960, false);
+        stream.set_speech_start_markers(false);
+
+        assert!(!stream.next_packet(&[0x58; 80], false).marker);
+        let _ = stream.next_packet(&[0x10], false);
+        assert!(!stream.next_packet(&[0x58; 80], false).marker);
     }
 }

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -2,6 +2,7 @@
 //! E2E SRTP protect, and the reverse). The byte-level crypto/framing lives in the sibling
 //! `wacore::voip` modules; this stitches it together. Pure logic: no socket, clock, or runtime.
 
+use super::audio::AudioFormat;
 use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
     derive_srtcp_keys, protect_srtcp, unprotect_srtcp, verify_warp_mi_tag,
@@ -48,6 +49,8 @@ pub struct CallSession {
     pub call_creator: Jid,
     pub direction: CallDirection,
     pub is_video: bool,
+    /// The single media profile selected for this call.
+    pub audio_format: Option<AudioFormat>,
     /// For an OUTGOING call: the callee device JIDs the offer rang, so when one accepts/rejects the
     /// caller can dismiss the rest (`accepted_elsewhere`). Empty for incoming calls and single-device
     /// callees. Lives on the session so it is dropped automatically whenever the call deregisters --
@@ -70,6 +73,7 @@ impl CallSession {
             call_creator,
             direction: CallDirection::Outgoing,
             is_video: false,
+            audio_format: None,
             ring_devices: Vec::new(),
             answering_device: None,
             phase: CallPhase::Idle,
@@ -83,6 +87,7 @@ impl CallSession {
             call_creator,
             direction: CallDirection::Incoming,
             is_video: false,
+            audio_format: None,
             ring_devices: Vec::new(),
             answering_device: None,
             phase: CallPhase::Ringing,
@@ -360,6 +365,11 @@ impl MediaPipeline {
 
     pub fn send_ssrc(&self) -> u32 {
         self.rtp.ssrc
+    }
+
+    /// Select the negotiated audio RTP payload type without resetting sequence/timestamp state.
+    pub fn set_audio_payload_type(&mut self, payload_type: u8) -> bool {
+        self.rtp.set_payload_type(payload_type)
     }
 
     /// An SRTCP-protected Sender Report for the audio stream (our send SSRC), or the accumulated

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -372,9 +372,9 @@ impl MediaPipeline {
         self.rtp.set_payload_type(payload_type)
     }
 
-    /// Native Opus does not use MLOW's marker-driven speech-resume state.
-    pub fn set_audio_speech_start_markers(&mut self, enabled: bool) {
-        self.rtp.set_speech_start_markers(enabled);
+    /// Select MLOW's TOC-aware DTX and marker behavior independently from the shared payload type.
+    pub fn set_audio_mlow_profile(&mut self, enabled: bool) {
+        self.rtp.set_mlow_profile(enabled);
     }
 
     /// An SRTCP-protected Sender Report for the audio stream (our send SSRC), or the accumulated

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -372,6 +372,11 @@ impl MediaPipeline {
         self.rtp.set_payload_type(payload_type)
     }
 
+    /// Native Opus does not use MLOW's marker-driven speech-resume state.
+    pub fn set_audio_speech_start_markers(&mut self, enabled: bool) {
+        self.rtp.set_speech_start_markers(enabled);
+    }
+
     /// An SRTCP-protected Sender Report for the audio stream (our send SSRC), or the accumulated
     /// packet/octet totals since the call began. Emitted periodically by the engine.
     pub(crate) fn audio_sender_report(


### PR DESCRIPTION
## Summary

- add an encoded-audio source/sink boundary so applications can provide raw MLOW or Opus packets without linking a codec
- split the VoIP runtime, MLOW, and libopus Cargo features while keeping `voip` backward compatible
- preserve the selected audio format through signaling, RTP/SRTP, call state, and peer format checks
- negotiate native Opus bidirectionally, with PT120/16 kHz as the production profile and PT111/48 kHz as an explicit variant
- reduce codec hot-path allocations and add focused protocol, engine, handler, and feature-matrix coverage

## Root cause

Clearing the MLOW capability selected the Android Opus encoder, so Android-to-Rust audio worked. The answer still omitted the directional `voip_settings` field that selects the Android decoder, leaving Rust-to-Android packets on the MLOW decode path.

Native Opus answers now send the matching capability plus a minimal uncompressed settings overlay:

- `encode.use_mlow_codec_v1=false`
- `options.enable_48khz_rtp_clock=false`

Codec selection and RTP clock selection remain independent.

## Impact

- `WA_AUDIO_CODEC=opus` now provides full-duplex native Opus
- MLOW remains the compatibility default and keeps its pure-Rust PCM path
- external FFmpeg/libavcodec/process integrations can inject complete raw codec packets through `encoded_audio`
- deployments can omit MLOW and/or libopus when those codecs are supplied externally
- MLOW and Opus packet scratch/history buffers are reused on hot paths

## Validation

- live Android ↔ CLI full-duplex native Opus call
- `cargo fmt --all`
- `cargo clippy --all --tests`
- `cargo test --workspace --exclude e2e-tests`
- `cargo test -p whatsapp-rust-voip-cli --no-default-features --features voip-opus`
- `cargo test -p whatsapp-rust-voip-cli --no-default-features --features voip-mlow`

The local E2E crate was excluded because it requires the separate mock WebSocket server.