### PR TITLE
perf(core): reduce allocation churn across sync and crypto paths

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -270,13 +270,11 @@ impl Client {
         tracing::instrument(name = "wa.media.download", level = "debug", skip_all, err(Debug))
     )]
     pub async fn download(&self, downloadable: &dyn Downloadable) -> Result<Vec<u8>> {
-        // Stream each attempt into a FRESH in-memory buffer: the CDN read and the
-        // AES/HMAC decrypt interleave in one blocking pass (overlapping network
-        // with CPU, ~halving peak memory vs. fetch-whole-then-decrypt), and a new
-        // buffer per attempt means a failed host that wrote a longer body can't
-        // leave a stale tail behind a shorter successful retry. Pre-size to the
-        // declared plaintext length, capped so a bogus length can't drive a huge
-        // speculative allocation.
+        // Each attempt owns a fresh buffer, so failed hosts cannot leave a stale
+        // tail behind a shorter retry. Streaming clients decrypt directly into a
+        // pre-sized output. Buffered clients already paid for a complete response
+        // Vec, so authenticate and decrypt that allocation in place instead of
+        // keeping a second file-sized output alive beside it.
         let cap = downloadable
             .file_length()
             .unwrap_or(0)
@@ -285,11 +283,15 @@ impl Client {
             |force| self.prepare_requests(downloadable, force),
             || async { self.invalidate_media_conn().await },
             |request| async move {
-                let writer = std::io::Cursor::new(Vec::with_capacity(cap));
-                match self.streaming_download_and_decrypt(&request, writer).await {
-                    Ok((writer, Ok(()))) => Ok(writer.into_inner()),
-                    Ok((_, Err(e))) => Err(e),
-                    Err(e) => Err(DownloadRequestError::other(e)),
+                if self.http_client.supports_streaming() {
+                    let writer = std::io::Cursor::new(Vec::with_capacity(cap));
+                    match self.streaming_download_and_decrypt(&request, writer).await {
+                        Ok((writer, Ok(()))) => Ok(writer.into_inner()),
+                        Ok((_, Err(e))) => Err(e),
+                        Err(e) => Err(DownloadRequestError::other(e)),
+                    }
+                } else {
+                    self.buffered_download_to_vec(&request).await
                 }
             },
         )
@@ -470,69 +472,73 @@ impl Client {
     async fn buffered_download_and_decrypt<W: Write + Seek + Send + 'static>(
         &self,
         request: &wacore::download::DownloadRequest,
-        mut writer: W,
+        writer: W,
     ) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
-        let http_request = crate::http::HttpRequest::get(request.url.clone());
-        let resp = match self.http_client.execute(http_request).await {
-            Ok(r) => r,
-            Err(e) => return Ok((writer, Err(DownloadRequestError::other(e)))),
+        let body = match self.buffered_download_to_vec(request).await {
+            Ok(body) => body,
+            Err(err) => return Ok((writer, Err(err))),
         };
 
-        if resp.status_code >= 300 {
-            let err = if is_media_auth_error(resp.status_code) {
-                DownloadRequestError::auth(resp.status_code)
-            } else if matches!(resp.status_code, 404 | 410) {
-                DownloadRequestError::not_found(resp.status_code)
-            } else {
-                DownloadRequestError::other(anyhow!(
-                    "Download failed with status: {}",
-                    resp.status_code
-                ))
-            };
-            return Ok((writer, Err(err)));
-        }
-
-        let decryption = request.decryption.clone();
-
-        // Offload blocking decrypt+write to avoid stalling the async executor
+        // The expensive authentication/decrypt already ran in the helper. Keep
+        // potentially blocking file I/O off the async executor as well.
         Ok(wacore::runtime::blocking(&*self.runtime, move || {
+            let mut writer = writer;
             if let Err(e) = writer.seek(SeekFrom::Start(0)) {
                 return (writer, Err(DownloadRequestError::other(e)));
             }
-
-            let result = (|| -> std::result::Result<(), DownloadRequestError> {
-                let reader = std::io::Cursor::new(resp.body);
-                match &decryption {
-                    MediaDecryption::Encrypted {
-                        media_key,
-                        media_type,
-                    } => {
-                        DownloadUtils::decrypt_stream_to_writer(
-                            reader,
-                            media_key,
-                            *media_type,
-                            &mut writer,
-                        )
-                        .map_err(DownloadRequestError::other)?;
-                    }
-                    MediaDecryption::Plaintext { file_sha256 } => {
-                        DownloadUtils::copy_and_validate_plaintext_to_writer(
-                            reader,
-                            file_sha256,
-                            &mut writer,
-                        )
-                        .map_err(DownloadRequestError::other)?;
-                    }
-                }
-                writer
-                    .seek(SeekFrom::Start(0))
-                    .map_err(DownloadRequestError::other)?;
-                Ok(())
-            })();
+            let result = writer
+                .write_all(&body)
+                .and_then(|()| writer.seek(SeekFrom::Start(0)).map(|_| ()))
+                .map_err(DownloadRequestError::other);
 
             (writer, result)
         })
         .await)
+    }
+
+    /// Execute a non-streaming HTTP download and reuse the response allocation
+    /// for the final plaintext. This is especially important on WASM, where the
+    /// JS `Uint8Array` must already be copied into linear memory at the FFI edge.
+    async fn buffered_download_to_vec(
+        &self,
+        request: &wacore::download::DownloadRequest,
+    ) -> std::result::Result<Vec<u8>, DownloadRequestError> {
+        let http_request = crate::http::HttpRequest::get(request.url.clone());
+        let response = self
+            .http_client
+            .execute(http_request)
+            .await
+            .map_err(DownloadRequestError::other)?;
+        if response.status_code >= 300 {
+            return Err(if is_media_auth_error(response.status_code) {
+                DownloadRequestError::auth(response.status_code)
+            } else if matches!(response.status_code, 404 | 410) {
+                DownloadRequestError::not_found(response.status_code)
+            } else {
+                DownloadRequestError::other(anyhow!(
+                    "Download failed with status: {}",
+                    response.status_code
+                ))
+            });
+        }
+
+        let decryption = request.decryption.clone();
+        wacore::runtime::blocking(&*self.runtime, move || {
+            let mut body = response.body;
+            match &decryption {
+                MediaDecryption::Encrypted {
+                    media_key,
+                    media_type,
+                } => DownloadUtils::verify_and_decrypt_in_place(&mut body, media_key, *media_type)
+                    .map_err(DownloadRequestError::other)?,
+                MediaDecryption::Plaintext { file_sha256 } => {
+                    DownloadUtils::validate_plaintext_sha256(&body, file_sha256)
+                        .map_err(DownloadRequestError::other)?;
+                }
+            }
+            Ok(body)
+        })
+        .await
     }
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,7 @@
 use crate::client::Client;
+use crate::http::{
+    HTTP_STATUS_GONE, HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK, HTTP_STATUS_REDIRECTION_START,
+};
 use crate::mediaconn::{MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS, MediaConn, is_media_auth_error};
 use anyhow::{Result, anyhow};
 use std::io::{Seek, SeekFrom, Write};
@@ -119,6 +122,38 @@ impl DownloadRequestError {
     fn into_anyhow(self) -> anyhow::Error {
         match self {
             Self::Auth(err) | Self::NotFound(err) | Self::Other(err) => err,
+        }
+    }
+}
+
+fn validate_download_status(status_code: u16) -> std::result::Result<(), DownloadRequestError> {
+    if status_code < HTTP_STATUS_REDIRECTION_START {
+        return Ok(());
+    }
+
+    let error = if is_media_auth_error(status_code) {
+        DownloadRequestError::auth(status_code)
+    } else if matches!(status_code, HTTP_STATUS_NOT_FOUND | HTTP_STATUS_GONE) {
+        DownloadRequestError::not_found(status_code)
+    } else {
+        DownloadRequestError::other(anyhow!("Download failed with status: {status_code}"))
+    };
+    Err(error)
+}
+
+fn decrypt_or_validate_buffered_body(
+    body: &mut Vec<u8>,
+    decryption: &MediaDecryption,
+) -> std::result::Result<(), DownloadRequestError> {
+    match decryption {
+        MediaDecryption::Encrypted {
+            media_key,
+            media_type,
+        } => DownloadUtils::verify_and_decrypt_in_place(body, media_key, *media_type)
+            .map_err(DownloadRequestError::other),
+        MediaDecryption::Plaintext { file_sha256 } => {
+            DownloadUtils::validate_plaintext_sha256(body, file_sha256)
+                .map_err(DownloadRequestError::other)
         }
     }
 }
@@ -323,7 +358,7 @@ impl Client {
             .execute(crate::http::HttpRequest::get(&url))
             .await
             .map_err(|e| anyhow!("sticker pack request failed: {e}"))?;
-        if response.status_code != 200 {
+        if response.status_code != HTTP_STATUS_OK {
             return Err(anyhow!(
                 "sticker pack endpoint returned status {}",
                 response.status_code
@@ -422,18 +457,7 @@ impl Client {
                     .execute_streaming(http_request)
                     .map_err(DownloadRequestError::other)?;
 
-                if resp.status_code >= 300 {
-                    return Err(if is_media_auth_error(resp.status_code) {
-                        DownloadRequestError::auth(resp.status_code)
-                    } else if matches!(resp.status_code, 404 | 410) {
-                        DownloadRequestError::not_found(resp.status_code)
-                    } else {
-                        DownloadRequestError::other(anyhow!(
-                            "Download failed with status: {}",
-                            resp.status_code
-                        ))
-                    });
-                }
+                validate_download_status(resp.status_code)?;
 
                 match &decryption {
                     MediaDecryption::Encrypted {
@@ -474,32 +498,36 @@ impl Client {
         request: &wacore::download::DownloadRequest,
         writer: W,
     ) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
-        let body = match self.buffered_download_to_vec(request).await {
+        let mut body = match self.buffered_download_body(request).await {
             Ok(body) => body,
             Err(err) => return Ok((writer, Err(err))),
         };
+        let decryption = request.decryption.clone();
 
-        // The expensive authentication/decrypt already ran in the helper. Keep
-        // potentially blocking file I/O off the async executor as well.
+        // Keep authentication/decryption and writer I/O in one blocking task so
+        // non-streaming writer downloads pay for a single executor round-trip.
         Ok(wacore::runtime::blocking(&*self.runtime, move || {
             let mut writer = writer;
-            if let Err(e) = writer.seek(SeekFrom::Start(0)) {
-                return (writer, Err(DownloadRequestError::other(e)));
-            }
-            let result = writer
-                .write_all(&body)
-                .and_then(|()| writer.seek(SeekFrom::Start(0)).map(|_| ()))
-                .map_err(DownloadRequestError::other);
+            let result = (|| {
+                decrypt_or_validate_buffered_body(&mut body, &decryption)?;
+                writer
+                    .seek(SeekFrom::Start(0))
+                    .map_err(DownloadRequestError::other)?;
+                writer
+                    .write_all(&body)
+                    .map_err(DownloadRequestError::other)?;
+                writer
+                    .seek(SeekFrom::Start(0))
+                    .map_err(DownloadRequestError::other)?;
+                Ok(())
+            })();
 
             (writer, result)
         })
         .await)
     }
 
-    /// Execute a non-streaming HTTP download and reuse the response allocation
-    /// for the final plaintext. This is especially important on WASM, where the
-    /// JS `Uint8Array` must already be copied into linear memory at the FFI edge.
-    async fn buffered_download_to_vec(
+    async fn buffered_download_body(
         &self,
         request: &wacore::download::DownloadRequest,
     ) -> std::result::Result<Vec<u8>, DownloadRequestError> {
@@ -509,33 +537,21 @@ impl Client {
             .execute(http_request)
             .await
             .map_err(DownloadRequestError::other)?;
-        if response.status_code >= 300 {
-            return Err(if is_media_auth_error(response.status_code) {
-                DownloadRequestError::auth(response.status_code)
-            } else if matches!(response.status_code, 404 | 410) {
-                DownloadRequestError::not_found(response.status_code)
-            } else {
-                DownloadRequestError::other(anyhow!(
-                    "Download failed with status: {}",
-                    response.status_code
-                ))
-            });
-        }
+        validate_download_status(response.status_code)?;
+        Ok(response.body)
+    }
 
+    /// Execute a non-streaming HTTP download and reuse the response allocation
+    /// for the final plaintext. This is especially important on WASM, where the
+    /// JS `Uint8Array` must already be copied into linear memory at the FFI edge.
+    async fn buffered_download_to_vec(
+        &self,
+        request: &wacore::download::DownloadRequest,
+    ) -> std::result::Result<Vec<u8>, DownloadRequestError> {
+        let mut body = self.buffered_download_body(request).await?;
         let decryption = request.decryption.clone();
         wacore::runtime::blocking(&*self.runtime, move || {
-            let mut body = response.body;
-            match &decryption {
-                MediaDecryption::Encrypted {
-                    media_key,
-                    media_type,
-                } => DownloadUtils::verify_and_decrypt_in_place(&mut body, media_key, *media_type)
-                    .map_err(DownloadRequestError::other)?,
-                MediaDecryption::Plaintext { file_sha256 } => {
-                    DownloadUtils::validate_plaintext_sha256(&body, file_sha256)
-                        .map_err(DownloadRequestError::other)?;
-                }
-            }
+            decrypt_or_validate_buffered_body(&mut body, &decryption)?;
             Ok(body)
         })
         .await
@@ -600,6 +616,33 @@ mod tests {
             .expect("hash derivation should succeed")
             .file_sha256
             .to_vec()
+    }
+
+    #[test]
+    fn download_statuses_have_one_shared_classification() {
+        use crate::http::{HTTP_STATUS_FORBIDDEN, HTTP_STATUS_UNAUTHORIZED};
+
+        assert!(validate_download_status(HTTP_STATUS_OK).is_ok());
+        assert!(matches!(
+            validate_download_status(HTTP_STATUS_UNAUTHORIZED),
+            Err(DownloadRequestError::Auth(_))
+        ));
+        assert!(matches!(
+            validate_download_status(HTTP_STATUS_FORBIDDEN),
+            Err(DownloadRequestError::Auth(_))
+        ));
+        assert!(matches!(
+            validate_download_status(HTTP_STATUS_NOT_FOUND),
+            Err(DownloadRequestError::NotFound(_))
+        ));
+        assert!(matches!(
+            validate_download_status(HTTP_STATUS_GONE),
+            Err(DownloadRequestError::NotFound(_))
+        ));
+        assert!(matches!(
+            validate_download_status(HTTP_STATUS_REDIRECTION_START),
+            Err(DownloadRequestError::Other(_))
+        ));
     }
 
     #[test]

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -1,24 +1,127 @@
 use crate::types::events::{Event, LazyHistorySync};
+use bytes::Bytes;
 use std::sync::Arc;
-use wacore::history_sync::{HistoryMsgSecretRecord, TcTokenCandidate, process_history_sync};
+use wacore::history_sync::{
+    HistoryMsgSecretRecord, HistoryMsgSecretRecordRef, TcTokenCandidate,
+    process_history_sync_bytes_filtered,
+};
+use wacore::messages::DetachedHistorySyncNotification;
+use wacore::msg_secret::{MsgSecretPolicy, MsgSecretRetention, RetentionClass};
 use wacore::store::traits::MsgSecretEntry;
 use wacore_binary::{Jid, JidExt as _};
-use waproto::whatsapp::message::HistorySyncNotification;
 
 use crate::client::Client;
+
+const HISTORY_MSG_SECRET_SIZE: usize = wacore::reporting_token::MESSAGE_SECRET_SIZE;
+
+/// Immutable seed policy snapshot shared by the streaming filter and the
+/// persistence pass. Keeping one snapshot prevents a long parse from applying
+/// different time boundaries at its two stages.
+#[derive(Clone, Copy)]
+struct HistorySecretSeedConfig {
+    enabled: bool,
+    policy: MsgSecretPolicy,
+    retention: MsgSecretRetention,
+    now: i64,
+}
+
+impl HistorySecretSeedConfig {
+    fn snapshot(config: &crate::cache_config::CacheConfig) -> Self {
+        Self {
+            enabled: config.seed_msg_secrets_from_history,
+            policy: config.msg_secret_policy,
+            retention: config.msg_secret_retention,
+            now: wacore::time::now_secs(),
+        }
+    }
+
+    #[inline]
+    fn accepts_secret(self, secret_len: usize) -> bool {
+        self.enabled && self.policy.persists() && secret_len == HISTORY_MSG_SECRET_SIZE
+    }
+
+    fn retained_class(
+        self,
+        secret_len: usize,
+        chat_is_bot: bool,
+        is_bot_invocation: bool,
+        is_poll_or_event: bool,
+        timestamp: Option<u64>,
+    ) -> Option<RetentionClass> {
+        if !self.accepts_secret(secret_len) {
+            return None;
+        }
+        let class = wacore::msg_secret::classify_from_flags(
+            chat_is_bot || is_bot_invocation,
+            is_poll_or_event,
+        );
+        if self.policy.bot_only() && class != RetentionClass::Bot {
+            return None;
+        }
+        if self.policy.prunes()
+            && !wacore::msg_secret::within_seed_horizon(&self.retention, class, timestamp, self.now)
+        {
+            return None;
+        }
+        Some(class)
+    }
+}
+
+/// Allocation-free adapter around the immutable policy. Common JID shapes use
+/// wacore-binary's borrowed parser and the same [`JidExt`] classification as an
+/// owned [`Jid`]; compatibility-only edge cases retain the owned fallback.
+struct HistorySecretSeedFilter {
+    config: HistorySecretSeedConfig,
+    last_conversation_index: Option<usize>,
+    last_chat_is_bot: Option<bool>,
+}
+
+impl HistorySecretSeedFilter {
+    fn new(config: HistorySecretSeedConfig) -> Self {
+        Self {
+            config,
+            last_conversation_index: None,
+            last_chat_is_bot: None,
+        }
+    }
+
+    fn retain(&mut self, record: HistoryMsgSecretRecordRef<'_>) -> bool {
+        if !self.config.accepts_secret(record.secret.len()) {
+            return false;
+        }
+        if self.last_conversation_index != Some(record.conversation_index) {
+            self.last_conversation_index = Some(record.conversation_index);
+            self.last_chat_is_bot = wacore_binary::jid::parse_jid_ref(record.chat_id)
+                .map(|chat| chat.is_bot())
+                .or_else(|| record.chat_id.parse::<Jid>().ok().map(|chat| chat.is_bot()));
+        }
+        let Some(chat_is_bot) = self.last_chat_is_bot else {
+            return false;
+        };
+        self.config
+            .retained_class(
+                record.secret.len(),
+                chat_is_bot,
+                record.is_bot_invocation,
+                record.is_poll_or_event,
+                record.timestamp,
+            )
+            .is_some()
+    }
+}
 
 impl Client {
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.media.history_sync", level = "debug", skip_all, fields(msg_id = %message_id)))]
     pub(crate) async fn handle_history_sync(
         self: &Arc<Self>,
         message_id: String,
-        notification: HistorySyncNotification,
+        notification: DetachedHistorySyncNotification,
     ) {
         if self.is_shutting_down() {
             log::debug!(
                 "Dropping history sync {} during shutdown (Type: {:?})",
                 message_id,
-                notification.sync_type
+                notification.notification.sync_type
             );
             return;
         }
@@ -27,7 +130,7 @@ impl Client {
             log::debug!(
                 "Skipping history sync for message {} (Type: {:?})",
                 message_id,
-                notification.sync_type
+                notification.notification.sync_type
             );
             // Send receipt so the phone considers this chunk delivered and stops
             // retrying. This intentionally diverges from WhatsApp Web's AB prop
@@ -65,12 +168,17 @@ impl Client {
     pub(crate) async fn process_history_sync_task(
         self: &Arc<Self>,
         message_id: String,
-        mut notification: HistorySyncNotification,
+        notification: DetachedHistorySyncNotification,
     ) {
         if self.is_shutting_down() {
             log::debug!("Aborting history sync {} before processing", message_id);
             return;
         }
+
+        let DetachedHistorySyncNotification {
+            mut notification,
+            inline_payload,
+        } = notification;
 
         log::info!(
             "Processing history sync for message {} (Size: {}, Type: {:?})",
@@ -94,9 +202,7 @@ impl Client {
         }
 
         // Use take() to avoid cloning large payloads - moves ownership instead
-        let compressed_data = if let Some(inline_payload) =
-            notification.initial_hist_bootstrap_inline_payload.take()
-        {
+        let compressed_data = if let Some(inline_payload) = inline_payload {
             log::info!(
                 "Found inline history sync payload ({} bytes). Using directly.",
                 inline_payload.len()
@@ -111,16 +217,14 @@ impl Client {
                 );
                 return;
             }
-            // Stream-decrypt: reads encrypted chunks (8KB) from the network and
-            // decrypts on the fly into a Vec, avoiding holding the full encrypted
-            // blob in memory alongside the decrypted one.
-            match self
-                .download_to_writer(&notification, std::io::Cursor::new(Vec::new()))
-                .await
-            {
-                Ok(cursor) => {
+            // The native in-memory downloader streams decryption and safely
+            // pre-sizes its fresh retry buffer from the declared file length.
+            // Reuse it here so a ~1 MiB history blob does not climb the Vec
+            // doubling ladder (1 MiB -> 2 MiB) on every successful download.
+            match self.download(&notification).await {
+                Ok(bytes) => {
                     log::info!("Successfully downloaded history sync blob.");
-                    cursor.into_inner()
+                    Bytes::from(bytes)
                 }
                 Err(e) => {
                     if self.is_shutting_down() {
@@ -140,6 +244,7 @@ impl Client {
             let device_snapshot = self.persistence_manager.get_device_snapshot();
             device_snapshot.pn.as_ref().map(|j| j.to_non_ad().user)
         };
+        let secret_seed_config = HistorySecretSeedConfig::snapshot(&self.cache_config);
 
         // Always carry the compressed input through (a move, no copy or extra
         // inflate); handler interest is evaluated at dispatch time below, so a
@@ -149,15 +254,23 @@ impl Client {
         // Large blobs: use blocking thread to avoid stalling the async runtime.
         const INLINE_THRESHOLD: usize = 256 * 1024;
         let parse_result = if compressed_data.len() < INLINE_THRESHOLD {
-            Some(process_history_sync(
+            let mut secret_filter = HistorySecretSeedFilter::new(secret_seed_config);
+            Some(process_history_sync_bytes_filtered(
                 compressed_data,
                 own_user.as_deref(),
                 true,
+                move |record| secret_filter.retain(record),
             ))
         } else {
             let (result_tx, result_rx) = futures::channel::oneshot::channel();
             let blocking_fut = self.runtime.spawn_blocking(Box::new(move || {
-                let result = process_history_sync(compressed_data, own_user.as_deref(), true);
+                let mut secret_filter = HistorySecretSeedFilter::new(secret_seed_config);
+                let result = process_history_sync_bytes_filtered(
+                    compressed_data,
+                    own_user.as_deref(),
+                    true,
+                    move |record| secret_filter.retain(record),
+                );
                 let _ = result_tx.send(result);
             }));
             self.runtime
@@ -208,8 +321,11 @@ impl Client {
                     self.store_tc_token_candidate(candidate).await;
                 }
 
-                self.store_history_sync_msg_secrets(sync_result.msg_secret_records)
-                    .await;
+                self.store_history_sync_msg_secrets(
+                    sync_result.msg_secret_records,
+                    secret_seed_config,
+                )
+                .await;
 
                 // Bulk PN-LID identity seed from field 15; persist and migrations
                 // run detached, like the other batch learn paths. `Other`
@@ -264,11 +380,21 @@ impl Client {
         }
     }
 
-    async fn store_history_sync_msg_secrets(&self, records: Vec<HistoryMsgSecretRecord>) -> usize {
-        use wacore::msg_secret::{self, RetentionClass};
-        const SECRET_LEN: usize = wacore::reporting_token::MESSAGE_SECRET_SIZE;
-
-        if !self.cache_config.seed_msg_secrets_from_history {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "wa.history.secrets.store",
+            level = "debug",
+            skip_all,
+            fields(records = records.len() as u64)
+        )
+    )]
+    async fn store_history_sync_msg_secrets(
+        &self,
+        records: Vec<HistoryMsgSecretRecord>,
+        seed_config: HistorySecretSeedConfig,
+    ) -> usize {
+        if !seed_config.enabled {
             // Opt-out of the pairing-time seed; live capture still runs.
             log::debug!(
                 target: "Client/MsgSecret",
@@ -276,95 +402,97 @@ impl Client {
             );
             return 0;
         }
-        let policy = self.cache_config.msg_secret_policy;
-        if !policy.persists() {
+        if !seed_config.policy.persists() {
             // Disabled: rely on the resolver / app store, seed nothing.
             log::debug!(
                 target: "Client/MsgSecret",
-                "Skipping history-sync msg_secret seed (policy = {policy:?})"
+                "Skipping history-sync msg_secret seed (policy = {:?})",
+                seed_config.policy
             );
             return 0;
         }
-        let retention = &self.cache_config.msg_secret_retention;
-        let now = wacore::time::now_secs();
 
         let device_snapshot = self.persistence_manager.get_device_snapshot();
         let own_pn = device_snapshot.pn.as_ref().map(|j| j.to_non_ad());
         let own_lid = device_snapshot.lid.as_ref().map(|j| j.to_non_ad());
 
-        let mut entries = Vec::new();
-        for record in records {
-            if record.secret.len() != SECRET_LEN {
-                continue;
-            }
-            let Ok(chat) = record.chat_id.parse::<Jid>() else {
-                continue;
-            };
-            // Same three-way rule as the live path. A group bot prompt is a bot
-            // context via its botMetadata (record.is_bot_invocation), so BotOnly
-            // keeps it and a later bot reply can still decrypt.
-            let class = msg_secret::classify_from_flags(
-                chat.is_bot() || record.is_bot_invocation,
-                record.is_poll_or_event,
-            );
-            // BotOnly seeds only bot-context secrets.
-            if policy.bot_only() && class != RetentionClass::Bot {
-                continue;
-            }
-            // Drop secrets whose parent is already past its retention horizon:
-            // no add-on can still reference them, so seeding is pure waste. Full
-            // skips the filter (prunes() is false) and seeds everything.
-            if policy.prunes()
-                && !msg_secret::within_seed_horizon(retention, class, record.timestamp, now)
-            {
-                continue;
-            }
-            let expires_at =
-                msg_secret::expires_at(policy, retention, class, record.timestamp, now);
-            let message_ts = record
-                .timestamp
-                .and_then(|t| i64::try_from(t).ok())
-                .unwrap_or(0);
+        let entries = {
+            #[cfg(feature = "tracing")]
+            let _build_span = tracing::trace_span!(
+                "wa.history.secrets.build_entries",
+                records = records.len() as u64,
+            )
+            .entered();
+            let mut entries = Vec::new();
+            for record in records {
+                if !seed_config.accepts_secret(record.secret.len()) {
+                    continue;
+                }
+                let Ok(chat) = record.chat_id.parse::<Jid>() else {
+                    continue;
+                };
+                let Some(class) = seed_config.retained_class(
+                    record.secret.len(),
+                    chat.is_bot(),
+                    record.is_bot_invocation,
+                    record.is_poll_or_event,
+                    record.timestamp,
+                ) else {
+                    continue;
+                };
+                let expires_at = wacore::msg_secret::expires_at(
+                    seed_config.policy,
+                    &seed_config.retention,
+                    class,
+                    record.timestamp,
+                    seed_config.now,
+                );
+                let message_ts = record
+                    .timestamp
+                    .and_then(|t| i64::try_from(t).ok())
+                    .unwrap_or(0);
 
-            let mut senders =
-                history_msg_secret_senders(&chat, &record, own_pn.as_ref(), own_lid.as_ref());
-            if chat.is_bot()
-                && let Some(lid) = own_lid.as_ref()
-            {
-                push_unique_sender(&mut senders, lid.to_non_ad());
-            }
-            if senders.is_empty() {
-                continue;
-            }
+                let mut senders =
+                    history_msg_secret_senders(&chat, &record, own_pn.as_ref(), own_lid.as_ref());
+                if chat.is_bot()
+                    && let Some(lid) = own_lid.as_ref()
+                {
+                    push_unique_sender(&mut senders, lid.to_non_ad());
+                }
+                if senders.is_empty() {
+                    continue;
+                }
 
-            let sender_count = senders.len();
-            let mut chat_id = chat.to_non_ad_string();
-            let mut msg_id = record.msg_id.into_string();
-            let mut secret = record.secret.into_vec();
-            for (idx, sender) in senders.into_iter().enumerate() {
-                let last_sender = idx + 1 == sender_count;
-                entries.push(MsgSecretEntry {
-                    chat: if last_sender {
-                        std::mem::take(&mut chat_id)
-                    } else {
-                        chat_id.clone()
-                    },
-                    sender: sender.to_non_ad_string(),
-                    msg_id: if last_sender {
-                        std::mem::take(&mut msg_id)
-                    } else {
-                        msg_id.clone()
-                    },
-                    secret: if last_sender {
-                        std::mem::take(&mut secret)
-                    } else {
-                        secret.clone()
-                    },
-                    expires_at,
-                    message_ts,
-                });
+                let sender_count = senders.len();
+                let mut chat_id = chat.to_non_ad_string();
+                let mut msg_id = record.msg_id.into_string();
+                let mut secret = record.secret.into_vec();
+                for (idx, sender) in senders.into_iter().enumerate() {
+                    let last_sender = idx + 1 == sender_count;
+                    entries.push(MsgSecretEntry {
+                        chat: if last_sender {
+                            std::mem::take(&mut chat_id)
+                        } else {
+                            chat_id.clone()
+                        },
+                        sender: sender.to_non_ad_string(),
+                        msg_id: if last_sender {
+                            std::mem::take(&mut msg_id)
+                        } else {
+                            msg_id.clone()
+                        },
+                        secret: if last_sender {
+                            std::mem::take(&mut secret)
+                        } else {
+                            secret.clone()
+                        },
+                        expires_at,
+                        message_ts,
+                    });
+                }
             }
-        }
+            entries
+        };
 
         if entries.is_empty() {
             return 0;
@@ -504,6 +632,7 @@ mod tests {
     use std::io::Write;
     use std::sync::atomic::Ordering;
     use waproto::whatsapp as wa;
+    use waproto::whatsapp::message::HistorySyncNotification;
 
     fn compress_history_sync(history_sync: &wa::HistorySync) -> Vec<u8> {
         let raw = history_sync.encode_to_vec();
@@ -560,7 +689,7 @@ mod tests {
         };
 
         client
-            .process_history_sync_task("HIST_SYNC_SECRET".to_string(), notification)
+            .process_history_sync_task("HIST_SYNC_SECRET".to_string(), notification.into())
             .await;
 
         let got = client
@@ -594,7 +723,7 @@ mod tests {
         };
 
         client
-            .process_history_sync_task("HIST_SYNC_LID".to_string(), notification)
+            .process_history_sync_task("HIST_SYNC_LID".to_string(), notification.into())
             .await;
 
         assert_eq!(
@@ -637,7 +766,7 @@ mod tests {
         client.core.event_bus.add_handler(handler);
 
         client
-            .process_history_sync_task("HIST_LAZY_EVENT".to_string(), notification)
+            .process_history_sync_task("HIST_LAZY_EVENT".to_string(), notification.into())
             .await;
 
         let event = event_rx.try_recv().expect("HistorySync event dispatched");
@@ -708,7 +837,7 @@ mod tests {
         };
 
         client
-            .process_history_sync_task("HIST_SYNC_BOT_SECRET".to_string(), notification)
+            .process_history_sync_task("HIST_SYNC_BOT_SECRET".to_string(), notification.into())
             .await;
 
         let backend = client.persistence_manager.backend();
@@ -824,7 +953,7 @@ mod tests {
             ],
         );
         client
-            .process_history_sync_task("S1".to_string(), notification)
+            .process_history_sync_task("S1".to_string(), notification.into())
             .await;
 
         let backend = client.persistence_manager.backend();
@@ -859,7 +988,7 @@ mod tests {
             vec![history_msg(chat, "OLD_POLL", &[0x33u8; 32], ts, true)],
         );
         client
-            .process_history_sync_task("S2".to_string(), notification)
+            .process_history_sync_task("S2".to_string(), notification.into())
             .await;
 
         assert_eq!(
@@ -887,7 +1016,7 @@ mod tests {
             vec![history_msg(chat, "ANCIENT", &[0x44u8; 32], old_ts, false)],
         );
         client
-            .process_history_sync_task("S3".to_string(), notification)
+            .process_history_sync_task("S3".to_string(), notification.into())
             .await;
 
         assert_eq!(
@@ -914,7 +1043,7 @@ mod tests {
             vec![history_msg(chat, "ANY", &[0x55u8; 32], now - 60, false)],
         );
         client
-            .process_history_sync_task("S4".to_string(), notification)
+            .process_history_sync_task("S4".to_string(), notification.into())
             .await;
 
         assert_eq!(
@@ -942,7 +1071,7 @@ mod tests {
             vec![history_msg(chat, "RECENT", &[0x66u8; 32], msg_ts, false)],
         );
         client
-            .process_history_sync_task("S5".to_string(), notification)
+            .process_history_sync_task("S5".to_string(), notification.into())
             .await;
 
         let backend = client.persistence_manager.backend();
@@ -1002,7 +1131,7 @@ mod tests {
             vec![history_msg(chat, "RECENT", &[0x77u8; 32], now - 60, false)],
         );
         client
-            .process_history_sync_task("S6".to_string(), notification)
+            .process_history_sync_task("S6".to_string(), notification.into())
             .await;
 
         assert_eq!(
@@ -1090,7 +1219,7 @@ mod tests {
             ],
         );
         client
-            .process_history_sync_task("SB".to_string(), notification)
+            .process_history_sync_task("SB".to_string(), notification.into())
             .await;
 
         let backend = client.persistence_manager.backend();

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,11 @@
 pub use wacore::net::{HttpClient, HttpRequest, HttpResponse};
 
+pub(crate) const HTTP_STATUS_OK: u16 = 200;
+pub(crate) const HTTP_STATUS_REDIRECTION_START: u16 = 300;
+pub(crate) const HTTP_STATUS_UNAUTHORIZED: u16 = 401;
+pub(crate) const HTTP_STATUS_FORBIDDEN: u16 = 403;
+pub(crate) const HTTP_STATUS_NOT_FOUND: u16 = 404;
+pub(crate) const HTTP_STATUS_GONE: u16 = 410;
+
 #[cfg(feature = "ureq-client")]
 pub use whatsapp_rust_ureq_http_client::UreqHttpClient;

--- a/src/mediaconn.rs
+++ b/src/mediaconn.rs
@@ -3,6 +3,7 @@
 //! Protocol types are defined in `wacore::iq::mediaconn`.
 
 use crate::client::Client;
+use crate::http::{HTTP_STATUS_FORBIDDEN, HTTP_STATUS_UNAUTHORIZED};
 use crate::request::IqError;
 use std::time::Duration;
 use wacore::iq::mediaconn::MediaConnSpec;
@@ -18,7 +19,10 @@ pub(crate) const MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS: usize = 1;
 /// Returns `true` if the HTTP status code indicates a media auth error
 /// that should trigger a media connection refresh and retry.
 pub(crate) fn is_media_auth_error(status_code: u16) -> bool {
-    matches!(status_code, 401 | 403)
+    matches!(
+        status_code,
+        HTTP_STATUS_UNAUTHORIZED | HTTP_STATUS_FORBIDDEN
+    )
 }
 
 /// Media connection with runtime-specific fields.

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -613,7 +613,6 @@ impl Client {
         let mut local_identity_reacted = false;
 
         for payload in payloads {
-            let ciphertext = &payload.ciphertext[..];
             let enc_type = payload.enc_type;
             let enc_type_str = enc_type.as_wire_str();
             let padding_version = payload.padding_version;
@@ -622,51 +621,43 @@ impl Client {
             // server retransmits the malformed stanza forever. Mirrors the
             // `handle_decrypt_failure` shape (dispatch event + spawn wire I/O
             // so the session lock isn't held across the send).
-            let parsed_message = if enc_type == EncType::PreKeyMessage {
-                match PreKeySignalMessage::try_from(ciphertext) {
-                    Ok(m) => CiphertextMessage::PreKeySignalMessage(m),
-                    Err(e) => {
-                        log::error!(
-                            "[msg:{}] Failed to parse PreKeySignalMessage from {}: {e:?}. Sending nack.",
-                            info.id,
-                            info.source.sender.observe()
-                        );
-                        // |= so a later dedup'd return (false) can't clobber
-                        // a true set by a prior iteration in this batch.
-                        outcome.had_failure = true;
-                        outcome.undecryptable |= self
-                            .dispatch_undecryptable_event(
-                                Arc::clone(info),
-                                false,
-                                crate::types::events::UnavailableType::Unknown,
-                                decrypt_fail_mode,
-                            )
-                            .await;
-                        self.spawn_nack(info, NackReason::ParsingError, None);
-                        continue;
-                    }
+            let parsed_message = {
+                #[cfg(feature = "tracing")]
+                let _parse_span = tracing::trace_span!(
+                    "wa.recv.session_parse",
+                    ciphertext_bytes = payload.ciphertext.len() as u64,
+                    enc_type = enc_type_str
+                )
+                .entered();
+                if enc_type == EncType::PreKeyMessage {
+                    PreKeySignalMessage::try_from(payload.ciphertext.clone())
+                        .map(CiphertextMessage::PreKeySignalMessage)
+                } else {
+                    SignalMessage::try_from(payload.ciphertext.clone())
+                        .map(CiphertextMessage::SignalMessage)
                 }
-            } else {
-                match SignalMessage::try_from(ciphertext) {
-                    Ok(m) => CiphertextMessage::SignalMessage(m),
-                    Err(e) => {
-                        log::error!(
-                            "[msg:{}] Failed to parse SignalMessage from {}: {e:?}. Sending nack.",
-                            info.id,
-                            info.source.sender.observe()
-                        );
-                        outcome.had_failure = true;
-                        outcome.undecryptable |= self
-                            .dispatch_undecryptable_event(
-                                Arc::clone(info),
-                                false,
-                                crate::types::events::UnavailableType::Unknown,
-                                decrypt_fail_mode,
-                            )
-                            .await;
-                        self.spawn_nack(info, NackReason::ParsingError, None);
-                        continue;
-                    }
+            };
+            let parsed_message = match parsed_message {
+                Ok(message) => message,
+                Err(e) => {
+                    log::error!(
+                        "[msg:{}] Failed to parse {enc_type_str} Signal envelope from {}: {e:?}. Sending nack.",
+                        info.id,
+                        info.source.sender.observe()
+                    );
+                    // |= so a later dedup'd return (false) can't clobber a true
+                    // set by a prior iteration in this batch.
+                    outcome.had_failure = true;
+                    outcome.undecryptable |= self
+                        .dispatch_undecryptable_event(
+                            Arc::clone(info),
+                            false,
+                            crate::types::events::UnavailableType::Unknown,
+                            decrypt_fail_mode,
+                        )
+                        .await;
+                    self.spawn_nack(info, NackReason::ParsingError, None);
+                    continue;
                 }
             };
 
@@ -711,8 +702,17 @@ impl Client {
                 &adapter.signed_pre_key_store,
                 &mut rng,
                 UsePQRatchet::No,
-            )
-            .await;
+            );
+            #[cfg(feature = "tracing")]
+            let decrypt_res = tracing::Instrument::instrument(
+                decrypt_res,
+                tracing::trace_span!(
+                    "wa.recv.session_crypto",
+                    ciphertext_bytes = payload.ciphertext.len() as u64,
+                    enc_type = enc_type_str
+                ),
+            );
+            let decrypt_res = decrypt_res.await;
 
             match decrypt_res {
                 Ok(decrypted) => {
@@ -1161,7 +1161,7 @@ impl Client {
         } in deferred
         {
             match self
-                .handle_decrypted_plaintext(enc_type, &plaintext, padding_version, info)
+                .handle_decrypted_plaintext(enc_type, plaintext, padding_version, info)
                 .await
             {
                 Ok(plaintext_outcome) => {
@@ -1249,7 +1249,7 @@ impl Client {
                     if let Err(e) = self
                         .handle_decrypted_plaintext(
                             "skmsg",
-                            &padded_plaintext,
+                            padded_plaintext,
                             padding_version,
                             info,
                         )
@@ -1407,11 +1407,15 @@ impl Client {
     pub(crate) async fn handle_decrypted_plaintext(
         self: &Arc<Self>,
         enc_type: &str,
-        padded_plaintext: &[u8],
+        padded_plaintext: Vec<u8>,
         padding_version: u8,
         info: &Arc<MessageInfo>,
     ) -> Result<PlaintextHandleOutcome, anyhow::Error> {
-        let original_msg = wacore::messages::decode_plaintext(padded_plaintext, padding_version)?;
+        let (original_msg, history_sync_taken) =
+            wacore::messages::decode_plaintext_detached_history_sync(
+                padded_plaintext,
+                padding_version,
+            )?;
         log::debug!(
             "[msg:{}] Successfully decrypted message from {}: type={} [batch path]",
             info.id,
@@ -1521,12 +1525,6 @@ impl Client {
         {
             self.handle_pdo_response(pdo_response, info).await;
         }
-
-        // Note: msg might be modified by take() below
-        let history_sync_taken = msg
-            .protocol_message
-            .as_option_mut()
-            .and_then(|pm| pm.history_sync_notification.take());
 
         // history_sync_notification is self-only (our phone drives history sync).
         // A spoofed one from a peer would force a download of attacker-controlled

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -671,7 +671,7 @@ impl Client {
                         "sender_jid": sender_encryption_jid.to_string(),
                         "timestamp": info.timestamp,
                         "enc_type": enc_type_str,
-                        "payload_base64": BASE64_STANDARD.encode(ciphertext),
+                        "payload_base64": BASE64_STANDARD.encode(payload.ciphertext.as_ref()),
                     });
 
                     let content_bytes = serde_json::to_vec_pretty(&payload).unwrap_or_default();

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7774,7 +7774,7 @@ async fn app_state_sync_key_share_honored_only_from_self() {
         create_test_message_info("5510000@s.whatsapp.net", "AKS1", "5510000@s.whatsapp.net");
     info.source.is_from_me = false;
     client
-        .handle_decrypted_plaintext("msg", &padded, 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded.clone(), 2, &Arc::new(info))
         .await
         .unwrap();
     assert!(
@@ -7798,7 +7798,7 @@ async fn app_state_sync_key_share_honored_only_from_self() {
     );
     info.source.is_from_me = true;
     client
-        .handle_decrypted_plaintext("msg", &padded, 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded, 2, &Arc::new(info))
         .await
         .unwrap();
     assert!(
@@ -7949,7 +7949,7 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     let info = Arc::new(info);
     tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        client.handle_decrypted_plaintext("msg", &MessageUtils::encode_and_pad(&request), 2, &info),
+        client.handle_decrypted_plaintext("msg", MessageUtils::encode_and_pad(&request), 2, &info),
     )
     .await
     .expect("the inbound lane must not wait for offline sync")
@@ -7967,7 +7967,7 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     );
     tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        client.handle_decrypted_plaintext("msg", &MessageUtils::encode_and_pad(&request), 2, &info),
+        client.handle_decrypted_plaintext("msg", MessageUtils::encode_and_pad(&request), 2, &info),
     )
     .await
     .expect("the redelivery must not wait for offline sync")
@@ -8268,7 +8268,7 @@ async fn lid_migration_mapping_sync_honored_only_from_self() {
         create_test_message_info("5510000@s.whatsapp.net", "LMS1", "5510000@s.whatsapp.net");
     info.source.is_from_me = false;
     client
-        .handle_decrypted_plaintext("msg", &padded, 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded.clone(), 2, &Arc::new(info))
         .await
         .unwrap();
     assert!(
@@ -8284,7 +8284,7 @@ async fn lid_migration_mapping_sync_honored_only_from_self() {
     );
     info.source.is_from_me = true;
     client
-        .handle_decrypted_plaintext("msg", &padded, 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded, 2, &Arc::new(info))
         .await
         .unwrap();
     assert_eq!(

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -13,7 +13,7 @@ use wacore::iq::prekeys::{
     DigestKeyBundleSpec, PreKeyCountSpec, PreKeyFetchReason, PreKeyFetchSpec, PreKeyUploadSpec,
 };
 use wacore::libsignal::protocol::{KeyPair, PreKeyBundle, PublicKey};
-use wacore::libsignal::store::record_helpers::new_pre_key_record;
+use wacore::libsignal::store::record_helpers::{encode_pre_key_record_to, new_pre_key_record};
 use wacore::store::commands::DeviceCommand;
 use wacore_binary::Jid;
 
@@ -516,8 +516,6 @@ impl Client {
             // the async executor responsive. Records are encoded into one contiguous
             // buffer with zero-copy Bytes slices instead of an alloc per record.
             let (encoded_batch, generated) = wacore::runtime::blocking(&*self.runtime, move || {
-                use buffa::Message;
-
                 // Seed one CSPRNG and advance it per key, rather than reseeding from
                 // entropy on every iteration.
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
@@ -536,7 +534,7 @@ impl Client {
                     let pre_key_id = gen_start + i as u32;
                     let key_pair = KeyPair::generate(&mut rng);
                     let start = buf.len();
-                    new_pre_key_record(pre_key_id, &key_pair).encode(&mut buf);
+                    encode_pre_key_record_to(pre_key_id, &key_pair, &mut buf);
                     offsets.push((pre_key_id, start..buf.len()));
                     pubkeys.push((pre_key_id, key_pair.public_key));
                 }

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -13,7 +13,7 @@ use wacore::iq::prekeys::{
     DigestKeyBundleSpec, PreKeyCountSpec, PreKeyFetchReason, PreKeyFetchSpec, PreKeyUploadSpec,
 };
 use wacore::libsignal::protocol::{KeyPair, PreKeyBundle, PublicKey};
-use wacore::libsignal::store::record_helpers::{encode_pre_key_record_to, new_pre_key_record};
+use wacore::libsignal::store::record_helpers::encode_pre_key_record_to;
 use wacore::store::commands::DeviceCommand;
 use wacore_binary::Jid;
 
@@ -387,11 +387,9 @@ impl Client {
             if raw > MAX_PREKEY_ID { 1 } else { raw }
         };
         let key_pair = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
-        let record = new_pre_key_record(id, &key_pair);
-        use buffa::Message;
-        backend
-            .store_prekey(id, &record.encode_to_vec(), false)
-            .await?;
+        let mut encoded_record = Vec::new();
+        encode_pre_key_record_to(id, &key_pair, &mut encoded_record);
+        backend.store_prekey(id, &encoded_record, false).await?;
         self.persistence_manager
             .process_command(DeviceCommand::SetPreKeyWatermarks {
                 next_pre_key_id: id.saturating_add(1),

--- a/src/sync_task.rs
+++ b/src/sync_task.rs
@@ -1,11 +1,11 @@
 use wacore::appstate::patch_decode::WAPatchName;
-use waproto::whatsapp::message::HistorySyncNotification;
+use wacore::messages::DetachedHistorySyncNotification;
 
 #[derive(Debug)]
 pub enum MajorSyncTask {
     HistorySync {
         message_id: String,
-        notification: Box<HistorySyncNotification>,
+        notification: Box<DetachedHistorySyncNotification>,
     },
     AppStateSync {
         name: WAPatchName,

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -158,6 +158,24 @@ pub fn parse_jid_fast(s: &str) -> Option<ParsedJidParts<'_>> {
     })
 }
 
+/// Parse the allocation-free JID shapes into the same borrowed type used by
+/// the binary decoder.
+///
+/// Returns `None` when the string needs [`Jid`]'s compatibility fallback or
+/// names an unknown server. Callers that must accept those edge cases can fall
+/// back to `s.parse::<Jid>()`; normal user/group/LID/bot JIDs stay borrowed.
+#[inline]
+pub fn parse_jid_ref(s: &str) -> Option<JidRef<'_>> {
+    let parts = parse_jid_fast(s)?;
+    Some(JidRef {
+        user: NodeStr::Borrowed(parts.user),
+        server: Server::try_from(parts.server).ok()?,
+        agent: parts.agent,
+        device: parts.device,
+        integrator: parts.integrator,
+    })
+}
+
 /// Known WhatsApp server identifiers.
 ///
 /// Maps to the wire protocol's AD_JID domain type (u8) and the `@server` suffix
@@ -707,14 +725,8 @@ impl FromStr for Jid {
     type Err = JidError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Try fast path first for well-formed JIDs
-        if let Some(parts) = parse_jid_fast(s) {
-            return Ok(Jid {
-                user: CompactString::from(parts.user),
-                server: Server::try_from(parts.server)?,
-                agent: parts.agent,
-                device: parts.device,
-                integrator: parts.integrator,
-            });
+        if let Some(jid) = parse_jid_ref(s) {
+            return Ok(jid.to_owned());
         }
 
         // Fallback to original parsing for edge cases and validation
@@ -1147,6 +1159,27 @@ mod tests {
             "Formatted string did not match expected output for {}",
             input
         );
+    }
+
+    #[test]
+    fn borrowed_parser_matches_owned_fast_path_and_bot_classification() {
+        for raw in [
+            "5511999998888:7@s.whatsapp.net",
+            "120363012345678901@g.us",
+            "123456789012345@lid",
+            "assistant@bot",
+            "13135551234@s.whatsapp.net",
+        ] {
+            let borrowed = parse_jid_ref(raw).expect("common JID should stay borrowed");
+            let owned = raw.parse::<Jid>().unwrap();
+
+            assert!(matches!(borrowed.user, NodeStr::Borrowed(_)));
+            assert_eq!(borrowed.to_owned(), owned);
+            assert_eq!(borrowed.is_bot(), owned.is_bot());
+        }
+
+        assert!(parse_jid_ref("g.us").is_none(), "server-only uses fallback");
+        assert!(parse_jid_ref("user@unknown").is_none());
     }
 
     #[test]

--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -63,6 +63,12 @@ pub struct InflateReader<'a> {
 impl<'a> InflateReader<'a> {
     /// Output decompress window per pump; also the compaction threshold.
     const CHUNK: usize = 64 * 1024;
+    /// Keep one extra output window between sequential streams. Record framing
+    /// commonly leaves a small unconsumed suffix when the next pump begins, so
+    /// `reserve(CHUNK)` briefly needs more than one window. Shrinking back to a
+    /// single window after every history-sync blob only forces the same 64 KiB
+    /// allocation and copy on the next blob.
+    const RETAINED_CAPACITY: usize = Self::CHUNK * 2;
     /// Cap on retained free-list entries, so concurrently-alive readers on one
     /// thread don't grow the pool unbounded.
     const POOL_MAX: usize = 4;
@@ -218,9 +224,12 @@ impl Drop for InflateReader<'_> {
             let mut buf = std::mem::take(&mut self.buf);
             // A large top-level record (e.g. a big conversation, up to `max`) can
             // grow `buf` to many MB; don't retain that allocation in the pool for
-            // the thread's lifetime. Shrink back toward the normal working size.
+            // the thread's lifetime. Keep the two-window steady-state used by
+            // framed streams, but shrink genuinely oversized records.
             buf.clear();
-            buf.shrink_to(Self::CHUNK);
+            if buf.capacity() > Self::RETAINED_CAPACITY {
+                buf.shrink_to(Self::RETAINED_CAPACITY);
+            }
             INFLATE_POOL.with(|p| {
                 let mut pool = p.borrow_mut();
                 if pool.len() < Self::POOL_MAX {
@@ -479,7 +488,8 @@ mod tests {
     #[test]
     fn drop_shrinks_oversized_buffer_before_pooling() {
         // Buffering a large record grows `buf` to many MB; on return to the pool it
-        // must be shrunk back toward CHUNK, not parked at full size for the thread.
+        // must be shrunk back toward the bounded steady-state capacity, not parked
+        // at full size for the thread.
         INFLATE_POOL.with(|p| p.borrow_mut().clear());
         let big = varied(2 * 1024 * 1024);
         let compressed = zlib(&big);
@@ -490,7 +500,7 @@ mod tests {
         }
         let pooled = INFLATE_POOL.with(|p| p.borrow().last().map(|(_, b)| b.capacity()));
         assert!(
-            matches!(pooled, Some(cap) if cap <= InflateReader::CHUNK * 2),
+            matches!(pooled, Some(cap) if cap <= InflateReader::RETAINED_CAPACITY),
             "pooled buffer not shrunk: {pooled:?}"
         );
     }

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
+
 /// SipHash with fixed keys: the default RandomState seeds per process, so
 /// bucket layout (and thus cache behavior) differed between benchmark runs.
 type DetState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
@@ -24,12 +26,12 @@ fn main() {
     divan::main();
 }
 use wacore_libsignal::protocol::{
-    ChainKey, CiphertextMessage, Direction, GenericSignedPreKey, IdentityChange, IdentityKey,
-    IdentityKeyPair, IdentityKeyStore, KeyPair, MessageKeyGenerator, PreKeyBundle, PreKeyId,
-    PreKeyRecord, PreKeyStore, ProtocolAddress, RootKey, SenderKeyDistributionMessage,
-    SenderKeyRecord, SenderKeyStore, SessionRecord, SessionState, SessionStore, SignedPreKeyId,
-    SignedPreKeyRecord, SignedPreKeyStore, Timestamp, UsePQRatchet, consts,
-    create_sender_key_distribution_message, group_decrypt, group_encrypt, message_decrypt,
+    ChainKey, CiphertextMessage, CiphertextMessageType, Direction, GenericSignedPreKey,
+    IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore, KeyPair, MessageKeyGenerator,
+    PreKeyBundle, PreKeyId, PreKeyRecord, PreKeyStore, ProtocolAddress, RootKey,
+    SenderKeyDistributionMessage, SenderKeyRecord, SenderKeyStore, SessionRecord, SessionState,
+    SessionStore, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore, Timestamp, UsePQRatchet,
+    consts, create_sender_key_distribution_message, group_decrypt, group_encrypt, message_decrypt,
     message_encrypt, process_prekey_bundle, process_sender_key_distribution_message,
 };
 use wacore_libsignal::store::sender_key_name::SenderKeyName;
@@ -916,164 +918,182 @@ fn bench_key_generation() {
     }
 }
 
-/// Creates a session with multiple archived previous sessions.
-/// This simulates a scenario where Alice has re-keyed multiple times.
-fn setup_with_archived_sessions() -> (User, User, Vec<Vec<u8>>) {
+const FIRST_SESSION_GENERATION: u32 = 1;
+const LAST_SESSION_GENERATION: u32 = 10;
+const SESSION_OPEN_PAYLOAD: &[u8] = b"session open";
+const SESSION_ACK_PAYLOAD: &[u8] = b"session ack";
+const ARCHIVED_SESSION_PAYLOAD: &[u8] = b"message from archived session";
+
+/// Complete one PreKey handshake in both directions. Alice's pending PreKey is
+/// cleared only after she decrypts Bob's acknowledgement, so messages emitted
+/// after this helper are guaranteed to be plain Signal envelopes.
+async fn establish_session_generation(
+    alice: &mut User,
+    bob: &mut User,
+    generation: u32,
+    rng: &mut rand::rngs::StdRng,
+) {
+    if generation != FIRST_SESSION_GENERATION {
+        alice.session_store = InMemorySessionStore::new();
+        bob.prekey_id = generation.into();
+        bob.prekey_pair = KeyPair::generate(rng);
+        let prekey_record = PreKeyRecord::new(bob.prekey_id, &bob.prekey_pair);
+        bob.prekey_store
+            .save_pre_key(bob.prekey_id, &prekey_record)
+            .await
+            .expect("store fresh prekey");
+    }
+
+    process_prekey_bundle(
+        &bob.address,
+        &mut alice.session_store,
+        &mut alice.identity_store,
+        &bob.get_prekey_bundle(),
+        rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("establish session generation");
+
+    let opening = message_encrypt(
+        SESSION_OPEN_PAYLOAD,
+        &bob.address,
+        &mut alice.session_store,
+        &mut alice.identity_store,
+    )
+    .await
+    .expect("encrypt session opening");
+    assert_eq!(opening.message_type(), CiphertextMessageType::PreKey);
+    message_decrypt(
+        &opening,
+        &alice.address,
+        &mut bob.session_store,
+        &mut bob.identity_store,
+        &mut bob.prekey_store,
+        &bob.signed_prekey_store,
+        rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("decrypt session opening");
+
+    let acknowledgement = message_encrypt(
+        SESSION_ACK_PAYLOAD,
+        &alice.address,
+        &mut bob.session_store,
+        &mut bob.identity_store,
+    )
+    .await
+    .expect("encrypt session acknowledgement");
+    assert_eq!(
+        acknowledgement.message_type(),
+        CiphertextMessageType::Whisper
+    );
+    message_decrypt(
+        &acknowledgement,
+        &bob.address,
+        &mut alice.session_store,
+        &mut alice.identity_store,
+        &mut alice.prekey_store,
+        &alice.signed_prekey_store,
+        rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("decrypt session acknowledgement");
+}
+
+/// Build ten complete sessions and retain a message from the oldest one. Bob's
+/// current state is generation ten, while the matching state is the deepest of
+/// nine archived sessions.
+fn setup_with_archived_session() -> (User, User, Bytes) {
     let mut alice = User::new("alice", 1);
     let mut bob = User::new("bob", 1);
     let mut rng = bench_rng();
 
-    // Store ciphertexts encrypted with each session version
-    let mut old_ciphertexts = Vec::new();
+    let archived_ciphertext = futures::executor::block_on(async {
+        establish_session_generation(&mut alice, &mut bob, FIRST_SESSION_GENERATION, &mut rng)
+            .await;
 
-    futures::executor::block_on(async {
-        // Create initial session and send first message
-        let bob_bundle = bob.get_prekey_bundle();
-        process_prekey_bundle(
-            &bob.address,
-            &mut alice.session_store,
-            &mut alice.identity_store,
-            &bob_bundle,
-            &mut rng,
-            UsePQRatchet::No,
-        )
-        .await
-        .expect("session 1");
-
-        // Send a message with this session (to be used for previous session decryption)
-        let msg = message_encrypt(
-            b"Message from session 1",
+        let archived_message = message_encrypt(
+            ARCHIVED_SESSION_PAYLOAD,
             &bob.address,
             &mut alice.session_store,
             &mut alice.identity_store,
         )
         .await
-        .expect("encrypt");
-        old_ciphertexts.push(msg.serialize().to_vec());
+        .expect("encrypt archived-session message");
+        let archived_ciphertext = match archived_message {
+            CiphertextMessage::SignalMessage(message) => {
+                Bytes::copy_from_slice(message.serialized())
+            }
+            message => panic!(
+                "completed handshake emitted {:?}, expected SignalMessage",
+                message.message_type()
+            ),
+        };
 
-        // Bob processes Alice's first message to establish his side
-        let ct = CiphertextMessage::PreKeySignalMessage(
-            wacore_libsignal::protocol::PreKeySignalMessage::try_from(
-                old_ciphertexts[0].as_slice(),
-            )
-            .unwrap(),
-        );
-        message_decrypt(
-            &ct,
-            &alice.address,
-            &mut bob.session_store,
-            &mut bob.identity_store,
-            &mut bob.prekey_store,
-            &bob.signed_prekey_store,
-            &mut rng,
-            UsePQRatchet::No,
-        )
-        .await
-        .expect("decrypt");
-
-        // Now create multiple new sessions to archive the old one
-        // Each new PreKey message from Alice will archive Bob's current session
-        for i in 2..=10 {
-            // Alice creates a fresh session (simulating re-keying)
-            alice.session_store = InMemorySessionStore::new();
-
-            // Generate new prekeys for Bob
-            bob.prekey_id = (i as u32).into();
-            bob.prekey_pair = KeyPair::generate(&mut rng);
-            let prekey_record = PreKeyRecord::new(bob.prekey_id, &bob.prekey_pair);
-            bob.prekey_store
-                .save_pre_key(bob.prekey_id, &prekey_record)
-                .await
-                .unwrap();
-
-            let bob_bundle = bob.get_prekey_bundle();
-            process_prekey_bundle(
-                &bob.address,
-                &mut alice.session_store,
-                &mut alice.identity_store,
-                &bob_bundle,
-                &mut rng,
-                UsePQRatchet::No,
-            )
-            .await
-            .expect("new session");
-
-            // Send PreKey message to establish new session on Bob's side
-            let msg = message_encrypt(
-                format!("Message from session {}", i).as_bytes(),
-                &bob.address,
-                &mut alice.session_store,
-                &mut alice.identity_store,
-            )
-            .await
-            .expect("encrypt");
-
-            let ct = CiphertextMessage::PreKeySignalMessage(
-                wacore_libsignal::protocol::PreKeySignalMessage::try_from(msg.serialize()).unwrap(),
-            );
-            message_decrypt(
-                &ct,
-                &alice.address,
-                &mut bob.session_store,
-                &mut bob.identity_store,
-                &mut bob.prekey_store,
-                &bob.signed_prekey_store,
-                &mut rng,
-                UsePQRatchet::No,
-            )
-            .await
-            .expect("decrypt");
-
-            // Store the message encrypted with this session
-            let msg2 = message_encrypt(
-                format!("Another message from session {}", i).as_bytes(),
-                &bob.address,
-                &mut alice.session_store,
-                &mut alice.identity_store,
-            )
-            .await
-            .expect("encrypt");
-            old_ciphertexts.push(msg2.serialize().to_vec());
+        for generation in (FIRST_SESSION_GENERATION + 1)..=LAST_SESSION_GENERATION {
+            establish_session_generation(&mut alice, &mut bob, generation, &mut rng).await;
         }
+
+        let record = bob
+            .session_store
+            .load_session(&alice.address)
+            .await
+            .expect("load benchmark session")
+            .expect("benchmark session exists");
+        let expected_archived = (LAST_SESSION_GENERATION - FIRST_SESSION_GENERATION) as usize;
+        assert_eq!(record.previous_session_count(), expected_archived);
+
+        archived_ciphertext
     });
 
-    (alice, bob, old_ciphertexts)
+    (alice, bob, archived_ciphertext)
 }
 
-// Benchmark decryption that requires searching through previous sessions.
-// This tests the take/restore optimization for previous session iteration.
+/// Rejecting a PreKey envelope as a plain Signal envelope is a format-probing
+/// benchmark, not a session-decryption benchmark.
 #[divan::bench]
-fn bench_decrypt_with_previous_session(bencher: divan::Bencher) {
+fn bench_reject_prekey_as_signal(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_with_archived_sessions)
+        .with_inputs(setup_dm_with_first_message)
         .bench_refs(|data| {
-            let (alice, bob, ciphertexts) = data;
+            let (_, _, ciphertext) = data;
+            let parsed = wacore_libsignal::protocol::SignalMessage::try_from(ciphertext.as_slice());
+            assert!(parsed.is_err());
+            drop(black_box(parsed));
+        });
+}
+
+/// Decrypt a valid Signal envelope by searching the deepest archived session.
+#[divan::bench]
+fn bench_decrypt_with_archived_session(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_with_archived_session)
+        .bench_refs(|data| {
+            let (alice, bob, ciphertext) = data;
             let mut rng = bench_rng();
 
-            // Try to decrypt an old message (encrypted with a previous session)
-            // This forces the decryption to iterate through previous sessions
-            futures::executor::block_on(async {
-                for ciphertext in ciphertexts.iter().take(5) {
-                    // Try to parse as SignalMessage (non-PreKey)
-                    if let Ok(signal_msg) =
-                        wacore_libsignal::protocol::SignalMessage::try_from(ciphertext.as_slice())
-                    {
-                        let ct = CiphertextMessage::SignalMessage(signal_msg);
-                        let result = message_decrypt(
-                            &ct,
-                            &alice.address,
-                            &mut bob.session_store,
-                            &mut bob.identity_store,
-                            &mut bob.prekey_store,
-                            &bob.signed_prekey_store,
-                            &mut rng,
-                            UsePQRatchet::No,
-                        )
-                        .await;
-                        let _ = black_box(result);
-                    }
-                }
+            let plaintext = futures::executor::block_on(async {
+                let signal_message =
+                    wacore_libsignal::protocol::SignalMessage::try_from(ciphertext.clone())
+                        .expect("parse archived-session message");
+                let ciphertext = CiphertextMessage::SignalMessage(signal_message);
+                message_decrypt(
+                    &ciphertext,
+                    &alice.address,
+                    &mut bob.session_store,
+                    &mut bob.identity_store,
+                    &mut bob.prekey_store,
+                    &bob.signed_prekey_store,
+                    &mut rng,
+                    UsePQRatchet::No,
+                )
+                .await
+                .expect("decrypt archived-session message")
             });
+            black_box(plaintext);
         });
 }
 

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -38,6 +38,7 @@ enum SerializedBytes {
 }
 
 impl SerializedBytes {
+    #[inline]
     fn as_slice(&self) -> &[u8] {
         match self {
             Self::Owned(bytes) => bytes,
@@ -45,6 +46,7 @@ impl SerializedBytes {
         }
     }
 
+    #[inline]
     fn into_boxed_slice(self) -> Box<[u8]> {
         match self {
             Self::Owned(bytes) => bytes,
@@ -203,10 +205,13 @@ impl SignalMessage {
         self.serialized.into_boxed_slice()
     }
 
+    #[inline]
     pub fn body(&self) -> Result<&[u8]> {
-        if self.ciphertext_range.get().is_none() {
-            let _ = self.ciphertext_range.set(self.decode_ciphertext_range()?);
+        if let Some(range) = self.ciphertext_range.get() {
+            return Ok(&self.serialized.as_slice()[range.clone()]);
         }
+
+        let _ = self.ciphertext_range.set(self.decode_ciphertext_range()?);
         let range = self
             .ciphertext_range
             .get()
@@ -214,18 +219,30 @@ impl SignalMessage {
         Ok(&self.serialized.as_slice()[range.clone()])
     }
 
-    fn decode_ciphertext_range(&self) -> Result<Range<usize>> {
-        let serialized = self.serialized.as_slice();
+    #[inline]
+    fn decode_view_from(serialized: &[u8]) -> Result<waproto::whatsapp::SignalMessageView<'_>> {
         let proto_bytes = &serialized[1..serialized.len() - Self::MAC_LENGTH];
-        let view = waproto::whatsapp::SignalMessageView::decode_view(proto_bytes)
-            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-        match view.ciphertext {
-            Some(ciphertext) => subslice_range(serialized, ciphertext)
-                .ok_or(SignalProtocolError::InvalidProtobufEncoding),
-            None => Err(SignalProtocolError::InvalidProtobufEncoding),
-        }
+        waproto::whatsapp::SignalMessageView::decode_view(proto_bytes)
+            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)
     }
 
+    fn ciphertext_range_from(
+        serialized: &[u8],
+        view: &waproto::whatsapp::SignalMessageView<'_>,
+    ) -> Result<Range<usize>> {
+        let ciphertext = view
+            .ciphertext
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        subslice_range(serialized, ciphertext).ok_or(SignalProtocolError::InvalidProtobufEncoding)
+    }
+
+    fn decode_ciphertext_range(&self) -> Result<Range<usize>> {
+        let serialized = self.serialized.as_slice();
+        let view = Self::decode_view_from(serialized)?;
+        Self::ciphertext_range_from(serialized, &view)
+    }
+
+    #[inline]
     fn try_from_serialized(serialized: SerializedBytes) -> Result<Self> {
         let value = serialized.as_slice();
         if value.len() < Self::MAC_LENGTH + 1 {
@@ -239,10 +256,7 @@ impl SignalMessage {
             ));
         }
 
-        let view = waproto::whatsapp::SignalMessageView::decode_view(
-            &value[1..value.len() - Self::MAC_LENGTH],
-        )
-        .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+        let view = Self::decode_view_from(value)?;
 
         let Some(sender_ratchet_key) = view.ratchet_key else {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
@@ -252,11 +266,7 @@ impl SignalMessage {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         };
         let previous_counter = view.previous_counter.unwrap_or(0);
-        let Some(ciphertext) = view.ciphertext else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let ciphertext_range = subslice_range(value, ciphertext)
-            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let ciphertext_range = Self::ciphertext_range_from(value, &view)?;
         let range_cache = OnceLock::new();
         let _ = range_cache.set(ciphertext_range);
 

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -5,6 +5,7 @@
 
 use buffa::Message;
 use buffa::view::MessageView;
+use bytes::Bytes;
 use hmac::{Hmac, KeyInit, Mac};
 use rand::{CryptoRng, Rng};
 use sha2::Sha256;
@@ -28,40 +29,80 @@ fn get_or_try_init_bytes(
     Ok(cache.get().expect("just set"))
 }
 
-/// Serialized protocol bytes are owned on the send path, where callers consume
-/// them without a copy, and shared on the receive path, where nested Signal
-/// envelopes can all point into the transport's existing `Bytes` allocation.
-#[derive(Debug, Clone)]
-enum SerializedBytes {
-    Owned(Box<[u8]>),
-    Shared(bytes::Bytes),
-}
-
-impl SerializedBytes {
-    #[inline]
-    fn as_slice(&self) -> &[u8] {
-        match self {
-            Self::Owned(bytes) => bytes,
-            Self::Shared(bytes) => bytes,
-        }
-    }
-
-    #[inline]
-    fn into_boxed_slice(self) -> Box<[u8]> {
-        match self {
-            Self::Owned(bytes) => bytes,
-            // Received messages normally die after decryption. Preserve the
-            // existing owned-return API for uncommon consumers that extract
-            // their wire representation explicitly.
-            Self::Shared(bytes) => Box::from(bytes.as_ref()),
-        }
-    }
-}
-
 fn subslice_range(parent: &[u8], child: &[u8]) -> Option<Range<usize>> {
     let start = (child.as_ptr() as usize).checked_sub(parent.as_ptr() as usize)?;
     let end = start.checked_add(child.len())?;
     (end <= parent.len()).then_some(start..end)
+}
+
+/// Own a borrowed wire buffer in one allocation. Constructing `Bytes` from a
+/// boxed slice keeps its allocation directly recoverable by
+/// [`bytes_into_boxed_slice`] until sharing is actually requested.
+#[inline]
+fn bytes_from_slice(value: &[u8]) -> Bytes {
+    Bytes::from(Box::<[u8]>::from(value))
+}
+
+/// Preserve the historical owned-return API. `Bytes -> Vec` reuses a unique,
+/// full backing allocation and copies only when the input is a shared slice,
+/// which is the only case where returning one standalone `Box<[u8]>` requires
+/// new ownership.
+#[inline]
+fn bytes_into_boxed_slice(value: Bytes) -> Box<[u8]> {
+    Vec::<u8>::from(value).into_boxed_slice()
+}
+
+const PROTOBUF_TAG_WIRE_BITS: u32 = 3;
+const VERSION_NIBBLE_BITS: u32 = 4;
+const VERSION_NIBBLE_MASK: u8 = (1 << VERSION_NIBBLE_BITS) - 1;
+
+#[inline]
+fn wire_tag_value(field: u32, wire_type: buffa::encoding::WireType) -> u64 {
+    (u64::from(field) << PROTOBUF_TAG_WIRE_BITS) | wire_type as u64
+}
+
+#[inline]
+fn wire_tag_len(field: u32, wire_type: buffa::encoding::WireType) -> usize {
+    buffa::encoding::varint_len(wire_tag_value(field, wire_type))
+}
+
+#[inline]
+fn varint_field_len(field: u32, value: u64) -> usize {
+    wire_tag_len(field, buffa::encoding::WireType::Varint) + buffa::encoding::varint_len(value)
+}
+
+#[inline]
+fn bytes_field_len(field: u32, value_len: usize) -> usize {
+    wire_tag_len(field, buffa::encoding::WireType::LengthDelimited)
+        + buffa::encoding::varint_len(value_len as u64)
+        + value_len
+}
+
+#[inline]
+fn push_varint_field(field: u32, value: u64, output: &mut Vec<u8>) {
+    buffa::encoding::Tag::new(field, buffa::encoding::WireType::Varint).encode(output);
+    buffa::encoding::encode_varint(value, output);
+}
+
+/// Append a protobuf bytes field and return the value's range in `output`.
+#[inline]
+fn push_bytes_field(field: u32, value: &[u8], output: &mut Vec<u8>) -> Range<usize> {
+    buffa::encoding::Tag::new(field, buffa::encoding::WireType::LengthDelimited).encode(output);
+    buffa::encoding::encode_varint(value.len() as u64, output);
+    let start = output.len();
+    output.extend_from_slice(value);
+    start..output.len()
+}
+
+#[inline]
+fn encode_version_byte(message_version: u8, current_version: u8) -> u8 {
+    ((message_version & VERSION_NIBBLE_MASK) << VERSION_NIBBLE_BITS)
+        | (current_version & VERSION_NIBBLE_MASK)
+}
+
+#[inline]
+fn decode_message_version(version_byte: u8) -> u8 {
+    version_byte >> VERSION_NIBBLE_BITS
 }
 
 // Signal's original implementation uses version 4, but WhatsApp Web,
@@ -71,6 +112,106 @@ pub const SENDERKEY_MESSAGE_CURRENT_VERSION: u8 = 3;
 
 const MIN_SUPPORTED_VERSION: u8 = 3;
 const MAX_SUPPORTED_VERSION: u8 = 4;
+
+struct ParsedSignalMessage {
+    message_version: u8,
+    sender_ratchet_key: PublicKey,
+    counter: u32,
+    ciphertext_range: Range<usize>,
+}
+
+/// Expand validation into each ownership adapter so parse errors are lowered
+/// directly into its final `Result`. A function returning an intermediate
+/// parsed value prevents that optimization on current LLVM and adds work to
+/// the common format-probing failure path.
+macro_rules! parse_signal_message {
+    ($value:expr) => {{
+        let value: &[u8] = $value;
+        if value.len() < SignalMessage::MAC_LENGTH + 1 {
+            return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
+        }
+        let message_version = decode_message_version(value[0]);
+        if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&message_version) {
+            return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
+                message_version,
+            ));
+        }
+
+        let view = SignalMessage::decode_view_from(value)?;
+        let sender_ratchet_key = view
+            .ratchet_key
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let sender_ratchet_key = PublicKey::deserialize(sender_ratchet_key)?;
+        let counter = view
+            .counter
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let ciphertext_range = SignalMessage::ciphertext_range_from(value, &view)?;
+
+        ParsedSignalMessage {
+            message_version,
+            sender_ratchet_key,
+            counter,
+            ciphertext_range,
+        }
+    }};
+}
+
+struct ParsedPreKeySignalMessage {
+    message_version: u8,
+    registration_id: u32,
+    pre_key_id: Option<PreKeyId>,
+    signed_pre_key_id: SignedPreKeyId,
+    base_key: PublicKey,
+    identity_key: IdentityKey,
+    message_range: Range<usize>,
+    message: ParsedSignalMessage,
+}
+
+/// Parse both layers of a PreKey envelope before either ownership adapter
+/// allocates or increments a reference count.
+macro_rules! parse_pre_key_signal_message {
+    ($value:expr) => {{
+        let value: &[u8] = $value;
+        if value.is_empty() {
+            return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
+        }
+
+        let message_version = decode_message_version(value[0]);
+        if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&message_version) {
+            return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
+                message_version,
+            ));
+        }
+
+        let view = waproto::whatsapp::PreKeySignalMessageView::decode_view(&value[1..])
+            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+        let base_key = view
+            .base_key
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let identity_key = view
+            .identity_key
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let message_bytes = view
+            .message
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let signed_pre_key_id = view
+            .signed_pre_key_id
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let message_range = subslice_range(value, message_bytes)
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+
+        ParsedPreKeySignalMessage {
+            message_version,
+            registration_id: view.registration_id.unwrap_or_default(),
+            pre_key_id: view.pre_key_id.map(Into::into),
+            signed_pre_key_id: signed_pre_key_id.into(),
+            base_key: PublicKey::deserialize(base_key)?,
+            identity_key: IdentityKey::try_from(identity_key)?,
+            message_range,
+            message: parse_signal_message!(message_bytes),
+        }
+    }};
+}
 
 #[derive(Debug)]
 pub enum CiphertextMessage {
@@ -110,31 +251,37 @@ impl CiphertextMessage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+struct SignalStorage {
+    /// Immutable, reference-counted ownership lets a decoded Signal envelope
+    /// remain a slice of its transport or enclosing PreKey allocation.
+    serialized: Bytes,
+    ciphertext_range: Range<usize>,
+}
+
+impl SignalStorage {
+    #[inline]
+    fn serialized(&self) -> &[u8] {
+        self.serialized.as_ref()
+    }
+
+    #[inline]
+    fn ciphertext(&self) -> &[u8] {
+        &self.serialized[self.ciphertext_range.clone()]
+    }
+
+    #[inline]
+    fn into_boxed_slice(self) -> Box<[u8]> {
+        bytes_into_boxed_slice(self.serialized)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SignalMessage {
     message_version: u8,
     sender_ratchet_key: PublicKey,
     counter: u32,
-    previous_counter: u32,
-    serialized: SerializedBytes,
-    ciphertext_range: OnceLock<Range<usize>>,
-}
-
-impl Clone for SignalMessage {
-    fn clone(&self) -> Self {
-        let ciphertext_range = OnceLock::new();
-        if let Some(range) = self.ciphertext_range.get() {
-            let _ = ciphertext_range.set(range.clone());
-        }
-        Self {
-            message_version: self.message_version,
-            sender_ratchet_key: self.sender_ratchet_key,
-            counter: self.counter,
-            previous_counter: self.previous_counter,
-            serialized: self.serialized.clone(),
-            ciphertext_range,
-        }
-    }
+    storage: SignalStorage,
 }
 
 impl SignalMessage {
@@ -151,17 +298,32 @@ impl SignalMessage {
         sender_identity_key: &IdentityKey,
         receiver_identity_key: &IdentityKey,
     ) -> Result<Self> {
-        let message = waproto::whatsapp::SignalMessage {
-            ratchet_key: Some(sender_ratchet_key.serialize().to_vec()),
-            counter: Some(counter),
-            previous_counter: Some(previous_counter),
-            ciphertext: Some(Vec::<u8>::from(ciphertext)),
-        };
-        let mut size_cache = buffa::SizeCache::new();
-        let message_len = message.compute_size(&mut size_cache) as usize;
-        let mut serialized = Vec::with_capacity(1 + message_len + Self::MAC_LENGTH);
-        serialized.push(((message_version & 0xF) << 4) | CIPHERTEXT_MESSAGE_CURRENT_VERSION);
-        message.write_to(&mut size_cache, &mut serialized);
+        use waproto::tags::signal_message as tags;
+
+        // Encode the tiny envelope straight into its final allocation. The
+        // generated field tags keep this schema-driven, while direct framing
+        // avoids allocating a temporary Vec for both the ratchet key and the
+        // potentially large ciphertext before copying them into the envelope.
+        let ratchet_key = sender_ratchet_key.serialize();
+        let proto_len = bytes_field_len(tags::RATCHET_KEY, ratchet_key.len())
+            + varint_field_len(tags::COUNTER, u64::from(counter))
+            + varint_field_len(tags::PREVIOUS_COUNTER, u64::from(previous_counter))
+            + bytes_field_len(tags::CIPHERTEXT, ciphertext.len());
+        let mut serialized = Vec::with_capacity(1 + proto_len + Self::MAC_LENGTH);
+        serialized.push(encode_version_byte(
+            message_version,
+            CIPHERTEXT_MESSAGE_CURRENT_VERSION,
+        ));
+        push_bytes_field(tags::RATCHET_KEY, &ratchet_key, &mut serialized);
+        push_varint_field(tags::COUNTER, u64::from(counter), &mut serialized);
+        push_varint_field(
+            tags::PREVIOUS_COUNTER,
+            u64::from(previous_counter),
+            &mut serialized,
+        );
+        let ciphertext_range = push_bytes_field(tags::CIPHERTEXT, ciphertext, &mut serialized);
+        debug_assert_eq!(serialized.len(), 1 + proto_len);
+
         let mac = Self::compute_mac(
             sender_identity_key,
             receiver_identity_key,
@@ -169,14 +331,14 @@ impl SignalMessage {
             &serialized,
         )?;
         serialized.extend_from_slice(&mac);
-        let serialized = serialized.into_boxed_slice();
         Ok(Self {
             message_version,
             sender_ratchet_key,
             counter,
-            previous_counter,
-            serialized: SerializedBytes::Owned(serialized),
-            ciphertext_range: OnceLock::new(),
+            storage: SignalStorage {
+                serialized: Bytes::from(serialized),
+                ciphertext_range,
+            },
         })
     }
 
@@ -197,26 +359,17 @@ impl SignalMessage {
 
     #[inline]
     pub fn serialized(&self) -> &[u8] {
-        self.serialized.as_slice()
+        self.storage.serialized()
     }
 
     #[inline]
     pub fn into_serialized(self) -> Box<[u8]> {
-        self.serialized.into_boxed_slice()
+        self.storage.into_boxed_slice()
     }
 
     #[inline]
     pub fn body(&self) -> Result<&[u8]> {
-        if let Some(range) = self.ciphertext_range.get() {
-            return Ok(&self.serialized.as_slice()[range.clone()]);
-        }
-
-        let _ = self.ciphertext_range.set(self.decode_ciphertext_range()?);
-        let range = self
-            .ciphertext_range
-            .get()
-            .expect("ciphertext range was just initialized");
-        Ok(&self.serialized.as_slice()[range.clone()])
+        Ok(self.storage.ciphertext())
     }
 
     #[inline]
@@ -236,48 +389,41 @@ impl SignalMessage {
         subslice_range(serialized, ciphertext).ok_or(SignalProtocolError::InvalidProtobufEncoding)
     }
 
-    fn decode_ciphertext_range(&self) -> Result<Range<usize>> {
-        let serialized = self.serialized.as_slice();
-        let view = Self::decode_view_from(serialized)?;
-        Self::ciphertext_range_from(serialized, &view)
+    fn rebase_serialized(&mut self, serialized: Bytes) {
+        let ciphertext_range = self.storage.ciphertext_range.clone();
+        debug_assert_eq!(self.storage.serialized(), serialized.as_ref());
+        self.storage = SignalStorage {
+            serialized,
+            ciphertext_range,
+        };
     }
 
     #[inline]
-    fn try_from_serialized(serialized: SerializedBytes) -> Result<Self> {
-        let value = serialized.as_slice();
-        if value.len() < Self::MAC_LENGTH + 1 {
-            return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
+    fn from_parsed(serialized: Bytes, parsed: ParsedSignalMessage) -> Self {
+        Self {
+            message_version: parsed.message_version,
+            sender_ratchet_key: parsed.sender_ratchet_key,
+            counter: parsed.counter,
+            storage: SignalStorage {
+                serialized,
+                ciphertext_range: parsed.ciphertext_range,
+            },
         }
-        let message_version = value[0] >> 4;
+    }
 
-        if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&message_version) {
-            return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
-                message_version,
-            ));
-        }
+    #[inline]
+    fn try_from_borrowed(value: &[u8]) -> Result<Self> {
+        // Validate before taking ownership. Besides avoiding wasted work for
+        // malformed input, this preserves the allocation-free rejection path
+        // used when callers probe a ciphertext's Signal envelope type.
+        let parsed = parse_signal_message!(value);
+        Ok(Self::from_parsed(bytes_from_slice(value), parsed))
+    }
 
-        let view = Self::decode_view_from(value)?;
-
-        let Some(sender_ratchet_key) = view.ratchet_key else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let sender_ratchet_key = PublicKey::deserialize(sender_ratchet_key)?;
-        let Some(counter) = view.counter else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let previous_counter = view.previous_counter.unwrap_or(0);
-        let ciphertext_range = Self::ciphertext_range_from(value, &view)?;
-        let range_cache = OnceLock::new();
-        let _ = range_cache.set(ciphertext_range);
-
-        Ok(Self {
-            message_version,
-            sender_ratchet_key,
-            counter,
-            previous_counter,
-            serialized,
-            ciphertext_range: range_cache,
-        })
+    #[inline]
+    fn try_from_shared(serialized: Bytes) -> Result<Self> {
+        let parsed = parse_signal_message!(&serialized);
+        Ok(Self::from_parsed(serialized, parsed))
     }
 
     pub fn verify_mac(
@@ -286,7 +432,7 @@ impl SignalMessage {
         receiver_identity_key: &IdentityKey,
         mac_key: &[u8],
     ) -> Result<bool> {
-        let serialized = self.serialized.as_slice();
+        let serialized = self.storage.serialized();
         let our_mac = &Self::compute_mac(
             sender_identity_key,
             receiver_identity_key,
@@ -329,7 +475,7 @@ impl SignalMessage {
 
 impl AsRef<[u8]> for SignalMessage {
     fn as_ref(&self) -> &[u8] {
-        self.serialized.as_slice()
+        self.storage.serialized()
     }
 }
 
@@ -337,15 +483,15 @@ impl TryFrom<&[u8]> for SignalMessage {
     type Error = SignalProtocolError;
 
     fn try_from(value: &[u8]) -> Result<Self> {
-        Self::try_from_serialized(SerializedBytes::Owned(Box::from(value)))
+        Self::try_from_borrowed(value)
     }
 }
 
-impl TryFrom<bytes::Bytes> for SignalMessage {
+impl TryFrom<Bytes> for SignalMessage {
     type Error = SignalProtocolError;
 
-    fn try_from(value: bytes::Bytes) -> Result<Self> {
-        Self::try_from_serialized(SerializedBytes::Shared(value))
+    fn try_from(value: Bytes) -> Result<Self> {
+        Self::try_from_shared(value)
     }
 }
 
@@ -358,7 +504,7 @@ pub struct PreKeySignalMessage {
     base_key: PublicKey,
     identity_key: IdentityKey,
     message: SignalMessage,
-    serialized: SerializedBytes,
+    serialized: Bytes,
 }
 
 impl PreKeySignalMessage {
@@ -369,24 +515,57 @@ impl PreKeySignalMessage {
         signed_pre_key_id: SignedPreKeyId,
         base_key: PublicKey,
         identity_key: IdentityKey,
-        message: SignalMessage,
+        mut message: SignalMessage,
     ) -> Result<Self> {
-        let proto_message = waproto::whatsapp::PreKeySignalMessage {
-            registration_id: Some(registration_id),
-            pre_key_id: pre_key_id.map(|id| id.into()),
-            signed_pre_key_id: Some(signed_pre_key_id.into()),
-            base_key: Some(base_key.serialize().to_vec()),
-            identity_key: Some(identity_key.serialize().to_vec()),
-            message: Some(Vec::from(message.as_ref())),
-            // Post-quantum (Kyber) prekeys are not implemented; classic X3DH only.
-            kyber_pre_key_id: None,
-            kyber_ciphertext: None,
-        };
-        let mut size_cache = buffa::SizeCache::new();
-        let message_len = proto_message.compute_size(&mut size_cache) as usize;
-        let mut serialized = Vec::with_capacity(1 + message_len);
-        serialized.push(((message_version & 0xF) << 4) | CIPHERTEXT_MESSAGE_CURRENT_VERSION);
-        proto_message.write_to(&mut size_cache, &mut serialized);
+        use waproto::tags::pre_key_signal_message as tags;
+
+        let pre_key_id_value = pre_key_id.map(Into::<u32>::into);
+        let signed_pre_key_id_value: u32 = signed_pre_key_id.into();
+        let base_key_bytes = base_key.serialize();
+        let identity_key_bytes = identity_key.serialize();
+        let nested_message = message.serialized();
+
+        // Follow the generated encoder's ascending-tag order while writing all
+        // byte fields directly into the final envelope. This removes three
+        // temporary Vec allocations/copies without changing canonical wire
+        // output.
+        let proto_len = pre_key_id_value
+            .map(|id| varint_field_len(tags::PRE_KEY_ID, u64::from(id)))
+            .unwrap_or_default()
+            + bytes_field_len(tags::BASE_KEY, base_key_bytes.len())
+            + bytes_field_len(tags::IDENTITY_KEY, identity_key_bytes.len())
+            + bytes_field_len(tags::MESSAGE, nested_message.len())
+            + varint_field_len(tags::REGISTRATION_ID, u64::from(registration_id))
+            + varint_field_len(tags::SIGNED_PRE_KEY_ID, u64::from(signed_pre_key_id_value));
+        let mut serialized = Vec::with_capacity(1 + proto_len);
+        serialized.push(encode_version_byte(
+            message_version,
+            CIPHERTEXT_MESSAGE_CURRENT_VERSION,
+        ));
+        if let Some(id) = pre_key_id_value {
+            push_varint_field(tags::PRE_KEY_ID, u64::from(id), &mut serialized);
+        }
+        push_bytes_field(tags::BASE_KEY, &base_key_bytes, &mut serialized);
+        push_bytes_field(tags::IDENTITY_KEY, &identity_key_bytes, &mut serialized);
+        let message_range = push_bytes_field(tags::MESSAGE, nested_message, &mut serialized);
+        push_varint_field(
+            tags::REGISTRATION_ID,
+            u64::from(registration_id),
+            &mut serialized,
+        );
+        push_varint_field(
+            tags::SIGNED_PRE_KEY_ID,
+            u64::from(signed_pre_key_id_value),
+            &mut serialized,
+        );
+        debug_assert_eq!(serialized.len(), 1 + proto_len);
+
+        let serialized = Bytes::from(serialized);
+        // The outer envelope must be contiguous, so it necessarily copied the
+        // inner bytes once. Rebase the retained parsed message onto that copy
+        // and release its old allocation: steady-state PreKey storage is now a
+        // single allocation shared by both handles.
+        message.rebase_serialized(serialized.slice(message_range));
         Ok(Self {
             message_version,
             registration_id,
@@ -395,8 +574,34 @@ impl PreKeySignalMessage {
             base_key,
             identity_key,
             message,
-            serialized: SerializedBytes::Owned(serialized.into_boxed_slice()),
+            serialized,
         })
+    }
+
+    #[inline]
+    fn from_parsed(serialized: Bytes, parsed: ParsedPreKeySignalMessage) -> Self {
+        let ParsedPreKeySignalMessage {
+            message_version,
+            registration_id,
+            pre_key_id,
+            signed_pre_key_id,
+            base_key,
+            identity_key,
+            message_range,
+            message,
+        } = parsed;
+        let message = SignalMessage::from_parsed(serialized.slice(message_range), message);
+
+        Self {
+            message_version,
+            registration_id,
+            pre_key_id,
+            signed_pre_key_id,
+            base_key,
+            identity_key,
+            message,
+            serialized,
+        }
     }
 
     #[inline]
@@ -436,18 +641,26 @@ impl PreKeySignalMessage {
 
     #[inline]
     pub fn serialized(&self) -> &[u8] {
-        self.serialized.as_slice()
+        self.serialized.as_ref()
     }
 
     #[inline]
     pub fn into_serialized(self) -> Box<[u8]> {
-        self.serialized.into_boxed_slice()
+        let Self {
+            message,
+            serialized,
+            ..
+        } = self;
+        // Release the nested slice first so a uniquely-owned outer allocation
+        // can be recovered by `Bytes -> Vec` without a copy.
+        drop(message);
+        bytes_into_boxed_slice(serialized)
     }
 }
 
 impl AsRef<[u8]> for PreKeySignalMessage {
     fn as_ref(&self) -> &[u8] {
-        self.serialized.as_slice()
+        self.serialized.as_ref()
     }
 }
 
@@ -455,56 +668,17 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
     type Error = SignalProtocolError;
 
     fn try_from(value: &[u8]) -> Result<Self> {
-        Self::try_from(bytes::Bytes::copy_from_slice(value))
+        let parsed = parse_pre_key_signal_message!(value);
+        Ok(Self::from_parsed(bytes_from_slice(value), parsed))
     }
 }
 
-impl TryFrom<bytes::Bytes> for PreKeySignalMessage {
+impl TryFrom<Bytes> for PreKeySignalMessage {
     type Error = SignalProtocolError;
 
-    fn try_from(value: bytes::Bytes) -> Result<Self> {
-        if value.is_empty() {
-            return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
-        }
-
-        let message_version = value[0] >> 4;
-
-        if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&message_version) {
-            return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
-                message_version,
-            ));
-        }
-
-        let view = waproto::whatsapp::PreKeySignalMessageView::decode_view(&value[1..])
-            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-
-        let Some(base_key) = view.base_key else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let Some(identity_key) = view.identity_key else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let Some(message) = view.message else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let Some(signed_pre_key_id) = view.signed_pre_key_id else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-
-        let message_range =
-            subslice_range(&value, message).ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-        let base_key = PublicKey::deserialize(base_key)?;
-
-        Ok(PreKeySignalMessage {
-            message_version,
-            registration_id: view.registration_id.unwrap_or(0),
-            pre_key_id: view.pre_key_id.map(|id| id.into()),
-            signed_pre_key_id: signed_pre_key_id.into(),
-            base_key,
-            identity_key: IdentityKey::try_from(identity_key)?,
-            message: SignalMessage::try_from(value.slice(message_range))?,
-            serialized: SerializedBytes::Shared(value),
-        })
+    fn try_from(value: Bytes) -> Result<Self> {
+        let parsed = parse_pre_key_signal_message!(&value);
+        Ok(Self::from_parsed(value, parsed))
     }
 }
 
@@ -1059,6 +1233,234 @@ impl TryFrom<&[u8]> for DecryptionErrorMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_MESSAGE_VERSION: u8 = CIPHERTEXT_MESSAGE_CURRENT_VERSION;
+    const TEST_MAC_KEY: [u8; 32] = [0xA5; 32];
+    const TEST_RATCHET_SEED: u8 = 0x11;
+    const TEST_SENDER_IDENTITY_SEED: u8 = 0x22;
+    const TEST_RECEIVER_IDENTITY_SEED: u8 = 0x33;
+    const TEST_BASE_KEY_SEED: u8 = 0x44;
+
+    fn public_key_from_seed(seed: u8) -> PublicKey {
+        PrivateKey::deserialize(&[seed; 32])
+            .expect("test private key")
+            .public_key()
+            .expect("test public key")
+    }
+
+    fn test_signal_message(
+        counter: u32,
+        previous_counter: u32,
+        ciphertext: &[u8],
+    ) -> SignalMessage {
+        SignalMessage::new(
+            TEST_MESSAGE_VERSION,
+            &TEST_MAC_KEY,
+            public_key_from_seed(TEST_RATCHET_SEED),
+            counter,
+            previous_counter,
+            ciphertext,
+            &IdentityKey::new(public_key_from_seed(TEST_SENDER_IDENTITY_SEED)),
+            &IdentityKey::new(public_key_from_seed(TEST_RECEIVER_IDENTITY_SEED)),
+        )
+        .expect("test SignalMessage")
+    }
+
+    fn generated_signal_wire(counter: u32, previous_counter: u32, ciphertext: &[u8]) -> Vec<u8> {
+        let sender_identity = IdentityKey::new(public_key_from_seed(TEST_SENDER_IDENTITY_SEED));
+        let receiver_identity = IdentityKey::new(public_key_from_seed(TEST_RECEIVER_IDENTITY_SEED));
+        let proto = waproto::whatsapp::SignalMessage {
+            ratchet_key: Some(public_key_from_seed(TEST_RATCHET_SEED).serialize().to_vec()),
+            counter: Some(counter),
+            previous_counter: Some(previous_counter),
+            ciphertext: Some(ciphertext.to_vec()),
+        };
+        let mut wire =
+            Vec::with_capacity(1 + proto.encoded_len() as usize + SignalMessage::MAC_LENGTH);
+        wire.push(encode_version_byte(
+            TEST_MESSAGE_VERSION,
+            CIPHERTEXT_MESSAGE_CURRENT_VERSION,
+        ));
+        wire.extend_from_slice(&proto.encode_to_vec());
+        let mac =
+            SignalMessage::compute_mac(&sender_identity, &receiver_identity, &TEST_MAC_KEY, &wire)
+                .expect("test MAC");
+        wire.extend_from_slice(&mac);
+        wire
+    }
+
+    fn generated_pre_key_wire(
+        registration_id: u32,
+        pre_key_id: Option<PreKeyId>,
+        signed_pre_key_id: SignedPreKeyId,
+        nested_message: &[u8],
+    ) -> Vec<u8> {
+        let proto = waproto::whatsapp::PreKeySignalMessage {
+            registration_id: Some(registration_id),
+            pre_key_id: pre_key_id.map(Into::into),
+            signed_pre_key_id: Some(signed_pre_key_id.into()),
+            base_key: Some(
+                public_key_from_seed(TEST_BASE_KEY_SEED)
+                    .serialize()
+                    .to_vec(),
+            ),
+            identity_key: Some(
+                public_key_from_seed(TEST_SENDER_IDENTITY_SEED)
+                    .serialize()
+                    .to_vec(),
+            ),
+            message: Some(nested_message.to_vec()),
+            kyber_pre_key_id: None,
+            kyber_ciphertext: None,
+        };
+        let mut wire = Vec::with_capacity(1 + proto.encoded_len() as usize);
+        wire.push(encode_version_byte(
+            TEST_MESSAGE_VERSION,
+            CIPHERTEXT_MESSAGE_CURRENT_VERSION,
+        ));
+        wire.extend_from_slice(&proto.encode_to_vec());
+        wire
+    }
+
+    #[test]
+    fn direct_signal_encoder_matches_generated_wire() {
+        let counters = [0, 127, 128, u32::MAX];
+        let ciphertexts = [Vec::new(), vec![0x5A], vec![0xC3; 128]];
+
+        for counter in counters {
+            for previous_counter in counters {
+                for ciphertext in &ciphertexts {
+                    let direct = test_signal_message(counter, previous_counter, ciphertext);
+                    let generated = generated_signal_wire(counter, previous_counter, ciphertext);
+                    assert_eq!(direct.serialized(), generated);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn direct_pre_key_encoder_matches_generated_wire() {
+        let signal_wire = generated_signal_wire(128, 127, &[0x7E; 64]);
+        let cases = [
+            (0, None, 0),
+            (127, Some(127), 127),
+            (128, Some(128), 128),
+            (u32::MAX, Some(u32::MAX), u32::MAX),
+        ];
+
+        for (registration_id, pre_key_id, signed_pre_key_id) in cases {
+            let pre_key_id = pre_key_id.map(Into::into);
+            let signed_pre_key_id = signed_pre_key_id.into();
+            let direct = PreKeySignalMessage::new(
+                TEST_MESSAGE_VERSION,
+                registration_id,
+                pre_key_id,
+                signed_pre_key_id,
+                public_key_from_seed(TEST_BASE_KEY_SEED),
+                IdentityKey::new(public_key_from_seed(TEST_SENDER_IDENTITY_SEED)),
+                SignalMessage::try_from(signal_wire.as_slice()).expect("nested SignalMessage"),
+            )
+            .expect("test PreKeySignalMessage");
+            let generated = generated_pre_key_wire(
+                registration_id,
+                pre_key_id,
+                signed_pre_key_id,
+                &signal_wire,
+            );
+            assert_eq!(direct.serialized(), generated);
+        }
+    }
+
+    #[test]
+    fn parsed_signal_body_shares_its_wire_allocation() {
+        let wire = test_signal_message(7, 3, &[0x42; 256]).into_serialized();
+
+        let borrowed = SignalMessage::try_from(wire.as_ref()).expect("borrowed SignalMessage");
+        assert!(
+            subslice_range(
+                borrowed.serialized(),
+                borrowed.body().expect("borrowed Signal body"),
+            )
+            .is_some()
+        );
+
+        let transport = Bytes::from(wire);
+        let transport_ptr = transport.as_ptr();
+        let shared = SignalMessage::try_from(transport).expect("shared SignalMessage");
+        assert_eq!(shared.serialized().as_ptr(), transport_ptr);
+        assert!(
+            subslice_range(
+                shared.serialized(),
+                shared.body().expect("shared Signal body"),
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn parsed_pre_key_and_nested_signal_share_one_wire_allocation() {
+        let signal_wire = generated_signal_wire(9, 4, &[0x24; 256]);
+        let wire = PreKeySignalMessage::new(
+            TEST_MESSAGE_VERSION,
+            128,
+            Some(127.into()),
+            129.into(),
+            public_key_from_seed(TEST_BASE_KEY_SEED),
+            IdentityKey::new(public_key_from_seed(TEST_SENDER_IDENTITY_SEED)),
+            SignalMessage::try_from(signal_wire.as_slice()).expect("nested SignalMessage"),
+        )
+        .expect("test PreKeySignalMessage")
+        .into_serialized();
+
+        let borrowed =
+            PreKeySignalMessage::try_from(wire.as_ref()).expect("borrowed PreKeySignalMessage");
+        assert!(subslice_range(borrowed.serialized(), borrowed.message().serialized()).is_some());
+        assert!(
+            subslice_range(
+                borrowed.serialized(),
+                borrowed
+                    .message()
+                    .body()
+                    .expect("borrowed nested Signal body"),
+            )
+            .is_some()
+        );
+
+        let transport = Bytes::from(wire);
+        let transport_ptr = transport.as_ptr();
+        let shared = PreKeySignalMessage::try_from(transport).expect("shared PreKeySignalMessage");
+        assert_eq!(shared.serialized().as_ptr(), transport_ptr);
+        assert!(subslice_range(shared.serialized(), shared.message().serialized()).is_some());
+        assert!(
+            subslice_range(
+                shared.serialized(),
+                shared.message().body().expect("shared nested Signal body"),
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn consuming_unique_encoded_messages_reuses_their_wire_allocations() {
+        let signal = test_signal_message(1, 0, b"signal");
+        let signal_ptr = signal.serialized().as_ptr();
+        let signal_wire = signal.into_serialized();
+        assert_eq!(signal_wire.as_ptr(), signal_ptr);
+
+        let pre_key = PreKeySignalMessage::new(
+            TEST_MESSAGE_VERSION,
+            1,
+            Some(1.into()),
+            1.into(),
+            public_key_from_seed(TEST_BASE_KEY_SEED),
+            IdentityKey::new(public_key_from_seed(TEST_SENDER_IDENTITY_SEED)),
+            SignalMessage::try_from(signal_wire.as_ref()).expect("nested SignalMessage"),
+        )
+        .expect("test PreKeySignalMessage");
+        let pre_key_ptr = pre_key.serialized().as_ptr();
+        let pre_key_wire = pre_key.into_serialized();
+        assert_eq!(pre_key_wire.as_ptr(), pre_key_ptr);
+    }
 
     #[test]
     fn decryption_error_proto_uses_buffa_size_cache_encoding() {

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -8,6 +8,7 @@ use buffa::view::MessageView;
 use hmac::{Hmac, KeyInit, Mac};
 use rand::{CryptoRng, Rng};
 use sha2::Sha256;
+use std::ops::Range;
 use std::sync::OnceLock;
 use subtle::ConstantTimeEq;
 
@@ -25,6 +26,40 @@ fn get_or_try_init_bytes(
     let _ = cache.set(init()?);
     // get() can't be None: even if a racing set() lost, the winner's value is stored
     Ok(cache.get().expect("just set"))
+}
+
+/// Serialized protocol bytes are owned on the send path, where callers consume
+/// them without a copy, and shared on the receive path, where nested Signal
+/// envelopes can all point into the transport's existing `Bytes` allocation.
+#[derive(Debug, Clone)]
+enum SerializedBytes {
+    Owned(Box<[u8]>),
+    Shared(bytes::Bytes),
+}
+
+impl SerializedBytes {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Owned(bytes) => bytes,
+            Self::Shared(bytes) => bytes,
+        }
+    }
+
+    fn into_boxed_slice(self) -> Box<[u8]> {
+        match self {
+            Self::Owned(bytes) => bytes,
+            // Received messages normally die after decryption. Preserve the
+            // existing owned-return API for uncommon consumers that extract
+            // their wire representation explicitly.
+            Self::Shared(bytes) => Box::from(bytes.as_ref()),
+        }
+    }
+}
+
+fn subslice_range(parent: &[u8], child: &[u8]) -> Option<Range<usize>> {
+    let start = (child.as_ptr() as usize).checked_sub(parent.as_ptr() as usize)?;
+    let end = start.checked_add(child.len())?;
+    (end <= parent.len()).then_some(start..end)
 }
 
 // Signal's original implementation uses version 4, but WhatsApp Web,
@@ -79,15 +114,15 @@ pub struct SignalMessage {
     sender_ratchet_key: PublicKey,
     counter: u32,
     previous_counter: u32,
-    serialized: Box<[u8]>,
-    ciphertext_cache: OnceLock<Box<[u8]>>,
+    serialized: SerializedBytes,
+    ciphertext_range: OnceLock<Range<usize>>,
 }
 
 impl Clone for SignalMessage {
     fn clone(&self) -> Self {
-        let ciphertext_cache = OnceLock::new();
-        if let Some(ct) = self.ciphertext_cache.get() {
-            let _ = ciphertext_cache.set(ct.clone());
+        let ciphertext_range = OnceLock::new();
+        if let Some(range) = self.ciphertext_range.get() {
+            let _ = ciphertext_range.set(range.clone());
         }
         Self {
             message_version: self.message_version,
@@ -95,7 +130,7 @@ impl Clone for SignalMessage {
             counter: self.counter,
             previous_counter: self.previous_counter,
             serialized: self.serialized.clone(),
-            ciphertext_cache,
+            ciphertext_range,
         }
     }
 }
@@ -138,8 +173,8 @@ impl SignalMessage {
             sender_ratchet_key,
             counter,
             previous_counter,
-            serialized,
-            ciphertext_cache: OnceLock::new(),
+            serialized: SerializedBytes::Owned(serialized),
+            ciphertext_range: OnceLock::new(),
         })
     }
 
@@ -160,26 +195,79 @@ impl SignalMessage {
 
     #[inline]
     pub fn serialized(&self) -> &[u8] {
-        &self.serialized
+        self.serialized.as_slice()
     }
 
     #[inline]
     pub fn into_serialized(self) -> Box<[u8]> {
-        self.serialized
+        self.serialized.into_boxed_slice()
     }
 
     pub fn body(&self) -> Result<&[u8]> {
-        get_or_try_init_bytes(&self.ciphertext_cache, || self.decode_ciphertext())
+        if self.ciphertext_range.get().is_none() {
+            let _ = self.ciphertext_range.set(self.decode_ciphertext_range()?);
+        }
+        let range = self
+            .ciphertext_range
+            .get()
+            .expect("ciphertext range was just initialized");
+        Ok(&self.serialized.as_slice()[range.clone()])
     }
 
-    fn decode_ciphertext(&self) -> Result<Box<[u8]>> {
-        let proto_bytes = &self.serialized[1..self.serialized.len() - Self::MAC_LENGTH];
+    fn decode_ciphertext_range(&self) -> Result<Range<usize>> {
+        let serialized = self.serialized.as_slice();
+        let proto_bytes = &serialized[1..serialized.len() - Self::MAC_LENGTH];
         let view = waproto::whatsapp::SignalMessageView::decode_view(proto_bytes)
             .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
         match view.ciphertext {
-            Some(ciphertext) => Ok(Box::from(ciphertext)),
+            Some(ciphertext) => subslice_range(serialized, ciphertext)
+                .ok_or(SignalProtocolError::InvalidProtobufEncoding),
             None => Err(SignalProtocolError::InvalidProtobufEncoding),
         }
+    }
+
+    fn try_from_serialized(serialized: SerializedBytes) -> Result<Self> {
+        let value = serialized.as_slice();
+        if value.len() < Self::MAC_LENGTH + 1 {
+            return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
+        }
+        let message_version = value[0] >> 4;
+
+        if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&message_version) {
+            return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
+                message_version,
+            ));
+        }
+
+        let view = waproto::whatsapp::SignalMessageView::decode_view(
+            &value[1..value.len() - Self::MAC_LENGTH],
+        )
+        .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+
+        let Some(sender_ratchet_key) = view.ratchet_key else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let sender_ratchet_key = PublicKey::deserialize(sender_ratchet_key)?;
+        let Some(counter) = view.counter else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let previous_counter = view.previous_counter.unwrap_or(0);
+        let Some(ciphertext) = view.ciphertext else {
+            return Err(SignalProtocolError::InvalidProtobufEncoding);
+        };
+        let ciphertext_range = subslice_range(value, ciphertext)
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
+        let range_cache = OnceLock::new();
+        let _ = range_cache.set(ciphertext_range);
+
+        Ok(Self {
+            message_version,
+            sender_ratchet_key,
+            counter,
+            previous_counter,
+            serialized,
+            ciphertext_range: range_cache,
+        })
     }
 
     pub fn verify_mac(
@@ -188,13 +276,14 @@ impl SignalMessage {
         receiver_identity_key: &IdentityKey,
         mac_key: &[u8],
     ) -> Result<bool> {
+        let serialized = self.serialized.as_slice();
         let our_mac = &Self::compute_mac(
             sender_identity_key,
             receiver_identity_key,
             mac_key,
-            &self.serialized[..self.serialized.len() - Self::MAC_LENGTH],
+            &serialized[..serialized.len() - Self::MAC_LENGTH],
         )?;
-        let their_mac = &self.serialized[self.serialized.len() - Self::MAC_LENGTH..];
+        let their_mac = &serialized[serialized.len() - Self::MAC_LENGTH..];
         let result: bool = our_mac.ct_eq(their_mac).into();
         if !result {
             // A warning instead of an error because we try multiple sessions.
@@ -230,7 +319,7 @@ impl SignalMessage {
 
 impl AsRef<[u8]> for SignalMessage {
     fn as_ref(&self) -> &[u8] {
-        &self.serialized
+        self.serialized.as_slice()
     }
 }
 
@@ -238,46 +327,15 @@ impl TryFrom<&[u8]> for SignalMessage {
     type Error = SignalProtocolError;
 
     fn try_from(value: &[u8]) -> Result<Self> {
-        if value.len() < SignalMessage::MAC_LENGTH + 1 {
-            return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
-        }
-        let message_version = value[0] >> 4;
+        Self::try_from_serialized(SerializedBytes::Owned(Box::from(value)))
+    }
+}
 
-        if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&message_version) {
-            return Err(SignalProtocolError::UnrecognizedCiphertextVersion(
-                message_version,
-            ));
-        }
+impl TryFrom<bytes::Bytes> for SignalMessage {
+    type Error = SignalProtocolError;
 
-        let view = waproto::whatsapp::SignalMessageView::decode_view(
-            &value[1..value.len() - SignalMessage::MAC_LENGTH],
-        )
-        .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-
-        let Some(sender_ratchet_key) = view.ratchet_key else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let sender_ratchet_key = PublicKey::deserialize(sender_ratchet_key)?;
-        let Some(counter) = view.counter else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let previous_counter = view.previous_counter.unwrap_or(0);
-        let Some(ciphertext) = view.ciphertext else {
-            return Err(SignalProtocolError::InvalidProtobufEncoding);
-        };
-        let ciphertext: Box<[u8]> = Box::from(ciphertext);
-
-        let ciphertext_cache = OnceLock::new();
-        let _ = ciphertext_cache.set(ciphertext);
-
-        Ok(SignalMessage {
-            message_version,
-            sender_ratchet_key,
-            counter,
-            previous_counter,
-            serialized: Box::from(value),
-            ciphertext_cache,
-        })
+    fn try_from(value: bytes::Bytes) -> Result<Self> {
+        Self::try_from_serialized(SerializedBytes::Shared(value))
     }
 }
 
@@ -290,7 +348,7 @@ pub struct PreKeySignalMessage {
     base_key: PublicKey,
     identity_key: IdentityKey,
     message: SignalMessage,
-    serialized: Box<[u8]>,
+    serialized: SerializedBytes,
 }
 
 impl PreKeySignalMessage {
@@ -327,7 +385,7 @@ impl PreKeySignalMessage {
             base_key,
             identity_key,
             message,
-            serialized: serialized.into_boxed_slice(),
+            serialized: SerializedBytes::Owned(serialized.into_boxed_slice()),
         })
     }
 
@@ -368,18 +426,18 @@ impl PreKeySignalMessage {
 
     #[inline]
     pub fn serialized(&self) -> &[u8] {
-        &self.serialized
+        self.serialized.as_slice()
     }
 
     #[inline]
     pub fn into_serialized(self) -> Box<[u8]> {
-        self.serialized
+        self.serialized.into_boxed_slice()
     }
 }
 
 impl AsRef<[u8]> for PreKeySignalMessage {
     fn as_ref(&self) -> &[u8] {
-        &self.serialized
+        self.serialized.as_slice()
     }
 }
 
@@ -387,6 +445,14 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
     type Error = SignalProtocolError;
 
     fn try_from(value: &[u8]) -> Result<Self> {
+        Self::try_from(bytes::Bytes::copy_from_slice(value))
+    }
+}
+
+impl TryFrom<bytes::Bytes> for PreKeySignalMessage {
+    type Error = SignalProtocolError;
+
+    fn try_from(value: bytes::Bytes) -> Result<Self> {
         if value.is_empty() {
             return Err(SignalProtocolError::CiphertextMessageTooShort(value.len()));
         }
@@ -415,6 +481,8 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         };
 
+        let message_range =
+            subslice_range(&value, message).ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
         let base_key = PublicKey::deserialize(base_key)?;
 
         Ok(PreKeySignalMessage {
@@ -424,8 +492,8 @@ impl TryFrom<&[u8]> for PreKeySignalMessage {
             signed_pre_key_id: signed_pre_key_id.into(),
             base_key,
             identity_key: IdentityKey::try_from(identity_key)?,
-            message: SignalMessage::try_from(message)?,
-            serialized: Box::from(value),
+            message: SignalMessage::try_from(value.slice(message_range))?,
+            serialized: SerializedBytes::Shared(value),
         })
     }
 }

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -1188,6 +1188,7 @@ fn decrypt_with_message_keys(
     })
 }
 
+#[must_use = "the deferred sender ratchet must be applied after authenticated decryption succeeds"]
 struct DeferredSenderRatchet {
     receiver_root_key: RootKey,
     previous_counter: u32,

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -72,7 +72,7 @@ const fn forward_jump_limit(is_self: bool) -> usize {
     }
 }
 use crate::protocol::ratchet::keys::MessageKeyGenerator;
-use crate::protocol::ratchet::{ChainKey, UsePQRatchet};
+use crate::protocol::ratchet::{ChainKey, RootKey, UsePQRatchet};
 use crate::protocol::state::{DecryptSnapshot, PreKeyId, SessionState};
 use crate::protocol::{
     CiphertextMessage, CiphertextMessageType, Direction, IdentityChange, IdentityKeyStore, KeyPair,
@@ -1080,7 +1080,8 @@ fn decrypt_with_pending_state<R: Rng + CryptoRng>(
     their_ephemeral: &PublicKey,
     counter: u32,
 ) -> Result<Vec<u8>> {
-    let chain_key = get_or_create_chain_key(state, their_ephemeral, remote_address, csprng)?;
+    let (chain_key, deferred_ratchet) =
+        get_or_create_chain_key(state, their_ephemeral, remote_address)?;
 
     let message_key_gen = get_or_create_message_key(
         state,
@@ -1091,14 +1092,23 @@ fn decrypt_with_pending_state<R: Rng + CryptoRng>(
         counter,
     )?;
 
-    decrypt_with_message_keys(
+    let plaintext = decrypt_with_message_keys(
         current_or_previous,
         state,
         ciphertext,
         original_message_type,
         remote_address,
         message_key_gen,
-    )
+    )?;
+
+    // Generating a new sender ratchet requires fresh entropy and a second DH.
+    // Neither can affect inbound MAC verification, so perform them only after
+    // the candidate session has authenticated the message.
+    if let Some(deferred_ratchet) = deferred_ratchet {
+        deferred_ratchet.apply(state, their_ephemeral, csprng)?;
+    }
+
+    Ok(plaintext)
 }
 
 fn decrypt_with_message_keys(
@@ -1178,14 +1188,37 @@ fn decrypt_with_message_keys(
     })
 }
 
-fn get_or_create_chain_key<R: Rng + CryptoRng>(
+struct DeferredSenderRatchet {
+    receiver_root_key: RootKey,
+    previous_counter: u32,
+}
+
+impl DeferredSenderRatchet {
+    fn apply<R: Rng + CryptoRng>(
+        self,
+        state: &mut SessionState,
+        their_ephemeral: &PublicKey,
+        csprng: &mut R,
+    ) -> Result<()> {
+        let our_new_ephemeral = KeyPair::generate(csprng);
+        let sender_chain = self
+            .receiver_root_key
+            .create_chain(their_ephemeral, &our_new_ephemeral.private_key)?;
+
+        state.set_root_key(&sender_chain.0);
+        state.set_previous_counter(self.previous_counter);
+        state.set_sender_chain(&our_new_ephemeral, &sender_chain.1);
+        Ok(())
+    }
+}
+
+fn get_or_create_chain_key(
     state: &mut SessionState,
     their_ephemeral: &PublicKey,
     remote_address: &ProtocolAddress,
-    csprng: &mut R,
-) -> Result<ChainKey> {
+) -> Result<(ChainKey, Option<DeferredSenderRatchet>)> {
     if let Some(chain) = state.get_receiver_chain_key(their_ephemeral)? {
-        return Ok(chain);
+        return Ok((chain, None));
     }
 
     log::debug!("{remote_address} creating new chains.");
@@ -1193,24 +1226,15 @@ fn get_or_create_chain_key<R: Rng + CryptoRng>(
     let root_key = state.root_key()?;
     let our_ephemeral = state.sender_ratchet_private_key()?;
     let receiver_chain = root_key.create_chain(their_ephemeral, &our_ephemeral)?;
-    let our_new_ephemeral = KeyPair::generate(csprng);
-    let sender_chain = receiver_chain
-        .0
-        .create_chain(their_ephemeral, &our_new_ephemeral.private_key)?;
-
-    state.set_root_key(&sender_chain.0);
-    state.add_receiver_chain(their_ephemeral, &receiver_chain.1);
 
     let current_index = state.get_sender_chain_key()?.index();
-    let previous_index = if current_index > 0 {
-        current_index - 1
-    } else {
-        0
+    let deferred_ratchet = DeferredSenderRatchet {
+        receiver_root_key: receiver_chain.0,
+        previous_counter: current_index.saturating_sub(1),
     };
-    state.set_previous_counter(previous_index);
-    state.set_sender_chain(&our_new_ephemeral, &sender_chain.1);
+    state.add_receiver_chain(their_ephemeral, &receiver_chain.1);
 
-    Ok(receiver_chain.1)
+    Ok((receiver_chain.1, Some(deferred_ratchet)))
 }
 
 fn get_or_create_message_key(
@@ -2105,13 +2129,22 @@ mod tests {
             let corrupted = SignalMessage::try_from(corrupted_bytes.as_slice())
                 .expect("protobuf is intact, only MAC region is modified");
 
+            // This message carries a fresh inbound ratchet key. Authentication
+            // failure must not generate the deferred outbound ratchet or consume
+            // caller entropy.
+            const DECRYPT_RNG_SEED: u64 = 0xD3FE_22ED;
+            let mut decrypt_rng =
+                <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(DECRYPT_RNG_SEED);
+            let mut untouched_rng =
+                <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(DECRYPT_RNG_SEED);
+
             // Bob tries to decrypt the corrupted message
             let err = message_decrypt_signal(
                 &corrupted,
                 &tp.alice_addr,
                 &mut tp.bob_sessions,
                 &mut tp.bob_identity,
-                &mut rng,
+                &mut decrypt_rng,
             )
             .await
             .expect_err("decryption should fail due to corrupted MAC");
@@ -2121,6 +2154,8 @@ mod tests {
                 matches!(err, SignalProtocolError::BadMac(_)),
                 "expected BadMac, got: {err}"
             );
+            use rand::RngExt as _;
+            assert_eq!(decrypt_rng.random::<u64>(), untouched_rng.random::<u64>());
         });
     }
 

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -14,12 +14,23 @@ use waproto::whatsapp as wa;
 pub fn encode_pre_key_record_to(id: u32, key_pair: &KeyPair, out: &mut Vec<u8>) {
     use buffa::ViewEncode as _;
 
-    wa::PreKeyRecordStructureView {
+    let view = wa::PreKeyRecordStructureView {
         id: Some(id),
         public_key: Some(key_pair.public_key.public_key_bytes()),
         private_key: Some(key_pair.private_key.serialize()),
-    }
-    .encode(out);
+    };
+
+    // `ViewEncode::encode` computes the size but leaves capacity management to
+    // the sink. Reserve from that schema-derived size, then reuse the same
+    // cache for the write: an empty output allocates once, while a retained
+    // batch buffer remains allocation-free.
+    let mut cache = buffa::SizeCache::new();
+    let encoded_len = buffa::checked_encode_size(view.compute_size(&mut cache))
+        .unwrap_or_else(|_| buffa::encode_size_overflow()) as usize;
+    let start_len = out.len();
+    out.reserve(encoded_len);
+    view.write_to(&mut cache, out);
+    buffa::debug_assert_two_pass(out.len() - start_len, encoded_len);
 }
 
 pub fn new_pre_key_record(id: u32, key_pair: &KeyPair) -> wa::PreKeyRecordStructure {
@@ -124,11 +135,20 @@ mod tests {
         use buffa::Message as _;
 
         let key_pair = KeyPair::generate(&mut rand::rng());
-        for id in [1, (1 << 24) - 1, u32::MAX] {
+        let mut actual = Vec::new();
+        let mut retained_allocation = None;
+        for id in [u32::MAX, (1 << 24) - 1, 1] {
             let expected = new_pre_key_record(id, &key_pair).encode_to_vec();
-            let mut actual = Vec::with_capacity(expected.len());
+            actual.clear();
             encode_pre_key_record_to(id, &key_pair, &mut actual);
             assert_eq!(actual, expected);
+
+            if let Some((ptr, capacity)) = retained_allocation {
+                assert_eq!(actual.as_ptr(), ptr);
+                assert_eq!(actual.capacity(), capacity);
+            } else {
+                retained_allocation = Some((actual.as_ptr(), actual.capacity()));
+            }
 
             let decoded = wa::PreKeyRecordStructure::decode_from_slice(&actual)
                 .expect("borrowed record should decode");

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -5,6 +5,23 @@ use crate::protocol::{
 use chrono::Utc;
 use waproto::whatsapp as wa;
 
+/// Append a pre-key record directly from the key pair's fixed-size buffers.
+///
+/// The generated protobuf view keeps both key fields borrowed, avoiding the two
+/// temporary `Vec<u8>` allocations performed by [`new_pre_key_record`]. The
+/// schema-generated `ViewEncode` implementation remains the single source of
+/// truth for field numbers and wire types.
+pub fn encode_pre_key_record_to(id: u32, key_pair: &KeyPair, out: &mut Vec<u8>) {
+    use buffa::ViewEncode as _;
+
+    wa::PreKeyRecordStructureView {
+        id: Some(id),
+        public_key: Some(key_pair.public_key.public_key_bytes()),
+        private_key: Some(key_pair.private_key.serialize()),
+    }
+    .encode(out);
+}
+
 pub fn new_pre_key_record(id: u32, key_pair: &KeyPair) -> wa::PreKeyRecordStructure {
     wa::PreKeyRecordStructure {
         id: Some(id),
@@ -101,6 +118,31 @@ mod tests {
     use super::*;
     use crate::protocol::{GenericSignedPreKey, KeyPair, PreKeyRecord};
     use rand::Rng;
+
+    #[test]
+    fn borrowed_prekey_encoder_matches_owned_encoder() {
+        use buffa::Message as _;
+
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        for id in [1, (1 << 24) - 1, u32::MAX] {
+            let expected = new_pre_key_record(id, &key_pair).encode_to_vec();
+            let mut actual = Vec::with_capacity(expected.len());
+            encode_pre_key_record_to(id, &key_pair, &mut actual);
+            assert_eq!(actual, expected);
+
+            let decoded = wa::PreKeyRecordStructure::decode_from_slice(&actual)
+                .expect("borrowed record should decode");
+            assert_eq!(decoded.id, Some(id));
+            assert_eq!(
+                decoded.public_key.as_deref(),
+                Some(key_pair.public_key.public_key_bytes())
+            );
+            assert_eq!(
+                decoded.private_key.as_deref(),
+                Some(key_pair.private_key.serialize().as_slice())
+            );
+        }
+    }
 
     #[test]
     fn test_prekey_serialization_length() -> Result<(), Box<dyn std::error::Error>> {

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -14,6 +14,10 @@ use waproto::whatsapp as wa;
 use waproto::whatsapp::ExternalBlobReference;
 use waproto::whatsapp::message::HistorySyncNotification;
 
+const MEDIA_MAC_SIZE: usize = 10;
+const AES_BLOCK_SIZE: usize = 16;
+const STREAM_CHUNK_SIZE: usize = 8 * 1024;
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum MediaDecryptionError {
@@ -366,22 +370,18 @@ impl DownloadUtils {
         use aes::Aes256;
         use aes::cipher::KeyInit;
 
-        const MAC_SIZE: usize = 10;
-        const BLOCK: usize = 16;
-        const CHUNK: usize = 8 * 1024;
-
         fn decrypt_cbc_block(
             cblock: &[u8],
             cipher: &Aes256,
-            prev_block: &[u8; BLOCK],
-        ) -> Result<([u8; BLOCK], [u8; BLOCK])> {
+            prev_block: &[u8; AES_BLOCK_SIZE],
+        ) -> Result<([u8; AES_BLOCK_SIZE], [u8; AES_BLOCK_SIZE])> {
             use aes::cipher::{Block, BlockCipherDecrypt};
-            let cblock_arr: [u8; BLOCK] = cblock
+            let cblock_arr: [u8; AES_BLOCK_SIZE] = cblock
                 .try_into()
                 .map_err(|_| anyhow!("Invalid block size"))?;
             let mut block: Block<Aes256> = cblock_arr.into();
             cipher.decrypt_block(&mut block);
-            let mut decrypted: [u8; BLOCK] = block.into();
+            let mut decrypted: [u8; AES_BLOCK_SIZE] = block.into();
             for (b, &p) in decrypted.iter_mut().zip(prev_block.iter()) {
                 *b ^= p;
             }
@@ -398,10 +398,11 @@ impl DownloadUtils {
             Aes256::new_from_slice(&cipher_key).map_err(|_| anyhow!("Bad AES key length"))?;
 
         let mut bytes_written: u64 = 0;
-        let mut tail: Vec<u8> = Vec::with_capacity(CHUNK + BLOCK + MAC_SIZE);
+        let mut tail: Vec<u8> =
+            Vec::with_capacity(STREAM_CHUNK_SIZE + AES_BLOCK_SIZE + MEDIA_MAC_SIZE);
         let mut prev_block = iv;
 
-        let mut read_buf = [0u8; CHUNK];
+        let mut read_buf = [0u8; STREAM_CHUNK_SIZE];
 
         loop {
             let n = reader.read(&mut read_buf)?;
@@ -410,16 +411,16 @@ impl DownloadUtils {
             }
             tail.extend_from_slice(&read_buf[..n]);
 
-            if tail.len() > MAC_SIZE + BLOCK {
-                let mut processable_len = tail.len() - (MAC_SIZE + BLOCK);
-                processable_len -= processable_len % BLOCK;
-                if processable_len >= BLOCK {
+            if tail.len() > MEDIA_MAC_SIZE + AES_BLOCK_SIZE {
+                let mut processable_len = tail.len() - (MEDIA_MAC_SIZE + AES_BLOCK_SIZE);
+                processable_len -= processable_len % AES_BLOCK_SIZE;
+                if processable_len >= AES_BLOCK_SIZE {
                     hmac.update(&tail[..processable_len]);
-                    for cblock in tail[..processable_len].chunks_exact(BLOCK) {
+                    for cblock in tail[..processable_len].chunks_exact(AES_BLOCK_SIZE) {
                         let (decrypted, cblock_arr) =
                             decrypt_cbc_block(cblock, &cipher, &prev_block)?;
                         writer.write_all(&decrypted)?;
-                        bytes_written += BLOCK as u64;
+                        bytes_written += AES_BLOCK_SIZE as u64;
                         prev_block = cblock_arr;
                     }
                     // Drain processed bytes, reusing the Vec's existing allocation
@@ -428,20 +429,22 @@ impl DownloadUtils {
             }
         }
 
-        if tail.len() < MAC_SIZE + BLOCK || !(tail.len() - MAC_SIZE).is_multiple_of(BLOCK) {
+        if tail.len() < MEDIA_MAC_SIZE + AES_BLOCK_SIZE
+            || !(tail.len() - MEDIA_MAC_SIZE).is_multiple_of(AES_BLOCK_SIZE)
+        {
             return Err(anyhow!("Invalid final media size"));
         }
-        let mac_index = tail.len() - MAC_SIZE;
+        let mac_index = tail.len() - MEDIA_MAC_SIZE;
         let (final_ciphertext, mac_bytes) = tail.split_at(mac_index);
         hmac.update(final_ciphertext);
         let expected_mac_full = hmac.finalize().into_bytes();
-        let expected_mac = &expected_mac_full[..MAC_SIZE];
+        let expected_mac = &expected_mac_full[..MEDIA_MAC_SIZE];
         if subtle::ConstantTimeEq::ct_eq(mac_bytes, expected_mac).unwrap_u8() == 0 {
             return Err(anyhow!("MAC mismatch"));
         }
 
         let mut final_plain = Vec::with_capacity(final_ciphertext.len());
-        for cblock in final_ciphertext.chunks_exact(BLOCK) {
+        for cblock in final_ciphertext.chunks_exact(AES_BLOCK_SIZE) {
             let (decrypted, cblock_arr) = decrypt_cbc_block(cblock, &cipher, &prev_block)?;
             final_plain.extend_from_slice(&decrypted);
             prev_block = cblock_arr;
@@ -450,7 +453,7 @@ impl DownloadUtils {
             Some(&v) => v as usize,
             None => return Err(anyhow!("Empty plaintext after decrypt")),
         };
-        if pad_len == 0 || pad_len > BLOCK || pad_len > final_plain.len() {
+        if pad_len == 0 || pad_len > AES_BLOCK_SIZE || pad_len > final_plain.len() {
             return Err(anyhow!("Invalid PKCS7 padding"));
         }
         if !final_plain[final_plain.len() - pad_len..]
@@ -512,33 +515,92 @@ impl DownloadUtils {
         media_key: &[u8],
         media_type: MediaType,
     ) -> std::result::Result<Vec<u8>, MediaDecryptionError> {
-        const MAC_SIZE: usize = 10;
-        if encrypted_payload.len() <= MAC_SIZE {
+        let mut output = encrypted_payload.to_vec();
+        Self::verify_and_decrypt_in_place(&mut output, media_key, media_type)?;
+        Ok(output)
+    }
+
+    /// Authenticate and decrypt an encrypted media payload in its existing
+    /// allocation. This is the zero-copy counterpart to [`Self::verify_and_decrypt`]
+    /// for buffered HTTP clients: the trailing MAC and PKCS#7 padding are removed
+    /// by truncating the input vector after CBC decryption.
+    ///
+    /// Authentication is completed before any byte is mutated. Consequently an
+    /// invalid MAC leaves `encrypted_payload` unchanged.
+    pub fn verify_and_decrypt_in_place(
+        encrypted_payload: &mut Vec<u8>,
+        media_key: &[u8],
+        media_type: MediaType,
+    ) -> std::result::Result<(), MediaDecryptionError> {
+        use aes::Aes256;
+        use aes::cipher::{Block, BlockCipherDecrypt, KeyInit};
+
+        if encrypted_payload.len() <= MEDIA_MAC_SIZE {
             return Err(MediaDecryptionError::PayloadTooShort);
         }
 
-        let (ciphertext, received_mac) =
-            encrypted_payload.split_at(encrypted_payload.len() - MAC_SIZE);
-
+        let ciphertext_len = encrypted_payload.len() - MEDIA_MAC_SIZE;
+        let received_mac: [u8; MEDIA_MAC_SIZE] = encrypted_payload[ciphertext_len..]
+            .try_into()
+            .map_err(|_| MediaDecryptionError::PayloadTooShort)?;
         let (iv, cipher_key, mac_key) = Self::get_media_keys(media_key, media_type)?;
 
         let computed_mac_full = {
             let mut mac =
                 CryptographicMac::new("HmacSha256", &mac_key).map_err(MediaDecryptionError::Mac)?;
             mac.update(&iv);
-            mac.update(ciphertext);
+            mac.update(&encrypted_payload[..ciphertext_len]);
             mac.finalize()
         };
-        if subtle::ConstantTimeEq::ct_eq(&computed_mac_full[..MAC_SIZE], received_mac).unwrap_u8()
+        if subtle::ConstantTimeEq::ct_eq(&computed_mac_full[..MEDIA_MAC_SIZE], &received_mac)
+            .unwrap_u8()
             == 0
         {
             return Err(MediaDecryptionError::InvalidMac);
         }
+        if ciphertext_len == 0 || !ciphertext_len.is_multiple_of(AES_BLOCK_SIZE) {
+            return Err(MediaDecryptionError::Decryption(
+                AesCbcDecryptionError::BadCiphertext("invalid ciphertext length"),
+            ));
+        }
 
-        let mut output = Vec::new();
-        aes_256_cbc_decrypt_into(ciphertext, &cipher_key, &iv, &mut output)
-            .map_err(MediaDecryptionError::Decryption)?;
-        Ok(output)
+        encrypted_payload.truncate(ciphertext_len);
+        let cipher = Aes256::new_from_slice(&cipher_key)
+            .map_err(|_| MediaDecryptionError::Decryption(AesCbcDecryptionError::BadKeyOrIv))?;
+        let mut previous = iv;
+        for ciphertext_block in encrypted_payload.chunks_exact_mut(AES_BLOCK_SIZE) {
+            let current: [u8; AES_BLOCK_SIZE] = (&*ciphertext_block).try_into().map_err(|_| {
+                MediaDecryptionError::Decryption(AesCbcDecryptionError::BadCiphertext(
+                    "invalid ciphertext block",
+                ))
+            })?;
+            let mut plaintext_block: Block<Aes256> = current.into();
+            cipher.decrypt_block(&mut plaintext_block);
+            for (byte, previous_byte) in plaintext_block.iter_mut().zip(previous) {
+                *byte ^= previous_byte;
+            }
+            ciphertext_block.copy_from_slice(&plaintext_block);
+            previous = current;
+        }
+
+        let padding_len = encrypted_payload
+            .last()
+            .copied()
+            .map(usize::from)
+            .unwrap_or_default();
+        if padding_len == 0
+            || padding_len > AES_BLOCK_SIZE
+            || padding_len > encrypted_payload.len()
+            || !encrypted_payload[encrypted_payload.len() - padding_len..]
+                .iter()
+                .all(|byte| usize::from(*byte) == padding_len)
+        {
+            return Err(MediaDecryptionError::Decryption(
+                AesCbcDecryptionError::BadCiphertext("invalid padding"),
+            ));
+        }
+        encrypted_payload.truncate(encrypted_payload.len() - padding_len);
+        Ok(())
     }
 }
 
@@ -591,6 +653,76 @@ mod tests {
             ],
             auth: "test-auth-token".into(),
         }
+    }
+
+    fn encrypted_media_fixture(
+        plaintext: &[u8],
+        media_key: &[u8],
+        media_type: MediaType,
+    ) -> Vec<u8> {
+        use crate::libsignal::crypto::aes_256_cbc_encrypt_into;
+
+        let (iv, cipher_key, mac_key) =
+            DownloadUtils::get_media_keys(media_key, media_type).unwrap();
+        let mut payload = Vec::new();
+        aes_256_cbc_encrypt_into(plaintext, &cipher_key, &iv, &mut payload).unwrap();
+        let mut mac = CryptographicMac::new("HmacSha256", &mac_key).unwrap();
+        mac.update(&iv);
+        mac.update(&payload);
+        payload.extend_from_slice(&mac.finalize()[..MEDIA_MAC_SIZE]);
+        payload
+    }
+
+    #[test]
+    fn in_place_media_decrypt_matches_streaming_without_reallocating() {
+        let media_key = [0x42; 32];
+        for plaintext_len in [0_usize, 1, 15, 16, 17, 8 * 1024 + 7, 128 * 1024 + 3] {
+            let plaintext: Vec<u8> = (0..plaintext_len)
+                .map(|index| index.wrapping_mul(31) as u8)
+                .collect();
+            let encrypted = encrypted_media_fixture(&plaintext, &media_key, MediaType::History);
+            let streaming = DownloadUtils::decrypt_stream(
+                std::io::Cursor::new(&encrypted),
+                &media_key,
+                MediaType::History,
+            )
+            .unwrap();
+
+            let mut in_place = encrypted;
+            let allocation = in_place.as_ptr();
+            let capacity = in_place.capacity();
+            DownloadUtils::verify_and_decrypt_in_place(
+                &mut in_place,
+                &media_key,
+                MediaType::History,
+            )
+            .unwrap();
+
+            assert_eq!(in_place, plaintext, "plaintext length {plaintext_len}");
+            assert_eq!(in_place, streaming, "plaintext length {plaintext_len}");
+            assert_eq!(in_place.as_ptr(), allocation, "allocation must be reused");
+            assert_eq!(in_place.capacity(), capacity, "capacity must be reused");
+        }
+    }
+
+    #[test]
+    fn in_place_media_decrypt_authenticates_before_mutating() {
+        let media_key = [0x24; 32];
+        let mut encrypted =
+            encrypted_media_fixture(b"authenticated payload", &media_key, MediaType::History);
+        let last = encrypted.len() - 1;
+        encrypted[last] ^= 1;
+        let original = encrypted.clone();
+
+        assert!(matches!(
+            DownloadUtils::verify_and_decrypt_in_place(
+                &mut encrypted,
+                &media_key,
+                MediaType::History,
+            ),
+            Err(MediaDecryptionError::InvalidMac)
+        ));
+        assert_eq!(encrypted, original);
     }
 
     #[test]

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -525,8 +525,10 @@ impl DownloadUtils {
     /// for buffered HTTP clients: the trailing MAC and PKCS#7 padding are removed
     /// by truncating the input vector after CBC decryption.
     ///
-    /// Authentication is completed before any byte is mutated. Consequently an
-    /// invalid MAC leaves `encrypted_payload` unchanged.
+    /// Authentication is completed before any byte is mutated, so an invalid
+    /// MAC leaves `encrypted_payload` unchanged. Errors after successful
+    /// authentication, such as malformed padding, may leave the buffer
+    /// truncated or partially decrypted.
     pub fn verify_and_decrypt_in_place(
         encrypted_payload: &mut Vec<u8>,
         media_key: &[u8],

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -74,9 +74,45 @@ pub fn process_history_sync(
     own_user: Option<&str>,
     retain_blob: bool,
 ) -> Result<HistorySyncResult, HistorySyncError> {
-    let mut result = process_history_sync_streaming(&compressed_data, own_user, MAX_DECOMPRESSED)?;
+    process_history_sync_bytes(Bytes::from(compressed_data), own_user, retain_blob)
+}
+
+/// [`process_history_sync`] for callers that already own a shared byte buffer.
+/// Keeping the compressed blob as `Bytes` lets an inline payload remain a view
+/// into its decrypted message until it is handed to the caller's lazy event,
+/// without changing the streaming parser or duplicating protocol logic.
+pub fn process_history_sync_bytes(
+    compressed_data: Bytes,
+    own_user: Option<&str>,
+    retain_blob: bool,
+) -> Result<HistorySyncResult, HistorySyncError> {
+    process_history_sync_bytes_filtered(compressed_data, own_user, retain_blob, |_| true)
+}
+
+/// [`process_history_sync_bytes`] with an allocation-free predicate for the
+/// message-secret subset the caller actually intends to retain.
+///
+/// The predicate receives a borrowed view before any owned record is built.
+/// This lets policy-owning callers reject obsolete records without teaching
+/// the generic wire parser about retention rules, while the default APIs keep
+/// their accept-all behaviour.
+pub fn process_history_sync_bytes_filtered<F>(
+    compressed_data: Bytes,
+    own_user: Option<&str>,
+    retain_blob: bool,
+    record_filter: F,
+) -> Result<HistorySyncResult, HistorySyncError>
+where
+    F: for<'a> FnMut(HistoryMsgSecretRecordRef<'a>) -> bool,
+{
+    let mut result = process_history_sync_streaming(
+        &compressed_data,
+        own_user,
+        MAX_DECOMPRESSED,
+        record_filter,
+    )?;
     if retain_blob {
-        result.compressed_bytes = Some(Bytes::from(compressed_data));
+        result.compressed_bytes = Some(compressed_data);
     }
     Ok(result)
 }
@@ -264,11 +300,15 @@ impl<'a> FieldWalker<'a> {
 /// secrets, tctokens, pushname and nctSalt as each top-level field is
 /// buffered, so peak memory is bounded by the largest single conversation
 /// rather than the whole blob.
-fn process_history_sync_streaming(
+fn process_history_sync_streaming<F>(
     compressed_data: &[u8],
     own_user: Option<&str>,
     max_decompressed: u64,
-) -> Result<HistorySyncResult, HistorySyncError> {
+    mut record_filter: F,
+) -> Result<HistorySyncResult, HistorySyncError>
+where
+    F: for<'a> FnMut(HistoryMsgSecretRecordRef<'a>) -> bool,
+{
     let mut walker = FieldWalker::new(compressed_data, max_decompressed);
     let mut result = HistorySyncResult {
         own_pushname: None,
@@ -294,10 +334,13 @@ fn process_history_sync_streaming(
     // doubling. Extrapolating from the first conversation alone overshot to
     // the clamp on measured blobs (doubling the transient peak), so the
     // sample must first reach RESERVE_SAMPLE_RECORDS; the doubling ladder up
-    // to that point copies only ~2x its own bytes, which is noise. The clamp
-    // bounds over-allocation to ~2 MB.
+    // to that point copies only ~2x its own bytes, which is noise. Give the
+    // projection 12.5% headroom: a tiny tail-ratio underestimate must not leave
+    // capacity just below the real count and make Vec double a multi-megabyte
+    // record buffer near EOF. The clamp still bounds over-allocation to ~2 MB.
     const RESERVE_SAMPLE_RECORDS: usize = 128;
     const RECORD_RESERVE_CAP: usize = 16384;
+    const RESERVE_HEADROOM_DIVISOR: usize = 8;
     let mut density_reserved = false;
 
     while let Some(field) = walker.next_field()? {
@@ -308,10 +351,14 @@ fn process_history_sync_streaming(
         match field.field_number {
             // conversations (repeated)
             tags::history_sync::CONVERSATIONS => {
+                let conversation_index = result.conversations_processed;
                 result.conversations_processed += 1;
-                if let Some(candidate) =
-                    extract_conversation_fields(value, &mut result.msg_secret_records)
-                {
+                if let Some(candidate) = extract_conversation_fields(
+                    value,
+                    conversation_index,
+                    &mut result.msg_secret_records,
+                    &mut record_filter,
+                ) {
                     result.tc_token_candidates.push(candidate);
                 }
                 if !density_reserved && result.msg_secret_records.len() >= RESERVE_SAMPLE_RECORDS {
@@ -320,12 +367,23 @@ fn process_history_sync_streaming(
                     // if nothing decompressed yet, impossible past a record.
                     let parsed = walker.parsed_bytes().max(1);
                     let records = result.msg_secret_records.len();
-                    let estimated = ((records as u64).saturating_mul(walker.estimated_total_out())
+                    let projected = ((records as u64).saturating_mul(walker.estimated_total_out())
                         / parsed) as usize;
-                    let estimated = estimated.min(RECORD_RESERVE_CAP);
-                    result
-                        .msg_secret_records
-                        .reserve(estimated.saturating_sub(records));
+                    let estimated = projected
+                        .saturating_add(projected / RESERVE_HEADROOM_DIVISOR)
+                        .min(RECORD_RESERVE_CAP);
+                    let additional = estimated.saturating_sub(records);
+                    #[cfg(feature = "tracing")]
+                    let _reserve_span = tracing::trace_span!(
+                        "wa.history.reserve_secret_records",
+                        records = records as u64,
+                        projected = projected as u64,
+                        target_capacity = estimated as u64,
+                        capacity_before = result.msg_secret_records.capacity() as u64,
+                        additional = additional as u64,
+                    )
+                    .entered();
+                    result.msg_secret_records.reserve(additional);
                 }
             }
             // pushnames (repeated) — only our own is needed
@@ -1380,6 +1438,47 @@ pub struct HistoryMsgSecretRecord {
     pub is_bot_invocation: bool,
 }
 
+/// Borrowed message-secret candidate passed to
+/// [`process_history_sync_bytes_filtered`] before ownership is materialized.
+///
+/// All fields point into the current conversation buffer and are valid only
+/// for the duration of the predicate call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HistoryMsgSecretRecordRef<'a> {
+    /// Zero-based top-level conversation index within this history-sync blob.
+    /// Consecutive candidates with the same index share `chat_id`, allowing
+    /// policy callbacks to cache per-conversation classification without
+    /// copying or hashing the borrowed JID.
+    pub conversation_index: usize,
+    pub chat_id: &'a str,
+    pub from_me: bool,
+    pub key_participant: Option<&'a str>,
+    pub web_msg_participant: Option<&'a str>,
+    pub msg_id: &'a str,
+    pub secret: &'a [u8],
+    pub timestamp: Option<u64>,
+    pub is_poll_or_event: bool,
+    pub is_bot_invocation: bool,
+}
+
+impl HistoryMsgSecretRecordRef<'_> {
+    fn into_owned(self, chat_id_shared: &mut Option<Arc<str>>) -> HistoryMsgSecretRecord {
+        HistoryMsgSecretRecord {
+            chat_id: chat_id_shared
+                .get_or_insert_with(|| Arc::from(self.chat_id))
+                .clone(),
+            from_me: self.from_me,
+            key_participant: self.key_participant.map(str::to_owned),
+            web_msg_participant: self.web_msg_participant.map(str::to_owned),
+            msg_id: CompactString::new(self.msg_id),
+            secret: SecretBytes::from(self.secret),
+            timestamp: self.timestamp,
+            is_poll_or_event: self.is_poll_or_event,
+            is_bot_invocation: self.is_bot_invocation,
+        }
+    }
+}
+
 /// Partial reader for one conversation: walks its protobuf fields directly
 /// (id, messages[], tctoken trio) and decodes each `HistorySyncMsg` ONE AT A
 /// TIME, extracting its secret record and dropping it immediately. This avoids
@@ -1391,10 +1490,15 @@ pub struct HistoryMsgSecretRecord {
 /// tctoken. Decoding the whole conversation as one view (all-or-nothing) would
 /// drop every record + the tctoken on any single bad message, and would also
 /// materialize the entire conversation tree at once.
-fn extract_conversation_fields(
+fn extract_conversation_fields<F>(
     data: &[u8],
+    conversation_index: usize,
     records: &mut Vec<HistoryMsgSecretRecord>,
-) -> Option<TcTokenCandidate> {
+    record_filter: &mut F,
+) -> Option<TcTokenCandidate>
+where
+    F: for<'a> FnMut(HistoryMsgSecretRecordRef<'a>) -> bool,
+{
     let mut pos = 0;
     // Conversation.id precedes messages/tctoken in tag order, so it is
     // captured before any message is processed.
@@ -1449,19 +1553,23 @@ fn extract_conversation_fields(
                     match fast_extract(&data[pos..end]) {
                         FastExtract::NoRecord => {}
                         FastExtract::Record(r) => {
-                            records.push(HistoryMsgSecretRecord {
-                                chat_id: chat_id_shared
-                                    .get_or_insert_with(|| Arc::from(chat_id))
-                                    .clone(),
-                                from_me: r.from_me,
-                                key_participant: r.key_participant.map(str::to_owned),
-                                web_msg_participant: r.web_msg_participant.map(str::to_owned),
-                                msg_id: CompactString::new(r.msg_id),
-                                secret: SecretBytes::from(r.secret),
-                                timestamp: r.timestamp,
-                                is_poll_or_event: r.is_poll_or_event,
-                                is_bot_invocation: r.is_bot_invocation,
-                            });
+                            push_filtered_secret_record(
+                                HistoryMsgSecretRecordRef {
+                                    conversation_index,
+                                    chat_id,
+                                    from_me: r.from_me,
+                                    key_participant: r.key_participant,
+                                    web_msg_participant: r.web_msg_participant,
+                                    msg_id: r.msg_id,
+                                    secret: r.secret,
+                                    timestamp: r.timestamp,
+                                    is_poll_or_event: r.is_poll_or_event,
+                                    is_bot_invocation: r.is_bot_invocation,
+                                },
+                                &mut chat_id_shared,
+                                records,
+                                record_filter,
+                            );
                         }
                         // Rare wire shapes (repeated message-typed fields,
                         // pathological nesting): fall back to full decode.
@@ -1469,7 +1577,14 @@ fn extract_conversation_fields(
                             if let Ok(msg) =
                                 waproto::codec::history_sync_msg_decode(&data[pos..end])
                             {
-                                push_secret_record(chat_id, &mut chat_id_shared, msg, records);
+                                push_secret_record(
+                                    chat_id,
+                                    conversation_index,
+                                    &mut chat_id_shared,
+                                    msg,
+                                    records,
+                                    record_filter,
+                                );
                             }
                         }
                     }
@@ -1530,12 +1645,16 @@ fn extract_conversation_fields(
 /// Extract a single message's secret record (if any) into `out`.
 /// `chat_id_shared` memoizes the conversation id `Arc` so it is allocated only
 /// when the first record is actually pushed.
-fn push_secret_record(
+fn push_secret_record<F>(
     chat_id: &str,
+    conversation_index: usize,
     chat_id_shared: &mut Option<Arc<str>>,
     history_msg: wa::HistorySyncMsg,
     out: &mut Vec<HistoryMsgSecretRecord>,
-) {
+    record_filter: &mut F,
+) where
+    F: for<'a> FnMut(HistoryMsgSecretRecordRef<'a>) -> bool,
+{
     let Some(web_msg) = history_msg.message.as_option() else {
         return;
     };
@@ -1565,19 +1684,37 @@ fn push_secret_record(
     let is_poll_or_event = inner.is_some_and(message_is_poll_or_event);
     let is_bot_invocation = inner.is_some_and(message_invokes_bot);
 
-    out.push(HistoryMsgSecretRecord {
-        chat_id: chat_id_shared
-            .get_or_insert_with(|| Arc::from(chat_id))
-            .clone(),
-        from_me: key.from_me.unwrap_or(false),
-        key_participant: key.participant.clone(),
-        web_msg_participant: web_msg.participant.clone(),
-        msg_id: msg_id.into(),
-        secret: secret.into(),
-        timestamp: web_msg.message_timestamp,
-        is_poll_or_event,
-        is_bot_invocation,
-    });
+    push_filtered_secret_record(
+        HistoryMsgSecretRecordRef {
+            conversation_index,
+            chat_id,
+            from_me: key.from_me.unwrap_or(false),
+            key_participant: key.participant.as_deref(),
+            web_msg_participant: web_msg.participant.as_deref(),
+            msg_id,
+            secret,
+            timestamp: web_msg.message_timestamp,
+            is_poll_or_event,
+            is_bot_invocation,
+        },
+        chat_id_shared,
+        out,
+        record_filter,
+    );
+}
+
+#[inline]
+fn push_filtered_secret_record<F>(
+    candidate: HistoryMsgSecretRecordRef<'_>,
+    chat_id_shared: &mut Option<Arc<str>>,
+    out: &mut Vec<HistoryMsgSecretRecord>,
+    record_filter: &mut F,
+) where
+    F: for<'a> FnMut(HistoryMsgSecretRecordRef<'a>) -> bool,
+{
+    if record_filter(candidate) {
+        out.push(candidate.into_owned(chat_id_shared));
+    }
 }
 
 fn base_message_view(message: &wa::Message) -> &wa::Message {
@@ -1806,8 +1943,16 @@ mod tests {
     fn oracle_records(raw_msg: &[u8]) -> Vec<HistoryMsgSecretRecord> {
         let mut out = Vec::new();
         let mut shared = None;
+        let mut accept_all = |_: HistoryMsgSecretRecordRef<'_>| true;
         if let Ok(msg) = wa::HistorySyncMsg::decode_from_slice(raw_msg) {
-            push_secret_record("5511777776666@s.whatsapp.net", &mut shared, msg, &mut out);
+            push_secret_record(
+                "5511777776666@s.whatsapp.net",
+                0,
+                &mut shared,
+                msg,
+                &mut out,
+                &mut accept_all,
+            );
         }
         out
     }
@@ -2730,6 +2875,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn borrowed_record_filter_runs_before_owned_records_are_collected() {
+        let chat = "5511777776666@s.whatsapp.net";
+        let mut dropped = keyed("DROP", false, None);
+        dropped.message_secret = Some(vec![0x11; 32]);
+        let mut kept = keyed("KEEP", true, None);
+        kept.message_secret = Some(vec![0x22; 32]);
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: chat.to_string(),
+                messages: vec![
+                    wa::HistorySyncMsg {
+                        message: buffa::MessageField::some(dropped),
+                        ..Default::default()
+                    },
+                    wa::HistorySyncMsg {
+                        message: buffa::MessageField::some(kept),
+                        ..Default::default()
+                    },
+                ],
+                tc_token: Some(vec![0x33; 8]),
+                tc_token_timestamp: Some(123),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut visited = Vec::new();
+        let result = process_history_sync_bytes_filtered(
+            Bytes::from(encode_and_compress(&hs)),
+            None,
+            false,
+            |record| {
+                assert_eq!(record.conversation_index, 0);
+                assert_eq!(record.chat_id, chat);
+                assert_eq!(record.secret.len(), 32);
+                visited.push(record.msg_id.to_string());
+                record.msg_id == "KEEP"
+            },
+        )
+        .unwrap();
+
+        assert_eq!(visited, ["DROP", "KEEP"]);
+        assert_eq!(result.conversations_processed, 1);
+        assert_eq!(result.tc_token_candidates.len(), 1);
+        assert_eq!(result.msg_secret_records.len(), 1);
+        assert_eq!(result.msg_secret_records[0].msg_id, "KEEP");
+        assert!(result.msg_secret_records[0].from_me);
+    }
+
     /// Regression: a single malformed message inside a conversation must NOT
     /// discard the conversation's other message secrets or its tctoken. The
     /// pre-fix code decoded the whole conversation as one view (all-or-nothing),
@@ -2963,6 +3159,7 @@ mod tests {
     /// independent implementation instead of a second production path.
     fn reference_full_walk(decompressed: &[u8], own_user: Option<&str>) -> HistorySyncResult {
         let mut pos = 0;
+        let mut accept_all = |_: HistoryMsgSecretRecordRef<'_>| true;
         let mut result = HistorySyncResult {
             own_pushname: None,
             nct_salt: None,
@@ -2984,10 +3181,13 @@ mod tests {
                     let (len, vlen) = read_varint(&decompressed[pos..]).unwrap();
                     pos += vlen;
                     let end = checked_end(pos, len, decompressed.len()).unwrap();
+                    let conversation_index = result.conversations_processed;
                     result.conversations_processed += 1;
                     if let Some(candidate) = extract_conversation_fields(
                         &decompressed[pos..end],
+                        conversation_index,
                         &mut result.msg_secret_records,
+                        &mut accept_all,
                     ) {
                         result.tc_token_candidates.push(candidate);
                     }

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -376,6 +376,99 @@ pub fn decode_plaintext(padded_plaintext: &[u8], padding_version: u8) -> Result<
         .map_err(|e| anyhow::anyhow!("Failed to decode decrypted plaintext: {e}"))
 }
 
+/// History-sync metadata detached from a decoded plaintext while the large
+/// inline blob keeps sharing the decrypt buffer. The generated owned protobuf
+/// type remains the single source for protocol fields; only its byte payload is
+/// represented separately so async processing does not need a megabyte copy.
+#[derive(Debug)]
+pub struct DetachedHistorySyncNotification {
+    pub notification: wa::message::HistorySyncNotification,
+    pub inline_payload: Option<buffa::bytes::Bytes>,
+}
+
+impl From<wa::message::HistorySyncNotification> for DetachedHistorySyncNotification {
+    fn from(mut notification: wa::message::HistorySyncNotification) -> Self {
+        let inline_payload = notification
+            .initial_hist_bootstrap_inline_payload
+            .take()
+            .map(buffa::bytes::Bytes::from);
+        Self {
+            notification,
+            inline_payload,
+        }
+    }
+}
+
+/// Decode an owned plaintext while detaching an inline history-sync payload as
+/// a zero-copy `Bytes` slice.
+///
+/// The message view is still converted through Buffa's generated
+/// `to_owned_from_source`; clearing only the already-detached history field
+/// preserves every other message/protocol field and unknown-field behavior.
+pub fn decode_plaintext_detached_history_sync(
+    padded_plaintext: Vec<u8>,
+    padding_version: u8,
+) -> Result<(wa::Message, Option<DetachedHistorySyncNotification>)> {
+    let unpadded_len = MessageUtils::unpadded_message_len(&padded_plaintext, padding_version)?;
+    let source = buffa::bytes::Bytes::from(padded_plaintext).slice(0..unpadded_len);
+
+    #[cfg(feature = "tracing")]
+    let decode_span = tracing::trace_span!(
+        "wa.message.decode_plaintext_view",
+        plaintext_bytes = source.len() as u64
+    );
+    #[cfg(feature = "tracing")]
+    let decode_guard = decode_span.enter();
+    let mut view = wa::MessageView::decode_view(&source)
+        .map_err(|e| anyhow::anyhow!("Failed to decode decrypted plaintext: {e}"))?;
+    #[cfg(feature = "tracing")]
+    drop(decode_guard);
+
+    let history_view = take_history_sync_notification_view(&mut view);
+    let history_sync = history_view
+        .map(|mut history| {
+            let inline_payload = history
+                .initial_hist_bootstrap_inline_payload
+                .take()
+                .map(|payload| source.slice_ref(payload));
+            let notification = history
+                .to_owned_from_source(Some(&source))
+                .map_err(|e| anyhow::anyhow!("Failed to own history-sync metadata: {e}"))?;
+            Ok::<_, anyhow::Error>(DetachedHistorySyncNotification {
+                notification,
+                inline_payload,
+            })
+        })
+        .transpose()?;
+
+    #[cfg(feature = "tracing")]
+    let materialize_span = tracing::trace_span!(
+        "wa.message.materialize_plaintext",
+        plaintext_bytes = source.len() as u64
+    );
+    #[cfg(feature = "tracing")]
+    let _materialize_guard = materialize_span.enter();
+    let message = view
+        .to_owned_from_source(Some(&source))
+        .map_err(|e| anyhow::anyhow!("Failed to own decrypted plaintext: {e}"))?;
+    Ok((message, history_sync))
+}
+
+fn take_history_sync_notification_view<'a>(
+    message: &mut wa::MessageView<'a>,
+) -> Option<wa::message::HistorySyncNotificationView<'a>> {
+    // Mirror `unwrap_device_sent`: when a valid DSM wrapper exists, only its
+    // inner message is dispatched. Otherwise the top-level message is used.
+    let message = match message.device_sent_message.as_mut() {
+        Some(device_sent) if device_sent.message.is_set() => device_sent.message.as_mut()?,
+        _ => message,
+    };
+    let protocol = message.protocol_message.as_mut()?;
+    let history = protocol.history_sync_notification.as_option()?.clone();
+    protocol.history_sync_notification = buffa::MessageFieldView::unset();
+    Some(history)
+}
+
 /// Use when borrowed fields are enough and a full owned message is avoidable.
 pub fn decode_plaintext_view(
     padded_plaintext: &[u8],
@@ -867,6 +960,27 @@ mod plaintext_view_tests {
         }
     }
 
+    fn history_notification(payload: Vec<u8>) -> wa::message::HistorySyncNotification {
+        wa::message::HistorySyncNotification {
+            file_length: Some(payload.len() as u64),
+            sync_type: Some(wa::message::HistorySyncType::INITIAL_BOOTSTRAP),
+            initial_hist_bootstrap_inline_payload: Some(payload),
+            progress: Some(73),
+            ..Default::default()
+        }
+    }
+
+    fn message_with_history(payload: Vec<u8>, text: &str) -> wa::Message {
+        wa::Message {
+            conversation: Some(text.to_owned()),
+            protocol_message: buffa::MessageField::some(wa::message::ProtocolMessage {
+                history_sync_notification: buffa::MessageField::some(history_notification(payload)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn decode_plaintext_view_borrows_message_fields() {
         let msg = wa::Message {
@@ -894,6 +1008,65 @@ mod plaintext_view_tests {
 
         assert_eq!(view.conversation(), Some("hello"));
         assert!(view.bytes().len() < padded_len);
+    }
+
+    #[test]
+    fn detached_history_payload_shares_plaintext_and_preserves_message() {
+        let inline_payload = vec![0xA5; 1024];
+        let padded = padded(&message_with_history(inline_payload.clone(), "preserved"));
+        let plaintext_start = padded.as_ptr() as usize;
+        let plaintext_end = plaintext_start + padded.len();
+
+        let (decoded, detached) = decode_plaintext_detached_history_sync(padded, 2)
+            .expect("owned view decode should succeed");
+        let detached = detached.expect("history notification should be detached");
+        let payload = detached
+            .inline_payload
+            .expect("inline history payload should be detached");
+
+        assert_eq!(decoded.conversation.as_deref(), Some("preserved"));
+        assert!(
+            decoded
+                .protocol_message
+                .as_option()
+                .is_some_and(|protocol| !protocol.history_sync_notification.is_set()),
+            "only the detached history field should be cleared"
+        );
+        assert_eq!(detached.notification.file_length, Some(1024));
+        assert_eq!(detached.notification.progress, Some(73));
+        assert_eq!(payload.as_ref(), inline_payload);
+        assert!(
+            (plaintext_start..plaintext_end).contains(&(payload.as_ptr() as usize)),
+            "the detached payload must remain a slice of the original decrypt buffer"
+        );
+    }
+
+    #[test]
+    fn detached_history_follows_device_sent_unwrap_semantics() {
+        let inner_payload = vec![0x11; 64];
+        let inner = message_with_history(inner_payload.clone(), "inner");
+        let mut wrapped = wrap_device_sent(inner, "1@s.whatsapp.net".into());
+        wrapped.protocol_message = buffa::MessageField::some(wa::message::ProtocolMessage {
+            history_sync_notification: buffa::MessageField::some(history_notification(vec![
+                0x22;
+                32
+            ])),
+            ..Default::default()
+        });
+
+        let (decoded, detached) = decode_plaintext_detached_history_sync(padded(&wrapped), 2)
+            .expect("device-sent message should decode");
+        let decoded = unwrap_device_sent(decoded);
+        let detached = detached.expect("inner history notification should be detached");
+
+        assert_eq!(decoded.conversation.as_deref(), Some("inner"));
+        assert!(
+            decoded
+                .protocol_message
+                .as_option()
+                .is_some_and(|protocol| !protocol.history_sync_notification.is_set())
+        );
+        assert_eq!(detached.inline_payload.as_deref(), Some(&inner_payload[..]));
     }
 
     #[test]

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -175,7 +175,11 @@ impl MessageUtils {
             + len_delimited_len(TAG_DSM_MESSAGE, content_len);
         let own_cap = len_delimited_len(TAG_DEVICE_SENT_MESSAGE, dsm_len) + mci_field_len + MAX_PAD;
         let mut own_devices = Vec::with_capacity(own_cap);
-        push_varint((TAG_DEVICE_SENT_MESSAGE << 3) | 2, &mut own_devices); // field 31 key
+        push_wire_tag(
+            TAG_DEVICE_SENT_MESSAGE,
+            buffa::encoding::WireType::LengthDelimited,
+            &mut own_devices,
+        );
         push_varint(dsm_len as u64, &mut own_devices); // DeviceSentMessage length
         push_len_delimited(TAG_DSM_DESTINATION_JID, dest, &mut own_devices);
         push_len_delimited(TAG_DSM_MESSAGE, &recipient[..content_len], &mut own_devices);
@@ -223,7 +227,11 @@ impl MessageUtils {
             + len_delimited_len(TAG_DSM_MESSAGE, content_len);
         let own_cap = len_delimited_len(TAG_DEVICE_SENT_MESSAGE, dsm_len) + mci_field_len + MAX_PAD;
         let mut own_devices = Vec::with_capacity(own_cap);
-        push_varint((TAG_DEVICE_SENT_MESSAGE << 3) | 2, &mut own_devices); // field 31 key
+        push_wire_tag(
+            TAG_DEVICE_SENT_MESSAGE,
+            buffa::encoding::WireType::LengthDelimited,
+            &mut own_devices,
+        );
         push_varint(dsm_len as u64, &mut own_devices); // DeviceSentMessage length
         push_len_delimited(TAG_DSM_DESTINATION_JID, dest, &mut own_devices);
         push_len_delimited(TAG_DSM_MESSAGE, content, &mut own_devices);
@@ -270,7 +278,11 @@ impl MessageUtils {
             + len_delimited_len(TAG_DSM_MESSAGE, content_len);
         let own_cap = len_delimited_len(TAG_DEVICE_SENT_MESSAGE, dsm_len) + mci_field_len + MAX_PAD;
         let mut own_devices = Vec::with_capacity(own_cap);
-        push_varint((TAG_DEVICE_SENT_MESSAGE << 3) | 2, &mut own_devices); // field 31 key
+        push_wire_tag(
+            TAG_DEVICE_SENT_MESSAGE,
+            buffa::encoding::WireType::LengthDelimited,
+            &mut own_devices,
+        );
         push_varint(dsm_len as u64, &mut own_devices); // DeviceSentMessage length
         push_len_delimited(TAG_DSM_DESTINATION_JID, dest, &mut own_devices);
         push_len_delimited(TAG_DSM_MESSAGE, &recipient[..content_len], &mut own_devices);
@@ -402,9 +414,12 @@ impl From<wa::message::HistorySyncNotification> for DetachedHistorySyncNotificat
 /// Decode an owned plaintext while detaching an inline history-sync payload as
 /// a zero-copy `Bytes` slice.
 ///
-/// The message view is still converted through Buffa's generated
-/// `to_owned_from_source`; clearing only the already-detached history field
-/// preserves every other message/protocol field and unknown-field behavior.
+/// Only the generated schema tags needed to reach the inline byte field are
+/// inspected. The field is removed from a lazily rewritten wire buffer before
+/// the regular generated decoder runs, so the large payload is never copied
+/// into the owned protobuf tree. Every other field is still decoded by Buffa's
+/// generated implementation, keeping protobuf merge and unknown-field
+/// semantics in one place.
 pub fn decode_plaintext_detached_history_sync(
     padded_plaintext: Vec<u8>,
     padding_version: u8,
@@ -412,61 +427,191 @@ pub fn decode_plaintext_detached_history_sync(
     let unpadded_len = MessageUtils::unpadded_message_len(&padded_plaintext, padding_version)?;
     let source = buffa::bytes::Bytes::from(padded_plaintext).slice(0..unpadded_len);
 
+    // Mirror `unwrap_device_sent`: once a DSM carries an inner message, only
+    // that message is dispatched. Inspecting just this generated-tag path
+    // avoids decoding/materializing the complete MessageView graph.
+    let history_path = if contains_nested_message_field(&source, DEVICE_SENT_INNER_MESSAGE_PATH)? {
+        DEVICE_SENT_HISTORY_PAYLOAD_PATH
+    } else {
+        DIRECT_HISTORY_PAYLOAD_PATH
+    };
+
     #[cfg(feature = "tracing")]
     let decode_span = tracing::trace_span!(
-        "wa.message.decode_plaintext_view",
+        "wa.message.detach_history_sync_payload",
         plaintext_bytes = source.len() as u64
     );
     #[cfg(feature = "tracing")]
     let decode_guard = decode_span.enter();
-    let mut view = wa::MessageView::decode_view(&source)
-        .map_err(|e| anyhow::anyhow!("Failed to decode decrypted plaintext: {e}"))?;
+    let redaction = redact_nested_bytes_field(&source, 0, history_path)?;
     #[cfg(feature = "tracing")]
     drop(decode_guard);
 
-    let history_view = take_history_sync_notification_view(&mut view);
-    let history_sync = history_view
-        .map(|mut history| {
-            let inline_payload = history
-                .initial_hist_bootstrap_inline_payload
-                .take()
-                .map(|payload| source.slice_ref(payload));
-            let notification = history
-                .to_owned_from_source(Some(&source))
-                .map_err(|e| anyhow::anyhow!("Failed to own history-sync metadata: {e}"))?;
-            Ok::<_, anyhow::Error>(DetachedHistorySyncNotification {
-                notification,
-                inline_payload,
-            })
-        })
-        .transpose()?;
-
     #[cfg(feature = "tracing")]
     let materialize_span = tracing::trace_span!(
-        "wa.message.materialize_plaintext",
-        plaintext_bytes = source.len() as u64
+        "wa.message.decode_plaintext",
+        plaintext_bytes = source.len() as u64,
+        payload_detached = redaction.detached_value.is_some()
     );
     #[cfg(feature = "tracing")]
     let _materialize_guard = materialize_span.enter();
-    let message = view
-        .to_owned_from_source(Some(&source))
-        .map_err(|e| anyhow::anyhow!("Failed to own decrypted plaintext: {e}"))?;
+    let encoded = redaction.rewritten.as_deref().unwrap_or(&source);
+    let mut message = waproto::codec::message_decode(encoded)
+        .map_err(|e| anyhow::anyhow!("Failed to decode decrypted plaintext: {e}"))?;
+
+    let mut history_sync =
+        take_history_sync_notification(&mut message).map(DetachedHistorySyncNotification::from);
+    if let Some(payload_range) = redaction.detached_value {
+        let detached = history_sync
+            .as_mut()
+            .ok_or_else(|| anyhow!("inline history-sync payload had no decoded notification"))?;
+        detached.inline_payload = Some(source.slice(payload_range));
+    }
+
     Ok((message, history_sync))
 }
 
-fn take_history_sync_notification_view<'a>(
-    message: &mut wa::MessageView<'a>,
-) -> Option<wa::message::HistorySyncNotificationView<'a>> {
+fn take_history_sync_notification(
+    message: &mut wa::Message,
+) -> Option<wa::message::HistorySyncNotification> {
     // Mirror `unwrap_device_sent`: when a valid DSM wrapper exists, only its
     // inner message is dispatched. Otherwise the top-level message is used.
-    let message = match message.device_sent_message.as_mut() {
-        Some(device_sent) if device_sent.message.is_set() => device_sent.message.as_mut()?,
+    let message = match message.device_sent_message.as_option_mut() {
+        Some(device_sent) if device_sent.message.is_set() => device_sent.message.as_option_mut()?,
         _ => message,
     };
-    let protocol = message.protocol_message.as_mut()?;
-    let history = protocol.history_sync_notification.as_option()?.clone();
-    protocol.history_sync_notification = buffa::MessageFieldView::unset();
-    Some(history)
+    message
+        .protocol_message
+        .as_option_mut()?
+        .history_sync_notification
+        .take()
+}
+
+#[derive(Default)]
+struct WireRedaction {
+    /// Present only when at least one target field was removed. Rewriting is
+    /// lazy so plaintexts without inline history never clone their wire bytes.
+    rewritten: Option<Vec<u8>>,
+    /// Byte range in the original plaintext. For a repeated singular bytes
+    /// field, protobuf merge semantics select the final occurrence.
+    detached_value: Option<std::ops::Range<usize>>,
+}
+
+/// Whether a nested message field path is set on the wire.
+///
+/// This deliberately recognizes only length-delimited fields, the schema wire
+/// type for every segment in the supplied generated-tag paths. A mismatched
+/// known field is left for the regular decoder to reject with its canonical
+/// error after routing has been selected.
+fn contains_nested_message_field(message: &[u8], path: &[u32]) -> Result<bool, buffa::DecodeError> {
+    let Some((&field_number, remaining_path)) = path.split_first() else {
+        return Ok(false);
+    };
+
+    let mut remaining = message;
+    while !remaining.is_empty() {
+        let mut after_tag = remaining;
+        let tag = buffa::encoding::Tag::decode(&mut after_tag)?;
+        if tag.field_number() == field_number
+            && tag.wire_type() == buffa::encoding::WireType::LengthDelimited
+        {
+            let value_range = length_delimited_value_range(message.len(), after_tag)?;
+            if remaining_path.is_empty()
+                || contains_nested_message_field(&message[value_range.clone()], remaining_path)?
+            {
+                return Ok(true);
+            }
+            remaining = &message[value_range.end..];
+        } else {
+            buffa::encoding::skip_field_depth(tag, &mut after_tag, buffa::RECURSION_LIMIT)?;
+            remaining = after_tag;
+        }
+    }
+    Ok(false)
+}
+
+/// Remove every occurrence of the bytes field at `path`, rebuilding only the
+/// containing length-delimited fields whose sizes changed. Unrelated wire
+/// fields are copied byte-for-byte, while their eventual interpretation stays
+/// with the generated decoder.
+fn redact_nested_bytes_field(
+    message: &[u8],
+    absolute_offset: usize,
+    path: &[u32],
+) -> Result<WireRedaction, buffa::DecodeError> {
+    let Some((&field_number, remaining_path)) = path.split_first() else {
+        return Ok(WireRedaction::default());
+    };
+
+    let mut result = WireRedaction::default();
+    let mut copied_until = 0;
+    let mut remaining = message;
+
+    while !remaining.is_empty() {
+        let field_start = message.len() - remaining.len();
+        let mut after_tag = remaining;
+        let tag = buffa::encoding::Tag::decode(&mut after_tag)?;
+
+        if tag.field_number() == field_number
+            && tag.wire_type() == buffa::encoding::WireType::LengthDelimited
+        {
+            let tag_end = message.len() - after_tag.len();
+            let value_range = length_delimited_value_range(message.len(), after_tag)?;
+
+            if remaining_path.is_empty() {
+                let rewritten = result.rewritten.get_or_insert_with(Vec::new);
+                rewritten.extend_from_slice(&message[copied_until..field_start]);
+                copied_until = value_range.end;
+                result.detached_value =
+                    Some(absolute_offset + value_range.start..absolute_offset + value_range.end);
+            } else {
+                let child = redact_nested_bytes_field(
+                    &message[value_range.clone()],
+                    absolute_offset + value_range.start,
+                    remaining_path,
+                )?;
+                if let Some(child_range) = child.detached_value {
+                    result.detached_value = Some(child_range);
+                }
+                if let Some(child_bytes) = child.rewritten {
+                    let rewritten = result.rewritten.get_or_insert_with(Vec::new);
+                    rewritten.extend_from_slice(&message[copied_until..field_start]);
+                    // Preserve the original tag bytes. Only the containing
+                    // length changes, so that varint is intentionally rebuilt.
+                    rewritten.extend_from_slice(&message[field_start..tag_end]);
+                    push_varint(child_bytes.len() as u64, rewritten);
+                    rewritten.extend_from_slice(&child_bytes);
+                    copied_until = value_range.end;
+                }
+            }
+
+            remaining = &message[value_range.end..];
+        } else {
+            buffa::encoding::skip_field_depth(tag, &mut after_tag, buffa::RECURSION_LIMIT)?;
+            remaining = after_tag;
+        }
+    }
+
+    if let Some(rewritten) = result.rewritten.as_mut() {
+        rewritten.extend_from_slice(&message[copied_until..]);
+    }
+    Ok(result)
+}
+
+fn length_delimited_value_range(
+    message_len: usize,
+    mut after_tag: &[u8],
+) -> Result<std::ops::Range<usize>, buffa::DecodeError> {
+    let value_len = buffa::encoding::decode_varint(&mut after_tag)?;
+    let value_len = usize::try_from(value_len).map_err(|_| buffa::DecodeError::MessageTooLarge)?;
+    let value_start = message_len - after_tag.len();
+    let value_end = value_start
+        .checked_add(value_len)
+        .ok_or(buffa::DecodeError::MessageTooLarge)?;
+    if value_end > message_len {
+        return Err(buffa::DecodeError::UnexpectedEof);
+    }
+    Ok(value_start..value_end)
 }
 
 /// Use when borrowed fields are enough and a full owned message is avoidable.
@@ -553,11 +698,26 @@ pub struct DmPlaintexts {
 // Protobuf field numbers spliced by `encode_dm_plaintexts`, sourced from the
 // generated schema tags so a .proto renumber breaks here at compile time
 // instead of silently changing the wire payload.
-const TAG_DEVICE_SENT_MESSAGE: u64 = waproto::tags::message::DEVICE_SENT_MESSAGE as u64;
-const TAG_MESSAGE_CONTEXT_INFO: u64 = waproto::tags::message::MESSAGE_CONTEXT_INFO as u64;
-const TAG_DSM_DESTINATION_JID: u64 =
-    waproto::tags::message::device_sent_message::DESTINATION_JID as u64;
-const TAG_DSM_MESSAGE: u64 = waproto::tags::message::device_sent_message::MESSAGE as u64;
+const TAG_DEVICE_SENT_MESSAGE: u32 = waproto::tags::message::DEVICE_SENT_MESSAGE;
+const TAG_MESSAGE_CONTEXT_INFO: u32 = waproto::tags::message::MESSAGE_CONTEXT_INFO;
+const TAG_DSM_DESTINATION_JID: u32 = waproto::tags::message::device_sent_message::DESTINATION_JID;
+const TAG_DSM_MESSAGE: u32 = waproto::tags::message::device_sent_message::MESSAGE;
+
+const DEVICE_SENT_INNER_MESSAGE_PATH: &[u32] = &[TAG_DEVICE_SENT_MESSAGE, TAG_DSM_MESSAGE];
+const DIRECT_HISTORY_PAYLOAD_PATH: &[u32] = &[
+    waproto::tags::message::PROTOCOL_MESSAGE,
+    waproto::tags::message::protocol_message::HISTORY_SYNC_NOTIFICATION,
+    waproto::tags::message::history_sync_notification::INITIAL_HIST_BOOTSTRAP_INLINE_PAYLOAD,
+];
+const DEVICE_SENT_HISTORY_PAYLOAD_PATH: &[u32] = &[
+    TAG_DEVICE_SENT_MESSAGE,
+    TAG_DSM_MESSAGE,
+    waproto::tags::message::PROTOCOL_MESSAGE,
+    waproto::tags::message::protocol_message::HISTORY_SYNC_NOTIFICATION,
+    waproto::tags::message::history_sync_notification::INITIAL_HIST_BOOTSTRAP_INLINE_PAYLOAD,
+];
+
+const PROTOBUF_WIRE_TYPE_BITS: u32 = 3;
 
 /// Append a base-128 varint (protobuf wire format).
 #[inline]
@@ -569,12 +729,22 @@ fn push_varint(mut v: u64, out: &mut Vec<u8>) {
     out.push(v as u8);
 }
 
+#[inline]
+fn wire_tag_value(field: u32, wire_type: buffa::encoding::WireType) -> u64 {
+    (u64::from(field) << PROTOBUF_WIRE_TYPE_BITS) | wire_type as u64
+}
+
+#[inline]
+fn push_wire_tag(field: u32, wire_type: buffa::encoding::WireType, out: &mut Vec<u8>) {
+    push_varint(wire_tag_value(field, wire_type), out);
+}
+
 /// Append a length-delimited protobuf field (wire type 2): a string field, or a
 /// nested message field carrying already-encoded `bytes`. The latter is the splice
 /// point that lets the shared content be reused without re-encoding it.
 #[inline]
-fn push_len_delimited(field: u64, bytes: &[u8], out: &mut Vec<u8>) {
-    push_varint((field << 3) | 2, out); // wire type 2 = length-delimited
+fn push_len_delimited(field: u32, bytes: &[u8], out: &mut Vec<u8>) {
+    push_wire_tag(field, buffa::encoding::WireType::LengthDelimited, out);
     push_varint(bytes.len() as u64, out);
     out.extend_from_slice(bytes);
 }
@@ -594,15 +764,19 @@ fn varint_len(mut v: u64) -> usize {
 /// bytes (key + length varint + payload). Mirrors what `push_len_delimited`
 /// writes, so a nested field's length can be pre-computed without a temp buffer.
 #[inline]
-fn len_delimited_len(field: u64, payload_len: usize) -> usize {
-    varint_len((field << 3) | 2) + varint_len(payload_len as u64) + payload_len
+fn len_delimited_len(field: u32, payload_len: usize) -> usize {
+    varint_len(wire_tag_value(
+        field,
+        buffa::encoding::WireType::LengthDelimited,
+    )) + varint_len(payload_len as u64)
+        + payload_len
 }
 
 /// Append a message_context_info as a nested length-delimited field, encoding it
 /// straight into `out` (no intermediate `Vec`). Used for the small
 /// `message_context_info` field on both plaintexts.
 #[inline]
-fn push_message_field(field: u64, msg: &wa::MessageContextInfo, out: &mut Vec<u8>) {
+fn push_message_field(field: u32, msg: &wa::MessageContextInfo, out: &mut Vec<u8>) {
     let mut cache = buffa::SizeCache::new();
     let size = waproto::codec::message_context_info_compute_size(msg, &mut cache);
     push_message_field_sized(field, msg, size, &mut cache, out);
@@ -614,13 +788,13 @@ fn push_message_field(field: u64, msg: &wa::MessageContextInfo, out: &mut Vec<u8
 /// 0; `write_to` consumes them, so this avoids measuring the sub-tree twice.
 #[inline]
 fn push_message_field_sized(
-    field: u64,
+    field: u32,
     msg: &wa::MessageContextInfo,
     size: usize,
     cache: &mut buffa::SizeCache,
     out: &mut Vec<u8>,
 ) {
-    push_varint((field << 3) | 2, out);
+    push_wire_tag(field, buffa::encoding::WireType::LengthDelimited, out);
     push_varint(size as u64, out);
     waproto::codec::message_context_info_write_to(msg, cache, out);
 }
@@ -1741,22 +1915,16 @@ mod device_sent_tests {
         );
     }
 
-    /// Pin the spliced field numbers to the prost-generated schema: encode a probe
+    /// Pin the spliced field numbers to the generated schema: encode a probe
     /// with only the relevant field set and read the first protobuf key. If the
-    /// .proto ever renumbers one of these fields, prost regenerates and this fails
+    /// .proto ever renumbers one of these fields, Buffa regenerates and this fails
     /// with a precise message, so the hand-written framing cannot silently drift.
     #[test]
-    fn splice_tags_match_prost_schema() {
-        fn first_field_number(bytes: &[u8]) -> u64 {
-            let (mut key, mut shift) = (0u64, 0u32);
-            for &b in bytes {
-                key |= u64::from(b & 0x7f) << shift;
-                if b & 0x80 == 0 {
-                    break;
-                }
-                shift += 7;
-            }
-            key >> 3
+    fn splice_tags_match_generated_schema() {
+        fn first_field_number(mut bytes: &[u8]) -> u32 {
+            buffa::encoding::Tag::decode(&mut bytes)
+                .expect("probe should start with a valid protobuf tag")
+                .field_number()
         }
 
         let outer_dsm = wa::Message {


### PR DESCRIPTION
## Why

Several high-volume paths were doing avoidable ownership work: history sync materialized records that retention policy would immediately discard, inline sync payloads were copied out of decrypted messages, buffered media downloads kept encrypted and plaintext file-sized allocations alive together, and Signal/prekey helpers allocated temporary byte vectors around already-owned buffers.

That churn raises peak memory and CPU cost for every client, particularly during initial sync and on constrained runtimes. It also made allocation profiles less actionable because parsing, cryptography, and materialization were grouped together.

## What changed

- add `Bytes`-based history-sync entry points and a borrowed record predicate that runs before owned records are created; existing APIs retain their accept-all behavior
- centralize message-secret retention policy and cache per-conversation classification using a zero-based conversation index
- detach inline history payloads as shared slices of the decrypted plaintext while preserving the generated protobuf message semantics for every other field
- parse Signal envelopes from shared ciphertext buffers and split parsing, cryptography, and plaintext materialization into focused tracing spans
- expose an allocation-free borrowed JID parser for common protocol JIDs, with the existing compatibility parser as the fallback
- retain the zlib pool's measured two-window steady state while still shrinking genuinely oversized buffers
- authenticate buffered media before mutation, then decrypt CBC in place and truncate MAC/padding instead of allocating a second file-sized output; streaming clients keep the streaming path
- encode prekey records directly from borrowed fixed-size key buffers through the generated protobuf view
- add differential, equivalence, ownership, authentication, and allocation-regression coverage for the new paths

The protocol schema and generated encoders remain the source of truth; the changes do not duplicate wire logic or alter wire formats.

## Measured impact

Allocation-instrumented synthetic history sync runs showed:

- early record filtering: allocation churn **21.61 MiB → 14.00 MiB** and allocations **~84k → ~26k**
- borrowed JID classification in the history task: allocations **4,093 → 97**
- pooled inflate work per history span: **0.970 MiB → 0.470 MiB**
- buffered media download/decrypt span: **4.355 MiB → 2.146 MiB**
- prekey upload span: allocations **5,810 → 4,186** and churn **0.504 MiB → 0.455 MiB**

The default public behavior is unchanged; consumers opt into filtering only when they own a retention policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests -- -D warnings`
- `cargo test --all`, including the complete mock-server E2E suite
- focused tests for filter-before-materialization, detached-buffer ownership, borrowed/owned JID parity, in-place decrypt equivalence and auth-before-mutation, zlib pool bounds, and borrowed prekey wire equivalence
