### PR TITLE
feat(core): add typed USync query engine

### DIFF
--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -973,18 +973,19 @@ impl Client {
         record: &wacore::store::traits::DeviceListRecord,
     ) -> Vec<Jid> {
         let base = query_jid.to_non_ad();
-        record
-            .devices
-            .iter()
-            .map(|d| {
-                debug_assert!(
-                    d.device_id <= u16::MAX as u32,
-                    "device_id {} overflows u16",
-                    d.device_id
-                );
-                base.with_device_hosting(d.device_id as u16, d.is_hosted)
-            })
-            .collect()
+        let mut devices = Vec::with_capacity(record.devices.len());
+        for device in &record.devices {
+            match u16::try_from(device.device_id) {
+                Ok(device_id) => {
+                    devices.push(base.with_device_hosting(device_id, device.is_hosted));
+                }
+                Err(_) => warn!(
+                    "reconstruct_device_jids: device_id {} exceeds u16; skipping",
+                    device.device_id
+                ),
+            }
+        }
+        devices
     }
 
     /// Background loop placeholder for device registry cleanup.
@@ -2236,6 +2237,25 @@ mod tests {
         assert_eq!(devices.len(), 1);
         assert!(devices[0].is_lid(), "device JID should be LID-typed");
         assert_eq!(devices[0].user, lid, "device JID user should be the LID");
+    }
+
+    #[test]
+    fn reconstruct_device_jids_skips_unrepresentable_persisted_ids() {
+        let record = wacore::store::traits::DeviceListRecord {
+            user: "13135550100".into(),
+            devices: vec![
+                wacore::store::traits::DeviceInfo::new(7, None).with_hosting(true),
+                wacore::store::traits::DeviceInfo::new(u32::from(u16::MAX) + 1, None),
+            ],
+            timestamp: 0,
+            phash: None,
+            raw_id: None,
+        };
+
+        assert_eq!(
+            Client::reconstruct_device_jids(&Jid::pn("13135550100"), &record),
+            vec![Jid::new("13135550100", Server::Hosted).with_device(7)]
+        );
     }
 
     // A present-but-empty record must read as a miss (None), not Some([]). The

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -612,18 +612,19 @@ impl Client {
                     && stored_raw_id != decoded.raw_id
                 {
                     info!(
-                        "raw_id mismatch for user {user}: stored={stored_raw_id}, received={}. Clearing record.",
+                        "raw_id mismatch for user {user}: stored={stored_raw_id}, received={}. Resetting companion devices.",
                         decoded.raw_id
                     );
                     self.clear_device_record(user, device.jid.server.as_str(), &record)
                         .await;
-                    record.devices.clear();
+                    record.devices.retain(|device| device.device_id == 0);
+                } else {
+                    // Filter stale devices by valid_indexes. A raw_id reset already
+                    // removed every companion while preserving primary metadata.
+                    record.devices =
+                        wacore::adv::filter_devices_by_key_index(&record.devices, &decoded);
                 }
                 record.raw_id = Some(decoded.raw_id);
-
-                // Filter stale devices by valid_indexes
-                record.devices =
-                    wacore::adv::filter_devices_by_key_index(&record.devices, &decoded);
 
                 // Only add the new device if its key_index is accepted by the ADV list
                 if !record.devices.iter().any(|d| d.device_id == device_id)
@@ -644,11 +645,9 @@ impl Client {
         }
 
         // WA Web `AdvDeviceNotificationApi.handleDeviceAddNotification` re-adds the
-        // primary (device 0) to the rebuilt list unconditionally, so a raw_id
-        // mismatch (which clears the list) never drops it. `filter_devices_by_key_index`
-        // only keeps device 0 when it is already in the input, so after a clear the
-        // primary would otherwise be lost, leaving a record with no device 0 (or an
-        // empty list) that suppresses the usync re-fetch forever.
+        // primary (device 0) to the rebuilt list unconditionally. Preserve an
+        // existing primary and its metadata across a raw_id reset; restore a
+        // neutral entry only when the input record did not contain one.
         //
         // The primary's key_index is never read (`filter_devices_by_key_index` keeps
         // device 0 regardless and `is_key_index_valid` is not applied to it), so store
@@ -802,8 +801,8 @@ impl Client {
     }
 
     /// Delete `sender_key_devices` rows whose `device_jid` matches the given
-    /// (user, device_id) under either LID or PN addressing. Both alias keys
-    /// for the user are tried via `resolve_lookup_keys`. The in-memory cache
+    /// (user, device_id) under every standard and hosted Signal namespace.
+    /// Both aliases are resolved by `resolve_lookup_keys`. The in-memory cache
     /// is also evicted for groups that indexed the removed JID — necessary
     /// because a future re-add of the same device_id would otherwise hit
     /// a stale `has_key=true` entry and skip SKDM.
@@ -818,14 +817,11 @@ impl Client {
         device_id: u16,
     ) -> Result<(), wacore::store::error::StoreError> {
         let lookup = self.resolve_lookup_keys(user).await;
-        let servers = [wacore_binary::Server::Lid, wacore_binary::Server::Pn];
         let mut candidates: Vec<String> = Vec::with_capacity(4);
-        for server in servers {
-            for key in lookup.all_keys() {
-                let mut jid = Jid::new(key, server);
-                jid.device = device_id;
-                candidates.push(jid.to_string());
-            }
+        for (key, server) in lookup.signal_namespaces() {
+            let mut jid = Jid::new(key, server);
+            jid.device = device_id;
+            candidates.push(jid.to_string());
         }
         let refs: Vec<&str> = candidates.iter().map(|s| s.as_str()).collect();
         self.persistence_manager
@@ -1824,6 +1820,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_sender_key_rows_covers_standard_and_hosted_user_namespaces() {
+        let client = create_test_client().await;
+        let lid = "100000000000001";
+        let pn = "15551234567";
+        setup_lid_pn(&client, lid, pn).await;
+
+        let removed_jids = [
+            Jid::new(pn, Server::Pn).with_device(5).to_string(),
+            Jid::new(lid, Server::Lid).with_device(5).to_string(),
+            Jid::new(pn, Server::Hosted).with_device(5).to_string(),
+            Jid::new(lid, Server::HostedLid).with_device(5).to_string(),
+        ];
+        let retained_jid = Jid::new(pn, Server::Hosted).with_device(6).to_string();
+        let mut entries: Vec<_> = removed_jids
+            .iter()
+            .map(|jid| (jid.as_str(), true))
+            .collect();
+        entries.push((retained_jid.as_str(), true));
+
+        let group = "120363000000000001@g.us";
+        client
+            .persistence_manager
+            .set_sender_key_status(group, &entries)
+            .await
+            .unwrap();
+
+        client
+            .delete_sender_key_rows_for_device(pn, 5)
+            .await
+            .unwrap();
+
+        let rows = client
+            .persistence_manager
+            .get_sender_key_devices(group)
+            .await
+            .unwrap();
+        for removed_jid in removed_jids {
+            assert!(
+                rows.iter().all(|(jid, _)| jid != &removed_jid),
+                "sender-key row was not deleted for {removed_jid}"
+            );
+        }
+        assert!(rows.iter().any(|(jid, _)| jid == &retained_jid));
+    }
+
+    #[tokio::test]
     async fn test_patch_device_update_key_index() {
         let client = create_test_client().await;
 
@@ -1949,19 +1991,23 @@ mod tests {
         }
     }
 
-    // raw_id mismatch clears the list and rebuilds from the notification; the
-    // primary (device 0) must survive. Regression guard for a record that would
-    // otherwise persist without device 0 (and then suppress usync forever).
+    // A raw_id mismatch drops stale companions and rebuilds from the notification;
+    // the primary (device 0) and its existing metadata must survive.
     #[tokio::test]
     async fn test_patch_device_add_raw_id_mismatch_preserves_primary() {
         let client = create_test_client().await;
 
+        let mut record = record_with_raw_id("15551234567", &[0, 5], 1);
+        record
+            .devices
+            .iter_mut()
+            .find(|device| device.device_id == 0)
+            .unwrap()
+            .is_hosted = true;
+
         client
             .device_registry_cache
-            .raw_insert_for_tests(
-                "15551234567".to_string(),
-                Arc::new(record_with_raw_id("15551234567", &[0, 5], 1)),
-            )
+            .raw_insert_for_tests("15551234567".to_string(), Arc::new(record))
             .await;
 
         // New raw_id (2) != stored (1) → clear + rebuild. Notified device 19 has a
@@ -1991,8 +2037,10 @@ mod tests {
                     updated.devices
                 )
             });
-        // The re-seeded primary carries no key index (it is never read for device 0).
+        // The existing primary metadata is retained; it is not reconstructed from
+        // the incoming companion's namespace.
         assert_eq!(dev0.key_index, None);
+        assert!(dev0.is_hosted);
         assert!(updated.devices.iter().any(|d| d.device_id == 19));
         // Stale companion from the old identity is dropped by the clear.
         assert!(!updated.devices.iter().any(|d| d.device_id == 5));

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -576,6 +576,7 @@ impl Client {
         key_index_info: Option<&wacore::stanza::devices::KeyIndexInfo>,
     ) {
         let device_id = device.device_id();
+        let is_hosted = wacore_binary::JidExt::is_hosted(&device.jid);
 
         let Some(mut record) = self.load_device_record(user).await else {
             return;
@@ -610,18 +611,18 @@ impl Client {
                 if !record.devices.iter().any(|d| d.device_id == device_id)
                     && wacore::adv::is_key_index_valid(device.key_index, &decoded)
                 {
-                    record.devices.push(wacore::store::traits::DeviceInfo {
-                        device_id,
-                        key_index: device.key_index,
-                    });
+                    record.devices.push(
+                        wacore::store::traits::DeviceInfo::new(device_id, device.key_index)
+                            .with_hosting(is_hosted),
+                    );
                 }
             } else {
                 warn!("patch_device_add: failed to decode key-index-list for user {user}");
-                self.append_device_if_new(&mut record, device_id, device.key_index);
+                self.append_device_if_new(&mut record, device_id, device.key_index, is_hosted);
             }
         } else {
             // No signed bytes — fall back to simple append
-            self.append_device_if_new(&mut record, device_id, device.key_index);
+            self.append_device_if_new(&mut record, device_id, device.key_index, is_hosted);
         }
 
         // WA Web `AdvDeviceNotificationApi.handleDeviceAddNotification` re-adds the
@@ -635,10 +636,9 @@ impl Client {
         // device 0 regardless and `is_key_index_valid` is not applied to it), so store
         // `None` to match how device 0 is recorded everywhere else.
         if !record.devices.iter().any(|d| d.device_id == 0) {
-            record.devices.push(wacore::store::traits::DeviceInfo {
-                device_id: 0,
-                key_index: None,
-            });
+            record
+                .devices
+                .push(wacore::store::traits::DeviceInfo::new(0, None));
         }
 
         // New devices are picked up automatically by `resolve_skdm_targets`:
@@ -656,12 +656,13 @@ impl Client {
         record: &mut wacore::store::traits::DeviceListRecord,
         device_id: u32,
         key_index: Option<u32>,
+        is_hosted: bool,
     ) {
         if !record.devices.iter().any(|d| d.device_id == device_id) {
-            record.devices.push(wacore::store::traits::DeviceInfo {
-                device_id,
-                key_index,
-            });
+            record.devices.push(
+                wacore::store::traits::DeviceInfo::new(device_id, key_index)
+                    .with_hosting(is_hosted),
+            );
         }
     }
 
@@ -934,14 +935,13 @@ impl Client {
     }
 
     /// Reconstruct `Vec<Jid>` from a `DeviceListRecord`, using the query JID's
-    /// user part and server type. This ensures that a PN-typed query always
-    /// returns PN-typed device JIDs even if the record is stored under a LID key
-    /// (and vice versa), which matters after PN-to-LID migration.
+    /// user part and addressing family while honoring each device's hosted bit.
+    /// This keeps PN/LID selection independent from the registry's storage key.
     fn reconstruct_device_jids(
         query_jid: &Jid,
         record: &wacore::store::traits::DeviceListRecord,
     ) -> Vec<Jid> {
-        let user = &query_jid.user;
+        let base = query_jid.to_non_ad();
         record
             .devices
             .iter()
@@ -951,12 +951,7 @@ impl Client {
                     "device_id {} overflows u16",
                     d.device_id
                 );
-                let device = d.device_id as u16;
-                if query_jid.is_lid() {
-                    Jid::lid_device(user.clone(), device)
-                } else {
-                    Jid::pn_device(user.clone(), device)
-                }
+                base.with_device_hosting(d.device_id as u16, d.is_hosted)
             })
             .collect()
     }
@@ -1051,10 +1046,7 @@ mod tests {
             user: user.into(),
             devices: device_ids
                 .iter()
-                .map(|&id| wacore::store::traits::DeviceInfo {
-                    device_id: id,
-                    key_index: None,
-                })
+                .map(|&id| wacore::store::traits::DeviceInfo::new(id, None))
                 .collect(),
             timestamp: wacore::time::now_secs(),
             phash: None,
@@ -1355,10 +1347,7 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: pn.into(),
-                devices: vec![wacore::store::traits::DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                }],
+                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1380,14 +1369,8 @@ mod tests {
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: lid.into(),
                 devices: vec![
-                    wacore::store::traits::DeviceInfo {
-                        device_id: 0,
-                        key_index: None,
-                    },
-                    wacore::store::traits::DeviceInfo {
-                        device_id: 11,
-                        key_index: None,
-                    },
+                    wacore::store::traits::DeviceInfo::new(0, None),
+                    wacore::store::traits::DeviceInfo::new(11, None),
                 ],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
@@ -1419,10 +1402,7 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: "5511999990003".into(),
-                devices: vec![wacore::store::traits::DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                }],
+                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1438,10 +1418,7 @@ mod tests {
         client
             .update_device_lists(vec![wacore::store::traits::DeviceListRecord {
                 user: "5511999990004".into(),
-                devices: vec![wacore::store::traits::DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                }],
+                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1479,10 +1456,7 @@ mod tests {
         client
             .update_device_list(wacore::store::traits::DeviceListRecord {
                 user: "5511999990005".into(),
-                devices: vec![wacore::store::traits::DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                }],
+                devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -1799,14 +1773,8 @@ mod tests {
         let record = wacore::store::traits::DeviceListRecord {
             user: "15551234567".to_string(),
             devices: vec![
-                wacore::store::traits::DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                wacore::store::traits::DeviceInfo {
-                    device_id: 3,
-                    key_index: Some(1),
-                },
+                wacore::store::traits::DeviceInfo::new(0, None),
+                wacore::store::traits::DeviceInfo::new(3, Some(1)),
             ],
             timestamp: 1000,
             phash: None,
@@ -1885,9 +1853,8 @@ mod tests {
             user: user.into(),
             devices: device_ids
                 .iter()
-                .map(|&id| wacore::store::traits::DeviceInfo {
-                    device_id: id,
-                    key_index: if id == 0 { None } else { Some(7) },
+                .map(|&id| {
+                    wacore::store::traits::DeviceInfo::new(id, if id == 0 { None } else { Some(7) })
                 })
                 .collect(),
             timestamp: 1000,
@@ -1998,16 +1965,7 @@ mod tests {
         // Store device list under PN in backend
         let record = DeviceListRecord {
             user: pn.to_string(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 39,
-                    key_index: Some(25),
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(39, Some(25))],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2115,10 +2073,7 @@ mod tests {
         // Seed backend DB directly (bypassing the in-process cache)
         let record = DeviceListRecord {
             user: "15551234567".into(),
-            devices: vec![DeviceInfo {
-                device_id: 0,
-                key_index: None,
-            }],
+            devices: vec![DeviceInfo::new(0, None)],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2171,16 +2126,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "15551234567".into(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 3,
-                    key_index: Some(5),
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(3, Some(5))],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2255,16 +2201,7 @@ mod tests {
         // Pre-populate device registry with device 0 AND device 3
         let record = DeviceListRecord {
             user: "15551234567".into(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 3,
-                    key_index: Some(5),
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(3, Some(5))],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2358,10 +2295,7 @@ mod tests {
         backend
             .update_device_list(DeviceListRecord {
                 user: pn.to_string(),
-                devices: vec![DeviceInfo {
-                    device_id: 5,
-                    key_index: None,
-                }],
+                devices: vec![DeviceInfo::new(5, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2376,10 +2310,7 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: pn.to_string(),
-                devices: vec![DeviceInfo {
-                    device_id: 7,
-                    key_index: None,
-                }],
+                devices: vec![DeviceInfo::new(7, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2411,10 +2342,7 @@ mod tests {
         backend
             .update_device_list(DeviceListRecord {
                 user: pn.to_string(),
-                devices: vec![DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                }],
+                devices: vec![DeviceInfo::new(0, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -2455,10 +2383,7 @@ mod tests {
             backend
                 .update_device_list(DeviceListRecord {
                     user: user.to_string(),
-                    devices: vec![DeviceInfo {
-                        device_id: 1,
-                        key_index: None,
-                    }],
+                    devices: vec![DeviceInfo::new(1, None)],
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,
@@ -2513,10 +2438,7 @@ mod tests {
 
         let legacy = DeviceListRecord {
             user: pn.to_string(),
-            devices: vec![DeviceInfo {
-                device_id: 9,
-                key_index: None,
-            }],
+            devices: vec![DeviceInfo::new(9, None)],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -2534,10 +2456,7 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: pn.to_string(),
-                devices: vec![DeviceInfo {
-                    device_id: 10,
-                    key_index: None,
-                }],
+                devices: vec![DeviceInfo::new(10, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use log::{debug, info, warn};
 use std::sync::Arc;
-use wacore_binary::Jid;
+use wacore_binary::{Jid, Server};
 
 use super::Client;
 
@@ -75,6 +75,24 @@ impl UserLookupKeys {
         match self {
             Self::LidWithPn { lid, .. } | Self::PnWithLid { lid, .. } => lid,
             Self::Unknown { user } => user,
+        }
+    }
+
+    /// Signal namespaces that may hold sessions for this identity.
+    fn signal_namespaces(&self) -> [(&str, Server); 4] {
+        match self {
+            Self::LidWithPn { lid, pn } | Self::PnWithLid { lid, pn } => [
+                (pn, Server::Pn),
+                (lid, Server::Lid),
+                (pn, Server::Hosted),
+                (lid, Server::HostedLid),
+            ],
+            Self::Unknown { user } => [
+                (user, Server::Pn),
+                (user, Server::Lid),
+                (user, Server::Hosted),
+                (user, Server::HostedLid),
+            ],
         }
     }
 }
@@ -634,7 +652,9 @@ impl Client {
         //
         // The primary's key_index is never read (`filter_devices_by_key_index` keeps
         // device 0 regardless and `is_key_index_valid` is not applied to it), so store
-        // `None` to match how device 0 is recorded everywhere else.
+        // `None` to match how device 0 is recorded everywhere else. Hosting belongs
+        // to each device-list entry, so the companion notification cannot classify
+        // the primary.
         if !record.devices.iter().any(|d| d.device_id == 0) {
             record
                 .devices
@@ -666,20 +686,16 @@ impl Client {
         }
     }
 
-    /// Delete Signal sessions for specific device IDs under both LID and PN
-    /// addresses, then flush. Shared by `clear_device_record` and
-    /// `patch_device_remove`.
+    /// Delete Signal sessions for specific device IDs in every user namespace,
+    /// then flush. Shared by `clear_device_record` and `patch_device_remove`.
     async fn delete_sessions_for_devices(&self, user: &str, device_ids: &[u16]) {
         let lookup = self.resolve_lookup_keys(user).await;
-        let servers = [wacore_binary::Server::Lid, wacore_binary::Server::Pn];
-        for server in servers {
-            for key in lookup.all_keys() {
-                for &device_id in device_ids {
-                    let mut jid = Jid::new(key, server);
-                    jid.device = device_id;
-                    let addr = wacore::types::jid::JidExt::to_protocol_address(&jid);
-                    self.signal_cache.delete_session(&addr).await;
-                }
+        for (key, server) in lookup.signal_namespaces() {
+            for &device_id in device_ids {
+                let mut jid = Jid::new(key, server);
+                jid.device = device_id;
+                let addr = wacore::types::jid::JidExt::to_protocol_address(&jid);
+                self.signal_cache.delete_session(&addr).await;
             }
         }
         self.flush_signal_cache_batch_safe_logged("delete_sessions_for_devices", None)
@@ -1766,6 +1782,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_sessions_covers_standard_and_hosted_user_namespaces() {
+        use wacore::libsignal::protocol::SessionRecord;
+
+        let client = create_test_client().await;
+        let lid = "100000000000001";
+        let pn = "15551234567";
+        setup_lid_pn(&client, lid, pn).await;
+
+        let addresses: Vec<_> = [
+            Jid::new(pn, Server::Pn).with_device(5),
+            Jid::new(lid, Server::Lid).with_device(5),
+            Jid::new(pn, Server::Hosted).with_device(5),
+            Jid::new(lid, Server::HostedLid).with_device(5),
+        ]
+        .iter()
+        .map(wacore::types::jid::JidExt::to_protocol_address)
+        .collect();
+
+        for address in &addresses {
+            client
+                .signal_cache
+                .put_session(address, SessionRecord::new_fresh())
+                .await;
+        }
+
+        client.delete_sessions_for_devices(pn, &[5]).await;
+
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        for address in addresses {
+            assert!(
+                !client
+                    .signal_cache
+                    .has_session(&address, &*snapshot.backend)
+                    .await
+                    .unwrap(),
+                "session was not deleted for {}",
+                address.as_str()
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_patch_device_update_key_index() {
         let client = create_test_client().await;
 
@@ -1817,6 +1875,34 @@ mod tests {
         assert_eq!(updated.devices.len(), 2);
         let dev3 = updated.devices.iter().find(|d| d.device_id == 3).unwrap();
         assert_eq!(dev3.key_index, Some(2));
+    }
+
+    #[tokio::test]
+    async fn hosted_companion_does_not_reclassify_primary_device() {
+        let client = create_test_client().await;
+        setup_device_record(&client, "15551234567", &[0]).await;
+
+        let mut elem = make_device_element(3, Some(2));
+        elem.jid.server = Server::Hosted;
+        client.patch_device_add("15551234567", &elem, None).await;
+
+        let updated = client
+            .device_registry_cache
+            .get("15551234567")
+            .await
+            .unwrap();
+        assert!(
+            updated
+                .devices
+                .iter()
+                .any(|device| device.device_id == 3 && device.is_hosted)
+        );
+        assert!(
+            updated
+                .devices
+                .iter()
+                .any(|device| device.device_id == 0 && !device.is_hosted)
+        );
     }
 
     /// Encode an `ADVSignedKeyIndexList` whose decoded `raw_id`/`valid_indexes`

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -10,6 +10,8 @@ use wacore_binary::{Jid, Server};
 
 use super::Client;
 
+const SIGNAL_NAMESPACE_COUNT: usize = 4;
+
 /// Per-group device-list snapshot for `resolve_group_devices_memoized`.
 /// Valid while the producing `GroupInfo` Arc is still the cached one AND the
 /// device-topology generation is unchanged.
@@ -79,7 +81,7 @@ impl UserLookupKeys {
     }
 
     /// Signal namespaces that may hold sessions for this identity.
-    fn signal_namespaces(&self) -> [(&str, Server); 4] {
+    fn signal_namespaces(&self) -> [(&str, Server); SIGNAL_NAMESPACE_COUNT] {
         match self {
             Self::LidWithPn { lid, pn } | Self::PnWithLid { lid, pn } => [
                 (pn, Server::Pn),
@@ -626,22 +628,22 @@ impl Client {
                 }
                 record.raw_id = Some(decoded.raw_id);
 
-                // Only add the new device if its key_index is accepted by the ADV list
-                if !record.devices.iter().any(|d| d.device_id == device_id)
-                    && wacore::adv::is_key_index_valid(device.key_index, &decoded)
-                {
-                    record.devices.push(
-                        wacore::store::traits::DeviceInfo::new(device_id, device.key_index)
-                            .with_hosting(is_hosted),
+                // Only trust notification metadata when its key index is accepted.
+                if wacore::adv::is_key_index_valid(device.key_index, &decoded) {
+                    self.append_or_refresh_device(
+                        &mut record,
+                        device_id,
+                        device.key_index,
+                        is_hosted,
                     );
                 }
             } else {
                 warn!("patch_device_add: failed to decode key-index-list for user {user}");
-                self.append_device_if_new(&mut record, device_id, device.key_index, is_hosted);
+                self.append_or_refresh_device(&mut record, device_id, device.key_index, is_hosted);
             }
         } else {
             // No signed bytes — fall back to simple append
-            self.append_device_if_new(&mut record, device_id, device.key_index, is_hosted);
+            self.append_or_refresh_device(&mut record, device_id, device.key_index, is_hosted);
         }
 
         // WA Web `AdvDeviceNotificationApi.handleDeviceAddNotification` re-adds the
@@ -669,19 +671,24 @@ impl Client {
         }
     }
 
-    /// Append a device if it doesn't already exist in the record.
-    fn append_device_if_new(
+    /// Append a new device or refresh the addressing metadata of an existing one.
+    fn append_or_refresh_device(
         &self,
         record: &mut wacore::store::traits::DeviceListRecord,
         device_id: u32,
         key_index: Option<u32>,
         is_hosted: bool,
     ) {
-        if !record.devices.iter().any(|d| d.device_id == device_id) {
-            record.devices.push(
+        match record
+            .devices
+            .iter_mut()
+            .find(|device| device.device_id == device_id)
+        {
+            Some(device) => device.is_hosted = is_hosted,
+            None => record.devices.push(
                 wacore::store::traits::DeviceInfo::new(device_id, key_index)
                     .with_hosting(is_hosted),
-            );
+            ),
         }
     }
 
@@ -817,13 +824,25 @@ impl Client {
         device_id: u16,
     ) -> Result<(), wacore::store::error::StoreError> {
         let lookup = self.resolve_lookup_keys(user).await;
-        let mut candidates: Vec<String> = Vec::with_capacity(4);
-        for (key, server) in lookup.signal_namespaces() {
-            let mut jid = Jid::new(key, server);
-            jid.device = device_id;
-            candidates.push(jid.to_string());
+        let namespaces = lookup.signal_namespaces();
+        let mut device_id_buffer = itoa::Buffer::new();
+        let device_id_text = device_id_buffer.format(device_id);
+        let separator_len = ':'.len_utf8() + '@'.len_utf8();
+        let capacity = namespaces
+            .iter()
+            .map(|(key, server)| {
+                key.len() + device_id_text.len() + server.as_str().len() + separator_len
+            })
+            .sum();
+        let mut candidates = String::with_capacity(capacity);
+        let mut ranges = [(0, 0); SIGNAL_NAMESPACE_COUNT];
+        for ((key, server), range) in namespaces.into_iter().zip(&mut ranges) {
+            let start = candidates.len();
+            wacore_binary::push_jid_to_string(key, server, 0, device_id, &mut candidates);
+            *range = (start, candidates.len());
         }
-        let refs: Vec<&str> = candidates.iter().map(|s| s.as_str()).collect();
+        let refs: [&str; SIGNAL_NAMESPACE_COUNT] =
+            ranges.map(|(start, end)| &candidates[start..end]);
         self.persistence_manager
             .delete_sender_key_device_rows(&refs)
             .await?;
@@ -1726,8 +1745,9 @@ mod tests {
 
         setup_device_record(&client, "15551234567", &[0, 3]).await;
 
-        // Patch: add device 3 again — should not duplicate
-        let elem = make_device_element(3, None);
+        // Patch: add device 3 again — should refresh its namespace, not duplicate it.
+        let mut elem = make_device_element(3, None);
+        elem.jid.server = Server::Hosted;
         client.patch_device_add("15551234567", &elem, None).await;
 
         let updated = client
@@ -1740,6 +1760,12 @@ mod tests {
             1
         );
         assert!(updated.devices.iter().any(|d| d.device_id == 0));
+        assert!(
+            updated
+                .devices
+                .iter()
+                .any(|d| d.device_id == 3 && d.is_hosted)
+        );
         assert_eq!(updated.devices.len(), 2);
     }
 
@@ -1989,6 +2015,41 @@ mod tests {
             phash: None,
             raw_id: Some(raw_id),
         }
+    }
+
+    #[tokio::test]
+    async fn signed_device_add_refreshes_existing_hosting_metadata() {
+        let client = create_test_client().await;
+        client
+            .device_registry_cache
+            .raw_insert_for_tests(
+                "15551234567".to_string(),
+                Arc::new(record_with_raw_id("15551234567", &[0, 5], 1)),
+            )
+            .await;
+
+        let key_index_info = wacore::stanza::devices::KeyIndexInfo {
+            timestamp: 100,
+            signed_bytes: Some(make_signed_key_index_bytes(1, 0, vec![7])),
+        };
+        let mut elem = make_device_element(5, Some(7));
+        elem.jid.server = Server::Hosted;
+        client
+            .patch_device_add("15551234567", &elem, Some(&key_index_info))
+            .await;
+
+        let updated = client
+            .device_registry_cache
+            .get("15551234567")
+            .await
+            .unwrap();
+        assert_eq!(updated.devices.len(), 2);
+        assert!(
+            updated
+                .devices
+                .iter()
+                .any(|device| device.device_id == 5 && device.is_hosted)
+        );
     }
 
     // A raw_id mismatch drops stale companions and rebuilds from the notification;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -2093,10 +2093,7 @@ mod tests {
         backend
             .update_device_list(DeviceListRecord {
                 user: pn.to_string(),
-                devices: vec![DeviceInfo {
-                    device_id: 3,
-                    key_index: None,
-                }],
+                devices: vec![DeviceInfo::new(3, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use log::debug;
 use wacore::iq::usync::LidQuerySpec;
-use wacore::store::traits::LidPnMappingEntry;
+use wacore::store::traits::{LidPnMappingEntry, SignalStore};
 use wacore_binary::Jid;
 
 use super::Client;
@@ -878,20 +878,35 @@ impl Client {
     ) -> bool {
         use log::warn;
 
-        let outcome = self
-            .migrate_signal_sessions(&Jid::pn(pn), &Jid::lid(lid))
+        let backend = self.persistence_manager.backend();
+        if let Ok(false) = self
+            .signal_cache
+            .has_state_for_user(pn, backend.as_ref())
+            .await
+        {
+            return false;
+        }
+
+        let standard = self
+            .migrate_signal_sessions_with_backend(&Jid::pn(pn), &Jid::lid(lid), backend.as_ref())
             .await;
-        let migrated_sessions = outcome.migrated != 0;
-        if outcome.has_state_changes()
+        let hosted = self
+            .migrate_signal_sessions_with_backend(
+                &Jid::new(pn, wacore_binary::Server::Hosted),
+                &Jid::new(lid, wacore_binary::Server::HostedLid),
+                backend.as_ref(),
+            )
+            .await;
+        let migrated_sessions = standard.migrated != 0 || hosted.migrated != 0;
+        if (standard.has_state_changes()
+            || hosted.has_state_changes()
             || self
                 .signal_cache
                 .has_pending_pairwise_writes_for_user(pn)
-                .await
+                .await)
+            && let Err(error) = self.signal_cache.flush(backend.as_ref()).await
         {
-            let backend = self.persistence_manager.backend();
-            if let Err(error) = self.signal_cache.flush(backend.as_ref()).await {
-                warn!("Failed to flush signal cache after migration: {error:?}");
-            }
+            warn!("Failed to flush signal cache after migration: {error:?}");
         }
         migrated_sessions
     }
@@ -901,9 +916,6 @@ impl Client {
         from: &Jid,
         to: &Jid,
     ) -> crate::features::SignalSessionMigration {
-        use log::{info, warn};
-        use wacore::types::jid::JidExt;
-
         let backend = self.persistence_manager.backend();
 
         // Nothing to migrate unless the PN side has Signal state. For a freshly
@@ -917,6 +929,23 @@ impl Client {
         {
             return crate::features::SignalSessionMigration::default();
         }
+
+        self.migrate_signal_sessions_with_backend(from, to, backend.as_ref())
+            .await
+    }
+
+    /// Migrate one matching address-family pair after the caller has established
+    /// that this user may have Signal state. Splitting the existence probe from
+    /// the scan lets LID discovery cover both regular and hosted namespaces with
+    /// one backend probe and one final flush.
+    async fn migrate_signal_sessions_with_backend(
+        &self,
+        from: &Jid,
+        to: &Jid,
+        backend: &dyn SignalStore,
+    ) -> crate::features::SignalSessionMigration {
+        use log::{info, warn};
+        use wacore::types::jid::JidExt;
 
         let mut outcome = crate::features::SignalSessionMigration::default();
 
@@ -944,11 +973,7 @@ impl Client {
 
             // PN wins on conflict — mirrors whatsmeow's `MigratePNToLID`
             // (`ON CONFLICT DO UPDATE SET session=excluded.session`).
-            match self
-                .signal_cache
-                .get_session(&pn_proto, backend.as_ref())
-                .await
-            {
+            match self.signal_cache.get_session(&pn_proto, backend).await {
                 Ok(Some(session)) => {
                     outcome.total += 1;
                     self.signal_cache.put_session(&lid_proto, session).await;
@@ -978,38 +1003,32 @@ impl Client {
             // Match the LID lookup result explicitly so a transient read
             // failure isn't collapsed with `Ok(None)` and used as license
             // to overwrite a potentially-valid LID identity.
-            match self
-                .signal_cache
-                .get_identity(&pn_proto, backend.as_ref())
-                .await
-            {
-                Ok(Some(identity_data)) => match self
-                    .signal_cache
-                    .get_identity(&lid_proto, backend.as_ref())
-                    .await
-                {
-                    Ok(None) => {
-                        self.signal_cache
-                            .put_identity(&lid_proto, &identity_data)
-                            .await;
-                        self.signal_cache.delete_identity(&pn_proto).await;
-                        outcome.migrated_identities += 1;
-                        info!("Migrated identity {} -> {}", pn_proto, lid_proto);
-                    }
-                    Ok(Some(_)) => {
-                        // LID-wins: existing LID identity preserved; drop the PN copy.
-                        self.signal_cache.delete_identity(&pn_proto).await;
-                        outcome.discarded_identities += 1;
-                    }
-                    Err(e) => {
-                        outcome.skipped_identities += 1;
-                        warn!(
-                            "Skipping identity migration {} -> {}: \
+            match self.signal_cache.get_identity(&pn_proto, backend).await {
+                Ok(Some(identity_data)) => {
+                    match self.signal_cache.get_identity(&lid_proto, backend).await {
+                        Ok(None) => {
+                            self.signal_cache
+                                .put_identity(&lid_proto, &identity_data)
+                                .await;
+                            self.signal_cache.delete_identity(&pn_proto).await;
+                            outcome.migrated_identities += 1;
+                            info!("Migrated identity {} -> {}", pn_proto, lid_proto);
+                        }
+                        Ok(Some(_)) => {
+                            // LID-wins: existing LID identity preserved; drop the PN copy.
+                            self.signal_cache.delete_identity(&pn_proto).await;
+                            outcome.discarded_identities += 1;
+                        }
+                        Err(e) => {
+                            outcome.skipped_identities += 1;
+                            warn!(
+                                "Skipping identity migration {} -> {}: \
                              failed to read LID identity: {e:?}",
-                            pn_proto, lid_proto
-                        );
+                                pn_proto, lid_proto
+                            );
+                        }
                     }
-                },
+                }
                 Ok(None) => {}
                 Err(error) => {
                     outcome.skipped_identities += 1;
@@ -2328,6 +2347,57 @@ mod tests {
              link to the peer's outbound chain.",
             surviving_regid, WORKING_REGID
         );
+    }
+
+    #[tokio::test]
+    async fn lid_discovery_migrates_standard_and_hosted_signal_namespaces() {
+        use wacore::libsignal::protocol::SessionRecord;
+        use wacore::types::jid::JidExt as _;
+
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "13135550100";
+        let lid = "100000000000100";
+        let backend = client.persistence_manager.backend();
+        let pairs = [
+            (Server::Pn, Server::Lid, 11),
+            (Server::Hosted, Server::HostedLid, 12),
+        ];
+
+        for (from_server, _, registration_id) in pairs {
+            let source = Jid::new(pn, from_server).to_protocol_address();
+            client
+                .signal_cache
+                .put_session(
+                    &source,
+                    SessionRecord::deserialize(&tagged_session_blob(registration_id)).unwrap(),
+                )
+                .await;
+        }
+        client.signal_cache.flush(backend.as_ref()).await.unwrap();
+
+        assert!(
+            client
+                .migrate_signal_sessions_on_lid_discovery(pn, lid)
+                .await
+        );
+        for (from_server, to_server, _) in pairs {
+            let source = Jid::new(pn, from_server).to_protocol_address();
+            let destination = Jid::new(lid, to_server).to_protocol_address();
+            assert!(
+                backend
+                    .get_session(source.as_str())
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(
+                backend
+                    .get_session(destination.as_str())
+                    .await
+                    .unwrap()
+                    .is_some()
+            );
+        }
     }
 
     /// A freshly-resolved peer (no prior PN Signal state) must short-circuit the

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -1266,16 +1266,7 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: recipient.user.to_string(),
-                devices: vec![
-                    DeviceInfo {
-                        device_id: 0,
-                        key_index: None,
-                    },
-                    DeviceInfo {
-                        device_id: 1,
-                        key_index: None,
-                    },
-                ],
+                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(1, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -615,9 +615,9 @@ pub(crate) async fn handle_account_sync_devices(
         user: from_jid.user.to_string(),
         devices: devices
             .iter()
-            .map(|d| DeviceInfo {
-                device_id: d.jid.device as u32,
-                key_index: d.key_index,
+            .map(|d| {
+                DeviceInfo::new(d.jid.device as u32, d.key_index)
+                    .with_hosting(wacore_binary::JidExt::is_hosted(&d.jid))
             })
             .collect(),
         timestamp,

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -884,10 +884,7 @@ mod tests {
         // Pre-populate device registry so clear_device_record has something to clear
         let record = wacore::store::traits::DeviceListRecord {
             user: "5511999999999".into(),
-            devices: vec![wacore::store::traits::DeviceInfo {
-                device_id: 1,
-                key_index: None,
-            }],
+            devices: vec![wacore::store::traits::DeviceInfo::new(1, None)],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: Some(42),
@@ -1201,10 +1198,7 @@ mod tests {
                 "5511666666666".into(),
                 Arc::new(wacore::store::traits::DeviceListRecord {
                     user: "5511666666666".into(),
-                    devices: vec![wacore::store::traits::DeviceInfo {
-                        device_id: 1,
-                        key_index: None,
-                    }],
+                    devices: vec![wacore::store::traits::DeviceInfo::new(1, None)],
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: Some(1),

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3032,10 +3032,7 @@ mod tests {
         for user in &participant_users {
             let record = DeviceListRecord {
                 user: (*user).into(),
-                devices: vec![DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                }],
+                devices: vec![DeviceInfo::new(0, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: None,
                 raw_id: None,
@@ -4472,10 +4469,7 @@ mod tests {
             client
                 .update_device_list(wacore::store::traits::DeviceListRecord {
                     user,
-                    devices: vec![wacore::store::traits::DeviceInfo {
-                        device_id: 0,
-                        key_index: None,
-                    }],
+                    devices: vec![wacore::store::traits::DeviceInfo::new(0, None)],
                     timestamp: wacore::time::now_secs(),
                     phash: None,
                     raw_id: None,

--- a/src/usync.rs
+++ b/src/usync.rs
@@ -3,12 +3,35 @@
 //! Device list IQ specification is defined in `wacore::iq::usync`.
 
 use crate::client::Client;
+use crate::request::IqError;
 use log::{debug, warn};
 use std::collections::HashSet;
 use wacore::iq::usync::{DeviceListResponse, DeviceListSpec};
 use wacore_binary::Jid;
 
+pub use wacore::iq::usync::{
+    UsyncAddressingMode, UsyncBotCommand, UsyncBotProfessionalType, UsyncBotProfileResult,
+    UsyncBotPrompt, UsyncBusinessResult, UsyncContactResult, UsyncContext, UsyncDeviceListResult,
+    UsyncDeviceResult, UsyncDeviceSyncHint, UsyncDevicesResult, UsyncDisappearingModeResult,
+    UsyncFeature, UsyncFeatureResult, UsyncKeyIndexResult, UsyncMode, UsyncOutcome, UsyncProtocol,
+    UsyncProtocolKind, UsyncProtocolResult, UsyncProtocolState, UsyncQuery, UsyncResponse,
+    UsyncStatusResult, UsyncSubprotocolError, UsyncTextStatusResult, UsyncUser, UsyncUserResult,
+    UsyncValidationError,
+};
+
 impl Client {
+    /// Executes a typed USync query.
+    ///
+    /// The client generates the protocol `sid` independently from the IQ ID,
+    /// matching WhatsApp Web. This neutral operation only returns decoded wire
+    /// data; cache and persistence effects remain in specialized client APIs.
+    pub async fn query_usync(&self, query: UsyncQuery) -> Result<UsyncResponse, IqError> {
+        let sid = self.generate_request_id();
+        let spec = wacore::iq::usync::UsyncQuerySpec::new(query, sid)
+            .map_err(|error| IqError::EncodeError(error.into()))?;
+        self.execute(spec).await
+    }
+
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.usync.get_user_devices", level = "debug", skip_all, fields(users = jids.len()), err(Debug)))]
     pub(crate) async fn get_user_devices(&self, jids: &[Jid]) -> Result<Vec<Jid>, anyhow::Error> {
         let mut jids_to_fetch: HashSet<Jid> = HashSet::with_capacity(jids.len());
@@ -179,15 +202,16 @@ impl Client {
             let mut devices: Vec<wacore::store::traits::DeviceInfo> = user_list
                 .devices
                 .iter()
-                .map(|d| wacore::store::traits::DeviceInfo {
-                    device_id: d.device as u32,
+                .map(|d| {
                     // Server-returned key_index takes priority over cached
-                    key_index: d.key_index.or_else(|| {
+                    let key_index = d.key_index.or_else(|| {
                         existing_key_indices
                             .get(&(d.device as u32))
                             .copied()
                             .flatten()
-                    }),
+                    });
+                    wacore::store::traits::DeviceInfo::new(d.device as u32, key_index)
+                        .with_hosting(d.is_hosted)
                 })
                 .collect();
 
@@ -199,9 +223,7 @@ impl Client {
             // Convert filtered DeviceInfo list back to JIDs for return
             let user_jid = &user_list.user;
             for d in &devices {
-                let mut jid = user_jid.clone();
-                jid.device = d.device_id as u16;
-                fetched_devices.push(jid);
+                fetched_devices.push(user_jid.with_device_hosting(d.device_id as u16, d.is_hosted));
             }
 
             // An empty device list is never valid — WA Web always keeps the primary
@@ -337,16 +359,7 @@ mod tests {
         // Insert a device record into the registry (simulates prior usync/notification)
         let record = DeviceListRecord {
             user: "1234567890".into(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 3,
-                    key_index: Some(10),
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(3, Some(10))],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -369,16 +382,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "100000012345678".into(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 39,
-                    key_index: Some(25),
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(39, Some(25))],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -401,10 +405,7 @@ mod tests {
         // Insert into backend DB via update_device_list
         let record = DeviceListRecord {
             user: "9876543210".into(),
-            devices: vec![DeviceInfo {
-                device_id: 5,
-                key_index: None,
-            }],
+            devices: vec![DeviceInfo::new(5, None)],
             timestamp: wacore::time::now_secs(),
             phash: None,
             raw_id: None,
@@ -481,16 +482,7 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: "2222222222".into(),
-                devices: vec![
-                    DeviceInfo {
-                        device_id: 0,
-                        key_index: None,
-                    },
-                    DeviceInfo {
-                        device_id: 7,
-                        key_index: None,
-                    },
-                ],
+                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(7, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: Some("2:oldB".to_string()),
                 raw_id: None,
@@ -502,10 +494,7 @@ mod tests {
         let response = DeviceListResponse {
             device_lists: vec![UserDeviceList {
                 user: "1111111111@s.whatsapp.net".parse().unwrap(),
-                devices: vec![UsyncDevice {
-                    device: 0,
-                    key_index: None,
-                }],
+                devices: vec![UsyncDevice::new(0, None)],
                 phash: Some("2:a".to_string()),
                 key_index_bytes: None,
             }],
@@ -531,6 +520,44 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn process_response_preserves_hosted_device_addressing() {
+        use wacore::iq::usync::DeviceListResponse;
+        use wacore::usync::{UserDeviceList, UsyncDevice};
+
+        let client = create_test_client().await;
+        let user = Jid::pn("1111111111");
+        let response = DeviceListResponse {
+            device_lists: vec![UserDeviceList {
+                user: user.clone(),
+                devices: vec![
+                    UsyncDevice::new(0, None),
+                    UsyncDevice::new(7, Some(3)).with_hosting(true),
+                ],
+                phash: Some("2:hosted".to_string()),
+                key_index_bytes: None,
+            }],
+            lid_mappings: Vec::new(),
+        };
+
+        let fetched = client.process_device_list_response(&response).await;
+        assert!(
+            fetched
+                .iter()
+                .any(|jid| jid.device == 7 && jid.server == wacore_binary::Server::Hosted)
+        );
+
+        let cached = client
+            .get_devices_from_registry(&user)
+            .await
+            .expect("processed devices should be cached");
+        assert!(
+            cached
+                .iter()
+                .any(|jid| jid.device == 7 && jid.server == wacore_binary::Server::Hosted)
+        );
+    }
+
     /// A usync that returns an empty device list for a user is transient or
     /// corrupt (WA Web always keeps device 0). `process_device_list_response`
     /// must not persist it: a good cached record stays intact instead of being
@@ -545,16 +572,7 @@ mod tests {
         client
             .update_device_list(DeviceListRecord {
                 user: "3333333333".into(),
-                devices: vec![
-                    DeviceInfo {
-                        device_id: 0,
-                        key_index: None,
-                    },
-                    DeviceInfo {
-                        device_id: 4,
-                        key_index: None,
-                    },
-                ],
+                devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(4, None)],
                 timestamp: wacore::time::now_secs(),
                 phash: Some("3:old".to_string()),
                 raw_id: None,

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4033,16 +4033,7 @@ mod tests {
 
         let record = DeviceListRecord {
             user: "1234567890".to_string(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 1,
-                    key_index: Some(42),
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(1, Some(42))],
             timestamp: 1234567890,
             phash: Some("2:abcdef".to_string()),
             raw_id: None,
@@ -4069,10 +4060,7 @@ mod tests {
 
         let record1 = DeviceListRecord {
             user: "1234567890".to_string(),
-            devices: vec![DeviceInfo {
-                device_id: 0,
-                key_index: None,
-            }],
+            devices: vec![DeviceInfo::new(0, None)],
             timestamp: 1000,
             phash: Some("2:old".to_string()),
             raw_id: None,
@@ -4084,16 +4072,7 @@ mod tests {
 
         let record2 = DeviceListRecord {
             user: "1234567890".to_string(),
-            devices: vec![
-                DeviceInfo {
-                    device_id: 0,
-                    key_index: None,
-                },
-                DeviceInfo {
-                    device_id: 2,
-                    key_index: None,
-                },
-            ],
+            devices: vec![DeviceInfo::new(0, None), DeviceInfo::new(2, None)],
             timestamp: 2000,
             phash: Some("2:new".to_string()),
             raw_id: None,

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -209,8 +209,38 @@ impl serde::Serialize for Server {
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Server {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = <&str>::deserialize(deserializer)?;
-        Server::try_from(s).map_err(serde::de::Error::custom)
+        struct ServerVisitor;
+
+        impl serde::de::Visitor<'_> for ServerVisitor {
+            type Value = Server;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a known WhatsApp server identifier")
+            }
+
+            fn visit_borrowed_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Server::try_from(value).map_err(E::custom)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Server::try_from(value).map_err(E::custom)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Server::try_from(value.as_str()).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(ServerVisitor)
     }
 }
 
@@ -1083,6 +1113,17 @@ impl TryFrom<String> for Jid {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn server_deserializes_borrowed_and_owned_strings() {
+        let borrowed: Server = serde_json::from_str("\"s.whatsapp.net\"").unwrap();
+        let owned: Server =
+            serde_json::from_value(serde_json::Value::String("lid".to_owned())).unwrap();
+
+        assert_eq!(borrowed, Server::Pn);
+        assert_eq!(owned, Server::Lid);
+    }
 
     /// `observe()` must never leak a raw phone number, must keep pseudonymous /
     /// non-personal JIDs intact for correlation, and must preserve device.

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -560,6 +560,23 @@ impl Jid {
         }
     }
 
+    /// Construct a device JID and select the hosted variant of PN/LID when
+    /// indicated by a device-list entry.
+    ///
+    /// Non-user namespaces are left unchanged because they have no hosted
+    /// counterpart on the wire.
+    pub fn with_device_hosting(&self, device_id: u16, is_hosted: bool) -> Self {
+        let mut jid = self.with_device(device_id);
+        jid.server = match (jid.server, is_hosted) {
+            (Server::Pn | Server::Hosted, true) => Server::Hosted,
+            (Server::Pn | Server::Hosted, false) => Server::Pn,
+            (Server::Lid | Server::HostedLid, true) => Server::HostedLid,
+            (Server::Lid | Server::HostedLid, false) => Server::Lid,
+            (server, _) => server,
+        };
+        jid
+    }
+
     pub fn to_non_ad(&self) -> Self {
         Self {
             user: self.user.clone(),
@@ -1592,6 +1609,27 @@ mod tests {
         assert_eq!(jid.device, 33);
         assert!(jid.is_lid());
         assert!(jid.is_ad());
+    }
+
+    #[test]
+    fn with_device_hosting_preserves_addressing_family() {
+        let hosted_pn = Jid::pn("1234567890").with_device_hosting(7, true);
+        assert_eq!(hosted_pn.server, Server::Hosted);
+        assert_eq!(hosted_pn.device, 7);
+
+        let hosted_lid = Jid::lid("100000012345678").with_device_hosting(8, true);
+        assert_eq!(hosted_lid.server, Server::HostedLid);
+        assert_eq!(hosted_lid.device, 8);
+
+        let regular = Jid::pn("1234567890").with_device_hosting(9, false);
+        assert_eq!(regular.server, Server::Pn);
+
+        let regular_from_hosted =
+            Jid::new("1234567890", Server::Hosted).with_device_hosting(9, false);
+        assert_eq!(regular_from_hosted.server, Server::Pn);
+
+        let group = Jid::group("123-456").with_device_hosting(10, true);
+        assert_eq!(group.server, Server::Group);
     }
 
     #[test]

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -547,7 +547,8 @@ fn is_option_type(ty: &syn::Type) -> bool {
 //      { tag: String } catches unknown tags.
 //      Emits: wire_tag(), impl Serialize (SerializeMap), and a sibling
 //             <Name>Tag unit enum (unit-string WireEnum) for parser dispatch.
-//      No Deserialize — follow-up work; not needed by current consumers.
+//      Adding `content = "data"` selects Serde's adjacent representation,
+//      supports tuple payloads, and emits both Serialize and Deserialize.
 //
 //   3. int          (enum has #[wire(kind = "int")])
 //      Unit variants + optional #[wire_fallback] tuple with i32. Each variant
@@ -578,9 +579,11 @@ pub fn derive_wire_enum(input: TokenStream) -> TokenStream {
 
     match cfg.kind {
         WireKind::IntTagged => expand_wire_enum_int(&input.ident, &variants).into(),
-        WireKind::StringTagged(discriminator) => {
-            expand_wire_enum_tagged(&input.ident, &variants, &discriminator).into()
-        }
+        WireKind::StringTagged {
+            discriminator,
+            content,
+        } => expand_wire_enum_tagged(&input.ident, &variants, &discriminator, content.as_deref())
+            .into(),
         WireKind::UnitString => expand_wire_enum_unit(&input.ident, &variants).into(),
     }
 }
@@ -589,7 +592,10 @@ pub fn derive_wire_enum(input: TokenStream) -> TokenStream {
 
 enum WireKind {
     UnitString,
-    StringTagged(String),
+    StringTagged {
+        discriminator: String,
+        content: Option<String>,
+    },
     IntTagged,
 }
 
@@ -599,6 +605,7 @@ struct WireEnumCfg {
 
 fn parse_enum_level_wire(attrs: &[syn::Attribute]) -> syn::Result<WireEnumCfg> {
     let mut tag_field: Option<String> = None;
+    let mut content_field: Option<String> = None;
     let mut kind_is_int = false;
 
     for attr in attrs {
@@ -609,6 +616,9 @@ fn parse_enum_level_wire(attrs: &[syn::Attribute]) -> syn::Result<WireEnumCfg> {
             if meta.path.is_ident("tag") {
                 let lit: syn::LitStr = meta.value()?.parse()?;
                 tag_field = Some(lit.value());
+            } else if meta.path.is_ident("content") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                content_field = Some(lit.value());
             } else if meta.path.is_ident("kind") {
                 let lit: syn::LitStr = meta.value()?.parse()?;
                 match lit.value().as_str() {
@@ -628,15 +638,23 @@ fn parse_enum_level_wire(attrs: &[syn::Attribute]) -> syn::Result<WireEnumCfg> {
     }
 
     let kind = if kind_is_int {
-        if tag_field.is_some() {
+        if tag_field.is_some() || content_field.is_some() {
             return Err(syn::Error::new_spanned(
                 &attrs[0],
-                "#[wire(kind = \"int\")] is incompatible with #[wire(tag = \"...\")]",
+                "#[wire(kind = \"int\")] is incompatible with tagged string fields",
             ));
         }
         WireKind::IntTagged
-    } else if let Some(t) = tag_field {
-        WireKind::StringTagged(t)
+    } else if let Some(discriminator) = tag_field {
+        WireKind::StringTagged {
+            discriminator,
+            content: content_field,
+        }
+    } else if content_field.is_some() {
+        return Err(syn::Error::new_spanned(
+            &attrs[0],
+            "#[wire(content = \"...\")] requires #[wire(tag = \"...\")]",
+        ));
     } else {
         WireKind::UnitString
     };
@@ -1221,6 +1239,7 @@ fn expand_wire_enum_tagged(
     name: &syn::Ident,
     variants: &syn::punctuated::Punctuated<syn::Variant, syn::Token![,]>,
     discriminator: &str,
+    content: Option<&str>,
 ) -> proc_macro2::TokenStream {
     let mut infos = Vec::with_capacity(variants.len());
     for v in variants {
@@ -1296,6 +1315,33 @@ fn expand_wire_enum_tagged(
         }
     }
 
+    if content.is_some() {
+        if let Some(info) = fallback {
+            return syn::Error::new_spanned(
+                &info.ident,
+                "adjacently tagged WireEnum does not support #[wire_fallback]",
+            )
+            .to_compile_error();
+        }
+        for info in &infos {
+            let fields = match &info.fields {
+                syn::Fields::Named(fields) => &fields.named,
+                syn::Fields::Unnamed(fields) => &fields.unnamed,
+                syn::Fields::Unit => continue,
+            };
+            if let Some(field) = fields
+                .iter()
+                .find(|field| field_has_wire_skip(&field.attrs))
+            {
+                return syn::Error::new_spanned(
+                    field,
+                    "adjacently tagged WireEnum does not support #[wire(skip)]",
+                )
+                .to_compile_error();
+            }
+        }
+    }
+
     // --- wire_tag(&self) -> &str ---
 
     let wire_tag_arms: Vec<_> = infos
@@ -1317,71 +1363,275 @@ fn expand_wire_enum_tagged(
             }
         })
         .collect();
+    let wire_tag_return = if fallback.is_some() {
+        quote! { &str }
+    } else {
+        quote! { &'static str }
+    };
 
-    // --- Serialize arms ---
+    // --- Serde implementation ---
 
-    let serialize_arms: Vec<_> = infos
-        .iter()
-        .map(|info| {
-            let id = &info.ident;
-            if info.is_fallback {
-                // Only the discriminator is written (already done before match).
-                quote! { #name::#id { tag: _ } => {} }
-            } else {
+    let discriminator_lit = discriminator;
+    let serde_impl = if let Some(content_lit) = content {
+        let borrowed_ident = quote::format_ident!("__{}WireBorrowed", name);
+        let owned_ident = quote::format_ident!("__{}WireOwned", name);
+
+        let borrowed_variants: Vec<_> = infos
+            .iter()
+            .map(|info| {
+                let id = &info.ident;
+                let VariantWire::Str(primary) = info.wire.as_ref().unwrap() else {
+                    unreachable!()
+                };
+                let aliases = info
+                    .aliases
+                    .iter()
+                    .map(|alias| quote! { #[serde(alias = #alias)] });
+                let fields = match &info.fields {
+                    syn::Fields::Unit => quote! {},
+                    syn::Fields::Named(fields) => {
+                        let declarations = fields.named.iter().map(|field| {
+                            let field_id = field.ident.as_ref().unwrap();
+                            let ty = &field.ty;
+                            quote! { #field_id: &'__wire #ty }
+                        });
+                        quote! { { #(#declarations),* } }
+                    }
+                    syn::Fields::Unnamed(fields) => {
+                        let declarations = fields.unnamed.iter().map(|field| {
+                            let ty = &field.ty;
+                            quote! { &'__wire #ty }
+                        });
+                        quote! { ( #(#declarations),* ) }
+                    }
+                };
+                quote! {
+                    #[serde(rename = #primary)]
+                    #(#aliases)*
+                    #id #fields
+                }
+            })
+            .collect();
+
+        let owned_variants: Vec<_> = infos
+            .iter()
+            .map(|info| {
+                let id = &info.ident;
+                let VariantWire::Str(primary) = info.wire.as_ref().unwrap() else {
+                    unreachable!()
+                };
+                let aliases = info
+                    .aliases
+                    .iter()
+                    .map(|alias| quote! { #[serde(alias = #alias)] });
+                let fields = match &info.fields {
+                    syn::Fields::Unit => quote! {},
+                    syn::Fields::Named(fields) => {
+                        let declarations = fields.named.iter().map(|field| {
+                            let field_id = field.ident.as_ref().unwrap();
+                            let ty = &field.ty;
+                            quote! { #field_id: #ty }
+                        });
+                        quote! { { #(#declarations),* } }
+                    }
+                    syn::Fields::Unnamed(fields) => {
+                        let declarations = fields.unnamed.iter().map(|field| {
+                            let ty = &field.ty;
+                            quote! { #ty }
+                        });
+                        quote! { ( #(#declarations),* ) }
+                    }
+                };
+                quote! {
+                    #[serde(rename = #primary)]
+                    #(#aliases)*
+                    #id #fields
+                }
+            })
+            .collect();
+
+        let borrow_arms: Vec<_> = infos
+            .iter()
+            .map(|info| {
+                let id = &info.ident;
                 match &info.fields {
-                    syn::Fields::Unit => quote! { #name::#id => {} },
-                    syn::Fields::Named(named) => {
-                        let bindings: Vec<proc_macro2::TokenStream> = named
+                    syn::Fields::Unit => {
+                        quote! { #name::#id => #borrowed_ident::#id }
+                    }
+                    syn::Fields::Named(fields) => {
+                        let bindings = fields
                             .named
                             .iter()
-                            .map(|f| {
-                                let id = f.ident.as_ref().unwrap();
-                                if field_has_wire_skip(&f.attrs) {
-                                    quote! { #id: _ }
-                                } else {
-                                    quote! { #id }
-                                }
-                            })
-                            .collect();
-                        let entries: Vec<proc_macro2::TokenStream> = named
-                            .named
-                            .iter()
-                            .filter(|f| !field_has_wire_skip(&f.attrs))
-                            .map(|f| {
-                                let id = f.ident.as_ref().unwrap();
-                                let key = id.to_string();
-                                if is_option_type(&f.ty) {
-                                    quote! {
-                                        if let ::core::option::Option::Some(__v) = #id {
-                                            ::serde::ser::SerializeMap::serialize_entry(
-                                                &mut map, #key, __v
-                                            )?;
-                                        }
-                                    }
-                                } else {
-                                    quote! {
-                                        ::serde::ser::SerializeMap::serialize_entry(
-                                            &mut map, #key, #id
-                                        )?;
-                                    }
-                                }
-                            })
-                            .collect();
+                            .map(|field| field.ident.as_ref().unwrap());
+                        let values = bindings.clone();
                         quote! {
-                            #name::#id { #(#bindings),* } => {
-                                #(#entries)*
-                            }
+                            #name::#id { #(#bindings),* } =>
+                                #borrowed_ident::#id { #(#values),* }
                         }
                     }
-                    syn::Fields::Unnamed(_) => {
+                    syn::Fields::Unnamed(fields) => {
+                        let bindings: Vec<_> = (0..fields.unnamed.len())
+                            .map(|index| quote::format_ident!("__field_{index}"))
+                            .collect();
+                        let values = &bindings;
                         quote! {
-                            compile_error!("tagged WireEnum tuple variants are not supported — use named fields or unit");
+                            #name::#id(#(#bindings),*) =>
+                                #borrowed_ident::#id(#(#values),*)
                         }
                     }
                 }
+            })
+            .collect();
+
+        let own_arms: Vec<_> = infos
+            .iter()
+            .map(|info| {
+                let id = &info.ident;
+                match &info.fields {
+                    syn::Fields::Unit => quote! { #owned_ident::#id => #name::#id },
+                    syn::Fields::Named(fields) => {
+                        let bindings = fields
+                            .named
+                            .iter()
+                            .map(|field| field.ident.as_ref().unwrap());
+                        let values = bindings.clone();
+                        quote! {
+                            #owned_ident::#id { #(#bindings),* } =>
+                                #name::#id { #(#values),* }
+                        }
+                    }
+                    syn::Fields::Unnamed(fields) => {
+                        let bindings: Vec<_> = (0..fields.unnamed.len())
+                            .map(|index| quote::format_ident!("__field_{index}"))
+                            .collect();
+                        let values = &bindings;
+                        quote! {
+                            #owned_ident::#id(#(#bindings),*) =>
+                                #name::#id(#(#values),*)
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        quote! {
+            #[doc(hidden)]
+            #[derive(::serde::Serialize)]
+            #[serde(tag = #discriminator_lit, content = #content_lit)]
+            enum #borrowed_ident<'__wire> {
+                #(#borrowed_variants),*
             }
-        })
-        .collect();
+
+            #[doc(hidden)]
+            #[derive(::serde::Deserialize)]
+            #[serde(tag = #discriminator_lit, content = #content_lit)]
+            enum #owned_ident {
+                #(#owned_variants),*
+            }
+
+            impl ::serde::Serialize for #name {
+                fn serialize<S: ::serde::Serializer>(
+                    &self,
+                    serializer: S,
+                ) -> ::core::result::Result<S::Ok, S::Error> {
+                    let value = match self {
+                        #(#borrow_arms),*
+                    };
+                    ::serde::Serialize::serialize(&value, serializer)
+                }
+            }
+
+            impl<'de> ::serde::Deserialize<'de> for #name {
+                fn deserialize<D: ::serde::Deserializer<'de>>(
+                    deserializer: D,
+                ) -> ::core::result::Result<Self, D::Error> {
+                    let value = <#owned_ident as ::serde::Deserialize>::deserialize(deserializer)?;
+                    ::core::result::Result::Ok(match value {
+                        #(#own_arms),*
+                    })
+                }
+            }
+        }
+    } else {
+        let serialize_arms: Vec<_> = infos
+            .iter()
+            .map(|info| {
+                let id = &info.ident;
+                if info.is_fallback {
+                    quote! { #name::#id { tag: _ } => {} }
+                } else {
+                    match &info.fields {
+                        syn::Fields::Unit => quote! { #name::#id => {} },
+                        syn::Fields::Named(named) => {
+                            let bindings: Vec<proc_macro2::TokenStream> = named
+                                .named
+                                .iter()
+                                .map(|field| {
+                                    let id = field.ident.as_ref().unwrap();
+                                    if field_has_wire_skip(&field.attrs) {
+                                        quote! { #id: _ }
+                                    } else {
+                                        quote! { #id }
+                                    }
+                                })
+                                .collect();
+                            let entries: Vec<proc_macro2::TokenStream> = named
+                                .named
+                                .iter()
+                                .filter(|field| !field_has_wire_skip(&field.attrs))
+                                .map(|field| {
+                                    let id = field.ident.as_ref().unwrap();
+                                    let key = id.to_string();
+                                    if is_option_type(&field.ty) {
+                                        quote! {
+                                            if let ::core::option::Option::Some(__v) = #id {
+                                                ::serde::ser::SerializeMap::serialize_entry(
+                                                    &mut map, #key, __v
+                                                )?;
+                                            }
+                                        }
+                                    } else {
+                                        quote! {
+                                            ::serde::ser::SerializeMap::serialize_entry(
+                                                &mut map, #key, #id
+                                            )?;
+                                        }
+                                    }
+                                })
+                                .collect();
+                            quote! {
+                                #name::#id { #(#bindings),* } => {
+                                    #(#entries)*
+                                }
+                            }
+                        }
+                        syn::Fields::Unnamed(_) => quote! {
+                            compile_error!("tagged WireEnum tuple variants require #[wire(content = \"...\")]");
+                        },
+                    }
+                }
+            })
+            .collect();
+
+        quote! {
+            impl ::serde::Serialize for #name {
+                fn serialize<S: ::serde::Serializer>(
+                    &self,
+                    serializer: S,
+                ) -> ::core::result::Result<S::Ok, S::Error> {
+                    use ::serde::ser::SerializeMap;
+                    let mut map = serializer.serialize_map(None)?;
+                    ::serde::ser::SerializeMap::serialize_entry(
+                        &mut map, #discriminator_lit, self.wire_tag()
+                    )?;
+                    match self {
+                        #(#serialize_arms,)*
+                    }
+                    ::serde::ser::SerializeMap::end(map)
+                }
+            }
+        }
+    };
 
     // --- Sibling <Name>Tag unit enum (unit-string WireEnum) ---
 
@@ -1416,13 +1666,11 @@ fn expand_wire_enum_tagged(
 
     // --- Final expansion ---
 
-    let discriminator_lit = discriminator;
-
     quote! {
         impl #name {
             /// The wire tag this variant serializes as — the JSON discriminator
             /// and the exact tag the parser dispatches on.
-            pub fn wire_tag(&self) -> &str {
+            pub fn wire_tag(&self) -> #wire_tag_return {
                 match self {
                     #(#wire_tag_arms,)*
                 }
@@ -1435,22 +1683,7 @@ fn expand_wire_enum_tagged(
             }
         }
 
-        impl ::serde::Serialize for #name {
-            fn serialize<S: ::serde::Serializer>(
-                &self,
-                serializer: S,
-            ) -> ::core::result::Result<S::Ok, S::Error> {
-                use ::serde::ser::SerializeMap;
-                let mut map = serializer.serialize_map(None)?;
-                ::serde::ser::SerializeMap::serialize_entry(
-                    &mut map, #discriminator_lit, self.wire_tag()
-                )?;
-                match self {
-                    #(#serialize_arms,)*
-                }
-                ::serde::ser::SerializeMap::end(map)
-            }
-        }
+        #serde_impl
 
         /// Sibling unit enum listing every canonical wire tag for parser
         /// dispatch. Primary wire tags and any `#[wire_alias]` entries all

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -961,14 +961,52 @@ fn expand_wire_enum_unit(
         };
     }
 
-    let deserialize_impl = if fallback.is_some() {
+    let deserialize_impl = if let Some(fb) = fallback {
+        let fb_ident = &fb.ident;
         quote! {
             impl<'de> ::serde::Deserialize<'de> for #name {
                 fn deserialize<D: ::serde::Deserializer<'de>>(
                     deserializer: D,
                 ) -> ::core::result::Result<Self, D::Error> {
-                    let s = <::std::string::String as ::serde::Deserialize>::deserialize(deserializer)?;
-                    ::core::result::Result::Ok(<Self as ::core::convert::From<&str>>::from(s.as_str()))
+                    struct WireEnumVisitor;
+
+                    impl<'de> ::serde::de::Visitor<'de> for WireEnumVisitor {
+                        type Value = #name;
+
+                        fn expecting(
+                            &self,
+                            formatter: &mut ::core::fmt::Formatter<'_>,
+                        ) -> ::core::fmt::Result {
+                            formatter.write_str("a wire enum string")
+                        }
+
+                        fn visit_str<E>(
+                            self,
+                            value: &str,
+                        ) -> ::core::result::Result<Self::Value, E>
+                        where
+                            E: ::serde::de::Error,
+                        {
+                            ::core::result::Result::Ok(
+                                <#name as ::core::convert::From<&str>>::from(value),
+                            )
+                        }
+
+                        fn visit_string<E>(
+                            self,
+                            value: ::std::string::String,
+                        ) -> ::core::result::Result<Self::Value, E>
+                        where
+                            E: ::serde::de::Error,
+                        {
+                            ::core::result::Result::Ok(match value.as_str() {
+                                #(#from_arms,)*
+                                _ => #name::#fb_ident(value),
+                            })
+                        }
+                    }
+
+                    deserializer.deserialize_str(WireEnumVisitor)
                 }
             }
         }
@@ -978,9 +1016,31 @@ fn expand_wire_enum_unit(
                 fn deserialize<D: ::serde::Deserializer<'de>>(
                     deserializer: D,
                 ) -> ::core::result::Result<Self, D::Error> {
-                    let s = <::std::string::String as ::serde::Deserialize>::deserialize(deserializer)?;
-                    <Self as ::core::convert::TryFrom<&str>>::try_from(s.as_str())
-                        .map_err(|e| <D::Error as ::serde::de::Error>::custom(e.to_string()))
+                    struct WireEnumVisitor;
+
+                    impl<'de> ::serde::de::Visitor<'de> for WireEnumVisitor {
+                        type Value = #name;
+
+                        fn expecting(
+                            &self,
+                            formatter: &mut ::core::fmt::Formatter<'_>,
+                        ) -> ::core::fmt::Result {
+                            formatter.write_str("a known wire enum string")
+                        }
+
+                        fn visit_str<E>(
+                            self,
+                            value: &str,
+                        ) -> ::core::result::Result<Self::Value, E>
+                        where
+                            E: ::serde::de::Error,
+                        {
+                            <#name as ::core::convert::TryFrom<&str>>::try_from(value)
+                                .map_err(E::custom)
+                        }
+                    }
+
+                    deserializer.deserialize_str(WireEnumVisitor)
                 }
             }
         }

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -187,10 +187,7 @@ mod tests {
     use buffa::Message;
 
     fn dev(id: u32, key_index: Option<u32>) -> DeviceInfo {
-        DeviceInfo {
-            device_id: id,
-            key_index,
-        }
+        DeviceInfo::new(id, key_index)
     }
 
     #[test]

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -290,12 +290,7 @@ fn is_on_whatsapp_query(spec: &IsOnWhatsAppSpec) -> UsyncQuery {
         .iter()
         .map(|user| {
             if user.jid.is_pn() {
-                let phone = if user.jid.user.starts_with('+') {
-                    user.jid.user.to_string()
-                } else {
-                    format!("+{}", user.jid.user)
-                };
-                let mut typed = UsyncUser::from_phone(phone);
+                let mut typed = UsyncUser::from_phone(user.jid.user.clone());
                 if let Some(lid) = &user.known_lid {
                     typed = typed.with_known_lid(Jid::lid(lid.as_str()));
                 }
@@ -841,6 +836,13 @@ mod tests {
             assert!(query.get_optional_child("contact").is_some());
             assert!(query.get_optional_child("lid").is_some());
             assert!(query.get_optional_child("business").is_some());
+
+            let contact = usync
+                .get_optional_child("list")
+                .and_then(|list| list.get_optional_child("user"))
+                .and_then(|user| user.get_optional_child("contact"))
+                .unwrap();
+            assert_eq!(contact.content_as_string().as_deref(), Some("+1234567890"));
         } else {
             panic!("Expected NodeContent::Nodes");
         }

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -69,6 +69,11 @@ mod query;
 
 pub use query::*;
 
+const USYNC_ERROR_PREFIX: &str = "usync ";
+const USYNC_ERROR_CODE_SEPARATOR: &str = " error ";
+const USYNC_ERROR_TEXT_SEPARATOR: &str = ": ";
+const UNKNOWN_ERROR_CODE: &str = "unknown";
+
 /// Usync mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
 pub enum UsyncMode {
@@ -118,12 +123,27 @@ pub struct UsyncSubprotocolError {
 }
 
 fn usync_subprotocol_error_message(tag: &str, error: &UsyncSubprotocolError) -> String {
+    let mut code_buffer = itoa::Buffer::new();
     let code = error
         .code
-        .map(|code| code.to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-    let text = error.text.as_deref().unwrap_or("");
-    format!("usync {tag} error {code}: {text}")
+        .map(|code| code_buffer.format(code))
+        .unwrap_or(UNKNOWN_ERROR_CODE);
+    let text = error.text.as_deref().filter(|text| !text.is_empty());
+    let capacity = USYNC_ERROR_PREFIX.len()
+        + tag.len()
+        + USYNC_ERROR_CODE_SEPARATOR.len()
+        + code.len()
+        + text.map_or(0, |text| USYNC_ERROR_TEXT_SEPARATOR.len() + text.len());
+    let mut message = String::with_capacity(capacity);
+    message.push_str(USYNC_ERROR_PREFIX);
+    message.push_str(tag);
+    message.push_str(USYNC_ERROR_CODE_SEPARATOR);
+    message.push_str(code);
+    if let Some(text) = text {
+        message.push_str(USYNC_ERROR_TEXT_SEPARATOR);
+        message.push_str(text);
+    }
+    message
 }
 
 #[derive(Debug, Clone)]
@@ -1237,6 +1257,28 @@ mod tests {
 
         let err = spec.parse_response(&response.as_node_ref()).unwrap_err();
         assert!(err.to_string().contains("usync status error 403: blocked"));
+    }
+
+    #[test]
+    fn subprotocol_error_message_omits_empty_text_separator() {
+        let error = |text| UsyncSubprotocolError {
+            code: Some(401),
+            text,
+            backoff: None,
+        };
+
+        assert_eq!(
+            usync_subprotocol_error_message("status", &error(None)),
+            "usync status error 401"
+        );
+        assert_eq!(
+            usync_subprotocol_error_message("status", &error(Some(String::new()))),
+            "usync status error 401"
+        );
+        assert_eq!(
+            usync_subprotocol_error_message("status", &error(Some("blocked".to_owned()))),
+            "usync status error 401: blocked"
+        );
     }
 
     #[test]

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -52,15 +52,22 @@
 
 use crate::WireEnum;
 use crate::iq::spec::IqSpec;
-use crate::iq::tctoken::build_tc_token_node;
 use crate::request::InfoQuery;
 use crate::stanza::business::VerifiedName;
 use anyhow::anyhow;
 use log::warn;
 use std::collections::HashMap;
-use wacore_binary::builder::NodeBuilder;
+use wacore_binary::NodeRef;
 use wacore_binary::{Jid, Server};
-use wacore_binary::{Node, NodeContent, NodeContentRef, NodeRef};
+
+#[cfg(test)]
+use wacore_binary::builder::NodeBuilder;
+#[cfg(test)]
+use wacore_binary::{Node, NodeContent};
+
+mod query;
+
+pub use query::*;
 
 /// Usync mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
@@ -72,6 +79,9 @@ pub enum UsyncMode {
     /// Full mode - used for user info with more details.
     #[wire = "full"]
     Full,
+    /// Delta mode - used for incremental contact synchronization.
+    #[wire = "delta"]
+    Delta,
 }
 
 /// Usync context.
@@ -87,6 +97,9 @@ pub enum UsyncContext {
     /// Message context - for message-related operations.
     #[wire = "message"]
     Message,
+    /// VoIP context - used by call setup when refreshing device lists.
+    #[wire = "voip"]
+    Voip,
 }
 
 #[derive(Debug, Clone)]
@@ -94,46 +107,6 @@ pub struct IsOnWhatsAppUser {
     pub jid: Jid,
     /// Helps server optimize the lookup (WA Web pre-populates this from its LID cache).
     pub known_lid: Option<wacore_binary::CompactString>,
-}
-
-fn build_user_nodes(users: &[IsOnWhatsAppUser]) -> Vec<Node> {
-    users
-        .iter()
-        .map(|user| {
-            if user.jid.is_pn() {
-                let phone = if user.jid.user.starts_with('+') {
-                    user.jid.user.to_string()
-                } else {
-                    format!("+{}", user.jid.user)
-                };
-                let mut children = vec![NodeBuilder::new("contact").string_content(phone).build()];
-                if let Some(lid) = &user.known_lid {
-                    children.push(
-                        NodeBuilder::new("lid")
-                            .attr("jid", Jid::lid(lid.as_str()))
-                            .build(),
-                    );
-                }
-                NodeBuilder::new("user").children(children).build()
-            } else {
-                NodeBuilder::new("user")
-                    .attr("jid", user.jid.to_non_ad())
-                    .build()
-            }
-        })
-        .collect()
-}
-
-/// Common fields parsed from a usync `<user>` node.
-struct ParsedUserFields {
-    jid: Jid,
-    lid: Option<Jid>,
-    lid_error: Option<UsyncSubprotocolError>,
-    is_business: bool,
-    business_error: Option<UsyncSubprotocolError>,
-    status: Option<String>,
-    status_error: Option<UsyncSubprotocolError>,
-    verified_name: Option<VerifiedName>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,24 +117,6 @@ pub struct UsyncSubprotocolError {
     pub backoff: Option<u32>,
 }
 
-fn parse_subprotocol_error(protocol_node: &NodeRef<'_>) -> Option<UsyncSubprotocolError> {
-    let error_node = protocol_node.get_optional_child("error")?;
-    Some(UsyncSubprotocolError {
-        code: error_node
-            .attrs()
-            .optional_string("code")
-            .and_then(|s| s.parse().ok()),
-        text: error_node
-            .attrs()
-            .optional_string("text")
-            .map(|s| s.to_string()),
-        backoff: error_node
-            .attrs()
-            .optional_string("backoff")
-            .and_then(|s| s.parse().ok()),
-    })
-}
-
 fn usync_subprotocol_error_message(tag: &str, error: &UsyncSubprotocolError) -> String {
     let code = error
         .code
@@ -169,137 +124,6 @@ fn usync_subprotocol_error_message(tag: &str, error: &UsyncSubprotocolError) -> 
         .unwrap_or_else(|| "unknown".to_string());
     let text = error.text.as_deref().unwrap_or("");
     format!("usync {tag} error {code}: {text}")
-}
-
-fn parse_lid_fields(user_node: &NodeRef<'_>) -> (Option<Jid>, Option<UsyncSubprotocolError>) {
-    match user_node.get_optional_child("lid") {
-        Some(lid_node) => {
-            if let Some(error) = parse_subprotocol_error(lid_node) {
-                (None, Some(error))
-            } else {
-                (
-                    lid_node
-                        .attrs()
-                        .optional_string("val")
-                        .and_then(|val| val.parse::<Jid>().ok()),
-                    None,
-                )
-            }
-        }
-        None => (None, None),
-    }
-}
-
-fn parse_contact_fields(
-    user_node: &NodeRef<'_>,
-    jid: &Jid,
-) -> (bool, Option<UsyncSubprotocolError>) {
-    match user_node.get_optional_child("contact") {
-        Some(contact_node) => {
-            if let Some(error) = parse_subprotocol_error(contact_node) {
-                (false, Some(error))
-            } else {
-                (
-                    contact_node
-                        .get_attr("type")
-                        .is_some_and(|value| value.as_str() == "in"),
-                    None,
-                )
-            }
-        }
-        None if jid.is_lid() => (true, None),
-        None => (false, None),
-    }
-}
-
-fn parse_verified_name_from_business(business_node: &NodeRef<'_>) -> Option<VerifiedName> {
-    let vn_node = business_node.get_optional_child("verified_name")?;
-    // Treat an <error> child or an empty marker (no name, no cert) as absent,
-    // mirroring the status/picture parsers, so `verified_name.is_some()` means a
-    // real verified name was returned.
-    if vn_node.get_optional_child("error").is_some() {
-        return None;
-    }
-    let parsed = VerifiedName::try_from_node(vn_node).ok()?;
-    if parsed.name.is_none() && parsed.certificate.is_none() {
-        return None;
-    }
-    Some(parsed)
-}
-
-fn parse_business_fields(
-    user_node: &NodeRef<'_>,
-) -> (bool, Option<VerifiedName>, Option<UsyncSubprotocolError>) {
-    match user_node.get_optional_child("business") {
-        Some(business_node) => {
-            if let Some(error) = parse_subprotocol_error(business_node) {
-                (false, None, Some(error))
-            } else {
-                (true, parse_verified_name_from_business(business_node), None)
-            }
-        }
-        None => (false, None, None),
-    }
-}
-
-/// Parse common fields from a usync `<user>` node.
-fn parse_user_common_fields(user_node: &NodeRef<'_>) -> Option<ParsedUserFields> {
-    let jid = user_node
-        .attrs()
-        .optional_string("jid")?
-        .parse::<Jid>()
-        .ok()?;
-
-    let (lid, lid_error) = parse_lid_fields(user_node);
-
-    let (status, status_error) = match user_node.get_optional_child("status") {
-        Some(status_node) => {
-            if let Some(error) = parse_subprotocol_error(status_node) {
-                (None, Some(error))
-            } else {
-                let status = match status_node.content.as_deref() {
-                    Some(NodeContentRef::String(s)) if !s.is_empty() => Some(s.to_string()),
-                    _ => None,
-                };
-                (status, None)
-            }
-        }
-        None => (None, None),
-    };
-
-    let (is_business, verified_name, business_error) = parse_business_fields(user_node);
-
-    Some(ParsedUserFields {
-        jid,
-        lid,
-        lid_error,
-        is_business,
-        business_error,
-        status,
-        status_error,
-        verified_name,
-    })
-}
-
-fn parse_picture_id_fields(
-    user_node: &NodeRef<'_>,
-) -> (Option<String>, Option<UsyncSubprotocolError>) {
-    match user_node.get_optional_child("picture") {
-        Some(pic_node) => {
-            if let Some(error) = parse_subprotocol_error(pic_node) {
-                (None, Some(error))
-            } else {
-                (
-                    pic_node
-                        .attrs()
-                        .optional_string("id")
-                        .map(|s| s.to_string()),
-                    None,
-                )
-            }
-        }
-        None => (None, None),
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -373,116 +197,157 @@ impl IsOnWhatsAppSpec {
     }
 }
 
-fn build_business_query_node() -> Node {
-    NodeBuilder::new("business")
-        .children(vec![NodeBuilder::new("verified_name").build()])
-        .build()
-}
+const LEGACY_RESULT_PROTOCOLS: &[UsyncProtocolKind] = &[
+    UsyncProtocolKind::Contact,
+    UsyncProtocolKind::Lid,
+    UsyncProtocolKind::Business,
+    UsyncProtocolKind::Status,
+    UsyncProtocolKind::Picture,
+    UsyncProtocolKind::Devices,
+];
 
-/// Check `<usync><result>` for per-protocol errors.
-fn check_usync_result_errors(usync: &NodeRef<'_>) -> Result<(), anyhow::Error> {
-    check_usync_result_errors_for(
-        usync,
-        &["contact", "lid", "business", "status", "picture", "devices"],
-    )
-}
-
-fn check_usync_result_errors_for(
-    usync: &NodeRef<'_>,
-    tags: &[&'static str],
+fn reject_result_errors(
+    response: &UsyncResponse,
+    protocols: &[UsyncProtocolKind],
 ) -> Result<(), anyhow::Error> {
-    let Some(result_node) = usync.get_optional_child("result") else {
-        return Ok(());
-    };
-    for &tag in tags {
-        if let Some(protocol_node) = result_node.get_optional_child(tag)
-            && let Some(error) = parse_subprotocol_error(protocol_node)
+    for state in &response.protocol_states {
+        if protocols.contains(&state.protocol)
+            && let Some(error) = &state.error
         {
-            return Err(anyhow!(usync_subprotocol_error_message(tag, &error)));
+            return Err(anyhow!(usync_subprotocol_error_message(
+                state.protocol.as_str(),
+                error
+            )));
         }
     }
     Ok(())
 }
 
-fn warn_usync_result_error(usync: &NodeRef<'_>, tag: &'static str) {
-    if let Some(result_node) = usync.get_optional_child("result")
-        && let Some(protocol_node) = result_node.get_optional_child(tag)
-        && let Some(error) = parse_subprotocol_error(protocol_node)
+fn warn_result_error(response: &UsyncResponse, protocol: UsyncProtocolKind) {
+    if let Some(error) = response
+        .protocol_state(protocol)
+        .and_then(|state| state.error.as_ref())
     {
         warn!(
             target: "usync",
             "{}; continuing with returned users",
-            usync_subprotocol_error_message(tag, &error)
+            usync_subprotocol_error_message(protocol.as_str(), error)
         );
     }
+}
+
+fn project_lid(user: &UsyncUserResult) -> (Option<Jid>, Option<UsyncSubprotocolError>) {
+    match user.protocol(UsyncProtocolKind::Lid) {
+        Some(UsyncProtocolResult::Lid(UsyncOutcome::Value(lid))) => (lid.clone(), None),
+        Some(UsyncProtocolResult::Lid(UsyncOutcome::Error(error))) => {
+            (None, Some((**error).clone()))
+        }
+        _ => (None, None),
+    }
+}
+
+fn project_business(
+    user: &UsyncUserResult,
+) -> (bool, Option<VerifiedName>, Option<UsyncSubprotocolError>) {
+    match user.protocol(UsyncProtocolKind::Business) {
+        Some(UsyncProtocolResult::Business(UsyncOutcome::Value(business))) => {
+            (true, business.verified_name.clone(), None)
+        }
+        Some(UsyncProtocolResult::Business(UsyncOutcome::Error(error))) => {
+            (false, None, Some((**error).clone()))
+        }
+        _ => (false, None, None),
+    }
+}
+
+pub(crate) fn project_lid_mapping(user: &UsyncUserResult) -> Option<UsyncLidMapping> {
+    let user_jid = user.id.as_ref()?;
+    if user_jid.server != Server::Pn {
+        return None;
+    }
+    let Some(UsyncProtocolResult::Lid(UsyncOutcome::Value(Some(lid)))) =
+        user.protocol(UsyncProtocolKind::Lid)
+    else {
+        return None;
+    };
+    Some(UsyncLidMapping {
+        phone_number: user_jid.user.clone(),
+        lid: lid.user.clone(),
+    })
+}
+
+fn is_on_whatsapp_query(spec: &IsOnWhatsAppSpec) -> UsyncQuery {
+    let mut protocols = Vec::with_capacity(3);
+    if spec.query_type == IsOnWhatsAppQueryType::Pn {
+        protocols.push(UsyncProtocol::Contact {
+            addressing_mode: UsyncAddressingMode::Pn,
+        });
+    }
+    protocols.extend([UsyncProtocol::Lid, UsyncProtocol::BusinessVerifiedName]);
+
+    let users = spec
+        .users
+        .iter()
+        .map(|user| {
+            if user.jid.is_pn() {
+                let phone = if user.jid.user.starts_with('+') {
+                    user.jid.user.to_string()
+                } else {
+                    format!("+{}", user.jid.user)
+                };
+                let mut typed = UsyncUser::from_phone(phone);
+                if let Some(lid) = &user.known_lid {
+                    typed = typed.with_known_lid(Jid::lid(lid.as_str()));
+                }
+                typed
+            } else {
+                UsyncUser::from_jid(user.jid.to_non_ad())
+            }
+        })
+        .collect();
+
+    // Existing specs historically allow an empty list. The public typed API is
+    // stricter, but legacy construction keeps its established wire behavior.
+    UsyncQuery::from_parts_unchecked(
+        UsyncMode::Query,
+        UsyncContext::Interactive,
+        protocols,
+        users,
+    )
 }
 
 impl IqSpec for IsOnWhatsAppSpec {
     type Response = Vec<IsOnWhatsAppResult>;
 
     fn build_iq(&self) -> InfoQuery<'static> {
-        let mut query_children = Vec::new();
-        if self.query_type == IsOnWhatsAppQueryType::Pn {
-            query_children.push(NodeBuilder::new("contact").build());
-        }
-        query_children.push(NodeBuilder::new("lid").build());
-        query_children.push(build_business_query_node());
-
-        let query_node = NodeBuilder::new("query").children(query_children).build();
-
-        let user_nodes = build_user_nodes(&self.users);
-        let list_node = NodeBuilder::new("list").children(user_nodes).build();
-
-        let usync_node = NodeBuilder::new("usync")
-            .attr("sid", self.sid.as_str())
-            .attr("mode", UsyncMode::Query.as_str())
-            .attr("last", "true")
-            .attr("index", "0")
-            .attr("context", UsyncContext::Interactive.as_str())
-            .children(vec![query_node, list_node])
-            .build();
-
-        InfoQuery::get(
-            "usync",
-            Jid::new("", Server::Pn),
-            Some(NodeContent::Nodes(vec![usync_node])),
-        )
+        is_on_whatsapp_query(self).build_info_query(&self.sid)
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        let usync = response
-            .get_optional_child("usync")
-            .ok_or_else(|| anyhow!("Response missing <usync> node"))?;
+        let response = parse_usync_response(response)?;
+        reject_result_errors(&response, LEGACY_RESULT_PROTOCOLS)?;
 
-        check_usync_result_errors(usync)?;
-
-        let list = usync
-            .get_optional_child("list")
-            .ok_or_else(|| anyhow!("Response missing <list> node"))?;
-
-        let mut results = Vec::new();
-
-        for user_node in list.get_children_by_tag("user") {
-            let Some(jid_str) = user_node.attrs().optional_string("jid") else {
+        let mut results = Vec::with_capacity(response.users.len());
+        for user in response.users {
+            let Some(jid) = user.id.clone() else {
                 continue;
             };
-            let Ok(jid) = jid_str.parse::<Jid>() else {
-                continue;
+            let (is_registered, contact_error) = match user.protocol(UsyncProtocolKind::Contact) {
+                Some(UsyncProtocolResult::Contact(UsyncOutcome::Value(contact))) => {
+                    (contact.contact_type == "in", None)
+                }
+                Some(UsyncProtocolResult::Contact(UsyncOutcome::Error(error))) => {
+                    (false, Some((**error).clone()))
+                }
+                _ => (jid.is_lid(), None),
             };
-
-            let pn_jid = user_node
-                .attrs()
-                .optional_string("pn_jid")
-                .and_then(|s| s.parse::<Jid>().ok());
-
-            let (lid, lid_error) = parse_lid_fields(user_node);
-            let (is_registered, contact_error) = parse_contact_fields(user_node, &jid);
-            let (is_business, verified_name, business_error) = parse_business_fields(user_node);
+            let (lid, lid_error) = project_lid(&user);
+            let (is_business, verified_name, business_error) = project_business(&user);
 
             results.push(IsOnWhatsAppResult {
                 jid,
                 lid,
-                pn_jid,
+                pn_jid: user.pn_jid,
                 is_registered,
                 contact_error,
                 lid_error,
@@ -526,109 +391,105 @@ impl UserInfoSpec {
     }
 }
 
+fn user_info_query(spec: &UserInfoSpec) -> UsyncQuery {
+    let users = spec
+        .jids
+        .iter()
+        .map(|jid| {
+            let bare = jid.to_non_ad();
+            let key = bare.to_string();
+            let mut user = UsyncUser::from_jid(bare);
+            if let Some(token) = spec.tc_tokens.get(&key) {
+                user = user.with_tc_token(token.clone());
+            }
+            user
+        })
+        .collect();
+    UsyncQuery::from_parts_unchecked(
+        UsyncMode::Full,
+        UsyncContext::Background,
+        vec![
+            UsyncProtocol::BusinessVerifiedName,
+            UsyncProtocol::Status,
+            UsyncProtocol::Picture,
+            UsyncProtocol::DevicesV2,
+            UsyncProtocol::Lid,
+        ],
+        users,
+    )
+}
+
 impl IqSpec for UserInfoSpec {
     type Response = HashMap<Jid, UserInfo>;
 
     fn build_iq(&self) -> InfoQuery<'static> {
-        let query_node = NodeBuilder::new("query")
-            .children(vec![
-                NodeBuilder::new("business")
-                    .children(vec![NodeBuilder::new("verified_name").build()])
-                    .build(),
-                NodeBuilder::new("status").build(),
-                NodeBuilder::new("picture").build(),
-                NodeBuilder::new("devices").attr("version", "2").build(),
-                NodeBuilder::new("lid").build(),
-            ])
-            .build();
-
-        let user_nodes: Vec<Node> = self
-            .jids
-            .iter()
-            .map(|jid| {
-                let key = jid.to_non_ad().to_string();
-                let mut builder = NodeBuilder::new("user").attr("jid", key.clone());
-                if let Some(token) = self.tc_tokens.get(&key) {
-                    builder = builder.children([build_tc_token_node(token)]);
-                }
-                builder.build()
-            })
-            .collect();
-
-        let list_node = NodeBuilder::new("list").children(user_nodes).build();
-
-        let usync_node = NodeBuilder::new("usync")
-            .attr("sid", self.sid.as_str())
-            .attr("mode", UsyncMode::Full.as_str())
-            .attr("last", "true")
-            .attr("index", "0")
-            .attr("context", UsyncContext::Background.as_str())
-            .children(vec![query_node, list_node])
-            .build();
-
-        InfoQuery::get(
-            "usync",
-            Jid::new("", Server::Pn),
-            Some(NodeContent::Nodes(vec![usync_node])),
-        )
+        user_info_query(self).build_info_query(&self.sid)
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        let usync = response
-            .get_optional_child("usync")
-            .ok_or_else(|| anyhow!("Response missing <usync> node"))?;
-        check_usync_result_errors(usync)?;
+        let response = parse_usync_response(response)?;
+        reject_result_errors(&response, LEGACY_RESULT_PROTOCOLS)?;
 
-        let list = usync
-            .get_optional_child("list")
-            .ok_or_else(|| anyhow!("Response missing <list> node"))?;
+        let mut results = HashMap::with_capacity(response.users.len());
+        for user in response.users {
+            let Some(jid) = user.id.clone() else {
+                continue;
+            };
+            let (lid, lid_error) = project_lid(&user);
+            let (status, status_error) = match user.protocol(UsyncProtocolKind::Status) {
+                Some(UsyncProtocolResult::Status(UsyncOutcome::Value(status))) => {
+                    (status.status.as_ref().map(ToString::to_string), None)
+                }
+                Some(UsyncProtocolResult::Status(UsyncOutcome::Error(error))) => {
+                    (None, Some((**error).clone()))
+                }
+                _ => (None, None),
+            };
+            let (picture_id, picture_error) = match user.protocol(UsyncProtocolKind::Picture) {
+                Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(id))) => {
+                    (Some(id.to_string()), None)
+                }
+                Some(UsyncProtocolResult::Picture(UsyncOutcome::Error(error))) => {
+                    (None, Some((**error).clone()))
+                }
+                _ => (None, None),
+            };
+            let (is_business, verified_name, business_error) = project_business(&user);
+            let (devices, devices_error) = match user.protocol(UsyncProtocolKind::Devices) {
+                Some(UsyncProtocolResult::Devices(UsyncOutcome::Value(devices))) => (
+                    devices
+                        .device_list
+                        .as_ref()
+                        .map(|list| list.devices.iter().map(|device| device.id).collect())
+                        .unwrap_or_default(),
+                    None,
+                ),
+                Some(UsyncProtocolResult::Devices(UsyncOutcome::Error(error))) => {
+                    (Vec::new(), Some((**error).clone()))
+                }
+                _ => (Vec::new(), None),
+            };
 
-        let mut results = HashMap::new();
-
-        for user_node in list.get_children_by_tag("user") {
-            if let Some(fields) = parse_user_common_fields(user_node) {
-                let (picture_id, picture_error) = parse_picture_id_fields(user_node);
-                let (devices, devices_error) = parse_user_device_ids(user_node);
-                results.insert(
-                    fields.jid.clone(),
-                    UserInfo {
-                        jid: fields.jid,
-                        lid: fields.lid,
-                        lid_error: fields.lid_error,
-                        status: fields.status,
-                        status_error: fields.status_error,
-                        picture_id,
-                        picture_error,
-                        is_business: fields.is_business,
-                        business_error: fields.business_error,
-                        verified_name: fields.verified_name,
-                        devices,
-                        devices_error,
-                    },
-                );
-            }
+            results.insert(
+                jid.clone(),
+                UserInfo {
+                    jid,
+                    lid,
+                    lid_error,
+                    status,
+                    status_error,
+                    picture_id,
+                    picture_error,
+                    is_business,
+                    business_error,
+                    verified_name,
+                    devices,
+                    devices_error,
+                },
+            );
         }
-
         Ok(results)
     }
-}
-
-/// Device IDs plus a subprotocol error if `<devices><error>` was returned.
-fn parse_user_device_ids(user_node: &NodeRef<'_>) -> (Vec<u16>, Option<UsyncSubprotocolError>) {
-    let Some(devices_node) = user_node.get_optional_child("devices") else {
-        return (Vec::new(), None);
-    };
-    if let Some(error) = parse_subprotocol_error(devices_node) {
-        return (Vec::new(), Some(error));
-    }
-    let Some(device_list) = devices_node.get_optional_child("device-list") else {
-        return (Vec::new(), None);
-    };
-    let devices = device_list
-        .get_children_by_tag("device")
-        .filter_map(|d| d.attrs().optional_string("id").and_then(|s| s.parse().ok()))
-        .collect();
-    (devices, None)
 }
 
 // Re-export types from wacore::usync for convenience
@@ -709,73 +570,64 @@ impl DeviceListSpec {
     }
 }
 
-impl IqSpec for DeviceListSpec {
-    type Response = DeviceListResponse;
+pub(crate) fn device_list_query(
+    jids: &[Jid],
+    hashes: Option<&HashMap<Jid, (String, i64)>>,
+) -> UsyncQuery {
+    let users = jids
+        .iter()
+        .map(|jid| {
+            let bare = jid.to_non_ad();
+            let mut user = UsyncUser::from_jid(bare.clone());
+            if let Some((device_hash, timestamp)) = hashes.and_then(|hashes| hashes.get(&bare)) {
+                user = user.with_device_sync(
+                    UsyncDeviceSyncHint::new()
+                        .with_device_hash(device_hash.as_str())
+                        .with_timestamp(*timestamp),
+                );
+            }
+            user
+        })
+        .collect();
+    UsyncQuery::from_parts_unchecked(
+        UsyncMode::Query,
+        UsyncContext::Message,
+        vec![UsyncProtocol::DevicesV2],
+        users,
+    )
+}
 
-    fn build_iq(&self) -> InfoQuery<'static> {
-        let query_node = NodeBuilder::new("query")
-            .children(vec![
-                NodeBuilder::new("devices").attr("version", "2").build(),
-            ])
-            .build();
+pub(crate) fn project_device_list_response(
+    response: UsyncResponse,
+) -> Result<DeviceListResponse, anyhow::Error> {
+    const NON_DEVICE_PROTOCOLS: &[UsyncProtocolKind] = &[
+        UsyncProtocolKind::Contact,
+        UsyncProtocolKind::Lid,
+        UsyncProtocolKind::Business,
+        UsyncProtocolKind::Status,
+        UsyncProtocolKind::Picture,
+    ];
 
-        let user_nodes: Vec<Node> = self
-            .jids
-            .iter()
-            .map(|jid| {
-                let bare = jid.to_non_ad();
-                let mut builder = NodeBuilder::new("user").attr("jid", bare.clone());
-                // WA Web sends the cached per-user device list hash so the server
-                // can answer "unchanged" by omitting the user from the response.
-                if let Some((device_hash, ts)) = self.hashes.get(&bare) {
-                    builder = builder.children([NodeBuilder::new("devices")
-                        .attr("device_hash", device_hash.as_str())
-                        .attr("ts", ts.to_string())
-                        .build()]);
-                }
-                builder.build()
-            })
-            .collect();
+    reject_result_errors(&response, NON_DEVICE_PROTOCOLS)?;
+    warn_result_error(&response, UsyncProtocolKind::Devices);
 
-        let list_node = NodeBuilder::new("list").children(user_nodes).build();
+    let mut device_lists = Vec::with_capacity(response.users.len());
+    let mut lid_mappings = Vec::new();
+    for user in response.users {
+        if let Some(mapping) = project_lid_mapping(&user) {
+            lid_mappings.push(mapping);
+        }
+        let Some(user_jid) = user.id else {
+            continue;
+        };
 
-        let usync_node = NodeBuilder::new("usync")
-            .attr("sid", self.sid.as_str())
-            .attr("mode", UsyncMode::Query.as_str())
-            .attr("last", "true")
-            .attr("index", "0")
-            .attr("context", UsyncContext::Message.as_str())
-            .children(vec![query_node, list_node])
-            .build();
-
-        InfoQuery::get(
-            "usync",
-            Jid::new("", Server::Pn),
-            Some(NodeContent::Nodes(vec![usync_node])),
-        )
-    }
-
-    fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        let usync = response
-            .get_optional_child("usync")
-            .ok_or_else(|| anyhow!("<usync> not found in usync response"))?;
-        check_usync_result_errors_for(usync, &["contact", "lid", "business", "status", "picture"])?;
-        warn_usync_result_error(usync, "devices");
-        let list_node = usync
-            .get_optional_child("list")
-            .ok_or_else(|| anyhow!("<list> not found in usync response"))?;
-
-        let mut device_lists = Vec::new();
-        let mut lid_mappings = Vec::new();
-
-        for user_node in list_node.get_children_by_tag("user") {
-            let user_jid = user_node
-                .attrs()
-                .optional_jid("jid")
-                .ok_or_else(|| anyhow!("user node missing required 'jid' attribute"))?;
-            if let Some(devices_node) = user_node.get_optional_child("devices")
-                && let Some(error) = parse_subprotocol_error(devices_node)
-            {
+        let devices = user
+            .protocols
+            .into_iter()
+            .find(|result| result.kind() == UsyncProtocolKind::Devices);
+        let devices = match devices {
+            Some(UsyncProtocolResult::Devices(UsyncOutcome::Value(devices))) => devices,
+            Some(UsyncProtocolResult::Devices(UsyncOutcome::Error(error))) => {
                 warn!(
                     target: "usync",
                     "{} for {user_jid}; skipping user",
@@ -783,91 +635,60 @@ impl IqSpec for DeviceListSpec {
                 );
                 continue;
             }
-
-            // Extract LID mapping if present
-            if user_jid.server == wacore_binary::Server::Pn
-                && let Some(lid_node) = user_node.get_optional_child("lid")
-            {
-                let lid_val = lid_node.attrs().optional_string("val").unwrap_or_default();
-                if !lid_val.is_empty()
-                    && let Ok(lid_jid) = lid_val.parse::<Jid>()
-                    && lid_jid.server == wacore_binary::Server::Lid
-                {
-                    lid_mappings.push(UsyncLidMapping {
-                        phone_number: user_jid.user.clone(),
-                        lid: lid_jid.user.clone(),
-                    });
-                }
-            }
-
-            // Extract device list - skip user if not present
-            let device_list_node = match user_node
-                .get_optional_child_by_tag(&["devices", "device-list"])
-            {
-                Some(node) => node,
-                None => {
-                    warn!(target: "usync", "<device-list> not found for user {user_jid}, skipping");
-                    continue;
-                }
-            };
-
-            // Extract phash from device-list node attributes
-            let phash = device_list_node
-                .attrs()
-                .optional_string("hash")
-                .map(|s| s.to_string());
-
-            // Parse key-index-list from <devices> node
-            let devices_parent = user_node.get_optional_child("devices");
-            let key_index_bytes = devices_parent
-                .and_then(|dp| dp.get_optional_child("key-index-list"))
-                .and_then(|ki| match ki.content.as_deref() {
-                    Some(NodeContentRef::Bytes(b)) if !b.is_empty() => Some(b.to_vec()),
-                    _ => None,
-                });
-
-            let mut devices = Vec::new();
-            for device_node in device_list_node.get_children_by_tag("device") {
-                let Some(device_id_str) = device_node.attrs().optional_string("id") else {
-                    warn!(target: "usync", "device node missing 'id' attribute for user {user_jid}, skipping device");
-                    continue;
-                };
-                let Ok(device_id) = device_id_str.parse::<u16>() else {
-                    warn!(target: "usync", "invalid device id '{}' for user {user_jid}, skipping device", device_id_str);
-                    continue;
-                };
-
-                let key_index = device_node
-                    .attrs()
-                    .optional_string("key-index")
-                    .and_then(|s| s.parse::<u32>().ok());
-                devices.push(crate::usync::UsyncDevice {
-                    device: device_id,
-                    key_index,
-                });
-            }
-
-            let has_companion = devices.iter().any(|d| d.device != 0);
-            if has_companion && key_index_bytes.is_none() {
-                warn!(
-                    target: "usync",
-                    "User {user_jid} has companion devices but no signedKeyIndexBytes, skipping"
-                );
+            _ => {
+                warn!(target: "usync", "<device-list> not found for user {user_jid}, skipping");
                 continue;
             }
+        };
+        let Some(device_list) = devices.device_list else {
+            warn!(target: "usync", "<device-list> not found for user {user_jid}, skipping");
+            continue;
+        };
+        let key_index_bytes = devices
+            .key_index
+            .and_then(|key_index| key_index.signed_key_index_bytes)
+            .filter(|bytes| !bytes.is_empty());
+        let parsed_devices = device_list
+            .devices
+            .into_iter()
+            .map(|device| {
+                crate::usync::UsyncDevice::new(device.id, device.key_index)
+                    .with_hosting(device.is_hosted)
+            })
+            .collect::<Vec<_>>();
 
-            device_lists.push(UserDeviceList {
-                user: user_jid.to_non_ad(),
-                devices,
-                phash,
-                key_index_bytes,
-            });
+        let has_companion = parsed_devices.iter().any(|device| device.device != 0);
+        if has_companion && key_index_bytes.is_none() {
+            warn!(
+                target: "usync",
+                "User {user_jid} has companion devices but no signedKeyIndexBytes, skipping"
+            );
+            continue;
         }
 
-        Ok(DeviceListResponse {
-            device_lists,
-            lid_mappings,
-        })
+        device_lists.push(UserDeviceList {
+            user: user_jid,
+            devices: parsed_devices,
+            phash: device_list.hash.map(|hash| hash.to_string()),
+            key_index_bytes,
+        });
+    }
+
+    Ok(DeviceListResponse {
+        device_lists,
+        lid_mappings,
+    })
+}
+
+impl IqSpec for DeviceListSpec {
+    type Response = DeviceListResponse;
+
+    fn build_iq(&self) -> InfoQuery<'static> {
+        device_list_query(&self.jids, Some(&self.hashes)).build_info_query(&self.sid)
+    }
+
+    fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
+        project_device_list_response(parse_usync_response(response)?)
     }
 }
 
@@ -890,6 +711,20 @@ impl LidQuerySpec {
     }
 }
 
+fn lid_query(spec: &LidQuerySpec) -> UsyncQuery {
+    let users = spec
+        .jids
+        .iter()
+        .map(|jid| UsyncUser::from_jid(jid.to_non_ad()))
+        .collect();
+    UsyncQuery::from_parts_unchecked(
+        UsyncMode::Query,
+        UsyncContext::Background,
+        vec![UsyncProtocol::Lid],
+        users,
+    )
+}
+
 /// Response: just the LID mappings learned.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -901,66 +736,33 @@ impl IqSpec for LidQuerySpec {
     type Response = LidQueryResponse;
 
     fn build_iq(&self) -> InfoQuery<'static> {
-        let query_node = NodeBuilder::new("query")
-            .children(vec![NodeBuilder::new("lid").build()])
-            .build();
-
-        let user_nodes: Vec<Node> = self
-            .jids
-            .iter()
-            .map(|jid| {
-                NodeBuilder::new("user")
-                    .attr("jid", jid.to_non_ad())
-                    .build()
-            })
-            .collect();
-
-        let list_node = NodeBuilder::new("list").children(user_nodes).build();
-
-        let usync_node = NodeBuilder::new("usync")
-            .attr("sid", self.sid.as_str())
-            .attr("mode", UsyncMode::Query.as_str())
-            .attr("last", "true")
-            .attr("index", "0")
-            // WA Web ContactSyncApi uses "background" for LID resolution
-            .attr("context", UsyncContext::Background.as_str())
-            .children(vec![query_node, list_node])
-            .build();
-
-        InfoQuery::get(
-            "usync",
-            Jid::new("", Server::Pn),
-            Some(NodeContent::Nodes(vec![usync_node])),
-        )
+        lid_query(self).build_info_query(&self.sid)
     }
 
     fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
-        let usync = response
-            .get_optional_child("usync")
-            .ok_or_else(|| anyhow!("LID query response missing <usync> node"))?;
-        check_usync_result_errors(usync)?;
-        let list = usync
-            .get_optional_child("list")
-            .ok_or_else(|| anyhow!("LID query response missing <list> node"))?;
-        for user_node in list.get_children_by_tag("user") {
-            let user_jid = user_node
-                .attrs()
-                .optional_string("jid")
-                .map(|jid| jid.to_string())
-                .unwrap_or_else(|| "<unknown>".to_string());
-            if let Some(lid_node) = user_node.get_optional_child("lid")
-                && let Some(error) = parse_subprotocol_error(lid_node)
-            {
-                warn!(
-                    target: "usync",
-                    "{} for {user_jid}; skipping user",
-                    usync_subprotocol_error_message("lid", &error)
-                );
+        let response = parse_usync_response(response)?;
+        reject_result_errors(&response, LEGACY_RESULT_PROTOCOLS)?;
+
+        let mut lid_mappings = Vec::with_capacity(response.users.len());
+        for user in response.users {
+            let Some(user_jid) = user.id.as_ref() else {
                 continue;
+            };
+            match user.protocol(UsyncProtocolKind::Lid) {
+                Some(UsyncProtocolResult::Lid(UsyncOutcome::Error(error))) => {
+                    warn!(
+                        target: "usync",
+                        "{} for {user_jid}; skipping user",
+                        usync_subprotocol_error_message("lid", error)
+                    );
+                }
+                _ => {
+                    if let Some(mapping) = project_lid_mapping(&user) {
+                        lid_mappings.push(mapping);
+                    }
+                }
             }
         }
-
-        let lid_mappings = crate::usync::parse_lid_mappings_from_response(response);
         Ok(LidQueryResponse { lid_mappings })
     }
 }
@@ -1575,7 +1377,10 @@ mod tests {
                                     .children([
                                         NodeBuilder::new("device").attr("id", "0").build(),
                                         NodeBuilder::new("device").attr("id", "1").build(),
-                                        NodeBuilder::new("device").attr("id", "5").build(),
+                                        NodeBuilder::new("device")
+                                            .attr("id", "5")
+                                            .attr("is_hosted", "true")
+                                            .build(),
                                     ])
                                     .build(),
                                 build_test_key_index_list_node(&[0, 1, 5]),
@@ -1593,6 +1398,7 @@ mod tests {
         assert_eq!(result.device_lists[0].devices[0].device, 0);
         assert_eq!(result.device_lists[0].devices[1].device, 1);
         assert_eq!(result.device_lists[0].devices[2].device, 5);
+        assert!(result.device_lists[0].devices[2].is_hosted);
         assert_eq!(
             result.device_lists[0].phash,
             Some("2:abcdef123456".to_string())
@@ -1810,6 +1616,26 @@ mod tests {
     #[test]
     fn parse_verified_name_skips_error_and_empty() {
         let business = |vn: Node| NodeBuilder::new("business").children([vn]).build();
+        let parse = |business: Node| {
+            let response = NodeBuilder::new("iq")
+                .attr("type", "result")
+                .children([NodeBuilder::new("usync")
+                    .children([NodeBuilder::new("list")
+                        .children([NodeBuilder::new("user")
+                            .attr("jid", Jid::pn("1234567890"))
+                            .children([business])
+                            .build()])
+                        .build()])
+                    .build()])
+                .build();
+            let parsed = parse_usync_response(&response.as_node_ref()).unwrap();
+            match parsed.users[0].protocol(UsyncProtocolKind::Business) {
+                Some(UsyncProtocolResult::Business(UsyncOutcome::Value(result))) => {
+                    result.verified_name.clone()
+                }
+                other => panic!("unexpected business result: {other:?}"),
+            }
+        };
 
         // <verified_name><error/></verified_name> -> absent
         let err = business(
@@ -1817,11 +1643,11 @@ mod tests {
                 .children([NodeBuilder::new("error").attr("code", "404").build()])
                 .build(),
         );
-        assert!(parse_verified_name_from_business(&err.as_node_ref()).is_none());
+        assert!(parse(err).is_none());
 
         // empty <verified_name/> (no attrs, no cert) -> absent
         let empty = business(NodeBuilder::new("verified_name").build());
-        assert!(parse_verified_name_from_business(&empty.as_node_ref()).is_none());
+        assert!(parse(empty).is_none());
 
         // real name attr -> present
         let real = business(
@@ -1830,10 +1656,7 @@ mod tests {
                 .build(),
         );
         assert_eq!(
-            parse_verified_name_from_business(&real.as_node_ref())
-                .expect("real name")
-                .name
-                .as_deref(),
+            parse(real).expect("real name").name.as_deref(),
             Some("Acme")
         );
     }

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -56,9 +56,10 @@ use crate::request::InfoQuery;
 use crate::stanza::business::VerifiedName;
 use anyhow::anyhow;
 use log::warn;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use wacore_binary::Jid;
 use wacore_binary::NodeRef;
-use wacore_binary::{Jid, Server};
 
 #[cfg(test)]
 use wacore_binary::builder::NodeBuilder;
@@ -114,11 +115,14 @@ pub struct IsOnWhatsAppUser {
     pub known_lid: Option<wacore_binary::CompactString>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncSubprotocolError {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub backoff: Option<u32>,
 }
 
@@ -282,7 +286,7 @@ fn project_business(
 
 pub(crate) fn project_lid_mapping(user: &UsyncUserResult) -> Option<UsyncLidMapping> {
     let user_jid = user.id.as_ref()?;
-    if user_jid.server != Server::Pn {
+    if !user_jid.server.is_pn_family() {
         return None;
     }
     let Some(UsyncProtocolResult::Lid(UsyncOutcome::Value(Some(lid)))) =
@@ -786,6 +790,7 @@ impl IqSpec for LidQuerySpec {
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use wacore_binary::Server;
 
     /// Build a dummy key-index-list node for device IDs (used in test fixtures)
     fn build_test_key_index_list_node(device_ids: &[u16]) -> Node {
@@ -1571,6 +1576,26 @@ mod tests {
         assert_eq!(result.lid_mappings.len(), 1);
         assert_eq!(result.lid_mappings[0].phone_number, "9876543210");
         assert_eq!(result.lid_mappings[0].lid, "100000000000987");
+    }
+
+    #[test]
+    fn lid_mapping_projection_accepts_standard_and_hosted_namespaces() {
+        for (pn_server, lid_server) in [
+            (Server::Pn, Server::Lid),
+            (Server::Hosted, Server::HostedLid),
+        ] {
+            let user = UsyncUserResult {
+                id: Some(Jid::new("13135550100", pn_server)),
+                pn_jid: None,
+                protocols: vec![UsyncProtocolResult::Lid(UsyncOutcome::Value(Some(
+                    Jid::new("100000000000100", lid_server),
+                )))],
+            };
+
+            let mapping = project_lid_mapping(&user).expect("expected LID mapping");
+            assert_eq!(mapping.phone_number, "13135550100");
+            assert_eq!(mapping.lid, "100000000000100");
+        }
     }
 
     #[test]

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -447,7 +447,7 @@ impl IqSpec for UserInfoSpec {
             };
             let (picture_id, picture_error) = match user.protocol(UsyncProtocolKind::Picture) {
                 Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(id))) => {
-                    (Some(id.to_string()), None)
+                    (id.as_ref().map(ToString::to_string), None)
                 }
                 Some(UsyncProtocolResult::Picture(UsyncOutcome::Error(error))) => {
                     (None, Some((**error).clone()))

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -447,7 +447,7 @@ impl IqSpec for UserInfoSpec {
             };
             let (picture_id, picture_error) = match user.protocol(UsyncProtocolKind::Picture) {
                 Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(id))) => {
-                    (id.as_ref().map(ToString::to_string), None)
+                    (Some(id.to_string()), None)
                 }
                 Some(UsyncProtocolResult::Picture(UsyncOutcome::Error(error))) => {
                     (None, Some((**error).clone()))

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -12,7 +12,6 @@ use crate::iq::tctoken::build_tc_token_node;
 use crate::request::InfoQuery;
 use crate::stanza::business::VerifiedName;
 use anyhow::{Context, anyhow};
-use log::warn;
 use thiserror::Error;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{CompactString, Jid, Node, NodeContent, NodeContentRef, NodeRef, Server};
@@ -961,7 +960,7 @@ pub enum UsyncProtocolResult {
     TextStatus(UsyncOutcome<UsyncTextStatusResult>),
     DisappearingMode(UsyncOutcome<UsyncDisappearingModeResult>),
     Business(UsyncOutcome<Box<UsyncBusinessResult>>),
-    Picture(UsyncOutcome<Option<u64>>),
+    Picture(UsyncOutcome<u64>),
     Lid(UsyncOutcome<Option<Jid>>),
     Username(UsyncOutcome<Option<CompactString>>),
     Bot(UsyncOutcome<Box<UsyncBotProfileResult>>),
@@ -1093,7 +1092,7 @@ fn parse_protocol_result(
             UsyncProtocolResult::Business(outcome!(parse_business(node).map(Box::new)))
         }
         UsyncProtocolKind::Picture => {
-            UsyncProtocolResult::Picture(outcome!(optional_u64(node, ATTR_ID)))
+            UsyncProtocolResult::Picture(outcome!(required_u64(node, ATTR_ID)))
         }
         UsyncProtocolKind::Lid => UsyncProtocolResult::Lid(outcome!(optional_lid(node, ATTR_VAL))),
         UsyncProtocolKind::Username => {
@@ -1173,10 +1172,7 @@ fn parse_device_list(node: &NodeRef<'_>) -> Result<UsyncDeviceListResult, anyhow
     let capacity = node.children().map_or(0, <[_]>::len);
     let mut devices = Vec::with_capacity(capacity);
     for device in node.get_children_by_tag(TAG_DEVICE) {
-        match parse_device(device) {
-            Ok(device) => devices.push(device),
-            Err(error) => warn!(target: "usync", "skipping malformed USync device: {error}"),
-        }
+        devices.push(parse_device(device)?);
     }
     Ok(UsyncDeviceListResult { hash, devices })
 }
@@ -1433,9 +1429,11 @@ fn required_compact_string(node: &NodeRef<'_>, key: &str) -> Result<CompactStrin
     Ok(value)
 }
 
-fn optional_u64(node: &NodeRef<'_>, key: &str) -> Result<Option<u64>, anyhow::Error> {
+fn required_u64(node: &NodeRef<'_>, key: &str) -> Result<u64, anyhow::Error> {
     let mut attrs = node.attrs();
-    let value = attrs.optional_u64(key);
+    let value = attrs
+        .optional_u64(key)
+        .ok_or_else(|| anyhow!("<{}> is missing required '{key}' attribute", node.tag))?;
     attrs.finish()?;
     Ok(value)
 }
@@ -1861,40 +1859,33 @@ mod tests {
     }
 
     #[test]
-    fn devices_parser_skips_malformed_entries_without_dropping_siblings() {
-        let devices = NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
-            .children([NodeBuilder::new(TAG_DEVICE_LIST)
-                .children([
-                    NodeBuilder::new(TAG_DEVICE).build(),
-                    NodeBuilder::new(TAG_DEVICE)
-                        .attr(ATTR_ID, (u64::from(u16::MAX) + 1).to_string())
-                        .build(),
-                    NodeBuilder::new(TAG_DEVICE)
-                        .attr(ATTR_ID, "7")
-                        .attr(ATTR_KEY_INDEX, "9")
-                        .build(),
-                ])
-                .build()])
-            .build();
-        let user = NodeBuilder::new(TAG_USER)
-            .attr(ATTR_JID, Jid::pn("15550000001"))
-            .children([devices])
-            .build();
+    fn devices_parser_rejects_malformed_lists_instead_of_returning_partial_data() {
+        let malformed_devices = [
+            NodeBuilder::new(TAG_DEVICE).build(),
+            NodeBuilder::new(TAG_DEVICE)
+                .attr(ATTR_ID, "invalid")
+                .build(),
+            NodeBuilder::new(TAG_DEVICE)
+                .attr(ATTR_ID, (u64::from(u16::MAX) + 1).to_string())
+                .build(),
+        ];
 
-        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
-        let Some(UsyncProtocolResult::Devices(UsyncOutcome::Value(devices))) =
-            parsed.users[0].protocol(UsyncProtocolKind::Devices)
-        else {
-            panic!("expected devices result");
-        };
-        assert_eq!(
-            devices.device_list.as_ref().unwrap().devices,
-            [UsyncDeviceResult {
-                id: 7,
-                key_index: Some(9),
-                is_hosted: false,
-            }]
-        );
+        for malformed in malformed_devices {
+            let devices = NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
+                .children([NodeBuilder::new(TAG_DEVICE_LIST)
+                    .children([
+                        NodeBuilder::new(TAG_DEVICE).attr(ATTR_ID, "7").build(),
+                        malformed,
+                    ])
+                    .build()])
+                .build();
+            let user = NodeBuilder::new(TAG_USER)
+                .attr(ATTR_JID, Jid::pn("15550000001"))
+                .children([devices])
+                .build();
+
+            assert!(parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).is_err());
+        }
     }
 
     #[test]
@@ -2024,7 +2015,7 @@ mod tests {
         let user = &parsed.users[0];
         assert!(matches!(
             user.protocol(UsyncProtocolKind::Picture),
-            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(Some(42))))
+            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(42)))
         ));
         assert!(matches!(
             user.protocol(UsyncProtocolKind::Lid),
@@ -2058,17 +2049,13 @@ mod tests {
     }
 
     #[test]
-    fn picture_without_id_is_a_successful_absent_value() {
+    fn picture_without_id_is_rejected() {
         let user = NodeBuilder::new(TAG_USER)
             .attr(ATTR_JID, Jid::pn("15550000001"))
             .children([NodeBuilder::new(UsyncProtocolKind::Picture.as_str()).build()])
             .build();
 
-        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
-        assert!(matches!(
-            parsed.users[0].protocol(UsyncProtocolKind::Picture),
-            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(None)))
-        ));
+        assert!(parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).is_err());
     }
 
     #[test]

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -12,6 +12,7 @@ use crate::iq::tctoken::build_tc_token_node;
 use crate::request::InfoQuery;
 use crate::stanza::business::VerifiedName;
 use anyhow::{Context, anyhow};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{CompactString, Jid, Node, NodeContent, NodeContentRef, NodeRef, Server};
@@ -171,14 +172,17 @@ pub enum UsyncFeature {
 }
 
 /// Per-user cache hints carried by the devices v2 subprotocol.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncDeviceSyncHint {
     /// Cached device-list hash, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_hash: Option<CompactString>,
     /// Timestamp associated with the cached hash.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<i64>,
     /// Expected timestamp used to detect stale key-index state.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_timestamp: Option<i64>,
 }
 
@@ -222,21 +226,54 @@ impl Default for UsyncDeviceSyncHint {
     }
 }
 
-/// A validated USync user input.
+/// A USync user input.
 ///
-/// Fields are private so callers cannot remove the identity established by a
-/// constructor. Protocol-specific additions are explicit builder methods.
-#[derive(Debug, Clone)]
+/// Constructors establish an identity and protocol-specific additions use
+/// explicit builder methods. Deserialization applies the same phone and JID
+/// normalization as those constructors; all invariants are validated when the
+/// user becomes part of [`UsyncQuery::new`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UsyncUser {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_usync_jid"
+    )]
     id: Option<Jid>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_usync_jid"
+    )]
     pn_jid: Option<Jid>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_usync_phone"
+    )]
     phone: Option<CompactString>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_usync_jid"
+    )]
     known_lid: Option<Jid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     device_sync: Option<UsyncDeviceSyncHint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     persona_id: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     username_pin: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     contact_type: Option<CompactString>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_helpers::serialize_optional_bytes",
+        deserialize_with = "crate::serde_helpers::deserialize_optional_bytes"
+    )]
     tc_token: Option<Vec<u8>>,
 }
 
@@ -283,11 +320,7 @@ impl UsyncUser {
     }
 
     pub fn with_phone(mut self, phone: impl Into<CompactString>) -> Self {
-        let mut phone = phone.into();
-        if !phone.is_empty() && phone.bytes().all(|byte| byte.is_ascii_digit()) {
-            phone.insert(0, E164_PREFIX);
-        }
-        self.phone = Some(phone);
+        self.phone = Some(normalize_usync_phone(phone.into()));
         self
     }
 
@@ -407,6 +440,29 @@ impl UsyncUser {
     }
 }
 
+fn normalize_usync_phone(mut phone: CompactString) -> CompactString {
+    if !phone.is_empty() && phone.bytes().all(|byte| byte.is_ascii_digit()) {
+        phone.insert(0, E164_PREFIX);
+    }
+    phone
+}
+
+fn deserialize_optional_usync_phone<'de, D>(
+    deserializer: D,
+) -> Result<Option<CompactString>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<CompactString>::deserialize(deserializer).map(|phone| phone.map(normalize_usync_phone))
+}
+
+fn deserialize_optional_usync_jid<'de, D>(deserializer: D) -> Result<Option<Jid>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<Jid>::deserialize(deserializer).map(|jid| jid.map(normalize_usync_user_jid))
+}
+
 /// Remove device addressing while retaining identity-bearing fields.
 ///
 /// PN/LID domain bytes can surface through `agent` during binary decoding but
@@ -444,7 +500,8 @@ fn validate_user_jid(jid: &Jid, index: usize) -> Result<(), UsyncValidationError
 }
 
 /// A known, typed USync subprotocol request.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum UsyncProtocol {
     Contact {
@@ -634,12 +691,32 @@ pub enum UsyncValidationError {
 }
 
 /// A complete typed USync query, validated before it reaches the network.
-#[derive(Debug, Clone)]
+///
+/// Deserialization always delegates to [`Self::new`], so a serialized input
+/// cannot bypass protocol uniqueness or per-user validation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "UsyncQueryData")]
 pub struct UsyncQuery {
     mode: UsyncMode,
     context: UsyncContext,
     protocols: Vec<UsyncProtocol>,
     users: Vec<UsyncUser>,
+}
+
+#[derive(Deserialize)]
+struct UsyncQueryData {
+    mode: UsyncMode,
+    context: UsyncContext,
+    protocols: Vec<UsyncProtocol>,
+    users: Vec<UsyncUser>,
+}
+
+impl TryFrom<UsyncQueryData> for UsyncQuery {
+    type Error = UsyncValidationError;
+
+    fn try_from(value: UsyncQueryData) -> Result<Self, Self::Error> {
+        Self::new(value.mode, value.context, value.protocols, value.users)
+    }
 }
 
 impl UsyncQuery {
@@ -780,16 +857,21 @@ impl IqSpec for UsyncQuerySpec {
 }
 
 /// Result-level state for a single protocol.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncProtocolState {
     pub protocol: UsyncProtocolKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub refresh_seconds: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<UsyncSubprotocolError>,
 }
 
 /// Full neutral response from a typed USync query.
-#[derive(Debug, Clone)]
+///
+/// Its serialization walks this model by reference; no projection tree is
+/// constructed by the core.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncResponse {
     pub protocol_states: Vec<UsyncProtocolState>,
@@ -806,10 +888,12 @@ impl UsyncResponse {
 
 /// Per-user response. `id` is optional because contact-only results without a
 /// JID are accepted by WhatsApp Web.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncUserResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Jid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pn_jid: Option<Jid>,
     pub protocols: Vec<UsyncProtocolResult>,
 }
@@ -823,7 +907,8 @@ impl UsyncUserResult {
 /// A protocol value or its per-user error. Errors are boxed because they are
 /// rare and contain owned strings; this keeps every successful result variant
 /// from inheriting their size.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum UsyncOutcome<T> {
     Value(T),
     Error(Box<UsyncSubprotocolError>),
@@ -845,61 +930,77 @@ impl<T> UsyncOutcome<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncContactResult {
     pub contact_type: CompactString,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<CompactString>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncDeviceResult {
     pub id: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key_index: Option<u32>,
     pub is_hosted: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncDeviceListResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<CompactString>,
     pub devices: Vec<UsyncDeviceResult>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncKeyIndexResult {
     pub timestamp: i64,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_helpers::serialize_optional_bytes",
+        deserialize_with = "crate::serde_helpers::deserialize_optional_bytes"
+    )]
     pub signed_key_index_bytes: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_timestamp: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncDevicesResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_list: Option<UsyncDeviceListResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key_index: Option<UsyncKeyIndexResult>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncBusinessResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub verified_name: Option<VerifiedName>,
 }
 
 /// About/status payload. WhatsApp Web consumes only `status`, while the
 /// optional wire timestamp is retained for callers that need a lossless
 /// projection of responses carrying `t`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncStatusResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncDisappearingModeResult {
     pub duration_seconds: u32,
@@ -907,30 +1008,34 @@ pub struct UsyncDisappearingModeResult {
     pub ephemerality_disabled: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncTextStatusResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub emoji: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ephemeral_duration_seconds: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_update_time: Option<CompactString>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncFeatureResult {
     pub feature: UsyncFeature,
     pub value: CompactString,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncBotPrompt {
     pub emoji: CompactString,
     pub text: CompactString,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncBotCommand {
     pub name: CompactString,
@@ -950,7 +1055,7 @@ pub enum UsyncBotProfessionalType {
     Other(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct UsyncBotProfileResult {
     pub name: CompactString,
@@ -962,15 +1067,20 @@ pub struct UsyncBotProfileResult {
     pub persona_id: CompactString,
     pub commands: Vec<UsyncBotCommand>,
     pub commands_description: CompactString,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_meta_created: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub creator_name: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub creator_profile_url: Option<CompactString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub posing_as_professional: Option<UsyncBotProfessionalType>,
 }
 
 /// Sparse per-user result. Large, uncommon payloads are boxed so their layout
 /// does not inflate every status/contact/device item in large sync responses.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum UsyncProtocolResult {
     Contact(UsyncOutcome<UsyncContactResult>),
@@ -1493,6 +1603,11 @@ fn checked_u32(value: u64, attribute: &str) -> Result<u32, anyhow::Error> {
 mod tests {
     use super::*;
 
+    const TEST_PHONE: &str = "13135550100";
+    const TEST_E164_PHONE: &str = "+13135550100";
+    const TEST_PN_JID: &str = "13135550100@s.whatsapp.net";
+    const TEST_AGENT_BOT_JID: &str = "13135550100.2@bot";
+
     fn response(result: Vec<Node>, users: Vec<Node>) -> Node {
         NodeBuilder::new("iq")
             .attr("type", "result")
@@ -1518,7 +1633,7 @@ mod tests {
     #[test]
     fn typed_query_builds_canonical_envelope_and_protocol_inputs() {
         let user = UsyncUser::from_jid(Jid::lid("100000001").with_device(7))
-            .with_pn_jid(Jid::pn("15550000001").with_device(8))
+            .with_pn_jid(Jid::pn(TEST_PHONE).with_device(8))
             .with_known_lid(Jid::lid("100000001").with_device(9))
             .with_device_sync(
                 UsyncDeviceSyncHint::new()
@@ -1574,10 +1689,7 @@ mod tests {
             .and_then(|list| list.get_optional_child(TAG_USER))
             .unwrap();
         assert_eq!(user.attrs.get(ATTR_JID).unwrap().as_str(), "100000001@lid");
-        assert_eq!(
-            user.attrs.get(ATTR_PN_JID).unwrap().as_str(),
-            "15550000001@s.whatsapp.net"
-        );
+        assert_eq!(user.attrs.get(ATTR_PN_JID).unwrap().as_str(), TEST_PN_JID);
         let devices = user
             .get_optional_child(UsyncProtocolKind::Devices.as_str())
             .unwrap();
@@ -1595,12 +1707,69 @@ mod tests {
     #[test]
     fn digit_only_phone_inputs_are_normalized_to_e164() {
         assert_eq!(
-            UsyncUser::from_phone("15550000001").phone.as_deref(),
-            Some("+15550000001")
+            UsyncUser::from_phone(TEST_PHONE).phone.as_deref(),
+            Some(TEST_E164_PHONE)
         );
         assert_eq!(
-            UsyncUser::from_phone("+15550000001").phone.as_deref(),
-            Some("+15550000001")
+            UsyncUser::from_phone(TEST_E164_PHONE).phone.as_deref(),
+            Some(TEST_E164_PHONE)
+        );
+    }
+
+    #[test]
+    fn query_serde_round_trip_reuses_canonical_validation_and_normalization() {
+        let query = UsyncQuery::new(
+            UsyncMode::Delta,
+            UsyncContext::Background,
+            vec![
+                UsyncProtocol::Contact {
+                    addressing_mode: UsyncAddressingMode::Pn,
+                },
+                UsyncProtocol::DevicesV2,
+                UsyncProtocol::Status,
+                UsyncProtocol::Features(vec![UsyncFeature::EncryptV2, UsyncFeature::Voip]),
+            ],
+            vec![
+                UsyncUser::from_phone(TEST_PHONE)
+                    .with_device_sync(
+                        UsyncDeviceSyncHint::new()
+                            .with_device_hash("2:hash")
+                            .with_timestamp(100),
+                    )
+                    .with_tc_token(vec![1, 2, 3]),
+            ],
+        )
+        .unwrap();
+
+        let encoded = serde_json::to_vec(&query).unwrap();
+        let decoded: UsyncQuery = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, query);
+
+        let normalized: UsyncQuery = serde_json::from_value(serde_json::json!({
+            "mode": "query",
+            "context": "interactive",
+            "protocols": [{
+                "type": "contact",
+                "data": { "addressing_mode": "pn" }
+            }],
+            "users": [{ "phone": TEST_PHONE }]
+        }))
+        .unwrap();
+        assert_eq!(
+            normalized.users()[0].phone.as_deref(),
+            Some(TEST_E164_PHONE)
+        );
+
+        let duplicate = serde_json::from_value::<UsyncQuery>(serde_json::json!({
+            "mode": "query",
+            "context": "interactive",
+            "protocols": [{ "type": "status" }, { "type": "status" }],
+            "users": [{ "phone": TEST_PHONE }]
+        }))
+        .unwrap_err();
+        assert!(
+            duplicate.to_string().contains("duplicate USync protocol"),
+            "unexpected deserialization error: {duplicate}"
         );
     }
 
@@ -1610,7 +1779,7 @@ mod tests {
             UsyncMode::Query,
             UsyncContext::Interactive,
             vec![UsyncProtocol::Status, UsyncProtocol::Status],
-            vec![UsyncUser::from_jid(Jid::pn("15550000001"))],
+            vec![UsyncUser::from_jid(Jid::pn(TEST_PHONE))],
         )
         .unwrap_err();
         assert_eq!(
@@ -1622,7 +1791,7 @@ mod tests {
             UsyncMode::Query,
             UsyncContext::Interactive,
             vec![UsyncProtocol::Status],
-            vec![UsyncUser::from_phone("+15550000001")],
+            vec![UsyncUser::from_phone(TEST_E164_PHONE)],
         )
         .unwrap_err();
         assert_eq!(
@@ -1643,11 +1812,9 @@ mod tests {
             UsyncMode::Query,
             UsyncContext::Interactive,
             vec![UsyncProtocol::DevicesV2],
-            vec![
-                UsyncUser::from_jid(Jid::pn("15550000001")).with_device_sync(
-                    UsyncDeviceSyncHint::new().with_device_hash(CompactString::default()),
-                ),
-            ],
+            vec![UsyncUser::from_jid(Jid::pn(TEST_PHONE)).with_device_sync(
+                UsyncDeviceSyncHint::new().with_device_hash(CompactString::default()),
+            )],
         )
         .unwrap_err();
         assert_eq!(
@@ -1660,7 +1827,7 @@ mod tests {
             UsyncContext::Interactive,
             vec![UsyncProtocol::Status],
             vec![UsyncUser::from_jid(Jid {
-                user: "13135550001".into(),
+                user: TEST_PHONE.into(),
                 server: Server::Bot,
                 agent: 2,
                 device: 7,
@@ -1672,7 +1839,7 @@ mod tests {
             agent_qualified_bot,
             UsyncValidationError::InvalidUserJid {
                 index: 0,
-                jid: "13135550001.2@bot".to_owned(),
+                jid: TEST_AGENT_BOT_JID.to_owned(),
             }
         );
     }
@@ -1681,8 +1848,8 @@ mod tests {
     fn query_validation_never_silently_drops_user_inputs() {
         let cases = [
             (
-                UsyncUser::from_jid(Jid::pn("15550000001"))
-                    .with_phone("+15550000001")
+                UsyncUser::from_jid(Jid::pn(TEST_PHONE))
+                    .with_phone(TEST_E164_PHONE)
                     .with_contact_type("in"),
                 vec![UsyncProtocol::Contact {
                     addressing_mode: UsyncAddressingMode::Pn,
@@ -1690,23 +1857,23 @@ mod tests {
                 UsyncValidationError::ConflictingContactInputs { index: 0 },
             ),
             (
-                UsyncUser::from_jid(Jid::pn("15550000001"))
+                UsyncUser::from_jid(Jid::pn(TEST_PHONE))
                     .with_device_sync(UsyncDeviceSyncHint::new().with_timestamp(1)),
                 vec![UsyncProtocol::Status],
                 UsyncValidationError::DeviceSyncWithoutProtocol { index: 0 },
             ),
             (
-                UsyncUser::from_jid(Jid::pn("15550000001")).with_tc_token(vec![1]),
+                UsyncUser::from_jid(Jid::pn(TEST_PHONE)).with_tc_token(vec![1]),
                 vec![UsyncProtocol::DevicesV2],
                 UsyncValidationError::TcTokenWithoutProtocol { index: 0 },
             ),
             (
-                UsyncUser::from_jid(Jid::pn("15550000001")).with_persona_id("persona-1"),
+                UsyncUser::from_jid(Jid::pn(TEST_PHONE)).with_persona_id("persona-1"),
                 vec![UsyncProtocol::Status],
                 UsyncValidationError::PersonaIdWithoutProtocol { index: 0 },
             ),
             (
-                UsyncUser::from_jid(Jid::pn("15550000001")).with_known_lid(Jid::lid("100000001")),
+                UsyncUser::from_jid(Jid::pn(TEST_PHONE)).with_known_lid(Jid::lid("100000001")),
                 vec![UsyncProtocol::Status],
                 UsyncValidationError::KnownLidWithoutProtocol { index: 0 },
             ),
@@ -1793,7 +1960,7 @@ mod tests {
                 NodeBuilder::new(TAG_USER)
                     .children([NodeBuilder::new(UsyncProtocolKind::Contact.as_str())
                         .attr(ATTR_TYPE, "out")
-                        .string_content("+15550000001")
+                        .string_content(TEST_E164_PHONE)
                         .build()])
                     .build(),
             ],
@@ -1828,7 +1995,7 @@ mod tests {
             .attr(
                 ATTR_JID,
                 Jid {
-                    user: "13135550001".into(),
+                    user: TEST_PHONE.into(),
                     server: Server::Bot,
                     agent: 2,
                     device: 7,
@@ -1912,7 +2079,7 @@ mod tests {
             ])
             .build();
         let user = NodeBuilder::new(TAG_USER)
-            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .attr(ATTR_JID, Jid::pn(TEST_PHONE))
             .children([devices])
             .build();
         let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
@@ -1956,7 +2123,7 @@ mod tests {
                     .build()])
                 .build();
             let user = NodeBuilder::new(TAG_USER)
-                .attr(ATTR_JID, Jid::pn("15550000001"))
+                .attr(ATTR_JID, Jid::pn(TEST_PHONE))
                 .children([devices])
                 .build();
 
@@ -2071,7 +2238,7 @@ mod tests {
             ])
             .build();
         let user = NodeBuilder::new(TAG_USER)
-            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .attr(ATTR_JID, Jid::pn(TEST_PHONE))
             .children([
                 NodeBuilder::new(UsyncProtocolKind::Picture.as_str())
                     .attr(ATTR_ID, "42")
@@ -2127,7 +2294,7 @@ mod tests {
     #[test]
     fn picture_without_id_is_rejected() {
         let user = NodeBuilder::new(TAG_USER)
-            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .attr(ATTR_JID, Jid::pn(TEST_PHONE))
             .children([NodeBuilder::new(UsyncProtocolKind::Picture.as_str()).build()])
             .build();
 
@@ -2135,11 +2302,84 @@ mod tests {
     }
 
     #[test]
+    fn response_serde_round_trip_preserves_sparse_and_binary_results() {
+        let response = UsyncResponse {
+            protocol_states: vec![UsyncProtocolState {
+                protocol: UsyncProtocolKind::Status,
+                refresh_seconds: Some(60),
+                error: Some(UsyncSubprotocolError {
+                    code: Some(401),
+                    text: None,
+                    backoff: Some(5),
+                }),
+            }],
+            users: vec![UsyncUserResult {
+                id: Some(Jid::new("100000001", Server::HostedLid)),
+                pn_jid: Some(Jid::new(TEST_PHONE, Server::Hosted)),
+                protocols: vec![
+                    UsyncProtocolResult::Devices(UsyncOutcome::Value(UsyncDevicesResult {
+                        device_list: Some(UsyncDeviceListResult {
+                            hash: Some("2:hash".into()),
+                            devices: vec![UsyncDeviceResult {
+                                id: 7,
+                                key_index: Some(3),
+                                is_hosted: true,
+                            }],
+                        }),
+                        key_index: Some(UsyncKeyIndexResult {
+                            timestamp: 100,
+                            signed_key_index_bytes: Some(vec![1, 2, 3, 4]),
+                            expected_timestamp: None,
+                        }),
+                    })),
+                    UsyncProtocolResult::Status(UsyncOutcome::Value(UsyncStatusResult {
+                        status: Some(CompactString::default()),
+                        timestamp: None,
+                    })),
+                    UsyncProtocolResult::Business(UsyncOutcome::Value(Box::new(
+                        UsyncBusinessResult {
+                            verified_name: Some(VerifiedName {
+                                name: Some("Business".to_owned()),
+                                serial: None,
+                                issuer: None,
+                                certificate: Some(Vec::new()),
+                            }),
+                        },
+                    ))),
+                    UsyncProtocolResult::Bot(UsyncOutcome::Value(Box::new(
+                        UsyncBotProfileResult {
+                            name: "Assistant".into(),
+                            attributes: "helpful".into(),
+                            description: "Description".into(),
+                            category: "utility".into(),
+                            is_default: false,
+                            prompts: Vec::new(),
+                            persona_id: "persona-1".into(),
+                            commands: Vec::new(),
+                            commands_description: CompactString::default(),
+                            is_meta_created: None,
+                            creator_name: None,
+                            creator_profile_url: None,
+                            posing_as_professional: Some(UsyncBotProfessionalType::Other(
+                                "future".to_owned(),
+                            )),
+                        },
+                    ))),
+                ],
+            }],
+        };
+
+        let encoded = serde_json::to_vec(&response).unwrap();
+        let decoded: UsyncResponse = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, response);
+    }
+
+    #[test]
     fn parser_rejects_non_lid_values() {
         let invalid_lid = NodeBuilder::new(TAG_USER)
-            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .attr(ATTR_JID, Jid::pn(TEST_PHONE))
             .children([NodeBuilder::new(UsyncProtocolKind::Lid.as_str())
-                .attr(ATTR_VAL, Jid::pn("15550000001"))
+                .attr(ATTR_VAL, Jid::pn(TEST_PHONE))
                 .build()])
             .build();
         assert!(

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -83,6 +83,7 @@ const FIRST_PAGE_INDEX: &str = "0";
 const LAST_PAGE: &str = "true";
 const DEVICES_VERSION: &str = "2";
 const BOT_PROFILE_VERSION: &str = "1";
+const E164_PREFIX: char = '+';
 
 /// Addressing mode used by the contact subprotocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, WireEnum)]
@@ -272,22 +273,26 @@ impl UsyncUser {
     }
 
     pub fn with_id(mut self, jid: Jid) -> Self {
-        self.id = Some(jid.into_non_ad());
+        self.id = Some(normalize_usync_user_jid(jid));
         self
     }
 
     pub fn with_pn_jid(mut self, jid: Jid) -> Self {
-        self.pn_jid = Some(jid.into_non_ad());
+        self.pn_jid = Some(normalize_usync_user_jid(jid));
         self
     }
 
     pub fn with_phone(mut self, phone: impl Into<CompactString>) -> Self {
-        self.phone = Some(phone.into());
+        let mut phone = phone.into();
+        if !phone.is_empty() && phone.bytes().all(|byte| byte.is_ascii_digit()) {
+            phone.insert(0, E164_PREFIX);
+        }
+        self.phone = Some(phone);
         self
     }
 
     pub fn with_known_lid(mut self, lid: Jid) -> Self {
-        self.known_lid = Some(lid.into_non_ad());
+        self.known_lid = Some(normalize_usync_user_jid(lid));
         self
     }
 
@@ -402,6 +407,20 @@ impl UsyncUser {
     }
 }
 
+/// Remove device addressing while retaining identity-bearing fields.
+///
+/// PN/LID domain bytes can surface through `agent` during binary decoding but
+/// are not part of those user identities. Other namespaces render the agent,
+/// so validation can reject unsupported agent-qualified query inputs instead
+/// of silently querying a different user.
+fn normalize_usync_user_jid(mut jid: Jid) -> Jid {
+    jid.device = 0;
+    if !jid.server.renders_agent() {
+        jid.agent = 0;
+    }
+    jid
+}
+
 fn validate_user_jid(jid: &Jid, index: usize) -> Result<(), UsyncValidationError> {
     let supported = !jid.user.is_empty()
         && matches!(
@@ -414,7 +433,7 @@ fn validate_user_jid(jid: &Jid, index: usize) -> Result<(), UsyncValidationError
                 | Server::Interop
                 | Server::Bot
         );
-    if supported {
+    if supported && jid.agent == 0 {
         Ok(())
     } else {
         Err(UsyncValidationError::InvalidUserJid {
@@ -1037,8 +1056,10 @@ fn parse_protocol_states(result: &NodeRef<'_>) -> Result<Vec<UsyncProtocolState>
 
 fn parse_user_result(user: &NodeRef<'_>) -> Result<Option<UsyncUserResult>, anyhow::Error> {
     let mut attrs = user.attrs();
-    let id = attrs.optional_jid(ATTR_JID).map(|jid| jid.to_non_ad());
-    let pn_jid = attrs.optional_jid(ATTR_PN_JID).map(|jid| jid.to_non_ad());
+    let id = attrs.optional_jid(ATTR_JID).map(normalize_usync_user_jid);
+    let pn_jid = attrs
+        .optional_jid(ATTR_PN_JID)
+        .map(normalize_usync_user_jid);
     attrs.finish()?;
 
     let capacity = user.children().map_or(0, <[_]>::len);
@@ -1572,6 +1593,18 @@ mod tests {
     }
 
     #[test]
+    fn digit_only_phone_inputs_are_normalized_to_e164() {
+        assert_eq!(
+            UsyncUser::from_phone("15550000001").phone.as_deref(),
+            Some("+15550000001")
+        );
+        assert_eq!(
+            UsyncUser::from_phone("+15550000001").phone.as_deref(),
+            Some("+15550000001")
+        );
+    }
+
+    #[test]
     fn query_validation_rejects_ambiguous_or_invalid_inputs() {
         let duplicate = UsyncQuery::new(
             UsyncMode::Query,
@@ -1620,6 +1653,27 @@ mod tests {
         assert_eq!(
             empty_hash,
             UsyncValidationError::EmptyDeviceHash { index: 0 }
+        );
+
+        let agent_qualified_bot = UsyncQuery::new(
+            UsyncMode::Query,
+            UsyncContext::Interactive,
+            vec![UsyncProtocol::Status],
+            vec![UsyncUser::from_jid(Jid {
+                user: "13135550001".into(),
+                server: Server::Bot,
+                agent: 2,
+                device: 7,
+                integrator: 0,
+            })],
+        )
+        .unwrap_err();
+        assert_eq!(
+            agent_qualified_bot,
+            UsyncValidationError::InvalidUserJid {
+                index: 0,
+                jid: "13135550001.2@bot".to_owned(),
+            }
         );
     }
 
@@ -1766,6 +1820,28 @@ mod tests {
             parsed.users[0].protocols[0],
             UsyncProtocolResult::Contact(UsyncOutcome::Value(_))
         ));
+    }
+
+    #[test]
+    fn parser_preserves_identity_bearing_agents_while_stripping_devices() {
+        let user = NodeBuilder::new(TAG_USER)
+            .attr(
+                ATTR_JID,
+                Jid {
+                    user: "13135550001".into(),
+                    server: Server::Bot,
+                    agent: 2,
+                    device: 7,
+                    integrator: 0,
+                },
+            )
+            .children([NodeBuilder::new(UsyncProtocolKind::Status.as_str()).build()])
+            .build();
+
+        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
+        let id = parsed.users[0].id.as_ref().unwrap();
+        assert_eq!(id.agent, 2);
+        assert_eq!(id.device, 0);
     }
 
     #[test]

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -1,0 +1,2029 @@
+//! Canonical typed model and wire codec for USync queries.
+//!
+//! This module deliberately models only protocols observed in WhatsApp Web.
+//! Arbitrary protocol nodes remain available through the low-level IQ API;
+//! keeping that escape hatch separate prevents custom wire data from weakening
+//! the invariants of the typed path.
+
+use super::{UsyncContext, UsyncMode, UsyncSubprotocolError};
+use crate::WireEnum;
+use crate::iq::spec::IqSpec;
+use crate::iq::tctoken::build_tc_token_node;
+use crate::request::InfoQuery;
+use crate::stanza::business::VerifiedName;
+use anyhow::{Context, anyhow};
+use thiserror::Error;
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::{CompactString, Jid, Node, NodeContent, NodeContentRef, NodeRef, Server};
+
+const USYNC_NAMESPACE: &str = "usync";
+const TAG_USYNC: &str = "usync";
+const TAG_QUERY: &str = "query";
+const TAG_RESULT: &str = "result";
+const TAG_LIST: &str = "list";
+const TAG_USER: &str = "user";
+const TAG_ERROR: &str = "error";
+const TAG_VERIFIED_NAME: &str = "verified_name";
+const TAG_DEVICE_LIST: &str = "device-list";
+const TAG_DEVICE: &str = "device";
+const TAG_KEY_INDEX_LIST: &str = "key-index-list";
+const TAG_PROFILE: &str = "profile";
+const TAG_NAME: &str = "name";
+const TAG_ATTRIBUTES: &str = "attributes";
+const TAG_DESCRIPTION: &str = "description";
+const TAG_CATEGORY: &str = "category";
+const TAG_DEFAULT: &str = "default";
+const TAG_PROMPTS: &str = "prompts";
+const TAG_PROMPT: &str = "prompt";
+const TAG_EMOJI: &str = "emoji";
+const TAG_TEXT: &str = "text";
+const TAG_COMMANDS: &str = "commands";
+const TAG_COMMAND: &str = "command";
+const TAG_IS_META_CREATED: &str = "is_meta_created";
+const TAG_CREATOR: &str = "creator";
+const TAG_PROFILE_URL: &str = "profile_url";
+const TAG_POSING_AS_PROFESSIONAL: &str = "posing_as_professional";
+
+const ATTR_SID: &str = "sid";
+const ATTR_MODE: &str = "mode";
+const ATTR_CONTEXT: &str = "context";
+const ATTR_INDEX: &str = "index";
+const ATTR_LAST: &str = "last";
+const ATTR_JID: &str = "jid";
+const ATTR_PN_JID: &str = "pn_jid";
+const ATTR_VERSION: &str = "version";
+const ATTR_BOT_VERSION: &str = "v";
+const ATTR_LID: &str = "lid";
+const ATTR_ADDRESSING_MODE: &str = "addressing_mode";
+const ATTR_DEVICE_HASH: &str = "device_hash";
+const ATTR_TIMESTAMP: &str = "ts";
+const ATTR_TIME: &str = "t";
+const ATTR_EXPECTED_TIMESTAMP: &str = "expected_ts";
+const ATTR_PERSONA_ID: &str = "persona_id";
+const ATTR_USERNAME: &str = "username";
+const ATTR_PIN: &str = "pin";
+const ATTR_TYPE: &str = "type";
+const ATTR_VAL: &str = "val";
+const ATTR_VALUE: &str = "value";
+const ATTR_CODE: &str = "code";
+const ATTR_TEXT: &str = "text";
+const ATTR_BACKOFF: &str = "backoff";
+const ATTR_REFRESH: &str = "refresh";
+const ATTR_ID: &str = "id";
+const ATTR_KEY_INDEX: &str = "key-index";
+const ATTR_IS_HOSTED: &str = "is_hosted";
+const ATTR_HASH: &str = "hash";
+const ATTR_DURATION: &str = "duration";
+const ATTR_EPHEMERALITY_DISABLED: &str = "ephemerality_disabled";
+const ATTR_CONTENT: &str = "content";
+const ATTR_EPHEMERAL_DURATION: &str = "ephemeral_duration_sec";
+const ATTR_LAST_UPDATE_TIME: &str = "last_update_time";
+
+const FIRST_PAGE_INDEX: &str = "0";
+const LAST_PAGE: &str = "true";
+const DEVICES_VERSION: &str = "2";
+const BOT_PROFILE_VERSION: &str = "1";
+
+/// Addressing mode used by the contact subprotocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, WireEnum)]
+#[non_exhaustive]
+pub enum UsyncAddressingMode {
+    #[wire_default]
+    #[wire = "pn"]
+    Pn,
+    #[wire = "lid"]
+    Lid,
+}
+
+/// Known USync protocol tags from the captured WhatsApp Web client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, WireEnum)]
+#[non_exhaustive]
+pub enum UsyncProtocolKind {
+    #[wire = "feature"]
+    Feature,
+    #[wire = "devices"]
+    Devices,
+    #[wire = "contact"]
+    Contact,
+    #[wire = "picture"]
+    Picture,
+    #[wire = "status"]
+    Status,
+    #[wire = "business"]
+    Business,
+    #[wire = "disappearing_mode"]
+    DisappearingMode,
+    #[wire = "lid"]
+    Lid,
+    #[wire = "bot"]
+    Bot,
+    #[wire = "username"]
+    Username,
+    #[wire = "text_status"]
+    TextStatus,
+}
+
+impl UsyncProtocolKind {
+    const fn bit(self) -> u16 {
+        match self {
+            Self::Feature => 1 << 0,
+            Self::Devices => 1 << 1,
+            Self::Contact => 1 << 2,
+            Self::Picture => 1 << 3,
+            Self::Status => 1 << 4,
+            Self::Business => 1 << 5,
+            Self::DisappearingMode => 1 << 6,
+            Self::Lid => 1 << 7,
+            Self::Bot => 1 << 8,
+            Self::Username => 1 << 9,
+            Self::TextStatus => 1 << 10,
+        }
+    }
+}
+
+/// Feature names accepted by the USync feature protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, WireEnum)]
+#[non_exhaustive]
+pub enum UsyncFeature {
+    #[wire = "document"]
+    Document,
+    #[wire = "encrypt"]
+    Encrypt,
+    #[wire = "encrypt_blist"]
+    EncryptBlocklist,
+    #[wire = "encrypt_contact"]
+    EncryptContact,
+    #[wire = "encrypt_group_gen2"]
+    EncryptGroupGen2,
+    #[wire = "encrypt_image"]
+    EncryptImage,
+    #[wire = "encrypt_location"]
+    EncryptLocation,
+    #[wire = "encrypt_url"]
+    EncryptUrl,
+    #[wire = "encrypt_v2"]
+    EncryptV2,
+    #[wire = "voip"]
+    Voip,
+    #[wire = "multi_agent"]
+    MultiAgent,
+}
+
+/// Per-user cache hints carried by the devices v2 subprotocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncDeviceSyncHint {
+    /// Cached device-list hash, if known.
+    pub device_hash: Option<CompactString>,
+    /// Timestamp associated with the cached hash.
+    pub timestamp: Option<i64>,
+    /// Expected timestamp used to detect stale key-index state.
+    pub expected_timestamp: Option<i64>,
+}
+
+impl UsyncDeviceSyncHint {
+    /// Construct an empty hint.
+    pub const fn new() -> Self {
+        Self {
+            device_hash: None,
+            timestamp: None,
+            expected_timestamp: None,
+        }
+    }
+
+    /// Attach a cached device-list hash.
+    pub fn with_device_hash(mut self, device_hash: impl Into<CompactString>) -> Self {
+        self.device_hash = Some(device_hash.into());
+        self
+    }
+
+    /// Attach the cached device-list timestamp.
+    pub const fn with_timestamp(mut self, timestamp: i64) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Attach the expected key-index timestamp.
+    pub const fn with_expected_timestamp(mut self, expected_timestamp: i64) -> Self {
+        self.expected_timestamp = Some(expected_timestamp);
+        self
+    }
+
+    /// Whether this hint contributes no wire attributes.
+    pub fn is_empty(&self) -> bool {
+        self.device_hash.is_none() && self.timestamp.is_none() && self.expected_timestamp.is_none()
+    }
+}
+
+impl Default for UsyncDeviceSyncHint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A validated USync user input.
+///
+/// Fields are private so callers cannot remove the identity established by a
+/// constructor. Protocol-specific additions are explicit builder methods.
+#[derive(Debug, Clone)]
+pub struct UsyncUser {
+    id: Option<Jid>,
+    pn_jid: Option<Jid>,
+    phone: Option<CompactString>,
+    known_lid: Option<Jid>,
+    device_sync: Option<UsyncDeviceSyncHint>,
+    persona_id: Option<CompactString>,
+    username: Option<CompactString>,
+    username_pin: Option<CompactString>,
+    contact_type: Option<CompactString>,
+    tc_token: Option<Vec<u8>>,
+}
+
+impl UsyncUser {
+    pub fn from_jid(jid: Jid) -> Self {
+        Self::empty().with_id(jid)
+    }
+
+    pub fn from_phone(phone: impl Into<CompactString>) -> Self {
+        Self::empty().with_phone(phone)
+    }
+
+    pub fn from_username(username: impl Into<CompactString>) -> Self {
+        Self::empty().with_username(username)
+    }
+
+    pub fn from_pn_jid(pn_jid: Jid) -> Self {
+        Self::empty().with_pn_jid(pn_jid)
+    }
+
+    fn empty() -> Self {
+        Self {
+            id: None,
+            pn_jid: None,
+            phone: None,
+            known_lid: None,
+            device_sync: None,
+            persona_id: None,
+            username: None,
+            username_pin: None,
+            contact_type: None,
+            tc_token: None,
+        }
+    }
+
+    pub fn with_id(mut self, jid: Jid) -> Self {
+        self.id = Some(jid);
+        self
+    }
+
+    pub fn with_pn_jid(mut self, jid: Jid) -> Self {
+        self.pn_jid = Some(jid);
+        self
+    }
+
+    pub fn with_phone(mut self, phone: impl Into<CompactString>) -> Self {
+        self.phone = Some(phone.into());
+        self
+    }
+
+    pub fn with_known_lid(mut self, lid: Jid) -> Self {
+        self.known_lid = Some(lid);
+        self
+    }
+
+    pub fn with_device_sync(mut self, hint: UsyncDeviceSyncHint) -> Self {
+        self.device_sync = Some(hint);
+        self
+    }
+
+    pub fn with_persona_id(mut self, persona_id: impl Into<CompactString>) -> Self {
+        self.persona_id = Some(persona_id.into());
+        self
+    }
+
+    pub fn with_username(mut self, username: impl Into<CompactString>) -> Self {
+        self.username = Some(username.into());
+        self
+    }
+
+    pub fn with_username_pin(mut self, pin: impl Into<CompactString>) -> Self {
+        self.username_pin = Some(pin.into());
+        self
+    }
+
+    pub fn with_contact_type(mut self, contact_type: impl Into<CompactString>) -> Self {
+        self.contact_type = Some(contact_type.into());
+        self
+    }
+
+    pub fn with_tc_token(mut self, token: impl Into<Vec<u8>>) -> Self {
+        self.tc_token = Some(token.into());
+        self
+    }
+
+    fn has_identity(&self) -> bool {
+        self.id.is_some()
+            || self.pn_jid.is_some()
+            || self.phone.is_some()
+            || self.username.is_some()
+    }
+
+    fn validate(
+        &self,
+        index: usize,
+        protocols: &[UsyncProtocol],
+    ) -> Result<(), UsyncValidationError> {
+        if !self.has_identity() {
+            return Err(UsyncValidationError::MissingUserIdentity { index });
+        }
+        if let Some(jid) = &self.id {
+            validate_user_jid(jid, index)?;
+        }
+        if let Some(pn_jid) = &self.pn_jid {
+            validate_user_jid(pn_jid, index)?;
+            if !matches!(pn_jid.server, Server::Pn | Server::Hosted) {
+                return Err(UsyncValidationError::InvalidPnJid { index });
+            }
+        }
+        if self.phone.as_ref().is_some_and(CompactString::is_empty) {
+            return Err(UsyncValidationError::EmptyPhone { index });
+        }
+        if self.username.as_ref().is_some_and(CompactString::is_empty) {
+            return Err(UsyncValidationError::EmptyUsername { index });
+        }
+        if self.username_pin.is_some() && self.username.is_none() {
+            return Err(UsyncValidationError::UsernamePinWithoutUsername { index });
+        }
+        if let Some(lid) = &self.known_lid
+            && (lid.user.is_empty() || !matches!(lid.server, Server::Lid | Server::HostedLid))
+        {
+            return Err(UsyncValidationError::InvalidKnownLid { index });
+        }
+        if self
+            .device_sync
+            .as_ref()
+            .and_then(|hint| hint.device_hash.as_ref())
+            .is_some_and(CompactString::is_empty)
+        {
+            return Err(UsyncValidationError::EmptyDeviceHash { index });
+        }
+
+        let has_protocol = |kind| protocols.iter().any(|protocol| protocol.kind() == kind);
+        let contact_inputs = usize::from(self.phone.is_some())
+            + usize::from(self.username.is_some())
+            + usize::from(self.contact_type.is_some());
+        if contact_inputs > 1 {
+            return Err(UsyncValidationError::ConflictingContactInputs { index });
+        }
+        if contact_inputs != 0 && !has_protocol(UsyncProtocolKind::Contact) {
+            return Err(UsyncValidationError::ContactInputWithoutProtocol { index });
+        }
+        if self
+            .device_sync
+            .as_ref()
+            .is_some_and(|hint| !hint.is_empty())
+            && !has_protocol(UsyncProtocolKind::Devices)
+        {
+            return Err(UsyncValidationError::DeviceSyncWithoutProtocol { index });
+        }
+        if self.tc_token.is_some() && !has_protocol(UsyncProtocolKind::Status) {
+            return Err(UsyncValidationError::TcTokenWithoutProtocol { index });
+        }
+        if self.persona_id.is_some() && !has_protocol(UsyncProtocolKind::Bot) {
+            return Err(UsyncValidationError::PersonaIdWithoutProtocol { index });
+        }
+        let known_lid_is_used = has_protocol(UsyncProtocolKind::Lid)
+            || (has_protocol(UsyncProtocolKind::Contact) && self.username.is_some());
+        if self.known_lid.is_some() && !known_lid_is_used {
+            return Err(UsyncValidationError::KnownLidWithoutProtocol { index });
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_user_jid(jid: &Jid, index: usize) -> Result<(), UsyncValidationError> {
+    let supported = !jid.user.is_empty()
+        && matches!(
+            jid.server,
+            Server::Pn
+                | Server::Lid
+                | Server::Hosted
+                | Server::HostedLid
+                | Server::Messenger
+                | Server::Interop
+                | Server::Bot
+        );
+    if supported {
+        Ok(())
+    } else {
+        Err(UsyncValidationError::InvalidUserJid {
+            index,
+            jid: jid.to_string(),
+        })
+    }
+}
+
+/// A known, typed USync subprotocol request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UsyncProtocol {
+    Contact {
+        addressing_mode: UsyncAddressingMode,
+    },
+    DevicesV2,
+    Status,
+    TextStatus,
+    DisappearingMode,
+    BusinessVerifiedName,
+    Picture,
+    Lid,
+    Username,
+    BotProfileV1,
+    Features(Vec<UsyncFeature>),
+}
+
+impl UsyncProtocol {
+    pub const fn kind(&self) -> UsyncProtocolKind {
+        match self {
+            Self::Contact { .. } => UsyncProtocolKind::Contact,
+            Self::DevicesV2 => UsyncProtocolKind::Devices,
+            Self::Status => UsyncProtocolKind::Status,
+            Self::TextStatus => UsyncProtocolKind::TextStatus,
+            Self::DisappearingMode => UsyncProtocolKind::DisappearingMode,
+            Self::BusinessVerifiedName => UsyncProtocolKind::Business,
+            Self::Picture => UsyncProtocolKind::Picture,
+            Self::Lid => UsyncProtocolKind::Lid,
+            Self::Username => UsyncProtocolKind::Username,
+            Self::BotProfileV1 => UsyncProtocolKind::Bot,
+            Self::Features(_) => UsyncProtocolKind::Feature,
+        }
+    }
+
+    fn validate(&self) -> Result<(), UsyncValidationError> {
+        if matches!(self, Self::Features(features) if features.is_empty()) {
+            return Err(UsyncValidationError::EmptyFeatureSet);
+        }
+        Ok(())
+    }
+
+    fn build_query_node(&self) -> Node {
+        let kind = self.kind();
+        match self {
+            Self::Contact { addressing_mode } => {
+                let builder = NodeBuilder::new(kind.as_str());
+                if *addressing_mode == UsyncAddressingMode::Lid {
+                    builder
+                        .attr(ATTR_ADDRESSING_MODE, addressing_mode.as_str())
+                        .build()
+                } else {
+                    builder.build()
+                }
+            }
+            Self::DevicesV2 => NodeBuilder::new(kind.as_str())
+                .attr(ATTR_VERSION, DEVICES_VERSION)
+                .build(),
+            Self::BusinessVerifiedName => NodeBuilder::new(kind.as_str())
+                .children([NodeBuilder::new(TAG_VERIFIED_NAME).build()])
+                .build(),
+            Self::BotProfileV1 => NodeBuilder::new(kind.as_str())
+                .children([NodeBuilder::new(TAG_PROFILE)
+                    .attr(ATTR_BOT_VERSION, BOT_PROFILE_VERSION)
+                    .build()])
+                .build(),
+            Self::Features(features) => NodeBuilder::new(kind.as_str())
+                .children(
+                    features
+                        .iter()
+                        .map(|feature| NodeBuilder::new(feature.as_str()).build()),
+                )
+                .build(),
+            _ => NodeBuilder::new(kind.as_str()).build(),
+        }
+    }
+
+    fn build_user_node(&self, user: &UsyncUser) -> Option<Node> {
+        match self {
+            Self::Contact { .. } => {
+                if let Some(phone) = &user.phone {
+                    return Some(
+                        NodeBuilder::new(UsyncProtocolKind::Contact.as_str())
+                            .string_content(phone.clone())
+                            .build(),
+                    );
+                }
+                if let Some(username) = &user.username {
+                    let mut builder = NodeBuilder::new(UsyncProtocolKind::Contact.as_str())
+                        .attr(ATTR_USERNAME, username.clone());
+                    if let Some(pin) = &user.username_pin {
+                        builder = builder.attr(ATTR_PIN, pin.clone());
+                    }
+                    if let Some(lid) = &user.known_lid {
+                        builder = builder.attr(ATTR_LID, lid.clone());
+                    }
+                    return Some(builder.build());
+                }
+                user.contact_type.as_ref().map(|contact_type| {
+                    NodeBuilder::new(UsyncProtocolKind::Contact.as_str())
+                        .attr(ATTR_TYPE, contact_type.clone())
+                        .build()
+                })
+            }
+            Self::DevicesV2 => user.device_sync.as_ref().and_then(|hint| {
+                if hint.is_empty() {
+                    return None;
+                }
+                let mut builder = NodeBuilder::new(UsyncProtocolKind::Devices.as_str());
+                if let Some(hash) = &hint.device_hash {
+                    builder = builder.attr(ATTR_DEVICE_HASH, hash.clone());
+                }
+                if let Some(timestamp) = hint.timestamp {
+                    builder = builder.attr(ATTR_TIMESTAMP, timestamp.to_string());
+                }
+                if let Some(expected) = hint.expected_timestamp {
+                    builder = builder.attr(ATTR_EXPECTED_TIMESTAMP, expected.to_string());
+                }
+                Some(builder.build())
+            }),
+            Self::Status => user
+                .tc_token
+                .as_ref()
+                .map(|token| build_tc_token_node(token)),
+            Self::Lid => user.known_lid.as_ref().map(|lid| {
+                NodeBuilder::new(UsyncProtocolKind::Lid.as_str())
+                    .attr(ATTR_JID, lid.clone())
+                    .build()
+            }),
+            Self::BotProfileV1 => {
+                let mut profile = NodeBuilder::new(TAG_PROFILE);
+                if let Some(persona_id) = &user.persona_id {
+                    profile = profile.attr(ATTR_PERSONA_ID, persona_id.clone());
+                }
+                Some(
+                    NodeBuilder::new(UsyncProtocolKind::Bot.as_str())
+                        .children([profile.build()])
+                        .build(),
+                )
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Validation failure at the boundary of the typed USync API.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum UsyncValidationError {
+    #[error("a USync query must contain at least one protocol")]
+    EmptyProtocols,
+    #[error("a USync query must contain at least one user")]
+    EmptyUsers,
+    #[error("duplicate USync protocol: {0}")]
+    DuplicateProtocol(UsyncProtocolKind),
+    #[error("the USync feature protocol requires at least one feature")]
+    EmptyFeatureSet,
+    #[error("USync user at index {index} has no identity")]
+    MissingUserIdentity { index: usize },
+    #[error("USync user at index {index} has an invalid JID: {jid}")]
+    InvalidUserJid { index: usize, jid: String },
+    #[error("USync user at index {index} has a non-PN pn_jid value")]
+    InvalidPnJid { index: usize },
+    #[error("USync user at index {index} has an empty phone number")]
+    EmptyPhone { index: usize },
+    #[error("USync user at index {index} has an empty username")]
+    EmptyUsername { index: usize },
+    #[error("USync user at index {index} has a username pin without a username")]
+    UsernamePinWithoutUsername { index: usize },
+    #[error("USync user at index {index} has a non-LID known_lid value")]
+    InvalidKnownLid { index: usize },
+    #[error("USync user at index {index} has an empty device hash")]
+    EmptyDeviceHash { index: usize },
+    #[error("USync user at index {index} has conflicting contact inputs")]
+    ConflictingContactInputs { index: usize },
+    #[error("USync user at index {index} has contact input without the contact protocol")]
+    ContactInputWithoutProtocol { index: usize },
+    #[error("USync user at index {index} has device sync input without the devices protocol")]
+    DeviceSyncWithoutProtocol { index: usize },
+    #[error("USync user at index {index} has a trusted-contact token without the status protocol")]
+    TcTokenWithoutProtocol { index: usize },
+    #[error("USync user at index {index} has a persona ID without the bot protocol")]
+    PersonaIdWithoutProtocol { index: usize },
+    #[error("USync user at index {index} has a known LID unused by the selected protocols")]
+    KnownLidWithoutProtocol { index: usize },
+    #[error("USync sid must not be empty")]
+    EmptySid,
+}
+
+/// A complete typed USync query, validated before it reaches the network.
+#[derive(Debug, Clone)]
+pub struct UsyncQuery {
+    mode: UsyncMode,
+    context: UsyncContext,
+    protocols: Vec<UsyncProtocol>,
+    users: Vec<UsyncUser>,
+}
+
+impl UsyncQuery {
+    pub fn new(
+        mode: UsyncMode,
+        context: UsyncContext,
+        protocols: Vec<UsyncProtocol>,
+        users: Vec<UsyncUser>,
+    ) -> Result<Self, UsyncValidationError> {
+        if protocols.is_empty() {
+            return Err(UsyncValidationError::EmptyProtocols);
+        }
+        if users.is_empty() {
+            return Err(UsyncValidationError::EmptyUsers);
+        }
+
+        let mut seen = 0_u16;
+        for protocol in &protocols {
+            protocol.validate()?;
+            let kind = protocol.kind();
+            let bit = kind.bit();
+            if seen & bit != 0 {
+                return Err(UsyncValidationError::DuplicateProtocol(kind));
+            }
+            seen |= bit;
+        }
+        for (index, user) in users.iter().enumerate() {
+            user.validate(index, &protocols)?;
+        }
+
+        Ok(Self {
+            mode,
+            context,
+            protocols,
+            users,
+        })
+    }
+
+    pub fn mode(&self) -> UsyncMode {
+        self.mode
+    }
+
+    pub fn context(&self) -> UsyncContext {
+        self.context
+    }
+
+    pub fn protocols(&self) -> &[UsyncProtocol] {
+        &self.protocols
+    }
+
+    pub fn users(&self) -> &[UsyncUser] {
+        &self.users
+    }
+
+    pub(super) fn from_parts_unchecked(
+        mode: UsyncMode,
+        context: UsyncContext,
+        protocols: Vec<UsyncProtocol>,
+        users: Vec<UsyncUser>,
+    ) -> Self {
+        Self {
+            mode,
+            context,
+            protocols,
+            users,
+        }
+    }
+
+    pub(crate) fn build_node(&self, sid: &str) -> Node {
+        let query = NodeBuilder::new(TAG_QUERY)
+            .children(self.protocols.iter().map(UsyncProtocol::build_query_node))
+            .build();
+
+        let users = self.users.iter().map(|user| {
+            let mut builder = NodeBuilder::new(TAG_USER);
+            if let Some(jid) = &user.id {
+                builder = builder.attr(ATTR_JID, jid.clone());
+            }
+            if let Some(pn_jid) = &user.pn_jid {
+                builder = builder.attr(ATTR_PN_JID, pn_jid.clone());
+            }
+            builder
+                .children(
+                    self.protocols
+                        .iter()
+                        .filter_map(|protocol| protocol.build_user_node(user)),
+                )
+                .build()
+        });
+
+        let list = NodeBuilder::new(TAG_LIST).children(users).build();
+        NodeBuilder::new(TAG_USYNC)
+            .attr(ATTR_SID, sid)
+            .attr(ATTR_MODE, self.mode.as_str())
+            .attr(ATTR_CONTEXT, self.context.as_str())
+            .attr(ATTR_INDEX, FIRST_PAGE_INDEX)
+            .attr(ATTR_LAST, LAST_PAGE)
+            .children([query, list])
+            .build()
+    }
+
+    pub(super) fn build_info_query(&self, sid: &str) -> InfoQuery<'static> {
+        InfoQuery::get(
+            USYNC_NAMESPACE,
+            Jid::new("", Server::Pn),
+            Some(NodeContent::Nodes(vec![self.build_node(sid)])),
+        )
+    }
+}
+
+/// Low-level IQ spec used by the runtime-aware client wrapper.
+#[derive(Debug, Clone)]
+pub struct UsyncQuerySpec {
+    query: UsyncQuery,
+    sid: String,
+}
+
+impl UsyncQuerySpec {
+    pub fn new(query: UsyncQuery, sid: impl Into<String>) -> Result<Self, UsyncValidationError> {
+        let sid = sid.into();
+        if sid.is_empty() {
+            return Err(UsyncValidationError::EmptySid);
+        }
+        Ok(Self { query, sid })
+    }
+}
+
+impl IqSpec for UsyncQuerySpec {
+    type Response = UsyncResponse;
+
+    fn build_iq(&self) -> InfoQuery<'static> {
+        self.query.build_info_query(&self.sid)
+    }
+
+    fn parse_response(&self, response: &NodeRef<'_>) -> Result<Self::Response, anyhow::Error> {
+        parse_usync_response(response)
+    }
+}
+
+/// Result-level state for a single protocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncProtocolState {
+    pub protocol: UsyncProtocolKind,
+    pub refresh_seconds: Option<u32>,
+    pub error: Option<UsyncSubprotocolError>,
+}
+
+/// Full neutral response from a typed USync query.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct UsyncResponse {
+    pub protocol_states: Vec<UsyncProtocolState>,
+    pub users: Vec<UsyncUserResult>,
+}
+
+impl UsyncResponse {
+    pub fn protocol_state(&self, protocol: UsyncProtocolKind) -> Option<&UsyncProtocolState> {
+        self.protocol_states
+            .iter()
+            .find(|state| state.protocol == protocol)
+    }
+}
+
+/// Per-user response. `id` is optional because contact-only results without a
+/// JID are accepted by WhatsApp Web.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct UsyncUserResult {
+    pub id: Option<Jid>,
+    pub pn_jid: Option<Jid>,
+    pub protocols: Vec<UsyncProtocolResult>,
+}
+
+impl UsyncUserResult {
+    pub fn protocol(&self, kind: UsyncProtocolKind) -> Option<&UsyncProtocolResult> {
+        self.protocols.iter().find(|result| result.kind() == kind)
+    }
+}
+
+/// A protocol value or its per-user error. Errors are boxed because they are
+/// rare and contain owned strings; this keeps every successful result variant
+/// from inheriting their size.
+#[derive(Debug, Clone)]
+pub enum UsyncOutcome<T> {
+    Value(T),
+    Error(Box<UsyncSubprotocolError>),
+}
+
+impl<T> UsyncOutcome<T> {
+    pub fn value(&self) -> Option<&T> {
+        match self {
+            Self::Value(value) => Some(value),
+            Self::Error(_) => None,
+        }
+    }
+
+    pub fn error(&self) -> Option<&UsyncSubprotocolError> {
+        match self {
+            Self::Value(_) => None,
+            Self::Error(error) => Some(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncContactResult {
+    pub contact_type: CompactString,
+    pub username: Option<CompactString>,
+    pub content: Option<CompactString>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncDeviceResult {
+    pub id: u16,
+    pub key_index: Option<u32>,
+    pub is_hosted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncDeviceListResult {
+    pub hash: Option<CompactString>,
+    pub devices: Vec<UsyncDeviceResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncKeyIndexResult {
+    pub timestamp: i64,
+    pub signed_key_index_bytes: Option<Vec<u8>>,
+    pub expected_timestamp: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncDevicesResult {
+    pub device_list: Option<UsyncDeviceListResult>,
+    pub key_index: Option<UsyncKeyIndexResult>,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct UsyncBusinessResult {
+    pub verified_name: Option<VerifiedName>,
+}
+
+/// About/status payload. WhatsApp Web consumes only `status`, while the
+/// optional wire timestamp is retained for callers that need a lossless
+/// projection of responses carrying `t`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncStatusResult {
+    pub status: Option<CompactString>,
+    pub timestamp: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncDisappearingModeResult {
+    pub duration_seconds: u32,
+    pub setting_timestamp: i64,
+    pub ephemerality_disabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncTextStatusResult {
+    pub text: Option<CompactString>,
+    pub emoji: Option<CompactString>,
+    pub ephemeral_duration_seconds: Option<u32>,
+    pub last_update_time: Option<CompactString>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncFeatureResult {
+    pub feature: UsyncFeature,
+    pub value: CompactString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncBotPrompt {
+    pub emoji: CompactString,
+    pub text: CompactString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncBotCommand {
+    pub name: CompactString,
+    pub description: CompactString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UsyncBotProfessionalType {
+    Unknown,
+    Yes,
+    No,
+    Other(CompactString),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UsyncBotProfileResult {
+    pub name: CompactString,
+    pub attributes: CompactString,
+    pub description: CompactString,
+    pub category: CompactString,
+    pub is_default: bool,
+    pub prompts: Vec<UsyncBotPrompt>,
+    pub persona_id: CompactString,
+    pub commands: Vec<UsyncBotCommand>,
+    pub commands_description: CompactString,
+    pub is_meta_created: Option<bool>,
+    pub creator_name: Option<CompactString>,
+    pub creator_profile_url: Option<CompactString>,
+    pub posing_as_professional: Option<UsyncBotProfessionalType>,
+}
+
+/// Sparse per-user result. Large, uncommon payloads are boxed so their layout
+/// does not inflate every status/contact/device item in large sync responses.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum UsyncProtocolResult {
+    Contact(UsyncOutcome<UsyncContactResult>),
+    Devices(UsyncOutcome<UsyncDevicesResult>),
+    Status(UsyncOutcome<UsyncStatusResult>),
+    TextStatus(UsyncOutcome<UsyncTextStatusResult>),
+    DisappearingMode(UsyncOutcome<UsyncDisappearingModeResult>),
+    Business(UsyncOutcome<Box<UsyncBusinessResult>>),
+    Picture(UsyncOutcome<u64>),
+    Lid(UsyncOutcome<Option<Jid>>),
+    Username(UsyncOutcome<Option<CompactString>>),
+    Bot(UsyncOutcome<Box<UsyncBotProfileResult>>),
+    Features(UsyncOutcome<Vec<UsyncFeatureResult>>),
+}
+
+impl UsyncProtocolResult {
+    pub const fn kind(&self) -> UsyncProtocolKind {
+        match self {
+            Self::Contact(_) => UsyncProtocolKind::Contact,
+            Self::Devices(_) => UsyncProtocolKind::Devices,
+            Self::Status(_) => UsyncProtocolKind::Status,
+            Self::TextStatus(_) => UsyncProtocolKind::TextStatus,
+            Self::DisappearingMode(_) => UsyncProtocolKind::DisappearingMode,
+            Self::Business(_) => UsyncProtocolKind::Business,
+            Self::Picture(_) => UsyncProtocolKind::Picture,
+            Self::Lid(_) => UsyncProtocolKind::Lid,
+            Self::Username(_) => UsyncProtocolKind::Username,
+            Self::Bot(_) => UsyncProtocolKind::Bot,
+            Self::Features(_) => UsyncProtocolKind::Feature,
+        }
+    }
+}
+
+pub(crate) fn parse_usync_response(response: &NodeRef<'_>) -> Result<UsyncResponse, anyhow::Error> {
+    let usync = response
+        .get_optional_child(TAG_USYNC)
+        .ok_or_else(|| anyhow!("USync response is missing <{TAG_USYNC}>"))?;
+
+    let protocol_states = match usync.get_optional_child(TAG_RESULT) {
+        Some(result) => parse_protocol_states(result)?,
+        None => Vec::new(),
+    };
+
+    let list = usync
+        .get_optional_child(TAG_LIST)
+        .ok_or_else(|| anyhow!("USync response is missing <{TAG_LIST}>"))?;
+    let capacity = list.children().map_or(0, <[_]>::len);
+    let mut users = Vec::with_capacity(capacity);
+    for user in list.get_children_by_tag(TAG_USER) {
+        if let Some(parsed) = parse_user_result(user)? {
+            users.push(parsed);
+        }
+    }
+
+    Ok(UsyncResponse {
+        protocol_states,
+        users,
+    })
+}
+
+fn parse_protocol_states(result: &NodeRef<'_>) -> Result<Vec<UsyncProtocolState>, anyhow::Error> {
+    let capacity = result.children().map_or(0, <[_]>::len);
+    let mut states = Vec::with_capacity(capacity);
+    for node in result.children().into_iter().flatten() {
+        let Ok(protocol) = UsyncProtocolKind::try_from(node.tag.as_ref()) else {
+            continue;
+        };
+        let error = parse_subprotocol_error(node)?;
+        let mut attrs = node.attrs();
+        let refresh_seconds = attrs
+            .optional_u64(ATTR_REFRESH)
+            .map(|value| checked_u32(value, ATTR_REFRESH))
+            .transpose()?;
+        attrs.finish()?;
+        states.push(UsyncProtocolState {
+            protocol,
+            refresh_seconds,
+            error,
+        });
+    }
+    Ok(states)
+}
+
+fn parse_user_result(user: &NodeRef<'_>) -> Result<Option<UsyncUserResult>, anyhow::Error> {
+    let mut attrs = user.attrs();
+    let id = attrs.optional_jid(ATTR_JID).map(|jid| jid.to_non_ad());
+    let pn_jid = attrs.optional_jid(ATTR_PN_JID).map(|jid| jid.to_non_ad());
+    attrs.finish()?;
+
+    let capacity = user.children().map_or(0, <[_]>::len);
+    let mut protocols = Vec::with_capacity(capacity);
+    let mut has_contact = false;
+    for node in user.children().into_iter().flatten() {
+        let Ok(kind) = UsyncProtocolKind::try_from(node.tag.as_ref()) else {
+            continue;
+        };
+        has_contact |= kind == UsyncProtocolKind::Contact;
+        protocols.push(parse_protocol_result(kind, node)?);
+    }
+
+    // Matches WA Web's parser: an id-less entry is retained only when the
+    // contact protocol returned a node.
+    if id.is_none() && !has_contact {
+        return Ok(None);
+    }
+
+    Ok(Some(UsyncUserResult {
+        id,
+        pn_jid,
+        protocols,
+    }))
+}
+
+fn parse_protocol_result(
+    kind: UsyncProtocolKind,
+    node: &NodeRef<'_>,
+) -> Result<UsyncProtocolResult, anyhow::Error> {
+    macro_rules! outcome {
+        ($parser:expr) => {
+            match parse_subprotocol_error(node)? {
+                Some(error) => UsyncOutcome::Error(Box::new(error)),
+                None => UsyncOutcome::Value($parser?),
+            }
+        };
+    }
+
+    Ok(match kind {
+        UsyncProtocolKind::Contact => UsyncProtocolResult::Contact(outcome!(parse_contact(node))),
+        UsyncProtocolKind::Devices => UsyncProtocolResult::Devices(outcome!(parse_devices(node))),
+        UsyncProtocolKind::Status => UsyncProtocolResult::Status(outcome!(parse_status(node))),
+        UsyncProtocolKind::TextStatus => {
+            UsyncProtocolResult::TextStatus(outcome!(parse_text_status(node)))
+        }
+        UsyncProtocolKind::DisappearingMode => {
+            UsyncProtocolResult::DisappearingMode(outcome!(parse_disappearing_mode(node)))
+        }
+        UsyncProtocolKind::Business => {
+            UsyncProtocolResult::Business(outcome!(parse_business(node).map(Box::new)))
+        }
+        UsyncProtocolKind::Picture => {
+            UsyncProtocolResult::Picture(outcome!(required_u64(node, ATTR_ID)))
+        }
+        UsyncProtocolKind::Lid => UsyncProtocolResult::Lid(outcome!(optional_lid(node, ATTR_VAL))),
+        UsyncProtocolKind::Username => {
+            UsyncProtocolResult::Username(outcome!(Ok::<_, anyhow::Error>(
+                node.content_as_string()
+            )))
+        }
+        UsyncProtocolKind::Bot => {
+            UsyncProtocolResult::Bot(outcome!(parse_bot_profile(node).map(Box::new)))
+        }
+        UsyncProtocolKind::Feature => UsyncProtocolResult::Features(outcome!(parse_features(node))),
+    })
+}
+
+fn parse_subprotocol_error(
+    protocol: &NodeRef<'_>,
+) -> Result<Option<UsyncSubprotocolError>, anyhow::Error> {
+    let Some(error) = protocol.get_optional_child(TAG_ERROR) else {
+        return Ok(None);
+    };
+    let mut attrs = error.attrs();
+    let code = attrs
+        .optional_u64(ATTR_CODE)
+        .map(|value| checked_u16(value, ATTR_CODE))
+        .transpose()?;
+    let text = attrs
+        .optional_string(ATTR_TEXT)
+        .map(|value| value.into_owned());
+    let backoff = attrs
+        .optional_u64(ATTR_BACKOFF)
+        .map(|value| checked_u32(value, ATTR_BACKOFF))
+        .transpose()?;
+    attrs.finish()?;
+    Ok(Some(UsyncSubprotocolError {
+        code,
+        text,
+        backoff,
+    }))
+}
+
+fn parse_contact(node: &NodeRef<'_>) -> Result<UsyncContactResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let contact_type = CompactString::from(attrs.required_string(ATTR_TYPE)?.as_ref());
+    let username = attrs
+        .optional_string(ATTR_USERNAME)
+        .map(|value| CompactString::from(value.as_ref()));
+    attrs.finish()?;
+    Ok(UsyncContactResult {
+        contact_type,
+        username,
+        content: node.content_as_string(),
+    })
+}
+
+fn parse_devices(node: &NodeRef<'_>) -> Result<UsyncDevicesResult, anyhow::Error> {
+    let device_list = node
+        .get_optional_child(TAG_DEVICE_LIST)
+        .map(parse_device_list)
+        .transpose()?;
+    let key_index = node
+        .get_optional_child(TAG_KEY_INDEX_LIST)
+        .map(parse_key_index)
+        .transpose()?;
+    Ok(UsyncDevicesResult {
+        device_list,
+        key_index,
+    })
+}
+
+fn parse_device_list(node: &NodeRef<'_>) -> Result<UsyncDeviceListResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let hash = attrs
+        .optional_string(ATTR_HASH)
+        .map(|value| CompactString::from(value.as_ref()));
+    attrs.finish()?;
+
+    let capacity = node.children().map_or(0, <[_]>::len);
+    let mut devices = Vec::with_capacity(capacity);
+    for device in node.get_children_by_tag(TAG_DEVICE) {
+        let mut attrs = device.attrs();
+        let raw_id = attrs
+            .optional_u64(ATTR_ID)
+            .ok_or_else(|| anyhow!("USync device is missing '{ATTR_ID}'"))?;
+        let id = checked_u16(raw_id, ATTR_ID)?;
+        let key_index = attrs
+            .optional_u64(ATTR_KEY_INDEX)
+            .map(|value| checked_u32(value, ATTR_KEY_INDEX))
+            .transpose()?;
+        let is_hosted = attrs.optional_bool_value(ATTR_IS_HOSTED).unwrap_or(false);
+        attrs.finish()?;
+        devices.push(UsyncDeviceResult {
+            id,
+            key_index,
+            is_hosted,
+        });
+    }
+    Ok(UsyncDeviceListResult { hash, devices })
+}
+
+fn parse_key_index(node: &NodeRef<'_>) -> Result<UsyncKeyIndexResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let timestamp = attrs
+        .optional_unix_time(ATTR_TIMESTAMP)
+        .ok_or_else(|| anyhow!("USync key-index-list is missing '{ATTR_TIMESTAMP}'"))?;
+    let expected_timestamp = attrs.optional_unix_time(ATTR_EXPECTED_TIMESTAMP);
+    attrs.finish()?;
+
+    let signed_key_index_bytes = match node.content.as_deref() {
+        Some(NodeContentRef::Bytes(bytes)) => Some(bytes.to_vec()),
+        None => None,
+        Some(_) => {
+            return Err(anyhow!(
+                "USync key-index-list contains non-binary signed key bytes"
+            ));
+        }
+    };
+    Ok(UsyncKeyIndexResult {
+        timestamp,
+        signed_key_index_bytes,
+        expected_timestamp,
+    })
+}
+
+fn parse_status(node: &NodeRef<'_>) -> Result<UsyncStatusResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let code = attrs.optional_u64(ATTR_CODE);
+    let timestamp = attrs.optional_unix_time(ATTR_TIME);
+    attrs.finish()?;
+    let status = match node.content_as_string() {
+        Some(content) if !content.is_empty() => Some(content),
+        Some(_) => None,
+        None if code == Some(401) => Some(CompactString::from("")),
+        None => None,
+    };
+    Ok(UsyncStatusResult { status, timestamp })
+}
+
+fn parse_text_status(node: &NodeRef<'_>) -> Result<UsyncTextStatusResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let text = attrs
+        .optional_string(ATTR_TEXT)
+        .map(|value| CompactString::from(value.as_ref()));
+    let ephemeral_duration_seconds = attrs
+        .optional_u64(ATTR_EPHEMERAL_DURATION)
+        .map(|value| checked_u32(value, ATTR_EPHEMERAL_DURATION))
+        .transpose()?;
+    let last_update_time = attrs
+        .optional_string(ATTR_LAST_UPDATE_TIME)
+        .map(|value| CompactString::from(value.as_ref()));
+    attrs.finish()?;
+
+    let emoji = match node.get_optional_child(TAG_EMOJI) {
+        Some(emoji) => optional_compact_string(emoji, ATTR_CONTENT)?,
+        None => None,
+    };
+    Ok(UsyncTextStatusResult {
+        text,
+        emoji,
+        ephemeral_duration_seconds,
+        last_update_time,
+    })
+}
+
+fn parse_disappearing_mode(
+    node: &NodeRef<'_>,
+) -> Result<UsyncDisappearingModeResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let duration_seconds = attrs
+        .optional_u64(ATTR_DURATION)
+        .map(|value| checked_u32(value, ATTR_DURATION))
+        .transpose()?
+        .unwrap_or_default();
+    let setting_timestamp = attrs
+        .optional_unix_time(ATTR_TIME)
+        .ok_or_else(|| anyhow!("USync disappearing mode is missing '{ATTR_TIME}'"))?;
+    let ephemerality_disabled = attrs
+        .optional_bool_value(ATTR_EPHEMERALITY_DISABLED)
+        .unwrap_or(false);
+    attrs.finish()?;
+    Ok(UsyncDisappearingModeResult {
+        duration_seconds,
+        setting_timestamp,
+        ephemerality_disabled,
+    })
+}
+
+fn parse_business(node: &NodeRef<'_>) -> Result<UsyncBusinessResult, anyhow::Error> {
+    let verified_name = match node.get_optional_child(TAG_VERIFIED_NAME) {
+        Some(verified_name) if verified_name.get_optional_child(TAG_ERROR).is_none() => {
+            let parsed = VerifiedName::try_from_node(verified_name)?;
+            (parsed.name.is_some()
+                || parsed.serial.is_some()
+                || parsed.issuer.is_some()
+                || parsed.certificate.is_some())
+            .then_some(parsed)
+        }
+        _ => None,
+    };
+    Ok(UsyncBusinessResult { verified_name })
+}
+
+fn parse_features(node: &NodeRef<'_>) -> Result<Vec<UsyncFeatureResult>, anyhow::Error> {
+    let capacity = node.children().map_or(0, <[_]>::len);
+    let mut features = Vec::with_capacity(capacity);
+    for child in node.children().into_iter().flatten() {
+        let Ok(feature) = UsyncFeature::try_from(child.tag.as_ref()) else {
+            continue;
+        };
+        let value = required_compact_string(child, ATTR_VALUE)?;
+        features.push(UsyncFeatureResult { feature, value });
+    }
+    Ok(features)
+}
+
+fn parse_bot_profile(node: &NodeRef<'_>) -> Result<UsyncBotProfileResult, anyhow::Error> {
+    let profile = required_child(node, TAG_PROFILE)?;
+    let name = required_child_text(profile, TAG_NAME)?;
+    let attributes = required_child_text(profile, TAG_ATTRIBUTES)?;
+    let description = required_child_text(profile, TAG_DESCRIPTION)?;
+    let category = required_child_text(profile, TAG_CATEGORY)?;
+    let is_default = profile
+        .get_optional_child(TAG_DEFAULT)
+        .and_then(NodeRef::content_as_string)
+        .is_some_and(|value| value == "true");
+    let persona_id = optional_compact_string(profile, ATTR_PERSONA_ID)?.unwrap_or_default();
+    let prompts = parse_bot_prompts(profile.get_optional_child(TAG_PROMPTS))?;
+    let (commands, commands_description) =
+        parse_bot_commands(profile.get_optional_child(TAG_COMMANDS))?;
+    let is_meta_created = profile
+        .get_optional_child(TAG_IS_META_CREATED)
+        .and_then(NodeRef::content_as_string)
+        .map(|value| value == "true");
+
+    let (creator_name, creator_profile_url) = match profile.get_optional_child(TAG_CREATOR) {
+        Some(creator) => (
+            optional_child_text(creator, TAG_NAME),
+            optional_child_text(creator, TAG_PROFILE_URL),
+        ),
+        None => (None, None),
+    };
+    let posing_as_professional = profile
+        .get_optional_child(TAG_POSING_AS_PROFESSIONAL)
+        .map(|posing| required_compact_string(posing, ATTR_TYPE))
+        .transpose()?
+        .map(|value| match value.as_str() {
+            "unknown" => UsyncBotProfessionalType::Unknown,
+            "yes" => UsyncBotProfessionalType::Yes,
+            "no" => UsyncBotProfessionalType::No,
+            _ => UsyncBotProfessionalType::Other(value),
+        });
+
+    Ok(UsyncBotProfileResult {
+        name,
+        attributes,
+        description,
+        category,
+        is_default,
+        prompts,
+        persona_id,
+        commands,
+        commands_description,
+        is_meta_created,
+        creator_name,
+        creator_profile_url,
+        posing_as_professional,
+    })
+}
+
+fn parse_bot_prompts(node: Option<&NodeRef<'_>>) -> Result<Vec<UsyncBotPrompt>, anyhow::Error> {
+    let Some(node) = node else {
+        return Ok(Vec::new());
+    };
+    let capacity = node.children().map_or(0, <[_]>::len);
+    let mut prompts = Vec::with_capacity(capacity);
+    for prompt in node.get_children_by_tag(TAG_PROMPT) {
+        prompts.push(UsyncBotPrompt {
+            emoji: optional_child_text(prompt, TAG_EMOJI).unwrap_or_default(),
+            text: optional_child_text(prompt, TAG_TEXT).unwrap_or_default(),
+        });
+    }
+    Ok(prompts)
+}
+
+fn parse_bot_commands(
+    node: Option<&NodeRef<'_>>,
+) -> Result<(Vec<UsyncBotCommand>, CompactString), anyhow::Error> {
+    let Some(node) = node else {
+        return Ok((Vec::new(), CompactString::default()));
+    };
+    let capacity = node.children().map_or(0, <[_]>::len);
+    let mut commands = Vec::with_capacity(capacity);
+    for command in node.get_children_by_tag(TAG_COMMAND) {
+        commands.push(UsyncBotCommand {
+            name: optional_child_text(command, TAG_NAME).unwrap_or_default(),
+            description: optional_child_text(command, TAG_DESCRIPTION).unwrap_or_default(),
+        });
+    }
+    Ok((
+        commands,
+        optional_child_text(node, TAG_DESCRIPTION).unwrap_or_default(),
+    ))
+}
+
+fn required_child<'a>(node: &'a NodeRef<'a>, tag: &str) -> Result<&'a NodeRef<'a>, anyhow::Error> {
+    node.get_optional_child(tag)
+        .ok_or_else(|| anyhow!("<{}> is missing required <{tag}> child", node.tag))
+}
+
+fn required_child_text(node: &NodeRef<'_>, tag: &str) -> Result<CompactString, anyhow::Error> {
+    required_child(node, tag)?
+        .content_as_string()
+        .ok_or_else(|| anyhow!("<{tag}> is missing text content"))
+}
+
+fn optional_child_text(node: &NodeRef<'_>, tag: &str) -> Option<CompactString> {
+    node.get_optional_child(tag)
+        .and_then(NodeRef::content_as_string)
+}
+
+fn optional_compact_string(
+    node: &NodeRef<'_>,
+    key: &str,
+) -> Result<Option<CompactString>, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let value = attrs
+        .optional_string(key)
+        .map(|value| CompactString::from(value.as_ref()));
+    attrs.finish()?;
+    Ok(value)
+}
+
+fn required_compact_string(node: &NodeRef<'_>, key: &str) -> Result<CompactString, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let value = CompactString::from(attrs.required_string(key)?.as_ref());
+    attrs.finish()?;
+    Ok(value)
+}
+
+fn required_u64(node: &NodeRef<'_>, key: &str) -> Result<u64, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let value = attrs
+        .optional_u64(key)
+        .ok_or_else(|| anyhow!("<{}> is missing required '{key}' attribute", node.tag))?;
+    attrs.finish()?;
+    Ok(value)
+}
+
+fn optional_lid(node: &NodeRef<'_>, key: &str) -> Result<Option<Jid>, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let value = attrs.optional_jid(key).map(|jid| jid.to_non_ad());
+    attrs.finish()?;
+    match value {
+        Some(jid) if !jid.server.is_lid_family() => Err(anyhow!(
+            "<{}> contains a non-LID '{key}' attribute",
+            node.tag
+        )),
+        value => Ok(value),
+    }
+}
+
+fn checked_u16(value: u64, attribute: &str) -> Result<u16, anyhow::Error> {
+    u16::try_from(value).with_context(|| format!("'{attribute}' value {value} exceeds u16"))
+}
+
+fn checked_u32(value: u64, attribute: &str) -> Result<u32, anyhow::Error> {
+    u32::try_from(value).with_context(|| format!("'{attribute}' value {value} exceeds u32"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response(result: Vec<Node>, users: Vec<Node>) -> Node {
+        NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new(TAG_USYNC)
+                .children([
+                    NodeBuilder::new(TAG_RESULT).children(result).build(),
+                    NodeBuilder::new(TAG_LIST).children(users).build(),
+                ])
+                .build()])
+            .build()
+    }
+
+    fn protocol_error(code: u16, text: &str, backoff: Option<u32>) -> Node {
+        let mut error = NodeBuilder::new(TAG_ERROR)
+            .attr(ATTR_CODE, code.to_string())
+            .attr(ATTR_TEXT, text);
+        if let Some(backoff) = backoff {
+            error = error.attr(ATTR_BACKOFF, backoff.to_string());
+        }
+        error.build()
+    }
+
+    #[test]
+    fn typed_query_builds_canonical_envelope_and_protocol_inputs() {
+        let user = UsyncUser::from_jid(Jid::lid("100000001"))
+            .with_pn_jid(Jid::pn("15550000001"))
+            .with_known_lid(Jid::lid("100000001"))
+            .with_device_sync(
+                UsyncDeviceSyncHint::new()
+                    .with_device_hash("2:hash")
+                    .with_timestamp(100)
+                    .with_expected_timestamp(101),
+            )
+            .with_tc_token(vec![1, 2, 3]);
+        let query = UsyncQuery::new(
+            UsyncMode::Delta,
+            UsyncContext::Voip,
+            vec![
+                UsyncProtocol::Contact {
+                    addressing_mode: UsyncAddressingMode::Lid,
+                },
+                UsyncProtocol::DevicesV2,
+                UsyncProtocol::Status,
+                UsyncProtocol::Lid,
+                UsyncProtocol::Features(vec![UsyncFeature::Voip]),
+            ],
+            vec![user],
+        )
+        .unwrap();
+        let spec = UsyncQuerySpec::new(query, "sid-1").unwrap();
+        let iq = spec.build_iq();
+        let NodeContent::Nodes(nodes) = iq.content.as_ref().unwrap() else {
+            panic!("USync IQ content must contain child nodes");
+        };
+        let usync = nodes.first().unwrap();
+        assert_eq!(usync.attrs.get(ATTR_SID).unwrap().as_str(), "sid-1");
+        assert_eq!(usync.attrs.get(ATTR_MODE).unwrap().as_str(), "delta");
+        assert_eq!(usync.attrs.get(ATTR_CONTEXT).unwrap().as_str(), "voip");
+
+        let query_node = usync.get_optional_child(TAG_QUERY).unwrap();
+        let contact = query_node
+            .get_optional_child(UsyncProtocolKind::Contact.as_str())
+            .unwrap();
+        assert_eq!(
+            contact.attrs.get(ATTR_ADDRESSING_MODE).unwrap().as_str(),
+            "lid"
+        );
+        let feature = query_node
+            .get_optional_child(UsyncProtocolKind::Feature.as_str())
+            .unwrap();
+        assert!(
+            feature
+                .get_optional_child(UsyncFeature::Voip.as_str())
+                .is_some()
+        );
+
+        let user = usync
+            .get_optional_child(TAG_LIST)
+            .and_then(|list| list.get_optional_child(TAG_USER))
+            .unwrap();
+        let devices = user
+            .get_optional_child(UsyncProtocolKind::Devices.as_str())
+            .unwrap();
+        assert_eq!(
+            devices.attrs.get(ATTR_EXPECTED_TIMESTAMP).unwrap().as_str(),
+            "101"
+        );
+        assert!(user.get_optional_child("tctoken").is_some());
+    }
+
+    #[test]
+    fn query_validation_rejects_ambiguous_or_invalid_inputs() {
+        let duplicate = UsyncQuery::new(
+            UsyncMode::Query,
+            UsyncContext::Interactive,
+            vec![UsyncProtocol::Status, UsyncProtocol::Status],
+            vec![UsyncUser::from_jid(Jid::pn("15550000001"))],
+        )
+        .unwrap_err();
+        assert_eq!(
+            duplicate,
+            UsyncValidationError::DuplicateProtocol(UsyncProtocolKind::Status)
+        );
+
+        let contact_without_protocol = UsyncQuery::new(
+            UsyncMode::Query,
+            UsyncContext::Interactive,
+            vec![UsyncProtocol::Status],
+            vec![UsyncUser::from_phone("+15550000001")],
+        )
+        .unwrap_err();
+        assert_eq!(
+            contact_without_protocol,
+            UsyncValidationError::ContactInputWithoutProtocol { index: 0 }
+        );
+
+        let invalid_pn = UsyncQuery::new(
+            UsyncMode::Query,
+            UsyncContext::Interactive,
+            vec![UsyncProtocol::Status],
+            vec![UsyncUser::from_pn_jid(Jid::lid("100000001"))],
+        )
+        .unwrap_err();
+        assert_eq!(invalid_pn, UsyncValidationError::InvalidPnJid { index: 0 });
+
+        let empty_hash = UsyncQuery::new(
+            UsyncMode::Query,
+            UsyncContext::Interactive,
+            vec![UsyncProtocol::DevicesV2],
+            vec![
+                UsyncUser::from_jid(Jid::pn("15550000001")).with_device_sync(
+                    UsyncDeviceSyncHint::new().with_device_hash(CompactString::default()),
+                ),
+            ],
+        )
+        .unwrap_err();
+        assert_eq!(
+            empty_hash,
+            UsyncValidationError::EmptyDeviceHash { index: 0 }
+        );
+    }
+
+    #[test]
+    fn query_validation_never_silently_drops_user_inputs() {
+        let cases = [
+            (
+                UsyncUser::from_jid(Jid::pn("15550000001"))
+                    .with_phone("+15550000001")
+                    .with_contact_type("in"),
+                vec![UsyncProtocol::Contact {
+                    addressing_mode: UsyncAddressingMode::Pn,
+                }],
+                UsyncValidationError::ConflictingContactInputs { index: 0 },
+            ),
+            (
+                UsyncUser::from_jid(Jid::pn("15550000001"))
+                    .with_device_sync(UsyncDeviceSyncHint::new().with_timestamp(1)),
+                vec![UsyncProtocol::Status],
+                UsyncValidationError::DeviceSyncWithoutProtocol { index: 0 },
+            ),
+            (
+                UsyncUser::from_jid(Jid::pn("15550000001")).with_tc_token(vec![1]),
+                vec![UsyncProtocol::DevicesV2],
+                UsyncValidationError::TcTokenWithoutProtocol { index: 0 },
+            ),
+            (
+                UsyncUser::from_jid(Jid::pn("15550000001")).with_persona_id("persona-1"),
+                vec![UsyncProtocol::Status],
+                UsyncValidationError::PersonaIdWithoutProtocol { index: 0 },
+            ),
+            (
+                UsyncUser::from_jid(Jid::pn("15550000001")).with_known_lid(Jid::lid("100000001")),
+                vec![UsyncProtocol::Status],
+                UsyncValidationError::KnownLidWithoutProtocol { index: 0 },
+            ),
+        ];
+
+        for (user, protocols, expected) in cases {
+            let error = UsyncQuery::new(
+                UsyncMode::Query,
+                UsyncContext::Interactive,
+                protocols,
+                vec![user],
+            )
+            .unwrap_err();
+            assert_eq!(error, expected);
+        }
+    }
+
+    #[test]
+    fn typed_query_uses_protocol_specific_attribute_names() {
+        let query = UsyncQuery::new(
+            UsyncMode::Query,
+            UsyncContext::Interactive,
+            vec![
+                UsyncProtocol::Contact {
+                    addressing_mode: UsyncAddressingMode::Pn,
+                },
+                UsyncProtocol::BotProfileV1,
+            ],
+            vec![
+                UsyncUser::from_username("test_user")
+                    .with_username_pin("test_pin")
+                    .with_known_lid(Jid::lid("100000001"))
+                    .with_persona_id("persona-1"),
+            ],
+        )
+        .unwrap();
+        let usync = query.build_node("sid-1");
+        let query_node = usync.get_optional_child(TAG_QUERY).unwrap();
+        let bot_profile = query_node
+            .get_optional_child(UsyncProtocolKind::Bot.as_str())
+            .and_then(|bot| bot.get_optional_child(TAG_PROFILE))
+            .unwrap();
+        assert_eq!(
+            bot_profile.attrs.get(ATTR_BOT_VERSION).unwrap().as_str(),
+            BOT_PROFILE_VERSION
+        );
+        assert!(!bot_profile.attrs.contains_key(ATTR_VERSION));
+
+        let user = usync
+            .get_optional_child(TAG_LIST)
+            .and_then(|list| list.get_optional_child(TAG_USER))
+            .unwrap();
+        let contact = user
+            .get_optional_child(UsyncProtocolKind::Contact.as_str())
+            .unwrap();
+        assert_eq!(contact.attrs.get(ATTR_USERNAME).unwrap(), "test_user");
+        assert_eq!(contact.attrs.get(ATTR_PIN).unwrap(), "test_pin");
+        assert_eq!(
+            contact.attrs.get(ATTR_LID).unwrap().as_str(),
+            "100000001@lid"
+        );
+        assert!(!contact.attrs.contains_key(ATTR_JID));
+
+        let persona = user
+            .get_optional_child(UsyncProtocolKind::Bot.as_str())
+            .and_then(|bot| bot.get_optional_child(TAG_PROFILE))
+            .and_then(|profile| profile.attrs.get(ATTR_PERSONA_ID))
+            .unwrap();
+        assert_eq!(persona, "persona-1");
+    }
+
+    #[test]
+    fn parser_preserves_global_errors_refresh_and_idless_contacts() {
+        let node = response(
+            vec![
+                NodeBuilder::new(UsyncProtocolKind::Status.as_str())
+                    .attr(ATTR_REFRESH, "300")
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
+                    .children([protocol_error(429, "rate limited", Some(30))])
+                    .build(),
+            ],
+            vec![
+                NodeBuilder::new(TAG_USER)
+                    .children([NodeBuilder::new(UsyncProtocolKind::Contact.as_str())
+                        .attr(ATTR_TYPE, "out")
+                        .string_content("+15550000001")
+                        .build()])
+                    .build(),
+            ],
+        );
+        let parsed = parse_usync_response(&node.as_node_ref()).unwrap();
+        assert_eq!(parsed.protocol_states.len(), 2);
+        assert_eq!(
+            parsed
+                .protocol_state(UsyncProtocolKind::Status)
+                .unwrap()
+                .refresh_seconds,
+            Some(300)
+        );
+        let error = parsed
+            .protocol_state(UsyncProtocolKind::Devices)
+            .unwrap()
+            .error
+            .as_ref()
+            .unwrap();
+        assert_eq!(error.code, Some(429));
+        assert_eq!(error.backoff, Some(30));
+        assert_eq!(parsed.users[0].id, None);
+        assert!(matches!(
+            parsed.users[0].protocols[0],
+            UsyncProtocolResult::Contact(UsyncOutcome::Value(_))
+        ));
+    }
+
+    #[test]
+    fn status_parser_preserves_absent_null_empty_and_text() {
+        let users = vec![
+            NodeBuilder::new(TAG_USER)
+                .attr(ATTR_JID, Jid::lid("1"))
+                .build(),
+            NodeBuilder::new(TAG_USER)
+                .attr(ATTR_JID, Jid::lid("2"))
+                .children([NodeBuilder::new(UsyncProtocolKind::Status.as_str())
+                    .attr(ATTR_TIMESTAMP, "999")
+                    .build()])
+                .build(),
+            NodeBuilder::new(TAG_USER)
+                .attr(ATTR_JID, Jid::lid("3"))
+                .children([NodeBuilder::new(UsyncProtocolKind::Status.as_str())
+                    .attr(ATTR_CODE, "401")
+                    .build()])
+                .build(),
+            NodeBuilder::new(TAG_USER)
+                .attr(ATTR_JID, Jid::lid("4"))
+                .children([NodeBuilder::new(UsyncProtocolKind::Status.as_str())
+                    .attr(ATTR_TIME, "123")
+                    .string_content("available")
+                    .build()])
+                .build(),
+        ];
+        let parsed = parse_usync_response(&response(Vec::new(), users).as_node_ref()).unwrap();
+        assert!(parsed.users[0].protocols.is_empty());
+        assert!(matches!(
+            &parsed.users[1].protocols[0],
+            UsyncProtocolResult::Status(UsyncOutcome::Value(value))
+                if value.status.is_none() && value.timestamp.is_none()
+        ));
+        assert!(matches!(
+            &parsed.users[2].protocols[0],
+            UsyncProtocolResult::Status(UsyncOutcome::Value(value))
+                if value.status.as_ref().is_some_and(CompactString::is_empty)
+        ));
+        assert!(matches!(
+            &parsed.users[3].protocols[0],
+            UsyncProtocolResult::Status(UsyncOutcome::Value(value))
+                if value.status.as_deref() == Some("available") && value.timestamp == Some(123)
+        ));
+    }
+
+    #[test]
+    fn devices_parser_preserves_hosting_and_key_index_metadata() {
+        let devices = NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
+            .children([
+                NodeBuilder::new(TAG_DEVICE_LIST)
+                    .attr(ATTR_HASH, "2:abc")
+                    .children([
+                        NodeBuilder::new(TAG_DEVICE).attr(ATTR_ID, "0").build(),
+                        NodeBuilder::new(TAG_DEVICE)
+                            .attr(ATTR_ID, "7")
+                            .attr(ATTR_KEY_INDEX, "9")
+                            .attr(ATTR_IS_HOSTED, "true")
+                            .build(),
+                    ])
+                    .build(),
+                NodeBuilder::new(TAG_KEY_INDEX_LIST)
+                    .attr(ATTR_TIMESTAMP, "1000")
+                    .attr(ATTR_EXPECTED_TIMESTAMP, "1001")
+                    .bytes(vec![1, 2, 3])
+                    .build(),
+            ])
+            .build();
+        let user = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .children([devices])
+            .build();
+        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
+        let UsyncProtocolResult::Devices(UsyncOutcome::Value(devices)) =
+            &parsed.users[0].protocols[0]
+        else {
+            panic!("expected devices result");
+        };
+        let list = devices.device_list.as_ref().unwrap();
+        assert_eq!(list.hash.as_deref(), Some("2:abc"));
+        assert!(list.devices[1].is_hosted);
+        assert_eq!(list.devices[1].key_index, Some(9));
+        let key_index = devices.key_index.as_ref().unwrap();
+        assert_eq!(key_index.timestamp, 1000);
+        assert_eq!(key_index.expected_timestamp, Some(1001));
+        assert_eq!(
+            key_index.signed_key_index_bytes.as_deref(),
+            Some(&[1, 2, 3][..])
+        );
+    }
+
+    #[test]
+    fn parser_handles_disappearing_text_status_features_and_user_error() {
+        let user = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::lid("100000001"))
+            .children([
+                NodeBuilder::new(UsyncProtocolKind::DisappearingMode.as_str())
+                    .attr(ATTR_DURATION, "86400")
+                    .attr(ATTR_TIME, "123")
+                    .attr(ATTR_EPHEMERALITY_DISABLED, "true")
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::TextStatus.as_str())
+                    .attr(ATTR_TEXT, "hello")
+                    .attr(ATTR_EPHEMERAL_DURATION, "60")
+                    .attr(ATTR_LAST_UPDATE_TIME, "124")
+                    .children([NodeBuilder::new(TAG_EMOJI).attr(ATTR_CONTENT, "👋").build()])
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::Feature.as_str())
+                    .children([NodeBuilder::new(UsyncFeature::Voip.as_str())
+                        .attr(ATTR_VALUE, "1")
+                        .build()])
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::Username.as_str())
+                    .children([protocol_error(404, "missing", None)])
+                    .build(),
+            ])
+            .build();
+        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
+        assert!(matches!(
+            parsed.users[0].protocol(UsyncProtocolKind::DisappearingMode),
+            Some(UsyncProtocolResult::DisappearingMode(UsyncOutcome::Value(value)))
+                if value.duration_seconds == 86400 && value.ephemerality_disabled
+        ));
+        assert!(matches!(
+            parsed.users[0].protocol(UsyncProtocolKind::TextStatus),
+            Some(UsyncProtocolResult::TextStatus(UsyncOutcome::Value(value)))
+                if value.emoji.as_deref() == Some("👋")
+        ));
+        assert!(matches!(
+            parsed.users[0].protocol(UsyncProtocolKind::Feature),
+            Some(UsyncProtocolResult::Features(UsyncOutcome::Value(values)))
+                if values == &[UsyncFeatureResult { feature: UsyncFeature::Voip, value: "1".into() }]
+        ));
+        assert!(matches!(
+            parsed.users[0].protocol(UsyncProtocolKind::Username),
+            Some(UsyncProtocolResult::Username(UsyncOutcome::Error(error)))
+                if error.code == Some(404)
+        ));
+    }
+
+    #[test]
+    fn parser_projects_picture_lid_username_and_bot_results() {
+        let bot_profile = NodeBuilder::new(TAG_PROFILE)
+            .attr(ATTR_PERSONA_ID, "persona-1")
+            .children([
+                NodeBuilder::new(TAG_NAME)
+                    .string_content("Test Bot")
+                    .build(),
+                NodeBuilder::new(TAG_ATTRIBUTES)
+                    .string_content("helpful")
+                    .build(),
+                NodeBuilder::new(TAG_DESCRIPTION)
+                    .string_content("Description")
+                    .build(),
+                NodeBuilder::new(TAG_CATEGORY)
+                    .string_content("utility")
+                    .build(),
+                NodeBuilder::new(TAG_DEFAULT).string_content("true").build(),
+                NodeBuilder::new(TAG_PROMPTS)
+                    .children([NodeBuilder::new(TAG_PROMPT)
+                        .children([
+                            NodeBuilder::new(TAG_EMOJI).string_content("👋").build(),
+                            NodeBuilder::new(TAG_TEXT).string_content("Hello").build(),
+                        ])
+                        .build()])
+                    .build(),
+                NodeBuilder::new(TAG_COMMANDS)
+                    .children([
+                        NodeBuilder::new(TAG_DESCRIPTION)
+                            .string_content("Available commands")
+                            .build(),
+                        NodeBuilder::new(TAG_COMMAND)
+                            .children([
+                                NodeBuilder::new(TAG_NAME).string_content("help").build(),
+                                NodeBuilder::new(TAG_DESCRIPTION)
+                                    .string_content("Show help")
+                                    .build(),
+                            ])
+                            .build(),
+                    ])
+                    .build(),
+                NodeBuilder::new(TAG_IS_META_CREATED)
+                    .string_content("false")
+                    .build(),
+                NodeBuilder::new(TAG_CREATOR)
+                    .children([
+                        NodeBuilder::new(TAG_NAME).string_content("Creator").build(),
+                        NodeBuilder::new(TAG_PROFILE_URL)
+                            .string_content("https://example.test/profile")
+                            .build(),
+                    ])
+                    .build(),
+                NodeBuilder::new(TAG_POSING_AS_PROFESSIONAL)
+                    .attr(ATTR_TYPE, "yes")
+                    .build(),
+            ])
+            .build();
+        let user = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .children([
+                NodeBuilder::new(UsyncProtocolKind::Picture.as_str())
+                    .attr(ATTR_ID, "42")
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::Lid.as_str())
+                    .attr(ATTR_VAL, Jid::lid("100000001"))
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::Username.as_str())
+                    .string_content("test_user")
+                    .build(),
+                NodeBuilder::new(UsyncProtocolKind::Bot.as_str())
+                    .children([bot_profile])
+                    .build(),
+            ])
+            .build();
+        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
+        let user = &parsed.users[0];
+        assert!(matches!(
+            user.protocol(UsyncProtocolKind::Picture),
+            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(42)))
+        ));
+        assert!(matches!(
+            user.protocol(UsyncProtocolKind::Lid),
+            Some(UsyncProtocolResult::Lid(UsyncOutcome::Value(Some(lid))))
+                if *lid == Jid::lid("100000001")
+        ));
+        assert!(matches!(
+            user.protocol(UsyncProtocolKind::Username),
+            Some(UsyncProtocolResult::Username(UsyncOutcome::Value(Some(username))))
+                if username == "test_user"
+        ));
+        let Some(UsyncProtocolResult::Bot(UsyncOutcome::Value(bot))) =
+            user.protocol(UsyncProtocolKind::Bot)
+        else {
+            panic!("expected bot result");
+        };
+        assert_eq!(bot.persona_id, "persona-1");
+        assert_eq!(bot.prompts[0].text, "Hello");
+        assert_eq!(bot.commands[0].name, "help");
+        assert_eq!(bot.commands_description, "Available commands");
+        assert_eq!(bot.is_meta_created, Some(false));
+        assert_eq!(bot.creator_name.as_deref(), Some("Creator"));
+        assert_eq!(
+            bot.posing_as_professional,
+            Some(UsyncBotProfessionalType::Yes)
+        );
+    }
+
+    #[test]
+    fn parser_rejects_non_lid_values_and_numeric_overflow() {
+        let invalid_lid = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .children([NodeBuilder::new(UsyncProtocolKind::Lid.as_str())
+                .attr(ATTR_VAL, Jid::pn("15550000001"))
+                .build()])
+            .build();
+        assert!(
+            parse_usync_response(&response(Vec::new(), vec![invalid_lid]).as_node_ref()).is_err()
+        );
+
+        let overflowing_device = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .children([NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
+                .children([NodeBuilder::new(TAG_DEVICE_LIST)
+                    .children([NodeBuilder::new(TAG_DEVICE)
+                        .attr(ATTR_ID, (u64::from(u16::MAX) + 1).to_string())
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+        assert!(
+            parse_usync_response(&response(Vec::new(), vec![overflowing_device]).as_node_ref())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn sparse_result_layout_stays_bounded() {
+        assert!(std::mem::size_of::<UsyncProtocolResult>() <= 96);
+    }
+}

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -12,6 +12,7 @@ use crate::iq::tctoken::build_tc_token_node;
 use crate::request::InfoQuery;
 use crate::stanza::business::VerifiedName;
 use anyhow::{Context, anyhow};
+use log::warn;
 use thiserror::Error;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{CompactString, Jid, Node, NodeContent, NodeContentRef, NodeRef, Server};
@@ -272,12 +273,12 @@ impl UsyncUser {
     }
 
     pub fn with_id(mut self, jid: Jid) -> Self {
-        self.id = Some(jid);
+        self.id = Some(jid.into_non_ad());
         self
     }
 
     pub fn with_pn_jid(mut self, jid: Jid) -> Self {
-        self.pn_jid = Some(jid);
+        self.pn_jid = Some(jid.into_non_ad());
         self
     }
 
@@ -287,7 +288,7 @@ impl UsyncUser {
     }
 
     pub fn with_known_lid(mut self, lid: Jid) -> Self {
-        self.known_lid = Some(lid);
+        self.known_lid = Some(lid.into_non_ad());
         self
     }
 
@@ -918,13 +919,17 @@ pub struct UsyncBotCommand {
     pub description: CompactString,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
 #[non_exhaustive]
 pub enum UsyncBotProfessionalType {
+    #[wire = "unknown"]
     Unknown,
+    #[wire = "yes"]
     Yes,
+    #[wire = "no"]
     No,
-    Other(CompactString),
+    #[wire_fallback]
+    Other(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -956,7 +961,7 @@ pub enum UsyncProtocolResult {
     TextStatus(UsyncOutcome<UsyncTextStatusResult>),
     DisappearingMode(UsyncOutcome<UsyncDisappearingModeResult>),
     Business(UsyncOutcome<Box<UsyncBusinessResult>>),
-    Picture(UsyncOutcome<u64>),
+    Picture(UsyncOutcome<Option<u64>>),
     Lid(UsyncOutcome<Option<Jid>>),
     Username(UsyncOutcome<Option<CompactString>>),
     Bot(UsyncOutcome<Box<UsyncBotProfileResult>>),
@@ -1088,7 +1093,7 @@ fn parse_protocol_result(
             UsyncProtocolResult::Business(outcome!(parse_business(node).map(Box::new)))
         }
         UsyncProtocolKind::Picture => {
-            UsyncProtocolResult::Picture(outcome!(required_u64(node, ATTR_ID)))
+            UsyncProtocolResult::Picture(outcome!(optional_u64(node, ATTR_ID)))
         }
         UsyncProtocolKind::Lid => UsyncProtocolResult::Lid(outcome!(optional_lid(node, ATTR_VAL))),
         UsyncProtocolKind::Username => {
@@ -1168,24 +1173,31 @@ fn parse_device_list(node: &NodeRef<'_>) -> Result<UsyncDeviceListResult, anyhow
     let capacity = node.children().map_or(0, <[_]>::len);
     let mut devices = Vec::with_capacity(capacity);
     for device in node.get_children_by_tag(TAG_DEVICE) {
-        let mut attrs = device.attrs();
-        let raw_id = attrs
-            .optional_u64(ATTR_ID)
-            .ok_or_else(|| anyhow!("USync device is missing '{ATTR_ID}'"))?;
-        let id = checked_u16(raw_id, ATTR_ID)?;
-        let key_index = attrs
-            .optional_u64(ATTR_KEY_INDEX)
-            .map(|value| checked_u32(value, ATTR_KEY_INDEX))
-            .transpose()?;
-        let is_hosted = attrs.optional_bool_value(ATTR_IS_HOSTED).unwrap_or(false);
-        attrs.finish()?;
-        devices.push(UsyncDeviceResult {
-            id,
-            key_index,
-            is_hosted,
-        });
+        match parse_device(device) {
+            Ok(device) => devices.push(device),
+            Err(error) => warn!(target: "usync", "skipping malformed USync device: {error}"),
+        }
     }
     Ok(UsyncDeviceListResult { hash, devices })
+}
+
+fn parse_device(node: &NodeRef<'_>) -> Result<UsyncDeviceResult, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let raw_id = attrs
+        .optional_u64(ATTR_ID)
+        .ok_or_else(|| anyhow!("USync device is missing '{ATTR_ID}'"))?;
+    let id = checked_u16(raw_id, ATTR_ID)?;
+    let key_index = attrs
+        .optional_u64(ATTR_KEY_INDEX)
+        .map(|value| checked_u32(value, ATTR_KEY_INDEX))
+        .transpose()?;
+    let is_hosted = attrs.optional_bool_value(ATTR_IS_HOSTED).unwrap_or(false);
+    attrs.finish()?;
+    Ok(UsyncDeviceResult {
+        id,
+        key_index,
+        is_hosted,
+    })
 }
 
 fn parse_key_index(node: &NodeRef<'_>) -> Result<UsyncKeyIndexResult, anyhow::Error> {
@@ -1331,14 +1343,8 @@ fn parse_bot_profile(node: &NodeRef<'_>) -> Result<UsyncBotProfileResult, anyhow
     };
     let posing_as_professional = profile
         .get_optional_child(TAG_POSING_AS_PROFESSIONAL)
-        .map(|posing| required_compact_string(posing, ATTR_TYPE))
-        .transpose()?
-        .map(|value| match value.as_str() {
-            "unknown" => UsyncBotProfessionalType::Unknown,
-            "yes" => UsyncBotProfessionalType::Yes,
-            "no" => UsyncBotProfessionalType::No,
-            _ => UsyncBotProfessionalType::Other(value),
-        });
+        .map(parse_bot_professional_type)
+        .transpose()?;
 
     Ok(UsyncBotProfileResult {
         name,
@@ -1427,11 +1433,18 @@ fn required_compact_string(node: &NodeRef<'_>, key: &str) -> Result<CompactStrin
     Ok(value)
 }
 
-fn required_u64(node: &NodeRef<'_>, key: &str) -> Result<u64, anyhow::Error> {
+fn optional_u64(node: &NodeRef<'_>, key: &str) -> Result<Option<u64>, anyhow::Error> {
     let mut attrs = node.attrs();
-    let value = attrs
-        .optional_u64(key)
-        .ok_or_else(|| anyhow!("<{}> is missing required '{key}' attribute", node.tag))?;
+    let value = attrs.optional_u64(key);
+    attrs.finish()?;
+    Ok(value)
+}
+
+fn parse_bot_professional_type(
+    node: &NodeRef<'_>,
+) -> Result<UsyncBotProfessionalType, anyhow::Error> {
+    let mut attrs = node.attrs();
+    let value = UsyncBotProfessionalType::from(attrs.required_string(ATTR_TYPE)?.as_ref());
     attrs.finish()?;
     Ok(value)
 }
@@ -1485,9 +1498,9 @@ mod tests {
 
     #[test]
     fn typed_query_builds_canonical_envelope_and_protocol_inputs() {
-        let user = UsyncUser::from_jid(Jid::lid("100000001"))
-            .with_pn_jid(Jid::pn("15550000001"))
-            .with_known_lid(Jid::lid("100000001"))
+        let user = UsyncUser::from_jid(Jid::lid("100000001").with_device(7))
+            .with_pn_jid(Jid::pn("15550000001").with_device(8))
+            .with_known_lid(Jid::lid("100000001").with_device(9))
             .with_device_sync(
                 UsyncDeviceSyncHint::new()
                     .with_device_hash("2:hash")
@@ -1541,6 +1554,11 @@ mod tests {
             .get_optional_child(TAG_LIST)
             .and_then(|list| list.get_optional_child(TAG_USER))
             .unwrap();
+        assert_eq!(user.attrs.get(ATTR_JID).unwrap().as_str(), "100000001@lid");
+        assert_eq!(
+            user.attrs.get(ATTR_PN_JID).unwrap().as_str(),
+            "15550000001@s.whatsapp.net"
+        );
         let devices = user
             .get_optional_child(UsyncProtocolKind::Devices.as_str())
             .unwrap();
@@ -1548,6 +1566,10 @@ mod tests {
             devices.attrs.get(ATTR_EXPECTED_TIMESTAMP).unwrap().as_str(),
             "101"
         );
+        let lid = user
+            .get_optional_child(UsyncProtocolKind::Lid.as_str())
+            .unwrap();
+        assert_eq!(lid.attrs.get(ATTR_JID).unwrap().as_str(), "100000001@lid");
         assert!(user.get_optional_child("tctoken").is_some());
     }
 
@@ -1839,6 +1861,43 @@ mod tests {
     }
 
     #[test]
+    fn devices_parser_skips_malformed_entries_without_dropping_siblings() {
+        let devices = NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
+            .children([NodeBuilder::new(TAG_DEVICE_LIST)
+                .children([
+                    NodeBuilder::new(TAG_DEVICE).build(),
+                    NodeBuilder::new(TAG_DEVICE)
+                        .attr(ATTR_ID, (u64::from(u16::MAX) + 1).to_string())
+                        .build(),
+                    NodeBuilder::new(TAG_DEVICE)
+                        .attr(ATTR_ID, "7")
+                        .attr(ATTR_KEY_INDEX, "9")
+                        .build(),
+                ])
+                .build()])
+            .build();
+        let user = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .children([devices])
+            .build();
+
+        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
+        let Some(UsyncProtocolResult::Devices(UsyncOutcome::Value(devices))) =
+            parsed.users[0].protocol(UsyncProtocolKind::Devices)
+        else {
+            panic!("expected devices result");
+        };
+        assert_eq!(
+            devices.device_list.as_ref().unwrap().devices,
+            [UsyncDeviceResult {
+                id: 7,
+                key_index: Some(9),
+                is_hosted: false,
+            }]
+        );
+    }
+
+    #[test]
     fn parser_handles_disappearing_text_status_features_and_user_error() {
         let user = NodeBuilder::new(TAG_USER)
             .attr(ATTR_JID, Jid::lid("100000001"))
@@ -1965,7 +2024,7 @@ mod tests {
         let user = &parsed.users[0];
         assert!(matches!(
             user.protocol(UsyncProtocolKind::Picture),
-            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(42)))
+            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(Some(42))))
         ));
         assert!(matches!(
             user.protocol(UsyncProtocolKind::Lid),
@@ -1992,10 +2051,28 @@ mod tests {
             bot.posing_as_professional,
             Some(UsyncBotProfessionalType::Yes)
         );
+        assert_eq!(
+            UsyncBotProfessionalType::from("future"),
+            UsyncBotProfessionalType::Other("future".to_owned())
+        );
     }
 
     #[test]
-    fn parser_rejects_non_lid_values_and_numeric_overflow() {
+    fn picture_without_id_is_a_successful_absent_value() {
+        let user = NodeBuilder::new(TAG_USER)
+            .attr(ATTR_JID, Jid::pn("15550000001"))
+            .children([NodeBuilder::new(UsyncProtocolKind::Picture.as_str()).build()])
+            .build();
+
+        let parsed = parse_usync_response(&response(Vec::new(), vec![user]).as_node_ref()).unwrap();
+        assert!(matches!(
+            parsed.users[0].protocol(UsyncProtocolKind::Picture),
+            Some(UsyncProtocolResult::Picture(UsyncOutcome::Value(None)))
+        ));
+    }
+
+    #[test]
+    fn parser_rejects_non_lid_values() {
         let invalid_lid = NodeBuilder::new(TAG_USER)
             .attr(ATTR_JID, Jid::pn("15550000001"))
             .children([NodeBuilder::new(UsyncProtocolKind::Lid.as_str())
@@ -2004,21 +2081,6 @@ mod tests {
             .build();
         assert!(
             parse_usync_response(&response(Vec::new(), vec![invalid_lid]).as_node_ref()).is_err()
-        );
-
-        let overflowing_device = NodeBuilder::new(TAG_USER)
-            .attr(ATTR_JID, Jid::pn("15550000001"))
-            .children([NodeBuilder::new(UsyncProtocolKind::Devices.as_str())
-                .children([NodeBuilder::new(TAG_DEVICE_LIST)
-                    .children([NodeBuilder::new(TAG_DEVICE)
-                        .attr(ATTR_ID, (u64::from(u16::MAX) + 1).to_string())
-                        .build()])
-                    .build()])
-                .build()])
-            .build();
-        assert!(
-            parse_usync_response(&response(Vec::new(), vec![overflowing_device]).as_node_ref())
-                .is_err()
         );
     }
 

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -85,6 +85,7 @@ const LAST_PAGE: &str = "true";
 const DEVICES_VERSION: &str = "2";
 const BOT_PROFILE_VERSION: &str = "1";
 const E164_PREFIX: char = '+';
+const E164_MAX_DIGITS: usize = 15;
 
 /// Addressing mode used by the contact subprotocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, WireEnum)]
@@ -383,8 +384,13 @@ impl UsyncUser {
                 return Err(UsyncValidationError::InvalidPnJid { index });
             }
         }
-        if self.phone.as_ref().is_some_and(CompactString::is_empty) {
-            return Err(UsyncValidationError::EmptyPhone { index });
+        if let Some(phone) = &self.phone {
+            if phone.is_empty() {
+                return Err(UsyncValidationError::EmptyPhone { index });
+            }
+            if !is_canonical_usync_phone(phone) {
+                return Err(UsyncValidationError::InvalidPhone { index });
+            }
         }
         if self.username.as_ref().is_some_and(CompactString::is_empty) {
             return Err(UsyncValidationError::EmptyUsername { index });
@@ -447,6 +453,19 @@ fn normalize_usync_phone(mut phone: CompactString) -> CompactString {
     phone
 }
 
+fn is_canonical_usync_phone(phone: &str) -> bool {
+    let Some(digits) = phone.strip_prefix(E164_PREFIX) else {
+        return false;
+    };
+    let Some((&first, rest)) = digits.as_bytes().split_first() else {
+        return false;
+    };
+    digits.len() <= E164_MAX_DIGITS
+        && first.is_ascii_digit()
+        && first != b'0'
+        && rest.iter().all(u8::is_ascii_digit)
+}
+
 fn deserialize_optional_usync_phone<'de, D>(
     deserializer: D,
 ) -> Result<Option<CompactString>, D::Error>
@@ -500,22 +519,33 @@ fn validate_user_jid(jid: &Jid, index: usize) -> Result<(), UsyncValidationError
 }
 
 /// A known, typed USync subprotocol request.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
+#[wire(tag = "type", content = "data")]
 #[non_exhaustive]
 pub enum UsyncProtocol {
+    #[wire = "contact"]
     Contact {
         addressing_mode: UsyncAddressingMode,
     },
+    #[wire = "devices"]
     DevicesV2,
+    #[wire = "status"]
     Status,
+    #[wire = "text_status"]
     TextStatus,
+    #[wire = "disappearing_mode"]
     DisappearingMode,
+    #[wire = "business"]
     BusinessVerifiedName,
+    #[wire = "picture"]
     Picture,
+    #[wire = "lid"]
     Lid,
+    #[wire = "username"]
     Username,
+    #[wire = "bot"]
     BotProfileV1,
+    #[wire = "feature"]
     Features(Vec<UsyncFeature>),
 }
 
@@ -544,10 +574,10 @@ impl UsyncProtocol {
     }
 
     fn build_query_node(&self) -> Node {
-        let kind = self.kind();
+        let tag = self.wire_tag();
         match self {
             Self::Contact { addressing_mode } => {
-                let builder = NodeBuilder::new(kind.as_str());
+                let builder = NodeBuilder::new(tag);
                 if *addressing_mode == UsyncAddressingMode::Lid {
                     builder
                         .attr(ATTR_ADDRESSING_MODE, addressing_mode.as_str())
@@ -556,25 +586,25 @@ impl UsyncProtocol {
                     builder.build()
                 }
             }
-            Self::DevicesV2 => NodeBuilder::new(kind.as_str())
+            Self::DevicesV2 => NodeBuilder::new(tag)
                 .attr(ATTR_VERSION, DEVICES_VERSION)
                 .build(),
-            Self::BusinessVerifiedName => NodeBuilder::new(kind.as_str())
+            Self::BusinessVerifiedName => NodeBuilder::new(tag)
                 .children([NodeBuilder::new(TAG_VERIFIED_NAME).build()])
                 .build(),
-            Self::BotProfileV1 => NodeBuilder::new(kind.as_str())
+            Self::BotProfileV1 => NodeBuilder::new(tag)
                 .children([NodeBuilder::new(TAG_PROFILE)
                     .attr(ATTR_BOT_VERSION, BOT_PROFILE_VERSION)
                     .build()])
                 .build(),
-            Self::Features(features) => NodeBuilder::new(kind.as_str())
+            Self::Features(features) => NodeBuilder::new(tag)
                 .children(
                     features
                         .iter()
                         .map(|feature| NodeBuilder::new(feature.as_str()).build()),
                 )
                 .build(),
-            _ => NodeBuilder::new(kind.as_str()).build(),
+            _ => NodeBuilder::new(tag).build(),
         }
     }
 
@@ -666,6 +696,8 @@ pub enum UsyncValidationError {
     InvalidPnJid { index: usize },
     #[error("USync user at index {index} has an empty phone number")]
     EmptyPhone { index: usize },
+    #[error("USync user at index {index} has an invalid phone number")]
+    InvalidPhone { index: usize },
     #[error("USync user at index {index} has an empty username")]
     EmptyUsername { index: usize },
     #[error("USync user at index {index} has a username pin without a username")]
@@ -1079,20 +1111,31 @@ pub struct UsyncBotProfileResult {
 
 /// Sparse per-user result. Large, uncommon payloads are boxed so their layout
 /// does not inflate every status/contact/device item in large sync responses.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, WireEnum)]
+#[wire(tag = "type", content = "data")]
 #[non_exhaustive]
 pub enum UsyncProtocolResult {
+    #[wire = "contact"]
     Contact(UsyncOutcome<UsyncContactResult>),
+    #[wire = "devices"]
     Devices(UsyncOutcome<UsyncDevicesResult>),
+    #[wire = "status"]
     Status(UsyncOutcome<UsyncStatusResult>),
+    #[wire = "text_status"]
     TextStatus(UsyncOutcome<UsyncTextStatusResult>),
+    #[wire = "disappearing_mode"]
     DisappearingMode(UsyncOutcome<UsyncDisappearingModeResult>),
+    #[wire = "business"]
     Business(UsyncOutcome<Box<UsyncBusinessResult>>),
+    #[wire = "picture"]
     Picture(UsyncOutcome<u64>),
+    #[wire = "lid"]
     Lid(UsyncOutcome<Option<Jid>>),
+    #[wire = "username"]
     Username(UsyncOutcome<Option<CompactString>>),
+    #[wire = "bot"]
     Bot(UsyncOutcome<Box<UsyncBotProfileResult>>),
+    #[wire = "feature"]
     Features(UsyncOutcome<Vec<UsyncFeatureResult>>),
 }
 
@@ -1176,11 +1219,11 @@ fn parse_user_result(user: &NodeRef<'_>) -> Result<Option<UsyncUserResult>, anyh
     let mut protocols = Vec::with_capacity(capacity);
     let mut has_contact = false;
     for node in user.children().into_iter().flatten() {
-        let Ok(kind) = UsyncProtocolKind::try_from(node.tag.as_ref()) else {
+        let Ok(tag) = UsyncProtocolResultTag::try_from(node.tag.as_ref()) else {
             continue;
         };
-        has_contact |= kind == UsyncProtocolKind::Contact;
-        protocols.push(parse_protocol_result(kind, node)?);
+        has_contact |= tag == UsyncProtocolResultTag::Contact;
+        protocols.push(parse_protocol_result(tag, node)?);
     }
 
     // Matches WA Web's parser: an id-less entry is retained only when the
@@ -1197,7 +1240,7 @@ fn parse_user_result(user: &NodeRef<'_>) -> Result<Option<UsyncUserResult>, anyh
 }
 
 fn parse_protocol_result(
-    kind: UsyncProtocolKind,
+    tag: UsyncProtocolResultTag,
     node: &NodeRef<'_>,
 ) -> Result<UsyncProtocolResult, anyhow::Error> {
     macro_rules! outcome {
@@ -1209,32 +1252,40 @@ fn parse_protocol_result(
         };
     }
 
-    Ok(match kind {
-        UsyncProtocolKind::Contact => UsyncProtocolResult::Contact(outcome!(parse_contact(node))),
-        UsyncProtocolKind::Devices => UsyncProtocolResult::Devices(outcome!(parse_devices(node))),
-        UsyncProtocolKind::Status => UsyncProtocolResult::Status(outcome!(parse_status(node))),
-        UsyncProtocolKind::TextStatus => {
+    Ok(match tag {
+        UsyncProtocolResultTag::Contact => {
+            UsyncProtocolResult::Contact(outcome!(parse_contact(node)))
+        }
+        UsyncProtocolResultTag::Devices => {
+            UsyncProtocolResult::Devices(outcome!(parse_devices(node)))
+        }
+        UsyncProtocolResultTag::Status => UsyncProtocolResult::Status(outcome!(parse_status(node))),
+        UsyncProtocolResultTag::TextStatus => {
             UsyncProtocolResult::TextStatus(outcome!(parse_text_status(node)))
         }
-        UsyncProtocolKind::DisappearingMode => {
+        UsyncProtocolResultTag::DisappearingMode => {
             UsyncProtocolResult::DisappearingMode(outcome!(parse_disappearing_mode(node)))
         }
-        UsyncProtocolKind::Business => {
+        UsyncProtocolResultTag::Business => {
             UsyncProtocolResult::Business(outcome!(parse_business(node).map(Box::new)))
         }
-        UsyncProtocolKind::Picture => {
+        UsyncProtocolResultTag::Picture => {
             UsyncProtocolResult::Picture(outcome!(required_u64(node, ATTR_ID)))
         }
-        UsyncProtocolKind::Lid => UsyncProtocolResult::Lid(outcome!(optional_lid(node, ATTR_VAL))),
-        UsyncProtocolKind::Username => {
+        UsyncProtocolResultTag::Lid => {
+            UsyncProtocolResult::Lid(outcome!(optional_lid(node, ATTR_VAL)))
+        }
+        UsyncProtocolResultTag::Username => {
             UsyncProtocolResult::Username(outcome!(Ok::<_, anyhow::Error>(
                 node.content_as_string()
             )))
         }
-        UsyncProtocolKind::Bot => {
+        UsyncProtocolResultTag::Bot => {
             UsyncProtocolResult::Bot(outcome!(parse_bot_profile(node).map(Box::new)))
         }
-        UsyncProtocolKind::Feature => UsyncProtocolResult::Features(outcome!(parse_features(node))),
+        UsyncProtocolResultTag::Features => {
+            UsyncProtocolResult::Features(outcome!(parse_features(node)))
+        }
     })
 }
 
@@ -1742,6 +1793,9 @@ mod tests {
         .unwrap();
 
         let encoded = serde_json::to_vec(&query).unwrap();
+        let encoded_value: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(encoded_value["protocols"][1]["type"], "devices");
+        assert_eq!(encoded_value["protocols"][3]["type"], "feature");
         let decoded: UsyncQuery = serde_json::from_slice(&encoded).unwrap();
         assert_eq!(decoded, query);
 
@@ -1771,6 +1825,24 @@ mod tests {
             duplicate.to_string().contains("duplicate USync protocol"),
             "unexpected deserialization error: {duplicate}"
         );
+    }
+
+    #[test]
+    fn query_validation_rejects_non_canonical_phone_inputs() {
+        const INVALID_PHONES: &[&str] = &["+", "abc", "+12 34", "+0123", "+1234567890123456"];
+
+        for phone in INVALID_PHONES {
+            let error = UsyncQuery::new(
+                UsyncMode::Query,
+                UsyncContext::Interactive,
+                vec![UsyncProtocol::Contact {
+                    addressing_mode: UsyncAddressingMode::Pn,
+                }],
+                vec![UsyncUser::from_phone(*phone)],
+            )
+            .unwrap_err();
+            assert_eq!(error, UsyncValidationError::InvalidPhone { index: 0 });
+        }
     }
 
     #[test]

--- a/wacore/src/lib.rs
+++ b/wacore/src/lib.rs
@@ -42,6 +42,7 @@ pub mod request;
 pub mod runtime;
 pub mod secret_enc_addon;
 pub mod send;
+mod serde_helpers;
 pub mod session;
 pub mod shortcake;
 pub mod stanza;

--- a/wacore/src/serde_helpers.rs
+++ b/wacore/src/serde_helpers.rs
@@ -1,0 +1,119 @@
+use core::fmt;
+
+use serde::Serialize;
+use serde::de::{SeqAccess, Visitor};
+
+const MAX_PREALLOCATED_BYTE_BUFFER: usize = 1024 * 1024;
+
+struct Bytes<'a>(&'a [u8]);
+
+impl Serialize for Bytes<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(self.0)
+    }
+}
+
+pub(crate) fn serialize_optional_bytes<T, S>(
+    value: &Option<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: AsRef<[u8]>,
+    S: serde::Serializer,
+{
+    match value {
+        Some(value) => serializer.serialize_some(&Bytes(value.as_ref())),
+        None => serializer.serialize_none(),
+    }
+}
+
+struct ByteBufferVisitor;
+
+impl<'de> Visitor<'de> for ByteBufferVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a byte buffer")
+    }
+
+    fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(value.to_vec())
+    }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(value.to_vec())
+    }
+
+    fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let capacity = sequence
+            .size_hint()
+            .unwrap_or(0)
+            .min(MAX_PREALLOCATED_BYTE_BUFFER);
+        let mut bytes = Vec::with_capacity(capacity);
+        while let Some(byte) = sequence.next_element()? {
+            bytes.push(byte);
+        }
+        Ok(bytes)
+    }
+}
+
+struct OptionalBytesVisitor;
+
+impl<'de> Visitor<'de> for OptionalBytesVisitor {
+    type Value = Option<Vec<u8>>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an optional byte buffer")
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_byte_buf(ByteBufferVisitor)
+            .map(Some)
+    }
+}
+
+pub(crate) fn deserialize_optional_bytes<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_option(OptionalBytesVisitor)
+}

--- a/wacore/src/stanza/business.rs
+++ b/wacore/src/stanza/business.rs
@@ -3,7 +3,7 @@
 //! Reference: WhatsApp Web `WAWebHandleBusinessNotification`
 
 use anyhow::{Result, anyhow};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use wacore_binary::Jid;
 use wacore_binary::NodeRef;
 
@@ -34,12 +34,17 @@ pub enum BusinessNotificationType {
 }
 
 /// Verified name certificate information.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerifiedName {
     pub name: Option<String>,
     pub serial: Option<String>,
     pub issuer: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_helpers::serialize_optional_bytes",
+        deserialize_with = "crate::serde_helpers::deserialize_optional_bytes"
+    )]
     pub certificate: Option<Vec<u8>>,
 }
 

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -562,9 +562,8 @@ impl ProtocolStore for InMemoryBackend {
             return Ok(());
         }
         let mut state = self.state.lock().await;
-        let targets: std::collections::HashSet<&str> = device_jids.iter().copied().collect();
         for group_map in state.sender_key_devices.values_mut() {
-            group_map.retain(|jid, _| !targets.contains(jid.as_str()));
+            group_map.retain(|jid, _| !device_jids.contains(&jid.as_str()));
         }
         Ok(())
     }

--- a/wacore/src/store/traits.rs
+++ b/wacore/src/store/traits.rs
@@ -87,6 +87,42 @@ pub struct DeviceInfo {
     pub device_id: u32,
     /// The key index, if known
     pub key_index: Option<u32>,
+    /// Whether the device uses the hosted PN/LID address space.
+    #[serde(default)]
+    pub is_hosted: bool,
+}
+
+impl DeviceInfo {
+    /// Construct a regular device entry.
+    pub const fn new(device_id: u32, key_index: Option<u32>) -> Self {
+        Self {
+            device_id,
+            key_index,
+            is_hosted: false,
+        }
+    }
+
+    /// Apply the hosted bit reported by the device-list source.
+    pub const fn with_hosting(mut self, is_hosted: bool) -> Self {
+        self.is_hosted = is_hosted;
+        self
+    }
+}
+
+#[cfg(test)]
+mod device_info_tests {
+    use super::DeviceInfo;
+
+    #[test]
+    fn hosted_flag_is_backward_compatible_with_persisted_json() {
+        let legacy: DeviceInfo = serde_json::from_str(r#"{"device_id":7,"key_index":3}"#).unwrap();
+        assert!(!legacy.is_hosted);
+
+        let hosted = DeviceInfo::new(7, Some(3)).with_hosting(true);
+        let roundtrip: DeviceInfo =
+            serde_json::from_str(&serde_json::to_string(&hosted).unwrap()).unwrap();
+        assert!(roundtrip.is_hosted);
+    }
 }
 
 /// Device list record matching WhatsApp Web's DeviceListRecord structure.

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -1,6 +1,8 @@
-use anyhow::{Result, anyhow};
+use crate::iq::usync::{
+    device_list_query, parse_usync_response, project_device_list_response, project_lid_mapping,
+};
+use anyhow::Result;
 use wacore_binary::Jid;
-use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Node, NodeRef};
 
 /// A LID mapping learned from usync response
@@ -16,6 +18,25 @@ pub struct UsyncLidMapping {
 pub struct UsyncDevice {
     pub device: u16,
     pub key_index: Option<u32>,
+    /// Whether this device belongs to the hosted address space.
+    pub is_hosted: bool,
+}
+
+impl UsyncDevice {
+    /// Construct a regular device entry.
+    pub const fn new(device: u16, key_index: Option<u32>) -> Self {
+        Self {
+            device,
+            key_index,
+            is_hosted: false,
+        }
+    }
+
+    /// Apply the hosted bit reported by the device list.
+    pub const fn with_hosting(mut self, is_hosted: bool) -> Self {
+        self.is_hosted = is_hosted;
+        self
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -27,113 +48,14 @@ pub struct UserDeviceList {
 }
 
 pub fn build_get_user_devices_query(jids: &[Jid], sid: &str) -> Node {
-    let user_nodes = jids
-        .iter()
-        .map(|jid| {
-            NodeBuilder::new("user")
-                .attr("jid", jid.to_non_ad())
-                .build()
-        })
-        .collect::<Vec<_>>();
-
-    let query_node = NodeBuilder::new("query")
-        .children([NodeBuilder::new("devices").attr("version", "2").build()])
-        .build();
-
-    let list_node = NodeBuilder::new("list").children(user_nodes).build();
-
-    NodeBuilder::new("usync")
-        .attrs([
-            ("context", "message"),
-            ("index", "0"),
-            ("last", "true"),
-            ("mode", "query"),
-            ("sid", sid),
-        ])
-        .children([query_node, list_node])
-        .build()
+    device_list_query(jids, None).build_node(sid)
 }
 
 /// Parse usync response returning devices grouped by user with phash.
 /// This is the full-featured version that includes the participant hash.
 pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Vec<UserDeviceList>> {
-    let list_node = resp_node
-        .get_optional_child_by_tag(&["usync", "list"])
-        .ok_or_else(|| anyhow!("<usync> or <list> not found in usync response"))?;
-
-    let mut result = Vec::new();
-
-    for user_node in list_node.get_children_by_tag("user") {
-        let user_jid = user_node.attrs().jid("jid");
-        let device_list_node = user_node
-            .get_optional_child_by_tag(&["devices", "device-list"])
-            .ok_or_else(|| anyhow!("<device-list> not found for user {}", user_jid.observe()))?;
-
-        // Extract phash from device-list node attributes
-        let phash = device_list_node
-            .attrs()
-            .optional_string("hash")
-            .map(|s| s.to_string());
-
-        // Parse key-index-list from <devices> node (sibling of <device-list>)
-        // WA Web: WAWebUsyncDevice.deviceParser() extracts both deviceList and keyIndex
-        let devices_parent = user_node.get_optional_child("devices");
-        let key_index_bytes = devices_parent
-            .and_then(|dp| dp.get_optional_child("key-index-list"))
-            .and_then(|ki| match &ki.content {
-                Some(wacore_binary::NodeContent::Bytes(b)) if !b.is_empty() => Some(b.clone()),
-                _ => None,
-            });
-
-        let capacity = device_list_node.children().map_or(0, |c| c.len());
-        let mut devices = Vec::with_capacity(capacity);
-        for device_node in device_list_node.get_children_by_tag("device") {
-            let device_id_str = match device_node.attrs().optional_string("id") {
-                Some(id) => id,
-                None => {
-                    log::warn!(target: "usync", "device node missing 'id' attribute, skipping");
-                    continue;
-                }
-            };
-            let device_id: u16 = match device_id_str.parse() {
-                Ok(id) => id,
-                Err(_) => {
-                    log::warn!(target: "usync", "invalid device id '{device_id_str}' for user {}, skipping", user_jid.observe());
-                    continue;
-                }
-            };
-
-            let key_index = device_node
-                .attrs()
-                .optional_string("key-index")
-                .and_then(|s| s.parse::<u32>().ok());
-            devices.push(UsyncDevice {
-                device: device_id,
-                key_index,
-            });
-        }
-
-        // WA Web: WAWebHandleAdvForUsyncApi.handleADVSyncResult() rejects usync results
-        // that have companion devices but no signedKeyIndexBytes.
-        let has_companion = devices.iter().any(|d| d.device != 0);
-        if has_companion && key_index_bytes.is_none() {
-            log::warn!(
-                target: "usync",
-                "User {} has companion devices but no signedKeyIndexBytes, skipping",
-                user_jid.observe()
-            );
-            continue;
-        }
-
-        result.push(UserDeviceList {
-            user: user_jid.to_non_ad(),
-            devices,
-            phash,
-            key_index_bytes,
-        });
-    }
-
-    Ok(result)
+    let response = parse_usync_response(&resp_node.as_node_ref())?;
+    Ok(project_device_list_response(response)?.device_lists)
 }
 
 /// Parse usync response returning a flat list of device JIDs.
@@ -143,56 +65,25 @@ pub fn parse_get_user_devices_response(resp_node: &Node) -> Result<Vec<Jid>> {
         .into_iter()
         .flat_map(|u| {
             let user_jid = u.user;
-            u.devices.into_iter().map(move |d| {
-                let mut jid = user_jid.clone();
-                jid.device = d.device;
-                jid
-            })
+            u.devices
+                .into_iter()
+                .map(move |d| user_jid.with_device_hosting(d.device, d.is_hosted))
         })
         .collect())
 }
 
 /// Parse LID mappings from a usync `NodeRef` response (zero-copy path).
 pub fn parse_lid_mappings_from_response(resp_node: &NodeRef<'_>) -> Vec<UsyncLidMapping> {
-    let mut mappings = Vec::new();
-
-    let list_node = match resp_node.get_optional_child_by_tag(&["usync", "list"]) {
-        Some(node) => node,
-        None => return mappings,
-    };
-
-    for user_node in list_node.get_children_by_tag("user") {
-        let user_jid_str = match user_node.attrs().optional_string("jid") {
-            Some(jid) => jid,
-            None => continue,
-        };
-        let user_jid: Jid = match user_jid_str.parse() {
-            Ok(j) => j,
-            Err(_) => continue,
-        };
-
-        if user_jid.server != wacore_binary::Server::Pn {
-            continue;
-        }
-
-        if let Some(lid_node) = user_node.get_optional_child("lid") {
-            let lid_val = match lid_node.attrs().optional_string("val") {
-                Some(v) => v,
-                None => continue,
-            };
-            if !lid_val.is_empty()
-                && let Ok(lid_jid) = lid_val.parse::<Jid>()
-                && lid_jid.server == wacore_binary::Server::Lid
-            {
-                mappings.push(UsyncLidMapping {
-                    phone_number: user_jid.user.clone(),
-                    lid: lid_jid.user.clone(),
-                });
-            }
-        }
-    }
-
-    mappings
+    parse_usync_response(resp_node).map_or_else(
+        |_| Vec::new(),
+        |response| {
+            response
+                .users
+                .iter()
+                .filter_map(project_lid_mapping)
+                .collect()
+        },
+    )
 }
 
 #[cfg(test)]
@@ -429,6 +320,7 @@ mod tests {
             NodeBuilder::new("device")
                 .attr("id", "4")
                 .attr("key-index", "93")
+                .attr("is_hosted", "true")
                 .build(),
             NodeBuilder::new("device")
                 .attr("id", "24")
@@ -476,9 +368,13 @@ mod tests {
         // Device 4: key-index="93"
         assert_eq!(result[0].devices[1].device, 4);
         assert_eq!(result[0].devices[1].key_index, Some(93));
+        assert!(result[0].devices[1].is_hosted);
 
         // Device 24: key-index="113"
         assert_eq!(result[0].devices[2].device, 24);
         assert_eq!(result[0].devices[2].key_index, Some(113));
+
+        let flat = parse_get_user_devices_response(&response).unwrap();
+        assert_eq!(flat[1].server, wacore_binary::Server::Hosted);
     }
 }


### PR DESCRIPTION
## Summary

- add a validated, typed USync request/response model for every protocol observed in the captured client
- generate USync session IDs inside the client and preserve protocol errors, refresh hints, optional status timestamps, device key-index metadata, and hosted addressing
- make existing specialized specs and legacy helpers reuse the canonical builder/parser instead of maintaining parallel wire logic
- expose the existing USync model directly through a format-agnostic Serde contract; deserialized queries always pass through the canonical validator and responses serialize without projection trees or cloned collections
- derive adjacent tagged protocol serialization and parser dispatch from the same explicit wire tags while preserving the existing Rust enum shapes
- serialize binary fields by reference and deserialize them into their final buffers, preserving absent, empty, and non-empty values without intermediate encodings
- deserialize known wire enums from borrowed strings without heap allocation, while retaining owned unknown values for forward-compatible enums
- canonicalize digit-only phone inputs and reject malformed or out-of-range international numbers before building a request
- persist hosted device metadata with backward-compatible deserialization, migrate both regular and hosted Signal namespaces, and reject unrepresentable persisted device IDs without truncation

## Protocol evidence

The request builders and response parsers were checked against the captured USync modules under `docs/captured-js/WAWeb/Usync/`, including the distinct `t` and `ts` attributes, bot profile versioning, LID attributes, sparse results, per-protocol errors, strict picture/device parsing, and hosted device markers. Hosted Signal addressing follows the captured `WAWeb/Signal/Address.js` namespace mapping.

## Compatibility

Persisted `DeviceInfo` values that predate `is_hosted` deserialize as regular devices. Constructors were added for `DeviceInfo` and `UsyncDevice` so callers do not need to repeat defaults. The public `UsyncProtocol::Features(Vec<_>)` shape and adjacent `type`/`data` representation are preserved while their discriminators now share the protocol wire-tag source of truth.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests -- -D warnings`
- 46 focused USync tests
- 12 wire-enum Serde contract tests
- 53 device-registry tests
- 46 LID/PN migration tests
- complete core library suite: 1,178 passed, 1 intentionally ignored
- workspace unit and integration suites excluding E2E (all executed tests passed)
