### PR TITLE
perf(send): reduce DM allocation and serialization churn

### DIFF
--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -157,6 +157,26 @@ struct SendBranchOutput {
     dm_phash: Option<String>,
 }
 
+/// Keep each branch future out of the shared send frame. In tracing builds the
+/// dedicated span lets allocation profilers distinguish this deliberate box
+/// from work performed while polling the selected branch.
+#[inline]
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(
+        name = "wa.send.branch_box",
+        level = "debug",
+        skip_all,
+        fields(future_bytes = std::mem::size_of::<F>())
+    )
+)]
+fn box_send_branch<F>(future: F) -> std::pin::Pin<Box<F>>
+where
+    F: std::future::Future,
+{
+    Box::pin(future)
+}
+
 /// True when every SKDM target belongs to our own account (PN or LID user).
 /// Own devices are never memoized warm (WA Web's `!isMeDevice` guard on
 /// `markHasSenderKey`), so an own-only `needs` set is the permanent
@@ -1457,9 +1477,9 @@ impl Client {
             issue_tc_token_after_send: should_issue_tc_token_after_send,
             dm_phash,
         } = if peer && !to.is_group() {
-            Box::pin(self.send_peer_branch(to, message, request_id)).await?
+            box_send_branch(self.send_peer_branch(to, message, request_id)).await?
         } else if to.is_group() {
-            Box::pin(self.send_group_branch(
+            box_send_branch(self.send_group_branch(
                 to,
                 message,
                 request_id,
@@ -1469,7 +1489,7 @@ impl Client {
             ))
             .await?
         } else {
-            Box::pin(self.send_dm_branch(
+            box_send_branch(self.send_dm_branch(
                 to,
                 message,
                 request_id,

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -655,6 +655,13 @@ impl Jid {
         push_jid_to_string(&self.user, self.server, self.agent, self.device, buf);
     }
 
+    /// Write the Display representation to any [`fmt::Write`] sink without an
+    /// intermediate `String`.
+    #[inline]
+    pub fn write_display_to<W: fmt::Write + ?Sized>(&self, writer: &mut W) -> fmt::Result {
+        write_jid_fallible(writer, &self.user, self.server, self.agent, self.device)
+    }
+
     /// Compare device identity (user, server, device) without allocation.
     #[inline]
     pub fn device_eq(&self, other: &Jid) -> bool {
@@ -899,7 +906,7 @@ impl fmt::Write for JidStackWriter {
 }
 
 #[inline]
-fn write_jid_fallible<W: fmt::Write>(
+fn write_jid_fallible<W: fmt::Write + ?Sized>(
     w: &mut W,
     user: &str,
     server: Server,
@@ -912,10 +919,10 @@ fn write_jid_fallible<W: fmt::Write>(
 impl fmt::Display for Jid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut w = JidStackWriter::new();
-        if write_jid_fallible(&mut w, &self.user, self.server, self.agent, self.device).is_ok() {
+        if self.write_display_to(&mut w).is_ok() {
             return f.write_str(w.as_str());
         }
-        write_jid_fallible(f, &self.user, self.server, self.agent, self.device)
+        self.write_display_to(f)
     }
 }
 
@@ -1701,7 +1708,8 @@ mod tests {
 
     /// Verify that all JID formatting paths produce identical output:
     /// `Jid::Display`, `JidRef::Display`, `push_jid_to_string`, `push_jid_to_compact`,
-    /// and `Jid::push_to`. Exercises the agent-elision rules across server variants.
+    /// `Jid::push_to`, and the generic writer. Exercises the agent-elision rules
+    /// across server variants.
     #[test]
     fn test_jid_format_parity() {
         struct Case {
@@ -1853,6 +1861,10 @@ mod tests {
             let mut push_buf = String::new();
             jid.push_to(&mut push_buf);
 
+            // Generic fmt::Write path.
+            let mut write_buf = String::new();
+            jid.write_display_to(&mut write_buf).unwrap();
+
             assert_eq!(display, ref_display, "case {i}: Display vs JidRef::Display");
             assert_eq!(
                 display, string_buf,
@@ -1864,6 +1876,7 @@ mod tests {
                 "case {i}: Display vs push_jid_to_compact"
             );
             assert_eq!(display, push_buf, "case {i}: Display vs Jid::push_to");
+            assert_eq!(display, write_buf, "case {i}: Display vs generic writer");
         }
     }
 }

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -79,6 +79,10 @@ impl MessageUtils {
     /// the shared bytes are spliced + padded here instead of re-encoding the message.
     /// `content` must be the message's encoding with no reporting context spliced on (the
     /// caller only takes this path when the message has no top-level message_context_info).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "wa.send.dm_plaintext", level = "debug", skip_all)
+    )]
     pub fn pad_with_context_from_encoded(
         content: &[u8],
         extra_context: Option<&wa::MessageContextInfo>,
@@ -203,6 +207,10 @@ impl MessageUtils {
     /// into `content`. The DM send path reuses the single message encode it also feeds to
     /// the reporting token, so the message is no longer encoded twice per send. `content`
     /// must be the message's encoding with no reporting context spliced on.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "wa.send.dm_plaintexts", level = "debug", skip_all)
+    )]
     pub fn dm_plaintexts_from_encoded(
         content: &[u8],
         extra_context: Option<&wa::MessageContextInfo>,
@@ -300,6 +308,10 @@ impl MessageUtils {
         }
     }
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "wa.send.participant_hash", level = "debug", skip_all)
+    )]
     pub fn participant_list_hash<'a>(
         devices: impl IntoIterator<Item = &'a wacore_binary::Jid>,
     ) -> Result<String> {

--- a/wacore/src/reporting_token.rs
+++ b/wacore/src/reporting_token.rs
@@ -259,7 +259,8 @@ const USE_CASE_REPORT_TOKEN: &str = "Report Token";
 
 /// Keeps the normal reporting-token info (`stanza || sender || remote || use-case`)
 /// on the stack. This is a performance threshold, not a protocol limit: longer
-/// inputs transparently use an exactly-sized heap buffer.
+/// inputs transparently use a heap buffer with room for subsequent formatter
+/// writes.
 const REPORTING_TOKEN_INFO_INLINE_CAPACITY: usize = 128;
 
 enum ReportingTokenInfo {
@@ -292,7 +293,10 @@ impl ReportingTokenInfo {
                     return;
                 }
 
-                let mut heap = Vec::with_capacity(end);
+                // JIDs are emitted in multiple `fmt::Write` calls. Keep one
+                // inline buffer's worth of spare capacity so promotion does not
+                // immediately reallocate on the remaining JID/use-case writes.
+                let mut heap = Vec::with_capacity(end + REPORTING_TOKEN_INFO_INLINE_CAPACITY);
                 heap.extend_from_slice(&bytes[..*len]);
                 heap.extend_from_slice(value);
                 *self = Self::Heap(heap);
@@ -899,6 +903,21 @@ mod tests {
                 "only the oversized case should use the heap fallback"
             );
         }
+    }
+
+    #[test]
+    fn heap_promotion_reserves_space_for_follow_up_writes() {
+        let mut info = ReportingTokenInfo::with_capacity(REPORTING_TOKEN_INFO_INLINE_CAPACITY);
+        info.extend_from_slice(&[0; REPORTING_TOKEN_INFO_INLINE_CAPACITY]);
+        info.extend_from_slice(&[1]);
+
+        let ReportingTokenInfo::Heap(bytes) = info else {
+            panic!("overflowing inline reporting info should promote to heap");
+        };
+        assert!(
+            bytes.capacity() >= bytes.len() + REPORTING_TOKEN_INFO_INLINE_CAPACITY,
+            "heap promotion should absorb subsequent formatter writes"
+        );
     }
 
     #[test]

--- a/wacore/src/reporting_token.rs
+++ b/wacore/src/reporting_token.rs
@@ -17,7 +17,7 @@
 //! without seeing the full message content. Only specific fields are extracted
 //! based on a predefined whitelist matching WhatsApp Web behavior.
 
-use std::sync::LazyLock;
+use std::{fmt, sync::LazyLock};
 
 use anyhow::{Result, anyhow};
 use hkdf::Hkdf;
@@ -257,6 +257,65 @@ pub const REPORTING_TOKEN_SIZE: usize = 16;
 /// This string is appended to the HKDF info as per WhatsApp Web implementation.
 const USE_CASE_REPORT_TOKEN: &str = "Report Token";
 
+/// Keeps the normal reporting-token info (`stanza || sender || remote || use-case`)
+/// on the stack. This is a performance threshold, not a protocol limit: longer
+/// inputs transparently use an exactly-sized heap buffer.
+const REPORTING_TOKEN_INFO_INLINE_CAPACITY: usize = 128;
+
+enum ReportingTokenInfo {
+    Inline {
+        bytes: [u8; REPORTING_TOKEN_INFO_INLINE_CAPACITY],
+        len: usize,
+    },
+    Heap(Vec<u8>),
+}
+
+impl ReportingTokenInfo {
+    fn with_capacity(capacity: usize) -> Self {
+        if capacity <= REPORTING_TOKEN_INFO_INLINE_CAPACITY {
+            Self::Inline {
+                bytes: [0; REPORTING_TOKEN_INFO_INLINE_CAPACITY],
+                len: 0,
+            }
+        } else {
+            Self::Heap(Vec::with_capacity(capacity))
+        }
+    }
+
+    fn extend_from_slice(&mut self, value: &[u8]) {
+        match self {
+            Self::Inline { bytes, len } => {
+                let end = *len + value.len();
+                if end <= bytes.len() {
+                    bytes[*len..end].copy_from_slice(value);
+                    *len = end;
+                    return;
+                }
+
+                let mut heap = Vec::with_capacity(end);
+                heap.extend_from_slice(&bytes[..*len]);
+                heap.extend_from_slice(value);
+                *self = Self::Heap(heap);
+            }
+            Self::Heap(bytes) => bytes.extend_from_slice(value),
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Inline { bytes, len } => &bytes[..*len],
+            Self::Heap(bytes) => bytes,
+        }
+    }
+}
+
+impl fmt::Write for ReportingTokenInfo {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.extend_from_slice(value.as_bytes());
+        Ok(())
+    }
+}
+
 /// HKDF-Extract with no salt is `HMAC-SHA256(zero_block, ikm)`, so the zero-key
 /// ipad/opad schedule is constant across every send. Cache it once and clone per
 /// derivation instead of re-running `Hkdf::new(None, ..)`'s two compressions each
@@ -277,14 +336,79 @@ pub fn generate_message_secret() -> [u8; MESSAGE_SECRET_SIZE] {
 ///
 /// The info is constructed as: stanza_id || sender_jid || remote_jid || "Report Token"
 /// This matches WhatsApp Web's Binary.build(stanzaId, senderJid, remoteJid, REPORT_TOKEN)
-fn build_hkdf_info(stanza_id: &str, sender_jid: &str, remote_jid: &str) -> Vec<u8> {
-    let cap = stanza_id.len() + sender_jid.len() + remote_jid.len() + USE_CASE_REPORT_TOKEN.len();
-    let mut info = Vec::with_capacity(cap);
+fn build_hkdf_info_with(
+    stanza_id: &str,
+    sender_len: usize,
+    remote_len: usize,
+    write_jids: impl FnOnce(&mut ReportingTokenInfo) -> fmt::Result,
+) -> Result<ReportingTokenInfo> {
+    let capacity = stanza_id
+        .len()
+        .checked_add(sender_len)
+        .and_then(|len| len.checked_add(remote_len))
+        .and_then(|len| len.checked_add(USE_CASE_REPORT_TOKEN.len()))
+        .ok_or_else(|| anyhow!("Reporting token HKDF info length overflow"))?;
+
+    let mut info = ReportingTokenInfo::with_capacity(capacity);
     info.extend_from_slice(stanza_id.as_bytes());
-    info.extend_from_slice(sender_jid.as_bytes());
-    info.extend_from_slice(remote_jid.as_bytes());
+    write_jids(&mut info).map_err(|_| anyhow!("Failed to format reporting token JIDs"))?;
     info.extend_from_slice(USE_CASE_REPORT_TOKEN.as_bytes());
-    info
+    Ok(info)
+}
+
+fn build_hkdf_info(
+    stanza_id: &str,
+    sender_jid: &str,
+    remote_jid: &str,
+) -> Result<ReportingTokenInfo> {
+    build_hkdf_info_with(stanza_id, sender_jid.len(), remote_jid.len(), |info| {
+        info.extend_from_slice(sender_jid.as_bytes());
+        info.extend_from_slice(remote_jid.as_bytes());
+        Ok(())
+    })
+}
+
+fn build_hkdf_info_for_jids(
+    stanza_id: &str,
+    sender_jid: &Jid,
+    remote_jid: &Jid,
+) -> Result<ReportingTokenInfo> {
+    // Start inline and let the infallible writer promote only unusually long
+    // protocol inputs. Avoiding a separate sizing pass formats each JID once.
+    build_hkdf_info_with(stanza_id, 0, 0, |info| {
+        sender_jid.write_display_to(info)?;
+        remote_jid.write_display_to(info)
+    })
+}
+
+fn validate_message_secret(message_secret: &[u8]) -> Result<()> {
+    if message_secret.len() == MESSAGE_SECRET_SIZE {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "Invalid message secret size: expected {}, got {}",
+        MESSAGE_SECRET_SIZE,
+        message_secret.len()
+    ))
+}
+
+fn derive_reporting_token_key_from_info(
+    message_secret: &[u8],
+    info: &[u8],
+) -> Result<[u8; REPORTING_TOKEN_KEY_SIZE]> {
+    // No-salt extract via the cached zero-keyed HMAC; output is byte-identical to
+    // `Hkdf::new(None, message_secret)` but skips the constant ipad/opad schedule.
+    let mut extract = REPORTING_TOKEN_EXTRACT_HMAC.clone();
+    extract.update(message_secret);
+    let prk = extract.finalize().into_bytes();
+    let mut key = [0u8; REPORTING_TOKEN_KEY_SIZE];
+    Hkdf::<Sha256>::from_prk(&prk)
+        .expect("PRK is hash-sized")
+        .expand(info, &mut key)
+        .map_err(|e| anyhow!("HKDF expand failed: {}", e))?;
+
+    Ok(key)
 }
 
 /// Derive the reporting token key from the message secret using HKDF.
@@ -303,28 +427,20 @@ pub fn derive_reporting_token_key(
     sender_jid: &str,
     remote_jid: &str,
 ) -> Result<[u8; REPORTING_TOKEN_KEY_SIZE]> {
-    if message_secret.len() != MESSAGE_SECRET_SIZE {
-        return Err(anyhow!(
-            "Invalid message secret size: expected {}, got {}",
-            MESSAGE_SECRET_SIZE,
-            message_secret.len()
-        ));
-    }
+    validate_message_secret(message_secret)?;
+    let info = build_hkdf_info(stanza_id, sender_jid, remote_jid)?;
+    derive_reporting_token_key_from_info(message_secret, info.as_bytes())
+}
 
-    let info = build_hkdf_info(stanza_id, sender_jid, remote_jid);
-
-    // No-salt extract via the cached zero-keyed HMAC; output is byte-identical to
-    // `Hkdf::new(None, message_secret)` but skips the constant ipad/opad schedule.
-    let mut extract = REPORTING_TOKEN_EXTRACT_HMAC.clone();
-    extract.update(message_secret);
-    let prk = extract.finalize().into_bytes();
-    let mut key = [0u8; REPORTING_TOKEN_KEY_SIZE];
-    Hkdf::<Sha256>::from_prk(&prk)
-        .expect("PRK is hash-sized")
-        .expand(&info, &mut key)
-        .map_err(|e| anyhow!("HKDF expand failed: {}", e))?;
-
-    Ok(key)
+fn derive_reporting_token_key_for_jids(
+    message_secret: &[u8],
+    stanza_id: &str,
+    sender_jid: &Jid,
+    remote_jid: &Jid,
+) -> Result<[u8; REPORTING_TOKEN_KEY_SIZE]> {
+    validate_message_secret(message_secret)?;
+    let info = build_hkdf_info_for_jids(stanza_id, sender_jid, remote_jid)?;
+    derive_reporting_token_key_from_info(message_secret, info.as_bytes())
 }
 
 /// Decode a varint from a byte slice.
@@ -591,6 +707,10 @@ pub fn generate_reporting_token(
 /// again. The DM send path encodes the message once for the wire plaintext and threads
 /// those same bytes here, so a token-bearing DM no longer encodes its message a second
 /// time per send just to extract the token's whitelisted fields.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(name = "wa.send.reporting_token", level = "debug", skip_all)
+)]
 pub fn generate_reporting_token_from_encoded(
     message: &wa::Message,
     encoded_message: &[u8],
@@ -615,11 +735,8 @@ pub fn generate_reporting_token_from_encoded(
         generate_message_secret()
     };
 
-    let sender_jid_str = sender_jid.to_string();
-    let remote_jid_str = remote_jid.to_string();
-
     let key =
-        derive_reporting_token_key(&message_secret, stanza_id, &sender_jid_str, &remote_jid_str)
+        derive_reporting_token_key_for_jids(&message_secret, stanza_id, sender_jid, remote_jid)
             .ok()?;
 
     let token = calculate_reporting_token(&key, &content).ok()?;
@@ -632,6 +749,10 @@ pub fn generate_reporting_token_from_encoded(
 }
 
 /// Build the `<reporting>` node for a message stanza.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(name = "wa.send.reporting_node", level = "debug", skip_all)
+)]
 pub fn build_reporting_node(result: &ReportingTokenResult) -> Node {
     let token_node = NodeBuilder::new("reporting_token")
         .attrs([("v", result.version.to_string())])
@@ -742,20 +863,60 @@ mod tests {
     }
 
     #[test]
+    fn jid_key_derivation_matches_string_api_for_inline_and_heap_info() {
+        let secret = [0x42; MESSAGE_SECRET_SIZE];
+        let stanza_id = "3EB0E0E5F2D4F618589C0B";
+        let cases = [
+            (
+                Jid::pn_device("5511999887766".to_owned(), 7),
+                Jid::pn_device("5511888776655".to_owned(), 3),
+            ),
+            (
+                Jid::pn("sender".repeat(REPORTING_TOKEN_INFO_INLINE_CAPACITY)),
+                Jid::pn("remote".repeat(REPORTING_TOKEN_INFO_INLINE_CAPACITY)),
+            ),
+        ];
+
+        for (case_index, (sender, remote)) in cases.iter().enumerate() {
+            let sender_string = sender.to_string();
+            let remote_string = remote.to_string();
+            let expected =
+                derive_reporting_token_key(&secret, stanza_id, &sender_string, &remote_string)
+                    .expect("string inputs should derive a key");
+            let actual = derive_reporting_token_key_for_jids(&secret, stanza_id, sender, remote)
+                .expect("JID inputs should derive a key");
+
+            assert_eq!(
+                actual, expected,
+                "JID derivation mismatch in case {case_index}"
+            );
+
+            let info = build_hkdf_info_for_jids(stanza_id, sender, remote)
+                .expect("JIDs should build HKDF info");
+            assert_eq!(
+                matches!(info, ReportingTokenInfo::Heap(_)),
+                case_index == 1,
+                "only the oversized case should use the heap fallback"
+            );
+        }
+    }
+
+    #[test]
     fn derive_key_matches_plain_hkdf_extract() {
         // The cached zero-keyed HMAC extract must produce a key byte-identical to
         // `Hkdf::new(None, secret)` across a spread of secrets.
         let stanza_id = "3EB0E0E5F2D4F618589C0B";
         let sender_jid = "5511999887766@s.whatsapp.net";
         let remote_jid = "5511888776655@s.whatsapp.net";
-        let info = build_hkdf_info(stanza_id, sender_jid, remote_jid);
+        let info = build_hkdf_info(stanza_id, sender_jid, remote_jid)
+            .expect("test inputs should build HKDF info");
 
         for seed in 0u8..32 {
             let secret = [seed.wrapping_mul(37).wrapping_add(11); MESSAGE_SECRET_SIZE];
 
             let mut expected = [0u8; REPORTING_TOKEN_KEY_SIZE];
             Hkdf::<Sha256>::new(None, &secret)
-                .expand(&info, &mut expected)
+                .expand(info.as_bytes(), &mut expected)
                 .expect("valid output length");
 
             let got = derive_reporting_token_key(&secret, stanza_id, sender_jid, remote_jid)
@@ -1477,12 +1638,13 @@ mod tests {
     #[test]
     fn test_hkdf_info_construction() {
         // Verify the HKDF info is constructed correctly
-        let info = build_hkdf_info("STANZA", "sender@s.whatsapp.net", "remote@s.whatsapp.net");
+        let info = build_hkdf_info("STANZA", "sender@s.whatsapp.net", "remote@s.whatsapp.net")
+            .expect("test inputs should build HKDF info");
 
         let expected = b"STANZAsender@s.whatsapp.netremote@s.whatsapp.netReport Token";
         assert_eq!(
-            info,
-            expected.to_vec(),
+            info.as_bytes(),
+            expected,
             "HKDF info construction changed! This will break token verification."
         );
     }

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -136,7 +136,7 @@ pub async fn prepare_dm_stanza(
     let own_other_devices = partitioned_devices.own_other_devices();
     let total_devices = valid_devices.len();
 
-    let phash = MessageUtils::participant_list_hash(valid_devices.iter()).ok();
+    let phash = MessageUtils::participant_list_hash(valid_devices).ok();
 
     // Splice the shared content into the recipient plaintext and, when present, the
     // own-device DeviceSentMessage plaintext. With no own companion devices (e.g. an
@@ -206,7 +206,7 @@ pub async fn prepare_dm_stanza(
 
     // All per-device encrypts failed: an empty <participants> would silently
     // drop the message. WA Web's encryptAndSendUserMsg rejects here too.
-    let attempted_devices = recipient_devices.len() + own_other_devices.len();
+    let attempted_devices = total_devices;
     if participant_nodes.is_empty() && attempted_devices > 0 {
         return Err(anyhow!(
             "encryption failed for all {attempted_devices} recipient device(s)"

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -8,27 +8,53 @@ fn is_exact_dm_sender_device(device_jid: &Jid, own_jid: &Jid, own_lid: Option<&J
             .is_some_and(|lid| device_jid.is_same_user_as(lid) && device_jid.device == lid.device)
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(name = "wa.send.dm_partition", level = "debug", skip_all)
+)]
 pub(crate) fn partition_dm_devices(
-    all_devices: Vec<Jid>,
+    mut all_devices: Vec<Jid>,
     own_jid: &Jid,
     own_lid: Option<&Jid>,
-) -> (Vec<Jid>, Vec<Jid>) {
-    let mut recipient_devices = Vec::with_capacity(all_devices.len());
-    let mut own_other_devices = Vec::with_capacity(4);
-
-    for device_jid in all_devices {
-        if is_exact_dm_sender_device(&device_jid, own_jid, own_lid) {
+) -> PartitionedDmDevices {
+    // Unstable partition is intentional: participant wire order is not
+    // significant and phash sorts independently. Classifying in one pass and
+    // reusing the caller's buffer avoids allocating recipient + own-device
+    // Vecs on every DM send.
+    let mut recipient_count = 0;
+    let mut device_index = 0;
+    while device_index < all_devices.len() {
+        if is_exact_dm_sender_device(&all_devices[device_index], own_jid, own_lid) {
+            all_devices.swap_remove(device_index);
             continue;
         }
 
-        if device_jid.matches_user_or_lid(own_jid, own_lid) {
-            own_other_devices.push(device_jid);
-        } else {
-            recipient_devices.push(device_jid);
+        if !all_devices[device_index].matches_user_or_lid(own_jid, own_lid) {
+            all_devices.swap(device_index, recipient_count);
+            recipient_count += 1;
         }
+        device_index += 1;
     }
 
-    (recipient_devices, own_other_devices)
+    PartitionedDmDevices {
+        devices: all_devices,
+        recipient_count,
+    }
+}
+
+pub(crate) struct PartitionedDmDevices {
+    devices: Vec<Jid>,
+    recipient_count: usize,
+}
+
+impl PartitionedDmDevices {
+    pub(crate) fn recipient_devices(&self) -> &[Jid] {
+        &self.devices[..self.recipient_count]
+    }
+
+    pub(crate) fn own_other_devices(&self) -> &[Jid] {
+        &self.devices[self.recipient_count..]
+    }
 }
 
 /// Result of `prepare_dm_stanza` — carries the stanza node and the
@@ -100,9 +126,10 @@ pub async fn prepare_dm_stanza(
 
     // Partition first so phash reflects the actual sent set (sender excluded) and so
     // the own-device plaintext can be skipped when there's nothing to send it to.
-    let total_devices = all_devices.len();
-    let (recipient_devices, own_other_devices) =
-        partition_dm_devices(all_devices, own_jid, own_lid);
+    let partitioned_devices = partition_dm_devices(all_devices, own_jid, own_lid);
+    let recipient_devices = partitioned_devices.recipient_devices();
+    let own_other_devices = partitioned_devices.own_other_devices();
+    let total_devices = recipient_devices.len() + own_other_devices.len();
 
     let phash = MessageUtils::participant_list_hash(
         recipient_devices.iter().chain(own_other_devices.iter()),
@@ -150,7 +177,7 @@ pub async fn prepare_dm_stanza(
             runtime,
             stores,
             resolver,
-            &recipient_devices,
+            recipient_devices,
             &recipient_plaintext,
             hide_decrypt_fail,
             mediatype,
@@ -165,7 +192,7 @@ pub async fn prepare_dm_stanza(
             runtime,
             stores,
             resolver,
-            &own_other_devices,
+            own_other_devices,
             &own_devices_plaintext,
             hide_decrypt_fail,
             mediatype,
@@ -354,4 +381,36 @@ where
     }
 
     Ok(stanza_builder.children(children).build())
+}
+
+#[cfg(test)]
+mod partition_tests {
+    use super::*;
+
+    #[test]
+    fn partition_dm_devices_reuses_input_allocation() {
+        let own_jid = Jid::lid_device("123456789".to_owned(), 7);
+        let devices = vec![
+            Jid::lid_device("987654321".to_owned(), 0),
+            Jid::lid_device("123456789".to_owned(), 0),
+            own_jid.clone(),
+            Jid::lid_device("987654321".to_owned(), 1),
+        ];
+        let allocation = devices.as_ptr();
+        let capacity = devices.capacity();
+
+        let partitioned = partition_dm_devices(devices, &own_jid, None);
+
+        assert_eq!(partitioned.devices.as_ptr(), allocation);
+        assert_eq!(partitioned.devices.capacity(), capacity);
+        assert_eq!(partitioned.recipient_devices().len(), 2);
+        assert_eq!(partitioned.own_other_devices().len(), 1);
+        assert!(
+            partitioned
+                .recipient_devices()
+                .iter()
+                .all(|device| device.user == "987654321")
+        );
+        assert_eq!(partitioned.own_other_devices()[0].device, 0);
+    }
 }

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -48,6 +48,10 @@ pub(crate) struct PartitionedDmDevices {
 }
 
 impl PartitionedDmDevices {
+    pub(crate) fn valid_devices(&self) -> &[Jid] {
+        &self.devices
+    }
+
     pub(crate) fn recipient_devices(&self) -> &[Jid] {
         &self.devices[..self.recipient_count]
     }
@@ -127,14 +131,12 @@ pub async fn prepare_dm_stanza(
     // Partition first so phash reflects the actual sent set (sender excluded) and so
     // the own-device plaintext can be skipped when there's nothing to send it to.
     let partitioned_devices = partition_dm_devices(all_devices, own_jid, own_lid);
+    let valid_devices = partitioned_devices.valid_devices();
     let recipient_devices = partitioned_devices.recipient_devices();
     let own_other_devices = partitioned_devices.own_other_devices();
-    let total_devices = recipient_devices.len() + own_other_devices.len();
+    let total_devices = valid_devices.len();
 
-    let phash = MessageUtils::participant_list_hash(
-        recipient_devices.iter().chain(own_other_devices.iter()),
-    )
-    .ok();
+    let phash = MessageUtils::participant_list_hash(valid_devices.iter()).ok();
 
     // Splice the shared content into the recipient plaintext and, when present, the
     // own-device DeviceSentMessage plaintext. With no own companion devices (e.g. an
@@ -403,6 +405,7 @@ mod partition_tests {
 
         assert_eq!(partitioned.devices.as_ptr(), allocation);
         assert_eq!(partitioned.devices.capacity(), capacity);
+        assert_eq!(partitioned.valid_devices().len(), 3);
         assert_eq!(partitioned.recipient_devices().len(), 2);
         assert_eq!(partitioned.own_other_devices().len(), 1);
         assert!(

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -1055,7 +1055,9 @@ fn test_dm_encryption_excludes_sender_device() {
         Jid::lid_device("987654321".to_string(), 0),          // Recipient
     ];
 
-    let (recipient_devices, own_other_devices) = partition_dm_devices(all_devices, &own_jid, None);
+    let partitioned = partition_dm_devices(all_devices, &own_jid, None);
+    let recipient_devices = partitioned.recipient_devices();
+    let own_other_devices = partitioned.own_other_devices();
 
     // Verifications
 
@@ -1102,8 +1104,9 @@ fn test_dm_encryption_treats_own_lid_devices_as_self() {
         Jid::lid_device("987654321012345".to_string(), 0),  // Recipient
     ];
 
-    let (recipient_devices, own_other_devices) =
-        partition_dm_devices(all_devices, &own_pn, Some(&own_lid));
+    let partitioned = partition_dm_devices(all_devices, &own_pn, Some(&own_lid));
+    let recipient_devices = partitioned.recipient_devices();
+    let own_other_devices = partitioned.own_other_devices();
 
     assert!(
         !own_other_devices

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -392,8 +392,16 @@ mod tests {
 
         let serialized = serde_json::to_value(info).expect("serialize message info");
         let root = serialized.as_object().expect("message info object");
-        let source = root["source"].as_object().expect("message source object");
-        let meta = root["meta_info"].as_object().expect("message meta object");
+        let source = root
+            .get("source")
+            .expect("serialized message info should contain source")
+            .as_object()
+            .expect("message source object");
+        let meta = root
+            .get("meta_info")
+            .expect("serialized message info should contain meta_info")
+            .as_object()
+            .expect("message meta object");
 
         assert!(source.contains_key("sender_alt"));
         assert!(!source.contains_key("recipient_alt"));

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -106,10 +106,15 @@ pub struct MessageSource {
     pub sender: Jid,
     pub is_from_me: bool,
     pub is_group: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub addressing_mode: Option<AddressingMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sender_alt: Option<Jid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recipient_alt: Option<Jid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub broadcast_list_owner: Option<Jid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub recipient: Option<Jid>,
 }
 
@@ -259,21 +264,30 @@ impl BotEditType {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MsgBotInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub edit_type: Option<BotEditType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub edit_target_id: Option<MessageId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub edit_sender_timestamp_ms: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct MsgMetaInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_id: Option<MessageId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_sender: Option<Jid>,
     /// `<meta target_chat_jid="…">` — present when the bot reply addresses a
     /// chat distinct from the stanza-level `from` (used for msmsg secret
     /// lookup; see WA Web `decryptMsmsgBotMessage`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_chat: Option<Jid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated_lid_session: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_message_id: Option<MessageId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_message_sender_jid: Option<Jid>,
     /// `<meta content_type=...>` attr. Server marks reactions/edits as
     /// `"add_on"`; mirrors `WAWebHandleMsgParser` b()'s metadata read.
@@ -307,16 +321,21 @@ pub struct MessageInfo {
     pub multicast: bool,
     pub media_type: String,
     pub edit: EditAttribute,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_info: Option<MsgBotInfo>,
     pub meta_info: MsgMetaInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub verified_name: Option<wa::VerifiedNameCertificate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_sent_meta: Option<DeviceSentMeta>,
     /// Ephemeral duration in seconds, extracted from `contextInfo.expiration`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ephemeral_expiration: Option<u32>,
     /// Whether this message was delivered during offline sync.
     pub is_offline: bool,
     /// Set when this message was recovered via PDO rather than normal decryption.
     /// Contains the PDO request message ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub unavailable_request_id: Option<String>,
     /// Server-store timestamp in microseconds (envelope `sts` attr). Used by
     /// WA Web for read-self watermark ordering across companion devices.
@@ -363,6 +382,29 @@ impl MessageInfo {
 mod tests {
     use super::*;
     use buffa::MessageField;
+
+    #[test]
+    fn message_info_serde_omits_only_absent_optional_fields() {
+        let mut info = MessageInfo::default();
+        info.source.sender_alt = Some("15550000001@lid".parse().unwrap());
+        info.meta_info.target_id = Some("TARGET".to_owned());
+        info.unavailable_request_id = Some("REQUEST".to_owned());
+
+        let serialized = serde_json::to_value(info).expect("serialize message info");
+        let root = serialized.as_object().expect("message info object");
+        let source = root["source"].as_object().expect("message source object");
+        let meta = root["meta_info"].as_object().expect("message meta object");
+
+        assert!(source.contains_key("sender_alt"));
+        assert!(!source.contains_key("recipient_alt"));
+        assert!(meta.contains_key("target_id"));
+        assert!(!meta.contains_key("target_sender"));
+        assert!(root.contains_key("unavailable_request_id"));
+        assert!(!root.contains_key("bot_info"));
+        assert!(!root.contains_key("verified_name"));
+        assert!(!root.contains_key("device_sent_meta"));
+        assert!(!root.contains_key("ephemeral_expiration"));
+    }
 
     #[test]
     fn is_self_fanout_matches_only_own_dm_with_recipient() {


### PR DESCRIPTION
## Summary

- partition DM devices in-place, reuse the resolver-owned allocation, and consume the resulting contiguous device slice directly
- derive reporting-token HKDF info from JIDs through an inline buffer with a growth-cushioned heap fallback for oversized inputs
- omit absent optional message metadata during serialization
- add opt-in tracing spans for allocation attribution in the send path

## Why

Small DM sends allocated two device vectors, three temporary reporting-token strings/buffers, and serialized absent metadata as explicit nulls. These costs repeat for every message.

## Performance

Measured on a 30,000-message DM send workload with alternating A/B artifacts:

- 150,000 fewer Rust allocations (5 per message)
- 7.44 MB less requested allocation churn
- client CPU median: 7.59 s → 7.53 s (-0.8%)
- average RSS median: 174.1 MB → 173.1 MB
- throughput unchanged at ~2,859 msg/s

The profile build grows by 1,367 bytes (+0.013%). Oversized reporting inputs retain an allocation-backed fallback; promotion reserves room for subsequent formatter writes, so the fallback avoids an immediate second allocation. The inline capacity remains a performance threshold, not a protocol limit.

## Serialization note

Absent optional `MessageInfo` fields are now intentionally omitted instead of serialized as explicit `null` values. Present field values are unchanged. This output-shape change reduces serialization work and payload size.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p wacore-binary -p wacore --no-default-features --all-targets -- -D warnings`
- `cargo test -p wacore-binary --no-default-features --lib` (105 passed)
- `cargo test -p wacore --no-default-features --lib` (1,133 passed, 1 nightly test ignored)
- 30,000-message alternating A/B workload with no losses and unchanged throughput

The complete workspace matrix is delegated to this PR's GitHub Actions.