### PR TITLE
chore: remove dead public API surface from wacore and libsignal

### DIFF
--- a/src/appstate_sync.rs
+++ b/src/appstate_sync.rs
@@ -1,6 +1,6 @@
 // Re-export everything from wacore::appstate_sync for backwards compatibility
 pub use wacore::appstate::Mutation;
-pub use wacore::appstate_sync::{AppStateProcessor, AppStateSyncDriver, AppStateSyncError};
+pub use wacore::appstate_sync::{AppStateProcessor, AppStateSyncError};
 
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]

--- a/wacore/libsignal/src/core/address.rs
+++ b/wacore/libsignal/src/core/address.rs
@@ -59,48 +59,6 @@ impl<const KIND: u8> std::hash::Hash for SpecificServiceId<KIND> {
     }
 }
 
-impl<const KIND: u8> SpecificServiceId<KIND>
-where
-    ServiceId: From<Self>,
-    Self: TryFrom<ServiceId>,
-{
-    #[inline]
-    pub fn service_id_binary(&self) -> Vec<u8> {
-        ServiceId::from(*self).service_id_binary()
-    }
-
-    #[inline]
-    pub fn service_id_fixed_width_binary(&self) -> ServiceIdFixedWidthBinaryBytes {
-        ServiceId::from(*self).service_id_fixed_width_binary()
-    }
-
-    pub fn service_id_string(&self) -> String {
-        ServiceId::from(*self).service_id_string()
-    }
-
-    #[inline]
-    pub fn parse_from_service_id_binary(bytes: &[u8]) -> Option<Self> {
-        ServiceId::parse_from_service_id_binary(bytes)?
-            .try_into()
-            .ok()
-    }
-
-    #[inline]
-    pub fn parse_from_service_id_fixed_width_binary(
-        bytes: &ServiceIdFixedWidthBinaryBytes,
-    ) -> Option<Self> {
-        ServiceId::parse_from_service_id_fixed_width_binary(bytes)?
-            .try_into()
-            .ok()
-    }
-
-    pub fn parse_from_service_id_string(input: &str) -> Option<Self> {
-        ServiceId::parse_from_service_id_string(input)?
-            .try_into()
-            .ok()
-    }
-}
-
 impl<const KIND: u8> From<Uuid> for SpecificServiceId<KIND> {
     #[inline]
     fn from(value: Uuid) -> Self {
@@ -146,86 +104,11 @@ impl ServiceId {
     }
 
     #[inline]
-    pub fn service_id_binary(&self) -> Vec<u8> {
-        if let Self::Aci(aci) = self {
-            aci.0.as_bytes().to_vec()
-        } else {
-            self.service_id_fixed_width_binary().to_vec()
-        }
-    }
-
-    #[inline]
-    pub fn service_id_fixed_width_binary(&self) -> ServiceIdFixedWidthBinaryBytes {
-        let mut result = [0; 17];
-        result[0] = self.kind().into();
-        result[1..].copy_from_slice(self.raw_uuid().as_bytes());
-        result
-    }
-
-    pub fn service_id_string(&self) -> String {
-        if let Self::Aci(aci) = self {
-            aci.0.to_string()
-        } else {
-            format!("{}:{}", self.kind(), self.raw_uuid())
-        }
-    }
-
-    #[inline]
-    pub fn parse_from_service_id_binary(bytes: &[u8]) -> Option<Self> {
-        match bytes.len() {
-            16 => Some(Self::Aci(Uuid::from_slice(bytes).ok()?.into())),
-            17 => {
-                let result = Self::parse_from_service_id_fixed_width_binary(
-                    bytes.try_into().expect("already measured"),
-                )?;
-                if result.kind() == ServiceIdKind::Aci {
-                    None
-                } else {
-                    Some(result)
-                }
-            }
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub fn parse_from_service_id_fixed_width_binary(
-        bytes: &ServiceIdFixedWidthBinaryBytes,
-    ) -> Option<Self> {
-        let uuid = Uuid::from_slice(&bytes[1..]).ok()?;
-        match ServiceIdKind::try_from(bytes[0]).ok()? {
-            ServiceIdKind::Aci => Some(Self::Aci(uuid.into())),
-            ServiceIdKind::Pni => Some(Self::Pni(uuid.into())),
-        }
-    }
-
-    pub fn parse_from_service_id_string(input: &str) -> Option<Self> {
-        fn try_parse_hyphenated(input: &str) -> Option<Uuid> {
-            if input.len() != uuid::fmt::Hyphenated::LENGTH {
-                return None;
-            }
-            Uuid::try_parse(input).ok()
-        }
-
-        if let Some(uuid_string) = input.strip_prefix("PNI:") {
-            let uuid = try_parse_hyphenated(uuid_string)?;
-            Some(Self::Pni(uuid.into()))
-        } else {
-            let uuid = try_parse_hyphenated(input)?;
-            Some(Self::Aci(uuid.into()))
-        }
-    }
-
-    #[inline]
     pub fn raw_uuid(self) -> Uuid {
         match self {
             ServiceId::Aci(aci) => aci.into(),
             ServiceId::Pni(pni) => pni.into(),
         }
-    }
-
-    pub fn to_protocol_address(&self, device_id: DeviceId) -> ProtocolAddress {
-        ProtocolAddress::new(self.service_id_string(), device_id)
     }
 }
 

--- a/wacore/libsignal/src/core/mod.rs
+++ b/wacore/libsignal/src/core/mod.rs
@@ -11,14 +11,3 @@ pub use address::{
     Aci, DeviceId, Pni, ProtocolAddress, ServiceId, ServiceIdFixedWidthBinaryBytes, ServiceIdKind,
     WrongKindOfServiceIdError,
 };
-
-/// Simple wrapper that invokes a lambda.
-///
-/// Once try-blocks are stabilized
-/// (https://github.com/rust-lang/rust/issues/31436), usages of this function
-/// can be removed and replaced with the new syntax.
-#[inline]
-#[track_caller]
-pub fn try_scoped<T, E>(f: impl FnOnce() -> Result<T, E>) -> Result<T, E> {
-    f()
-}

--- a/wacore/libsignal/src/crypto/aes_gcm.rs
+++ b/wacore/libsignal/src/crypto/aes_gcm.rs
@@ -171,7 +171,6 @@ pub struct Aes256GcmEncryption {
 }
 
 impl Aes256GcmEncryption {
-    pub const TAG_SIZE: usize = TAG_SIZE;
     pub const NONCE_SIZE: usize = NONCE_SIZE;
 
     pub fn new(key: &[u8], nonce: &[u8], associated_data: &[u8]) -> Result<Self> {
@@ -200,7 +199,6 @@ pub struct Aes256GcmDecryption {
 }
 
 impl Aes256GcmDecryption {
-    pub const TAG_SIZE: usize = TAG_SIZE;
     pub const NONCE_SIZE: usize = NONCE_SIZE;
 
     pub fn new(key: &[u8], nonce: &[u8], associated_data: &[u8]) -> Result<Self> {

--- a/wacore/libsignal/src/crypto/hash.rs
+++ b/wacore/libsignal/src/crypto/hash.rs
@@ -45,11 +45,6 @@ impl CryptographicMac {
         }
     }
 
-    pub fn update_and_get(&mut self, input: &[u8]) -> &mut Self {
-        self.update(input);
-        self
-    }
-
     pub fn finalize(&mut self) -> Vec<u8> {
         match self {
             Self::HmacSha1(sha1) => sha1.finalize_reset().into_bytes().to_vec(),

--- a/wacore/libsignal/src/protocol/error.rs
+++ b/wacore/libsignal/src/protocol/error.rs
@@ -103,16 +103,6 @@ pub enum SignalProtocolError {
     SealedSenderSelfSend,
 }
 
-impl SignalProtocolError {
-    /// Convenience factory for [`SignalProtocolError::ApplicationCallbackError`].
-    #[inline]
-    pub fn for_application_callback<E: std::error::Error + Send + Sync + UnwindSafe + 'static>(
-        method: &'static str,
-    ) -> impl FnOnce(E) -> Self {
-        move |error| Self::ApplicationCallbackError(method, Box::new(error))
-    }
-}
-
 impl From<CurveError> for SignalProtocolError {
     fn from(e: CurveError) -> Self {
         match e {

--- a/wacore/libsignal/src/protocol/identity_key.rs
+++ b/wacore/libsignal/src/protocol/identity_key.rs
@@ -14,8 +14,6 @@ use crate::protocol::{
     KeyPair, PrivateKey, PublicKey, Result, SignalProtocolError, stores::IdentityKeyPairStructure,
 };
 
-// Used for domain separation between alternate-identity signatures and other key-to-key signatures.
-
 /// A public key that represents the identity of a user.
 ///
 /// Wrapper for [`PublicKey`].

--- a/wacore/libsignal/src/protocol/identity_key.rs
+++ b/wacore/libsignal/src/protocol/identity_key.rs
@@ -15,8 +15,6 @@ use crate::protocol::{
 };
 
 // Used for domain separation between alternate-identity signatures and other key-to-key signatures.
-const ALTERNATE_IDENTITY_SIGNATURE_PREFIX_1: &[u8] = &[0xFF; 32];
-const ALTERNATE_IDENTITY_SIGNATURE_PREFIX_2: &[u8] = b"Signal_PNI_Signature";
 
 /// A public key that represents the identity of a user.
 ///
@@ -61,21 +59,6 @@ impl IdentityKey {
     pub fn decode(value: &[u8]) -> Result<Self> {
         let pk = PublicKey::try_from(value)?;
         Ok(Self { public_key: pk })
-    }
-
-    /// Given a trusted identity `self`, verify that `other` represents an alternate identity for
-    /// this user.
-    ///
-    /// `signature` must be calculated from [`IdentityKeyPair::sign_alternate_identity`].
-    pub fn verify_alternate_identity(&self, other: &IdentityKey, signature: &[u8]) -> Result<bool> {
-        Ok(self.public_key.verify_signature_for_multipart_message(
-            &[
-                ALTERNATE_IDENTITY_SIGNATURE_PREFIX_1,
-                ALTERNATE_IDENTITY_SIGNATURE_PREFIX_2,
-                &other.serialize(),
-            ],
-            signature,
-        ))
     }
 }
 
@@ -144,22 +127,6 @@ impl IdentityKeyPair {
 
         let result = structure.encode_to_vec();
         result.into_boxed_slice()
-    }
-
-    /// Generate a signature claiming that `other` represents the same user as `self`.
-    pub fn sign_alternate_identity<R: Rng + CryptoRng>(
-        &self,
-        other: &IdentityKey,
-        rng: &mut R,
-    ) -> Result<[u8; 64]> {
-        Ok(self.private_key.calculate_signature_for_multipart_message(
-            &[
-                ALTERNATE_IDENTITY_SIGNATURE_PREFIX_1,
-                ALTERNATE_IDENTITY_SIGNATURE_PREFIX_2,
-                &other.serialize(),
-            ],
-            rng,
-        )?)
     }
 }
 

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -1184,45 +1184,6 @@ pub struct DecryptionErrorMessage {
 }
 
 impl DecryptionErrorMessage {
-    #[allow(clippy::disallowed_methods)]
-    pub fn for_original(
-        original_bytes: &[u8],
-        original_type: CiphertextMessageType,
-        original_timestamp: Timestamp,
-        original_sender_device_id: u32,
-    ) -> Result<Self> {
-        let ratchet_key = match original_type {
-            CiphertextMessageType::Whisper => {
-                Some(*SignalMessage::try_from(original_bytes)?.sender_ratchet_key())
-            }
-            CiphertextMessageType::PreKey => Some(
-                *PreKeySignalMessage::try_from(original_bytes)?
-                    .message()
-                    .sender_ratchet_key(),
-            ),
-            CiphertextMessageType::SenderKey => None,
-            CiphertextMessageType::Plaintext => {
-                return Err(SignalProtocolError::InvalidArgument(
-                    "cannot create a DecryptionErrorMessage for plaintext content; it is not encrypted".to_string()
-                ));
-            }
-        };
-
-        let proto_message = DecryptionErrorMessageProto {
-            timestamp: Some(original_timestamp.epoch_millis()),
-            ratchet_key: ratchet_key.map(|k| k.serialize().into()),
-            device_id: Some(original_sender_device_id),
-        };
-        let serialized = proto_message.encode_to_vec();
-
-        Ok(Self {
-            ratchet_key,
-            timestamp: original_timestamp,
-            device_id: original_sender_device_id,
-            serialized: serialized.into_boxed_slice(),
-        })
-    }
-
     #[inline]
     pub fn timestamp(&self) -> Timestamp {
         self.timestamp

--- a/wacore/libsignal/src/protocol/ratchet/params.rs
+++ b/wacore/libsignal/src/protocol/ratchet/params.rs
@@ -57,11 +57,6 @@ impl AliceSignalProtocolParameters {
         self.their_one_time_pre_key = Some(ec_public);
     }
 
-    pub fn with_their_one_time_pre_key(mut self, ec_public: PublicKey) -> Self {
-        self.set_their_one_time_pre_key(ec_public);
-        self
-    }
-
     #[inline]
     pub fn our_identity_key_pair(&self) -> &IdentityKeyPair {
         &self.our_identity_key_pair

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -517,14 +517,6 @@ pub struct SenderKeyRecord {
 const RESERVED_ITERATION_FIELD: u32 = super::local_field::COUNTER_RESERVATION_FIELD;
 
 impl SenderKeyRecord {
-    /// Replaces the states wholesale, so the wire gate — which belongs to the
-    /// advance being replaced — resets with them.
-    pub fn set_states_for_testing(&mut self, states: std::collections::VecDeque<SenderKeyState>) {
-        self.states = states;
-        self.wire_gated = false;
-        self.reserved_iteration = 0;
-    }
-
     pub fn new_empty() -> Self {
         Self {
             states: VecDeque::with_capacity(consts::MAX_SENDER_KEY_STATES),

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -439,10 +439,6 @@ impl SessionState {
         Ok(ChainKey::new(chain_key_bytes, index))
     }
 
-    pub fn get_sender_chain_key_bytes(&self) -> Result<Vec<u8>, InvalidSessionError> {
-        Ok(self.get_sender_chain_key()?.key().to_vec())
-    }
-
     pub fn set_sender_chain_key(
         &mut self,
         next_chain_key: &ChainKey,
@@ -1218,37 +1214,6 @@ impl SessionRecord {
             .session_version()?)
     }
 
-    pub fn local_identity_key_bytes(&self) -> Result<Vec<u8>, SignalProtocolError> {
-        Ok(self
-            .session_state()
-            .ok_or_else(|| {
-                SignalProtocolError::InvalidState(
-                    "local_identity_key_bytes",
-                    "No current session".into(),
-                )
-            })?
-            .local_identity_key_bytes()?)
-    }
-
-    pub fn remote_identity_key_bytes(&self) -> Result<Option<Vec<u8>>, SignalProtocolError> {
-        Ok(self
-            .session_state()
-            .ok_or_else(|| {
-                SignalProtocolError::InvalidState(
-                    "remote_identity_key_bytes",
-                    "No current session".into(),
-                )
-            })?
-            .remote_identity_key_bytes()?)
-    }
-
-    pub fn has_usable_sender_chain(&self) -> Result<bool, SignalProtocolError> {
-        match &self.current_session {
-            Some(session) => Ok(session.has_usable_sender_chain()?),
-            None => Ok(false),
-        }
-    }
-
     pub fn alice_base_key(&self) -> Result<&[u8], SignalProtocolError> {
         Ok(self
             .session_state()
@@ -1256,44 +1221,6 @@ impl SessionRecord {
                 SignalProtocolError::InvalidState("alice_base_key", "No current session".into())
             })?
             .alice_base_key())
-    }
-
-    pub fn get_receiver_chain_key_bytes(
-        &self,
-        sender: &PublicKey,
-    ) -> Result<Option<Box<[u8]>>, SignalProtocolError> {
-        Ok(self
-            .session_state()
-            .ok_or_else(|| {
-                SignalProtocolError::InvalidState(
-                    "get_receiver_chain_key",
-                    "No current session".into(),
-                )
-            })?
-            .get_receiver_chain_key(sender)?
-            .map(|chain| chain.key()[..].into()))
-    }
-
-    pub fn get_sender_chain_key_bytes(&self) -> Result<Vec<u8>, SignalProtocolError> {
-        Ok(self
-            .session_state()
-            .ok_or_else(|| {
-                SignalProtocolError::InvalidState(
-                    "get_sender_chain_key_bytes",
-                    "No current session".into(),
-                )
-            })?
-            .get_sender_chain_key_bytes()?)
-    }
-
-    pub fn current_ratchet_key_matches(
-        &self,
-        key: &PublicKey,
-    ) -> Result<bool, SignalProtocolError> {
-        match &self.current_session {
-            Some(session) => Ok(&session.sender_ratchet_key()? == key),
-            None => Ok(false),
-        }
     }
 }
 

--- a/wacore/libsignal/src/store/mod.rs
+++ b/wacore/libsignal/src/store/mod.rs
@@ -1,7 +1,7 @@
 pub mod record_helpers;
 pub mod sender_key_name;
 
-use crate::protocol::{IdentityKeyStore, ProtocolAddress, SessionRecord};
+use crate::protocol::{ProtocolAddress, SessionRecord};
 use async_trait::async_trait;
 use std::error::Error;
 use waproto::whatsapp::{PreKeyRecordStructure, SignedPreKeyRecordStructure};
@@ -55,14 +55,4 @@ pub trait SessionStore: Send + Sync {
     async fn contains_session(&self, address: &ProtocolAddress) -> Result<bool, StoreError>;
     async fn delete_session(&self, address: &ProtocolAddress) -> Result<(), StoreError>;
     async fn delete_all_sessions(&self, name: &str) -> Result<(), StoreError>;
-}
-
-pub trait SignalProtocolStore:
-    IdentityKeyStore + PreKeyStore + SignedPreKeyStore + SessionStore
-{
-}
-
-impl<T: IdentityKeyStore + PreKeyStore + SignedPreKeyStore + SessionStore> SignalProtocolStore
-    for T
-{
 }

--- a/wacore/libsignal/src/store/sender_key_name.rs
+++ b/wacore/libsignal/src/store/sender_key_name.rs
@@ -1,5 +1,3 @@
-use crate::protocol::ProtocolAddress;
-
 /// Identifies a sender key by group + sender address.
 ///
 /// Stores a single `"{group_id}:{sender_id}"` buffer with an offset,
@@ -52,21 +50,5 @@ impl SenderKeyName {
     #[inline]
     pub fn cache_key(&self) -> &str {
         &self.buf
-    }
-
-    /// Construct from a group JID and a protocol address.
-    /// Uses `ProtocolAddress::as_str()` to avoid allocating the sender string.
-    pub fn from_jid(group_jid: &impl std::fmt::Display, sender: &ProtocolAddress) -> Self {
-        Self::from_parts(&group_jid.to_string(), sender.as_str())
-    }
-
-    pub fn to_protocol_address(&self) -> ProtocolAddress {
-        let group = self.group_id();
-        let sender = self.sender_id();
-        let mut name = String::with_capacity(group.len() + 1 + sender.len());
-        name.push_str(group);
-        name.push('\n');
-        name.push_str(sender);
-        ProtocolAddress::new(name, 0.into())
     }
 }

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -3,20 +3,15 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
 use async_lock::Mutex;
-use async_trait::async_trait;
 use thiserror::Error;
 
 use crate::appstate::hash::HashState;
 use crate::appstate::keys::ExpandedAppStateKeys;
-use crate::appstate::patch_decode::{
-    CollectionSyncError, PatchList, WAPatchName, parse_patch_list, parse_patch_list_ref,
-    parse_patch_lists, parse_patch_lists_ref,
-};
+use crate::appstate::patch_decode::{CollectionSyncError, PatchList};
 use crate::appstate::{
     collect_key_id_refs_from_patch_list, expand_app_state_keys, process_patch, process_snapshot,
 };
 use crate::store::traits::Backend;
-use wacore_binary::{Node, NodeRef};
 use waproto::whatsapp as wa;
 
 // Re-export Mutation from appstate for convenience
@@ -191,20 +186,9 @@ impl AppStateProcessor {
         Ok(())
     }
 
-    pub async fn decode_patch_list_ref(
-        &self,
-        stanza_root: &NodeRef<'_>,
-        download: &BlobDownloadFn<'_>,
-        validate_macs: bool,
-    ) -> Result<(Vec<Mutation>, HashState, PatchList)> {
-        let pl = parse_patch_list_ref(stanza_root)?;
-        self.process_parsed_patch_list(pl, download, validate_macs)
-            .await
-    }
-
     /// Process an already-parsed single PatchList: download external blobs via
     /// `download`, then decode + apply. Lets a caller that parsed the response for
-    /// pre-download avoid re-parsing it. See [`decode_patch_list_ref`].
+    /// pre-download avoid re-parsing it.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.process_parsed", level = "debug", skip_all, fields(name = ?pl.name), err(Debug)))]
     pub async fn process_parsed_patch_list(
         &self,
@@ -216,44 +200,9 @@ impl AppStateProcessor {
         self.process_patch_list(pl, validate_macs).await
     }
 
-    pub async fn decode_patch_list(
-        &self,
-        stanza_root: &Node,
-        download: &BlobDownloadFn<'_>,
-        validate_macs: bool,
-    ) -> Result<(Vec<Mutation>, HashState, PatchList)> {
-        let pl = parse_patch_list(stanza_root)?;
-        self.process_parsed_patch_list(pl, download, validate_macs)
-            .await
-    }
-
-    pub async fn decode_multi_patch_list_ref(
-        &self,
-        stanza_root: &NodeRef<'_>,
-        download: &BlobDownloadFn<'_>,
-        validate_macs: bool,
-    ) -> Result<Vec<(Vec<Mutation>, HashState, PatchList)>> {
-        let patch_lists = parse_patch_lists_ref(stanza_root)?;
-        self.process_patch_lists(patch_lists, download, validate_macs)
-            .await
-    }
-
-    /// Decode a multi-collection IQ response into per-collection results.
-    /// Each collection is parsed and processed independently.
-    pub async fn decode_multi_patch_list(
-        &self,
-        stanza_root: &Node,
-        download: &BlobDownloadFn<'_>,
-        validate_macs: bool,
-    ) -> Result<Vec<(Vec<Mutation>, HashState, PatchList)>> {
-        let patch_lists = parse_patch_lists(stanza_root)?;
-        self.process_patch_lists(patch_lists, download, validate_macs)
-            .await
-    }
-
     /// Process already-parsed patch lists, downloading any external blobs via
     /// `download`. Lets callers that already parsed the IQ response (e.g. to
-    /// pre-download blobs) avoid re-parsing it. See [`decode_multi_patch_list_ref`].
+    /// pre-download blobs) avoid re-parsing it.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.process_lists", level = "debug", skip_all, fields(count = patch_lists.len()), err(Debug)))]
     pub async fn process_patch_lists(
         &self,
@@ -599,57 +548,6 @@ impl AppStateProcessor {
         download_external_blobs(pl, download)?;
         self.get_missing_key_ids(pl).await
     }
-
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.sync_collection", level = "debug", skip_all, fields(name = ?name), err(Debug)))]
-    pub async fn sync_collection<D>(
-        &self,
-        driver: &D,
-        name: WAPatchName,
-        validate_macs: bool,
-        download: &BlobDownloadFn<'_>,
-    ) -> Result<Vec<Mutation>>
-    where
-        D: AppStateSyncDriver + Sync,
-    {
-        let mut all = Vec::new();
-        // Bound re-fetches so a server that keeps returning a retryable collection
-        // (e.g. an empty-ltHash patch without a snapshot) can't loop forever.
-        const MAX_RETRIES: usize = 5;
-        let mut retries = 0;
-        loop {
-            let state = self.backend.get_version(name.as_str()).await?;
-            let node = driver.fetch_collection(name, state.version).await?;
-            let (mut muts, _new_state, list) = self
-                .decode_patch_list(&node, download, validate_macs)
-                .await?;
-            all.append(&mut muts);
-            // A retryable error (or conflict-with-more) left the version unadvanced;
-            // re-fetch (now requesting a snapshot, since the version is still 0)
-            // rather than reporting success. Mirrors the batched path's needs_refetch.
-            // Fatal / conflict-without-more fall through and end the loop.
-            if matches!(
-                list.error,
-                Some(CollectionSyncError::Retry { .. })
-                    | Some(CollectionSyncError::Conflict { has_more: true })
-            ) {
-                retries += 1;
-                if retries >= MAX_RETRIES {
-                    break;
-                }
-                continue;
-            }
-            if !list.has_more_patches {
-                break;
-            }
-        }
-        Ok(all)
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait AppStateSyncDriver {
-    async fn fetch_collection(&self, name: WAPatchName, after_version: u64) -> Result<Node>;
 }
 
 /// A snapshot is stale when the collection already holds a version at or beyond the
@@ -688,6 +586,7 @@ mod snapshot_guard_tests {
 #[cfg(test)]
 mod external_blob_tests {
     use super::*;
+    use crate::appstate::patch_decode::WAPatchName;
 
     fn pl_with_snapshot_ref(snapshot_ref: Option<wa::ExternalBlobReference>) -> PatchList {
         PatchList {

--- a/wacore/src/client.rs
+++ b/wacore/src/client.rs
@@ -18,14 +18,4 @@ impl CoreClient {
             event_bus: CoreEventBus::new(),
         }
     }
-
-    /// Gets the current device state
-    pub fn get_device(&self) -> &Device {
-        &self.device
-    }
-
-    /// Updates device state (pure function)
-    pub fn update_device(&mut self, device: Device) {
-        self.device = device;
-    }
 }

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -1,6 +1,6 @@
 use crate::libsignal::crypto::{
     DecryptionError as AesCbcDecryptionError, Error as CryptoError, aes_256_cbc_decrypt_in_place,
-    aes_256_cbc_decrypt_into, hmac_sha256_two_part,
+    hmac_sha256_two_part,
 };
 use anyhow::{Result, anyhow};
 use base64::Engine as _;
@@ -504,13 +504,6 @@ impl DownloadUtils {
             .try_into()
             .map_err(|_| anyhow!("HKDF output has unexpected length for MAC key"))?;
         Ok((iv, cipher_key, mac_key))
-    }
-
-    pub fn decrypt_cbc(cipher_key: &[u8], iv: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
-        let mut output = Vec::new();
-        aes_256_cbc_decrypt_into(ciphertext, cipher_key, iv, &mut output)
-            .map_err(anyhow::Error::new)?;
-        Ok(output)
     }
 
     pub fn verify_and_decrypt(

--- a/wacore/src/iq/contacts.rs
+++ b/wacore/src/iq/contacts.rs
@@ -101,13 +101,6 @@ impl ProfilePictureSpec {
         self
     }
 
-    /// Set the existing picture ID for cache optimization.
-    /// The server may return an empty result if the picture hasn't changed.
-    pub fn with_existing_id(mut self, id: String) -> Self {
-        self.existing_id = Some(id);
-        self
-    }
-
     /// Override the default request timeout.
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -247,10 +247,6 @@ impl GroupParticipantOptions {
         Self::new(phone_number)
     }
 
-    pub fn from_lid_and_phone(lid: Jid, phone_number: Jid) -> Self {
-        Self::new(lid).with_phone_number(phone_number)
-    }
-
     pub fn with_phone_number(mut self, phone_number: Jid) -> Self {
         self.phone_number = Some(phone_number);
         self
@@ -330,11 +326,6 @@ impl GroupCreateOptions {
 
     pub fn with_member_add_mode(mut self, mode: MemberAddMode) -> Self {
         self.member_add_mode = Some(mode);
-        self
-    }
-
-    pub fn with_membership_approval_mode(mut self, mode: MembershipApprovalMode) -> Self {
-        self.membership_approval_mode = Some(mode);
         self
     }
 

--- a/wacore/src/iq/tctoken.rs
+++ b/wacore/src/iq/tctoken.rs
@@ -93,18 +93,6 @@ fn unix_now() -> i64 {
     crate::time::now_secs()
 }
 
-/// Check if a tcToken has expired using default constants.
-///
-/// For AB-prop-aware expiration, use [`is_tc_token_expired_with`].
-pub fn is_tc_token_expired(token_timestamp: i64) -> bool {
-    is_tc_token_expired_at(
-        token_timestamp,
-        unix_now(),
-        TC_TOKEN_BUCKET_DURATION,
-        TC_TOKEN_NUM_BUCKETS,
-    )
-}
-
 /// Check if a tcToken has expired using configurable receiver-side timing.
 pub fn is_tc_token_expired_with(token_timestamp: i64, config: &TcTokenConfig) -> bool {
     let cfg = config.clamped();
@@ -146,13 +134,6 @@ fn expiration_cutoff_at(now: i64, bucket_duration: i64, num_buckets: i64) -> i64
     let current_bucket = bucket_index(now, bucket_duration);
     let expired_bucket = current_bucket - (num_buckets - 1);
     expired_bucket * bucket_duration
-}
-
-/// Check if we should issue a new tcToken to a contact (default constants).
-///
-/// For AB-prop-aware check, use [`should_send_new_tc_token_with`].
-pub fn should_send_new_tc_token(sender_timestamp: Option<i64>) -> bool {
-    should_send_new_tc_token_at(sender_timestamp, unix_now(), TC_TOKEN_BUCKET_DURATION)
 }
 
 /// Check if we should issue a new tcToken using configurable sender bucket duration.

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -152,16 +152,6 @@ impl Default for PairCodeOptions {
     }
 }
 
-impl PairCodeOptions {
-    /// Convenience constructor with the phone number preset and other fields defaulted.
-    pub fn for_phone(phone_number: impl Into<String>) -> Self {
-        Self {
-            phone_number: phone_number.into(),
-            ..Self::default()
-        }
-    }
-}
-
 /// State machine for pair code authentication flow.
 #[derive(Default)]
 pub enum PairCodeState {

--- a/wacore/src/poll.rs
+++ b/wacore/src/poll.rs
@@ -49,36 +49,6 @@ pub fn derive_vote_encryption_key(
     )
 }
 
-/// Encrypt a poll vote with a pre-derived 32-byte key, symmetric to
-/// [`decrypt_poll_vote`]. Returns `(payload_with_tag, iv)`.
-///
-/// Kept for callers that built their own key via [`derive_vote_encryption_key`].
-/// New code should prefer [`encrypt_poll_vote_with_secret`], which derives
-/// the key in a single step from the parent poll's `messageSecret`.
-pub fn encrypt_poll_vote(
-    selected_option_hashes: &[Vec<u8>],
-    encryption_key: &[u8; 32],
-    stanza_id: &str,
-    voter_jid: &str,
-) -> Result<(Vec<u8>, [u8; GCM_IV_SIZE])> {
-    use crate::libsignal::crypto::aes_256_gcm_encrypt;
-    use rand::Rng;
-
-    let plaintext = encode_selected_options(selected_option_hashes);
-
-    let mut iv = [0u8; GCM_IV_SIZE];
-    rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut iv);
-
-    // poll_creator_jid is not part of the AAD; supply an empty placeholder.
-    let aad = build_aad(&poll_vote_addon_ctx(stanza_id, "", voter_jid));
-
-    let mut payload = Vec::with_capacity(plaintext.len() + GCM_TAG_SIZE);
-    aes_256_gcm_encrypt(encryption_key, &iv, &aad, &plaintext, &mut payload)
-        .map_err(|e| anyhow!("AES-GCM encrypt failed: {e}"))?;
-
-    Ok((payload, iv))
-}
-
 /// Encrypt a poll vote given the parent poll's `messageSecret`. Returns
 /// `(payload_with_tag, iv)`.
 pub fn encrypt_poll_vote_with_secret(

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -419,10 +419,6 @@ impl Device {
         }
     }
 
-    pub fn is_ready_for_presence(&self) -> bool {
-        self.pn.is_some() && !self.push_name.is_empty()
-    }
-
     /// Mirrors WA Web `WAWebUserPrefsMultiDevice.isRegistered()`:
     /// `!!(m() && getMaybeMeDevicePn())`.
     pub fn is_registered(&self) -> bool {

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -119,10 +119,6 @@ pub struct MessageSource {
 }
 
 impl MessageSource {
-    pub fn is_incoming_broadcast(&self) -> bool {
-        (!self.is_from_me || self.broadcast_list_owner.is_some()) && self.chat.is_broadcast_list()
-    }
-
     /// Our own outgoing DM to a user or bot, echoed back to this device
     /// (`is_from_me` with a `recipient`). The server's offline queue only
     /// releases these on a `<receipt type="sender">`, so they must not be

--- a/wacore/src/usync.rs
+++ b/wacore/src/usync.rs
@@ -1,9 +1,6 @@
-use crate::iq::usync::{
-    device_list_query, parse_usync_response, project_device_list_response, project_lid_mapping,
-};
+use crate::iq::usync::{parse_usync_response, project_device_list_response};
 use anyhow::Result;
-use wacore_binary::Jid;
-use wacore_binary::{Node, NodeRef};
+use wacore_binary::{Jid, Node};
 
 /// A LID mapping learned from usync response
 #[derive(Debug, Clone)]
@@ -47,10 +44,6 @@ pub struct UserDeviceList {
     pub key_index_bytes: Option<Vec<u8>>,
 }
 
-pub fn build_get_user_devices_query(jids: &[Jid], sid: &str) -> Node {
-    device_list_query(jids, None).build_node(sid)
-}
-
 /// Parse usync response returning devices grouped by user with phash.
 /// This is the full-featured version that includes the participant hash.
 pub fn parse_get_user_devices_response_with_phash(resp_node: &Node) -> Result<Vec<UserDeviceList>> {
@@ -70,20 +63,6 @@ pub fn parse_get_user_devices_response(resp_node: &Node) -> Result<Vec<Jid>> {
                 .map(move |d| user_jid.with_device_hosting(d.device, d.is_hosted))
         })
         .collect())
-}
-
-/// Parse LID mappings from a usync `NodeRef` response (zero-copy path).
-pub fn parse_lid_mappings_from_response(resp_node: &NodeRef<'_>) -> Vec<UsyncLidMapping> {
-    parse_usync_response(resp_node).map_or_else(
-        |_| Vec::new(),
-        |response| {
-            response
-                .users
-                .iter()
-                .filter_map(project_lid_mapping)
-                .collect()
-        },
-    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Dead-code sweep of the workspace's internal crates, guided by [hawk](https://github.com/astral-sh/hawk) — a workspace-aware reachability lint for unnecessary public Rust APIs. Removes **562 lines** of public surface that nothing reaches: 46 items across `wacore` and `wacore-libsignal`.

## How the candidates were chosen

hawk ran over the whole workspace with the consumer-facing crates (`whatsapp-rust`, `waproto`, storages, transports, http clients, plugins) marked as external boundaries, so their public APIs anchor liveness. It reported ~2.5k `dead_public` items; 81% sit in the vendored abprops/mex catalogs, which are complete registries by design and were set aside. The remaining 119 real-code findings were each cross-checked textually (all cfg-gated code, tests, examples, and known out-of-workspace consumers included) before touching anything — only items with zero references anywhere were removed.

## What was removed

- `ServiceId` binary/string codec surface (`service_id_binary`, `parse_from_service_id_*`, …) and its `SpecificServiceId` mirrors — Signal-upstream API our protocol paths never use
- Unused `SessionRecord`/`SessionState` byte accessors (`local_identity_key_bytes`, `get_receiver_chain_key_bytes`, `current_ratchet_key_matches`, …) and `SenderKeyRecord::set_states_for_testing` (no test uses it)
- The alternate-identity signature pair (`sign_alternate_identity`/`verify_alternate_identity`) and its prefix constants
- The `sync_collection` driver subsystem (`AppStateSyncDriver` trait + the four `decode_patch_list*` wrappers it was the sole caller of) — superseded by the batched sync path
- The `SignalProtocolStore` blanket trait, `DecryptionErrorMessage::for_original`, `CryptographicMac::update_and_get`, `try_scoped`
- One-off builders and convenience wrappers: `GroupCreateOptions::with_membership_approval_mode`, `GroupParticipantOptions::from_lid_and_phone`, `ProfilePictureSpec::with_existing_id`, `PairCodeOptions::for_phone`, `encrypt_poll_vote`, `is_tc_token_expired`/`should_send_new_tc_token` (the `_with` variants stay), `build_get_user_devices_query`, `parse_lid_mappings_from_response`, `DownloadUtils::decrypt_cbc`, `CoreClient::get_device`/`update_device`, `Device::is_ready_for_presence`, `MessageSource::is_incoming_broadcast`, duplicate `TAG_SIZE` consts

One re-export adjusted accordingly: `whatsapp_rust::appstate_sync` no longer re-exports the removed `AppStateSyncDriver` (breaking, pre-1.0).

## Deliberately kept despite being flagged

- Vendored abprops/mex catalogs — complete registries, regenerated wholesale
- `time::set_time_provider`/`set_monotonic_provider` — the pluggable-clock extension points
- `EventKind::CAPACITY` — referenced by a compile-time tripwire (`const _: () = assert!(…)`), which reachability analysis doesn't count
- VoIP parity constants and helpers (`WHATSAPP_RELAY_PORT`, `SRTCP_TRAILER_LEN`, …) — fresh port, kept for protocol documentation and upcoming work

## Validation

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p wacore-libsignal --lib` (181 passed) and `cargo test -p wacore --lib` (1193 passed)
- Full matrix, wasm32 build, and benchmarks left to CI
