### PR TITLE
fix(contacts): short-circuit user-directed IQs for the system JID

### DIFF
--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -209,8 +209,7 @@ impl<'a> Contacts<'a> {
         preview: bool,
         timeout: Option<Duration>,
     ) -> Result<Option<ProfilePicture>, ContactError> {
-        // The system JID never answers this IQ, so sending would burn the whole
-        // request timeout; WA Web resolves it locally without a server round-trip.
+        // The system JID never answers this IQ; skip it to save the full timeout.
         if jid.is_psa() {
             return Ok(None);
         }
@@ -269,8 +268,7 @@ impl<'a> Contacts<'a> {
         &self,
         jids: &[Jid],
     ) -> Result<HashMap<Jid, UserInfo>, ContactError> {
-        // Usync never targets the system JID (WA Web filters it out before
-        // querying), so drop it here instead of asking about a user that can't answer.
+        // The system JID is not usync-eligible and would never answer.
         let queried: Vec<Jid> = jids.iter().filter(|jid| !jid.is_psa()).cloned().collect();
         if queried.is_empty() {
             return Ok(HashMap::new());
@@ -376,7 +374,7 @@ mod tests {
         // proving the short-circuit is scoped to the system JID.
         let err = client
             .contacts()
-            .get_profile_picture(&Jid::pn("15550000001"), false)
+            .get_profile_picture(&Jid::pn("12025550111"), false)
             .await
             .unwrap_err();
 
@@ -398,7 +396,7 @@ mod tests {
 
         let err = client
             .contacts()
-            .get_user_info(&[psa_jid(), Jid::pn("15550000001")])
+            .get_user_info(&[psa_jid(), Jid::pn("12025550111")])
             .await
             .unwrap_err();
 

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -209,6 +209,12 @@ impl<'a> Contacts<'a> {
         preview: bool,
         timeout: Option<Duration>,
     ) -> Result<Option<ProfilePicture>, ContactError> {
+        // The system JID never answers this IQ, so sending would burn the whole
+        // request timeout; WA Web resolves it locally without a server round-trip.
+        if jid.is_psa() {
+            return Ok(None);
+        }
+
         debug!(
             "get_profile_picture: fetching {} picture for {}",
             if preview { "preview" } else { "full" },
@@ -263,37 +269,42 @@ impl<'a> Contacts<'a> {
         &self,
         jids: &[Jid],
     ) -> Result<HashMap<Jid, UserInfo>, ContactError> {
-        if jids.is_empty() {
+        // Usync never targets the system JID (WA Web filters it out before
+        // querying), so drop it here instead of asking about a user that can't answer.
+        let queried: Vec<Jid> = jids.iter().filter(|jid| !jid.is_psa()).cloned().collect();
+        if queried.is_empty() {
             return Ok(HashMap::new());
         }
 
-        debug!("get_user_info: fetching info for {} JIDs", jids.len());
+        debug!("get_user_info: fetching info for {} JIDs", queried.len());
 
         let request_id = self.client.generate_request_id();
-        let mut spec = UserInfoSpec::new(jids.to_vec(), request_id);
 
         // Attach per-user tctokens so the status/about of privacy-restricted
         // contacts is returned, matching WA Web's USyncStatusProtocol.getUserElement.
+        let mut tc_tokens: HashMap<String, Vec<u8>> = HashMap::new();
         if self
             .client
             .ab_props()
             .is_enabled(wacore::iq::abprops::web::PROFILE_SCRAPING_PRIVACY_TOKEN_IN_ABOUT_USYNC)
             .await
         {
-            let lookups = futures::future::join_all(jids.iter().map(|jid| async move {
+            let lookups = futures::future::join_all(queried.iter().map(|jid| async move {
                 (
                     jid.to_non_ad().to_string(),
                     self.client.lookup_tc_token_for_jid(jid).await,
                 )
             }))
             .await;
-            let tc_tokens: HashMap<String, Vec<u8>> = lookups
+            tc_tokens = lookups
                 .into_iter()
                 .filter_map(|(key, token)| token.map(|t| (key, t)))
                 .collect();
-            if !tc_tokens.is_empty() {
-                spec = spec.with_tc_tokens(tc_tokens);
-            }
+        }
+
+        let mut spec = UserInfoSpec::new(queried, request_id);
+        if !tc_tokens.is_empty() {
+            spec = spec.with_tc_tokens(tc_tokens);
         }
 
         let info = self.client.execute(spec).await?;
@@ -339,5 +350,58 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("only supports PN and LID JIDs"));
+    }
+
+    fn psa_jid() -> Jid {
+        Jid::pn("0")
+    }
+
+    #[tokio::test]
+    async fn profile_picture_for_system_jid_short_circuits_without_iq() {
+        let client = crate::test_utils::create_test_client().await;
+
+        let result = client
+            .contacts()
+            .get_profile_picture(&psa_jid(), false)
+            .await;
+
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[tokio::test]
+    async fn profile_picture_for_regular_jid_still_hits_the_wire() {
+        let client = crate::test_utils::create_test_client().await;
+
+        // Disconnected client: reaching the send path is what produces this error,
+        // proving the short-circuit is scoped to the system JID.
+        let err = client
+            .contacts()
+            .get_profile_picture(&Jid::pn("15550000001"), false)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ContactError::Iq(IqError::NotConnected)));
+    }
+
+    #[tokio::test]
+    async fn user_info_with_only_system_jid_returns_empty_without_iq() {
+        let client = crate::test_utils::create_test_client().await;
+
+        let info = client.contacts().get_user_info(&[psa_jid()]).await.unwrap();
+
+        assert!(info.is_empty());
+    }
+
+    #[tokio::test]
+    async fn user_info_still_queries_remaining_jids_after_filtering() {
+        let client = crate::test_utils::create_test_client().await;
+
+        let err = client
+            .contacts()
+            .get_user_info(&[psa_jid(), Jid::pn("15550000001")])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ContactError::Iq(IqError::NotConnected)));
     }
 }

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -350,6 +350,7 @@ pub const MESSENGER_SERVER: &str = "msgr";
 pub const INTEROP_SERVER: &str = "interop";
 pub const BOT_SERVER: &str = "bot";
 pub const STATUS_BROADCAST_USER: &str = "status";
+pub const PSA_USER: &str = "0";
 
 pub type MessageId = String;
 pub type MessageServerId = i32;
@@ -418,6 +419,13 @@ pub trait JidExt {
 
     fn is_status_broadcast(&self) -> bool {
         self.server() == Server::Broadcast && self.user() == STATUS_BROADCAST_USER
+    }
+
+    /// The system/announcements account (`0@s.whatsapp.net` / `0@c.us`).
+    /// It never answers user-directed IQs, so requests must be short-circuited
+    /// client-side (WA Web excludes it via `isPSA` before hitting the server).
+    fn is_psa(&self) -> bool {
+        matches!(self.server(), Server::Pn | Server::Legacy) && self.user() == PSA_USER
     }
 
     fn is_bot(&self) -> bool {
@@ -1207,6 +1215,21 @@ impl TryFrom<String> for Jid {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn is_psa_matches_system_jid_in_both_user_namespaces() {
+        assert!(Jid::from_str("0@s.whatsapp.net").unwrap().is_psa());
+        assert!(Jid::from_str("0@c.us").unwrap().is_psa());
+        assert!(parse_jid_ref("0@s.whatsapp.net").unwrap().is_psa());
+    }
+
+    #[test]
+    fn is_psa_rejects_regular_and_non_pn_jids() {
+        assert!(!Jid::from_str("10@s.whatsapp.net").unwrap().is_psa());
+        assert!(!Jid::from_str("0@lid").unwrap().is_psa());
+        assert!(!Jid::from_str("status@broadcast").unwrap().is_psa());
+        assert!(!Jid::from_str("0@g.us").unwrap().is_psa());
+    }
 
     #[test]
     fn display_eq_matches_owned_and_borrowed_jids_without_normalizing() {


### PR DESCRIPTION
Fixes #1079.

## Problem

A profile-picture IQ for the system/announcements JID `0@s.whatsapp.net` never gets a reply from the server, so every call burned the full request timeout (~30 s) instead of failing fast like ordinary missing avatars do (`item-not-found` within a few hundred ms).

## Why this is the right fix

The official client never sends these requests in the first place:

- `WAWebProfilePicThumbCollection.findImpl` only calls `requestProfilePicFromServer` for user/group/newsletter WIDs **and** `!isPSA(wid)`; the PSA WID resolves locally with `{ id, tag: null }` (i.e. "no picture") without a round-trip.
- `WAWebWid.isPSA` is exactly `user === "0"` on the user namespace.
- The usync side is filtered the same way: `WAWebMexUsync` drops non-eligible WIDs via `isEligibleForUSync` (`isUser && !isPSA`) before querying, and skips the query entirely if nothing is left.

So the server never answering this IQ is untested territory for the official client, and the guard belongs client-side.

## Changes

- `JidExt::is_psa()` on the shared trait (covers `0@s.whatsapp.net` and legacy `0@c.us`), so every call site shares one zero-allocation check instead of ad-hoc string comparisons.
- `get_profile_picture[_with_timeout]` returns `Ok(None)` immediately for the system JID, matching what WA Web reports for it.
- `get_user_info` filters the system JID out of the usync batch (returning an empty map if nothing remains), mirroring the `isEligibleForUSync` filter. The reorder also keeps a single `Vec` allocation: the filtered list is moved into the spec instead of `jids.to_vec()` plus a filter pass.

`is_on_whatsapp` was left untouched on purpose: WA Web's `WAWebQueryExistsJob` does not filter PSA, so we keep parity there.

## Tests

- `is_psa` unit tests in `wacore-binary` (both namespaces, `JidRef`, and negatives for `0@lid`, `0@g.us`, `status@broadcast`, regular users).
- Behavior tests in `features::contacts`: the system JID short-circuits without touching the wire, while regular JIDs still reach the send path; same pair for `get_user_info` (PSA-only input returns an empty map, mixed input still queries the remainder).

`cargo fmt`, `cargo clippy --all --all-targets -- -D warnings` and the test suites for the touched crates all pass.
