### PR TITLE
feat(plugins): add extensible client architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Read these when working on the relevant area:
 - `agent_docs/debugging.md` — evcxr REPL, binary protocol debugging
 - `agent_docs/binary_size_ci.md` — size-tracking CI: metrics, budgets, baseline semantics
 - `agent_docs/observability.md` — per-session stats (I/O, memory report, TaskInstrument/CPU), design rules
+- `agent_docs/plugin_architecture.md` — native plugin host, lifecycle/capability invariants, future foreign adapter seam
 - `agent_docs/signal_durability.md` — Signal counter leases, pre-wire gates, crash recovery, review checklist
 
 When adding comments to the code, dont be so verbose, also only explain why, not what

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,6 +4379,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "whatsapp-rust-plugin-metrics"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bon",
+ "portable-atomic",
+ "serde",
+ "serde_json",
+ "tokio",
+ "whatsapp-rust",
+]
+
+[[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "base64",
+ "bon",
  "buffa",
  "bytes",
  "cbc 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/jlucaso1/whatsapp-rust"
 readme = "README.md"
 description = "Rust client for WhatsApp Web"
 
+[package.metadata.docs.rs]
+features = ["plugins"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [workspace]
 members = [
     ".",
@@ -49,6 +53,9 @@ disallowed_methods = "deny"
 # Ban std 64-bit atomic types: absent on 32-bit targets (Xtensa/ESP32). Use
 # portable_atomic. Host-only test/bench counters carry an inline allow.
 disallowed_types = "deny"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(docsrs)"] }
 
 [workspace.dependencies]
 # Shared dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,12 @@ zlib-rs = { version = "0.6.5", default-features = false, features = ["std", "rus
 
 [features]
 debug-snapshots = ["wacore/debug-snapshots"]
+# Generation-scoped extension lifecycle. Kept opt-in so ordinary clients do not
+# retain lifecycle state or branches when no extension host is present.
+client-lifecycle = []
 # Build-time native plugin host. Kept opt-in so clients that do not use plugins
 # retain the pre-host binary footprint.
-plugins = ["dep:bon"]
+plugins = ["client-lifecycle", "dep:bon"]
 # Optional observability. Off by default: no `tracing` dep, zero overhead.
 # Emits tracing spans/events only; the application installs the subscriber
 # (and any OpenTelemetry bridge). See examples/observability.rs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ zlib-rs = { version = "0.6.5", default-features = false, features = ["std", "rus
 
 [features]
 debug-snapshots = ["wacore/debug-snapshots"]
+# Build-time native plugin host. Kept opt-in so clients that do not use plugins
+# retain the pre-host binary footprint.
+plugins = []
 # Optional observability. Off by default: no `tracing` dep, zero overhead.
 # Emits tracing spans/events only; the application installs the subscriber
 # (and any OpenTelemetry bridge). See examples/observability.rs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     ".",
     "examples/voip-cli",
     "http_clients/ureq-client",
+    "plugins/metrics",
     "storages/chat-store",
     "storages/sqlite-storage",
     "tests/bench-integration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ zlib-rs = { version = "0.6.5", default-features = false, features = ["std", "rus
 debug-snapshots = ["wacore/debug-snapshots"]
 # Build-time native plugin host. Kept opt-in so clients that do not use plugins
 # retain the pre-host binary footprint.
-plugins = []
+plugins = ["dep:bon"]
 # Optional observability. Off by default: no `tracing` dep, zero overhead.
 # Emits tracing spans/events only; the application installs the subscriber
 # (and any OpenTelemetry bridge). See examples/observability.rs.
@@ -173,6 +173,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 buffa = { workspace = true }
 bytes = { workspace = true }
+bon = { workspace = true, optional = true }
 chrono = { workspace = true, features = ["clock"] }
 event-listener = { workspace = true }
 futures = { workspace = true, features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A high-performance, async Rust library for the WhatsApp Web API. Inspired by [wh
 - **Profile** — Set push name, status text, profile picture
 - **Privacy** — Fetch/set privacy settings, disappearing messages
 - **Modular** — Pluggable storage, transport, HTTP client, and async runtime; SQLite, Tokio WebSocket, and ureq ship as the defaults, swap any of them with `default-features = false`
+- **Native plugins** — Build-time, type-safe extensions with scoped capabilities and lifecycle ownership behind the `plugins` feature
 - **Runtime agnostic** — Bring your own async runtime via the `Runtime` trait (Tokio included by default)
 
 For the full API reference and guides, see the **[documentation](https://whatsapp-rust.jlucaso.com)**.
@@ -59,6 +60,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 The default cargo features wire up the Tokio WebSocket transport, the ureq HTTP client, the SQLite store, and the Tokio runtime; only the storage backend has to be chosen explicitly. Every piece is replaceable through the builder (`with_transport_factory`, `with_http_client`, `with_runtime`) for custom environments such as wasm or embedded targets.
+
+Native plugin APIs are opt-in: use `features = ["plugins"]` when implementing a
+plugin in the application. Published plugin crates can enable that feature in
+their own `whatsapp-rust` dependency, and Cargo feature unification activates it
+for the consumer. See [`agent_docs/plugin_architecture.md`](agent_docs/plugin_architecture.md)
+for the host contract and type-safe API example.
 
 ### One dependency is enough
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -78,10 +78,10 @@ queue retention, and cumulative delivery/backpressure totals; publishers can
 read their own totals through `PluginEvents::stats()`.
 
 Health is sticky for the lifetime of the host: lifecycle errors/panics,
-timeouts, task-drain timeouts, isolated core-event panics, resource teardown
-panics, publication failures, and queue drops mark only the responsible plugin
-as degraded. Concurrent snapshots are intentionally approximate, and carry no
-message content, JIDs, or phone numbers.
+timeouts, spawned-task panics, task-drain timeouts, isolated core-event panics,
+resource teardown panics, publication failures, and queue drops mark only the
+responsible plugin as degraded. Concurrent snapshots are intentionally
+approximate, and carry no message content, JIDs, or phone numbers.
 
 ### 3. `BotBuilder::with_task_instrument` — CPU / custom attribution (opt-in)
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -58,10 +58,30 @@ figures come from the `wacore::stats::HeapSize` trait:
 Semantics: honest estimates for attribution and leak detection, not
 byte-exact accounting. The e2e `memory_soak.rs` logs the byte totals next to
 RSS; its growth-bound assertions are on entry counts.
-When a new cache is added to `Client`, add it to `memory_report()` (the
-`MemoryReport::collections()` list keeps the total and `Display` in sync) and
-— if it can dominate memory — implement `HeapSize` for its value type next to
-that type's definition.
+When a new cache is added to `Client`, add it to `memory_report()` (the common
+`MemoryReport::collections()` list or its feature-gated report section) and —
+if it can dominate memory — implement `HeapSize` for its value type next to that
+type's definition.
+
+With the opt-in `plugins` feature, the report also includes installed plugins,
+active install/connection tasks, retained connection generations, core-event
+subscriptions, custom-event endpoints, and unique queued payload bytes. Fanout
+shares one envelope, so queued payload memory is counted once even when several
+endpoints retain it.
+
+### Plugin host snapshots (opt-in)
+
+`Client::plugin_stats()` is computed only when called and returns lifecycle,
+health, task, subscription, and custom-event counters keyed by public manifest
+ID. `PluginEventRouter::stats()` provides endpoint capacity, current unique
+queue retention, and cumulative delivery/backpressure totals; publishers can
+read their own totals through `PluginEvents::stats()`.
+
+Health is sticky for the lifetime of the host: lifecycle errors/panics,
+timeouts, task-drain timeouts, isolated core-event panics, resource teardown
+panics, publication failures, and queue drops mark only the responsible plugin
+as degraded. Concurrent snapshots are intentionally approximate, and carry no
+message content, JIDs, or phone numbers.
 
 ### 3. `BotBuilder::with_task_instrument` — CPU / custom attribution (opt-in)
 

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -1,0 +1,277 @@
+# Native Plugin Architecture
+
+This document defines the native plugin contract, its lifecycle and ownership
+invariants, and the boundary a future foreign-language adapter must preserve.
+The implementation is intentionally native-only today: bridge, sidecar, and
+wire-protocol work starts only with a concrete consumer.
+
+## Scope
+
+The initial plugin model supports:
+
+- build-time registration and transactional installation;
+- type-safe Rust APIs exposed through a plugin marker;
+- capability-shaped access to core events, tasks, messaging, IQ, and custom
+  events;
+- install-scoped and connection-generation-scoped work;
+- bounded custom-event delivery with explicit backpressure;
+- on-demand health, resource, and queue snapshots.
+
+It does not support dynamic installation, ingress interception, pre-ack
+decisions, a foreign wire protocol, process isolation, or sandboxing. Those
+features must be justified by a real use case because they add materially
+stronger compatibility and durability contracts.
+
+The host lives in the main `whatsapp-rust` crate, not `wacore`: plugins need
+high-level client operations and lifecycle coordination. It is enabled by the
+opt-in `plugins` feature, which enables `client-lifecycle`. A default build has
+neither plugin/lifecycle fields nor their runtime branches.
+
+## Construction boundary
+
+`ClientBuilder` is the canonical low-level construction path. It validates
+dependencies at runtime and returns `Result`; `BotBuilder` remains the
+typestate-preserving facade and delegates to the same path.
+
+Construction follows one publication boundary:
+
+1. validate client dependencies and all plugin manifests;
+2. resolve plugin dependencies topologically;
+3. assemble an inert `Arc<Client>`;
+4. install the upstream lifecycle and plugins while staging their APIs;
+5. start client services;
+6. atomically activate lifecycle/plugin resources and publish the completed
+   build.
+
+Plugin tasks requested during installation remain parked until activation. A
+client leaked through an installation `Weak<Client>` cannot run before the
+construction gate opens.
+
+Installation is transactional. Duplicate IDs or marker types, malformed
+versions, missing/duplicate dependencies, and cycles fail before client
+assembly. If an install fails, is cancelled, panics, or races terminal
+shutdown, staged resources close synchronously and asynchronous shutdown hooks
+run in reverse installation order. Staged APIs stay alive through task drains
+and shutdown hooks.
+
+Plugins are install-once for one `Client`; reconnecting does not replace the
+plugin instance or its exposed API.
+
+## Type-safe APIs
+
+Each plugin chooses an associated API type:
+
+```rust
+use std::sync::Arc;
+
+use anyhow::Result;
+use whatsapp_rust::{ClientPlugin, PluginContext, PluginFuture, PluginManifest};
+
+struct SearchPlugin;
+
+struct SearchApi {
+    // Clone capability handles or plugin-owned state here.
+}
+
+impl SearchApi {
+    async fn search(&self, query: &str) -> Result<Vec<String>> {
+        // Plugin-specific behavior.
+        Ok(vec![query.to_owned()])
+    }
+}
+
+impl ClientPlugin for SearchPlugin {
+    type Api = SearchApi;
+
+    fn manifest(&self) -> PluginManifest {
+        PluginManifest::new("example.search", "0.1.0")
+    }
+
+    fn install(&self, _context: PluginContext) -> PluginFuture<'_, Result<Arc<Self::Api>>> {
+        Box::pin(async { Ok(Arc::new(SearchApi {})) })
+    }
+}
+```
+
+Register and consume it as follows:
+
+```rust
+let client = Client::builder()
+    // platform dependencies...
+    .with_plugin(SearchPlugin)
+    .build()
+    .await?
+    .into_client();
+
+let search: Arc<SearchApi> = client
+    .plugin::<SearchPlugin>()
+    .expect("search plugin is installed");
+let matches = search.search("hello").await?;
+```
+
+The registry is keyed by `TypeId` of the plugin marker, not the API type. Two
+plugins may therefore expose the same API type without colliding.
+`Client::plugin::<P>()` returns `Option<Arc<P::Api>>` because the set of plugins
+is selected at runtime by the builder. Encoding that set in `Client` generics
+would make the client type viral and substantially increase monomorphization.
+
+During installation, `PluginContext::plugin::<P>()` exposes only directly
+declared dependencies. The context keeps a weak dependency view so an API that
+retains its context cannot create a registry ownership cycle. APIs should keep
+plugin-owned state and cloned capability handles; they do not receive the raw
+backend or Signal stores.
+
+The workspace crate `plugins/metrics` is the public-API conformance example. It
+must remain buildable without private access to the main crate.
+
+## Capabilities and trust
+
+A native plugin is trusted in-process Rust code. Its manifest requests
+capabilities, and `PluginContext` exposes only the corresponding small handles:
+
+| Capability identifier | Native handle | Boundary |
+| --- | --- | --- |
+| `events.core.observe` | `PluginCoreEvents` | Selective observation of sealed core events |
+| `tasks.spawn` | `PluginTasks` / `PluginConnectionTasks` | Runtime-agnostic, cancellation-tracked work |
+| `messaging.send` | `PluginMessaging` | High-level message sends |
+| `iq.execute` | `PluginIq` | Typed `IqSpec` execution |
+| `events.plugin.publish` | `PluginEvents` | Publication only in the plugin's own namespace |
+
+This is API shaping, not a security boundary: native code can use any other
+crate dependency available to its process. Runtime grant enforcement belongs
+at a future FFI/sidecar boundary, where every foreign command must be checked.
+Do not add a per-call native capability checker that suggests sandboxing it
+cannot provide.
+
+Capability handles keep `Weak<Client>` internally and reject calls before
+activation or after shutdown. This avoids `Client -> plugin API -> Client`
+cycles and gives terminal resource invalidation a synchronous boundary.
+
+## Lifecycle and task ownership
+
+The host maps the client's existing `connection_generation` to
+`PluginConnectionScope`:
+
+```text
+install once
+    |
+    +-- install-scoped tasks ---------------------------> terminal shutdown
+    |
+    +-- generation N: ready -> cancel -> closed
+    +-- generation N+1: ready -> cancel -> closed
+```
+
+- `install` runs once while the client is inert.
+- `on_ready` runs in dependency order after authentication for that generation.
+- scope cancellation is synchronous when a reconnect or terminal teardown
+  starts.
+- generation tasks drain before `on_closed`; `on_closed` runs in reverse
+  dependency order after authoritative cleanup.
+- install tasks drain before terminal `shutdown`; shutdown hooks run in reverse
+  dependency order.
+- the separately configured upstream lifecycle wraps the plugin order: it is
+  readied first and closed/shut down last.
+
+`PluginTasks` survives reconnects and ends only on rollback or terminal
+shutdown. `PluginConnectionTasks` is tied to one generation and must not leak
+work into a later connection.
+
+Callbacks are serialized, bounded by timeouts, and isolated from panics,
+including panics while constructing, polling, cancelling, or destroying their
+futures. One faulty plugin must not suppress later callbacks. Stale `Ready`
+work is bounded under reconnect pressure; every accepted `Closed` callback is
+lossless and precedes terminal `Shutdown`, so the queue may temporarily exceed
+its target to preserve cleanup.
+
+`signal_shutdown_sync()` closes tasks, subscriptions, event routes, and
+capability handles promptly. `disconnect().await` remains required for async
+task barriers, hooks, durability flushing, and transport teardown. `Drop` can
+only provide the synchronous signal.
+
+## Event boundaries
+
+Core events remain the sealed `wacore::types::events::Event` contract.
+Subscriptions use explicit `EventInterest`; interest changes go through the
+retained `Subscription`, and the aggregate 128-bit mask provides the producer
+fast path. Plugin core handlers run inline, must not block, and should hand work
+to a task capability. `PluginCoreEvents` retains its subscriptions for the
+plugin lifetime; early removal is not part of the initial plugin API. Requesting
+`RawNode` retains a forwarding lease for the same lifetime.
+
+Custom events never enter the core enum or consume an `EventInterest` bit.
+`PluginEventRouter` routes exact `(plugin_id, topic)` selectors and gives each
+consumer an independently bounded queue with `DropNewest` or `DropOldest`.
+Fanout shares one immutable envelope/payload across matching queues.
+
+The native envelope carries:
+
+- plugin ID and validated topic;
+- schema version and payload encoding;
+- opaque payload bytes;
+- connection generation at publication;
+- route-local monotonic sequence.
+
+Dropped events consume sequence numbers so consumers can detect gaps. A route
+clock resets only after its final subscriber leaves. Publishers can check the
+exact route before serializing, and the router filters before constructing an
+envelope; a future adapter must preserve that filter before waking or crossing
+FFI.
+
+`PluginEventSubscription` is an RAII endpoint. Dropping it atomically removes
+all its selectors. Router shutdown rejects new work but lets receivers drain
+already queued envelopes.
+
+## Diagnostics
+
+`Client::plugin_stats()` reports per-plugin lifecycle state, sticky health,
+callback/task failures, active task scopes, subscriptions, and publisher
+counters. `PluginEventRouter::stats()` and `PluginEvents::stats()` expose queue
+and backpressure totals. `Client::memory_report()` includes plugin resources
+and counts a shared queued payload once across fanout.
+
+Snapshots are on-demand, approximate under concurrency, and contain no JIDs,
+phone numbers, or message bodies. See `observability.md` for accounting rules.
+
+## Future foreign-language adapter seam
+
+A future bridge should be a Rust adapter at the host boundary, not a second
+client lifecycle. It can map a foreign endpoint onto the existing semantics:
+
+- build-time registration and stable install-scoped handles across reconnects;
+- explicit capability grants checked for every foreign command;
+- exact core/custom-event subscriptions before serialization or FFI wake-up;
+- one bounded queue and overflow policy per endpoint;
+- lifecycle events keyed by connection generation;
+- event sequences, drop counters, timeouts, and typed failures;
+- synchronous terminal invalidation followed by bounded asynchronous cleanup.
+
+The native structs are not the wire schema. When a bridge consumer is in scope,
+define a separate versioned protocol from a working native + foreign vertical
+slice. It must specify payload/command size limits, batching, unknown-field
+behavior, removed-field reservations, error codes, lifecycle deadlines, schema
+generation, and drift tests. Capability identifiers may be reused, but native
+traits, `Client`, runtime objects, stores, and raw backend access must not cross
+that protocol.
+
+Sidecars, WASM Components/WIT, and sandboxing remain separate decisions. A
+sidecar is justified only when process isolation or a non-FFI runtime is a real
+consumer requirement.
+
+## Review checklist
+
+When extending the host:
+
+- keep default builds free of plugin fields, branches, and linked code;
+- keep `wacore` independent of the high-level plugin host;
+- add capabilities narrowly; never expose the raw backend or Signal stores;
+- choose install- or connection-scoped ownership explicitly for every task;
+- keep core-event handlers non-blocking and custom-event queues bounded;
+- preserve LIFO rollback/shutdown and per-generation close ordering;
+- isolate faults so one plugin cannot strand unrelated cleanup;
+- add plugin resource accounting and health degradation for new retained state
+  or failure modes;
+- validate native and `wasm32-unknown-unknown` builds;
+- measure both feature-disabled and enabled-with-no-plugin paths before claiming
+  zero overhead;
+- defer interception/pre-ack work until its interaction with
+  `signal_durability.md` has a dedicated design.

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -166,6 +166,12 @@ Capability handles keep `Weak<Client>` internally and reject calls before
 activation or after shutdown. This avoids `Client -> plugin API -> Client`
 cycles and gives terminal resource invalidation a synchronous boundary.
 
+`PluginCoreEvents::subscribe` returns the ownership token for its registration.
+Dropping or explicitly unsubscribing that token removes the handler, any
+`RawNodeLease`, and its host registry entry immediately. The host indexes live
+tokens weakly so terminal shutdown can invalidate retained tokens without
+extending the lifetime of registrations that plugins already released.
+
 ## Lifecycle and task ownership
 
 The host maps the client's existing `connection_generation` to

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -125,6 +125,13 @@ plugins may therefore expose the same API type without colliding.
 is selected at runtime by the builder. Encoding that set in `Client` generics
 would make the client type viral and substantially increase monomorphization.
 
+An adapter that represents runtime-defined plugins implements
+`UntypedClientPlugin` and registers each instance with
+`with_untyped_plugin(...)`. Those instances are keyed only by manifest ID, may
+share one concrete Rust adapter type, and do not appear in
+`Client::plugin::<P>()`. Native plugins keep the typed path above; a future
+bridge multiplexes its language-specific handles behind the untyped adapter.
+
 During installation, `PluginContext::plugin::<P>()` exposes only directly
 declared dependencies. The context keeps a weak dependency view so an API that
 retains its context cannot create a registry ownership cycle. APIs should keep
@@ -251,7 +258,10 @@ phone numbers, or message bodies. See `observability.md` for accounting rules.
 ## Future foreign-language adapter seam
 
 A future bridge should be a Rust adapter at the host boundary, not a second
-client lifecycle. It can map a foreign endpoint onto the existing semantics:
+client lifecycle. Each runtime-defined instance can use
+`UntypedClientPlugin`, so one adapter type can host multiple manifest IDs
+without colliding in the native `TypeId` API registry. It can map a foreign
+endpoint onto the existing semantics:
 
 - build-time registration and stable install-scoped handles across reconnects;
 - explicit capability grants checked for every foreign command;

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -131,6 +131,8 @@ An adapter that represents runtime-defined plugins implements
 share one concrete Rust adapter type, and do not appear in
 `Client::plugin::<P>()`. Native plugins keep the typed path above; a future
 bridge multiplexes its language-specific handles behind the untyped adapter.
+`with_untyped_plugin_arc(...)` also accepts a trait object when a host needs to
+erase multiple adapter implementations before configuring the client.
 
 During installation, `PluginContext::plugin::<P>()` exposes only directly
 declared dependencies. The context keeps a weak dependency view so an API that
@@ -199,14 +201,16 @@ host waits only through the configured task-drain deadline, then proceeds and
 marks the plugin degraded if work remains. Plugin tasks must not block an
 executor thread or detach untracked work.
 
-`PluginHostConfig` independently configures per-callback and per-task-drain
-deadlines; both default to five seconds and reject zero. Callbacks are
-serialized, bounded by those timeouts, and isolated from panics,
-including panics while constructing, polling, cancelling, or destroying their
-futures. One faulty plugin must not suppress later callbacks. Stale `Ready`
-work is bounded under reconnect pressure; every accepted `Closed` callback is
-lossless and precedes terminal `Shutdown`, so the queue may temporarily exceed
-its target to preserve cleanup.
+`PluginHostConfig` independently configures installation, per-callback, and
+per-task-drain deadlines. Installation defaults to thirty seconds; callbacks
+and drains default to five seconds; all reject zero. A timed-out partial
+installation is cancelled and follows the same LIFO rollback as an explicit
+failure. Callbacks are serialized, bounded by their timeout, and isolated from
+panics, including panics while constructing, polling, cancelling, or destroying
+their futures. One faulty plugin must not suppress later callbacks. Stale
+`Ready` work is bounded under reconnect pressure; every accepted `Closed`
+callback is lossless and precedes terminal `Shutdown`, so the queue may
+temporarily exceed its target to preserve cleanup.
 
 `signal_shutdown_sync()` closes tasks, subscriptions, event routes, and
 capability handles promptly. `disconnect().await` remains required for async

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -27,6 +27,15 @@ high-level client operations and lifecycle coordination. It is enabled by the
 opt-in `plugins` feature, which enables `client-lifecycle`. A default build has
 neither plugin/lifecycle fields nor their runtime branches.
 
+The public feature surface stays intentionally small: `plugins` is the normal
+opt-in and `client-lifecycle` is the advanced low-level seam for hosts that need
+lifecycle integration without the native plugin host. Capabilities and
+individual plugins do not become Cargo features. An external plugin crate can
+enable `whatsapp-rust/plugins` in its own dependency, so Cargo feature unification
+activates the host for its consumer. The host remains opt-in because LTO is not
+a compatibility guarantee for client layout, reachable branches, dependencies,
+compile time, or final binary size.
+
 ## Construction boundary
 
 `ClientBuilder` is the canonical low-level construction path. It validates
@@ -165,16 +174,20 @@ install once
 - `on_ready` runs in dependency order after authentication for that generation.
 - scope cancellation is synchronous when a reconnect or terminal teardown
   starts.
-- generation tasks drain before `on_closed`; `on_closed` runs in reverse
-  dependency order after authoritative cleanup.
-- install tasks drain before terminal `shutdown`; shutdown hooks run in reverse
-  dependency order.
+- generation task cancellation is signalled before `on_closed`; the host waits
+  for the drain up to its configured timeout, then continues in reverse
+  dependency order and marks the plugin degraded if work remains.
+- install task cancellation follows the same bounded drain before terminal
+  `shutdown`; shutdown hooks run in reverse dependency order.
 - the separately configured upstream lifecycle wraps the plugin order: it is
   readied first and closed/shut down last.
 
-`PluginTasks` survives reconnects and ends only on rollback or terminal
-shutdown. `PluginConnectionTasks` is tied to one generation and must not leak
-work into a later connection.
+`PluginTasks` survives reconnects and receives cancellation only on rollback or
+terminal shutdown. `PluginConnectionTasks` is tied to one generation:
+cancellation is signalled synchronously, while actual future destruction is
+cooperative at executor poll boundaries. Plugin tasks must not block an executor
+thread or detach untracked work. A non-cooperative task may outlive the bounded
+drain, in which case teardown proceeds and diagnostics remain degraded.
 
 Callbacks are serialized, bounded by timeouts, and isolated from panics,
 including panics while constructing, polling, cancelling, or destroying their
@@ -224,10 +237,12 @@ already queued envelopes.
 ## Diagnostics
 
 `Client::plugin_stats()` reports per-plugin lifecycle state, sticky health,
-callback/task failures, active task scopes, subscriptions, and publisher
-counters. `PluginEventRouter::stats()` and `PluginEvents::stats()` expose queue
-and backpressure totals. `Client::memory_report()` includes plugin resources
-and counts a shared queued payload once across fanout.
+callback failures, spawned-task panics, drain timeouts, active task scopes,
+subscriptions, and publisher counters. Spawned task panics are isolated during
+polling and cancellation so a dead worker cannot remain falsely healthy.
+`PluginEventRouter::stats()` and `PluginEvents::stats()` expose queue and
+backpressure totals. `Client::memory_report()` includes plugin resources and
+counts a shared queued payload once across fanout.
 
 Snapshots are on-demand, approximate under concurrency, and contain no JIDs,
 phone numbers, or message bodies. See `observability.md` for accounting rules.

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -215,9 +215,10 @@ Core events remain the sealed `wacore::types::events::Event` contract.
 Subscriptions use explicit `EventInterest`; interest changes go through the
 retained `Subscription`, and the aggregate 128-bit mask provides the producer
 fast path. Plugin core handlers run inline, must not block, and should hand work
-to a task capability. `PluginCoreEvents` retains its subscriptions for the
-plugin lifetime; early removal is not part of the initial plugin API. Requesting
-`RawNode` retains a forwarding lease for the same lifetime.
+to a task capability. `PluginCoreEvents::subscribe` returns an owned token;
+dropping or explicitly unsubscribing it removes the handler immediately, while
+host shutdown invalidates tokens retained by plugin APIs. Updating its interest
+also acquires or releases the `RawNode` forwarding lease in the same operation.
 
 Custom events never enter the core enum or consume an `EventInterest` bit.
 `PluginEventRouter` routes exact `(plugin_id, topic)` selectors and gives each

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -54,7 +54,8 @@ Construction follows one publication boundary:
 
 Plugin tasks requested during installation remain parked until activation. A
 client leaked through an installation `Weak<Client>` cannot run before the
-construction gate opens.
+construction gate opens. Plugin APIs, manifests, diagnostics, and custom-event
+routing also remain hidden until that final publication succeeds.
 
 Installation is transactional. Duplicate IDs or marker types, malformed
 versions, missing/duplicate dependencies, and cycles fail before client

--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -191,13 +191,17 @@ install once
   readied first and closed/shut down last.
 
 `PluginTasks` survives reconnects and receives cancellation only on rollback or
-terminal shutdown. `PluginConnectionTasks` is tied to one generation:
-cancellation is signalled synchronously, while actual future destruction is
-cooperative at executor poll boundaries. Plugin tasks must not block an executor
-thread or detach untracked work. A non-cooperative task may outlive the bounded
-drain, in which case teardown proceeds and diagnostics remain degraded.
+terminal shutdown. `PluginConnectionTasks` is tied to one generation. Their
+default `spawn` drops the future when cancellation wins. `spawn_cooperative`
+instead keeps polling accepted work after signalling shutdown; that future must
+observe `shutdown_signal()` or `cancellation_signal()` and finish itself. The
+host waits only through the configured task-drain deadline, then proceeds and
+marks the plugin degraded if work remains. Plugin tasks must not block an
+executor thread or detach untracked work.
 
-Callbacks are serialized, bounded by timeouts, and isolated from panics,
+`PluginHostConfig` independently configures per-callback and per-task-drain
+deadlines; both default to five seconds and reject zero. Callbacks are
+serialized, bounded by those timeouts, and isolated from panics,
 including panics while constructing, polling, cancelling, or destroying their
 futures. One faulty plugin must not suppress later callbacks. Stale `Ready`
 work is bounded under reconnect pressure; every accepted `Closed` callback is

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -1660,7 +1660,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
     // accept flow, so the raw-node-forwarding crutch the old hand-rolled inbound path needed is gone.
     let manages_media = accept || target.is_some();
     let observer = Arc::new(CallObserver::new(client.clone(), accept, video, audio));
-    client.register_handler(observer.clone());
+    let _observer_subscription = client.subscribe_handler(observer.clone());
 
     if let Some(peer) = target {
         let client2 = client.clone();

--- a/plugins/metrics/Cargo.toml
+++ b/plugins/metrics/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "whatsapp-rust-plugin-metrics"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Reference external metrics plugin for whatsapp-rust"
+
+[dependencies]
+anyhow = { workspace = true }
+bon = { workspace = true }
+portable-atomic = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+whatsapp-rust = { path = "../..", default-features = false, features = ["plugins"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+whatsapp-rust = { path = "../..", default-features = false, features = [
+    "plugins",
+    "tokio-runtime",
+] }
+
+[lints]
+workspace = true

--- a/plugins/metrics/src/lib.rs
+++ b/plugins/metrics/src/lib.rs
@@ -1,0 +1,483 @@
+//! Reference out-of-core plugin exercising typed APIs, scoped tasks, and custom events.
+//!
+//! ```ignore
+//! let client = Client::builder()
+//!     // platform dependencies...
+//!     .with_plugin(MetricsPlugin::default())
+//!     .build()
+//!     .await?
+//!     .into_client();
+//! let metrics = client
+//!     .plugin::<MetricsPlugin>()
+//!     .expect("metrics plugin was registered");
+//! let events = client
+//!     .plugin_event_router()
+//!     .expect("metrics publishes custom events")
+//!     .subscribe(
+//!         [metrics.tick_selector()],
+//!         PluginEventEndpointConfig::new(64, PluginEventOverflow::DropOldest),
+//!     )?;
+//! ```
+
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+use portable_atomic::{AtomicBool, AtomicU64, Ordering};
+use serde::{Deserialize, Serialize};
+use whatsapp_rust::wacore::types::events::{Event, EventHandler, EventInterest, EventKind};
+use whatsapp_rust::{
+    ClientPlugin, PluginCapability, PluginConnectionScope, PluginEventPayloadEncoding,
+    PluginEventSelector, PluginEventTopic, PluginEvents, PluginFuture, PluginManifest, PluginTasks,
+};
+
+pub const METRICS_PLUGIN_ID: &str = "wa.metrics";
+pub const METRICS_TICK_TOPIC: &str = "tick";
+pub const METRICS_TICK_SCHEMA_VERSION: u32 = 1;
+
+/// Stable snapshot exposed by [`MetricsApi`] and encoded in every tick event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[non_exhaustive]
+pub struct MetricsSnapshot {
+    pub core_events: u64,
+    pub messages: u64,
+    pub receipts: u64,
+    pub connected: u64,
+    pub disconnected: u64,
+    pub install_ticks: u64,
+    pub connection_ticks: u64,
+    pub ready_scopes: u64,
+    pub closed_scopes: u64,
+    pub events_enqueued: u64,
+    pub events_dropped: u64,
+    pub publish_failures: u64,
+    pub active_generation: Option<u64>,
+    pub last_closed_generation: Option<u64>,
+    pub shutdown: bool,
+}
+
+#[derive(Default)]
+struct MetricsState {
+    core_events: AtomicU64,
+    messages: AtomicU64,
+    receipts: AtomicU64,
+    connected: AtomicU64,
+    disconnected: AtomicU64,
+    install_ticks: AtomicU64,
+    connection_ticks: AtomicU64,
+    ready_scopes: AtomicU64,
+    closed_scopes: AtomicU64,
+    events_enqueued: AtomicU64,
+    events_dropped: AtomicU64,
+    publish_failures: AtomicU64,
+    active_generation: Mutex<Option<u64>>,
+    last_closed_generation: Mutex<Option<u64>>,
+    shutdown: AtomicBool,
+}
+
+impl MetricsState {
+    fn snapshot(&self) -> MetricsSnapshot {
+        let active_generation = *self
+            .active_generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let last_closed_generation = *self
+            .last_closed_generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        MetricsSnapshot::builder()
+            .core_events(self.core_events.load(Ordering::Relaxed))
+            .messages(self.messages.load(Ordering::Relaxed))
+            .receipts(self.receipts.load(Ordering::Relaxed))
+            .connected(self.connected.load(Ordering::Relaxed))
+            .disconnected(self.disconnected.load(Ordering::Relaxed))
+            .install_ticks(self.install_ticks.load(Ordering::Relaxed))
+            .connection_ticks(self.connection_ticks.load(Ordering::Relaxed))
+            .ready_scopes(self.ready_scopes.load(Ordering::Relaxed))
+            .closed_scopes(self.closed_scopes.load(Ordering::Relaxed))
+            .events_enqueued(self.events_enqueued.load(Ordering::Relaxed))
+            .events_dropped(self.events_dropped.load(Ordering::Relaxed))
+            .publish_failures(self.publish_failures.load(Ordering::Relaxed))
+            .maybe_active_generation(active_generation)
+            .maybe_last_closed_generation(last_closed_generation)
+            .shutdown(self.shutdown.load(Ordering::Acquire))
+            .build()
+    }
+
+    fn open_scope(&self, generation: u64) {
+        self.ready_scopes.fetch_add(1, Ordering::Relaxed);
+        *self
+            .active_generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(generation);
+    }
+
+    fn close_scope(&self, generation: u64) {
+        let mut active = self
+            .active_generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *active == Some(generation) {
+            *active = None;
+        }
+    }
+
+    fn record_closed(&self, generation: u64) {
+        self.closed_scopes.fetch_add(1, Ordering::Relaxed);
+        *self
+            .last_closed_generation
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(generation);
+        self.close_scope(generation);
+    }
+}
+
+struct MetricsEventHandler(Arc<MetricsState>);
+
+impl EventHandler for MetricsEventHandler {
+    fn handle_event(&self, event: Arc<Event>) {
+        self.0.core_events.fetch_add(1, Ordering::Relaxed);
+        match event.kind() {
+            EventKind::Messages => {
+                self.0.messages.fetch_add(1, Ordering::Relaxed);
+            }
+            EventKind::Receipt => {
+                self.0.receipts.fetch_add(1, Ordering::Relaxed);
+            }
+            EventKind::Connected => {
+                self.0.connected.fetch_add(1, Ordering::Relaxed);
+            }
+            EventKind::Disconnected => {
+                self.0.disconnected.fetch_add(1, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Type-safe API returned by `client.plugin::<MetricsPlugin>()`.
+pub struct MetricsApi {
+    state: Arc<MetricsState>,
+    tick_selector: PluginEventSelector,
+}
+
+impl MetricsApi {
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        self.state.snapshot()
+    }
+
+    pub fn tick_selector(&self) -> PluginEventSelector {
+        self.tick_selector.clone()
+    }
+}
+
+/// One metrics-plugin installation. Construct a fresh value for each client.
+pub struct MetricsPlugin {
+    interval: Duration,
+    state: OnceLock<Arc<MetricsState>>,
+}
+
+impl MetricsPlugin {
+    pub const fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            state: OnceLock::new(),
+        }
+    }
+
+    fn state(&self) -> Result<Arc<MetricsState>> {
+        self.state
+            .get()
+            .cloned()
+            .context("metrics plugin is not installed")
+    }
+}
+
+impl Default for MetricsPlugin {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(10))
+    }
+}
+
+impl ClientPlugin for MetricsPlugin {
+    type Api = MetricsApi;
+
+    fn manifest(&self) -> PluginManifest {
+        PluginManifest::new(METRICS_PLUGIN_ID, env!("CARGO_PKG_VERSION"))
+            .with_capability(PluginCapability::CoreEvents)
+            .with_capability(PluginCapability::Tasks)
+            .with_capability(PluginCapability::PluginEvents)
+    }
+
+    fn install(
+        &self,
+        context: whatsapp_rust::PluginContext,
+    ) -> PluginFuture<'_, Result<Arc<Self::Api>>> {
+        Box::pin(async move {
+            ensure!(self.interval != Duration::ZERO, "metrics interval is zero");
+            let core_events = context
+                .core_events()
+                .cloned()
+                .context("core-events capability is missing")?;
+            let tasks = context
+                .tasks()
+                .cloned()
+                .context("tasks capability is missing")?;
+            let plugin_events = context
+                .plugin_events()
+                .cloned()
+                .context("plugin-events capability is missing")?;
+            let tick = PluginEventTopic::new(METRICS_TICK_TOPIC)?;
+            let state = Arc::new(MetricsState::default());
+            self.state
+                .set(state.clone())
+                .map_err(|_| anyhow::anyhow!("metrics plugin was installed more than once"))?;
+
+            core_events.subscribe(
+                EventInterest::of(&[
+                    EventKind::Messages,
+                    EventKind::Receipt,
+                    EventKind::Connected,
+                    EventKind::Disconnected,
+                ]),
+                Arc::new(MetricsEventHandler(state.clone())),
+            )?;
+
+            let api = Arc::new(MetricsApi {
+                state: state.clone(),
+                tick_selector: plugin_events.selector(&tick),
+            });
+            spawn_install_ticker(tasks, plugin_events, tick, state, self.interval)?;
+            Ok(api)
+        })
+    }
+
+    fn on_ready(&self, scope: PluginConnectionScope) -> PluginFuture<'_, Result<()>> {
+        Box::pin(async move {
+            let state = self.state()?;
+            let generation = scope.generation();
+            let tasks = scope
+                .tasks()
+                .cloned()
+                .context("connection tasks capability is missing")?;
+            state.open_scope(generation);
+            let worker_tasks = tasks.clone();
+            let worker_state = state.clone();
+            let interval = self.interval;
+            let guard = ConnectionGuard { state, generation };
+            tasks.spawn(async move {
+                let _guard = guard;
+                while worker_tasks.sleep(interval).await.is_ok() {
+                    worker_state
+                        .connection_ticks
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            })?;
+            Ok(())
+        })
+    }
+
+    fn on_closed(&self, scope: PluginConnectionScope) -> PluginFuture<'_, Result<()>> {
+        Box::pin(async move {
+            self.state()?.record_closed(scope.generation());
+            Ok(())
+        })
+    }
+
+    fn shutdown(&self) -> PluginFuture<'_, Result<()>> {
+        Box::pin(async move {
+            if let Some(state) = self.state.get() {
+                state.shutdown.store(true, Ordering::Release);
+            }
+            Ok(())
+        })
+    }
+}
+
+fn spawn_install_ticker(
+    tasks: PluginTasks,
+    plugin_events: PluginEvents,
+    topic: PluginEventTopic,
+    state: Arc<MetricsState>,
+    interval: Duration,
+) -> Result<()> {
+    let worker_tasks = tasks.clone();
+    tasks.spawn(async move {
+        while worker_tasks.sleep(interval).await.is_ok() {
+            state.install_ticks.fetch_add(1, Ordering::Relaxed);
+            if !plugin_events.has_subscribers(&topic) {
+                continue;
+            }
+            let Ok(payload) = serde_json::to_vec(&state.snapshot()) else {
+                state.publish_failures.fetch_add(1, Ordering::Relaxed);
+                continue;
+            };
+            match plugin_events.publish(
+                &topic,
+                METRICS_TICK_SCHEMA_VERSION,
+                PluginEventPayloadEncoding::Json,
+                payload,
+            ) {
+                Ok(report) => {
+                    state
+                        .events_enqueued
+                        .fetch_add(report.enqueued, Ordering::Relaxed);
+                    state
+                        .events_dropped
+                        .fetch_add(report.dropped, Ordering::Relaxed);
+                }
+                Err(_) => {
+                    state.publish_failures.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    })?;
+    Ok(())
+}
+
+struct ConnectionGuard {
+    state: Arc<MetricsState>,
+    generation: u64,
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.state.close_scope(self.generation);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use whatsapp_rust::async_channel::Receiver;
+    use whatsapp_rust::bytes::Bytes;
+    use whatsapp_rust::http::{HttpClient, HttpRequest, HttpResponse};
+    use whatsapp_rust::store::persistence_manager::PersistenceManager;
+    use whatsapp_rust::transport::{Transport, TransportEvent, TransportFactory};
+    use whatsapp_rust::wacore::store::InMemoryBackend;
+    use whatsapp_rust::{
+        Client, PluginEventEndpointConfig, PluginEventOverflow, PluginEventSubscribeError,
+        TokioRuntime,
+    };
+
+    use super::*;
+
+    #[test]
+    fn retired_scope_cannot_clear_a_newer_generation() {
+        let state = Arc::new(MetricsState::default());
+        state.open_scope(4);
+        let old_guard = ConnectionGuard {
+            state: state.clone(),
+            generation: 4,
+        };
+        state.open_scope(5);
+        drop(old_guard);
+        assert_eq!(state.snapshot().active_generation, Some(5));
+
+        state.record_closed(4);
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.active_generation, Some(5));
+        assert_eq!(snapshot.last_closed_generation, Some(4));
+        state.record_closed(5);
+        assert_eq!(state.snapshot().active_generation, None);
+    }
+
+    struct TestTransport;
+
+    #[whatsapp_rust::async_trait]
+    impl Transport for TestTransport {
+        async fn send(&self, _data: Bytes) -> Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self) {}
+    }
+
+    struct TestTransportFactory;
+
+    #[whatsapp_rust::async_trait]
+    impl TransportFactory for TestTransportFactory {
+        async fn create_transport(&self) -> Result<(Arc<dyn Transport>, Receiver<TransportEvent>)> {
+            let (_sender, receiver) = whatsapp_rust::async_channel::bounded(1);
+            Ok((Arc::new(TestTransport), receiver))
+        }
+    }
+
+    struct TestHttpClient;
+
+    #[whatsapp_rust::async_trait]
+    impl HttpClient for TestHttpClient {
+        async fn execute(&self, _request: HttpRequest) -> Result<HttpResponse> {
+            Ok(HttpResponse {
+                status_code: 200,
+                body: Vec::new(),
+            })
+        }
+    }
+
+    async fn test_client(interval: Duration) -> Arc<Client> {
+        let backend = Arc::new(InMemoryBackend::new());
+        let persistence = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("persistence manager"),
+        );
+        Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence)
+            .with_transport_factory(TestTransportFactory)
+            .with_http_client(TestHttpClient)
+            .with_plugin(MetricsPlugin::new(interval))
+            .build()
+            .await
+            .expect("metrics plugin client")
+            .into_client()
+    }
+
+    #[tokio::test]
+    async fn external_plugin_exposes_typed_api_and_bounded_events() {
+        let client = test_client(Duration::from_millis(2)).await;
+        let api = client.plugin::<MetricsPlugin>().expect("typed metrics API");
+        let router = client.plugin_event_router().expect("plugin event router");
+        let selector = api.tick_selector();
+        let events = router
+            .subscribe(
+                [selector.clone()],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            )
+            .expect("metrics event endpoint");
+
+        let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("metrics tick timeout")
+            .expect("metrics tick");
+        assert_eq!(&*event.plugin_id, METRICS_PLUGIN_ID);
+        assert_eq!(event.topic.as_str(), METRICS_TICK_TOPIC);
+        assert_eq!(event.schema_version, METRICS_TICK_SCHEMA_VERSION);
+        assert_eq!(event.payload_encoding, PluginEventPayloadEncoding::Json);
+        let payload: MetricsSnapshot =
+            serde_json::from_slice(&event.payload).expect("typed metrics payload");
+        assert!(payload.install_ticks > 0);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while events.stats().dropped == 0 {
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("bounded endpoint reports pressure");
+        assert!(api.snapshot().install_ticks >= payload.install_ticks);
+
+        client.disconnect().await;
+        assert!(api.snapshot().shutdown);
+        assert!(matches!(
+            router.subscribe(
+                [selector],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::Closed)
+        ));
+    }
+}

--- a/plugins/metrics/src/lib.rs
+++ b/plugins/metrics/src/lib.rs
@@ -359,7 +359,7 @@ mod tests {
     use whatsapp_rust::wacore::store::InMemoryBackend;
     use whatsapp_rust::{
         Client, PluginEventEndpointConfig, PluginEventOverflow, PluginEventSubscribeError,
-        TokioRuntime,
+        PluginHealth, TokioRuntime,
     };
 
     use super::*;
@@ -469,6 +469,14 @@ mod tests {
         .await
         .expect("bounded endpoint reports pressure");
         assert!(api.snapshot().install_ticks >= payload.install_ticks);
+        let stats = client.plugin_stats().expect("plugin host stats");
+        let metrics = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == METRICS_PLUGIN_ID)
+            .expect("metrics plugin stats");
+        assert_eq!(metrics.health, PluginHealth::Degraded);
+        assert!(metrics.events.expect("metrics event stats").dropped > 0);
 
         client.disconnect().await;
         assert!(api.snapshot().shutdown);

--- a/plugins/metrics/src/lib.rs
+++ b/plugins/metrics/src/lib.rs
@@ -27,8 +27,9 @@ use portable_atomic::{AtomicBool, AtomicU64, Ordering};
 use serde::{Deserialize, Serialize};
 use whatsapp_rust::wacore::types::events::{Event, EventHandler, EventInterest, EventKind};
 use whatsapp_rust::{
-    ClientPlugin, PluginCapability, PluginConnectionScope, PluginEventPayloadEncoding,
-    PluginEventSelector, PluginEventTopic, PluginEvents, PluginFuture, PluginManifest, PluginTasks,
+    ClientPlugin, PluginCapability, PluginConnectionScope, PluginCoreEventSubscription,
+    PluginEventPayloadEncoding, PluginEventSelector, PluginEventTopic, PluginEvents, PluginFuture,
+    PluginManifest, PluginTasks,
 };
 
 pub const METRICS_PLUGIN_ID: &str = "wa.metrics";
@@ -159,6 +160,7 @@ impl EventHandler for MetricsEventHandler {
 pub struct MetricsApi {
     state: Arc<MetricsState>,
     tick_selector: PluginEventSelector,
+    _core_events: PluginCoreEventSubscription,
 }
 
 impl MetricsApi {
@@ -233,7 +235,7 @@ impl ClientPlugin for MetricsPlugin {
                 .set(state.clone())
                 .map_err(|_| anyhow::anyhow!("metrics plugin was installed more than once"))?;
 
-            core_events.subscribe(
+            let core_events = core_events.subscribe(
                 EventInterest::of(&[
                     EventKind::Messages,
                     EventKind::Receipt,
@@ -246,6 +248,7 @@ impl ClientPlugin for MetricsPlugin {
             let api = Arc::new(MetricsApi {
                 state: state.clone(),
                 tick_selector: plugin_events.selector(&tick),
+                _core_events: core_events,
             });
             spawn_install_ticker(tasks, plugin_events, tick, state, self.interval)?;
             Ok(api)

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -846,7 +846,10 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// Register an already-shared manifest-ID-keyed plugin.
     #[cfg(feature = "plugins")]
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
-    pub fn with_untyped_plugin_arc<P: UntypedClientPlugin>(mut self, plugin: Arc<P>) -> Self {
+    pub fn with_untyped_plugin_arc<P: UntypedClientPlugin + ?Sized>(
+        mut self,
+        plugin: Arc<P>,
+    ) -> Self {
         self.plugins
             .push(PluginRegistration::new_untyped_arc(plugin));
         self

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -815,6 +815,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
 
     /// Register a native plugin without changing the builder's typestate.
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub fn with_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
         self.plugins.push(PluginRegistration::new(plugin));
         self
@@ -822,6 +823,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
 
     /// Register an already-shared native plugin without changing its marker type.
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins.push(PluginRegistration::new_arc(plugin));
         self

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -546,46 +546,7 @@ impl Bot {
         } = self;
 
         if let Some(receiver) = sync_task_receiver {
-            // This channel carries only HistorySync tasks: app-state sync runs via
-            // its own direct path (fetch_app_state_with_retry), nothing enqueues
-            // AppStateSync here. Chunks are independent (order-free upserts; the
-            // event carries chunk_order), so ingest concurrently, bounded low — each
-            // in-flight chunk decompresses a blob and the connect path is peak-
-            // memory-conscious (WA Web caps at histSyncChunk=3). Taking the permit in
-            // the recv loop backpressures history intake on a burst; since no
-            // app-state task flows here, that can't head-of-line block one.
-            const HISTORY_SYNC_CONCURRENCY: usize = 2;
-            let worker_client = Arc::downgrade(&client);
-            let history_permits = Arc::new(async_lock::Semaphore::new(HISTORY_SYNC_CONCURRENCY));
-            client
-                .runtime
-                .spawn(Box::pin(async move {
-                    while let Ok(task) = receiver.recv().await {
-                        let Some(worker_client) = worker_client.upgrade() else {
-                            break;
-                        };
-
-                        if matches!(task, crate::sync_task::MajorSyncTask::HistorySync { .. }) {
-                            let permit = history_permits.acquire_arc().await;
-                            let task_client = worker_client.clone();
-                            worker_client
-                                .runtime
-                                .spawn(Box::pin(async move {
-                                    let _permit = permit;
-                                    task_client.process_sync_task(task).await;
-                                }))
-                                .detach();
-                        } else {
-                            // Defensive: nothing enqueues AppStateSync today, but if
-                            // that changes it must run serially (ordered patches).
-                            worker_client.process_sync_task(task).await;
-                        }
-                    }
-                    info!(
-                        "Sync worker intake loop finished (detached history-sync tasks may still be running)."
-                    );
-                }))
-                .detach();
+            client.start_sync_task_worker(receiver);
         }
 
         if !event_handlers.is_empty() {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,6 +1,7 @@
 use crate::cache_config::CacheConfig;
 use crate::client::{Client, ClientBuilderError};
 use crate::pair_code::PairCodeOptions;
+#[cfg(feature = "plugins")]
 use crate::plugins::{ClientPlugin, PluginRegistration};
 use crate::store::commands::DeviceCommand;
 use crate::store::error::StoreError;
@@ -672,6 +673,7 @@ pub struct BotBuilder<
     resend_rate_limit: Option<(u32, u32)>,
     task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
+    #[cfg(feature = "plugins")]
     plugins: Vec<PluginRegistration>,
     _marker: PhantomData<(B, T, H, R)>,
 }
@@ -698,6 +700,7 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             resend_rate_limit: None,
             task_instrument: None,
             alloc_meter: None,
+            #[cfg(feature = "plugins")]
             plugins: Vec::new(),
             _marker: PhantomData,
         }
@@ -728,6 +731,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             resend_rate_limit: self.resend_rate_limit,
             task_instrument: self.task_instrument,
             alloc_meter: self.alloc_meter,
+            #[cfg(feature = "plugins")]
             plugins: self.plugins,
             _marker: PhantomData,
         }
@@ -849,12 +853,14 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     }
 
     /// Register a native plugin without changing the builder's typestate.
+    #[cfg(feature = "plugins")]
     pub fn with_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
         self.plugins.push(PluginRegistration::new(plugin));
         self
     }
 
     /// Register an already-shared native plugin without changing its marker type.
+    #[cfg(feature = "plugins")]
     pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins.push(PluginRegistration::new_arc(plugin));
         self
@@ -1297,16 +1303,18 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         }
 
         info!("Creating client...");
-        let mut client_builder = Client::builder()
+        let client_builder = Client::builder()
             .with_runtime_arc(runtime)
             .with_persistence_manager(persistence_manager)
             .with_transport_factory_arc(transport_factory)
             .with_http_client_arc(http_client)
             .with_cache_config(self.cache_config)
             .with_custom_enc_handlers(self.custom_enc_handlers)
-            .with_plugin_registrations(self.plugins)
             .with_skip_history_sync(self.skip_history_sync)
             .with_background_saver_interval(std::time::Duration::from_secs(30));
+        #[cfg(feature = "plugins")]
+        let client_builder = client_builder.with_plugin_registrations(self.plugins);
+        let mut client_builder = client_builder;
 
         if let Some(version) = self.override_version {
             client_builder = client_builder.with_version_override(version);
@@ -1402,8 +1410,10 @@ mod tests {
             .client()
     }
 
+    #[cfg(feature = "plugins")]
     struct BotBuilderPlugin;
 
+    #[cfg(feature = "plugins")]
     impl ClientPlugin for BotBuilderPlugin {
         type Api = &'static str;
 
@@ -1419,6 +1429,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "plugins")]
     #[tokio::test]
     async fn typestate_builder_preserves_registered_plugins() {
         let bot = Bot::builder()

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2,7 +2,7 @@ use crate::cache_config::CacheConfig;
 use crate::client::{Client, ClientBuilderError};
 use crate::pair_code::PairCodeOptions;
 #[cfg(feature = "plugins")]
-use crate::plugins::{ClientPlugin, PluginRegistration};
+use crate::plugins::{ClientPlugin, PluginRegistration, UntypedClientPlugin};
 use crate::store::commands::DeviceCommand;
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
@@ -826,6 +826,23 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins.push(PluginRegistration::new_arc(plugin));
+        self
+    }
+
+    /// Register a manifest-ID-keyed plugin that exposes no Rust typed API.
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    pub fn with_untyped_plugin<P: UntypedClientPlugin>(mut self, plugin: P) -> Self {
+        self.plugins.push(PluginRegistration::new_untyped(plugin));
+        self
+    }
+
+    /// Register an already-shared manifest-ID-keyed plugin.
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    pub fn with_untyped_plugin_arc<P: UntypedClientPlugin>(mut self, plugin: Arc<P>) -> Self {
+        self.plugins
+            .push(PluginRegistration::new_untyped_arc(plugin));
         self
     }
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -2,7 +2,7 @@ use crate::cache_config::CacheConfig;
 use crate::client::{Client, ClientBuilderError};
 use crate::pair_code::PairCodeOptions;
 #[cfg(feature = "plugins")]
-use crate::plugins::{ClientPlugin, PluginRegistration, UntypedClientPlugin};
+use crate::plugins::{ClientPlugin, PluginHostConfig, PluginRegistration, UntypedClientPlugin};
 use crate::store::commands::DeviceCommand;
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
@@ -636,6 +636,8 @@ pub struct BotBuilder<
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
     #[cfg(feature = "plugins")]
     plugins: Vec<PluginRegistration>,
+    #[cfg(feature = "plugins")]
+    plugin_host_config: PluginHostConfig,
     _marker: PhantomData<(B, T, H, R)>,
 }
 
@@ -663,6 +665,8 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             alloc_meter: None,
             #[cfg(feature = "plugins")]
             plugins: Vec::new(),
+            #[cfg(feature = "plugins")]
+            plugin_host_config: PluginHostConfig::default(),
             _marker: PhantomData,
         }
     }
@@ -694,6 +698,8 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             alloc_meter: self.alloc_meter,
             #[cfg(feature = "plugins")]
             plugins: self.plugins,
+            #[cfg(feature = "plugins")]
+            plugin_host_config: self.plugin_host_config,
             _marker: PhantomData,
         }
     }
@@ -843,6 +849,14 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     pub fn with_untyped_plugin_arc<P: UntypedClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins
             .push(PluginRegistration::new_untyped_arc(plugin));
+        self
+    }
+
+    /// Configure plugin lifecycle and tracked-task deadlines.
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    pub fn with_plugin_host_config(mut self, config: PluginHostConfig) -> Self {
+        self.plugin_host_config = config;
         self
     }
 
@@ -1293,7 +1307,9 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             .with_skip_history_sync(self.skip_history_sync)
             .with_background_saver_interval(std::time::Duration::from_secs(30));
         #[cfg(feature = "plugins")]
-        let client_builder = client_builder.with_plugin_registrations(self.plugins);
+        let client_builder = client_builder
+            .with_plugin_registrations(self.plugins)
+            .with_plugin_host_config(self.plugin_host_config);
         let mut client_builder = client_builder;
 
         if let Some(version) = self.override_version {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -590,14 +590,15 @@ impl Bot {
             client
                 .core
                 .event_bus
-                .add_handler(Arc::new(CallbackBusAdapter::new(
+                .subscribe_handler(Arc::new(CallbackBusAdapter::new(
                     client.clone(),
                     event_handlers,
                     event_delivery,
-                )));
+                )))
+                .detach();
         }
         for handler in raw_handlers {
-            client.core.event_bus.add_handler(handler);
+            client.core.event_bus.subscribe_handler(handler).detach();
         }
 
         // If pair code options are set, spawn a task to request pair code after socket is ready

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,6 +1,7 @@
 use crate::cache_config::CacheConfig;
 use crate::client::{Client, ClientBuilderError};
 use crate::pair_code::PairCodeOptions;
+use crate::plugins::{ClientPlugin, PluginRegistration};
 use crate::store::commands::DeviceCommand;
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
@@ -671,6 +672,7 @@ pub struct BotBuilder<
     resend_rate_limit: Option<(u32, u32)>,
     task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
+    plugins: Vec<PluginRegistration>,
     _marker: PhantomData<(B, T, H, R)>,
 }
 
@@ -696,6 +698,7 @@ impl BotBuilder<MissingBackend, DefaultTransportState, DefaultHttpState, Default
             resend_rate_limit: None,
             task_instrument: None,
             alloc_meter: None,
+            plugins: Vec::new(),
             _marker: PhantomData,
         }
     }
@@ -725,6 +728,7 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
             resend_rate_limit: self.resend_rate_limit,
             task_instrument: self.task_instrument,
             alloc_meter: self.alloc_meter,
+            plugins: self.plugins,
             _marker: PhantomData,
         }
     }
@@ -841,6 +845,18 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     pub fn with_alloc_meter(mut self, meter: Arc<wacore::stats::AllocMeter>) -> Self {
         self.task_instrument = Some(meter.clone());
         self.alloc_meter = Some(meter);
+        self
+    }
+
+    /// Register a native plugin without changing the builder's typestate.
+    pub fn with_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
+        self.plugins.push(PluginRegistration::new(plugin));
+        self
+    }
+
+    /// Register an already-shared native plugin without changing its marker type.
+    pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
+        self.plugins.push(PluginRegistration::new_arc(plugin));
         self
     }
 
@@ -1288,6 +1304,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             .with_http_client_arc(http_client)
             .with_cache_config(self.cache_config)
             .with_custom_enc_handlers(self.custom_enc_handlers)
+            .with_plugin_registrations(self.plugins)
             .with_skip_history_sync(self.skip_history_sync)
             .with_background_saver_interval(std::time::Duration::from_secs(30));
 
@@ -1383,6 +1400,41 @@ mod tests {
             .await
             .expect("build")
             .client()
+    }
+
+    struct BotBuilderPlugin;
+
+    impl ClientPlugin for BotBuilderPlugin {
+        type Api = &'static str;
+
+        fn manifest(&self) -> crate::plugins::PluginManifest {
+            crate::plugins::PluginManifest::new("bot-builder-test", "0.1.0")
+        }
+
+        fn install(
+            &self,
+            _context: crate::plugins::PluginContext,
+        ) -> wacore::runtime::BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new("installed")) })
+        }
+    }
+
+    #[tokio::test]
+    async fn typestate_builder_preserves_registered_plugins() {
+        let bot = Bot::builder()
+            .with_plugin(BotBuilderPlugin)
+            .with_backend_arc(create_test_sqlite_backend().await)
+            .with_transport_factory(TokioWebSocketTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_runtime(TokioRuntime)
+            .build()
+            .await
+            .expect("bot plugin build");
+        assert_eq!(
+            bot.client().plugin::<BotBuilderPlugin>().as_deref(),
+            Some(&"installed")
+        );
+        bot.client().disconnect().await;
     }
 
     fn pairing_code_event(code: &str) -> Arc<Event> {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,5 +1,5 @@
 use crate::cache_config::CacheConfig;
-use crate::client::Client;
+use crate::client::{Client, ClientBuilderError};
 use crate::pair_code::PairCodeOptions;
 use crate::store::commands::DeviceCommand;
 use crate::store::error::StoreError;
@@ -87,49 +87,8 @@ pub enum BotBuilderError {
     /// Initializing the device row in the storage backend failed.
     #[error("failed to initialize the device store: {0}")]
     Store(#[from] StoreError),
-    /// An inbound durability hook was registered with a backend that does not
-    /// implement the pending-inbound buffer it requires.
-    #[error("the configured backend does not support the inbound durability hook: {0}")]
-    UnsupportedDurabilityBackend(String),
-}
-
-/// Verify the backend round-trips a pending-inbound buffer entry before we accept
-/// an inbound durability hook. A backend relying on the no-op/`Err` trait
-/// defaults fails here instead of silently looping every inbound message unacked.
-async fn probe_durability_backend(
-    backend: &std::sync::Arc<dyn Backend>,
-) -> std::result::Result<(), BotBuilderError> {
-    // A real JID (a backend may validate the format) and an id unique per probe
-    // invocation (pid + atomic counter) so concurrent builders on the same store
-    // never race on a shared probe row and false-fail.
-    use portable_atomic::{AtomicU64, Ordering};
-    static PROBE_SEQ: AtomicU64 = AtomicU64::new(0);
-    const PROBE_JID: &str = "0@s.whatsapp.net";
-    const PROBE_PAYLOAD: &[u8] = b"probe";
-    let probe_id = format!(
-        "__wa_durability_probe_{}_{}__",
-        std::process::id(),
-        PROBE_SEQ.fetch_add(1, Ordering::Relaxed)
-    );
-    let map_err = |e: StoreError| BotBuilderError::UnsupportedDurabilityBackend(e.to_string());
-    backend
-        .store_pending_inbound(PROBE_JID, PROBE_JID, &probe_id, PROBE_PAYLOAD)
-        .await
-        .map_err(map_err)?;
-    let got = backend
-        .get_pending_inbound(PROBE_JID, PROBE_JID, &probe_id)
-        .await
-        .map_err(map_err)?;
-    backend
-        .delete_pending_inbound(PROBE_JID, PROBE_JID, &probe_id)
-        .await
-        .map_err(map_err)?;
-    if got.as_deref() != Some(PROBE_PAYLOAD) {
-        return Err(BotBuilderError::UnsupportedDurabilityBackend(
-            "pending-inbound buffer did not round-trip".to_string(),
-        ));
-    }
-    Ok(())
+    #[error(transparent)]
+    Client(#[from] ClientBuilderError),
 }
 
 /// `message` is `Arc` so cloning the context across spawned tasks only bumps a
@@ -1278,18 +1237,8 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             unreachable!("typestate guarantees all required fields are Provided")
         };
 
-        // Instrument the runtime before anything spawns through it, so every
-        // internal task (noise sender, saver, workers) reports to the hook.
-        // Default (None): the original runtime is used untouched. The Bot
-        // keeps its own copy for the `run()` path (see the field doc).
         let task_instrument = self.task_instrument;
         let alloc_meter = self.alloc_meter;
-        let runtime: Arc<dyn Runtime> = match task_instrument.clone() {
-            Some(instrument) => {
-                Arc::new(wacore::stats::InstrumentedRuntime::new(runtime, instrument))
-            }
-            None => runtime,
-        };
 
         // Note: For multi-account mode, create the backend with SqliteStore::new_for_device()
         // before passing it to with_backend_arc()
@@ -1331,57 +1280,37 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
         }
 
         info!("Creating client...");
-        let (client, sync_task_receiver) = Client::new_with_cache_config(
-            runtime.clone(),
-            persistence_manager.clone(),
-            transport_factory,
-            http_client,
-            self.override_version,
-            self.cache_config,
-        )
-        .await;
+        let mut client_builder = Client::builder()
+            .with_runtime_arc(runtime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory_arc(transport_factory)
+            .with_http_client_arc(http_client)
+            .with_cache_config(self.cache_config)
+            .with_custom_enc_handlers(self.custom_enc_handlers)
+            .with_skip_history_sync(self.skip_history_sync)
+            .with_background_saver_interval(std::time::Duration::from_secs(30));
 
-        let saver_handle = persistence_manager.run_background_saver(
-            runtime,
-            std::time::Duration::from_secs(30),
-            client.shutdown_signal(),
-        );
-        // Tie the saver task to Arc<Client> so extracting client() and outliving
-        // Bot keeps periodic persistence alive. Client::drop on the last Arc
-        // drops the AbortHandle and aborts the task.
-        let _ = client.saver_handle.set(saver_handle);
-
-        // Typed alloc-meter handle for resource_report (its poll hooks are
-        // already wired via task_instrument above).
-        if let Some(meter) = alloc_meter {
-            let _ = client.alloc_meter.set(meter);
+        if let Some(version) = self.override_version {
+            client_builder = client_builder.with_version_override(version);
         }
-
-        // Register custom enc handlers. Immutable after build, so set the whole
-        // map once; the receive hot path then reads it lock-free.
-        let _ = client.custom_enc_handlers.set(self.custom_enc_handlers);
-
-        // Inbound durability hook (opt-in). Immutable after build; the receive
-        // path reads it lock-free. Probe the backend first: a backend that does
-        // not implement the pending-inbound buffer would otherwise leave every
-        // inbound message unacked and looping forever at runtime, so reject it
-        // here with a clear error instead.
         if let Some(hook) = self.inbound_durability_hook {
-            probe_durability_backend(&client.persistence_manager.backend()).await?;
-            let _ = client.inbound_durability_hook.set(hook);
+            client_builder = client_builder.with_inbound_durability_hook_arc(hook);
         }
-
-        if self.skip_history_sync {
-            client.set_skip_history_sync(true);
-        }
-
         if let Some(count) = self.wanted_pre_key_count {
-            client.set_wanted_pre_key_count(count);
+            client_builder = client_builder.with_wanted_pre_key_count(count);
         }
-
         if let Some((burst, refill_per_min)) = self.resend_rate_limit {
-            client.set_resend_rate_limit(burst, refill_per_min);
+            client_builder = client_builder.with_resend_rate_limit(burst, refill_per_min);
         }
+        client_builder = match alloc_meter {
+            Some(meter) => client_builder.with_alloc_meter(meter),
+            None => match task_instrument.clone() {
+                Some(instrument) => client_builder.with_task_instrument(instrument),
+                None => client_builder,
+            },
+        };
+
+        let (client, sync_task_receiver) = client_builder.build().await?.into_parts();
 
         Ok(Bot {
             client,

--- a/src/client.rs
+++ b/src/client.rs
@@ -57,6 +57,25 @@ use portable_atomic::{AtomicI64, AtomicU64};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 
+/// Lease that keeps raw decoded stanza events enabled for one consumer.
+///
+/// Dropping the final lease disables forwarding. The lease holds only a weak
+/// client reference, so it cannot keep the client alive.
+#[must_use = "dropping the lease immediately releases raw-node forwarding"]
+pub struct RawNodeLease {
+    client: std::sync::Weak<Client>,
+}
+
+impl Drop for RawNodeLease {
+    fn drop(&mut self) {
+        let Some(client) = self.client.upgrade() else {
+            return;
+        };
+        let previous = client.raw_node_forwarding.fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(previous > 0, "raw-node forwarding lease underflow");
+    }
+}
+
 /// Filter for matching incoming stanzas (nodes) by tag and attributes.
 ///
 /// Used with [`Client::wait_for_node`] to wait for specific stanzas.
@@ -1020,9 +1039,8 @@ pub struct Client {
     /// its allocation-churn snapshot. Unset unless that builder method was used.
     pub(crate) alloc_meter: std::sync::OnceLock<Arc<wacore::stats::AllocMeter>>,
 
-    /// When true, emit `Event::RawNode` for every decoded stanza before router dispatch.
-    /// Default false — only enable when external consumers need raw protocol access.
-    raw_node_forwarding: AtomicBool,
+    /// Number of consumers currently requesting `Event::RawNode` forwarding.
+    raw_node_forwarding: AtomicUsize,
 
     /// Active VoIP calls and their media-task abort handles. `abort_all` runs from the
     /// connection-cleanup path so a disconnect/reconnect tears down every in-flight call. Behind the

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ mod builder;
 mod context_impl;
 mod device_registry;
 pub(crate) mod device_topology;
+mod extension_lifecycle;
 mod iq_ops;
 mod lid_pn;
 mod lifecycle;
@@ -16,6 +17,8 @@ mod sessions;
 mod voip;
 use builder::ClientAssembly;
 pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
+use extension_lifecycle::LifecycleRegistration;
+pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
 pub use voip::{CallError, Voip};
 
 use crate::cache::Cache;
@@ -665,6 +668,8 @@ pub struct Client {
     /// error / connect_failure / disconnect. Per-connection subscribers
     /// (keepalive, request waiters, read loop, offline flush) observe this.
     pub(crate) connection_shutdown: std::sync::Mutex<wacore::runtime::ShutdownNotifier>,
+    /// Allocated only when an extension host installs lifecycle callbacks.
+    lifecycle: Option<Arc<LifecycleRegistration>>,
     /// Per-session wire I/O and activity counters. Written at the transport
     /// chokepoints (noise sender task, read loop); the keepalive dead-socket
     /// watchdog reads its activity timestamps. Snapshot via [`Client::stats`].

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 mod accessors;
 mod adapters;
 mod app_state;
+mod builder;
 mod context_impl;
 mod device_registry;
 pub(crate) mod device_topology;
@@ -13,6 +14,8 @@ pub(crate) mod offline_resume;
 mod sender_keys;
 mod sessions;
 mod voip;
+use builder::ClientAssembly;
+pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
 pub use voip::{CallError, Voip};
 
 use crate::cache::Cache;

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ pub(crate) mod offline_resume;
 mod sender_keys;
 mod sessions;
 mod voip;
-use builder::ClientAssembly;
+use builder::{ClientAssembly, ClientExtensions};
 pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
 use extension_lifecycle::LifecycleRegistration;
 pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
@@ -689,6 +689,8 @@ pub struct Client {
     pub(crate) connection_shutdown: std::sync::Mutex<wacore::runtime::ShutdownNotifier>,
     /// Allocated only when an extension host installs lifecycle callbacks.
     lifecycle: Option<Arc<LifecycleRegistration>>,
+    /// Allocated only when at least one build-time plugin is registered.
+    pub(crate) plugin_host: Option<Arc<crate::plugins::PluginHost>>,
     /// Per-session wire I/O and activity counters. Written at the transport
     /// chokepoints (noise sender task, read loop); the keepalive dead-socket
     /// watchdog reads its activity timestamps. Snapshot via [`Client::stats`].

--- a/src/client.rs
+++ b/src/client.rs
@@ -704,6 +704,7 @@ pub struct Client {
     pub(crate) media_conn: Arc<RwLock<Option<crate::mediaconn::MediaConn>>>,
 
     pub(crate) is_logged_in: Arc<AtomicBool>,
+    #[cfg(feature = "client-lifecycle")]
     pub(crate) login_transition: std::sync::Mutex<()>,
     pub(crate) is_connecting: Arc<AtomicBool>,
     pub(crate) is_running: Arc<AtomicBool>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -690,6 +690,7 @@ pub struct Client {
     /// Allocated only when an extension host installs lifecycle callbacks.
     lifecycle: Option<Arc<LifecycleRegistration>>,
     /// Allocated only when at least one build-time plugin is registered.
+    #[cfg(feature = "plugins")]
     pub(crate) plugin_host: Option<Arc<crate::plugins::PluginHost>>,
     /// Per-session wire I/O and activity counters. Written at the transport
     /// chokepoints (noise sender task, read loop); the keepalive dead-socket

--- a/src/client.rs
+++ b/src/client.rs
@@ -659,6 +659,7 @@ pub struct Client {
     pub(crate) media_conn: Arc<RwLock<Option<crate::mediaconn::MediaConn>>>,
 
     pub(crate) is_logged_in: Arc<AtomicBool>,
+    pub(crate) login_transition: std::sync::Mutex<()>,
     pub(crate) is_connecting: Arc<AtomicBool>,
     pub(crate) is_running: Arc<AtomicBool>,
     /// Whether the noise socket is established (connected to WhatsApp servers).

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ mod builder;
 mod context_impl;
 mod device_registry;
 pub(crate) mod device_topology;
+#[cfg(feature = "client-lifecycle")]
 mod extension_lifecycle;
 mod iq_ops;
 mod lid_pn;
@@ -17,7 +18,9 @@ mod sessions;
 mod voip;
 use builder::{ClientAssembly, ClientExtensions};
 pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
+#[cfg(feature = "client-lifecycle")]
 use extension_lifecycle::LifecycleRegistration;
+#[cfg(feature = "client-lifecycle")]
 pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
 pub use voip::{CallError, Voip};
 
@@ -689,6 +692,7 @@ pub struct Client {
     /// (keepalive, request waiters, read loop, offline flush) observe this.
     pub(crate) connection_shutdown: std::sync::Mutex<wacore::runtime::ShutdownNotifier>,
     /// Allocated only when an extension host installs lifecycle callbacks.
+    #[cfg(feature = "client-lifecycle")]
     lifecycle: Option<Arc<LifecycleRegistration>>,
     /// Allocated only when at least one build-time plugin is registered.
     #[cfg(feature = "plugins")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -295,15 +295,31 @@ pub struct MemoryReport {
     pub signal_sessions: CollectionStats,
     pub signal_identities: CollectionStats,
     pub signal_sender_keys: CollectionStats,
+    #[cfg(feature = "plugins")]
+    pub plugins: u64,
+    #[cfg(feature = "plugins")]
+    pub plugin_install_tasks: u64,
+    #[cfg(feature = "plugins")]
+    pub plugin_connection_tasks: u64,
+    #[cfg(feature = "plugins")]
+    pub plugin_connection_generations: u64,
+    #[cfg(feature = "plugins")]
+    pub plugin_core_event_subscriptions: u64,
+    #[cfg(feature = "plugins")]
+    pub plugin_event_endpoints: u64,
+    #[cfg(feature = "plugins")]
+    pub plugin_event_endpoint_capacity: u64,
+    /// Unique custom-event envelopes and payload bytes still retained in endpoint queues.
+    #[cfg(feature = "plugins")]
+    pub plugin_event_queue: CollectionStats,
     // -- Misc --
     pub chatstate_handlers: usize,
     pub custom_enc_handlers: usize,
 }
 
 impl MemoryReport {
-    /// Every byte-carrying collection with its display name — the single list
-    /// [`Self::total_estimated_bytes`] and `Display` derive from, so a new
-    /// collection cannot be summed but not shown (or vice versa).
+    /// Common byte-carrying collections used by both totals and `Display`.
+    /// Feature-specific collections stay beside their gated report section.
     fn collections(&self) -> [(&'static str, &CollectionStats); 11] {
         [
             ("group_cache:", &self.group_cache),
@@ -322,7 +338,10 @@ impl MemoryReport {
 
     /// Sum of every estimated byte figure in the report.
     pub fn total_estimated_bytes(&self) -> u64 {
-        self.collections().iter().map(|(_, c)| c.bytes).sum()
+        let total: u64 = self.collections().iter().map(|(_, c)| c.bytes).sum();
+        #[cfg(feature = "plugins")]
+        let total = total.saturating_add(self.plugin_event_queue.bytes);
+        total
     }
 }
 
@@ -404,6 +423,28 @@ impl std::fmt::Display for MemoryReport {
             "  peak payload storage:   {} B",
             self.history_sync_payload_bytes_peak
         )?;
+        #[cfg(feature = "plugins")]
+        {
+            writeln!(f, "--- Plugins ---")?;
+            writeln!(f, "  installed:              {}", self.plugins)?;
+            writeln!(f, "  install tasks:          {}", self.plugin_install_tasks)?;
+            writeln!(
+                f,
+                "  connection tasks:       {} (generations: {})",
+                self.plugin_connection_tasks, self.plugin_connection_generations
+            )?;
+            writeln!(
+                f,
+                "  core subscriptions:     {}",
+                self.plugin_core_event_subscriptions
+            )?;
+            writeln!(
+                f,
+                "  event endpoints:        {} (capacity: {})",
+                self.plugin_event_endpoints, self.plugin_event_endpoint_capacity
+            )?;
+            line(f, "event_queue:", &self.plugin_event_queue)?;
+        }
         writeln!(f, "--- Misc ---")?;
         writeln!(f, "  chatstate_handlers:     {}", self.chatstate_handlers)?;
         writeln!(f, "  custom_enc_handlers:    {}", self.custom_enc_handlers)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,7 @@ pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
 #[cfg(feature = "client-lifecycle")]
 use extension_lifecycle::LifecycleRegistration;
 #[cfg(feature = "client-lifecycle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
 pub use voip::{CallError, Voip};
 

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -44,12 +44,24 @@ impl Client {
         self.core.event_bus.subscribe_handler(handler)
     }
 
-    /// Enable or disable raw node forwarding.
-    /// When enabled, `Event::RawNode` is emitted for every decoded stanza before
-    /// the stanza router dispatches it. Only enable when external consumers need
-    /// raw protocol access (e.g. voice call stanzas).
-    pub fn set_raw_node_forwarding(&self, enabled: bool) {
-        self.raw_node_forwarding.store(enabled, Ordering::Relaxed);
+    /// Acquire raw decoded stanza forwarding for one consumer.
+    ///
+    /// `Event::RawNode` remains enabled until every acquired lease is dropped.
+    pub fn acquire_raw_node_forwarding(self: &Arc<Self>) -> RawNodeLease {
+        let incremented = self
+            .raw_node_forwarding
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                count.checked_add(1)
+            })
+            .is_ok();
+        assert!(incremented, "raw-node forwarding lease counter overflow");
+        RawNodeLease {
+            client: Arc::downgrade(self),
+        }
+    }
+
+    pub(crate) fn raw_node_forwarding_enabled(&self) -> bool {
+        self.raw_node_forwarding.load(Ordering::Relaxed) != 0
     }
 
     /// Enable or disable skipping of history sync notifications at runtime.
@@ -525,6 +537,24 @@ impl Client {
         router.register(Arc::new(crate::handlers::presence::PresenceHandler));
 
         router
+    }
+}
+
+#[cfg(test)]
+mod raw_node_tests {
+    #[tokio::test]
+    async fn raw_node_forwarding_stays_enabled_until_the_last_lease_drops() {
+        let client = crate::test_utils::create_test_client().await;
+        assert!(!client.raw_node_forwarding_enabled());
+
+        let first = client.acquire_raw_node_forwarding();
+        let second = client.acquire_raw_node_forwarding();
+        assert!(client.raw_node_forwarding_enabled());
+
+        drop(first);
+        assert!(client.raw_node_forwarding_enabled());
+        drop(second);
+        assert!(!client.raw_node_forwarding_enabled());
     }
 }
 

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -193,6 +193,43 @@ impl Client {
             history_sync_activity.tasks as u64,
             history_sync_activity.payload_bytes as u64,
         );
+        #[cfg(feature = "plugins")]
+        let plugin_stats = self.plugin_stats();
+        #[cfg(feature = "plugins")]
+        let (
+            plugins,
+            plugin_install_tasks,
+            plugin_connection_tasks,
+            plugin_connection_generations,
+            plugin_core_event_subscriptions,
+        ) = plugin_stats
+            .as_ref()
+            .map(|host| {
+                host.plugins.iter().fold(
+                    (
+                        u64::try_from(host.plugins.len()).unwrap_or(u64::MAX),
+                        0u64,
+                        0u64,
+                        0u64,
+                        0u64,
+                    ),
+                    |(plugins, install, connection, generations, subscriptions), plugin| {
+                        (
+                            plugins,
+                            install.saturating_add(plugin.install_tasks),
+                            connection.saturating_add(plugin.connection_tasks),
+                            generations.saturating_add(plugin.connection_generations),
+                            subscriptions.saturating_add(plugin.core_event_subscriptions),
+                        )
+                    },
+                )
+            })
+            .unwrap_or_default();
+        #[cfg(feature = "plugins")]
+        let plugin_event_router = plugin_stats
+            .as_ref()
+            .and_then(|host| host.event_router)
+            .unwrap_or_default();
 
         MemoryReport {
             group_cache,
@@ -224,6 +261,25 @@ impl Client {
             signal_sessions,
             signal_identities,
             signal_sender_keys,
+            #[cfg(feature = "plugins")]
+            plugins,
+            #[cfg(feature = "plugins")]
+            plugin_install_tasks,
+            #[cfg(feature = "plugins")]
+            plugin_connection_tasks,
+            #[cfg(feature = "plugins")]
+            plugin_connection_generations,
+            #[cfg(feature = "plugins")]
+            plugin_core_event_subscriptions,
+            #[cfg(feature = "plugins")]
+            plugin_event_endpoints: plugin_event_router.active_endpoints,
+            #[cfg(feature = "plugins")]
+            plugin_event_endpoint_capacity: plugin_event_router.endpoint_capacity,
+            #[cfg(feature = "plugins")]
+            plugin_event_queue: CollectionStats::new(
+                plugin_event_router.queued_events,
+                plugin_event_router.queued_payload_bytes,
+            ),
             chatstate_handlers,
             custom_enc_handlers: self.custom_enc_handlers.get().map_or(0, |m| m.len()),
         }

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -27,9 +27,21 @@ impl Client {
         cache
     }
 
-    /// Registers an external event handler to the core event bus.
-    pub fn register_handler(&self, handler: Arc<dyn wacore::types::events::EventHandler>) {
-        self.core.event_bus.add_handler(handler);
+    /// Subscribe an external event handler with an explicit event filter.
+    pub fn subscribe(
+        &self,
+        interest: wacore::types::events::EventInterest,
+        handler: Arc<dyn wacore::types::events::EventHandler>,
+    ) -> wacore::types::events::Subscription {
+        self.core.event_bus.subscribe(interest, handler)
+    }
+
+    /// Subscribe using the handler's current registration-time interest hint.
+    pub fn subscribe_handler(
+        &self,
+        handler: Arc<dyn wacore::types::events::EventHandler>,
+    ) -> wacore::types::events::Subscription {
+        self.core.event_bus.subscribe_handler(handler)
     }
 
     /// Enable or disable raw node forwarding.

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -276,6 +276,42 @@ impl Client {
         pre_downloaded
     }
 
+    pub(crate) fn start_sync_task_worker(
+        self: &Arc<Self>,
+        receiver: async_channel::Receiver<crate::sync_task::MajorSyncTask>,
+    ) {
+        const HISTORY_SYNC_CONCURRENCY: usize = 2;
+
+        let worker_client = Arc::downgrade(self);
+        let history_permits = Arc::new(async_lock::Semaphore::new(HISTORY_SYNC_CONCURRENCY));
+        self.runtime
+            .spawn(Box::pin(async move {
+                while let Ok(task) = receiver.recv().await {
+                    let Some(worker_client) = worker_client.upgrade() else {
+                        break;
+                    };
+
+                    if matches!(task, crate::sync_task::MajorSyncTask::HistorySync { .. }) {
+                        let permit = history_permits.acquire_arc().await;
+                        let task_client = worker_client.clone();
+                        worker_client
+                            .runtime
+                            .spawn(Box::pin(async move {
+                                let _permit = permit;
+                                task_client.process_sync_task(task).await;
+                            }))
+                            .detach();
+                    } else {
+                        worker_client.process_sync_task(task).await;
+                    }
+                }
+                info!(
+                    "Sync worker intake loop finished (detached history-sync tasks may still be running)."
+                );
+            }))
+            .detach();
+    }
+
     /// Public entry point for processing [`MajorSyncTask`] from the sync channel.
     #[cfg_attr(
         feature = "tracing",

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,13 +1,18 @@
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use thiserror::Error;
 
 use super::Client;
 use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
+use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
 use crate::sync_task::MajorSyncTask;
 use crate::transport::TransportFactory;
+use crate::types::durability_hook::InboundDurabilityHook;
+use crate::types::enc_handler::EncHandler;
 use wacore::runtime::Runtime;
 
 /// Result of constructing a [`Client`].
@@ -42,7 +47,7 @@ impl ClientBuild {
 }
 
 /// A validated client-construction failure.
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ClientBuilderError {
     #[error("missing async runtime")]
@@ -53,6 +58,8 @@ pub enum ClientBuilderError {
     MissingTransportFactory,
     #[error("missing HTTP client")]
     MissingHttpClient,
+    #[error("the configured backend does not support the inbound durability hook: {0}")]
+    UnsupportedDurabilityBackend(String),
 }
 
 /// Runtime-validated, low-level builder for [`Client`].
@@ -67,6 +74,14 @@ pub struct ClientBuilder {
     http_client: Option<Arc<dyn HttpClient>>,
     override_version: Option<(u32, u32, u32)>,
     cache_config: CacheConfig,
+    custom_enc_handlers: HashMap<String, Arc<dyn EncHandler>>,
+    inbound_durability_hook: Option<Arc<dyn InboundDurabilityHook>>,
+    skip_history_sync: bool,
+    wanted_pre_key_count: Option<usize>,
+    resend_rate_limit: Option<(u32, u32)>,
+    task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
+    alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
+    background_saver_interval: Option<Duration>,
 }
 
 impl Default for ClientBuilder {
@@ -85,6 +100,14 @@ impl ClientBuilder {
             http_client: None,
             override_version: None,
             cache_config: CacheConfig::default(),
+            custom_enc_handlers: HashMap::new(),
+            inbound_durability_hook: None,
+            skip_history_sync: false,
+            wanted_pre_key_count: None,
+            resend_rate_limit: None,
+            task_instrument: None,
+            alloc_meter: None,
+            background_saver_interval: None,
         }
     }
 
@@ -148,6 +171,91 @@ impl ClientBuilder {
         self
     }
 
+    /// Register a handler for one encrypted payload type before the client starts.
+    pub fn with_enc_handler<H>(mut self, payload_type: impl Into<String>, handler: H) -> Self
+    where
+        H: EncHandler + 'static,
+    {
+        self.custom_enc_handlers
+            .insert(payload_type.into(), Arc::new(handler));
+        self
+    }
+
+    /// Register an already-shared encrypted payload handler.
+    pub fn with_enc_handler_arc(
+        mut self,
+        payload_type: impl Into<String>,
+        handler: Arc<dyn EncHandler>,
+    ) -> Self {
+        self.custom_enc_handlers
+            .insert(payload_type.into(), handler);
+        self
+    }
+
+    pub(crate) fn with_custom_enc_handlers(
+        mut self,
+        handlers: HashMap<String, Arc<dyn EncHandler>>,
+    ) -> Self {
+        self.custom_enc_handlers = handlers;
+        self
+    }
+
+    /// Install the durable-inbound hook after verifying backend support.
+    pub fn with_inbound_durability_hook<H>(mut self, hook: H) -> Self
+    where
+        H: InboundDurabilityHook + 'static,
+    {
+        self.inbound_durability_hook = Some(Arc::new(hook));
+        self
+    }
+
+    /// Install an already-shared durable-inbound hook.
+    pub fn with_inbound_durability_hook_arc(
+        mut self,
+        hook: Arc<dyn InboundDurabilityHook>,
+    ) -> Self {
+        self.inbound_durability_hook = Some(hook);
+        self
+    }
+
+    pub fn with_skip_history_sync(mut self, skip: bool) -> Self {
+        self.skip_history_sync = skip;
+        self
+    }
+
+    pub fn with_wanted_pre_key_count(mut self, count: usize) -> Self {
+        self.wanted_pre_key_count = Some(count);
+        self
+    }
+
+    pub fn with_resend_rate_limit(mut self, burst: u32, refill_per_min: u32) -> Self {
+        self.resend_rate_limit = Some((burst, refill_per_min));
+        self
+    }
+
+    /// Instrument every task spawned through the configured runtime.
+    pub fn with_task_instrument(
+        mut self,
+        instrument: Arc<dyn wacore::stats::TaskInstrument>,
+    ) -> Self {
+        self.task_instrument = Some(instrument);
+        self.alloc_meter = None;
+        self
+    }
+
+    /// Install allocation attribution as the task instrument.
+    pub fn with_alloc_meter(mut self, meter: Arc<wacore::stats::AllocMeter>) -> Self {
+        self.task_instrument = Some(meter.clone());
+        self.alloc_meter = Some(meter);
+        self
+    }
+
+    /// Run periodic device persistence for the lifetime of the client.
+    pub fn with_background_saver_interval(mut self, interval: Duration) -> Self {
+        self.background_saver_interval = Some(interval);
+        self
+    }
+
     /// Validate dependencies, assemble an inert client, then start its services.
     pub async fn build(self) -> Result<ClientBuild, ClientBuilderError> {
         self.build_boxed().await
@@ -158,25 +266,32 @@ impl ClientBuilder {
         self,
     ) -> wacore::runtime::BoxFuture<'static, Result<ClientBuild, ClientBuilderError>> {
         Box::pin(async move {
-            let runtime = self.runtime.ok_or(ClientBuilderError::MissingRuntime)?;
+            let runtime = self
+                .runtime
+                .as_ref()
+                .cloned()
+                .ok_or(ClientBuilderError::MissingRuntime)?;
             let persistence_manager = self
                 .persistence_manager
+                .as_ref()
+                .cloned()
                 .ok_or(ClientBuilderError::MissingPersistenceManager)?;
             let transport_factory = self
                 .transport_factory
+                .as_ref()
+                .cloned()
                 .ok_or(ClientBuilderError::MissingTransportFactory)?;
             let http_client = self
                 .http_client
+                .as_ref()
+                .cloned()
                 .ok_or(ClientBuilderError::MissingHttpClient)?;
 
-            Ok(Self::build_required(
-                runtime,
-                persistence_manager,
-                transport_factory,
-                http_client,
-                self.override_version,
-                self.cache_config,
-            ))
+            if self.inbound_durability_hook.is_some() {
+                probe_durability_backend(&persistence_manager.backend()).await?;
+            }
+
+            Ok(self.finish(runtime, persistence_manager, transport_factory, http_client))
         })
     }
 
@@ -188,16 +303,105 @@ impl ClientBuilder {
         override_version: Option<(u32, u32, u32)>,
         cache_config: CacheConfig,
     ) -> ClientBuild {
-        Client::assemble(
-            runtime,
-            persistence_manager,
-            transport_factory,
-            http_client,
+        Self {
             override_version,
             cache_config,
-        )
-        .start()
+            ..Self::new()
+        }
+        .finish(runtime, persistence_manager, transport_factory, http_client)
     }
+
+    fn finish(
+        self,
+        runtime: Arc<dyn Runtime>,
+        persistence_manager: Arc<PersistenceManager>,
+        transport_factory: Arc<dyn TransportFactory>,
+        http_client: Arc<dyn HttpClient>,
+    ) -> ClientBuild {
+        let runtime: Arc<dyn Runtime> = match self.task_instrument {
+            Some(instrument) => {
+                Arc::new(wacore::stats::InstrumentedRuntime::new(runtime, instrument))
+            }
+            None => runtime,
+        };
+
+        let assembly = Client::assemble(
+            Arc::clone(&runtime),
+            Arc::clone(&persistence_manager),
+            transport_factory,
+            http_client,
+            self.override_version,
+            self.cache_config,
+        );
+        let client = assembly.client();
+
+        if !self.custom_enc_handlers.is_empty() {
+            let _ = client.custom_enc_handlers.set(self.custom_enc_handlers);
+        }
+        if let Some(hook) = self.inbound_durability_hook {
+            let _ = client.inbound_durability_hook.set(hook);
+        }
+        if self.skip_history_sync {
+            client.set_skip_history_sync(true);
+        }
+        if let Some(count) = self.wanted_pre_key_count {
+            client.set_wanted_pre_key_count(count);
+        }
+        if let Some((burst, refill_per_min)) = self.resend_rate_limit {
+            client.set_resend_rate_limit(burst, refill_per_min);
+        }
+        if let Some(meter) = self.alloc_meter {
+            let _ = client.alloc_meter.set(meter);
+        }
+
+        let build = assembly.start();
+        if let Some(interval) = self.background_saver_interval {
+            let saver_handle = persistence_manager.run_background_saver(
+                runtime,
+                interval,
+                build.client.shutdown_signal(),
+            );
+            let _ = build.client.saver_handle.set(saver_handle);
+        }
+        build
+    }
+}
+
+async fn probe_durability_backend(
+    backend: &Arc<dyn crate::store::traits::Backend>,
+) -> Result<(), ClientBuilderError> {
+    use portable_atomic::{AtomicU64, Ordering};
+
+    static PROBE_SEQ: AtomicU64 = AtomicU64::new(0);
+    const PROBE_JID: &str = "0@s.whatsapp.net";
+    const PROBE_PAYLOAD: &[u8] = b"probe";
+    let probe_id = format!(
+        "__wa_durability_probe_{}_{}__",
+        std::process::id(),
+        PROBE_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+    let map_err =
+        |error: StoreError| ClientBuilderError::UnsupportedDurabilityBackend(error.to_string());
+
+    backend
+        .store_pending_inbound(PROBE_JID, PROBE_JID, &probe_id, PROBE_PAYLOAD)
+        .await
+        .map_err(map_err)?;
+    let stored = backend
+        .get_pending_inbound(PROBE_JID, PROBE_JID, &probe_id)
+        .await
+        .map_err(map_err)?;
+    backend
+        .delete_pending_inbound(PROBE_JID, PROBE_JID, &probe_id)
+        .await
+        .map_err(map_err)?;
+
+    if stored.as_deref() != Some(PROBE_PAYLOAD) {
+        return Err(ClientBuilderError::UnsupportedDurabilityBackend(
+            "pending-inbound buffer did not round-trip".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Owns the only path from a fully allocated client to started background
@@ -221,6 +425,10 @@ impl ClientAssembly {
     pub(super) fn start(self) -> ClientBuild {
         self.client.start_services();
         ClientBuild::new(self.client, self.sync_task_receiver)
+    }
+
+    fn client(&self) -> Arc<Client> {
+        Arc::clone(&self.client)
     }
 }
 
@@ -329,5 +537,44 @@ mod tests {
         let build = assembly.start();
         assert_eq!(spawns.load(Ordering::SeqCst), 2);
         build.client().signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn low_level_builder_installs_options_and_owned_services() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let meter = Arc::new(wacore::stats::AllocMeter::new());
+
+        let build = ClientBuilder::new()
+            .with_runtime(CountingRuntime {
+                spawns: Arc::clone(&spawns),
+            })
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_skip_history_sync(true)
+            .with_wanted_pre_key_count(123)
+            .with_alloc_meter(Arc::clone(&meter))
+            .with_background_saver_interval(Duration::from_secs(3600))
+            .build()
+            .await
+            .expect("complete builder");
+        let client = build.client();
+
+        assert!(client.skip_history_sync_enabled());
+        assert_eq!(client.wanted_pre_key_count(), 123);
+        assert!(
+            client
+                .alloc_meter
+                .get()
+                .is_some_and(|installed| Arc::ptr_eq(installed, &meter))
+        );
+        assert!(client.saver_handle.get().is_some());
+        assert_eq!(spawns.load(Ordering::SeqCst), 3);
+        client.signal_shutdown_sync();
     }
 }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -651,6 +651,45 @@ mod tests {
     }
 
     #[cfg(feature = "client-lifecycle")]
+    struct ConnectDuringInstallLifecycle {
+        client: async_channel::Sender<Arc<Client>>,
+        release: async_channel::Receiver<()>,
+        connect_invoked: async_channel::Sender<()>,
+        connect_finished: async_channel::Sender<bool>,
+    }
+
+    #[cfg(feature = "client-lifecycle")]
+    struct BlockingTransportFactory {
+        started: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    #[cfg(feature = "client-lifecycle")]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl TransportFactory for BlockingTransportFactory {
+        async fn create_transport(
+            &self,
+        ) -> Result<
+            (
+                Arc<dyn crate::transport::Transport>,
+                async_channel::Receiver<crate::transport::TransportEvent>,
+            ),
+            anyhow::Error,
+        > {
+            self.started
+                .send(())
+                .await
+                .map_err(|_| anyhow::anyhow!("transport-start receiver closed"))?;
+            self.release
+                .recv()
+                .await
+                .map_err(|_| anyhow::anyhow!("transport release closed"))?;
+            Err(anyhow::anyhow!("injected transport stop"))
+        }
+    }
+
+    #[cfg(feature = "client-lifecycle")]
     impl ClientLifecycle for RunDuringInstallLifecycle {
         fn install<'a>(
             &'a self,
@@ -667,6 +706,40 @@ mod tests {
                     .spawn(Box::pin(async move {
                         run_client.run().await;
                         let _ = run_finished.send(()).await;
+                    }))
+                    .detach();
+                self.client
+                    .send(client)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("test client receiver closed"))?;
+                self.release
+                    .recv()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("test install release closed"))?;
+                Ok(())
+            })
+        }
+    }
+
+    #[cfg(feature = "client-lifecycle")]
+    impl ClientLifecycle for ConnectDuringInstallLifecycle {
+        fn install<'a>(
+            &'a self,
+            client: std::sync::Weak<Client>,
+        ) -> wacore::runtime::BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                let client = client
+                    .upgrade()
+                    .ok_or_else(|| anyhow::anyhow!("client unavailable during install"))?;
+                let connect_client = client.clone();
+                let connect_invoked = self.connect_invoked.clone();
+                let connect_finished = self.connect_finished.clone();
+                client
+                    .runtime
+                    .spawn(Box::pin(async move {
+                        let _ = connect_invoked.send(()).await;
+                        let failed = connect_client.connect().await.is_err();
+                        let _ = connect_finished.send(failed).await;
                     }))
                     .detach();
                 self.client
@@ -846,6 +919,120 @@ mod tests {
             .await
             .expect("run stop timeout")
             .expect("run stopped");
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "client-lifecycle")]
+    async fn connect_leaked_during_install_waits_for_complete_construction() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (install_release_tx, install_release_rx) = async_channel::bounded(1);
+        let (connect_invoked_tx, connect_invoked_rx) = async_channel::bounded(1);
+        let (connect_finished_tx, connect_finished_rx) = async_channel::bounded(1);
+        let (transport_started_tx, transport_started_rx) = async_channel::bounded(1);
+        let (transport_release_tx, transport_release_rx) = async_channel::bounded(1);
+        let builder = complete_builder()
+            .await
+            .with_transport_factory(BlockingTransportFactory {
+                started: transport_started_tx,
+                release: transport_release_rx,
+            })
+            .with_lifecycle(ConnectDuringInstallLifecycle {
+                client: client_tx,
+                release: install_release_rx,
+                connect_invoked: connect_invoked_tx,
+                connect_finished: connect_finished_tx,
+            });
+        let build = tokio::spawn(async move { builder.build().await });
+        let leaked_client = client_rx
+            .recv()
+            .await
+            .expect("client leaked during install");
+        connect_invoked_rx
+            .recv()
+            .await
+            .expect("direct connect invoked");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), transport_started_rx.recv())
+                .await
+                .is_err(),
+            "transport started before construction activation"
+        );
+        assert!(!leaked_client.is_connecting.load(Ordering::Acquire));
+
+        install_release_tx
+            .send(())
+            .await
+            .expect("release installation");
+        let client = build
+            .await
+            .expect("builder task")
+            .expect("successful build")
+            .into_client();
+        tokio::time::timeout(Duration::from_secs(1), transport_started_rx.recv())
+            .await
+            .expect("connect remained gated after activation")
+            .expect("transport-start sender closed");
+        transport_release_tx
+            .send(())
+            .await
+            .expect("release transport");
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), connect_finished_rx.recv())
+                .await
+                .expect("direct connect did not finish")
+                .expect("connect-finished sender closed")
+        );
+        client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "client-lifecycle")]
+    async fn shutdown_during_install_rejects_leaked_connect() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (_install_release_tx, install_release_rx) = async_channel::bounded(1);
+        let (connect_invoked_tx, connect_invoked_rx) = async_channel::bounded(1);
+        let (connect_finished_tx, connect_finished_rx) = async_channel::bounded(1);
+        let (transport_started_tx, transport_started_rx) = async_channel::bounded(1);
+        let (_transport_release_tx, transport_release_rx) = async_channel::bounded(1);
+        let builder = complete_builder()
+            .await
+            .with_transport_factory(BlockingTransportFactory {
+                started: transport_started_tx,
+                release: transport_release_rx,
+            })
+            .with_lifecycle(ConnectDuringInstallLifecycle {
+                client: client_tx,
+                release: install_release_rx,
+                connect_invoked: connect_invoked_tx,
+                connect_finished: connect_finished_tx,
+            });
+        let build = tokio::spawn(async move { builder.build().await });
+        let leaked_client = client_rx
+            .recv()
+            .await
+            .expect("client leaked during install");
+        connect_invoked_rx
+            .recv()
+            .await
+            .expect("direct connect invoked");
+        leaked_client.signal_shutdown_sync();
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), build)
+                .await
+                .expect("lifecycle install ignored terminal shutdown")
+                .expect("builder task"),
+            Err(ClientBuilderError::LifecycleInstall(_))
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), connect_finished_rx.recv())
+                .await
+                .expect("direct connect did not observe rejection")
+                .expect("connect-finished sender closed")
+        );
+        assert!(transport_started_rx.try_recv().is_err());
+        assert!(!leaked_client.is_connecting.load(Ordering::Acquire));
     }
 
     #[tokio::test]

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 
-use super::Client;
+use super::{Client, ClientLifecycle, LifecycleRegistration};
 use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
 use crate::store::error::StoreError;
@@ -47,7 +47,7 @@ impl ClientBuild {
 }
 
 /// A validated client-construction failure.
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientBuilderError {
     #[error("missing async runtime")]
@@ -60,6 +60,8 @@ pub enum ClientBuilderError {
     MissingHttpClient,
     #[error("the configured backend does not support the inbound durability hook: {0}")]
     UnsupportedDurabilityBackend(String),
+    #[error("client lifecycle installation failed: {0}")]
+    LifecycleInstall(#[source] anyhow::Error),
 }
 
 /// Runtime-validated, low-level builder for [`Client`].
@@ -82,6 +84,7 @@ pub struct ClientBuilder {
     task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
     background_saver_interval: Option<Duration>,
+    lifecycle: Option<Arc<dyn ClientLifecycle>>,
 }
 
 impl Default for ClientBuilder {
@@ -108,6 +111,7 @@ impl ClientBuilder {
             task_instrument: None,
             alloc_meter: None,
             background_saver_interval: None,
+            lifecycle: None,
         }
     }
 
@@ -256,6 +260,21 @@ impl ClientBuilder {
         self
     }
 
+    /// Install the aggregate lifecycle used by extensions of this client.
+    pub fn with_lifecycle<L>(mut self, lifecycle: L) -> Self
+    where
+        L: ClientLifecycle + 'static,
+    {
+        self.lifecycle = Some(Arc::new(lifecycle));
+        self
+    }
+
+    /// Install an already-shared aggregate lifecycle.
+    pub fn with_lifecycle_arc(mut self, lifecycle: Arc<dyn ClientLifecycle>) -> Self {
+        self.lifecycle = Some(lifecycle);
+        self
+    }
+
     /// Validate dependencies, assemble an inert client, then start its services.
     pub async fn build(self) -> Result<ClientBuild, ClientBuilderError> {
         self.build_boxed().await
@@ -291,11 +310,12 @@ impl ClientBuilder {
                 probe_durability_backend(&persistence_manager.backend()).await?;
             }
 
-            Ok(self.finish(runtime, persistence_manager, transport_factory, http_client))
+            self.finish(runtime, persistence_manager, transport_factory, http_client)
+                .await
         })
     }
 
-    pub(crate) fn build_required(
+    pub(crate) async fn build_required(
         runtime: Arc<dyn Runtime>,
         persistence_manager: Arc<PersistenceManager>,
         transport_factory: Arc<dyn TransportFactory>,
@@ -303,21 +323,26 @@ impl ClientBuilder {
         override_version: Option<(u32, u32, u32)>,
         cache_config: CacheConfig,
     ) -> ClientBuild {
-        Self {
+        let result = Self {
             override_version,
             cache_config,
             ..Self::new()
         }
         .finish(runtime, persistence_manager, transport_factory, http_client)
+        .await;
+        match result {
+            Ok(build) => build,
+            Err(error) => unreachable!("default lifecycle-free build failed: {error}"),
+        }
     }
 
-    fn finish(
+    async fn finish(
         self,
         runtime: Arc<dyn Runtime>,
         persistence_manager: Arc<PersistenceManager>,
         transport_factory: Arc<dyn TransportFactory>,
         http_client: Arc<dyn HttpClient>,
-    ) -> ClientBuild {
+    ) -> Result<ClientBuild, ClientBuilderError> {
         let runtime: Arc<dyn Runtime> = match self.task_instrument {
             Some(instrument) => {
                 Arc::new(wacore::stats::InstrumentedRuntime::new(runtime, instrument))
@@ -325,6 +350,7 @@ impl ClientBuilder {
             None => runtime,
         };
 
+        let lifecycle = self.lifecycle.map(LifecycleRegistration::new).map(Arc::new);
         let assembly = Client::assemble(
             Arc::clone(&runtime),
             Arc::clone(&persistence_manager),
@@ -332,6 +358,7 @@ impl ClientBuilder {
             http_client,
             self.override_version,
             self.cache_config,
+            lifecycle,
         );
         let client = assembly.client();
 
@@ -353,6 +380,12 @@ impl ClientBuilder {
         if let Some(meter) = self.alloc_meter {
             let _ = client.alloc_meter.set(meter);
         }
+        if let Some(lifecycle) = &client.lifecycle {
+            lifecycle
+                .install(Arc::downgrade(&client))
+                .await
+                .map_err(ClientBuilderError::LifecycleInstall)?;
+        }
 
         let build = assembly.start();
         if let Some(interval) = self.background_saver_interval {
@@ -363,7 +396,7 @@ impl ClientBuilder {
             );
             let _ = build.client.saver_handle.set(saver_handle);
         }
-        build
+        Ok(build)
     }
 }
 
@@ -444,6 +477,27 @@ mod tests {
     use crate::test_utils::MockHttpClient;
     use crate::transport::mock::MockTransportFactory;
     use wacore::runtime::AbortHandle;
+
+    struct FailingLifecycle {
+        spawns: Arc<AtomicUsize>,
+        installed_client: std::sync::Mutex<Option<std::sync::Weak<Client>>>,
+    }
+
+    impl ClientLifecycle for FailingLifecycle {
+        fn install<'a>(
+            &'a self,
+            client: std::sync::Weak<Client>,
+        ) -> wacore::runtime::BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                assert_eq!(self.spawns.load(Ordering::SeqCst), 0);
+                *self
+                    .installed_client
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client);
+                Err(anyhow::anyhow!("injected install failure"))
+            })
+        }
+    }
 
     struct CountingRuntime {
         spawns: Arc<AtomicUsize>,
@@ -531,6 +585,7 @@ mod tests {
             Arc::new(MockHttpClient),
             None,
             CacheConfig::default(),
+            None,
         );
         assert_eq!(spawns.load(Ordering::SeqCst), 0);
 
@@ -576,5 +631,44 @@ mod tests {
         assert!(client.saver_handle.get().is_some());
         assert_eq!(spawns.load(Ordering::SeqCst), 3);
         client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn lifecycle_install_failure_publishes_nothing_and_starts_no_tasks() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let lifecycle = Arc::new(FailingLifecycle {
+            spawns: Arc::clone(&spawns),
+            installed_client: std::sync::Mutex::new(None),
+        });
+
+        let result = ClientBuilder::new()
+            .with_runtime(CountingRuntime {
+                spawns: Arc::clone(&spawns),
+            })
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ClientBuilderError::LifecycleInstall(_))
+        ));
+        assert_eq!(spawns.load(Ordering::SeqCst), 0);
+        assert!(
+            lifecycle
+                .installed_client
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_ref()
+                .is_some_and(|client| client.upgrade().is_none())
+        );
     }
 }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use super::{Client, ClientLifecycle, LifecycleRegistration};
 use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
+#[cfg(feature = "plugins")]
 use crate::plugins::{ClientPlugin, PluginHost, PluginPlan, PluginPlanError, PluginRegistration};
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
@@ -63,8 +64,10 @@ pub enum ClientBuilderError {
     UnsupportedDurabilityBackend(String),
     #[error("client lifecycle installation failed: {0}")]
     LifecycleInstall(#[source] anyhow::Error),
+    #[cfg(feature = "plugins")]
     #[error("plugin host installation failed: {0}")]
     PluginInstall(#[source] anyhow::Error),
+    #[cfg(feature = "plugins")]
     #[error("invalid plugin plan: {0}")]
     PluginPlan(#[from] PluginPlanError),
 }
@@ -90,6 +93,7 @@ pub struct ClientBuilder {
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
     background_saver_interval: Option<Duration>,
     lifecycle: Option<Arc<dyn ClientLifecycle>>,
+    #[cfg(feature = "plugins")]
     plugins: Vec<PluginRegistration>,
 }
 
@@ -118,6 +122,7 @@ impl ClientBuilder {
             alloc_meter: None,
             background_saver_interval: None,
             lifecycle: None,
+            #[cfg(feature = "plugins")]
             plugins: Vec::new(),
         }
     }
@@ -283,17 +288,20 @@ impl ClientBuilder {
     }
 
     /// Register a native plugin for transactional installation before services start.
+    #[cfg(feature = "plugins")]
     pub fn with_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
         self.plugins.push(PluginRegistration::new(plugin));
         self
     }
 
     /// Register an already-shared native plugin without changing its marker type.
+    #[cfg(feature = "plugins")]
     pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins.push(PluginRegistration::new_arc(plugin));
         self
     }
 
+    #[cfg(feature = "plugins")]
     pub(crate) fn with_plugin_registrations(
         mut self,
         registrations: Vec<PluginRegistration>,
@@ -370,6 +378,7 @@ impl ClientBuilder {
         transport_factory: Arc<dyn TransportFactory>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<ClientBuild, ClientBuilderError> {
+        #[cfg(feature = "plugins")]
         let plugin_plan = PluginPlan::prepare(self.plugins)?;
         let runtime: Arc<dyn Runtime> = match self.task_instrument {
             Some(instrument) => {
@@ -378,12 +387,17 @@ impl ClientBuilder {
             None => runtime,
         };
 
-        let mut lifecycle_handler = self.lifecycle;
-        let plugin_host = plugin_plan.map(|plan| {
-            let host = PluginHost::new(plan, lifecycle_handler.take());
-            lifecycle_handler = Some(host.clone());
-            host
-        });
+        let lifecycle_handler = self.lifecycle;
+        #[cfg(feature = "plugins")]
+        let (lifecycle_handler, plugin_host) = {
+            let mut lifecycle_handler = lifecycle_handler;
+            let plugin_host = plugin_plan.map(|plan| {
+                let host = PluginHost::new(plan, lifecycle_handler.take());
+                lifecycle_handler = Some(host.clone());
+                host
+            });
+            (lifecycle_handler, plugin_host)
+        };
         let lifecycle = lifecycle_handler
             .map(|handler| Arc::new(LifecycleRegistration::new(handler, Arc::clone(&runtime))));
         let assembly = Client::assemble(
@@ -395,6 +409,7 @@ impl ClientBuilder {
             self.cache_config,
             ClientExtensions {
                 lifecycle,
+                #[cfg(feature = "plugins")]
                 plugin_host,
             },
         );
@@ -421,11 +436,11 @@ impl ClientBuilder {
         if let Some(lifecycle) = &client.lifecycle
             && let Err(error) = lifecycle.install(Arc::downgrade(&client)).await
         {
-            return Err(if client.plugin_host.is_some() {
-                ClientBuilderError::PluginInstall(error)
-            } else {
-                ClientBuilderError::LifecycleInstall(error)
-            });
+            #[cfg(feature = "plugins")]
+            if client.plugin_host.is_some() {
+                return Err(ClientBuilderError::PluginInstall(error));
+            }
+            return Err(ClientBuilderError::LifecycleInstall(error));
         }
 
         let build = assembly.start();
@@ -437,6 +452,7 @@ impl ClientBuilder {
             );
             let _ = build.client.saver_handle.set(saver_handle);
         }
+        #[cfg(feature = "plugins")]
         if let Some(plugin_host) = &client.plugin_host {
             plugin_host.activate();
         }
@@ -491,6 +507,7 @@ pub(super) struct ClientAssembly {
 #[derive(Default)]
 pub(super) struct ClientExtensions {
     pub(super) lifecycle: Option<Arc<LifecycleRegistration>>,
+    #[cfg(feature = "plugins")]
     pub(super) plugin_host: Option<Arc<PluginHost>>,
 }
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -432,6 +432,7 @@ impl ClientBuilder {
             },
         );
         let client = assembly.client();
+        let mut construction = ClientConstructionGuard::new(Arc::clone(&client));
 
         if !self.custom_enc_handlers.is_empty() {
             let _ = client.custom_enc_handlers.set(self.custom_enc_handlers);
@@ -471,9 +472,31 @@ impl ClientBuilder {
             let _ = build.client.saver_handle.set(saver_handle);
         }
         #[cfg(feature = "plugins")]
-        if let Some(plugin_host) = &client.plugin_host {
-            plugin_host.activate();
+        if let Some(plugin_host) = &client.plugin_host
+            && !plugin_host.activate()
+        {
+            client.signal_shutdown_sync();
+            client.shutdown_lifecycle().await;
+            return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
+                "client shutdown began before plugin activation"
+            )));
         }
+        if let Some(lifecycle) = &client.lifecycle
+            && !lifecycle.activate()
+        {
+            client.signal_shutdown_sync();
+            client.shutdown_lifecycle().await;
+            #[cfg(feature = "plugins")]
+            if client.plugin_host.is_some() {
+                return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
+                    "client shutdown raced plugin activation"
+                )));
+            }
+            return Err(ClientBuilderError::LifecycleInstall(anyhow::anyhow!(
+                "client shutdown raced lifecycle activation"
+            )));
+        }
+        construction.disarm();
         Ok(build)
     }
 }
@@ -522,6 +545,32 @@ pub(super) struct ClientAssembly {
     sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
 }
 
+struct ClientConstructionGuard {
+    client: Arc<Client>,
+    armed: bool,
+}
+
+impl ClientConstructionGuard {
+    fn new(client: Arc<Client>) -> Self {
+        Self {
+            client,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ClientConstructionGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.client.signal_shutdown_sync();
+        }
+    }
+}
+
 #[derive(Default)]
 pub(super) struct ClientExtensions {
     pub(super) lifecycle: Option<Arc<LifecycleRegistration>>,
@@ -566,6 +615,43 @@ mod tests {
     struct FailingLifecycle {
         spawns: Arc<AtomicUsize>,
         installed_client: std::sync::Mutex<Option<std::sync::Weak<Client>>>,
+    }
+
+    struct RunDuringInstallLifecycle {
+        client: async_channel::Sender<Arc<Client>>,
+        release: async_channel::Receiver<()>,
+        run_finished: async_channel::Sender<()>,
+    }
+
+    impl ClientLifecycle for RunDuringInstallLifecycle {
+        fn install<'a>(
+            &'a self,
+            client: std::sync::Weak<Client>,
+        ) -> wacore::runtime::BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                let client = client
+                    .upgrade()
+                    .ok_or_else(|| anyhow::anyhow!("client unavailable during install"))?;
+                let run_client = client.clone();
+                let run_finished = self.run_finished.clone();
+                client
+                    .runtime
+                    .spawn(Box::pin(async move {
+                        run_client.run().await;
+                        let _ = run_finished.send(()).await;
+                    }))
+                    .detach();
+                self.client
+                    .send(client)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("test client receiver closed"))?;
+                self.release
+                    .recv()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("test install release closed"))?;
+                Ok(())
+            })
+        }
     }
 
     impl ClientLifecycle for FailingLifecycle {
@@ -690,6 +776,77 @@ mod tests {
         let build = assembly.start();
         assert_eq!(spawns.load(Ordering::SeqCst), 2);
         build.into_client().signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn run_leaked_during_install_waits_for_complete_construction() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let (run_finished_tx, run_finished_rx) = async_channel::bounded(1);
+        let builder = complete_builder()
+            .await
+            .with_lifecycle(RunDuringInstallLifecycle {
+                client: client_tx,
+                release: release_rx,
+                run_finished: run_finished_tx,
+            });
+        let build = tokio::spawn(async move { builder.build().await });
+        let leaked_client = client_rx
+            .recv()
+            .await
+            .expect("client leaked during install");
+        tokio::task::yield_now().await;
+        assert!(!leaked_client.is_running.load(Ordering::Acquire));
+
+        release_tx.send(()).await.expect("release installation");
+        let client = build
+            .await
+            .expect("builder task")
+            .expect("successful build")
+            .into_client();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !client.is_running.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("run released after activation");
+        client.signal_shutdown_sync();
+        tokio::time::timeout(Duration::from_secs(5), run_finished_rx.recv())
+            .await
+            .expect("run stop timeout")
+            .expect("run stopped");
+    }
+
+    #[tokio::test]
+    async fn shutdown_during_install_rejects_leaked_run_and_the_build() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let (run_finished_tx, run_finished_rx) = async_channel::bounded(1);
+        let builder = complete_builder()
+            .await
+            .with_lifecycle(RunDuringInstallLifecycle {
+                client: client_tx,
+                release: release_rx,
+                run_finished: run_finished_tx,
+            });
+        let build = tokio::spawn(async move { builder.build().await });
+        let leaked_client = client_rx
+            .recv()
+            .await
+            .expect("client leaked during install");
+        leaked_client.signal_shutdown_sync();
+        release_tx.send(()).await.expect("release installation");
+
+        assert!(matches!(
+            build.await.expect("builder task"),
+            Err(ClientBuilderError::LifecycleInstall(_))
+        ));
+        tokio::time::timeout(Duration::from_secs(5), run_finished_rx.recv())
+            .await
+            .expect("rejected run stop timeout")
+            .expect("rejected run stopped");
+        assert!(!leaked_client.is_running.load(Ordering::Acquire));
     }
 
     #[tokio::test]

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -11,7 +11,8 @@ use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
 #[cfg(feature = "plugins")]
 use crate::plugins::{
-    ClientPlugin, PluginHost, PluginPlan, PluginPlanError, PluginRegistration, UntypedClientPlugin,
+    ClientPlugin, PluginHost, PluginHostConfig, PluginPlan, PluginPlanError, PluginRegistration,
+    UntypedClientPlugin,
 };
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
@@ -69,6 +70,14 @@ pub enum ClientBuilderError {
     MissingHttpClient,
     #[error("background saver interval must be greater than zero")]
     InvalidBackgroundSaverInterval,
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    #[error("plugin callback timeout must be greater than zero")]
+    InvalidPluginCallbackTimeout,
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    #[error("plugin task-drain timeout must be greater than zero")]
+    InvalidPluginTaskDrainTimeout,
     #[error("the configured backend does not support the inbound durability hook: {0}")]
     UnsupportedDurabilityBackend(String),
     #[cfg(feature = "client-lifecycle")]
@@ -109,6 +118,8 @@ pub struct ClientBuilder {
     lifecycle: Option<Arc<dyn ClientLifecycle>>,
     #[cfg(feature = "plugins")]
     plugins: Vec<PluginRegistration>,
+    #[cfg(feature = "plugins")]
+    plugin_host_config: PluginHostConfig,
 }
 
 impl Default for ClientBuilder {
@@ -139,6 +150,8 @@ impl ClientBuilder {
             lifecycle: None,
             #[cfg(feature = "plugins")]
             plugins: Vec::new(),
+            #[cfg(feature = "plugins")]
+            plugin_host_config: PluginHostConfig::default(),
         }
     }
 
@@ -339,6 +352,14 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure plugin lifecycle and tracked-task deadlines.
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    pub fn with_plugin_host_config(mut self, config: PluginHostConfig) -> Self {
+        self.plugin_host_config = config;
+        self
+    }
+
     #[cfg(feature = "plugins")]
     pub(crate) fn with_plugin_registrations(
         mut self,
@@ -381,6 +402,15 @@ impl ClientBuilder {
 
             if self.background_saver_interval == Some(Duration::ZERO) {
                 return Err(ClientBuilderError::InvalidBackgroundSaverInterval);
+            }
+
+            #[cfg(feature = "plugins")]
+            if self.plugin_host_config.callback_timeout() == Duration::ZERO {
+                return Err(ClientBuilderError::InvalidPluginCallbackTimeout);
+            }
+            #[cfg(feature = "plugins")]
+            if self.plugin_host_config.task_drain_timeout() == Duration::ZERO {
+                return Err(ClientBuilderError::InvalidPluginTaskDrainTimeout);
             }
 
             if self.inbound_durability_hook.is_some() {
@@ -435,7 +465,7 @@ impl ClientBuilder {
         let (lifecycle_handler, plugin_host) = {
             let mut lifecycle_handler = lifecycle_handler;
             let plugin_host = plugin_plan.map(|plan| {
-                let host = PluginHost::new(plan, lifecycle_handler.take());
+                let host = PluginHost::new(plan, lifecycle_handler.take(), self.plugin_host_config);
                 lifecycle_handler = Some(host.clone());
                 host
             });

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -72,6 +72,10 @@ pub enum ClientBuilderError {
     InvalidBackgroundSaverInterval,
     #[cfg(feature = "plugins")]
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    #[error("plugin install timeout must be greater than zero")]
+    InvalidPluginInstallTimeout,
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     #[error("plugin callback timeout must be greater than zero")]
     InvalidPluginCallbackTimeout,
     #[cfg(feature = "plugins")]
@@ -96,7 +100,7 @@ pub enum ClientBuilderError {
 
 /// Runtime-validated, low-level builder for [`Client`].
 ///
-/// Unlike [`crate::BotBuilder`], this builder deliberately does not use
+/// Unlike [`crate::bot::BotBuilder`], this builder deliberately does not use
 /// typestate. FFI and embedded hosts can populate dependencies dynamically and
 /// receive a typed error without encoding Rust generic state in their wrapper.
 pub struct ClientBuilder {
@@ -346,7 +350,10 @@ impl ClientBuilder {
     /// Register an already-shared manifest-ID-keyed plugin.
     #[cfg(feature = "plugins")]
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
-    pub fn with_untyped_plugin_arc<P: UntypedClientPlugin>(mut self, plugin: Arc<P>) -> Self {
+    pub fn with_untyped_plugin_arc<P: UntypedClientPlugin + ?Sized>(
+        mut self,
+        plugin: Arc<P>,
+    ) -> Self {
         self.plugins
             .push(PluginRegistration::new_untyped_arc(plugin));
         self
@@ -404,6 +411,10 @@ impl ClientBuilder {
                 return Err(ClientBuilderError::InvalidBackgroundSaverInterval);
             }
 
+            #[cfg(feature = "plugins")]
+            if self.plugin_host_config.install_timeout() == Duration::ZERO {
+                return Err(ClientBuilderError::InvalidPluginInstallTimeout);
+            }
             #[cfg(feature = "plugins")]
             if self.plugin_host_config.callback_timeout() == Duration::ZERO {
                 return Err(ClientBuilderError::InvalidPluginCallbackTimeout);

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -352,8 +352,7 @@ impl ClientBuilder {
 
         let lifecycle = self
             .lifecycle
-            .map(|handler| LifecycleRegistration::new(handler, Arc::clone(&runtime)))
-            .map(Arc::new);
+            .map(|handler| Arc::new(LifecycleRegistration::new(handler, Arc::clone(&runtime))));
         let assembly = Client::assemble(
             Arc::clone(&runtime),
             Arc::clone(&persistence_manager),

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,0 +1,333 @@
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use super::Client;
+use crate::cache_config::CacheConfig;
+use crate::http::HttpClient;
+use crate::store::persistence_manager::PersistenceManager;
+use crate::sync_task::MajorSyncTask;
+use crate::transport::TransportFactory;
+use wacore::runtime::Runtime;
+
+/// Result of constructing a [`Client`].
+///
+/// The sync-task receiver has a single consumer and is therefore transferred
+/// together with the client rather than hidden behind a cloneable handle.
+pub struct ClientBuild {
+    client: Arc<Client>,
+    sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
+}
+
+impl ClientBuild {
+    pub(crate) fn new(
+        client: Arc<Client>,
+        sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
+    ) -> Self {
+        Self {
+            client,
+            sync_task_receiver,
+        }
+    }
+
+    /// Return the constructed client.
+    pub fn client(&self) -> Arc<Client> {
+        Arc::clone(&self.client)
+    }
+
+    /// Transfer ownership of the client and its sync-task receiver.
+    pub fn into_parts(self) -> (Arc<Client>, async_channel::Receiver<MajorSyncTask>) {
+        (self.client, self.sync_task_receiver)
+    }
+}
+
+/// A validated client-construction failure.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ClientBuilderError {
+    #[error("missing async runtime")]
+    MissingRuntime,
+    #[error("missing persistence manager")]
+    MissingPersistenceManager,
+    #[error("missing transport factory")]
+    MissingTransportFactory,
+    #[error("missing HTTP client")]
+    MissingHttpClient,
+}
+
+/// Runtime-validated, low-level builder for [`Client`].
+///
+/// Unlike [`crate::BotBuilder`], this builder deliberately does not use
+/// typestate. FFI and embedded hosts can populate dependencies dynamically and
+/// receive a typed error without encoding Rust generic state in their wrapper.
+pub struct ClientBuilder {
+    runtime: Option<Arc<dyn Runtime>>,
+    persistence_manager: Option<Arc<PersistenceManager>>,
+    transport_factory: Option<Arc<dyn TransportFactory>>,
+    http_client: Option<Arc<dyn HttpClient>>,
+    override_version: Option<(u32, u32, u32)>,
+    cache_config: CacheConfig,
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClientBuilder {
+    /// Create an empty builder. All four platform dependencies are required.
+    pub fn new() -> Self {
+        Self {
+            runtime: None,
+            persistence_manager: None,
+            transport_factory: None,
+            http_client: None,
+            override_version: None,
+            cache_config: CacheConfig::default(),
+        }
+    }
+
+    pub fn with_runtime<R>(mut self, runtime: R) -> Self
+    where
+        R: Runtime,
+    {
+        self.runtime = Some(Arc::new(runtime));
+        self
+    }
+
+    pub fn with_runtime_arc(mut self, runtime: Arc<dyn Runtime>) -> Self {
+        self.runtime = Some(runtime);
+        self
+    }
+
+    pub fn with_persistence_manager(
+        mut self,
+        persistence_manager: Arc<PersistenceManager>,
+    ) -> Self {
+        self.persistence_manager = Some(persistence_manager);
+        self
+    }
+
+    pub fn with_transport_factory<T>(mut self, transport_factory: T) -> Self
+    where
+        T: TransportFactory + 'static,
+    {
+        self.transport_factory = Some(Arc::new(transport_factory));
+        self
+    }
+
+    pub fn with_transport_factory_arc(
+        mut self,
+        transport_factory: Arc<dyn TransportFactory>,
+    ) -> Self {
+        self.transport_factory = Some(transport_factory);
+        self
+    }
+
+    pub fn with_http_client<H>(mut self, http_client: H) -> Self
+    where
+        H: HttpClient + 'static,
+    {
+        self.http_client = Some(Arc::new(http_client));
+        self
+    }
+
+    pub fn with_http_client_arc(mut self, http_client: Arc<dyn HttpClient>) -> Self {
+        self.http_client = Some(http_client);
+        self
+    }
+
+    pub fn with_version_override(mut self, version: (u32, u32, u32)) -> Self {
+        self.override_version = Some(version);
+        self
+    }
+
+    pub fn with_cache_config(mut self, cache_config: CacheConfig) -> Self {
+        self.cache_config = cache_config;
+        self
+    }
+
+    /// Validate dependencies, assemble an inert client, then start its services.
+    pub async fn build(self) -> Result<ClientBuild, ClientBuilderError> {
+        self.build_boxed().await
+    }
+
+    #[inline(never)]
+    fn build_boxed(
+        self,
+    ) -> wacore::runtime::BoxFuture<'static, Result<ClientBuild, ClientBuilderError>> {
+        Box::pin(async move {
+            let runtime = self.runtime.ok_or(ClientBuilderError::MissingRuntime)?;
+            let persistence_manager = self
+                .persistence_manager
+                .ok_or(ClientBuilderError::MissingPersistenceManager)?;
+            let transport_factory = self
+                .transport_factory
+                .ok_or(ClientBuilderError::MissingTransportFactory)?;
+            let http_client = self
+                .http_client
+                .ok_or(ClientBuilderError::MissingHttpClient)?;
+
+            Ok(Self::build_required(
+                runtime,
+                persistence_manager,
+                transport_factory,
+                http_client,
+                self.override_version,
+                self.cache_config,
+            ))
+        })
+    }
+
+    pub(crate) fn build_required(
+        runtime: Arc<dyn Runtime>,
+        persistence_manager: Arc<PersistenceManager>,
+        transport_factory: Arc<dyn TransportFactory>,
+        http_client: Arc<dyn HttpClient>,
+        override_version: Option<(u32, u32, u32)>,
+        cache_config: CacheConfig,
+    ) -> ClientBuild {
+        Client::assemble(
+            runtime,
+            persistence_manager,
+            transport_factory,
+            http_client,
+            override_version,
+            cache_config,
+        )
+        .start()
+    }
+}
+
+/// Owns the only path from a fully allocated client to started background
+/// services, preventing callers from publishing a partially configured client.
+pub(super) struct ClientAssembly {
+    client: Arc<Client>,
+    sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
+}
+
+impl ClientAssembly {
+    pub(super) fn new(
+        client: Arc<Client>,
+        sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
+    ) -> Self {
+        Self {
+            client,
+            sync_task_receiver,
+        }
+    }
+
+    pub(super) fn start(self) -> ClientBuild {
+        self.client.start_services();
+        ClientBuild::new(self.client, self.sync_task_receiver)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+    use crate::runtime_impl::TokioRuntime;
+    use crate::test_utils::MockHttpClient;
+    use crate::transport::mock::MockTransportFactory;
+    use wacore::runtime::AbortHandle;
+
+    struct CountingRuntime {
+        spawns: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for CountingRuntime {
+        fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+            self.spawns.fetch_add(1, Ordering::SeqCst);
+            TokioRuntime.spawn(future)
+        }
+
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            TokioRuntime.sleep(duration)
+        }
+
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            TokioRuntime.spawn_blocking(f)
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            TokioRuntime.yield_now()
+        }
+    }
+
+    #[tokio::test]
+    async fn validates_required_dependencies_before_assembly() {
+        assert!(matches!(
+            ClientBuilder::new().build().await,
+            Err(ClientBuilderError::MissingRuntime)
+        ));
+
+        assert!(matches!(
+            ClientBuilder::new()
+                .with_runtime(TokioRuntime)
+                .build()
+                .await,
+            Err(ClientBuilderError::MissingPersistenceManager)
+        ));
+
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        assert!(matches!(
+            ClientBuilder::new()
+                .with_runtime(TokioRuntime)
+                .with_persistence_manager(Arc::clone(&persistence_manager))
+                .build()
+                .await,
+            Err(ClientBuilderError::MissingTransportFactory)
+        ));
+
+        assert!(matches!(
+            ClientBuilder::new()
+                .with_runtime(TokioRuntime)
+                .with_persistence_manager(persistence_manager)
+                .with_transport_factory(MockTransportFactory::new())
+                .build()
+                .await,
+            Err(ClientBuilderError::MissingHttpClient)
+        ));
+    }
+
+    #[tokio::test]
+    async fn assembly_is_inert_until_started() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let runtime = Arc::new(CountingRuntime {
+            spawns: Arc::clone(&spawns),
+        }) as Arc<dyn Runtime>;
+
+        let assembly = Client::assemble(
+            runtime,
+            persistence_manager,
+            Arc::new(MockTransportFactory::new()),
+            Arc::new(MockHttpClient),
+            None,
+            CacheConfig::default(),
+        );
+        assert_eq!(spawns.load(Ordering::SeqCst), 0);
+
+        let build = assembly.start();
+        assert_eq!(spawns.load(Ordering::SeqCst), 2);
+        build.client().signal_shutdown_sync();
+    }
+}

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use super::{Client, ClientLifecycle, LifecycleRegistration};
 use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
+use crate::plugins::{ClientPlugin, PluginHost, PluginPlan, PluginPlanError, PluginRegistration};
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
 use crate::sync_task::MajorSyncTask;
@@ -62,6 +63,10 @@ pub enum ClientBuilderError {
     UnsupportedDurabilityBackend(String),
     #[error("client lifecycle installation failed: {0}")]
     LifecycleInstall(#[source] anyhow::Error),
+    #[error("plugin host installation failed: {0}")]
+    PluginInstall(#[source] anyhow::Error),
+    #[error("invalid plugin plan: {0}")]
+    PluginPlan(#[from] PluginPlanError),
 }
 
 /// Runtime-validated, low-level builder for [`Client`].
@@ -85,6 +90,7 @@ pub struct ClientBuilder {
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
     background_saver_interval: Option<Duration>,
     lifecycle: Option<Arc<dyn ClientLifecycle>>,
+    plugins: Vec<PluginRegistration>,
 }
 
 impl Default for ClientBuilder {
@@ -112,6 +118,7 @@ impl ClientBuilder {
             alloc_meter: None,
             background_saver_interval: None,
             lifecycle: None,
+            plugins: Vec::new(),
         }
     }
 
@@ -275,6 +282,26 @@ impl ClientBuilder {
         self
     }
 
+    /// Register a native plugin for transactional installation before services start.
+    pub fn with_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
+        self.plugins.push(PluginRegistration::new(plugin));
+        self
+    }
+
+    /// Register an already-shared native plugin without changing its marker type.
+    pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
+        self.plugins.push(PluginRegistration::new_arc(plugin));
+        self
+    }
+
+    pub(crate) fn with_plugin_registrations(
+        mut self,
+        registrations: Vec<PluginRegistration>,
+    ) -> Self {
+        self.plugins = registrations;
+        self
+    }
+
     /// Validate dependencies, assemble an inert client, then start its services.
     pub async fn build(self) -> Result<ClientBuild, ClientBuilderError> {
         self.build_boxed().await
@@ -343,6 +370,7 @@ impl ClientBuilder {
         transport_factory: Arc<dyn TransportFactory>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<ClientBuild, ClientBuilderError> {
+        let plugin_plan = PluginPlan::prepare(self.plugins)?;
         let runtime: Arc<dyn Runtime> = match self.task_instrument {
             Some(instrument) => {
                 Arc::new(wacore::stats::InstrumentedRuntime::new(runtime, instrument))
@@ -350,8 +378,13 @@ impl ClientBuilder {
             None => runtime,
         };
 
-        let lifecycle = self
-            .lifecycle
+        let mut lifecycle_handler = self.lifecycle;
+        let plugin_host = plugin_plan.map(|plan| {
+            let host = PluginHost::new(plan, lifecycle_handler.take());
+            lifecycle_handler = Some(host.clone());
+            host
+        });
+        let lifecycle = lifecycle_handler
             .map(|handler| Arc::new(LifecycleRegistration::new(handler, Arc::clone(&runtime))));
         let assembly = Client::assemble(
             Arc::clone(&runtime),
@@ -360,7 +393,10 @@ impl ClientBuilder {
             http_client,
             self.override_version,
             self.cache_config,
-            lifecycle,
+            ClientExtensions {
+                lifecycle,
+                plugin_host,
+            },
         );
         let client = assembly.client();
 
@@ -382,11 +418,14 @@ impl ClientBuilder {
         if let Some(meter) = self.alloc_meter {
             let _ = client.alloc_meter.set(meter);
         }
-        if let Some(lifecycle) = &client.lifecycle {
-            lifecycle
-                .install(Arc::downgrade(&client))
-                .await
-                .map_err(ClientBuilderError::LifecycleInstall)?;
+        if let Some(lifecycle) = &client.lifecycle
+            && let Err(error) = lifecycle.install(Arc::downgrade(&client)).await
+        {
+            return Err(if client.plugin_host.is_some() {
+                ClientBuilderError::PluginInstall(error)
+            } else {
+                ClientBuilderError::LifecycleInstall(error)
+            });
         }
 
         let build = assembly.start();
@@ -397,6 +436,9 @@ impl ClientBuilder {
                 build.client.shutdown_signal(),
             );
             let _ = build.client.saver_handle.set(saver_handle);
+        }
+        if let Some(plugin_host) = &client.plugin_host {
+            plugin_host.activate();
         }
         Ok(build)
     }
@@ -444,6 +486,12 @@ async fn probe_durability_backend(
 pub(super) struct ClientAssembly {
     client: Arc<Client>,
     sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
+}
+
+#[derive(Default)]
+pub(super) struct ClientExtensions {
+    pub(super) lifecycle: Option<Arc<LifecycleRegistration>>,
+    pub(super) plugin_host: Option<Arc<PluginHost>>,
 }
 
 impl ClientAssembly {
@@ -587,7 +635,7 @@ mod tests {
             Arc::new(MockHttpClient),
             None,
             CacheConfig::default(),
-            None,
+            ClientExtensions::default(),
         );
         assert_eq!(spawns.load(Ordering::SeqCst), 0);
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -516,6 +516,16 @@ impl ClientBuilder {
                 "client shutdown raced lifecycle activation"
             )));
         }
+        #[cfg(feature = "plugins")]
+        if let Some(plugin_host) = &client.plugin_host
+            && !plugin_host.publish_apis()
+        {
+            client.signal_shutdown_sync();
+            client.shutdown_lifecycle().await;
+            return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
+                "plugin APIs could not be published"
+            )));
+        }
         #[cfg(feature = "client-lifecycle")]
         construction.disarm();
         Ok(build)

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -845,7 +845,7 @@ mod tests {
     #[cfg(feature = "client-lifecycle")]
     async fn shutdown_during_install_rejects_leaked_run_and_the_build() {
         let (client_tx, client_rx) = async_channel::bounded(1);
-        let (release_tx, release_rx) = async_channel::bounded(1);
+        let (_release_tx, release_rx) = async_channel::bounded(1);
         let (run_finished_tx, run_finished_rx) = async_channel::bounded(1);
         let builder = complete_builder()
             .await
@@ -860,10 +860,12 @@ mod tests {
             .await
             .expect("client leaked during install");
         leaked_client.signal_shutdown_sync();
-        release_tx.send(()).await.expect("release installation");
 
         assert!(matches!(
-            build.await.expect("builder task"),
+            tokio::time::timeout(Duration::from_secs(2), build)
+                .await
+                .expect("lifecycle install ignored terminal shutdown")
+                .expect("builder task"),
             Err(ClientBuilderError::LifecycleInstall(_))
         ));
         tokio::time::timeout(Duration::from_secs(5), run_finished_rx.recv())

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -10,7 +10,9 @@ use super::{ClientLifecycle, LifecycleRegistration};
 use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
 #[cfg(feature = "plugins")]
-use crate::plugins::{ClientPlugin, PluginHost, PluginPlan, PluginPlanError, PluginRegistration};
+use crate::plugins::{
+    ClientPlugin, PluginHost, PluginPlan, PluginPlanError, PluginRegistration, UntypedClientPlugin,
+};
 use crate::store::error::StoreError;
 use crate::store::persistence_manager::PersistenceManager;
 use crate::sync_task::MajorSyncTask;
@@ -317,6 +319,23 @@ impl ClientBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins.push(PluginRegistration::new_arc(plugin));
+        self
+    }
+
+    /// Register a manifest-ID-keyed plugin that exposes no Rust typed API.
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    pub fn with_untyped_plugin<P: UntypedClientPlugin>(mut self, plugin: P) -> Self {
+        self.plugins.push(PluginRegistration::new_untyped(plugin));
+        self
+    }
+
+    /// Register an already-shared manifest-ID-keyed plugin.
+    #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
+    pub fn with_untyped_plugin_arc<P: UntypedClientPlugin>(mut self, plugin: Arc<P>) -> Self {
+        self.plugins
+            .push(PluginRegistration::new_untyped_arc(plugin));
         self
     }
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -19,8 +19,8 @@ use wacore::runtime::Runtime;
 
 /// Result of constructing a [`Client`].
 ///
-/// The sync-task receiver has a single consumer and is therefore transferred
-/// together with the client rather than hidden behind a cloneable handle.
+/// Consume with [`ClientBuild::into_client`] for the standard worker or
+/// [`ClientBuild::into_parts`] when the host owns that worker itself.
 pub struct ClientBuild {
     client: Arc<Client>,
     sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
@@ -37,12 +37,15 @@ impl ClientBuild {
         }
     }
 
-    /// Return the constructed client.
-    pub fn client(&self) -> Arc<Client> {
-        Arc::clone(&self.client)
+    /// Transfer the client and start its default major-sync worker.
+    pub fn into_client(self) -> Arc<Client> {
+        let (client, sync_task_receiver) = self.into_parts();
+        client.start_sync_task_worker(sync_task_receiver);
+        client
     }
 
-    /// Transfer ownership of the client and its sync-task receiver.
+    /// Transfer ownership of the client and its sole sync-task receiver.
+    /// The caller must drain the receiver for history sync to keep working.
     pub fn into_parts(self) -> (Arc<Client>, async_channel::Receiver<MajorSyncTask>) {
         (self.client, self.sync_task_receiver)
     }
@@ -60,6 +63,8 @@ pub enum ClientBuilderError {
     MissingTransportFactory,
     #[error("missing HTTP client")]
     MissingHttpClient,
+    #[error("background saver interval must be greater than zero")]
+    InvalidBackgroundSaverInterval,
     #[error("the configured backend does not support the inbound durability hook: {0}")]
     UnsupportedDurabilityBackend(String),
     #[error("client lifecycle installation failed: {0}")]
@@ -341,6 +346,10 @@ impl ClientBuilder {
                 .cloned()
                 .ok_or(ClientBuilderError::MissingHttpClient)?;
 
+            if self.background_saver_interval == Some(Duration::ZERO) {
+                return Err(ClientBuilderError::InvalidBackgroundSaverInterval);
+            }
+
             if self.inbound_durability_hook.is_some() {
                 probe_durability_backend(&persistence_manager.backend()).await?;
             }
@@ -398,8 +407,17 @@ impl ClientBuilder {
             });
             (lifecycle_handler, plugin_host)
         };
-        let lifecycle = lifecycle_handler
-            .map(|handler| Arc::new(LifecycleRegistration::new(handler, Arc::clone(&runtime))));
+        let lifecycle = lifecycle_handler.map(|handler| {
+            #[cfg(feature = "plugins")]
+            if let Some(plugin_host) = &plugin_host {
+                return Arc::new(LifecycleRegistration::new_with_timeout(
+                    handler,
+                    Arc::clone(&runtime),
+                    plugin_host.lifecycle_callback_timeout(),
+                ));
+            }
+            Arc::new(LifecycleRegistration::new(handler, Arc::clone(&runtime)))
+        });
         let assembly = Client::assemble(
             Arc::clone(&runtime),
             Arc::clone(&persistence_manager),
@@ -593,6 +611,19 @@ mod tests {
         }
     }
 
+    async fn complete_builder() -> ClientBuilder {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        ClientBuilder::new()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+    }
+
     #[tokio::test]
     async fn validates_required_dependencies_before_assembly() {
         assert!(matches!(
@@ -658,7 +689,7 @@ mod tests {
 
         let build = assembly.start();
         assert_eq!(spawns.load(Ordering::SeqCst), 2);
-        build.client().signal_shutdown_sync();
+        build.into_client().signal_shutdown_sync();
     }
 
     #[tokio::test]
@@ -685,7 +716,7 @@ mod tests {
             .build()
             .await
             .expect("complete builder");
-        let client = build.client();
+        let client = build.into_client();
 
         assert!(client.skip_history_sync_enabled());
         assert_eq!(client.wanted_pre_key_count(), 123);
@@ -696,8 +727,66 @@ mod tests {
                 .is_some_and(|installed| Arc::ptr_eq(installed, &meter))
         );
         assert!(client.saver_handle.get().is_some());
-        assert_eq!(spawns.load(Ordering::SeqCst), 3);
+        assert_eq!(spawns.load(Ordering::SeqCst), 4);
         client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn consuming_build_as_client_keeps_major_sync_worker_alive() {
+        let client = complete_builder()
+            .await
+            .build()
+            .await
+            .expect("complete builder")
+            .into_client();
+
+        assert!(!client.major_sync_task_sender.is_closed());
+        client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_background_saver_interval() {
+        let result = complete_builder()
+            .await
+            .with_background_saver_interval(Duration::ZERO)
+            .build()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(ClientBuilderError::InvalidBackgroundSaverInterval)
+        ));
+    }
+
+    struct PanickingInstallLifecycle {
+        when_polled: bool,
+    }
+
+    impl ClientLifecycle for PanickingInstallLifecycle {
+        fn install(
+            &self,
+            _client: std::sync::Weak<Client>,
+        ) -> wacore::runtime::BoxFuture<'_, anyhow::Result<()>> {
+            if !self.when_polled {
+                panic!("injected synchronous install panic");
+            }
+            Box::pin(async { panic!("injected asynchronous install panic") })
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_install_panics_are_typed_build_errors() {
+        for when_polled in [false, true] {
+            let result = complete_builder()
+                .await
+                .with_lifecycle(PanickingInstallLifecycle { when_polled })
+                .build()
+                .await;
+            assert!(matches!(
+                result,
+                Err(ClientBuilderError::LifecycleInstall(_))
+            ));
+        }
     }
 
     #[tokio::test]

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -350,7 +350,10 @@ impl ClientBuilder {
             None => runtime,
         };
 
-        let lifecycle = self.lifecycle.map(LifecycleRegistration::new).map(Arc::new);
+        let lifecycle = self
+            .lifecycle
+            .map(|handler| LifecycleRegistration::new(handler, Arc::clone(&runtime)))
+            .map(Arc::new);
         let assembly = Client::assemble(
             Arc::clone(&runtime),
             Arc::clone(&persistence_manager),

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 
 use thiserror::Error;
 
-use super::{Client, ClientLifecycle, LifecycleRegistration};
+use super::Client;
+#[cfg(feature = "client-lifecycle")]
+use super::{ClientLifecycle, LifecycleRegistration};
 use crate::cache_config::CacheConfig;
 use crate::http::HttpClient;
 #[cfg(feature = "plugins")]
@@ -67,6 +69,7 @@ pub enum ClientBuilderError {
     InvalidBackgroundSaverInterval,
     #[error("the configured backend does not support the inbound durability hook: {0}")]
     UnsupportedDurabilityBackend(String),
+    #[cfg(feature = "client-lifecycle")]
     #[error("client lifecycle installation failed: {0}")]
     LifecycleInstall(#[source] anyhow::Error),
     #[cfg(feature = "plugins")]
@@ -97,6 +100,7 @@ pub struct ClientBuilder {
     task_instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
     alloc_meter: Option<Arc<wacore::stats::AllocMeter>>,
     background_saver_interval: Option<Duration>,
+    #[cfg(feature = "client-lifecycle")]
     lifecycle: Option<Arc<dyn ClientLifecycle>>,
     #[cfg(feature = "plugins")]
     plugins: Vec<PluginRegistration>,
@@ -126,6 +130,7 @@ impl ClientBuilder {
             task_instrument: None,
             alloc_meter: None,
             background_saver_interval: None,
+            #[cfg(feature = "client-lifecycle")]
             lifecycle: None,
             #[cfg(feature = "plugins")]
             plugins: Vec::new(),
@@ -278,6 +283,7 @@ impl ClientBuilder {
     }
 
     /// Install the aggregate lifecycle used by extensions of this client.
+    #[cfg(feature = "client-lifecycle")]
     pub fn with_lifecycle<L>(mut self, lifecycle: L) -> Self
     where
         L: ClientLifecycle + 'static,
@@ -287,6 +293,7 @@ impl ClientBuilder {
     }
 
     /// Install an already-shared aggregate lifecycle.
+    #[cfg(feature = "client-lifecycle")]
     pub fn with_lifecycle_arc(mut self, lifecycle: Arc<dyn ClientLifecycle>) -> Self {
         self.lifecycle = Some(lifecycle);
         self
@@ -396,6 +403,7 @@ impl ClientBuilder {
             None => runtime,
         };
 
+        #[cfg(feature = "client-lifecycle")]
         let lifecycle_handler = self.lifecycle;
         #[cfg(feature = "plugins")]
         let (lifecycle_handler, plugin_host) = {
@@ -407,6 +415,7 @@ impl ClientBuilder {
             });
             (lifecycle_handler, plugin_host)
         };
+        #[cfg(feature = "client-lifecycle")]
         let lifecycle = lifecycle_handler.map(|handler| {
             #[cfg(feature = "plugins")]
             if let Some(plugin_host) = &plugin_host {
@@ -426,12 +435,14 @@ impl ClientBuilder {
             self.override_version,
             self.cache_config,
             ClientExtensions {
+                #[cfg(feature = "client-lifecycle")]
                 lifecycle,
                 #[cfg(feature = "plugins")]
                 plugin_host,
             },
         );
         let client = assembly.client();
+        #[cfg(feature = "client-lifecycle")]
         let mut construction = ClientConstructionGuard::new(Arc::clone(&client));
 
         if !self.custom_enc_handlers.is_empty() {
@@ -452,6 +463,7 @@ impl ClientBuilder {
         if let Some(meter) = self.alloc_meter {
             let _ = client.alloc_meter.set(meter);
         }
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &client.lifecycle
             && let Err(error) = lifecycle.install(Arc::downgrade(&client)).await
         {
@@ -481,6 +493,7 @@ impl ClientBuilder {
                 "client shutdown began before plugin activation"
             )));
         }
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &client.lifecycle
             && !lifecycle.activate()
         {
@@ -496,6 +509,7 @@ impl ClientBuilder {
                 "client shutdown raced lifecycle activation"
             )));
         }
+        #[cfg(feature = "client-lifecycle")]
         construction.disarm();
         Ok(build)
     }
@@ -545,11 +559,13 @@ pub(super) struct ClientAssembly {
     sync_task_receiver: async_channel::Receiver<MajorSyncTask>,
 }
 
+#[cfg(feature = "client-lifecycle")]
 struct ClientConstructionGuard {
     client: Arc<Client>,
     armed: bool,
 }
 
+#[cfg(feature = "client-lifecycle")]
 impl ClientConstructionGuard {
     fn new(client: Arc<Client>) -> Self {
         Self {
@@ -563,6 +579,7 @@ impl ClientConstructionGuard {
     }
 }
 
+#[cfg(feature = "client-lifecycle")]
 impl Drop for ClientConstructionGuard {
     fn drop(&mut self) {
         if self.armed {
@@ -573,6 +590,7 @@ impl Drop for ClientConstructionGuard {
 
 #[derive(Default)]
 pub(super) struct ClientExtensions {
+    #[cfg(feature = "client-lifecycle")]
     pub(super) lifecycle: Option<Arc<LifecycleRegistration>>,
     #[cfg(feature = "plugins")]
     pub(super) plugin_host: Option<Arc<PluginHost>>,
@@ -612,17 +630,20 @@ mod tests {
     use crate::transport::mock::MockTransportFactory;
     use wacore::runtime::AbortHandle;
 
+    #[cfg(feature = "client-lifecycle")]
     struct FailingLifecycle {
         spawns: Arc<AtomicUsize>,
         installed_client: std::sync::Mutex<Option<std::sync::Weak<Client>>>,
     }
 
+    #[cfg(feature = "client-lifecycle")]
     struct RunDuringInstallLifecycle {
         client: async_channel::Sender<Arc<Client>>,
         release: async_channel::Receiver<()>,
         run_finished: async_channel::Sender<()>,
     }
 
+    #[cfg(feature = "client-lifecycle")]
     impl ClientLifecycle for RunDuringInstallLifecycle {
         fn install<'a>(
             &'a self,
@@ -654,6 +675,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "client-lifecycle")]
     impl ClientLifecycle for FailingLifecycle {
         fn install<'a>(
             &'a self,
@@ -779,6 +801,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "client-lifecycle")]
     async fn run_leaked_during_install_waits_for_complete_construction() {
         let (client_tx, client_rx) = async_channel::bounded(1);
         let (release_tx, release_rx) = async_channel::bounded(1);
@@ -819,6 +842,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "client-lifecycle")]
     async fn shutdown_during_install_rejects_leaked_run_and_the_build() {
         let (client_tx, client_rx) = async_channel::bounded(1);
         let (release_tx, release_rx) = async_channel::bounded(1);
@@ -915,10 +939,12 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "client-lifecycle")]
     struct PanickingInstallLifecycle {
         when_polled: bool,
     }
 
+    #[cfg(feature = "client-lifecycle")]
     impl ClientLifecycle for PanickingInstallLifecycle {
         fn install(
             &self,
@@ -932,6 +958,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "client-lifecycle")]
     async fn lifecycle_install_panics_are_typed_build_errors() {
         for when_polled in [false, true] {
             let result = complete_builder()
@@ -947,6 +974,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "client-lifecycle")]
     async fn lifecycle_install_failure_publishes_nothing_and_starts_no_tasks() {
         let persistence_manager = Arc::new(
             PersistenceManager::new(crate::test_utils::create_test_backend().await)

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -490,41 +490,29 @@ impl ClientBuilder {
             );
             let _ = build.client.saver_handle.set(saver_handle);
         }
-        #[cfg(feature = "plugins")]
-        if let Some(plugin_host) = &client.plugin_host
-            && !plugin_host.activate()
-        {
-            client.signal_shutdown_sync();
-            client.shutdown_lifecycle().await;
-            return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
-                "client shutdown began before plugin activation"
-            )));
-        }
         #[cfg(feature = "client-lifecycle")]
-        if let Some(lifecycle) = &client.lifecycle
-            && !lifecycle.activate()
-        {
-            client.signal_shutdown_sync();
-            client.shutdown_lifecycle().await;
+        if let Some(lifecycle) = &client.lifecycle {
             #[cfg(feature = "plugins")]
-            if client.plugin_host.is_some() {
-                return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
-                    "client shutdown raced plugin activation"
+            let activated = if let Some(plugin_host) = &client.plugin_host {
+                lifecycle.activate_with(|| plugin_host.commit())
+            } else {
+                lifecycle.activate()
+            };
+            #[cfg(not(feature = "plugins"))]
+            let activated = lifecycle.activate();
+            if !activated {
+                client.signal_shutdown_sync();
+                client.shutdown_lifecycle().await;
+                #[cfg(feature = "plugins")]
+                if client.plugin_host.is_some() {
+                    return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
+                        "client shutdown raced plugin publication"
+                    )));
+                }
+                return Err(ClientBuilderError::LifecycleInstall(anyhow::anyhow!(
+                    "client shutdown raced lifecycle activation"
                 )));
             }
-            return Err(ClientBuilderError::LifecycleInstall(anyhow::anyhow!(
-                "client shutdown raced lifecycle activation"
-            )));
-        }
-        #[cfg(feature = "plugins")]
-        if let Some(plugin_host) = &client.plugin_host
-            && !plugin_host.publish_apis()
-        {
-            client.signal_shutdown_sync();
-            client.shutdown_lifecycle().await;
-            return Err(ClientBuilderError::PluginInstall(anyhow::anyhow!(
-                "plugin APIs could not be published"
-            )));
         }
         #[cfg(feature = "client-lifecycle")]
         construction.disarm();

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -70,12 +70,15 @@ pub enum ClientBuilderError {
     #[error("the configured backend does not support the inbound durability hook: {0}")]
     UnsupportedDurabilityBackend(String),
     #[cfg(feature = "client-lifecycle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
     #[error("client lifecycle installation failed: {0}")]
     LifecycleInstall(#[source] anyhow::Error),
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     #[error("plugin host installation failed: {0}")]
     PluginInstall(#[source] anyhow::Error),
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     #[error("invalid plugin plan: {0}")]
     PluginPlan(#[from] PluginPlanError),
 }
@@ -284,6 +287,7 @@ impl ClientBuilder {
 
     /// Install the aggregate lifecycle used by extensions of this client.
     #[cfg(feature = "client-lifecycle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
     pub fn with_lifecycle<L>(mut self, lifecycle: L) -> Self
     where
         L: ClientLifecycle + 'static,
@@ -294,6 +298,7 @@ impl ClientBuilder {
 
     /// Install an already-shared aggregate lifecycle.
     #[cfg(feature = "client-lifecycle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
     pub fn with_lifecycle_arc(mut self, lifecycle: Arc<dyn ClientLifecycle>) -> Self {
         self.lifecycle = Some(lifecycle);
         self
@@ -301,6 +306,7 @@ impl ClientBuilder {
 
     /// Register a native plugin for transactional installation before services start.
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub fn with_plugin<P: ClientPlugin>(mut self, plugin: P) -> Self {
         self.plugins.push(PluginRegistration::new(plugin));
         self
@@ -308,6 +314,7 @@ impl ClientBuilder {
 
     /// Register an already-shared native plugin without changing its marker type.
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub fn with_plugin_arc<P: ClientPlugin>(mut self, plugin: Arc<P>) -> Self {
         self.plugins.push(PluginRegistration::new_arc(plugin));
         self

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -964,9 +964,8 @@ impl Client {
     /// Background loop placeholder for device registry cleanup.
     /// Note: Cleanup functionality was removed as part of trait simplification.
     /// Device registry entries are managed through normal update/get operations.
-    pub(super) async fn device_registry_cleanup_loop(&self) {
-        // Simply wait for shutdown signal
-        self.shutdown_notifier.listen().await;
+    pub(super) async fn device_registry_cleanup_loop(shutdown: wacore::runtime::ShutdownSignal) {
+        wacore::runtime::wait_for_shutdown(&shutdown).await;
         debug!(
             target: "Client/DeviceRegistry",
             "Shutdown signaled, exiting cleanup loop"

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -307,6 +307,7 @@ impl LifecycleRegistration {
         self.close_scope_with(generation, || {});
     }
 
+    /// Non-noop hooks are test-only, must run off-executor, and must not re-enter lifecycle APIs.
     fn close_scope_with(self: &Arc<Self>, generation: u64, after_remove: impl FnOnce()) {
         let should_spawn = {
             let mut scopes = self.scopes();

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -382,6 +382,15 @@ impl LifecycleRegistration {
         }
     }
 
+    pub(super) fn cancel_active_scope(&self) {
+        if ready_publication_active(self) {
+            self.cancel_active_scope_inner();
+        } else {
+            let _publication = self.ready_publication();
+            self.cancel_active_scope_inner();
+        }
+    }
+
     pub(super) fn close_scope(self: &Arc<Self>, generation: u64) {
         self.close_scope_with(generation, || {});
     }
@@ -616,6 +625,12 @@ impl LifecycleRegistration {
         }
     }
 
+    fn cancel_active_scope_inner(&self) {
+        if let Some(scope) = &self.scopes().active {
+            scope.cancel();
+        }
+    }
+
     fn mark_terminal_and_cancel_scopes(&self) -> bool {
         let first_signal = !self.terminal.swap(true, Ordering::AcqRel);
         let scopes = self.scopes();
@@ -771,6 +786,70 @@ mod tests {
     struct ReentrantDisconnectLifecycle {
         client: std::sync::Mutex<Option<Weak<Client>>>,
         events: std::sync::Mutex<Vec<&'static str>>,
+    }
+
+    struct ReentrantReconnectLifecycle {
+        client: std::sync::Mutex<Option<Weak<Client>>>,
+        events: std::sync::Mutex<Vec<&'static str>>,
+        immediate: bool,
+    }
+
+    impl ClientLifecycle for ReentrantReconnectLifecycle {
+        fn install<'a>(&'a self, client: Weak<Client>) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                *self
+                    .client
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client);
+                Ok(())
+            })
+        }
+
+        fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("ready-started");
+                let client = self
+                    .client
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .as_ref()
+                    .and_then(Weak::upgrade)
+                    .expect("installed client");
+                if self.immediate {
+                    client.reconnect_immediately().await;
+                } else {
+                    client.reconnect().await;
+                }
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("ready-finished");
+                Ok(())
+            })
+        }
+
+        fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("closed");
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("shutdown");
+                Ok(())
+            })
+        }
     }
 
     impl ClientLifecycle for ReentrantDisconnectLifecycle {
@@ -1376,6 +1455,57 @@ mod tests {
         );
         assert!(!client.is_logged_in());
         assert!(!client.is_ready.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn ready_callback_reconnect_requests_retire_the_scope_before_returning() {
+        for immediate in [false, true] {
+            let persistence_manager = Arc::new(
+                PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                    .await
+                    .expect("persistence manager"),
+            );
+            let lifecycle = Arc::new(ReentrantReconnectLifecycle {
+                client: std::sync::Mutex::new(None),
+                events: std::sync::Mutex::new(Vec::new()),
+                immediate,
+            });
+            let client = Client::builder()
+                .with_runtime(TokioRuntime)
+                .with_persistence_manager(persistence_manager)
+                .with_transport_factory(MockTransportFactory::new())
+                .with_http_client(MockHttpClient)
+                .with_lifecycle_arc(lifecycle.clone())
+                .build()
+                .await
+                .expect("client build")
+                .into_client();
+            const GENERATION: u64 = 18;
+            client
+                .connection_generation
+                .store(GENERATION, Ordering::SeqCst);
+            let registration = client.lifecycle.as_ref().expect("lifecycle registration");
+            assert!(registration.begin_scope_if_current(GENERATION, || true));
+
+            tokio::time::timeout(Duration::from_secs(2), client.dispatch_connected())
+                .await
+                .expect("reentrant reconnect completed");
+            let scope = registration
+                .scope_for(GENERATION)
+                .expect("cancelled connection scope");
+            assert_eq!(scope.state(), ConnectionScopeState::Cancelled);
+            assert!(!client.is_ready.load(Ordering::Relaxed));
+
+            registration.close_scope(GENERATION);
+            registration.shutdown().await;
+            assert_eq!(
+                *lifecycle
+                    .events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()),
+                vec!["ready-started", "ready-finished", "closed", "shutdown"]
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -131,6 +131,8 @@ impl fmt::Debug for ConnectionScope {
 /// stalled extension cannot block reconnect. A future plugin host owns
 /// per-plugin ordering and isolation behind this client-level seam. `install`
 /// receives a weak client reference so retaining it cannot create a cycle.
+/// `signal_shutdown` is the non-blocking boundary for resources that must stop
+/// even when an FFI host cannot await `shutdown`.
 pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
     fn install<'a>(&'a self, _client: Weak<Client>) -> BoxFuture<'a, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
@@ -143,6 +145,10 @@ pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
     fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
     }
+
+    /// Stop synchronously owned resources before asynchronous shutdown begins.
+    /// Implementations must return promptly and make repeated calls harmless.
+    fn signal_shutdown(&self) {}
 
     fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
@@ -209,7 +215,7 @@ impl LifecycleRegistration {
         Self::new_with_timeout(handler, runtime, CALLBACK_TIMEOUT)
     }
 
-    fn new_with_timeout(
+    pub(super) fn new_with_timeout(
         handler: Arc<dyn ClientLifecycle>,
         runtime: Arc<dyn Runtime>,
         callback_timeout: Duration,
@@ -227,7 +233,14 @@ impl LifecycleRegistration {
     }
 
     pub(super) async fn install(&self, client: Weak<Client>) -> anyhow::Result<()> {
-        self.handler.install(client).await
+        let install = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.handler.install(client)
+        }))
+        .map_err(|_| anyhow::anyhow!("lifecycle install panicked before returning a future"))?;
+        std::panic::AssertUnwindSafe(install)
+            .catch_unwind()
+            .await
+            .map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?
     }
 
     pub(super) fn begin_scope_if_current(
@@ -352,8 +365,7 @@ impl LifecycleRegistration {
     }
 
     pub(super) async fn shutdown(self: &Arc<Self>) {
-        self.terminal.store(true, Ordering::Release);
-        self.cancel_active_scope();
+        self.signal_shutdown_sync();
         {
             let mut queue = self.callback_queue();
             queue.shutdown_requested = true;
@@ -369,6 +381,19 @@ impl LifecycleRegistration {
             return;
         }
         wacore::runtime::wait_for_shutdown(&completed).await;
+    }
+
+    pub(super) fn signal_shutdown_sync(&self) {
+        let first_signal = !self.terminal.swap(true, Ordering::AcqRel);
+        self.cancel_active_scope();
+        if first_signal
+            && std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.handler.signal_shutdown();
+            }))
+            .is_err()
+        {
+            log::warn!("Client lifecycle synchronous shutdown signal panicked");
+        }
     }
 
     fn enqueue_callback(self: &Arc<Self>, callback: LifecycleCallback) {
@@ -806,7 +831,7 @@ mod tests {
             .build()
             .await
             .expect("client build");
-        let client = build.client();
+        let client = build.into_client();
         const GENERATION: u64 = 9;
         client
             .connection_generation
@@ -884,7 +909,7 @@ mod tests {
             .build()
             .await
             .expect("client build")
-            .client();
+            .into_client();
         const GENERATION: u64 = 13;
         client
             .connection_generation
@@ -959,7 +984,7 @@ mod tests {
             .build()
             .await
             .expect("client build")
-            .client();
+            .into_client();
         const GENERATION: u64 = 17;
         client
             .connection_generation
@@ -1152,7 +1177,7 @@ mod tests {
             .build()
             .await
             .expect("client build")
-            .client();
+            .into_client();
         const GENERATION: u64 = 37;
         client
             .connection_generation
@@ -1306,7 +1331,7 @@ mod tests {
             .build()
             .await
             .expect("client build")
-            .client();
+            .into_client();
         client
             .subscribe_handler(Arc::new(LogoutOrderHandler {
                 lifecycle: lifecycle.clone(),

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -47,7 +47,7 @@ pub struct ConnectionScope {
 }
 
 impl ConnectionScope {
-    fn new(generation: u64) -> Self {
+    pub(crate) fn new(generation: u64) -> Self {
         Self {
             inner: Arc::new(ConnectionScopeInner {
                 generation,
@@ -88,7 +88,7 @@ impl ConnectionScope {
             .is_ok()
     }
 
-    fn cancel(&self) {
+    pub(crate) fn cancel(&self) {
         let mut state = self.inner.state.load(Ordering::Acquire);
         while state < SCOPE_CANCELLED {
             match self.inner.state.compare_exchange_weak(

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -1315,6 +1315,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejected_success_restores_logged_out_state() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle)
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+        client
+            .lifecycle
+            .as_ref()
+            .expect("lifecycle registration")
+            .signal_shutdown_sync();
+
+        let success = wacore_binary::builder::NodeBuilder::new("success").build();
+        client.handle_success(&success.as_node_ref()).await;
+
+        assert!(!client.is_logged_in());
+        assert_eq!(client.connection_generation.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn replaced_scope_stays_closeable_by_its_generation() {
         let lifecycle = Arc::new(RecordingLifecycle::default());
         let registration = Arc::new(LifecycleRegistration::new(

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -17,7 +17,7 @@ const CONSTRUCTION_INSTALLING: u8 = 0;
 const CONSTRUCTION_ACTIVE: u8 = 1;
 const CONSTRUCTION_REJECTED: u8 = 2;
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
-const CALLBACK_QUEUE_CAPACITY: usize = 64;
+const CALLBACK_QUEUE_TARGET_CAPACITY: usize = 64;
 
 std::thread_local! {
     static ACTIVE_CALLBACK: Cell<*const LifecycleRegistration> = const { Cell::new(std::ptr::null()) };
@@ -130,10 +130,11 @@ impl fmt::Debug for ConnectionScope {
 /// Aggregate lifecycle seam installed during [`Client`](super::Client) construction.
 ///
 /// Implementations must make `install` transactional. Connection callbacks are
-/// serialized and bounded; connection cleanup only schedules `on_closed` so a
-/// stalled extension cannot block reconnect. A future plugin host owns
-/// per-plugin ordering and isolation behind this client-level seam. `install`
-/// receives a weak client reference so retaining it cannot create a cycle.
+/// serialized, with bounded ready work; connection cleanup only schedules
+/// `on_closed` so a stalled extension cannot block reconnect. Closure callbacks
+/// are lossless and may temporarily exceed the target capacity. A future plugin
+/// host owns per-plugin ordering and isolation behind this client-level seam.
+/// `install` receives a weak client reference so retaining it cannot create a cycle.
 /// `signal_shutdown` is the non-blocking boundary for resources that must stop
 /// even when an FFI host cannot await `shutdown`.
 pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
@@ -197,31 +198,49 @@ struct CallbackQueue {
 }
 
 impl CallbackQueue {
-    fn push_bounded(&mut self, callback: LifecycleCallback) -> Option<LifecycleCallback> {
-        let dropped = (self.pending.len() >= CALLBACK_QUEUE_CAPACITY)
-            .then(|| self.pending.pop_front())
-            .flatten();
-        self.overflowed |= dropped.is_some();
-        self.pending.push_back(callback);
-        dropped
+    fn push_with_pressure_policy(
+        &mut self,
+        callback: LifecycleCallback,
+    ) -> Option<LifecycleCallback> {
+        if self.pending.len() < CALLBACK_QUEUE_TARGET_CAPACITY {
+            self.pending.push_back(callback);
+            return None;
+        }
+
+        self.overflowed = true;
+        let ready_position = self
+            .pending
+            .iter()
+            .position(|pending| matches!(pending, LifecycleCallback::Ready { .. }));
+        match (callback, ready_position) {
+            (callback @ LifecycleCallback::Ready { .. }, None) => Some(callback),
+            (callback, Some(position)) => {
+                let dropped = self.pending.remove(position);
+                self.pending.push_back(callback);
+                dropped
+            }
+            (callback, None) => {
+                // Every closed scope must reach the extension even when a callback stalls.
+                self.pending.push_back(callback);
+                None
+            }
+        }
     }
 
-    fn compact_for_shutdown(&mut self, keep_last_closed: bool) -> Vec<LifecycleCallback> {
+    fn compact_for_shutdown(&mut self) -> Vec<LifecycleCallback> {
         if !self.overflowed {
             return Vec::new();
         }
-        let last_closed = keep_last_closed
-            .then(|| {
-                self.pending
-                    .iter()
-                    .rposition(|callback| matches!(callback, LifecycleCallback::Closed(_)))
-            })
-            .flatten()
-            .and_then(|position| self.pending.remove(position));
-        let dropped = self.pending.drain(..).collect::<Vec<_>>();
-        if let Some(last_closed) = last_closed {
-            self.pending.push_back(last_closed);
+
+        let mut retained = VecDeque::with_capacity(self.pending.len());
+        let mut dropped = Vec::new();
+        for callback in self.pending.drain(..) {
+            match callback {
+                callback @ LifecycleCallback::Closed(_) => retained.push_back(callback),
+                callback => dropped.push(callback),
+            }
         }
+        self.pending = retained;
         dropped
     }
 }
@@ -495,14 +514,14 @@ impl LifecycleRegistration {
             let mut queue = self.callback_queue();
             let mut dropped = Vec::new();
             if queue.shutdown_requested {
-                dropped.extend(queue.push_bounded(LifecycleCallback::Closed(scope)));
-                dropped.extend(queue.compact_for_shutdown(no_open_scopes));
+                dropped.extend(queue.push_with_pressure_policy(LifecycleCallback::Closed(scope)));
+                dropped.extend(queue.compact_for_shutdown());
                 if no_open_scopes && !queue.shutdown_enqueued {
                     queue.shutdown_enqueued = true;
                     queue.pending.push_back(LifecycleCallback::Shutdown);
                 }
             } else {
-                dropped.extend(queue.push_bounded(LifecycleCallback::Closed(scope)));
+                dropped.extend(queue.push_with_pressure_policy(LifecycleCallback::Closed(scope)));
             }
             let should_spawn = !queue.pending.is_empty() && !queue.drain_scheduled;
             queue.drain_scheduled |= should_spawn;
@@ -560,7 +579,7 @@ impl LifecycleRegistration {
             if queue.shutdown_requested || self.terminal.load(Ordering::Acquire) {
                 (false, Some(callback))
             } else {
-                let dropped = queue.push_bounded(callback);
+                let dropped = queue.push_with_pressure_policy(callback);
                 let should_spawn = !queue.drain_scheduled;
                 queue.drain_scheduled = true;
                 (should_spawn, dropped)
@@ -580,7 +599,7 @@ impl LifecycleRegistration {
             if !queue.shutdown_requested || queue.shutdown_enqueued {
                 return;
             }
-            let dropped = queue.compact_for_shutdown(no_open_scopes);
+            let dropped = queue.compact_for_shutdown();
             if no_open_scopes {
                 queue.shutdown_enqueued = true;
                 queue.pending.push_back(LifecycleCallback::Shutdown);
@@ -1708,7 +1727,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn callback_queue_is_bounded_and_terminal_shutdown_compacts_backlog() {
+    async fn callback_queue_preserves_every_scope_closure_before_shutdown() {
         let (ready_started_tx, ready_started_rx) = async_channel::bounded(1);
         let (release_ready_tx, release_ready_rx) = async_channel::bounded(1);
         let lifecycle = Arc::new(QueuePressureLifecycle {
@@ -1735,14 +1754,21 @@ mod tests {
             .await
             .expect("ready callback started");
 
-        for generation in 2..(CALLBACK_QUEUE_CAPACITY as u64 * 4) {
+        let closed_callbacks = CALLBACK_QUEUE_TARGET_CAPACITY as u64 * 4 - 2;
+        for generation in 2..(CALLBACK_QUEUE_TARGET_CAPACITY as u64 * 4) {
             let scope = ConnectionScope::new(generation);
             scope.close();
             registration.enqueue_callback(LifecycleCallback::Closed(scope));
+
+            let (done, _done_rx) = async_channel::bounded(1);
+            registration.enqueue_callback(LifecycleCallback::Ready {
+                scope: ConnectionScope::new(generation + closed_callbacks),
+                done,
+            });
         }
         assert_eq!(
             registration.callback_queue().pending.len(),
-            CALLBACK_QUEUE_CAPACITY
+            usize::try_from(closed_callbacks).expect("closure count fits usize")
         );
 
         let shutdown_registration = registration.clone();
@@ -1752,7 +1778,11 @@ mod tests {
                 let compacted = {
                     let queue = registration.callback_queue();
                     if queue.shutdown_enqueued {
-                        assert_eq!(queue.pending.len(), 2);
+                        assert_eq!(
+                            queue.pending.len(),
+                            usize::try_from(closed_callbacks + 1)
+                                .expect("terminal callback count fits usize")
+                        );
                         true
                     } else {
                         false
@@ -1772,7 +1802,10 @@ mod tests {
             .await
             .expect("release ready callback");
         shutdown.await.expect("bounded terminal shutdown");
-        assert_eq!(lifecycle.closed_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            lifecycle.closed_calls.load(Ordering::SeqCst),
+            usize::try_from(closed_callbacks).expect("closure count fits usize")
+        );
         assert_eq!(lifecycle.shutdown_calls.load(Ordering::SeqCst), 1);
     }
 

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -19,6 +19,7 @@ const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 std::thread_local! {
     static ACTIVE_CALLBACK: Cell<*const LifecycleRegistration> = const { Cell::new(std::ptr::null()) };
+    static ACTIVE_READY_PUBLICATION: Cell<*const LifecycleRegistration> = const { Cell::new(std::ptr::null()) };
 }
 
 /// Observable state of one authenticated connection generation.
@@ -158,6 +159,7 @@ pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
 pub(super) struct LifecycleRegistration {
     handler: Arc<dyn ClientLifecycle>,
     runtime: Arc<dyn Runtime>,
+    ready_publication: std::sync::Mutex<()>,
     scopes: std::sync::Mutex<ScopeRegistry>,
     callback_queue: std::sync::Mutex<CallbackQueue>,
     shutdown_complete: AtomicBool,
@@ -193,6 +195,23 @@ struct CallbackContextGuard {
     previous: *const LifecycleRegistration,
 }
 
+struct ReadyPublicationGuard {
+    previous: *const LifecycleRegistration,
+}
+
+impl ReadyPublicationGuard {
+    fn enter(registration: &LifecycleRegistration) -> Self {
+        let previous = ACTIVE_READY_PUBLICATION.replace(registration);
+        Self { previous }
+    }
+}
+
+impl Drop for ReadyPublicationGuard {
+    fn drop(&mut self) {
+        ACTIVE_READY_PUBLICATION.set(self.previous);
+    }
+}
+
 impl CallbackContextGuard {
     fn enter(registration: &LifecycleRegistration) -> Self {
         let previous = ACTIVE_CALLBACK.replace(registration);
@@ -210,6 +229,10 @@ fn callback_context_active(registration: &LifecycleRegistration) -> bool {
     ACTIVE_CALLBACK.with(|active| std::ptr::eq(active.get(), registration))
 }
 
+fn ready_publication_active(registration: &LifecycleRegistration) -> bool {
+    ACTIVE_READY_PUBLICATION.with(|active| std::ptr::eq(active.get(), registration))
+}
+
 impl LifecycleRegistration {
     pub(super) fn new(handler: Arc<dyn ClientLifecycle>, runtime: Arc<dyn Runtime>) -> Self {
         Self::new_with_timeout(handler, runtime, CALLBACK_TIMEOUT)
@@ -223,6 +246,7 @@ impl LifecycleRegistration {
         Self {
             handler,
             runtime,
+            ready_publication: std::sync::Mutex::new(()),
             scopes: std::sync::Mutex::new(ScopeRegistry::default()),
             callback_queue: std::sync::Mutex::new(CallbackQueue::default()),
             shutdown_complete: AtomicBool::new(false),
@@ -300,19 +324,29 @@ impl LifecycleRegistration {
         done_rx.recv().await.unwrap_or(false) && !scope.is_cancelled()
     }
 
-    pub(super) fn cancel_scope(&self, generation: u64) {
-        if let Some(scope) = self.scope_for(generation) {
-            scope.cancel();
+    pub(super) fn publish_ready(&self, generation: u64, publish: impl FnOnce()) -> bool {
+        let _publication = self.ready_publication();
+        if self.terminal.load(Ordering::Acquire) {
+            return false;
         }
+        let Some(scope) = self.scope_for(generation) else {
+            return false;
+        };
+        if scope.state() != ConnectionScopeState::Ready {
+            return false;
+        }
+
+        let _publication_context = ReadyPublicationGuard::enter(self);
+        publish();
+        true
     }
 
-    pub(super) fn cancel_active_scope(&self) {
-        let scopes = self.scopes();
-        if let Some(scope) = &scopes.active {
-            scope.cancel();
-        }
-        for scope in &scopes.retired {
-            scope.cancel();
+    pub(super) fn cancel_scope(&self, generation: u64) {
+        if ready_publication_active(self) {
+            self.cancel_scope_inner(generation);
+        } else {
+            let _publication = self.ready_publication();
+            self.cancel_scope_inner(generation);
         }
     }
 
@@ -388,8 +422,12 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn signal_shutdown_sync(&self) {
-        let first_signal = !self.terminal.swap(true, Ordering::AcqRel);
-        self.cancel_active_scope();
+        let first_signal = if ready_publication_active(self) {
+            self.mark_terminal_and_cancel_scopes()
+        } else {
+            let _publication = self.ready_publication();
+            self.mark_terminal_and_cancel_scopes()
+        };
         if first_signal
             && std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 self.handler.signal_shutdown();
@@ -528,6 +566,30 @@ impl LifecycleRegistration {
         self.callback_queue
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn ready_publication(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.ready_publication
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn cancel_scope_inner(&self, generation: u64) {
+        if let Some(scope) = self.scope_for(generation) {
+            scope.cancel();
+        }
+    }
+
+    fn mark_terminal_and_cancel_scopes(&self) -> bool {
+        let first_signal = !self.terminal.swap(true, Ordering::AcqRel);
+        let scopes = self.scopes();
+        if let Some(scope) = &scopes.active {
+            scope.cancel();
+        }
+        for scope in &scopes.retired {
+            scope.cancel();
+        }
+        first_signal
     }
 
     fn scope_for(&self, generation: u64) -> Option<ConnectionScope> {
@@ -836,6 +898,115 @@ mod tests {
         scope.cancel();
         scope.close();
         assert_eq!(scope.state(), ConnectionScopeState::Closed);
+    }
+
+    #[tokio::test]
+    async fn terminal_signal_rejects_ready_publication() {
+        let registration = Arc::new(LifecycleRegistration::new(
+            Arc::new(RecordingLifecycle::default()),
+            Arc::new(TokioRuntime),
+        ));
+        const GENERATION: u64 = 43;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+        assert!(registration.ready(GENERATION).await);
+        registration.signal_shutdown_sync();
+
+        let published = AtomicBool::new(false);
+        assert!(!registration.publish_ready(GENERATION, || {
+            published.store(true, Ordering::Release);
+        }));
+        assert!(!published.load(Ordering::Acquire));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terminal_cancellation_waits_for_ready_publication() {
+        let registration = Arc::new(LifecycleRegistration::new(
+            Arc::new(RecordingLifecycle::default()),
+            Arc::new(TokioRuntime),
+        ));
+        const GENERATION: u64 = 47;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+        assert!(registration.ready(GENERATION).await);
+        let scope = registration
+            .scope_for(GENERATION)
+            .expect("ready connection scope");
+
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let (published_tx, published_rx) = std::sync::mpsc::sync_channel(1);
+        let publish_registration = registration.clone();
+        let publish = std::thread::spawn(move || {
+            let published = publish_registration.publish_ready(GENERATION, || {
+                let _ = started_tx.send(());
+                let _ = release_rx.recv();
+            });
+            let _ = published_tx.send(published);
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("ready publication started");
+
+        let (attempted_tx, attempted_rx) = std::sync::mpsc::sync_channel(1);
+        let (cancelled_tx, cancelled_rx) = std::sync::mpsc::sync_channel(1);
+        let cancel_registration = registration.clone();
+        let cancel = std::thread::spawn(move || {
+            let _ = attempted_tx.send(());
+            cancel_registration.signal_shutdown_sync();
+            let _ = cancelled_tx.send(());
+        });
+        attempted_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("terminal cancellation attempted");
+        assert!(
+            cancelled_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
+
+        release_tx.send(()).expect("release ready publication");
+        assert!(
+            published_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("ready publication completed")
+        );
+        cancelled_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("terminal cancellation completed");
+        publish.join().expect("publication thread");
+        cancel.join().expect("cancellation thread");
+        assert_eq!(scope.state(), ConnectionScopeState::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn ready_publication_allows_reentrant_terminal_signal() {
+        let registration = Arc::new(LifecycleRegistration::new(
+            Arc::new(RecordingLifecycle::default()),
+            Arc::new(TokioRuntime),
+        ));
+        const GENERATION: u64 = 53;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+        assert!(registration.ready(GENERATION).await);
+        let scope = registration
+            .scope_for(GENERATION)
+            .expect("ready connection scope");
+
+        let (completed_tx, completed_rx) = std::sync::mpsc::sync_channel(1);
+        let publish_registration = registration.clone();
+        let signal_registration = registration.clone();
+        let publish = std::thread::spawn(move || {
+            let published = publish_registration.publish_ready(GENERATION, || {
+                signal_registration.signal_shutdown_sync();
+            });
+            let _ = completed_tx.send(published);
+        });
+
+        assert!(
+            completed_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("reentrant terminal signal completed")
+        );
+        publish.join().expect("publication thread");
+        assert_eq!(scope.state(), ConnectionScopeState::Cancelled);
     }
 
     #[tokio::test]

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -1127,9 +1127,11 @@ mod tests {
             .await
             .expect("client build")
             .client();
-        client.register_handler(Arc::new(LogoutOrderHandler {
-            lifecycle: lifecycle.clone(),
-        }));
+        client
+            .subscribe_handler(Arc::new(LogoutOrderHandler {
+                lifecycle: lifecycle.clone(),
+            }))
+            .detach();
 
         client.logout().await.expect("client logout");
 

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -304,9 +304,13 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn close_scope(self: &Arc<Self>, generation: u64) {
-        let scope = {
+        self.close_scope_with(generation, || {});
+    }
+
+    fn close_scope_with(self: &Arc<Self>, generation: u64, after_remove: impl FnOnce()) {
+        let should_spawn = {
             let mut scopes = self.scopes();
-            if scopes
+            let scope = if scopes
                 .active
                 .as_ref()
                 .is_some_and(|scope| scope.generation() == generation)
@@ -318,15 +322,32 @@ impl LifecycleRegistration {
                     .iter()
                     .position(|scope| scope.generation() == generation)
                     .map(|position| scopes.retired.remove(position))
+            };
+            let Some(scope) = scope else {
+                return;
+            };
+
+            scope.close();
+            after_remove();
+
+            // Publish closure before exposing an empty registry so terminal
+            // shutdown cannot overtake the final on_closed callback.
+            let no_open_scopes = scopes.active.is_none() && scopes.retired.is_empty();
+            let mut queue = self.callback_queue();
+            queue.pending.push_back(LifecycleCallback::Closed(scope));
+            if no_open_scopes && queue.shutdown_requested && !queue.shutdown_enqueued {
+                queue.shutdown_enqueued = true;
+                queue.pending.push_back(LifecycleCallback::Shutdown);
+            }
+            if queue.drain_scheduled {
+                false
+            } else {
+                queue.drain_scheduled = true;
+                true
             }
         };
-        let Some(scope) = scope else {
-            return;
-        };
 
-        scope.close();
-        self.enqueue_callback(LifecycleCallback::Closed(scope));
-        self.enqueue_shutdown_if_ready();
+        self.spawn_callback_driver(should_spawn);
     }
 
     pub(super) async fn shutdown(self: &Arc<Self>) {
@@ -416,16 +437,18 @@ impl LifecycleRegistration {
 
             match callback {
                 LifecycleCallback::Ready { scope, done } => {
-                    self.run_callback("on_ready", self.handler.on_ready(scope.clone()))
+                    let callback_scope = scope.clone();
+                    self.run_callback("on_ready", move |handler| handler.on_ready(callback_scope))
                         .await;
                     let _ = done.try_send(!scope.is_cancelled());
                 }
                 LifecycleCallback::Closed(scope) => {
-                    self.run_callback("on_closed", self.handler.on_closed(scope))
+                    self.run_callback("on_closed", move |handler| handler.on_closed(scope))
                         .await;
                 }
                 LifecycleCallback::Shutdown => {
-                    self.run_callback("shutdown", self.handler.shutdown()).await;
+                    self.run_callback("shutdown", |handler| handler.shutdown())
+                        .await;
                     self.shutdown_complete.store(true, Ordering::Release);
                     self.shutdown_notifier.notify();
                 }
@@ -433,11 +456,19 @@ impl LifecycleRegistration {
         }
     }
 
-    async fn run_callback(
-        &self,
+    async fn run_callback<'a>(
+        &'a self,
         name: &'static str,
-        mut callback: BoxFuture<'_, anyhow::Result<()>>,
+        create: impl FnOnce(&'a dyn ClientLifecycle) -> BoxFuture<'a, anyhow::Result<()>>,
     ) {
+        let callback = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _callback_context = CallbackContextGuard::enter(self);
+            create(&*self.handler)
+        }));
+        let Ok(mut callback) = callback else {
+            log::warn!("Client lifecycle {name} panicked");
+            return;
+        };
         let callback = std::future::poll_fn(|context| {
             let _callback_context = CallbackContextGuard::enter(self);
             callback.as_mut().poll(context)
@@ -662,6 +693,30 @@ mod tests {
                 self.completed.store(true, Ordering::Release);
                 Ok(())
             })
+        }
+    }
+
+    #[derive(Default)]
+    struct SynchronousPanicLifecycle {
+        ready_calls: AtomicUsize,
+        closed_calls: AtomicUsize,
+        shutdown_calls: AtomicUsize,
+    }
+
+    impl ClientLifecycle for SynchronousPanicLifecycle {
+        fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            self.ready_calls.fetch_add(1, Ordering::SeqCst);
+            panic!("synchronous on_ready panic");
+        }
+
+        fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            self.closed_calls.fetch_add(1, Ordering::SeqCst);
+            panic!("synchronous on_closed panic");
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            self.shutdown_calls.fetch_add(1, Ordering::SeqCst);
+            panic!("synchronous shutdown panic");
         }
     }
 
@@ -1019,6 +1074,127 @@ mod tests {
 
         assert!(lifecycle.completed.load(Ordering::Acquire));
         assert_eq!(lifecycle.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn synchronous_callback_panics_do_not_strand_the_driver() {
+        let lifecycle = Arc::new(SynchronousPanicLifecycle::default());
+        let registration = Arc::new(LifecycleRegistration::new(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+        ));
+        const GENERATION: u64 = 23;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+
+        assert!(registration.ready(GENERATION).await);
+        registration.close_scope(GENERATION);
+        tokio::time::timeout(std::time::Duration::from_secs(2), registration.shutdown())
+            .await
+            .expect("callback driver recovered from synchronous panics");
+
+        assert_eq!(lifecycle.ready_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.closed_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.shutdown_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn final_scope_closure_is_published_before_shutdown() {
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let registration = Arc::new(LifecycleRegistration::new(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+        ));
+        const GENERATION: u64 = 29;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+
+        let removed = Arc::new(std::sync::Barrier::new(2));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let close_registration = Arc::clone(&registration);
+        let close_removed = Arc::clone(&removed);
+        let close_release = Arc::clone(&release);
+        let close = tokio::task::spawn_blocking(move || {
+            close_registration.close_scope_with(GENERATION, || {
+                close_removed.wait();
+                close_release.wait();
+            });
+        });
+
+        removed.wait();
+        let shutdown_registration = Arc::clone(&registration);
+        let shutdown = tokio::spawn(async move { shutdown_registration.shutdown().await });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!shutdown.is_finished());
+
+        release.wait();
+        close.await.expect("scope close task");
+        shutdown.await.expect("shutdown task");
+        assert_eq!(
+            lifecycle.events(),
+            vec!["closed:29".to_string(), "shutdown".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_cleanup_waiter_does_not_strand_its_scope() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .client();
+        const GENERATION: u64 = 37;
+        client
+            .connection_generation
+            .store(GENERATION, Ordering::SeqCst);
+        let registration = client.lifecycle.as_ref().expect("lifecycle registration");
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+        client.dispatch_connected().await;
+        let scope = registration
+            .scope_for(GENERATION)
+            .expect("connection scope");
+
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        *client.transport.lock().await = Some(Arc::new(BlockingDisconnect {
+            started: started_tx,
+            release: release_rx,
+        }));
+
+        let cleanup_client = Arc::clone(&client);
+        let cleanup = tokio::spawn(async move {
+            cleanup_client.cleanup_connection_state().await;
+        });
+        started_rx.recv().await.expect("cleanup reached transport");
+        cleanup.abort();
+        let _ = cleanup.await;
+        assert_eq!(scope.state(), ConnectionScopeState::Cancelled);
+
+        release_tx.send(()).await.expect("release cleanup");
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while scope.state() != ConnectionScopeState::Closed {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached cleanup closed the scope");
+        assert!(registration.scope_for(GENERATION).is_none());
+
+        registration.shutdown().await;
+        assert_eq!(
+            lifecycle.events(),
+            vec!["install", "ready:37", "closed:37", "shutdown"]
+        );
+        client.signal_shutdown_sync();
     }
 
     #[tokio::test]

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -1,14 +1,25 @@
+use std::cell::Cell;
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use super::Client;
-use wacore::runtime::{BoxFuture, ShutdownNotifier, ShutdownSignal};
+use futures::FutureExt;
+use wacore::runtime::{
+    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, timeout as rt_timeout,
+};
 
 const SCOPE_OPEN: u8 = 0;
 const SCOPE_READY: u8 = 1;
 const SCOPE_CANCELLED: u8 = 2;
 const SCOPE_CLOSED: u8 = 3;
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+std::thread_local! {
+    static ACTIVE_CALLBACK: Cell<*const LifecycleRegistration> = const { Cell::new(std::ptr::null()) };
+}
 
 /// Observable state of one authenticated connection generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,11 +123,11 @@ impl fmt::Debug for ConnectionScope {
 
 /// Aggregate lifecycle seam installed during [`Client`](super::Client) construction.
 ///
-/// Implementations must make `install` transactional. The remaining callbacks
-/// are serialized, awaited, and must not block indefinitely. A future plugin
-/// host owns per-plugin ordering, timeout, and error isolation behind this one
-/// client-level seam. `install` receives a weak client reference so retaining
-/// the handle cannot create a client-to-extension reference cycle.
+/// Implementations must make `install` transactional. Connection callbacks are
+/// serialized and bounded; connection cleanup only schedules `on_closed` so a
+/// stalled extension cannot block reconnect. A future plugin host owns
+/// per-plugin ordering and isolation behind this client-level seam. `install`
+/// receives a weak client reference so retaining it cannot create a cycle.
 pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
     fn install<'a>(&'a self, _client: Weak<Client>) -> BoxFuture<'a, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
@@ -137,10 +148,12 @@ pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
 
 pub(super) struct LifecycleRegistration {
     handler: Arc<dyn ClientLifecycle>,
+    runtime: Arc<dyn Runtime>,
     scopes: std::sync::Mutex<ScopeRegistry>,
-    callback_gate: async_lock::Mutex<()>,
-    shutdown_gate: async_lock::Mutex<bool>,
-    scope_changed: event_listener::Event,
+    callback_queue: std::sync::Mutex<CallbackQueue>,
+    shutdown_complete: AtomicBool,
+    shutdown_notifier: ShutdownNotifier,
+    callback_timeout: Duration,
     terminal: AtomicBool,
 }
 
@@ -150,14 +163,62 @@ struct ScopeRegistry {
     retired: Vec<ConnectionScope>,
 }
 
+enum LifecycleCallback {
+    Ready {
+        scope: ConnectionScope,
+        done: async_channel::Sender<bool>,
+    },
+    Closed(ConnectionScope),
+    Shutdown,
+}
+
+#[derive(Default)]
+struct CallbackQueue {
+    pending: VecDeque<LifecycleCallback>,
+    shutdown_requested: bool,
+    shutdown_enqueued: bool,
+    drain_scheduled: bool,
+}
+
+struct CallbackContextGuard {
+    previous: *const LifecycleRegistration,
+}
+
+impl CallbackContextGuard {
+    fn enter(registration: &LifecycleRegistration) -> Self {
+        let previous = ACTIVE_CALLBACK.replace(registration);
+        Self { previous }
+    }
+}
+
+impl Drop for CallbackContextGuard {
+    fn drop(&mut self) {
+        ACTIVE_CALLBACK.set(self.previous);
+    }
+}
+
+fn callback_context_active(registration: &LifecycleRegistration) -> bool {
+    ACTIVE_CALLBACK.with(|active| std::ptr::eq(active.get(), registration))
+}
+
 impl LifecycleRegistration {
-    pub(super) fn new(handler: Arc<dyn ClientLifecycle>) -> Self {
+    pub(super) fn new(handler: Arc<dyn ClientLifecycle>, runtime: Arc<dyn Runtime>) -> Self {
+        Self::new_with_timeout(handler, runtime, CALLBACK_TIMEOUT)
+    }
+
+    fn new_with_timeout(
+        handler: Arc<dyn ClientLifecycle>,
+        runtime: Arc<dyn Runtime>,
+        callback_timeout: Duration,
+    ) -> Self {
         Self {
             handler,
+            runtime,
             scopes: std::sync::Mutex::new(ScopeRegistry::default()),
-            callback_gate: async_lock::Mutex::new(()),
-            shutdown_gate: async_lock::Mutex::new(false),
-            scope_changed: event_listener::Event::new(),
+            callback_queue: std::sync::Mutex::new(CallbackQueue::default()),
+            shutdown_complete: AtomicBool::new(false),
+            shutdown_notifier: ShutdownNotifier::new(),
+            callback_timeout,
             terminal: AtomicBool::new(false),
         }
     }
@@ -166,18 +227,19 @@ impl LifecycleRegistration {
         self.handler.install(client).await
     }
 
-    pub(super) fn begin_scope(&self, generation: u64) {
+    pub(super) fn begin_scope_if_current(
+        &self,
+        generation: u64,
+        is_current: impl FnOnce() -> bool,
+    ) -> bool {
         if self.terminal.load(Ordering::Acquire) {
-            return;
+            return false;
         }
 
         let scope = ConnectionScope::new(generation);
-        let mut scopes = self
-            .scopes
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self.terminal.load(Ordering::Acquire) {
-            return;
+        let mut scopes = self.scopes();
+        if self.terminal.load(Ordering::Acquire) || !is_current() {
+            return false;
         }
         let replaced = scopes.active.replace(scope);
         if let Some(replaced) = replaced {
@@ -188,22 +250,38 @@ impl LifecycleRegistration {
             replaced.cancel();
             scopes.retired.push(replaced);
         }
+        true
     }
 
-    pub(super) async fn ready(&self, generation: u64) -> bool {
-        let _callback_guard = self.callback_gate.lock().await;
+    pub(super) async fn ready(self: &Arc<Self>, generation: u64) -> bool {
         if self.terminal.load(Ordering::Acquire) {
             return false;
         }
-        let scope = self.scope_for(generation);
-        let Some(scope) = scope.filter(ConnectionScope::mark_ready) else {
-            return false;
+        let (done_tx, done_rx) = async_channel::bounded(1);
+        let scope = {
+            let scopes = self.scopes();
+            let scope = scopes
+                .active
+                .as_ref()
+                .filter(|scope| scope.generation() == generation)
+                .or_else(|| {
+                    scopes
+                        .retired
+                        .iter()
+                        .find(|scope| scope.generation() == generation)
+                })
+                .cloned();
+            let Some(scope) = scope.filter(ConnectionScope::mark_ready) else {
+                return false;
+            };
+            self.enqueue_callback(LifecycleCallback::Ready {
+                scope: scope.clone(),
+                done: done_tx,
+            });
+            scope
         };
 
-        if let Err(error) = self.handler.on_ready(scope.clone()).await {
-            log::warn!("Client lifecycle on_ready failed: {error:#}");
-        }
-        !scope.is_cancelled()
+        done_rx.recv().await.unwrap_or(false) && !scope.is_cancelled()
     }
 
     pub(super) fn cancel_scope(&self, generation: u64) {
@@ -213,10 +291,7 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn cancel_active_scope(&self) {
-        let scopes = self
-            .scopes
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let scopes = self.scopes();
         if let Some(scope) = &scopes.active {
             scope.cancel();
         }
@@ -225,13 +300,9 @@ impl LifecycleRegistration {
         }
     }
 
-    pub(super) async fn close_scope(&self, generation: u64) {
-        let _callback_guard = self.callback_gate.lock().await;
+    pub(super) fn close_scope(self: &Arc<Self>, generation: u64) {
         let scope = {
-            let mut scopes = self
-                .scopes
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut scopes = self.scopes();
             if scopes
                 .active
                 .as_ref()
@@ -250,50 +321,153 @@ impl LifecycleRegistration {
             return;
         };
 
-        self.scope_changed.notify(usize::MAX);
         scope.close();
-        if let Err(error) = self.handler.on_closed(scope).await {
-            log::warn!("Client lifecycle on_closed failed: {error:#}");
-        }
+        self.enqueue_callback(LifecycleCallback::Closed(scope));
+        self.enqueue_shutdown_if_ready();
     }
 
-    pub(super) async fn shutdown(&self) {
+    pub(super) async fn shutdown(self: &Arc<Self>) {
         self.terminal.store(true, Ordering::Release);
         self.cancel_active_scope();
+        {
+            let mut queue = self.callback_queue();
+            queue.shutdown_requested = true;
+        }
+        self.enqueue_shutdown_if_ready();
 
-        let mut started = self.shutdown_gate.lock().await;
-        if *started {
+        if self.shutdown_complete.load(Ordering::Acquire) || callback_context_active(self) {
             return;
         }
-        *started = true;
 
-        loop {
-            let scope_changed = self.scope_changed.listen();
-            let callback_guard = self.callback_gate.lock().await;
-            if !self.has_open_scopes() {
-                if let Err(error) = self.handler.shutdown().await {
-                    log::warn!("Client lifecycle shutdown failed: {error:#}");
-                }
+        let completed = self.shutdown_notifier.subscribe();
+        if self.shutdown_complete.load(Ordering::Acquire) {
+            return;
+        }
+        wacore::runtime::wait_for_shutdown(&completed).await;
+    }
+
+    fn enqueue_callback(self: &Arc<Self>, callback: LifecycleCallback) {
+        let should_spawn = {
+            let mut queue = self.callback_queue();
+            queue.pending.push_back(callback);
+            if queue.drain_scheduled {
+                false
+            } else {
+                queue.drain_scheduled = true;
+                true
+            }
+        };
+        self.spawn_callback_driver(should_spawn);
+    }
+
+    fn enqueue_shutdown_if_ready(self: &Arc<Self>) {
+        let no_open_scopes = {
+            let scopes = self.scopes();
+            scopes.active.is_none() && scopes.retired.is_empty()
+        };
+        if !no_open_scopes {
+            return;
+        }
+
+        let should_spawn = {
+            let mut queue = self.callback_queue();
+            if !queue.shutdown_requested || queue.shutdown_enqueued {
                 return;
             }
-            drop(callback_guard);
-            scope_changed.await;
+            queue.shutdown_enqueued = true;
+            queue.pending.push_back(LifecycleCallback::Shutdown);
+            if queue.drain_scheduled {
+                false
+            } else {
+                queue.drain_scheduled = true;
+                true
+            }
+        };
+        self.spawn_callback_driver(should_spawn);
+    }
+
+    fn spawn_callback_driver(self: &Arc<Self>, should_spawn: bool) {
+        if !should_spawn {
+            return;
+        }
+        let registration = Arc::clone(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                registration.drive_callbacks().await;
+            }))
+            .detach();
+    }
+
+    async fn drive_callbacks(self: Arc<Self>) {
+        loop {
+            let callback = {
+                let mut queue = self.callback_queue();
+                match queue.pending.pop_front() {
+                    Some(callback) => callback,
+                    None => {
+                        queue.drain_scheduled = false;
+                        return;
+                    }
+                }
+            };
+
+            match callback {
+                LifecycleCallback::Ready { scope, done } => {
+                    self.run_callback("on_ready", self.handler.on_ready(scope.clone()))
+                        .await;
+                    let _ = done.try_send(!scope.is_cancelled());
+                }
+                LifecycleCallback::Closed(scope) => {
+                    self.run_callback("on_closed", self.handler.on_closed(scope))
+                        .await;
+                }
+                LifecycleCallback::Shutdown => {
+                    self.run_callback("shutdown", self.handler.shutdown()).await;
+                    self.shutdown_complete.store(true, Ordering::Release);
+                    self.shutdown_notifier.notify();
+                }
+            }
         }
     }
 
-    fn has_open_scopes(&self) -> bool {
-        let scopes = self
-            .scopes
+    async fn run_callback(
+        &self,
+        name: &'static str,
+        mut callback: BoxFuture<'_, anyhow::Result<()>>,
+    ) {
+        let callback = std::future::poll_fn(|context| {
+            let _callback_context = CallbackContextGuard::enter(self);
+            callback.as_mut().poll(context)
+        });
+        let result = std::panic::AssertUnwindSafe(rt_timeout(
+            &*self.runtime,
+            self.callback_timeout,
+            callback,
+        ))
+        .catch_unwind()
+        .await;
+        match result {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(error))) => log::warn!("Client lifecycle {name} failed: {error:#}"),
+            Ok(Err(_)) => log::warn!("Client lifecycle {name} timed out"),
+            Err(_) => log::warn!("Client lifecycle {name} panicked"),
+        }
+    }
+
+    fn scopes(&self) -> std::sync::MutexGuard<'_, ScopeRegistry> {
+        self.scopes
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        scopes.active.is_some() || !scopes.retired.is_empty()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn callback_queue(&self) -> std::sync::MutexGuard<'_, CallbackQueue> {
+        self.callback_queue
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     fn scope_for(&self, generation: u64) -> Option<ConnectionScope> {
-        let scopes = self
-            .scopes
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let scopes = self.scopes();
         scopes
             .active
             .as_ref()
@@ -409,6 +583,85 @@ mod tests {
         events: std::sync::Mutex<Vec<&'static str>>,
     }
 
+    #[derive(Default)]
+    struct ReentrantDisconnectLifecycle {
+        client: std::sync::Mutex<Option<Weak<Client>>>,
+        events: std::sync::Mutex<Vec<&'static str>>,
+    }
+
+    impl ClientLifecycle for ReentrantDisconnectLifecycle {
+        fn install<'a>(&'a self, client: Weak<Client>) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                *self
+                    .client
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(client);
+                Ok(())
+            })
+        }
+
+        fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("ready-started");
+                let client = self
+                    .client
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .as_ref()
+                    .and_then(Weak::upgrade)
+                    .expect("installed client");
+                client.disconnect().await;
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("ready-finished");
+                Ok(())
+            })
+        }
+
+        fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("closed");
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("shutdown");
+                Ok(())
+            })
+        }
+    }
+
+    struct BlockingShutdownLifecycle {
+        started: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+        calls: AtomicUsize,
+        completed: AtomicBool,
+    }
+
+    impl ClientLifecycle for BlockingShutdownLifecycle {
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let _ = self.started.try_send(());
+                let _ = self.release.recv().await;
+                self.completed.store(true, Ordering::Release);
+                Ok(())
+            })
+        }
+    }
+
     struct LogoutOrderHandler {
         lifecycle: Arc<RecordingLifecycle>,
     }
@@ -500,7 +753,7 @@ mod tests {
             .connection_generation
             .store(GENERATION, Ordering::SeqCst);
         let registration = client.lifecycle.as_ref().expect("lifecycle registration");
-        registration.begin_scope(GENERATION);
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
         client.dispatch_connected().await;
 
         let scope = lifecycle
@@ -538,7 +791,6 @@ mod tests {
             .expect("cleanup did not panic");
 
         assert_eq!(scope.state(), ConnectionScopeState::Closed);
-        assert_eq!(lifecycle.events(), vec!["install", "ready:9", "closed:9"]);
         client.shutdown_lifecycle().await;
         client.shutdown_lifecycle().await;
         assert_eq!(lifecycle.shutdowns.load(Ordering::SeqCst), 1);
@@ -578,11 +830,13 @@ mod tests {
         client
             .connection_generation
             .store(GENERATION, Ordering::SeqCst);
-        client
-            .lifecycle
-            .as_ref()
-            .expect("lifecycle registration")
-            .begin_scope(GENERATION);
+        assert!(
+            client
+                .lifecycle
+                .as_ref()
+                .expect("lifecycle registration")
+                .begin_scope_if_current(GENERATION, || true)
+        );
 
         let ready_client = Arc::clone(&client);
         let ready_task = tokio::spawn(async move {
@@ -610,12 +864,15 @@ mod tests {
         })
         .await
         .expect("scope cancellation");
-        assert!(!cleanup_task.is_finished());
+        tokio::time::timeout(std::time::Duration::from_secs(2), cleanup_task)
+            .await
+            .expect("cleanup completed while callback was blocked")
+            .expect("cleanup task did not panic");
+        assert_eq!(scope.state(), ConnectionScopeState::Closed);
 
         release_ready_tx.send(()).await.expect("release ready hook");
         ready_task.await.expect("ready task did not panic");
-        cleanup_task.await.expect("cleanup task did not panic");
-        assert_eq!(scope.state(), ConnectionScopeState::Closed);
+        client.shutdown_lifecycle().await;
         assert_eq!(
             *lifecycle
                 .events
@@ -627,25 +884,184 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ready_callback_can_disconnect_its_client() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(ReentrantDisconnectLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .client();
+        const GENERATION: u64 = 17;
+        client
+            .connection_generation
+            .store(GENERATION, Ordering::SeqCst);
+        assert!(
+            client
+                .lifecycle
+                .as_ref()
+                .expect("lifecycle registration")
+                .begin_scope_if_current(GENERATION, || true)
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            client.dispatch_connected(),
+        )
+        .await
+        .expect("reentrant disconnect completed");
+        client.shutdown_lifecycle().await;
+
+        assert_eq!(
+            *lifecycle
+                .events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["ready-started", "ready-finished", "closed", "shutdown"]
+        );
+        assert!(!client.is_logged_in());
+        assert!(!client.is_ready.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn callback_timeout_does_not_hold_connection_cleanup() {
+        let (ready_started_tx, ready_started_rx) = async_channel::bounded(1);
+        let (_release_ready_tx, release_ready_rx) = async_channel::bounded(1);
+        let lifecycle = Arc::new(BlockingReadyLifecycle {
+            ready_started: ready_started_tx,
+            release_ready: release_ready_rx,
+            scope: std::sync::Mutex::new(None),
+            events: std::sync::Mutex::new(Vec::new()),
+        });
+        let registration = Arc::new(LifecycleRegistration::new_with_timeout(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+            std::time::Duration::from_millis(20),
+        ));
+        const GENERATION: u64 = 19;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+
+        let ready_registration = Arc::clone(&registration);
+        let ready = tokio::spawn(async move { ready_registration.ready(GENERATION).await });
+        ready_started_rx
+            .recv()
+            .await
+            .expect("ready callback started");
+        let scope = lifecycle
+            .scope
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .expect("ready scope");
+
+        registration.cancel_scope(GENERATION);
+        registration.close_scope(GENERATION);
+        assert_eq!(scope.state(), ConnectionScopeState::Closed);
+        assert!(
+            !tokio::time::timeout(std::time::Duration::from_secs(1), ready)
+                .await
+                .expect("ready callback was bounded")
+                .expect("ready task did not panic")
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(1), registration.shutdown())
+            .await
+            .expect("lifecycle shutdown completed");
+
+        assert_eq!(
+            *lifecycle
+                .events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["ready-started", "closed"]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_shutdown_waiter_does_not_cancel_shutdown() {
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let lifecycle = Arc::new(BlockingShutdownLifecycle {
+            started: started_tx,
+            release: release_rx,
+            calls: AtomicUsize::new(0),
+            completed: AtomicBool::new(false),
+        });
+        let registration = Arc::new(LifecycleRegistration::new(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+        ));
+
+        let first_registration = Arc::clone(&registration);
+        let first = tokio::spawn(async move { first_registration.shutdown().await });
+        started_rx.recv().await.expect("shutdown callback started");
+        first.abort();
+        let _ = first.await;
+
+        release_tx
+            .send(())
+            .await
+            .expect("release shutdown callback");
+        tokio::time::timeout(std::time::Duration::from_secs(2), registration.shutdown())
+            .await
+            .expect("later shutdown waiter observed completion");
+
+        assert!(lifecycle.completed.load(Ordering::Acquire));
+        assert_eq!(lifecycle.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_generation_is_rejected_before_scope_publication() {
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let registration = Arc::new(LifecycleRegistration::new(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+        ));
+        let generation = portable_atomic::AtomicU64::new(24);
+        generation.store(25, Ordering::SeqCst);
+
+        assert!(
+            !registration
+                .begin_scope_if_current(24, || { generation.load(Ordering::SeqCst) == 24 })
+        );
+        assert!(registration.scope_for(24).is_none());
+        tokio::time::timeout(std::time::Duration::from_secs(2), registration.shutdown())
+            .await
+            .expect("shutdown did not wait for a rejected scope");
+        assert_eq!(lifecycle.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn replaced_scope_stays_closeable_by_its_generation() {
         let lifecycle = Arc::new(RecordingLifecycle::default());
-        let registration = LifecycleRegistration::new(lifecycle.clone());
+        let registration = Arc::new(LifecycleRegistration::new(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+        ));
 
-        registration.begin_scope(31);
+        assert!(registration.begin_scope_if_current(31, || true));
         assert!(registration.ready(31).await);
         let first = registration.scope_for(31).expect("first scope");
 
-        registration.begin_scope(32);
+        assert!(registration.begin_scope_if_current(32, || true));
         assert_eq!(first.state(), ConnectionScopeState::Cancelled);
         assert!(registration.scope_for(31).is_some());
         assert!(registration.ready(32).await);
 
-        registration.close_scope(31).await;
+        registration.close_scope(31);
         assert_eq!(first.state(), ConnectionScopeState::Closed);
         assert!(registration.scope_for(31).is_none());
         assert!(registration.scope_for(32).is_some());
 
-        registration.close_scope(32).await;
+        registration.close_scope(32);
         registration.shutdown().await;
         assert_eq!(
             lifecycle.events(),
@@ -656,9 +1072,12 @@ mod tests {
     #[tokio::test]
     async fn shutdown_waits_for_the_active_scope_and_is_terminal() {
         let lifecycle = Arc::new(RecordingLifecycle::default());
-        let registration = Arc::new(LifecycleRegistration::new(lifecycle.clone()));
+        let registration = Arc::new(LifecycleRegistration::new(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+        ));
         const GENERATION: u64 = 21;
-        registration.begin_scope(GENERATION);
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
         let scope = registration
             .scope_for(GENERATION)
             .expect("active connection scope");
@@ -676,14 +1095,14 @@ mod tests {
         .expect("scope cancellation");
         assert!(!shutdown.is_finished());
 
-        registration.close_scope(GENERATION).await;
+        registration.close_scope(GENERATION);
         shutdown.await.expect("shutdown did not panic");
         assert_eq!(
             lifecycle.events(),
             vec!["closed:21".to_string(), "shutdown".to_string()]
         );
 
-        registration.begin_scope(GENERATION + 1);
+        assert!(!registration.begin_scope_if_current(GENERATION + 1, || true));
         assert!(registration.scope_for(GENERATION + 1).is_none());
         assert!(!registration.ready(GENERATION + 1).await);
         registration.shutdown().await;

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use super::Client;
 use futures::FutureExt;
 use wacore::runtime::{
-    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, timeout as rt_timeout,
+    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, timeout as rt_timeout, wait_for_shutdown,
 };
 
 const SCOPE_OPEN: u8 = 0;
@@ -296,14 +296,32 @@ impl LifecycleRegistration {
     }
 
     pub(super) async fn install(&self, client: Weak<Client>) -> anyhow::Result<()> {
+        let rejected = self.construction_notifier.subscribe();
+        if self.construction_state.load(Ordering::Acquire) == CONSTRUCTION_REJECTED {
+            return Err(anyhow::anyhow!(
+                "client shutdown began during lifecycle installation"
+            ));
+        }
         let install = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.handler.install(client)
         }))
         .map_err(|_| anyhow::anyhow!("lifecycle install panicked before returning a future"))?;
-        let result = std::panic::AssertUnwindSafe(install)
-            .catch_unwind()
-            .await
-            .map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?;
+        let cancelled = Box::pin(wait_for_shutdown(&rejected));
+        let install = Box::pin(std::panic::AssertUnwindSafe(install).catch_unwind());
+        let result = match futures::future::select(cancelled, install).await {
+            futures::future::Either::Left((_, install)) => {
+                if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(install))).is_err()
+                {
+                    log::warn!("Lifecycle install future panicked while being cancelled");
+                }
+                return Err(anyhow::anyhow!(
+                    "client shutdown began during lifecycle installation"
+                ));
+            }
+            futures::future::Either::Right((result, _)) => {
+                result.map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?
+            }
+        };
         if result.is_ok()
             && self.construction_state.load(Ordering::Acquire) == CONSTRUCTION_REJECTED
         {
@@ -1852,16 +1870,27 @@ mod tests {
                 .await
                 .expect("persistence manager"),
         );
+        let lifecycle = Arc::new(RecordingLifecycle::default());
         let client = Client::builder()
             .with_runtime(TokioRuntime)
             .with_persistence_manager(persistence_manager)
             .with_transport_factory(MockTransportFactory::new())
             .with_http_client(MockHttpClient)
-            .with_lifecycle(RecordingLifecycle::default())
+            .with_lifecycle_arc(lifecycle.clone())
             .build()
             .await
             .expect("client build")
             .into_client();
+        const GENERATION: u64 = 41;
+        client
+            .connection_generation
+            .store(GENERATION, Ordering::SeqCst);
+        let registration = client.lifecycle.as_ref().expect("lifecycle registration");
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+        client.dispatch_connected().await;
+        let scope = registration
+            .scope_for(GENERATION)
+            .expect("connection scope");
         *client.transport.lock().await = Some(Arc::new(PanickingDisconnect));
 
         let cleanup_client = Arc::clone(&client);
@@ -1874,6 +1903,15 @@ mod tests {
             .expect_err("cleanup panic should reach its waiter");
 
         assert!(panic.is_panic());
+        assert_eq!(scope.state(), ConnectionScopeState::Closed);
+        assert!(registration.scope_for(GENERATION).is_none());
+        tokio::time::timeout(Duration::from_secs(2), registration.shutdown())
+            .await
+            .expect("shutdown waited for the panicked cleanup scope");
+        assert_eq!(
+            lifecycle.events(),
+            vec!["install", "ready:41", "closed:41", "shutdown"]
+        );
         client.signal_shutdown_sync();
     }
 

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -365,12 +365,7 @@ impl LifecycleRegistration {
     }
 
     pub(super) async fn shutdown(self: &Arc<Self>) {
-        self.signal_shutdown_sync();
-        {
-            let mut queue = self.callback_queue();
-            queue.shutdown_requested = true;
-        }
-        self.enqueue_shutdown_if_ready();
+        self.request_shutdown();
 
         if self.shutdown_complete.load(Ordering::Acquire) || callback_context_active(self) {
             return;
@@ -381,6 +376,15 @@ impl LifecycleRegistration {
             return;
         }
         wacore::runtime::wait_for_shutdown(&completed).await;
+    }
+
+    pub(super) fn request_shutdown(self: &Arc<Self>) {
+        self.signal_shutdown_sync();
+        {
+            let mut queue = self.callback_queue();
+            queue.shutdown_requested = true;
+        }
+        self.enqueue_shutdown_if_ready();
     }
 
     pub(super) fn signal_shutdown_sync(&self) {
@@ -723,6 +727,26 @@ mod tests {
     }
 
     #[derive(Default)]
+    struct EarlyShutdownLifecycle {
+        signalled: AtomicBool,
+        shutdowns: AtomicUsize,
+    }
+
+    impl ClientLifecycle for EarlyShutdownLifecycle {
+        fn signal_shutdown(&self) {
+            self.signalled.store(true, Ordering::Release);
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                assert!(self.signalled.load(Ordering::Acquire));
+                self.shutdowns.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+    }
+
+    #[derive(Default)]
     struct SynchronousPanicLifecycle {
         ready_calls: AtomicUsize,
         closed_calls: AtomicUsize,
@@ -883,6 +907,52 @@ mod tests {
             vec!["install", "ready:9", "closed:9", "shutdown"]
         );
         client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn disconnect_requests_lifecycle_shutdown_before_cancellable_io() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(EarlyShutdownLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (_release_tx, release_rx) = async_channel::bounded(1);
+        *client.transport.lock().await = Some(Arc::new(BlockingDisconnect {
+            started: started_tx,
+            release: release_rx,
+        }));
+
+        let disconnect_client = Arc::clone(&client);
+        let disconnect = tokio::spawn(async move {
+            disconnect_client.disconnect().await;
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), started_rx.recv())
+            .await
+            .expect("disconnect reached cancellable transport I/O")
+            .expect("transport remained alive");
+        assert!(lifecycle.signalled.load(Ordering::Acquire));
+
+        disconnect.abort();
+        let _ = disconnect.await;
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while lifecycle.shutdowns.load(Ordering::SeqCst) != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached lifecycle shutdown completed");
     }
 
     #[tokio::test]

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -70,10 +70,13 @@ impl ConnectionScope {
         }
     }
 
+    /// Fires when this scope stops owning connection work, whether it is
+    /// cancelled during retirement or reaches final closure after cleanup.
     pub fn cancellation_signal(&self) -> ShutdownSignal {
         self.inner.cancellation.subscribe()
     }
 
+    /// Returns `true` after either cancellation or final closure.
     pub fn is_cancelled(&self) -> bool {
         self.inner.state.load(Ordering::Acquire) >= SCOPE_CANCELLED
     }

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -1368,7 +1368,7 @@ mod tests {
             .store(GENERATION, Ordering::SeqCst);
         let registration = client.lifecycle.as_ref().expect("lifecycle registration");
         assert!(registration.begin_scope_if_current(GENERATION, || true));
-        client.dispatch_connected().await;
+        client.dispatch_connected(GENERATION).await;
 
         let scope = lifecycle
             .scopes
@@ -1532,7 +1532,7 @@ mod tests {
 
         let ready_client = Arc::clone(&client);
         let ready_task = tokio::spawn(async move {
-            ready_client.dispatch_connected().await;
+            ready_client.dispatch_connected(GENERATION).await;
         });
         ready_started_rx
             .recv()
@@ -1607,7 +1607,7 @@ mod tests {
 
         tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            client.dispatch_connected(),
+            client.dispatch_connected(GENERATION),
         )
         .await
         .expect("reentrant disconnect completed");
@@ -1654,9 +1654,12 @@ mod tests {
             let registration = client.lifecycle.as_ref().expect("lifecycle registration");
             assert!(registration.begin_scope_if_current(GENERATION, || true));
 
-            tokio::time::timeout(Duration::from_secs(2), client.dispatch_connected())
-                .await
-                .expect("reentrant reconnect completed");
+            tokio::time::timeout(
+                Duration::from_secs(2),
+                client.dispatch_connected(GENERATION),
+            )
+            .await
+            .expect("reentrant reconnect completed");
             let scope = registration
                 .scope_for(GENERATION)
                 .expect("cancelled connection scope");
@@ -1951,7 +1954,7 @@ mod tests {
             .store(GENERATION, Ordering::SeqCst);
         let registration = client.lifecycle.as_ref().expect("lifecycle registration");
         assert!(registration.begin_scope_if_current(GENERATION, || true));
-        client.dispatch_connected().await;
+        client.dispatch_connected(GENERATION).await;
         let scope = registration
             .scope_for(GENERATION)
             .expect("connection scope");
@@ -2014,7 +2017,7 @@ mod tests {
             .store(GENERATION, Ordering::SeqCst);
         let registration = client.lifecycle.as_ref().expect("lifecycle registration");
         assert!(registration.begin_scope_if_current(GENERATION, || true));
-        client.dispatch_connected().await;
+        client.dispatch_connected(GENERATION).await;
         let scope = registration
             .scope_for(GENERATION)
             .expect("connection scope");
@@ -2061,6 +2064,52 @@ mod tests {
             .await
             .expect("shutdown did not wait for a rejected scope");
         assert_eq!(lifecycle.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_connected_dispatch_cannot_claim_a_new_scope() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+        const STALE_GENERATION: u64 = 60;
+        const CURRENT_GENERATION: u64 = 62;
+        client
+            .connection_generation
+            .store(CURRENT_GENERATION, Ordering::SeqCst);
+        let registration = client.lifecycle.as_ref().expect("lifecycle registration");
+        assert!(registration.begin_scope_if_current(CURRENT_GENERATION, || true));
+
+        client.dispatch_connected(STALE_GENERATION).await;
+
+        let scope = registration
+            .scope_for(CURRENT_GENERATION)
+            .expect("current scope");
+        assert_eq!(scope.state(), ConnectionScopeState::Open);
+        assert!(!client.is_ready.load(Ordering::Relaxed));
+        assert_eq!(lifecycle.events(), vec!["install"]);
+
+        client.dispatch_connected(CURRENT_GENERATION).await;
+        assert_eq!(scope.state(), ConnectionScopeState::Ready);
+        assert!(client.is_ready.load(Ordering::Relaxed));
+        assert_eq!(lifecycle.events(), vec!["install", "ready:62"]);
+
+        registration.cancel_scope(CURRENT_GENERATION);
+        registration.close_scope(CURRENT_GENERATION);
+        registration.shutdown().await;
+        client.signal_shutdown_sync();
     }
 
     #[tokio::test]

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -1,0 +1,673 @@
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, Weak};
+
+use super::Client;
+use wacore::runtime::{BoxFuture, ShutdownNotifier, ShutdownSignal};
+
+const SCOPE_OPEN: u8 = 0;
+const SCOPE_READY: u8 = 1;
+const SCOPE_CANCELLED: u8 = 2;
+const SCOPE_CLOSED: u8 = 3;
+
+/// Observable state of one authenticated connection generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ConnectionScopeState {
+    Open,
+    Ready,
+    Cancelled,
+    Closed,
+}
+
+struct ConnectionScopeInner {
+    generation: u64,
+    state: AtomicU8,
+    cancellation: ShutdownNotifier,
+}
+
+/// Stable handle for work owned by one authenticated connection generation.
+///
+/// A scope is cancelled synchronously when its generation is retired and is
+/// marked closed only after the client's authoritative connection cleanup.
+#[derive(Clone)]
+pub struct ConnectionScope {
+    inner: Arc<ConnectionScopeInner>,
+}
+
+impl ConnectionScope {
+    fn new(generation: u64) -> Self {
+        Self {
+            inner: Arc::new(ConnectionScopeInner {
+                generation,
+                state: AtomicU8::new(SCOPE_OPEN),
+                cancellation: ShutdownNotifier::new(),
+            }),
+        }
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.inner.generation
+    }
+
+    pub fn state(&self) -> ConnectionScopeState {
+        match self.inner.state.load(Ordering::Acquire) {
+            SCOPE_OPEN => ConnectionScopeState::Open,
+            SCOPE_READY => ConnectionScopeState::Ready,
+            SCOPE_CANCELLED => ConnectionScopeState::Cancelled,
+            _ => ConnectionScopeState::Closed,
+        }
+    }
+
+    pub fn cancellation_signal(&self) -> ShutdownSignal {
+        self.inner.cancellation.subscribe()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.state.load(Ordering::Acquire) >= SCOPE_CANCELLED
+    }
+
+    fn mark_ready(&self) -> bool {
+        self.inner
+            .state
+            .compare_exchange(SCOPE_OPEN, SCOPE_READY, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    fn cancel(&self) {
+        let mut state = self.inner.state.load(Ordering::Acquire);
+        while state < SCOPE_CANCELLED {
+            match self.inner.state.compare_exchange_weak(
+                state,
+                SCOPE_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.inner.cancellation.notify();
+                    return;
+                }
+                Err(actual) => state = actual,
+            }
+        }
+    }
+
+    fn close(&self) {
+        let previous = self.inner.state.swap(SCOPE_CLOSED, Ordering::AcqRel);
+        if previous < SCOPE_CANCELLED {
+            self.inner.cancellation.notify();
+        }
+    }
+}
+
+impl fmt::Debug for ConnectionScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConnectionScope")
+            .field("generation", &self.generation())
+            .field("state", &self.state())
+            .finish()
+    }
+}
+
+/// Aggregate lifecycle seam installed during [`Client`](super::Client) construction.
+///
+/// Implementations must make `install` transactional. The remaining callbacks
+/// are serialized, awaited, and must not block indefinitely. A future plugin
+/// host owns per-plugin ordering, timeout, and error isolation behind this one
+/// client-level seam. `install` receives a weak client reference so retaining
+/// the handle cannot create a client-to-extension reference cycle.
+pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
+    fn install<'a>(&'a self, _client: Weak<Client>) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+pub(super) struct LifecycleRegistration {
+    handler: Arc<dyn ClientLifecycle>,
+    active_scope: std::sync::Mutex<Option<ConnectionScope>>,
+    callback_gate: async_lock::Mutex<()>,
+    shutdown_gate: async_lock::Mutex<bool>,
+    scope_changed: event_listener::Event,
+    terminal: AtomicBool,
+}
+
+impl LifecycleRegistration {
+    pub(super) fn new(handler: Arc<dyn ClientLifecycle>) -> Self {
+        Self {
+            handler,
+            active_scope: std::sync::Mutex::new(None),
+            callback_gate: async_lock::Mutex::new(()),
+            shutdown_gate: async_lock::Mutex::new(false),
+            scope_changed: event_listener::Event::new(),
+            terminal: AtomicBool::new(false),
+        }
+    }
+
+    pub(super) async fn install(&self, client: Weak<Client>) -> anyhow::Result<()> {
+        self.handler.install(client).await
+    }
+
+    pub(super) fn begin_scope(&self, generation: u64) {
+        if self.terminal.load(Ordering::Acquire) {
+            return;
+        }
+
+        let scope = ConnectionScope::new(generation);
+        let mut active = self
+            .active_scope
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.terminal.load(Ordering::Acquire) {
+            return;
+        }
+        let replaced = active.replace(scope);
+        drop(active);
+        if let Some(replaced) = replaced {
+            log::warn!(
+                "Replacing unclosed connection scope for generation {}",
+                replaced.generation()
+            );
+            replaced.cancel();
+            replaced.close();
+        }
+    }
+
+    pub(super) async fn ready(&self, generation: u64) -> bool {
+        let _callback_guard = self.callback_gate.lock().await;
+        if self.terminal.load(Ordering::Acquire) {
+            return false;
+        }
+        let scope = self.scope_for(generation);
+        let Some(scope) = scope.filter(ConnectionScope::mark_ready) else {
+            return false;
+        };
+
+        if let Err(error) = self.handler.on_ready(scope.clone()).await {
+            log::warn!("Client lifecycle on_ready failed: {error:#}");
+        }
+        !scope.is_cancelled()
+    }
+
+    pub(super) fn cancel_scope(&self, generation: u64) {
+        if let Some(scope) = self.scope_for(generation) {
+            scope.cancel();
+        }
+    }
+
+    pub(super) fn cancel_active_scope(&self) {
+        let scope = self
+            .active_scope
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(scope) = scope {
+            scope.cancel();
+        }
+    }
+
+    pub(super) async fn close_scope(&self, generation: u64) {
+        let _callback_guard = self.callback_gate.lock().await;
+        let scope = {
+            let mut active = self
+                .active_scope
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if active
+                .as_ref()
+                .is_some_and(|scope| scope.generation() == generation)
+            {
+                active.take()
+            } else {
+                None
+            }
+        };
+        let Some(scope) = scope else {
+            return;
+        };
+
+        self.scope_changed.notify(usize::MAX);
+        scope.close();
+        if let Err(error) = self.handler.on_closed(scope).await {
+            log::warn!("Client lifecycle on_closed failed: {error:#}");
+        }
+    }
+
+    pub(super) async fn shutdown(&self) {
+        self.terminal.store(true, Ordering::Release);
+        self.cancel_active_scope();
+
+        let mut started = self.shutdown_gate.lock().await;
+        if *started {
+            return;
+        }
+        *started = true;
+
+        loop {
+            let scope_changed = self.scope_changed.listen();
+            let callback_guard = self.callback_gate.lock().await;
+            if self.scope_for_active_generation().is_none() {
+                if let Err(error) = self.handler.shutdown().await {
+                    log::warn!("Client lifecycle shutdown failed: {error:#}");
+                }
+                return;
+            }
+            drop(callback_guard);
+            scope_changed.await;
+        }
+    }
+
+    fn scope_for_active_generation(&self) -> Option<ConnectionScope> {
+        self.active_scope
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn scope_for(&self, generation: u64) -> Option<ConnectionScope> {
+        self.active_scope
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .filter(|scope| scope.generation() == generation)
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::runtime_impl::TokioRuntime;
+    use crate::store::persistence_manager::PersistenceManager;
+    use crate::test_utils::MockHttpClient;
+    use crate::transport::mock::MockTransportFactory;
+
+    #[derive(Default)]
+    struct RecordingLifecycle {
+        events: std::sync::Mutex<Vec<String>>,
+        scopes: std::sync::Mutex<Vec<ConnectionScope>>,
+        shutdowns: AtomicUsize,
+    }
+
+    impl RecordingLifecycle {
+        fn events(&self) -> Vec<String> {
+            self.events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    impl ClientLifecycle for RecordingLifecycle {
+        fn install<'a>(&'a self, client: Weak<Client>) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                assert!(client.upgrade().is_some());
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("install".to_string());
+                Ok(())
+            })
+        }
+
+        fn on_ready<'a>(&'a self, scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push(format!("ready:{}", scope.generation()));
+                self.scopes
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push(scope);
+                Ok(())
+            })
+        }
+
+        fn on_closed<'a>(&'a self, scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push(format!("closed:{}", scope.generation()));
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.shutdowns.fetch_add(1, Ordering::SeqCst);
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("shutdown".to_string());
+                Ok(())
+            })
+        }
+    }
+
+    struct BlockingDisconnect {
+        started: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    #[async_trait]
+    impl crate::transport::Transport for BlockingDisconnect {
+        async fn send(&self, _data: Bytes) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self) {
+            let _ = self.started.try_send(());
+            let _ = self.release.recv().await;
+        }
+    }
+
+    struct BlockingReadyLifecycle {
+        ready_started: async_channel::Sender<()>,
+        release_ready: async_channel::Receiver<()>,
+        scope: std::sync::Mutex<Option<ConnectionScope>>,
+        events: std::sync::Mutex<Vec<&'static str>>,
+    }
+
+    struct LogoutOrderHandler {
+        lifecycle: Arc<RecordingLifecycle>,
+    }
+
+    impl wacore::types::events::EventHandler for LogoutOrderHandler {
+        fn handle_event(&self, event: Arc<wacore::types::events::Event>) {
+            if matches!(&*event, wacore::types::events::Event::LoggedOut(_)) {
+                self.lifecycle
+                    .events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("logged-out".to_string());
+            }
+        }
+
+        fn interest(&self) -> wacore::types::events::EventInterest {
+            wacore::types::events::EventInterest::of(&[wacore::types::events::EventKind::LoggedOut])
+        }
+    }
+
+    impl ClientLifecycle for BlockingReadyLifecycle {
+        fn on_ready<'a>(&'a self, scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                *self
+                    .scope
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(scope);
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("ready-started");
+                let _ = self.ready_started.try_send(());
+                let _ = self.release_ready.recv().await;
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("ready-finished");
+                Ok(())
+            })
+        }
+
+        fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.events
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push("closed");
+                Ok(())
+            })
+        }
+    }
+
+    #[test]
+    fn scope_state_machine_is_sticky_and_cancellable() {
+        let scope = ConnectionScope::new(41);
+        let cancellation = scope.cancellation_signal();
+
+        assert_eq!(scope.state(), ConnectionScopeState::Open);
+        assert!(scope.mark_ready());
+        assert_eq!(scope.state(), ConnectionScopeState::Ready);
+        scope.cancel();
+        assert_eq!(scope.state(), ConnectionScopeState::Cancelled);
+        assert!(cancellation.is_fired());
+        scope.cancel();
+        scope.close();
+        assert_eq!(scope.state(), ConnectionScopeState::Closed);
+    }
+
+    #[tokio::test]
+    async fn cleanup_cancels_before_io_and_closes_after_authoritative_teardown() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let build = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build");
+        let client = build.client();
+        const GENERATION: u64 = 9;
+        client
+            .connection_generation
+            .store(GENERATION, Ordering::SeqCst);
+        let registration = client.lifecycle.as_ref().expect("lifecycle registration");
+        registration.begin_scope(GENERATION);
+        client.dispatch_connected().await;
+
+        let scope = lifecycle
+            .scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .first()
+            .cloned()
+            .expect("ready scope");
+        let cancelled = scope.cancellation_signal();
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        *client.transport.lock().await = Some(Arc::new(BlockingDisconnect {
+            started: started_tx,
+            release: release_rx,
+        }));
+
+        let cleanup_client = Arc::clone(&client);
+        let cleanup = tokio::spawn(async move {
+            cleanup_client.cleanup_connection_state().await;
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), started_rx.recv())
+            .await
+            .expect("transport cleanup started")
+            .expect("transport remained alive");
+
+        assert_eq!(scope.state(), ConnectionScopeState::Cancelled);
+        assert!(cancelled.is_fired());
+        assert_eq!(lifecycle.events(), vec!["install", "ready:9"]);
+
+        release_tx.send(()).await.expect("release cleanup");
+        tokio::time::timeout(std::time::Duration::from_secs(2), cleanup)
+            .await
+            .expect("cleanup completed")
+            .expect("cleanup did not panic");
+
+        assert_eq!(scope.state(), ConnectionScopeState::Closed);
+        assert_eq!(lifecycle.events(), vec!["install", "ready:9", "closed:9"]);
+        client.shutdown_lifecycle().await;
+        client.shutdown_lifecycle().await;
+        assert_eq!(lifecycle.shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            lifecycle.events(),
+            vec!["install", "ready:9", "closed:9", "shutdown"]
+        );
+        client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn cancellation_does_not_wait_for_a_running_callback() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let (ready_started_tx, ready_started_rx) = async_channel::bounded(1);
+        let (release_ready_tx, release_ready_rx) = async_channel::bounded(1);
+        let lifecycle = Arc::new(BlockingReadyLifecycle {
+            ready_started: ready_started_tx,
+            release_ready: release_ready_rx,
+            scope: std::sync::Mutex::new(None),
+            events: std::sync::Mutex::new(Vec::new()),
+        });
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .client();
+        const GENERATION: u64 = 13;
+        client
+            .connection_generation
+            .store(GENERATION, Ordering::SeqCst);
+        client
+            .lifecycle
+            .as_ref()
+            .expect("lifecycle registration")
+            .begin_scope(GENERATION);
+
+        let ready_client = Arc::clone(&client);
+        let ready_task = tokio::spawn(async move {
+            ready_client.dispatch_connected().await;
+        });
+        ready_started_rx
+            .recv()
+            .await
+            .expect("ready callback started");
+        let scope = lifecycle
+            .scope
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+            .expect("ready scope");
+
+        let cleanup_client = Arc::clone(&client);
+        let cleanup_task = tokio::spawn(async move {
+            cleanup_client.cleanup_connection_state().await;
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !scope.is_cancelled() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scope cancellation");
+        assert!(!cleanup_task.is_finished());
+
+        release_ready_tx.send(()).await.expect("release ready hook");
+        ready_task.await.expect("ready task did not panic");
+        cleanup_task.await.expect("cleanup task did not panic");
+        assert_eq!(scope.state(), ConnectionScopeState::Closed);
+        assert_eq!(
+            *lifecycle
+                .events
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["ready-started", "ready-finished", "closed"]
+        );
+        client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_the_active_scope_and_is_terminal() {
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let registration = Arc::new(LifecycleRegistration::new(lifecycle.clone()));
+        const GENERATION: u64 = 21;
+        registration.begin_scope(GENERATION);
+        let scope = registration
+            .scope_for(GENERATION)
+            .expect("active connection scope");
+
+        let shutdown_registration = Arc::clone(&registration);
+        let shutdown = tokio::spawn(async move {
+            shutdown_registration.shutdown().await;
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !scope.is_cancelled() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scope cancellation");
+        assert!(!shutdown.is_finished());
+
+        registration.close_scope(GENERATION).await;
+        shutdown.await.expect("shutdown did not panic");
+        assert_eq!(
+            lifecycle.events(),
+            vec!["closed:21".to_string(), "shutdown".to_string()]
+        );
+
+        registration.begin_scope(GENERATION + 1);
+        assert!(registration.scope_for(GENERATION + 1).is_none());
+        assert!(!registration.ready(GENERATION + 1).await);
+        registration.shutdown().await;
+        assert_eq!(lifecycle.shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn logout_event_precedes_terminal_lifecycle_shutdown() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .client();
+        client.register_handler(Arc::new(LogoutOrderHandler {
+            lifecycle: lifecycle.clone(),
+        }));
+
+        client.logout().await.expect("client logout");
+
+        assert_eq!(
+            lifecycle.events(),
+            vec!["install", "logged-out", "shutdown"]
+        );
+    }
+}

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -15,6 +15,9 @@ const SCOPE_OPEN: u8 = 0;
 const SCOPE_READY: u8 = 1;
 const SCOPE_CANCELLED: u8 = 2;
 const SCOPE_CLOSED: u8 = 3;
+const CONSTRUCTION_INSTALLING: u8 = 0;
+const CONSTRUCTION_ACTIVE: u8 = 1;
+const CONSTRUCTION_REJECTED: u8 = 2;
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 const CALLBACK_QUEUE_CAPACITY: usize = 64;
 
@@ -167,6 +170,8 @@ pub(super) struct LifecycleRegistration {
     shutdown_notifier: ShutdownNotifier,
     callback_timeout: Duration,
     terminal: AtomicBool,
+    construction_state: AtomicU8,
+    construction_notifier: ShutdownNotifier,
 }
 
 #[derive(Default)]
@@ -285,6 +290,8 @@ impl LifecycleRegistration {
             shutdown_notifier: ShutdownNotifier::new(),
             callback_timeout,
             terminal: AtomicBool::new(false),
+            construction_state: AtomicU8::new(CONSTRUCTION_INSTALLING),
+            construction_notifier: ShutdownNotifier::new(),
         }
     }
 
@@ -293,10 +300,48 @@ impl LifecycleRegistration {
             self.handler.install(client)
         }))
         .map_err(|_| anyhow::anyhow!("lifecycle install panicked before returning a future"))?;
-        std::panic::AssertUnwindSafe(install)
+        let result = std::panic::AssertUnwindSafe(install)
             .catch_unwind()
             .await
-            .map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?
+            .map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?;
+        if result.is_ok()
+            && self.construction_state.load(Ordering::Acquire) == CONSTRUCTION_REJECTED
+        {
+            return Err(anyhow::anyhow!(
+                "client shutdown began during lifecycle installation"
+            ));
+        }
+        result
+    }
+
+    pub(super) fn activate(&self) -> bool {
+        if self.terminal.load(Ordering::Acquire) {
+            self.reject_construction();
+            return false;
+        }
+        match self.construction_state.compare_exchange(
+            CONSTRUCTION_INSTALLING,
+            CONSTRUCTION_ACTIVE,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => self.construction_notifier.notify(),
+            Err(CONSTRUCTION_ACTIVE) => {}
+            Err(_) => return false,
+        }
+        !self.terminal.load(Ordering::Acquire)
+    }
+
+    pub(super) async fn wait_until_active(&self) -> bool {
+        let activated = self.construction_notifier.subscribe();
+        match self.construction_state.load(Ordering::Acquire) {
+            CONSTRUCTION_ACTIVE => return !self.terminal.load(Ordering::Acquire),
+            CONSTRUCTION_REJECTED => return false,
+            _ => {}
+        }
+        wacore::runtime::wait_for_shutdown(&activated).await;
+        self.construction_state.load(Ordering::Acquire) == CONSTRUCTION_ACTIVE
+            && !self.terminal.load(Ordering::Acquire)
     }
 
     pub(super) fn begin_scope_if_current(
@@ -467,6 +512,7 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn signal_shutdown_sync(&self) {
+        self.reject_construction();
         let first_signal = if ready_publication_active(self) {
             self.mark_terminal_and_cancel_scopes()
         } else {
@@ -622,6 +668,21 @@ impl LifecycleRegistration {
     fn cancel_scope_inner(&self, generation: u64) {
         if let Some(scope) = self.scope_for(generation) {
             scope.cancel();
+        }
+    }
+
+    fn reject_construction(&self) {
+        if self
+            .construction_state
+            .compare_exchange(
+                CONSTRUCTION_INSTALLING,
+                CONSTRUCTION_REJECTED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            self.construction_notifier.notify();
         }
     }
 

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -169,6 +169,7 @@ pub(super) struct LifecycleRegistration {
     shutdown_notifier: ShutdownNotifier,
     callback_timeout: Duration,
     terminal: AtomicBool,
+    construction_transition: std::sync::Mutex<()>,
     construction_state: AtomicU8,
     construction_notifier: ShutdownNotifier,
 }
@@ -198,31 +199,32 @@ struct CallbackQueue {
 }
 
 impl CallbackQueue {
-    fn push_with_pressure_policy(
-        &mut self,
-        callback: LifecycleCallback,
-    ) -> Option<LifecycleCallback> {
-        if self.pending.len() < CALLBACK_QUEUE_TARGET_CAPACITY {
+    fn push_with_pressure_policy(&mut self, callback: LifecycleCallback) -> Vec<LifecycleCallback> {
+        if self.pending.len() < CALLBACK_QUEUE_TARGET_CAPACITY && !self.overflowed {
             self.pending.push_back(callback);
-            return None;
+            return Vec::new();
         }
 
-        self.overflowed = true;
-        let ready_position = self
-            .pending
-            .iter()
-            .position(|pending| matches!(pending, LifecycleCallback::Ready { .. }));
-        match (callback, ready_position) {
-            (callback @ LifecycleCallback::Ready { .. }, None) => Some(callback),
-            (callback, Some(position)) => {
-                let dropped = self.pending.remove(position);
+        self.overflowed |= self.pending.len() >= CALLBACK_QUEUE_TARGET_CAPACITY;
+        match callback {
+            callback @ LifecycleCallback::Ready { .. } => {
+                let mut dropped = Vec::new();
+                let mut retained = VecDeque::with_capacity(self.pending.len());
+                for pending in self.pending.drain(..) {
+                    if matches!(pending, LifecycleCallback::Ready { .. }) {
+                        dropped.push(pending);
+                    } else {
+                        retained.push_back(pending);
+                    }
+                }
+                self.pending = retained;
                 self.pending.push_back(callback);
                 dropped
             }
-            (callback, None) => {
-                // Every closed scope must reach the extension even when a callback stalls.
+            callback => {
+                // Closures are lossless, so the target remains soft under backlog.
                 self.pending.push_back(callback);
-                None
+                Vec::new()
             }
         }
     }
@@ -307,6 +309,7 @@ impl LifecycleRegistration {
             shutdown_notifier: ShutdownNotifier::new(),
             callback_timeout,
             terminal: AtomicBool::new(false),
+            construction_transition: std::sync::Mutex::new(()),
             construction_state: AtomicU8::new(CONSTRUCTION_INSTALLING),
             construction_notifier: ShutdownNotifier::new(),
         }
@@ -359,7 +362,22 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn activate(&self) -> bool {
+        self.activate_with(|| true)
+    }
+
+    pub(super) fn activate_with(&self, commit: impl FnOnce() -> bool) -> bool {
+        let _transition = self
+            .construction_transition
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if self.terminal.load(Ordering::Acquire) {
+            self.reject_construction();
+            return false;
+        }
+        if self.construction_state.load(Ordering::Acquire) == CONSTRUCTION_ACTIVE {
+            return true;
+        }
+        if !commit() {
             self.reject_construction();
             return false;
         }
@@ -373,7 +391,7 @@ impl LifecycleRegistration {
             Err(CONSTRUCTION_ACTIVE) => {}
             Err(_) => return false,
         }
-        !self.terminal.load(Ordering::Acquire)
+        true
     }
 
     pub(super) async fn wait_until_active(&self) -> bool {
@@ -558,13 +576,20 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn signal_shutdown_sync(&self) {
-        self.reject_construction();
-        let first_signal = if ready_publication_active(self) {
-            self.mark_terminal_and_cancel_scopes()
+        let first_signal = {
+            let _transition = self
+                .construction_transition
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            self.reject_construction();
+            !self.terminal.swap(true, Ordering::AcqRel)
+        };
+        if ready_publication_active(self) {
+            self.cancel_all_scopes()
         } else {
             let _publication = self.ready_publication();
-            self.mark_terminal_and_cancel_scopes()
-        };
+            self.cancel_all_scopes()
+        }
         if first_signal
             && std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 self.handler.signal_shutdown();
@@ -579,7 +604,7 @@ impl LifecycleRegistration {
         let (should_spawn, dropped) = {
             let mut queue = self.callback_queue();
             if queue.shutdown_requested || self.terminal.load(Ordering::Acquire) {
-                (false, Some(callback))
+                (false, vec![callback])
             } else {
                 let dropped = queue.push_with_pressure_policy(callback);
                 let should_spawn = !queue.drain_scheduled;
@@ -587,7 +612,7 @@ impl LifecycleRegistration {
                 (should_spawn, dropped)
             }
         };
-        warn_dropped_callbacks(dropped.into_iter().collect());
+        warn_dropped_callbacks(dropped);
         self.spawn_callback_driver(should_spawn);
     }
 
@@ -753,8 +778,7 @@ impl LifecycleRegistration {
         }
     }
 
-    fn mark_terminal_and_cancel_scopes(&self) -> bool {
-        let first_signal = !self.terminal.swap(true, Ordering::AcqRel);
+    fn cancel_all_scopes(&self) {
         let scopes = self.scopes();
         if let Some(scope) = &scopes.active {
             scope.cancel();
@@ -762,7 +786,6 @@ impl LifecycleRegistration {
         for scope in &scopes.retired {
             scope.cancel();
         }
-        first_signal
     }
 
     fn scope_for(&self, generation: u64) -> Option<ConnectionScope> {
@@ -1253,6 +1276,58 @@ mod tests {
         assert!(!published.load(Ordering::Acquire));
     }
 
+    #[test]
+    fn terminal_signal_waits_for_construction_commit() {
+        let registration = Arc::new(LifecycleRegistration::new(
+            Arc::new(RecordingLifecycle::default()),
+            Arc::new(TokioRuntime),
+        ));
+        let (commit_started_tx, commit_started_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_commit_tx, release_commit_rx) = std::sync::mpsc::sync_channel(1);
+        let (activation_tx, activation_rx) = std::sync::mpsc::sync_channel(1);
+        let activation_registration = registration.clone();
+        let activation = std::thread::spawn(move || {
+            let activated = activation_registration.activate_with(|| {
+                commit_started_tx.send(()).expect("publish commit start");
+                release_commit_rx.recv().expect("release publish commit");
+                true
+            });
+            activation_tx.send(activated).expect("activation result");
+        });
+        commit_started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("construction commit started");
+
+        let (shutdown_tx, shutdown_rx) = std::sync::mpsc::sync_channel(1);
+        let shutdown_registration = registration.clone();
+        let shutdown = std::thread::spawn(move || {
+            shutdown_registration.signal_shutdown_sync();
+            shutdown_tx.send(()).expect("shutdown result");
+        });
+        assert!(
+            shutdown_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err()
+        );
+
+        release_commit_tx.send(()).expect("finish publish commit");
+        assert!(
+            activation_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("construction activated")
+        );
+        shutdown_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("terminal signal completed");
+        activation.join().expect("activation thread");
+        shutdown.join().expect("shutdown thread");
+        assert_eq!(
+            registration.construction_state.load(Ordering::Acquire),
+            CONSTRUCTION_ACTIVE
+        );
+        assert!(registration.terminal.load(Ordering::Acquire));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn terminal_cancellation_waits_for_ready_publication() {
         let registration = Arc::new(LifecycleRegistration::new(
@@ -1731,6 +1806,63 @@ mod tests {
         );
     }
 
+    #[test]
+    fn callback_queue_retains_latest_ready_with_lossless_close_backlog() {
+        let mut queue = CallbackQueue::default();
+        for generation in 1..=CALLBACK_QUEUE_TARGET_CAPACITY as u64 {
+            let scope = ConnectionScope::new(generation);
+            scope.close();
+            assert!(
+                queue
+                    .push_with_pressure_policy(LifecycleCallback::Closed(scope))
+                    .is_empty()
+            );
+        }
+
+        let (first_done, _first_completion) = async_channel::bounded(1);
+        assert!(
+            queue
+                .push_with_pressure_policy(LifecycleCallback::Ready {
+                    scope: ConnectionScope::new(100),
+                    done: first_done,
+                })
+                .is_empty()
+        );
+        assert_eq!(queue.pending.len(), CALLBACK_QUEUE_TARGET_CAPACITY + 1);
+
+        let (latest_done, _latest_completion) = async_channel::bounded(1);
+        let mut dropped = queue.push_with_pressure_policy(LifecycleCallback::Ready {
+            scope: ConnectionScope::new(101),
+            done: latest_done,
+        });
+        assert_eq!(dropped.len(), 1);
+        let dropped = dropped.pop().expect("older ready callback is replaceable");
+        assert!(matches!(
+            dropped,
+            LifecycleCallback::Ready { scope, .. } if scope.generation() == 100
+        ));
+
+        let extra_closed = ConnectionScope::new(102);
+        extra_closed.close();
+        assert!(
+            queue
+                .push_with_pressure_policy(LifecycleCallback::Closed(extra_closed))
+                .is_empty()
+        );
+        assert_eq!(queue.pending.len(), CALLBACK_QUEUE_TARGET_CAPACITY + 2);
+        assert_eq!(
+            queue
+                .pending
+                .iter()
+                .filter(|callback| matches!(callback, LifecycleCallback::Ready { .. }))
+                .count(),
+            1
+        );
+        assert!(queue.pending.iter().any(|callback| {
+            matches!(callback, LifecycleCallback::Ready { scope, .. } if scope.generation() == 101)
+        }));
+    }
+
     #[tokio::test]
     async fn callback_queue_preserves_every_scope_closure_before_shutdown() {
         let (ready_started_tx, ready_started_rx) = async_channel::bounded(1);
@@ -1773,7 +1905,7 @@ mod tests {
         }
         assert_eq!(
             registration.callback_queue().pending.len(),
-            usize::try_from(closed_callbacks).expect("closure count fits usize")
+            usize::try_from(closed_callbacks + 1).expect("callback count fits usize")
         );
 
         let shutdown_registration = registration.clone();

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -484,7 +484,9 @@ impl LifecycleRegistration {
         self.close_scope_with(generation, || {});
     }
 
-    /// Non-noop hooks are test-only, must run off-executor, and must not re-enter lifecycle APIs.
+    /// `after_remove` runs with `scopes` held and before `callback_queue` is acquired.
+    /// It must not block an async executor or re-enter lifecycle APIs; blocking test hooks run
+    /// on a dedicated thread.
     fn close_scope_with(self: &Arc<Self>, generation: u64, after_remove: impl FnOnce()) {
         let (should_spawn, dropped) = {
             let mut scopes = self.scopes();

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -16,6 +16,7 @@ const SCOPE_READY: u8 = 1;
 const SCOPE_CANCELLED: u8 = 2;
 const SCOPE_CLOSED: u8 = 3;
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+const CALLBACK_QUEUE_CAPACITY: usize = 64;
 
 std::thread_local! {
     static ACTIVE_CALLBACK: Cell<*const LifecycleRegistration> = const { Cell::new(std::ptr::null()) };
@@ -189,6 +190,37 @@ struct CallbackQueue {
     shutdown_requested: bool,
     shutdown_enqueued: bool,
     drain_scheduled: bool,
+    overflowed: bool,
+}
+
+impl CallbackQueue {
+    fn push_bounded(&mut self, callback: LifecycleCallback) -> Option<LifecycleCallback> {
+        let dropped = (self.pending.len() >= CALLBACK_QUEUE_CAPACITY)
+            .then(|| self.pending.pop_front())
+            .flatten();
+        self.overflowed |= dropped.is_some();
+        self.pending.push_back(callback);
+        dropped
+    }
+
+    fn compact_for_shutdown(&mut self, keep_last_closed: bool) -> Vec<LifecycleCallback> {
+        if !self.overflowed {
+            return Vec::new();
+        }
+        let last_closed = keep_last_closed
+            .then(|| {
+                self.pending
+                    .iter()
+                    .rposition(|callback| matches!(callback, LifecycleCallback::Closed(_)))
+            })
+            .flatten()
+            .and_then(|position| self.pending.remove(position));
+        let dropped = self.pending.drain(..).collect::<Vec<_>>();
+        if let Some(last_closed) = last_closed {
+            self.pending.push_back(last_closed);
+        }
+        dropped
+    }
 }
 
 struct CallbackContextGuard {
@@ -356,7 +388,7 @@ impl LifecycleRegistration {
 
     /// Non-noop hooks are test-only, must run off-executor, and must not re-enter lifecycle APIs.
     fn close_scope_with(self: &Arc<Self>, generation: u64, after_remove: impl FnOnce()) {
-        let should_spawn = {
+        let (should_spawn, dropped) = {
             let mut scopes = self.scopes();
             let scope = if scopes
                 .active
@@ -382,19 +414,23 @@ impl LifecycleRegistration {
             // shutdown cannot overtake the final on_closed callback.
             let no_open_scopes = scopes.active.is_none() && scopes.retired.is_empty();
             let mut queue = self.callback_queue();
-            queue.pending.push_back(LifecycleCallback::Closed(scope));
-            if no_open_scopes && queue.shutdown_requested && !queue.shutdown_enqueued {
-                queue.shutdown_enqueued = true;
-                queue.pending.push_back(LifecycleCallback::Shutdown);
-            }
-            if queue.drain_scheduled {
-                false
+            let mut dropped = Vec::new();
+            if queue.shutdown_requested {
+                dropped.extend(queue.push_bounded(LifecycleCallback::Closed(scope)));
+                dropped.extend(queue.compact_for_shutdown(no_open_scopes));
+                if no_open_scopes && !queue.shutdown_enqueued {
+                    queue.shutdown_enqueued = true;
+                    queue.pending.push_back(LifecycleCallback::Shutdown);
+                }
             } else {
-                queue.drain_scheduled = true;
-                true
+                dropped.extend(queue.push_bounded(LifecycleCallback::Closed(scope)));
             }
+            let should_spawn = !queue.pending.is_empty() && !queue.drain_scheduled;
+            queue.drain_scheduled |= should_spawn;
+            (should_spawn, dropped)
         };
 
+        warn_dropped_callbacks(dropped);
         self.spawn_callback_driver(should_spawn);
     }
 
@@ -439,16 +475,18 @@ impl LifecycleRegistration {
     }
 
     fn enqueue_callback(self: &Arc<Self>, callback: LifecycleCallback) {
-        let should_spawn = {
+        let (should_spawn, dropped) = {
             let mut queue = self.callback_queue();
-            queue.pending.push_back(callback);
-            if queue.drain_scheduled {
-                false
+            if queue.shutdown_requested || self.terminal.load(Ordering::Acquire) {
+                (false, Some(callback))
             } else {
+                let dropped = queue.push_bounded(callback);
+                let should_spawn = !queue.drain_scheduled;
                 queue.drain_scheduled = true;
-                true
+                (should_spawn, dropped)
             }
         };
+        warn_dropped_callbacks(dropped.into_iter().collect());
         self.spawn_callback_driver(should_spawn);
     }
 
@@ -457,24 +495,21 @@ impl LifecycleRegistration {
             let scopes = self.scopes();
             scopes.active.is_none() && scopes.retired.is_empty()
         };
-        if !no_open_scopes {
-            return;
-        }
-
-        let should_spawn = {
+        let (should_spawn, dropped) = {
             let mut queue = self.callback_queue();
             if !queue.shutdown_requested || queue.shutdown_enqueued {
                 return;
             }
-            queue.shutdown_enqueued = true;
-            queue.pending.push_back(LifecycleCallback::Shutdown);
-            if queue.drain_scheduled {
-                false
-            } else {
-                queue.drain_scheduled = true;
-                true
+            let dropped = queue.compact_for_shutdown(no_open_scopes);
+            if no_open_scopes {
+                queue.shutdown_enqueued = true;
+                queue.pending.push_back(LifecycleCallback::Shutdown);
             }
+            let should_spawn = !queue.pending.is_empty() && !queue.drain_scheduled;
+            queue.drain_scheduled |= should_spawn;
+            (should_spawn, dropped)
         };
+        warn_dropped_callbacks(dropped);
         self.spawn_callback_driver(should_spawn);
     }
 
@@ -498,6 +533,7 @@ impl LifecycleRegistration {
                     Some(callback) => callback,
                     None => {
                         queue.drain_scheduled = false;
+                        queue.overflowed = false;
                         return;
                     }
                 }
@@ -605,6 +641,15 @@ impl LifecycleRegistration {
                     .find(|scope| scope.generation() == generation)
             })
             .cloned()
+    }
+}
+
+fn warn_dropped_callbacks(dropped: Vec<LifecycleCallback>) {
+    if !dropped.is_empty() {
+        log::warn!(
+            "Dropped {} stale client lifecycle callback(s) under queue pressure or terminal shutdown",
+            dropped.len()
+        );
     }
 }
 
@@ -787,6 +832,37 @@ mod tests {
         release: async_channel::Receiver<()>,
         calls: AtomicUsize,
         completed: AtomicBool,
+    }
+
+    struct QueuePressureLifecycle {
+        ready_started: async_channel::Sender<()>,
+        release_ready: async_channel::Receiver<()>,
+        closed_calls: AtomicUsize,
+        shutdown_calls: AtomicUsize,
+    }
+
+    impl ClientLifecycle for QueuePressureLifecycle {
+        fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                let _ = self.ready_started.try_send(());
+                let _ = self.release_ready.recv().await;
+                Ok(())
+            })
+        }
+
+        fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.closed_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.shutdown_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
     }
 
     impl ClientLifecycle for BlockingShutdownLifecycle {
@@ -1353,6 +1429,75 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner()),
             vec!["ready-started", "closed"]
         );
+    }
+
+    #[tokio::test]
+    async fn callback_queue_is_bounded_and_terminal_shutdown_compacts_backlog() {
+        let (ready_started_tx, ready_started_rx) = async_channel::bounded(1);
+        let (release_ready_tx, release_ready_rx) = async_channel::bounded(1);
+        let lifecycle = Arc::new(QueuePressureLifecycle {
+            ready_started: ready_started_tx,
+            release_ready: release_ready_rx,
+            closed_calls: AtomicUsize::new(0),
+            shutdown_calls: AtomicUsize::new(0),
+        });
+        let registration = Arc::new(LifecycleRegistration::new_with_timeout(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+            Duration::from_secs(1),
+        ));
+
+        let active_scope = ConnectionScope::new(1);
+        assert!(active_scope.mark_ready());
+        let (done, _done_rx) = async_channel::bounded(1);
+        registration.enqueue_callback(LifecycleCallback::Ready {
+            scope: active_scope,
+            done,
+        });
+        ready_started_rx
+            .recv()
+            .await
+            .expect("ready callback started");
+
+        for generation in 2..(CALLBACK_QUEUE_CAPACITY as u64 * 4) {
+            let scope = ConnectionScope::new(generation);
+            scope.close();
+            registration.enqueue_callback(LifecycleCallback::Closed(scope));
+        }
+        assert_eq!(
+            registration.callback_queue().pending.len(),
+            CALLBACK_QUEUE_CAPACITY
+        );
+
+        let shutdown_registration = registration.clone();
+        let shutdown = tokio::spawn(async move { shutdown_registration.shutdown().await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let compacted = {
+                    let queue = registration.callback_queue();
+                    if queue.shutdown_enqueued {
+                        assert_eq!(queue.pending.len(), 2);
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if compacted {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal backlog compaction");
+
+        release_ready_tx
+            .send(())
+            .await
+            .expect("release ready callback");
+        shutdown.await.expect("bounded terminal shutdown");
+        assert_eq!(lifecycle.closed_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.shutdown_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -702,6 +702,19 @@ mod tests {
         }
     }
 
+    struct PanickingDisconnect;
+
+    #[async_trait]
+    impl crate::transport::Transport for PanickingDisconnect {
+        async fn send(&self, _data: Bytes) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self) {
+            panic!("injected disconnect panic");
+        }
+    }
+
     struct BlockingReadyLifecycle {
         ready_started: async_channel::Sender<()>,
         release_ready: async_channel::Receiver<()>,
@@ -1127,6 +1140,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropping_last_client_owner_signals_standalone_lifecycle() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let lifecycle = Arc::new(EarlyShutdownLifecycle::default());
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle_arc(lifecycle.clone())
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+        let weak = Arc::downgrade(&client);
+
+        drop(client);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("background services released the client");
+        assert!(lifecycle.signalled.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
     async fn cancellation_does_not_wait_for_a_running_callback() {
         let persistence_manager = Arc::new(
             PersistenceManager::new(crate::test_utils::create_test_backend().await)
@@ -1461,6 +1506,38 @@ mod tests {
             lifecycle.events(),
             vec!["install", "ready:37", "closed:37", "shutdown"]
         );
+        client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn detached_cleanup_propagates_panics_to_its_waiter() {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        let client = Client::builder()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+            .with_lifecycle(RecordingLifecycle::default())
+            .build()
+            .await
+            .expect("client build")
+            .into_client();
+        *client.transport.lock().await = Some(Arc::new(PanickingDisconnect));
+
+        let cleanup_client = Arc::clone(&client);
+        let cleanup = tokio::spawn(async move {
+            cleanup_client.cleanup_connection_state().await;
+        });
+        let panic = tokio::time::timeout(Duration::from_secs(2), cleanup)
+            .await
+            .expect("cleanup waiter did not hang")
+            .expect_err("cleanup panic should reach its waiter");
+
+        assert!(panic.is_panic());
         client.signal_shutdown_sync();
     }
 

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -7,9 +7,7 @@ use std::time::Duration;
 
 use super::Client;
 use futures::FutureExt;
-use wacore::runtime::{
-    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, timeout as rt_timeout, wait_for_shutdown,
-};
+use wacore::runtime::{BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, wait_for_shutdown};
 
 const SCOPE_OPEN: u8 = 0;
 const SCOPE_READY: u8 = 1;
@@ -302,26 +300,35 @@ impl LifecycleRegistration {
                 "client shutdown began during lifecycle installation"
             ));
         }
-        let install = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut install = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.handler.install(client)
         }))
         .map_err(|_| anyhow::anyhow!("lifecycle install panicked before returning a future"))?;
         let cancelled = Box::pin(wait_for_shutdown(&rejected));
-        let install = Box::pin(std::panic::AssertUnwindSafe(install).catch_unwind());
-        let result = match futures::future::select(cancelled, install).await {
-            futures::future::Either::Left((_, install)) => {
-                if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(install))).is_err()
-                {
-                    log::warn!("Lifecycle install future panicked while being cancelled");
+        let result = {
+            let install_poll = std::future::poll_fn(|context| install.as_mut().poll(context));
+            let install_poll = Box::pin(std::panic::AssertUnwindSafe(install_poll).catch_unwind());
+            match futures::future::select(cancelled, install_poll).await {
+                futures::future::Either::Left((_, install_poll)) => {
+                    drop(install_poll);
+                    None
                 }
-                return Err(anyhow::anyhow!(
-                    "client shutdown began during lifecycle installation"
-                ));
-            }
-            futures::future::Either::Right((result, _)) => {
-                result.map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?
+                futures::future::Either::Right((result, _)) => Some(result),
             }
         };
+        let drop_panicked =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| drop(install))).is_err();
+        if drop_panicked {
+            return Err(anyhow::anyhow!(
+                "lifecycle install future panicked while being dropped"
+            ));
+        }
+        let Some(result) = result else {
+            return Err(anyhow::anyhow!(
+                "client shutdown began during lifecycle installation"
+            ));
+        };
+        let result = result.map_err(|_| anyhow::anyhow!("lifecycle install future panicked"))?;
         if result.is_ok()
             && self.construction_state.load(Ordering::Acquire) == CONSTRUCTION_REJECTED
         {
@@ -646,22 +653,37 @@ impl LifecycleRegistration {
             log::warn!("Client lifecycle {name} panicked");
             return;
         };
-        let callback = std::future::poll_fn(|context| {
+        let result = {
+            let callback_poll = std::future::poll_fn(|context| {
+                let _callback_context = CallbackContextGuard::enter(self);
+                callback.as_mut().poll(context)
+            });
+            let callback_poll =
+                Box::pin(std::panic::AssertUnwindSafe(callback_poll).catch_unwind());
+            match futures::future::select(callback_poll, self.runtime.sleep(self.callback_timeout))
+                .await
+            {
+                futures::future::Either::Left((result, _)) => Some(result),
+                futures::future::Either::Right(((), callback_poll)) => {
+                    drop(callback_poll);
+                    None
+                }
+            }
+        };
+        let drop_panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _callback_context = CallbackContextGuard::enter(self);
-            callback.as_mut().poll(context)
-        });
-        let result = std::panic::AssertUnwindSafe(rt_timeout(
-            &*self.runtime,
-            self.callback_timeout,
-            callback,
-        ))
-        .catch_unwind()
-        .await;
+            drop(callback);
+        }))
+        .is_err();
+        if drop_panicked {
+            log::warn!("Client lifecycle {name} panicked while being dropped");
+            return;
+        }
         match result {
-            Ok(Ok(Ok(()))) => {}
-            Ok(Ok(Err(error))) => log::warn!("Client lifecycle {name} failed: {error:#}"),
-            Ok(Err(_)) => log::warn!("Client lifecycle {name} timed out"),
-            Err(_) => log::warn!("Client lifecycle {name} panicked"),
+            Some(Ok(Ok(()))) => {}
+            Some(Ok(Err(error))) => log::warn!("Client lifecycle {name} failed: {error:#}"),
+            Some(Err(_)) => log::warn!("Client lifecycle {name} panicked"),
+            None => log::warn!("Client lifecycle {name} timed out"),
         }
     }
 
@@ -1062,6 +1084,31 @@ mod tests {
         shutdown_calls: AtomicUsize,
     }
 
+    #[derive(Default)]
+    struct DropPanickingFutureLifecycle {
+        closed_calls: AtomicUsize,
+        shutdown_calls: AtomicUsize,
+    }
+
+    struct DropPanickingPendingFuture;
+
+    impl Future for DropPanickingPendingFuture {
+        type Output = anyhow::Result<()>;
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            _context: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            std::task::Poll::Pending
+        }
+    }
+
+    impl Drop for DropPanickingPendingFuture {
+        fn drop(&mut self) {
+            panic!("injected lifecycle callback drop panic");
+        }
+    }
+
     impl ClientLifecycle for SynchronousPanicLifecycle {
         fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
             self.ready_calls.fetch_add(1, Ordering::SeqCst);
@@ -1076,6 +1123,26 @@ mod tests {
         fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
             self.shutdown_calls.fetch_add(1, Ordering::SeqCst);
             panic!("synchronous shutdown panic");
+        }
+    }
+
+    impl ClientLifecycle for DropPanickingFutureLifecycle {
+        fn on_ready<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(DropPanickingPendingFuture)
+        }
+
+        fn on_closed<'a>(&'a self, _scope: ConnectionScope) -> BoxFuture<'a, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.closed_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                self.shutdown_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
         }
     }
 
@@ -1759,6 +1826,31 @@ mod tests {
             .expect("callback driver recovered from synchronous panics");
 
         assert_eq!(lifecycle.ready_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.closed_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.shutdown_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn callback_drop_panics_do_not_strand_the_driver() {
+        let lifecycle = Arc::new(DropPanickingFutureLifecycle::default());
+        let registration = Arc::new(LifecycleRegistration::new_with_timeout(
+            lifecycle.clone(),
+            Arc::new(TokioRuntime),
+            Duration::from_millis(10),
+        ));
+        const GENERATION: u64 = 24;
+        assert!(registration.begin_scope_if_current(GENERATION, || true));
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), registration.ready(GENERATION))
+                .await
+                .expect("ready callback cancellation completed")
+        );
+        registration.close_scope(GENERATION);
+        tokio::time::timeout(Duration::from_secs(1), registration.shutdown())
+            .await
+            .expect("callback driver recovered from a drop panic");
+
         assert_eq!(lifecycle.closed_calls.load(Ordering::SeqCst), 1);
         assert_eq!(lifecycle.shutdown_calls.load(Ordering::SeqCst), 1);
     }

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -137,18 +137,24 @@ pub trait ClientLifecycle: wacore::sync_marker::MaybeSendSync {
 
 pub(super) struct LifecycleRegistration {
     handler: Arc<dyn ClientLifecycle>,
-    active_scope: std::sync::Mutex<Option<ConnectionScope>>,
+    scopes: std::sync::Mutex<ScopeRegistry>,
     callback_gate: async_lock::Mutex<()>,
     shutdown_gate: async_lock::Mutex<bool>,
     scope_changed: event_listener::Event,
     terminal: AtomicBool,
 }
 
+#[derive(Default)]
+struct ScopeRegistry {
+    active: Option<ConnectionScope>,
+    retired: Vec<ConnectionScope>,
+}
+
 impl LifecycleRegistration {
     pub(super) fn new(handler: Arc<dyn ClientLifecycle>) -> Self {
         Self {
             handler,
-            active_scope: std::sync::Mutex::new(None),
+            scopes: std::sync::Mutex::new(ScopeRegistry::default()),
             callback_gate: async_lock::Mutex::new(()),
             shutdown_gate: async_lock::Mutex::new(false),
             scope_changed: event_listener::Event::new(),
@@ -166,22 +172,21 @@ impl LifecycleRegistration {
         }
 
         let scope = ConnectionScope::new(generation);
-        let mut active = self
-            .active_scope
+        let mut scopes = self
+            .scopes
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if self.terminal.load(Ordering::Acquire) {
             return;
         }
-        let replaced = active.replace(scope);
-        drop(active);
+        let replaced = scopes.active.replace(scope);
         if let Some(replaced) = replaced {
             log::warn!(
                 "Replacing unclosed connection scope for generation {}",
                 replaced.generation()
             );
             replaced.cancel();
-            replaced.close();
+            scopes.retired.push(replaced);
         }
     }
 
@@ -208,12 +213,14 @@ impl LifecycleRegistration {
     }
 
     pub(super) fn cancel_active_scope(&self) {
-        let scope = self
-            .active_scope
+        let scopes = self
+            .scopes
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone();
-        if let Some(scope) = scope {
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(scope) = &scopes.active {
+            scope.cancel();
+        }
+        for scope in &scopes.retired {
             scope.cancel();
         }
     }
@@ -221,17 +228,22 @@ impl LifecycleRegistration {
     pub(super) async fn close_scope(&self, generation: u64) {
         let _callback_guard = self.callback_gate.lock().await;
         let scope = {
-            let mut active = self
-                .active_scope
+            let mut scopes = self
+                .scopes
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if active
+            if scopes
+                .active
                 .as_ref()
                 .is_some_and(|scope| scope.generation() == generation)
             {
-                active.take()
+                scopes.active.take()
             } else {
-                None
+                scopes
+                    .retired
+                    .iter()
+                    .position(|scope| scope.generation() == generation)
+                    .map(|position| scopes.retired.remove(position))
             }
         };
         let Some(scope) = scope else {
@@ -258,7 +270,7 @@ impl LifecycleRegistration {
         loop {
             let scope_changed = self.scope_changed.listen();
             let callback_guard = self.callback_gate.lock().await;
-            if self.scope_for_active_generation().is_none() {
+            if !self.has_open_scopes() {
                 if let Err(error) = self.handler.shutdown().await {
                     log::warn!("Client lifecycle shutdown failed: {error:#}");
                 }
@@ -269,19 +281,29 @@ impl LifecycleRegistration {
         }
     }
 
-    fn scope_for_active_generation(&self) -> Option<ConnectionScope> {
-        self.active_scope
+    fn has_open_scopes(&self) -> bool {
+        let scopes = self
+            .scopes
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        scopes.active.is_some() || !scopes.retired.is_empty()
     }
 
     fn scope_for(&self, generation: u64) -> Option<ConnectionScope> {
-        self.active_scope
+        let scopes = self
+            .scopes
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        scopes
+            .active
             .as_ref()
             .filter(|scope| scope.generation() == generation)
+            .or_else(|| {
+                scopes
+                    .retired
+                    .iter()
+                    .find(|scope| scope.generation() == generation)
+            })
             .cloned()
     }
 }
@@ -602,6 +624,33 @@ mod tests {
             vec!["ready-started", "ready-finished", "closed"]
         );
         client.signal_shutdown_sync();
+    }
+
+    #[tokio::test]
+    async fn replaced_scope_stays_closeable_by_its_generation() {
+        let lifecycle = Arc::new(RecordingLifecycle::default());
+        let registration = LifecycleRegistration::new(lifecycle.clone());
+
+        registration.begin_scope(31);
+        assert!(registration.ready(31).await);
+        let first = registration.scope_for(31).expect("first scope");
+
+        registration.begin_scope(32);
+        assert_eq!(first.state(), ConnectionScopeState::Cancelled);
+        assert!(registration.scope_for(31).is_some());
+        assert!(registration.ready(32).await);
+
+        registration.close_scope(31).await;
+        assert_eq!(first.state(), ConnectionScopeState::Closed);
+        assert!(registration.scope_for(31).is_none());
+        assert!(registration.scope_for(32).is_some());
+
+        registration.close_scope(32).await;
+        registration.shutdown().await;
+        assert_eq!(
+            lifecycle.events(),
+            vec!["ready:31", "ready:32", "closed:31", "closed:32", "shutdown",]
+        );
     }
 
     #[tokio::test]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -929,6 +929,19 @@ impl Client {
         #[cfg(not(feature = "client-lifecycle"))]
         self.connection_generation.fetch_add(1, Ordering::SeqCst);
         #[cfg(feature = "client-lifecycle")]
+        let scope_close = self.lifecycle.as_ref().map(|lifecycle| {
+            let lifecycle = Arc::clone(lifecycle);
+            scopeguard::guard((lifecycle, closed_generation), |(lifecycle, generation)| {
+                if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    lifecycle.close_scope(generation);
+                }))
+                .is_err()
+                {
+                    error!("Client lifecycle scope closure panicked");
+                }
+            })
+        });
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.cancel_scope(closed_generation);
         }
@@ -1089,9 +1102,7 @@ impl Client {
             proc.clear_key_cache().await;
         }
         #[cfg(feature = "client-lifecycle")]
-        if let Some(lifecycle) = &self.lifecycle {
-            lifecycle.close_scope(closed_generation);
-        }
+        drop(scope_close);
     }
 
     /// Waits for the noise socket to be established.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -31,7 +31,7 @@ impl Client {
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
         if let Some(lifecycle) = &self.lifecycle {
-            lifecycle.cancel_active_scope();
+            lifecycle.signal_shutdown_sync();
         }
         self.notify_connection_shutdown();
     }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -30,6 +30,9 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.cancel_active_scope();
+        }
         self.notify_connection_shutdown();
     }
 
@@ -72,13 +75,30 @@ impl Client {
     }
 
     /// Dispatch the Connected event and notify waiters.
-    pub(crate) fn dispatch_connected(&self) {
+    pub(crate) async fn dispatch_connected(&self) {
+        let generation = self.connection_generation.load(Ordering::SeqCst);
+        if let Some(lifecycle) = &self.lifecycle {
+            if !lifecycle.ready(generation).await {
+                debug!("Skipping Connected dispatch for retired generation {generation}");
+                return;
+            }
+            if self.connection_generation.load(Ordering::SeqCst) != generation {
+                debug!("Skipping Connected dispatch after generation changed");
+                return;
+            }
+        }
         self.is_ready.store(true, Ordering::Relaxed);
         wacore::telemetry::set_connected(true);
         self.core.event_bus.dispatch(Event::Connected(
             crate::types::events::Connected::builder().build(),
         ));
         self.connected_notifier.notify(usize::MAX);
+    }
+
+    pub(super) async fn shutdown_lifecycle(&self) {
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.shutdown().await;
+        }
     }
 
     /// Create a new `Client` with default cache configuration.
@@ -100,6 +120,7 @@ impl Client {
             override_version,
             CacheConfig::default(),
         )
+        .await
         .into_parts()
     }
 
@@ -120,6 +141,7 @@ impl Client {
             override_version,
             cache_config,
         )
+        .await
         .into_parts()
     }
 
@@ -130,6 +152,7 @@ impl Client {
         http_client: Arc<dyn crate::http::HttpClient>,
         override_version: Option<(u32, u32, u32)>,
         cache_config: CacheConfig,
+        lifecycle: Option<Arc<LifecycleRegistration>>,
     ) -> ClientAssembly {
         let mut unique_id_bytes = [0u8; 2];
         rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut unique_id_bytes);
@@ -157,6 +180,7 @@ impl Client {
             ik_handshake_failures: Arc::new(AtomicU32::new(0)),
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
+            lifecycle,
             stats: Arc::new(wacore::stats::SessionStats::new()),
 
             transport: Arc::new(Mutex::new(None)),
@@ -468,6 +492,7 @@ impl Client {
             );
             self.runtime.sleep(delay).await;
         }
+        self.shutdown_lifecycle().await;
         info!("Client run loop has shut down.");
     }
 
@@ -630,14 +655,14 @@ impl Client {
             warn!("Failed to send logout IQ: {e}");
         }
 
-        self.disconnect().await;
-
         self.core.event_bus.dispatch(Event::LoggedOut(
             crate::types::events::LoggedOut::builder()
                 .on_connect(false)
                 .reason(ConnectFailureReason::LoggedOut)
                 .build(),
         ));
+
+        self.disconnect().await;
 
         Ok(())
     }
@@ -698,6 +723,7 @@ impl Client {
         // final flush below and then be acked.
         self.msg_secret_buffer.seal();
         self.msg_secret_buffer.flush().await;
+        self.shutdown_lifecycle().await;
     }
 
     /// Backoff step used by [`reconnect()`] to create an offline window.
@@ -795,7 +821,11 @@ impl Client {
         // process_classified_message — no decrypt can START after the
         // permit-held cache settle below, so no rowless ratchet advances can
         // dirty the cache behind teardown's back.
-        self.connection_generation.fetch_add(1, Ordering::SeqCst);
+        let closed_generation = self.connection_generation.fetch_add(1, Ordering::SeqCst);
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.cancel_scope(closed_generation);
+        }
+        self.notify_connection_shutdown();
         // The coalesced-flush scheduler needs no explicit reset: its state is
         // generation-scoped, so the bump above already hands ownership to the
         // next connection's first request and retires any stale worker.
@@ -821,11 +851,6 @@ impl Client {
             // registry, so abort_all misses them. Drain them and notify `ended` so any waiter wakes.
             crate::voip::facade::drain_pending_outgoing_on_disconnect(self);
         }
-        // Signal the keepalive loop (and any other per-connection tasks) to
-        // exit promptly. Without this, a stale keepalive loop can overlap
-        // with the next one after reconnect. Uses the PER-CONNECTION signal
-        // so the terminal shutdown_notifier stays clean for reconnects.
-        self.notify_connection_shutdown();
         // Close the socket as part of cleanup so this path is authoritative
         // even when reached via the run loop's graceful-exit flow (not just
         // `Client::disconnect()`). Transport impls make `disconnect()`
@@ -954,6 +979,9 @@ impl Client {
         // Clear app state key cache — keys will be re-fetched from DB on demand
         if let Some(proc) = self.app_state_processor.lock().await.as_ref() {
             proc.clear_key_cache().await;
+        }
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.close_scope(closed_generation).await;
         }
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -101,6 +101,12 @@ impl Client {
         }
     }
 
+    fn request_lifecycle_shutdown(&self) {
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.request_shutdown();
+        }
+    }
+
     /// Create a new `Client` with default cache configuration.
     ///
     /// This is the standard constructor. Use [`Client::new_with_cache_config`]
@@ -684,6 +690,7 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        self.request_lifecycle_shutdown();
 
         // Drain buffered offline receipts into the flush window before
         // closing it, so a disconnect mid-offline-sync still acks the

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -782,6 +782,9 @@ impl Client {
     )]
     pub async fn reconnect(self: &Arc<Self>) {
         info!("Reconnecting: dropping transport for auto-reconnect.");
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.cancel_active_scope();
+        }
         wacore::telemetry::reconnect();
         self.intentional_reconnect.store(true, Ordering::Relaxed);
         self.auto_reconnect_errors
@@ -818,6 +821,9 @@ impl Client {
     )]
     pub async fn reconnect_immediately(self: &Arc<Self>) {
         info!("Reconnecting immediately (expected disconnect).");
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.cancel_active_scope();
+        }
         self.expected_disconnect.store(true, Ordering::Relaxed);
 
         // Same durable-before-receipts gate as disconnect().

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -81,27 +81,49 @@ impl Client {
         self.is_connected() && self.is_logged_in() && self.is_ready.load(Ordering::Relaxed)
     }
 
-    /// Dispatch the Connected event and notify waiters.
-    pub(crate) async fn dispatch_connected(&self) {
+    /// Dispatch the Connected event and notify waiters for the originating connection.
+    pub(crate) async fn dispatch_connected(&self, expected_generation: u64) {
         #[cfg(feature = "client-lifecycle")]
         {
-            let generation = self.connection_generation.load(Ordering::SeqCst);
             if let Some(lifecycle) = &self.lifecycle {
-                if !lifecycle.ready(generation).await {
-                    debug!("Skipping Connected dispatch for retired generation {generation}");
+                if !lifecycle.ready(expected_generation).await {
+                    debug!(
+                        "Skipping Connected dispatch for retired generation {expected_generation}"
+                    );
                     return;
                 }
-                if self.connection_generation.load(Ordering::SeqCst) != generation {
-                    debug!("Skipping Connected dispatch after generation changed");
+
+                // Cleanup takes the same lock before retiring the generation, so the final
+                // validation and publication form one transition with its generation bump.
+                let _login_transition = self
+                    .login_transition
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if self.connection_generation.load(Ordering::SeqCst) != expected_generation
+                    || self.expected_disconnect.load(Ordering::Acquire)
+                {
+                    debug!(
+                        "Skipping Connected dispatch after generation {expected_generation} retired"
+                    );
                     return;
                 }
-                if !lifecycle.publish_ready(generation, || self.publish_connected()) {
+                if !lifecycle.publish_ready(expected_generation, || self.publish_connected()) {
                     debug!("Skipping Connected dispatch after lifecycle cancellation");
                 }
                 return;
             }
         }
 
+        let _login_transition = self
+            .login_transition
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.connection_generation.load(Ordering::SeqCst) != expected_generation
+            || self.expected_disconnect.load(Ordering::Acquire)
+        {
+            debug!("Skipping Connected dispatch after its connection retired");
+            return;
+        }
         self.publish_connected();
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -812,7 +812,26 @@ impl Client {
         feature = "tracing",
         tracing::instrument(name = "wa.conn.cleanup", level = "debug", skip_all)
     )]
-    pub(crate) async fn cleanup_connection_state(&self) {
+    pub(crate) async fn cleanup_connection_state(self: &Arc<Self>) {
+        if self.lifecycle.is_none() {
+            self.cleanup_connection_state_inner().await;
+            return;
+        }
+
+        // Scope closure must survive a caller dropping its cleanup waiter.
+        let completed = wacore::runtime::ShutdownNotifier::new();
+        let completion = completed.subscribe();
+        let client = Arc::clone(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                client.cleanup_connection_state_inner().await;
+                completed.notify();
+            }))
+            .detach();
+        wacore::runtime::wait_for_shutdown(&completion).await;
+    }
+
+    async fn cleanup_connection_state_inner(&self) {
         // Bump the generation FIRST: it is the "this connection is over"
         // signal every per-connection loop already polls. Chat-lane workers
         // stop draining their queues (their remaining stanzas were never

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -406,8 +406,23 @@ impl Client {
     // keepalive-loop span. Identity (lid/pn) attribution comes from the
     // per-operation spans (send/request), which record it themselves.
     pub async fn run(self: &Arc<Self>) {
+        if let Some(lifecycle) = &self.lifecycle
+            && !lifecycle.wait_until_active().await
+        {
+            warn!("Client `run` rejected before construction completed.");
+            return;
+        }
+        let shutdown = self.shutdown_signal();
+        if shutdown.is_fired() {
+            warn!("Client `run` called after shutdown.");
+            return;
+        }
         if self.is_running.swap(true, Ordering::SeqCst) {
             warn!("Client `run` method called while already running.");
+            return;
+        }
+        if shutdown.is_fired() {
+            self.is_running.store(false, Ordering::SeqCst);
             return;
         }
         // Reconnects are counted at iteration start: every pass after the

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -86,7 +86,16 @@ impl Client {
                 debug!("Skipping Connected dispatch after generation changed");
                 return;
             }
+            if !lifecycle.publish_ready(generation, || self.publish_connected()) {
+                debug!("Skipping Connected dispatch after lifecycle cancellation");
+            }
+            return;
         }
+
+        self.publish_connected();
+    }
+
+    fn publish_connected(&self) {
         self.is_ready.store(true, Ordering::Relaxed);
         wacore::telemetry::set_connected(true);
         self.core.event_bus.dispatch(Event::Connected(

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -981,7 +981,7 @@ impl Client {
             proc.clear_key_cache().await;
         }
         if let Some(lifecycle) = &self.lifecycle {
-            lifecycle.close_scope(closed_generation).await;
+            lifecycle.close_scope(closed_generation);
         }
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -156,6 +156,7 @@ impl Client {
     ) -> ClientAssembly {
         let ClientExtensions {
             lifecycle,
+            #[cfg(feature = "plugins")]
             plugin_host,
         } = extensions;
         let mut unique_id_bytes = [0u8; 2];
@@ -185,6 +186,7 @@ impl Client {
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
             lifecycle,
+            #[cfg(feature = "plugins")]
             plugin_host,
             stats: Arc::new(wacore::stats::SessionStats::new()),
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -114,6 +114,7 @@ impl Client {
             }
         }
 
+        #[cfg(feature = "client-lifecycle")]
         let _login_transition = self
             .login_transition
             .lock()
@@ -228,6 +229,7 @@ impl Client {
             persistence_manager: persistence_manager.clone(),
             media_conn: Arc::new(RwLock::new(None)),
             is_logged_in: Arc::new(AtomicBool::new(false)),
+            #[cfg(feature = "client-lifecycle")]
             login_transition: std::sync::Mutex::new(()),
             is_connecting: Arc::new(AtomicBool::new(false)),
             is_running: Arc::new(AtomicBool::new(false)),
@@ -940,6 +942,7 @@ impl Client {
     }
 
     async fn cleanup_connection_state_inner(&self) {
+        #[cfg(feature = "client-lifecycle")]
         let login_transition = self
             .login_transition
             .lock()
@@ -984,6 +987,7 @@ impl Client {
         // outgoing stanzas, which are transport-scoped.
         self.clear_sent_node_waiters();
         self.is_logged_in.store(false, Ordering::Relaxed);
+        #[cfg(feature = "client-lifecycle")]
         drop(login_transition);
         self.is_ready.store(false, Ordering::Relaxed);
         // Publish the disconnected state BEFORE draining VoIP calls (it used to be cleared only after

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -36,6 +36,7 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.signal_shutdown_sync();
         }
@@ -82,20 +83,23 @@ impl Client {
 
     /// Dispatch the Connected event and notify waiters.
     pub(crate) async fn dispatch_connected(&self) {
-        let generation = self.connection_generation.load(Ordering::SeqCst);
-        if let Some(lifecycle) = &self.lifecycle {
-            if !lifecycle.ready(generation).await {
-                debug!("Skipping Connected dispatch for retired generation {generation}");
+        #[cfg(feature = "client-lifecycle")]
+        {
+            let generation = self.connection_generation.load(Ordering::SeqCst);
+            if let Some(lifecycle) = &self.lifecycle {
+                if !lifecycle.ready(generation).await {
+                    debug!("Skipping Connected dispatch for retired generation {generation}");
+                    return;
+                }
+                if self.connection_generation.load(Ordering::SeqCst) != generation {
+                    debug!("Skipping Connected dispatch after generation changed");
+                    return;
+                }
+                if !lifecycle.publish_ready(generation, || self.publish_connected()) {
+                    debug!("Skipping Connected dispatch after lifecycle cancellation");
+                }
                 return;
             }
-            if self.connection_generation.load(Ordering::SeqCst) != generation {
-                debug!("Skipping Connected dispatch after generation changed");
-                return;
-            }
-            if !lifecycle.publish_ready(generation, || self.publish_connected()) {
-                debug!("Skipping Connected dispatch after lifecycle cancellation");
-            }
-            return;
         }
 
         self.publish_connected();
@@ -110,12 +114,14 @@ impl Client {
         self.connected_notifier.notify(usize::MAX);
     }
 
+    #[cfg(feature = "client-lifecycle")]
     pub(super) async fn shutdown_lifecycle(&self) {
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.shutdown().await;
         }
     }
 
+    #[cfg(feature = "client-lifecycle")]
     fn request_lifecycle_shutdown(&self) {
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.request_shutdown();
@@ -176,6 +182,7 @@ impl Client {
         extensions: ClientExtensions,
     ) -> ClientAssembly {
         let ClientExtensions {
+            #[cfg(feature = "client-lifecycle")]
             lifecycle,
             #[cfg(feature = "plugins")]
             plugin_host,
@@ -207,6 +214,7 @@ impl Client {
             ik_handshake_failures: Arc::new(AtomicU32::new(0)),
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
+            #[cfg(feature = "client-lifecycle")]
             lifecycle,
             #[cfg(feature = "plugins")]
             plugin_host,
@@ -406,6 +414,7 @@ impl Client {
     // keepalive-loop span. Identity (lid/pn) attribution comes from the
     // per-operation spans (send/request), which record it themselves.
     pub async fn run(self: &Arc<Self>) {
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle
             && !lifecycle.wait_until_active().await
         {
@@ -536,6 +545,7 @@ impl Client {
             );
             self.runtime.sleep(delay).await;
         }
+        #[cfg(feature = "client-lifecycle")]
         self.shutdown_lifecycle().await;
         info!("Client run loop has shut down.");
     }
@@ -721,6 +731,7 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        #[cfg(feature = "client-lifecycle")]
         self.request_lifecycle_shutdown();
 
         // Drain buffered offline receipts into the flush window before
@@ -768,6 +779,7 @@ impl Client {
         // final flush below and then be acked.
         self.msg_secret_buffer.seal();
         self.msg_secret_buffer.flush().await;
+        #[cfg(feature = "client-lifecycle")]
         self.shutdown_lifecycle().await;
     }
 
@@ -797,6 +809,7 @@ impl Client {
     )]
     pub async fn reconnect(self: &Arc<Self>) {
         info!("Reconnecting: dropping transport for auto-reconnect.");
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.cancel_active_scope();
         }
@@ -836,6 +849,7 @@ impl Client {
     )]
     pub async fn reconnect_immediately(self: &Arc<Self>) {
         info!("Reconnecting immediately (expected disconnect).");
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.cancel_active_scope();
         }
@@ -863,6 +877,16 @@ impl Client {
         feature = "tracing",
         tracing::instrument(name = "wa.conn.cleanup", level = "debug", skip_all)
     )]
+    #[cfg(not(feature = "client-lifecycle"))]
+    pub(crate) async fn cleanup_connection_state(self: &Arc<Self>) {
+        self.cleanup_connection_state_inner().await;
+    }
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "wa.conn.cleanup", level = "debug", skip_all)
+    )]
+    #[cfg(feature = "client-lifecycle")]
     pub(crate) async fn cleanup_connection_state(self: &Arc<Self>) {
         if self.lifecycle.is_none() {
             self.cleanup_connection_state_inner().await;
@@ -900,7 +924,11 @@ impl Client {
         // process_classified_message — no decrypt can START after the
         // permit-held cache settle below, so no rowless ratchet advances can
         // dirty the cache behind teardown's back.
+        #[cfg(feature = "client-lifecycle")]
         let closed_generation = self.connection_generation.fetch_add(1, Ordering::SeqCst);
+        #[cfg(not(feature = "client-lifecycle"))]
+        self.connection_generation.fetch_add(1, Ordering::SeqCst);
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.cancel_scope(closed_generation);
         }
@@ -1060,6 +1088,7 @@ impl Client {
         if let Some(proc) = self.app_state_processor.lock().await.as_ref() {
             proc.clear_key_cache().await;
         }
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.close_scope(closed_generation);
         }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -335,7 +335,7 @@ impl Client {
             self_weak: std::sync::OnceLock::new(),
             saver_handle: std::sync::OnceLock::new(),
             alloc_meter: std::sync::OnceLock::new(),
-            raw_node_forwarding: AtomicBool::new(false),
+            raw_node_forwarding: AtomicUsize::new(0),
             #[cfg(feature = "voip-runtime")]
             call_registry: std::sync::Arc::new(wacore::voip::CallRegistry::new()),
             #[cfg(feature = "voip-runtime")]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -184,6 +184,7 @@ impl Client {
             persistence_manager: persistence_manager.clone(),
             media_conn: Arc::new(RwLock::new(None)),
             is_logged_in: Arc::new(AtomicBool::new(false)),
+            login_transition: std::sync::Mutex::new(()),
             is_connecting: Arc::new(AtomicBool::new(false)),
             is_running: Arc::new(AtomicBool::new(false)),
             is_connected: Arc::new(AtomicBool::new(false)),
@@ -846,6 +847,10 @@ impl Client {
     }
 
     async fn cleanup_connection_state_inner(&self) {
+        let login_transition = self
+            .login_transition
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // Bump the generation FIRST: it is the "this connection is over"
         // signal every per-connection loop already polls. Chat-lane workers
         // stop draining their queues (their remaining stanzas were never
@@ -869,6 +874,7 @@ impl Client {
         // outgoing stanzas, which are transport-scoped.
         self.clear_sent_node_waiters();
         self.is_logged_in.store(false, Ordering::Relaxed);
+        drop(login_transition);
         self.is_ready.store(false, Ordering::Relaxed);
         // Publish the disconnected state BEFORE draining VoIP calls (it used to be cleared only after
         // the socket teardown below): a concurrent accept()/call() setup that finishes its async work

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -11,6 +11,11 @@ impl Client {
     /// long is the reconnect backoff counter reset to its base.
     pub(crate) const STABLE_CONNECTION_RESET_MS: i64 = 30_000;
 
+    /// Create a runtime-validated low-level client builder.
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
+    }
+
     pub fn shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
         self.shutdown_notifier.subscribe()
     }
@@ -87,7 +92,7 @@ impl Client {
         http_client: Arc<dyn crate::http::HttpClient>,
         override_version: Option<(u32, u32, u32)>,
     ) -> (Arc<Self>, async_channel::Receiver<MajorSyncTask>) {
-        Self::new_with_cache_config(
+        ClientBuilder::build_required(
             runtime,
             persistence_manager,
             transport_factory,
@@ -95,7 +100,7 @@ impl Client {
             override_version,
             CacheConfig::default(),
         )
-        .await
+        .into_parts()
     }
 
     /// Create a new `Client` with a custom [`CacheConfig`].
@@ -107,6 +112,25 @@ impl Client {
         override_version: Option<(u32, u32, u32)>,
         cache_config: CacheConfig,
     ) -> (Arc<Self>, async_channel::Receiver<MajorSyncTask>) {
+        ClientBuilder::build_required(
+            runtime,
+            persistence_manager,
+            transport_factory,
+            http_client,
+            override_version,
+            cache_config,
+        )
+        .into_parts()
+    }
+
+    pub(super) fn assemble(
+        runtime: Arc<dyn Runtime>,
+        persistence_manager: Arc<PersistenceManager>,
+        transport_factory: Arc<dyn crate::transport::TransportFactory>,
+        http_client: Arc<dyn crate::http::HttpClient>,
+        override_version: Option<(u32, u32, u32)>,
+        cache_config: CacheConfig,
+    ) -> ClientAssembly {
         let mut unique_id_bytes = [0u8; 2];
         rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut unique_id_bytes);
 
@@ -303,9 +327,12 @@ impl Client {
             .attach_topology(Arc::clone(&arc.device_topology));
         let _ = arc.self_weak.set(Arc::downgrade(&arc));
 
-        // Warm up the LID-PN cache from persistent storage
-        let warm_up_arc = arc.clone();
-        arc.runtime
+        ClientAssembly::new(arc, rx)
+    }
+
+    pub(super) fn start_services(self: &Arc<Self>) {
+        let warm_up_arc = self.clone();
+        self.runtime
             .spawn(Box::pin(async move {
                 if let Err(e) = warm_up_arc.warm_up_lid_pn_cache().await {
                     warn!("Failed to warm up LID-PN cache: {e}");
@@ -313,15 +340,12 @@ impl Client {
             }))
             .detach();
 
-        // Start background task to clean up stale device registry entries
-        let cleanup_arc = arc.clone();
-        arc.runtime
+        let cleanup_arc = self.clone();
+        self.runtime
             .spawn(Box::pin(async move {
                 cleanup_arc.device_registry_cleanup_loop().await;
             }))
             .detach();
-
-        (arc, rx)
     }
 
     // Deliberately NOT instrumented: this span would live for the entire client

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -6,6 +6,12 @@ use super::*;
 /// accounts in more groups; an evicted entry just recomputes on next send.
 const GROUP_DEVICES_MEMO_CAPACITY: u64 = 64;
 
+impl Drop for Client {
+    fn drop(&mut self) {
+        self.signal_shutdown_sync();
+    }
+}
+
 impl Client {
     /// WA Web `resetDelay: 30000` — only after a connection has stayed up this
     /// long is the reconnect backoff counter reset to its base.
@@ -387,10 +393,10 @@ impl Client {
             }))
             .detach();
 
-        let cleanup_arc = self.clone();
+        let cleanup_shutdown = self.shutdown_signal();
         self.runtime
             .spawn(Box::pin(async move {
-                cleanup_arc.device_registry_cleanup_loop().await;
+                Client::device_registry_cleanup_loop(cleanup_shutdown).await;
             }))
             .detach();
     }
@@ -843,16 +849,21 @@ impl Client {
         }
 
         // Scope closure must survive a caller dropping its cleanup waiter.
-        let completed = wacore::runtime::ShutdownNotifier::new();
-        let completion = completed.subscribe();
+        let (completed, completion) = futures::channel::oneshot::channel();
         let client = Arc::clone(self);
         self.runtime
             .spawn(Box::pin(async move {
-                client.cleanup_connection_state_inner().await;
-                completed.notify();
+                let result = std::panic::AssertUnwindSafe(client.cleanup_connection_state_inner())
+                    .catch_unwind()
+                    .await;
+                let _ = completed.send(result);
             }))
             .detach();
-        wacore::runtime::wait_for_shutdown(&completion).await;
+        match completion.await {
+            Ok(Ok(())) => {}
+            Ok(Err(panic)) => std::panic::resume_unwind(panic),
+            Err(_) => error!("Detached connection cleanup stopped before completion"),
+        }
     }
 
     async fn cleanup_connection_state_inner(&self) {

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -152,8 +152,12 @@ impl Client {
         http_client: Arc<dyn crate::http::HttpClient>,
         override_version: Option<(u32, u32, u32)>,
         cache_config: CacheConfig,
-        lifecycle: Option<Arc<LifecycleRegistration>>,
+        extensions: ClientExtensions,
     ) -> ClientAssembly {
+        let ClientExtensions {
+            lifecycle,
+            plugin_host,
+        } = extensions;
         let mut unique_id_bytes = [0u8; 2];
         rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut unique_id_bytes);
 
@@ -181,6 +185,7 @@ impl Client {
             shutdown_notifier: wacore::runtime::ShutdownNotifier::new(),
             connection_shutdown: std::sync::Mutex::new(wacore::runtime::ShutdownNotifier::new()),
             lifecycle,
+            plugin_host,
             stats: Arc::new(wacore::stats::SessionStats::new()),
 
             transport: Arc::new(Mutex::new(None)),

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -576,6 +576,12 @@ impl Client {
     /// across crates, so consumers awaiting the connect graph directly would
     /// re-codegen it; the box makes them poll through a vtable instead.
     pub async fn connect(self: &Arc<Self>) -> Result<(), anyhow::Error> {
+        #[cfg(feature = "client-lifecycle")]
+        if let Some(lifecycle) = &self.lifecycle
+            && !lifecycle.wait_until_active().await
+        {
+            return Err(anyhow!("client construction did not activate"));
+        }
         self.connect_boxed().await
     }
 

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -697,6 +697,9 @@ impl Client {
         // Increment connection generation to invalidate any stale post-login tasks
         // from previous connections (e.g., during 515 reconnect cycles).
         let current_generation = self.connection_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.begin_scope(current_generation);
+        }
 
         info!(
             "Successfully authenticated with WhatsApp servers! (gen={})",
@@ -1104,7 +1107,7 @@ impl Client {
                         // Presence is NOT sent here — WhatsApp Web sends presence from the
                         // setting_pushName mutation handler (WAWebPushNameSync), not from
                         // criticalSyncDone. Our setting_pushName handler already does this.
-                        client_clone.dispatch_connected();
+                        client_clone.dispatch_connected().await;
                     }
                     Err(e) => {
                         client_clone.log_sync_error("critical app state sync", &e);
@@ -1166,7 +1169,7 @@ impl Client {
                 // for an outdated connection that was replaced mid-await.
                 check_generation!();
 
-                client_clone.dispatch_connected();
+                client_clone.dispatch_connected().await;
             }
         })).detach();
     }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -698,7 +698,14 @@ impl Client {
         // from previous connections (e.g., during 515 reconnect cycles).
         let current_generation = self.connection_generation.fetch_add(1, Ordering::SeqCst) + 1;
         if let Some(lifecycle) = &self.lifecycle {
-            lifecycle.begin_scope(current_generation);
+            let opened = lifecycle.begin_scope_if_current(current_generation, || {
+                self.connection_generation.load(Ordering::SeqCst) == current_generation
+                    && !self.expected_disconnect.load(Ordering::Acquire)
+            });
+            if !opened {
+                debug!("Ignoring <success> stanza retired during lifecycle publication");
+                return;
+            }
         }
 
         info!(

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -679,6 +679,10 @@ impl Client {
         tracing::instrument(name = "wa.conn.success", level = "debug", skip_all)
     )]
     pub(crate) async fn handle_success(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) {
+        let login_transition = self
+            .login_transition
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         // Skip processing if an expected disconnect is pending (e.g., 515 received).
         // This prevents race conditions where a spawned success handler runs after
         // cleanup_connection_state has already reset is_logged_in.
@@ -703,10 +707,12 @@ impl Client {
                     && !self.expected_disconnect.load(Ordering::Acquire)
             });
             if !opened {
+                self.is_logged_in.store(false, Ordering::SeqCst);
                 debug!("Ignoring <success> stanza retired during lifecycle publication");
                 return;
             }
         }
+        drop(login_transition);
 
         info!(
             "Successfully authenticated with WhatsApp servers! (gen={})",

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -679,6 +679,7 @@ impl Client {
         tracing::instrument(name = "wa.conn.success", level = "debug", skip_all)
     )]
     pub(crate) async fn handle_success(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) {
+        #[cfg(feature = "client-lifecycle")]
         let login_transition = self
             .login_transition
             .lock()
@@ -713,6 +714,7 @@ impl Client {
                 return;
             }
         }
+        #[cfg(feature = "client-lifecycle")]
         drop(login_transition);
 
         info!(

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -701,6 +701,7 @@ impl Client {
         // Increment connection generation to invalidate any stale post-login tasks
         // from previous connections (e.g., during 515 reconnect cycles).
         let current_generation = self.connection_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             let opened = lifecycle.begin_scope_if_current(current_generation, || {
                 self.connection_generation.load(Ordering::SeqCst) == current_generation

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1121,7 +1121,7 @@ impl Client {
                         // Presence is NOT sent here — WhatsApp Web sends presence from the
                         // setting_pushName mutation handler (WAWebPushNameSync), not from
                         // criticalSyncDone. Our setting_pushName handler already does this.
-                        client_clone.dispatch_connected().await;
+                        client_clone.dispatch_connected(task_generation).await;
                     }
                     Err(e) => {
                         client_clone.log_sync_error("critical app state sync", &e);
@@ -1183,7 +1183,7 @@ impl Client {
                 // for an outdated connection that was replaced mid-await.
                 check_generation!();
 
-                client_clone.dispatch_connected().await;
+                client_clone.dispatch_connected(task_generation).await;
             }
         })).detach();
     }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -192,13 +192,13 @@ impl Client {
                                             // observes these events or every raw node.
                                             "receipt" => {
                                                 !self.synchronous_ack
-                                                    && !self.raw_node_forwarding.load(Ordering::Relaxed)
+                                                    && !self.raw_node_forwarding_enabled()
                                                     && !self.core.event_bus.has_handler_for(
                                                         wacore::types::events::EventKind::Receipt,
                                                     )
                                             }
                                             "ack" => {
-                                                !self.raw_node_forwarding.load(Ordering::Relaxed)
+                                                !self.raw_node_forwarding_enabled()
                                                     && !self.core.event_bus.has_handler_for(
                                                         wacore::types::events::EventKind::ServerAck,
                                                     )
@@ -326,7 +326,7 @@ impl Client {
         // ACKs need shared ownership only for opt-in raw/node observers. The
         // usual response-waiter path borrows the node and can skip the Arc.
         if node.tag() == "ack"
-            && !self.raw_node_forwarding.load(Ordering::Relaxed)
+            && !self.raw_node_forwarding_enabled()
             && self.node_waiter_count.load(Ordering::Acquire) == 0
             && !self.offline_sync_metrics.active.load(Ordering::Acquire)
         {
@@ -457,7 +457,7 @@ impl Client {
 
         // Emit raw node before any early returns so all decoded stanzas
         // (including IQ responses and xmlstreamend) reach external observers
-        if self.raw_node_forwarding.load(Ordering::Relaxed) {
+        if self.raw_node_forwarding_enabled() {
             self.core
                 .event_bus
                 .dispatch(Event::RawNode(Arc::clone(&node)));

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -293,7 +293,9 @@ async fn test_ack_dispatches_server_ack_event() {
 
     let client = crate::test_utils::create_test_client().await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+    client
+        .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+        .detach();
 
     // Plain message ack (no waiter registered): event fires with the ack's
     // class, from and server timestamp; error is None.
@@ -1597,7 +1599,7 @@ async fn connect_failure_403_dispatches_account_locked_logout() {
     use wacore::types::events::ChannelEventHandler;
     let client = create_offline_sync_test_client().await;
     let (handler, events) = ChannelEventHandler::new();
-    client.register_handler(handler);
+    client.subscribe_handler(handler).detach();
 
     // location="rva" is a region routing token and must not change the verdict.
     let failure = NodeBuilder::new("failure")

--- a/src/features/labels.rs
+++ b/src/features/labels.rs
@@ -252,7 +252,7 @@ mod tests {
     fn run(m: &Mutation) -> (bool, Vec<Arc<Event>>) {
         let bus = CoreEventBus::new();
         let rec = Arc::new(Recorder::default());
-        bus.add_handler(rec.clone());
+        bus.subscribe_handler(rec.clone()).detach();
         let handled = dispatch_label_mutation(&bus, m, false);
         let events = rec.events.lock().unwrap().clone();
         (handled, events)

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -653,7 +653,7 @@ mod tests {
         let (client, sends) = make_sending_client_with_failure_after(None).await;
         let event_rx = register_native_opus_call(&client, Vec::new());
         let (handler, global_rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let mut cancelled = false;
         assert!(
@@ -829,7 +829,7 @@ mod tests {
 
         let (client, sends) = make_sending_client_with_failure_after(Some(1)).await;
         let (global_handler, global_rx) = ChannelEventHandler::new();
-        client.register_handler(global_handler);
+        client.subscribe_handler(global_handler).detach();
         let registry = client.call_registry();
         let generation = registry.insert(wacore::voip::CallSession::new_outgoing(
             "CALL-ID-0001",
@@ -875,7 +875,7 @@ mod tests {
 
         let (client, send_started, release_send) = make_blocking_sending_client().await;
         let (global_handler, global_rx) = ChannelEventHandler::new();
-        client.register_handler(global_handler);
+        client.subscribe_handler(global_handler).detach();
         let registry = client.call_registry();
         let stale_generation = registry.insert(wacore::voip::CallSession::new_incoming(
             "CALL-ID-0001",
@@ -966,7 +966,7 @@ mod tests {
 
         let client = make_sending_client().await;
         let (global_handler, global_rx) = ChannelEventHandler::new();
-        client.register_handler(global_handler);
+        client.subscribe_handler(global_handler).detach();
         let registry = client.call_registry();
         let session = wacore::voip::CallSession::new_incoming(
             "CALL-ID-0001",
@@ -1128,7 +1128,7 @@ mod tests {
 
         let client = make_client().await;
         let (global_handler, global_rx) = ChannelEventHandler::new();
-        client.register_handler(global_handler);
+        client.subscribe_handler(global_handler).detach();
         let registry = client.call_registry();
         let generation = registry.insert(wacore::voip::CallSession::new_incoming(
             "CALL-ID-0001",
@@ -1201,7 +1201,7 @@ mod tests {
     async fn offer_dispatches_event() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let node = node_to_owned_ref(&offer_stanza());
         let mut cancelled = false;
@@ -1222,7 +1222,7 @@ mod tests {
     async fn unrecognized_action_does_not_dispatch() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let node = node_to_owned_ref(
             &NodeBuilder::new("call")
@@ -1296,7 +1296,7 @@ mod tests {
     async fn malformed_stanza_does_not_error_or_dispatch() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let node = node_to_owned_ref(
             &NodeBuilder::new("call")
@@ -1479,7 +1479,7 @@ mod tests {
     async fn unanswered_incoming_terminate_surfaces_missed_call() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let mut cancelled = false;
         // The offer rings (marks the call ringing).
@@ -1517,7 +1517,7 @@ mod tests {
     async fn duplicate_terminate_does_not_refire_missed_call() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let mut cancelled = false;
         assert!(
@@ -1556,7 +1556,7 @@ mod tests {
     async fn outgoing_call_terminate_does_not_surface_missed_call() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let peer = Jid::new("222222222222222", Server::Lid);
         let creator = Jid::new("111111111111111", Server::Lid); // us, the caller
@@ -1602,7 +1602,7 @@ mod tests {
         ] {
             let client = make_client().await;
             let (handler, rx) = ChannelEventHandler::new();
-            client.register_handler(handler);
+            client.subscribe_handler(handler).detach();
 
             let mut cancelled = false;
             assert!(
@@ -1660,7 +1660,7 @@ mod tests {
     async fn timeout_terminate_surfaces_missed_call() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let mut cancelled = false;
         assert!(
@@ -1725,7 +1725,7 @@ mod tests {
         *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
 
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let mut cancelled = false;
         // The offer rings.
@@ -1776,7 +1776,7 @@ mod tests {
     async fn answered_call_then_caller_terminate_is_not_missed() {
         let client = make_client().await;
         let (handler, rx) = ChannelEventHandler::new();
-        client.register_handler(handler);
+        client.subscribe_handler(handler).detach();
 
         let mut cancelled = false;
         // The offer rings.

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -469,7 +469,7 @@ mod tests {
     async fn test_contacts_update_dispatches_contact_updated_event() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -500,7 +500,7 @@ mod tests {
         // Creates two mappings: old_lid→old_pn AND new_lid→new_pn.
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -554,7 +554,7 @@ mod tests {
     async fn test_contacts_modify_without_lid_skips_mapping() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -576,7 +576,7 @@ mod tests {
     async fn test_contacts_sync_dispatches_contact_sync_requested_event() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -602,7 +602,7 @@ mod tests {
     async fn test_contacts_add_remove_do_not_dispatch_events() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         for tag in ["add", "remove"] {
             let node = NodeBuilder::new("notification")
@@ -624,7 +624,7 @@ mod tests {
     async fn test_contacts_empty_notification_ignored() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         // No child element
         let node = NodeBuilder::new("notification")
@@ -648,7 +648,7 @@ mod tests {
     async fn test_contacts_modify_same_jid_still_dispatches() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -704,7 +704,7 @@ mod tests {
     async fn test_contacts_modify_missing_new_attr_drops_event() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -728,7 +728,7 @@ mod tests {
     async fn test_group_change_number_dispatches_with_new_owner_and_suggestions() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "w:gp2")
@@ -858,7 +858,7 @@ mod tests {
         // We don't maintain a userhash index, so this should be a no-op.
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "contacts")
@@ -879,7 +879,7 @@ mod tests {
     async fn test_identity_change_dispatches_event_and_invalidates_cache() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         // Pre-populate device registry so clear_device_record has something to clear
         let record = wacore::store::traits::DeviceListRecord {
@@ -942,7 +942,7 @@ mod tests {
     async fn test_identity_change_ignores_self_primary() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         // Set our own JID so the self-check works
         client
@@ -971,7 +971,7 @@ mod tests {
     async fn test_identity_change_ignores_companion_device() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let node = NodeBuilder::new("notification")
             .attr("type", "encrypt")
@@ -991,7 +991,7 @@ mod tests {
     async fn test_local_identity_change_dispatches_implicit_event() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let sender: Jid = "5511777777777@s.whatsapp.net".parse().unwrap();
         handle_local_identity_change(&client, sender).await;
@@ -1018,7 +1018,7 @@ mod tests {
     async fn test_local_identity_change_skips_self() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         client
             .persistence_manager
@@ -1040,7 +1040,7 @@ mod tests {
     async fn test_local_identity_change_skips_companion_device() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let sender: Jid = "5511777777777:5@s.whatsapp.net".parse().unwrap();
         handle_local_identity_change(&client, sender).await;
@@ -1151,7 +1151,7 @@ mod tests {
         use wacore::types::jid::JidExt;
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         // Prior identity present so the gate runs (the offline attr only defers the
         // eager session re-establishment, not the change notification).
@@ -1189,7 +1189,7 @@ mod tests {
         use wacore::types::jid::JidExt;
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let target: Jid = "5511666666666@s.whatsapp.net".parse().unwrap();
         let addr = target.to_protocol_address();
@@ -1280,7 +1280,7 @@ mod tests {
         use wacore::types::jid::JidExt;
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let pn = "5511555555555";
         let lid = "100000000000055";
@@ -1338,7 +1338,7 @@ mod tests {
         use wacore::types::jid::JidExt;
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         // Cold cache: no PN->LID mapping, so resolve_encryption_jid(PN) returns PN.
         let pn_jid: Jid = "5511444444444@s.whatsapp.net".parse().unwrap();

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -883,7 +883,7 @@ mod tests {
 
         // Register a handler BEFORE the task so retain_blob is true.
         let (handler, event_rx) = wacore::types::events::ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
 
         client
             .process_history_sync_task("HIST_LAZY_EVENT".to_string(), notification.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,9 +120,9 @@ pub use plugins::{
     PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow, PluginEventPayloadEncoding,
     PluginEventPublishError, PluginEventPublishReport, PluginEventReceiveError,
     PluginEventRouteError, PluginEventRouter, PluginEventSelector, PluginEventSubscribeError,
-    PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents, PluginIq,
-    PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError, PluginPlanError,
-    PluginResourceError, PluginTasks,
+    PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents,
+    PluginFuture, PluginIq, PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError,
+    PluginPlanError, PluginResourceError, PluginTasks,
 };
 pub mod request;
 pub(crate) mod signal_flush;
@@ -201,7 +201,7 @@ pub mod prelude {
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,
         PluginEventEndpointConfig, PluginEventOverflow, PluginEventPayloadEncoding,
         PluginEventRouter, PluginEventSelector, PluginEventSubscription, PluginEventTopic,
-        PluginEvents, PluginManifest,
+        PluginEvents, PluginFuture, PluginManifest,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,9 @@ pub use plugins::{
     PluginEventPublisherStats, PluginEventReceiveError, PluginEventRouteError, PluginEventRouter,
     PluginEventRouterStats, PluginEventSelector, PluginEventSubscribeError,
     PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents,
-    PluginFuture, PluginHealth, PluginHostStats, PluginIq, PluginIqError, PluginManifest,
-    PluginMessaging, PluginMessagingError, PluginPlanError, PluginResourceError, PluginState,
-    PluginStats, PluginTasks, UntypedClientPlugin,
+    PluginFuture, PluginHealth, PluginHostConfig, PluginHostStats, PluginIq, PluginIqError,
+    PluginManifest, PluginMessaging, PluginMessagingError, PluginPlanError, PluginResourceError,
+    PluginState, PluginStats, PluginTasks, UntypedClientPlugin,
 };
 pub mod request;
 pub(crate) mod signal_flush;
@@ -208,8 +208,8 @@ pub mod prelude {
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,
         PluginCoreEventSubscription, PluginEventEndpointConfig, PluginEventOverflow,
         PluginEventPayloadEncoding, PluginEventRouter, PluginEventSelector,
-        PluginEventSubscription, PluginEventTopic, PluginEvents, PluginFuture, PluginManifest,
-        UntypedClientPlugin,
+        PluginEventSubscription, PluginEventTopic, PluginEvents, PluginFuture, PluginHostConfig,
+        PluginManifest, UntypedClientPlugin,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,9 @@ pub(crate) mod msg_secret_buffer;
 pub mod pair;
 pub mod pair_code;
 pub mod passkey;
+#[cfg(feature = "plugins")]
 pub mod plugins;
+#[cfg(feature = "plugins")]
 pub use plugins::{
     ClientPlugin, PluginCapabilities, PluginCapability, PluginConnectionScope,
     PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginIq, PluginIqError,
@@ -190,6 +192,7 @@ pub mod prelude {
         Client, ClientBuilder, ClientBuilderError, ClientError, ClientLifecycle, ConnectionScope,
         ConnectionScopeState, RawNodeLease,
     };
+    #[cfg(feature = "plugins")]
     pub use crate::plugins::{
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext, PluginManifest,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,6 @@ pub mod types;
 
 pub mod client;
 pub(crate) mod flush_scope;
-pub use client::Client;
 /// Shared base error for transport/connection concerns; the per-domain error
 /// types embed it.
 pub use client::ClientError;
@@ -94,6 +93,7 @@ pub use client::{
     StatsSnapshot, StorageResourceReport, TransportResourceReport,
 };
 pub use client::{CallError, Voip};
+pub use client::{Client, ClientBuild, ClientBuilder, ClientBuilderError};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
 pub mod download;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,10 @@ pub mod prelude {
     pub use crate::shutdown::shutdown_signal;
     #[cfg(feature = "sqlite-storage")]
     pub use crate::store::SqliteStore;
-    pub use crate::types::events::{BatchOrigin, Event, EventKind, InboundMessage, MessageBatch};
+    pub use crate::types::events::{
+        BatchOrigin, ChannelEventHandler, Event, EventHandler, EventInterest, EventKind,
+        InboundMessage, MessageBatch, Subscription,
+    };
     pub use crate::types::message::MessageInfo;
     pub use crate::{Jid, Server};
     pub use wacore::proto_helpers::{MessageBuilderExt, MessageExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,9 @@ pub use client::{
     StatsSnapshot, StorageResourceReport, TransportResourceReport,
 };
 pub use client::{CallError, Voip};
-pub use client::{
-    Client, ClientBuild, ClientBuilder, ClientBuilderError, ClientLifecycle, ConnectionScope,
-    ConnectionScopeState, RawNodeLease,
-};
+pub use client::{Client, ClientBuild, ClientBuilder, ClientBuilderError, RawNodeLease};
+#[cfg(feature = "client-lifecycle")]
+pub use client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
 pub mod download;
@@ -192,10 +191,9 @@ pub mod version;
 /// `use whatsapp_rust::prelude::*;`.
 pub mod prelude {
     pub use crate::bot::{Bot, BotBuilder, BotHandle, EventDelivery, MessageContext};
-    pub use crate::client::{
-        Client, ClientBuilder, ClientBuilderError, ClientError, ClientLifecycle, ConnectionScope,
-        ConnectionScopeState, RawNodeLease,
-    };
+    pub use crate::client::{Client, ClientBuilder, ClientBuilderError, ClientError, RawNodeLease};
+    #[cfg(feature = "client-lifecycle")]
+    pub use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
     #[cfg(feature = "plugins")]
     pub use crate::plugins::{
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,13 @@ pub mod plugins;
 #[cfg(feature = "plugins")]
 pub use plugins::{
     ClientPlugin, PluginCapabilities, PluginCapability, PluginConnectionScope,
-    PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginIq, PluginIqError,
-    PluginManifest, PluginMessaging, PluginMessagingError, PluginPlanError, PluginResourceError,
-    PluginTasks,
+    PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginEventEndpointConfig,
+    PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow, PluginEventPayloadEncoding,
+    PluginEventPublishError, PluginEventPublishReport, PluginEventReceiveError,
+    PluginEventRouteError, PluginEventRouter, PluginEventSelector, PluginEventSubscribeError,
+    PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents, PluginIq,
+    PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError, PluginPlanError,
+    PluginResourceError, PluginTasks,
 };
 pub mod request;
 pub(crate) mod signal_flush;
@@ -194,7 +198,10 @@ pub mod prelude {
     };
     #[cfg(feature = "plugins")]
     pub use crate::plugins::{
-        ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext, PluginManifest,
+        ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,
+        PluginEventEndpointConfig, PluginEventOverflow, PluginEventPayloadEncoding,
+        PluginEventRouter, PluginEventSelector, PluginEventSubscription, PluginEventTopic,
+        PluginEvents, PluginManifest,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,10 @@ pub mod version;
 /// `use whatsapp_rust::prelude::*;`.
 pub mod prelude {
     pub use crate::bot::{Bot, BotBuilder, BotHandle, EventDelivery, MessageContext};
-    pub use crate::client::{Client, ClientError};
+    pub use crate::client::{
+        Client, ClientBuilder, ClientBuilderError, ClientError, ClientLifecycle, ConnectionScope,
+        ConnectionScopeState,
+    };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]
     pub use crate::runtime_impl::TokioRuntime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,11 +117,12 @@ pub use plugins::{
     ClientPlugin, PluginCapabilities, PluginCapability, PluginConnectionScope,
     PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginEventEndpointConfig,
     PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow, PluginEventPayloadEncoding,
-    PluginEventPublishError, PluginEventPublishReport, PluginEventReceiveError,
-    PluginEventRouteError, PluginEventRouter, PluginEventSelector, PluginEventSubscribeError,
-    PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents,
-    PluginFuture, PluginIq, PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError,
-    PluginPlanError, PluginResourceError, PluginTasks,
+    PluginEventPublishError, PluginEventPublishReport, PluginEventPublisherStats,
+    PluginEventReceiveError, PluginEventRouteError, PluginEventRouter, PluginEventRouterStats,
+    PluginEventSelector, PluginEventSubscribeError, PluginEventSubscription, PluginEventTopic,
+    PluginEventTryReceiveError, PluginEvents, PluginFuture, PluginHealth, PluginHostStats,
+    PluginIq, PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError,
+    PluginPlanError, PluginResourceError, PluginState, PluginStats, PluginTasks,
 };
 pub mod request;
 pub(crate) mod signal_flush;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,15 +119,15 @@ pub mod plugins;
 #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
 pub use plugins::{
     ClientPlugin, PluginCapabilities, PluginCapability, PluginConnectionScope,
-    PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginEventEndpointConfig,
-    PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow, PluginEventPayloadEncoding,
-    PluginEventPublishError, PluginEventPublishReport, PluginEventPublisherStats,
-    PluginEventReceiveError, PluginEventRouteError, PluginEventRouter, PluginEventRouterStats,
-    PluginEventSelector, PluginEventSubscribeError, PluginEventSubscription, PluginEventTopic,
-    PluginEventTryReceiveError, PluginEvents, PluginFuture, PluginHealth, PluginHostStats,
-    PluginIq, PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError,
-    PluginPlanError, PluginResourceError, PluginState, PluginStats, PluginTasks,
-    UntypedClientPlugin,
+    PluginConnectionTasks, PluginContext, PluginCoreEventSubscription, PluginCoreEvents,
+    PluginEventEndpointConfig, PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow,
+    PluginEventPayloadEncoding, PluginEventPublishError, PluginEventPublishReport,
+    PluginEventPublisherStats, PluginEventReceiveError, PluginEventRouteError, PluginEventRouter,
+    PluginEventRouterStats, PluginEventSelector, PluginEventSubscribeError,
+    PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents,
+    PluginFuture, PluginHealth, PluginHostStats, PluginIq, PluginIqError, PluginManifest,
+    PluginMessaging, PluginMessagingError, PluginPlanError, PluginResourceError, PluginState,
+    PluginStats, PluginTasks, UntypedClientPlugin,
 };
 pub mod request;
 pub(crate) mod signal_flush;
@@ -206,9 +206,10 @@ pub mod prelude {
     #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub use crate::plugins::{
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,
-        PluginEventEndpointConfig, PluginEventOverflow, PluginEventPayloadEncoding,
-        PluginEventRouter, PluginEventSelector, PluginEventSubscription, PluginEventTopic,
-        PluginEvents, PluginFuture, PluginManifest, UntypedClientPlugin,
+        PluginCoreEventSubscription, PluginEventEndpointConfig, PluginEventOverflow,
+        PluginEventPayloadEncoding, PluginEventRouter, PluginEventSelector,
+        PluginEventSubscription, PluginEventTopic, PluginEvents, PluginFuture, PluginManifest,
+        UntypedClientPlugin,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub use client::{
 pub use client::{CallError, Voip};
 pub use client::{
     Client, ClientBuild, ClientBuilder, ClientBuilderError, ClientLifecycle, ConnectionScope,
-    ConnectionScopeState,
+    ConnectionScopeState, RawNodeLease,
 };
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
@@ -181,7 +181,7 @@ pub mod prelude {
     pub use crate::bot::{Bot, BotBuilder, BotHandle, EventDelivery, MessageContext};
     pub use crate::client::{
         Client, ClientBuilder, ClientBuilderError, ClientError, ClientLifecycle, ConnectionScope,
-        ConnectionScopeState,
+        ConnectionScopeState, RawNodeLease,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub use plugins::{
     PluginEventTryReceiveError, PluginEvents, PluginFuture, PluginHealth, PluginHostStats,
     PluginIq, PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError,
     PluginPlanError, PluginResourceError, PluginState, PluginStats, PluginTasks,
+    UntypedClientPlugin,
 };
 pub mod request;
 pub(crate) mod signal_flush;
@@ -207,7 +208,7 @@ pub mod prelude {
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,
         PluginEventEndpointConfig, PluginEventOverflow, PluginEventPayloadEncoding,
         PluginEventRouter, PluginEventSelector, PluginEventSubscription, PluginEventTopic,
-        PluginEvents, PluginFuture, PluginManifest,
+        PluginEvents, PluginFuture, PluginManifest, UntypedClientPlugin,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,10 @@ pub use client::{
     StatsSnapshot, StorageResourceReport, TransportResourceReport,
 };
 pub use client::{CallError, Voip};
-pub use client::{Client, ClientBuild, ClientBuilder, ClientBuilderError};
+pub use client::{
+    Client, ClientBuild, ClientBuilder, ClientBuilderError, ClientLifecycle, ConnectionScope,
+    ConnectionScopeState,
+};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
 pub mod download;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Compile-checks the README examples as doctests, so the advertised quick
 // start can never silently rot.
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // Instrumenting large async fns (e.g. process_sync_task) wraps them in deep
 // `Instrumented` future types; the default depth limit overflows when the
 // `tracing` + `tracing-pii` paths combine. Raise it (compile-time only).
@@ -95,6 +96,7 @@ pub use client::{
 pub use client::{CallError, Voip};
 pub use client::{Client, ClientBuild, ClientBuilder, ClientBuilderError, RawNodeLease};
 #[cfg(feature = "client-lifecycle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
@@ -111,8 +113,10 @@ pub mod pair;
 pub mod pair_code;
 pub mod passkey;
 #[cfg(feature = "plugins")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
 pub mod plugins;
 #[cfg(feature = "plugins")]
+#[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
 pub use plugins::{
     ClientPlugin, PluginCapabilities, PluginCapability, PluginConnectionScope,
     PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginEventEndpointConfig,
@@ -194,8 +198,10 @@ pub mod prelude {
     pub use crate::bot::{Bot, BotBuilder, BotHandle, EventDelivery, MessageContext};
     pub use crate::client::{Client, ClientBuilder, ClientBuilderError, ClientError, RawNodeLease};
     #[cfg(feature = "client-lifecycle")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
     pub use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
     #[cfg(feature = "plugins")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]
     pub use crate::plugins::{
         ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext,
         PluginEventEndpointConfig, PluginEventOverflow, PluginEventPayloadEncoding,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,13 @@ pub(crate) mod msg_secret_buffer;
 pub mod pair;
 pub mod pair_code;
 pub mod passkey;
+pub mod plugins;
+pub use plugins::{
+    ClientPlugin, PluginCapabilities, PluginCapability, PluginConnectionScope,
+    PluginConnectionTasks, PluginContext, PluginCoreEvents, PluginIq, PluginIqError,
+    PluginManifest, PluginMessaging, PluginMessagingError, PluginPlanError, PluginResourceError,
+    PluginTasks,
+};
 pub mod request;
 pub(crate) mod signal_flush;
 pub use request::IqError;
@@ -182,6 +189,9 @@ pub mod prelude {
     pub use crate::client::{
         Client, ClientBuilder, ClientBuilderError, ClientError, ClientLifecycle, ConnectionScope,
         ConnectionScopeState, RawNodeLease,
+    };
+    pub use crate::plugins::{
+        ClientPlugin, PluginCapability, PluginConnectionScope, PluginContext, PluginManifest,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -915,7 +915,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
         let (handler, rx) = ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
 
         client.inbound_commit_batch.reset();
         for id in ["B1", "B2", "B3"] {
@@ -962,7 +962,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
         let (handler, rx) = ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
         client.commit_or_batch_inbound(item("L1"), false).await;
 
         assert_eq!(
@@ -1008,7 +1008,7 @@ mod tests {
         let client = create_test_client_with_failing_http("batch_no_hook").await;
         client.inbound_commit_batch.reset();
         let (handler, rx) = ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
 
         client.commit_or_batch_inbound(item("N1"), false).await;
         client.commit_or_batch_inbound(item("N2"), false).await;
@@ -1038,7 +1038,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
         let (handler, rx) = ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
 
         client.commit_or_batch_inbound(item("T1"), false).await;
         client.commit_or_batch_inbound(item("T2"), false).await;
@@ -1077,7 +1077,7 @@ mod tests {
         });
         let _ = client.inbound_durability_hook.set(hook.clone());
         let (handler, rx) = ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
 
         client.commit_or_batch_inbound(item("C1"), false).await;
         client.inbound_commit_batch.reset();

--- a/src/message/durability.rs
+++ b/src/message/durability.rs
@@ -234,7 +234,7 @@ mod tests {
         // Redelivery once the commit succeeds clears the buffer AND finally
         // dispatches the event (the original batch never did).
         let (handler, rx) = wacore::types::events::ChannelEventHandler::new();
-        client.core.event_bus.add_handler(handler);
+        client.core.event_bus.subscribe_handler(handler).detach();
         hook.succeed.store(true, Ordering::SeqCst);
         client.ack_or_replay_to_hook(&info).await;
         assert_eq!(hook.calls.load(Ordering::SeqCst), 3);

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -378,7 +378,7 @@ async fn batch_accumulates_undecryptable_and_dispatches_once() {
     .await;
 
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let sender_jid: Jid = "1234567890@s.whatsapp.net"
         .parse()
@@ -5010,7 +5010,7 @@ fn build_unavailable_stanza(sender: &str, msg_id: &str, with_enc: bool) -> Arc<O
 async fn test_undecryptable_fires_before_retry_task() {
     let client = create_test_client_for_retry_with_id("undec_sync").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let info = Arc::new(create_test_message_info(
         "5511999998888@s.whatsapp.net",
@@ -5070,7 +5070,7 @@ async fn test_undecryptable_fires_before_retry_task() {
 async fn test_undecryptable_dedup_is_atomic() {
     let client = create_test_client_for_retry_with_id("undec_atomic").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let info = Arc::new(create_test_message_info(
         "5511999998888@s.whatsapp.net",
@@ -5104,7 +5104,7 @@ async fn test_undecryptable_dedup_is_atomic() {
 async fn test_undecryptable_deduped_across_resends() {
     let client = create_test_client_for_retry_with_id("undec_double").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let info = Arc::new(create_test_message_info(
         "5511999998888@s.whatsapp.net",
@@ -5259,7 +5259,7 @@ async fn test_pdo_rejects_just_past_14d_boundary() {
 async fn test_unavailable_with_enc_skips_unavailable_shortcut() {
     let client = create_test_client_for_retry_with_id("unavailable_with_enc").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let node = build_unavailable_stanza("5511777776666@s.whatsapp.net", "UNAV_WITH_ENC_1", true);
     client.clone().handle_incoming_message(node).await;
@@ -5281,7 +5281,7 @@ async fn test_unavailable_with_enc_skips_unavailable_shortcut() {
 async fn test_unavailable_without_enc_dispatches_view_once_event() {
     let client = create_test_client_for_retry_with_id("unavailable_stub").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let node = build_unavailable_stanza("5511777776666@s.whatsapp.net", "UNAV_STUB_1", false);
     client.clone().handle_incoming_message(node).await;
@@ -5304,7 +5304,7 @@ async fn test_unavailable_without_enc_dispatches_view_once_event() {
 async fn view_once_stub_acks_without_pdo() {
     let (client, transport) = capturing_client("view_once_ack").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let node = build_unavailable_stanza("5511777776666@s.whatsapp.net", "VIEW_ONCE_ACK_1", false);
     client.clone().handle_incoming_message(node).await;
@@ -5350,7 +5350,7 @@ async fn bot_unavailable_stub_acks_without_pdo() {
     use crate::types::events::UnavailableType;
     let (client, transport) = capturing_client("bot_unavail_ack").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let node = build_unavailable_kind_stanza(
         "5511777776666@s.whatsapp.net",
@@ -5378,7 +5378,7 @@ async fn hosted_unavailable_stub_acks_without_pdo() {
     use crate::types::events::UnavailableType;
     let (client, transport) = capturing_client("hosted_unavail_ack").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let node = build_unavailable_kind_stanza(
         "5511777776666@s.whatsapp.net",
@@ -5406,7 +5406,7 @@ async fn hosted_numeric_bool_unavailable_stub_acks_without_pdo() {
     use crate::types::events::UnavailableType;
     let (client, transport) = capturing_client("hosted_num_ack").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let t = wacore::time::now_secs().to_string();
     let node = node_to_arc(
@@ -5441,7 +5441,7 @@ async fn plain_unavailable_stub_classifies_as_unknown() {
     use crate::types::events::UnavailableType;
     let (client, _transport) = capturing_client("plain_unavail").await;
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let node = build_unavailable_kind_stanza(
         "5511777776666@s.whatsapp.net",
@@ -6454,7 +6454,7 @@ async fn skdm_only_group_session_acknowledged_once_without_message_event() {
 
     let (client, transport) = capturing_client("skdm_only_group_ack").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -6516,9 +6516,9 @@ async fn session_plaintext_decode_error_is_not_acked_as_skdm_only() {
 
     let (client, transport) = capturing_client("bad_plaintext_no_skdm_ack").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -6580,9 +6580,9 @@ async fn mixed_skdm_and_bad_plaintext_session_is_nacked_not_positive_acked() {
 
     let (client, transport) = capturing_client("mixed_skdm_bad_plaintext").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -6645,9 +6645,9 @@ async fn bad_session_plaintext_skips_skmsg_sibling_after_nack() {
 
     let (client, transport) = capturing_client("bad_session_skips_skmsg").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -6720,7 +6720,7 @@ async fn group_skmsg_decrypts_under_sender_key_lock() {
 
     let (client, _transport) = capturing_client("group_skmsg_lock_happy").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -6915,9 +6915,9 @@ async fn group_skmsg_without_sender_key_takes_retry_path() {
 
     let (client, _transport) = capturing_client("group_skmsg_lock_bad").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
     let recorder = Arc::new(EventRecorder::default());
-    client.register_handler(recorder.clone());
+    client.subscribe_handler(recorder.clone()).detach();
 
     let mut alice = AlicePeer::new("146824178450541@lid").await;
     let group: Jid = "120363408782575461@g.us".parse().expect("group");
@@ -7016,7 +7016,7 @@ async fn session_content_group_message_acknowledged_once_without_fallback() {
 
     let (client, transport) = capturing_client("session_content_group_ack").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -7067,7 +7067,7 @@ async fn status_skdm_only_session_uses_one_status_receipt() {
 
     let (client, transport) = capturing_client("status_skdm_only_ack").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -7172,7 +7172,7 @@ async fn skdm_session_with_skmsg_sibling_acknowledged_once() {
 
     let (client, transport) = capturing_client("skdm_plus_skmsg_ack").await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
 
     let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
     let bob_addr = bob_jid.to_protocol_address();
@@ -8433,7 +8433,7 @@ fn encrypted_message_edit(
 async fn secret_encrypted_message_edit_dispatches_legacy_edit() {
     let (client, _transport) = capturing_client("secret_edit_dispatch").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "5511777776666@s.whatsapp.net";
     let parent_id = "PARENT_EDIT";
@@ -8492,7 +8492,7 @@ async fn secret_encrypted_message_edit_dispatches_legacy_edit() {
 async fn secret_encrypted_peer_edit_resolves_sender_from_envelope() {
     let (client, _transport) = capturing_client("secret_peer_edit_dispatch").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let group = "123456789012345678@g.us";
     let peer = "5511777776666@s.whatsapp.net";
@@ -8554,7 +8554,7 @@ async fn secret_encrypted_peer_edit_resolves_sender_from_envelope() {
 async fn run_secret_edit_with_window(test_id: &str, parent_ts: i64, edit_offset: i64) -> bool {
     let (client, _transport) = capturing_client(test_id).await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "5511777776666@s.whatsapp.net";
     let parent_id = "WINDOW_PARENT";
@@ -8689,7 +8689,7 @@ async fn secret_encrypted_edit_decrypts_via_resolver_when_store_empty() {
     seed_test_pn(&client).await;
 
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     assert!(
         client
@@ -8753,7 +8753,7 @@ async fn secret_encrypted_edit_decrypts_via_resolver_when_store_empty() {
 async fn decrypted_message_edit_recaptures_secret_for_next_edit() {
     let (client, _transport) = capturing_client("secret_edit_chain").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "5511777776666@s.whatsapp.net";
     let parent_id = "PARENT_EDIT";
@@ -8846,7 +8846,7 @@ async fn secret_encrypted_message_edit_uses_lid_pn_fallback_in_group() {
 
     let (client, _transport) = capturing_client("secret_edit_alt_group").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "120363021033254949@g.us";
     let parent_id = "GROUP_PARENT_EDIT";
@@ -8926,7 +8926,7 @@ async fn decrypted_message_edit_refreshes_alternate_secret_alias() {
 
     let (client, _transport) = capturing_client("secret_edit_alt_refresh").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "120363021033254949@g.us";
     let parent_id = "GROUP_PARENT_EDIT";
@@ -9054,7 +9054,7 @@ async fn msmsg_decrypts_when_secret_is_stored() {
     use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
     let (client, _transport) = capturing_client("msmsg_ok").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_pn = "5511000000001@s.whatsapp.net";
@@ -9130,7 +9130,7 @@ async fn msmsg_decrypts_when_secret_is_stored() {
 async fn msmsg_without_stored_secret_nacks_495() {
     let (client, transport) = capturing_client("msmsg_nosecret").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let bot_reply_id = "BOT_REPLY_NS";
     let outbound_id = "OUTBOUND_NS";
@@ -9246,7 +9246,7 @@ async fn msmsg_bot_edit_uses_edit_target_id_for_hkdf() {
     use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
     let (client, _transport) = capturing_client("msmsg_edit").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_pn = "5511000000001@s.whatsapp.net";
@@ -9395,7 +9395,7 @@ async fn msmsg_bot_edit_first_keeps_info_id() {
     use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
     let (client, _transport) = capturing_client("msmsg_first").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_pn = "5511000000001@s.whatsapp.net";
@@ -9467,7 +9467,7 @@ async fn msmsg_falls_back_to_info_id_when_primary_uses_edit_target() {
     use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
     let (client, _transport) = capturing_client("msmsg_fb_to_info").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_pn = "5511000000001@s.whatsapp.net";
@@ -9553,7 +9553,7 @@ async fn msmsg_falls_back_to_edit_target_when_primary_uses_info_id() {
     use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
     let (client, _transport) = capturing_client("msmsg_fb_to_edit").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_pn = "5511000000001@s.whatsapp.net";
@@ -10233,7 +10233,7 @@ async fn mixed_msmsg_and_unknown_enc_still_decrypts_msmsg() {
         )))
         .await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_lid = "999888777666555@lid";
@@ -10320,7 +10320,7 @@ async fn msmsg_alternate_lookup_resolves_lid_to_stored_pn() {
 
     let (client, _transport) = capturing_client("msmsg_alt_lookup").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_lid_user = "999888777666555";
@@ -10425,7 +10425,7 @@ async fn fanout_capture_lets_subsequent_msmsg_decrypt() {
         )))
         .await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let bot_chat: Jid = "867051314767696@bot".parse().unwrap();
     let our_lid_str = "999888777666555@lid";
@@ -10547,7 +10547,7 @@ async fn msmsg_outbound_put_and_inbound_get_match_for_lid_bot() {
         )))
         .await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let bot_chat: Jid = "867051314767696@bot".parse().unwrap();
     let outbound_id = "OUT_LID";
@@ -10635,7 +10635,7 @@ async fn msmsg_with_bot_device_suffix_round_trips() {
     use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
     let (client, _transport) = capturing_client("msmsg_bot_device").await;
     let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-    client.register_handler(collector.clone());
+    client.subscribe_handler(collector.clone()).detach();
 
     let chat = "867051314767696@bot";
     let our_pn = "5511000000001@s.whatsapp.net";
@@ -10833,7 +10833,7 @@ async fn enc_comment_inbound_dispatches_body_with_parent_link() {
     let (client, _transport) = capturing_client("enc_comment_inbound").await;
     ensure_bob_paired(&client).await;
     let (handler, rx) = ChannelEventHandler::new();
-    client.core.event_bus.add_handler(handler);
+    client.core.event_bus.subscribe_handler(handler).detach();
 
     let group: Jid = "120363400000000002@g.us".parse().expect("group");
     let author: Jid = "5511888887777@s.whatsapp.net".parse().expect("author");

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -842,7 +842,7 @@ mod tests {
     async fn refresh_code_matching_ref_dispatches_event() {
         let client = create_test_client().await;
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let pairing_ref = vec![5, 6, 7, 8];
         set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
@@ -867,7 +867,7 @@ mod tests {
     async fn refresh_code_without_force_manual_defaults_false() {
         let client = create_test_client().await;
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         let pairing_ref = vec![5, 6, 7, 8];
         set_waiting(&client, pairing_ref.clone(), wacore::time::now_secs(), 0).await;
@@ -891,7 +891,7 @@ mod tests {
     async fn refresh_code_mismatched_ref_is_ignored() {
         let client = create_test_client().await;
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
 
         set_waiting(&client, vec![5, 6, 7, 8], wacore::time::now_secs(), 0).await;
 

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -889,7 +889,9 @@ mod tests {
     async fn passkey_prologue_request_emits_event_without_committing_rotation() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
 
         let before = client
             .persistence_manager
@@ -926,7 +928,9 @@ mod tests {
     async fn passkey_prologue_request_from_non_server_is_ignored() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
 
         let child = NodeBuilder::new(TAG_PASSKEY_REQUEST_OPTIONS)
             .bytes(b"{}".to_vec())
@@ -951,7 +955,9 @@ mod tests {
     async fn passkey_prologue_request_without_inline_options_falls_back_to_fetch() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
 
         // No inline options: the handler falls back to an IQ fetch. The test client
         // isn't connected, so the fetch fails and surfaces a non-continuation error.
@@ -973,7 +979,9 @@ mod tests {
     async fn passkey_continuation_without_session_emits_error() {
         let client = create_test_client().await;
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone() as Arc<dyn EventHandler>);
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
 
         let primary = wa::PrimaryEphemeralIdentity {
             public_key: Some(vec![0xAB; 32]),

--- a/src/plugins/events.rs
+++ b/src/plugins/events.rs
@@ -1,0 +1,925 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::{Arc, Mutex, RwLock};
+
+use async_channel::{Receiver, Sender, TryRecvError, TrySendError};
+use bytes::Bytes;
+use portable_atomic::{AtomicBool, AtomicU64, Ordering};
+use thiserror::Error;
+
+use super::{PluginResourceError, PluginResources, valid_plugin_id};
+
+const MAX_ENDPOINT_CAPACITY: usize = 65_536;
+const MAX_ENDPOINT_SELECTORS: usize = 1_024;
+
+/// Encoding of a custom plugin event payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginEventPayloadEncoding {
+    Json,
+    Binary,
+}
+
+impl PluginEventPayloadEncoding {
+    pub const fn identifier(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Binary => "binary",
+        }
+    }
+}
+
+/// Validated second-level topic within one plugin namespace.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct PluginEventTopic(Arc<str>);
+
+impl PluginEventTopic {
+    pub fn new(topic: impl Into<String>) -> Result<Self, PluginEventRouteError> {
+        let topic = topic.into();
+        if !valid_topic(&topic) {
+            return Err(PluginEventRouteError::InvalidTopic { topic });
+        }
+        Ok(Self(Arc::from(topic)))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for PluginEventTopic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("PluginEventTopic")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl fmt::Display for PluginEventTopic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Exact `(plugin_id, topic)` route selected by one endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PluginEventSelector {
+    route: RouteKey,
+}
+
+impl PluginEventSelector {
+    pub fn new(
+        plugin_id: impl Into<String>,
+        topic: PluginEventTopic,
+    ) -> Result<Self, PluginEventRouteError> {
+        let plugin_id = plugin_id.into();
+        if !valid_plugin_id(&plugin_id) {
+            return Err(PluginEventRouteError::InvalidPluginId { plugin_id });
+        }
+        Ok(Self {
+            route: RouteKey {
+                plugin_id: Arc::from(plugin_id),
+                topic,
+            },
+        })
+    }
+
+    pub fn plugin_id(&self) -> &str {
+        &self.route.plugin_id
+    }
+
+    pub fn topic(&self) -> &PluginEventTopic {
+        &self.route.topic
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RouteKey {
+    plugin_id: Arc<str>,
+    topic: PluginEventTopic,
+}
+
+/// Routed event shared by every matching endpoint without copying its payload.
+#[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
+pub struct PluginEventEnvelope {
+    pub plugin_id: Arc<str>,
+    pub topic: PluginEventTopic,
+    pub schema_version: u32,
+    pub payload_encoding: PluginEventPayloadEncoding,
+    pub payload: Bytes,
+    pub connection_generation: u64,
+    /// Monotonic sequence for this route while it has at least one subscriber.
+    ///
+    /// Dropped events consume a sequence number, allowing one endpoint to detect loss. The
+    /// sequence resets after the last subscriber to the route is removed.
+    pub sequence: u64,
+}
+
+/// Behavior when one endpoint cannot keep up with publishers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginEventOverflow {
+    DropNewest,
+    DropOldest,
+}
+
+/// Required queue policy for one independent consumer endpoint.
+///
+/// Capacity counts envelopes rather than bytes. Native plugins are trusted, and payloads are
+/// shared across matching endpoints. A foreign adapter must enforce its wire payload limit before
+/// publishing into this router.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PluginEventEndpointConfig {
+    capacity: usize,
+    overflow: PluginEventOverflow,
+}
+
+impl PluginEventEndpointConfig {
+    pub const fn new(capacity: usize, overflow: PluginEventOverflow) -> Self {
+        Self { capacity, overflow }
+    }
+
+    pub const fn capacity(self) -> usize {
+        self.capacity
+    }
+
+    pub const fn overflow(self) -> PluginEventOverflow {
+        self.overflow
+    }
+}
+
+/// Syntactic route validation failure.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginEventRouteError {
+    #[error("invalid plugin id `{plugin_id}`")]
+    InvalidPluginId { plugin_id: String },
+    #[error("invalid plugin event topic `{topic}`")]
+    InvalidTopic { topic: String },
+}
+
+/// Endpoint registration failure.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginEventSubscribeError {
+    #[error(transparent)]
+    Resource(#[from] PluginResourceError),
+    #[error("at least one plugin event selector is required")]
+    EmptySelectors,
+    #[error("plugin event endpoint selector count exceeds the maximum of {max}")]
+    TooManySelectors { max: usize },
+    #[error("plugin event endpoint capacity {capacity} is outside 1..={max}")]
+    InvalidCapacity { capacity: usize, max: usize },
+    #[error("plugin `{plugin_id}` is not registered as a custom-event publisher")]
+    UnknownPublisher { plugin_id: String },
+    #[error("plugin event endpoint identifiers are exhausted")]
+    EndpointIdsExhausted,
+    #[error("the plugin event router is closed")]
+    Closed,
+}
+
+/// Custom event publication failure.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginEventPublishError {
+    #[error(transparent)]
+    Resource(#[from] PluginResourceError),
+    #[error("plugin event schema version must be greater than zero")]
+    InvalidSchemaVersion,
+    #[error("the plugin event router is closed")]
+    Closed,
+    #[error("the plugin event sequence is exhausted")]
+    SequenceExhausted,
+}
+
+/// Result of one non-blocking fan-out attempt.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginEventPublishReport {
+    pub matched: u64,
+    pub enqueued: u64,
+    pub dropped: u64,
+    pub closed: u64,
+}
+
+/// Cumulative state for one endpoint queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginEventEndpointStats {
+    pub enqueued: u64,
+    pub delivered: u64,
+    pub dropped: u64,
+    pub queue_depth: usize,
+    pub capacity: usize,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+#[error("the plugin event endpoint is closed")]
+pub struct PluginEventReceiveError;
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginEventTryReceiveError {
+    #[error("the plugin event endpoint queue is empty")]
+    Empty,
+    #[error("the plugin event endpoint is closed")]
+    Closed,
+}
+
+enum EnqueueOutcome {
+    Enqueued,
+    Dropped,
+    EnqueuedAfterDrop,
+    Closed,
+}
+
+struct EventEndpoint {
+    id: u64,
+    sender: Sender<Arc<PluginEventEnvelope>>,
+    overflow: PluginEventOverflow,
+    capacity: usize,
+    enqueued: AtomicU64,
+    delivered: AtomicU64,
+    dropped: AtomicU64,
+}
+
+impl EventEndpoint {
+    fn enqueue(&self, event: Arc<PluginEventEnvelope>) -> EnqueueOutcome {
+        match self.overflow {
+            PluginEventOverflow::DropNewest => match self.sender.try_send(event) {
+                Ok(()) => {
+                    self.enqueued.fetch_add(1, Ordering::Relaxed);
+                    EnqueueOutcome::Enqueued
+                }
+                Err(TrySendError::Full(_)) => {
+                    self.dropped.fetch_add(1, Ordering::Relaxed);
+                    EnqueueOutcome::Dropped
+                }
+                Err(TrySendError::Closed(_)) => EnqueueOutcome::Closed,
+            },
+            PluginEventOverflow::DropOldest => match self.sender.force_send(event) {
+                Ok(evicted) => {
+                    self.enqueued.fetch_add(1, Ordering::Relaxed);
+                    if evicted.is_some() {
+                        self.dropped.fetch_add(1, Ordering::Relaxed);
+                        EnqueueOutcome::EnqueuedAfterDrop
+                    } else {
+                        EnqueueOutcome::Enqueued
+                    }
+                }
+                Err(_) => EnqueueOutcome::Closed,
+            },
+        }
+    }
+
+    fn close(&self) {
+        self.sender.close();
+    }
+
+    fn stats(&self) -> PluginEventEndpointStats {
+        PluginEventEndpointStats {
+            enqueued: self.enqueued.load(Ordering::Relaxed),
+            delivered: self.delivered.load(Ordering::Relaxed),
+            dropped: self.dropped.load(Ordering::Relaxed),
+            queue_depth: self.sender.len(),
+            capacity: self.capacity,
+        }
+    }
+}
+
+struct RouteClock {
+    sequence: Mutex<u64>,
+}
+
+struct RouteEntry {
+    clock: Arc<RouteClock>,
+    endpoints: Arc<[Arc<EventEndpoint>]>,
+}
+
+#[derive(Default)]
+struct RouterState {
+    routes: HashMap<RouteKey, RouteEntry>,
+    endpoints: HashMap<u64, Arc<EventEndpoint>>,
+}
+
+struct PluginEventRouterInner {
+    plugin_ids: HashSet<Arc<str>>,
+    state: RwLock<RouterState>,
+    next_endpoint_id: AtomicU64,
+    closed: AtomicBool,
+}
+
+impl PluginEventRouterInner {
+    fn unsubscribe(&self, endpoint_id: u64, selectors: &[PluginEventSelector]) {
+        let endpoint = {
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let endpoint = state.endpoints.remove(&endpoint_id);
+            for selector in selectors {
+                let remove_route = if let Some(route) = state.routes.get_mut(&selector.route) {
+                    let remaining = route
+                        .endpoints
+                        .iter()
+                        .filter(|endpoint| endpoint.id != endpoint_id)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    route.endpoints = remaining.into();
+                    route.endpoints.is_empty()
+                } else {
+                    false
+                };
+                if remove_route {
+                    state.routes.remove(&selector.route);
+                }
+            }
+            endpoint
+        };
+        if let Some(endpoint) = endpoint {
+            endpoint.close();
+        }
+    }
+
+    fn close(&self) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let endpoints = {
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.routes.clear();
+            std::mem::take(&mut state.endpoints)
+        };
+        for endpoint in endpoints.into_values() {
+            endpoint.close();
+        }
+    }
+}
+
+/// Read-only subscription boundary for native consumers and future foreign adapters.
+///
+/// Routes are exact `(plugin_id, topic)` matches. Closing the router prevents new publications and
+/// subscriptions, while already queued envelopes remain available before receivers observe closure.
+#[derive(Clone)]
+pub struct PluginEventRouter {
+    inner: Arc<PluginEventRouterInner>,
+}
+
+impl PluginEventRouter {
+    pub(super) fn new(plugin_ids: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            inner: Arc::new(PluginEventRouterInner {
+                plugin_ids: plugin_ids.into_iter().map(Arc::from).collect(),
+                state: RwLock::new(RouterState::default()),
+                next_endpoint_id: AtomicU64::new(1),
+                closed: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    pub fn has_subscribers(&self, selector: &PluginEventSelector) -> bool {
+        if self.inner.closed.load(Ordering::Acquire) {
+            return false;
+        }
+        self.inner
+            .state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .routes
+            .get(&selector.route)
+            .is_some_and(|route| !route.endpoints.is_empty())
+    }
+
+    pub fn subscribe(
+        &self,
+        selectors: impl IntoIterator<Item = PluginEventSelector>,
+        config: PluginEventEndpointConfig,
+    ) -> Result<PluginEventSubscription, PluginEventSubscribeError> {
+        if config.capacity == 0 || config.capacity > MAX_ENDPOINT_CAPACITY {
+            return Err(PluginEventSubscribeError::InvalidCapacity {
+                capacity: config.capacity,
+                max: MAX_ENDPOINT_CAPACITY,
+            });
+        }
+        if self.inner.closed.load(Ordering::Acquire) {
+            return Err(PluginEventSubscribeError::Closed);
+        }
+
+        let mut seen = HashSet::new();
+        let mut unique_selectors = Vec::new();
+        for selector in selectors {
+            if !seen.insert(selector.route.clone()) {
+                continue;
+            }
+            if unique_selectors.len() == MAX_ENDPOINT_SELECTORS {
+                return Err(PluginEventSubscribeError::TooManySelectors {
+                    max: MAX_ENDPOINT_SELECTORS,
+                });
+            }
+            unique_selectors.push(selector);
+        }
+        let selectors = unique_selectors;
+        if selectors.is_empty() {
+            return Err(PluginEventSubscribeError::EmptySelectors);
+        }
+        for selector in &selectors {
+            if !self.inner.plugin_ids.contains(selector.plugin_id()) {
+                return Err(PluginEventSubscribeError::UnknownPublisher {
+                    plugin_id: selector.plugin_id().to_string(),
+                });
+            }
+        }
+
+        let endpoint_id = self
+            .inner
+            .next_endpoint_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| id.checked_add(1))
+            .map_err(|_| PluginEventSubscribeError::EndpointIdsExhausted)?;
+        let (sender, receiver) = async_channel::bounded(config.capacity);
+        let endpoint = Arc::new(EventEndpoint {
+            id: endpoint_id,
+            sender,
+            overflow: config.overflow,
+            capacity: config.capacity,
+            enqueued: AtomicU64::new(0),
+            delivered: AtomicU64::new(0),
+            dropped: AtomicU64::new(0),
+        });
+
+        {
+            let mut state = self
+                .inner
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if self.inner.closed.load(Ordering::Acquire) {
+                return Err(PluginEventSubscribeError::Closed);
+            }
+            state.endpoints.insert(endpoint_id, endpoint.clone());
+            for selector in &selectors {
+                let route = state
+                    .routes
+                    .entry(selector.route.clone())
+                    .or_insert_with(|| RouteEntry {
+                        clock: Arc::new(RouteClock {
+                            sequence: Mutex::new(0),
+                        }),
+                        endpoints: Arc::from([]),
+                    });
+                let endpoints = route
+                    .endpoints
+                    .iter()
+                    .cloned()
+                    .chain(std::iter::once(endpoint.clone()))
+                    .collect::<Vec<_>>();
+                route.endpoints = endpoints.into();
+            }
+        }
+
+        Ok(PluginEventSubscription {
+            router: self.clone(),
+            endpoint,
+            receiver,
+            selectors,
+        })
+    }
+
+    fn publish(
+        &self,
+        plugin_id: &Arc<str>,
+        topic: &PluginEventTopic,
+        schema_version: u32,
+        payload_encoding: PluginEventPayloadEncoding,
+        payload: Bytes,
+        connection_generation: u64,
+    ) -> Result<PluginEventPublishReport, PluginEventPublishError> {
+        if schema_version == 0 {
+            return Err(PluginEventPublishError::InvalidSchemaVersion);
+        }
+        if self.inner.closed.load(Ordering::Acquire) {
+            return Err(PluginEventPublishError::Closed);
+        }
+
+        let route_key = RouteKey {
+            plugin_id: plugin_id.clone(),
+            topic: topic.clone(),
+        };
+        let Some((clock, endpoints)) = self
+            .inner
+            .state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .routes
+            .get(&route_key)
+            .map(|route| (route.clock.clone(), route.endpoints.clone()))
+        else {
+            return Ok(PluginEventPublishReport::default());
+        };
+
+        let mut sequence = clock
+            .sequence
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let next_sequence = sequence
+            .checked_add(1)
+            .ok_or(PluginEventPublishError::SequenceExhausted)?;
+        *sequence = next_sequence;
+        let event = Arc::new(
+            PluginEventEnvelope::builder()
+                .plugin_id(plugin_id.clone())
+                .topic(topic.clone())
+                .schema_version(schema_version)
+                .payload_encoding(payload_encoding)
+                .payload(payload)
+                .connection_generation(connection_generation)
+                .sequence(next_sequence)
+                .build(),
+        );
+
+        let mut report = PluginEventPublishReport {
+            matched: u64::try_from(endpoints.len()).unwrap_or(u64::MAX),
+            ..PluginEventPublishReport::default()
+        };
+        for endpoint in endpoints.iter() {
+            match endpoint.enqueue(event.clone()) {
+                EnqueueOutcome::Enqueued => report.enqueued += 1,
+                EnqueueOutcome::Dropped => report.dropped += 1,
+                EnqueueOutcome::EnqueuedAfterDrop => {
+                    report.enqueued += 1;
+                    report.dropped += 1;
+                }
+                EnqueueOutcome::Closed => report.closed += 1,
+            }
+        }
+        Ok(report)
+    }
+
+    pub(super) fn close(&self) {
+        self.inner.close();
+    }
+}
+
+/// One bounded endpoint. Dropping it unregisters every selected route atomically.
+#[must_use = "dropping the subscription unregisters its plugin event routes"]
+pub struct PluginEventSubscription {
+    router: PluginEventRouter,
+    endpoint: Arc<EventEndpoint>,
+    receiver: Receiver<Arc<PluginEventEnvelope>>,
+    selectors: Vec<PluginEventSelector>,
+}
+
+impl PluginEventSubscription {
+    pub fn id(&self) -> u64 {
+        self.endpoint.id
+    }
+
+    pub fn selectors(&self) -> &[PluginEventSelector] {
+        &self.selectors
+    }
+
+    pub fn stats(&self) -> PluginEventEndpointStats {
+        self.endpoint.stats()
+    }
+
+    pub async fn recv(&self) -> Result<Arc<PluginEventEnvelope>, PluginEventReceiveError> {
+        let event = self
+            .receiver
+            .recv()
+            .await
+            .map_err(|_| PluginEventReceiveError)?;
+        self.endpoint.delivered.fetch_add(1, Ordering::Relaxed);
+        Ok(event)
+    }
+
+    pub fn try_recv(&self) -> Result<Arc<PluginEventEnvelope>, PluginEventTryReceiveError> {
+        let event = self.receiver.try_recv().map_err(|error| match error {
+            TryRecvError::Empty => PluginEventTryReceiveError::Empty,
+            TryRecvError::Closed => PluginEventTryReceiveError::Closed,
+        })?;
+        self.endpoint.delivered.fetch_add(1, Ordering::Relaxed);
+        Ok(event)
+    }
+}
+
+impl Drop for PluginEventSubscription {
+    fn drop(&mut self) {
+        self.router
+            .inner
+            .unsubscribe(self.endpoint.id, &self.selectors);
+    }
+}
+
+/// Context-bound custom event capability. A plugin can publish only under its own ID.
+///
+/// Consumers subscribe through [`PluginEventRouter`], keeping publication authority separate from
+/// native or future foreign endpoints.
+#[derive(Clone)]
+pub struct PluginEvents {
+    plugin_id: Arc<str>,
+    router: PluginEventRouter,
+    resources: Arc<PluginResources>,
+    connection_generation: Arc<AtomicU64>,
+}
+
+impl PluginEvents {
+    pub fn selector(&self, topic: &PluginEventTopic) -> PluginEventSelector {
+        PluginEventSelector {
+            route: RouteKey {
+                plugin_id: self.plugin_id.clone(),
+                topic: topic.clone(),
+            },
+        }
+    }
+
+    pub fn has_subscribers(&self, topic: &PluginEventTopic) -> bool {
+        self.router.has_subscribers(&self.selector(topic))
+    }
+
+    pub fn publish(
+        &self,
+        topic: &PluginEventTopic,
+        schema_version: u32,
+        payload_encoding: PluginEventPayloadEncoding,
+        payload: impl Into<Bytes>,
+    ) -> Result<PluginEventPublishReport, PluginEventPublishError> {
+        self.resources.ensure_active()?;
+        self.router.publish(
+            &self.plugin_id,
+            topic,
+            schema_version,
+            payload_encoding,
+            payload.into(),
+            self.connection_generation.load(Ordering::Acquire),
+        )
+    }
+}
+
+pub(super) fn publisher(
+    plugin_id: &str,
+    router: PluginEventRouter,
+    resources: Arc<PluginResources>,
+    connection_generation: Arc<AtomicU64>,
+) -> PluginEvents {
+    PluginEvents {
+        plugin_id: Arc::from(plugin_id),
+        router,
+        resources,
+        connection_generation,
+    }
+}
+
+fn valid_topic(topic: &str) -> bool {
+    valid_plugin_id(topic)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+
+    fn topic(value: &str) -> PluginEventTopic {
+        PluginEventTopic::new(value).expect("valid topic")
+    }
+
+    fn selector(plugin_id: &str, topic: &PluginEventTopic) -> PluginEventSelector {
+        PluginEventSelector::new(plugin_id, topic.clone()).expect("valid selector")
+    }
+
+    fn publish(
+        router: &PluginEventRouter,
+        plugin_id: &str,
+        topic: &PluginEventTopic,
+        value: u32,
+    ) -> PluginEventPublishReport {
+        router
+            .publish(
+                &Arc::from(plugin_id),
+                topic,
+                1,
+                PluginEventPayloadEncoding::Binary,
+                Bytes::copy_from_slice(&value.to_be_bytes()),
+                7,
+            )
+            .expect("event publication")
+    }
+
+    #[test]
+    fn routes_only_exact_plugin_and_topic_matches() {
+        let router = PluginEventRouter::new(["metrics".to_string(), "audit".to_string()]);
+        let tick = topic("tick");
+        let other = topic("other");
+        let subscription = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(4, PluginEventOverflow::DropNewest),
+            )
+            .expect("subscription");
+
+        assert_eq!(publish(&router, "metrics", &other, 1).matched, 0);
+        assert_eq!(publish(&router, "audit", &tick, 2).matched, 0);
+        assert_eq!(publish(&router, "metrics", &tick, 3).enqueued, 1);
+        let event = subscription.try_recv().expect("routed event");
+        assert_eq!(&*event.plugin_id, "metrics");
+        assert_eq!(event.topic, tick);
+        assert_eq!(event.connection_generation, 7);
+        assert_eq!(event.sequence, 1);
+        assert_eq!(event.payload, Bytes::copy_from_slice(&3u32.to_be_bytes()));
+    }
+
+    #[test]
+    fn drop_newest_preserves_the_queued_prefix_and_counts_loss() {
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        let tick = topic("tick");
+        let subscription = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(2, PluginEventOverflow::DropNewest),
+            )
+            .expect("subscription");
+
+        for value in 1..=4 {
+            publish(&router, "metrics", &tick, value);
+        }
+
+        assert_eq!(subscription.try_recv().expect("first").sequence, 1);
+        assert_eq!(subscription.try_recv().expect("second").sequence, 2);
+        assert!(matches!(
+            subscription.try_recv(),
+            Err(PluginEventTryReceiveError::Empty)
+        ));
+        assert_eq!(
+            subscription.stats(),
+            PluginEventEndpointStats {
+                enqueued: 2,
+                delivered: 2,
+                dropped: 2,
+                queue_depth: 0,
+                capacity: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn drop_oldest_preserves_the_latest_events_and_counts_evictions() {
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        let tick = topic("tick");
+        let subscription = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(2, PluginEventOverflow::DropOldest),
+            )
+            .expect("subscription");
+
+        for value in 1..=4 {
+            publish(&router, "metrics", &tick, value);
+        }
+
+        assert_eq!(subscription.try_recv().expect("third").sequence, 3);
+        assert_eq!(subscription.try_recv().expect("fourth").sequence, 4);
+        assert_eq!(subscription.stats().enqueued, 4);
+        assert_eq!(subscription.stats().dropped, 2);
+    }
+
+    #[test]
+    fn backpressure_is_isolated_per_endpoint() {
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        let tick = topic("tick");
+        let slow = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            )
+            .expect("slow endpoint");
+        let fast = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(4, PluginEventOverflow::DropNewest),
+            )
+            .expect("fast endpoint");
+
+        publish(&router, "metrics", &tick, 1);
+        publish(&router, "metrics", &tick, 2);
+
+        assert_eq!(slow.stats().dropped, 1);
+        assert_eq!(fast.stats().dropped, 0);
+        assert_eq!(fast.try_recv().expect("fast first").sequence, 1);
+        assert_eq!(fast.try_recv().expect("fast second").sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn drop_unregisters_and_router_close_wakes_receivers() {
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        let tick = topic("tick");
+        let selector = selector("metrics", &tick);
+        let subscription = router
+            .subscribe(
+                [selector.clone()],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            )
+            .expect("subscription");
+        assert!(router.has_subscribers(&selector));
+        drop(subscription);
+        assert!(!router.has_subscribers(&selector));
+        assert_eq!(publish(&router, "metrics", &tick, 1).matched, 0);
+
+        let subscription = router
+            .subscribe(
+                [selector],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            )
+            .expect("second subscription");
+        assert_eq!(publish(&router, "metrics", &tick, 2).enqueued, 1);
+        router.close();
+        assert_eq!(subscription.recv().await.expect("queued event").sequence, 1);
+        assert!(matches!(
+            subscription.recv().await,
+            Err(PluginEventReceiveError)
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_or_unknown_endpoint_configuration() {
+        assert!(PluginEventTopic::new("Invalid").is_err());
+        let tick = topic("tick");
+        assert!(PluginEventSelector::new("Invalid", tick.clone()).is_err());
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        assert!(matches!(
+            router.subscribe(
+                [selector("unknown", &tick)],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::UnknownPublisher { .. })
+        ));
+        assert!(matches!(
+            router.subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(0, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::InvalidCapacity { .. })
+        ));
+        assert!(matches!(
+            router.subscribe(
+                [],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::EmptySelectors)
+        ));
+        let too_many = (0..=MAX_ENDPOINT_SELECTORS)
+            .map(|index| selector("metrics", &topic(&format!("topic-{index}"))))
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            router.subscribe(
+                too_many,
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::TooManySelectors { .. })
+        ));
+    }
+
+    #[test]
+    fn concurrent_publish_keeps_route_sequences_in_queue_order() {
+        const THREADS: usize = 8;
+        const EVENTS_PER_THREAD: usize = 100;
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        let tick = topic("tick");
+        let subscription = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(
+                    THREADS * EVENTS_PER_THREAD,
+                    PluginEventOverflow::DropNewest,
+                ),
+            )
+            .expect("subscription");
+
+        let threads = (0..THREADS)
+            .map(|_| {
+                let router = router.clone();
+                let tick = tick.clone();
+                thread::spawn(move || {
+                    for value in 0..EVENTS_PER_THREAD {
+                        publish(&router, "metrics", &tick, value as u32);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        for thread in threads {
+            thread.join().expect("publisher thread");
+        }
+
+        for sequence in 1..=(THREADS * EVENTS_PER_THREAD) as u64 {
+            assert_eq!(
+                subscription.try_recv().expect("ordered event").sequence,
+                sequence
+            );
+        }
+        assert_eq!(subscription.stats().dropped, 0);
+    }
+}

--- a/src/plugins/events.rs
+++ b/src/plugins/events.rs
@@ -195,6 +195,10 @@ pub enum PluginEventPublishError {
 }
 
 /// Result of one non-blocking fan-out attempt.
+///
+/// `dropped` counts queue entries discarded while processing this call. Under `DropOldest`, the
+/// discarded entry may belong to an earlier publication from another namespace; cumulative
+/// publisher statistics attribute that loss to the discarded envelope's owner.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct PluginEventPublishReport {
@@ -219,6 +223,7 @@ pub struct PluginEventEndpointStats {
 ///
 /// `published` counts successful calls, including calls with no subscriber. Fanout fields count
 /// endpoint outcomes; `delivered` advances only when a receiver removes an envelope from its queue.
+/// `dropped` follows the discarded envelope, including cross-namespace `DropOldest` eviction.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct PluginEventPublisherStats {
@@ -301,7 +306,6 @@ impl PublisherCounters {
                 self.published.fetch_add(1, Ordering::Relaxed);
                 self.matched.fetch_add(report.matched, Ordering::Relaxed);
                 self.enqueued.fetch_add(report.enqueued, Ordering::Relaxed);
-                self.dropped.fetch_add(report.dropped, Ordering::Relaxed);
                 self.closed.fetch_add(report.closed, Ordering::Relaxed);
             }
             Err(_) => {
@@ -383,8 +387,9 @@ impl EventEndpoint {
                     self.enqueued.fetch_add(1, Ordering::Relaxed);
                     EnqueueOutcome::Enqueued
                 }
-                Err(TrySendError::Full(_)) => {
+                Err(TrySendError::Full(dropped)) => {
                     self.dropped.fetch_add(1, Ordering::Relaxed);
+                    dropped.publisher.dropped.fetch_add(1, Ordering::Relaxed);
                     EnqueueOutcome::Dropped
                 }
                 Err(TrySendError::Closed(_)) => EnqueueOutcome::Closed,
@@ -392,8 +397,9 @@ impl EventEndpoint {
             PluginEventOverflow::DropOldest => match self.sender.force_send(event) {
                 Ok(evicted) => {
                     self.enqueued.fetch_add(1, Ordering::Relaxed);
-                    if evicted.is_some() {
+                    if let Some(evicted) = evicted {
                         self.dropped.fetch_add(1, Ordering::Relaxed);
+                        evicted.publisher.dropped.fetch_add(1, Ordering::Relaxed);
                         EnqueueOutcome::EnqueuedAfterDrop
                     } else {
                         EnqueueOutcome::Enqueued
@@ -1085,6 +1091,36 @@ mod tests {
         assert_eq!(subscription.stats().dropped, 2);
         assert_eq!(router.stats().dropped, 2);
         assert_eq!(router.stats().delivered, 2);
+    }
+
+    #[test]
+    fn drop_oldest_charges_the_evicted_publisher_across_namespaces() {
+        let router = PluginEventRouter::new(["alpha".to_string(), "beta".to_string()]);
+        let tick = topic("tick");
+        let subscription = router
+            .subscribe(
+                [selector("alpha", &tick), selector("beta", &tick)],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropOldest),
+            )
+            .expect("subscription");
+
+        assert_eq!(publish(&router, "alpha", &tick, 1).dropped, 0);
+        assert_eq!(publish(&router, "beta", &tick, 2).dropped, 1);
+
+        let event = subscription.try_recv().expect("newest event");
+        assert_eq!(&*event.plugin_id, "beta");
+        assert_eq!(subscription.stats().dropped, 1);
+        assert_eq!(
+            router
+                .publisher_stats("alpha")
+                .expect("alpha stats")
+                .dropped,
+            1
+        );
+        let beta = router.publisher_stats("beta").expect("beta stats");
+        assert_eq!(beta.dropped, 0);
+        assert_eq!(beta.delivered, 1);
+        assert_eq!(router.stats().dropped, 1);
     }
 
     #[test]

--- a/src/plugins/events.rs
+++ b/src/plugins/events.rs
@@ -215,6 +215,46 @@ pub struct PluginEventEndpointStats {
     pub capacity: usize,
 }
 
+/// Cumulative publication and fanout counters for one plugin namespace.
+///
+/// `published` counts successful calls, including calls with no subscriber. Fanout fields count
+/// endpoint outcomes; `delivered` advances only when a receiver removes an envelope from its queue.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginEventPublisherStats {
+    pub published: u64,
+    pub publish_failures: u64,
+    pub matched: u64,
+    pub enqueued: u64,
+    pub delivered: u64,
+    pub dropped: u64,
+    pub closed: u64,
+}
+
+/// On-demand aggregate for the custom-event router.
+///
+/// Current occupancy may move while a concurrent snapshot is being assembled; cumulative counters
+/// remain monotonic but are not an atomic cross-publisher transaction.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginEventRouterStats {
+    pub registered_publishers: u64,
+    pub active_routes: u64,
+    pub active_endpoints: u64,
+    pub endpoint_capacity: u64,
+    /// Unique event envelopes retained by at least one endpoint queue.
+    pub queued_events: u64,
+    /// Payload bytes retained by those unique queued envelopes.
+    pub queued_payload_bytes: u64,
+    pub published: u64,
+    pub publish_failures: u64,
+    pub matched: u64,
+    pub enqueued: u64,
+    pub delivered: u64,
+    pub dropped: u64,
+    pub closed: u64,
+}
+
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 #[error("the plugin event endpoint is closed")]
@@ -236,9 +276,98 @@ enum EnqueueOutcome {
     Closed,
 }
 
+struct PluginEventPublication {
+    schema_version: u32,
+    payload_encoding: PluginEventPayloadEncoding,
+    payload: Bytes,
+    connection_generation: u64,
+}
+
+#[derive(Default)]
+struct PublisherCounters {
+    published: AtomicU64,
+    publish_failures: AtomicU64,
+    matched: AtomicU64,
+    enqueued: AtomicU64,
+    delivered: AtomicU64,
+    dropped: AtomicU64,
+    closed: AtomicU64,
+}
+
+impl PublisherCounters {
+    fn record_publish(&self, result: &Result<PluginEventPublishReport, PluginEventPublishError>) {
+        match result {
+            Ok(report) => {
+                self.published.fetch_add(1, Ordering::Relaxed);
+                self.matched.fetch_add(report.matched, Ordering::Relaxed);
+                self.enqueued.fetch_add(report.enqueued, Ordering::Relaxed);
+                self.dropped.fetch_add(report.dropped, Ordering::Relaxed);
+                self.closed.fetch_add(report.closed, Ordering::Relaxed);
+            }
+            Err(_) => {
+                self.publish_failures.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn snapshot(&self) -> PluginEventPublisherStats {
+        PluginEventPublisherStats {
+            published: self.published.load(Ordering::Relaxed),
+            publish_failures: self.publish_failures.load(Ordering::Relaxed),
+            matched: self.matched.load(Ordering::Relaxed),
+            enqueued: self.enqueued.load(Ordering::Relaxed),
+            delivered: self.delivered.load(Ordering::Relaxed),
+            dropped: self.dropped.load(Ordering::Relaxed),
+            closed: self.closed.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct QueueMemory {
+    events: AtomicU64,
+    payload_bytes: AtomicU64,
+}
+
+struct QueuedPluginEvent {
+    envelope: Arc<PluginEventEnvelope>,
+    publisher: Arc<PublisherCounters>,
+    memory: Arc<QueueMemory>,
+    payload_bytes: u64,
+}
+
+impl QueuedPluginEvent {
+    fn new(
+        envelope: Arc<PluginEventEnvelope>,
+        publisher: Arc<PublisherCounters>,
+        memory: Arc<QueueMemory>,
+    ) -> Arc<Self> {
+        let payload_bytes = u64::try_from(envelope.payload.len()).unwrap_or(u64::MAX);
+        memory.events.fetch_add(1, Ordering::Relaxed);
+        memory
+            .payload_bytes
+            .fetch_add(payload_bytes, Ordering::Relaxed);
+        Arc::new(Self {
+            envelope,
+            publisher,
+            memory,
+            payload_bytes,
+        })
+    }
+}
+
+impl Drop for QueuedPluginEvent {
+    fn drop(&mut self) {
+        self.memory.events.fetch_sub(1, Ordering::Relaxed);
+        self.memory
+            .payload_bytes
+            .fetch_sub(self.payload_bytes, Ordering::Relaxed);
+    }
+}
+
 struct EventEndpoint {
     id: u64,
-    sender: Sender<Arc<PluginEventEnvelope>>,
+    sender: Sender<Arc<QueuedPluginEvent>>,
     overflow: PluginEventOverflow,
     capacity: usize,
     enqueued: AtomicU64,
@@ -247,7 +376,7 @@ struct EventEndpoint {
 }
 
 impl EventEndpoint {
-    fn enqueue(&self, event: Arc<PluginEventEnvelope>) -> EnqueueOutcome {
+    fn enqueue(&self, event: Arc<QueuedPluginEvent>) -> EnqueueOutcome {
         match self.overflow {
             PluginEventOverflow::DropNewest => match self.sender.try_send(event) {
                 Ok(()) => {
@@ -306,7 +435,8 @@ struct RouterState {
 }
 
 struct PluginEventRouterInner {
-    plugin_ids: HashSet<Arc<str>>,
+    publishers: HashMap<Arc<str>, Arc<PublisherCounters>>,
+    queue_memory: Arc<QueueMemory>,
     state: RwLock<RouterState>,
     next_endpoint_id: AtomicU64,
     closed: AtomicBool,
@@ -373,9 +503,14 @@ pub struct PluginEventRouter {
 
 impl PluginEventRouter {
     pub(super) fn new(plugin_ids: impl IntoIterator<Item = String>) -> Self {
+        let publishers = plugin_ids
+            .into_iter()
+            .map(|plugin_id| (Arc::from(plugin_id), Arc::new(PublisherCounters::default())))
+            .collect();
         Self {
             inner: Arc::new(PluginEventRouterInner {
-                plugin_ids: plugin_ids.into_iter().map(Arc::from).collect(),
+                publishers,
+                queue_memory: Arc::new(QueueMemory::default()),
                 state: RwLock::new(RouterState::default()),
                 next_endpoint_id: AtomicU64::new(1),
                 closed: AtomicBool::new(false),
@@ -394,6 +529,59 @@ impl PluginEventRouter {
             .routes
             .get(&selector.route)
             .is_some_and(|route| !route.endpoints.is_empty())
+    }
+
+    /// Cumulative counters for one registered publisher.
+    pub fn publisher_stats(&self, plugin_id: &str) -> Option<PluginEventPublisherStats> {
+        self.inner
+            .publishers
+            .get(plugin_id)
+            .map(|stats| stats.snapshot())
+    }
+
+    /// Aggregate counters and current queue occupancy.
+    pub fn stats(&self) -> PluginEventRouterStats {
+        let (active_routes, active_endpoints, endpoint_capacity) = {
+            let state = self
+                .inner
+                .state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let endpoint_capacity = state.endpoints.values().fold(0u64, |total, endpoint| {
+                total.saturating_add(u64::try_from(endpoint.capacity).unwrap_or(u64::MAX))
+            });
+            (
+                u64::try_from(state.routes.len()).unwrap_or(u64::MAX),
+                u64::try_from(state.endpoints.len()).unwrap_or(u64::MAX),
+                endpoint_capacity,
+            )
+        };
+        let mut snapshot = PluginEventRouterStats {
+            registered_publishers: u64::try_from(self.inner.publishers.len()).unwrap_or(u64::MAX),
+            active_routes,
+            active_endpoints,
+            endpoint_capacity,
+            queued_events: self.inner.queue_memory.events.load(Ordering::Relaxed),
+            queued_payload_bytes: self
+                .inner
+                .queue_memory
+                .payload_bytes
+                .load(Ordering::Relaxed),
+            ..PluginEventRouterStats::default()
+        };
+        for publisher in self.inner.publishers.values() {
+            let publisher = publisher.snapshot();
+            snapshot.published = snapshot.published.saturating_add(publisher.published);
+            snapshot.publish_failures = snapshot
+                .publish_failures
+                .saturating_add(publisher.publish_failures);
+            snapshot.matched = snapshot.matched.saturating_add(publisher.matched);
+            snapshot.enqueued = snapshot.enqueued.saturating_add(publisher.enqueued);
+            snapshot.delivered = snapshot.delivered.saturating_add(publisher.delivered);
+            snapshot.dropped = snapshot.dropped.saturating_add(publisher.dropped);
+            snapshot.closed = snapshot.closed.saturating_add(publisher.closed);
+        }
+        snapshot
     }
 
     pub fn subscribe(
@@ -429,7 +617,7 @@ impl PluginEventRouter {
             return Err(PluginEventSubscribeError::EmptySelectors);
         }
         for selector in &selectors {
-            if !self.inner.plugin_ids.contains(selector.plugin_id()) {
+            if !self.inner.publishers.contains_key(selector.plugin_id()) {
                 return Err(PluginEventSubscribeError::UnknownPublisher {
                     plugin_id: selector.plugin_id().to_string(),
                 });
@@ -492,14 +680,24 @@ impl PluginEventRouter {
 
     fn publish(
         &self,
+        publisher: Arc<PublisherCounters>,
         plugin_id: &Arc<str>,
         topic: &PluginEventTopic,
-        schema_version: u32,
-        payload_encoding: PluginEventPayloadEncoding,
-        payload: Bytes,
-        connection_generation: u64,
+        publication: PluginEventPublication,
     ) -> Result<PluginEventPublishReport, PluginEventPublishError> {
-        if schema_version == 0 {
+        let result = self.publish_inner(Arc::clone(&publisher), plugin_id, topic, publication);
+        publisher.record_publish(&result);
+        result
+    }
+
+    fn publish_inner(
+        &self,
+        publisher: Arc<PublisherCounters>,
+        plugin_id: &Arc<str>,
+        topic: &PluginEventTopic,
+        publication: PluginEventPublication,
+    ) -> Result<PluginEventPublishReport, PluginEventPublishError> {
+        if publication.schema_version == 0 {
             return Err(PluginEventPublishError::InvalidSchemaVersion);
         }
         if self.inner.closed.load(Ordering::Acquire) {
@@ -530,17 +728,19 @@ impl PluginEventRouter {
             .checked_add(1)
             .ok_or(PluginEventPublishError::SequenceExhausted)?;
         *sequence = next_sequence;
-        let event = Arc::new(
+        let envelope = Arc::new(
             PluginEventEnvelope::builder()
                 .plugin_id(plugin_id.clone())
                 .topic(topic.clone())
-                .schema_version(schema_version)
-                .payload_encoding(payload_encoding)
-                .payload(payload)
-                .connection_generation(connection_generation)
+                .schema_version(publication.schema_version)
+                .payload_encoding(publication.payload_encoding)
+                .payload(publication.payload)
+                .connection_generation(publication.connection_generation)
                 .sequence(next_sequence)
                 .build(),
         );
+        let event =
+            QueuedPluginEvent::new(envelope, publisher, Arc::clone(&self.inner.queue_memory));
 
         let mut report = PluginEventPublishReport {
             matched: u64::try_from(endpoints.len()).unwrap_or(u64::MAX),
@@ -570,7 +770,7 @@ impl PluginEventRouter {
 pub struct PluginEventSubscription {
     router: PluginEventRouter,
     endpoint: Arc<EventEndpoint>,
-    receiver: Receiver<Arc<PluginEventEnvelope>>,
+    receiver: Receiver<Arc<QueuedPluginEvent>>,
     selectors: Vec<PluginEventSelector>,
 }
 
@@ -594,7 +794,8 @@ impl PluginEventSubscription {
             .await
             .map_err(|_| PluginEventReceiveError)?;
         self.endpoint.delivered.fetch_add(1, Ordering::Relaxed);
-        Ok(event)
+        event.publisher.delivered.fetch_add(1, Ordering::Relaxed);
+        Ok(event.envelope.clone())
     }
 
     pub fn try_recv(&self) -> Result<Arc<PluginEventEnvelope>, PluginEventTryReceiveError> {
@@ -603,7 +804,8 @@ impl PluginEventSubscription {
             TryRecvError::Closed => PluginEventTryReceiveError::Closed,
         })?;
         self.endpoint.delivered.fetch_add(1, Ordering::Relaxed);
-        Ok(event)
+        event.publisher.delivered.fetch_add(1, Ordering::Relaxed);
+        Ok(event.envelope.clone())
     }
 }
 
@@ -623,6 +825,7 @@ impl Drop for PluginEventSubscription {
 pub struct PluginEvents {
     plugin_id: Arc<str>,
     router: PluginEventRouter,
+    stats: Arc<PublisherCounters>,
     resources: Arc<PluginResources>,
     connection_generation: Arc<AtomicU64>,
 }
@@ -641,6 +844,10 @@ impl PluginEvents {
         self.router.has_subscribers(&self.selector(topic))
     }
 
+    pub fn stats(&self) -> PluginEventPublisherStats {
+        self.stats.snapshot()
+    }
+
     pub fn publish(
         &self,
         topic: &PluginEventTopic,
@@ -648,14 +855,20 @@ impl PluginEvents {
         payload_encoding: PluginEventPayloadEncoding,
         payload: impl Into<Bytes>,
     ) -> Result<PluginEventPublishReport, PluginEventPublishError> {
-        self.resources.ensure_active()?;
+        if let Err(error) = self.resources.ensure_active() {
+            self.stats.publish_failures.fetch_add(1, Ordering::Relaxed);
+            return Err(error.into());
+        }
         self.router.publish(
+            Arc::clone(&self.stats),
             &self.plugin_id,
             topic,
-            schema_version,
-            payload_encoding,
-            payload.into(),
-            self.connection_generation.load(Ordering::Acquire),
+            PluginEventPublication {
+                schema_version,
+                payload_encoding,
+                payload: payload.into(),
+                connection_generation: self.connection_generation.load(Ordering::Acquire),
+            },
         )
     }
 }
@@ -665,13 +878,15 @@ pub(super) fn publisher(
     router: PluginEventRouter,
     resources: Arc<PluginResources>,
     connection_generation: Arc<AtomicU64>,
-) -> PluginEvents {
-    PluginEvents {
+) -> Option<PluginEvents> {
+    let stats = router.inner.publishers.get(plugin_id)?.clone();
+    Some(PluginEvents {
         plugin_id: Arc::from(plugin_id),
         router,
+        stats,
         resources,
         connection_generation,
-    }
+    })
 }
 
 fn valid_topic(topic: &str) -> bool {
@@ -698,16 +913,88 @@ mod tests {
         topic: &PluginEventTopic,
         value: u32,
     ) -> PluginEventPublishReport {
+        let publisher = router
+            .inner
+            .publishers
+            .get(plugin_id)
+            .cloned()
+            .expect("registered publisher");
         router
             .publish(
+                publisher,
                 &Arc::from(plugin_id),
                 topic,
-                1,
-                PluginEventPayloadEncoding::Binary,
-                Bytes::copy_from_slice(&value.to_be_bytes()),
-                7,
+                PluginEventPublication {
+                    schema_version: 1,
+                    payload_encoding: PluginEventPayloadEncoding::Binary,
+                    payload: Bytes::copy_from_slice(&value.to_be_bytes()),
+                    connection_generation: 7,
+                },
             )
             .expect("event publication")
+    }
+
+    #[test]
+    fn router_stats_count_shared_queue_payload_once_and_keep_cumulative_totals() {
+        let router = PluginEventRouter::new(["metrics".to_string()]);
+        let tick = topic("tick");
+        let first = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(2, PluginEventOverflow::DropNewest),
+            )
+            .expect("first endpoint");
+        let second = router
+            .subscribe(
+                [selector("metrics", &tick)],
+                PluginEventEndpointConfig::new(3, PluginEventOverflow::DropNewest),
+            )
+            .expect("second endpoint");
+
+        assert_eq!(publish(&router, "metrics", &tick, 1).enqueued, 2);
+        assert_eq!(
+            router.stats(),
+            PluginEventRouterStats {
+                registered_publishers: 1,
+                active_routes: 1,
+                active_endpoints: 2,
+                endpoint_capacity: 5,
+                queued_events: 1,
+                queued_payload_bytes: 4,
+                published: 1,
+                publish_failures: 0,
+                matched: 2,
+                enqueued: 2,
+                delivered: 0,
+                dropped: 0,
+                closed: 0,
+            }
+        );
+
+        first.try_recv().expect("first delivery");
+        assert_eq!(router.stats().queued_events, 1);
+        second.try_recv().expect("second delivery");
+        assert_eq!(router.stats().queued_events, 0);
+        assert_eq!(router.stats().queued_payload_bytes, 0);
+        assert_eq!(router.stats().delivered, 2);
+
+        drop(first);
+        drop(second);
+        let stats = router.stats();
+        assert_eq!(stats.active_routes, 0);
+        assert_eq!(stats.active_endpoints, 0);
+        assert_eq!(stats.published, 1);
+        assert_eq!(stats.delivered, 2);
+        assert_eq!(
+            router.publisher_stats("metrics"),
+            Some(PluginEventPublisherStats {
+                published: 1,
+                matched: 2,
+                enqueued: 2,
+                delivered: 2,
+                ..PluginEventPublisherStats::default()
+            })
+        );
     }
 
     #[test]
@@ -764,6 +1051,17 @@ mod tests {
                 capacity: 2,
             }
         );
+        assert_eq!(
+            router.publisher_stats("metrics"),
+            Some(PluginEventPublisherStats {
+                published: 4,
+                matched: 4,
+                enqueued: 2,
+                delivered: 2,
+                dropped: 2,
+                ..PluginEventPublisherStats::default()
+            })
+        );
     }
 
     #[test]
@@ -785,6 +1083,8 @@ mod tests {
         assert_eq!(subscription.try_recv().expect("fourth").sequence, 4);
         assert_eq!(subscription.stats().enqueued, 4);
         assert_eq!(subscription.stats().dropped, 2);
+        assert_eq!(router.stats().dropped, 2);
+        assert_eq!(router.stats().delivered, 2);
     }
 
     #[test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -139,25 +139,29 @@ impl PluginManifest {
     }
 }
 
+/// Target-correct future returned by native plugin entry points.
+pub type PluginFuture<'a, T> = BoxFuture<'a, T>;
+
 /// A trusted native plugin installed exactly once while the client is still inert.
 /// Capabilities shape the handles it receives; they are not an in-process sandbox.
+/// A plugin value belongs to one client installation, even when registered through an `Arc`.
 pub trait ClientPlugin: MaybeSendSync + 'static {
     type Api: MaybeSendSync + 'static;
 
     fn manifest(&self) -> PluginManifest;
 
-    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>>;
+    fn install(&self, context: PluginContext) -> PluginFuture<'_, anyhow::Result<Arc<Self::Api>>>;
 
-    fn on_ready(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+    fn on_ready(&self, _scope: PluginConnectionScope) -> PluginFuture<'_, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
     }
 
-    fn on_closed(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+    fn on_closed(&self, _scope: PluginConnectionScope) -> PluginFuture<'_, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
     }
 
     /// Release plugin-owned state. This may run after `install` began but returned an error.
-    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+    fn shutdown(&self) -> PluginFuture<'_, anyhow::Result<()>> {
         Box::pin(async { Ok(()) })
     }
 }
@@ -329,6 +333,17 @@ impl PluginTasks {
 
     pub fn shutdown_signal(&self) -> ShutdownSignal {
         self.resources.shutdown.subscribe()
+    }
+
+    /// Sleep through the configured runtime, returning promptly when this plugin shuts down.
+    pub async fn sleep(&self, duration: Duration) -> Result<(), PluginResourceError> {
+        self.resources.ensure_active()?;
+        let shutdown = self.resources.shutdown.subscribe();
+        let cancelled = Box::pin(wait_for_shutdown(&shutdown));
+        match futures::future::select(cancelled, self.runtime.sleep(duration)).await {
+            futures::future::Either::Left(_) => Err(PluginResourceError::ShuttingDown),
+            futures::future::Either::Right(_) => self.resources.ensure_active(),
+        }
     }
 }
 
@@ -505,6 +520,22 @@ impl PluginConnectionTasks {
         }
         spawn_until_cancelled(&self.runtime, self.scope.cancellation_signal(), future);
         Ok(())
+    }
+
+    /// Sleep through the configured runtime, returning promptly when this generation retires.
+    pub async fn sleep(&self, duration: Duration) -> Result<(), PluginResourceError> {
+        if self.scope.is_cancelled() {
+            return Err(PluginResourceError::ShuttingDown);
+        }
+        let cancellation = self.scope.cancellation_signal();
+        let cancelled = Box::pin(wait_for_shutdown(&cancellation));
+        match futures::future::select(cancelled, self.runtime.sleep(duration)).await {
+            futures::future::Either::Left(_) => Err(PluginResourceError::ShuttingDown),
+            futures::future::Either::Right(_) if self.scope.is_cancelled() => {
+                Err(PluginResourceError::ShuttingDown)
+            }
+            futures::future::Either::Right(_) => Ok(()),
+        }
     }
 }
 
@@ -2212,6 +2243,44 @@ mod tests {
             tasks.spawn(async {}),
             Err(PluginResourceError::ShuttingDown)
         ));
+    }
+
+    #[tokio::test]
+    async fn task_sleeps_return_when_their_owner_is_cancelled() {
+        let resources = PluginResources::new();
+        resources.activate();
+        let install_tasks = PluginTasks {
+            runtime: Arc::new(TokioRuntime),
+            resources: resources.clone(),
+        };
+        let install_sleeper =
+            tokio::spawn(async move { install_tasks.sleep(Duration::from_secs(60)).await });
+        tokio::task::yield_now().await;
+        resources.close();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), install_sleeper)
+                .await
+                .expect("install sleep cancellation")
+                .expect("install sleeper task"),
+            Err(PluginResourceError::ShuttingDown)
+        );
+
+        let scope = ConnectionScope::new(91);
+        let connection_tasks = PluginConnectionTasks {
+            runtime: Arc::new(TokioRuntime),
+            scope: scope.clone(),
+        };
+        let connection_sleeper =
+            tokio::spawn(async move { connection_tasks.sleep(Duration::from_secs(60)).await });
+        tokio::task::yield_now().await;
+        scope.cancel();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), connection_sleeper)
+                .await
+                .expect("connection sleep cancellation")
+                .expect("connection sleeper task"),
+            Err(PluginResourceError::ShuttingDown)
+        );
     }
 
     struct UpstreamLifecycle {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,5 +1,15 @@
 //! Build-time client plugins and their capability-scoped host.
 
+mod events;
+
+pub use events::{
+    PluginEventEndpointConfig, PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow,
+    PluginEventPayloadEncoding, PluginEventPublishError, PluginEventPublishReport,
+    PluginEventReceiveError, PluginEventRouteError, PluginEventRouter, PluginEventSelector,
+    PluginEventSubscribeError, PluginEventSubscription, PluginEventTopic,
+    PluginEventTryReceiveError, PluginEvents,
+};
+
 use std::any::{Any, TypeId};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::future::Future;
@@ -9,6 +19,7 @@ use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::Duration;
 
 use futures::FutureExt;
+use portable_atomic::AtomicU64;
 use thiserror::Error;
 use wacore::iq::spec::IqSpec;
 use wacore::runtime::{
@@ -29,6 +40,7 @@ const CAP_CORE_EVENTS: u8 = 1 << 0;
 const CAP_TASKS: u8 = 1 << 1;
 const CAP_MESSAGING: u8 = 1 << 2;
 const CAP_IQ: u8 = 1 << 3;
+const CAP_PLUGIN_EVENTS: u8 = 1 << 4;
 const PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A capability a plugin asks the host to expose during installation.
@@ -39,6 +51,7 @@ pub enum PluginCapability {
     Tasks,
     Messaging,
     Iq,
+    PluginEvents,
 }
 
 impl PluginCapability {
@@ -48,6 +61,7 @@ impl PluginCapability {
             Self::Tasks => "tasks.spawn",
             Self::Messaging => "messaging.send",
             Self::Iq => "iq.execute",
+            Self::PluginEvents => "events.plugin.publish",
         }
     }
 
@@ -57,6 +71,7 @@ impl PluginCapability {
             Self::Tasks => CAP_TASKS,
             Self::Messaging => CAP_MESSAGING,
             Self::Iq => CAP_IQ,
+            Self::PluginEvents => CAP_PLUGIN_EVENTS,
         }
     }
 }
@@ -408,6 +423,7 @@ pub struct PluginContext {
     tasks: Option<PluginTasks>,
     messaging: Option<PluginMessaging>,
     iq: Option<PluginIq>,
+    plugin_events: Option<PluginEvents>,
 }
 
 impl PluginContext {
@@ -436,6 +452,10 @@ impl PluginContext {
 
     pub fn iq(&self) -> Option<&PluginIq> {
         self.iq.as_ref()
+    }
+
+    pub fn plugin_events(&self) -> Option<&PluginEvents> {
+        self.plugin_events.as_ref()
     }
 }
 
@@ -887,6 +907,7 @@ pub(crate) struct PluginHost {
     installed: OnceLock<Vec<InstalledPlugin>>,
     apis: OnceLock<HashMap<TypeId, ErasedApi>>,
     runtime: OnceLock<Arc<dyn Runtime>>,
+    event_router: Option<PluginEventRouter>,
     callback_timeout: Duration,
 }
 
@@ -904,7 +925,18 @@ impl PluginHost {
             .ordered
             .iter()
             .map(|plugin| plugin.manifest.clone())
-            .collect();
+            .collect::<Vec<_>>();
+        let event_publishers = manifests
+            .iter()
+            .filter(|manifest| {
+                manifest
+                    .capabilities
+                    .contains(PluginCapability::PluginEvents)
+            })
+            .map(|manifest| manifest.id.clone())
+            .collect::<Vec<_>>();
+        let event_router =
+            (!event_publishers.is_empty()).then(|| PluginEventRouter::new(event_publishers));
         Arc::new(Self {
             ordered: plan.ordered,
             manifests,
@@ -912,6 +944,7 @@ impl PluginHost {
             installed: OnceLock::new(),
             apis: OnceLock::new(),
             runtime: OnceLock::new(),
+            event_router,
             callback_timeout,
         })
     }
@@ -934,16 +967,17 @@ impl PluginHost {
     fn context(
         &self,
         client: &Weak<Client>,
-        manifest: &PluginManifest,
-        dependency_markers: &[TypeId],
+        planned: &PlannedPlugin,
         resources: Arc<PluginResources>,
         apis: Arc<ApiRegistry>,
         runtime: Arc<dyn Runtime>,
+        connection_generation: Arc<AtomicU64>,
     ) -> PluginContext {
+        let manifest = &planned.manifest;
         let capabilities = manifest.capabilities;
         PluginContext {
             plugin_id: manifest.id.clone(),
-            dependencies: apis.dependency_view(dependency_markers),
+            dependencies: apis.dependency_view(&planned.dependency_markers),
             core_events: capabilities
                 .contains(PluginCapability::CoreEvents)
                 .then(|| PluginCoreEvents {
@@ -967,6 +1001,18 @@ impl PluginHost {
                 .then(|| PluginIq {
                     client: client.clone(),
                     resources: Arc::clone(&resources),
+                }),
+            plugin_events: self
+                .event_router
+                .as_ref()
+                .filter(|_| capabilities.contains(PluginCapability::PluginEvents))
+                .map(|router| {
+                    events::publisher(
+                        &manifest.id,
+                        router.clone(),
+                        Arc::clone(&resources),
+                        connection_generation,
+                    )
                 }),
         }
     }
@@ -993,6 +1039,7 @@ impl PluginHost {
             anyhow::bail!("client was dropped during plugin installation");
         };
         let runtime = strong_client.runtime.clone();
+        let connection_generation = strong_client.connection_generation.clone();
         drop(strong_client);
         self.runtime
             .set(runtime.clone())
@@ -1012,11 +1059,11 @@ impl PluginHost {
             let resources = PluginResources::new();
             let context = self.context(
                 &client,
-                &planned.manifest,
-                &planned.dependency_markers,
+                planned,
                 Arc::clone(&resources),
                 Arc::clone(&staging),
                 runtime.clone(),
+                connection_generation.clone(),
             );
             rollback.current = Some(InstalledPlugin {
                 plugin: planned.plugin.clone(),
@@ -1119,6 +1166,9 @@ impl ClientLifecycle for PluginHost {
     }
 
     fn signal_shutdown(&self) {
+        if let Some(router) = &self.event_router {
+            router.close();
+        }
         for plugin in self.installed.get().into_iter().flatten().rev() {
             plugin.resources.close();
         }
@@ -1246,12 +1296,23 @@ impl Client {
             .map(|host| host.manifests())
             .unwrap_or_default()
     }
+
+    /// Subscribe to custom events emitted by installed plugins.
+    ///
+    /// Returns `None` when no manifest requested custom-event publication.
+    pub fn plugin_event_router(&self) -> Option<PluginEventRouter> {
+        self.plugin_host
+            .as_ref()
+            .and_then(|host| host.event_router.clone())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;
+
+    use bytes::Bytes;
 
     use super::*;
     use crate::client::{ClientBuilder, ClientBuilderError};
@@ -2508,7 +2569,7 @@ mod tests {
     struct CapabilityProbe;
 
     impl ClientPlugin for CapabilityProbe {
-        type Api = [bool; 4];
+        type Api = [bool; 5];
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("capability-probe", "0.1.0")
@@ -2522,6 +2583,7 @@ mod tests {
                     context.tasks().is_some(),
                     context.messaging().is_some(),
                     context.iq().is_some(),
+                    context.plugin_events().is_some(),
                 ]))
             })
         }
@@ -2538,8 +2600,117 @@ mod tests {
         let client = build.into_client();
         assert_eq!(
             client.plugin::<CapabilityProbe>().as_deref(),
-            Some(&[false, false, true, false])
+            Some(&[false, false, true, false, false])
         );
+        assert!(client.plugin_event_router().is_none());
         client.disconnect().await;
+    }
+
+    struct PluginEventPublisher;
+
+    impl ClientPlugin for PluginEventPublisher {
+        type Api = PluginEvents;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("event-publisher", "0.1.0")
+                .with_capability(PluginCapability::PluginEvents)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                context
+                    .plugin_events()
+                    .cloned()
+                    .map(Arc::new)
+                    .ok_or_else(|| anyhow::anyhow!("plugin events capability missing"))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn typed_plugin_api_publishes_only_to_exact_bounded_routes() {
+        let client = complete_builder()
+            .await
+            .with_plugin(PluginEventPublisher)
+            .with_plugin(CapabilityProbe)
+            .build()
+            .await
+            .expect("plugin event publisher")
+            .into_client();
+        let publisher = client
+            .plugin::<PluginEventPublisher>()
+            .expect("typed publisher API");
+        let router = client.plugin_event_router().expect("plugin event router");
+        let tick = PluginEventTopic::new("tick").expect("valid topic");
+        let silent_selector =
+            PluginEventSelector::new("capability-probe", tick.clone()).expect("valid selector");
+        assert!(matches!(
+            router.subscribe(
+                [silent_selector],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::UnknownPublisher { .. })
+        ));
+        let selector = publisher.selector(&tick);
+        let subscription = router
+            .subscribe(
+                [selector.clone()],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            )
+            .expect("bounded event endpoint");
+
+        assert!(publisher.has_subscribers(&tick));
+        let generation = client.connection_generation.load(Ordering::Acquire);
+        assert_eq!(
+            publisher
+                .publish(
+                    &tick,
+                    2,
+                    PluginEventPayloadEncoding::Json,
+                    r#"{"messages":1}"#,
+                )
+                .expect("publish tick"),
+            PluginEventPublishReport {
+                matched: 1,
+                enqueued: 1,
+                dropped: 0,
+                closed: 0,
+            }
+        );
+        let event = subscription.recv().await.expect("routed tick");
+        assert_eq!(&*event.plugin_id, "event-publisher");
+        assert_eq!(event.topic, tick);
+        assert_eq!(event.schema_version, 2);
+        assert_eq!(event.payload_encoding, PluginEventPayloadEncoding::Json);
+        assert_eq!(event.payload, Bytes::from_static(br#"{"messages":1}"#));
+        assert_eq!(event.connection_generation, generation);
+        assert_eq!(event.sequence, 1);
+
+        let next_generation = client.connection_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        publisher
+            .publish(&tick, 2, PluginEventPayloadEncoding::Json, Bytes::new())
+            .expect("publish after generation change");
+        let event = subscription.recv().await.expect("next generation tick");
+        assert_eq!(event.connection_generation, next_generation);
+        assert_eq!(event.sequence, 2);
+
+        client.disconnect().await;
+        assert!(matches!(
+            publisher.publish(&tick, 2, PluginEventPayloadEncoding::Json, Bytes::new(),),
+            Err(PluginEventPublishError::Resource(
+                PluginResourceError::ShuttingDown
+            ))
+        ));
+        assert!(matches!(
+            subscription.recv().await,
+            Err(PluginEventReceiveError)
+        ));
+        assert!(matches!(
+            router.subscribe(
+                [selector],
+                PluginEventEndpointConfig::new(1, PluginEventOverflow::DropNewest),
+            ),
+            Err(PluginEventSubscribeError::Closed)
+        ));
     }
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1031,6 +1031,7 @@ struct PluginInstallRollback {
     installed: Vec<InstalledPlugin>,
     current: Option<InstalledPlugin>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
+    staged_apis: Option<Arc<ApiRegistry>>,
     armed: bool,
 }
 
@@ -1041,6 +1042,7 @@ impl PluginInstallRollback {
             installed: Vec::with_capacity(capacity),
             current: None,
             upstream: None,
+            staged_apis: None,
             armed: true,
         }
     }
@@ -1062,6 +1064,7 @@ impl PluginInstallRollback {
         let current = self.current.take();
         let installed = std::mem::take(&mut self.installed);
         let upstream = self.upstream.take();
+        let staged_apis = self.staged_apis.take();
         self.armed = false;
         if current.is_none() && installed.is_empty() && upstream.is_none() {
             return None;
@@ -1078,7 +1081,8 @@ impl PluginInstallRollback {
         let cleanup_runtime = runtime.clone();
         runtime
             .spawn(Box::pin(async move {
-                shutdown_staged_plugins(cleanup_runtime, current, installed, upstream).await;
+                shutdown_staged_plugins(cleanup_runtime, current, installed, upstream, staged_apis)
+                    .await;
                 completed.notify();
             }))
             .detach();
@@ -1102,6 +1106,7 @@ impl PluginInstallRollback {
     fn disarm(&mut self) {
         self.armed = false;
         self.upstream = None;
+        self.staged_apis = None;
     }
 }
 
@@ -1120,6 +1125,7 @@ pub(crate) struct PluginHost {
     runtime: OnceLock<Arc<dyn Runtime>>,
     event_router: Option<PluginEventRouter>,
     callback_timeout: Duration,
+    terminal: AtomicBool,
 }
 
 impl PluginHost {
@@ -1157,6 +1163,7 @@ impl PluginHost {
             runtime: OnceLock::new(),
             event_router,
             callback_timeout,
+            terminal: AtomicBool::new(false),
         })
     }
 
@@ -1280,16 +1287,20 @@ impl PluginHost {
             .map_err(|_| anyhow::anyhow!("plugin host was installed more than once"))?;
 
         let mut rollback = PluginInstallRollback::new(runtime.clone(), self.ordered.len());
+        self.abort_install_if_terminal(&mut rollback).await?;
         if let Some(upstream) = &self.upstream {
             if let Err(error) = plugin_callback(|| upstream.install(client.clone())).await {
                 rollback.disarm();
                 return Err(error);
             }
             rollback.upstream = Some(upstream.clone());
+            self.abort_install_if_terminal(&mut rollback).await?;
         }
 
         let staging = Arc::new(ApiRegistry::default());
+        rollback.staged_apis = Some(Arc::clone(&staging));
         for planned in &self.ordered {
+            self.abort_install_if_terminal(&mut rollback).await?;
             let resources = PluginResources::new();
             let context = self.context(
                 &client,
@@ -1315,12 +1326,14 @@ impl PluginHost {
                 }
             };
             staging.insert(planned.plugin.marker_type_id(), api);
+            self.abort_install_if_terminal(&mut rollback).await?;
             let Some(installed) = rollback.current.take() else {
                 rollback.rollback().await;
                 anyhow::bail!("plugin installation rollback state was lost");
             };
             rollback.installed.push(installed);
         }
+        self.abort_install_if_terminal(&mut rollback).await?;
 
         self.apis
             .set(staging.snapshot())
@@ -1334,9 +1347,36 @@ impl PluginHost {
         Ok(())
     }
 
-    pub(crate) fn activate(&self) {
+    async fn abort_install_if_terminal(
+        &self,
+        rollback: &mut PluginInstallRollback,
+    ) -> anyhow::Result<()> {
+        if !self.terminal.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        rollback.rollback().await;
+        anyhow::bail!("plugin host shut down during installation")
+    }
+
+    pub(crate) fn activate(&self) -> bool {
+        if self.terminal.load(Ordering::Acquire) {
+            self.close_installed_resources();
+            return false;
+        }
         for plugin in self.installed.get().into_iter().flatten() {
             plugin.resources.activate();
+        }
+        if self.terminal.load(Ordering::Acquire) {
+            self.close_installed_resources();
+            false
+        } else {
+            true
+        }
+    }
+
+    fn close_installed_resources(&self) {
+        for plugin in self.installed.get().into_iter().flatten().rev() {
+            plugin.resources.close();
         }
     }
 
@@ -1425,12 +1465,11 @@ impl ClientLifecycle for PluginHost {
     }
 
     fn signal_shutdown(&self) {
+        self.terminal.store(true, Ordering::Release);
         if let Some(router) = &self.event_router {
             router.close();
         }
-        for plugin in self.installed.get().into_iter().flatten().rev() {
-            plugin.resources.close();
-        }
+        self.close_installed_resources();
         if let Some(upstream) = &self.upstream
             && std::panic::catch_unwind(AssertUnwindSafe(|| upstream.signal_shutdown())).is_err()
         {
@@ -1474,6 +1513,7 @@ async fn shutdown_staged_plugins(
     current: Option<InstalledPlugin>,
     mut installed: Vec<InstalledPlugin>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
+    staged_apis: Option<Arc<ApiRegistry>>,
 ) {
     if let Some(plugin) = current {
         if let Err(error) = wait_for_plugin_tasks(
@@ -1527,6 +1567,7 @@ async fn shutdown_staged_plugins(
     {
         log::warn!("Upstream lifecycle rollback failed: {error:#}");
     }
+    drop(staged_apis);
 }
 
 async fn wait_for_plugin_tasks(
@@ -1656,6 +1697,20 @@ mod tests {
         log: Log,
     }
 
+    struct ShutdownDuringPluginInstall;
+
+    impl ClientLifecycle for ShutdownDuringPluginInstall {
+        fn install(&self, client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async move {
+                client
+                    .upgrade()
+                    .ok_or_else(|| anyhow::anyhow!("client unavailable during install"))?
+                    .signal_shutdown_sync();
+                Ok(())
+            })
+        }
+    }
+
     impl ClientPlugin for FoundationPlugin {
         type Api = String;
 
@@ -1681,6 +1736,24 @@ mod tests {
                 Ok(())
             })
         }
+    }
+
+    #[tokio::test]
+    async fn shutdown_during_upstream_install_prevents_plugin_installation() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let result = complete_builder()
+            .await
+            .with_lifecycle(ShutdownDuringPluginInstall)
+            .with_plugin(FoundationPlugin { log: log.clone() })
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(ClientBuilderError::PluginInstall(_))));
+        assert!(
+            log.lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
     }
 
     struct DependentPlugin {
@@ -2017,10 +2090,15 @@ mod tests {
     struct RollbackPlugin {
         log: Log,
         task_dropped: Arc<AtomicBool>,
+        api_dropped: Arc<AtomicBool>,
+    }
+
+    struct RollbackApi {
+        _drop_flag: DropFlag,
     }
 
     impl ClientPlugin for RollbackPlugin {
-        type Api = ();
+        type Api = RollbackApi;
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("rollback", "0.1.0").with_capability(PluginCapability::Tasks)
@@ -2029,6 +2107,7 @@ mod tests {
         fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
             let log = self.log.clone();
             let task_dropped = self.task_dropped.clone();
+            let api_dropped = self.api_dropped.clone();
             Box::pin(async move {
                 record(&log, "install:rollback");
                 let guard = DropFlag(task_dropped);
@@ -2039,17 +2118,24 @@ mod tests {
                         let _guard = guard;
                         futures::future::pending::<()>().await;
                     })?;
-                Ok(Arc::new(()))
+                Ok(Arc::new(RollbackApi {
+                    _drop_flag: DropFlag(api_dropped),
+                }))
             })
         }
 
         fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
             let log = self.log.clone();
             let task_dropped = self.task_dropped.clone();
+            let api_dropped = self.api_dropped.clone();
             Box::pin(async move {
                 anyhow::ensure!(
                     task_dropped.load(Ordering::Acquire),
                     "rollback task still running during shutdown"
+                );
+                anyhow::ensure!(
+                    !api_dropped.load(Ordering::Acquire),
+                    "rollback API dropped before shutdown"
                 );
                 record(&log, "shutdown:rollback");
                 Ok(())
@@ -2092,6 +2178,7 @@ mod tests {
     async fn install_failure_rolls_back_resources_and_plugins_in_lifo_order() {
         let log = Arc::new(Mutex::new(Vec::new()));
         let task_dropped = Arc::new(AtomicBool::new(false));
+        let api_dropped = Arc::new(AtomicBool::new(false));
         let result = complete_builder()
             .await
             .with_lifecycle(UpstreamLifecycle { log: log.clone() })
@@ -2099,6 +2186,7 @@ mod tests {
             .with_plugin(RollbackPlugin {
                 log: log.clone(),
                 task_dropped: task_dropped.clone(),
+                api_dropped: api_dropped.clone(),
             })
             .build()
             .await;
@@ -2122,6 +2210,7 @@ mod tests {
         })
         .await
         .expect("rollback aborted the install-scoped task");
+        assert!(api_dropped.load(Ordering::Acquire));
     }
 
     struct BlockingFailingPlugin {
@@ -2199,6 +2288,7 @@ mod tests {
     async fn cancelled_explicit_rollback_finishes_detached_and_signals_upstream() {
         let log = Arc::new(Mutex::new(Vec::new()));
         let task_dropped = Arc::new(AtomicBool::new(false));
+        let api_dropped = Arc::new(AtomicBool::new(false));
         let signalled = Arc::new(AtomicBool::new(false));
         let shutdown_saw_signal = Arc::new(AtomicBool::new(false));
         let (started_tx, started_rx) = async_channel::bounded(1);
@@ -2218,6 +2308,7 @@ mod tests {
             .with_plugin(RollbackPlugin {
                 log: log.clone(),
                 task_dropped: task_dropped.clone(),
+                api_dropped: api_dropped.clone(),
             });
 
         let build = tokio::spawn(async move { builder.build().await });
@@ -2237,7 +2328,10 @@ mod tests {
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .last()
                     .is_some_and(|entry| entry == "shutdown:upstream");
-                if complete && task_dropped.load(Ordering::Acquire) {
+                if complete
+                    && task_dropped.load(Ordering::Acquire)
+                    && api_dropped.load(Ordering::Acquire)
+                {
                     break;
                 }
                 tokio::task::yield_now().await;
@@ -2303,6 +2397,7 @@ mod tests {
     async fn cancelled_build_closes_resources_and_schedules_lifo_rollback() {
         let log = Arc::new(Mutex::new(Vec::new()));
         let task_dropped = Arc::new(AtomicBool::new(false));
+        let api_dropped = Arc::new(AtomicBool::new(false));
         let (started_tx, started_rx) = async_channel::bounded(1);
         let (_release_tx, release_rx) = async_channel::bounded(1);
         let builder = complete_builder()
@@ -2315,6 +2410,7 @@ mod tests {
             .with_plugin(RollbackPlugin {
                 log: log.clone(),
                 task_dropped: task_dropped.clone(),
+                api_dropped: api_dropped.clone(),
             });
 
         let build = tokio::spawn(async move { builder.build().await });
@@ -2329,7 +2425,10 @@ mod tests {
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .last()
                     .is_some_and(|entry| entry == "shutdown:rollback");
-                if complete && task_dropped.load(Ordering::Acquire) {
+                if complete
+                    && task_dropped.load(Ordering::Acquire)
+                    && api_dropped.load(Ordering::Acquire)
+                {
                     break;
                 }
                 tokio::task::yield_now().await;
@@ -2386,6 +2485,7 @@ mod tests {
             .with_plugin(RollbackPlugin {
                 log: log.clone(),
                 task_dropped: Arc::new(AtomicBool::new(false)),
+                api_dropped: Arc::new(AtomicBool::new(false)),
             })
             .build()
             .await;
@@ -2933,6 +3033,7 @@ mod tests {
             .with_plugin(RollbackPlugin {
                 log: Arc::new(Mutex::new(Vec::new())),
                 task_dropped: task_dropped.clone(),
+                api_dropped: Arc::new(AtomicBool::new(false)),
             })
             .with_plugin(EventSubscriptionPlugin)
             .build()

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -370,7 +370,7 @@ struct PluginResources {
     shutdown: ShutdownNotifier,
     install_tasks: Arc<TaskTracker>,
     connection_tasks: Mutex<ConnectionTaskRegistry>,
-    subscriptions: Mutex<Vec<Arc<PluginCoreEventSubscriptionInner>>>,
+    subscriptions: Mutex<Vec<Weak<PluginCoreEventSubscriptionInner>>>,
     teardown_panics: AtomicU64,
 }
 
@@ -519,10 +519,9 @@ impl PluginCoreEventSubscriptionInner {
             return Ok(false);
         };
         if !subscription.update_interest(interest) {
-            let registration = (state.subscription.take(), state.raw_node_lease.take());
             drop(state);
             drop(acquired_raw_node_lease);
-            drop(registration);
+            self.close();
             return Ok(false);
         }
 
@@ -539,6 +538,7 @@ impl PluginCoreEventSubscriptionInner {
     }
 
     fn close(&self) -> bool {
+        let resources = self.resources.upgrade();
         let registration = {
             let mut state = self
                 .state
@@ -548,13 +548,16 @@ impl PluginCoreEventSubscriptionInner {
         };
         let active = registration.0.is_some();
         if std::panic::catch_unwind(AssertUnwindSafe(|| drop(registration))).is_err() {
-            if let Some(resources) = self.resources.upgrade() {
+            if let Some(resources) = &resources {
                 resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
             }
             log::warn!(
                 "Plugin `{}` core-event subscription panicked while closing",
                 self.plugin_id
             );
+        }
+        if let Some(resources) = resources {
+            resources.forget_subscription(self);
         }
         active
     }
@@ -669,8 +672,12 @@ impl PluginResources {
             if self.closed.load(Ordering::Acquire) {
                 true
             } else {
-                subscriptions.retain(|subscription| subscription.is_active());
-                subscriptions.push(Arc::clone(&registration));
+                subscriptions.retain(|subscription| {
+                    subscription
+                        .upgrade()
+                        .is_some_and(|subscription| subscription.is_active())
+                });
+                subscriptions.push(Arc::downgrade(&registration));
                 false
             }
         };
@@ -682,6 +689,16 @@ impl PluginResources {
                 inner: registration,
             })
         }
+    }
+
+    fn forget_subscription(&self, subscription: &PluginCoreEventSubscriptionInner) {
+        let subscription_ptr = std::ptr::from_ref(subscription);
+        self.subscriptions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(|candidate| {
+                candidate.strong_count() != 0 && !std::ptr::eq(candidate.as_ptr(), subscription_ptr)
+            });
     }
 
     fn connection_task_tracker(&self, generation: u64) -> (Arc<TaskTracker>, bool) {
@@ -788,7 +805,9 @@ impl PluginResources {
             std::mem::take(&mut *subscriptions)
         };
         for subscription in subscriptions {
-            subscription.close();
+            if let Some(subscription) = subscription.upgrade() {
+                subscription.close();
+            }
         }
     }
 }
@@ -826,6 +845,7 @@ impl PluginResources {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .iter()
+                .filter_map(Weak::upgrade)
                 .filter(|subscription| subscription.is_active())
                 .count(),
             teardown_panics: self.teardown_panics.load(Ordering::Relaxed),
@@ -5171,6 +5191,66 @@ mod tests {
                 .core_event_subscriptions,
             0
         );
+        client.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn dropped_plugin_subscriptions_leave_no_retained_registry_entries() {
+        let client = complete_builder()
+            .await
+            .build()
+            .await
+            .expect("client")
+            .into_client();
+        let resources = PluginResources::new();
+        resources.activate();
+        let diagnostics = PluginDiagnostics::new();
+        diagnostics.attach_resources(&resources);
+        let events = PluginCoreEvents {
+            client: Arc::downgrade(&client),
+            resources: Arc::clone(&resources),
+            plugin_id: Arc::from("subscription-churn"),
+            diagnostics,
+        };
+
+        let subscriptions = (0..128)
+            .map(|_| {
+                events
+                    .subscribe(
+                        EventInterest::of(&[EventKind::Connected]),
+                        Arc::new(NoopEventHandler),
+                    )
+                    .expect("subscription")
+            })
+            .collect::<Vec<_>>();
+        let registrations = subscriptions
+            .iter()
+            .map(|subscription| Arc::downgrade(&subscription.inner))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            resources
+                .subscriptions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .len(),
+            subscriptions.len()
+        );
+
+        drop(subscriptions);
+
+        assert!(
+            resources
+                .subscriptions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
+        assert!(
+            registrations
+                .into_iter()
+                .all(|registration| registration.upgrade().is_none())
+        );
+        assert_eq!(resources.stats().core_event_subscriptions, 0);
         client.disconnect().await;
     }
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -807,13 +807,41 @@ impl PluginInstallRollback {
         }
     }
 
-    async fn rollback(&mut self) {
+    fn schedule_rollback(&mut self) -> Option<ShutdownSignal> {
+        if !self.armed {
+            return None;
+        }
         self.close_resources();
         let current = self.current.take();
         let installed = std::mem::take(&mut self.installed);
         let upstream = self.upstream.take();
         self.armed = false;
-        shutdown_staged_plugins(self.runtime.clone(), current, installed, upstream).await;
+        if current.is_none() && installed.is_empty() && upstream.is_none() {
+            return None;
+        }
+        if let Some(upstream) = &upstream
+            && std::panic::catch_unwind(AssertUnwindSafe(|| upstream.signal_shutdown())).is_err()
+        {
+            log::warn!("Upstream lifecycle rollback shutdown signal panicked");
+        }
+
+        let completed = ShutdownNotifier::new();
+        let completion = completed.subscribe();
+        let runtime = self.runtime.clone();
+        let cleanup_runtime = runtime.clone();
+        runtime
+            .spawn(Box::pin(async move {
+                shutdown_staged_plugins(cleanup_runtime, current, installed, upstream).await;
+                completed.notify();
+            }))
+            .detach();
+        Some(completion)
+    }
+
+    async fn rollback(&mut self) {
+        if let Some(completion) = self.schedule_rollback() {
+            wait_for_shutdown(&completion).await;
+        }
     }
 
     fn take_installed(&mut self) -> Vec<InstalledPlugin> {
@@ -832,23 +860,7 @@ impl PluginInstallRollback {
 
 impl Drop for PluginInstallRollback {
     fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        self.close_resources();
-        let current = self.current.take();
-        let installed = std::mem::take(&mut self.installed);
-        let upstream = self.upstream.take();
-        if current.is_none() && installed.is_empty() && upstream.is_none() {
-            return;
-        }
-        let runtime = self.runtime.clone();
-        let cleanup_runtime = runtime.clone();
-        runtime
-            .spawn(Box::pin(async move {
-                shutdown_staged_plugins(cleanup_runtime, current, installed, upstream).await;
-            }))
-            .detach();
+        let _ = self.schedule_rollback();
     }
 }
 
@@ -1667,6 +1679,144 @@ mod tests {
         })
         .await
         .expect("rollback aborted the install-scoped task");
+    }
+
+    struct BlockingFailingPlugin {
+        log: Log,
+        started: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    impl ClientPlugin for BlockingFailingPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("blocking-failure", "0.1.0").with_dependency("rollback")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "install:blocking-failure");
+                anyhow::bail!("injected failure")
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            let started = self.started.clone();
+            let release = self.release.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:blocking-failure-started");
+                let _ = started.try_send(());
+                let _ = release.recv().await;
+                record(&log, "shutdown:blocking-failure-finished");
+                Ok(())
+            })
+        }
+    }
+
+    struct SignalAwareUpstream {
+        log: Log,
+        signalled: Arc<AtomicBool>,
+        shutdown_saw_signal: Arc<AtomicBool>,
+    }
+
+    impl ClientLifecycle for SignalAwareUpstream {
+        fn install(&self, _client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "install:upstream");
+                Ok(())
+            })
+        }
+
+        fn signal_shutdown(&self) {
+            if !self.signalled.swap(true, Ordering::AcqRel) {
+                record(&self.log, "signal:upstream");
+            }
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            let signalled = self.signalled.clone();
+            let shutdown_saw_signal = self.shutdown_saw_signal.clone();
+            Box::pin(async move {
+                shutdown_saw_signal.store(signalled.load(Ordering::Acquire), Ordering::Release);
+                record(&log, "shutdown:upstream");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_explicit_rollback_finishes_detached_and_signals_upstream() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let task_dropped = Arc::new(AtomicBool::new(false));
+        let signalled = Arc::new(AtomicBool::new(false));
+        let shutdown_saw_signal = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let builder = complete_builder()
+            .await
+            .with_lifecycle(SignalAwareUpstream {
+                log: log.clone(),
+                signalled: signalled.clone(),
+                shutdown_saw_signal: shutdown_saw_signal.clone(),
+            })
+            .with_plugin(BlockingFailingPlugin {
+                log: log.clone(),
+                started: started_tx,
+                release: release_rx,
+            })
+            .with_plugin(RollbackPlugin {
+                log: log.clone(),
+                task_dropped: task_dropped.clone(),
+            });
+
+        let build = tokio::spawn(async move { builder.build().await });
+        started_rx
+            .recv()
+            .await
+            .expect("failed plugin rollback started");
+        assert!(signalled.load(Ordering::Acquire));
+        build.abort();
+        let _ = build.await;
+        release_tx.send(()).await.expect("release rollback hook");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let complete = log
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .last()
+                    .is_some_and(|entry| entry == "shutdown:upstream");
+                if complete && task_dropped.load(Ordering::Acquire) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached rollback completed after build cancellation");
+
+        assert!(shutdown_saw_signal.load(Ordering::Acquire));
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:upstream",
+                "install:rollback",
+                "install:blocking-failure",
+                "signal:upstream",
+                "shutdown:blocking-failure-started",
+                "shutdown:blocking-failure-finished",
+                "shutdown:rollback",
+                "shutdown:upstream"
+            ]
+        );
     }
 
     struct BlockingInstallPlugin {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,1826 @@
+//! Build-time client plugins and their capability-scoped host.
+
+use std::any::{Any, TypeId};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use futures::FutureExt;
+use thiserror::Error;
+use wacore::iq::spec::IqSpec;
+use wacore::runtime::{
+    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, Spawnable, wait_for_shutdown,
+};
+use wacore::sync_marker::MaybeSendSync;
+use wacore::types::events::{EventHandler, EventInterest, Subscription};
+use wacore_binary::Jid;
+use waproto::whatsapp::Message;
+
+use crate::Client;
+use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
+use crate::request::IqError;
+use crate::send::{SendError, SendResult};
+
+const CAP_CORE_EVENTS: u8 = 1 << 0;
+const CAP_TASKS: u8 = 1 << 1;
+const CAP_MESSAGING: u8 = 1 << 2;
+const CAP_IQ: u8 = 1 << 3;
+
+/// A capability a plugin asks the host to expose during installation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum PluginCapability {
+    CoreEvents,
+    Tasks,
+    Messaging,
+    Iq,
+}
+
+impl PluginCapability {
+    pub const fn identifier(self) -> &'static str {
+        match self {
+            Self::CoreEvents => "events.core.observe",
+            Self::Tasks => "tasks.spawn",
+            Self::Messaging => "messaging.send",
+            Self::Iq => "iq.execute",
+        }
+    }
+
+    const fn bit(self) -> u8 {
+        match self {
+            Self::CoreEvents => CAP_CORE_EVENTS,
+            Self::Tasks => CAP_TASKS,
+            Self::Messaging => CAP_MESSAGING,
+            Self::Iq => CAP_IQ,
+        }
+    }
+}
+
+/// Compact set of capabilities requested by one plugin.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PluginCapabilities(u8);
+
+impl PluginCapabilities {
+    pub const NONE: Self = Self(0);
+
+    pub const fn with(self, capability: PluginCapability) -> Self {
+        Self(self.0 | capability.bit())
+    }
+
+    pub const fn contains(self, capability: PluginCapability) -> bool {
+        self.0 & capability.bit() != 0
+    }
+}
+
+/// Build-time declaration used for validation, ordering, and future foreign adapters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginManifest {
+    id: String,
+    version: String,
+    dependencies: Vec<String>,
+    capabilities: PluginCapabilities,
+}
+
+impl PluginManifest {
+    pub fn new(id: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            version: version.into(),
+            dependencies: Vec::new(),
+            capabilities: PluginCapabilities::NONE,
+        }
+    }
+
+    pub fn with_dependency(mut self, plugin_id: impl Into<String>) -> Self {
+        self.dependencies.push(plugin_id.into());
+        self
+    }
+
+    pub const fn with_capability(mut self, capability: PluginCapability) -> Self {
+        self.capabilities = self.capabilities.with(capability);
+        self
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn dependencies(&self) -> &[String] {
+        &self.dependencies
+    }
+
+    pub const fn capabilities(&self) -> PluginCapabilities {
+        self.capabilities
+    }
+}
+
+/// A trusted native plugin installed exactly once while the client is still inert.
+/// Capabilities shape the handles it receives; they are not an in-process sandbox.
+pub trait ClientPlugin: MaybeSendSync + 'static {
+    type Api: MaybeSendSync + 'static;
+
+    fn manifest(&self) -> PluginManifest;
+
+    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>>;
+
+    fn on_ready(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn on_closed(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    /// Release plugin-owned state. This may run after `install` began but returned an error.
+    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+/// Manifest validation or dependency-ordering failure.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PluginPlanError {
+    #[error("plugin {plugin_type} panicked while producing its manifest")]
+    ManifestPanicked { plugin_type: &'static str },
+    #[error("invalid plugin id `{id}`")]
+    InvalidId { id: String },
+    #[error("plugin `{plugin_id}` has an invalid version `{version}`")]
+    InvalidVersion { plugin_id: String, version: String },
+    #[error("plugin id `{id}` is registered more than once")]
+    DuplicateId { id: String },
+    #[error("plugin marker type `{plugin_type}` is registered more than once")]
+    DuplicateType { plugin_type: &'static str },
+    #[error("plugin `{plugin_id}` lists dependency `{dependency}` more than once")]
+    DuplicateDependency {
+        plugin_id: String,
+        dependency: String,
+    },
+    #[error("plugin `{plugin_id}` requires missing plugin `{dependency}`")]
+    MissingDependency {
+        plugin_id: String,
+        dependency: String,
+    },
+    #[error("plugin dependency cycle involves: {plugins:?}")]
+    DependencyCycle { plugins: Vec<String> },
+}
+
+/// Capability use after the client or plugin scope has ended.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginResourceError {
+    #[error("the client is no longer available")]
+    ClientUnavailable,
+    #[error("the plugin host has not started yet")]
+    NotActive,
+    #[error("the plugin scope is shutting down")]
+    ShuttingDown,
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PluginMessagingError {
+    #[error(transparent)]
+    Resource(#[from] PluginResourceError),
+    #[error(transparent)]
+    Send(#[from] SendError),
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PluginIqError {
+    #[error(transparent)]
+    Resource(#[from] PluginResourceError),
+    #[error(transparent)]
+    Iq(#[from] IqError),
+}
+
+struct PluginResources {
+    active: AtomicBool,
+    closed: AtomicBool,
+    activation: ShutdownNotifier,
+    shutdown: ShutdownNotifier,
+    subscriptions: Mutex<Vec<Subscription>>,
+}
+
+impl PluginResources {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            active: AtomicBool::new(false),
+            closed: AtomicBool::new(false),
+            activation: ShutdownNotifier::new(),
+            shutdown: ShutdownNotifier::new(),
+            subscriptions: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn activate(&self) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        self.active.store(true, Ordering::Release);
+        self.activation.notify();
+    }
+
+    fn ensure_active(&self) -> Result<(), PluginResourceError> {
+        if self.closed.load(Ordering::Acquire) {
+            Err(PluginResourceError::ShuttingDown)
+        } else if !self.active.load(Ordering::Acquire) {
+            Err(PluginResourceError::NotActive)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn retain_subscription(&self, subscription: Subscription) -> Result<(), PluginResourceError> {
+        let mut subscriptions = self
+            .subscriptions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.closed.load(Ordering::Acquire) {
+            drop(subscription);
+            return Err(PluginResourceError::ShuttingDown);
+        }
+        subscriptions.push(subscription);
+        Ok(())
+    }
+
+    fn close(&self) {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.shutdown.notify();
+        self.subscriptions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+    }
+}
+
+/// Install-scoped task capability. Work starts after the complete plugin set is published and
+/// stops during rollback or shutdown.
+#[derive(Clone)]
+pub struct PluginTasks {
+    runtime: Arc<dyn Runtime>,
+    resources: Arc<PluginResources>,
+}
+
+impl PluginTasks {
+    pub fn spawn<F>(&self, future: F) -> Result<(), PluginResourceError>
+    where
+        F: Future<Output = ()> + Spawnable,
+    {
+        if self.resources.closed.load(Ordering::Acquire) {
+            return Err(PluginResourceError::ShuttingDown);
+        }
+        spawn_after_activation(&self.runtime, Arc::clone(&self.resources), future);
+        Ok(())
+    }
+
+    pub fn shutdown_signal(&self) -> ShutdownSignal {
+        self.resources.shutdown.subscribe()
+    }
+}
+
+/// Selective subscription access to the sealed core event bus.
+/// Handlers run inline and must hand slow work to a task capability.
+#[derive(Clone)]
+pub struct PluginCoreEvents {
+    client: Weak<Client>,
+    resources: Arc<PluginResources>,
+}
+
+impl PluginCoreEvents {
+    pub fn subscribe(
+        &self,
+        interest: EventInterest,
+        handler: Arc<dyn EventHandler>,
+    ) -> Result<(), PluginResourceError> {
+        let client = self
+            .client
+            .upgrade()
+            .ok_or(PluginResourceError::ClientUnavailable)?;
+        let subscription = client.subscribe(interest, handler);
+        self.resources.retain_subscription(subscription)
+    }
+}
+
+/// High-level message sending without exposing the raw client or backend.
+#[derive(Clone)]
+pub struct PluginMessaging {
+    client: Weak<Client>,
+    resources: Arc<PluginResources>,
+}
+
+impl PluginMessaging {
+    pub async fn send_message(
+        &self,
+        to: Jid,
+        message: Message,
+    ) -> Result<SendResult, PluginMessagingError> {
+        self.resources.ensure_active()?;
+        let client = self
+            .client
+            .upgrade()
+            .ok_or(PluginResourceError::ClientUnavailable)?;
+        Ok(client.send_message(to, message).await?)
+    }
+
+    pub async fn send_text(
+        &self,
+        to: Jid,
+        text: String,
+    ) -> Result<SendResult, PluginMessagingError> {
+        self.resources.ensure_active()?;
+        let client = self
+            .client
+            .upgrade()
+            .ok_or(PluginResourceError::ClientUnavailable)?;
+        Ok(client.send_text(to, text).await?)
+    }
+}
+
+/// Typed IQ execution without exposing the raw client or stores.
+#[derive(Clone)]
+pub struct PluginIq {
+    client: Weak<Client>,
+    resources: Arc<PluginResources>,
+}
+
+impl PluginIq {
+    pub async fn execute<S>(&self, spec: S) -> Result<S::Response, PluginIqError>
+    where
+        S: IqSpec,
+    {
+        self.resources.ensure_active()?;
+        let client = self
+            .client
+            .upgrade()
+            .ok_or(PluginResourceError::ClientUnavailable)?;
+        Ok(client.execute(spec).await?)
+    }
+}
+
+/// Capabilities and already-installed dependencies visible during installation.
+pub struct PluginContext {
+    plugin_id: String,
+    apis: Arc<ApiRegistry>,
+    dependency_markers: Vec<TypeId>,
+    core_events: Option<PluginCoreEvents>,
+    tasks: Option<PluginTasks>,
+    messaging: Option<PluginMessaging>,
+    iq: Option<PluginIq>,
+}
+
+impl PluginContext {
+    pub fn plugin_id(&self) -> &str {
+        &self.plugin_id
+    }
+
+    pub fn plugin<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
+        if !self.dependency_markers.contains(&TypeId::of::<P>()) {
+            return None;
+        }
+        self.apis.get::<P>()
+    }
+
+    pub fn core_events(&self) -> Option<&PluginCoreEvents> {
+        self.core_events.as_ref()
+    }
+
+    pub fn tasks(&self) -> Option<&PluginTasks> {
+        self.tasks.as_ref()
+    }
+
+    pub fn messaging(&self) -> Option<&PluginMessaging> {
+        self.messaging.as_ref()
+    }
+
+    pub fn iq(&self) -> Option<&PluginIq> {
+        self.iq.as_ref()
+    }
+}
+
+/// One connection generation plus its optional connection-scoped task capability.
+#[derive(Clone)]
+pub struct PluginConnectionScope {
+    scope: ConnectionScope,
+    tasks: Option<PluginConnectionTasks>,
+}
+
+impl PluginConnectionScope {
+    pub fn generation(&self) -> u64 {
+        self.scope.generation()
+    }
+
+    pub fn state(&self) -> ConnectionScopeState {
+        self.scope.state()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.scope.is_cancelled()
+    }
+
+    pub fn cancellation_signal(&self) -> ShutdownSignal {
+        self.scope.cancellation_signal()
+    }
+
+    pub fn tasks(&self) -> Option<&PluginConnectionTasks> {
+        self.tasks.as_ref()
+    }
+}
+
+/// Task capability whose work is aborted synchronously when its generation retires.
+#[derive(Clone)]
+pub struct PluginConnectionTasks {
+    runtime: Arc<dyn Runtime>,
+    scope: ConnectionScope,
+}
+
+impl PluginConnectionTasks {
+    pub fn spawn<F>(&self, future: F) -> Result<(), PluginResourceError>
+    where
+        F: Future<Output = ()> + Spawnable,
+    {
+        if self.scope.is_cancelled() {
+            return Err(PluginResourceError::ShuttingDown);
+        }
+        spawn_until_cancelled(&self.runtime, self.scope.cancellation_signal(), future);
+        Ok(())
+    }
+}
+
+fn spawn_until_cancelled<F>(runtime: &Arc<dyn Runtime>, cancellation: ShutdownSignal, future: F)
+where
+    F: Future<Output = ()> + Spawnable,
+{
+    runtime
+        .spawn(Box::pin(async move {
+            let cancelled = Box::pin(wait_for_shutdown(&cancellation));
+            let work = Box::pin(future);
+            let _ = futures::future::select(cancelled, work).await;
+        }))
+        .detach();
+}
+
+fn spawn_after_activation<F>(runtime: &Arc<dyn Runtime>, resources: Arc<PluginResources>, future: F)
+where
+    F: Future<Output = ()> + Spawnable,
+{
+    let activation = resources.activation.subscribe();
+    let cancellation = resources.shutdown.subscribe();
+    runtime
+        .spawn(Box::pin(async move {
+            let cancelled = Box::pin(wait_for_shutdown(&cancellation));
+            let activated = Box::pin(wait_for_shutdown(&activation));
+            if matches!(
+                futures::future::select(cancelled, activated).await,
+                futures::future::Either::Left(_)
+            ) {
+                return;
+            }
+            if resources.closed.load(Ordering::Acquire) {
+                return;
+            }
+            let cancelled = Box::pin(wait_for_shutdown(&cancellation));
+            let work = Box::pin(future);
+            let _ = futures::future::select(cancelled, work).await;
+        }))
+        .detach();
+}
+
+trait ErasedApiValue: MaybeSendSync {
+    fn as_any(&self) -> &dyn Any;
+}
+
+struct TypedApi<T>(Arc<T>);
+
+impl<T: MaybeSendSync + 'static> ErasedApiValue for TypedApi<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+type ErasedApi = Arc<dyn ErasedApiValue>;
+
+#[derive(Default)]
+struct ApiRegistry {
+    values: Mutex<HashMap<TypeId, ErasedApi>>,
+}
+
+impl ApiRegistry {
+    fn insert(&self, marker: TypeId, api: ErasedApi) {
+        self.values
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(marker, api);
+    }
+
+    fn snapshot(&self) -> HashMap<TypeId, ErasedApi> {
+        self.values
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn get<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
+        let values = self
+            .values
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        downcast_api::<P::Api>(values.get(&TypeId::of::<P>())?)
+    }
+}
+
+fn downcast_api<T: MaybeSendSync + 'static>(api: &ErasedApi) -> Option<Arc<T>> {
+    api.as_any()
+        .downcast_ref::<TypedApi<T>>()
+        .map(|typed| typed.0.clone())
+}
+
+trait ErasedClientPlugin: MaybeSendSync {
+    fn marker_type_id(&self) -> TypeId;
+    fn marker_type_name(&self) -> &'static str;
+    fn manifest(&self) -> PluginManifest;
+    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<ErasedApi>>;
+    fn on_ready(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>>;
+    fn on_closed(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>>;
+    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>>;
+}
+
+struct PluginAdapter<P>(Arc<P>);
+
+impl<P: ClientPlugin> ErasedClientPlugin for PluginAdapter<P> {
+    fn marker_type_id(&self) -> TypeId {
+        TypeId::of::<P>()
+    }
+
+    fn marker_type_name(&self) -> &'static str {
+        std::any::type_name::<P>()
+    }
+
+    fn manifest(&self) -> PluginManifest {
+        self.0.manifest()
+    }
+
+    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<ErasedApi>> {
+        Box::pin(async move {
+            let api = self.0.install(context).await?;
+            Ok(Arc::new(TypedApi(api)) as ErasedApi)
+        })
+    }
+
+    fn on_ready(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        self.0.on_ready(scope)
+    }
+
+    fn on_closed(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        self.0.on_closed(scope)
+    }
+
+    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+        self.0.shutdown()
+    }
+}
+
+pub(crate) struct PluginRegistration {
+    plugin: Arc<dyn ErasedClientPlugin>,
+}
+
+impl PluginRegistration {
+    pub(crate) fn new<P: ClientPlugin>(plugin: P) -> Self {
+        Self::new_arc(Arc::new(plugin))
+    }
+
+    pub(crate) fn new_arc<P: ClientPlugin>(plugin: Arc<P>) -> Self {
+        Self {
+            plugin: Arc::new(PluginAdapter(plugin)),
+        }
+    }
+}
+
+struct PlannedPlugin {
+    plugin: Arc<dyn ErasedClientPlugin>,
+    manifest: PluginManifest,
+    dependency_markers: Vec<TypeId>,
+}
+
+pub(crate) struct PluginPlan {
+    ordered: Vec<PlannedPlugin>,
+}
+
+impl PluginPlan {
+    pub(crate) fn prepare(
+        registrations: Vec<PluginRegistration>,
+    ) -> Result<Option<Self>, PluginPlanError> {
+        if registrations.is_empty() {
+            return Ok(None);
+        }
+
+        let mut plugins = Vec::with_capacity(registrations.len());
+        let mut ids = HashMap::with_capacity(registrations.len());
+        let mut marker_types = HashSet::with_capacity(registrations.len());
+
+        for registration in registrations {
+            let plugin = registration.plugin;
+            let marker = plugin.marker_type_id();
+            if !marker_types.insert(marker) {
+                return Err(PluginPlanError::DuplicateType {
+                    plugin_type: plugin.marker_type_name(),
+                });
+            }
+            let manifest = std::panic::catch_unwind(AssertUnwindSafe(|| plugin.manifest()))
+                .map_err(|_| PluginPlanError::ManifestPanicked {
+                    plugin_type: plugin.marker_type_name(),
+                })?;
+            validate_manifest(&manifest)?;
+            let index = plugins.len();
+            if ids.insert(manifest.id.clone(), index).is_some() {
+                return Err(PluginPlanError::DuplicateId {
+                    id: manifest.id.clone(),
+                });
+            }
+            plugins.push(PlannedPlugin {
+                plugin,
+                manifest,
+                dependency_markers: Vec::new(),
+            });
+        }
+
+        let mut indegree = vec![0usize; plugins.len()];
+        let mut dependents = vec![Vec::new(); plugins.len()];
+        let mut dependency_markers = vec![Vec::new(); plugins.len()];
+        for (plugin_index, planned) in plugins.iter().enumerate() {
+            let mut seen = HashSet::with_capacity(planned.manifest.dependencies.len());
+            for dependency in &planned.manifest.dependencies {
+                if !seen.insert(dependency) {
+                    return Err(PluginPlanError::DuplicateDependency {
+                        plugin_id: planned.manifest.id.clone(),
+                        dependency: dependency.clone(),
+                    });
+                }
+                let Some(&dependency_index) = ids.get(dependency) else {
+                    return Err(PluginPlanError::MissingDependency {
+                        plugin_id: planned.manifest.id.clone(),
+                        dependency: dependency.clone(),
+                    });
+                };
+                indegree[plugin_index] += 1;
+                dependents[dependency_index].push(plugin_index);
+                dependency_markers[plugin_index]
+                    .push(plugins[dependency_index].plugin.marker_type_id());
+            }
+        }
+        for (planned, markers) in plugins.iter_mut().zip(dependency_markers) {
+            planned.dependency_markers = markers;
+        }
+
+        let mut ready = indegree
+            .iter()
+            .enumerate()
+            .filter_map(|(index, count)| (*count == 0).then_some(index))
+            .collect::<BTreeSet<_>>();
+        let mut order = Vec::with_capacity(plugins.len());
+        while let Some(index) = ready.pop_first() {
+            order.push(index);
+            for &dependent in &dependents[index] {
+                indegree[dependent] -= 1;
+                if indegree[dependent] == 0 {
+                    ready.insert(dependent);
+                }
+            }
+        }
+
+        if order.len() != plugins.len() {
+            let cycle = indegree
+                .iter()
+                .enumerate()
+                .filter(|(_, count)| **count > 0)
+                .map(|(index, _)| plugins[index].manifest.id.clone())
+                .collect();
+            return Err(PluginPlanError::DependencyCycle { plugins: cycle });
+        }
+
+        let mut slots = plugins.into_iter().map(Some).collect::<Vec<_>>();
+        let ordered = order
+            .into_iter()
+            .filter_map(|index| slots[index].take())
+            .collect();
+        Ok(Some(Self { ordered }))
+    }
+}
+
+fn validate_manifest(manifest: &PluginManifest) -> Result<(), PluginPlanError> {
+    if !valid_plugin_id(&manifest.id) {
+        return Err(PluginPlanError::InvalidId {
+            id: manifest.id.clone(),
+        });
+    }
+    if manifest.version.is_empty()
+        || manifest.version.len() > 64
+        || !manifest.version.bytes().all(|byte| byte.is_ascii_graphic())
+    {
+        return Err(PluginPlanError::InvalidVersion {
+            plugin_id: manifest.id.clone(),
+            version: manifest.version.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn valid_plugin_id(id: &str) -> bool {
+    if id.is_empty() || id.len() > 128 {
+        return false;
+    }
+    let mut previous_separator = true;
+    for byte in id.bytes() {
+        let separator = matches!(byte, b'.' | b'-' | b'_');
+        if separator {
+            if previous_separator {
+                return false;
+            }
+        } else if !byte.is_ascii_lowercase() && !byte.is_ascii_digit() {
+            return false;
+        }
+        previous_separator = separator;
+    }
+    !previous_separator && id.as_bytes()[0].is_ascii_lowercase()
+}
+
+struct InstalledPlugin {
+    plugin: Arc<dyn ErasedClientPlugin>,
+    manifest: PluginManifest,
+    resources: Arc<PluginResources>,
+}
+
+pub(crate) struct PluginHost {
+    ordered: Vec<PlannedPlugin>,
+    manifests: Vec<PluginManifest>,
+    upstream: Option<Arc<dyn ClientLifecycle>>,
+    installed: OnceLock<Vec<InstalledPlugin>>,
+    apis: OnceLock<HashMap<TypeId, ErasedApi>>,
+    runtime: OnceLock<Arc<dyn Runtime>>,
+}
+
+impl PluginHost {
+    pub(crate) fn new(plan: PluginPlan, upstream: Option<Arc<dyn ClientLifecycle>>) -> Arc<Self> {
+        let manifests = plan
+            .ordered
+            .iter()
+            .map(|plugin| plugin.manifest.clone())
+            .collect();
+        Arc::new(Self {
+            ordered: plan.ordered,
+            manifests,
+            upstream,
+            installed: OnceLock::new(),
+            apis: OnceLock::new(),
+            runtime: OnceLock::new(),
+        })
+    }
+
+    pub(crate) fn plugin<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
+        downcast_api::<P::Api>(self.apis.get()?.get(&TypeId::of::<P>())?)
+    }
+
+    pub(crate) fn manifests(&self) -> &[PluginManifest] {
+        &self.manifests
+    }
+
+    fn context(
+        &self,
+        client: &Weak<Client>,
+        manifest: &PluginManifest,
+        dependency_markers: &[TypeId],
+        resources: Arc<PluginResources>,
+        apis: Arc<ApiRegistry>,
+        runtime: Arc<dyn Runtime>,
+    ) -> PluginContext {
+        let capabilities = manifest.capabilities;
+        PluginContext {
+            plugin_id: manifest.id.clone(),
+            apis,
+            dependency_markers: dependency_markers.to_vec(),
+            core_events: capabilities
+                .contains(PluginCapability::CoreEvents)
+                .then(|| PluginCoreEvents {
+                    client: client.clone(),
+                    resources: Arc::clone(&resources),
+                }),
+            tasks: capabilities
+                .contains(PluginCapability::Tasks)
+                .then(|| PluginTasks {
+                    runtime: Arc::clone(&runtime),
+                    resources: Arc::clone(&resources),
+                }),
+            messaging: capabilities.contains(PluginCapability::Messaging).then(|| {
+                PluginMessaging {
+                    client: client.clone(),
+                    resources: Arc::clone(&resources),
+                }
+            }),
+            iq: capabilities
+                .contains(PluginCapability::Iq)
+                .then(|| PluginIq {
+                    client: client.clone(),
+                    resources: Arc::clone(&resources),
+                }),
+        }
+    }
+
+    fn connection_scope(
+        &self,
+        scope: ConnectionScope,
+        manifest: &PluginManifest,
+    ) -> PluginConnectionScope {
+        let tasks = manifest
+            .capabilities
+            .contains(PluginCapability::Tasks)
+            .then(|| self.runtime.get().cloned())
+            .flatten()
+            .map(|runtime| PluginConnectionTasks {
+                runtime,
+                scope: scope.clone(),
+            });
+        PluginConnectionScope { scope, tasks }
+    }
+
+    async fn install_all(&self, client: Weak<Client>) -> anyhow::Result<()> {
+        let Some(strong_client) = client.upgrade() else {
+            anyhow::bail!("client was dropped during plugin installation");
+        };
+        let runtime = strong_client.runtime.clone();
+        drop(strong_client);
+        self.runtime
+            .set(runtime.clone())
+            .map_err(|_| anyhow::anyhow!("plugin host was installed more than once"))?;
+
+        if let Some(upstream) = &self.upstream {
+            plugin_callback(|| upstream.install(client.clone())).await?;
+        }
+
+        let staging = Arc::new(ApiRegistry::default());
+        let mut installed: Vec<InstalledPlugin> = Vec::with_capacity(self.ordered.len());
+        for planned in &self.ordered {
+            let resources = PluginResources::new();
+            let context = self.context(
+                &client,
+                &planned.manifest,
+                &planned.dependency_markers,
+                Arc::clone(&resources),
+                Arc::clone(&staging),
+                runtime.clone(),
+            );
+            let api = match plugin_install(|| planned.plugin.install(context)).await {
+                Ok(api) => api,
+                Err(error) => {
+                    resources.close();
+                    for plugin in installed.iter().rev() {
+                        plugin.resources.close();
+                    }
+                    if let Err(shutdown_error) = plugin_callback(|| planned.plugin.shutdown()).await
+                    {
+                        log::warn!(
+                            "Plugin `{}` failed-install rollback failed: {shutdown_error:#}",
+                            planned.manifest.id
+                        );
+                    }
+                    self.rollback(&mut installed).await;
+                    anyhow::bail!(
+                        "plugin `{}` installation failed: {error:#}",
+                        planned.manifest.id
+                    );
+                }
+            };
+            staging.insert(planned.plugin.marker_type_id(), api);
+            installed.push(InstalledPlugin {
+                plugin: planned.plugin.clone(),
+                manifest: planned.manifest.clone(),
+                resources,
+            });
+        }
+
+        self.apis
+            .set(staging.snapshot())
+            .map_err(|_| anyhow::anyhow!("plugin APIs were published more than once"))?;
+        self.installed
+            .set(installed)
+            .map_err(|_| anyhow::anyhow!("plugins were installed more than once"))?;
+        Ok(())
+    }
+
+    pub(crate) fn activate(&self) {
+        for plugin in self.installed.get().into_iter().flatten() {
+            plugin.resources.activate();
+        }
+    }
+
+    async fn rollback(&self, installed: &mut Vec<InstalledPlugin>) {
+        for plugin in installed.iter().rev() {
+            plugin.resources.close();
+        }
+        while let Some(plugin) = installed.pop() {
+            if plugin_callback(|| plugin.plugin.shutdown()).await.is_err() {
+                log::warn!("Plugin `{}` rollback failed", plugin.manifest.id);
+            }
+        }
+        if let Some(upstream) = &self.upstream
+            && let Err(error) = plugin_callback(|| upstream.shutdown()).await
+        {
+            log::warn!("Upstream lifecycle rollback failed: {error:#}");
+        }
+    }
+}
+
+impl ClientLifecycle for PluginHost {
+    fn install(&self, client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async move { self.install_all(client).await })
+    }
+
+    fn on_ready(&self, scope: ConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async move {
+            if let Some(upstream) = &self.upstream {
+                plugin_callback(|| upstream.on_ready(scope.clone())).await?;
+            }
+            let mut failures = Vec::new();
+            for plugin in self.installed.get().into_iter().flatten() {
+                let plugin_scope = self.connection_scope(scope.clone(), &plugin.manifest);
+                if let Err(error) = plugin_callback(|| plugin.plugin.on_ready(plugin_scope)).await {
+                    failures.push(format!("{}: {error:#}", plugin.manifest.id));
+                }
+            }
+            finish_callbacks("ready", failures)
+        })
+    }
+
+    fn on_closed(&self, scope: ConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async move {
+            let mut failures = Vec::new();
+            for plugin in self.installed.get().into_iter().flatten().rev() {
+                let plugin_scope = self.connection_scope(scope.clone(), &plugin.manifest);
+                if let Err(error) = plugin_callback(|| plugin.plugin.on_closed(plugin_scope)).await
+                {
+                    failures.push(format!("{}: {error:#}", plugin.manifest.id));
+                }
+            }
+            if let Some(upstream) = &self.upstream
+                && let Err(error) = plugin_callback(|| upstream.on_closed(scope)).await
+            {
+                failures.push(format!("upstream: {error:#}"));
+            }
+            finish_callbacks("closed", failures)
+        })
+    }
+
+    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+        Box::pin(async move {
+            let mut failures = Vec::new();
+            for plugin in self.installed.get().into_iter().flatten().rev() {
+                plugin.resources.close();
+            }
+            for plugin in self.installed.get().into_iter().flatten().rev() {
+                if let Err(error) = plugin_callback(|| plugin.plugin.shutdown()).await {
+                    failures.push(format!("{}: {error:#}", plugin.manifest.id));
+                }
+            }
+            if let Some(upstream) = &self.upstream
+                && let Err(error) = plugin_callback(|| upstream.shutdown()).await
+            {
+                failures.push(format!("upstream: {error:#}"));
+            }
+            finish_callbacks("shutdown", failures)
+        })
+    }
+}
+
+impl Drop for PluginHost {
+    fn drop(&mut self) {
+        for plugin in self.installed.get().into_iter().flatten() {
+            plugin.resources.close();
+        }
+    }
+}
+
+async fn plugin_callback<'a>(
+    make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
+        .map_err(|_| anyhow::anyhow!("callback panicked before returning a future"))?;
+    AssertUnwindSafe(future)
+        .catch_unwind()
+        .await
+        .map_err(|_| anyhow::anyhow!("callback future panicked"))?
+}
+
+async fn plugin_install<'a>(
+    make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<ErasedApi>>,
+) -> anyhow::Result<ErasedApi> {
+    let future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
+        .map_err(|_| anyhow::anyhow!("install panicked before returning a future"))?;
+    AssertUnwindSafe(future)
+        .catch_unwind()
+        .await
+        .map_err(|_| anyhow::anyhow!("install future panicked"))?
+}
+
+fn finish_callbacks(stage: &str, failures: Vec<String>) -> anyhow::Result<()> {
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!("plugin {stage} callbacks failed: {}", failures.join("; "))
+    }
+}
+
+impl Client {
+    /// Return the API exposed by plugin marker `P`, if that plugin was installed.
+    pub fn plugin<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
+        self.plugin_host.as_ref()?.plugin::<P>()
+    }
+
+    /// Manifests in dependency-resolved installation order.
+    pub fn plugin_manifests(&self) -> &[PluginManifest] {
+        self.plugin_host
+            .as_ref()
+            .map(|host| host.manifests())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::client::{ClientBuilder, ClientBuilderError};
+    use crate::runtime_impl::TokioRuntime;
+    use crate::store::persistence_manager::PersistenceManager;
+    use crate::test_utils::MockHttpClient;
+    use crate::transport::mock::MockTransportFactory;
+
+    type Log = Arc<Mutex<Vec<String>>>;
+
+    fn record(log: &Log, value: impl Into<String>) {
+        log.lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(value.into());
+    }
+
+    async fn complete_builder() -> ClientBuilder {
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(crate::test_utils::create_test_backend().await)
+                .await
+                .expect("persistence manager"),
+        );
+        ClientBuilder::new()
+            .with_runtime(TokioRuntime)
+            .with_persistence_manager(persistence_manager)
+            .with_transport_factory(MockTransportFactory::new())
+            .with_http_client(MockHttpClient)
+    }
+
+    struct FoundationPlugin {
+        log: Log,
+    }
+
+    impl ClientPlugin for FoundationPlugin {
+        type Api = String;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("foundation", "0.1.0")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "install:foundation");
+                Ok(Arc::new("foundation-api".to_string()))
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:foundation");
+                Ok(())
+            })
+        }
+    }
+
+    struct DependentPlugin {
+        log: Log,
+    }
+
+    impl ClientPlugin for DependentPlugin {
+        type Api = String;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("dependent", "0.1.0").with_dependency("foundation")
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                let foundation = context
+                    .plugin::<FoundationPlugin>()
+                    .ok_or_else(|| anyhow::anyhow!("foundation API is unavailable"))?;
+                anyhow::ensure!(&*foundation == "foundation-api");
+                record(&log, "install:dependent");
+                Ok(Arc::new("dependent-api".to_string()))
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:dependent");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn installs_in_dependency_order_and_indexes_by_marker_type() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let build = complete_builder()
+            .await
+            .with_plugin(DependentPlugin { log: log.clone() })
+            .with_plugin(FoundationPlugin { log: log.clone() })
+            .build()
+            .await
+            .expect("valid plugin plan");
+        let client = build.client();
+
+        assert_eq!(
+            client
+                .plugin::<FoundationPlugin>()
+                .as_deref()
+                .map(String::as_str),
+            Some("foundation-api")
+        );
+        assert_eq!(
+            client
+                .plugin::<DependentPlugin>()
+                .as_deref()
+                .map(String::as_str),
+            Some("dependent-api")
+        );
+        assert_eq!(
+            client
+                .plugin_manifests()
+                .iter()
+                .map(PluginManifest::id)
+                .collect::<Vec<_>>(),
+            vec!["foundation", "dependent"]
+        );
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["install:foundation", "install:dependent"]
+        );
+
+        client.disconnect().await;
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:foundation",
+                "install:dependent",
+                "shutdown:dependent",
+                "shutdown:foundation"
+            ]
+        );
+    }
+
+    struct DeclarativePlugin<const MARKER: u8> {
+        id: &'static str,
+        dependency: Option<&'static str>,
+    }
+
+    struct TransitiveProbe;
+
+    impl ClientPlugin for TransitiveProbe {
+        type Api = bool;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("transitive-probe", "0.1.0").with_dependency("dependent")
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                anyhow::ensure!(context.plugin::<DependentPlugin>().is_some());
+                Ok(Arc::new(context.plugin::<FoundationPlugin>().is_none()))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn install_context_exposes_only_direct_declared_dependencies() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let build = complete_builder()
+            .await
+            .with_plugin(FoundationPlugin { log: log.clone() })
+            .with_plugin(DependentPlugin { log })
+            .with_plugin(TransitiveProbe)
+            .build()
+            .await
+            .expect("declared dependency plan");
+        let client = build.client();
+        assert_eq!(client.plugin::<TransitiveProbe>().as_deref(), Some(&true));
+        client.disconnect().await;
+    }
+
+    impl<const MARKER: u8> ClientPlugin for DeclarativePlugin<MARKER> {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            let manifest = PluginManifest::new(self.id, "0.1.0");
+            match self.dependency {
+                Some(dependency) => manifest.with_dependency(dependency),
+                None => manifest,
+            }
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new(())) })
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_ids_missing_dependencies_and_cycles() {
+        let duplicate = PluginPlan::prepare(vec![
+            PluginRegistration::new(DeclarativePlugin::<1> {
+                id: "same",
+                dependency: None,
+            }),
+            PluginRegistration::new(DeclarativePlugin::<2> {
+                id: "same",
+                dependency: None,
+            }),
+        ]);
+        assert!(matches!(
+            duplicate,
+            Err(PluginPlanError::DuplicateId { ref id }) if id == "same"
+        ));
+
+        let missing = PluginPlan::prepare(vec![PluginRegistration::new(DeclarativePlugin::<3> {
+            id: "orphan",
+            dependency: Some("absent"),
+        })]);
+        assert!(matches!(
+            missing,
+            Err(PluginPlanError::MissingDependency {
+                ref plugin_id,
+                ref dependency,
+            }) if plugin_id == "orphan" && dependency == "absent"
+        ));
+
+        let cycle = PluginPlan::prepare(vec![
+            PluginRegistration::new(DeclarativePlugin::<4> {
+                id: "cycle-a",
+                dependency: Some("cycle-b"),
+            }),
+            PluginRegistration::new(DeclarativePlugin::<5> {
+                id: "cycle-b",
+                dependency: Some("cycle-a"),
+            }),
+        ]);
+        assert!(matches!(
+            cycle,
+            Err(PluginPlanError::DependencyCycle { ref plugins })
+                if plugins == &["cycle-a", "cycle-b"]
+        ));
+    }
+
+    struct FixedManifestPlugin<const MARKER: u8>(PluginManifest);
+
+    impl<const MARKER: u8> ClientPlugin for FixedManifestPlugin<MARKER> {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            self.0.clone()
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new(())) })
+        }
+    }
+
+    struct PanickingManifestPlugin;
+
+    impl ClientPlugin for PanickingManifestPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            panic!("injected manifest panic")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new(())) })
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_or_ambiguous_manifests_without_installing() {
+        let duplicate_type = PluginPlan::prepare(vec![
+            PluginRegistration::new(FixedManifestPlugin::<1>(PluginManifest::new(
+                "first", "0.1.0",
+            ))),
+            PluginRegistration::new(FixedManifestPlugin::<1>(PluginManifest::new(
+                "second", "0.1.0",
+            ))),
+        ]);
+        assert!(matches!(
+            duplicate_type,
+            Err(PluginPlanError::DuplicateType { .. })
+        ));
+
+        let invalid_id = PluginPlan::prepare(vec![PluginRegistration::new(
+            FixedManifestPlugin::<2>(PluginManifest::new("Invalid", "0.1.0")),
+        )]);
+        assert!(matches!(invalid_id, Err(PluginPlanError::InvalidId { .. })));
+
+        let invalid_version = PluginPlan::prepare(vec![PluginRegistration::new(
+            FixedManifestPlugin::<3>(PluginManifest::new("invalid-version", "0.1 0")),
+        )]);
+        assert!(matches!(
+            invalid_version,
+            Err(PluginPlanError::InvalidVersion { .. })
+        ));
+
+        let duplicate_dependency = PluginPlan::prepare(vec![
+            PluginRegistration::new(FixedManifestPlugin::<4>(PluginManifest::new(
+                "base", "0.1.0",
+            ))),
+            PluginRegistration::new(FixedManifestPlugin::<5>(
+                PluginManifest::new("duplicate-dependency", "0.1.0")
+                    .with_dependency("base")
+                    .with_dependency("base"),
+            )),
+        ]);
+        assert!(matches!(
+            duplicate_dependency,
+            Err(PluginPlanError::DuplicateDependency { .. })
+        ));
+
+        let manifest_panic =
+            PluginPlan::prepare(vec![PluginRegistration::new(PanickingManifestPlugin)]);
+        assert!(matches!(
+            manifest_panic,
+            Err(PluginPlanError::ManifestPanicked { .. })
+        ));
+    }
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
+    struct RollbackPlugin {
+        log: Log,
+        task_dropped: Arc<AtomicBool>,
+    }
+
+    impl ClientPlugin for RollbackPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("rollback", "0.1.0").with_capability(PluginCapability::Tasks)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let log = self.log.clone();
+            let task_dropped = self.task_dropped.clone();
+            Box::pin(async move {
+                record(&log, "install:rollback");
+                let guard = DropFlag(task_dropped);
+                context
+                    .tasks()
+                    .ok_or_else(|| anyhow::anyhow!("tasks capability missing"))?
+                    .spawn(async move {
+                        let _guard = guard;
+                        futures::future::pending::<()>().await;
+                    })?;
+                Ok(Arc::new(()))
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:rollback");
+                Ok(())
+            })
+        }
+    }
+
+    struct FailingPlugin {
+        log: Log,
+    }
+
+    impl ClientPlugin for FailingPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("failing", "0.1.0").with_dependency("rollback")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "install:failing");
+                anyhow::bail!("injected failure")
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:failing");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn install_failure_rolls_back_resources_and_plugins_in_lifo_order() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let task_dropped = Arc::new(AtomicBool::new(false));
+        let result = complete_builder()
+            .await
+            .with_lifecycle(UpstreamLifecycle { log: log.clone() })
+            .with_plugin(FailingPlugin { log: log.clone() })
+            .with_plugin(RollbackPlugin {
+                log: log.clone(),
+                task_dropped: task_dropped.clone(),
+            })
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(ClientBuilderError::PluginInstall(_))));
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:upstream",
+                "install:rollback",
+                "install:failing",
+                "shutdown:failing",
+                "shutdown:rollback",
+                "shutdown:upstream"
+            ]
+        );
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !task_dropped.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("rollback aborted the install-scoped task");
+    }
+
+    struct PanickingPlugin {
+        log: Log,
+    }
+
+    impl ClientPlugin for PanickingPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("panicking", "0.1.0").with_dependency("rollback")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            record(&self.log, "install:panicking");
+            panic!("injected install panic")
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:panicking");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn install_panic_isolated_and_rolled_back() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let result = complete_builder()
+            .await
+            .with_plugin(PanickingPlugin { log: log.clone() })
+            .with_plugin(RollbackPlugin {
+                log: log.clone(),
+                task_dropped: Arc::new(AtomicBool::new(false)),
+            })
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(ClientBuilderError::PluginInstall(_))));
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:rollback",
+                "install:panicking",
+                "shutdown:panicking",
+                "shutdown:rollback"
+            ]
+        );
+    }
+
+    struct ScopedTaskPlugin {
+        install_started: Arc<AtomicBool>,
+        install_dropped: Arc<AtomicBool>,
+        connection_started: Arc<AtomicBool>,
+        connection_dropped: Arc<AtomicBool>,
+    }
+
+    impl ClientPlugin for ScopedTaskPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("scoped-tasks", "0.1.0").with_capability(PluginCapability::Tasks)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let started = self.install_started.clone();
+            let observed = self.install_started.clone();
+            let dropped = self.install_dropped.clone();
+            Box::pin(async move {
+                context
+                    .tasks()
+                    .ok_or_else(|| anyhow::anyhow!("tasks capability missing"))?
+                    .spawn(async move {
+                        started.store(true, Ordering::Release);
+                        let _guard = DropFlag(dropped);
+                        futures::future::pending::<()>().await;
+                    })?;
+                tokio::task::yield_now().await;
+                anyhow::ensure!(!observed.load(Ordering::Acquire));
+                Ok(Arc::new(()))
+            })
+        }
+
+        fn on_ready(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            let started = self.connection_started.clone();
+            let dropped = self.connection_dropped.clone();
+            Box::pin(async move {
+                scope
+                    .tasks()
+                    .ok_or_else(|| anyhow::anyhow!("connection tasks capability missing"))?
+                    .spawn(async move {
+                        started.store(true, Ordering::Release);
+                        let _guard = DropFlag(dropped);
+                        futures::future::pending::<()>().await;
+                    })?;
+                Ok(())
+            })
+        }
+    }
+
+    async fn wait_for_flag(flag: &AtomicBool) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !flag.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("task state transition");
+    }
+
+    #[tokio::test]
+    async fn install_tasks_start_after_publish_and_outlive_connection_tasks() {
+        let install_started = Arc::new(AtomicBool::new(false));
+        let install_dropped = Arc::new(AtomicBool::new(false));
+        let connection_started = Arc::new(AtomicBool::new(false));
+        let connection_dropped = Arc::new(AtomicBool::new(false));
+        let build = complete_builder()
+            .await
+            .with_plugin(ScopedTaskPlugin {
+                install_started: install_started.clone(),
+                install_dropped: install_dropped.clone(),
+                connection_started: connection_started.clone(),
+                connection_dropped: connection_dropped.clone(),
+            })
+            .build()
+            .await
+            .expect("scoped task plugin");
+        let client = build.client();
+        wait_for_flag(&install_started).await;
+
+        let scope = ConnectionScope::new(88);
+        client
+            .plugin_host
+            .as_ref()
+            .expect("plugin host")
+            .on_ready(scope.clone())
+            .await
+            .expect("plugin ready callback");
+        wait_for_flag(&connection_started).await;
+        scope.cancel();
+        wait_for_flag(&connection_dropped).await;
+        assert!(!install_dropped.load(Ordering::Acquire));
+
+        client.disconnect().await;
+        wait_for_flag(&install_dropped).await;
+    }
+
+    #[tokio::test]
+    async fn connection_scoped_tasks_stop_when_the_generation_is_cancelled() {
+        let scope = ConnectionScope::new(77);
+        let task_dropped = Arc::new(AtomicBool::new(false));
+        let tasks = PluginConnectionTasks {
+            runtime: Arc::new(TokioRuntime),
+            scope: scope.clone(),
+        };
+        let guard = DropFlag(task_dropped.clone());
+        tasks
+            .spawn(async move {
+                let _guard = guard;
+                futures::future::pending::<()>().await;
+            })
+            .expect("open connection scope");
+
+        scope.cancel();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !task_dropped.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("connection cancellation stopped the scoped task");
+        assert!(matches!(
+            tasks.spawn(async {}),
+            Err(PluginResourceError::ShuttingDown)
+        ));
+    }
+
+    struct UpstreamLifecycle {
+        log: Log,
+    }
+
+    impl ClientLifecycle for UpstreamLifecycle {
+        fn install(&self, _client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "install:upstream");
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:upstream");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn composes_existing_lifecycle_outside_plugin_lifo_order() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let build = complete_builder()
+            .await
+            .with_lifecycle(UpstreamLifecycle { log: log.clone() })
+            .with_plugin(FoundationPlugin { log: log.clone() })
+            .build()
+            .await
+            .expect("composed lifecycle");
+        let client = build.client();
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["install:upstream", "install:foundation"]
+        );
+
+        client.disconnect().await;
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:upstream",
+                "install:foundation",
+                "shutdown:foundation",
+                "shutdown:upstream"
+            ]
+        );
+    }
+
+    struct NoopEventHandler;
+
+    impl EventHandler for NoopEventHandler {
+        fn handle_event(&self, _event: Arc<wacore::types::events::Event>) {}
+    }
+
+    struct EventSubscriptionPlugin;
+
+    impl ClientPlugin for EventSubscriptionPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("event-subscription", "0.1.0")
+                .with_capability(PluginCapability::CoreEvents)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                context
+                    .core_events()
+                    .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
+                    .subscribe(
+                        EventInterest::of(&[wacore::types::events::EventKind::Connected]),
+                        Arc::new(NoopEventHandler),
+                    )?;
+                Ok(Arc::new(()))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_removes_plugin_event_subscriptions() {
+        let build = complete_builder()
+            .await
+            .with_plugin(EventSubscriptionPlugin)
+            .build()
+            .await
+            .expect("event subscription plugin");
+        let client = build.client();
+        assert!(
+            client
+                .core
+                .event_bus
+                .has_handler_for(wacore::types::events::EventKind::Connected)
+        );
+
+        client.disconnect().await;
+        assert!(
+            !client
+                .core
+                .event_bus
+                .has_handler_for(wacore::types::events::EventKind::Connected)
+        );
+    }
+
+    struct CapabilityProbe;
+
+    impl ClientPlugin for CapabilityProbe {
+        type Api = [bool; 4];
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("capability-probe", "0.1.0")
+                .with_capability(PluginCapability::Messaging)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                Ok(Arc::new([
+                    context.core_events().is_some(),
+                    context.tasks().is_some(),
+                    context.messaging().is_some(),
+                    context.iq().is_some(),
+                ]))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn context_exposes_only_declared_capabilities() {
+        let build = complete_builder()
+            .await
+            .with_plugin(CapabilityProbe)
+            .build()
+            .await
+            .expect("capability plugin");
+        let client = build.client();
+        assert_eq!(
+            client.plugin::<CapabilityProbe>().as_deref(),
+            Some(&[false, false, true, false])
+        );
+        client.disconnect().await;
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1081,9 +1081,19 @@ impl PluginInstallRollback {
         let cleanup_runtime = runtime.clone();
         runtime
             .spawn(Box::pin(async move {
-                shutdown_staged_plugins(cleanup_runtime, current, installed, upstream, staged_apis)
-                    .await;
+                let result = AssertUnwindSafe(shutdown_staged_plugins(
+                    cleanup_runtime,
+                    current,
+                    installed,
+                    upstream,
+                    staged_apis,
+                ))
+                .catch_unwind()
+                .await;
                 completed.notify();
+                if result.is_err() {
+                    log::warn!("Plugin installation rollback panicked");
+                }
             }))
             .detach();
         Some(completion)
@@ -1126,6 +1136,8 @@ pub(crate) struct PluginHost {
     event_router: Option<PluginEventRouter>,
     callback_timeout: Duration,
     terminal: AtomicBool,
+    terminal_notifier: ShutdownNotifier,
+    installing_resources: Mutex<Vec<Weak<PluginResources>>>,
 }
 
 impl PluginHost {
@@ -1164,6 +1176,8 @@ impl PluginHost {
             event_router,
             callback_timeout,
             terminal: AtomicBool::new(false),
+            terminal_notifier: ShutdownNotifier::new(),
+            installing_resources: Mutex::new(Vec::new()),
         })
     }
 
@@ -1286,6 +1300,13 @@ impl PluginHost {
             .set(runtime.clone())
             .map_err(|_| anyhow::anyhow!("plugin host was installed more than once"))?;
 
+        let installing_resources = &self.installing_resources;
+        let _installing_resources = scopeguard::guard((), move |_| {
+            installing_resources
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clear();
+        });
         let mut rollback = PluginInstallRollback::new(runtime.clone(), self.ordered.len());
         self.abort_install_if_terminal(&mut rollback).await?;
         if let Some(upstream) = &self.upstream {
@@ -1313,9 +1334,29 @@ impl PluginHost {
             rollback.current = Some(InstalledPlugin {
                 plugin: planned.plugin.clone(),
                 manifest: planned.manifest.clone(),
-                resources,
+                resources: Arc::clone(&resources),
             });
-            let api = match plugin_install(|| planned.plugin.install(context)).await {
+            if !self.track_installing_resources(&resources) {
+                rollback.rollback().await;
+                anyhow::bail!("plugin host shut down during installation");
+            }
+            let terminal = self.terminal_notifier.subscribe();
+            let cancelled = Box::pin(wait_for_shutdown(&terminal));
+            let install = Box::pin(plugin_install(|| planned.plugin.install(context)));
+            let install_result = match futures::future::select(cancelled, install).await {
+                futures::future::Either::Left((_, install)) => {
+                    if std::panic::catch_unwind(AssertUnwindSafe(|| drop(install))).is_err() {
+                        log::warn!(
+                            "Plugin `{}` install future panicked while being cancelled",
+                            planned.manifest.id
+                        );
+                    }
+                    rollback.rollback().await;
+                    anyhow::bail!("plugin host shut down during installation");
+                }
+                futures::future::Either::Right((result, _)) => result,
+            };
+            let api = match install_result {
                 Ok(api) => api,
                 Err(error) => {
                     rollback.rollback().await;
@@ -1356,6 +1397,33 @@ impl PluginHost {
         }
         rollback.rollback().await;
         anyhow::bail!("plugin host shut down during installation")
+    }
+
+    fn track_installing_resources(&self, resources: &Arc<PluginResources>) -> bool {
+        let mut installing = self
+            .installing_resources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.terminal.load(Ordering::Acquire) {
+            drop(installing);
+            resources.close();
+            return false;
+        }
+        installing.push(Arc::downgrade(resources));
+        true
+    }
+
+    fn close_installing_resources(&self) {
+        let resources = self
+            .installing_resources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>();
+        for resources in resources {
+            resources.close();
+        }
     }
 
     pub(crate) fn activate(&self) -> bool {
@@ -1466,6 +1534,8 @@ impl ClientLifecycle for PluginHost {
 
     fn signal_shutdown(&self) {
         self.terminal.store(true, Ordering::Release);
+        self.close_installing_resources();
+        self.terminal_notifier.notify();
         if let Some(router) = &self.event_router {
             router.close();
         }
@@ -1567,7 +1637,9 @@ async fn shutdown_staged_plugins(
     {
         log::warn!("Upstream lifecycle rollback failed: {error:#}");
     }
-    drop(staged_apis);
+    if std::panic::catch_unwind(AssertUnwindSafe(|| drop(staged_apis))).is_err() {
+        log::warn!("Plugin API panicked while being dropped during rollback");
+    }
 }
 
 async fn wait_for_plugin_tasks(
@@ -1699,6 +1771,57 @@ mod tests {
 
     struct ShutdownDuringPluginInstall;
 
+    struct CaptureInstallClient {
+        client: async_channel::Sender<Weak<Client>>,
+    }
+
+    impl ClientLifecycle for CaptureInstallClient {
+        fn install(&self, client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
+            let sender = self.client.clone();
+            Box::pin(async move {
+                sender.send(client).await?;
+                Ok(())
+            })
+        }
+    }
+
+    struct TerminalBlockingInstallPlugin {
+        started: async_channel::Sender<ShutdownSignal>,
+        install_dropped: Arc<AtomicBool>,
+        shutdown_called: Arc<AtomicBool>,
+    }
+
+    impl ClientPlugin for TerminalBlockingInstallPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("terminal-blocking-install", "0.1.0")
+                .with_capability(PluginCapability::Tasks)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let started = self.started.clone();
+            let install_dropped = self.install_dropped.clone();
+            Box::pin(async move {
+                let _drop = DropFlag(install_dropped);
+                let shutdown = context
+                    .tasks()
+                    .ok_or_else(|| anyhow::anyhow!("tasks capability missing"))?
+                    .shutdown_signal();
+                started.send(shutdown).await?;
+                futures::future::pending().await
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let shutdown_called = self.shutdown_called.clone();
+            Box::pin(async move {
+                shutdown_called.store(true, Ordering::Release);
+                Ok(())
+            })
+        }
+    }
+
     impl ClientLifecycle for ShutdownDuringPluginInstall {
         fn install(&self, client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
             Box::pin(async move {
@@ -1754,6 +1877,43 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_an_inflight_plugin_install_and_closes_its_resources() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let install_dropped = Arc::new(AtomicBool::new(false));
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let builder = complete_builder()
+            .await
+            .with_lifecycle(CaptureInstallClient { client: client_tx })
+            .with_plugin(TerminalBlockingInstallPlugin {
+                started: started_tx,
+                install_dropped: install_dropped.clone(),
+                shutdown_called: shutdown_called.clone(),
+            });
+
+        let build = tokio::spawn(async move { builder.build().await });
+        let client = client_rx
+            .recv()
+            .await
+            .expect("captured install client")
+            .upgrade()
+            .expect("client under construction");
+        let resource_shutdown = started_rx.recv().await.expect("plugin install started");
+
+        client.signal_shutdown_sync();
+        assert!(resource_shutdown.is_fired());
+        let result = tokio::time::timeout(Duration::from_secs(2), build)
+            .await
+            .expect("plugin install ignored terminal shutdown")
+            .expect("build task");
+
+        assert!(matches!(result, Err(ClientBuilderError::PluginInstall(_))));
+        assert!(install_dropped.load(Ordering::Acquire));
+        assert!(shutdown_called.load(Ordering::Acquire));
+        drop(client);
     }
 
     struct DependentPlugin {
@@ -2033,6 +2193,68 @@ mod tests {
         fn drop(&mut self) {
             self.0.store(true, Ordering::Release);
         }
+    }
+
+    struct PanickingDropApi;
+
+    impl Drop for PanickingDropApi {
+        fn drop(&mut self) {
+            panic!("injected API drop panic");
+        }
+    }
+
+    struct PanickingDropPlugin {
+        shutdown_called: Arc<AtomicBool>,
+    }
+
+    impl ClientPlugin for PanickingDropPlugin {
+        type Api = PanickingDropApi;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("panicking-drop", "0.1.0")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new(PanickingDropApi)) })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let shutdown_called = self.shutdown_called.clone();
+            Box::pin(async move {
+                shutdown_called.store(true, Ordering::Release);
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn panicking_staged_api_drop_cannot_strand_rollback_completion() {
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let plugin = Arc::new(PanickingDropPlugin {
+            shutdown_called: shutdown_called.clone(),
+        });
+        let manifest = plugin.manifest();
+        let erased_plugin: Arc<dyn ErasedClientPlugin> = Arc::new(PluginAdapter(plugin));
+        let resources = PluginResources::new();
+        let registry = Arc::new(ApiRegistry::default());
+        let api: ErasedApi = Arc::new(TypedApi(Arc::new(PanickingDropApi)));
+        registry.insert(TypeId::of::<PanickingDropPlugin>(), api);
+
+        let mut rollback = PluginInstallRollback::new(Arc::new(TokioRuntime), 1);
+        rollback.installed.push(InstalledPlugin {
+            plugin: erased_plugin,
+            manifest,
+            resources,
+        });
+        rollback.staged_apis = Some(registry);
+
+        tokio::time::timeout(Duration::from_secs(2), rollback.rollback())
+            .await
+            .expect("panicking API drop stranded rollback completion");
+        assert!(shutdown_called.load(Ordering::Acquire));
     }
 
     struct ContextRetainingApi {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -5,9 +5,9 @@ mod events;
 pub use events::{
     PluginEventEndpointConfig, PluginEventEndpointStats, PluginEventEnvelope, PluginEventOverflow,
     PluginEventPayloadEncoding, PluginEventPublishError, PluginEventPublishReport,
-    PluginEventReceiveError, PluginEventRouteError, PluginEventRouter, PluginEventSelector,
-    PluginEventSubscribeError, PluginEventSubscription, PluginEventTopic,
-    PluginEventTryReceiveError, PluginEvents,
+    PluginEventPublisherStats, PluginEventReceiveError, PluginEventRouteError, PluginEventRouter,
+    PluginEventRouterStats, PluginEventSelector, PluginEventSubscribeError,
+    PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents,
 };
 
 use std::any::{Any, TypeId};
@@ -226,6 +226,60 @@ pub enum PluginIqError {
     Iq(#[from] IqError),
 }
 
+/// Lifecycle state of one installed plugin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginState {
+    Installing,
+    Active,
+    ShuttingDown,
+    /// The bounded shutdown attempt completed; health and task counts show incomplete cleanup.
+    Stopped,
+}
+
+/// Sticky health derived from cumulative host and event-router failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginHealth {
+    Healthy,
+    Degraded,
+}
+
+/// On-demand runtime snapshot for one plugin, identified only by its public manifest ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginStats {
+    pub plugin_id: String,
+    pub state: PluginState,
+    pub health: PluginHealth,
+    /// Lifecycle hooks that returned successfully.
+    pub callbacks_completed: u64,
+    /// Lifecycle hook errors and isolated panics.
+    pub callback_failures: u64,
+    pub callback_timeouts: u64,
+    pub task_drain_timeouts: u64,
+    /// Core-event handler calls that returned without panicking.
+    pub core_events_delivered: u64,
+    /// Panics isolated before they could unwind through the client's event dispatcher.
+    pub core_event_panics: u64,
+    pub resource_teardown_panics: u64,
+    pub install_tasks: u64,
+    pub connection_tasks: u64,
+    pub connection_generations: u64,
+    pub core_event_subscriptions: u64,
+    pub events: Option<PluginEventPublisherStats>,
+}
+
+/// On-demand aggregate for the native plugin host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PluginHostStats {
+    pub terminal: bool,
+    pub health: PluginHealth,
+    pub plugins: Vec<PluginStats>,
+    pub event_router: Option<PluginEventRouterStats>,
+}
+
 struct PluginResources {
     active: AtomicBool,
     closed: AtomicBool,
@@ -234,6 +288,7 @@ struct PluginResources {
     install_tasks: Arc<TaskTracker>,
     connection_tasks: Mutex<ConnectionTaskRegistry>,
     subscriptions: Mutex<Vec<PluginCoreEventSubscription>>,
+    teardown_panics: AtomicU64,
 }
 
 #[derive(Default)]
@@ -301,6 +356,13 @@ impl TaskTracker {
     fn completion_signal(&self) -> ShutdownSignal {
         self.idle.subscribe()
     }
+
+    fn active(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .active
+    }
 }
 
 struct TaskLease {
@@ -339,6 +401,7 @@ impl PluginResources {
             install_tasks: TaskTracker::new(),
             connection_tasks: Mutex::new(ConnectionTaskRegistry::default()),
             subscriptions: Mutex::new(Vec::new()),
+            teardown_panics: AtomicU64::new(0),
         })
     }
 
@@ -494,6 +557,7 @@ impl PluginResources {
         };
         for subscription in subscriptions {
             if std::panic::catch_unwind(AssertUnwindSafe(|| drop(subscription))).is_err() {
+                self.teardown_panics.fetch_add(1, Ordering::Relaxed);
                 log::warn!("Plugin core-event subscription panicked while being dropped");
             }
         }
@@ -502,7 +566,174 @@ impl PluginResources {
 
 fn close_plugin_resources(plugin_id: &str, resources: &PluginResources) {
     if std::panic::catch_unwind(AssertUnwindSafe(|| resources.close())).is_err() {
+        resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
         log::warn!("Plugin `{plugin_id}` resource closure panicked");
+    }
+}
+
+impl PluginResources {
+    fn stats(&self) -> PluginResourceStats {
+        let (connection_generations, connection_trackers) = {
+            let registry = self
+                .connection_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            (
+                registry.trackers.len(),
+                registry.trackers.values().cloned().collect::<Vec<_>>(),
+            )
+        };
+        let connection_tasks = connection_trackers.iter().fold(0usize, |total, tracker| {
+            total.saturating_add(tracker.active())
+        });
+        PluginResourceStats {
+            active: self.active.load(Ordering::Acquire),
+            closed: self.closed.load(Ordering::Acquire),
+            install_tasks: self.install_tasks.active(),
+            connection_tasks,
+            connection_generations,
+            core_event_subscriptions: self
+                .subscriptions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .len(),
+            teardown_panics: self.teardown_panics.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct PluginResourceStats {
+    active: bool,
+    closed: bool,
+    install_tasks: usize,
+    connection_tasks: usize,
+    connection_generations: usize,
+    core_event_subscriptions: usize,
+    teardown_panics: u64,
+}
+
+struct PluginDiagnostics {
+    resources: Mutex<Weak<PluginResources>>,
+    callbacks_completed: AtomicU64,
+    callback_failures: AtomicU64,
+    callback_timeouts: AtomicU64,
+    task_drain_timeouts: AtomicU64,
+    core_events_delivered: AtomicU64,
+    core_event_panics: AtomicU64,
+    shutdown_complete: AtomicBool,
+}
+
+impl PluginDiagnostics {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            resources: Mutex::new(Weak::new()),
+            callbacks_completed: AtomicU64::new(0),
+            callback_failures: AtomicU64::new(0),
+            callback_timeouts: AtomicU64::new(0),
+            task_drain_timeouts: AtomicU64::new(0),
+            core_events_delivered: AtomicU64::new(0),
+            core_event_panics: AtomicU64::new(0),
+            shutdown_complete: AtomicBool::new(false),
+        })
+    }
+
+    fn attach_resources(&self, resources: &Arc<PluginResources>) {
+        *self
+            .resources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Arc::downgrade(resources);
+    }
+
+    fn record_callback(&self, result: &Result<(), PluginCallbackError>) {
+        match result {
+            Ok(()) => {
+                self.callbacks_completed.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(PluginCallbackError::Timeout { .. }) => {
+                self.callback_timeouts.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(PluginCallbackError::TimeoutCancellationPanic { .. }) => {
+                self.callback_timeouts.fetch_add(1, Ordering::Relaxed);
+                self.callback_failures.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(PluginCallbackError::Callback(_)) => {
+                self.callback_failures.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn record_task_drain(&self, result: &Result<(), PluginTaskDrainError>) {
+        if matches!(result, Err(PluginTaskDrainError::Timeout { .. })) {
+            self.task_drain_timeouts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn mark_stopped(&self) {
+        self.shutdown_complete.store(true, Ordering::Release);
+    }
+
+    fn snapshot(
+        &self,
+        plugin_id: &str,
+        terminal: bool,
+        events: Option<PluginEventPublisherStats>,
+    ) -> PluginStats {
+        let resources = self
+            .resources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .upgrade()
+            .map(|resources| resources.stats())
+            .unwrap_or_default();
+        let callbacks_completed = self.callbacks_completed.load(Ordering::Relaxed);
+        let callback_failures = self.callback_failures.load(Ordering::Relaxed);
+        let callback_timeouts = self.callback_timeouts.load(Ordering::Relaxed);
+        let task_drain_timeouts = self.task_drain_timeouts.load(Ordering::Relaxed);
+        let core_events_delivered = self.core_events_delivered.load(Ordering::Relaxed);
+        let core_event_panics = self.core_event_panics.load(Ordering::Relaxed);
+        let state = if self.shutdown_complete.load(Ordering::Acquire) {
+            PluginState::Stopped
+        } else if resources.closed || terminal {
+            PluginState::ShuttingDown
+        } else if resources.active {
+            PluginState::Active
+        } else {
+            PluginState::Installing
+        };
+        let event_degraded = events
+            .as_ref()
+            .is_some_and(|events| events.publish_failures > 0 || events.dropped > 0);
+        let health = if callback_failures > 0
+            || callback_timeouts > 0
+            || task_drain_timeouts > 0
+            || core_event_panics > 0
+            || resources.teardown_panics > 0
+            || event_degraded
+        {
+            PluginHealth::Degraded
+        } else {
+            PluginHealth::Healthy
+        };
+        PluginStats {
+            plugin_id: plugin_id.to_string(),
+            state,
+            health,
+            callbacks_completed,
+            callback_failures,
+            callback_timeouts,
+            task_drain_timeouts,
+            core_events_delivered,
+            core_event_panics,
+            resource_teardown_panics: resources.teardown_panics,
+            install_tasks: u64::try_from(resources.install_tasks).unwrap_or(u64::MAX),
+            connection_tasks: u64::try_from(resources.connection_tasks).unwrap_or(u64::MAX),
+            connection_generations: u64::try_from(resources.connection_generations)
+                .unwrap_or(u64::MAX),
+            core_event_subscriptions: u64::try_from(resources.core_event_subscriptions)
+                .unwrap_or(u64::MAX),
+            events,
+        }
     }
 }
 
@@ -549,6 +780,49 @@ impl PluginTasks {
 pub struct PluginCoreEvents {
     client: Weak<Client>,
     resources: Arc<PluginResources>,
+    plugin_id: Arc<str>,
+    diagnostics: Arc<PluginDiagnostics>,
+}
+
+struct PluginCoreEventHandler {
+    plugin_id: Arc<str>,
+    inner: Option<Arc<dyn EventHandler>>,
+    resources: Weak<PluginResources>,
+    diagnostics: Arc<PluginDiagnostics>,
+}
+
+impl EventHandler for PluginCoreEventHandler {
+    fn handle_event(&self, event: Arc<wacore::types::events::Event>) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        if std::panic::catch_unwind(AssertUnwindSafe(|| inner.handle_event(event))).is_err() {
+            self.diagnostics
+                .core_event_panics
+                .fetch_add(1, Ordering::Relaxed);
+            log::warn!("Plugin `{}` core-event handler panicked", self.plugin_id);
+        } else {
+            self.diagnostics
+                .core_events_delivered
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+impl Drop for PluginCoreEventHandler {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take()
+            && std::panic::catch_unwind(AssertUnwindSafe(|| drop(inner))).is_err()
+        {
+            if let Some(resources) = self.resources.upgrade() {
+                resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
+            }
+            log::warn!(
+                "Plugin `{}` core-event handler panicked while being dropped",
+                self.plugin_id
+            );
+        }
+    }
 }
 
 impl PluginCoreEvents {
@@ -564,6 +838,12 @@ impl PluginCoreEvents {
         let raw_node_lease = interest
             .wants(EventKind::RawNode)
             .then(|| client.acquire_raw_node_forwarding());
+        let handler = Arc::new(PluginCoreEventHandler {
+            plugin_id: Arc::clone(&self.plugin_id),
+            inner: Some(handler),
+            resources: Arc::downgrade(&self.resources),
+            diagnostics: Arc::clone(&self.diagnostics),
+        });
         let subscription = client.subscribe(interest, handler);
         self.resources
             .retain_subscription(subscription, raw_node_lease)
@@ -1057,6 +1337,7 @@ struct InstalledPlugin {
     plugin: Arc<dyn ErasedClientPlugin>,
     manifest: PluginManifest,
     resources: Arc<PluginResources>,
+    diagnostics: Arc<PluginDiagnostics>,
 }
 
 struct PluginInstallRollback {
@@ -1159,9 +1440,18 @@ impl Drop for PluginInstallRollback {
     }
 }
 
+struct PluginContextParts {
+    resources: Arc<PluginResources>,
+    apis: Arc<ApiRegistry>,
+    runtime: Arc<dyn Runtime>,
+    connection_generation: Arc<AtomicU64>,
+    diagnostics: Arc<PluginDiagnostics>,
+}
+
 pub(crate) struct PluginHost {
     ordered: Vec<PlannedPlugin>,
     manifests: Vec<PluginManifest>,
+    diagnostics: Vec<Arc<PluginDiagnostics>>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
     installed: OnceLock<Vec<InstalledPlugin>>,
     apis: OnceLock<HashMap<TypeId, ErasedApi>>,
@@ -1199,9 +1489,13 @@ impl PluginHost {
             .collect::<Vec<_>>();
         let event_router =
             (!event_publishers.is_empty()).then(|| PluginEventRouter::new(event_publishers));
+        let diagnostics = (0..manifests.len())
+            .map(|_| PluginDiagnostics::new())
+            .collect();
         Arc::new(Self {
             ordered: plan.ordered,
             manifests,
+            diagnostics,
             upstream,
             installed: OnceLock::new(),
             apis: OnceLock::new(),
@@ -1220,6 +1514,36 @@ impl PluginHost {
 
     pub(crate) fn manifests(&self) -> &[PluginManifest] {
         &self.manifests
+    }
+
+    pub(crate) fn stats(&self) -> PluginHostStats {
+        let terminal = self.terminal.load(Ordering::Acquire);
+        let plugins = self
+            .manifests
+            .iter()
+            .zip(&self.diagnostics)
+            .map(|(manifest, diagnostics)| {
+                let events = self
+                    .event_router
+                    .as_ref()
+                    .and_then(|router| router.publisher_stats(&manifest.id));
+                diagnostics.snapshot(&manifest.id, terminal, events)
+            })
+            .collect::<Vec<_>>();
+        let health = if plugins
+            .iter()
+            .any(|plugin| plugin.health == PluginHealth::Degraded)
+        {
+            PluginHealth::Degraded
+        } else {
+            PluginHealth::Healthy
+        };
+        PluginHostStats {
+            terminal,
+            health,
+            plugins,
+            event_router: self.event_router.as_ref().map(PluginEventRouter::stats),
+        }
     }
 
     pub(crate) fn lifecycle_callback_timeout(&self) -> Duration {
@@ -1243,11 +1567,15 @@ impl PluginHost {
         &self,
         client: &Weak<Client>,
         planned: &PlannedPlugin,
-        resources: Arc<PluginResources>,
-        apis: Arc<ApiRegistry>,
-        runtime: Arc<dyn Runtime>,
-        connection_generation: Arc<AtomicU64>,
+        parts: PluginContextParts,
     ) -> PluginContext {
+        let PluginContextParts {
+            resources,
+            apis,
+            runtime,
+            connection_generation,
+            diagnostics,
+        } = parts;
         let manifest = &planned.manifest;
         let capabilities = manifest.capabilities;
         PluginContext {
@@ -1258,6 +1586,8 @@ impl PluginHost {
                 .then(|| PluginCoreEvents {
                     client: client.clone(),
                     resources: Arc::clone(&resources),
+                    plugin_id: Arc::from(manifest.id.as_str()),
+                    diagnostics: Arc::clone(&diagnostics),
                 }),
             tasks: capabilities
                 .contains(PluginCapability::Tasks)
@@ -1281,7 +1611,7 @@ impl PluginHost {
                 .event_router
                 .as_ref()
                 .filter(|_| capabilities.contains(PluginCapability::PluginEvents))
-                .map(|router| {
+                .and_then(|router| {
                     events::publisher(
                         &manifest.id,
                         router.clone(),
@@ -1314,11 +1644,14 @@ impl PluginHost {
         PluginConnectionScope { scope, tasks }
     }
 
-    async fn wait_for_tasks(&self, completion_signals: Vec<ShutdownSignal>) -> anyhow::Result<()> {
+    async fn wait_for_tasks(
+        &self,
+        completion_signals: Vec<ShutdownSignal>,
+    ) -> Result<(), PluginTaskDrainError> {
         let runtime = self
             .runtime
             .get()
-            .ok_or_else(|| anyhow::anyhow!("plugin runtime is unavailable"))?;
+            .ok_or(PluginTaskDrainError::RuntimeUnavailable)?;
         wait_for_plugin_tasks(&**runtime, self.callback_timeout, completion_signals).await
     }
 
@@ -1353,21 +1686,26 @@ impl PluginHost {
 
         let staging = Arc::new(ApiRegistry::default());
         rollback.staged_apis = Some(Arc::clone(&staging));
-        for planned in &self.ordered {
+        for (planned, diagnostics) in self.ordered.iter().zip(&self.diagnostics) {
             self.abort_install_if_terminal(&mut rollback).await?;
             let resources = PluginResources::new();
+            diagnostics.attach_resources(&resources);
             let context = self.context(
                 &client,
                 planned,
-                Arc::clone(&resources),
-                Arc::clone(&staging),
-                runtime.clone(),
-                connection_generation.clone(),
+                PluginContextParts {
+                    resources: Arc::clone(&resources),
+                    apis: Arc::clone(&staging),
+                    runtime: runtime.clone(),
+                    connection_generation: connection_generation.clone(),
+                    diagnostics: Arc::clone(diagnostics),
+                },
             );
             rollback.current = Some(InstalledPlugin {
                 plugin: planned.plugin.clone(),
                 manifest: planned.manifest.clone(),
                 resources: Arc::clone(&resources),
+                diagnostics: Arc::clone(diagnostics),
             });
             if !self.track_installing_resources(&resources) {
                 rollback.rollback().await;
@@ -1440,6 +1778,7 @@ impl PluginHost {
         if self.terminal.load(Ordering::Acquire) {
             drop(installing);
             if std::panic::catch_unwind(AssertUnwindSafe(|| resources.close())).is_err() {
+                resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
                 log::warn!("Installing plugin resource closure panicked");
             }
             return false;
@@ -1458,6 +1797,7 @@ impl PluginHost {
             .collect::<Vec<_>>();
         for resources in resources {
             if std::panic::catch_unwind(AssertUnwindSafe(|| resources.close())).is_err() {
+                resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
                 log::warn!("Installing plugin resource closure panicked");
             }
         }
@@ -1488,11 +1828,10 @@ impl PluginHost {
     async fn run_callback<'a>(
         &'a self,
         make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
-    ) -> anyhow::Result<()> {
-        let runtime = self
-            .runtime
-            .get()
-            .ok_or_else(|| anyhow::anyhow!("plugin runtime is unavailable"))?;
+    ) -> Result<(), PluginCallbackError> {
+        let runtime = self.runtime.get().ok_or_else(|| {
+            PluginCallbackError::Callback(anyhow::anyhow!("plugin runtime is unavailable"))
+        })?;
         bounded_plugin_callback(&**runtime, self.callback_timeout, make_future).await
     }
 }
@@ -1530,10 +1869,11 @@ impl ClientLifecycle for PluginHost {
                     });
                 let plugin_scope =
                     self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
-                if let Err(error) = self
+                let result = self
                     .run_callback(|| plugin.plugin.on_ready(plugin_scope))
-                    .await
-                {
+                    .await;
+                plugin.diagnostics.record_callback(&result);
+                if let Err(error) = result {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
@@ -1551,10 +1891,11 @@ impl ClientLifecycle for PluginHost {
                     .contains(PluginCapability::Tasks)
                     .then(|| plugin.resources.close_connection_tasks(scope.generation()));
                 if let Some(task_tracker) = &task_tracker {
-                    match self
+                    let result = self
                         .wait_for_tasks(vec![task_tracker.completion_signal()])
-                        .await
-                    {
+                        .await;
+                    plugin.diagnostics.record_task_drain(&result);
+                    match result {
                         Ok(()) => plugin
                             .resources
                             .forget_connection_tasks(scope.generation(), task_tracker),
@@ -1565,10 +1906,11 @@ impl ClientLifecycle for PluginHost {
                 }
                 let plugin_scope =
                     self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
-                if let Err(error) = self
+                let result = self
                     .run_callback(|| plugin.plugin.on_closed(plugin_scope))
-                    .await
-                {
+                    .await;
+                plugin.diagnostics.record_callback(&result);
+                if let Err(error) = result {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
@@ -1601,13 +1943,17 @@ impl ClientLifecycle for PluginHost {
             let mut failures = Vec::new();
             self.signal_shutdown();
             for plugin in self.installed.get().into_iter().flatten().rev() {
-                if let Err(error) = self
+                let task_result = self
                     .wait_for_tasks(plugin.resources.task_completion_signals())
-                    .await
-                {
+                    .await;
+                plugin.diagnostics.record_task_drain(&task_result);
+                if let Err(error) = task_result {
                     failures.push(format!("{} tasks: {error:#}", plugin.manifest.id));
                 }
-                if let Err(error) = self.run_callback(|| plugin.plugin.shutdown()).await {
+                let callback_result = self.run_callback(|| plugin.plugin.shutdown()).await;
+                plugin.diagnostics.record_callback(&callback_result);
+                plugin.diagnostics.mark_stopped();
+                if let Err(error) = callback_result {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
@@ -1627,6 +1973,26 @@ impl Drop for PluginHost {
     }
 }
 
+#[derive(Debug, Error)]
+enum PluginCallbackError {
+    #[error("callback timed out after {timeout_seconds:.3} seconds")]
+    Timeout { timeout_seconds: f64 },
+    #[error(
+        "callback timed out after {timeout_seconds:.3} seconds and panicked while being cancelled"
+    )]
+    TimeoutCancellationPanic { timeout_seconds: f64 },
+    #[error(transparent)]
+    Callback(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+enum PluginTaskDrainError {
+    #[error("plugin runtime is unavailable")]
+    RuntimeUnavailable,
+    #[error("plugin tasks did not stop within {timeout_seconds:.3} seconds")]
+    Timeout { timeout_seconds: f64 },
+}
+
 async fn shutdown_staged_plugins(
     runtime: Arc<dyn Runtime>,
     current: Option<InstalledPlugin>,
@@ -1635,23 +2001,26 @@ async fn shutdown_staged_plugins(
     staged_apis: Option<Arc<ApiRegistry>>,
 ) {
     if let Some(plugin) = current {
-        if let Err(error) = wait_for_plugin_tasks(
+        let task_result = wait_for_plugin_tasks(
             &*runtime,
             PLUGIN_CALLBACK_TIMEOUT,
             plugin.resources.task_completion_signals(),
         )
-        .await
-        {
+        .await;
+        plugin.diagnostics.record_task_drain(&task_result);
+        if let Err(error) = task_result {
             log::warn!(
                 "Plugin `{}` failed-install task cleanup failed: {error:#}",
                 plugin.manifest.id
             );
         }
-        if let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+        let callback_result = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
             plugin.plugin.shutdown()
         })
-        .await
-        {
+        .await;
+        plugin.diagnostics.record_callback(&callback_result);
+        plugin.diagnostics.mark_stopped();
+        if let Err(error) = callback_result {
             log::warn!(
                 "Plugin `{}` failed-install rollback failed: {error:#}",
                 plugin.manifest.id
@@ -1659,23 +2028,26 @@ async fn shutdown_staged_plugins(
         }
     }
     while let Some(plugin) = installed.pop() {
-        if let Err(error) = wait_for_plugin_tasks(
+        let task_result = wait_for_plugin_tasks(
             &*runtime,
             PLUGIN_CALLBACK_TIMEOUT,
             plugin.resources.task_completion_signals(),
         )
-        .await
-        {
+        .await;
+        plugin.diagnostics.record_task_drain(&task_result);
+        if let Err(error) = task_result {
             log::warn!(
                 "Plugin `{}` rollback task cleanup failed: {error:#}",
                 plugin.manifest.id
             );
         }
-        if let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+        let callback_result = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
             plugin.plugin.shutdown()
         })
-        .await
-        {
+        .await;
+        plugin.diagnostics.record_callback(&callback_result);
+        plugin.diagnostics.mark_stopped();
+        if let Err(error) = callback_result {
             log::warn!("Plugin `{}` rollback failed: {error:#}", plugin.manifest.id);
         }
     }
@@ -1695,7 +2067,7 @@ async fn wait_for_plugin_tasks(
     runtime: &dyn Runtime,
     timeout: Duration,
     completion_signals: Vec<ShutdownSignal>,
-) -> anyhow::Result<()> {
+) -> Result<(), PluginTaskDrainError> {
     let wait_for_all = async move {
         for signal in completion_signals {
             wait_for_shutdown(&signal).await;
@@ -1703,11 +2075,8 @@ async fn wait_for_plugin_tasks(
     };
     runtime_timeout(runtime, timeout, wait_for_all)
         .await
-        .map_err(|_| {
-            anyhow::anyhow!(
-                "plugin tasks did not stop within {:.3} seconds",
-                timeout.as_secs_f64()
-            )
+        .map_err(|_| PluginTaskDrainError::Timeout {
+            timeout_seconds: timeout.as_secs_f64(),
         })
 }
 
@@ -1715,23 +2084,21 @@ async fn bounded_plugin_callback<'a>(
     runtime: &dyn Runtime,
     timeout: Duration,
     make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
-) -> anyhow::Result<()> {
+) -> Result<(), PluginCallbackError> {
     let callback = Box::pin(plugin_callback(make_future));
     match futures::future::select(callback, runtime.sleep(timeout)).await {
-        futures::future::Either::Left((result, _)) => result,
+        futures::future::Either::Left((result, _)) => result.map_err(PluginCallbackError::Callback),
         futures::future::Either::Right(((), callback)) => {
             let cancellation_panicked =
                 std::panic::catch_unwind(AssertUnwindSafe(|| drop(callback))).is_err();
             if cancellation_panicked {
-                anyhow::bail!(
-                    "callback timed out after {:.3} seconds and panicked while being cancelled",
-                    timeout.as_secs_f64()
-                );
+                return Err(PluginCallbackError::TimeoutCancellationPanic {
+                    timeout_seconds: timeout.as_secs_f64(),
+                });
             }
-            anyhow::bail!(
-                "callback timed out after {:.3} seconds",
-                timeout.as_secs_f64()
-            )
+            Err(PluginCallbackError::Timeout {
+                timeout_seconds: timeout.as_secs_f64(),
+            })
         }
     }
 }
@@ -1792,6 +2159,11 @@ impl Client {
             .as_ref()
             .map(|host| host.manifests())
             .unwrap_or_default()
+    }
+
+    /// Snapshot lifecycle, task, subscription, and custom-event health for installed plugins.
+    pub fn plugin_stats(&self) -> Option<PluginHostStats> {
+        self.plugin_host.as_ref().map(|host| host.stats())
     }
 
     /// Subscribe to custom events emitted by installed plugins.
@@ -2322,6 +2694,7 @@ mod tests {
             plugin: erased_plugin,
             manifest,
             resources,
+            diagnostics: PluginDiagnostics::new(),
         });
         rollback.staged_apis = Some(registry);
 
@@ -2903,12 +3276,22 @@ mod tests {
         wait_for_flag(&install_started).await;
         let host = client.plugin_host.as_ref().expect("plugin host").clone();
         let resources = Arc::clone(&host.installed.get().expect("installed plugins")[0].resources);
+        let stats = client.plugin_stats().expect("plugin stats");
+        assert_eq!(stats.health, PluginHealth::Healthy);
+        assert_eq!(stats.plugins[0].state, PluginState::Active);
+        assert_eq!(stats.plugins[0].install_tasks, 1);
+        assert_eq!(stats.plugins[0].connection_tasks, 0);
 
         let scope = ConnectionScope::new(88);
         host.on_ready(scope.clone())
             .await
             .expect("plugin ready callback");
         wait_for_flag(&connection_started).await;
+        let stats = client.plugin_stats().expect("ready plugin stats");
+        assert_eq!(stats.plugins[0].install_tasks, 1);
+        assert_eq!(stats.plugins[0].connection_tasks, 1);
+        assert_eq!(stats.plugins[0].connection_generations, 1);
+        assert_eq!(stats.plugins[0].callbacks_completed, 1);
         scope.cancel();
         wait_for_flag(&connection_dropped).await;
         tokio::time::timeout(Duration::from_secs(1), async {
@@ -2931,10 +3314,18 @@ mod tests {
         assert!(connection_dropped.load(Ordering::Acquire));
         assert!(closed_after_task.load(Ordering::Acquire));
         assert!(!install_dropped.load(Ordering::Acquire));
+        let stats = client.plugin_stats().expect("closed plugin stats");
+        assert_eq!(stats.plugins[0].connection_tasks, 0);
+        assert_eq!(stats.plugins[0].connection_generations, 0);
+        assert_eq!(stats.plugins[0].callbacks_completed, 2);
 
         client.disconnect().await;
         assert!(install_dropped.load(Ordering::Acquire));
         assert!(shutdown_after_task.load(Ordering::Acquire));
+        let stats = client.plugin_stats().expect("stopped plugin stats");
+        assert_eq!(stats.plugins[0].state, PluginState::Stopped);
+        assert_eq!(stats.plugins[0].install_tasks, 0);
+        assert_eq!(stats.plugins[0].callbacks_completed, 3);
     }
 
     #[tokio::test]
@@ -3184,6 +3575,23 @@ mod tests {
             *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
             vec!["ready:stalling-ready", "ready:following-ready"]
         );
+        let stats = host.stats();
+        assert_eq!(stats.health, PluginHealth::Degraded);
+        let stalling = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "stalling-ready")
+            .expect("stalling plugin stats");
+        assert_eq!(stalling.health, PluginHealth::Degraded);
+        assert_eq!(stalling.callback_timeouts, 1);
+        assert_eq!(stalling.callback_failures, 0);
+        let following = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "following-ready")
+            .expect("following plugin stats");
+        assert_eq!(following.health, PluginHealth::Healthy);
+        assert_eq!(following.callbacks_completed, 1);
         client.disconnect().await;
     }
 
@@ -3216,6 +3624,22 @@ mod tests {
             *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
             vec!["ready:drop-panicking-ready", "ready:following-drop-panic"]
         );
+        let stats = host.stats();
+        let panicking = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "drop-panicking-ready")
+            .expect("drop-panicking plugin stats");
+        assert_eq!(panicking.health, PluginHealth::Degraded);
+        assert_eq!(panicking.callback_timeouts, 1);
+        assert_eq!(panicking.callback_failures, 1);
+        let following = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "following-drop-panic")
+            .expect("following plugin stats");
+        assert_eq!(following.health, PluginHealth::Healthy);
+        assert_eq!(following.callbacks_completed, 1);
         client.disconnect().await;
     }
 
@@ -3264,6 +3688,38 @@ mod tests {
     impl Drop for PanickingDropEventHandler {
         fn drop(&mut self) {
             panic!("injected event handler drop panic");
+        }
+    }
+
+    struct PanickingCoreEventHandler;
+
+    impl EventHandler for PanickingCoreEventHandler {
+        fn handle_event(&self, _event: Arc<wacore::types::events::Event>) {
+            panic!("injected core-event handler panic");
+        }
+    }
+
+    struct PanickingCoreEventPlugin;
+
+    impl ClientPlugin for PanickingCoreEventPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("panicking-core-event", "0.1.0")
+                .with_capability(PluginCapability::CoreEvents)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                context
+                    .core_events()
+                    .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
+                    .subscribe(
+                        EventInterest::of(&[EventKind::Connected]),
+                        Arc::new(PanickingCoreEventHandler),
+                    )?;
+                Ok(Arc::new(()))
+            })
         }
     }
 
@@ -3413,6 +3869,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn panicking_core_event_handler_is_isolated_and_degrades_only_its_plugin() {
+        let client = complete_builder()
+            .await
+            .with_plugin(PanickingCoreEventPlugin)
+            .with_plugin(ShutdownSignalPlugin)
+            .build()
+            .await
+            .expect("panicking core-event client")
+            .into_client();
+
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            client
+                .core
+                .event_bus
+                .dispatch(wacore::types::events::Event::Connected(
+                    wacore::types::events::Connected::builder().build(),
+                ));
+        }));
+
+        assert!(result.is_ok());
+        let stats = client.plugin_stats().expect("plugin stats");
+        assert_eq!(stats.health, PluginHealth::Degraded);
+        let panicking = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "panicking-core-event")
+            .expect("panicking plugin stats");
+        assert_eq!(panicking.health, PluginHealth::Degraded);
+        assert_eq!(panicking.core_event_panics, 1);
+        assert_eq!(panicking.core_events_delivered, 0);
+        let unaffected = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "shutdown-signal")
+            .expect("unaffected plugin stats");
+        assert_eq!(unaffected.health, PluginHealth::Healthy);
+        client.disconnect().await;
+    }
+
+    #[test]
+    fn delayed_plugin_handler_drop_is_isolated_and_counted() {
+        let resources = PluginResources::new();
+        let diagnostics = PluginDiagnostics::new();
+        diagnostics.attach_resources(&resources);
+        let handler = Arc::new(PluginCoreEventHandler {
+            plugin_id: Arc::from("delayed-drop"),
+            inner: Some(Arc::new(PanickingDropEventHandler)),
+            resources: Arc::downgrade(&resources),
+            diagnostics,
+        });
+        let delayed_snapshot = handler.clone();
+        drop(handler);
+
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| drop(delayed_snapshot)));
+
+        assert!(result.is_ok());
+        assert_eq!(resources.stats().teardown_panics, 1);
+    }
+
+    #[tokio::test]
     async fn panicking_handler_drop_does_not_strand_later_plugins_or_upstream() {
         let upstream_signalled = Arc::new(AtomicBool::new(false));
         let client = complete_builder()
@@ -3433,6 +3949,14 @@ mod tests {
         assert!(result.is_ok());
         assert!(plugin_shutdown.is_fired());
         assert!(upstream_signalled.load(Ordering::Acquire));
+        let stats = client.plugin_stats().expect("plugin stats");
+        let panicking = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "panicking-subscription")
+            .expect("panicking plugin stats");
+        assert_eq!(panicking.health, PluginHealth::Degraded);
+        assert_eq!(panicking.resource_teardown_panics, 1);
         client.disconnect().await;
     }
 
@@ -3617,6 +4141,7 @@ mod tests {
             .expect("bounded event endpoint");
 
         assert!(publisher.has_subscribers(&tick));
+        const TICK_PAYLOAD: &[u8] = br#"{"messages":1}"#;
         let generation = client.connection_generation.load(Ordering::Acquire);
         assert_eq!(
             publisher
@@ -3624,7 +4149,7 @@ mod tests {
                     &tick,
                     2,
                     PluginEventPayloadEncoding::Json,
-                    r#"{"messages":1}"#,
+                    Bytes::from_static(TICK_PAYLOAD),
                 )
                 .expect("publish tick"),
             PluginEventPublishReport {
@@ -3634,12 +4159,31 @@ mod tests {
                 closed: 0,
             }
         );
+        let stats = client.plugin_stats().expect("plugin host stats");
+        assert_eq!(stats.health, PluginHealth::Healthy);
+        let publisher_stats = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "event-publisher")
+            .expect("publisher stats");
+        assert_eq!(publisher_stats.state, PluginState::Active);
+        assert_eq!(publisher_stats.events.expect("event stats").published, 1);
+        let memory = client.memory_report().await;
+        assert_eq!(memory.plugins, 2);
+        assert_eq!(memory.plugin_event_endpoints, 1);
+        assert_eq!(memory.plugin_event_endpoint_capacity, 1);
+        assert_eq!(memory.plugin_event_queue.entries, 1);
+        assert_eq!(
+            memory.plugin_event_queue.bytes,
+            u64::try_from(TICK_PAYLOAD.len()).expect("payload length")
+        );
+        assert!(memory.total_estimated_bytes() >= memory.plugin_event_queue.bytes);
         let event = subscription.recv().await.expect("routed tick");
         assert_eq!(&*event.plugin_id, "event-publisher");
         assert_eq!(event.topic, tick);
         assert_eq!(event.schema_version, 2);
         assert_eq!(event.payload_encoding, PluginEventPayloadEncoding::Json);
-        assert_eq!(event.payload, Bytes::from_static(br#"{"messages":1}"#));
+        assert_eq!(event.payload, Bytes::from_static(TICK_PAYLOAD));
         assert_eq!(event.connection_generation, generation);
         assert_eq!(event.sequence, 1);
 
@@ -3669,5 +4213,30 @@ mod tests {
             ),
             Err(PluginEventSubscribeError::Closed)
         ));
+        let stats = client.plugin_stats().expect("terminal plugin stats");
+        assert_eq!(stats.health, PluginHealth::Degraded);
+        let publisher_stats = stats
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == "event-publisher")
+            .expect("terminal publisher stats");
+        assert_eq!(publisher_stats.state, PluginState::Stopped);
+        assert_eq!(publisher_stats.health, PluginHealth::Degraded);
+        assert_eq!(
+            publisher_stats.events,
+            Some(PluginEventPublisherStats {
+                published: 2,
+                publish_failures: 1,
+                matched: 2,
+                enqueued: 2,
+                delivered: 2,
+                dropped: 0,
+                closed: 0,
+            })
+        );
+        let router_stats = stats.event_router.expect("terminal router stats");
+        assert_eq!(router_stats.active_endpoints, 0);
+        assert_eq!(router_stats.queued_events, 0);
+        assert_eq!(router_stats.delivered, 2);
     }
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -389,31 +389,54 @@ impl PluginResources {
         }
     }
 
-    fn connection_task_tracker(&self, generation: u64) -> Arc<TaskTracker> {
+    fn connection_task_tracker(&self, generation: u64) -> (Arc<TaskTracker>, bool) {
         let mut registry = self
             .connection_tasks
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if registry.closed {
-            return TaskTracker::closed();
+            return (TaskTracker::closed(), false);
         }
-        Arc::clone(
-            registry
-                .trackers
-                .entry(generation)
-                .or_insert_with(TaskTracker::new),
-        )
+        match registry.trackers.entry(generation) {
+            std::collections::hash_map::Entry::Occupied(entry) => (Arc::clone(entry.get()), false),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let tracker = TaskTracker::new();
+                entry.insert(Arc::clone(&tracker));
+                (tracker, true)
+            }
+        }
+    }
+
+    fn retire_connection_tasks_on_cancel(
+        self: &Arc<Self>,
+        runtime: &Arc<dyn Runtime>,
+        generation: u64,
+        tracker: Arc<TaskTracker>,
+        cancellation: ShutdownSignal,
+    ) {
+        // Lifecycle queue pressure may discard on_closed, so retirement follows cancellation.
+        let resources = Arc::downgrade(self);
+        runtime
+            .spawn(Box::pin(async move {
+                wait_for_shutdown(&cancellation).await;
+                tracker.close();
+                wait_for_shutdown(&tracker.completion_signal()).await;
+                if let Some(resources) = resources.upgrade() {
+                    resources.forget_connection_tasks(generation, &tracker);
+                }
+            }))
+            .detach();
     }
 
     fn close_connection_tasks(&self, generation: u64) -> Arc<TaskTracker> {
-        let tracker = Arc::clone(
-            self.connection_tasks
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .trackers
-                .entry(generation)
-                .or_insert_with(TaskTracker::closed),
-        );
+        let tracker = self
+            .connection_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .trackers
+            .get(&generation)
+            .cloned()
+            .unwrap_or_else(TaskTracker::closed);
         tracker.close();
         tracker
     }
@@ -1492,7 +1515,19 @@ impl ClientLifecycle for PluginHost {
                     .manifest
                     .capabilities
                     .contains(PluginCapability::Tasks)
-                    .then(|| plugin.resources.connection_task_tracker(scope.generation()));
+                    .then(|| {
+                        let (tracker, created) =
+                            plugin.resources.connection_task_tracker(scope.generation());
+                        if created && let Some(runtime) = self.runtime.get() {
+                            plugin.resources.retire_connection_tasks_on_cancel(
+                                runtime,
+                                scope.generation(),
+                                Arc::clone(&tracker),
+                                scope.cancellation_signal(),
+                            );
+                        }
+                        tracker
+                    });
                 let plugin_scope =
                     self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
                 if let Err(error) = self
@@ -1681,35 +1716,60 @@ async fn bounded_plugin_callback<'a>(
     timeout: Duration,
     make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
 ) -> anyhow::Result<()> {
-    match runtime_timeout(runtime, timeout, plugin_callback(make_future)).await {
-        Ok(result) => result,
-        Err(_) => anyhow::bail!(
-            "callback timed out after {:.3} seconds",
-            timeout.as_secs_f64()
-        ),
+    let callback = Box::pin(plugin_callback(make_future));
+    match futures::future::select(callback, runtime.sleep(timeout)).await {
+        futures::future::Either::Left((result, _)) => result,
+        futures::future::Either::Right(((), callback)) => {
+            let cancellation_panicked =
+                std::panic::catch_unwind(AssertUnwindSafe(|| drop(callback))).is_err();
+            if cancellation_panicked {
+                anyhow::bail!(
+                    "callback timed out after {:.3} seconds and panicked while being cancelled",
+                    timeout.as_secs_f64()
+                );
+            }
+            anyhow::bail!(
+                "callback timed out after {:.3} seconds",
+                timeout.as_secs_f64()
+            )
+        }
     }
 }
 
 async fn plugin_callback<'a>(
     make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
 ) -> anyhow::Result<()> {
-    let future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
+    let mut future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
         .map_err(|_| anyhow::anyhow!("callback panicked before returning a future"))?;
-    AssertUnwindSafe(future)
-        .catch_unwind()
-        .await
-        .map_err(|_| anyhow::anyhow!("callback future panicked"))?
+    let result = AssertUnwindSafe(std::future::poll_fn(|context| {
+        future.as_mut().poll(context)
+    }))
+    .catch_unwind()
+    .await
+    .map_err(|_| anyhow::anyhow!("callback future panicked"));
+    let drop_result = std::panic::catch_unwind(AssertUnwindSafe(|| drop(future)));
+    if drop_result.is_err() {
+        anyhow::bail!("callback future panicked while being dropped");
+    }
+    result?
 }
 
 async fn plugin_install<'a>(
     make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<ErasedApi>>,
 ) -> anyhow::Result<ErasedApi> {
-    let future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
+    let mut future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
         .map_err(|_| anyhow::anyhow!("install panicked before returning a future"))?;
-    AssertUnwindSafe(future)
-        .catch_unwind()
-        .await
-        .map_err(|_| anyhow::anyhow!("install future panicked"))?
+    let result = AssertUnwindSafe(std::future::poll_fn(|context| {
+        future.as_mut().poll(context)
+    }))
+    .catch_unwind()
+    .await
+    .map_err(|_| anyhow::anyhow!("install future panicked"));
+    let drop_result = std::panic::catch_unwind(AssertUnwindSafe(|| drop(future)));
+    if drop_result.is_err() {
+        anyhow::bail!("install future panicked while being dropped");
+    }
+    result?
 }
 
 fn finish_callbacks(stage: &str, failures: Vec<String>) -> anyhow::Result<()> {
@@ -2841,24 +2901,33 @@ mod tests {
             .expect("scoped task plugin");
         let client = build.into_client();
         wait_for_flag(&install_started).await;
+        let host = client.plugin_host.as_ref().expect("plugin host").clone();
+        let resources = Arc::clone(&host.installed.get().expect("installed plugins")[0].resources);
 
         let scope = ConnectionScope::new(88);
-        client
-            .plugin_host
-            .as_ref()
-            .expect("plugin host")
-            .on_ready(scope.clone())
+        host.on_ready(scope.clone())
             .await
             .expect("plugin ready callback");
         wait_for_flag(&connection_started).await;
         scope.cancel();
-        client
-            .plugin_host
-            .as_ref()
-            .expect("plugin host")
-            .on_closed(scope)
-            .await
-            .expect("plugin closed callback");
+        wait_for_flag(&connection_dropped).await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let retained = resources
+                    .connection_tasks
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .trackers
+                    .contains_key(&scope.generation());
+                if !retained {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled generation tracker retired without on_closed");
+        host.on_closed(scope).await.expect("plugin closed callback");
         assert!(connection_dropped.load(Ordering::Acquire));
         assert!(closed_after_task.load(Ordering::Acquire));
         assert!(!install_dropped.load(Ordering::Acquire));
@@ -3007,6 +3076,49 @@ mod tests {
         }
     }
 
+    struct DropPanickingReadyPlugin {
+        log: Log,
+    }
+
+    struct DropPanickingPendingFuture;
+
+    impl Future for DropPanickingPendingFuture {
+        type Output = anyhow::Result<()>;
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            _context: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            std::task::Poll::Pending
+        }
+    }
+
+    impl Drop for DropPanickingPendingFuture {
+        fn drop(&mut self) {
+            panic!("injected callback cancellation panic");
+        }
+    }
+
+    impl ClientPlugin for DropPanickingReadyPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("drop-panicking-ready", "0.1.0")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new(())) })
+        }
+
+        fn on_ready(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            record(&self.log, "ready:drop-panicking-ready");
+            Box::pin(DropPanickingPendingFuture)
+        }
+    }
+
     #[tokio::test]
     async fn upstream_ready_failure_does_not_suppress_plugins() {
         let log = Arc::new(Mutex::new(Vec::new()));
@@ -3071,6 +3183,38 @@ mod tests {
         assert_eq!(
             *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
             vec!["ready:stalling-ready", "ready:following-ready"]
+        );
+        client.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn panicking_timeout_cancellation_does_not_suppress_following_plugins() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let plan = PluginPlan::prepare(vec![
+            PluginRegistration::new(DropPanickingReadyPlugin { log: log.clone() }),
+            PluginRegistration::new(ReadyPlugin::<4> {
+                id: "following-drop-panic",
+                dependency: Some("drop-panicking-ready"),
+                log: log.clone(),
+                stalls: false,
+            }),
+        ])
+        .expect("valid callback plan")
+        .expect("non-empty callback plan");
+        let host = PluginHost::new_with_callback_timeout(plan, None, Duration::from_millis(10));
+        let client = complete_builder()
+            .await
+            .with_lifecycle_arc(host.clone())
+            .build()
+            .await
+            .expect("callback cancellation client")
+            .into_client();
+
+        let result = host.on_ready(ConnectionScope::new(93)).await;
+        assert!(result.is_err());
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["ready:drop-panicking-ready", "ready:following-drop-panic"]
         );
         client.disconnect().await;
     }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -252,19 +252,28 @@ impl PluginResources {
         subscription: Subscription,
         raw_node_lease: Option<RawNodeLease>,
     ) -> Result<(), PluginResourceError> {
-        let mut subscriptions = self
-            .subscriptions
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self.closed.load(Ordering::Acquire) {
-            drop(subscription);
-            return Err(PluginResourceError::ShuttingDown);
-        }
-        subscriptions.push(PluginCoreEventSubscription {
+        let registration = PluginCoreEventSubscription {
             _subscription: subscription,
             _raw_node_lease: raw_node_lease,
-        });
-        Ok(())
+        };
+        let rejected = {
+            let mut subscriptions = self
+                .subscriptions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if self.closed.load(Ordering::Acquire) {
+                Some(registration)
+            } else {
+                subscriptions.push(registration);
+                None
+            }
+        };
+        if let Some(rejected) = rejected {
+            drop(rejected);
+            Err(PluginResourceError::ShuttingDown)
+        } else {
+            Ok(())
+        }
     }
 
     fn close(&self) {
@@ -394,8 +403,7 @@ impl PluginIq {
 /// Capabilities and already-installed dependencies visible during installation.
 pub struct PluginContext {
     plugin_id: String,
-    apis: Arc<ApiRegistry>,
-    dependency_markers: Vec<TypeId>,
+    dependencies: HashMap<TypeId, WeakErasedApi>,
     core_events: Option<PluginCoreEvents>,
     tasks: Option<PluginTasks>,
     messaging: Option<PluginMessaging>,
@@ -407,11 +415,11 @@ impl PluginContext {
         &self.plugin_id
     }
 
+    /// Return a declared dependency without making retained contexts own it.
+    /// Clone the returned API during installation if it must outlive this call.
     pub fn plugin<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
-        if !self.dependency_markers.contains(&TypeId::of::<P>()) {
-            return None;
-        }
-        self.apis.get::<P>()
+        let api = self.dependencies.get(&TypeId::of::<P>())?.upgrade()?;
+        downcast_api::<P::Api>(&api)
     }
 
     pub fn core_events(&self) -> Option<&PluginCoreEvents> {
@@ -532,6 +540,7 @@ impl<T: MaybeSendSync + 'static> ErasedApiValue for TypedApi<T> {
 }
 
 type ErasedApi = Arc<dyn ErasedApiValue>;
+type WeakErasedApi = Weak<dyn ErasedApiValue>;
 
 #[derive(Default)]
 struct ApiRegistry {
@@ -553,12 +562,15 @@ impl ApiRegistry {
             .clone()
     }
 
-    fn get<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
+    fn dependency_view(&self, markers: &[TypeId]) -> HashMap<TypeId, WeakErasedApi> {
         let values = self
             .values
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        downcast_api::<P::Api>(values.get(&TypeId::of::<P>())?)
+        markers
+            .iter()
+            .filter_map(|marker| values.get(marker).map(|api| (*marker, Arc::downgrade(api))))
+            .collect()
     }
 }
 
@@ -931,8 +943,7 @@ impl PluginHost {
         let capabilities = manifest.capabilities;
         PluginContext {
             plugin_id: manifest.id.clone(),
-            apis,
-            dependency_markers: dependency_markers.to_vec(),
+            dependencies: apis.dependency_view(dependency_markers),
             core_events: capabilities
                 .contains(PluginCapability::CoreEvents)
                 .then(|| PluginCoreEvents {
@@ -1578,6 +1589,58 @@ mod tests {
         fn drop(&mut self) {
             self.0.store(true, Ordering::Release);
         }
+    }
+
+    struct ContextRetainingApi {
+        _context: PluginContext,
+        _drop_flag: DropFlag,
+    }
+
+    struct ContextRetainingPlugin {
+        api_dropped: Arc<AtomicBool>,
+    }
+
+    impl ClientPlugin for ContextRetainingPlugin {
+        type Api = ContextRetainingApi;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("context-retaining", "0.1.0")
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let api_dropped = self.api_dropped.clone();
+            Box::pin(async move {
+                Ok(Arc::new(ContextRetainingApi {
+                    _context: context,
+                    _drop_flag: DropFlag(api_dropped),
+                }))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn retained_context_does_not_cycle_with_the_api_registry() {
+        let api_dropped = Arc::new(AtomicBool::new(false));
+        let build = complete_builder()
+            .await
+            .with_plugin(ContextRetainingPlugin {
+                api_dropped: api_dropped.clone(),
+            })
+            .build()
+            .await
+            .expect("context-retaining plugin");
+        let (client, sync_tasks) = build.into_parts();
+        drop(sync_tasks);
+        let api = client
+            .plugin::<ContextRetainingPlugin>()
+            .expect("retained-context API");
+        let weak_api = Arc::downgrade(&api);
+        drop(api);
+
+        client.disconnect().await;
+        drop(client);
+        wait_for_flag(&api_dropped).await;
+        assert!(weak_api.upgrade().is_none());
     }
 
     struct RollbackPlugin {
@@ -2305,7 +2368,7 @@ mod tests {
     struct ReentrantSubscriptionPlugin;
 
     impl ClientPlugin for ReentrantSubscriptionPlugin {
-        type Api = ();
+        type Api = PluginCoreEvents;
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("reentrant-subscription", "0.1.0")
@@ -2324,7 +2387,7 @@ mod tests {
                         events: events.clone(),
                     }),
                 )?;
-                Ok(Arc::new(()))
+                Ok(Arc::new(events))
             })
         }
     }
@@ -2376,6 +2439,40 @@ mod tests {
             .recv_timeout(Duration::from_secs(2))
             .expect("reentrant handler teardown must not deadlock");
         shutdown.join().expect("shutdown thread");
+        client.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn rejected_subscription_drops_reentrant_handler_outside_the_subscription_lock() {
+        let client = complete_builder()
+            .await
+            .with_plugin(ReentrantSubscriptionPlugin)
+            .build()
+            .await
+            .expect("reentrant subscription plugin")
+            .into_client();
+        let events = client
+            .plugin::<ReentrantSubscriptionPlugin>()
+            .expect("plugin event API");
+        client.signal_shutdown_sync();
+
+        let (completed_tx, completed_rx) = std::sync::mpsc::sync_channel(1);
+        let subscribe_events = events.clone();
+        let subscribe = std::thread::spawn(move || {
+            let result = subscribe_events.subscribe(
+                EventInterest::of(&[EventKind::Connected]),
+                Arc::new(ReentrantSubscriptionHandler {
+                    events: (*subscribe_events).clone(),
+                }),
+            );
+            let _ = completed_tx.send(result);
+        });
+
+        let result = completed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("rejected reentrant subscription must not deadlock");
+        assert!(matches!(result, Err(PluginResourceError::ShuttingDown)));
+        subscribe.join().expect("subscription thread");
         client.disconnect().await;
     }
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -204,6 +204,8 @@ pub enum PluginResourceError {
     NotActive,
     #[error("the plugin scope is shutting down")]
     ShuttingDown,
+    #[error("the plugin task capacity is exhausted")]
+    TaskCapacityExceeded,
 }
 
 #[derive(Debug, Error)]
@@ -229,7 +231,97 @@ struct PluginResources {
     closed: AtomicBool,
     activation: ShutdownNotifier,
     shutdown: ShutdownNotifier,
+    install_tasks: Arc<TaskTracker>,
+    connection_tasks: Mutex<ConnectionTaskRegistry>,
     subscriptions: Mutex<Vec<PluginCoreEventSubscription>>,
+}
+
+#[derive(Default)]
+struct ConnectionTaskRegistry {
+    closed: bool,
+    trackers: HashMap<u64, Arc<TaskTracker>>,
+}
+
+#[derive(Default)]
+struct TaskTrackerState {
+    active: usize,
+    closed: bool,
+}
+
+struct TaskTracker {
+    state: Mutex<TaskTrackerState>,
+    idle: ShutdownNotifier,
+}
+
+impl TaskTracker {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(TaskTrackerState::default()),
+            idle: ShutdownNotifier::new(),
+        })
+    }
+
+    fn closed() -> Arc<Self> {
+        let tracker = Self::new();
+        tracker.close();
+        tracker
+    }
+
+    fn register(self: &Arc<Self>) -> Result<TaskLease, PluginResourceError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.closed {
+            return Err(PluginResourceError::ShuttingDown);
+        }
+        state.active = state
+            .active
+            .checked_add(1)
+            .ok_or(PluginResourceError::TaskCapacityExceeded)?;
+        Ok(TaskLease {
+            tracker: Arc::clone(self),
+        })
+    }
+
+    fn close(&self) {
+        let idle = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.closed = true;
+            state.active == 0
+        };
+        if idle {
+            self.idle.notify();
+        }
+    }
+
+    fn completion_signal(&self) -> ShutdownSignal {
+        self.idle.subscribe()
+    }
+}
+
+struct TaskLease {
+    tracker: Arc<TaskTracker>,
+}
+
+impl Drop for TaskLease {
+    fn drop(&mut self) {
+        let idle = {
+            let mut state = self
+                .tracker
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.active = state.active.saturating_sub(1);
+            state.closed && state.active == 0
+        };
+        if idle {
+            self.tracker.idle.notify();
+        }
+    }
 }
 
 struct PluginCoreEventSubscription {
@@ -244,6 +336,8 @@ impl PluginResources {
             closed: AtomicBool::new(false),
             activation: ShutdownNotifier::new(),
             shutdown: ShutdownNotifier::new(),
+            install_tasks: TaskTracker::new(),
+            connection_tasks: Mutex::new(ConnectionTaskRegistry::default()),
             subscriptions: Mutex::new(Vec::new()),
         })
     }
@@ -295,9 +389,77 @@ impl PluginResources {
         }
     }
 
+    fn connection_task_tracker(&self, generation: u64) -> Arc<TaskTracker> {
+        let mut registry = self
+            .connection_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry.closed {
+            return TaskTracker::closed();
+        }
+        Arc::clone(
+            registry
+                .trackers
+                .entry(generation)
+                .or_insert_with(TaskTracker::new),
+        )
+    }
+
+    fn close_connection_tasks(&self, generation: u64) -> Arc<TaskTracker> {
+        let tracker = Arc::clone(
+            self.connection_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .trackers
+                .entry(generation)
+                .or_insert_with(TaskTracker::closed),
+        );
+        tracker.close();
+        tracker
+    }
+
+    fn forget_connection_tasks(&self, generation: u64, tracker: &Arc<TaskTracker>) {
+        let mut registry = self
+            .connection_tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if registry
+            .trackers
+            .get(&generation)
+            .is_some_and(|current| Arc::ptr_eq(current, tracker))
+        {
+            registry.trackers.remove(&generation);
+        }
+    }
+
+    fn task_completion_signals(&self) -> Vec<ShutdownSignal> {
+        let mut signals = vec![self.install_tasks.completion_signal()];
+        signals.extend(
+            self.connection_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .trackers
+                .values()
+                .map(|tracker| tracker.completion_signal()),
+        );
+        signals
+    }
+
     fn close(&self) {
         if self.closed.swap(true, Ordering::AcqRel) {
             return;
+        }
+        self.install_tasks.close();
+        let connection_trackers = {
+            let mut registry = self
+                .connection_tasks
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            registry.closed = true;
+            registry.trackers.values().cloned().collect::<Vec<_>>()
+        };
+        for tracker in connection_trackers {
+            tracker.close();
         }
         self.shutdown.notify();
         let subscriptions = {
@@ -327,7 +489,8 @@ impl PluginTasks {
         if self.resources.closed.load(Ordering::Acquire) {
             return Err(PluginResourceError::ShuttingDown);
         }
-        spawn_after_activation(&self.runtime, Arc::clone(&self.resources), future);
+        let lease = self.resources.install_tasks.register()?;
+        spawn_after_activation(&self.runtime, Arc::clone(&self.resources), lease, future);
         Ok(())
     }
 
@@ -508,6 +671,7 @@ impl PluginConnectionScope {
 pub struct PluginConnectionTasks {
     runtime: Arc<dyn Runtime>,
     scope: ConnectionScope,
+    tracker: Arc<TaskTracker>,
 }
 
 impl PluginConnectionTasks {
@@ -518,7 +682,13 @@ impl PluginConnectionTasks {
         if self.scope.is_cancelled() {
             return Err(PluginResourceError::ShuttingDown);
         }
-        spawn_until_cancelled(&self.runtime, self.scope.cancellation_signal(), future);
+        let lease = self.tracker.register()?;
+        spawn_until_cancelled(
+            &self.runtime,
+            self.scope.cancellation_signal(),
+            lease,
+            future,
+        );
         Ok(())
     }
 
@@ -539,12 +709,17 @@ impl PluginConnectionTasks {
     }
 }
 
-fn spawn_until_cancelled<F>(runtime: &Arc<dyn Runtime>, cancellation: ShutdownSignal, future: F)
-where
+fn spawn_until_cancelled<F>(
+    runtime: &Arc<dyn Runtime>,
+    cancellation: ShutdownSignal,
+    lease: TaskLease,
+    future: F,
+) where
     F: Future<Output = ()> + Spawnable,
 {
     runtime
         .spawn(Box::pin(async move {
+            let _lease = lease;
             let cancelled = Box::pin(wait_for_shutdown(&cancellation));
             let work = Box::pin(future);
             let _ = futures::future::select(cancelled, work).await;
@@ -552,14 +727,19 @@ where
         .detach();
 }
 
-fn spawn_after_activation<F>(runtime: &Arc<dyn Runtime>, resources: Arc<PluginResources>, future: F)
-where
+fn spawn_after_activation<F>(
+    runtime: &Arc<dyn Runtime>,
+    resources: Arc<PluginResources>,
+    lease: TaskLease,
+    future: F,
+) where
     F: Future<Output = ()> + Spawnable,
 {
     let activation = resources.activation.subscribe();
     let cancellation = resources.shutdown.subscribe();
     runtime
         .spawn(Box::pin(async move {
+            let _lease = lease;
             let cancelled = Box::pin(wait_for_shutdown(&cancellation));
             let activated = Box::pin(wait_for_shutdown(&activation));
             if matches!(
@@ -990,8 +1170,18 @@ impl PluginHost {
 
     pub(crate) fn lifecycle_callback_timeout(&self) -> Duration {
         let callback_count = self.ordered.len() + usize::from(self.upstream.is_some());
+        let task_barrier_count = self
+            .ordered
+            .iter()
+            .filter(|plugin| {
+                plugin
+                    .manifest
+                    .capabilities
+                    .contains(PluginCapability::Tasks)
+            })
+            .count();
         self.callback_timeout
-            .saturating_mul(callback_count as u32)
+            .saturating_mul((callback_count + task_barrier_count) as u32)
             .saturating_add(Duration::from_secs(1))
     }
 
@@ -1052,17 +1242,30 @@ impl PluginHost {
         &self,
         scope: ConnectionScope,
         manifest: &PluginManifest,
+        task_tracker: Option<Arc<TaskTracker>>,
     ) -> PluginConnectionScope {
-        let tasks = manifest
-            .capabilities
-            .contains(PluginCapability::Tasks)
-            .then(|| self.runtime.get().cloned())
-            .flatten()
-            .map(|runtime| PluginConnectionTasks {
-                runtime,
-                scope: scope.clone(),
-            });
+        let tasks = if manifest.capabilities.contains(PluginCapability::Tasks) {
+            self.runtime
+                .get()
+                .cloned()
+                .zip(task_tracker)
+                .map(|(runtime, tracker)| PluginConnectionTasks {
+                    runtime,
+                    scope: scope.clone(),
+                    tracker,
+                })
+        } else {
+            None
+        };
         PluginConnectionScope { scope, tasks }
+    }
+
+    async fn wait_for_tasks(&self, completion_signals: Vec<ShutdownSignal>) -> anyhow::Result<()> {
+        let runtime = self
+            .runtime
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("plugin runtime is unavailable"))?;
+        wait_for_plugin_tasks(&**runtime, self.callback_timeout, completion_signals).await
     }
 
     async fn install_all(&self, client: Weak<Client>) -> anyhow::Result<()> {
@@ -1163,7 +1366,13 @@ impl ClientLifecycle for PluginHost {
                 failures.push(format!("upstream: {error:#}"));
             }
             for plugin in self.installed.get().into_iter().flatten() {
-                let plugin_scope = self.connection_scope(scope.clone(), &plugin.manifest);
+                let task_tracker = plugin
+                    .manifest
+                    .capabilities
+                    .contains(PluginCapability::Tasks)
+                    .then(|| plugin.resources.connection_task_tracker(scope.generation()));
+                let plugin_scope =
+                    self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
                 if let Err(error) = self
                     .run_callback(|| plugin.plugin.on_ready(plugin_scope))
                     .await
@@ -1179,7 +1388,26 @@ impl ClientLifecycle for PluginHost {
         Box::pin(async move {
             let mut failures = Vec::new();
             for plugin in self.installed.get().into_iter().flatten().rev() {
-                let plugin_scope = self.connection_scope(scope.clone(), &plugin.manifest);
+                let task_tracker = plugin
+                    .manifest
+                    .capabilities
+                    .contains(PluginCapability::Tasks)
+                    .then(|| plugin.resources.close_connection_tasks(scope.generation()));
+                if let Some(task_tracker) = &task_tracker {
+                    match self
+                        .wait_for_tasks(vec![task_tracker.completion_signal()])
+                        .await
+                    {
+                        Ok(()) => plugin
+                            .resources
+                            .forget_connection_tasks(scope.generation(), task_tracker),
+                        Err(error) => {
+                            failures.push(format!("{} tasks: {error:#}", plugin.manifest.id));
+                        }
+                    }
+                }
+                let plugin_scope =
+                    self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
                 if let Err(error) = self
                     .run_callback(|| plugin.plugin.on_closed(plugin_scope))
                     .await
@@ -1215,6 +1443,12 @@ impl ClientLifecycle for PluginHost {
             let mut failures = Vec::new();
             self.signal_shutdown();
             for plugin in self.installed.get().into_iter().flatten().rev() {
+                if let Err(error) = self
+                    .wait_for_tasks(plugin.resources.task_completion_signals())
+                    .await
+                {
+                    failures.push(format!("{} tasks: {error:#}", plugin.manifest.id));
+                }
                 if let Err(error) = self.run_callback(|| plugin.plugin.shutdown()).await {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
@@ -1241,18 +1475,43 @@ async fn shutdown_staged_plugins(
     mut installed: Vec<InstalledPlugin>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
 ) {
-    if let Some(plugin) = current
-        && let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+    if let Some(plugin) = current {
+        if let Err(error) = wait_for_plugin_tasks(
+            &*runtime,
+            PLUGIN_CALLBACK_TIMEOUT,
+            plugin.resources.task_completion_signals(),
+        )
+        .await
+        {
+            log::warn!(
+                "Plugin `{}` failed-install task cleanup failed: {error:#}",
+                plugin.manifest.id
+            );
+        }
+        if let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
             plugin.plugin.shutdown()
         })
         .await
-    {
-        log::warn!(
-            "Plugin `{}` failed-install rollback failed: {error:#}",
-            plugin.manifest.id
-        );
+        {
+            log::warn!(
+                "Plugin `{}` failed-install rollback failed: {error:#}",
+                plugin.manifest.id
+            );
+        }
     }
     while let Some(plugin) = installed.pop() {
+        if let Err(error) = wait_for_plugin_tasks(
+            &*runtime,
+            PLUGIN_CALLBACK_TIMEOUT,
+            plugin.resources.task_completion_signals(),
+        )
+        .await
+        {
+            log::warn!(
+                "Plugin `{}` rollback task cleanup failed: {error:#}",
+                plugin.manifest.id
+            );
+        }
         if let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
             plugin.plugin.shutdown()
         })
@@ -1268,6 +1527,26 @@ async fn shutdown_staged_plugins(
     {
         log::warn!("Upstream lifecycle rollback failed: {error:#}");
     }
+}
+
+async fn wait_for_plugin_tasks(
+    runtime: &dyn Runtime,
+    timeout: Duration,
+    completion_signals: Vec<ShutdownSignal>,
+) -> anyhow::Result<()> {
+    let wait_for_all = async move {
+        for signal in completion_signals {
+            wait_for_shutdown(&signal).await;
+        }
+    };
+    runtime_timeout(runtime, timeout, wait_for_all)
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "plugin tasks did not stop within {:.3} seconds",
+                timeout.as_secs_f64()
+            )
+        })
 }
 
 async fn bounded_plugin_callback<'a>(
@@ -1766,7 +2045,12 @@ mod tests {
 
         fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
             let log = self.log.clone();
+            let task_dropped = self.task_dropped.clone();
             Box::pin(async move {
+                anyhow::ensure!(
+                    task_dropped.load(Ordering::Acquire),
+                    "rollback task still running during shutdown"
+                );
                 record(&log, "shutdown:rollback");
                 Ok(())
             })
@@ -2123,6 +2407,8 @@ mod tests {
         install_dropped: Arc<AtomicBool>,
         connection_started: Arc<AtomicBool>,
         connection_dropped: Arc<AtomicBool>,
+        closed_after_task: Arc<AtomicBool>,
+        shutdown_after_task: Arc<AtomicBool>,
     }
 
     impl ClientPlugin for ScopedTaskPlugin {
@@ -2166,6 +2452,24 @@ mod tests {
                 Ok(())
             })
         }
+
+        fn on_closed(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            let task_dropped = self.connection_dropped.load(Ordering::Acquire);
+            let closed_after_task = self.closed_after_task.clone();
+            Box::pin(async move {
+                closed_after_task.store(task_dropped, Ordering::Release);
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let task_dropped = self.install_dropped.load(Ordering::Acquire);
+            let shutdown_after_task = self.shutdown_after_task.clone();
+            Box::pin(async move {
+                shutdown_after_task.store(task_dropped, Ordering::Release);
+                Ok(())
+            })
+        }
     }
 
     async fn wait_for_flag(flag: &AtomicBool) {
@@ -2184,6 +2488,8 @@ mod tests {
         let install_dropped = Arc::new(AtomicBool::new(false));
         let connection_started = Arc::new(AtomicBool::new(false));
         let connection_dropped = Arc::new(AtomicBool::new(false));
+        let closed_after_task = Arc::new(AtomicBool::new(false));
+        let shutdown_after_task = Arc::new(AtomicBool::new(false));
         let build = complete_builder()
             .await
             .with_plugin(ScopedTaskPlugin {
@@ -2191,6 +2497,8 @@ mod tests {
                 install_dropped: install_dropped.clone(),
                 connection_started: connection_started.clone(),
                 connection_dropped: connection_dropped.clone(),
+                closed_after_task: closed_after_task.clone(),
+                shutdown_after_task: shutdown_after_task.clone(),
             })
             .build()
             .await
@@ -2208,11 +2516,20 @@ mod tests {
             .expect("plugin ready callback");
         wait_for_flag(&connection_started).await;
         scope.cancel();
-        wait_for_flag(&connection_dropped).await;
+        client
+            .plugin_host
+            .as_ref()
+            .expect("plugin host")
+            .on_closed(scope)
+            .await
+            .expect("plugin closed callback");
+        assert!(connection_dropped.load(Ordering::Acquire));
+        assert!(closed_after_task.load(Ordering::Acquire));
         assert!(!install_dropped.load(Ordering::Acquire));
 
         client.disconnect().await;
-        wait_for_flag(&install_dropped).await;
+        assert!(install_dropped.load(Ordering::Acquire));
+        assert!(shutdown_after_task.load(Ordering::Acquire));
     }
 
     #[tokio::test]
@@ -2222,6 +2539,7 @@ mod tests {
         let tasks = PluginConnectionTasks {
             runtime: Arc::new(TokioRuntime),
             scope: scope.clone(),
+            tracker: TaskTracker::new(),
         };
         let guard = DropFlag(task_dropped.clone());
         tasks
@@ -2269,6 +2587,7 @@ mod tests {
         let connection_tasks = PluginConnectionTasks {
             runtime: Arc::new(TokioRuntime),
             scope: scope.clone(),
+            tracker: TaskTracker::new(),
         };
         let connection_sleeper =
             tokio::spawn(async move { connection_tasks.sleep(Duration::from_secs(60)).await });

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -36,11 +36,11 @@ use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState, RawN
 use crate::request::IqError;
 use crate::send::{SendError, SendResult};
 
-const CAP_CORE_EVENTS: u8 = 1 << 0;
-const CAP_TASKS: u8 = 1 << 1;
-const CAP_MESSAGING: u8 = 1 << 2;
-const CAP_IQ: u8 = 1 << 3;
-const CAP_PLUGIN_EVENTS: u8 = 1 << 4;
+const CAP_CORE_EVENTS: u64 = 1 << 0;
+const CAP_TASKS: u64 = 1 << 1;
+const CAP_MESSAGING: u64 = 1 << 2;
+const CAP_IQ: u64 = 1 << 3;
+const CAP_PLUGIN_EVENTS: u64 = 1 << 4;
 const DEFAULT_PLUGIN_INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_PLUGIN_TASK_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -67,7 +67,7 @@ impl PluginCapability {
         }
     }
 
-    const fn bit(self) -> u8 {
+    const fn bit(self) -> u64 {
         match self {
             Self::CoreEvents => CAP_CORE_EVENTS,
             Self::Tasks => CAP_TASKS,
@@ -80,7 +80,7 @@ impl PluginCapability {
 
 /// Compact set of capabilities requested by one plugin.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct PluginCapabilities(u8);
+pub struct PluginCapabilities(u64);
 
 impl PluginCapabilities {
     pub const NONE: Self = Self(0);
@@ -2844,6 +2844,27 @@ mod tests {
             .with_persistence_manager(persistence_manager)
             .with_transport_factory(MockTransportFactory::new())
             .with_http_client(MockHttpClient)
+    }
+
+    #[test]
+    fn capability_bits_are_distinct_and_composable() {
+        let capabilities = [
+            PluginCapability::CoreEvents,
+            PluginCapability::Tasks,
+            PluginCapability::Messaging,
+            PluginCapability::Iq,
+            PluginCapability::PluginEvents,
+        ];
+        let combined = capabilities
+            .into_iter()
+            .fold(PluginCapabilities::NONE, PluginCapabilities::with);
+
+        assert!(
+            capabilities
+                .into_iter()
+                .all(|capability| combined.contains(capability))
+        );
+        assert_eq!(combined.0.count_ones(), capabilities.len() as u32);
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -995,7 +995,7 @@ impl PluginConnectionScope {
     }
 }
 
-/// Task capability whose work is aborted synchronously when its generation retires.
+/// Task capability whose cancellation is signalled synchronously when its generation retires.
 #[derive(Clone)]
 pub struct PluginConnectionTasks {
     runtime: Arc<dyn Runtime>,

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -272,10 +272,14 @@ impl PluginResources {
             return;
         }
         self.shutdown.notify();
-        self.subscriptions
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clear();
+        let subscriptions = {
+            let mut subscriptions = self
+                .subscriptions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *subscriptions)
+        };
+        drop(subscriptions);
     }
 }
 
@@ -2281,6 +2285,50 @@ mod tests {
         }
     }
 
+    struct ReentrantSubscriptionHandler {
+        events: PluginCoreEvents,
+    }
+
+    impl EventHandler for ReentrantSubscriptionHandler {
+        fn handle_event(&self, _event: Arc<wacore::types::events::Event>) {}
+    }
+
+    impl Drop for ReentrantSubscriptionHandler {
+        fn drop(&mut self) {
+            let _ = self.events.subscribe(
+                EventInterest::of(&[EventKind::Connected]),
+                Arc::new(NoopEventHandler),
+            );
+        }
+    }
+
+    struct ReentrantSubscriptionPlugin;
+
+    impl ClientPlugin for ReentrantSubscriptionPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("reentrant-subscription", "0.1.0")
+                .with_capability(PluginCapability::CoreEvents)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                let events = context
+                    .core_events()
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?;
+                events.subscribe(
+                    EventInterest::of(&[EventKind::Connected]),
+                    Arc::new(ReentrantSubscriptionHandler {
+                        events: events.clone(),
+                    }),
+                )?;
+                Ok(Arc::new(()))
+            })
+        }
+    }
+
     #[tokio::test]
     async fn shutdown_removes_plugin_event_subscriptions_and_raw_lease() {
         let build = complete_builder()
@@ -2306,6 +2354,29 @@ mod tests {
                 .has_handler_for(wacore::types::events::EventKind::Connected)
         );
         assert!(!client.raw_node_forwarding_enabled());
+    }
+
+    #[tokio::test]
+    async fn resource_close_drops_reentrant_handlers_outside_the_subscription_lock() {
+        let client = complete_builder()
+            .await
+            .with_plugin(ReentrantSubscriptionPlugin)
+            .build()
+            .await
+            .expect("reentrant subscription plugin")
+            .into_client();
+        let shutdown_client = client.clone();
+        let (completed_tx, completed_rx) = std::sync::mpsc::sync_channel(1);
+        let shutdown = std::thread::spawn(move || {
+            shutdown_client.signal_shutdown_sync();
+            let _ = completed_tx.send(());
+        });
+
+        completed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reentrant handler teardown must not deadlock");
+        shutdown.join().expect("shutdown thread");
+        client.disconnect().await;
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6,20 +6,22 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::Duration;
 
 use futures::FutureExt;
 use thiserror::Error;
 use wacore::iq::spec::IqSpec;
 use wacore::runtime::{
-    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, Spawnable, wait_for_shutdown,
+    BoxFuture, Runtime, ShutdownNotifier, ShutdownSignal, Spawnable, timeout as runtime_timeout,
+    wait_for_shutdown,
 };
 use wacore::sync_marker::MaybeSendSync;
-use wacore::types::events::{EventHandler, EventInterest, Subscription};
+use wacore::types::events::{EventHandler, EventInterest, EventKind, Subscription};
 use wacore_binary::Jid;
 use waproto::whatsapp::Message;
 
 use crate::Client;
-use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
+use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState, RawNodeLease};
 use crate::request::IqError;
 use crate::send::{SendError, SendResult};
 
@@ -27,6 +29,7 @@ const CAP_CORE_EVENTS: u8 = 1 << 0;
 const CAP_TASKS: u8 = 1 << 1;
 const CAP_MESSAGING: u8 = 1 << 2;
 const CAP_IQ: u8 = 1 << 3;
+const PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A capability a plugin asks the host to expose during installation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -207,7 +210,12 @@ struct PluginResources {
     closed: AtomicBool,
     activation: ShutdownNotifier,
     shutdown: ShutdownNotifier,
-    subscriptions: Mutex<Vec<Subscription>>,
+    subscriptions: Mutex<Vec<PluginCoreEventSubscription>>,
+}
+
+struct PluginCoreEventSubscription {
+    _subscription: Subscription,
+    _raw_node_lease: Option<RawNodeLease>,
 }
 
 impl PluginResources {
@@ -239,7 +247,11 @@ impl PluginResources {
         }
     }
 
-    fn retain_subscription(&self, subscription: Subscription) -> Result<(), PluginResourceError> {
+    fn retain_subscription(
+        &self,
+        subscription: Subscription,
+        raw_node_lease: Option<RawNodeLease>,
+    ) -> Result<(), PluginResourceError> {
         let mut subscriptions = self
             .subscriptions
             .lock()
@@ -248,7 +260,10 @@ impl PluginResources {
             drop(subscription);
             return Err(PluginResourceError::ShuttingDown);
         }
-        subscriptions.push(subscription);
+        subscriptions.push(PluginCoreEventSubscription {
+            _subscription: subscription,
+            _raw_node_lease: raw_node_lease,
+        });
         Ok(())
     }
 
@@ -307,8 +322,12 @@ impl PluginCoreEvents {
             .client
             .upgrade()
             .ok_or(PluginResourceError::ClientUnavailable)?;
+        let raw_node_lease = interest
+            .wants(EventKind::RawNode)
+            .then(|| client.acquire_raw_node_forwarding());
         let subscription = client.subscribe(interest, handler);
-        self.resources.retain_subscription(subscription)
+        self.resources
+            .retain_subscription(subscription, raw_node_lease)
     }
 }
 
@@ -760,6 +779,79 @@ struct InstalledPlugin {
     resources: Arc<PluginResources>,
 }
 
+struct PluginInstallRollback {
+    runtime: Arc<dyn Runtime>,
+    installed: Vec<InstalledPlugin>,
+    current: Option<InstalledPlugin>,
+    upstream: Option<Arc<dyn ClientLifecycle>>,
+    armed: bool,
+}
+
+impl PluginInstallRollback {
+    fn new(runtime: Arc<dyn Runtime>, capacity: usize) -> Self {
+        Self {
+            runtime,
+            installed: Vec::with_capacity(capacity),
+            current: None,
+            upstream: None,
+            armed: true,
+        }
+    }
+
+    fn close_resources(&self) {
+        if let Some(current) = &self.current {
+            current.resources.close();
+        }
+        for plugin in self.installed.iter().rev() {
+            plugin.resources.close();
+        }
+    }
+
+    async fn rollback(&mut self) {
+        self.close_resources();
+        let current = self.current.take();
+        let installed = std::mem::take(&mut self.installed);
+        let upstream = self.upstream.take();
+        self.armed = false;
+        shutdown_staged_plugins(self.runtime.clone(), current, installed, upstream).await;
+    }
+
+    fn take_installed(&mut self) -> Vec<InstalledPlugin> {
+        std::mem::take(&mut self.installed)
+    }
+
+    fn restore_installed(&mut self, installed: Vec<InstalledPlugin>) {
+        self.installed = installed;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+        self.upstream = None;
+    }
+}
+
+impl Drop for PluginInstallRollback {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.close_resources();
+        let current = self.current.take();
+        let installed = std::mem::take(&mut self.installed);
+        let upstream = self.upstream.take();
+        if current.is_none() && installed.is_empty() && upstream.is_none() {
+            return;
+        }
+        let runtime = self.runtime.clone();
+        let cleanup_runtime = runtime.clone();
+        runtime
+            .spawn(Box::pin(async move {
+                shutdown_staged_plugins(cleanup_runtime, current, installed, upstream).await;
+            }))
+            .detach();
+    }
+}
+
 pub(crate) struct PluginHost {
     ordered: Vec<PlannedPlugin>,
     manifests: Vec<PluginManifest>,
@@ -767,10 +859,19 @@ pub(crate) struct PluginHost {
     installed: OnceLock<Vec<InstalledPlugin>>,
     apis: OnceLock<HashMap<TypeId, ErasedApi>>,
     runtime: OnceLock<Arc<dyn Runtime>>,
+    callback_timeout: Duration,
 }
 
 impl PluginHost {
     pub(crate) fn new(plan: PluginPlan, upstream: Option<Arc<dyn ClientLifecycle>>) -> Arc<Self> {
+        Self::new_with_callback_timeout(plan, upstream, PLUGIN_CALLBACK_TIMEOUT)
+    }
+
+    fn new_with_callback_timeout(
+        plan: PluginPlan,
+        upstream: Option<Arc<dyn ClientLifecycle>>,
+        callback_timeout: Duration,
+    ) -> Arc<Self> {
         let manifests = plan
             .ordered
             .iter()
@@ -783,6 +884,7 @@ impl PluginHost {
             installed: OnceLock::new(),
             apis: OnceLock::new(),
             runtime: OnceLock::new(),
+            callback_timeout,
         })
     }
 
@@ -792,6 +894,13 @@ impl PluginHost {
 
     pub(crate) fn manifests(&self) -> &[PluginManifest] {
         &self.manifests
+    }
+
+    pub(crate) fn lifecycle_callback_timeout(&self) -> Duration {
+        let callback_count = self.ordered.len() + usize::from(self.upstream.is_some());
+        self.callback_timeout
+            .saturating_mul(callback_count as u32)
+            .saturating_add(Duration::from_secs(1))
     }
 
     fn context(
@@ -862,12 +971,16 @@ impl PluginHost {
             .set(runtime.clone())
             .map_err(|_| anyhow::anyhow!("plugin host was installed more than once"))?;
 
+        let mut rollback = PluginInstallRollback::new(runtime.clone(), self.ordered.len());
         if let Some(upstream) = &self.upstream {
-            plugin_callback(|| upstream.install(client.clone())).await?;
+            if let Err(error) = plugin_callback(|| upstream.install(client.clone())).await {
+                rollback.disarm();
+                return Err(error);
+            }
+            rollback.upstream = Some(upstream.clone());
         }
 
         let staging = Arc::new(ApiRegistry::default());
-        let mut installed: Vec<InstalledPlugin> = Vec::with_capacity(self.ordered.len());
         for planned in &self.ordered {
             let resources = PluginResources::new();
             let context = self.context(
@@ -878,21 +991,15 @@ impl PluginHost {
                 Arc::clone(&staging),
                 runtime.clone(),
             );
+            rollback.current = Some(InstalledPlugin {
+                plugin: planned.plugin.clone(),
+                manifest: planned.manifest.clone(),
+                resources,
+            });
             let api = match plugin_install(|| planned.plugin.install(context)).await {
                 Ok(api) => api,
                 Err(error) => {
-                    resources.close();
-                    for plugin in installed.iter().rev() {
-                        plugin.resources.close();
-                    }
-                    if let Err(shutdown_error) = plugin_callback(|| planned.plugin.shutdown()).await
-                    {
-                        log::warn!(
-                            "Plugin `{}` failed-install rollback failed: {shutdown_error:#}",
-                            planned.manifest.id
-                        );
-                    }
-                    self.rollback(&mut installed).await;
+                    rollback.rollback().await;
                     anyhow::bail!(
                         "plugin `{}` installation failed: {error:#}",
                         planned.manifest.id
@@ -900,19 +1007,22 @@ impl PluginHost {
                 }
             };
             staging.insert(planned.plugin.marker_type_id(), api);
-            installed.push(InstalledPlugin {
-                plugin: planned.plugin.clone(),
-                manifest: planned.manifest.clone(),
-                resources,
-            });
+            let Some(installed) = rollback.current.take() else {
+                rollback.rollback().await;
+                anyhow::bail!("plugin installation rollback state was lost");
+            };
+            rollback.installed.push(installed);
         }
 
         self.apis
             .set(staging.snapshot())
             .map_err(|_| anyhow::anyhow!("plugin APIs were published more than once"))?;
-        self.installed
-            .set(installed)
-            .map_err(|_| anyhow::anyhow!("plugins were installed more than once"))?;
+        let installed = rollback.take_installed();
+        if let Err(installed) = self.installed.set(installed) {
+            rollback.restore_installed(installed);
+            anyhow::bail!("plugins were installed more than once");
+        }
+        rollback.disarm();
         Ok(())
     }
 
@@ -922,20 +1032,15 @@ impl PluginHost {
         }
     }
 
-    async fn rollback(&self, installed: &mut Vec<InstalledPlugin>) {
-        for plugin in installed.iter().rev() {
-            plugin.resources.close();
-        }
-        while let Some(plugin) = installed.pop() {
-            if plugin_callback(|| plugin.plugin.shutdown()).await.is_err() {
-                log::warn!("Plugin `{}` rollback failed", plugin.manifest.id);
-            }
-        }
-        if let Some(upstream) = &self.upstream
-            && let Err(error) = plugin_callback(|| upstream.shutdown()).await
-        {
-            log::warn!("Upstream lifecycle rollback failed: {error:#}");
-        }
+    async fn run_callback<'a>(
+        &'a self,
+        make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
+    ) -> anyhow::Result<()> {
+        let runtime = self
+            .runtime
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("plugin runtime is unavailable"))?;
+        bounded_plugin_callback(&**runtime, self.callback_timeout, make_future).await
     }
 }
 
@@ -946,13 +1051,18 @@ impl ClientLifecycle for PluginHost {
 
     fn on_ready(&self, scope: ConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
-            if let Some(upstream) = &self.upstream {
-                plugin_callback(|| upstream.on_ready(scope.clone())).await?;
-            }
             let mut failures = Vec::new();
+            if let Some(upstream) = &self.upstream
+                && let Err(error) = self.run_callback(|| upstream.on_ready(scope.clone())).await
+            {
+                failures.push(format!("upstream: {error:#}"));
+            }
             for plugin in self.installed.get().into_iter().flatten() {
                 let plugin_scope = self.connection_scope(scope.clone(), &plugin.manifest);
-                if let Err(error) = plugin_callback(|| plugin.plugin.on_ready(plugin_scope)).await {
+                if let Err(error) = self
+                    .run_callback(|| plugin.plugin.on_ready(plugin_scope))
+                    .await
+                {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
@@ -965,13 +1075,15 @@ impl ClientLifecycle for PluginHost {
             let mut failures = Vec::new();
             for plugin in self.installed.get().into_iter().flatten().rev() {
                 let plugin_scope = self.connection_scope(scope.clone(), &plugin.manifest);
-                if let Err(error) = plugin_callback(|| plugin.plugin.on_closed(plugin_scope)).await
+                if let Err(error) = self
+                    .run_callback(|| plugin.plugin.on_closed(plugin_scope))
+                    .await
                 {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
             if let Some(upstream) = &self.upstream
-                && let Err(error) = plugin_callback(|| upstream.on_closed(scope)).await
+                && let Err(error) = self.run_callback(|| upstream.on_closed(scope)).await
             {
                 failures.push(format!("upstream: {error:#}"));
             }
@@ -979,19 +1091,28 @@ impl ClientLifecycle for PluginHost {
         })
     }
 
+    fn signal_shutdown(&self) {
+        for plugin in self.installed.get().into_iter().flatten().rev() {
+            plugin.resources.close();
+        }
+        if let Some(upstream) = &self.upstream
+            && std::panic::catch_unwind(AssertUnwindSafe(|| upstream.signal_shutdown())).is_err()
+        {
+            log::warn!("Upstream lifecycle synchronous shutdown signal panicked");
+        }
+    }
+
     fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
             let mut failures = Vec::new();
+            self.signal_shutdown();
             for plugin in self.installed.get().into_iter().flatten().rev() {
-                plugin.resources.close();
-            }
-            for plugin in self.installed.get().into_iter().flatten().rev() {
-                if let Err(error) = plugin_callback(|| plugin.plugin.shutdown()).await {
+                if let Err(error) = self.run_callback(|| plugin.plugin.shutdown()).await {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
             if let Some(upstream) = &self.upstream
-                && let Err(error) = plugin_callback(|| upstream.shutdown()).await
+                && let Err(error) = self.run_callback(|| upstream.shutdown()).await
             {
                 failures.push(format!("upstream: {error:#}"));
             }
@@ -1002,9 +1123,56 @@ impl ClientLifecycle for PluginHost {
 
 impl Drop for PluginHost {
     fn drop(&mut self) {
-        for plugin in self.installed.get().into_iter().flatten() {
-            plugin.resources.close();
+        self.signal_shutdown();
+    }
+}
+
+async fn shutdown_staged_plugins(
+    runtime: Arc<dyn Runtime>,
+    current: Option<InstalledPlugin>,
+    mut installed: Vec<InstalledPlugin>,
+    upstream: Option<Arc<dyn ClientLifecycle>>,
+) {
+    if let Some(plugin) = current
+        && let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+            plugin.plugin.shutdown()
+        })
+        .await
+    {
+        log::warn!(
+            "Plugin `{}` failed-install rollback failed: {error:#}",
+            plugin.manifest.id
+        );
+    }
+    while let Some(plugin) = installed.pop() {
+        if let Err(error) = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+            plugin.plugin.shutdown()
+        })
+        .await
+        {
+            log::warn!("Plugin `{}` rollback failed: {error:#}", plugin.manifest.id);
         }
+    }
+    if let Some(upstream) = upstream
+        && let Err(error) =
+            bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || upstream.shutdown())
+                .await
+    {
+        log::warn!("Upstream lifecycle rollback failed: {error:#}");
+    }
+}
+
+async fn bounded_plugin_callback<'a>(
+    runtime: &dyn Runtime,
+    timeout: Duration,
+    make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    match runtime_timeout(runtime, timeout, plugin_callback(make_future)).await {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!(
+            "callback timed out after {:.3} seconds",
+            timeout.as_secs_f64()
+        ),
     }
 }
 
@@ -1159,7 +1327,7 @@ mod tests {
             .build()
             .await
             .expect("valid plugin plan");
-        let client = build.client();
+        let client = build.into_client();
 
         assert_eq!(
             client
@@ -1233,7 +1401,7 @@ mod tests {
             .build()
             .await
             .expect("declared dependency plan");
-        let client = build.client();
+        let client = build.into_client();
         assert_eq!(client.plugin::<TransitiveProbe>().as_deref(), Some(&true));
         client.disconnect().await;
     }
@@ -1501,6 +1669,93 @@ mod tests {
         .expect("rollback aborted the install-scoped task");
     }
 
+    struct BlockingInstallPlugin {
+        log: Log,
+        started: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    impl ClientPlugin for BlockingInstallPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("blocking-install", "0.1.0").with_dependency("rollback")
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let log = self.log.clone();
+            let started = self.started.clone();
+            let release = self.release.clone();
+            Box::pin(async move {
+                record(&log, "install:blocking");
+                let _ = started.try_send(());
+                release.recv().await?;
+                Ok(Arc::new(()))
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = self.log.clone();
+            Box::pin(async move {
+                record(&log, "shutdown:blocking");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_build_closes_resources_and_schedules_lifo_rollback() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let task_dropped = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (_release_tx, release_rx) = async_channel::bounded(1);
+        let builder = complete_builder()
+            .await
+            .with_plugin(BlockingInstallPlugin {
+                log: log.clone(),
+                started: started_tx,
+                release: release_rx,
+            })
+            .with_plugin(RollbackPlugin {
+                log: log.clone(),
+                task_dropped: task_dropped.clone(),
+            });
+
+        let build = tokio::spawn(async move { builder.build().await });
+        started_rx.recv().await.expect("blocking install started");
+        build.abort();
+        let _ = build.await;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let complete = log
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .last()
+                    .is_some_and(|entry| entry == "shutdown:rollback");
+                if complete && task_dropped.load(Ordering::Acquire) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled build rollback completed");
+
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:rollback",
+                "install:blocking",
+                "shutdown:blocking",
+                "shutdown:rollback"
+            ]
+        );
+    }
+
     struct PanickingPlugin {
         log: Log,
     }
@@ -1631,7 +1886,7 @@ mod tests {
             .build()
             .await
             .expect("scoped task plugin");
-        let client = build.client();
+        let client = build.into_client();
         wait_for_flag(&install_started).await;
 
         let scope = ConnectionScope::new(88);
@@ -1703,6 +1958,121 @@ mod tests {
         }
     }
 
+    struct FailingReadyLifecycle;
+
+    impl ClientLifecycle for FailingReadyLifecycle {
+        fn on_ready(&self, _scope: ConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            Box::pin(async { anyhow::bail!("injected upstream ready failure") })
+        }
+    }
+
+    struct ReadyPlugin<const MARKER: u8> {
+        id: &'static str,
+        dependency: Option<&'static str>,
+        log: Log,
+        stalls: bool,
+    }
+
+    impl<const MARKER: u8> ClientPlugin for ReadyPlugin<MARKER> {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            let manifest = PluginManifest::new(self.id, "0.1.0");
+            match self.dependency {
+                Some(dependency) => manifest.with_dependency(dependency),
+                None => manifest,
+            }
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new(())) })
+        }
+
+        fn on_ready(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            let id = self.id;
+            let log = self.log.clone();
+            let stalls = self.stalls;
+            Box::pin(async move {
+                record(&log, format!("ready:{id}"));
+                if stalls {
+                    futures::future::pending::<()>().await;
+                }
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn upstream_ready_failure_does_not_suppress_plugins() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let client = complete_builder()
+            .await
+            .with_lifecycle(FailingReadyLifecycle)
+            .with_plugin(ReadyPlugin::<1> {
+                id: "ready-probe",
+                dependency: None,
+                log: log.clone(),
+                stalls: false,
+            })
+            .build()
+            .await
+            .expect("ready probe client")
+            .into_client();
+
+        let result = client
+            .plugin_host
+            .as_ref()
+            .expect("plugin host")
+            .on_ready(ConnectionScope::new(91))
+            .await;
+        assert!(result.is_err());
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["ready:ready-probe"]
+        );
+        client.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn timed_out_plugin_callback_does_not_suppress_following_plugins() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let plan = PluginPlan::prepare(vec![
+            PluginRegistration::new(ReadyPlugin::<2> {
+                id: "stalling-ready",
+                dependency: None,
+                log: log.clone(),
+                stalls: true,
+            }),
+            PluginRegistration::new(ReadyPlugin::<3> {
+                id: "following-ready",
+                dependency: Some("stalling-ready"),
+                log: log.clone(),
+                stalls: false,
+            }),
+        ])
+        .expect("valid callback plan")
+        .expect("non-empty callback plan");
+        let host = PluginHost::new_with_callback_timeout(plan, None, Duration::from_millis(10));
+        let client = complete_builder()
+            .await
+            .with_lifecycle_arc(host.clone())
+            .build()
+            .await
+            .expect("callback timeout client")
+            .into_client();
+
+        let result = host.on_ready(ConnectionScope::new(92)).await;
+        assert!(result.is_err());
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["ready:stalling-ready", "ready:following-ready"]
+        );
+        client.disconnect().await;
+    }
+
     #[tokio::test]
     async fn composes_existing_lifecycle_outside_plugin_lifo_order() {
         let log = Arc::new(Mutex::new(Vec::new()));
@@ -1713,7 +2083,7 @@ mod tests {
             .build()
             .await
             .expect("composed lifecycle");
-        let client = build.client();
+        let client = build.into_client();
         assert_eq!(
             *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
             vec!["install:upstream", "install:foundation"]
@@ -1753,7 +2123,7 @@ mod tests {
                     .core_events()
                     .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
                     .subscribe(
-                        EventInterest::of(&[wacore::types::events::EventKind::Connected]),
+                        EventInterest::of(&[EventKind::Connected, EventKind::RawNode]),
                         Arc::new(NoopEventHandler),
                     )?;
                 Ok(Arc::new(()))
@@ -1762,20 +2132,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shutdown_removes_plugin_event_subscriptions() {
+    async fn shutdown_removes_plugin_event_subscriptions_and_raw_lease() {
         let build = complete_builder()
             .await
             .with_plugin(EventSubscriptionPlugin)
             .build()
             .await
             .expect("event subscription plugin");
-        let client = build.client();
+        let client = build.into_client();
         assert!(
             client
                 .core
                 .event_bus
                 .has_handler_for(wacore::types::events::EventKind::Connected)
         );
+        assert!(client.raw_node_forwarding_enabled());
 
         client.disconnect().await;
         assert!(
@@ -1784,6 +2155,36 @@ mod tests {
                 .event_bus
                 .has_handler_for(wacore::types::events::EventKind::Connected)
         );
+        assert!(!client.raw_node_forwarding_enabled());
+    }
+
+    #[tokio::test]
+    async fn synchronous_shutdown_closes_plugin_resources_with_live_client_refs() {
+        let task_dropped = Arc::new(AtomicBool::new(false));
+        let client = complete_builder()
+            .await
+            .with_plugin(RollbackPlugin {
+                log: Arc::new(Mutex::new(Vec::new())),
+                task_dropped: task_dropped.clone(),
+            })
+            .with_plugin(EventSubscriptionPlugin)
+            .build()
+            .await
+            .expect("plugin resource client")
+            .into_client();
+        let retained_client = client.clone();
+
+        client.signal_shutdown_sync();
+        wait_for_flag(&task_dropped).await;
+
+        assert!(!retained_client.raw_node_forwarding_enabled());
+        assert!(
+            !retained_client
+                .core
+                .event_bus
+                .has_handler_for(EventKind::Connected)
+        );
+        retained_client.disconnect().await;
     }
 
     struct CapabilityProbe;
@@ -1816,7 +2217,7 @@ mod tests {
             .build()
             .await
             .expect("capability plugin");
-        let client = build.client();
+        let client = build.into_client();
         assert_eq!(
             client.plugin::<CapabilityProbe>().as_deref(),
             Some(&[false, false, true, false])

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -278,6 +278,8 @@ pub struct PluginStats {
 pub struct PluginHostStats {
     pub terminal: bool,
     pub health: PluginHealth,
+    pub upstream_callback_failures: u64,
+    pub upstream_callback_timeouts: u64,
     pub plugins: Vec<PluginStats>,
     pub event_router: Option<PluginEventRouterStats>,
 }
@@ -407,12 +409,23 @@ impl PluginResources {
         })
     }
 
+    #[cfg(test)]
     fn activate(&self) {
+        self.prepare_activation();
+        self.publish_activation();
+    }
+
+    fn prepare_activation(&self) {
         if self.closed.load(Ordering::Acquire) {
             return;
         }
         self.active.store(true, Ordering::Release);
-        self.activation.notify();
+    }
+
+    fn publish_activation(&self) {
+        if self.active.load(Ordering::Acquire) && !self.closed.load(Ordering::Acquire) {
+            self.activation.notify();
+        }
     }
 
     fn ensure_active(&self) -> Result<(), PluginResourceError> {
@@ -809,6 +822,12 @@ struct PluginCoreEventHandler {
 
 impl EventHandler for PluginCoreEventHandler {
     fn handle_event(&self, event: Arc<wacore::types::events::Event>) {
+        let Some(resources) = self.resources.upgrade() else {
+            return;
+        };
+        if resources.ensure_active().is_err() {
+            return;
+        }
         let Some(inner) = &self.inner else {
             return;
         };
@@ -1570,6 +1589,8 @@ pub(crate) struct PluginHost {
     terminal: AtomicBool,
     terminal_notifier: ShutdownNotifier,
     installing_resources: Mutex<Vec<Weak<PluginResources>>>,
+    upstream_callback_failures: AtomicU64,
+    upstream_callback_timeouts: AtomicU64,
 }
 
 impl PluginHost {
@@ -1614,6 +1635,8 @@ impl PluginHost {
             terminal: AtomicBool::new(false),
             terminal_notifier: ShutdownNotifier::new(),
             installing_resources: Mutex::new(Vec::new()),
+            upstream_callback_failures: AtomicU64::new(0),
+            upstream_callback_timeouts: AtomicU64::new(0),
         })
     }
 
@@ -1638,6 +1661,8 @@ impl PluginHost {
 
     pub(crate) fn stats(&self) -> PluginHostStats {
         let terminal = self.terminal.load(Ordering::Acquire);
+        let upstream_callback_failures = self.upstream_callback_failures.load(Ordering::Relaxed);
+        let upstream_callback_timeouts = self.upstream_callback_timeouts.load(Ordering::Relaxed);
         let plugins = self
             .manifests
             .iter()
@@ -1650,9 +1675,11 @@ impl PluginHost {
                 diagnostics.snapshot(&manifest.id, terminal, events)
             })
             .collect::<Vec<_>>();
-        let health = if plugins
-            .iter()
-            .any(|plugin| plugin.health == PluginHealth::Degraded)
+        let health = if upstream_callback_failures > 0
+            || upstream_callback_timeouts > 0
+            || plugins
+                .iter()
+                .any(|plugin| plugin.health == PluginHealth::Degraded)
         {
             PluginHealth::Degraded
         } else {
@@ -1661,6 +1688,8 @@ impl PluginHost {
         PluginHostStats {
             terminal,
             health,
+            upstream_callback_failures,
+            upstream_callback_timeouts,
             plugins,
             event_router: self.event_router.as_ref().map(PluginEventRouter::stats),
         }
@@ -1933,23 +1962,11 @@ impl PluginHost {
         }
     }
 
-    pub(crate) fn activate(&self) -> bool {
+    pub(crate) fn commit(&self) -> bool {
         if self.terminal.load(Ordering::Acquire) {
             self.close_installed_resources();
             return false;
         }
-        for plugin in self.installed_plugins() {
-            plugin.resources.activate();
-        }
-        if self.terminal.load(Ordering::Acquire) {
-            self.close_installed_resources();
-            false
-        } else {
-            true
-        }
-    }
-
-    pub(crate) fn publish_apis(&self) -> bool {
         let Some(installed) = self.installed.get() else {
             return false;
         };
@@ -1957,16 +1974,22 @@ impl PluginHost {
             .staged_apis
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(apis) = staged.take() else {
-            return self.apis.get().is_some();
-        };
-        match self.apis.set(apis) {
-            Ok(()) => true,
-            Err(apis) => {
-                *staged = Some(apis);
-                false
-            }
+        if let Some(apis) = staged.take()
+            && let Err(apis) = self.apis.set(apis)
+        {
+            *staged = Some(apis);
+            return false;
         }
+        if self.apis.get().is_none() {
+            return false;
+        }
+        for plugin in &installed.plugins {
+            plugin.resources.prepare_activation();
+        }
+        for plugin in &installed.plugins {
+            plugin.resources.publish_activation();
+        }
+        true
     }
 
     fn close_installed_resources(&self) {
@@ -1984,6 +2007,26 @@ impl PluginHost {
         })?;
         bounded_plugin_callback(&**runtime, self.callback_timeout, make_future).await
     }
+
+    fn record_upstream_callback(&self, result: &Result<(), PluginCallbackError>) {
+        match result {
+            Ok(()) => {}
+            Err(PluginCallbackError::Timeout { .. }) => {
+                self.upstream_callback_timeouts
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            Err(PluginCallbackError::TimeoutCancellationPanic { .. }) => {
+                self.upstream_callback_timeouts
+                    .fetch_add(1, Ordering::Relaxed);
+                self.upstream_callback_failures
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            Err(PluginCallbackError::Callback(_)) => {
+                self.upstream_callback_failures
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 }
 
 impl ClientLifecycle for PluginHost {
@@ -1994,10 +2037,12 @@ impl ClientLifecycle for PluginHost {
     fn on_ready(&self, scope: ConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
             let mut failures = Vec::new();
-            if let Some(upstream) = &self.upstream
-                && let Err(error) = self.run_callback(|| upstream.on_ready(scope.clone())).await
-            {
-                failures.push(format!("upstream: {error:#}"));
+            if let Some(upstream) = &self.upstream {
+                let result = self.run_callback(|| upstream.on_ready(scope.clone())).await;
+                self.record_upstream_callback(&result);
+                if let Err(error) = result {
+                    failures.push(format!("upstream: {error:#}"));
+                }
             }
             for plugin in self.installed_plugins() {
                 let task_tracker = plugin
@@ -2062,10 +2107,12 @@ impl ClientLifecycle for PluginHost {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
-            if let Some(upstream) = &self.upstream
-                && let Err(error) = self.run_callback(|| upstream.on_closed(scope)).await
-            {
-                failures.push(format!("upstream: {error:#}"));
+            if let Some(upstream) = &self.upstream {
+                let result = self.run_callback(|| upstream.on_closed(scope)).await;
+                self.record_upstream_callback(&result);
+                if let Err(error) = result {
+                    failures.push(format!("upstream: {error:#}"));
+                }
             }
             finish_callbacks("closed", failures)
         })
@@ -2082,6 +2129,8 @@ impl ClientLifecycle for PluginHost {
         if let Some(upstream) = &self.upstream
             && std::panic::catch_unwind(AssertUnwindSafe(|| upstream.signal_shutdown())).is_err()
         {
+            self.upstream_callback_failures
+                .fetch_add(1, Ordering::Relaxed);
             log::warn!("Upstream lifecycle synchronous shutdown signal panicked");
         }
     }
@@ -2105,10 +2154,12 @@ impl ClientLifecycle for PluginHost {
                     failures.push(format!("{}: {error:#}", plugin.manifest.id));
                 }
             }
-            if let Some(upstream) = &self.upstream
-                && let Err(error) = self.run_callback(|| upstream.shutdown()).await
-            {
-                failures.push(format!("upstream: {error:#}"));
+            if let Some(upstream) = &self.upstream {
+                let result = self.run_callback(|| upstream.shutdown()).await;
+                self.record_upstream_callback(&result);
+                if let Err(error) = result {
+                    failures.push(format!("upstream: {error:#}"));
+                }
             }
             finish_callbacks("shutdown", failures)
         })
@@ -3938,6 +3989,11 @@ mod tests {
             *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
             vec!["ready:ready-probe"]
         );
+        let stats = client.plugin_stats().expect("plugin host stats");
+        assert_eq!(stats.health, PluginHealth::Degraded);
+        assert_eq!(stats.upstream_callback_failures, 1);
+        assert_eq!(stats.upstream_callback_timeouts, 0);
+        assert_eq!(stats.plugins[0].health, PluginHealth::Healthy);
         client.disconnect().await;
     }
 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -166,6 +166,29 @@ pub trait ClientPlugin: MaybeSendSync + 'static {
     }
 }
 
+/// A trusted plugin instance identified only by its manifest ID.
+///
+/// Unlike [`ClientPlugin`], this trait publishes no Rust type-indexed API, so
+/// multiple instances of the same adapter type may be registered. It is the
+/// intended host seam for runtime-defined or foreign-language plugins.
+pub trait UntypedClientPlugin: MaybeSendSync + 'static {
+    fn manifest(&self) -> PluginManifest;
+
+    fn install(&self, context: PluginContext) -> PluginFuture<'_, anyhow::Result<()>>;
+
+    fn on_ready(&self, _scope: PluginConnectionScope) -> PluginFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn on_closed(&self, _scope: PluginConnectionScope) -> PluginFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn shutdown(&self) -> PluginFuture<'_, anyhow::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
 /// Manifest validation or dependency-ordering failure.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -1248,10 +1271,10 @@ fn downcast_api<T: MaybeSendSync + 'static>(api: &ErasedApi) -> Option<Arc<T>> {
 }
 
 trait ErasedClientPlugin: MaybeSendSync {
-    fn marker_type_id(&self) -> TypeId;
+    fn marker_type_id(&self) -> Option<TypeId>;
     fn marker_type_name(&self) -> &'static str;
     fn manifest(&self) -> PluginManifest;
-    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<ErasedApi>>;
+    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Option<ErasedApi>>>;
     fn on_ready(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>>;
     fn on_closed(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>>;
     fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>>;
@@ -1260,8 +1283,8 @@ trait ErasedClientPlugin: MaybeSendSync {
 struct PluginAdapter<P>(Arc<P>);
 
 impl<P: ClientPlugin> ErasedClientPlugin for PluginAdapter<P> {
-    fn marker_type_id(&self) -> TypeId {
-        TypeId::of::<P>()
+    fn marker_type_id(&self) -> Option<TypeId> {
+        Some(TypeId::of::<P>())
     }
 
     fn marker_type_name(&self) -> &'static str {
@@ -1272,10 +1295,45 @@ impl<P: ClientPlugin> ErasedClientPlugin for PluginAdapter<P> {
         self.0.manifest()
     }
 
-    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<ErasedApi>> {
+    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Option<ErasedApi>>> {
         Box::pin(async move {
             let api = self.0.install(context).await?;
-            Ok(Arc::new(TypedApi(api)) as ErasedApi)
+            Ok(Some(Arc::new(TypedApi(api)) as ErasedApi))
+        })
+    }
+
+    fn on_ready(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        self.0.on_ready(scope)
+    }
+
+    fn on_closed(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+        self.0.on_closed(scope)
+    }
+
+    fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+        self.0.shutdown()
+    }
+}
+
+struct UntypedPluginAdapter<P>(Arc<P>);
+
+impl<P: UntypedClientPlugin> ErasedClientPlugin for UntypedPluginAdapter<P> {
+    fn marker_type_id(&self) -> Option<TypeId> {
+        None
+    }
+
+    fn marker_type_name(&self) -> &'static str {
+        std::any::type_name::<P>()
+    }
+
+    fn manifest(&self) -> PluginManifest {
+        self.0.manifest()
+    }
+
+    fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Option<ErasedApi>>> {
+        Box::pin(async move {
+            self.0.install(context).await?;
+            Ok(None)
         })
     }
 
@@ -1306,6 +1364,16 @@ impl PluginRegistration {
             plugin: Arc::new(PluginAdapter(plugin)),
         }
     }
+
+    pub(crate) fn new_untyped<P: UntypedClientPlugin>(plugin: P) -> Self {
+        Self::new_untyped_arc(Arc::new(plugin))
+    }
+
+    pub(crate) fn new_untyped_arc<P: UntypedClientPlugin>(plugin: Arc<P>) -> Self {
+        Self {
+            plugin: Arc::new(UntypedPluginAdapter(plugin)),
+        }
+    }
 }
 
 struct PlannedPlugin {
@@ -1332,8 +1400,9 @@ impl PluginPlan {
 
         for registration in registrations {
             let plugin = registration.plugin;
-            let marker = plugin.marker_type_id();
-            if !marker_types.insert(marker) {
+            if let Some(marker) = plugin.marker_type_id()
+                && !marker_types.insert(marker)
+            {
                 return Err(PluginPlanError::DuplicateType {
                     plugin_type: plugin.marker_type_name(),
                 });
@@ -1376,8 +1445,9 @@ impl PluginPlan {
                 };
                 indegree[plugin_index] += 1;
                 dependents[dependency_index].push(plugin_index);
-                dependency_markers[plugin_index]
-                    .push(plugins[dependency_index].plugin.marker_type_id());
+                if let Some(marker) = plugins[dependency_index].plugin.marker_type_id() {
+                    dependency_markers[plugin_index].push(marker);
+                }
             }
         }
         for (planned, markers) in plugins.iter_mut().zip(dependency_markers) {
@@ -1895,7 +1965,17 @@ impl PluginHost {
                     );
                 }
             };
-            staging.insert(planned.plugin.marker_type_id(), api);
+            match (planned.plugin.marker_type_id(), api) {
+                (Some(marker), Some(api)) => staging.insert(marker, api),
+                (None, None) => {}
+                _ => {
+                    rollback.rollback().await;
+                    anyhow::bail!(
+                        "plugin `{}` returned an API inconsistent with its registration",
+                        planned.manifest.id
+                    );
+                }
+            }
             self.abort_install_if_terminal(&mut rollback).await?;
             let Some(installed) = rollback.current.take() else {
                 rollback.rollback().await;
@@ -2320,9 +2400,9 @@ async fn plugin_callback<'a>(
     result?
 }
 
-async fn plugin_install<'a>(
-    make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<ErasedApi>>,
-) -> anyhow::Result<ErasedApi> {
+async fn plugin_install<'a, T>(
+    make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<T>>,
+) -> anyhow::Result<T> {
     let mut future = std::panic::catch_unwind(AssertUnwindSafe(make_future))
         .map_err(|_| anyhow::anyhow!("install panicked before returning a future"))?;
     let result = AssertUnwindSafe(std::future::poll_fn(|context| {
@@ -2419,6 +2499,40 @@ mod tests {
 
     struct FoundationPlugin {
         log: Log,
+    }
+
+    struct RuntimePluginAdapter {
+        id: &'static str,
+        dependency: Option<&'static str>,
+        log: Log,
+    }
+
+    impl UntypedClientPlugin for RuntimePluginAdapter {
+        fn manifest(&self) -> PluginManifest {
+            let manifest = PluginManifest::new(self.id, "0.1.0");
+            match self.dependency {
+                Some(dependency) => manifest.with_dependency(dependency),
+                None => manifest,
+            }
+        }
+
+        fn install(&self, _context: PluginContext) -> BoxFuture<'_, anyhow::Result<()>> {
+            let id = self.id;
+            let log = Arc::clone(&self.log);
+            Box::pin(async move {
+                record(&log, format!("install:{id}"));
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let id = self.id;
+            let log = Arc::clone(&self.log);
+            Box::pin(async move {
+                record(&log, format!("shutdown:{id}"));
+                Ok(())
+            })
+        }
     }
 
     struct ShutdownDuringPluginInstall;
@@ -2564,6 +2678,51 @@ mod tests {
                 Ok(())
             })
         }
+    }
+
+    #[tokio::test]
+    async fn untyped_instances_share_an_adapter_type_and_remain_manifest_keyed() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let client = complete_builder()
+            .await
+            .with_untyped_plugin(RuntimePluginAdapter {
+                id: "runtime-dependent",
+                dependency: Some("runtime-foundation"),
+                log: Arc::clone(&log),
+            })
+            .with_untyped_plugin(RuntimePluginAdapter {
+                id: "runtime-foundation",
+                dependency: None,
+                log: Arc::clone(&log),
+            })
+            .build()
+            .await
+            .expect("untyped plugin plan")
+            .into_client();
+
+        assert_eq!(
+            client
+                .plugin_manifests()
+                .iter()
+                .map(PluginManifest::id)
+                .collect::<Vec<_>>(),
+            vec!["runtime-foundation", "runtime-dependent"]
+        );
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["install:runtime-foundation", "install:runtime-dependent"]
+        );
+
+        client.disconnect().await;
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec![
+                "install:runtime-foundation",
+                "install:runtime-dependent",
+                "shutdown:runtime-dependent",
+                "shutdown:runtime-foundation"
+            ]
+        );
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -41,6 +41,7 @@ const CAP_TASKS: u8 = 1 << 1;
 const CAP_MESSAGING: u8 = 1 << 2;
 const CAP_IQ: u8 = 1 << 3;
 const CAP_PLUGIN_EVENTS: u8 = 1 << 4;
+const DEFAULT_PLUGIN_INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_PLUGIN_TASK_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -96,6 +97,7 @@ impl PluginCapabilities {
 /// Deadlines applied by the native plugin host.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PluginHostConfig {
+    install_timeout: Duration,
     callback_timeout: Duration,
     task_drain_timeout: Duration,
 }
@@ -103,9 +105,16 @@ pub struct PluginHostConfig {
 impl PluginHostConfig {
     pub const fn new() -> Self {
         Self {
+            install_timeout: DEFAULT_PLUGIN_INSTALL_TIMEOUT,
             callback_timeout: DEFAULT_PLUGIN_CALLBACK_TIMEOUT,
             task_drain_timeout: DEFAULT_PLUGIN_TASK_DRAIN_TIMEOUT,
         }
+    }
+
+    /// Bound each plugin and upstream lifecycle installation.
+    pub const fn with_install_timeout(mut self, timeout: Duration) -> Self {
+        self.install_timeout = timeout;
+        self
     }
 
     /// Bound each `on_ready`, `on_closed`, and `shutdown` callback.
@@ -118,6 +127,10 @@ impl PluginHostConfig {
     pub const fn with_task_drain_timeout(mut self, timeout: Duration) -> Self {
         self.task_drain_timeout = timeout;
         self
+    }
+
+    pub const fn install_timeout(self) -> Duration {
+        self.install_timeout
     }
 
     pub const fn callback_timeout(self) -> Duration {
@@ -1565,9 +1578,9 @@ impl<P: ClientPlugin> ErasedClientPlugin for PluginAdapter<P> {
     }
 }
 
-struct UntypedPluginAdapter<P>(Arc<P>);
+struct UntypedPluginAdapter<P: ?Sized>(Arc<P>);
 
-impl<P: UntypedClientPlugin> ErasedClientPlugin for UntypedPluginAdapter<P> {
+impl<P: UntypedClientPlugin + ?Sized> ErasedClientPlugin for UntypedPluginAdapter<P> {
     fn marker_type_id(&self) -> Option<TypeId> {
         None
     }
@@ -1619,7 +1632,7 @@ impl PluginRegistration {
         Self::new_untyped_arc(Arc::new(plugin))
     }
 
-    pub(crate) fn new_untyped_arc<P: UntypedClientPlugin>(plugin: Arc<P>) -> Self {
+    pub(crate) fn new_untyped_arc<P: UntypedClientPlugin + ?Sized>(plugin: Arc<P>) -> Self {
         Self {
             plugin: Arc::new(UntypedPluginAdapter(plugin)),
         }
@@ -2187,11 +2200,16 @@ impl PluginHost {
             PluginInstallRollback::new(runtime.clone(), self.ordered.len(), self.config);
         self.abort_install_if_terminal(&mut rollback).await?;
         if let Some(upstream) = &self.upstream {
-            if let Err(error) = plugin_callback(|| upstream.install(client.clone())).await {
-                rollback.disarm();
+            rollback.upstream = Some(upstream.clone());
+            if let Err(error) =
+                bounded_plugin_install(&*runtime, self.config.install_timeout(), || {
+                    upstream.install(client.clone())
+                })
+                .await
+            {
+                rollback.rollback().await;
                 return Err(error);
             }
-            rollback.upstream = Some(upstream.clone());
             self.abort_install_if_terminal(&mut rollback).await?;
         }
 
@@ -2224,7 +2242,11 @@ impl PluginHost {
             }
             let terminal = self.terminal_notifier.subscribe();
             let cancelled = Box::pin(wait_for_shutdown(&terminal));
-            let install = Box::pin(plugin_install(|| planned.plugin.install(context)));
+            let install = Box::pin(bounded_plugin_install(
+                &*runtime,
+                self.config.install_timeout(),
+                || planned.plugin.install(context),
+            ));
             let install_result = match futures::future::select(cancelled, install).await {
                 futures::future::Either::Left((_, install)) => {
                     if std::panic::catch_unwind(AssertUnwindSafe(|| drop(install))).is_err() {
@@ -2702,6 +2724,29 @@ async fn plugin_install<'a, T>(
     result?
 }
 
+async fn bounded_plugin_install<'a, T>(
+    runtime: &dyn Runtime,
+    timeout: Duration,
+    make_future: impl FnOnce() -> BoxFuture<'a, anyhow::Result<T>>,
+) -> anyhow::Result<T> {
+    let install = Box::pin(plugin_install(make_future));
+    match futures::future::select(install, runtime.sleep(timeout)).await {
+        futures::future::Either::Left((result, _)) => result,
+        futures::future::Either::Right(((), install)) => {
+            if std::panic::catch_unwind(AssertUnwindSafe(|| drop(install))).is_err() {
+                anyhow::bail!(
+                    "install timed out after {:.3} seconds and panicked while being cancelled",
+                    timeout.as_secs_f64()
+                );
+            }
+            anyhow::bail!(
+                "install timed out after {:.3} seconds",
+                timeout.as_secs_f64()
+            )
+        }
+    }
+}
+
 fn finish_callbacks(stage: &str, failures: Vec<String>) -> anyhow::Result<()> {
     if failures.is_empty() {
         Ok(())
@@ -2783,6 +2828,16 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_zero_plugin_host_deadlines() {
+        let install = complete_builder()
+            .await
+            .with_plugin_host_config(PluginHostConfig::new().with_install_timeout(Duration::ZERO))
+            .build()
+            .await;
+        assert!(matches!(
+            install,
+            Err(ClientBuilderError::InvalidPluginInstallTimeout)
+        ));
+
         let callback = complete_builder()
             .await
             .with_plugin_host_config(PluginHostConfig::new().with_callback_timeout(Duration::ZERO))
@@ -2845,6 +2900,10 @@ mod tests {
     }
 
     struct ShutdownDuringPluginInstall;
+
+    struct FailingInstallLifecycle {
+        log: Log,
+    }
 
     struct CaptureInstallClient {
         client: async_channel::Sender<Weak<Client>>,
@@ -2962,6 +3021,24 @@ mod tests {
         }
     }
 
+    impl ClientLifecycle for FailingInstallLifecycle {
+        fn install(&self, _client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = Arc::clone(&self.log);
+            Box::pin(async move {
+                record(&log, "install:failing-upstream");
+                anyhow::bail!("injected upstream install failure")
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let log = Arc::clone(&self.log);
+            Box::pin(async move {
+                record(&log, "shutdown:failing-upstream");
+                Ok(())
+            })
+        }
+    }
+
     impl ClientPlugin for FoundationPlugin {
         type Api = String;
 
@@ -2992,6 +3069,11 @@ mod tests {
     #[tokio::test]
     async fn untyped_instances_share_an_adapter_type_and_remain_manifest_keyed() {
         let log = Arc::new(Mutex::new(Vec::new()));
+        let foundation: Arc<dyn UntypedClientPlugin> = Arc::new(RuntimePluginAdapter {
+            id: "runtime-foundation",
+            dependency: None,
+            log: Arc::clone(&log),
+        });
         let client = complete_builder()
             .await
             .with_untyped_plugin(RuntimePluginAdapter {
@@ -2999,11 +3081,7 @@ mod tests {
                 dependency: Some("runtime-foundation"),
                 log: Arc::clone(&log),
             })
-            .with_untyped_plugin(RuntimePluginAdapter {
-                id: "runtime-foundation",
-                dependency: None,
-                log: Arc::clone(&log),
-            })
+            .with_untyped_plugin_arc(foundation)
             .build()
             .await
             .expect("untyped plugin plan")
@@ -3049,6 +3127,27 @@ mod tests {
             log.lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn upstream_install_failure_runs_partial_rollback() {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let result = complete_builder()
+            .await
+            .with_lifecycle(FailingInstallLifecycle {
+                log: Arc::clone(&log),
+            })
+            .with_plugin(FoundationPlugin {
+                log: Arc::clone(&log),
+            })
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(ClientBuilderError::PluginInstall(_))));
+        assert_eq!(
+            *log.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            vec!["install:failing-upstream", "shutdown:failing-upstream"]
         );
     }
 
@@ -3176,6 +3275,31 @@ mod tests {
         assert!(install_dropped.load(Ordering::Acquire));
         assert!(shutdown_called.load(Ordering::Acquire));
         drop(client);
+    }
+
+    #[tokio::test]
+    async fn install_timeout_rolls_back_the_partial_plugin() {
+        let (started_tx, started_rx) = async_channel::unbounded();
+        let install_dropped = Arc::new(AtomicBool::new(false));
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+        let result = complete_builder()
+            .await
+            .with_plugin_host_config(
+                PluginHostConfig::new().with_install_timeout(Duration::from_millis(10)),
+            )
+            .with_plugin(TerminalBlockingInstallPlugin {
+                started: started_tx,
+                install_dropped: install_dropped.clone(),
+                shutdown_called: shutdown_called.clone(),
+            })
+            .build()
+            .await;
+
+        let resource_shutdown = started_rx.recv().await.expect("plugin install started");
+        assert!(matches!(result, Err(ClientBuilderError::PluginInstall(_))));
+        assert!(resource_shutdown.is_fired());
+        assert!(install_dropped.load(Ordering::Acquire));
+        assert!(shutdown_called.load(Ordering::Acquire));
     }
 
     struct DependentPlugin {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1552,12 +1552,17 @@ struct PluginContextParts {
     diagnostics: Arc<PluginDiagnostics>,
 }
 
+struct InstalledPlugins {
+    plugins: Vec<InstalledPlugin>,
+    staged_apis: Mutex<Option<HashMap<TypeId, ErasedApi>>>,
+}
+
 pub(crate) struct PluginHost {
     ordered: Vec<PlannedPlugin>,
     manifests: Vec<PluginManifest>,
     diagnostics: Vec<Arc<PluginDiagnostics>>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
-    installed: OnceLock<Vec<InstalledPlugin>>,
+    installed: OnceLock<InstalledPlugins>,
     apis: OnceLock<HashMap<TypeId, ErasedApi>>,
     runtime: OnceLock<Arc<dyn Runtime>>,
     event_router: Option<PluginEventRouter>,
@@ -1614,6 +1619,17 @@ impl PluginHost {
 
     pub(crate) fn plugin<P: ClientPlugin>(&self) -> Option<Arc<P::Api>> {
         downcast_api::<P::Api>(self.apis.get()?.get(&TypeId::of::<P>())?)
+    }
+
+    fn is_published(&self) -> bool {
+        self.apis.get().is_some()
+    }
+
+    fn installed_plugins(&self) -> &[InstalledPlugin] {
+        self.installed
+            .get()
+            .map(|installed| installed.plugins.as_slice())
+            .unwrap_or_default()
     }
 
     pub(crate) fn manifests(&self) -> &[PluginManifest] {
@@ -1860,12 +1876,13 @@ impl PluginHost {
         }
         self.abort_install_if_terminal(&mut rollback).await?;
 
-        self.apis
-            .set(staging.snapshot())
-            .map_err(|_| anyhow::anyhow!("plugin APIs were published more than once"))?;
         let installed = rollback.take_installed();
+        let installed = InstalledPlugins {
+            plugins: installed,
+            staged_apis: Mutex::new(Some(staging.snapshot())),
+        };
         if let Err(installed) = self.installed.set(installed) {
-            rollback.restore_installed(installed);
+            rollback.restore_installed(installed.plugins);
             anyhow::bail!("plugins were installed more than once");
         }
         rollback.disarm();
@@ -1921,7 +1938,7 @@ impl PluginHost {
             self.close_installed_resources();
             return false;
         }
-        for plugin in self.installed.get().into_iter().flatten() {
+        for plugin in self.installed_plugins() {
             plugin.resources.activate();
         }
         if self.terminal.load(Ordering::Acquire) {
@@ -1932,8 +1949,28 @@ impl PluginHost {
         }
     }
 
+    pub(crate) fn publish_apis(&self) -> bool {
+        let Some(installed) = self.installed.get() else {
+            return false;
+        };
+        let mut staged = installed
+            .staged_apis
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(apis) = staged.take() else {
+            return self.apis.get().is_some();
+        };
+        match self.apis.set(apis) {
+            Ok(()) => true,
+            Err(apis) => {
+                *staged = Some(apis);
+                false
+            }
+        }
+    }
+
     fn close_installed_resources(&self) {
-        for plugin in self.installed.get().into_iter().flatten().rev() {
+        for plugin in self.installed_plugins().iter().rev() {
             close_plugin_resources(&plugin.manifest.id, &plugin.resources);
         }
     }
@@ -1962,7 +1999,7 @@ impl ClientLifecycle for PluginHost {
             {
                 failures.push(format!("upstream: {error:#}"));
             }
-            for plugin in self.installed.get().into_iter().flatten() {
+            for plugin in self.installed_plugins() {
                 let task_tracker = plugin
                     .manifest
                     .capabilities
@@ -1996,7 +2033,7 @@ impl ClientLifecycle for PluginHost {
     fn on_closed(&self, scope: ConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
             let mut failures = Vec::new();
-            for plugin in self.installed.get().into_iter().flatten().rev() {
+            for plugin in self.installed_plugins().iter().rev() {
                 let task_tracker = plugin
                     .manifest
                     .capabilities
@@ -2053,7 +2090,7 @@ impl ClientLifecycle for PluginHost {
         Box::pin(async move {
             let mut failures = Vec::new();
             self.signal_shutdown();
-            for plugin in self.installed.get().into_iter().flatten().rev() {
+            for plugin in self.installed_plugins().iter().rev() {
                 let task_result = self
                     .wait_for_tasks(plugin.resources.task_completion_signals())
                     .await;
@@ -2268,13 +2305,17 @@ impl Client {
     pub fn plugin_manifests(&self) -> &[PluginManifest] {
         self.plugin_host
             .as_ref()
+            .filter(|host| host.is_published())
             .map(|host| host.manifests())
             .unwrap_or_default()
     }
 
     /// Snapshot lifecycle, task, subscription, and custom-event health for installed plugins.
     pub fn plugin_stats(&self) -> Option<PluginHostStats> {
-        self.plugin_host.as_ref().map(|host| host.stats())
+        self.plugin_host
+            .as_ref()
+            .filter(|host| host.is_published())
+            .map(|host| host.stats())
     }
 
     /// Subscribe to custom events emitted by installed plugins.
@@ -2283,12 +2324,15 @@ impl Client {
     pub fn plugin_event_router(&self) -> Option<PluginEventRouter> {
         self.plugin_host
             .as_ref()
+            .filter(|host| host.is_published())
             .and_then(|host| host.event_router.clone())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::sync::Barrier;
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;
 
@@ -2332,6 +2376,41 @@ mod tests {
         client: async_channel::Sender<Weak<Client>>,
     }
 
+    struct BlockingFirstSpawnRuntime {
+        blocked: AtomicBool,
+        entered: async_channel::Sender<()>,
+        release: Arc<Barrier>,
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for BlockingFirstSpawnRuntime {
+        fn spawn(
+            &self,
+            future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+        ) -> wacore::runtime::AbortHandle {
+            if !self.blocked.swap(true, Ordering::AcqRel) {
+                self.entered.try_send(()).expect("first spawn observer");
+                self.release.wait();
+            }
+            TokioRuntime.spawn(future)
+        }
+
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            TokioRuntime.sleep(duration)
+        }
+
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            TokioRuntime.spawn_blocking(f)
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            TokioRuntime.yield_now()
+        }
+    }
+
     impl ClientLifecycle for CaptureInstallClient {
         fn install(&self, client: Weak<Client>) -> BoxFuture<'_, anyhow::Result<()>> {
             let sender = self.client.clone();
@@ -2339,6 +2418,24 @@ mod tests {
                 sender.send(client).await?;
                 Ok(())
             })
+        }
+    }
+
+    struct PublicationProbePlugin;
+
+    impl ClientPlugin for PublicationProbePlugin {
+        type Api = String;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("publication-probe", "0.1.0")
+                .with_capability(PluginCapability::PluginEvents)
+        }
+
+        fn install(
+            &self,
+            _context: PluginContext,
+        ) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async { Ok(Arc::new("published-api".to_string())) })
         }
     }
 
@@ -2434,6 +2531,95 @@ mod tests {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .is_empty()
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn plugin_surfaces_publish_only_after_final_activation() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (entered_tx, entered_rx) = async_channel::bounded(1);
+        let release = Arc::new(Barrier::new(2));
+        let builder = complete_builder()
+            .await
+            .with_runtime(BlockingFirstSpawnRuntime {
+                blocked: AtomicBool::new(false),
+                entered: entered_tx,
+                release: Arc::clone(&release),
+            })
+            .with_lifecycle(CaptureInstallClient { client: client_tx })
+            .with_plugin(PublicationProbePlugin);
+
+        let build = tokio::spawn(async move { builder.build().await });
+        let leaked_client = client_rx
+            .recv()
+            .await
+            .expect("captured install client")
+            .upgrade()
+            .expect("client under construction");
+        entered_rx.recv().await.expect("client service startup");
+
+        assert!(leaked_client.plugin::<PublicationProbePlugin>().is_none());
+        assert!(leaked_client.plugin_manifests().is_empty());
+        assert!(leaked_client.plugin_stats().is_none());
+        assert!(leaked_client.plugin_event_router().is_none());
+
+        release.wait();
+        let client = build
+            .await
+            .expect("builder task")
+            .expect("successful build")
+            .into_client();
+        assert_eq!(
+            client
+                .plugin::<PublicationProbePlugin>()
+                .as_deref()
+                .map(String::as_str),
+            Some("published-api")
+        );
+        assert_eq!(client.plugin_manifests().len(), 1);
+        assert!(client.plugin_stats().is_some());
+        assert!(client.plugin_event_router().is_some());
+        client.disconnect().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rejected_construction_never_publishes_staged_plugin_surfaces() {
+        let (client_tx, client_rx) = async_channel::bounded(1);
+        let (entered_tx, entered_rx) = async_channel::bounded(1);
+        let release = Arc::new(Barrier::new(2));
+        let builder = complete_builder()
+            .await
+            .with_runtime(BlockingFirstSpawnRuntime {
+                blocked: AtomicBool::new(false),
+                entered: entered_tx,
+                release: Arc::clone(&release),
+            })
+            .with_lifecycle(CaptureInstallClient { client: client_tx })
+            .with_plugin(PublicationProbePlugin);
+
+        let build = tokio::spawn(async move { builder.build().await });
+        let leaked_client = client_rx
+            .recv()
+            .await
+            .expect("captured install client")
+            .upgrade()
+            .expect("client under construction");
+        entered_rx.recv().await.expect("client service startup");
+        leaked_client.signal_shutdown_sync();
+
+        assert!(leaked_client.plugin::<PublicationProbePlugin>().is_none());
+        assert!(leaked_client.plugin_manifests().is_empty());
+        assert!(leaked_client.plugin_stats().is_none());
+        assert!(leaked_client.plugin_event_router().is_none());
+
+        release.wait();
+        assert!(matches!(
+            build.await.expect("builder task"),
+            Err(ClientBuilderError::PluginInstall(_))
+        ));
+        assert!(leaked_client.plugin::<PublicationProbePlugin>().is_none());
+        assert!(leaked_client.plugin_manifests().is_empty());
+        assert!(leaked_client.plugin_stats().is_none());
+        assert!(leaked_client.plugin_event_router().is_none());
     }
 
     #[tokio::test]
@@ -3405,7 +3591,8 @@ mod tests {
         let client = build.into_client();
         wait_for_flag(&install_started).await;
         let host = client.plugin_host.as_ref().expect("plugin host").clone();
-        let resources = Arc::clone(&host.installed.get().expect("installed plugins")[0].resources);
+        let resources =
+            Arc::clone(&host.installed.get().expect("installed plugins").plugins[0].resources);
         let stats = client.plugin_stats().expect("plugin stats");
         assert_eq!(stats.health, PluginHealth::Healthy);
         assert_eq!(stats.plugins[0].state, PluginState::Active);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -41,7 +41,8 @@ const CAP_TASKS: u8 = 1 << 1;
 const CAP_MESSAGING: u8 = 1 << 2;
 const CAP_IQ: u8 = 1 << 3;
 const CAP_PLUGIN_EVENTS: u8 = 1 << 4;
-const PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_PLUGIN_TASK_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A capability a plugin asks the host to expose during installation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -89,6 +90,48 @@ impl PluginCapabilities {
 
     pub const fn contains(self, capability: PluginCapability) -> bool {
         self.0 & capability.bit() != 0
+    }
+}
+
+/// Deadlines applied by the native plugin host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PluginHostConfig {
+    callback_timeout: Duration,
+    task_drain_timeout: Duration,
+}
+
+impl PluginHostConfig {
+    pub const fn new() -> Self {
+        Self {
+            callback_timeout: DEFAULT_PLUGIN_CALLBACK_TIMEOUT,
+            task_drain_timeout: DEFAULT_PLUGIN_TASK_DRAIN_TIMEOUT,
+        }
+    }
+
+    /// Bound each `on_ready`, `on_closed`, and `shutdown` callback.
+    pub const fn with_callback_timeout(mut self, timeout: Duration) -> Self {
+        self.callback_timeout = timeout;
+        self
+    }
+
+    /// Bound each install- or connection-scoped task drain.
+    pub const fn with_task_drain_timeout(mut self, timeout: Duration) -> Self {
+        self.task_drain_timeout = timeout;
+        self
+    }
+
+    pub const fn callback_timeout(self) -> Duration {
+        self.callback_timeout
+    }
+
+    pub const fn task_drain_timeout(self) -> Duration {
+        self.task_drain_timeout
+    }
+}
+
+impl Default for PluginHostConfig {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -932,6 +975,26 @@ impl PluginTasks {
     where
         F: Future<Output = ()> + Spawnable,
     {
+        self.spawn_with_mode(future, PluginTaskShutdown::Abort)
+    }
+
+    /// Track work that must observe [`shutdown_signal`](Self::shutdown_signal)
+    /// and finish itself after shutdown is signalled.
+    pub fn spawn_cooperative<F>(&self, future: F) -> Result<(), PluginResourceError>
+    where
+        F: Future<Output = ()> + Spawnable,
+    {
+        self.spawn_with_mode(future, PluginTaskShutdown::Cooperative)
+    }
+
+    fn spawn_with_mode<F>(
+        &self,
+        future: F,
+        shutdown: PluginTaskShutdown,
+    ) -> Result<(), PluginResourceError>
+    where
+        F: Future<Output = ()> + Spawnable,
+    {
         if self.resources.closed.load(Ordering::Acquire) {
             return Err(PluginResourceError::ShuttingDown);
         }
@@ -943,6 +1006,7 @@ impl PluginTasks {
             Arc::clone(&self.plugin_id),
             lease,
             future,
+            shutdown,
         );
         Ok(())
     }
@@ -1195,6 +1259,26 @@ impl PluginConnectionTasks {
     where
         F: Future<Output = ()> + Spawnable,
     {
+        self.spawn_with_mode(future, PluginTaskShutdown::Abort)
+    }
+
+    /// Track work that must observe [`cancellation_signal`](Self::cancellation_signal)
+    /// and finish itself after this generation is cancelled.
+    pub fn spawn_cooperative<F>(&self, future: F) -> Result<(), PluginResourceError>
+    where
+        F: Future<Output = ()> + Spawnable,
+    {
+        self.spawn_with_mode(future, PluginTaskShutdown::Cooperative)
+    }
+
+    fn spawn_with_mode<F>(
+        &self,
+        future: F,
+        shutdown: PluginTaskShutdown,
+    ) -> Result<(), PluginResourceError>
+    where
+        F: Future<Output = ()> + Spawnable,
+    {
         if self.scope.is_cancelled() {
             return Err(PluginResourceError::ShuttingDown);
         }
@@ -1206,8 +1290,13 @@ impl PluginConnectionTasks {
             Arc::clone(&self.plugin_id),
             lease,
             future,
+            shutdown,
         );
         Ok(())
+    }
+
+    pub fn cancellation_signal(&self) -> ShutdownSignal {
+        self.scope.cancellation_signal()
     }
 
     /// Sleep through the configured runtime, returning promptly when this generation retires.
@@ -1305,6 +1394,12 @@ impl<F: Future<Output = ()>> Drop for GuardedPluginTask<F> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum PluginTaskShutdown {
+    Abort,
+    Cooperative,
+}
+
 fn spawn_until_cancelled<F>(
     runtime: &Arc<dyn Runtime>,
     cancellation: ShutdownSignal,
@@ -1312,6 +1407,7 @@ fn spawn_until_cancelled<F>(
     plugin_id: Arc<str>,
     lease: TaskLease,
     future: F,
+    shutdown: PluginTaskShutdown,
 ) where
     F: Future<Output = ()> + Spawnable,
 {
@@ -1319,9 +1415,14 @@ fn spawn_until_cancelled<F>(
     runtime
         .spawn(Box::pin(async move {
             let _lease = lease;
-            let cancelled = Box::pin(wait_for_shutdown(&cancellation));
             let work = Box::pin(work);
-            let _ = futures::future::select(cancelled, work).await;
+            match shutdown {
+                PluginTaskShutdown::Abort => {
+                    let cancelled = Box::pin(wait_for_shutdown(&cancellation));
+                    let _ = futures::future::select(cancelled, work).await;
+                }
+                PluginTaskShutdown::Cooperative => work.await,
+            }
         }))
         .detach();
 }
@@ -1333,6 +1434,7 @@ fn spawn_after_activation<F>(
     plugin_id: Arc<str>,
     lease: TaskLease,
     future: F,
+    shutdown: PluginTaskShutdown,
 ) where
     F: Future<Output = ()> + Spawnable,
 {
@@ -1353,9 +1455,14 @@ fn spawn_after_activation<F>(
             if resources.closed.load(Ordering::Acquire) {
                 return;
             }
-            let cancelled = Box::pin(wait_for_shutdown(&cancellation));
             let work = Box::pin(work);
-            let _ = futures::future::select(cancelled, work).await;
+            match shutdown {
+                PluginTaskShutdown::Abort => {
+                    let cancelled = Box::pin(wait_for_shutdown(&cancellation));
+                    let _ = futures::future::select(cancelled, work).await;
+                }
+                PluginTaskShutdown::Cooperative => work.await,
+            }
         }))
         .detach();
 }
@@ -1678,6 +1785,7 @@ struct InstalledPlugin {
 
 struct PluginInstallRollback {
     runtime: Arc<dyn Runtime>,
+    config: PluginHostConfig,
     installed: Vec<InstalledPlugin>,
     current: Option<InstalledPlugin>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
@@ -1686,9 +1794,10 @@ struct PluginInstallRollback {
 }
 
 impl PluginInstallRollback {
-    fn new(runtime: Arc<dyn Runtime>, capacity: usize) -> Self {
+    fn new(runtime: Arc<dyn Runtime>, capacity: usize, config: PluginHostConfig) -> Self {
         Self {
             runtime,
+            config,
             installed: Vec::with_capacity(capacity),
             current: None,
             upstream: None,
@@ -1729,10 +1838,12 @@ impl PluginInstallRollback {
         let completion = completed.subscribe();
         let runtime = self.runtime.clone();
         let cleanup_runtime = runtime.clone();
+        let config = self.config;
         runtime
             .spawn(Box::pin(async move {
                 let result = AssertUnwindSafe(shutdown_staged_plugins(
                     cleanup_runtime,
+                    config,
                     current,
                     installed,
                     upstream,
@@ -1798,7 +1909,7 @@ pub(crate) struct PluginHost {
     apis: OnceLock<HashMap<TypeId, ErasedApi>>,
     runtime: OnceLock<Arc<dyn Runtime>>,
     event_router: Option<PluginEventRouter>,
-    callback_timeout: Duration,
+    config: PluginHostConfig,
     terminal: AtomicBool,
     terminal_notifier: ShutdownNotifier,
     installing_resources: Mutex<Vec<Weak<PluginResources>>>,
@@ -1807,14 +1918,31 @@ pub(crate) struct PluginHost {
 }
 
 impl PluginHost {
-    pub(crate) fn new(plan: PluginPlan, upstream: Option<Arc<dyn ClientLifecycle>>) -> Arc<Self> {
-        Self::new_with_callback_timeout(plan, upstream, PLUGIN_CALLBACK_TIMEOUT)
+    pub(crate) fn new(
+        plan: PluginPlan,
+        upstream: Option<Arc<dyn ClientLifecycle>>,
+        config: PluginHostConfig,
+    ) -> Arc<Self> {
+        Self::new_with_config(plan, upstream, config)
     }
 
+    #[cfg(test)]
     fn new_with_callback_timeout(
         plan: PluginPlan,
         upstream: Option<Arc<dyn ClientLifecycle>>,
         callback_timeout: Duration,
+    ) -> Arc<Self> {
+        Self::new_with_config(
+            plan,
+            upstream,
+            PluginHostConfig::new().with_callback_timeout(callback_timeout),
+        )
+    }
+
+    fn new_with_config(
+        plan: PluginPlan,
+        upstream: Option<Arc<dyn ClientLifecycle>>,
+        config: PluginHostConfig,
     ) -> Arc<Self> {
         let manifests = plan
             .ordered
@@ -1844,7 +1972,7 @@ impl PluginHost {
             apis: OnceLock::new(),
             runtime: OnceLock::new(),
             event_router,
-            callback_timeout,
+            config,
             terminal: AtomicBool::new(false),
             terminal_notifier: ShutdownNotifier::new(),
             installing_resources: Mutex::new(Vec::new()),
@@ -1920,8 +2048,14 @@ impl PluginHost {
                     .contains(PluginCapability::Tasks)
             })
             .count();
-        self.callback_timeout
-            .saturating_mul((callback_count + task_barrier_count) as u32)
+        self.config
+            .callback_timeout()
+            .saturating_mul(callback_count as u32)
+            .saturating_add(
+                self.config
+                    .task_drain_timeout()
+                    .saturating_mul(task_barrier_count as u32),
+            )
             .saturating_add(Duration::from_secs(1))
     }
 
@@ -2023,7 +2157,12 @@ impl PluginHost {
             .runtime
             .get()
             .ok_or(PluginTaskDrainError::RuntimeUnavailable)?;
-        wait_for_plugin_tasks(&**runtime, self.callback_timeout, completion_signals).await
+        wait_for_plugin_tasks(
+            &**runtime,
+            self.config.task_drain_timeout(),
+            completion_signals,
+        )
+        .await
     }
 
     async fn install_all(&self, client: Weak<Client>) -> anyhow::Result<()> {
@@ -2044,7 +2183,8 @@ impl PluginHost {
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .clear();
         });
-        let mut rollback = PluginInstallRollback::new(runtime.clone(), self.ordered.len());
+        let mut rollback =
+            PluginInstallRollback::new(runtime.clone(), self.ordered.len(), self.config);
         self.abort_install_if_terminal(&mut rollback).await?;
         if let Some(upstream) = &self.upstream {
             if let Err(error) = plugin_callback(|| upstream.install(client.clone())).await {
@@ -2228,7 +2368,7 @@ impl PluginHost {
         let runtime = self.runtime.get().ok_or_else(|| {
             PluginCallbackError::Callback(anyhow::anyhow!("plugin runtime is unavailable"))
         })?;
-        bounded_plugin_callback(&**runtime, self.callback_timeout, make_future).await
+        bounded_plugin_callback(&**runtime, self.config.callback_timeout(), make_future).await
     }
 
     fn record_upstream_callback(&self, result: &Result<(), PluginCallbackError>) {
@@ -2417,6 +2557,7 @@ enum PluginTaskDrainError {
 
 async fn shutdown_staged_plugins(
     runtime: Arc<dyn Runtime>,
+    config: PluginHostConfig,
     current: Option<InstalledPlugin>,
     mut installed: Vec<InstalledPlugin>,
     upstream: Option<Arc<dyn ClientLifecycle>>,
@@ -2425,7 +2566,7 @@ async fn shutdown_staged_plugins(
     if let Some(plugin) = current {
         let task_result = wait_for_plugin_tasks(
             &*runtime,
-            PLUGIN_CALLBACK_TIMEOUT,
+            config.task_drain_timeout(),
             plugin.resources.task_completion_signals(),
         )
         .await;
@@ -2436,7 +2577,7 @@ async fn shutdown_staged_plugins(
                 plugin.manifest.id
             );
         }
-        let callback_result = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+        let callback_result = bounded_plugin_callback(&*runtime, config.callback_timeout(), || {
             plugin.plugin.shutdown()
         })
         .await;
@@ -2452,7 +2593,7 @@ async fn shutdown_staged_plugins(
     while let Some(plugin) = installed.pop() {
         let task_result = wait_for_plugin_tasks(
             &*runtime,
-            PLUGIN_CALLBACK_TIMEOUT,
+            config.task_drain_timeout(),
             plugin.resources.task_completion_signals(),
         )
         .await;
@@ -2463,7 +2604,7 @@ async fn shutdown_staged_plugins(
                 plugin.manifest.id
             );
         }
-        let callback_result = bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || {
+        let callback_result = bounded_plugin_callback(&*runtime, config.callback_timeout(), || {
             plugin.plugin.shutdown()
         })
         .await;
@@ -2475,7 +2616,7 @@ async fn shutdown_staged_plugins(
     }
     if let Some(upstream) = upstream
         && let Err(error) =
-            bounded_plugin_callback(&*runtime, PLUGIN_CALLBACK_TIMEOUT, || upstream.shutdown())
+            bounded_plugin_callback(&*runtime, config.callback_timeout(), || upstream.shutdown())
                 .await
     {
         log::warn!("Upstream lifecycle rollback failed: {error:#}");
@@ -2638,6 +2779,31 @@ mod tests {
             .with_persistence_manager(persistence_manager)
             .with_transport_factory(MockTransportFactory::new())
             .with_http_client(MockHttpClient)
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_plugin_host_deadlines() {
+        let callback = complete_builder()
+            .await
+            .with_plugin_host_config(PluginHostConfig::new().with_callback_timeout(Duration::ZERO))
+            .build()
+            .await;
+        assert!(matches!(
+            callback,
+            Err(ClientBuilderError::InvalidPluginCallbackTimeout)
+        ));
+
+        let task_drain = complete_builder()
+            .await
+            .with_plugin_host_config(
+                PluginHostConfig::new().with_task_drain_timeout(Duration::ZERO),
+            )
+            .build()
+            .await;
+        assert!(matches!(
+            task_drain,
+            Err(ClientBuilderError::InvalidPluginTaskDrainTimeout)
+        ));
     }
 
     struct FoundationPlugin {
@@ -3358,7 +3524,8 @@ mod tests {
         let api: ErasedApi = Arc::new(TypedApi(Arc::new(PanickingDropApi)));
         registry.insert(TypeId::of::<PanickingDropPlugin>(), api);
 
-        let mut rollback = PluginInstallRollback::new(Arc::new(TokioRuntime), 1);
+        let mut rollback =
+            PluginInstallRollback::new(Arc::new(TokioRuntime), 1, PluginHostConfig::default());
         rollback.installed.push(InstalledPlugin {
             plugin: erased_plugin,
             manifest,
@@ -3849,6 +4016,123 @@ mod tests {
         shutdown_after_task: Arc<AtomicBool>,
     }
 
+    struct CooperativeTaskPlugin {
+        install_started: Arc<AtomicBool>,
+        install_finished: Arc<AtomicBool>,
+        connection_started: Arc<AtomicBool>,
+        connection_finished: Arc<AtomicBool>,
+        closed_after_task: Arc<AtomicBool>,
+        shutdown_after_task: Arc<AtomicBool>,
+    }
+
+    impl ClientPlugin for CooperativeTaskPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("cooperative-tasks", "0.1.0")
+                .with_capability(PluginCapability::Tasks)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let tasks = context
+                .tasks()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("tasks capability missing"));
+            let started = Arc::clone(&self.install_started);
+            let finished = Arc::clone(&self.install_finished);
+            Box::pin(async move {
+                let tasks = tasks?;
+                let shutdown = tasks.shutdown_signal();
+                tasks.spawn_cooperative(async move {
+                    started.store(true, Ordering::Release);
+                    wait_for_shutdown(&shutdown).await;
+                    tokio::task::yield_now().await;
+                    finished.store(true, Ordering::Release);
+                })?;
+                Ok(Arc::new(()))
+            })
+        }
+
+        fn on_ready(&self, scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            let tasks = scope
+                .tasks()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("connection tasks capability missing"));
+            let started = Arc::clone(&self.connection_started);
+            let finished = Arc::clone(&self.connection_finished);
+            Box::pin(async move {
+                let tasks = tasks?;
+                let cancelled = tasks.cancellation_signal();
+                tasks.spawn_cooperative(async move {
+                    started.store(true, Ordering::Release);
+                    wait_for_shutdown(&cancelled).await;
+                    tokio::task::yield_now().await;
+                    finished.store(true, Ordering::Release);
+                })?;
+                Ok(())
+            })
+        }
+
+        fn on_closed(&self, _scope: PluginConnectionScope) -> BoxFuture<'_, anyhow::Result<()>> {
+            let finished = self.connection_finished.load(Ordering::Acquire);
+            let observed = Arc::clone(&self.closed_after_task);
+            Box::pin(async move {
+                observed.store(finished, Ordering::Release);
+                Ok(())
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let finished = self.install_finished.load(Ordering::Acquire);
+            let observed = Arc::clone(&self.shutdown_after_task);
+            Box::pin(async move {
+                observed.store(finished, Ordering::Release);
+                Ok(())
+            })
+        }
+    }
+
+    struct TimedDrainPlugin {
+        started: Arc<AtomicBool>,
+        finished: Arc<AtomicBool>,
+        release_tx: async_channel::Sender<()>,
+        release_rx: async_channel::Receiver<()>,
+    }
+
+    impl ClientPlugin for TimedDrainPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("timed-drain", "0.1.0").with_capability(PluginCapability::Tasks)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            let tasks = context
+                .tasks()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("tasks capability missing"));
+            let started = Arc::clone(&self.started);
+            let finished = Arc::clone(&self.finished);
+            let release = self.release_rx.clone();
+            Box::pin(async move {
+                tasks?.spawn_cooperative(async move {
+                    started.store(true, Ordering::Release);
+                    let _ = release.recv().await;
+                    finished.store(true, Ordering::Release);
+                })?;
+                Ok(Arc::new(()))
+            })
+        }
+
+        fn shutdown(&self) -> BoxFuture<'_, anyhow::Result<()>> {
+            let release = self.release_tx.clone();
+            Box::pin(async move {
+                let _ = release.try_send(());
+                Ok(())
+            })
+        }
+    }
+
     impl ClientPlugin for ScopedTaskPlugin {
         type Api = ();
 
@@ -3996,6 +4280,88 @@ mod tests {
         assert_eq!(stats.plugins[0].state, PluginState::Stopped);
         assert_eq!(stats.plugins[0].install_tasks, 0);
         assert_eq!(stats.plugins[0].callbacks_completed, 3);
+    }
+
+    #[tokio::test]
+    async fn cooperative_tasks_drain_before_lifecycle_callbacks() {
+        let install_started = Arc::new(AtomicBool::new(false));
+        let install_finished = Arc::new(AtomicBool::new(false));
+        let connection_started = Arc::new(AtomicBool::new(false));
+        let connection_finished = Arc::new(AtomicBool::new(false));
+        let closed_after_task = Arc::new(AtomicBool::new(false));
+        let shutdown_after_task = Arc::new(AtomicBool::new(false));
+        let config = PluginHostConfig::new()
+            .with_callback_timeout(Duration::from_secs(1))
+            .with_task_drain_timeout(Duration::from_secs(1));
+        let client = complete_builder()
+            .await
+            .with_plugin_host_config(config)
+            .with_plugin(CooperativeTaskPlugin {
+                install_started: Arc::clone(&install_started),
+                install_finished: Arc::clone(&install_finished),
+                connection_started: Arc::clone(&connection_started),
+                connection_finished: Arc::clone(&connection_finished),
+                closed_after_task: Arc::clone(&closed_after_task),
+                shutdown_after_task: Arc::clone(&shutdown_after_task),
+            })
+            .build()
+            .await
+            .expect("cooperative task plugin")
+            .into_client();
+        let host = client.plugin_host.as_ref().expect("plugin host").clone();
+        assert_eq!(host.config, config);
+        wait_for_flag(&install_started).await;
+
+        let scope = ConnectionScope::new(212);
+        host.on_ready(scope.clone())
+            .await
+            .expect("cooperative ready callback");
+        wait_for_flag(&connection_started).await;
+        scope.cancel();
+        host.on_closed(scope)
+            .await
+            .expect("cooperative closed callback");
+        assert!(connection_finished.load(Ordering::Acquire));
+        assert!(closed_after_task.load(Ordering::Acquire));
+
+        client.disconnect().await;
+        assert!(install_finished.load(Ordering::Acquire));
+        assert!(shutdown_after_task.load(Ordering::Acquire));
+        let stats = client.plugin_stats().expect("cooperative plugin stats");
+        assert_eq!(stats.plugins[0].task_drain_timeouts, 0);
+        assert_eq!(stats.plugins[0].health, PluginHealth::Healthy);
+    }
+
+    #[tokio::test]
+    async fn configured_task_drain_timeout_degrades_and_continues_shutdown() {
+        let started = Arc::new(AtomicBool::new(false));
+        let finished = Arc::new(AtomicBool::new(false));
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let client = complete_builder()
+            .await
+            .with_plugin_host_config(
+                PluginHostConfig::new()
+                    .with_callback_timeout(Duration::from_secs(1))
+                    .with_task_drain_timeout(Duration::from_millis(10)),
+            )
+            .with_plugin(TimedDrainPlugin {
+                started: Arc::clone(&started),
+                finished: Arc::clone(&finished),
+                release_tx,
+                release_rx,
+            })
+            .build()
+            .await
+            .expect("timed drain plugin")
+            .into_client();
+        wait_for_flag(&started).await;
+
+        client.disconnect().await;
+        wait_for_flag(&finished).await;
+        let stats = client.plugin_stats().expect("timed drain stats");
+        assert_eq!(stats.plugins[0].task_drain_timeouts, 1);
+        assert_eq!(stats.plugins[0].health, PluginHealth::Degraded);
+        assert_eq!(stats.plugins[0].state, PluginState::Stopped);
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -314,7 +314,7 @@ struct PluginResources {
     shutdown: ShutdownNotifier,
     install_tasks: Arc<TaskTracker>,
     connection_tasks: Mutex<ConnectionTaskRegistry>,
-    subscriptions: Mutex<Vec<PluginCoreEventSubscription>>,
+    subscriptions: Mutex<Vec<Arc<PluginCoreEventSubscriptionInner>>>,
     teardown_panics: AtomicU64,
 }
 
@@ -413,9 +413,134 @@ impl Drop for TaskLease {
     }
 }
 
-struct PluginCoreEventSubscription {
-    _subscription: Subscription,
-    _raw_node_lease: Option<RawNodeLease>,
+struct PluginCoreEventSubscriptionState {
+    subscription: Option<Subscription>,
+    raw_node_lease: Option<RawNodeLease>,
+    interest: EventInterest,
+}
+
+struct PluginCoreEventSubscriptionInner {
+    client: Weak<Client>,
+    resources: Weak<PluginResources>,
+    plugin_id: Arc<str>,
+    state: Mutex<PluginCoreEventSubscriptionState>,
+}
+
+impl PluginCoreEventSubscriptionInner {
+    fn is_active(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .subscription
+            .is_some()
+    }
+
+    fn update_interest(&self, interest: EventInterest) -> Result<bool, PluginResourceError> {
+        let resources = self
+            .resources
+            .upgrade()
+            .ok_or(PluginResourceError::ShuttingDown)?;
+        if resources.closed.load(Ordering::Acquire) {
+            return Err(PluginResourceError::ShuttingDown);
+        }
+
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let wants_raw_node = interest.wants(EventKind::RawNode);
+        let acquired_raw_node_lease = if wants_raw_node && state.raw_node_lease.is_none() {
+            Some(
+                self.client
+                    .upgrade()
+                    .ok_or(PluginResourceError::ClientUnavailable)?
+                    .acquire_raw_node_forwarding(),
+            )
+        } else {
+            None
+        };
+        let Some(subscription) = state.subscription.as_ref() else {
+            return Ok(false);
+        };
+        if !subscription.update_interest(interest) {
+            let registration = (state.subscription.take(), state.raw_node_lease.take());
+            drop(state);
+            drop(acquired_raw_node_lease);
+            drop(registration);
+            return Ok(false);
+        }
+
+        state.interest = interest;
+        if let Some(lease) = acquired_raw_node_lease {
+            state.raw_node_lease = Some(lease);
+        }
+        let retired_raw_node_lease = (!wants_raw_node)
+            .then(|| state.raw_node_lease.take())
+            .flatten();
+        drop(state);
+        drop(retired_raw_node_lease);
+        Ok(true)
+    }
+
+    fn close(&self) -> bool {
+        let registration = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            (state.subscription.take(), state.raw_node_lease.take())
+        };
+        let active = registration.0.is_some();
+        if std::panic::catch_unwind(AssertUnwindSafe(|| drop(registration))).is_err() {
+            if let Some(resources) = self.resources.upgrade() {
+                resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
+            }
+            log::warn!(
+                "Plugin `{}` core-event subscription panicked while closing",
+                self.plugin_id
+            );
+        }
+        active
+    }
+}
+
+/// Ownership token for one plugin core-event subscription.
+///
+/// Dropping the token unsubscribes immediately. Host shutdown also invalidates
+/// a retained token, so keeping it in a plugin API cannot extend client work.
+#[must_use = "dropping the token immediately unregisters the plugin event handler"]
+pub struct PluginCoreEventSubscription {
+    inner: Arc<PluginCoreEventSubscriptionInner>,
+}
+
+impl PluginCoreEventSubscription {
+    pub fn interest(&self) -> EventInterest {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .interest
+    }
+
+    /// Replace the filter while preserving the handler registration.
+    pub fn update_interest(&self, interest: EventInterest) -> Result<bool, PluginResourceError> {
+        self.inner.update_interest(interest)
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.inner.is_active()
+    }
+
+    /// Remove the handler now instead of waiting for `Drop`.
+    pub fn unsubscribe(&self) -> bool {
+        self.inner.close()
+    }
+}
+
+impl Drop for PluginCoreEventSubscription {
+    fn drop(&mut self) {
+        self.inner.close();
+    }
 }
 
 impl PluginResources {
@@ -463,30 +588,43 @@ impl PluginResources {
 
     fn retain_subscription(
         &self,
+        client: Weak<Client>,
+        resources: Weak<PluginResources>,
+        plugin_id: Arc<str>,
+        interest: EventInterest,
         subscription: Subscription,
         raw_node_lease: Option<RawNodeLease>,
-    ) -> Result<(), PluginResourceError> {
-        let registration = PluginCoreEventSubscription {
-            _subscription: subscription,
-            _raw_node_lease: raw_node_lease,
-        };
+    ) -> Result<PluginCoreEventSubscription, PluginResourceError> {
+        let registration = Arc::new(PluginCoreEventSubscriptionInner {
+            client,
+            resources,
+            plugin_id,
+            state: Mutex::new(PluginCoreEventSubscriptionState {
+                subscription: Some(subscription),
+                raw_node_lease,
+                interest,
+            }),
+        });
         let rejected = {
             let mut subscriptions = self
                 .subscriptions
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if self.closed.load(Ordering::Acquire) {
-                Some(registration)
+                true
             } else {
-                subscriptions.push(registration);
-                None
+                subscriptions.retain(|subscription| subscription.is_active());
+                subscriptions.push(Arc::clone(&registration));
+                false
             }
         };
-        if let Some(rejected) = rejected {
-            drop(rejected);
+        if rejected {
+            registration.close();
             Err(PluginResourceError::ShuttingDown)
         } else {
-            Ok(())
+            Ok(PluginCoreEventSubscription {
+                inner: registration,
+            })
         }
     }
 
@@ -594,10 +732,7 @@ impl PluginResources {
             std::mem::take(&mut *subscriptions)
         };
         for subscription in subscriptions {
-            if std::panic::catch_unwind(AssertUnwindSafe(|| drop(subscription))).is_err() {
-                self.teardown_panics.fetch_add(1, Ordering::Relaxed);
-                log::warn!("Plugin core-event subscription panicked while being dropped");
-            }
+            subscription.close();
         }
     }
 }
@@ -634,7 +769,9 @@ impl PluginResources {
                 .subscriptions
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .len(),
+                .iter()
+                .filter(|subscription| subscription.is_active())
+                .count(),
             teardown_panics: self.teardown_panics.load(Ordering::Relaxed),
         }
     }
@@ -888,7 +1025,7 @@ impl PluginCoreEvents {
         &self,
         interest: EventInterest,
         handler: Arc<dyn EventHandler>,
-    ) -> Result<(), PluginResourceError> {
+    ) -> Result<PluginCoreEventSubscription, PluginResourceError> {
         let client = self
             .client
             .upgrade()
@@ -903,8 +1040,14 @@ impl PluginCoreEvents {
             diagnostics: Arc::clone(&self.diagnostics),
         });
         let subscription = client.subscribe(interest, handler);
-        self.resources
-            .retain_subscription(subscription, raw_node_lease)
+        self.resources.retain_subscription(
+            self.client.clone(),
+            Arc::downgrade(&self.resources),
+            Arc::clone(&self.plugin_id),
+            interest,
+            subscription,
+            raw_node_lease,
+        )
     }
 }
 
@@ -4317,7 +4460,7 @@ mod tests {
     struct PanickingCoreEventPlugin;
 
     impl ClientPlugin for PanickingCoreEventPlugin {
-        type Api = ();
+        type Api = PluginCoreEventSubscription;
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("panicking-core-event", "0.1.0")
@@ -4326,14 +4469,14 @@ mod tests {
 
         fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
             Box::pin(async move {
-                context
+                let subscription = context
                     .core_events()
                     .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
                     .subscribe(
                         EventInterest::of(&[EventKind::Connected]),
                         Arc::new(PanickingCoreEventHandler),
                     )?;
-                Ok(Arc::new(()))
+                Ok(Arc::new(subscription))
             })
         }
     }
@@ -4341,7 +4484,7 @@ mod tests {
     struct PanickingSubscriptionPlugin;
 
     impl ClientPlugin for PanickingSubscriptionPlugin {
-        type Api = ();
+        type Api = PluginCoreEventSubscription;
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("panicking-subscription", "0.1.0")
@@ -4350,14 +4493,14 @@ mod tests {
 
         fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
             Box::pin(async move {
-                context
+                let subscription = context
                     .core_events()
                     .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
                     .subscribe(
                         EventInterest::of(&[EventKind::Connected]),
                         Arc::new(PanickingDropEventHandler),
                     )?;
-                Ok(Arc::new(()))
+                Ok(Arc::new(subscription))
             })
         }
     }
@@ -4391,7 +4534,7 @@ mod tests {
     }
 
     impl ClientPlugin for EventSubscriptionPlugin {
-        type Api = ();
+        type Api = PluginCoreEventSubscription;
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("event-subscription", "0.1.0")
@@ -4400,14 +4543,14 @@ mod tests {
 
         fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
             Box::pin(async move {
-                context
+                let subscription = context
                     .core_events()
                     .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
                     .subscribe(
                         EventInterest::of(&[EventKind::Connected, EventKind::RawNode]),
                         Arc::new(NoopEventHandler),
                     )?;
-                Ok(Arc::new(()))
+                Ok(Arc::new(subscription))
             })
         }
     }
@@ -4431,8 +4574,13 @@ mod tests {
 
     struct ReentrantSubscriptionPlugin;
 
+    struct ReentrantSubscriptionApi {
+        events: PluginCoreEvents,
+        _subscription: PluginCoreEventSubscription,
+    }
+
     impl ClientPlugin for ReentrantSubscriptionPlugin {
-        type Api = PluginCoreEvents;
+        type Api = ReentrantSubscriptionApi;
 
         fn manifest(&self) -> PluginManifest {
             PluginManifest::new("reentrant-subscription", "0.1.0")
@@ -4445,13 +4593,16 @@ mod tests {
                     .core_events()
                     .cloned()
                     .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?;
-                events.subscribe(
+                let subscription = events.subscribe(
                     EventInterest::of(&[EventKind::Connected]),
                     Arc::new(ReentrantSubscriptionHandler {
                         events: events.clone(),
                     }),
                 )?;
-                Ok(Arc::new(events))
+                Ok(Arc::new(ReentrantSubscriptionApi {
+                    events,
+                    _subscription: subscription,
+                }))
             })
         }
     }
@@ -4481,6 +4632,56 @@ mod tests {
                 .has_handler_for(wacore::types::events::EventKind::Connected)
         );
         assert!(!client.raw_node_forwarding_enabled());
+    }
+
+    #[tokio::test]
+    async fn plugin_subscription_updates_interest_and_can_unsubscribe_early() {
+        let client = complete_builder()
+            .await
+            .with_plugin(EventSubscriptionPlugin)
+            .build()
+            .await
+            .expect("event subscription plugin")
+            .into_client();
+        let subscription = client
+            .plugin::<EventSubscriptionPlugin>()
+            .expect("subscription API");
+
+        assert!(subscription.is_active());
+        assert!(subscription.interest().wants(EventKind::RawNode));
+        assert!(client.raw_node_forwarding_enabled());
+        assert!(
+            subscription
+                .update_interest(EventInterest::of(&[EventKind::Connected]))
+                .expect("interest update")
+        );
+        assert!(!client.raw_node_forwarding_enabled());
+        assert!(!subscription.interest().wants(EventKind::RawNode));
+        assert!(client.core.event_bus.has_handler_for(EventKind::Connected));
+        assert!(
+            subscription
+                .update_interest(EventInterest::of(&[EventKind::RawNode]))
+                .expect("raw-node interest update")
+        );
+        assert!(client.raw_node_forwarding_enabled());
+        assert!(!client.core.event_bus.has_handler_for(EventKind::Connected));
+
+        assert!(subscription.unsubscribe());
+        assert!(!subscription.is_active());
+        assert!(!subscription.unsubscribe());
+        assert!(!client.raw_node_forwarding_enabled());
+        assert!(!client.core.event_bus.has_handler_for(EventKind::Connected));
+        assert_eq!(
+            client
+                .plugin_stats()
+                .expect("plugin stats")
+                .plugins
+                .first()
+                .expect("plugin stats entry")
+                .core_event_subscriptions,
+            0
+        );
+        client.disconnect().await;
     }
 
     #[tokio::test]
@@ -4615,10 +4816,10 @@ mod tests {
         let (completed_tx, completed_rx) = std::sync::mpsc::sync_channel(1);
         let subscribe_events = events.clone();
         let subscribe = std::thread::spawn(move || {
-            let result = subscribe_events.subscribe(
+            let result = subscribe_events.events.subscribe(
                 EventInterest::of(&[EventKind::Connected]),
                 Arc::new(ReentrantSubscriptionHandler {
-                    events: (*subscribe_events).clone(),
+                    events: subscribe_events.events.clone(),
                 }),
             );
             let _ = completed_tx.send(result);

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -469,7 +469,17 @@ impl PluginResources {
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             std::mem::take(&mut *subscriptions)
         };
-        drop(subscriptions);
+        for subscription in subscriptions {
+            if std::panic::catch_unwind(AssertUnwindSafe(|| drop(subscription))).is_err() {
+                log::warn!("Plugin core-event subscription panicked while being dropped");
+            }
+        }
+    }
+}
+
+fn close_plugin_resources(plugin_id: &str, resources: &PluginResources) {
+    if std::panic::catch_unwind(AssertUnwindSafe(|| resources.close())).is_err() {
+        log::warn!("Plugin `{plugin_id}` resource closure panicked");
     }
 }
 
@@ -1049,10 +1059,10 @@ impl PluginInstallRollback {
 
     fn close_resources(&self) {
         if let Some(current) = &self.current {
-            current.resources.close();
+            close_plugin_resources(&current.manifest.id, &current.resources);
         }
         for plugin in self.installed.iter().rev() {
-            plugin.resources.close();
+            close_plugin_resources(&plugin.manifest.id, &plugin.resources);
         }
     }
 
@@ -1406,7 +1416,9 @@ impl PluginHost {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if self.terminal.load(Ordering::Acquire) {
             drop(installing);
-            resources.close();
+            if std::panic::catch_unwind(AssertUnwindSafe(|| resources.close())).is_err() {
+                log::warn!("Installing plugin resource closure panicked");
+            }
             return false;
         }
         installing.push(Arc::downgrade(resources));
@@ -1422,7 +1434,9 @@ impl PluginHost {
             .filter_map(Weak::upgrade)
             .collect::<Vec<_>>();
         for resources in resources {
-            resources.close();
+            if std::panic::catch_unwind(AssertUnwindSafe(|| resources.close())).is_err() {
+                log::warn!("Installing plugin resource closure panicked");
+            }
         }
     }
 
@@ -1444,7 +1458,7 @@ impl PluginHost {
 
     fn close_installed_resources(&self) {
         for plugin in self.installed.get().into_iter().flatten().rev() {
-            plugin.resources.close();
+            close_plugin_resources(&plugin.manifest.id, &plugin.resources);
         }
     }
 
@@ -3097,6 +3111,70 @@ mod tests {
 
     struct EventSubscriptionPlugin;
 
+    struct PanickingDropEventHandler;
+
+    impl EventHandler for PanickingDropEventHandler {
+        fn handle_event(&self, _event: Arc<wacore::types::events::Event>) {}
+    }
+
+    impl Drop for PanickingDropEventHandler {
+        fn drop(&mut self) {
+            panic!("injected event handler drop panic");
+        }
+    }
+
+    struct PanickingSubscriptionPlugin;
+
+    impl ClientPlugin for PanickingSubscriptionPlugin {
+        type Api = ();
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("panicking-subscription", "0.1.0")
+                .with_capability(PluginCapability::CoreEvents)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                context
+                    .core_events()
+                    .ok_or_else(|| anyhow::anyhow!("core events capability missing"))?
+                    .subscribe(
+                        EventInterest::of(&[EventKind::Connected]),
+                        Arc::new(PanickingDropEventHandler),
+                    )?;
+                Ok(Arc::new(()))
+            })
+        }
+    }
+
+    struct ShutdownSignalPlugin;
+
+    impl ClientPlugin for ShutdownSignalPlugin {
+        type Api = ShutdownSignal;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("shutdown-signal", "0.1.0").with_capability(PluginCapability::Tasks)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                context
+                    .tasks()
+                    .map(PluginTasks::shutdown_signal)
+                    .map(Arc::new)
+                    .ok_or_else(|| anyhow::anyhow!("tasks capability missing"))
+            })
+        }
+    }
+
+    struct ShutdownSignalLifecycle(Arc<AtomicBool>);
+
+    impl ClientLifecycle for ShutdownSignalLifecycle {
+        fn signal_shutdown(&self) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
     impl ClientPlugin for EventSubscriptionPlugin {
         type Api = ();
 
@@ -3188,6 +3266,30 @@ mod tests {
                 .has_handler_for(wacore::types::events::EventKind::Connected)
         );
         assert!(!client.raw_node_forwarding_enabled());
+    }
+
+    #[tokio::test]
+    async fn panicking_handler_drop_does_not_strand_later_plugins_or_upstream() {
+        let upstream_signalled = Arc::new(AtomicBool::new(false));
+        let client = complete_builder()
+            .await
+            .with_lifecycle(ShutdownSignalLifecycle(upstream_signalled.clone()))
+            .with_plugin(ShutdownSignalPlugin)
+            .with_plugin(PanickingSubscriptionPlugin)
+            .build()
+            .await
+            .expect("panicking subscription client")
+            .into_client();
+        let plugin_shutdown = client
+            .plugin::<ShutdownSignalPlugin>()
+            .expect("shutdown signal API");
+
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| client.signal_shutdown_sync()));
+
+        assert!(result.is_ok());
+        assert!(plugin_shutdown.is_fired());
+        assert!(upstream_signalled.load(Ordering::Acquire));
+        client.disconnect().await;
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -258,6 +258,8 @@ pub struct PluginStats {
     pub callback_failures: u64,
     pub callback_timeouts: u64,
     pub task_drain_timeouts: u64,
+    /// Spawned workers that panicked while running or being cancelled.
+    pub task_panics: u64,
     /// Core-event handler calls that returned without panicking.
     pub core_events_delivered: u64,
     /// Panics isolated before they could unwind through the client's event dispatcher.
@@ -619,6 +621,7 @@ struct PluginDiagnostics {
     callback_failures: AtomicU64,
     callback_timeouts: AtomicU64,
     task_drain_timeouts: AtomicU64,
+    task_panics: AtomicU64,
     core_events_delivered: AtomicU64,
     core_event_panics: AtomicU64,
     shutdown_complete: AtomicBool,
@@ -632,6 +635,7 @@ impl PluginDiagnostics {
             callback_failures: AtomicU64::new(0),
             callback_timeouts: AtomicU64::new(0),
             task_drain_timeouts: AtomicU64::new(0),
+            task_panics: AtomicU64::new(0),
             core_events_delivered: AtomicU64::new(0),
             core_event_panics: AtomicU64::new(0),
             shutdown_complete: AtomicBool::new(false),
@@ -690,6 +694,7 @@ impl PluginDiagnostics {
         let callback_failures = self.callback_failures.load(Ordering::Relaxed);
         let callback_timeouts = self.callback_timeouts.load(Ordering::Relaxed);
         let task_drain_timeouts = self.task_drain_timeouts.load(Ordering::Relaxed);
+        let task_panics = self.task_panics.load(Ordering::Relaxed);
         let core_events_delivered = self.core_events_delivered.load(Ordering::Relaxed);
         let core_event_panics = self.core_event_panics.load(Ordering::Relaxed);
         let state = if self.shutdown_complete.load(Ordering::Acquire) {
@@ -707,6 +712,7 @@ impl PluginDiagnostics {
         let health = if callback_failures > 0
             || callback_timeouts > 0
             || task_drain_timeouts > 0
+            || task_panics > 0
             || core_event_panics > 0
             || resources.teardown_panics > 0
             || event_degraded
@@ -723,6 +729,7 @@ impl PluginDiagnostics {
             callback_failures,
             callback_timeouts,
             task_drain_timeouts,
+            task_panics,
             core_events_delivered,
             core_event_panics,
             resource_teardown_panics: resources.teardown_panics,
@@ -743,6 +750,8 @@ impl PluginDiagnostics {
 pub struct PluginTasks {
     runtime: Arc<dyn Runtime>,
     resources: Arc<PluginResources>,
+    diagnostics: Arc<PluginDiagnostics>,
+    plugin_id: Arc<str>,
 }
 
 impl PluginTasks {
@@ -754,7 +763,14 @@ impl PluginTasks {
             return Err(PluginResourceError::ShuttingDown);
         }
         let lease = self.resources.install_tasks.register()?;
-        spawn_after_activation(&self.runtime, Arc::clone(&self.resources), lease, future);
+        spawn_after_activation(
+            &self.runtime,
+            Arc::clone(&self.resources),
+            Arc::clone(&self.diagnostics),
+            Arc::clone(&self.plugin_id),
+            lease,
+            future,
+        );
         Ok(())
     }
 
@@ -985,6 +1001,8 @@ pub struct PluginConnectionTasks {
     runtime: Arc<dyn Runtime>,
     scope: ConnectionScope,
     tracker: Arc<TaskTracker>,
+    diagnostics: Arc<PluginDiagnostics>,
+    plugin_id: Arc<str>,
 }
 
 impl PluginConnectionTasks {
@@ -999,6 +1017,8 @@ impl PluginConnectionTasks {
         spawn_until_cancelled(
             &self.runtime,
             self.scope.cancellation_signal(),
+            Arc::clone(&self.diagnostics),
+            Arc::clone(&self.plugin_id),
             lease,
             future,
         );
@@ -1022,19 +1042,100 @@ impl PluginConnectionTasks {
     }
 }
 
+struct GuardedPluginTask<F: Future<Output = ()>> {
+    future: Option<std::pin::Pin<Box<F>>>,
+    diagnostics: Arc<PluginDiagnostics>,
+    plugin_id: Arc<str>,
+    failure_recorded: bool,
+}
+
+impl<F> GuardedPluginTask<F>
+where
+    F: Future<Output = ()>,
+{
+    fn new(future: F, diagnostics: Arc<PluginDiagnostics>, plugin_id: Arc<str>) -> Self {
+        Self {
+            future: Some(Box::pin(future)),
+            diagnostics,
+            plugin_id,
+            failure_recorded: false,
+        }
+    }
+
+    fn record_panic(&mut self, stage: &str) {
+        if !self.failure_recorded {
+            self.failure_recorded = true;
+            self.diagnostics.task_panics.fetch_add(1, Ordering::Relaxed);
+        }
+        log::warn!("Plugin `{}` task panicked {stage}", self.plugin_id);
+    }
+
+    fn drop_future(&mut self) -> bool {
+        let future = self.future.take();
+        std::panic::catch_unwind(AssertUnwindSafe(|| drop(future))).is_err()
+    }
+}
+
+impl<F> Unpin for GuardedPluginTask<F> where F: Future<Output = ()> {}
+
+impl<F> Future for GuardedPluginTask<F>
+where
+    F: Future<Output = ()>,
+{
+    type Output = ();
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.get_mut();
+        let Some(future) = this.future.as_mut() else {
+            return std::task::Poll::Ready(());
+        };
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| future.as_mut().poll(context)));
+        match result {
+            Ok(std::task::Poll::Pending) => std::task::Poll::Pending,
+            Ok(std::task::Poll::Ready(())) => {
+                if this.drop_future() {
+                    this.record_panic("after completion");
+                }
+                std::task::Poll::Ready(())
+            }
+            Err(_) => {
+                this.record_panic("while running");
+                if this.drop_future() {
+                    this.record_panic("while cleaning up after failure");
+                }
+                std::task::Poll::Ready(())
+            }
+        }
+    }
+}
+
+impl<F: Future<Output = ()>> Drop for GuardedPluginTask<F> {
+    fn drop(&mut self) {
+        if self.drop_future() {
+            self.record_panic("while being cancelled");
+        }
+    }
+}
+
 fn spawn_until_cancelled<F>(
     runtime: &Arc<dyn Runtime>,
     cancellation: ShutdownSignal,
+    diagnostics: Arc<PluginDiagnostics>,
+    plugin_id: Arc<str>,
     lease: TaskLease,
     future: F,
 ) where
     F: Future<Output = ()> + Spawnable,
 {
+    let work = GuardedPluginTask::new(future, diagnostics, plugin_id);
     runtime
         .spawn(Box::pin(async move {
             let _lease = lease;
             let cancelled = Box::pin(wait_for_shutdown(&cancellation));
-            let work = Box::pin(future);
+            let work = Box::pin(work);
             let _ = futures::future::select(cancelled, work).await;
         }))
         .detach();
@@ -1043,6 +1144,8 @@ fn spawn_until_cancelled<F>(
 fn spawn_after_activation<F>(
     runtime: &Arc<dyn Runtime>,
     resources: Arc<PluginResources>,
+    diagnostics: Arc<PluginDiagnostics>,
+    plugin_id: Arc<str>,
     lease: TaskLease,
     future: F,
 ) where
@@ -1050,6 +1153,7 @@ fn spawn_after_activation<F>(
 {
     let activation = resources.activation.subscribe();
     let cancellation = resources.shutdown.subscribe();
+    let work = GuardedPluginTask::new(future, diagnostics, plugin_id);
     runtime
         .spawn(Box::pin(async move {
             let _lease = lease;
@@ -1065,7 +1169,7 @@ fn spawn_after_activation<F>(
                 return;
             }
             let cancelled = Box::pin(wait_for_shutdown(&cancellation));
-            let work = Box::pin(future);
+            let work = Box::pin(work);
             let _ = futures::future::select(cancelled, work).await;
         }))
         .detach();
@@ -1578,6 +1682,7 @@ impl PluginHost {
         } = parts;
         let manifest = &planned.manifest;
         let capabilities = manifest.capabilities;
+        let plugin_id: Arc<str> = Arc::from(manifest.id.as_str());
         PluginContext {
             plugin_id: manifest.id.clone(),
             dependencies: apis.dependency_view(&planned.dependency_markers),
@@ -1586,7 +1691,7 @@ impl PluginHost {
                 .then(|| PluginCoreEvents {
                     client: client.clone(),
                     resources: Arc::clone(&resources),
-                    plugin_id: Arc::from(manifest.id.as_str()),
+                    plugin_id: Arc::clone(&plugin_id),
                     diagnostics: Arc::clone(&diagnostics),
                 }),
             tasks: capabilities
@@ -1594,6 +1699,8 @@ impl PluginHost {
                 .then(|| PluginTasks {
                     runtime: Arc::clone(&runtime),
                     resources: Arc::clone(&resources),
+                    diagnostics: Arc::clone(&diagnostics),
+                    plugin_id,
                 }),
             messaging: capabilities.contains(PluginCapability::Messaging).then(|| {
                 PluginMessaging {
@@ -1625,10 +1732,14 @@ impl PluginHost {
     fn connection_scope(
         &self,
         scope: ConnectionScope,
-        manifest: &PluginManifest,
+        plugin: &InstalledPlugin,
         task_tracker: Option<Arc<TaskTracker>>,
     ) -> PluginConnectionScope {
-        let tasks = if manifest.capabilities.contains(PluginCapability::Tasks) {
+        let tasks = if plugin
+            .manifest
+            .capabilities
+            .contains(PluginCapability::Tasks)
+        {
             self.runtime
                 .get()
                 .cloned()
@@ -1637,6 +1748,8 @@ impl PluginHost {
                     runtime,
                     scope: scope.clone(),
                     tracker,
+                    diagnostics: Arc::clone(&plugin.diagnostics),
+                    plugin_id: Arc::from(plugin.manifest.id.as_str()),
                 })
         } else {
             None
@@ -1867,8 +1980,7 @@ impl ClientLifecycle for PluginHost {
                         }
                         tracker
                     });
-                let plugin_scope =
-                    self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
+                let plugin_scope = self.connection_scope(scope.clone(), plugin, task_tracker);
                 let result = self
                     .run_callback(|| plugin.plugin.on_ready(plugin_scope))
                     .await;
@@ -1904,8 +2016,7 @@ impl ClientLifecycle for PluginHost {
                         }
                     }
                 }
-                let plugin_scope =
-                    self.connection_scope(scope.clone(), &plugin.manifest, task_tracker);
+                let plugin_scope = self.connection_scope(scope.clone(), plugin, task_tracker);
                 let result = self
                     .run_callback(|| plugin.plugin.on_closed(plugin_scope))
                     .await;
@@ -2641,6 +2752,25 @@ mod tests {
         }
     }
 
+    struct PendingDropPanic;
+
+    impl Future for PendingDropPanic {
+        type Output = ();
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            _context: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            std::task::Poll::Pending
+        }
+    }
+
+    impl Drop for PendingDropPanic {
+        fn drop(&mut self) {
+            panic!("injected task cancellation panic");
+        }
+    }
+
     struct PanickingDropApi;
 
     impl Drop for PanickingDropApi {
@@ -3336,6 +3466,8 @@ mod tests {
             runtime: Arc::new(TokioRuntime),
             scope: scope.clone(),
             tracker: TaskTracker::new(),
+            diagnostics: PluginDiagnostics::new(),
+            plugin_id: Arc::from("connection-task-test"),
         };
         let guard = DropFlag(task_dropped.clone());
         tasks
@@ -3360,12 +3492,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn spawned_task_panics_are_isolated_and_degrade_health() {
+        let diagnostics = PluginDiagnostics::new();
+        let plugin_id: Arc<str> = Arc::from("panicking-task-test");
+        let resources = PluginResources::new();
+        diagnostics.attach_resources(&resources);
+        resources.activate();
+        let install_tasks = PluginTasks {
+            runtime: Arc::new(TokioRuntime),
+            resources: resources.clone(),
+            diagnostics: diagnostics.clone(),
+            plugin_id: plugin_id.clone(),
+        };
+        install_tasks
+            .spawn(async { panic!("injected install task panic") })
+            .expect("spawn install task");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while diagnostics.task_panics.load(Ordering::Relaxed) < 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("install task panic was not recorded");
+        assert_eq!(resources.install_tasks.active(), 0);
+
+        let connection_scope = ConnectionScope::new(101);
+        let connection_tracker = TaskTracker::new();
+        let connection_tasks = PluginConnectionTasks {
+            runtime: Arc::new(TokioRuntime),
+            scope: connection_scope,
+            tracker: connection_tracker.clone(),
+            diagnostics: diagnostics.clone(),
+            plugin_id: plugin_id.clone(),
+        };
+        connection_tasks
+            .spawn(async { panic!("injected connection task panic") })
+            .expect("spawn connection task");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while diagnostics.task_panics.load(Ordering::Relaxed) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("connection task panic was not recorded");
+        assert_eq!(connection_tracker.active(), 0);
+
+        let cancellation_scope = ConnectionScope::new(102);
+        let cancellation_tracker = TaskTracker::new();
+        let cancellation_tasks = PluginConnectionTasks {
+            runtime: Arc::new(TokioRuntime),
+            scope: cancellation_scope.clone(),
+            tracker: cancellation_tracker.clone(),
+            diagnostics: diagnostics.clone(),
+            plugin_id,
+        };
+        cancellation_tasks
+            .spawn(PendingDropPanic)
+            .expect("spawn cancellation task");
+        cancellation_scope.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while diagnostics.task_panics.load(Ordering::Relaxed) < 3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("task cancellation panic was not recorded");
+        assert_eq!(cancellation_tracker.active(), 0);
+
+        let stats = diagnostics.snapshot("panicking-task-test", false, None);
+        assert_eq!(stats.task_panics, 3);
+        assert_eq!(stats.health, PluginHealth::Degraded);
+        resources.close();
+    }
+
+    #[tokio::test]
     async fn task_sleeps_return_when_their_owner_is_cancelled() {
         let resources = PluginResources::new();
         resources.activate();
         let install_tasks = PluginTasks {
             runtime: Arc::new(TokioRuntime),
             resources: resources.clone(),
+            diagnostics: PluginDiagnostics::new(),
+            plugin_id: Arc::from("install-sleep-test"),
         };
         let install_sleeper =
             tokio::spawn(async move { install_tasks.sleep(Duration::from_secs(60)).await });
@@ -3384,6 +3595,8 @@ mod tests {
             runtime: Arc::new(TokioRuntime),
             scope: scope.clone(),
             tracker: TaskTracker::new(),
+            diagnostics: PluginDiagnostics::new(),
+            plugin_id: Arc::from("connection-sleep-test"),
         };
         let connection_sleeper =
             tokio::spawn(async move { connection_tasks.sleep(Duration::from_secs(60)).await });

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1708,7 +1708,7 @@ mod tests {
         .await;
 
         let collector = Arc::new(TestEventCollector::default());
-        client.register_handler(collector.clone());
+        client.subscribe_handler(collector.clone()).detach();
         (client, collector)
     }
 

--- a/src/types/enc_handler.rs
+++ b/src/types/enc_handler.rs
@@ -151,7 +151,7 @@ mod tests {
             .await
             .expect("Failed to build bot");
 
-        // Verify no custom handlers are registered (the map is set, just empty)
-        assert_eq!(bot.client().custom_enc_handlers.get().unwrap().len(), 0);
+        // Keep the hot-path map unallocated when no extension uses it.
+        assert!(bot.client().custom_enc_handlers.get().is_none());
     }
 }

--- a/storages/chat-store/src/lib.rs
+++ b/storages/chat-store/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```ignore
 //! let chat_store = ChatStore::new(&sqlite_store).await?;
-//! client.register_handler(chat_store.handler());
+//! let _chat_subscription = client.subscribe_handler(chat_store.handler());
 //!
 //! let chats = chat_store.chats(false, 50).await?;
 //! let page = chat_store.messages(&chats[0].jid, None, 40).await?;

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -58,7 +58,7 @@ pub(crate) enum WriterMsg {
 /// Wire-up:
 /// ```ignore
 /// let chat_store = ChatStore::new(&sqlite_store).await?;
-/// client.register_handler(chat_store.handler());
+/// let _chat_subscription = client.subscribe_handler(chat_store.handler());
 /// let mut changes = chat_store.subscribe();
 /// ```
 pub struct ChatStore {

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -213,7 +213,7 @@ impl TestClient {
         if push_name_pre_seeded {
             client.set_force_active_delivery_receipts(true);
         }
-        client.register_handler(event_handler);
+        client.subscribe_handler(event_handler).detach();
 
         // The mock server no longer auto-pairs (legacy timer is off by
         // default). Spawn an out-of-process "phone" that POSTs the first
@@ -222,7 +222,7 @@ impl TestClient {
         // Uses its own ChannelEventHandler because async_channel is MPMC:
         // sharing event_rx would steal events from wait_for_event below.
         let (qr_handler, qr_rx) = ChannelEventHandler::new();
-        client.register_handler(qr_handler);
+        client.subscribe_handler(qr_handler).detach();
         let _qr_responder = spawn_qr_autoresponder_http(qr_rx);
 
         let run_handle = bot.spawn();

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -448,8 +448,10 @@ impl CoreEventBusInner {
         let snapshot = Arc::new(HandlerSnapshot { handlers });
         // Retire the entry before clearing bits; an early read may only be a
         // harmless false positive.
-        *guard = Arc::clone(&snapshot);
+        let retired = std::mem::replace(&mut *guard, Arc::clone(&snapshot));
         self.store_aggregate(&snapshot);
+        drop(guard);
+        drop(retired);
         true
     }
 
@@ -2324,6 +2326,42 @@ mod tests {
         assert!(!bus.has_handler_for(EventKind::Connected));
         bus.dispatch(Event::Connected(Connected::builder().build()));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn handler_drop_can_unsubscribe_from_the_same_bus() {
+        use std::sync::Mutex;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        struct OwnsSubscription(Mutex<Option<Subscription>>);
+        impl EventHandler for OwnsSubscription {
+            fn handle_event(&self, _: Arc<Event>) {}
+        }
+        impl Drop for OwnsSubscription {
+            fn drop(&mut self) {
+                self.0
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .take();
+            }
+        }
+
+        let bus = CoreEventBus::new();
+        let owned = bus.subscribe_handler(ChannelEventHandler::new().0);
+        let owner = Arc::new(OwnsSubscription(Mutex::new(Some(owned))));
+        let outer = bus.subscribe_handler(owner.clone());
+        drop(owner);
+
+        let (done_tx, done_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            drop(outer);
+            let _ = done_tx.send(());
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("handler drop re-entered event-bus removal");
+        assert!(!bus.has_handlers());
     }
 
     #[test]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -4,6 +4,7 @@ use crate::types::message::MessageInfo;
 use crate::types::presence::{ChatPresence, ChatPresenceMedia, ReceiptType};
 use bytes::Bytes;
 use chrono::{DateTime, Duration, Utc};
+use portable_atomic::{AtomicU64, Ordering};
 use serde::Serialize;
 use std::fmt;
 use std::sync::{Arc, OnceLock, RwLock};
@@ -204,7 +205,7 @@ impl Serialize for LazyHistorySync {
 /// Discriminant for each [`Event`] variant, used to express handler interest
 /// without materializing the event. One per `Event` variant, in declaration
 /// order; the value doubles as a bit index in [`EventInterest`], so there can
-/// be at most 64 kinds.
+/// be at most 128 kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 #[non_exhaustive]
@@ -281,9 +282,9 @@ impl EventKind {
 // fails compilation instead of silently corrupting the mask at runtime.
 const _: () = assert!((EventKind::ServerAck as u8) < EventKind::CAPACITY);
 
-/// A set of [`EventKind`]s a handler wants delivered. The event bus skips
-/// materializing and dispatching events whose kind no handler wants, so a
-/// handler that subscribes to a few kinds never pays for boxing the others.
+/// A set of [`EventKind`]s a handler wants delivered. Producers can query the
+/// aggregate interest before building expensive payloads, and dispatch avoids
+/// allocating an `Arc<Event>` when no handler wants the kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventInterest(u128);
 
@@ -323,14 +324,18 @@ impl EventInterest {
     pub const fn union(self, other: Self) -> Self {
         EventInterest(self.0 | other.0)
     }
+
+    const fn words(self) -> (u64, u64) {
+        (self.0 as u64, (self.0 >> 64) as u64)
+    }
 }
 
 pub trait EventHandler: crate::sync_marker::MaybeSendSync {
     fn handle_event(&self, event: Arc<Event>);
 
-    /// Which event kinds this handler wants. Defaults to all kinds, so the bus
-    /// keeps delivering everything to handlers that don't opt into a narrower
-    /// set. Override to let the bus skip materializing unwanted events.
+    /// Registration-time interest hint used by
+    /// [`CoreEventBus::subscribe_handler`]. The bus captures it once; use
+    /// [`Subscription::update_interest`] for later changes.
     fn interest(&self) -> EventInterest {
         EventInterest::ALL
     }
@@ -341,7 +346,7 @@ pub trait EventHandler: crate::sync_marker::MaybeSendSync {
 /// # Example
 /// ```ignore
 /// let (handler, rx) = ChannelEventHandler::new();
-/// client.register_handler(handler);
+/// let _subscription = client.subscribe_handler(handler);
 /// while let Ok(event) = rx.recv().await {
 ///     if matches!(&*event, Event::Connected(_)) { break; }
 /// }
@@ -363,22 +368,174 @@ impl EventHandler for ChannelEventHandler {
     }
 }
 
+#[derive(Clone)]
+struct HandlerEntry {
+    id: u64,
+    interest: EventInterest,
+    handler: Arc<dyn EventHandler>,
+}
+
 /// Immutable snapshot of the registered handlers. `dispatch` clones only the
 /// outer `Arc` (one refcount bump, no `Vec` allocation), then drops the lock and
-/// iterates the snapshot. Handler interest is re-evaluated per dispatch so a
-/// handler whose `interest()` widens at runtime still receives the new kinds.
+/// iterates it. Interests change only through the subscription that owns an
+/// entry, so one snapshot always contains a coherent handler/filter pair.
 #[derive(Default)]
 struct HandlerSnapshot {
-    handlers: Vec<Arc<dyn EventHandler>>,
+    handlers: Vec<HandlerEntry>,
+}
+
+struct CoreEventBusInner {
+    handlers: RwLock<Arc<HandlerSnapshot>>,
+    next_id: AtomicU64,
+    interest_low: AtomicU64,
+    interest_high: AtomicU64,
+}
+
+impl Default for CoreEventBusInner {
+    fn default() -> Self {
+        Self {
+            handlers: RwLock::new(Arc::new(HandlerSnapshot::default())),
+            next_id: AtomicU64::new(1),
+            interest_low: AtomicU64::new(0),
+            interest_high: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CoreEventBusInner {
+    fn snapshot(&self) -> Arc<HandlerSnapshot> {
+        self.handlers
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn publish_interest(&self, interest: EventInterest) {
+        let (low, high) = interest.words();
+        if low != 0 {
+            self.interest_low.fetch_or(low, Ordering::Release);
+        }
+        if high != 0 {
+            self.interest_high.fetch_or(high, Ordering::Release);
+        }
+    }
+
+    fn store_aggregate(&self, snapshot: &HandlerSnapshot) {
+        let aggregate = snapshot
+            .handlers
+            .iter()
+            .fold(EventInterest::none(), |all, entry| {
+                all.union(entry.interest)
+            });
+        let (low, high) = aggregate.words();
+        self.interest_low.store(low, Ordering::Release);
+        self.interest_high.store(high, Ordering::Release);
+    }
+
+    fn remove(&self, id: u64) -> bool {
+        let mut guard = self
+            .handlers
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let current = &**guard;
+        let Some(position) = current.handlers.iter().position(|entry| entry.id == id) else {
+            return false;
+        };
+        let mut handlers = Vec::with_capacity(current.handlers.len() - 1);
+        handlers.extend(current.handlers[..position].iter().cloned());
+        handlers.extend(current.handlers[position + 1..].iter().cloned());
+        let snapshot = Arc::new(HandlerSnapshot { handlers });
+        // Retire the entry before clearing bits; an early read may only be a
+        // harmless false positive.
+        *guard = Arc::clone(&snapshot);
+        self.store_aggregate(&snapshot);
+        true
+    }
+
+    fn update_interest(&self, id: u64, interest: EventInterest) -> bool {
+        let mut guard = self
+            .handlers
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let current = &**guard;
+        let Some(position) = current.handlers.iter().position(|entry| entry.id == id) else {
+            return false;
+        };
+        if current.handlers[position].interest == interest {
+            return true;
+        }
+
+        // Publish additions first so a completed snapshot update can never be
+        // hidden by the lock-free producer filter.
+        self.publish_interest(interest);
+        let mut handlers = current.handlers.clone();
+        handlers[position].interest = interest;
+        let snapshot = Arc::new(HandlerSnapshot { handlers });
+        *guard = Arc::clone(&snapshot);
+        self.store_aggregate(&snapshot);
+        true
+    }
+
+    fn has_handler_for(&self, kind: EventKind) -> bool {
+        let bit = kind as u8;
+        if bit < 64 {
+            self.interest_low.load(Ordering::Acquire) & (1u64 << bit) != 0
+        } else {
+            self.interest_high.load(Ordering::Acquire) & (1u64 << (bit - 64)) != 0
+        }
+    }
+}
+
+/// Removal token for one event-handler registration.
+///
+/// Dropping it removes the handler. A dispatch that already cloned the old
+/// snapshot may still complete once, while later dispatches cannot see it.
+#[must_use = "dropping the subscription immediately unregisters the event handler"]
+pub struct Subscription {
+    bus: std::sync::Weak<CoreEventBusInner>,
+    id: u64,
+    active: bool,
+}
+
+impl Subscription {
+    /// Replace this registration's filter without re-registering its handler.
+    /// Returns `false` if the bus no longer exists or the entry was removed.
+    pub fn update_interest(&self, interest: EventInterest) -> bool {
+        self.active
+            && self
+                .bus
+                .upgrade()
+                .is_some_and(|bus| bus.update_interest(self.id, interest))
+    }
+
+    /// Remove the handler now instead of waiting for `Drop`.
+    pub fn unsubscribe(mut self) -> bool {
+        let removed = self.remove();
+        self.active = false;
+        removed
+    }
+
+    /// Keep this registration for the remaining lifetime of the event bus.
+    pub fn detach(mut self) {
+        self.active = false;
+    }
+
+    fn remove(&self) -> bool {
+        self.bus.upgrade().is_some_and(|bus| bus.remove(self.id))
+    }
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        if self.active {
+            self.remove();
+        }
+    }
 }
 
 #[derive(Default, Clone)]
 pub struct CoreEventBus {
-    // Copy-on-write: the snapshot is only swapped (under the lock) when a
-    // handler is added, which happens at startup. `dispatch` takes a cheap
-    // outer-Arc clone and then drops the lock, so a concurrent `add_handler`
-    // can never invalidate a snapshot a dispatch is iterating.
-    handlers: Arc<RwLock<Arc<HandlerSnapshot>>>,
+    inner: Arc<CoreEventBusInner>,
 }
 
 impl CoreEventBus {
@@ -387,22 +544,43 @@ impl CoreEventBus {
     }
 
     fn snapshot(&self) -> Arc<HandlerSnapshot> {
-        self.handlers
-            .read()
-            .expect("RwLock should not be poisoned")
-            .clone()
+        self.inner.snapshot()
     }
 
-    pub fn add_handler(&self, handler: Arc<dyn EventHandler>) {
+    /// Register `handler` with an explicit, stable filter.
+    pub fn subscribe(
+        &self,
+        interest: EventInterest,
+        handler: Arc<dyn EventHandler>,
+    ) -> Subscription {
         let mut guard = self
+            .inner
             .handlers
             .write()
-            .expect("RwLock should not be poisoned");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let current = &**guard;
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
         let mut handlers = Vec::with_capacity(current.handlers.len() + 1);
         handlers.extend(current.handlers.iter().cloned());
-        handlers.push(handler);
+        handlers.push(HandlerEntry {
+            id,
+            interest,
+            handler,
+        });
+        // An early bit only takes the slow path against the previous snapshot.
+        self.inner.publish_interest(interest);
         *guard = Arc::new(HandlerSnapshot { handlers });
+        Subscription {
+            bus: Arc::downgrade(&self.inner),
+            id,
+            active: true,
+        }
+    }
+
+    /// Register using the handler's current [`EventHandler::interest`] hint.
+    pub fn subscribe_handler(&self, handler: Arc<dyn EventHandler>) -> Subscription {
+        let interest = handler.interest();
+        self.subscribe(interest, handler)
     }
 
     /// Returns true if there are any event handlers registered.
@@ -415,25 +593,19 @@ impl CoreEventBus {
     /// skip producing an event nobody would receive (e.g. retaining a large
     /// `HistorySync` blob when only message-only handlers are registered).
     pub fn has_handler_for(&self, kind: EventKind) -> bool {
-        self.snapshot()
-            .handlers
-            .iter()
-            .any(|h| h.interest().wants(kind))
+        self.inner.has_handler_for(kind)
     }
 
     pub fn dispatch(&self, event: Event) {
-        let snapshot = self.snapshot();
-        // Skip materializing the event (Arc) when no handler wants this kind. The
-        // interest is re-evaluated here (not read from a cached aggregate) so a
-        // handler whose interest() widens at runtime is never short-circuited out.
         let kind = event.kind();
-        if !snapshot.handlers.iter().any(|h| h.interest().wants(kind)) {
+        if !self.has_handler_for(kind) {
             return;
         }
+        let snapshot = self.snapshot();
         let event = Arc::new(event);
-        for handler in &snapshot.handlers {
-            if handler.interest().wants(kind) {
-                handler.handle_event(Arc::clone(&event));
+        for entry in &snapshot.handlers {
+            if entry.interest.wants(kind) {
+                entry.handler.handle_event(Arc::clone(&event));
             }
         }
     }
@@ -1920,8 +2092,8 @@ mod tests {
             kinds: Mutex::new(Vec::new()),
             interest: EventInterest::ALL,
         });
-        bus.add_handler(only_msg.clone());
-        bus.add_handler(all.clone());
+        let _only_msg = bus.subscribe_handler(only_msg.clone());
+        let _all = bus.subscribe_handler(all.clone());
 
         bus.dispatch(Event::Connected(Connected::builder().build()));
 
@@ -1942,53 +2114,48 @@ mod tests {
             }
         }
         let bus2 = CoreEventBus::new();
-        bus2.add_handler(Arc::new(Counter));
+        let _counter = bus2.subscribe_handler(Arc::new(Counter));
         bus2.dispatch(Event::Connected(Connected::builder().build()));
         assert_eq!(CALLS.load(Ordering::SeqCst), 0);
     }
 
     #[test]
-    fn dispatch_respects_dynamically_widened_interest() {
-        use std::sync::Mutex;
+    fn subscription_updates_interest_explicitly() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        // A handler whose interest() widens after registration. dispatch must
-        // re-read interest each time (never a stale cached aggregate), so the
-        // newly-wanted kind is delivered.
         struct Dynamic {
-            interest: Mutex<EventInterest>,
             hits: AtomicUsize,
         }
         impl EventHandler for Dynamic {
             fn handle_event(&self, _: Arc<Event>) {
                 self.hits.fetch_add(1, Ordering::SeqCst);
             }
-            fn interest(&self) -> EventInterest {
-                *self.interest.lock().unwrap()
-            }
         }
 
         let bus = CoreEventBus::new();
         let h = Arc::new(Dynamic {
-            interest: Mutex::new(EventInterest::of(&[EventKind::Messages])),
             hits: AtomicUsize::new(0),
         });
-        bus.add_handler(h.clone());
+        let subscription = bus.subscribe(EventInterest::of(&[EventKind::Messages]), h.clone());
 
         // Not yet interested in Connected: dropped before materialization.
         bus.dispatch(Event::Connected(Connected::builder().build()));
         assert_eq!(h.hits.load(Ordering::SeqCst), 0);
         assert!(!bus.has_handler_for(EventKind::Connected));
 
-        // Widen interest at runtime.
-        *h.interest.lock().unwrap() = EventInterest::ALL;
+        assert!(subscription.update_interest(EventInterest::ALL));
         assert!(bus.has_handler_for(EventKind::Connected));
         bus.dispatch(Event::Connected(Connected::builder().build()));
         assert_eq!(
             h.hits.load(Ordering::SeqCst),
             1,
-            "a handler whose interest widened at runtime must receive the newly-wanted kind"
+            "the updated subscription must receive the newly-wanted kind"
         );
+
+        assert!(subscription.update_interest(EventInterest::none()));
+        assert!(!bus.has_handler_for(EventKind::Connected));
+        bus.dispatch(Event::Connected(Connected::builder().build()));
+        assert_eq!(h.hits.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -2007,13 +2174,15 @@ mod tests {
         assert!(!bus.has_handler_for(EventKind::Messages));
         assert!(!bus.has_handler_for(EventKind::Receipt));
 
-        bus.add_handler(Arc::new(Narrow(EventInterest::of(&[EventKind::Messages]))));
+        let _messages =
+            bus.subscribe_handler(Arc::new(Narrow(EventInterest::of(&[EventKind::Messages]))));
         assert!(bus.has_handlers());
         assert!(bus.has_handler_for(EventKind::Messages));
         assert!(!bus.has_handler_for(EventKind::Receipt));
 
         // has_handler_for is true once any registered handler wants the kind.
-        bus.add_handler(Arc::new(Narrow(EventInterest::of(&[EventKind::Receipt]))));
+        let _receipt =
+            bus.subscribe_handler(Arc::new(Narrow(EventInterest::of(&[EventKind::Receipt]))));
         assert!(bus.has_handler_for(EventKind::Messages));
         assert!(bus.has_handler_for(EventKind::Receipt));
         assert!(!bus.has_handler_for(EventKind::Connected));
@@ -2035,11 +2204,12 @@ mod tests {
 
         let bus = CoreEventBus::new();
         let log = Arc::new(Mutex::new(Vec::new()));
+        let mut subscriptions = Vec::new();
         for id in 0..5u32 {
-            bus.add_handler(Arc::new(Tagged {
+            subscriptions.push(bus.subscribe_handler(Arc::new(Tagged {
                 id,
                 log: log.clone(),
-            }));
+            })));
         }
         bus.dispatch(Event::Connected(Connected::builder().build()));
         // Copy-on-write rebuilds must keep registration order intact.
@@ -2073,14 +2243,15 @@ mod tests {
                         }
                     }
                     self.bus
-                        .add_handler(Arc::new(Late(self.invocations.clone())));
+                        .subscribe_handler(Arc::new(Late(self.invocations.clone())))
+                        .detach();
                 }
             }
         }
 
         let bus = CoreEventBus::new();
         let invocations = Arc::new(AtomicUsize::new(0));
-        bus.add_handler(Arc::new(AddsDuringDispatch {
+        let _registration = bus.subscribe_handler(Arc::new(AddsDuringDispatch {
             bus: bus.clone(),
             invocations: invocations.clone(),
             added: Mutex::new(false),
@@ -2095,5 +2266,71 @@ mod tests {
         // Second dispatch sees both handlers (original adds nothing new now).
         bus.dispatch(Event::Connected(Connected::builder().build()));
         assert_eq!(invocations.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn dropping_subscription_unregisters_handler() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct Counter(Arc<AtomicUsize>);
+        impl EventHandler for Counter {
+            fn handle_event(&self, _: Arc<Event>) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let bus = CoreEventBus::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let subscription = bus.subscribe_handler(Arc::new(Counter(Arc::clone(&calls))));
+        bus.dispatch(Event::Connected(Connected::builder().build()));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        drop(subscription);
+        assert!(!bus.has_handlers());
+        assert!(!bus.has_handler_for(EventKind::Connected));
+        bus.dispatch(Event::Connected(Connected::builder().build()));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn in_flight_dispatch_can_finish_after_unsubscribe() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct Blocking {
+            started: Arc<Barrier>,
+            release: Arc<Barrier>,
+            calls: Arc<AtomicUsize>,
+        }
+        impl EventHandler for Blocking {
+            fn handle_event(&self, _: Arc<Event>) {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.started.wait();
+                self.release.wait();
+            }
+        }
+
+        let bus = CoreEventBus::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let subscription = bus.subscribe_handler(Arc::new(Blocking {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+            calls: Arc::clone(&calls),
+        }));
+        let dispatch_bus = bus.clone();
+        let dispatch = std::thread::spawn(move || {
+            dispatch_bus.dispatch(Event::Connected(Connected::builder().build()));
+        });
+
+        started.wait();
+        drop(subscription);
+        release.wait();
+        dispatch.join().expect("dispatch thread");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        bus.dispatch(Event::Connected(Connected::builder().build()));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -906,7 +906,7 @@ pub enum Event {
 
     /// Raw decoded stanza, emitted before router dispatch.
     /// Library extension — no WA Web equivalent (WA Web has no raw stanza observer).
-    /// Gated by `Client::set_raw_node_forwarding(true)` to avoid overhead when unused.
+    /// Gated by `Client::acquire_raw_node_forwarding()` to avoid overhead when unused.
     #[serde(skip)]
     RawNode(Arc<OwnedNodeRef>),
 


### PR DESCRIPTION
## Status

**Ready for review; Phase 3 and the selected pre-merge extensibility foundations are complete.**

This remains a single, cumulative PR for the plugin-architecture refactor. Phase 4 items are demand-driven and outside this delivery. Current head `30d06ff6` includes `origin/main` at `aa2582ca` (including #1070 and #1069). The complete local suite, all-test Clippy, minimal native/WASM plugin builds, and all 40 plugin-host tests are green on current head `30d06ff6`; the final A/B remains green at `60fda0bc`. All review threads are resolved, and GitHub checks plus fresh AI reviews are rerunning on the published head. No merge into `main` was performed.

- [x] Phase 0 — removable event subscriptions, aggregate interest fast path, raw-node forwarding leases
- [x] Phase 1 — canonical client construction and generation-scoped extension lifecycle
- [x] Phase 2 — native plugin model and event routing
  - [x] Phase 2.1 — transactional native Rust host, typed APIs, capabilities, dependency ordering, and scoped tasks
  - [x] Phase 2.2 — bounded `PluginEventRouter` keyed by `(plugin_id, topic)`
  - [x] Phase 2.3 — runtime-agnostic task clock and external native metrics vertical slice
- [x] Phase 3 — hardening, observability, conformance, and stabilization
  - [x] Phase 3.1 — scoped task completion barriers before connection and terminal teardown
  - [x] Phase 3.2 — lifecycle queue/reconnect hardening and activation gates
    - [x] bounded `Ready` admission with lossless per-generation `Closed` delivery
    - [x] synchronous scope retirement when reconnect is requested
    - [x] shutdown-safe plugin activation and client startup gate
    - [x] lifecycle integration fully absent unless `client-lifecycle` or `plugins` is enabled
  - [x] Phase 3.3 — native plugin observability, conformance, and stabilization
    - [x] on-demand host/plugin health and lifecycle/task/resource snapshots
    - [x] per-publisher/router delivery, backpressure, and unique queue-memory accounting
    - [x] public-only metrics-plugin conformance coverage and strict native/WASM validation
    - [x] persisted host invariants and future-adapter seam in `agent_docs/plugin_architecture.md`
    - [x] manifest-ID-keyed untyped adapters, owned core-event subscriptions, and cooperative task draining
    - [x] bounded installation with partial LIFO rollback and configurable host deadlines
    - [x] isolated A/B benchmark and stabilization sign-off

The bridge and baileyrs are not implementation dependencies of this PR. The native seams are being designed so a foreign-language adapter can be added later without rebuilding the client lifecycle or plugin model. The foreign command/protocol boundary remains deliberately deferred until a real bridge consumer is in scope.

## Why

Client construction was split between high-level and low-level paths, and background services could only be coordinated through client-specific initialization. There was also no public lifecycle model aligned with the client's existing connection generation, which a plugin host needs to cancel connection-owned work reliably across expected disconnects, failures, reconnects, and terminal shutdown.

The existing event bus also had permanent registrations, evaluated handler interest dynamically under a read lock, and exposed raw-node forwarding as a global last-write-wins boolean. Those contracts could not safely support independently owned plugin or foreign-consumer subscriptions.

Phases 0 and 1 establish those foundations. Phase 2 now adds the native host and bounded custom-event routing without introducing the foreign protocol or bridge implementation yet, keeping that later boundary driven by a real foreign vertical slice.

## What changed in Phase 0

- replace permanent event registration with `Subscription`, a `#[must_use]` RAII token that unregisters on drop
- capture explicit `EventInterest` at subscription time and support controlled updates through `Subscription::update_interest`
- maintain aggregate interest in two portable `AtomicU64` words, making `has_handler_for` lock-free without requiring unavailable `AtomicU128`
- preserve copy-on-write dispatch snapshots: an in-flight dispatch may finish once after unsubscribe, while later dispatches cannot see the removed handler
- replace raw-node forwarding's shared boolean with reference-counted `RawNodeLease` ownership, so independent consumers cannot disable one another
- correct the documented `EventInterest` capacity from 64 to 128 kinds
- migrate all internal registrations to the ownership-aware API

## What changed in Phase 1

- add a canonical, runtime-validated `ClientBuilder` and typed `ClientBuilderError`
- split client construction into inert assembly and explicit service startup so no task observes a partially installed client
- route `BotBuilder` through the canonical pipeline while preserving its typestate API
- centralize cache, runtime, transport, HTTP, persistence, encryption-handler, durability, history, pre-key, resend, instrumentation, and background-saver configuration
- add an aggregate `ClientLifecycle` seam installed through `Weak<Client>`, with rollback before publication on installation failure
- formalize `ConnectionScope` around the existing connection generation: ready after authentication, synchronous cancellation immediately after generation bump, and close only after authoritative cleanup
- serialize lifecycle callbacks through one isolated driver with timeout and panic isolation, bound stale `Ready` work at 64 entries, and preserve every per-generation `Closed` callback before terminal `Shutdown`
- make final `Closed` publication atomic with terminal `Shutdown`, preserving lifecycle order under races
- move lifecycle-enabled cleanup into an authoritative detached task so cancelling its waiter cannot strand a generation; lifecycle-free clients retain the direct fast path
- add terminal, idempotent and cancellation-safe async shutdown that waits for an active connection scope to close
- preserve explicit logout ordering and cancel-only behavior from synchronous drop/shutdown signaling

## What changed in Phase 2.1

- add `ClientPlugin { type Api; manifest(); install(); on_ready(); on_closed(); shutdown() }` for trusted native plugins registered at build time
- support registration from both `ClientBuilder` and the typestate-preserving `BotBuilder`
- expose type-safe APIs through `client.plugin::<P>() -> Option<Arc<P::Api>>`, keyed by the plugin marker rather than the API type, so two plugins may expose the same Rust type without collision
- validate manifests before client assembly: IDs, versions, duplicate marker/manifest IDs, duplicate or missing dependencies, and dependency cycles
- resolve dependencies topologically and expose only direct, declared dependency APIs during installation
- install transactionally while the client is inert; publish the API typemap only after every plugin succeeds, and roll back the failing plugin, prior plugins, and the upstream lifecycle in LIFO order
- compose an existing `ClientLifecycle` outside the plugin order instead of replacing it
- shape native access through small capability handles for core events, tasks, messaging, and typed IQ; no backend or Signal store handle is exposed, and native capabilities are explicitly not a sandbox
- keep capability handles on `Weak<Client>` plus plugin resource state, avoiding `Client -> plugin API -> Client` cycles and rejecting use before publication or after shutdown
- distinguish install-scoped tasks from generation-scoped tasks; install work starts only after the complete plugin set and client services are published, survives reconnects, and is cancelled on rollback/terminal shutdown, while connection work is cancelled with its `ConnectionScope`
- retain core-event subscription leases as plugin resources; synchronously cancel tasks/subscriptions, then await tracked install- and connection-scoped task completion before `on_closed`, rollback, or LIFO shutdown hooks
- isolate manifest/install/lifecycle panics, including panics while polling returned futures
- keep native type erasure compatible with native `Send + Sync` and the existing WASM `MaybeSendSync` convention, without unsafe code
- gate the entire native host behind the opt-in Cargo feature `plugins`; default/no-plugin builds have no plugin field, branch, allocation, or linked code

## What changed in Phase 2.2

- add a `PluginEventRouter` separate from `CoreEventBus`, so custom plugin traffic neither changes the sealed core `Event` contract nor consumes `EventInterest` bits
- allocate the router only when an installed manifest requests `PluginCapability::PluginEvents`
- bind publication authority to the installing plugin ID through `PluginEvents`; a plugin cannot publish into another plugin namespace
- route exact `(plugin_id, topic)` selectors before a native endpoint or future FFI adapter is awakened
- give every endpoint an independently bounded queue with explicit `DropNewest` / `DropOldest` behavior and cumulative delivery/drop/depth statistics
- cap one endpoint at 1,024 selectors and 65,536 queued envelopes, rejecting invalid publishers, topics, capacities, and schema version zero with typed errors
- share immutable `Arc<PluginEventEnvelope>` payloads across matching endpoints and carry schema version, encoding, connection generation, and route-local sequence
- serialize sequence assignment with fan-out for concurrent publisher order; discarded events consume a sequence number so consumers can detect loss, and a route resets only after its last subscriber leaves
- keep publication non-blocking with copy-on-write route endpoint slices; shutdown rejects new work while allowing receivers to drain already queued envelopes
- cover exact routing, both overflow policies, concurrent order, generation capture, closure/drain semantics, and a typed native plugin vertical slice

## What changed in Phase 2.3

- add the target-correct `PluginFuture<'a, T>` alias so public plugin futures are `Send` on native and remain valid on single-threaded WASM
- add cancellation-aware `PluginTasks::sleep` and `PluginConnectionTasks::sleep`; install-scoped clocks survive reconnects while connection-scoped clocks terminate with their generation
- add `plugins/metrics` as an external, unpublished workspace crate that consumes only the public plugin API, proving the host is usable outside the main crate
- expose a type-safe `MetricsApi` through `client.plugin::<MetricsPlugin>()` with sealed snapshot payloads and a reusable typed tick selector
- count only selectively subscribed core events, publish periodic JSON ticks only when the custom-event route has subscribers, and account for enqueue/drop/serialization failures
- keep the periodic worker install-scoped, keep connection generation state connection-scoped, and verify stale scopes cannot clear a newer generation
- exercise bounded backpressure, typed API lookup, reconnect-surviving install work, generation cancellation, and shutdown through public-only integration tests
- leave bridge adapters, wire schemas, grants, and foreign commands out of this slice; the native vertical slice supplies the concrete semantics those future boundaries must preserve

## Review hardening through Phase 3.2

- make staged plugin installation cancellation-safe: dropping `ClientBuilder::build()` closes resources immediately and schedules bounded LIFO shutdown for the current plugin, previously installed plugins, and the installed upstream lifecycle
- bound every plugin/upstream lifecycle callback independently so one stalled plugin cannot suppress later callbacks; upstream readiness failures are aggregated instead of short-circuiting plugin readiness
- retain a `RawNodeLease` whenever a plugin subscribes to `EventKind::RawNode`
- replace the unsafe standalone `ClientBuild::client()` path with consuming `into_client()`, which starts the default major-sync worker; advanced hosts still use `into_parts()` and own the sole receiver
- isolate both synchronous and polled panics from `ClientLifecycle::install` as typed `ClientBuilderError::LifecycleInstall` failures
- add the non-blocking `ClientLifecycle::signal_shutdown` boundary so FFI-style synchronous shutdown closes plugin tasks, subscriptions, leases, and capability handles even while other references remain alive
- reject `Duration::ZERO` for the background saver instead of starting a permanent hot loop
- request terminal lifecycle shutdown before the first cancellable `disconnect()` await, closing plugin resources immediately while preserving the durability flush and connection-shutdown ordering
- detach explicit install rollback before awaiting it, so aborting a failed build during a stalled hook cannot suppress the remaining LIFO callbacks
- synchronously signal an installed upstream lifecycle before any asynchronous rollback callback; panic isolation and idempotence remain enforced
- release the event-bus write lock before dropping retired copy-on-write snapshots, so a handler destructor may unsubscribe another handler from the same bus without deadlocking
- serialize authentication-success scope publication against connection-generation teardown, so a rejected or obsolete scope cannot leave the client reporting a logged-in state
- take plugin-owned subscriptions out of the resource mutex before destroying them, allowing handler teardown to reenter subscription APIs without deadlock
- destroy subscriptions rejected after shutdown only after releasing the resource mutex, covering the symmetric reentrant-handler path
- serialize `Connected` publication against generation and terminal cancellation, while allowing a `Connected` handler to signal shutdown reentrantly without deadlock
- make `PluginContext` dependency views weak and non-owning, so an API may retain its context without creating an `ApiRegistry -> API -> context -> registry` cycle
- signal standalone lifecycle resources when the last `Arc<Client>` drops, and make the device-registry waiter own only a shutdown signal so it cannot keep the client alive forever
- propagate panics from detached authoritative cleanup back to its waiter through a cancellation-safe oneshot, preventing a custom transport panic from hanging disconnect/run forever
- gate `Client::run()` on successful construction/lifecycle activation, so a leaked client cannot connect while plugin installation is incomplete or after construction was rejected
- make lifecycle/plugin activation sticky and terminal: shutdown racing installation rejects the build, closes staged resources, and cannot later republish the host
- retain staged plugin APIs through detached rollback, so API destructors cannot run before their plugin/upstream shutdown barriers and hooks
- keep standalone lifecycle integration behind `client-lifecycle`; `plugins` enables it transitively, while default clients retain the lifecycle-free field/layout and cleanup fast path
- close a retired `ConnectionScope` from an unwind guard immediately after the generation bump, so cancellation or a transport panic cannot strand terminal shutdown
- make detached installation rollback completion unwind-safe even when a staged API destructor panics; later waiters always observe completion
- race standalone and plugin installation against terminal shutdown, close staged plugin resources synchronously, and cancel non-cooperative install futures without requiring them to wake themselves
- isolate each plugin-owned subscription destructor and each plugin resource closure during shutdown/rollback, so one panicking handler cannot strand later plugins or the upstream lifecycle
- retire generation task trackers from the sticky `ConnectionScope` cancellation signal, so task cleanup does not depend on lifecycle callback scheduling
- explicitly poll and destroy lifecycle/plugin futures inside unwind barriers, including timeout cancellation and normal installation teardown, so a panicking future destructor cannot strand later callbacks
- preserve every queued scope closure under callback pressure; stale `Ready` work remains bounded, while lossless `Closed` delivery may temporarily exceed the target before ordered `Shutdown`

## What changed in Phase 3.3

- add `Client::plugin_stats()` with per-manifest lifecycle state, sticky health, callback/task failures, active task generations, subscriptions, and isolated teardown/core-event panics
- add per-publisher `PluginEvents::stats()` plus aggregate `PluginEventRouter::stats()` for delivery, backpressure, endpoint capacity, and queue occupancy
- share one internal queued envelope across fanout and count its payload memory once until the final endpoint releases it
- integrate plugin counts and unique queued custom-event bytes into the existing on-demand `MemoryReport`, fully gated behind `plugins`
- isolate plugin core-event handler execution and delayed handler destruction so one plugin cannot unwind through the core dispatcher or suppress unrelated teardown
- derive health per plugin from cumulative lifecycle errors/panics, timeouts, task-drain timeouts, event publication failures/drops, and isolated resource failures; unaffected plugins remain healthy
- extend the external metrics plugin test through public APIs to prove backpressure is visible as degraded health without bridge-specific code
- keep snapshots approximate and allocation-on-demand; default/no-plugin builds contain none of the observability fields, counters, or branches
- document construction, type-safe APIs, capabilities, lifecycle/task ownership, event/backpressure rules, diagnostics, and the deliberately deferred foreign-adapter contract in `agent_docs/plugin_architecture.md`

## Latest review hardening

- bind readiness and `Connected` publication to the authentication task generation, serialized against authoritative cleanup; a stale success task cannot claim a replacement scope
- isolate install- and connection-scoped plugin-task panics, attribute them to the owning `plugin_id`, increment `PluginStats::task_panics`, and make plugin health sticky-degraded
- clarify task ownership: cancellation is signalled synchronously, while destruction is cooperative and awaited only within the documented bounded drain
- publish feature-gated API badges on docs.rs and document feature discovery for direct consumers and external plugin crates
- gate direct `Client::connect()` on successful construction activation, matching `run()` and preventing leaked install-time handles from starting transport early
- attribute `DropOldest` and `DropNewest` losses to the publisher that owned the discarded envelope, including cross-namespace endpoint queues; the per-call report still records the eviction caused by that call
- keep plugin APIs, manifests, diagnostics, and custom-event routing staged until final lifecycle activation commits the build; a rejected construction never exposes plugin-owned state
- serialize plugin publication and lifecycle activation with terminal shutdown; APIs and every resource become active before install-scoped tasks are awakened, with no fallible publication step after work can run
- compile the login/publication synchronization mutex and all of its lock paths only with `client-lifecycle`, preserving the default client layout and fast path
- preserve every mandatory `Closed` callback under pressure while coalescing replaceable readiness work to the latest `Ready`, even when closures already exceed the soft queue target
- expose sticky upstream lifecycle failure/timeout counters and include them in aggregate plugin-host health without degrading unaffected plugins
- add public manifest-ID-keyed `UntypedClientPlugin` registration, including `Arc<dyn UntypedClientPlugin>`, so a future bridge can host multiple runtime-defined instances without native `TypeId` collisions
- make plugin core-event registrations explicitly owned: the returned token supports early unsubscribe and atomic interest/`RawNodeLease` updates, and host shutdown invalidates retained tokens
- store retained subscription registrations weakly and self-prune them during close, so drop/unsubscribe churn releases both the handler allocation and registry slot immediately
- distinguish abort-on-cancel tasks from cooperative tasks that observe install or connection cancellation, with independently configurable callback and task-drain deadlines
- bound plugin and upstream installation separately (30 seconds by default), cancel yielding installs on timeout, and run partial cleanup through the same LIFO rollback contract
- widen the private capability set to 64 bits and verify current identifiers remain distinct, leaving room for storage and middleware capabilities without another representation change

## Cargo feature policy

`plugins` remains opt-in, and `client-lifecycle` remains the smaller opt-in seam for hosts that do not need the plugin host. External plugin crates should enable `whatsapp-rust/plugins` on their dependency; Cargo feature unification then activates it transitively, so application users do not need to discover a second switch. docs.rs builds with `plugins` and labels gated APIs.

LTO is an optimization, not an API or size guarantee. In the current release harness, enabling `plugins` without installing a plugin had equivalent throughput but increased the stripped binary by 180,104 bytes (+0.89%). Keeping the host opt-in therefore avoids a permanent size tax while preserving an uncomplicated consumer path. No additional fine-grained plugin feature matrix is planned.

## Known limitations and pre-merge decisions

This checklist is intentionally honest about the current boundary. Checked items are foundations committed in this PR; unchecked items remain explicit limitations, not behavior implied by the API.

### Foundations added before merge

- [x] Public manifest-ID-keyed untyped plugin registration for future foreign adapters; `TypeId` remains only the native typed API lookup key.
- [x] Plugin-owned core-event subscription handles with early unsubscribe, explicit interest updates, and immediate self-pruning registry cleanup.
- [x] Abort-on-cancel and cooperative tracked-task modes with host-configurable install/callback/task-drain deadlines.
- [x] Bounded plugin/upstream installation and partial LIFO rollback, including cancellation-time destructor isolation.
- [x] A 64-bit capability set with collision coverage, leaving expansion room for future narrow handles.

### Deliberately deferred until a real vertical slice

- [ ] Bounded foreign core-event endpoints with schema generation and drift tests.
- [ ] Versioned foreign command/event protocol with scoped runtime grants.
- [ ] Namespaced plugin storage with quota, migration, transaction, and cleanup semantics.
- [ ] Per-plugin resource budgets for task count, queued bytes, and payload size, plus task naming.
- [ ] Queued/watchdog delivery for core-event handlers; native handlers remain inline and must offload slow work.
- [ ] Preemptive isolation for code that blocks an executor thread; native deadlines can cancel only futures that yield.
- [ ] Dependency version ranges, optional dependencies, conflicts, and declared event schemas.
- [ ] Dynamic install/uninstall or marketplace loading.
- [ ] Ingress/send middleware and privileged pre-ack interception.
- [ ] Sidecar, WASM Component, or sandbox execution.

Native plugins are trusted in-process code. Capabilities shape the API they receive; they are not a security boundary. Runtime enforcement belongs at a future foreign-process/WASM boundary. The unchecked deferred items will not be silently approximated in this PR.

## Consumer migration guide (breaking changes)

This guide compares the current `main` API with this PR's current head. It will be updated whenever a later commit changes a public contract. Phase 2.2/2.3 plugin additions are opt-in and do not add source-migration requirements for existing consumers; `06050d0c` adds the drop-time lifecycle guarantee and `5b4a3b4f` makes scoped task teardown an awaited barrier before plugin hooks. `47dcf10a`, `1ee952b9`, and `c86f6d52` harden lifecycle ordering/construction without widening the public API. `63bb4d95` makes standalone lifecycle APIs explicitly opt-in through `client-lifecycle`; the `plugins` feature enables it transitively. `54cbf95c` hardens unwind and terminal-install behavior without widening the public API. `271d8423` isolates destructor panics during resource teardown, `e2f6bc4c` makes scope retirement and future cancellation unwind-safe, and `e72f2729` makes per-generation closure delivery lossless under queue pressure. `667689ab` adds opt-in observability snapshots and counters, `3244e32c` only clarifies an internal lock contract, and `dc55c1e3` persists the architecture contract. None adds a source-migration requirement. The latest hardening adds the non-exhaustive `PluginStats::task_panics` diagnostic and clarifies cooperative task cancellation; ordinary consumers require no change, while plugin authors should make long-running work observe the provided shutdown signal or use the cancellation-aware task helpers. `7f025d32` gates direct connect during construction, and `b4b9c63c` corrects cross-namespace overflow attribution. These are behavioral fixes and add no source-migration requirement; telemetry consumers should read `PluginEventPublishReport::dropped` as loss caused by that publish call and `PluginEventPublisherStats::dropped` as loss of envelopes owned by that publisher. `f1a8138b` delays every public plugin surface until the final construction commit; normal post-build consumers require no change. `29481d9e` adds manifest-keyed untyped registration, `03c4b8bb` makes plugin core-event subscriptions owner-scoped, `1444153b` adds cooperative task draining, `60fda0bc` bounds installation/partial rollback, `bfdb2699` makes closed subscription registry cleanup immediate, `21b430c2` records that ownership contract in the RFC, and `30d06ff6` widens the private capability mask for future handles. These are additive relative to `main`; plugin authors adopting this PR must retain subscription tokens and choose task cancellation semantics explicitly.

### Upgrade checklist

| Consumer pattern | Required action |
| --- | --- |
| `BotBuilder::with_event_handler(...)` and closure-based bot handlers | None; these APIs keep their existing ownership behavior. |
| `Client::register_handler(...)` or `CoreEventBus::add_handler(...)` | Migrate to a retained `Subscription`, or explicitly call `.detach()` for process-lifetime registration. |
| A mutable `EventHandler::interest()` implementation | Move changes to `Subscription::update_interest(...)`; interest is captured once at registration. |
| `Client::set_raw_node_forwarding(bool)` | Hold a `RawNodeLease` from `acquire_raw_node_forwarding()` for exactly as long as forwarding is needed. |
| Exhaustive matching on `BotBuilderError::UnsupportedDurabilityBackend` | Match the nested `BotBuilderError::Client(ClientBuilderError::UnsupportedDurabilityBackend(_))`. |
| `Client::new(...)` / `Client::new_with_cache_config(...)` | None; both compatibility constructors remain available. The new low-level builder is optional. |
| Default-feature consumers not using plugins or lifecycle extensions | None; both subsystems and their runtime branches are absent from default builds. |
| Consumers using `ClientLifecycle`, `ConnectionScope`, or `ClientBuilder::with_lifecycle` without plugins | Enable Cargo feature `client-lifecycle`. Consumers enabling `plugins` already receive it transitively. |
| Custom plugin-event consumers | Retain `PluginEventSubscription`, choose a bounded queue/overflow policy, and route by `(plugin_id, topic, schema_version)`; `EventInterest::ALL` does not include custom events. Treat publish-report drops as call-attributed and publisher-stat drops as discarded-envelope-owner-attributed. |
| Plugin code calling `PluginCoreEvents::subscribe(...)` | Retain the returned `PluginCoreEventSubscription` in plugin-owned state/API. Dropping it now unregisters immediately; use `update_interest` or `unsubscribe` for explicit changes. |
| Runtime-defined or future foreign adapters | Implement `UntypedClientPlugin` and register by manifest ID with `with_untyped_plugin(...)` / `with_untyped_plugin_arc(...)`; this path intentionally exposes no Rust `Client::plugin::<P>()` API. |
| Long-running plugin tasks | Use `spawn` for abort-on-cancel work. Use `spawn_cooperative` only when the future observes `shutdown_signal()` / `cancellation_signal()` and can finish within the configured drain deadline. |
| Hosts with slow plugin initialization or cleanup | Configure `PluginHostConfig`; install defaults to 30 seconds, callbacks/drains to 5 seconds, and zero durations are rejected. A timed-out install is rolled back. |
| Code using plugin/lifecycle resources during terminal `Client::disconnect()` | Stop that work before calling disconnect; terminal resource invalidation is now synchronous at the start of the call. |
| Dropping the final `Arc<Client>` without `disconnect().await` | No source change. `Client::Drop` now emits the synchronous lifecycle signal, but durable flush/transport cleanup still require explicit async disconnect. |

### 1. Retain event subscriptions

Registrations now have an owner. Dropping the returned token unregisters the handler, so ignoring the result no longer creates a permanent registration.

Before:

```rust
client.register_handler(handler);
// or, for direct wacore users: core_event_bus.add_handler(handler);
```

After, with scoped ownership:

```rust
let subscription = client.subscribe_handler(handler);

// Keep `subscription` in the component that owns the handler.
// Dropping it unregisters the handler.
drop(subscription);
```

For an explicit filter:

```rust
let subscription = client.subscribe(
    EventInterest::of(&[EventKind::Messages, EventKind::Receipt]),
    handler,
);
```

If the old process-lifetime behavior is genuinely intended, make that choice explicit:

```rust
client.subscribe_handler(handler).detach();
```

An in-flight dispatch may finish once from its previous immutable snapshot after unsubscribe; subsequent dispatches cannot see the removed handler.

### 2. Update dynamic event interest through the token

`EventHandler::interest()` is now a registration-time hint. The bus does not call it for every event. Code that previously mutated handler state and expected `interest()` to widen automatically must retain its `Subscription` and update the filter explicitly:

```rust
let subscription = client.subscribe_handler(handler);
subscription.update_interest(EventInterest::of(&[
    EventKind::Messages,
    EventKind::Connected,
]));
```

This contract enables the lock-free aggregate-interest fast path while keeping changes explicit and race-safe.

### 3. Replace the raw-node boolean with an ownership lease

Before:

```rust
client.set_raw_node_forwarding(true);
// consume raw nodes
client.set_raw_node_forwarding(false);
```

After:

```rust
let raw_forwarding = client.acquire_raw_node_forwarding();
let raw_events = client.subscribe(
    EventInterest::of(&[EventKind::RawNode]),
    handler,
);

// consume raw nodes

drop(raw_events);
drop(raw_forwarding);
```

Each consumer owns an independent lease. One consumer can no longer disable forwarding while another still needs it. Plugin core-event subscriptions acquire the corresponding raw-node lease automatically.

### 4. Adjust `BotBuilderError` pattern matches

Durability validation moved into the canonical client builder, so the old top-level variant is now nested.

Before:

```rust
match Bot::builder() /* ... */ .build().await {
    Err(BotBuilderError::UnsupportedDurabilityBackend(reason)) => {
        // handle unsupported durability backend
    }
    result => { /* ... */ }
}
```

After:

```rust
match Bot::builder() /* ... */ .build().await {
    Err(BotBuilderError::Client(
        ClientBuilderError::UnsupportedDurabilityBackend(reason),
    )) => {
        // handle unsupported durability backend
    }
    result => { /* ... */ }
}
```

Both error enums are `#[non_exhaustive]`; downstream matches should retain a fallback arm.

### 5. Optional low-level builder migration

The existing `Client::new*` constructors remain source-compatible. Dynamic hosts and FFI layers may instead use the new runtime-validated builder:

```rust
let client = Client::builder()
    .with_runtime(runtime)
    .with_persistence_manager(persistence)
    .with_transport_factory(transport)
    .with_http_client(http)
    .build()
    .await?
    .into_client();
```

Use `into_client()` for a standalone client; it starts the standard major-sync worker. Only advanced hosts that take responsibility for draining the sole receiver should call `into_parts()`.

### 6. Account for terminal lifecycle timing

`Client::disconnect()` now invokes the prompt, idempotent `ClientLifecycle::signal_shutdown` boundary before its first cancellable await. Plugin tasks, subscriptions, raw-node leases, and capability handles therefore stop immediately when terminal disconnect begins; the durability flush, outbound flush, and connection-shutdown notification retain their existing order afterward. Consumers must not depend on plugin capabilities remaining usable during that terminal flush window.

Dropping the final `Arc<Client>` invokes the same synchronous signal so standalone lifecycle work cannot remain parked. This is not a substitute for `disconnect().await`: `Drop` cannot perform the async durability flush or transport teardown.

### 7. Enable standalone lifecycle APIs explicitly

Lifecycle extension APIs no longer contribute fields, branches, callback-driver code, or binary-size cost to the default client. Consumers that use lifecycle integration directly must opt in:

```toml
whatsapp-rust = { version = "...", features = ["client-lifecycle"] }
```

The `plugins` feature includes `client-lifecycle`, so native plugin consumers do not need to list both. Default consumers that use neither API require no source or manifest change.

### New plugin contract (opt-in, not a migration requirement)

Enable Cargo feature `plugins`, register native plugins only during build, and retrieve their typed API by marker:

```rust
let client = Client::builder()
    // required platform dependencies...
    .with_plugin(MetricsPlugin::new())
    .build()
    .await?
    .into_client();

let metrics: Arc<MetricsApi> = client
    .plugin::<MetricsPlugin>()
    .expect("MetricsPlugin was registered");
```

Plugin API handles survive reconnects; connection-scoped work does not. Native plugins are trusted in-process Rust code, and capability handles shape available APIs without claiming sandbox enforcement.

Dependency lookup through `PluginContext::plugin::<P>()` is deliberately non-owning at the context level. If an API retains its `PluginContext` and needs a dependency later, it must retain the returned `Arc<P::Api>` during installation; retaining the context alone does not keep dependencies or the staging registry alive.

The reference metrics plugin demonstrates the complete type-safe path:

```rust
let metrics = client
    .plugin::<MetricsPlugin>()
    .expect("metrics plugin installed");
let snapshot: MetricsSnapshot = metrics.snapshot();
let selector: PluginEventSelector = metrics.tick_selector();
```

### Subscribe to custom plugin events

Custom events use their own exact, bounded router. They are intentionally not delivered through `CoreEventBus`, and `EventInterest::ALL` continues to mean all core events only.

```rust
let router = client
    .plugin_event_router()
    .expect("at least one installed plugin publishes custom events");
let tick = PluginEventTopic::new("tick")?;
let events = router.subscribe(
    [PluginEventSelector::new("metrics", tick)?],
    PluginEventEndpointConfig::new(256, PluginEventOverflow::DropOldest),
)?;

while let Ok(event) = events.recv().await {
    // Dispatch by event.plugin_id/topic/schema_version and decode event.payload.
}
```

Retain `PluginEventSubscription` for as long as the endpoint should exist. Select a queue capacity and overflow policy deliberately, inspect `events.stats()` for loss/backpressure, and treat `sequence` gaps as discarded events. This is a new opt-in API; existing core-event consumers require no migration.

## Main synchronization

Merge commit `d4abef10` brings in current `origin/main` at `aa2582ca`. That mainline includes #1070's removal of the obsolete device-registry cleanup task and #1069's typed stanza-response/retry work. The synchronization was conflict-free. The plugin host continues to expose only high-level messaging/IQ capabilities, and no new plugin branch was added to stanza or retry hot paths.

Current head `30d06ff6` is based on that main commit. The definitive non-E2E workspace suite, all-test Clippy, formatting, minimal plugin build, and plugin-enabled WASM build pass locally. The local E2E binary still requires the repository's Bartender service; the GitHub E2E job is authoritative and is rerunning on this push. No benchmark or project manifest was edited for this synchronization or the final A/B.

## Performance

### Current whole-branch A/B after main synchronization

The definitive comparison uses clean `main` `aa2582ca` and head `60fda0bc`. Both release clients were prebuilt from isolated source paths, passed through `CLIENT_BIN_OVERRIDE`, and exercised on ports 18082/18083 without editing any benchmark `Cargo.toml`. Plugins were disabled, so this measures the ordinary consumer hot path. Five clean runs per side sent 30,000 ping-pongs at a 3,000/s cap; one additional PR run was discarded in full because host CPU pressure reached 5.17% versus roughly 0.16-0.22% in the retained batch.

Main → PR medians were 2,859.33/s → 2,859.23/s throughput, 3.770 s → 3.580 s client CPU, 36.4 MB → 35.4 MB HWM, 0.54 ms → 0.56 ms ack latency, and 0.58 ms → 0.59 ms pong latency. The throughput ranges overlap (2,848.38-2,859.62/s versus 2,847.89-2,859.51/s), and all retained runs delivered 150,000 acknowledgements and pongs per side with zero loss or failures. The non-LTO release harness artifact changed from 27,094,008 to 26,807,696 bytes (-286,312 / -1.06%). No measurable feature-disabled regression is present.

### Phase 3.3 observability

The isolated A/B compares `e72f2729` (before native observability) with `667689ab` (observability). Both release clients enabled `whatsapp-rust/plugins` but installed no plugin, so this measures the unused opt-in runtime path. Cargo `paths` overrides, dedicated target/lock paths, and distinct ports kept the source and runs isolated; the pre-existing benchmark `Cargo.toml` and `Cargo.lock` retained SHA-256 `aea5f2e39dd88d569fcca4db37728c10ce04ea283033ee6858a77791ccaf2d1d` and `d81fa43e9802b569845eba1f24b219430d378e108cb87cf07cca1ae4ae52b19b` throughout.

Ten order-alternated normal pairs ran on ports 18621–18640, with 30,000 ping-pongs at 3,000/s per run. Baseline → candidate side medians were 2,859.175/s → 2,859.280/s throughput, 3.460 s → 3.570 s client CPU, 26.65 → 26.75 MB RSS average, 35.45 → 35.45 MB HWM, and 9.95 → 9.95 MB anonymous RSS average. Four order-alternated stress pairs ran on ports 18641–18648, with 100,000 ping-pongs at 6,000/s per run: 5,846.965/s → 5,847.030/s, 9.000 s → 9.105 s client CPU, 39.85 → 39.80 MB RSS average, 55.20 → 55.05 MB HWM, and 22.95 → 23.00 MB anonymous RSS average. All 28 runs completed; each side delivered 700,000 acknowledgements and pongs with zero loss or pong failures.

The CPU samples do not establish a stable regression: normal paired deltas ranged from -0.12 s to +0.44 s with a +0.035 s median, while stress ranged from -0.39 s to +0.49 s with a +0.105 s median; median host interference also moved in opposite directions between the batches (4.0% → 3.8% normal, 4.65% → 5.3% stress). Throughput and memory were unchanged at the experiment's resolution.

For artifact size, both commits were additionally built from the same physical source path. With `plugins` enabled, observability adds 113,000 B to the unstripped ELF (+0.418%), 78,368 B of `.text` (+0.392%), 880 B of data, and 528 B of BSS. This is the explicit opt-in diagnostics cost. With `plugins` disabled, allocated section sizes are identical on both sides (`text=19,829,371`, `data=373,592`, `bss=3,944`) and both stripped files are 20,208,840 B. The full ELFs are not byte-identical because Rust/LLVM codegen identity and layout metadata changed, so the supported claim is zero feature-disabled allocated-size growth rather than binary identity.

### Phase 3.2 lifecycle opt-in and binary-size gate

The same release/LTO demo used by the Binary Size workflow was rebuilt from a clean target at updated `main` and current head `63bb4d95`. Baseline → candidate measured 8,066,742 → 8,073,590 bytes of `.text` (+6,848 B / +6.69 KiB) and 10,089,576 → 10,097,032 stripped bytes (+7,456 B / +7.28 KiB). Before the standalone lifecycle split, the candidate measured 8,105,526 bytes of `.text`; feature-gating recovered 31,936 B and leaves roughly 25 KiB below the 32 KiB CI budget.

The default client now contains neither the lifecycle field nor its cleanup/startup branches. `client-lifecycle` restores the standalone API and `plugins` enables it transitively.

The isolated runtime A/B compares `c86f6d52` (before the split) with `63bb4d95` using Cargo `paths` overrides, prebuilt binaries, separate targets, and five order-alternated pairs on ports 18501–18510. Across five 30,000-ping-pong runs per side, median throughput was 2,859.28/s → 2,859.43/s (+0.005%), client CPU 3.86 s → 3.92 s, RSS average 26.7 → 26.6 MB, HWM 35.5 → 35.0 MB, and anonymous RSS average 10.2 → 10.1 MB. Median host CPU interference was 7.4% → 9.4%, so the 0.06 s client CPU difference is within sampling/interference noise. Each side delivered 150,000 acknowledgements and pongs with zero loss.

The non-LTO harness artifact shrank 87,200 B (-0.325%) and `.text` shrank 78,380 B (-0.394%). The pre-existing benchmark `Cargo.toml` and `Cargo.lock` retained their exact SHA-256 hashes before and after the build/run sequence.

### Whole branch after updated-main synchronization

The benchmarked `9e7aba15` head was built against the same dirty-but-unchanged `whatsapp-benchs` checkout as `main` `87fbcb55`, using Cargo path overrides, prebuilt binaries, and ports 18101–18106; neither benchmark manifest changed. Across three paired 30,000-ping-pong runs at 3,000/s, median actual throughput was 2,859.09/s → 2,859.27/s (+0.006%), median client CPU was 3.93 s → 3.86 s, median RSS average was 27.0 → 26.9 MB, and median HWM was 35.5 → 36.0 MB. Every run delivered all 30,000 acknowledgements and pongs with zero loss. The non-LTO release artifact shrank 194,328 bytes (-0.720%) and `.text` shrank 168,732 bytes (-0.843%). This shows no measurable hot-path regression after combining the plugin foundations with `#1062`; the HWM delta is within the observed run-to-run spread. The later `2137fcb5` hardening changes cold authentication/teardown synchronization, handler/subscription destruction, and install-time dependency ownership. Phase 2.2 at its isolated head `9cef55db` is benchmarked independently below.

### Phase 2.3

The isolated A/B compares `9cef55db` with `57ec05dc`. Both prebuilt release clients used Cargo source-path overrides and `--features whatsapp-rust/plugins` without installing a plugin; the external metrics crate therefore proves compile-time/public-API integration without entering the unused runtime path. Ten order-alternated pairs ran on dedicated ports 18401–18420 after AC power was restored. An earlier battery/power-saving batch was discarded in full and is not used here. The pre-existing `whatsapp-benchs` manifests retained their exact hashes before and after every batch.

Across the ten valid 30,000-ping-pong runs per side, median throughput was 2,859.02/s → 2,859.31/s (+0.01%), client CPU 3.590 s → 3.585 s (-0.14%), RSS average 26.6 → 26.5 MB (-0.38%), HWM 35.25 → 35.05 MB (-0.57%), and anonymous RSS average 10.05 → 10.00 MB (-0.50%). Each side delivered 300,000 acknowledgements and 300,000 pongs with zero loss. Median host CPU interference was 4.45% → 4.50%; the deliberately retained first warm-up pair had higher interference, so medians rather than selected samples are reported.

The release harness artifact changed by +544 bytes (+0.002%); `.text` changed by +232 bytes, data by +40 bytes, BSS by -232 bytes, and total allocated sections by +40 bytes. These results show no measurable unused-runtime or memory regression from the task clock/API slice.

### Phase 2.2

The isolated A/B compares the pre-router head `2137fcb5` with `9cef55db`. Both binaries used Cargo source-path overrides, temporary targets and lockfiles, and dedicated ports 18321–18336; the pre-existing `whatsapp-benchs` `Cargo.toml` and `Cargo.lock` hashes remained unchanged.

With `plugins` disabled, five paired 30,000-ping-pong runs produced median throughput of 2,859.20/s → 2,859.21/s. Three samples showed unrelated host CPU or memory pressure, so resource medians use the clean subset (four baseline and three candidate runs): CPU 3.54 s → 3.64 s, RSS average 26.35 → 26.5 MB, HWM 35.2 → 35.3 MB, and anonymous RSS average 9.9 → 10.1 MB. The non-LTO artifact changed by +9,896 bytes (+0.037%) and `.text` by +4,988 bytes (+0.025%), despite the feature-disabled code being absent; this is within link/code-layout noise.

The stronger opt-in check rebuilt both sides with Cargo flag `--features whatsapp-rust/plugins` but installed no plugin. Across three clean paired runs, median throughput was 2,859.29/s → 2,859.33/s, client CPU 3.56 s → 3.37 s, RSS average 26.4 → 26.4 MB, HWM 35.4 → 35.0 MB, and anonymous RSS average 10.0 → 10.1 MB. The candidate artifact was 15,824 bytes smaller (-0.059%) and `.text` 4,280 bytes smaller (-0.022%). Every one of the 16 runs delivered all 30,000 acknowledgements and pongs with zero loss. The CPU differences are sampling/run-order noise; neither build mode shows a throughput, memory-retention, or unused-runtime regression.

### Phase 2.1

The Binary Size check first detected that compiling the native host into default builds added 83.16 KiB stripped and 71.56 KiB of `.text`. That evidence triggered the intended opt-in feature boundary instead of a budget waiver. A same-toolchain release/LTO demo build at the pre-host head `66f464a9` and the feature-gated head `7c2e584c` is now byte-for-byte identical with plugins disabled: 10,112,136 stripped bytes and 8,087,734 `.text` bytes on both sides. The normal `whatsapp-benchs` A/B used prebuilt source overrides and separate ports; its `Cargo.toml` remained untouched. Across three paired runs (30,000 ping-pongs at 3,000/s per side), median actual throughput was 2,859.23/s → 2,859.42/s (+0.01%), sampled client CPU was 3.85 s → 3.70 s, and median HWM was 35.6 → 35.1 MB. Every run delivered all acknowledgements and pongs with zero loss. The non-LTO harness artifact changed by +17,096 bytes (+0.063%); `.text` changed by +2,368 bytes, consistent with codegen/link-layout noise from the declared opt-in feature rather than a default runtime path.

### Phase 1

Phase 1 A/B measurements used isolated copies of `whatsapp-benchs` against the updated `main` at `cd29cef4`, with three normal runs per side:

- connect median: 5.517 s → 5.518 s (+0.02%)
- 20 reconnect cycles median: 7.202 s → 7.219 s (+0.24%); every run completed 21 authentications
- 10,000 ping-pongs median actual rate: 1,817.76/s → 1,817.56/s (-0.01%), with 10,000 acknowledgements, 10,000 pongs, and zero loss in every run
- DHAT over 20 reconnect cycles: 29,768,739 → 29,318,034 allocated bytes (-1.5%); peak live allocation 2,416,246 → 2,184,867 bytes; live-at-end unchanged at 27,190 bytes
- release benchmark artifact: +43,624 bytes (+0.162%)

### Phase 0 and lifecycle review hardening

The focused A/B compares the pre-Phase-0 head `a0da3e2e` with `3bd4bd58`. Both sides used the same `whatsapp-benchs` checkout and prebuilt source overrides; the benchmark `Cargo.toml` was not changed. Normal measurements are medians from three paired runs on separate ports:

- 30,000 ping-pongs at a 3,000/s rate cap: 2,858.81/s → 2,859.12/s (+0.01%); client CPU 4.40 s → 4.49 s (+0.09 s); HWM 35.7 → 35.9 MB; all six runs delivered every acknowledgement and pong with zero loss
- 50 reconnect cycles: client CPU 0.37 s → 0.38 s (+0.01 s); HWM 21.3 → 21.3 MB; median RSS growth 7.0 → 6.2 MB and anonymous RSS growth 3.9 → 3.4 MB; all six storms completed
- DHAT over 50 reconnect cycles: 68,505,259 → 68,360,740 allocated bytes (-0.21%), 391,946 → 393,066 allocation blocks (+0.29%), peak live allocation 2,418,051 → 2,186,598 bytes, and live-at-end unchanged at 27,190 bytes
- release benchmark artifact: 27,063,904 → 27,082,800 bytes (+18,896 bytes, +0.070%)

The normal-run CPU differences are at sampler resolution and throughput is unchanged. DHAT and equal live-at-end show no lifecycle retention regression.

## Validation

Current-head validation additionally passed:

- `cargo fmt --all -- --check` and `git diff --check`
- `cargo clippy --all --tests -- -D warnings`
- `cargo test --workspace --exclude e2e-tests` (including 1,500 passed / 2 ignored in `wacore` and 1,269 passed / 1 ignored in `whatsapp-rust`)
- all 40 plugin-host unit regressions and the external `whatsapp-rust-plugin-metrics` crate
- `cargo check -p whatsapp-rust --no-default-features --features plugins`
- WASM: `cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features --features plugins` with `getrandom_backend=wasm_js`
- five clean final A/B runs per side against current main, with zero lost ack/pong

Focused regressions now also cover manifest-keyed trait-object adapters, owned plugin subscription updates/unsubscribe, immediate registry cleanup after burst churn, capability-bit composition, cooperative connection/install task drains, bounded drain degradation, zero-deadline validation, installation timeout cleanup, and upstream partial-install rollback.

- Phase 0 regressions: unsubscribe during dispatch, explicit interest widening/narrowing, concurrent registration, two simultaneous raw-forwarding consumers, and final-lease teardown
- Phase 1 regressions: authentication/teardown races, cancellation-safe cleanup, callback panic isolation, and final close/shutdown ordering
- cancellation regressions: abort terminal disconnect during transport I/O and abort explicit rollback during a stalled shutdown hook; detached cleanup completes in both cases
- reentrant teardown regressions: handler `Drop` may unsubscribe from the same bus or reenter plugin subscription APIs without deadlock, including the post-shutdown rejection path
- ready-publication regressions: terminal cancellation waits for an in-flight publication, suppresses later `Connected`, and remains safe when shutdown is signalled from the event handler itself
- Phase 2.2 regressions: exact selector filtering, bounded overflow/drop accounting, concurrent per-route sequence order, route reset, shutdown drain, and typed API/event vertical slice
- Phase 2.3 regressions: public-only external metrics plugin, typed API/snapshot/selector, selective core events, install- versus connection-scoped clocks, bounded tick delivery, stale-generation protection, and shutdown
- Phase 3.1 regressions: generation tasks finish before `on_closed`, install tasks finish before terminal hooks, rollback waits for task destruction, and task-drain timeout remains bounded
- Phase 3.3 regressions: shared fanout memory counts once, publisher/router totals remain cumulative, queue drops degrade only the responsible plugin, core-event panics are isolated, delayed handler destruction is contained, and memory-report totals include retained custom-event payloads
- lifecycle queue regressions: stale `Ready` admission remains capped, ordinary close ordering is retained, and all 254 queued generation closures are delivered before terminal `shutdown`
- reconnect regressions: `reconnect()` and `reconnect_immediately()` invoked from `on_ready` synchronously cancel the active generation and suppress its stale `Connected` publication
- lifecycle drop regressions: the final client owner signals a standalone lifecycle, and the obsolete device-registry cleanup task is absent so a fresh client releases its last strong owner without explicit shutdown
- detached cleanup regressions: a custom transport panic reaches the cleanup waiter instead of leaving it parked forever, and the retired scope is closed on the unwind path
- terminal-install regressions: standalone lifecycle and plugin install futures that never complete are cancelled within a bound; staged task signals fire synchronously and LIFO shutdown still runs
- rollback unwind regression: a staged API with a panicking destructor cannot strand the builder waiting for detached cleanup completion
- resource-teardown regression: a panicking plugin event-handler destructor cannot suppress later plugin shutdown signals or the installed upstream lifecycle
- tracker-retirement regression: cancelling a connection generation removes its task tracker before `on_closed`, so bounded lifecycle queue eviction cannot retain stale generations
- future-teardown regressions: pending plugin and aggregate lifecycle callbacks whose destructors panic are cancelled within an unwind boundary and cannot suppress later hooks or terminal shutdown
- ownership regression: an API retaining `PluginContext` is released with the client instead of cycling through the staging registry
- a lifecycle-rejected authentication success cannot leave `is_logged_in` set
- `cargo test --all` built and linked the complete workspace locally; only the E2E runtime failed because no Bartender mock server was reachable. Pulling the repository-pinned private image remains HTTP 403 with the available GitHub token, so the GitHub E2E job is authoritative.
- GitHub E2E passed on head `1ee952b9`; all checks were green there, including WASM, formatting, clippy, all-features, no-SIMD, binary size, and CodSpeed
- The complete local suite, all-test Clippy, all 40 plugin-host tests, minimal native/WASM plugin builds, formatting, and diff checks are green on current head `30d06ff6`, which contains `origin/main` at `aa2582ca`. All review threads are resolved. GitHub checks and AI reviews are rerunning on this head and remain under monitoring.