### PR TITLE
chore(deps): update workspace dependencies to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "buffa"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ce1f34252b8e2516042e1002d56c160908a7ff8a1c9d47e97836558d1c83a"
+checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
 dependencies = [
  "base64",
  "bytes",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-build"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcfe99b1fc17c2ba15b99de057667da0fa2e7825c6a9f454fd9244dfcf5d171"
+checksum = "247d43740a4854a9c1b98a5931d6d67d8f8b41ffeb2a43ca008d460e79b1eb2c"
 dependencies = [
  "buffa",
  "buffa-codegen",
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-codegen"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb7d9d432a6b8d1810089cf6779e5f8ae640b421502ab96771c2eb20ccb85c2"
+checksum = "2074a9c2f76b2ebe6af40f7bf67b6a19d6ce3663253ef2a55124dc93f38b230e"
 dependencies = [
  "buffa",
  "buffa-descriptor",
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "buffa-descriptor"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3865eb96d1d2fe968f077752c47fb192cb2ce02262dcb90b37948ea93f673f2"
+checksum = "964d735e0b06cb24fa15a68c5aa99549abcc7e0bbeb76298f2fec57912fb79c1"
 dependencies = [
  "buffa",
  "rustversion",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,9 @@ zerocopy = { version = "0.8.55", default-features = false, features = ["derive"]
 async-lock = { version = "3", default-features = false }
 async-trait = "0.1.91"
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
-buffa = { version = "0.9.0", default-features = false, features = ["json"] }
-buffa-build = { version = "0.9.0", default-features = false }
-buffa-descriptor = { version = "0.9.0", default-features = false }
+buffa = { version = "0.9.1", default-features = false, features = ["json"] }
+buffa-build = { version = "0.9.1", default-features = false }
+buffa-descriptor = { version = "0.9.1", default-features = false }
 bytemuck = { version = "1.25", default-features = false }
 bytes = { version = "1.12", default-features = false }
 bon = { version = "3.9.3", default-features = false, features = ["std"] }


### PR DESCRIPTION
## Summary

Updates workspace dependencies to their latest published versions, manifests and lockfile. Follow-up to #1075, which already brought everything else to latest two days ago — this round the delta is small.

## Notable bumps

- `buffa`, `buffa-build`, `buffa-descriptor` 0.9.0 → 0.9.1. The buffa-build codegen reruns over `whatsapp.proto` at build time, so a clean workspace clippy validates the generated code end to end.
- transitive: `cc` 1.3.0 → 1.4.0

## Held back

- `base64` stays on 0.22.1: buffa 0.9.1 itself still depends on the 0.22 line, so moving the workspace to 0.23.0 would duplicate the crate in the binary. Revisit once buffa moves to 0.23.
- `libsqlite3-sys` stays on 0.37: `diesel` 2.3.11 (latest) still links `>=0.17.2, <0.38.0`, and cargo allows only one linked copy of `sqlite3` — same situation as #1075.
- the intentionally pinned `webrtc-util` alias is untouched

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- full test matrix, wasm32 build, and benchmarks left to CI
