### PR TITLE
fix(chat-store): resolve PN/LID aliases so receipts reach their rows

### DIFF
--- a/storages/chat-store/src/lib.rs
+++ b/storages/chat-store/src/lib.rs
@@ -31,6 +31,7 @@
 mod error;
 #[cfg(feature = "search")]
 mod fts;
+mod lid;
 mod materialize;
 mod queries;
 mod schema;

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -16,7 +16,7 @@
 //! `accountLid` column, and the chat-store needs no schema of its own.
 
 use diesel::prelude::*;
-use diesel::sql_types::{Bool, Integer, Text};
+use diesel::sql_types::{BigInt, Binary, Bool, Integer, Nullable, Text};
 use wacore_binary::{Jid, Server};
 
 use crate::schema;
@@ -145,6 +145,16 @@ struct DupMessage {
     status: i32,
     #[diesel(sql_type = Bool)]
     starred: bool,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    edited_at_ms: Option<i64>,
+    #[diesel(sql_type = Bool)]
+    revoked: bool,
+    #[diesel(sql_type = Nullable<Text>)]
+    text_content: Option<String>,
+    #[diesel(sql_type = Text)]
+    kind: String,
+    #[diesel(sql_type = Nullable<Binary>)]
+    proto: Option<Vec<u8>>,
 }
 
 /// Fold a peer's split PN/LID pair into one thread and return the surviving
@@ -190,11 +200,15 @@ pub(crate) fn merge_split_chat(
     }
 
     // Same message stored under both keys (fanout echo vs. history overlap):
-    // fold the source copy's advance-only columns into the surviving row —
-    // the destination row keeps its content (it may carry a newer edit or a
-    // tombstone the source copy predates).
+    // fold the source copy into the surviving row under the live-path rules —
+    // status/starred advance-only, a source tombstone wins (`apply_revoke`),
+    // a strictly newer source edit brings its content (`apply_edit`); short
+    // of those, the destination row keeps its content.
     let dups: Vec<DupMessage> = diesel::sql_query(
-        "SELECT m.msg_id AS id, m.status AS status, m.starred AS starred FROM messages m \
+        "SELECT m.msg_id AS id, m.status AS status, m.starred AS starred, \
+                m.edited_at_ms AS edited_at_ms, m.revoked AS revoked, \
+                m.text_content AS text_content, m.kind AS kind, m.proto AS proto \
+         FROM messages m \
          WHERE m.device_id = ? AND m.chat_jid = ? AND EXISTS \
          (SELECT 1 FROM messages d WHERE d.device_id = m.device_id \
           AND d.chat_jid = ? AND d.msg_id = m.msg_id)",
@@ -214,6 +228,28 @@ pub(crate) fn merge_split_chat(
             diesel::update(crate::store::message_row(device_id, dest, &dup.id))
                 .set(dsl::starred.eq(true))
                 .execute(conn)?;
+        }
+        if dup.revoked {
+            diesel::update(crate::store::message_row(device_id, dest, &dup.id))
+                .set((
+                    dsl::revoked.eq(true),
+                    dsl::text_content.eq(None::<String>),
+                    dsl::proto.eq(None::<Vec<u8>>),
+                ))
+                .execute(conn)?;
+        } else if let Some(edited) = dup.edited_at_ms {
+            diesel::update(
+                crate::store::message_row(device_id, dest, &dup.id)
+                    .filter(dsl::revoked.eq(false))
+                    .filter(dsl::edited_at_ms.is_null().or(dsl::edited_at_ms.le(edited))),
+            )
+            .set((
+                dsl::text_content.eq(dup.text_content.as_deref()),
+                dsl::kind.eq(&dup.kind),
+                dsl::proto.eq(dup.proto.as_deref()),
+                dsl::edited_at_ms.eq(Some(edited)),
+            ))
+            .execute(conn)?;
         }
     }
     // UPDATE OR IGNORE: PK collisions (the dups above) stay behind and are

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -1,0 +1,287 @@
+//! LID/PN peer-identity resolution for chat keys.
+//!
+//! A 1:1 peer has two interchangeable wire identities — phone number
+//! (`@s.whatsapp.net`) and LID (`@lid`) — and traffic for one thread can
+//! arrive under either, independent of which key its rows were stored under.
+//! WA Web reconciles the two at lookup time
+//! (`WAWebDBBulkGetRootMsgs.fixMsgKeysWithPnMapping`,
+//! `WAWebLidMigrationUtils.getAlternateMsgKey`) and routes inbound 1:1
+//! traffic to the existing thread whichever identity addressed it
+//! (`WAWebMessageProcessUtils.selectChatForOneOnOneMessage`): legacy chat ids
+//! stay stable, only brand-new chats are keyed by LID.
+//!
+//! The device store's `lid_pn_mapping` table lives in the same database file
+//! and is bidirectional, so both candidate keys of a peer are always
+//! derivable — it already is the alias index WA Web keeps as the chat table's
+//! `accountLid` column, and the chat-store needs no schema of its own.
+
+use diesel::prelude::*;
+use diesel::sql_types::{Bool, Integer, Text};
+use wacore_binary::{Jid, Server};
+
+use crate::schema;
+use crate::store::ChangeSet;
+
+/// Bare 1:1 user chat key — the only namespace with a PN/LID alias. Hosted
+/// and interop namespaces alias differently and are left alone.
+fn user_chat(chat: &str) -> Option<Jid> {
+    let jid: Jid = chat.parse().ok()?;
+    (jid.device == 0 && jid.integrator == 0 && matches!(jid.server, Server::Pn | Server::Lid))
+        .then_some(jid)
+}
+
+#[derive(QueryableByName)]
+struct UserRow {
+    #[diesel(sql_type = Text)]
+    user: String,
+}
+
+/// The peer's other identity, from the device store's mapping table. PN
+/// resolves to its most recently updated LID (the same rule as
+/// `SqliteStore::get_pn_mapping`); LID resolves straight to its PN.
+pub(crate) fn counterpart_chat_key(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+) -> QueryResult<Option<String>> {
+    let Some(jid) = user_chat(chat) else {
+        return Ok(None);
+    };
+    let (sql, server) = if jid.is_lid() {
+        (
+            "SELECT phone_number AS user FROM lid_pn_mapping \
+             WHERE lid = ? AND device_id = ? LIMIT 1",
+            Server::Pn,
+        )
+    } else {
+        (
+            "SELECT lid AS user FROM lid_pn_mapping \
+             WHERE phone_number = ? AND device_id = ? ORDER BY updated_at DESC LIMIT 1",
+            Server::Lid,
+        )
+    };
+    let row: Option<UserRow> = diesel::sql_query(sql)
+        .bind::<Text, _>(jid.user.as_str())
+        .bind::<Integer, _>(device_id)
+        .get_result(conn)
+        .optional()?;
+    Ok(row.map(|r| Jid::new(r.user, server).to_string()))
+}
+
+/// Every key the peer's rows may live under: the given key plus its mapped
+/// counterpart. Read queries filter with these so either identity finds the
+/// thread (and a not-yet-merged split reads as one thread).
+pub(crate) fn chat_key_candidates(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+) -> QueryResult<Vec<String>> {
+    let mut keys = vec![chat.to_string()];
+    if let Some(alt) = counterpart_chat_key(conn, device_id, chat)? {
+        keys.push(alt);
+    }
+    Ok(keys)
+}
+
+/// Storage key for a chat addressed as `wire_chat`, WA Web
+/// `selectChatForOneOnOneMessage` parity: an existing thread keeps its key
+/// whichever identity addressed it; a brand-new chat with a known LID is
+/// keyed by the LID. Rows split across both keys (the state receipts dropped
+/// under the wrong identity leave behind) are merged before routing.
+pub(crate) fn route_chat_key(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    wire_chat: &str,
+    cs: &mut ChangeSet,
+) -> QueryResult<String> {
+    let Some(alt) = counterpart_chat_key(conn, device_id, wire_chat)? else {
+        return Ok(wire_chat.to_string());
+    };
+    let existing: Vec<String> = {
+        use schema::chats::dsl;
+        dsl::chats
+            .filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::jid.eq_any([wire_chat, alt.as_str()])),
+            )
+            .select(dsl::jid)
+            .load(conn)?
+    };
+    match (
+        existing.iter().any(|j| j == wire_chat),
+        existing.contains(&alt),
+    ) {
+        (true, true) => merge_split_chat(conn, device_id, wire_chat, &alt, cs),
+        (true, false) => Ok(wire_chat.to_string()),
+        (false, true) => Ok(alt),
+        (false, false) => Ok(lid_side(wire_chat, &alt).to_string()),
+    }
+}
+
+fn lid_side<'a>(a: &'a str, b: &'a str) -> &'a str {
+    if a.ends_with("@lid") { a } else { b }
+}
+
+fn newest_message_ts(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+) -> QueryResult<Option<i64>> {
+    use schema::messages::dsl;
+    dsl::messages
+        .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
+        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .select(dsl::timestamp_ms)
+        .first(conn)
+        .optional()
+}
+
+#[derive(QueryableByName)]
+struct DupMessage {
+    #[diesel(sql_type = Text)]
+    id: String,
+    #[diesel(sql_type = Integer)]
+    status: i32,
+    #[diesel(sql_type = Bool)]
+    starred: bool,
+}
+
+/// Fold a peer's split PN/LID pair into one thread and return the surviving
+/// key. Destination is the side with the newer message activity — that is the
+/// thread the peer is living in — with ties (and the empty/empty case) going
+/// to the LID side, the canonical identity going forward. Idempotent: with
+/// nothing under the source key this is a no-op.
+pub(crate) fn merge_split_chat(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    a: &str,
+    b: &str,
+    cs: &mut ChangeSet,
+) -> QueryResult<String> {
+    if a == b {
+        return Ok(a.to_string());
+    }
+    let ts_a = newest_message_ts(conn, device_id, a)?;
+    let ts_b = newest_message_ts(conn, device_id, b)?;
+    let (src, dest) = match (ts_a, ts_b) {
+        (Some(ta), Some(tb)) if ta > tb => (b, a),
+        (Some(ta), Some(tb)) if ta < tb => (a, b),
+        (Some(_), None) => (b, a),
+        (None, Some(_)) => (a, b),
+        _ => {
+            let dest = lid_side(a, b);
+            if dest == a { (b, a) } else { (a, b) }
+        }
+    };
+    let src_has_chat_row = {
+        use schema::chats::dsl;
+        dsl::chats
+            .filter(dsl::device_id.eq(device_id).and(dsl::jid.eq(src)))
+            .select(dsl::jid)
+            .first::<String>(conn)
+            .optional()?
+            .is_some()
+    };
+    let src_ts = if src == a { ts_a } else { ts_b };
+    // Nothing lives under the source key: already reconciled (or never split).
+    if !src_has_chat_row && src_ts.is_none() {
+        return Ok(dest.to_string());
+    }
+
+    // Same message stored under both keys (fanout echo vs. history overlap):
+    // fold the source copy's advance-only columns into the surviving row —
+    // the destination row keeps its content (it may carry a newer edit or a
+    // tombstone the source copy predates).
+    let dups: Vec<DupMessage> = diesel::sql_query(
+        "SELECT m.msg_id AS id, m.status AS status, m.starred AS starred FROM messages m \
+         WHERE m.device_id = ? AND m.chat_jid = ? AND EXISTS \
+         (SELECT 1 FROM messages d WHERE d.device_id = m.device_id \
+          AND d.chat_jid = ? AND d.msg_id = m.msg_id)",
+    )
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
+    .load(conn)?;
+    for dup in &dups {
+        use schema::messages::dsl;
+        diesel::update(
+            crate::store::message_row(device_id, dest, &dup.id).filter(dsl::status.lt(dup.status)),
+        )
+        .set(dsl::status.eq(dup.status))
+        .execute(conn)?;
+        if dup.starred {
+            diesel::update(crate::store::message_row(device_id, dest, &dup.id))
+                .set(dsl::starred.eq(true))
+                .execute(conn)?;
+        }
+    }
+    // UPDATE OR IGNORE: PK collisions (the dups above) stay behind and are
+    // dropped after. rowids survive the UPDATE, so the FTS external-content
+    // index stays consistent; the leftover DELETE fires its cleanup trigger.
+    diesel::sql_query(
+        "UPDATE OR IGNORE messages SET chat_jid = ? WHERE device_id = ? AND chat_jid = ?",
+    )
+    .bind::<Text, _>(dest)
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .execute(conn)?;
+    diesel::sql_query("DELETE FROM messages WHERE device_id = ? AND chat_jid = ?")
+        .bind::<Integer, _>(device_id)
+        .bind::<Text, _>(src)
+        .execute(conn)?;
+
+    // Satellites: the newest reaction per (msg, sender) and the highest
+    // receipt per (msg, user) win across the pair, matching their live-path
+    // monotonic rules — drop the losing destination rows, then move.
+    diesel::sql_query(
+        "DELETE FROM reactions WHERE device_id = ?1 AND chat_jid = ?3 AND EXISTS \
+         (SELECT 1 FROM reactions s WHERE s.device_id = ?1 AND s.chat_jid = ?2 \
+          AND s.msg_id = reactions.msg_id AND s.sender_jid = reactions.sender_jid \
+          AND s.ts_ms > reactions.ts_ms)",
+    )
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
+    .execute(conn)?;
+    diesel::sql_query(
+        "UPDATE OR IGNORE reactions SET chat_jid = ? WHERE device_id = ? AND chat_jid = ?",
+    )
+    .bind::<Text, _>(dest)
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .execute(conn)?;
+    diesel::sql_query("DELETE FROM reactions WHERE device_id = ? AND chat_jid = ?")
+        .bind::<Integer, _>(device_id)
+        .bind::<Text, _>(src)
+        .execute(conn)?;
+
+    diesel::sql_query(
+        "DELETE FROM message_receipts WHERE device_id = ?1 AND chat_jid = ?3 AND EXISTS \
+         (SELECT 1 FROM message_receipts s WHERE s.device_id = ?1 AND s.chat_jid = ?2 \
+          AND s.msg_id = message_receipts.msg_id AND s.user_jid = message_receipts.user_jid \
+          AND s.receipt_type > message_receipts.receipt_type)",
+    )
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
+    .execute(conn)?;
+    diesel::sql_query(
+        "UPDATE OR IGNORE message_receipts SET chat_jid = ? WHERE device_id = ? AND chat_jid = ?",
+    )
+    .bind::<Text, _>(dest)
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .execute(conn)?;
+    diesel::sql_query("DELETE FROM message_receipts WHERE device_id = ? AND chat_jid = ?")
+        .bind::<Integer, _>(device_id)
+        .bind::<Text, _>(src)
+        .execute(conn)?;
+
+    crate::store::merge_chat_metadata(conn, device_id, src, dest)?;
+
+    cs.chats = true;
+    cs.message_chats.insert(src.to_string());
+    cs.message_chats.insert(dest.to_string());
+    Ok(dest.to_string())
+}

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -55,8 +55,11 @@ pub(crate) fn counterpart_chat_key(
         )
     } else {
         (
+            // The lid tiebreak keeps routing stable when updated_at ties —
+            // flapping between counterpart keys would re-split the thread.
             "SELECT lid AS user FROM lid_pn_mapping \
-             WHERE phone_number = ? AND device_id = ? ORDER BY updated_at DESC LIMIT 1",
+             WHERE phone_number = ? AND device_id = ? \
+             ORDER BY updated_at DESC, lid DESC LIMIT 1",
             Server::Lid,
         )
     };
@@ -239,8 +242,8 @@ pub(crate) fn merge_split_chat(
             diesel::update(
                 crate::store::message_row(device_id, dest, &dup.id)
                     .filter(dsl::revoked.eq(false))
-                    // Strictly newer: on a timestamp tie the destination keeps
-                    // its content (the copies carry the same edit anyway).
+                    // Strictly newer: a tie may be two competing edits, and
+                    // keeping the destination's copy is the deterministic pick.
                     .filter(dsl::edited_at_ms.is_null().or(dsl::edited_at_ms.lt(edited))),
             )
             .set((

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -199,11 +199,9 @@ pub(crate) fn merge_split_chat(
         return Ok(dest.to_string());
     }
 
-    // Same message stored under both keys (fanout echo vs. history overlap):
-    // fold the source copy into the surviving row under the live-path rules —
-    // status/starred advance-only, a source tombstone wins (`apply_revoke`),
-    // a strictly newer source edit brings its content (`apply_edit`); short
-    // of those, the destination row keeps its content.
+    // A message duplicated across the pair folds by the live-path precedence
+    // rules — anything less loses receipts, stars, tombstones or edits that
+    // reached only the losing side before the split healed.
     let dups: Vec<DupMessage> = diesel::sql_query(
         "SELECT m.msg_id AS id, m.status AS status, m.starred AS starred, \
                 m.edited_at_ms AS edited_at_ms, m.revoked AS revoked, \
@@ -241,7 +239,9 @@ pub(crate) fn merge_split_chat(
             diesel::update(
                 crate::store::message_row(device_id, dest, &dup.id)
                     .filter(dsl::revoked.eq(false))
-                    .filter(dsl::edited_at_ms.is_null().or(dsl::edited_at_ms.le(edited))),
+                    // Strictly newer: on a timestamp tie the destination keeps
+                    // its content (the copies carry the same edit anyway).
+                    .filter(dsl::edited_at_ms.is_null().or(dsl::edited_at_ms.lt(edited))),
             )
             .set((
                 dsl::text_content.eq(dup.text_content.as_deref()),

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -174,6 +174,9 @@ impl ChatStore {
 
     /// One page of a chat's messages, newest first. Pass the cursor of the
     /// oldest message you already have to get the page before it.
+    ///
+    /// A 1:1 chat may be addressed by either of the peer's identities (phone
+    /// number or LID); the query resolves the alias, so both find the thread.
     pub async fn messages(
         &self,
         chat: &Jid,
@@ -187,8 +190,10 @@ impl ChatStore {
         let rows: Vec<MessageRow> = self
             .db()
             .run(move |conn| {
+                let keys =
+                    crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 let mut query = dsl::messages
-                    .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(&chat)))
+                    .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq_any(keys)))
                     .into_boxed();
                 if let Some(cursor) = &before {
                     query = query.filter(
@@ -217,11 +222,13 @@ impl ChatStore {
         let row: Option<MessageRow> = self
             .db()
             .run(move |conn| {
+                let keys =
+                    crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 dsl::messages
                     .filter(
                         dsl::device_id
                             .eq(device_id)
-                            .and(dsl::chat_jid.eq(&chat))
+                            .and(dsl::chat_jid.eq_any(keys))
                             .and(dsl::msg_id.eq(&msg_id)),
                     )
                     .first(conn)
@@ -240,11 +247,13 @@ impl ChatStore {
         let rows: Vec<(String, String, i64)> = self
             .db()
             .run(move |conn| {
+                let keys =
+                    crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 dsl::reactions
                     .filter(
                         dsl::device_id
                             .eq(device_id)
-                            .and(dsl::chat_jid.eq(&chat))
+                            .and(dsl::chat_jid.eq_any(keys))
                             .and(dsl::msg_id.eq(&msg_id)),
                     )
                     .select((dsl::sender_jid, dsl::emoji, dsl::ts_ms))
@@ -272,11 +281,13 @@ impl ChatStore {
         let rows: Vec<(String, i32, i64)> = self
             .db()
             .run(move |conn| {
+                let keys =
+                    crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 dsl::message_receipts
                     .filter(
                         dsl::device_id
                             .eq(device_id)
-                            .and(dsl::chat_jid.eq(&chat))
+                            .and(dsl::chat_jid.eq_any(keys))
                             .and(dsl::msg_id.eq(&msg_id)),
                     )
                     .select((dsl::user_jid, dsl::receipt_type, dsl::ts_ms))

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -47,6 +47,7 @@ pub(crate) enum WriterMsg {
         text: Option<String>,
         timestamp_ms: i64,
     },
+    Reconcile(Jid),
     // String, not StoreError: one batch outcome fans out to many waiters and
     // StoreError is not Clone.
     Flush(oneshot::Sender<std::result::Result<(), String>>),
@@ -147,6 +148,12 @@ impl ChatStore {
     /// it cannot race the server ack / receipts that follow it in event order.
     /// Status starts at [`MessageStatus::Pending`](crate::types::MessageStatus::Pending)
     /// and is lifted by acks/receipts.
+    ///
+    /// `chat` may be either of a 1:1 peer's identities (phone number or LID):
+    /// the row is stored on the peer's one thread regardless — an existing
+    /// thread keeps its key, a brand-new chat with a known LID mapping is
+    /// keyed by the LID (WA Web behavior) — and every query resolves the
+    /// alias, so reads by either identity keep working.
     pub fn record_outgoing(
         &self,
         chat: &Jid,
@@ -164,6 +171,21 @@ impl ChatStore {
                 text: extract_text(base),
                 timestamp_ms: timestamp.timestamp_millis(),
             })
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+    }
+
+    /// Reconcile a 1:1 peer's PN- and LID-keyed rows into a single thread.
+    ///
+    /// Receipts dropped under the wrong identity (before this crate resolved
+    /// PN/LID aliases) left some stores with a split pair: a populated chat
+    /// under the phone-number key plus a stray `@lid` twin. Live traffic for
+    /// the peer now heals such a pair on its own; this makes the repair
+    /// on-demand for embedders that want it eagerly. Idempotent — a peer with
+    /// one thread (or no LID mapping yet) is a no-op. Goes through the writer
+    /// queue; use [`flush`](Self::flush) to await completion.
+    pub fn reconcile_chat(&self, chat: &Jid) -> Result<()> {
+        self.tx
+            .send(WriterMsg::Reconcile(chat.clone()))
             .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
     }
 
@@ -386,10 +408,10 @@ fn count_uncovered_incoming(
 
 /// Chats/contacts touched by a batch, accumulated for post-commit invalidation.
 #[derive(Default)]
-struct ChangeSet {
-    chats: bool,
-    contacts: bool,
-    message_chats: BTreeSet<String>,
+pub(crate) struct ChangeSet {
+    pub(crate) chats: bool,
+    pub(crate) contacts: bool,
+    pub(crate) message_chats: BTreeSet<String>,
 }
 
 async fn writer_loop(
@@ -485,6 +507,13 @@ fn apply_writer_msg(
 ) -> QueryResult<()> {
     match msg {
         WriterMsg::Event(event) => apply_event(conn, device_id, event, cs),
+        WriterMsg::Reconcile(chat) => {
+            let wire = chat.to_string();
+            if let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, &wire)? {
+                crate::lid::merge_split_chat(conn, device_id, &wire, &alt, cs)?;
+            }
+            Ok(())
+        }
         WriterMsg::Outgoing {
             chat,
             msg_id,
@@ -493,7 +522,11 @@ fn apply_writer_msg(
             text,
             timestamp_ms,
         } => {
-            let chat_str = chat.to_string();
+            let wire = chat.to_string();
+            let chat_str = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
+            if chat_str != wire {
+                cs.message_chats.insert(wire);
+            }
             let stored = insert_message(
                 conn,
                 device_id,
@@ -549,7 +582,11 @@ fn apply_event(
         Event::Receipt(receipt) => apply_receipt(conn, device_id, receipt, cs),
         Event::ServerAck(ack) => apply_server_ack(conn, device_id, ack, cs),
         Event::UndecryptableMessage(undec) => {
-            let chat = undec.info.source.chat.to_string();
+            let wire = undec.info.source.chat.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
+            if chat != wire {
+                cs.message_chats.insert(wire);
+            }
             let sender = undec.info.source.sender.to_string();
             let inserted = insert_message(
                 conn,
@@ -616,7 +653,7 @@ fn apply_event(
                 .pinned
                 .unwrap_or(false)
                 .then(|| update.timestamp.timestamp_millis());
-            let chat = update.jid.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &update.jid.to_string(), cs)?;
             ensure_chat(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
                 .set(schema::chats::pinned_at.eq(pinned_at))
@@ -638,7 +675,7 @@ fn apply_event(
             } else {
                 None
             };
-            let chat = update.jid.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &update.jid.to_string(), cs)?;
             ensure_chat(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
                 .set(schema::chats::muted_until.eq(muted_until))
@@ -647,7 +684,7 @@ fn apply_event(
             Ok(())
         }
         Event::ArchiveUpdate(update) => {
-            let chat = update.jid.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &update.jid.to_string(), cs)?;
             ensure_chat(conn, device_id, &chat)?;
             diesel::update(chat_row(device_id, &chat))
                 .set(schema::chats::archived.eq(update.action.archived.unwrap_or(false)))
@@ -656,7 +693,7 @@ fn apply_event(
             Ok(())
         }
         Event::MarkChatAsReadUpdate(update) => {
-            let chat = update.jid.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &update.jid.to_string(), cs)?;
             ensure_chat(conn, device_id, &chat)?;
             if update.action.read.unwrap_or(false) {
                 // A delayed replay only covers messages up to its range;
@@ -721,7 +758,8 @@ fn apply_event(
             Ok(())
         }
         Event::StarUpdate(update) => {
-            let chat = update.chat_jid.to_string();
+            let chat =
+                crate::lid::route_chat_key(conn, device_id, &update.chat_jid.to_string(), cs)?;
             diesel::update(message_row(device_id, &chat, &update.message_id))
                 .set(schema::messages::starred.eq(update.action.starred.unwrap_or(false)))
                 .execute(conn)?;
@@ -729,7 +767,7 @@ fn apply_event(
             Ok(())
         }
         Event::DeleteChatUpdate(update) => {
-            let chat = update.jid.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &update.jid.to_string(), cs)?;
             let bound = range_bound(&update.action.message_range);
             delete_chat_rows(conn, device_id, &chat, true, bound.as_ref())?;
             // A delayed delete only covers up to its range: when newer
@@ -753,7 +791,7 @@ fn apply_event(
             Ok(())
         }
         Event::ClearChatUpdate(update) => {
-            let chat = update.jid.to_string();
+            let chat = crate::lid::route_chat_key(conn, device_id, &update.jid.to_string(), cs)?;
             let bound = range_bound(&update.action.message_range);
             delete_chat_rows(
                 conn,
@@ -780,7 +818,8 @@ fn apply_event(
             Ok(())
         }
         Event::DeleteMessageForMeUpdate(update) => {
-            let chat = update.chat_jid.to_string();
+            let chat =
+                crate::lid::route_chat_key(conn, device_id, &update.chat_jid.to_string(), cs)?;
             // Capture the victim's read state before it goes: deleting an
             // unread inbound row must also drop its badge (sentinel -1 and
             // already-read rows are untouched).
@@ -833,7 +872,11 @@ fn apply_inbound(
     cs: &mut ChangeSet,
 ) -> QueryResult<()> {
     let info = &inbound.info;
-    let chat = info.source.chat.to_string();
+    let wire = info.source.chat.to_string();
+    let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
+    if chat != wire {
+        cs.message_chats.insert(wire);
+    }
     let sender = info.source.sender.to_string();
     let ts_ms = info.timestamp.timestamp_millis();
 
@@ -1220,6 +1263,14 @@ fn apply_receipt(
         ReceiptType::Read => wa::web_message_info::Status::READ as i32,
         ReceiptType::Played => wa::web_message_info::Status::PLAYED as i32,
         ReceiptType::ReadSelf | ReceiptType::PlayedSelf => {
+            // Self receipts are LID-addressed once the peer is; the thread may
+            // be keyed by either identity (or split) — route to where it lives
+            // so the read state lands on the real rows, not a stray twin.
+            let wire = chat;
+            let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
+            if chat != wire {
+                cs.message_chats.insert(wire);
+            }
             // Read on another of our devices — up to the covered messages.
             // WA read state is "read up to X": the boundary is the newest
             // covered row (falling back to the receipt's own timestamp).
@@ -1276,10 +1327,11 @@ fn apply_receipt(
     };
 
     let user = receipt.source.sender.to_string();
+    let mut missed: Vec<&String> = Vec::new();
     for msg_id in &receipt.message_ids {
         // Peer receipts only ever advance the delivery state of our own
         // messages, and never backwards.
-        diesel::update(
+        let updated = diesel::update(
             message_row(device_id, &chat, msg_id).filter(
                 schema::messages::from_me
                     .eq(true)
@@ -1288,6 +1340,9 @@ fn apply_receipt(
         )
         .set(schema::messages::status.eq(status))
         .execute(conn)?;
+        if updated == 0 {
+            missed.push(msg_id);
+        }
 
         // Derived from the JID: the library's receipt parser leaves
         // `source.is_group` defaulted, so the flag can't be trusted here.
@@ -1317,6 +1372,32 @@ fn apply_receipt(
             )
             .set((dsl::receipt_type.eq(status), dsl::ts_ms.eq(ts_ms)))
             .execute(conn)?;
+        }
+    }
+    // A modern peer addresses the receipt by whichever identity it has for
+    // the thread — LID receipts for PN-keyed rows or vice versa. Retry the
+    // misses under the mapped counterpart key (WA Web's alternate-key
+    // fallback, `fixMsgKeysWithPnMapping`); costs one indexed lookup and only
+    // on the miss path, so the already-consistent case stays free.
+    if !missed.is_empty()
+        && !receipt.source.chat.is_group()
+        && let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, &chat)?
+    {
+        let mut matched_alt = false;
+        for msg_id in missed {
+            matched_alt |= diesel::update(
+                message_row(device_id, &alt, msg_id).filter(
+                    schema::messages::from_me
+                        .eq(true)
+                        .and(schema::messages::status.lt(status)),
+                ),
+            )
+            .set(schema::messages::status.eq(status))
+            .execute(conn)?
+                > 0;
+        }
+        if matched_alt {
+            cs.message_chats.insert(alt);
         }
     }
     cs.message_chats.insert(chat);
@@ -1363,18 +1444,19 @@ fn apply_server_ack(
         .execute(conn)?
     };
     if updated > 0 {
-        // Acks usually carry the chat; when they don't, resolve it from the
-        // row we just updated so consumers still get invalidated.
-        let chat = match &ack.from {
-            Some(from) => Some(from.to_string()),
-            None => dsl::messages
-                .filter(dsl::device_id.eq(device_id).and(dsl::msg_id.eq(&ack.id)))
-                .select(dsl::chat_jid)
-                .first(conn)
-                .optional()?,
-        };
-        if let Some(chat) = chat {
+        // Resolve the chat from the row itself: the ack's `from` is the wire
+        // identity, which may not be the key the row is stored under (PN/LID
+        // aliasing). Emit both so consumers keyed by either get invalidated.
+        let row_chat: Option<String> = dsl::messages
+            .filter(dsl::device_id.eq(device_id).and(dsl::msg_id.eq(&ack.id)))
+            .select(dsl::chat_jid)
+            .first(conn)
+            .optional()?;
+        if let Some(chat) = row_chat {
             cs.message_chats.insert(chat);
+        }
+        if let Some(from) = &ack.from {
+            cs.message_chats.insert(from.to_string());
         }
     }
     Ok(())
@@ -1427,7 +1509,7 @@ fn apply_history_conversation(
     conv: &wa::Conversation,
     cs: &mut ChangeSet,
 ) -> QueryResult<()> {
-    let chat = conv.id.as_str();
+    let chat = &crate::lid::route_chat_key(conn, device_id, conv.id.as_str(), cs)?;
     let last_ts_ms = conv
         .conversation_timestamp
         .map(|s| (s as i64).saturating_mul(1000))
@@ -1740,6 +1822,90 @@ fn ensure_chat(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> Query
     Ok(())
 }
 
+/// Union a split pair's chat rows into `dest` and drop `src` (the message
+/// rows have already moved). Activity and preview re-derive from the merged
+/// messages; the self-read state is the union of both sides so neither
+/// side's covered messages re-badge; sticky user prefs (pin/mute/archive,
+/// name, ephemeral) keep dest's value and fall back to src's. A manual-unread
+/// marker on either side survives; otherwise the badge is recounted.
+pub(crate) fn merge_chat_metadata(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    src: &str,
+    dest: &str,
+) -> QueryResult<()> {
+    use schema::chats::dsl;
+    type PrefRow = (
+        i64,
+        i32,
+        Option<i64>,
+        Option<i64>,
+        bool,
+        Option<i32>,
+        Option<String>,
+    );
+    let prefs = |conn: &mut SqliteConnection, key: &str| -> QueryResult<Option<PrefRow>> {
+        chat_row(device_id, key)
+            .select((
+                dsl::last_message_ts,
+                dsl::unread_count,
+                dsl::pinned_at,
+                dsl::muted_until,
+                dsl::archived,
+                dsl::ephemeral_expiration,
+                dsl::name,
+            ))
+            .first(conn)
+            .optional()
+    };
+    let Some(src_row) = prefs(conn, src)? else {
+        return Ok(());
+    };
+    let src_state = read_state(conn, device_id, src)?;
+    ensure_chat(conn, device_id, dest)?;
+    let dest_row = prefs(conn, dest)?.unwrap_or((0, 0, None, None, false, None, None));
+    let dest_state = read_state(conn, device_id, dest)?;
+
+    let mut merged = ReadState {
+        watermark_ms: src_state.watermark_ms.max(dest_state.watermark_ms),
+        extra_ids: dest_state.extra_ids,
+    };
+    for id in src_state.extra_ids {
+        if !merged.extra_ids.contains(&id) {
+            merged.extra_ids.push(id);
+        }
+    }
+    if merged.extra_ids.len() > READ_EXTRA_IDS_CAP {
+        let overflow = merged.extra_ids.len() - READ_EXTRA_IDS_CAP;
+        merged.extra_ids.drain(..overflow);
+    }
+    let ids_json = (!merged.extra_ids.is_empty())
+        .then(|| serde_json::to_string(&merged.extra_ids).ok())
+        .flatten();
+
+    let unread = if src_row.1 == UNREAD_MARKER || dest_row.1 == UNREAD_MARKER {
+        UNREAD_MARKER
+    } else {
+        count_unread(conn, device_id, dest, &merged)?
+    };
+    diesel::update(chat_row(device_id, dest))
+        .set((
+            dsl::last_message_ts.eq(src_row.0.max(dest_row.0)),
+            dsl::unread_count.eq(unread),
+            dsl::pinned_at.eq(dest_row.2.or(src_row.2)),
+            dsl::muted_until.eq(dest_row.3.or(src_row.3)),
+            dsl::archived.eq(dest_row.4 || src_row.4),
+            dsl::ephemeral_expiration.eq(dest_row.5.or(src_row.5)),
+            dsl::name.eq(dest_row.6.or(src_row.6)),
+            dsl::read_boundary_ms.eq(merged.watermark_ms),
+            dsl::read_boundary_ids.eq(ids_json),
+        ))
+        .execute(conn)?;
+    recompute_chat_preview(conn, device_id, dest)?;
+    diesel::delete(chat_row(device_id, src)).execute(conn)?;
+    Ok(())
+}
+
 fn upsert_contact_push_name(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1905,7 +2071,7 @@ fn chat_row(device_id: i32, chat: &str) -> ChatRowFilter<'_> {
     )
 }
 
-type MessageRowFilter<'a> = diesel::dsl::Filter<
+pub(crate) type MessageRowFilter<'a> = diesel::dsl::Filter<
     schema::messages::table,
     diesel::dsl::And<
         diesel::dsl::And<
@@ -1916,7 +2082,11 @@ type MessageRowFilter<'a> = diesel::dsl::Filter<
     >,
 >;
 
-fn message_row<'a>(device_id: i32, chat: &'a str, msg_id: &'a str) -> MessageRowFilter<'a> {
+pub(crate) fn message_row<'a>(
+    device_id: i32,
+    chat: &'a str,
+    msg_id: &'a str,
+) -> MessageRowFilter<'a> {
     schema::messages::table.filter(
         schema::messages::device_id
             .eq(device_id)

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1340,6 +1340,9 @@ fn apply_receipt(
         )
         .set(schema::messages::status.eq(status))
         .execute(conn)?;
+        // Zero rows covers both the real PN/LID miss and a replay against a
+        // row already at/past the target; the alt retry stays harmless for
+        // the latter (advance-only) and still heals a lagging split copy.
         if updated == 0 {
             missed.push(msg_id);
         }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3094,3 +3094,92 @@ async fn merge_folds_src_side_edit_and_revoke() {
     assert!(revoked.revoked);
     assert!(revoked.text.is_none());
 }
+
+/// Competing edits on both copies of the same message: the strictly newer
+/// edit wins the merge in either direction.
+#[tokio::test]
+async fn merge_keeps_strictly_newer_edit_across_sides() {
+    let (store, chat_store) = test_store().await;
+
+    // No mapping: duplicate copies under each identity, then both sides edit.
+    for chat in [PEER, PEER_LID] {
+        feed(
+            &chat_store,
+            [
+                message_event(
+                    wa::Message::text("v0-a"),
+                    incoming_info(chat, chat, "MSG-CE1", 1_700_000_000),
+                ),
+                message_event(
+                    wa::Message::text("v0-b"),
+                    incoming_info(chat, chat, "MSG-CE2", 1_700_000_010),
+                ),
+            ],
+        )
+        .await;
+    }
+    let edit = |target: &str, text: &str| wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some(target.into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text(text))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [
+            // CE1: the PN (destination) side carries the newer edit.
+            message_event(
+                edit("MSG-CE1", "lid antiga"),
+                incoming_info(PEER_LID, PEER_LID, "MSG-CE1-EL", 1_700_000_050),
+            ),
+            message_event(
+                edit("MSG-CE1", "pn mais nova"),
+                incoming_info(PEER, PEER, "MSG-CE1-EP", 1_700_000_080),
+            ),
+            // CE2: the LID (source) side carries the newer edit.
+            message_event(
+                edit("MSG-CE2", "pn antiga"),
+                incoming_info(PEER, PEER, "MSG-CE2-EP", 1_700_000_050),
+            ),
+            message_event(
+                edit("MSG-CE2", "lid mais nova"),
+                incoming_info(PEER_LID, PEER_LID, "MSG-CE2-EL", 1_700_000_080),
+            ),
+            // Newest activity keeps the PN side as merge destination.
+            message_event(
+                wa::Message::text("mais nova"),
+                incoming_info(PEER, PEER, "MSG-CE-NW", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let ce1 = chat_store
+        .message(&jid(PEER), "MSG-CE1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(ce1.text.as_deref(), Some("pn mais nova"));
+    assert_eq!(
+        ce1.edited_at.map(|t| t.timestamp()),
+        Some(1_700_000_080),
+        "destination's newer edit must not be clobbered by the source's older one"
+    );
+    let ce2 = chat_store
+        .message(&jid(PEER), "MSG-CE2")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(ce2.text.as_deref(), Some("lid mais nova"));
+    assert_eq!(ce2.edited_at.map(|t| t.timestamp()), Some(1_700_000_080));
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3003,3 +3003,94 @@ async fn lid_reaction_reaches_pn_keyed_message() {
     // No twin chat was opened for the reaction.
     assert_eq!(chat_store.chats(false, 10).await.unwrap().len(), 1);
 }
+
+/// An edit or revoke that reached only one side of a split survives the
+/// merge: the source copy's newer edit content and tombstone fold into the
+/// surviving row (same monotonic rules as the live path).
+#[tokio::test]
+async fn merge_folds_src_side_edit_and_revoke() {
+    let (store, chat_store) = test_store().await;
+
+    // No mapping: duplicate copies of both messages under each identity.
+    for chat in [PEER, PEER_LID] {
+        feed(
+            &chat_store,
+            [
+                message_event(
+                    wa::Message::text("typo"),
+                    incoming_info(chat, chat, "MSG-ED", 1_700_000_000),
+                ),
+                message_event(
+                    wa::Message::text("apaga"),
+                    incoming_info(chat, chat, "MSG-RV", 1_700_000_010),
+                ),
+            ],
+        )
+        .await;
+    }
+    // Edit and revoke land only on the LID side.
+    let edit = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-ED".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::MESSAGE_EDIT),
+            edited_message: MessageField::from_box(Box::new(wa::Message::text("consertada"))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let revoke = wa::Message {
+        protocol_message: MessageField::some(wa::message::ProtocolMessage {
+            key: MessageField::some(wa::MessageKey {
+                id: Some("MSG-RV".into()),
+                ..Default::default()
+            }),
+            r#type: Some(wa::message::protocol_message::Type::REVOKE),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [
+            message_event(
+                edit,
+                incoming_info(PEER_LID, PEER_LID, "MSG-ED2", 1_700_000_050),
+            ),
+            message_event(
+                revoke,
+                incoming_info(PEER_LID, PEER_LID, "MSG-RV2", 1_700_000_060),
+            ),
+            // Newer activity on the PN side makes it the merge destination.
+            message_event(
+                wa::Message::text("mais nova"),
+                incoming_info(PEER, PEER, "MSG-NW", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER));
+    let edited = chat_store
+        .message(&jid(PEER), "MSG-ED")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(edited.text.as_deref(), Some("consertada"));
+    assert!(edited.edited_at.is_some());
+    let revoked = chat_store
+        .message(&jid(PEER), "MSG-RV")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(revoked.revoked);
+    assert!(revoked.text.is_none());
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -2589,3 +2589,417 @@ async fn server_nack_marks_outgoing_failed() {
         .unwrap();
     assert_eq!(msg.status, MessageStatus::ServerAck);
 }
+
+// ── LID/PN identity resolution (issue #1078) ────────────────────────────────
+
+const PEER_LID: &str = "111000011112222@lid";
+
+/// Learn PEER <-> PEER_LID in the device store's mapping table, the alias
+/// index the chat-store resolves against.
+async fn add_lid_mapping(store: &SqliteStore) {
+    use wacore::store::traits::{LidPnMappingEntry, ProtocolStore};
+    // The mapping table's FK needs the device row the client normally creates.
+    store.create_new_device().await.expect("create device");
+    store
+        .put_lid_mapping(&LidPnMappingEntry {
+            lid: "111000011112222".into(),
+            phone_number: "559900000001".into(),
+            created_at: 1_700_000_000,
+            updated_at: 1_700_000_000,
+            learning_source: "usync".into(),
+        })
+        .await
+        .expect("put mapping");
+}
+
+fn read_receipt(chat: &str, ids: Vec<&str>, ts: i64) -> Event {
+    Event::Receipt(
+        Receipt::builder()
+            .source(MessageSource {
+                chat: jid(chat),
+                sender: jid(chat),
+                ..Default::default()
+            })
+            .message_ids(ids.into_iter().map(String::from).collect())
+            .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+            .r#type(ReceiptType::Read)
+            .offline(false)
+            .build(),
+    )
+}
+
+/// The issue #1078 scenario: rows stored under the phone-number key before
+/// any mapping was known, delivered/read receipts arriving LID-keyed.
+#[tokio::test]
+async fn lid_receipt_advances_pn_keyed_rows() {
+    let (store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-SPLIT",
+            &wa::Message::text("oi"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-SPLIT".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .build(),
+        )],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    feed(
+        &chat_store,
+        [read_receipt(PEER_LID, vec!["OUT-SPLIT"], 1_700_000_200)],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&chat, "OUT-SPLIT")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+    // No stray @lid twin was created by the receipt.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, chat);
+    // Either identity reads the same thread.
+    let via_lid = chat_store
+        .message(&jid(PEER_LID), "OUT-SPLIT")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(via_lid.status, MessageStatus::Read);
+}
+
+/// The mirror direction: LID-keyed rows, PN-keyed receipt.
+#[tokio::test]
+async fn pn_receipt_advances_lid_keyed_rows() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER_LID),
+            "OUT-L",
+            &wa::Message::text("oi"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    add_lid_mapping(&store).await;
+    feed(
+        &chat_store,
+        [read_receipt(PEER, vec!["OUT-L"], 1_700_000_200)],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&jid(PEER_LID), "OUT-L")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+/// Without a mapping the receipt still can't be attributed (the pre-fix
+/// behavior); once the mapping is learned, a replayed receipt heals the row.
+#[tokio::test]
+async fn receipt_heals_once_mapping_is_learned() {
+    let (store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-H",
+            &wa::Message::text("oi"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [read_receipt(PEER_LID, vec!["OUT-H"], 1_700_000_200)],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "OUT-H").await.unwrap().unwrap();
+    assert_eq!(msg.status, MessageStatus::Pending);
+
+    add_lid_mapping(&store).await;
+    feed(
+        &chat_store,
+        [read_receipt(PEER_LID, vec!["OUT-H"], 1_700_000_300)],
+    )
+    .await;
+    let msg = chat_store.message(&chat, "OUT-H").await.unwrap().unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+/// With the mapping known up front, a brand-new chat is keyed by the LID (WA
+/// Web `selectChatForOneOnOneMessage`) even when addressed by phone number,
+/// so later LID-keyed receipts hit exactly.
+#[tokio::test]
+async fn known_mapping_keys_new_chat_by_lid() {
+    let (store, chat_store) = test_store().await;
+    add_lid_mapping(&store).await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-NEW",
+            &wa::Message::text("primeira"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [read_receipt(PEER_LID, vec!["OUT-NEW"], 1_700_000_200)],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER_LID));
+    // The embedder still addresses (and reads) by phone number.
+    let msg = chat_store
+        .message(&jid(PEER), "OUT-NEW")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+/// An inbound LID-addressed message joins the peer's existing PN-keyed
+/// thread instead of opening a twin chat.
+#[tokio::test]
+async fn inbound_lid_message_joins_existing_pn_thread() {
+    let (store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("antes"),
+            incoming_info(PEER, PEER, "MSG-P1", 1_700_000_000),
+        )],
+    )
+    .await;
+    add_lid_mapping(&store).await;
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("depois"),
+            incoming_info(PEER_LID, PEER_LID, "MSG-L1", 1_700_000_100),
+        )],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER));
+    assert_eq!(chats[0].unread_count, 2);
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("depois"));
+    let messages = chat_store.messages(&jid(PEER_LID), None, 10).await.unwrap();
+    assert_eq!(messages.len(), 2);
+}
+
+/// A read-self receipt arriving LID-keyed clears the PN-keyed thread's badge
+/// instead of materializing an empty @lid chat row.
+#[tokio::test]
+async fn lid_read_self_clears_pn_thread_badge() {
+    let (store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("um"),
+                incoming_info(PEER, PEER, "MSG-RS-A", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("dois"),
+                incoming_info(PEER, PEER, "MSG-RS-B", 1_700_000_010),
+            ),
+        ],
+    )
+    .await;
+    add_lid_mapping(&store).await;
+    feed(
+        &chat_store,
+        [Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(PEER_LID),
+                    sender: jid(PEER_LID),
+                    ..Default::default()
+                })
+                .message_ids(vec!["MSG-RS-A".to_string(), "MSG-RS-B".to_string()])
+                .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                .r#type(ReceiptType::ReadSelf)
+                .offline(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER));
+    assert_eq!(chats[0].unread_count, 0);
+}
+
+/// Splits left behind by the pre-fix behavior merge on demand: messages fold
+/// into the newer-activity side, the badge is recounted, sticky prefs
+/// survive, and the repair is idempotent.
+#[tokio::test]
+async fn reconcile_merges_split_pair() {
+    let (store, chat_store) = test_store().await;
+
+    // No mapping yet: two independent chats form (the split).
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("via pn"),
+                incoming_info(PEER, PEER, "MSG-SP-A", 1_700_000_000),
+            ),
+            Event::PinUpdate(
+                wacore::types::events::PinUpdate::builder()
+                    .jid(jid(PEER))
+                    .timestamp(Utc.timestamp_opt(1_700_000_050, 0).unwrap())
+                    .action(Box::new(wa::sync_action_value::PinAction {
+                        pinned: Some(true),
+                    }))
+                    .from_full_sync(false)
+                    .build(),
+            ),
+            message_event(
+                wa::Message::text("via lid"),
+                incoming_info(PEER_LID, PEER_LID, "MSG-SP-B", 1_700_000_100),
+            ),
+        ],
+    )
+    .await;
+    assert_eq!(chat_store.chats(false, 10).await.unwrap().len(), 2);
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    // Newest activity was on the LID side, so that key survives.
+    assert_eq!(chats[0].jid, jid(PEER_LID));
+    assert_eq!(chats[0].unread_count, 2);
+    assert!(chats[0].pinned_at.is_some());
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("via lid"));
+    let messages = chat_store.messages(&jid(PEER), None, 10).await.unwrap();
+    assert_eq!(messages.len(), 2);
+
+    // Idempotent.
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].unread_count, 2);
+}
+
+/// The same message stored under both keys keeps the most advanced status
+/// after the merge.
+#[tokio::test]
+async fn merge_advances_duplicate_row_status() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DUP",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_outgoing(
+            &jid(PEER_LID),
+            "OUT-DUP",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    // Only the LID copy saw the read receipt.
+    feed(
+        &chat_store,
+        [read_receipt(PEER_LID, vec!["OUT-DUP"], 1_700_000_200)],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    // PN side had the newer activity, so it is the surviving key…
+    assert_eq!(chats[0].jid, jid(PEER));
+    // …and the duplicate's Read status survived onto it.
+    let msg = chat_store
+        .message(&jid(PEER), "OUT-DUP")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+/// A reaction addressed by the peer's other identity lands on the stored
+/// message (routing picks the existing thread).
+#[tokio::test]
+async fn lid_reaction_reaches_pn_keyed_message() {
+    let (store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("alvo"),
+            incoming_info(PEER, PEER, "MSG-R1", 1_700_000_000),
+        )],
+    )
+    .await;
+    add_lid_mapping(&store).await;
+
+    let reaction = wa::Message {
+        reaction_message: MessageField::some(wa::message::ReactionMessage {
+            key: MessageField::some(wa::MessageKey {
+                remote_jid: Some(PEER_LID.to_string()),
+                from_me: Some(false),
+                id: Some("MSG-R1".to_string()),
+                ..Default::default()
+            }),
+            text: Some("👍".to_string()),
+            sender_timestamp_ms: Some(1_700_000_100_000),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    feed(
+        &chat_store,
+        [message_event(
+            reaction,
+            incoming_info(PEER_LID, PEER_LID, "MSG-R1-REACT", 1_700_000_100),
+        )],
+    )
+    .await;
+
+    let reactions = chat_store.reactions(&jid(PEER), "MSG-R1").await.unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "👍");
+    // No twin chat was opened for the reaction.
+    assert_eq!(chat_store.chats(false, 10).await.unwrap().len(), 1);
+}


### PR DESCRIPTION
Fixes #1078.

## Problem

The chat-store keyed everything by exact chat string while a 1:1 peer has two interchangeable wire identities — phone number (`@s.whatsapp.net`) and LID (`@lid`). Rows stored under the PN key (the natural outcome of a first-ever send addressed by phone number, before any mapping is learned) never matched the LID-keyed receipts modern peers send: `apply_receipt` updated zero rows and dropped them silently, so ticks froze at server-ack forever, while the stray traffic materialized an empty `@lid` twin chat beside the populated PN one. The same exact-key blindness affected reactions, revokes/edits, star/delete updates and read-self receipts — receipts were just the most visible symptom.

## Why this shape

Verified against the current WA Web bundle (`2.3000.1043466400`, restored via whatspec's pinned `bundle-store`):

- **Receipt reconciliation happens at message-lookup time.** `WAWebDBBulkGetRootMsgs` retries missed LID-keyed lookups under the mapped PN (`fixMsgKeysWithPnMapping`), and post-migration translates every key through the chat table's `accountLid` alias (`fixMsgKeysWithChatId`). The alternate-key fallback (`WAWebLidMigrationUtils.getAlternateMsgKey`) is applied pervasively — reactions, revokes, delete-for-me, retries, orphan receipts.
- **Chat ids stay stable; the alias routes.** `WAWebMessageProcessUtils.selectChatForOneOnOneMessage` sends inbound 1:1 traffic to the existing thread whichever identity addressed it, and keys only brand-new chats by LID. WA Web never rewrites an existing thread's id.
- **No new schema needed here.** WA Web keeps `accountLid` as a column because its lid↔pn cache lives elsewhere; this crate shares a database file with the device store, whose `lid_pn_mapping` table is already bidirectional and indexed both ways — both candidate keys of a peer are always derivable, so the mapping table *is* the alias index.

## Changes

New `lid` module resolving against `lid_pn_mapping` (PN→LID picks the most recently updated row, same rule as `SqliteStore::get_pn_mapping`), used three ways:

- **Receipt fallback (miss path only):** delivered/read/played updates that match zero rows retry once under the counterpart key. The already-consistent case pays nothing — the lookup only runs on a miss. Read-self receipts route to the thread the rows actually live in instead of `ensure_chat`-ing an empty `@lid` row.
- **Canonical routing on every chat-keyed write** (inbound messages, outgoing records, undecryptable placeholders, history-sync conversations, pin/mute/archive/mark-read/star/clear/delete updates): an existing thread keeps its key whichever identity addressed it; a brand-new chat with a known mapping is keyed by the LID. Groups and unmapped peers short-circuit. Server-ack invalidation now resolves the chat from the updated row rather than trusting the ack's wire identity.
- **Read queries accept either identity:** `messages`/`message`/`reactions`/`receipts` filter over both candidate keys, so embedders that address by phone number keep working unchanged (and a not-yet-repaired split reads as one thread).

Splits left behind by the old behavior heal two ways: routing merges the pair automatically when live traffic next touches the peer, and a new public `ChatStore::reconcile_chat(&Jid)` does it on demand (idempotent, through the writer queue). The merge folds messages/reactions/per-user receipts into the side with the newer activity (ties go to the LID side) with advance-only conflict resolution, unions the self-read state, recounts the badge, keeps sticky prefs (pin/mute/archive/name/ephemeral), and re-derives the preview. Row moves are `UPDATE`s, so rowids — and with them the FTS external-content index — stay consistent.

## Performance

- Receipts: zero added cost on the hit path; one indexed point lookup + retry only when the exact key misses.
- Writes: one mapping lookup plus one chats probe per 1:1 event (both indexed point queries on the already-open write transaction); groups pay a string parse only.
- Reads: one mapping lookup per query call, dwarfed by the page query itself.
- Merge: proportional to the split chat, runs once per affected peer.

## Tests

Nine new integration tests: the exact issue scenario (PN rows + LID receipt) and its mirror, healing after the mapping is learned late, LID-keyed new-chat routing with PN reads, inbound LID traffic joining an existing PN thread, LID read-self clearing the PN thread's badge without a twin row, split-pair reconcile (metadata union, badge recount, idempotence), duplicate-row status advancement across the merge, and a cross-identity reaction. The pre-existing 49 tests pass unchanged, with and without the `search` feature.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` (also with `--features search`) and the test suites for `whatsapp-rust-chat-store` and `whatsapp-rust` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXHFFZUDmaTkTxxbxU3VzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXHFFZUDmaTkTxxbxU3VzZ)_