### PR TITLE
fix(appstate): recover missing keys across companion devices

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mock-server:
-        image: ghcr.io/whiskeysockets-devtools/bartender:latest
+        image: ghcr.io/whiskeysockets-devtools/bartender@sha256:f9fb8ca27b1872eb9d5129c92d7dc5b972cb8a615cce1f1a17eb8e4c7800c144
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.BARTENDER_GHCR_TOKEN }}
@@ -37,7 +37,11 @@ jobs:
           - 8080:8080
         env:
           CHATSTATE_TTL_SECS: "3"
-        options: --log-driver none
+        # Keep service-side evidence for flakes without allowing logs to consume the runner disk.
+        options: >-
+          --log-driver local
+          --log-opt max-size=10m
+          --log-opt max-file=1
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mock-server:
-        image: ghcr.io/whiskeysockets-devtools/bartender@sha256:15285064d2b3a89da9159c6d48e8e68dee14e38aaba05bc8fc7ac44d6071ef6a
+        image: ghcr.io/whiskeysockets-devtools/bartender@sha256:975e9ce5143b56b527deea1afb5aed9423461671c546fc521473a25d1ffe26fa
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.BARTENDER_GHCR_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mock-server:
-        image: ghcr.io/whiskeysockets-devtools/bartender@sha256:f9fb8ca27b1872eb9d5129c92d7dc5b972cb8a615cce1f1a17eb8e4c7800c144
+        image: ghcr.io/whiskeysockets-devtools/bartender@sha256:15285064d2b3a89da9159c6d48e8e68dee14e38aaba05bc8fc7ac44d6071ef6a
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.BARTENDER_GHCR_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,7 @@ jobs:
           --log-driver local
           --log-opt max-size=10m
           --log-opt max-file=1
+          --log-opt compress=false
     steps:
       - uses: actions/checkout@v6
         with:

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -5,12 +5,19 @@ E2E tests live in `tests/e2e/` and run against a mock WhatsApp server. They test
 ## Test Infrastructure
 
 - **`tests/e2e/src/lib.rs`**: `TestClient` helper — connects to mock server, waits for pairing + sync, provides event-based assertions.
-- Each test creates isolated in-memory SQLite DBs (UUID-based), so tests have no shared state.
-- Tests across files run **in parallel**; tests within a file run **sequentially**.
+- Each `TestClient` owns an isolated `InMemoryBackend`; the mock server is shared.
+- Libtest runs tests within a test binary **in parallel** by default. Never rely on test order.
+- Use `unique_push_name()` for server-side account isolation. For a multi-device test,
+  create one unique name and pass it only to that test's related clients.
+- CI pins the mock-server image by digest. Update it deliberately with the matching
+  server change so an unchanged client commit always runs against the same protocol peer.
+- Local runs must start the mock with `CHATSTATE_TTL_SECS=3`; `chatstate_ttl.rs`
+  intentionally uses the same shortened expiry as CI.
 
-## File Organization for Parallelism
+## File Organization
 
-Split test files by domain so they run concurrently. Cargo runs each test binary (file) in parallel, but tests within a binary run sequentially. A single large file becomes the bottleneck.
+Split test files by domain so ownership and failures stay clear. Do not use file boundaries
+as a synchronization mechanism; correctness must not depend on how Cargo schedules test targets.
 
 ```
 tests/e2e/tests/
@@ -19,7 +26,7 @@ tests/e2e/tests/
 ├── groups.rs            # Group CRUD, admin, settings
 ├── media.rs             # Upload, download, send media
 ├── messaging.rs         # Send/receive text messages
-├── chatstate_ttl.rs     # Chatstate TTL expiry (35s sleep — own file for parallelism)
+├── chatstate_ttl.rs     # Chatstate expiry with the CI's 3-second mock TTL
 ├── offline_groups.rs    # Offline group notifications
 ├── offline_messages.rs  # Offline message queuing + delivery
 ├── offline_receipts.rs  # Offline receipt + presence delivery
@@ -30,6 +37,14 @@ tests/e2e/tests/
 ```
 
 When adding new tests, place them in the file matching their domain. If a file grows beyond ~10-15 tests, consider splitting further.
+
+## Recovery and Race Regressions
+
+Make recovery tests deterministic with narrow `test-util` fault hooks, then wait for an
+observable event, stanza, or bounded state transition. Do not depend on CPU load to hit a race, and
+do not raise a readiness timeout to hide a failed bootstrap phase. `app_state.rs`'s missing-key
+test is the reference pattern: remove exactly the required state, trigger a real sync, and
+assert that recovery reaches the wire.
 
 ## Event-Driven Waiting (Preferred)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -484,14 +484,7 @@ impl ClientError {
         match self {
             ClientError::NotConnected => true,
             ClientError::EncryptSend(e) => e.is_transport_unavailable(),
-            // Transport loss can now arrive wrapped in an IQ failure (the base
-            // error gained `Iq`); unwrap it so retry/reconnect still triggers.
-            ClientError::Iq(e) => match e {
-                crate::request::IqError::NotConnected => true,
-                crate::request::IqError::EncryptSend(e) => e.is_transport_unavailable(),
-                crate::request::IqError::ClientState(client) => client.is_transport_unavailable(),
-                _ => false,
-            },
+            ClientError::Iq(e) => e.is_transport_unavailable(),
             _ => false,
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -884,6 +884,9 @@ pub struct Client {
     /// until a worker is actually inside the (blocked) flush.
     #[cfg(test)]
     pub(crate) signal_flush_test_in_attempt: AtomicU32,
+    /// Keeps retry regressions deterministic without corrupting the test database.
+    #[cfg(test)]
+    pub(crate) app_state_key_share_prepare_test_failures: AtomicU32,
 
     /// Holds the background saver's AbortHandle so the task lifetime follows
     /// `Arc<Client>` ref count instead of the Bot wrapper's. Set once by

--- a/src/client.rs
+++ b/src/client.rs
@@ -685,7 +685,7 @@ pub struct Client {
     pub(crate) needs_initial_full_sync: Arc<AtomicBool>,
 
     pub(crate) app_state_processor: async_lock::Mutex<Option<Arc<AppStateProcessor>>>,
-    pub(crate) app_state_key_requests: Arc<Mutex<HashMap<String, wacore::time::Instant>>>,
+    pub(crate) app_state_key_requests: Arc<Mutex<HashMap<Vec<u8>, wacore::time::Instant>>>,
     /// Tracks collections currently being synced to prevent duplicate sync tasks.
     /// Matches WA Web's in-flight tracking set in WAWebSyncdCollectionsStateMachine.
     pub(crate) app_state_syncing: Arc<Mutex<HashSet<WAPatchName>>>,

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -22,6 +22,62 @@ struct AppStateKeyRequestSchedule {
     sent: bool,
 }
 
+enum AppStateKeyRequestProgress {
+    Scheduled(AppStateKeyRequestSchedule),
+    KeysReady,
+    TimedOut,
+}
+
+async fn app_state_keys_available(
+    backend: &dyn crate::store::traits::Backend,
+    key_ids: &[Vec<u8>],
+) -> bool {
+    for key_id in key_ids {
+        if backend.get_sync_key(key_id).await.ok().flatten().is_none() {
+            return false;
+        }
+    }
+    true
+}
+
+async fn remove_available_app_state_keys(
+    backend: &dyn crate::store::traits::Backend,
+    missing: &mut Vec<Vec<u8>>,
+) {
+    let mut index = 0;
+    while index < missing.len() {
+        if backend
+            .get_sync_key(&missing[index])
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            missing.swap_remove(index);
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn finalize_app_state_key_request_peers(
+    mut peers: Vec<Jid>,
+    current_device: u16,
+    primary: Jid,
+) -> Result<Vec<Jid>, anyhow::Error> {
+    peers.retain(|jid| jid.device != current_device);
+    wacore::types::jid::sort_dedup_by_device(&mut peers);
+    if peers.is_empty() && current_device != primary.device {
+        peers.push(primary);
+    }
+    if peers.is_empty() {
+        return Err(anyhow::anyhow!(
+            "no peer devices available for app-state key request"
+        ));
+    }
+    Ok(peers)
+}
+
 impl Client {
     pub(crate) async fn get_app_state_processor(&self) -> Arc<AppStateProcessor> {
         let mut guard = self.app_state_processor.lock().await;
@@ -654,34 +710,30 @@ impl Client {
         let backend = self.persistence_manager.backend();
         let mut retry_after = APP_STATE_KEY_PARTIAL_RETRY;
         loop {
-            // Register the listener before the store check: the notifier is not sticky,
-            // so a key-share persisted in the check→listen gap would be lost.
             let listener = self.initial_keys_synced_notifier.listen();
-
-            let mut index = 0;
-            while index < missing.len() {
-                if backend
-                    .get_sync_key(&missing[index])
-                    .await
-                    .ok()
-                    .flatten()
-                    .is_some()
-                {
-                    missing.swap_remove(index);
-                } else {
-                    index += 1;
-                }
-            }
+            remove_available_app_state_keys(&*backend, &mut missing).await;
             if missing.is_empty() {
                 return true;
             }
 
-            let schedule = self
-                .request_missing_keys_with_dedup(&missing, retry_after)
-                .await;
+            let request = self.request_missing_keys_with_dedup(&missing, retry_after);
+            let schedule = match self
+                .await_app_state_key_request(&*backend, &missing, deadline, listener, request)
+                .await
+            {
+                AppStateKeyRequestProgress::Scheduled(schedule) => schedule,
+                AppStateKeyRequestProgress::KeysReady => return true,
+                AppStateKeyRequestProgress::TimedOut => return false,
+            };
             if schedule.sent {
                 debug!(target: "Client/AppState", "Requested {} missing app-state key(s); retrying after {retry_after:?} if no share arrives", missing.len());
                 retry_after = retry_after.saturating_mul(2).min(APP_STATE_KEY_RETRY_MAX);
+            }
+
+            let listener = self.initial_keys_synced_notifier.listen();
+            remove_available_app_state_keys(&*backend, &mut missing).await;
+            if missing.is_empty() {
+                return true;
             }
 
             let remaining = deadline.saturating_duration_since(wacore::time::Instant::now());
@@ -695,6 +747,48 @@ impl Client {
             let wait = remaining.min(retry_wait);
             if !wait.is_zero() {
                 let _ = rt_timeout(&*self.runtime, wait, listener).await;
+            }
+        }
+    }
+
+    async fn await_app_state_key_request<F>(
+        &self,
+        backend: &dyn crate::store::traits::Backend,
+        missing: &[Vec<u8>],
+        deadline: wacore::time::Instant,
+        mut listener: event_listener::EventListener,
+        request: F,
+    ) -> AppStateKeyRequestProgress
+    where
+        F: std::future::Future<Output = AppStateKeyRequestSchedule>,
+    {
+        futures::pin_mut!(request);
+        loop {
+            let remaining = deadline.saturating_duration_since(wacore::time::Instant::now());
+            if remaining.is_zero() {
+                return if app_state_keys_available(backend, missing).await {
+                    AppStateKeyRequestProgress::KeysReady
+                } else {
+                    AppStateKeyRequestProgress::TimedOut
+                };
+            }
+
+            let notified = rt_timeout(&*self.runtime, remaining, listener);
+            futures::pin_mut!(notified);
+            match futures::future::select(request.as_mut(), notified.as_mut()).await {
+                futures::future::Either::Left((schedule, _)) => {
+                    return AppStateKeyRequestProgress::Scheduled(schedule);
+                }
+                futures::future::Either::Right((notification, _)) => {
+                    let next_listener = self.initial_keys_synced_notifier.listen();
+                    if app_state_keys_available(backend, missing).await {
+                        return AppStateKeyRequestProgress::KeysReady;
+                    }
+                    if notification.is_err() {
+                        return AppStateKeyRequestProgress::TimedOut;
+                    }
+                    listener = next_listener;
+                }
             }
         }
     }
@@ -788,23 +882,16 @@ impl Client {
         let primary = own_jid.to_non_ad();
         drop(device_snapshot);
 
-        let mut peers = match self.get_user_devices(std::slice::from_ref(&primary)).await {
+        let peers = match self.get_user_devices(std::slice::from_ref(&primary)).await {
             Ok(devices) => devices,
             Err(error) => {
                 warn!(
                     "Own device-list query failed; requesting app-state keys from primary only: {error}"
                 );
-                vec![primary]
+                Vec::new()
             }
         };
-        peers.retain(|jid| jid.device != current_device);
-        wacore::types::jid::sort_dedup_by_device(&mut peers);
-        if peers.is_empty() {
-            return Err(anyhow::anyhow!(
-                "no peer devices available for app-state key request"
-            ));
-        }
-        Ok(peers)
+        finalize_app_state_key_request_peers(peers, current_device, primary)
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.request_keys", level = "debug", skip_all, fields(count = raw_key_ids.len()), err(Debug)))]
@@ -1031,6 +1118,46 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn key_arrival_finishes_before_a_slow_fanout() {
+        let client = crate::test_utils::create_test_client_with_name("appstate_slow_peer").await;
+        let backend = client.persistence_manager.backend();
+        let key_id = vec![7, 8, 9, 10];
+        let listener = client.initial_keys_synced_notifier.listen();
+        let notifier = client.initial_keys_synced_notifier.clone();
+        let writer = backend.clone();
+        let stored_id = key_id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            writer
+                .set_sync_key(&stored_id, crate::store::traits::AppStateSyncKey::default())
+                .await
+                .expect("store recovered key");
+            notifier.notify(usize::MAX);
+        });
+
+        let progress = client
+            .await_app_state_key_request(
+                &*backend,
+                std::slice::from_ref(&key_id),
+                wacore::time::Instant::now() + Duration::from_secs(1),
+                listener,
+                std::future::pending::<AppStateKeyRequestSchedule>(),
+            )
+            .await;
+
+        assert!(matches!(progress, AppStateKeyRequestProgress::KeysReady));
+    }
+
+    #[test]
+    fn empty_companion_discovery_falls_back_to_primary() {
+        let primary: Jid = "5511000000000@s.whatsapp.net".parse().expect("primary jid");
+        let peers = finalize_app_state_key_request_peers(Vec::new(), 7, primary.clone())
+            .expect("companion fallback");
+        assert_eq!(peers, vec![primary.clone()]);
+        assert!(finalize_app_state_key_request_peers(Vec::new(), 0, primary).is_err());
+    }
 
     #[tokio::test]
     async fn active_key_wait_shortens_a_passive_dedup_stamp() {

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -9,11 +9,17 @@ use super::*;
 const APPSTATE_BLOB_DOWNLOAD_CONCURRENCY: usize = 4;
 const APP_STATE_KEY_REQUEST_DEDUP: Duration = Duration::from_secs(24 * 3600);
 const APP_STATE_KEY_PARTIAL_RETRY: Duration = Duration::from_secs(10);
+const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AppStateKeyRequestDelivery {
     AllPeers,
     SomePeers,
+}
+
+struct AppStateKeyRequestSchedule {
+    retry_at: wacore::time::Instant,
+    sent: bool,
 }
 
 impl Client {
@@ -432,7 +438,8 @@ impl Client {
                         Vec::new()
                     }
                 };
-                self.request_missing_keys_with_dedup(missing).await;
+                self.request_missing_keys_with_dedup(&missing, APP_STATE_KEY_REQUEST_DEDUP)
+                    .await;
 
                 // full_sync is true only when this collection had a snapshot
                 // (version was 0 before sync). This prevents server_sync-triggered
@@ -608,7 +615,8 @@ impl Client {
                     Vec::new()
                 }
             };
-            self.request_missing_keys_with_dedup(missing).await;
+            self.request_missing_keys_with_dedup(&missing, APP_STATE_KEY_REQUEST_DEDUP)
+                .await;
 
             wacore::telemetry::appstate_mutations(mutations.len() as u64);
             for m in mutations {
@@ -638,95 +646,134 @@ impl Client {
     /// deduped request means an earlier one is still in flight, so the key may yet land
     /// here, and a re-verify that fails can't be masked by treating "request sent" as
     /// success or by a wake from an unrelated key share.
-    async fn request_keys_and_wait(&self, missing: Vec<Vec<u8>>, timeout: Duration) -> bool {
+    async fn request_keys_and_wait(&self, mut missing: Vec<Vec<u8>>, timeout: Duration) -> bool {
         if missing.is_empty() {
             return true;
         }
-        let count = missing.len();
         let deadline = wacore::time::Instant::now() + timeout;
-        let mut requested = false;
+        let backend = self.persistence_manager.backend();
+        let mut retry_after = APP_STATE_KEY_PARTIAL_RETRY;
         loop {
             // Register the listener before the store check: the notifier is not sticky,
             // so a key-share persisted in the check→listen gap would be lost.
             let listener = self.initial_keys_synced_notifier.listen();
-            if self.all_sync_keys_present(&missing).await {
+
+            let mut index = 0;
+            while index < missing.len() {
+                if backend
+                    .get_sync_key(&missing[index])
+                    .await
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    missing.swap_remove(index);
+                } else {
+                    index += 1;
+                }
+            }
+            if missing.is_empty() {
                 return true;
             }
-            // Send the explicit re-request once, after confirming the keys are still
-            // missing.
-            if !requested {
-                self.request_missing_keys_with_dedup(missing.clone()).await;
-                requested = true;
-                debug!(target: "Client/AppState", "Requested {count} missing app-state key(s); waiting up to {timeout:?} for the re-share");
+
+            let schedule = self
+                .request_missing_keys_with_dedup(&missing, retry_after)
+                .await;
+            if schedule.sent {
+                debug!(target: "Client/AppState", "Requested {} missing app-state key(s); retrying after {retry_after:?} if no share arrives", missing.len());
+                retry_after = retry_after.saturating_mul(2).min(APP_STATE_KEY_RETRY_MAX);
             }
+
             let remaining = deadline.saturating_duration_since(wacore::time::Instant::now());
             if remaining.is_zero() {
                 return false;
             }
-            // A single share may cover only part of `missing`, and the notifier is global
-            // (an unrelated share wakes us too), so keep re-checking on each wake until
-            // every key lands or the deadline passes — don't give up on the first wake
-            // while budget remains.
-            let _ = rt_timeout(&*self.runtime, remaining, listener).await;
-        }
-    }
 
-    /// True iff every given app-state sync-key id is already stored.
-    async fn all_sync_keys_present(&self, ids: &[Vec<u8>]) -> bool {
-        let backend = self.persistence_manager.backend();
-        for id in ids {
-            if backend.get_sync_key(id).await.ok().flatten().is_none() {
-                return false;
+            let retry_wait = schedule
+                .retry_at
+                .saturating_duration_since(wacore::time::Instant::now());
+            let wait = remaining.min(retry_wait);
+            if !wait.is_zero() {
+                let _ = rt_timeout(&*self.runtime, wait, listener).await;
             }
         }
-        true
     }
 
     /// Request missing app-state keys with dedup stamps.
     /// Total failure removes stamps; partial fanout gets a short retry deadline.
-    /// Returns true iff a fresh key request was actually sent (some ids passed the
-    /// per-key dedup and the send succeeded), so the caller knows whether a re-share
-    /// is plausibly inbound and worth waiting for.
-    async fn request_missing_keys_with_dedup(&self, missing: Vec<Vec<u8>>) -> bool {
+    async fn request_missing_keys_with_dedup(
+        &self,
+        missing: &[Vec<u8>],
+        retry_after: Duration,
+    ) -> AppStateKeyRequestSchedule {
         if missing.is_empty() {
-            return false;
+            return AppStateKeyRequestSchedule {
+                retry_at: wacore::time::Instant::now() + retry_after,
+                sent: false,
+            };
         }
-        let mut to_request: Vec<Vec<u8>> = Vec::with_capacity(missing.len());
         let mut guard = self.app_state_key_requests.lock().await;
         let now = wacore::time::Instant::now();
+        let requested_retry_at = now + retry_after;
+        guard.retain(|_, retry_at| now < *retry_at);
+
+        let mut to_request: Option<Vec<&[u8]>> = None;
+        let mut next_retry_at = requested_retry_at;
         for key_id in missing {
-            let should = guard
-                .get(key_id.as_slice())
-                .is_none_or(|retry_at| now >= *retry_at);
-            if should {
-                guard.insert(key_id.clone(), now + APP_STATE_KEY_REQUEST_DEDUP);
-                to_request.push(key_id);
+            if let Some(retry_at) = guard.get_mut(key_id.as_slice()) {
+                if *retry_at > requested_retry_at {
+                    *retry_at = requested_retry_at;
+                }
+                next_retry_at = next_retry_at.min(*retry_at);
+            } else {
+                guard.insert(key_id.clone(), requested_retry_at);
+                to_request
+                    .get_or_insert_with(|| Vec::with_capacity(missing.len()))
+                    .push(key_id.as_slice());
             }
         }
-        guard.retain(|_, retry_at| now < *retry_at);
         drop(guard);
-        if to_request.is_empty() {
-            return false;
-        }
+
+        let Some(to_request) = to_request else {
+            return AppStateKeyRequestSchedule {
+                retry_at: next_retry_at,
+                sent: false,
+            };
+        };
+
         match self.request_app_state_keys(&to_request).await {
-            Ok(AppStateKeyRequestDelivery::AllPeers) => true,
+            Ok(AppStateKeyRequestDelivery::AllPeers) => AppStateKeyRequestSchedule {
+                retry_at: next_retry_at,
+                sent: true,
+            },
             Ok(AppStateKeyRequestDelivery::SomePeers) => {
                 let retry_at = wacore::time::Instant::now() + APP_STATE_KEY_PARTIAL_RETRY;
                 let mut guard = self.app_state_key_requests.lock().await;
                 for key_id in &to_request {
-                    if let Some(deadline) = guard.get_mut(key_id.as_slice()) {
-                        *deadline = retry_at;
+                    if let Some(deadline) = guard.get_mut(*key_id) {
+                        *deadline = (*deadline).min(retry_at);
                     }
                 }
-                true
+                AppStateKeyRequestSchedule {
+                    retry_at: next_retry_at.min(retry_at),
+                    sent: true,
+                }
             }
             Err(e) => {
                 warn!("Failed to send app state key request: {e}");
                 let mut guard = self.app_state_key_requests.lock().await;
                 for key_id in &to_request {
-                    guard.remove(key_id.as_slice());
+                    if guard
+                        .get(*key_id)
+                        .is_some_and(|deadline| *deadline == requested_retry_at)
+                    {
+                        guard.remove(*key_id);
+                    }
                 }
-                false
+                AppStateKeyRequestSchedule {
+                    retry_at: wacore::time::Instant::now() + retry_after,
+                    sent: false,
+                }
             }
         }
     }
@@ -763,7 +810,7 @@ impl Client {
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.request_keys", level = "debug", skip_all, fields(count = raw_key_ids.len()), err(Debug)))]
     async fn request_app_state_keys(
         &self,
-        raw_key_ids: &[Vec<u8>],
+        raw_key_ids: &[&[u8]],
     ) -> Result<AppStateKeyRequestDelivery, anyhow::Error> {
         if raw_key_ids.is_empty() {
             return Ok(AppStateKeyRequestDelivery::AllPeers);
@@ -772,7 +819,7 @@ impl Client {
         let key_ids: Vec<wa::message::AppStateSyncKeyId> = raw_key_ids
             .iter()
             .map(|k| wa::message::AppStateSyncKeyId {
-                key_id: Some(k.clone()),
+                key_id: Some(k.to_vec()),
             })
             .collect();
         let msg = wa::Message {
@@ -978,5 +1025,48 @@ impl Client {
 
         let spec = CleanDirtyBitsSpec::single(bit);
         self.execute(spec).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn active_key_wait_shortens_a_passive_dedup_stamp() {
+        let client = crate::test_utils::create_test_client_with_name("appstate_retry_stamp").await;
+        let key_id = vec![1, 2, 3, 4];
+        client.app_state_key_requests.lock().await.insert(
+            key_id.clone(),
+            wacore::time::Instant::now() + APP_STATE_KEY_REQUEST_DEDUP,
+        );
+
+        let started = wacore::time::Instant::now();
+        let schedule = client
+            .request_missing_keys_with_dedup(
+                std::slice::from_ref(&key_id),
+                APP_STATE_KEY_PARTIAL_RETRY,
+            )
+            .await;
+
+        assert!(
+            !schedule.sent,
+            "an in-flight request must not be duplicated"
+        );
+        assert!(schedule.retry_at > started);
+        assert!(
+            schedule.retry_at.saturating_duration_since(started)
+                <= APP_STATE_KEY_PARTIAL_RETRY + Duration::from_millis(100),
+            "an active waiter must retry before the passive 24-hour deadline"
+        );
+        assert_eq!(
+            client
+                .app_state_key_requests
+                .lock()
+                .await
+                .get(key_id.as_slice())
+                .copied(),
+            Some(schedule.retry_at)
+        );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -8,6 +8,7 @@ use super::*;
 /// bounded here because a snapshot can be multi-MB and a batch carries several.
 const APPSTATE_BLOB_DOWNLOAD_CONCURRENCY: usize = 4;
 const APP_STATE_KEY_REQUEST_DEDUP: Duration = Duration::from_secs(24 * 3600);
+const APP_STATE_KEY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const APP_STATE_KEY_PARTIAL_RETRY: Duration = Duration::from_secs(10);
 const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 
@@ -44,6 +45,69 @@ fn classify_app_state_key_request_failures(
         "App-state key request failed for {failure_count}/{peer_count} peer device(s): {failures}"
     );
     Ok(AppStateKeyRequestDelivery::SomePeers)
+}
+
+#[cold]
+#[inline(never)]
+fn append_app_state_key_request_failure(
+    failures: &mut Option<String>,
+    message: std::fmt::Arguments<'_>,
+) {
+    let failures = failures.get_or_insert_with(String::new);
+    if !failures.is_empty() {
+        failures.push_str(", ");
+    }
+    let _ = std::fmt::Write::write_fmt(failures, message);
+}
+
+async fn collect_app_state_key_request_results<F, E>(
+    runtime: &dyn wacore::runtime::Runtime,
+    mut requests: futures::stream::FuturesUnordered<F>,
+    timeout: Duration,
+) -> Result<AppStateKeyRequestDelivery, anyhow::Error>
+where
+    F: std::future::Future<Output = (u16, std::result::Result<(), E>)>,
+    E: std::fmt::Display,
+{
+    use futures::StreamExt;
+    use futures::future::Either;
+
+    let peer_count = requests.len();
+    let mut failure_count = 0;
+    let mut failures = None;
+    let mut deadline = runtime.sleep(timeout);
+    while !requests.is_empty() {
+        match futures::future::select(requests.next(), deadline.as_mut()).await {
+            Either::Left((Some((device, result)), _)) => {
+                if let Err(error) = result {
+                    failure_count += 1;
+                    append_app_state_key_request_failure(
+                        &mut failures,
+                        format_args!("device {device}: {error}"),
+                    );
+                }
+            }
+            Either::Left((None, _)) => break,
+            Either::Right(((), _)) => {
+                let timed_out = requests.len();
+                failure_count += timed_out;
+                append_app_state_key_request_failure(
+                    &mut failures,
+                    format_args!("{timed_out} peer request(s) timed out"),
+                );
+                break;
+            }
+        }
+    }
+
+    if failure_count != 0 {
+        return classify_app_state_key_request_failures(
+            peer_count,
+            failure_count,
+            failures.as_deref().unwrap_or_default(),
+        );
+    }
+    Ok(AppStateKeyRequestDelivery::AllPeers)
 }
 
 async fn app_state_keys_available(
@@ -459,7 +523,7 @@ impl Client {
             // the explicit request on this connection; otherwise a fixed short wait.
             let key_wait = match key_wait_deadline {
                 Some(deadline) => deadline.saturating_duration_since(wacore::time::Instant::now()),
-                None => Duration::from_secs(10),
+                None => APP_STATE_KEY_REQUEST_TIMEOUT,
             };
             if !missing_all.is_empty() && !self.request_keys_and_wait(missing_all, key_wait).await {
                 // The re-shared key didn't land in time. Report failure rather than a
@@ -671,7 +735,7 @@ impl Client {
                 .unwrap_or_default();
             if !missing.is_empty()
                 && !self
-                    .request_keys_and_wait(missing, Duration::from_secs(10))
+                    .request_keys_and_wait(missing, APP_STATE_KEY_REQUEST_TIMEOUT)
                     .await
             {
                 // Report failure (not a partial success) so the caller retries instead of
@@ -945,8 +1009,7 @@ impl Client {
             ..Default::default()
         };
 
-        let peer_count = peers.len();
-        let mut requests = futures::stream::FuturesUnordered::new();
+        let requests = futures::stream::FuturesUnordered::new();
         for peer in peers {
             let msg = &msg;
             requests.push(async move {
@@ -971,28 +1034,12 @@ impl Client {
             });
         }
 
-        let mut failure_count = 0;
-        let mut failures = None;
-        use futures::StreamExt;
-        while let Some((device, result)) = requests.next().await {
-            if let Err(error) = result {
-                failure_count += 1;
-                let failures = failures.get_or_insert_with(String::new);
-                if !failures.is_empty() {
-                    failures.push_str(", ");
-                }
-                let _ =
-                    std::fmt::Write::write_fmt(failures, format_args!("device {device}: {error}"));
-            }
-        }
-        if failure_count != 0 {
-            return classify_app_state_key_request_failures(
-                peer_count,
-                failure_count,
-                failures.as_deref().unwrap_or_default(),
-            );
-        }
-        Ok(AppStateKeyRequestDelivery::AllPeers)
+        collect_app_state_key_request_results(
+            &*self.runtime,
+            requests,
+            APP_STATE_KEY_REQUEST_TIMEOUT,
+        )
+        .await
     }
 
     /// Send an app state patch to the server for a given collection.
@@ -1185,6 +1232,39 @@ mod tests {
             .await;
 
         assert!(matches!(progress, AppStateKeyRequestProgress::KeysReady));
+    }
+
+    #[tokio::test]
+    async fn passive_key_request_fanout_is_bounded() {
+        async fn peer_request(
+            device: u16,
+            completes: bool,
+        ) -> (u16, std::result::Result<(), anyhow::Error>) {
+            if !completes {
+                std::future::pending::<()>().await;
+            }
+            (device, Ok(()))
+        }
+
+        let client =
+            crate::test_utils::create_test_client_with_name("appstate_fanout_timeout").await;
+        let requests = futures::stream::FuturesUnordered::new();
+        requests.push(peer_request(1, true));
+        requests.push(peer_request(2, false));
+
+        let delivery = tokio::time::timeout(
+            Duration::from_secs(1),
+            collect_app_state_key_request_results(
+                &*client.runtime,
+                requests,
+                Duration::from_millis(20),
+            ),
+        )
+        .await
+        .expect("fanout collection must finish")
+        .expect("one completed peer must preserve partial delivery");
+
+        assert_eq!(delivery, AppStateKeyRequestDelivery::SomePeers);
     }
 
     #[test]

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -687,13 +687,12 @@ impl Client {
         let mut guard = self.app_state_key_requests.lock().await;
         let now = wacore::time::Instant::now();
         for key_id in missing {
-            let hex_id = hex::encode(&key_id);
             let should = guard
-                .get(&hex_id)
+                .get(key_id.as_slice())
                 .map(|t| t.elapsed() > std::time::Duration::from_secs(24 * 3600))
                 .unwrap_or(true);
             if should {
-                guard.insert(hex_id, now);
+                guard.insert(key_id.clone(), now);
                 to_request.push(key_id);
             }
         }
@@ -706,11 +705,40 @@ impl Client {
             warn!("Failed to send app state key request: {e}");
             let mut guard = self.app_state_key_requests.lock().await;
             for key_id in &to_request {
-                guard.remove(&hex::encode(key_id));
+                guard.remove(key_id.as_slice());
             }
             return false;
         }
         true
+    }
+
+    async fn app_state_key_request_peers(&self) -> Result<Vec<Jid>, anyhow::Error> {
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        let own_jid = device_snapshot
+            .pn
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no own JID available for app-state key request"))?;
+        let current_device = own_jid.device;
+        let primary = own_jid.to_non_ad();
+        drop(device_snapshot);
+
+        let mut peers = match self.get_user_devices(std::slice::from_ref(&primary)).await {
+            Ok(devices) => devices,
+            Err(error) => {
+                warn!(
+                    "Own device-list query failed; requesting app-state keys from primary only: {error}"
+                );
+                vec![primary]
+            }
+        };
+        peers.retain(|jid| jid.device != current_device);
+        wacore::types::jid::sort_dedup_by_device(&mut peers);
+        if peers.is_empty() {
+            return Err(anyhow::anyhow!(
+                "no peer devices available for app-state key request"
+            ));
+        }
+        Ok(peers)
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.request_keys", level = "debug", skip_all, fields(count = raw_key_ids.len()), err(Debug)))]
@@ -718,20 +746,7 @@ impl Client {
         if raw_key_ids.is_empty() {
             return Ok(());
         }
-        let device_snapshot = self.persistence_manager.get_device_snapshot();
-        // The primary owns app-state keys; the companion has no self-session.
-        let own_jid = match device_snapshot.pn.as_ref() {
-            Some(j) => j.to_non_ad(),
-            None => {
-                return Err(anyhow::anyhow!(
-                    "no own JID available for app-state key request"
-                ));
-            }
-        };
-        drop(device_snapshot);
-        // Key delivery can complete before pairing leaves a primary LID session behind.
-        self.ensure_e2e_sessions(std::slice::from_ref(&own_jid))
-            .await?;
+        let peers = self.app_state_key_request_peers().await?;
         let key_ids: Vec<wa::message::AppStateSyncKeyId> = raw_key_ids
             .iter()
             .map(|k| wa::message::AppStateSyncKeyId {
@@ -748,17 +763,53 @@ impl Client {
             }),
             ..Default::default()
         };
-        self.send_message_impl(
-            own_jid,
-            &msg,
-            Some(self.generate_message_id()),
-            true,
-            false,
-            None,
-            vec![],
-            None,
-        )
-        .await?;
+
+        let peer_count = peers.len();
+        let results = futures::future::join_all(peers.into_iter().map(|peer| {
+            let msg = &msg;
+            async move {
+                let device = peer.device;
+                let result = async {
+                    self.ensure_e2e_sessions(std::slice::from_ref(&peer))
+                        .await?;
+                    self.send_message_impl(
+                        peer,
+                        msg,
+                        Some(self.generate_message_id()),
+                        true,
+                        false,
+                        None,
+                        Vec::new(),
+                        None,
+                    )
+                    .await
+                }
+                .await;
+                (device, result)
+            }
+        }))
+        .await;
+
+        let mut failures = Vec::new();
+        for (device, result) in results {
+            if let Err(error) = result {
+                failures.push(format!("device {device}: {error}"));
+            }
+        }
+        if failures.len() == peer_count {
+            return Err(anyhow::anyhow!(
+                "app-state key request failed for all {peer_count} peer device(s): {}",
+                failures.join(", ")
+            ));
+        }
+        if !failures.is_empty() {
+            warn!(
+                "App-state key request failed for {}/{} peer device(s): {}",
+                failures.len(),
+                peer_count,
+                failures.join(", ")
+            );
+        }
         Ok(())
     }
 

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -7,6 +7,14 @@ use super::*;
 /// fetching). WA Web fans these out under `Promise.all` (`Syncd/CollectionHandler`);
 /// bounded here because a snapshot can be multi-MB and a batch carries several.
 const APPSTATE_BLOB_DOWNLOAD_CONCURRENCY: usize = 4;
+const APP_STATE_KEY_REQUEST_DEDUP: Duration = Duration::from_secs(24 * 3600);
+const APP_STATE_KEY_PARTIAL_RETRY: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AppStateKeyRequestDelivery {
+    AllPeers,
+    SomePeers,
+}
 
 impl Client {
     pub(crate) async fn get_app_state_processor(&self) -> Arc<AppStateProcessor> {
@@ -675,7 +683,7 @@ impl Client {
     }
 
     /// Request missing app-state keys with dedup stamps.
-    /// On send failure, removes stamps so keys can be retried next sync.
+    /// Total failure removes stamps; partial fanout gets a short retry deadline.
     /// Returns true iff a fresh key request was actually sent (some ids passed the
     /// per-key dedup and the send succeeded), so the caller knows whether a re-share
     /// is plausibly inbound and worth waiting for.
@@ -689,27 +697,39 @@ impl Client {
         for key_id in missing {
             let should = guard
                 .get(key_id.as_slice())
-                .map(|t| t.elapsed() > std::time::Duration::from_secs(24 * 3600))
+                .map(|retry_at| now >= *retry_at)
                 .unwrap_or(true);
             if should {
-                guard.insert(key_id.clone(), now);
+                guard.insert(key_id.clone(), now + APP_STATE_KEY_REQUEST_DEDUP);
                 to_request.push(key_id);
             }
         }
-        guard.retain(|_, t| t.elapsed() < std::time::Duration::from_secs(24 * 3600));
+        guard.retain(|_, retry_at| now < *retry_at);
         drop(guard);
         if to_request.is_empty() {
             return false;
         }
-        if let Err(e) = self.request_app_state_keys(&to_request).await {
-            warn!("Failed to send app state key request: {e}");
-            let mut guard = self.app_state_key_requests.lock().await;
-            for key_id in &to_request {
-                guard.remove(key_id.as_slice());
+        match self.request_app_state_keys(&to_request).await {
+            Ok(AppStateKeyRequestDelivery::AllPeers) => true,
+            Ok(AppStateKeyRequestDelivery::SomePeers) => {
+                let retry_at = wacore::time::Instant::now() + APP_STATE_KEY_PARTIAL_RETRY;
+                let mut guard = self.app_state_key_requests.lock().await;
+                for key_id in &to_request {
+                    if let Some(deadline) = guard.get_mut(key_id.as_slice()) {
+                        *deadline = retry_at;
+                    }
+                }
+                true
             }
-            return false;
+            Err(e) => {
+                warn!("Failed to send app state key request: {e}");
+                let mut guard = self.app_state_key_requests.lock().await;
+                for key_id in &to_request {
+                    guard.remove(key_id.as_slice());
+                }
+                false
+            }
         }
-        true
     }
 
     async fn app_state_key_request_peers(&self) -> Result<Vec<Jid>, anyhow::Error> {
@@ -742,9 +762,12 @@ impl Client {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.request_keys", level = "debug", skip_all, fields(count = raw_key_ids.len()), err(Debug)))]
-    async fn request_app_state_keys(&self, raw_key_ids: &[Vec<u8>]) -> Result<(), anyhow::Error> {
+    async fn request_app_state_keys(
+        &self,
+        raw_key_ids: &[Vec<u8>],
+    ) -> Result<AppStateKeyRequestDelivery, anyhow::Error> {
         if raw_key_ids.is_empty() {
-            return Ok(());
+            return Ok(AppStateKeyRequestDelivery::AllPeers);
         }
         let peers = self.app_state_key_request_peers().await?;
         let key_ids: Vec<wa::message::AppStateSyncKeyId> = raw_key_ids
@@ -809,8 +832,9 @@ impl Client {
                 peer_count,
                 failures.join(", ")
             );
+            return Ok(AppStateKeyRequestDelivery::SomePeers);
         }
-        Ok(())
+        Ok(AppStateKeyRequestDelivery::AllPeers)
     }
 
     /// Send an app state patch to the server for a given collection.

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -719,12 +719,8 @@ impl Client {
             return Ok(());
         }
         let device_snapshot = self.persistence_manager.get_device_snapshot();
-        // Address the request to the PRIMARY (device 0), not our own device JID: this is
-        // a peer message and `device_snapshot.pn` carries OUR device number, so sending
-        // it as-is encrypts to ourselves (no self-session exists) and fails with
-        // "session ... not found". The primary is the app-state key source and we hold a
-        // session with it from pairing. Mirrors whatsmeow's `ownID.ToNonAD()`.
-        let own_jid = match device_snapshot.pn.clone() {
+        // The primary owns app-state keys; the companion has no self-session.
+        let own_jid = match device_snapshot.pn.as_ref() {
             Some(j) => j.to_non_ad(),
             None => {
                 return Err(anyhow::anyhow!(
@@ -732,6 +728,10 @@ impl Client {
                 ));
             }
         };
+        drop(device_snapshot);
+        // Key delivery can complete before pairing leaves a primary LID session behind.
+        self.ensure_e2e_sessions(std::slice::from_ref(&own_jid))
+            .await?;
         let key_ids: Vec<wa::message::AppStateSyncKeyId> = raw_key_ids
             .iter()
             .map(|k| wa::message::AppStateSyncKeyId {

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -697,8 +697,7 @@ impl Client {
         for key_id in missing {
             let should = guard
                 .get(key_id.as_slice())
-                .map(|retry_at| now >= *retry_at)
-                .unwrap_or(true);
+                .is_none_or(|retry_at| now >= *retry_at);
             if should {
                 guard.insert(key_id.clone(), now + APP_STATE_KEY_REQUEST_DEDUP);
                 to_request.push(key_id);

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -12,6 +12,12 @@ const APP_STATE_KEY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const APP_STATE_KEY_PARTIAL_RETRY: Duration = Duration::from_secs(10);
 const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 
+fn initial_app_state_key_retry(timeout: Duration) -> Duration {
+    (timeout / 2)
+        .max(Duration::from_millis(1))
+        .min(APP_STATE_KEY_PARTIAL_RETRY)
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AppStateKeyRequestDelivery {
     AllPeers,
@@ -797,7 +803,7 @@ impl Client {
         }
         let deadline = wacore::time::Instant::now() + timeout;
         let backend = self.persistence_manager.backend();
-        let mut retry_after = APP_STATE_KEY_PARTIAL_RETRY;
+        let mut retry_after = initial_app_state_key_retry(timeout);
         loop {
             let listener = self.initial_keys_synced_notifier.listen();
             remove_available_app_state_keys(&*backend, &mut missing).await;
@@ -924,7 +930,10 @@ impl Client {
             };
         };
 
-        match self.request_app_state_keys(&to_request).await {
+        match self
+            .request_app_state_keys(&to_request, retry_after.min(APP_STATE_KEY_REQUEST_TIMEOUT))
+            .await
+        {
             Ok(AppStateKeyRequestDelivery::AllPeers) => AppStateKeyRequestSchedule {
                 retry_at: next_retry_at,
                 sent: true,
@@ -954,7 +963,7 @@ impl Client {
                     }
                 }
                 AppStateKeyRequestSchedule {
-                    retry_at: wacore::time::Instant::now() + retry_after,
+                    retry_at: requested_retry_at,
                     sent: false,
                 }
             }
@@ -987,6 +996,7 @@ impl Client {
     async fn request_app_state_keys(
         &self,
         raw_key_ids: &[&[u8]],
+        fanout_timeout: Duration,
     ) -> Result<AppStateKeyRequestDelivery, anyhow::Error> {
         if raw_key_ids.is_empty() {
             return Ok(AppStateKeyRequestDelivery::AllPeers);
@@ -1034,12 +1044,7 @@ impl Client {
             });
         }
 
-        collect_app_state_key_request_results(
-            &*self.runtime,
-            requests,
-            APP_STATE_KEY_REQUEST_TIMEOUT,
-        )
-        .await
+        collect_app_state_key_request_results(&*self.runtime, requests, fanout_timeout).await
     }
 
     /// Send an app state patch to the server for a given collection.
@@ -1328,6 +1333,18 @@ mod tests {
                 .get(key_id.as_slice())
                 .copied(),
             Some(schedule.retry_at)
+        );
+    }
+
+    #[test]
+    fn ordinary_key_wait_leaves_time_for_a_retry() {
+        let retry = initial_app_state_key_retry(APP_STATE_KEY_REQUEST_TIMEOUT);
+
+        assert_eq!(retry, Duration::from_secs(5));
+        assert!(retry < APP_STATE_KEY_REQUEST_TIMEOUT);
+        assert_eq!(
+            initial_app_state_key_retry(Duration::from_secs(180)),
+            APP_STATE_KEY_PARTIAL_RETRY
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -28,6 +28,24 @@ enum AppStateKeyRequestProgress {
     TimedOut,
 }
 
+#[cold]
+#[inline(never)]
+fn classify_app_state_key_request_failures(
+    peer_count: usize,
+    failure_count: usize,
+    failures: &str,
+) -> Result<AppStateKeyRequestDelivery, anyhow::Error> {
+    if failure_count == peer_count {
+        return Err(anyhow::anyhow!(
+            "app-state key request failed for all {peer_count} peer device(s): {failures}"
+        ));
+    }
+    warn!(
+        "App-state key request failed for {failure_count}/{peer_count} peer device(s): {failures}"
+    );
+    Ok(AppStateKeyRequestDelivery::SomePeers)
+}
+
 async fn app_state_keys_available(
     backend: &dyn crate::store::traits::Backend,
     key_ids: &[Vec<u8>],
@@ -65,6 +83,13 @@ fn finalize_app_state_key_request_peers(
     current_device: u16,
     primary: Jid,
 ) -> Result<Vec<Jid>, anyhow::Error> {
+    // WA Web derives every sibling address from the account's PN namespace.
+    for peer in &mut peers {
+        peer.user.clone_from(&primary.user);
+        peer.server = primary.server;
+        peer.agent = primary.agent;
+        peer.integrator = primary.integrator;
+    }
     peers.retain(|jid| jid.device != current_device);
     wacore::types::jid::sort_dedup_by_device(&mut peers);
     if peers.is_empty() && current_device != primary.device {
@@ -921,9 +946,10 @@ impl Client {
         };
 
         let peer_count = peers.len();
-        let results = futures::future::join_all(peers.into_iter().map(|peer| {
+        let mut requests = futures::stream::FuturesUnordered::new();
+        for peer in peers {
             let msg = &msg;
-            async move {
+            requests.push(async move {
                 let device = peer.device;
                 let result = async {
                     self.ensure_e2e_sessions(std::slice::from_ref(&peer))
@@ -942,30 +968,29 @@ impl Client {
                 }
                 .await;
                 (device, result)
-            }
-        }))
-        .await;
+            });
+        }
 
-        let mut failures = Vec::new();
-        for (device, result) in results {
+        let mut failure_count = 0;
+        let mut failures = None;
+        use futures::StreamExt;
+        while let Some((device, result)) = requests.next().await {
             if let Err(error) = result {
-                failures.push(format!("device {device}: {error}"));
+                failure_count += 1;
+                let failures = failures.get_or_insert_with(String::new);
+                if !failures.is_empty() {
+                    failures.push_str(", ");
+                }
+                let _ =
+                    std::fmt::Write::write_fmt(failures, format_args!("device {device}: {error}"));
             }
         }
-        if failures.len() == peer_count {
-            return Err(anyhow::anyhow!(
-                "app-state key request failed for all {peer_count} peer device(s): {}",
-                failures.join(", ")
-            ));
-        }
-        if !failures.is_empty() {
-            warn!(
-                "App-state key request failed for {}/{} peer device(s): {}",
-                failures.len(),
+        if failure_count != 0 {
+            return classify_app_state_key_request_failures(
                 peer_count,
-                failures.join(", ")
+                failure_count,
+                failures.as_deref().unwrap_or_default(),
             );
-            return Ok(AppStateKeyRequestDelivery::SomePeers);
         }
         Ok(AppStateKeyRequestDelivery::AllPeers)
     }
@@ -1128,14 +1153,26 @@ mod tests {
         let notifier = client.initial_keys_synced_notifier.clone();
         let writer = backend.clone();
         let stored_id = key_id.clone();
+        let (fanout_polled_tx, fanout_polled_rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            fanout_polled_rx.await.expect("fanout must be polled");
             writer
-                .set_sync_key(&stored_id, crate::store::traits::AppStateSyncKey::default())
+                .set_sync_key(
+                    &stored_id,
+                    crate::store::traits::AppStateSyncKey {
+                        key_data: vec![7; 32],
+                        ..Default::default()
+                    },
+                )
                 .await
                 .expect("store recovered key");
             notifier.notify(usize::MAX);
         });
+
+        let slow_fanout = async move {
+            let _ = fanout_polled_tx.send(());
+            std::future::pending::<AppStateKeyRequestSchedule>().await
+        };
 
         let progress = client
             .await_app_state_key_request(
@@ -1143,7 +1180,7 @@ mod tests {
                 std::slice::from_ref(&key_id),
                 wacore::time::Instant::now() + Duration::from_secs(1),
                 listener,
-                std::future::pending::<AppStateKeyRequestSchedule>(),
+                slow_fanout,
             )
             .await;
 
@@ -1157,6 +1194,23 @@ mod tests {
             .expect("companion fallback");
         assert_eq!(peers, vec![primary.clone()]);
         assert!(finalize_app_state_key_request_peers(Vec::new(), 0, primary).is_err());
+    }
+
+    #[test]
+    fn app_state_peers_use_the_own_pn_namespace() {
+        let primary = Jid::pn("5511000000000");
+        let peers = finalize_app_state_key_request_peers(
+            vec![
+                Jid::lid_device("100000000000001", 0),
+                Jid::lid_device("100000000000001", 7),
+                Jid::pn_device("5511000000000", 7),
+            ],
+            33,
+            primary.clone(),
+        )
+        .expect("peer devices");
+
+        assert_eq!(peers, vec![primary, Jid::pn_device("5511000000000", 7)]);
     }
 
     #[tokio::test]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -249,6 +249,8 @@ impl Client {
             signal_flush_test_block: AtomicBool::new(false),
             #[cfg(test)]
             signal_flush_test_in_attempt: AtomicU32::new(0),
+            #[cfg(test)]
+            app_state_key_share_prepare_test_failures: AtomicU32::new(0),
             custom_enc_handlers: std::sync::OnceLock::new(),
             inbound_durability_hook: std::sync::OnceLock::new(),
             retry_admission: std::sync::OnceLock::new(),

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -15,6 +15,8 @@ pub struct FlushScope {
     count: AtomicUsize,
     idle: event_listener::Event,
     closed: std::sync::Mutex<bool>,
+    #[cfg(test)]
+    track_rejections: AtomicUsize,
 }
 
 impl Default for FlushScope {
@@ -29,6 +31,8 @@ impl FlushScope {
             count: AtomicUsize::new(0),
             idle: event_listener::Event::new(),
             closed: std::sync::Mutex::new(false),
+            #[cfg(test)]
+            track_rejections: AtomicUsize::new(0),
         }
     }
 
@@ -48,6 +52,8 @@ impl FlushScope {
         {
             let closed = self.closed.lock().unwrap_or_else(|e| e.into_inner());
             if *closed {
+                #[cfg(test)]
+                self.track_rejections.fetch_add(1, Ordering::Relaxed);
                 return None;
             }
             self.count.fetch_add(1, Ordering::Relaxed);
@@ -112,6 +118,11 @@ impl FlushScope {
     #[cfg(test)]
     pub fn pending(&self) -> usize {
         self.count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub fn track_rejections(&self) -> usize {
+        self.track_rejections.load(Ordering::Relaxed)
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,6 +3,7 @@ use crate::types::events::Event;
 use crate::types::message::MessageInfo;
 use log::{debug, warn};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use wacore::libsignal::crypto::DecryptionError;
 use wacore::libsignal::protocol::SenderKeyDistributionMessage;
 use wacore::libsignal::protocol::SenderKeyStore;
@@ -100,10 +101,54 @@ pub(crate) struct PlaintextHandleOutcome {
     skdm_only: bool,
 }
 
+const INBOUND_COMMIT_PENDING: u8 = 0;
+const INBOUND_COMMIT_DURABLE: u8 = 1;
+const INBOUND_COMMIT_DROPPED: u8 = 2;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InboundCommitTicketState {
+    Pending,
+    Durable,
+    Dropped,
+}
+
+#[derive(Clone)]
+pub(crate) struct InboundCommitTicket(Arc<AtomicU8>);
+
+impl InboundCommitTicket {
+    fn new() -> Self {
+        Self(Arc::new(AtomicU8::new(INBOUND_COMMIT_PENDING)))
+    }
+
+    fn state(&self) -> InboundCommitTicketState {
+        match self.0.load(Ordering::Acquire) {
+            INBOUND_COMMIT_DURABLE => InboundCommitTicketState::Durable,
+            INBOUND_COMMIT_DROPPED => InboundCommitTicketState::Dropped,
+            _ => InboundCommitTicketState::Pending,
+        }
+    }
+
+    fn resolve(&self, state: u8) {
+        let _ = self.0.compare_exchange(
+            INBOUND_COMMIT_PENDING,
+            state,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    fn mark_durable(&self) {
+        self.resolve(INBOUND_COMMIT_DURABLE);
+    }
+
+    fn mark_dropped(&self) {
+        self.resolve(INBOUND_COMMIT_DROPPED);
+    }
+}
+
 pub(crate) enum InboundCommitState {
     Durable,
-    Deferred,
+    Deferred(Option<InboundCommitTicket>),
     Failed,
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -100,6 +100,13 @@ pub(crate) struct PlaintextHandleOutcome {
     skdm_only: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InboundCommitState {
+    Durable,
+    Deferred,
+    Failed,
+}
+
 /// A decrypted session plaintext buffered during the locked decrypt loop and
 /// handled after the per-sender session lock is released.
 struct DeferredPlaintext {

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -28,9 +28,29 @@ const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 #[derive(Default)]
 struct BatchState {
     entries: Vec<InboundMessage>,
+    /// A dropped request must not outlive the reconnect that discarded it.
+    commit_ticket: Option<InboundCommitTicket>,
     /// Sum of `message_encoded_len` of the entries, for the byte cap.
     bytes: usize,
     timer_armed: bool,
+}
+
+struct PendingInboundBatch {
+    entries: Vec<InboundMessage>,
+    commit_ticket: Option<InboundCommitTicket>,
+}
+
+impl PendingInboundBatch {
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn mark_dropped(self) -> Vec<InboundMessage> {
+        if let Some(ticket) = self.commit_ticket {
+            ticket.mark_dropped();
+        }
+        self.entries
+    }
 }
 
 pub(crate) struct InboundCommitBatcher {
@@ -94,12 +114,15 @@ impl InboundCommitBatcher {
     }
 
     /// Take the accumulated batch, invalidating any armed timer.
-    fn take(&self) -> Vec<InboundMessage> {
+    fn take(&self) -> PendingInboundBatch {
         let mut state = self.lock();
         self.epoch.fetch_add(1, Ordering::AcqRel);
         state.bytes = 0;
         state.timer_armed = false;
-        std::mem::take(&mut state.entries)
+        PendingInboundBatch {
+            entries: std::mem::take(&mut state.entries),
+            commit_ticket: state.commit_ticket.take(),
+        }
     }
 
     pub(crate) fn is_active(&self) -> bool {
@@ -138,7 +161,7 @@ impl InboundCommitBatcher {
     /// — staying active with a widened semaphore would batch live traffic
     /// while flushes hold only 1 of its permits.
     pub(crate) fn force_live_dropping_entries(&self) {
-        let dropped = self.take();
+        let dropped = self.take().mark_dropped();
         if !dropped.is_empty() {
             log::warn!(
                 "Dropping {} uncommitted inbound messages on forced drain exit; the server will redeliver them",
@@ -155,7 +178,7 @@ impl InboundCommitBatcher {
     /// advances have no rows; flushing them later would make each redelivery
     /// an ackable duplicate).
     pub(crate) fn reset(&self) -> bool {
-        let dropped = self.take();
+        let dropped = self.take().mark_dropped();
         if !dropped.is_empty() {
             log::debug!(
                 "Dropping {} uncommitted inbound messages; the server will redeliver them",
@@ -192,11 +215,15 @@ impl Client {
 struct ReinsertGuard<'a> {
     batcher: &'a InboundCommitBatcher,
     items: Option<std::sync::Arc<[InboundMessage]>>,
+    commit_ticket: Option<InboundCommitTicket>,
 }
 
 impl ReinsertGuard<'_> {
-    fn disarm(&mut self) {
+    fn mark_durable(&mut self) {
         self.items = None;
+        if let Some(ticket) = self.commit_ticket.take() {
+            ticket.mark_durable();
+        }
     }
 }
 
@@ -219,6 +246,13 @@ impl Drop for ReinsertGuard<'_> {
         // flushes cover the gap regardless.
         state.timer_armed = false;
         state.entries = restored;
+        if let Some(ticket) = self.commit_ticket.take() {
+            if state.commit_ticket.is_some() {
+                ticket.mark_dropped();
+            } else {
+                state.commit_ticket = Some(ticket);
+            }
+        }
         log::warn!(
             "Restored {} uncommitted inbound messages to the batch after a failed or cancelled commit",
             state.entries.len()
@@ -227,20 +261,28 @@ impl Drop for ReinsertGuard<'_> {
 }
 
 impl Client {
-    /// Queue a decrypted message for the next batch commit. Returns the armed
-    /// timer epoch when this push started a fresh batch (the caller spawns the
-    /// timeout flush), `None` otherwise.
-    fn enqueue_inbound_commit(&self, item: InboundMessage) -> Option<u64> {
+    fn enqueue_inbound_commit(
+        &self,
+        item: InboundMessage,
+        track_commit: bool,
+    ) -> (Option<u64>, Option<InboundCommitTicket>) {
         let batcher = &self.inbound_commit_batch;
         let mut state = batcher.lock();
         state.bytes += waproto::codec::message_encoded_len(&item.message);
         state.entries.push(item);
-        if !state.timer_armed {
+        let ticket = track_commit.then(|| {
+            state
+                .commit_ticket
+                .get_or_insert_with(InboundCommitTicket::new)
+                .clone()
+        });
+        let epoch = if !state.timer_armed {
             state.timer_armed = true;
             Some(batcher.epoch.load(Ordering::Acquire))
         } else {
             None
-        }
+        };
+        (epoch, ticket)
     }
 
     /// Batch a message decrypted while the offline drain is active, or commit
@@ -248,13 +290,14 @@ impl Client {
     pub(crate) async fn commit_or_batch_inbound(
         self: &Arc<Self>,
         item: InboundMessage,
+        track_commit: bool,
     ) -> InboundCommitState {
         if !self.inbound_commit_batch.is_active() {
             // Arc::from([item]) builds the event/hook slice in one allocation;
             // a Vec would add an alloc+dealloc per live message (measured
             // ~18ns and 2x the allocations of this step).
             return if self
-                .commit_inbound_batch(std::sync::Arc::from([item]), BatchOrigin::Live)
+                .commit_inbound_batch(std::sync::Arc::from([item]), BatchOrigin::Live, None)
                 .await
             {
                 InboundCommitState::Durable
@@ -262,7 +305,8 @@ impl Client {
                 InboundCommitState::Failed
             };
         }
-        if let Some(epoch) = self.enqueue_inbound_commit(item) {
+        let (timer_epoch, ticket) = self.enqueue_inbound_commit(item, track_commit);
+        if let Some(epoch) = timer_epoch {
             // Weak: a sleeper must not keep the whole Client graph alive for
             // up to 3s after the app drops its handle.
             let client = Arc::downgrade(self);
@@ -283,7 +327,7 @@ impl Client {
                 }))
                 .detach();
         }
-        InboundCommitState::Deferred
+        InboundCommitState::Deferred(ticket)
     }
 
     /// Size/byte-cap check, run at the end of stanza processing while the
@@ -295,9 +339,12 @@ impl Client {
             state.entries.len() >= MAX_BATCH_MESSAGES || state.bytes >= MAX_BATCH_BYTES
         };
         if over {
-            let batch = self.inbound_commit_batch.take();
+            let PendingInboundBatch {
+                entries,
+                commit_ticket,
+            } = self.inbound_commit_batch.take();
             let durable = self
-                .commit_inbound_batch(batch.into(), BatchOrigin::OfflineDrain)
+                .commit_inbound_batch(entries.into(), BatchOrigin::OfflineDrain, commit_ticket)
                 .await;
             // A durable commit may be the retry that clears a deferred
             // drain→live transition (failed end-of-drain tail).
@@ -366,8 +413,12 @@ impl Client {
             // flushed". Idempotent and cheap when the cache is already clean.
             self.drain_signal_flush_reporting().await
         } else {
-            self.commit_inbound_batch(batch.into(), BatchOrigin::OfflineDrain)
-                .await
+            self.commit_inbound_batch(
+                batch.entries.into(),
+                BatchOrigin::OfflineDrain,
+                batch.commit_ticket,
+            )
+            .await
         };
         if let Some(generation) = expected_generation
             && self.connection_generation.load(Ordering::Acquire) != generation
@@ -477,8 +528,12 @@ impl Client {
             let durable = if batch.is_empty() {
                 true
             } else {
-                self.commit_inbound_batch(batch.into(), BatchOrigin::OfflineDrain)
-                    .await
+                self.commit_inbound_batch(
+                    batch.entries.into(),
+                    BatchOrigin::OfflineDrain,
+                    batch.commit_ticket,
+                )
+                .await
             };
             // Permit still held: no stanza can be mid-decrypt while the cache
             // is settled. Flush-before-clear preserves in-flight sender-key
@@ -611,8 +666,12 @@ impl Client {
         // stanza — widening to 64 permits first would let new workers be
         // mid-decrypt under it. The deferred-retry loop completes the
         // transition moments later, outside any raw-flush window.
-        self.commit_inbound_batch(batch.into(), BatchOrigin::OfflineDrain)
-            .await
+        self.commit_inbound_batch(
+            batch.entries.into(),
+            BatchOrigin::OfflineDrain,
+            batch.commit_ticket,
+        )
+        .await
     }
 
     /// Commit one batch: durable buffer → Signal flush → hook → clear buffer →
@@ -640,14 +699,18 @@ impl Client {
         self: &Arc<Self>,
         items: std::sync::Arc<[InboundMessage]>,
         origin: BatchOrigin,
+        commit_ticket: Option<InboundCommitTicket>,
     ) -> bool {
+        let is_drain = matches!(origin, BatchOrigin::OfflineDrain);
+        debug_assert!(is_drain || commit_ticket.is_none());
         if items.is_empty() {
+            debug_assert!(commit_ticket.is_none());
             return true;
         }
-        let is_drain = matches!(origin, BatchOrigin::OfflineDrain);
         let mut reinsert = ReinsertGuard {
             batcher: &self.inbound_commit_batch,
             items: is_drain.then(|| std::sync::Arc::clone(&items)),
+            commit_ticket,
         };
         #[cfg(test)]
         if self
@@ -733,7 +796,7 @@ impl Client {
             // Rows durable and Signal flushed: from here on a cancelled
             // future must not restore the entries — redelivery replays from
             // the rows.
-            reinsert.disarm();
+            reinsert.mark_durable();
 
             if let Err(e) = hook.on_messages(self.clone(), &items).await {
                 log::warn!(
@@ -766,7 +829,7 @@ impl Client {
             if is_drain && !self.drain_signal_flush_reporting().await {
                 return false;
             }
-            reinsert.disarm();
+            reinsert.mark_durable();
         }
 
         // Acks first (everything durable by now): handle_event runs
@@ -856,7 +919,7 @@ mod tests {
 
         client.inbound_commit_batch.reset();
         for id in ["B1", "B2", "B3"] {
-            client.commit_or_batch_inbound(item(id)).await;
+            client.commit_or_batch_inbound(item(id), false).await;
         }
         assert!(
             hook.batches.lock().expect("hook lock").is_empty(),
@@ -900,7 +963,7 @@ mod tests {
         let _ = client.inbound_durability_hook.set(hook.clone());
         let (handler, rx) = ChannelEventHandler::new();
         client.core.event_bus.add_handler(handler);
-        client.commit_or_batch_inbound(item("L1")).await;
+        client.commit_or_batch_inbound(item("L1"), false).await;
 
         assert_eq!(
             hook.batches.lock().expect("hook lock").clone(),
@@ -923,7 +986,9 @@ mod tests {
         let _ = client.inbound_durability_hook.set(hook.clone());
 
         for i in 0..MAX_BATCH_MESSAGES {
-            client.commit_or_batch_inbound(item(&format!("S{i}"))).await;
+            client
+                .commit_or_batch_inbound(item(&format!("S{i}")), false)
+                .await;
         }
         client.maybe_flush_inbound_commits().await;
 
@@ -945,8 +1010,8 @@ mod tests {
         let (handler, rx) = ChannelEventHandler::new();
         client.core.event_bus.add_handler(handler);
 
-        client.commit_or_batch_inbound(item("N1")).await;
-        client.commit_or_batch_inbound(item("N2")).await;
+        client.commit_or_batch_inbound(item("N1"), false).await;
+        client.commit_or_batch_inbound(item("N2"), false).await;
         client
             .flush_inbound_commits_under_permit(false, None, None)
             .await;
@@ -975,13 +1040,13 @@ mod tests {
         let (handler, rx) = ChannelEventHandler::new();
         client.core.event_bus.add_handler(handler);
 
-        client.commit_or_batch_inbound(item("T1")).await;
-        client.commit_or_batch_inbound(item("T2")).await;
+        client.commit_or_batch_inbound(item("T1"), false).await;
+        client.commit_or_batch_inbound(item("T2"), false).await;
         let generation = client.connection_generation.load(Ordering::Acquire);
         client.finish_inbound_commit_drain(generation).await;
         assert!(!client.inbound_commit_batch.is_active());
         // A message arriving after the transition commits immediately as Live.
-        client.commit_or_batch_inbound(item("T3")).await;
+        client.commit_or_batch_inbound(item("T3"), false).await;
 
         let batches = hook.batches.lock().expect("hook lock").clone();
         assert_eq!(
@@ -1014,7 +1079,7 @@ mod tests {
         let (handler, rx) = ChannelEventHandler::new();
         client.core.event_bus.add_handler(handler);
 
-        client.commit_or_batch_inbound(item("C1")).await;
+        client.commit_or_batch_inbound(item("C1"), false).await;
         client.inbound_commit_batch.reset();
         client
             .flush_inbound_commits_under_permit(false, None, None)
@@ -1022,6 +1087,21 @@ mod tests {
 
         assert!(hook.batches.lock().expect("hook lock").is_empty());
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn reset_cancels_a_tracked_deferred_commit() {
+        let client = create_test_client_with_failing_http("batch_tracked_reset").await;
+        client.inbound_commit_batch.reset();
+
+        let ticket = match client.commit_or_batch_inbound(item("C2"), true).await {
+            InboundCommitState::Deferred(Some(ticket)) => ticket,
+            _ => panic!("drain commit must be tracked"),
+        };
+        assert_eq!(ticket.state(), InboundCommitTicketState::Pending);
+
+        assert!(client.inbound_commit_batch.reset());
+        assert_eq!(ticket.state(), InboundCommitTicketState::Dropped);
     }
 
     // A failed end-of-drain tail must NOT switch to live mode: the restored
@@ -1040,7 +1120,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
 
-        client.commit_or_batch_inbound(item("T1")).await;
+        client.commit_or_batch_inbound(item("T1"), false).await;
 
         client
             .inbound_commit_batch
@@ -1064,7 +1144,7 @@ mod tests {
             .inbound_commit_batch
             .fail_commits
             .store(false, Ordering::Release);
-        client.commit_or_batch_inbound(item("T2")).await;
+        client.commit_or_batch_inbound(item("T2"), false).await;
         assert!(
             hook.batches.lock().expect("hook lock").is_empty(),
             "deferred mode must accumulate, not commit live"
@@ -1110,7 +1190,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
 
-        client.commit_or_batch_inbound(item("R1")).await;
+        client.commit_or_batch_inbound(item("R1"), false).await;
         client
             .inbound_commit_batch
             .fail_commits
@@ -1149,7 +1229,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
 
-        client.commit_or_batch_inbound(item("F1")).await;
+        client.commit_or_batch_inbound(item("F1"), false).await;
         client
             .inbound_commit_batch
             .fail_flushes
@@ -1214,7 +1294,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
 
-        client.commit_or_batch_inbound(item("B1")).await;
+        client.commit_or_batch_inbound(item("B1"), false).await;
         client
             .inbound_commit_batch
             .fail_commits
@@ -1303,7 +1383,7 @@ mod tests {
         assert!(client.try_buffer_offline_receipt(&buffered));
         assert_eq!(client.offline_receipt_buffer.lock().expect("buf").len(), 1);
 
-        client.commit_or_batch_inbound(item("D1")).await;
+        client.commit_or_batch_inbound(item("D1"), false).await;
         assert!(
             client
                 .flush_inbound_commits_under_permit(false, None, None)

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -245,15 +245,22 @@ impl Client {
 
     /// Batch a message decrypted while the offline drain is active, or commit
     /// immediately (batch of one) on the live path.
-    pub(crate) async fn commit_or_batch_inbound(self: &Arc<Self>, item: InboundMessage) {
+    pub(crate) async fn commit_or_batch_inbound(
+        self: &Arc<Self>,
+        item: InboundMessage,
+    ) -> InboundCommitState {
         if !self.inbound_commit_batch.is_active() {
             // Arc::from([item]) builds the event/hook slice in one allocation;
             // a Vec would add an alloc+dealloc per live message (measured
             // ~18ns and 2x the allocations of this step).
-            let _ = self
+            return if self
                 .commit_inbound_batch(std::sync::Arc::from([item]), BatchOrigin::Live)
-                .await;
-            return;
+                .await
+            {
+                InboundCommitState::Durable
+            } else {
+                InboundCommitState::Failed
+            };
         }
         if let Some(epoch) = self.enqueue_inbound_commit(item) {
             // Weak: a sleeper must not keep the whole Client graph alive for
@@ -276,6 +283,7 @@ impl Client {
                 }))
                 .detach();
         }
+        InboundCommitState::Deferred
     }
 
     /// Size/byte-cap check, run at the end of stanza processing while the
@@ -408,6 +416,8 @@ impl Client {
         // the durable flush that triggered this completion persisted their
         // Signal state.
         self.flush_offline_receipts();
+        // Key-share jobs may have observed the earlier failed transition.
+        self.offline_sync_notifier.notify(usize::MAX);
         log::info!("Deferred drain-to-live transition completed after a durable flush");
     }
 

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -9,7 +9,7 @@ impl Client {
         self: &Arc<Self>,
         msg: wa::Message,
         info: &Arc<MessageInfo>,
-    ) {
+    ) -> InboundCommitState {
         use wacore::proto_helpers::MessageExt;
         wacore::telemetry::recv("decrypted");
         self.stats.record_message_received();
@@ -56,7 +56,7 @@ impl Client {
                     .origin(wacore::types::events::BatchOrigin::Live)
                     .build(),
             ));
-            return;
+            return InboundCommitState::Durable;
         }
 
         // Live traffic commits (and acks) as a batch of one; during the
@@ -69,7 +69,7 @@ impl Client {
                 .info(info)
                 .build(),
         )
-        .await;
+        .await
     }
 
     /// Acknowledge a received message so the server drops it from the offline

--- a/src/message/dispatch.rs
+++ b/src/message/dispatch.rs
@@ -9,6 +9,7 @@ impl Client {
         self: &Arc<Self>,
         msg: wa::Message,
         info: &Arc<MessageInfo>,
+        track_commit: bool,
     ) -> InboundCommitState {
         use wacore::proto_helpers::MessageExt;
         wacore::telemetry::recv("decrypted");
@@ -68,6 +69,7 @@ impl Client {
                 .message(dispatch_msg)
                 .info(info)
                 .build(),
+            track_commit,
         )
         .await
     }

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -45,6 +45,7 @@ impl Client {
                                 .message(Arc::new(msg))
                                 .info(Arc::clone(info))
                                 .build(),
+                            false,
                         )
                         .await;
                     }
@@ -149,7 +150,7 @@ mod tests {
             Arc::from([test_item("MSG_OK_1"), test_item("MSG_OK_2")]);
         let infos: Vec<_> = items.iter().map(|i| Arc::clone(&i.info)).collect();
         client
-            .commit_inbound_batch(Arc::clone(&items), BatchOrigin::OfflineDrain)
+            .commit_inbound_batch(Arc::clone(&items), BatchOrigin::OfflineDrain, None)
             .await;
 
         assert_eq!(hook.calls.load(Ordering::SeqCst), 1, "one commit per batch");
@@ -192,6 +193,7 @@ mod tests {
                     .info(Arc::clone(&info))
                     .build()]),
                 BatchOrigin::OfflineDrain,
+                None,
             )
             .await;
 

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -704,7 +704,7 @@ impl Client {
             info.id,
             info.source.sender.observe()
         );
-        self.dispatch_parsed_message(msg, info).await;
+        self.dispatch_parsed_message(msg, info, false).await;
     }
 
     /// Resolve `target_sender` for a msmsg stanza: echo from `<meta>` when

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1559,15 +1559,23 @@ impl Client {
                 ..Default::default()
             })
         } else {
-            let commit_state = self.dispatch_parsed_message(msg, info).await;
+            let commit_state = self
+                .dispatch_parsed_message(msg, info, app_state_key_share_job.is_some())
+                .await;
             if let Some((requester, request)) = app_state_key_share_job {
-                if commit_state == InboundCommitState::Failed {
-                    warn!(
-                        "[msg:{}] Deferring app-state key-share recovery to the requester's retry because the inbound request was not durable",
-                        info.id
-                    );
-                } else {
-                    self.schedule_app_state_sync_key_share(requester, request);
+                match commit_state {
+                    InboundCommitState::Durable => {
+                        self.schedule_app_state_sync_key_share(requester, request, None);
+                    }
+                    InboundCommitState::Deferred(Some(ticket)) => {
+                        self.schedule_app_state_sync_key_share(requester, request, Some(ticket));
+                    }
+                    InboundCommitState::Deferred(None) | InboundCommitState::Failed => {
+                        warn!(
+                            "[msg:{}] Deferring app-state key-share recovery to the requester's retry because the inbound request was not durable",
+                            info.id
+                        );
+                    }
                 }
             }
             Ok(PlaintextHandleOutcome {

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1484,19 +1484,7 @@ impl Client {
             && let Some(request) = protocol_msg.app_state_sync_key_request.as_option()
         {
             if info.source.is_from_me {
-                match self.prepare_app_state_sync_key_share(request).await {
-                    Ok((message, message_id)) => {
-                        app_state_key_share_job =
-                            Some((info.source.sender.clone(), message, message_id));
-                    }
-                    Err(error) => {
-                        warn!(
-                            "[msg:{}] Failed to prepare app_state_sync_key_share for {}: {error:?}",
-                            info.id,
-                            info.source.sender.observe()
-                        );
-                    }
-                }
+                app_state_key_share_job = Some((info.source.sender.clone(), request.clone()));
             } else {
                 warn!(
                     "[msg:{}] Dropping app_state_sync_key_request from non-self sender {}",
@@ -1572,14 +1560,14 @@ impl Client {
             })
         } else {
             let commit_state = self.dispatch_parsed_message(msg, info).await;
-            if let Some((requester, message, message_id)) = app_state_key_share_job {
+            if let Some((requester, request)) = app_state_key_share_job {
                 if commit_state == InboundCommitState::Failed {
                     warn!(
                         "[msg:{}] Deferring app-state key-share recovery to the requester's retry because the inbound request was not durable",
                         info.id
                     );
                 } else {
-                    self.schedule_app_state_sync_key_share(requester, message, message_id);
+                    self.schedule_app_state_sync_key_share(requester, request);
                 }
             }
             Ok(PlaintextHandleOutcome {

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1479,19 +1479,23 @@ impl Client {
             }
         }
 
+        let mut app_state_key_share_job = None;
         if let Some(protocol_msg) = msg.protocol_message.as_option()
             && let Some(request) = protocol_msg.app_state_sync_key_request.as_option()
         {
             if info.source.is_from_me {
-                if let Err(error) = self
-                    .handle_app_state_sync_key_request(request, &info.source.sender)
-                    .await
-                {
-                    warn!(
-                        "[msg:{}] Failed to answer app_state_sync_key_request from {}: {error:?}",
-                        info.id,
-                        info.source.sender.observe()
-                    );
+                match self.prepare_app_state_sync_key_share(request).await {
+                    Ok((message, message_id)) => {
+                        app_state_key_share_job =
+                            Some((info.source.sender.clone(), message, message_id));
+                    }
+                    Err(error) => {
+                        warn!(
+                            "[msg:{}] Failed to prepare app_state_sync_key_share for {}: {error:?}",
+                            info.id,
+                            info.source.sender.observe()
+                        );
+                    }
                 }
             } else {
                 warn!(
@@ -1567,7 +1571,17 @@ impl Client {
                 ..Default::default()
             })
         } else {
-            self.dispatch_parsed_message(msg, info).await;
+            let commit_state = self.dispatch_parsed_message(msg, info).await;
+            if let Some((requester, message, message_id)) = app_state_key_share_job {
+                if commit_state == InboundCommitState::Failed {
+                    warn!(
+                        "[msg:{}] Deferring app-state key-share recovery to the requester's retry because the inbound request was not durable",
+                        info.id
+                    );
+                } else {
+                    self.schedule_app_state_sync_key_share(requester, message, message_id);
+                }
+            }
             Ok(PlaintextHandleOutcome {
                 dispatched: true,
                 ..Default::default()

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1463,11 +1463,8 @@ impl Client {
             .await;
         }
 
-        // app_state_sync_key_share is a self-only protocol message (app-state
-        // sync keys shared between our own devices). A peer could otherwise
-        // inject keys and forge app-state mutations, so honour it only from
-        // self. WA Web `WAWebKeyManagementHandleKeyShareApi` gates on
-        // `isMeAccountNonLid(from)`; whatsmeow on `info.IsFromMe`.
+        // A peer-provided key could forge app-state mutations, so match WA Web's
+        // `isMeAccount(from)` gate before accepting a share.
         if let Some(protocol_msg) = msg.protocol_message.as_option()
             && let Some(keys) = protocol_msg.app_state_sync_key_share.as_option()
         {
@@ -1476,6 +1473,29 @@ impl Client {
             } else {
                 warn!(
                     "[msg:{}] Dropping app_state_sync_key_share from non-self sender {}",
+                    info.id,
+                    info.source.sender.observe()
+                );
+            }
+        }
+
+        if let Some(protocol_msg) = msg.protocol_message.as_option()
+            && let Some(request) = protocol_msg.app_state_sync_key_request.as_option()
+        {
+            if info.source.is_from_me {
+                if let Err(error) = self
+                    .handle_app_state_sync_key_request(request, &info.source.sender)
+                    .await
+                {
+                    warn!(
+                        "[msg:{}] Failed to answer app_state_sync_key_request from {}: {error:?}",
+                        info.id,
+                        info.source.sender.observe()
+                    );
+                }
+            } else {
+                warn!(
+                    "[msg:{}] Dropping app_state_sync_key_request from non-self sender {}",
                     info.id,
                     info.source.sender.observe()
                 );

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -80,9 +80,11 @@ impl Client {
 
         let device_snapshot = self.persistence_manager.get_device_snapshot();
         let key_store = device_snapshot.backend.clone();
+        drop(device_snapshot);
 
         let mut stored_count = 0;
         let mut failed_count = 0;
+        let mut fulfilled_request_ids = Vec::new();
 
         for key in &keys.keys {
             if let Some(components) = extract_key_components(key) {
@@ -94,14 +96,22 @@ impl Client {
 
                 if let Err(e) = key_store.set_sync_key(components.key_id, new_key).await {
                     log::error!(
-                        "Failed to store app state sync key {:?}: {:?}",
-                        hex::encode(components.key_id),
+                        "Failed to store app state sync key {:02x?}: {:?}",
+                        components.key_id,
                         e
                     );
                     failed_count += 1;
                 } else {
                     stored_count += 1;
+                    fulfilled_request_ids.push(components.key_id);
                 }
+            }
+        }
+
+        if !fulfilled_request_ids.is_empty() {
+            let mut requests = self.app_state_key_requests.lock().await;
+            for key_id in fulfilled_request_ids {
+                requests.remove(key_id);
             }
         }
 
@@ -122,6 +132,76 @@ impl Client {
                 .store(true, std::sync::atomic::Ordering::Relaxed);
             self.initial_keys_synced_notifier.notify(usize::MAX);
         }
+    }
+
+    pub(super) async fn build_app_state_sync_key_share(
+        &self,
+        request: &wa::message::AppStateSyncKeyRequest,
+    ) -> Result<wa::message::AppStateSyncKeyShare, anyhow::Error> {
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        let key_store = device_snapshot.backend.clone();
+        drop(device_snapshot);
+
+        let keys = futures::future::try_join_all(request.key_ids.iter().filter_map(|requested| {
+            let key_id = requested.key_id.as_deref()?;
+            let key_store = &key_store;
+            Some(async move {
+                let key_data = if let Some(stored) = key_store.get_sync_key(key_id).await? {
+                    let fingerprint = wa::message::AppStateSyncKeyFingerprint::decode_from_slice(
+                        &stored.fingerprint,
+                    )?;
+                    buffa::MessageField::some(wa::message::AppStateSyncKeyData {
+                        key_data: Some(stored.key_data),
+                        fingerprint: buffa::MessageField::some(fingerprint),
+                        timestamp: Some(stored.timestamp),
+                    })
+                } else {
+                    buffa::MessageField::default()
+                };
+
+                Ok::<_, anyhow::Error>(wa::message::AppStateSyncKey {
+                    key_id: buffa::MessageField::some(requested.clone()),
+                    key_data,
+                })
+            })
+        }))
+        .await?;
+
+        Ok(wa::message::AppStateSyncKeyShare { keys })
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "wa.recv.appstate_key_request", level = "debug", skip_all, fields(requester = %requester.observe(), count = request.key_ids.len()), err(Debug))
+    )]
+    pub(crate) async fn handle_app_state_sync_key_request(
+        &self,
+        request: &wa::message::AppStateSyncKeyRequest,
+        requester: &Jid,
+    ) -> Result<(), anyhow::Error> {
+        let share = self.build_app_state_sync_key_share(request).await?;
+        let message = wa::Message {
+            protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
+                r#type: Some(wa::message::protocol_message::Type::AppStateSyncKeyShare),
+                app_state_sync_key_share: buffa::MessageField::some(share),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        self.ensure_e2e_sessions(std::slice::from_ref(requester))
+            .await?;
+        self.send_message_impl(
+            requester.clone(),
+            &message,
+            Some(self.generate_message_id()),
+            true,
+            false,
+            None,
+            Vec::new(),
+            None,
+        )
+        .await
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.skdm", level = "debug", skip_all, fields(group = %group_jid.observe(), sender = %sender_jid.observe())))]

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -201,32 +201,45 @@ impl Client {
     pub(crate) async fn prepare_app_state_sync_key_share(
         &self,
         request: &wa::message::AppStateSyncKeyRequest,
-    ) -> Result<(wa::Message, String), anyhow::Error> {
+    ) -> Result<wa::Message, anyhow::Error> {
+        #[cfg(test)]
+        if self
+            .app_state_key_share_prepare_test_failures
+            .fetch_update(
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+                |remaining| remaining.checked_sub(1),
+            )
+            .is_ok()
+        {
+            anyhow::bail!("injected app-state key-share preparation failure");
+        }
+
         let share = self.build_app_state_sync_key_share(request).await?;
-        let message = wa::Message {
+        Ok(wa::Message {
             protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
                 r#type: Some(wa::message::protocol_message::Type::AppStateSyncKeyShare),
                 app_state_sync_key_share: buffa::MessageField::some(share),
                 ..Default::default()
             }),
             ..Default::default()
-        };
-        Ok((message, self.generate_message_id()))
+        })
     }
 
     pub(crate) fn schedule_app_state_sync_key_share(
         self: &Arc<Self>,
         requester: Jid,
-        message: wa::Message,
-        message_id: String,
+        request: wa::message::AppStateSyncKeyRequest,
     ) {
         let weak = Arc::downgrade(self);
         let runtime = self.runtime.clone();
+        let message_id = self.generate_message_id();
         self.runtime
             .spawn(Box::pin(async move {
                 let mut attempt = 0;
                 let mut retry_delay = APP_STATE_KEY_SHARE_SEND_RETRY;
                 let mut reconnect_after = None;
+                let mut message = None;
 
                 loop {
                     let wait_deadline =
@@ -278,13 +291,24 @@ impl Client {
                         drop(client);
                         continue;
                     };
-                    let result = client
-                        .send_app_state_sync_key_share_once(
-                            &requester,
-                            &message,
-                            &message_id,
-                        )
-                        .await;
+                    let result = async {
+                        if message.is_none() {
+                            message = Some(
+                                client
+                                    .prepare_app_state_sync_key_share(&request)
+                                    .await?,
+                            );
+                        }
+                        let Some(message) = message.as_ref() else {
+                            return Err(anyhow::anyhow!(
+                                "app-state key-share preparation produced no message"
+                            ));
+                        };
+                        client
+                            .send_app_state_sync_key_share_once(&requester, message, &message_id)
+                            .await
+                    }
+                    .await;
                     drop(flush_guard);
                     drop(client);
 

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -164,14 +164,21 @@ impl Client {
             let key_store = &key_store;
             Some(async move {
                 let key_data = if let Some(stored) = key_store.get_sync_key(key_id).await? {
-                    let fingerprint = wa::message::AppStateSyncKeyFingerprint::decode_from_slice(
+                    match wa::message::AppStateSyncKeyFingerprint::decode_from_slice(
                         &stored.fingerprint,
-                    )?;
-                    buffa::MessageField::some(wa::message::AppStateSyncKeyData {
-                        key_data: Some(stored.key_data),
-                        fingerprint: buffa::MessageField::some(fingerprint),
-                        timestamp: Some(stored.timestamp),
-                    })
+                    ) {
+                        Ok(fingerprint) => {
+                            buffa::MessageField::some(wa::message::AppStateSyncKeyData {
+                                key_data: Some(stored.key_data),
+                                fingerprint: buffa::MessageField::some(fingerprint),
+                                timestamp: Some(stored.timestamp),
+                            })
+                        }
+                        Err(error) => {
+                            warn!(target: "Client/AppState", "Stored app-state key fingerprint is invalid; returning orphan: {error}");
+                            buffa::MessageField::default()
+                        }
+                    }
                 } else {
                     buffa::MessageField::default()
                 };
@@ -446,11 +453,21 @@ mod tests {
 
     #[test]
     fn key_share_reconnects_for_direct_and_iq_connection_loss() {
+        use wacore_binary::builder::NodeBuilder;
+
         let direct = anyhow::Error::new(crate::client::ClientError::NotConnected);
         assert!(app_state_key_share_requires_reconnect(&direct));
 
         let iq = anyhow::Error::new(crate::request::IqError::NotConnected);
         assert!(app_state_key_share_requires_reconnect(&iq));
+
+        let channel_closed = anyhow::Error::new(crate::request::IqError::InternalChannelClosed);
+        assert!(app_state_key_share_requires_reconnect(&channel_closed));
+
+        let disconnected = anyhow::Error::new(crate::request::IqError::Disconnected(Box::new(
+            NodeBuilder::new("disconnect").build(),
+        )));
+        assert!(app_state_key_share_requires_reconnect(&disconnected));
 
         let non_transport = anyhow::anyhow!("pre-wire failure");
         assert!(!app_state_key_share_requires_reconnect(&non_transport));

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -3,6 +3,9 @@
 use super::*;
 use buffa::Message as _;
 
+const APP_STATE_KEY_SHARE_SEND_ATTEMPTS: u8 = 3;
+const APP_STATE_KEY_SHARE_SEND_RETRY: std::time::Duration = std::time::Duration::from_secs(1);
+
 impl Client {
     /// Handles a newsletter plaintext message.
     /// Newsletters are not E2E encrypted and use the <plaintext> tag directly.
@@ -172,13 +175,12 @@ impl Client {
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "wa.recv.appstate_key_request", level = "debug", skip_all, fields(requester = %requester.observe(), count = request.key_ids.len()), err(Debug))
+        tracing::instrument(name = "wa.recv.appstate_key_request.prepare", level = "debug", skip_all, fields(count = request.key_ids.len()), err(Debug))
     )]
-    pub(crate) async fn handle_app_state_sync_key_request(
+    pub(crate) async fn prepare_app_state_sync_key_share(
         &self,
         request: &wa::message::AppStateSyncKeyRequest,
-        requester: &Jid,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(wa::Message, String), anyhow::Error> {
         let share = self.build_app_state_sync_key_share(request).await?;
         let message = wa::Message {
             protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
@@ -188,13 +190,123 @@ impl Client {
             }),
             ..Default::default()
         };
+        Ok((message, self.generate_message_id()))
+    }
 
+    pub(crate) fn schedule_app_state_sync_key_share(
+        self: &Arc<Self>,
+        requester: Jid,
+        message: wa::Message,
+        message_id: String,
+    ) {
+        let weak = Arc::downgrade(self);
+        let runtime = self.runtime.clone();
+        self.runtime
+            .spawn(Box::pin(async move {
+                let mut attempt = 0;
+                let mut retry_delay = APP_STATE_KEY_SHARE_SEND_RETRY;
+                let mut reconnect_after = None;
+
+                loop {
+                    let wait_deadline =
+                        wacore::time::Instant::now() + Client::DEFAULT_OFFLINE_SYNC_TIMEOUT;
+                    loop {
+                        let Some(client) = weak.upgrade() else {
+                            return;
+                        };
+                        let listener = client.offline_sync_notifier.listen();
+                        let ready = client
+                            .offline_sync_completed
+                            .load(std::sync::atomic::Ordering::Acquire)
+                            && !client.inbound_commit_batch.is_active()
+                            && reconnect_after.is_none_or(|generation| {
+                                client
+                                    .connection_generation
+                                    .load(std::sync::atomic::Ordering::Acquire)
+                                    != generation
+                            });
+                        drop(client);
+
+                        if ready {
+                            reconnect_after = None;
+                            break;
+                        }
+                        let remaining = wait_deadline
+                            .saturating_duration_since(wacore::time::Instant::now());
+                        if remaining.is_zero()
+                            || wacore::runtime::timeout(&*runtime, remaining, listener)
+                                .await
+                                .is_err()
+                        {
+                            warn!(
+                                "Dropping deferred app-state key share to {} after offline sync timeout",
+                                requester.observe()
+                            );
+                            return;
+                        }
+                    }
+
+                    let Some(client) = weak.upgrade() else {
+                        return;
+                    };
+                    let Some(flush_guard) = client.outbound_flush.try_track() else {
+                        return;
+                    };
+                    let send_generation = client
+                        .connection_generation
+                        .load(std::sync::atomic::Ordering::Acquire);
+                    let result = client
+                        .send_app_state_sync_key_share_once(
+                            &requester,
+                            &message,
+                            &message_id,
+                        )
+                        .await;
+                    drop(flush_guard);
+                    drop(client);
+
+                    let Err(error) = result else {
+                        return;
+                    };
+                    attempt += 1;
+                    warn!(
+                        "App-state key share to {} failed (attempt {attempt}/{APP_STATE_KEY_SHARE_SEND_ATTEMPTS}): {error}",
+                        requester.observe()
+                    );
+                    if attempt >= APP_STATE_KEY_SHARE_SEND_ATTEMPTS {
+                        return;
+                    }
+
+                    let transport_unavailable = error.chain().any(|cause| {
+                        cause
+                            .downcast_ref::<crate::socket::error::EncryptSendError>()
+                            .is_some_and(
+                                crate::socket::error::EncryptSendError::is_transport_unavailable,
+                            )
+                    });
+                    if transport_unavailable {
+                        reconnect_after = Some(send_generation);
+                    } else {
+                        runtime.sleep(retry_delay).await;
+                    }
+                    retry_delay = retry_delay.saturating_mul(2);
+                }
+            }))
+            .detach();
+    }
+
+    async fn send_app_state_sync_key_share_once(
+        &self,
+        requester: &Jid,
+        message: &wa::Message,
+        message_id: &str,
+    ) -> Result<(), anyhow::Error> {
         self.ensure_e2e_sessions(std::slice::from_ref(requester))
             .await?;
         self.send_message_impl(
             requester.clone(),
-            &message,
-            Some(self.generate_message_id()),
+            message,
+            Some(message_id.to_owned()),
             true,
             false,
             None,

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -263,12 +263,14 @@ impl Client {
                     let Some(client) = weak.upgrade() else {
                         return;
                     };
-                    let Some(flush_guard) = client.outbound_flush.try_track() else {
-                        return;
-                    };
                     let send_generation = client
                         .connection_generation
                         .load(std::sync::atomic::Ordering::Acquire);
+                    let Some(flush_guard) = client.outbound_flush.try_track() else {
+                        reconnect_after = Some(send_generation);
+                        drop(client);
+                        continue;
+                    };
                     let result = client
                         .send_app_state_sync_key_share_once(
                             &requester,

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -151,57 +151,14 @@ impl Client {
         }
     }
 
-    pub(super) async fn build_app_state_sync_key_share(
-        &self,
-        request: &wa::message::AppStateSyncKeyRequest,
-    ) -> Result<wa::message::AppStateSyncKeyShare, anyhow::Error> {
-        let device_snapshot = self.persistence_manager.get_device_snapshot();
-        let key_store = device_snapshot.backend.clone();
-        drop(device_snapshot);
-
-        let keys = futures::future::try_join_all(request.key_ids.iter().filter_map(|requested| {
-            let key_id = requested.key_id.as_deref()?;
-            let key_store = &key_store;
-            Some(async move {
-                let key_data = if let Some(stored) = key_store.get_sync_key(key_id).await? {
-                    match wa::message::AppStateSyncKeyFingerprint::decode_from_slice(
-                        &stored.fingerprint,
-                    ) {
-                        Ok(fingerprint) => {
-                            buffa::MessageField::some(wa::message::AppStateSyncKeyData {
-                                key_data: Some(stored.key_data),
-                                fingerprint: buffa::MessageField::some(fingerprint),
-                                timestamp: Some(stored.timestamp),
-                            })
-                        }
-                        Err(error) => {
-                            warn!(target: "Client/AppState", "Stored app-state key fingerprint is invalid; returning orphan: {error}");
-                            buffa::MessageField::default()
-                        }
-                    }
-                } else {
-                    buffa::MessageField::default()
-                };
-
-                Ok::<_, anyhow::Error>(wa::message::AppStateSyncKey {
-                    key_id: buffa::MessageField::some(requested.clone()),
-                    key_data,
-                })
-            })
-        }))
-        .await?;
-
-        Ok(wa::message::AppStateSyncKeyShare { keys })
-    }
-
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.recv.appstate_key_request.prepare", level = "debug", skip_all, fields(count = request.key_ids.len()), err(Debug))
     )]
-    pub(crate) async fn prepare_app_state_sync_key_share(
+    pub(super) async fn build_app_state_sync_key_share(
         &self,
         request: &wa::message::AppStateSyncKeyRequest,
-    ) -> Result<wa::Message, anyhow::Error> {
+    ) -> Result<wa::message::AppStateSyncKeyShare, anyhow::Error> {
         #[cfg(test)]
         if self
             .app_state_key_share_prepare_test_failures
@@ -215,15 +172,41 @@ impl Client {
             anyhow::bail!("injected app-state key-share preparation failure");
         }
 
-        let share = self.build_app_state_sync_key_share(request).await?;
-        Ok(wa::Message {
-            protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
-                r#type: Some(wa::message::protocol_message::Type::AppStateSyncKeyShare),
-                app_state_sync_key_share: buffa::MessageField::some(share),
-                ..Default::default()
-            }),
-            ..Default::default()
-        })
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        let key_store = device_snapshot.backend.clone();
+        drop(device_snapshot);
+
+        let mut keys = Vec::with_capacity(request.key_ids.len());
+        for requested in &request.key_ids {
+            let Some(key_id) = requested.key_id.as_deref() else {
+                continue;
+            };
+            let key_data = if let Some(stored) = key_store.get_sync_key(key_id).await? {
+                match wa::message::AppStateSyncKeyFingerprint::decode_from_slice(
+                    &stored.fingerprint,
+                ) {
+                    Ok(fingerprint) => {
+                        buffa::MessageField::some(wa::message::AppStateSyncKeyData {
+                            key_data: Some(stored.key_data),
+                            fingerprint: buffa::MessageField::some(fingerprint),
+                            timestamp: Some(stored.timestamp),
+                        })
+                    }
+                    Err(error) => {
+                        warn!(target: "Client/AppState", "Stored app-state key fingerprint is invalid; returning orphan: {error}");
+                        buffa::MessageField::default()
+                    }
+                }
+            } else {
+                buffa::MessageField::default()
+            };
+            keys.push(wa::message::AppStateSyncKey {
+                key_id: buffa::MessageField::some(requested.clone()),
+                key_data,
+            });
+        }
+
+        Ok(wa::message::AppStateSyncKeyShare { keys })
     }
 
     pub(crate) fn schedule_app_state_sync_key_share(
@@ -291,24 +274,45 @@ impl Client {
                         drop(client);
                         continue;
                     };
-                    let result = async {
-                        if message.is_none() {
-                            message = Some(
-                                client
-                                    .prepare_app_state_sync_key_share(&request)
-                                    .await?,
-                            );
+                    let result = match message.as_ref() {
+                        Some(message) => {
+                            client
+                                .send_app_state_sync_key_share_once(
+                                    &requester,
+                                    message,
+                                    &message_id,
+                                )
+                                .await
                         }
-                        let Some(message) = message.as_ref() else {
-                            return Err(anyhow::anyhow!(
-                                "app-state key-share preparation produced no message"
-                            ));
-                        };
-                        client
-                            .send_app_state_sync_key_share_once(&requester, message, &message_id)
-                            .await
-                    }
-                    .await;
+                        None => match client.build_app_state_sync_key_share(&request).await {
+                            Ok(share) => {
+                                let prepared = wa::Message {
+                                    protocol_message: buffa::MessageField::some(
+                                        wa::message::ProtocolMessage {
+                                            r#type: Some(
+                                                wa::message::protocol_message::Type::AppStateSyncKeyShare,
+                                            ),
+                                            app_state_sync_key_share: buffa::MessageField::some(
+                                                share,
+                                            ),
+                                            ..Default::default()
+                                        },
+                                    ),
+                                    ..Default::default()
+                                };
+                                let result = client
+                                    .send_app_state_sync_key_share_once(
+                                        &requester,
+                                        &prepared,
+                                        &message_id,
+                                    )
+                                    .await;
+                                message = Some(prepared);
+                                result
+                            }
+                            Err(error) => Err(error),
+                        },
+                    };
                     drop(flush_guard);
                     drop(client);
 

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -6,6 +6,20 @@ use buffa::Message as _;
 const APP_STATE_KEY_SHARE_SEND_ATTEMPTS: u8 = 3;
 const APP_STATE_KEY_SHARE_SEND_RETRY: std::time::Duration = std::time::Duration::from_secs(1);
 
+fn app_state_key_share_requires_reconnect(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<crate::client::ClientError>()
+            .is_some_and(crate::client::ClientError::is_transport_unavailable)
+            || cause
+                .downcast_ref::<crate::request::IqError>()
+                .is_some_and(crate::request::IqError::is_transport_unavailable)
+            || cause
+                .downcast_ref::<crate::socket::error::EncryptSendError>()
+                .is_some_and(crate::socket::error::EncryptSendError::is_transport_unavailable)
+    })
+}
+
 impl Client {
     /// Handles a newsletter plaintext message.
     /// Newsletters are not E2E encrypted and use the <plaintext> tag directly.
@@ -277,14 +291,7 @@ impl Client {
                         return;
                     }
 
-                    let transport_unavailable = error.chain().any(|cause| {
-                        cause
-                            .downcast_ref::<crate::socket::error::EncryptSendError>()
-                            .is_some_and(
-                                crate::socket::error::EncryptSendError::is_transport_unavailable,
-                            )
-                    });
-                    if transport_unavailable {
+                    if app_state_key_share_requires_reconnect(&error) {
                         reconnect_after = Some(send_generation);
                     } else {
                         runtime.sleep(retry_delay).await;
@@ -428,5 +435,22 @@ impl Client {
                 sender_jid.observe()
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::app_state_key_share_requires_reconnect;
+
+    #[test]
+    fn key_share_reconnects_for_direct_and_iq_connection_loss() {
+        let direct = anyhow::Error::new(crate::client::ClientError::NotConnected);
+        assert!(app_state_key_share_requires_reconnect(&direct));
+
+        let iq = anyhow::Error::new(crate::request::IqError::NotConnected);
+        assert!(app_state_key_share_requires_reconnect(&iq));
+
+        let non_transport = anyhow::anyhow!("pre-wire failure");
+        assert!(!app_state_key_share_requires_reconnect(&non_transport));
     }
 }

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -48,7 +48,7 @@ impl Client {
                         info.id,
                         info.source.chat.observe()
                     );
-                    self.dispatch_parsed_message(msg, info).await;
+                    self.dispatch_parsed_message(msg, info, false).await;
                 }
                 Err(e) => {
                     log::warn!(
@@ -213,6 +213,7 @@ impl Client {
         self: &Arc<Self>,
         requester: Jid,
         request: wa::message::AppStateSyncKeyRequest,
+        mut commit_ticket: Option<InboundCommitTicket>,
     ) {
         let weak = Arc::downgrade(self);
         let runtime = self.runtime.clone();
@@ -232,9 +233,22 @@ impl Client {
                             return;
                         };
                         let listener = client.offline_sync_notifier.listen();
-                        let ready = client
-                            .offline_sync_completed
-                            .load(std::sync::atomic::Ordering::Acquire)
+                        let commit_ready = match commit_ticket
+                            .as_ref()
+                            .map(InboundCommitTicket::state)
+                        {
+                            Some(InboundCommitTicketState::Pending) => false,
+                            Some(InboundCommitTicketState::Dropped) => return,
+                            Some(InboundCommitTicketState::Durable) => {
+                                commit_ticket = None;
+                                true
+                            }
+                            None => true,
+                        };
+                        let ready = commit_ready
+                            && client
+                                .offline_sync_completed
+                                .load(std::sync::atomic::Ordering::Acquire)
                             && !client.inbound_commit_batch.is_active()
                             && reconnect_after.is_none_or(|generation| {
                                 client

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -548,7 +548,8 @@ use wacore::libsignal::protocol::{
     PreKeyBundle, PreKeyRecord, PreKeyStore as SigPreKeyStore, ProtocolAddress, SenderKeyName,
     SenderKeyRecord, SenderKeyStore as SigSenderKeyStore, SessionRecord,
     SessionStore as SigSessionStore, SignedPreKeyStore as SigSignedPreKeyStore, UsePQRatchet,
-    create_sender_key_distribution_message, group_encrypt, message_encrypt, process_prekey_bundle,
+    create_sender_key_distribution_message, group_encrypt, message_decrypt_signal, message_encrypt,
+    process_prekey_bundle,
 };
 use wacore::libsignal::protocol::{IdentityKeyStore as SigIdentityKeyStore, SignalProtocolError};
 
@@ -697,6 +698,20 @@ impl AlicePeer {
             ..Default::default()
         });
         self.encrypt(bob_addr, &plaintext).await
+    }
+
+    async fn decrypt_signal(&mut self, bob_addr: &ProtocolAddress, ciphertext: &[u8]) -> Vec<u8> {
+        let message = SignalMessage::try_from(ciphertext).expect("signal message");
+        message_decrypt_signal(
+            &message,
+            bob_addr,
+            &mut self.sessions,
+            &mut self.identity,
+            &mut rand::make_rng::<rand::rngs::StdRng>(),
+        )
+        .await
+        .expect("decrypt signal message")
+        .plaintext
     }
 
     async fn create_group_skdm(
@@ -5674,6 +5689,46 @@ fn has_message_to_after(frames: &[bytes::Bytes], start: usize, to: &str) -> bool
     })
 }
 
+async fn decrypt_peer_message_after(
+    peer: &mut AlicePeer,
+    remote_address: &ProtocolAddress,
+    frames: &[bytes::Bytes],
+    start: usize,
+    to: &str,
+) -> Option<wa::Message> {
+    let (ciphertext, padding_version) =
+        frames
+            .iter()
+            .enumerate()
+            .skip(start)
+            .find_map(|(index, frame)| {
+                let buf = decode_frame(index, frame)?;
+                let node = wacore_binary::marshal::unmarshal_ref(&buf[1..]).ok()?;
+                if node.tag.as_ref() != "message"
+                    || !node
+                        .get_attr("to")
+                        .is_some_and(|value| value.as_str() == to)
+                {
+                    return None;
+                }
+                let enc = node.get_optional_child_by_tag(&["enc"])?;
+                if !enc
+                    .get_attr("type")
+                    .is_some_and(|value| value.as_str() == "msg")
+                {
+                    return None;
+                }
+                Some((
+                    enc.content_bytes()?.to_vec(),
+                    enc.get_attr("v")
+                        .and_then(|value| value.as_str().parse().ok())
+                        .unwrap_or(2),
+                ))
+            })?;
+    let plaintext = peer.decrypt_signal(remote_address, &ciphertext).await;
+    wacore::messages::decode_plaintext(&plaintext, padding_version).ok()
+}
+
 /// First `<ack class="message">` on the wire as `(to, recipient)`.
 fn find_message_ack(frames: &[bytes::Bytes]) -> Option<(String, Option<String>)> {
     for (i, frame) in frames.iter().enumerate() {
@@ -7841,6 +7896,7 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
 
 #[tokio::test]
 async fn app_state_key_share_waits_outside_the_offline_message_lane() {
+    use buffa::Message as _;
     use std::sync::atomic::Ordering;
     use wacore::messages::MessageUtils;
 
@@ -7864,13 +7920,14 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     let _ = client.inbound_commit_batch.reset();
     client.swap_message_semaphore(1);
     assert!(client.inbound_commit_batch.is_active());
+    let requested_key_id = vec![1, 2, 3, 4];
     let request = wa::Message {
         protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
             r#type: Some(wa::message::protocol_message::Type::AppStateSyncKeyRequest),
             app_state_sync_key_request: buffa::MessageField::some(
                 wa::message::AppStateSyncKeyRequest {
                     key_ids: vec![wa::message::AppStateSyncKeyId {
-                        key_id: Some(vec![1, 2, 3, 4]),
+                        key_id: Some(requested_key_id.clone()),
                     }],
                 },
             ),
@@ -7924,6 +7981,25 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
         "a non-durable request must not put a key share on the wire"
     );
 
+    let fingerprint = wa::message::AppStateSyncKeyFingerprint {
+        raw_id: Some(42),
+        current_index: Some(1),
+        device_indexes: vec![0, 1],
+    };
+    client
+        .persistence_manager
+        .backend()
+        .set_sync_key(
+            &requested_key_id,
+            crate::store::traits::AppStateSyncKey {
+                key_data: vec![7; 32],
+                fingerprint: fingerprint.encode_to_vec(),
+                timestamp: 456,
+            },
+        )
+        .await
+        .expect("store key learned during the offline drain");
+
     client
         .inbound_commit_batch
         .fail_commits
@@ -7949,6 +8025,26 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     })
     .await
     .expect("deferred key share should send after the drain");
+
+    let response = decrypt_peer_message_after(
+        &mut peer,
+        &own_address,
+        &transport.sent(),
+        sent_before,
+        requester_str,
+    )
+    .await
+    .expect("decrypt deferred key share");
+    let shared_key = response
+        .protocol_message
+        .as_option()
+        .and_then(|protocol| protocol.app_state_sync_key_share.as_option())
+        .and_then(|share| share.keys.first())
+        .and_then(|key| key.key_data.as_option())
+        .expect("the deferred response must include the key learned during the drain");
+    assert_eq!(shared_key.key_data.as_deref(), Some(&[7; 32][..]));
+    assert_eq!(shared_key.fingerprint.as_option(), Some(&fingerprint));
+    assert_eq!(shared_key.timestamp, Some(456));
 }
 
 #[tokio::test]
@@ -7976,13 +8072,9 @@ async fn app_state_key_share_transport_retry_waits_for_reconnect() {
             key_id: Some(vec![4, 3, 2, 1]),
         }],
     };
-    let (message, message_id) = client
-        .prepare_app_state_sync_key_share(&request)
-        .await
-        .expect("prepare key share");
 
     transport.fail_next_sends(1);
-    client.schedule_app_state_sync_key_share(requester, message, message_id);
+    client.schedule_app_state_sync_key_share(requester, request);
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         while transport.failed_sends() == 0 {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -8015,6 +8107,53 @@ async fn app_state_key_share_transport_retry_waits_for_reconnect() {
 }
 
 #[tokio::test]
+async fn app_state_key_share_preparation_failure_is_retried() {
+    let (client, transport) = capturing_client("appstate_key_share_prepare_retry").await;
+    let requester_str = "5511000000001:36@s.whatsapp.net";
+    let requester: Jid = requester_str.parse().expect("requester jid");
+    let mut peer = AlicePeer::new(requester_str).await;
+    let (bundle, own_jid) = bobs_prekey_bundle(&client).await;
+    let own_address = own_jid.to_protocol_address();
+    peer.install_bob_session(&own_address, &bundle).await;
+    let establishing = peer.encrypt_text(&own_address, "establish session").await;
+    let (decrypted, _, _, session_present) =
+        submit_and_check_session(&client, &requester, &establishing).await;
+    assert!(decrypted && session_present, "precondition: peer session");
+
+    client.flush_signal_cache().await.expect("flush session");
+    client
+        .outbound_flush
+        .flush(&*client.runtime, std::time::Duration::from_secs(1))
+        .await;
+    let sent_before = transport.sent_count();
+    client
+        .app_state_key_share_prepare_test_failures
+        .store(1, std::sync::atomic::Ordering::Release);
+    client.schedule_app_state_sync_key_share(
+        requester,
+        wa::message::AppStateSyncKeyRequest {
+            key_ids: vec![wa::message::AppStateSyncKeyId {
+                key_id: Some(vec![4, 3, 2, 1]),
+            }],
+        },
+    );
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        while !has_message_to_after(&transport.sent(), sent_before, requester_str) {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("a transient preparation failure must keep the response job alive");
+    assert_eq!(
+        client
+            .app_state_key_share_prepare_test_failures
+            .load(std::sync::atomic::Ordering::Acquire),
+        0
+    );
+}
+
+#[tokio::test]
 async fn app_state_key_share_survives_a_closed_flush_scope() {
     let (client, transport) = capturing_client("appstate_key_share_closed_flush").await;
     let requester_str = "5511000000001:35@s.whatsapp.net";
@@ -8039,14 +8178,10 @@ async fn app_state_key_share_survives_a_closed_flush_scope() {
             key_id: Some(vec![4, 3, 2, 1]),
         }],
     };
-    let (message, message_id) = client
-        .prepare_app_state_sync_key_share(&request)
-        .await
-        .expect("prepare key share");
 
     client.outbound_flush.close();
     let rejected_before = client.outbound_flush.track_rejections();
-    client.schedule_app_state_sync_key_share(requester, message, message_id);
+    client.schedule_app_state_sync_key_share(requester, request);
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         while client.outbound_flush.track_rejections() == rejected_before {
             tokio::task::yield_now().await;

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7989,6 +7989,62 @@ async fn app_state_key_share_transport_retry_waits_for_reconnect() {
     assert!(transport.sent_count() > sent_before);
 }
 
+#[tokio::test]
+async fn app_state_key_share_survives_a_closed_flush_scope() {
+    let (client, transport) = capturing_client("appstate_key_share_closed_flush").await;
+    let requester_str = "5511000000001:35@s.whatsapp.net";
+    let requester: Jid = requester_str.parse().expect("requester jid");
+    let mut peer = AlicePeer::new(requester_str).await;
+    let (bundle, own_jid) = bobs_prekey_bundle(&client).await;
+    let own_address = own_jid.to_protocol_address();
+    peer.install_bob_session(&own_address, &bundle).await;
+    let establishing = peer.encrypt_text(&own_address, "establish session").await;
+    let (decrypted, _, _, session_present) =
+        submit_and_check_session(&client, &requester, &establishing).await;
+    assert!(decrypted && session_present, "precondition: peer session");
+
+    client.flush_signal_cache().await.expect("flush session");
+    client
+        .outbound_flush
+        .flush(&*client.runtime, std::time::Duration::from_secs(1))
+        .await;
+    let sent_before = transport.sent_count();
+    let request = wa::message::AppStateSyncKeyRequest {
+        key_ids: vec![wa::message::AppStateSyncKeyId {
+            key_id: Some(vec![4, 3, 2, 1]),
+        }],
+    };
+    let (message, message_id) = client
+        .prepare_app_state_sync_key_share(&request)
+        .await
+        .expect("prepare key share");
+
+    client.outbound_flush.close();
+    let rejected_before = client.outbound_flush.track_rejections();
+    client.schedule_app_state_sync_key_share(requester, message, message_id);
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while client.outbound_flush.track_rejections() == rejected_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("key-share job should observe the closed scope");
+    assert_eq!(transport.sent_count(), sent_before);
+
+    client
+        .connection_generation
+        .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+    client.outbound_flush.reopen();
+    client.offline_sync_notifier.notify(usize::MAX);
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while transport.sent_count() == sent_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("key-share job should resume on the new connection");
+}
+
 /// Security regression: the primary's `lid_migration_mapping_sync_message`
 /// must be honoured only from self — a peer could otherwise poison the
 /// LID-PN cache and flip the account to LID wire addressing.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7684,6 +7684,11 @@ async fn app_state_sync_key_share_honored_only_from_self() {
     };
     let padded = MessageUtils::encode_and_pad(&share);
     let backend = client.persistence_manager.backend();
+    client
+        .app_state_key_requests
+        .lock()
+        .await
+        .insert(key_id.clone(), wacore::time::Instant::now());
 
     // Non-self sender: the key share must be dropped.
     let mut info =
@@ -7696,6 +7701,14 @@ async fn app_state_sync_key_share_honored_only_from_self() {
     assert!(
         backend.get_sync_key(&key_id).await.unwrap().is_none(),
         "app-state sync key from a non-self sender must not be stored"
+    );
+    assert!(
+        client
+            .app_state_key_requests
+            .lock()
+            .await
+            .contains_key(key_id.as_slice()),
+        "a spoofed key share must not clear missing-key tracking"
     );
 
     // Self sender: the key share is honoured and stored.
@@ -7712,6 +7725,77 @@ async fn app_state_sync_key_share_honored_only_from_self() {
     assert!(
         backend.get_sync_key(&key_id).await.unwrap().is_some(),
         "app-state sync key from self must be stored"
+    );
+    assert!(
+        !client
+            .app_state_key_requests
+            .lock()
+            .await
+            .contains_key(key_id.as_slice()),
+        "a stored key must become requestable again if it is later lost"
+    );
+}
+
+#[tokio::test]
+async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
+    use buffa::Message as _;
+
+    let client = crate::test_utils::create_test_client().await;
+    let backend = client.persistence_manager.backend();
+    let known_id = vec![1, 2, 3, 4, 5, 6];
+    let orphan_id = vec![6, 5, 4, 3, 2, 1];
+    let fingerprint = wa::message::AppStateSyncKeyFingerprint {
+        raw_id: Some(7),
+        current_index: Some(3),
+        device_indexes: vec![0, 3],
+    };
+    backend
+        .set_sync_key(
+            &known_id,
+            crate::store::traits::AppStateSyncKey {
+                key_data: vec![9; 32],
+                fingerprint: fingerprint.encode_to_vec(),
+                timestamp: 123,
+            },
+        )
+        .await
+        .unwrap();
+
+    let request = wa::message::AppStateSyncKeyRequest {
+        key_ids: vec![
+            wa::message::AppStateSyncKeyId {
+                key_id: Some(known_id.clone()),
+            },
+            wa::message::AppStateSyncKeyId {
+                key_id: Some(orphan_id.clone()),
+            },
+            wa::message::AppStateSyncKeyId { key_id: None },
+        ],
+    };
+    let share = client
+        .build_app_state_sync_key_share(&request)
+        .await
+        .unwrap();
+
+    assert_eq!(share.keys.len(), 2, "keyless requests must be ignored");
+    let known = &share.keys[0];
+    assert_eq!(
+        known.key_id.as_option().and_then(|id| id.key_id.as_ref()),
+        Some(&known_id)
+    );
+    let known_data = known.key_data.as_option().expect("known key data");
+    assert_eq!(known_data.key_data.as_deref(), Some(&[9; 32][..]));
+    assert_eq!(known_data.fingerprint.as_option(), Some(&fingerprint));
+    assert_eq!(known_data.timestamp, Some(123));
+
+    let orphan = &share.keys[1];
+    assert_eq!(
+        orphan.key_id.as_option().and_then(|id| id.key_id.as_ref()),
+        Some(&orphan_id)
+    );
+    assert!(
+        orphan.key_data.is_unset(),
+        "an unknown ID must be returned without fabricated key data"
     );
 }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5659,6 +5659,21 @@ fn decode_frame(index: usize, frame: &[u8]) -> Option<Vec<u8>> {
     (!buf.is_empty()).then_some(buf)
 }
 
+fn has_message_to_after(frames: &[bytes::Bytes], start: usize, to: &str) -> bool {
+    frames.iter().enumerate().skip(start).any(|(index, frame)| {
+        let Some(buf) = decode_frame(index, frame) else {
+            return false;
+        };
+        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+            return false;
+        };
+        node.tag.as_ref() == "message"
+            && node
+                .get_attr("to")
+                .is_some_and(|value| value.as_str() == to)
+    })
+}
+
 /// First `<ack class="message">` on the wire as `(to, recipient)`.
 fn find_message_ack(frames: &[bytes::Bytes]) -> Option<(String, Option<String>)> {
     for (i, frame) in frames.iter().enumerate() {
@@ -7797,6 +7812,181 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
         orphan.key_data.is_unset(),
         "an unknown ID must be returned without fabricated key data"
     );
+}
+
+#[tokio::test]
+async fn app_state_key_share_waits_outside_the_offline_message_lane() {
+    use std::sync::atomic::Ordering;
+    use wacore::messages::MessageUtils;
+
+    let (client, transport) = capturing_client("appstate_key_share_offline").await;
+    let requester_str = "5511000000001:33@s.whatsapp.net";
+    let requester: Jid = requester_str.parse().expect("requester jid");
+    let mut peer = AlicePeer::new(requester_str).await;
+    let (bundle, own_jid) = bobs_prekey_bundle(&client).await;
+    let own_address = own_jid.to_protocol_address();
+    peer.install_bob_session(&own_address, &bundle).await;
+    let establishing = peer.encrypt_text(&own_address, "establish session").await;
+    let (decrypted, _, _, session_present) =
+        submit_and_check_session(&client, &requester, &establishing).await;
+    assert!(decrypted && session_present, "precondition: peer session");
+
+    client.flush_signal_cache().await.expect("flush session");
+
+    client
+        .offline_sync_completed
+        .store(false, Ordering::Release);
+    let _ = client.inbound_commit_batch.reset();
+    client.swap_message_semaphore(1);
+    assert!(client.inbound_commit_batch.is_active());
+    let request = wa::Message {
+        protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
+            r#type: Some(wa::message::protocol_message::Type::AppStateSyncKeyRequest),
+            app_state_sync_key_request: buffa::MessageField::some(
+                wa::message::AppStateSyncKeyRequest {
+                    key_ids: vec![wa::message::AppStateSyncKeyId {
+                        key_id: Some(vec![1, 2, 3, 4]),
+                    }],
+                },
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let mut info = create_test_message_info(requester_str, "AKR_OFFLINE", requester_str);
+    info.source.is_from_me = true;
+    tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        client.handle_decrypted_plaintext(
+            "msg",
+            &MessageUtils::encode_and_pad(&request),
+            2,
+            &Arc::new(info),
+        ),
+    )
+    .await
+    .expect("the inbound lane must not wait for offline sync")
+    .expect("handle key request");
+
+    client
+        .outbound_flush
+        .flush(&*client.runtime, std::time::Duration::from_secs(1))
+        .await;
+    let sent_before = transport.sent_count();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        transport.sent_count(),
+        sent_before,
+        "the response must stay deferred while the inbound drain is active"
+    );
+
+    client
+        .inbound_commit_batch
+        .fail_commits
+        .store(true, Ordering::Release);
+    assert!(
+        !client
+            .flush_inbound_commits_under_permit(true, None, None)
+            .await,
+        "the injected commit failure must keep the request non-durable"
+    );
+    client.offline_sync_completed.store(true, Ordering::Release);
+    client.offline_sync_notifier.notify(usize::MAX);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        !has_message_to_after(&transport.sent(), sent_before, requester_str),
+        "a non-durable request must not put a key share on the wire"
+    );
+
+    client
+        .inbound_commit_batch
+        .fail_commits
+        .store(false, Ordering::Release);
+    assert!(
+        client
+            .flush_inbound_commits_under_permit(false, None, None)
+            .await,
+        "the retried inbound commit must become durable"
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let mut observed = sent_before;
+        loop {
+            let count = transport.sent_count();
+            if count != observed {
+                observed = count;
+                if has_message_to_after(&transport.sent(), sent_before, requester_str) {
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("deferred key share should send after the drain");
+}
+
+#[tokio::test]
+async fn app_state_key_share_transport_retry_waits_for_reconnect() {
+    let (client, transport) = capturing_client("appstate_key_share_retry").await;
+    let requester_str = "5511000000001:34@s.whatsapp.net";
+    let requester: Jid = requester_str.parse().expect("requester jid");
+    let mut peer = AlicePeer::new(requester_str).await;
+    let (bundle, own_jid) = bobs_prekey_bundle(&client).await;
+    let own_address = own_jid.to_protocol_address();
+    peer.install_bob_session(&own_address, &bundle).await;
+    let establishing = peer.encrypt_text(&own_address, "establish session").await;
+    let (decrypted, _, _, session_present) =
+        submit_and_check_session(&client, &requester, &establishing).await;
+    assert!(decrypted && session_present, "precondition: peer session");
+
+    client.flush_signal_cache().await.expect("flush session");
+    client
+        .outbound_flush
+        .flush(&*client.runtime, std::time::Duration::from_secs(1))
+        .await;
+    let sent_before = transport.sent_count();
+    let request = wa::message::AppStateSyncKeyRequest {
+        key_ids: vec![wa::message::AppStateSyncKeyId {
+            key_id: Some(vec![4, 3, 2, 1]),
+        }],
+    };
+    let (message, message_id) = client
+        .prepare_app_state_sync_key_share(&request)
+        .await
+        .expect("prepare key share");
+
+    transport.fail_next_sends(1);
+    client.schedule_app_state_sync_key_share(requester, message, message_id);
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while transport.failed_sends() == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("key-share job should observe the transport failure");
+
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    assert_eq!(
+        transport.sent_count(),
+        sent_before,
+        "an uncertain transport failure must not retry on the same Noise connection"
+    );
+
+    client
+        .connection_generation
+        .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+    client.offline_sync_notifier.notify(usize::MAX);
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while transport.sent_count() == sent_before {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("key-share job should retry on the new connection generation");
+
+    assert_eq!(transport.failed_sends(), 1);
+    assert!(transport.sent_count() > sent_before);
 }
 
 /// Security regression: the primary's `lid_migration_mapping_sync_message`

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5675,18 +5675,27 @@ fn decode_frame(index: usize, frame: &[u8]) -> Option<Vec<u8>> {
 }
 
 fn has_message_to_after(frames: &[bytes::Bytes], start: usize, to: &str) -> bool {
-    frames.iter().enumerate().skip(start).any(|(index, frame)| {
-        let Some(buf) = decode_frame(index, frame) else {
-            return false;
-        };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
-            return false;
-        };
-        node.tag.as_ref() == "message"
-            && node
-                .get_attr("to")
-                .is_some_and(|value| value.as_str() == to)
-    })
+    message_count_to_after(frames, start, to) != 0
+}
+
+fn message_count_to_after(frames: &[bytes::Bytes], start: usize, to: &str) -> usize {
+    frames
+        .iter()
+        .enumerate()
+        .skip(start)
+        .filter(|(index, frame)| {
+            let Some(buf) = decode_frame(*index, frame) else {
+                return false;
+            };
+            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+                return false;
+            };
+            node.tag.as_ref() == "message"
+                && node
+                    .get_attr("to")
+                    .is_some_and(|value| value.as_str() == to)
+        })
+        .count()
 }
 
 async fn decrypt_peer_message_after(
@@ -7937,14 +7946,10 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     };
     let mut info = create_test_message_info(requester_str, "AKR_OFFLINE", requester_str);
     info.source.is_from_me = true;
+    let info = Arc::new(info);
     tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        client.handle_decrypted_plaintext(
-            "msg",
-            &MessageUtils::encode_and_pad(&request),
-            2,
-            &Arc::new(info),
-        ),
+        client.handle_decrypted_plaintext("msg", &MessageUtils::encode_and_pad(&request), 2, &info),
     )
     .await
     .expect("the inbound lane must not wait for offline sync")
@@ -7955,6 +7960,18 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
         .flush(&*client.runtime, std::time::Duration::from_secs(1))
         .await;
     let sent_before = transport.sent_count();
+
+    assert!(
+        client.inbound_commit_batch.reset(),
+        "the first request must still be uncommitted"
+    );
+    tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        client.handle_decrypted_plaintext("msg", &MessageUtils::encode_and_pad(&request), 2, &info),
+    )
+    .await
+    .expect("the redelivery must not wait for offline sync")
+    .expect("handle redelivered key request");
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(
@@ -8045,6 +8062,12 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     assert_eq!(shared_key.key_data.as_deref(), Some(&[7; 32][..]));
     assert_eq!(shared_key.fingerprint.as_option(), Some(&fingerprint));
     assert_eq!(shared_key.timestamp, Some(456));
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        message_count_to_after(&transport.sent(), sent_before, requester_str),
+        1,
+        "a dropped request and its redelivery must produce one response"
+    );
 }
 
 #[tokio::test]
@@ -8074,7 +8097,7 @@ async fn app_state_key_share_transport_retry_waits_for_reconnect() {
     };
 
     transport.fail_next_sends(1);
-    client.schedule_app_state_sync_key_share(requester, request);
+    client.schedule_app_state_sync_key_share(requester, request, None);
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         while transport.failed_sends() == 0 {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -8136,6 +8159,7 @@ async fn app_state_key_share_preparation_failure_is_retried() {
                 key_id: Some(vec![4, 3, 2, 1]),
             }],
         },
+        None,
     );
 
     tokio::time::timeout(std::time::Duration::from_secs(3), async {
@@ -8181,7 +8205,7 @@ async fn app_state_key_share_survives_a_closed_flush_scope() {
 
     client.outbound_flush.close();
     let rejected_before = client.outbound_flush.track_rejections();
-    client.schedule_app_state_sync_key_share(requester, request);
+    client.schedule_app_state_sync_key_share(requester, request, None);
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         while client.outbound_flush.track_rejections() == rejected_before {
             tokio::task::yield_now().await;
@@ -8436,7 +8460,7 @@ async fn secret_encrypted_message_edit_dispatches_legacy_edit() {
     };
     let msg = encrypted_message_edit(target_key, chat, chat, parent_id, &secret, "edited", None);
 
-    client.dispatch_parsed_message(msg, &info).await;
+    client.dispatch_parsed_message(msg, &info, false).await;
 
     let got = collect_event(
         &client,
@@ -8499,7 +8523,7 @@ async fn secret_encrypted_peer_edit_resolves_sender_from_envelope() {
     // HKDF binds the real author (peer) as both original sender and editor.
     let msg = encrypted_message_edit(target_key, peer, peer, parent_id, &secret, "edited", None);
 
-    client.dispatch_parsed_message(msg, &info).await;
+    client.dispatch_parsed_message(msg, &info, false).await;
 
     let got = collect_event(
         &client,
@@ -8565,7 +8589,7 @@ async fn run_secret_edit_with_window(test_id: &str, parent_ts: i64, edit_offset:
         participant: None,
     };
     let msg = encrypted_message_edit(target_key, chat, chat, parent_id, &secret, "edited", None);
-    client.dispatch_parsed_message(msg, &info).await;
+    client.dispatch_parsed_message(msg, &info, false).await;
 
     collect_event(
         &client,
@@ -8700,7 +8724,7 @@ async fn secret_encrypted_edit_decrypts_via_resolver_when_store_empty() {
         None,
     );
 
-    client.dispatch_parsed_message(msg, &info).await;
+    client.dispatch_parsed_message(msg, &info, false).await;
 
     let got = collect_event(
         &client,
@@ -8763,7 +8787,9 @@ async fn decrypted_message_edit_recaptures_secret_for_next_edit() {
         "first",
         Some(second_secret.to_vec()),
     );
-    client.dispatch_parsed_message(first_msg, &first_info).await;
+    client
+        .dispatch_parsed_message(first_msg, &first_info, false)
+        .await;
     client.msg_secret_buffer.wait_flushed().await;
 
     let stored = client
@@ -8793,7 +8819,7 @@ async fn decrypted_message_edit_recaptures_secret_for_next_edit() {
         None,
     );
     client
-        .dispatch_parsed_message(second_msg, &second_info)
+        .dispatch_parsed_message(second_msg, &second_info, false)
         .await;
 
     let got = collect_event(
@@ -8871,7 +8897,7 @@ async fn secret_encrypted_message_edit_uses_lid_pn_fallback_in_group() {
         None,
     );
 
-    client.dispatch_parsed_message(msg, &info).await;
+    client.dispatch_parsed_message(msg, &info, false).await;
 
     let got = collect_event(
         &client,
@@ -8953,7 +8979,9 @@ async fn decrypted_message_edit_refreshes_alternate_secret_alias() {
         "first",
         Some(second_secret.to_vec()),
     );
-    client.dispatch_parsed_message(first_msg, &first_info).await;
+    client
+        .dispatch_parsed_message(first_msg, &first_info, false)
+        .await;
     client.msg_secret_buffer.wait_flushed().await;
 
     for sender in [sender_lid, sender_pn] {
@@ -8993,7 +9021,7 @@ async fn decrypted_message_edit_refreshes_alternate_secret_alias() {
         None,
     );
     client
-        .dispatch_parsed_message(second_msg, &second_info)
+        .dispatch_parsed_message(second_msg, &second_info, false)
         .await;
 
     let got = collect_event(
@@ -10876,7 +10904,7 @@ async fn enc_comment_inbound_dispatches_body_with_parent_link() {
         ..Default::default()
     });
 
-    client.dispatch_parsed_message(msg, &info).await;
+    client.dispatch_parsed_message(msg, &info, false).await;
 
     // Deadline-poll instead of a fixed sleep so a slow CI cannot race the
     // event delivery.

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7759,6 +7759,7 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
     let backend = client.persistence_manager.backend();
     let known_id = vec![1, 2, 3, 4, 5, 6];
     let orphan_id = vec![6, 5, 4, 3, 2, 1];
+    let corrupt_id = vec![9, 8, 7, 6, 5, 4];
     let fingerprint = wa::message::AppStateSyncKeyFingerprint {
         raw_id: Some(7),
         current_index: Some(3),
@@ -7775,6 +7776,17 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
         )
         .await
         .unwrap();
+    backend
+        .set_sync_key(
+            &corrupt_id,
+            crate::store::traits::AppStateSyncKey {
+                key_data: vec![8; 32],
+                fingerprint: vec![0xff],
+                timestamp: 456,
+            },
+        )
+        .await
+        .unwrap();
 
     let request = wa::message::AppStateSyncKeyRequest {
         key_ids: vec![
@@ -7784,6 +7796,9 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
             wa::message::AppStateSyncKeyId {
                 key_id: Some(orphan_id.clone()),
             },
+            wa::message::AppStateSyncKeyId {
+                key_id: Some(corrupt_id.clone()),
+            },
             wa::message::AppStateSyncKeyId { key_id: None },
         ],
     };
@@ -7792,7 +7807,7 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
         .await
         .unwrap();
 
-    assert_eq!(share.keys.len(), 2, "keyless requests must be ignored");
+    assert_eq!(share.keys.len(), 3, "keyless requests must be ignored");
     let known = &share.keys[0];
     assert_eq!(
         known.key_id.as_option().and_then(|id| id.key_id.as_ref()),
@@ -7811,6 +7826,16 @@ async fn app_state_sync_key_request_preserves_known_and_orphan_ids() {
     assert!(
         orphan.key_data.is_unset(),
         "an unknown ID must be returned without fabricated key data"
+    );
+
+    let corrupt = &share.keys[2];
+    assert_eq!(
+        corrupt.key_id.as_option().and_then(|id| id.key_id.as_ref()),
+        Some(&corrupt_id)
+    );
+    assert!(
+        corrupt.key_data.is_unset(),
+        "an unusable stored key must not suppress valid key shares"
     );
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -84,7 +84,9 @@ pub enum IqError {
 impl IqError {
     pub(crate) fn is_transport_unavailable(&self) -> bool {
         match self {
-            IqError::NotConnected => true,
+            IqError::NotConnected | IqError::Disconnected(_) | IqError::InternalChannelClosed => {
+                true
+            }
             IqError::EncryptSend(error) => error.is_transport_unavailable(),
             IqError::ClientState(client) => client.is_transport_unavailable(),
             _ => false,

--- a/src/request.rs
+++ b/src/request.rs
@@ -81,6 +81,17 @@ pub enum IqError {
     ParseError(#[from] anyhow::Error),
 }
 
+impl IqError {
+    pub(crate) fn is_transport_unavailable(&self) -> bool {
+        match self {
+            IqError::NotConnected => true,
+            IqError::EncryptSend(error) => error.is_transport_unavailable(),
+            IqError::ClientState(client) => client.is_transport_unavailable(),
+            _ => false,
+        }
+    }
+}
+
 impl From<wacore::request::IqError> for IqError {
     fn from(err: wacore::request::IqError) -> Self {
         match err {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -51,17 +51,34 @@ pub mod mock {
     /// client wrote to the wire.
     pub struct CapturingMockTransport {
         sent: std::sync::Mutex<Vec<bytes::Bytes>>,
+        remaining_failures: std::sync::atomic::AtomicUsize,
+        failed_sends: std::sync::atomic::AtomicUsize,
     }
 
     impl CapturingMockTransport {
         pub fn new() -> Self {
             Self {
                 sent: std::sync::Mutex::new(Vec::new()),
+                remaining_failures: std::sync::atomic::AtomicUsize::new(0),
+                failed_sends: std::sync::atomic::AtomicUsize::new(0),
             }
         }
 
         pub fn sent(&self) -> Vec<bytes::Bytes> {
             self.sent.lock().expect("capturing mutex").clone()
+        }
+
+        pub fn sent_count(&self) -> usize {
+            self.sent.lock().expect("capturing mutex").len()
+        }
+
+        pub fn fail_next_sends(&self, count: usize) {
+            self.remaining_failures
+                .store(count, std::sync::atomic::Ordering::Release);
+        }
+
+        pub fn failed_sends(&self) -> usize {
+            self.failed_sends.load(std::sync::atomic::Ordering::Acquire)
         }
     }
 
@@ -75,6 +92,19 @@ pub mod mock {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl Transport for CapturingMockTransport {
         async fn send(&self, data: bytes::Bytes) -> Result<(), anyhow::Error> {
+            if self
+                .remaining_failures
+                .fetch_update(
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                    |remaining| remaining.checked_sub(1),
+                )
+                .is_ok()
+            {
+                self.failed_sends
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return Err(anyhow::anyhow!("injected transport failure"));
+            }
             self.sent.lock().expect("capturing mutex").push(data);
             Ok(())
         }

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -103,8 +103,8 @@ pub struct TestClient {
 }
 
 async fn connect_diagnostics(
-    client: &Arc<whatsapp_rust::client::Client>,
-    backend: &Arc<InMemoryBackend>,
+    client: &whatsapp_rust::client::Client,
+    backend: &InMemoryBackend,
 ) -> String {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
@@ -120,8 +120,8 @@ async fn connect_diagnostics(
 }
 
 async fn collect_connect_diagnostics(
-    client: &Arc<whatsapp_rust::client::Client>,
-    backend: &Arc<InMemoryBackend>,
+    client: &whatsapp_rust::client::Client,
+    backend: &InMemoryBackend,
 ) -> String {
     async fn session_status(
         client: &whatsapp_rust::client::Client,

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use wacore::net::{HttpClient, HttpRequest};
 use wacore::store::InMemoryBackend;
-use wacore::store::traits::TcTokenEntry;
+use wacore::store::traits::{AppSyncStore, TcTokenEntry};
 use wacore::types::events::{ChannelEventHandler, Event};
 use wacore_binary::node::Node;
 use whatsapp_rust::Jid;
@@ -102,6 +102,45 @@ pub struct TestClient {
     pub backend: Arc<InMemoryBackend>,
 }
 
+async fn connect_diagnostics(
+    client: &Arc<whatsapp_rust::client::Client>,
+    backend: &Arc<InMemoryBackend>,
+) -> String {
+    let snapshot = client.persistence_manager().get_device_snapshot();
+    let primary = snapshot
+        .lid
+        .as_ref()
+        .or(snapshot.pn.as_ref())
+        .map(|jid| jid.to_non_ad());
+    let has_pn = snapshot.pn.is_some();
+    let has_lid = snapshot.lid.is_some();
+    drop(snapshot);
+
+    let primary_session = match primary {
+        Some(jid) => match client.signal().validate_session(&jid).await {
+            Ok(true) => "present",
+            Ok(false) => "absent",
+            Err(_) => "unknown",
+        },
+        None => "unavailable",
+    };
+    let sync_keys = backend.sync_key_count_for_test().await;
+    let report = client.memory_report().await;
+
+    format!(
+        "socket_connected={}, logged_in={}, has_pn={}, has_lid={}, sync_keys={}, \
+         primary_session={}, app_state_requests={}, app_state_syncs={}",
+        client.is_connected(),
+        client.is_logged_in(),
+        has_pn,
+        has_lid,
+        sync_keys,
+        primary_session,
+        report.app_state_key_requests,
+        report.app_state_syncing,
+    )
+}
+
 impl TestClient {
     /// Create a client, connect to the mock server, and wait for PairSuccess + Connected.
     /// Returns the connected TestClient with its JID available via `client.get_pn()`.
@@ -125,7 +164,7 @@ impl TestClient {
         Self::connect_inner(prefix, Some(push_name.to_string())).await
     }
 
-    async fn connect_inner(_prefix: &str, push_name: Option<String>) -> anyhow::Result<Self> {
+    async fn connect_inner(prefix: &str, push_name: Option<String>) -> anyhow::Result<Self> {
         let transport_factory = TokioWebSocketTransportFactory::new().with_url(mock_server_url());
         let (event_handler, event_rx) = ChannelEventHandler::new();
 
@@ -174,10 +213,11 @@ impl TestClient {
             .wait_for_connected(tokio::time::Duration::from_secs(60))
             .await
         {
+            let diagnostics = connect_diagnostics(&client, &backend).await;
             client.disconnect().await;
             drop(run_handle);
             return Err(anyhow::anyhow!(
-                "client never became ready after pairing: {e}"
+                "{prefix}: client never became ready after pairing ({diagnostics}): {e}"
             ));
         }
 
@@ -190,10 +230,11 @@ impl TestClient {
             .wait_for_startup_sync(tokio::time::Duration::from_secs(30))
             .await
         {
+            let diagnostics = connect_diagnostics(&client, &backend).await;
             client.disconnect().await;
             drop(run_handle);
             return Err(anyhow::anyhow!(
-                "startup sync did not settle before the connect deadline: {e}"
+                "{prefix}: startup sync did not settle ({diagnostics}): {e}"
             ));
         }
 
@@ -395,6 +436,19 @@ impl TestClient {
         self.wait_for_event(10, |e| matches!(e, Event::SelfPushNameUpdated(_)))
             .await?;
         Ok(())
+    }
+
+    pub async fn wait_for_sync_key(&self, key_id: &[u8], timeout_secs: u64) -> anyhow::Result<()> {
+        tokio::time::timeout(tokio::time::Duration::from_secs(timeout_secs), async {
+            loop {
+                if self.backend.get_sync_key(key_id).await?.is_some() {
+                    return Ok::<_, anyhow::Error>(());
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("Timed out waiting for app-state sync key"))?
     }
 
     // ── Connection lifecycle ────────────────────────────────────────────────

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -106,6 +106,23 @@ async fn connect_diagnostics(
     client: &Arc<whatsapp_rust::client::Client>,
     backend: &Arc<InMemoryBackend>,
 ) -> String {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+    match tokio::time::timeout(TIMEOUT, collect_connect_diagnostics(client, backend)).await {
+        Ok(diagnostics) => diagnostics,
+        Err(_) => format!(
+            "diagnostics_timed_out_after={}s, socket_connected={}, logged_in={}",
+            TIMEOUT.as_secs(),
+            client.is_connected(),
+            client.is_logged_in(),
+        ),
+    }
+}
+
+async fn collect_connect_diagnostics(
+    client: &Arc<whatsapp_rust::client::Client>,
+    backend: &Arc<InMemoryBackend>,
+) -> String {
     async fn session_status(
         client: &whatsapp_rust::client::Client,
         jid: Option<whatsapp_rust::Jid>,

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -106,36 +106,44 @@ async fn connect_diagnostics(
     client: &Arc<whatsapp_rust::client::Client>,
     backend: &Arc<InMemoryBackend>,
 ) -> String {
+    async fn session_status(
+        client: &whatsapp_rust::client::Client,
+        jid: Option<whatsapp_rust::Jid>,
+    ) -> &'static str {
+        match jid {
+            Some(jid) => match client.signal().validate_session(&jid).await {
+                Ok(true) => "present",
+                Ok(false) => "absent",
+                Err(_) => "unknown",
+            },
+            None => "unavailable",
+        }
+    }
+
     let snapshot = client.persistence_manager().get_device_snapshot();
-    let primary = snapshot
-        .lid
-        .as_ref()
-        .or(snapshot.pn.as_ref())
-        .map(|jid| jid.to_non_ad());
+    let primary_pn = snapshot.pn.as_ref().map(|jid| jid.to_non_ad());
+    let primary_lid = snapshot.lid.as_ref().map(|jid| jid.to_non_ad());
     let has_pn = snapshot.pn.is_some();
     let has_lid = snapshot.lid.is_some();
     drop(snapshot);
 
-    let primary_session = match primary {
-        Some(jid) => match client.signal().validate_session(&jid).await {
-            Ok(true) => "present",
-            Ok(false) => "absent",
-            Err(_) => "unknown",
-        },
-        None => "unavailable",
-    };
+    let (primary_pn_session, primary_lid_session) = futures::join!(
+        session_status(client, primary_pn),
+        session_status(client, primary_lid),
+    );
     let sync_keys = backend.sync_key_count_for_test().await;
     let report = client.memory_report().await;
 
     format!(
         "socket_connected={}, logged_in={}, has_pn={}, has_lid={}, sync_keys={}, \
-         primary_session={}, app_state_requests={}, app_state_syncs={}",
+         primary_pn_session={}, primary_lid_session={}, app_state_requests={}, app_state_syncs={}",
         client.is_connected(),
         client.is_logged_in(),
         has_pn,
         has_lid,
         sync_keys,
-        primary_session,
+        primary_pn_session,
+        primary_lid_session,
         report.app_state_key_requests,
         report.app_state_syncing,
     )
@@ -448,7 +456,12 @@ impl TestClient {
             }
         })
         .await
-        .map_err(|_| anyhow::anyhow!("Timed out waiting for app-state sync key"))?
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "Timed out after {}s waiting for app-state sync key {key_id:02x?}",
+                timeout_secs,
+            )
+        })?
     }
 
     // ── Connection lifecycle ────────────────────────────────────────────────

--- a/tests/e2e/tests/app_state.rs
+++ b/tests/e2e/tests/app_state.rs
@@ -1,7 +1,8 @@
 use e2e_tests::TestClient;
 use log::info;
+use wacore::store::traits::AppSyncStore;
 use wacore::types::events::Event;
-use whatsapp_rust::waproto::whatsapp as wa;
+use whatsapp_rust::{NodeFilter, waproto::whatsapp as wa};
 
 // ─── Initial Sync Tests ─────────────────────────────────────────────
 
@@ -252,10 +253,9 @@ async fn test_star_received_message() -> anyhow::Result<()> {
 async fn test_multi_device_app_state_sync() -> anyhow::Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
 
-    // Both clients use the same push_name → mock server assigns them the same phone
-    let push_name = "multidev_test_user";
-    let mut client_a1 = TestClient::connect_as("e2e_multidev_a1", push_name).await?;
-    let mut client_a2 = TestClient::connect_as("e2e_multidev_a2", push_name).await?;
+    let push_name = e2e_tests::unique_push_name("e2e_multidev");
+    let mut client_a1 = TestClient::connect_as("e2e_multidev_a1", &push_name).await?;
+    let mut client_a2 = TestClient::connect_as("e2e_multidev_a2", &push_name).await?;
 
     // Verify both devices got the same phone number
     let phone_a1 = client_a1.client.get_pn().expect("A1 should have JID");
@@ -300,6 +300,75 @@ async fn test_multi_device_app_state_sync() -> anyhow::Result<()> {
 
     client_a1.disconnect().await;
     client_a2.disconnect().await;
+    Ok(())
+}
+
+// ─── Recovery Tests ─────────────────────────────────────────────────
+
+/// A missing decode key must remain recoverable when the pairing session is absent.
+#[tokio::test]
+async fn test_missing_key_request_rebuilds_primary_session() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let account = e2e_tests::unique_push_name("e2e_as_key_recovery");
+    let mut client_a = TestClient::connect_as("e2e_as_key_recovery_a", &account).await?;
+    let mut client_b = TestClient::connect_as("e2e_as_key_recovery_b", &account).await?;
+    client_a.wait_for_app_state_sync().await?;
+    client_b.wait_for_app_state_sync().await?;
+
+    let key_id = client_a
+        .backend
+        .get_latest_sync_key_id()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("initial key share did not store a sync key"))?;
+    assert!(
+        client_a.backend.remove_sync_key_for_test(&key_id).await,
+        "active sync key must exist before the simulated loss"
+    );
+
+    let primary = client_a.jid().await;
+    client_a
+        .client
+        .signal()
+        .delete_sessions(std::slice::from_ref(&primary))
+        .await?;
+    assert!(
+        !client_a.client.signal().validate_session(&primary).await?,
+        "primary session must be absent before recovery"
+    );
+
+    let request = client_a
+        .client
+        .wait_for_sent_node(NodeFilter::tag("message").attr("category", "peer"));
+    let updated_name = e2e_tests::unique_push_name("key_recovery_update");
+    client_b
+        .client
+        .profile()
+        .set_push_name(&updated_name)
+        .await?;
+
+    let node = tokio::time::timeout(tokio::time::Duration::from_secs(10), request)
+        .await
+        .map_err(|_| anyhow::anyhow!("missing-key recovery did not send a peer request"))?
+        .map_err(|_| anyhow::anyhow!("peer request waiter was canceled"))?;
+    assert_eq!(
+        node.attrs().optional_jid("to").map(|jid| jid.user),
+        Some(primary.user.clone()),
+        "the key request must target this account's primary"
+    );
+    assert!(
+        client_a.client.signal().validate_session(&primary).await?,
+        "missing-key recovery must establish the primary session"
+    );
+    client_a.wait_for_sync_key(&key_id, 10).await?;
+    client_a
+        .wait_for_event(10, |event| {
+            matches!(event, Event::SelfPushNameUpdated(update) if update.new_name == updated_name)
+        })
+        .await?;
+
+    client_a.disconnect().await;
+    client_b.disconnect().await;
     Ok(())
 }
 

--- a/tests/e2e/tests/app_state.rs
+++ b/tests/e2e/tests/app_state.rs
@@ -311,10 +311,10 @@ async fn test_missing_key_request_rebuilds_primary_session() -> anyhow::Result<(
     let _ = env_logger::builder().is_test(true).try_init();
 
     let account = e2e_tests::unique_push_name("e2e_as_key_recovery");
-    let mut client_a = TestClient::connect_as("e2e_as_key_recovery_a", &account).await?;
     let mut client_b = TestClient::connect_as("e2e_as_key_recovery_b", &account).await?;
-    client_a.wait_for_app_state_sync().await?;
+    let mut client_a = TestClient::connect_as("e2e_as_key_recovery_a", &account).await?;
     client_b.wait_for_app_state_sync().await?;
+    client_a.wait_for_app_state_sync().await?;
 
     let key_id = client_a
         .backend
@@ -327,6 +327,14 @@ async fn test_missing_key_request_rebuilds_primary_session() -> anyhow::Result<(
     );
 
     let primary = client_a.jid().await;
+    let sibling = client_b
+        .client
+        .get_pn()
+        .ok_or_else(|| anyhow::anyhow!("sibling PN missing after connect"))?;
+    assert_ne!(
+        sibling.device, 0,
+        "the sibling companion must have a non-primary device id"
+    );
     client_a
         .client
         .signal()
@@ -337,9 +345,25 @@ async fn test_missing_key_request_rebuilds_primary_session() -> anyhow::Result<(
         "primary session must be absent before recovery"
     );
 
-    let request = client_a
+    let primary_request = client_a.client.wait_for_sent_node(
+        NodeFilter::tag("message")
+            .attr("category", "peer")
+            .attr("to", primary.to_string()),
+    );
+    let sibling_request = client_a.client.wait_for_sent_node(
+        NodeFilter::tag("message")
+            .attr("category", "peer")
+            .attr("to", sibling.to_string()),
+    );
+    let requester_lid = client_a
         .client
-        .wait_for_sent_node(NodeFilter::tag("message").attr("category", "peer"));
+        .get_lid()
+        .ok_or_else(|| anyhow::anyhow!("requester LID missing after connect"))?;
+    let sibling_share = client_b.client.wait_for_sent_node(
+        NodeFilter::tag("message")
+            .attr("category", "peer")
+            .attr("to", requester_lid.to_string()),
+    );
     let updated_name = e2e_tests::unique_push_name("key_recovery_update");
     client_b
         .client
@@ -347,14 +371,25 @@ async fn test_missing_key_request_rebuilds_primary_session() -> anyhow::Result<(
         .set_push_name(&updated_name)
         .await?;
 
-    let node = tokio::time::timeout(tokio::time::Duration::from_secs(10), request)
+    tokio::time::timeout(tokio::time::Duration::from_secs(10), primary_request)
         .await
-        .map_err(|_| anyhow::anyhow!("missing-key recovery did not send a peer request"))?
-        .map_err(|_| anyhow::anyhow!("peer request waiter was canceled"))?;
+        .map_err(|_| anyhow::anyhow!("missing-key recovery did not request the primary"))?
+        .map_err(|_| anyhow::anyhow!("primary request waiter was canceled"))?;
+    tokio::time::timeout(tokio::time::Duration::from_secs(10), sibling_request)
+        .await
+        .map_err(|_| anyhow::anyhow!("missing-key recovery did not request the sibling"))?
+        .map_err(|_| anyhow::anyhow!("sibling request waiter was canceled"))?;
+    let sibling_share = tokio::time::timeout(tokio::time::Duration::from_secs(10), sibling_share)
+        .await
+        .map_err(|_| anyhow::anyhow!("the sibling did not return an app-state key share"))?
+        .map_err(|_| anyhow::anyhow!("sibling key-share waiter was canceled"))?;
+    let share_target = sibling_share
+        .attrs()
+        .optional_jid("to")
+        .ok_or_else(|| anyhow::anyhow!("sibling key share had no target"))?;
     assert_eq!(
-        node.attrs().optional_jid("to").map(|jid| jid.user),
-        Some(primary.user.clone()),
-        "the key request must target this account's primary"
+        share_target, requester_lid,
+        "the key share must return only to the requesting device"
     );
     assert!(
         client_a.client.signal().validate_session(&primary).await?,

--- a/tests/e2e/tests/lid_sessions.rs
+++ b/tests/e2e/tests/lid_sessions.rs
@@ -581,6 +581,10 @@ async fn test_pn_only_session_causes_undecryptable_on_lid_lookup() -> anyhow::Re
         .expect("Message should decrypt after on-the-fly PN->LID migration");
     info!("Message decrypted despite PN-only backend state");
 
+    // Event delivery precedes the coalesced Signal flush; inspect durability only
+    // after crossing the same persistence boundary used by production shutdown.
+    client_a.client.flush_pending_signal_state().await?;
+
     client_a
         .assert_no_event(
             3,

--- a/tests/e2e/tests/lid_sessions.rs
+++ b/tests/e2e/tests/lid_sessions.rs
@@ -295,14 +295,14 @@ async fn test_stale_pn_session_does_not_break_lid_messaging() -> anyhow::Result<
     client_a
         .assert_no_event(
             3,
-            |e| matches!(e, Event::UndecryptableMessage(u) if !u.info.source.is_from_me),
+            |e| matches!(e, Event::UndecryptableMessage(_)),
             "A should have no undecryptable messages with stale PN session",
         )
         .await?;
     client_b
         .assert_no_event(
             3,
-            |e| matches!(e, Event::UndecryptableMessage(u) if !u.info.source.is_from_me),
+            |e| matches!(e, Event::UndecryptableMessage(_)),
             "B should have no undecryptable messages with stale PN session",
         )
         .await?;
@@ -470,14 +470,14 @@ async fn test_no_undecryptable_events_during_messaging() -> anyhow::Result<()> {
     client_a
         .assert_no_event(
             3,
-            |e| matches!(e, Event::UndecryptableMessage(u) if !u.info.source.is_from_me),
+            |e| matches!(e, Event::UndecryptableMessage(_)),
             "A should have no undecryptable messages",
         )
         .await?;
     client_b
         .assert_no_event(
             3,
-            |e| matches!(e, Event::UndecryptableMessage(u) if !u.info.source.is_from_me),
+            |e| matches!(e, Event::UndecryptableMessage(_)),
             "B should have no undecryptable messages",
         )
         .await?;
@@ -581,13 +581,10 @@ async fn test_pn_only_session_causes_undecryptable_on_lid_lookup() -> anyhow::Re
         .expect("Message should decrypt after on-the-fly PN->LID migration");
     info!("Message decrypted despite PN-only backend state");
 
-    // The peer message must not surface undecryptable. Ignore own self-fanout
-    // (is_from_me): offline self-sync redeliveries can BadMac independently of
-    // the PN→LID migration under test and would flake this assertion.
     client_a
         .assert_no_event(
             3,
-            |e| matches!(e, Event::UndecryptableMessage(u) if !u.info.source.is_from_me),
+            |e| matches!(e, Event::UndecryptableMessage(_)),
             "No undecryptable events after migration",
         )
         .await?;
@@ -695,11 +692,10 @@ async fn test_pn_migration_is_durable_across_followup_messages() -> anyhow::Resu
         backend_a.get_session(&pn_addr).await?.is_none(),
         "stale PN copy stays gone after migration"
     );
-    // Peer messages only; own self-fanout redeliveries are unrelated noise.
     client_a
         .assert_no_event(
             3,
-            |e| matches!(e, Event::UndecryptableMessage(u) if !u.info.source.is_from_me),
+            |e| matches!(e, Event::UndecryptableMessage(_)),
             "no undecryptable after PN→LID migration",
         )
         .await?;

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -157,6 +157,18 @@ impl InMemoryBackend {
     pub fn set_fail_sender_key_writes(&self, fail: bool) {
         self.fail_sender_key_writes.store(fail, Ordering::Relaxed);
     }
+
+    /// Lets recovery tests remove only the state needed to trigger a key request.
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn remove_sync_key_for_test(&self, key_id: &[u8]) -> bool {
+        self.state.lock().await.sync_keys.remove(key_id).is_some()
+    }
+
+    /// Keeps readiness failures attributable without exposing key material.
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn sync_key_count_for_test(&self) -> usize {
+        self.state.lock().await.sync_keys.len()
+    }
 }
 
 impl Default for InMemoryBackend {


### PR DESCRIPTION
## Why

A companion can receive an app-state patch whose key is no longer in its local store. WhatsApp Web asks the other devices on the same account for that key; this client only asked the primary. Recovery therefore failed when the primary session was missing or another companion held the remaining copy.

The E2E flake exposed that production gap rather than a test-only timing issue.

## What changed

- discover the account's other devices, exclude the current device, and fan out encrypted key requests concurrently
- bound passive fanout with the same 10-second recovery budget used by the active waiter; partial delivery remains useful and stalled peers are cancelled at the deadline
- fall back to the known primary when discovery fails or returns no usable peer
- actively retry still-missing keys with bounded backoff, overriding a passive 24-hour dedup stamp while a critical sync is waiting
- handle self-originated `AppStateSyncKeyRequest` messages and reply only to the requesting device
- preserve known keys and orphan IDs in one response; an unusable stored fingerprint becomes an orphan instead of suppressing valid keys
- commit the inbound request first, wait for the offline drain to become durable, then read the key store and build the response
- retry preparation and local send failures; after an uncertain transport failure, wait for a new Noise connection generation and reuse the exact message ID and plaintext
- keep missing-key dedup IDs as raw bytes and clear fulfilled stamps after durable storage
- improve bounded connection diagnostics and strengthen exact encrypted-routing, durability, reconnect, retry, and session-rebuild regressions

Requests and shares from another account remain rejected. No wire format, protocol gate, or production behavior is relaxed for tests.

## WhatsApp Web evidence

The behavior follows the captured client modules under `docs/captured-js/WAWeb/`:

- `Key/ManagementSendKeyRequestApi.js`: one request per peer with settled-result handling
- `Key/ManagementUtils.js`: enumerate this account's devices and exclude the current one
- `Handle/MsgProcess.js`, `Start/Backend.js`, and `Handle/DeferredMessages.js`: defer key requests until critical/offline processing is complete
- `Key/ManagementHandleKeyRequestApi.js`: read available keys and persist the response job only when deferred handling runs
- `Key/ManagementSendKeyShareApi.js`: preserve available keys and orphan IDs and target the requester
- `Persisted/JobDefinitions.js` and `Send/RequestedKeyShareJob.js`: persist one response snapshot and send that snapshot later
- `Key/ManagementHandleKeyShareApi.js`: accept shares only from this account

## Validation

CI passed on `50668070`: formatting, Clippy, workspace tests, all-features/VOIP, no-SIMD, WASM, binary size, CodSpeed benchmarks, and the complete E2E suite against the pinned Bartender image. Binary growth remains within budget (`.text` +27.56 KiB / 32 KiB; stripped +33.66 KiB / 64 KiB).

Focused regressions cover:

- a key learned later in the offline drain is present in the decrypted response
- a failed inbound commit cannot put a key share on the wire
- transient response preparation is retried
- uncertain transport delivery retries only after reconnect
- a closed flush scope preserves the response job across reconnect
- active recovery finishes when a key arrives despite a stalled peer
- complete missing-key recovery across primary and sibling companions
