### PR TITLE
feat(messages): surface business verified name from the message envelope

### DIFF
--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -843,6 +843,18 @@ fn apply_inbound(
         cs.contacts = true;
     }
 
+    // Same for business verified names, so display_name() can fall back to them.
+    if !info.source.is_from_me
+        && let Some(name) = info
+            .verified_name
+            .as_ref()
+            .and_then(|vn| vn.name.as_deref())
+        && !name.is_empty()
+    {
+        upsert_contact_business_name(conn, device_id, &sender, name)?;
+        cs.contacts = true;
+    }
+
     match classify(&inbound.message) {
         MessageOp::Store { kind, text } => {
             let inserted = insert_message(
@@ -1744,6 +1756,26 @@ fn upsert_contact_push_name(
         .on_conflict((dsl::device_id, dsl::jid))
         .do_update()
         .set(dsl::push_name.eq(push_name))
+        .execute(conn)?;
+    Ok(())
+}
+
+fn upsert_contact_business_name(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    jid: &str,
+    business_name: &str,
+) -> QueryResult<()> {
+    use schema::contacts::dsl;
+    diesel::insert_into(dsl::contacts)
+        .values((
+            dsl::device_id.eq(device_id),
+            dsl::jid.eq(jid),
+            dsl::business_name.eq(business_name),
+        ))
+        .on_conflict((dsl::device_id, dsl::jid))
+        .do_update()
+        .set(dsl::business_name.eq(business_name))
         .execute(conn)?;
     Ok(())
 }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -110,6 +110,70 @@ async fn live_text_message_materializes_chat_and_message() {
 }
 
 #[tokio::test]
+async fn business_verified_name_is_learned_from_live_messages() {
+    let (_store, chat_store) = test_store().await;
+
+    let mut info = incoming_info(PEER, PEER, "MSG-BIZ-1", 1_700_000_000);
+    info.verified_name = Some(Box::new(wacore::stanza::business::VerifiedName {
+        name: Some("Fictitious Biz Ltd".into()),
+        serial: Some("12345".into()),
+        issuer: Some("smb:wa".into()),
+        certificate: None,
+    }));
+    feed(
+        &chat_store,
+        [message_event(wa::Message::text("promo"), info)],
+    )
+    .await;
+
+    let contact = chat_store.contact(&jid(PEER)).await.unwrap().unwrap();
+    assert_eq!(contact.business_name.as_deref(), Some("Fictitious Biz Ltd"));
+    // No address-book or push name: the verified name is the display name.
+    assert_eq!(contact.display_name(), Some("Fictitious Biz Ltd"));
+}
+
+#[tokio::test]
+async fn later_message_without_verified_name_keeps_business_name() {
+    let (_store, chat_store) = test_store().await;
+
+    let mut info = incoming_info(PEER, PEER, "MSG-BIZ-2", 1_700_000_000);
+    info.verified_name = Some(Box::new(wacore::stanza::business::VerifiedName {
+        name: Some("Fictitious Biz Ltd".into()),
+        serial: None,
+        issuer: None,
+        certificate: None,
+    }));
+    let plain = incoming_info(PEER, PEER, "MSG-BIZ-3", 1_700_000_100);
+    feed(
+        &chat_store,
+        [
+            message_event(wa::Message::text("promo"), info),
+            message_event(wa::Message::text("follow-up"), plain),
+        ],
+    )
+    .await;
+
+    let contact = chat_store.contact(&jid(PEER)).await.unwrap().unwrap();
+    assert_eq!(contact.business_name.as_deref(), Some("Fictitious Biz Ltd"));
+}
+
+#[tokio::test]
+async fn nameless_verified_cert_creates_no_contact_row() {
+    let (_store, chat_store) = test_store().await;
+
+    let mut info = incoming_info(PEER, PEER, "MSG-BIZ-4", 1_700_000_000);
+    info.verified_name = Some(Box::new(wacore::stanza::business::VerifiedName {
+        name: None,
+        serial: None,
+        issuer: None,
+        certificate: Some(vec![0xff, 0x13]),
+    }));
+    feed(&chat_store, [message_event(wa::Message::text("hi"), info)]).await;
+
+    assert!(chat_store.contact(&jid(PEER)).await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn outgoing_status_advances_monotonically() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -1057,6 +1057,11 @@ pub fn parse_message_info(
     let verified_name_serial = attrs
         .optional_u64("verified_name")
         .and_then(|v| i64::try_from(v).ok());
+    // The display name only exists inside the <verified_name> child's cert protobuf.
+    let verified_name = node
+        .get_optional_child("verified_name")
+        .and_then(|vn| crate::stanza::business::VerifiedName::try_from_node(vn).ok())
+        .map(Box::new);
     let peer_recipient_pn = attrs.optional_jid("peer_recipient_pn");
 
     // <meta> child attrs (WAWebHandleMsgParser b()) and <reporting> children
@@ -1127,6 +1132,7 @@ pub fn parse_message_info(
         is_offline,
         server_timestamp_us,
         verified_level,
+        verified_name,
         verified_name_serial,
         peer_recipient_pn,
         meta_info,
@@ -1413,6 +1419,66 @@ mod parse_message_info_tests {
         );
     }
 
+    /// The `<verified_name>` child cert decodes into the business display
+    /// name (WAWebHandleMsgParser reads the same child into
+    /// `verifiedNameCert`; the name lives in the cert's details protobuf).
+    #[test]
+    #[allow(clippy::disallowed_methods)]
+    fn envelope_verified_name_cert_is_decoded() {
+        use buffa::Message;
+        let details = wa::verified_name_certificate::Details {
+            verified_name: Some("Fictitious Biz Ltd".into()),
+            issuer: Some("smb:wa".into()),
+            serial: Some(12345),
+            ..Default::default()
+        };
+        let cert = wa::VerifiedNameCertificate {
+            details: Some(details.encode_to_vec()),
+            ..Default::default()
+        };
+        let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
+        let node = NodeBuilder::new("message")
+            .attr("from", "99000000000001@s.whatsapp.net")
+            .attr("type", "text")
+            .attr("id", "MSG-VN-1")
+            .attr("t", "1777415965")
+            .attr("verified_name", "12345")
+            .children([NodeBuilder::new("verified_name")
+                .attr("v", "2")
+                .bytes(cert.encode_to_vec())
+                .build()])
+            .build();
+
+        let info = parse_message_info(&node.as_node_ref(), &own_pn, None).unwrap();
+
+        let vn = info.verified_name.expect("cert must reach MessageInfo");
+        assert_eq!(vn.name.as_deref(), Some("Fictitious Biz Ltd"));
+        assert_eq!(vn.serial.as_deref(), Some("12345"));
+        assert_eq!(vn.issuer.as_deref(), Some("smb:wa"));
+        assert_eq!(info.verified_name_serial, Some(12345));
+    }
+
+    /// Undecodable cert bytes must not fail message parsing; the node is
+    /// still surfaced, just without a decoded name.
+    #[test]
+    fn envelope_verified_name_bad_cert_does_not_fail_parse() {
+        let own_pn = Jid::from_str("559900000000@s.whatsapp.net").unwrap();
+        let node = NodeBuilder::new("message")
+            .attr("from", "99000000000001@s.whatsapp.net")
+            .attr("type", "text")
+            .attr("id", "MSG-VN-2")
+            .attr("t", "1777415965")
+            .children([NodeBuilder::new("verified_name")
+                .bytes(vec![0xff, 0x00, 0x13, 0x37])
+                .build()])
+            .build();
+
+        let info = parse_message_info(&node.as_node_ref(), &own_pn, None).unwrap();
+
+        let vn = info.verified_name.expect("node presence is surfaced");
+        assert!(vn.name.is_none());
+    }
+
     /// Envelope without any of the optional enrichment attrs leaves all
     /// four fields as `None`. Regression guard against accidentally
     /// defaulting them.
@@ -1429,6 +1495,7 @@ mod parse_message_info_tests {
 
         assert!(info.server_timestamp_us.is_none());
         assert!(info.verified_level.is_none());
+        assert!(info.verified_name.is_none());
         assert!(info.verified_name_serial.is_none());
         assert!(info.peer_recipient_pn.is_none());
     }

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -325,8 +325,10 @@ pub struct MessageInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_info: Option<MsgBotInfo>,
     pub meta_info: MsgMetaInfo,
+    /// Decoded `<verified_name>` child cert of business senders; the display
+    /// name is in `.name`. Boxed: most messages carry none.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verified_name: Option<wa::VerifiedNameCertificate>,
+    pub verified_name: Option<Box<crate::stanza::business::VerifiedName>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_sent_meta: Option<DeviceSentMeta>,
     /// Ephemeral duration in seconds, extracted from `contextInfo.expiration`.


### PR DESCRIPTION
Fixes #1076.

## Problem

Business senders attach a `VerifiedNameCertificate` to the message stanza (`<verified_name>` child), but envelope parsing only read the `verified_name` **attribute** (the cert serial). The display name inside the cert never reached the event surface, so no contact entry was ever created or enriched for a WABA sender — any UI built on the contacts store shows a bare phone number where official clients show "HDFC Bank Ltd" etc.

Notably, `MessageInfo` already had a `verified_name` field and the chat-store's `ContactEntry` already had `business_name` with a `display_name()` fallback — both were dead: nothing ever populated them.

## Why this shape

- **WA Web** extracts the same child in `WAWebHandleMsgParser` (`verifiedNameCert = e.child("verified_name").contentBytes()`), decodes the name out of the cert details in `WAWebValidateBusinessCertificate` (`details.verifiedName`, issuer `ent:wa`/`smb:wa`), and keeps the contact's verified name updated from live traffic (`updateContactWithVerifiedName` + `createOrUpdateVerifiedBusinessNameLidAware`).
- The decode logic already existed in this repo: `VerifiedName::try_from_node` is what the usync and business-notification parsers use, and it mirrors `WAWebCommonParsersVerifiedName` exactly. The message path now reuses it instead of growing a second decoder.

## Changes

- `parse_message_info` decodes the `<verified_name>` child into the previously-dead `MessageInfo.verified_name` field. The field's type changes from the raw proto cert (never populated, so nobody could be depending on it) to the decoded `wacore::stanza::business::VerifiedName`, matching the usync `UserInfo` surface. It is boxed so the common no-cert case costs one pointer in `MessageInfo` instead of ~100 bytes — this struct rides the hot message path.
- The chat-store learns `contacts.business_name` from inbound messages through the same write path that already learns push names, so `ContactEntry::display_name()` starts returning the verified name with no further API changes. Messages without a cert don't touch the column, so a later plain message can't clobber a learned name.
- Undecodable cert bytes never fail message parsing: the node is still surfaced, just without a decoded name (same behavior as the notification parser). No signature verification, matching WA Web, which only decodes.

## Tests

- Envelope parsing: cert decodes into name/serial/issuer alongside the serial attr; garbage cert bytes don't fail the parse; the no-attrs regression test now also guards `verified_name`.
- Chat-store: business name is learned from a live message and wins `display_name()` when nothing else is set; a later message without a cert keeps the learned name; a nameless cert creates no contact row.

`cargo fmt`, `cargo clippy --all --all-targets -- -D warnings` and the test suites for `wacore`, `whatsapp-rust` and `whatsapp-rust-chat-store` all pass.
