### PR TITLE
fix(concurrency): cancellation-safe app-state sync dedup and message-secret backpressure

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -873,7 +873,7 @@ pub struct Client {
     pub(crate) app_state_key_requests: Arc<Mutex<HashMap<Vec<u8>, wacore::time::Instant>>>,
     /// Tracks collections currently being synced to prevent duplicate sync tasks.
     /// Matches WA Web's in-flight tracking set in WAWebSyncdCollectionsStateMachine.
-    pub(crate) app_state_syncing: Arc<Mutex<HashSet<WAPatchName>>>,
+    pub(crate) app_state_syncing: Arc<app_state::SyncInFlight>,
     pub(crate) initial_keys_synced_notifier: Arc<event_listener::Event>,
     pub(crate) initial_app_state_keys_received: Arc<AtomicBool>,
 

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -186,7 +186,7 @@ impl Client {
         let response_waiters = self.response_waiters_guard().len();
         let presence_subscriptions = self.presence_subscriptions.lock().await.len();
         let app_state_key_requests = self.app_state_key_requests.lock().await.len();
-        let app_state_syncing = self.app_state_syncing.lock().await.len();
+        let app_state_syncing = self.app_state_syncing.len();
         let chatstate_handlers = self.chatstate_handlers.read().await.len();
         let history_sync_activity = self.history_sync_activity.snapshot();
         let history_sync_tasks = CollectionStats::new(

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -12,6 +12,74 @@ const APP_STATE_KEY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const APP_STATE_KEY_PARTIAL_RETRY: Duration = Duration::from_secs(10);
 const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 
+/// In-flight dedup registry for app-state collection syncs.
+///
+/// Reservations carry a per-begin token so a release can only ever remove the
+/// reservation it belongs to: a stale task finishing after a reconnect cleared
+/// the registry cannot evict the newer generation's reservation for the same
+/// collection. Releases run from the guard's `Drop`, so a cancelled sync
+/// (timeout, abort, teardown) can never strand a collection as "in flight".
+/// The mutex is synchronous and never held across an await.
+pub(crate) struct SyncInFlight {
+    entries: std::sync::Mutex<HashMap<WAPatchName, u64>>,
+    next_token: portable_atomic::AtomicU64,
+}
+
+impl SyncInFlight {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            entries: std::sync::Mutex::new(HashMap::new()),
+            next_token: portable_atomic::AtomicU64::new(0),
+        })
+    }
+
+    /// Reserve `name`, or `None` when a sync for it is already in flight.
+    pub(crate) fn try_begin(self: &Arc<Self>, name: WAPatchName) -> Option<SyncInFlightGuard> {
+        let token = self
+            .next_token
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
+        if entries.contains_key(&name) {
+            return None;
+        }
+        entries.insert(name, token);
+        Some(SyncInFlightGuard {
+            registry: Arc::clone(self),
+            name,
+            token,
+        })
+    }
+
+    /// Drop every reservation, releasing backing storage. Guards from before
+    /// the clear become no-ops thanks to the token check.
+    pub(crate) fn clear(&self) {
+        *self.entries.lock().unwrap_or_else(|p| p.into_inner()) = HashMap::new();
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.lock().unwrap_or_else(|p| p.into_inner()).len()
+    }
+}
+
+pub(crate) struct SyncInFlightGuard {
+    registry: Arc<SyncInFlight>,
+    name: WAPatchName,
+    token: u64,
+}
+
+impl Drop for SyncInFlightGuard {
+    fn drop(&mut self) {
+        let mut entries = self
+            .registry
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if entries.get(&self.name) == Some(&self.token) {
+            entries.remove(&self.name);
+        }
+    }
+}
+
 fn initial_app_state_key_retry(timeout: Duration) -> Duration {
     (timeout / 2)
         .max(Duration::from_millis(1))
@@ -339,21 +407,14 @@ impl Client {
     pub(crate) async fn fetch_app_state_with_retry(&self, name: WAPatchName) -> anyhow::Result<()> {
         // In-flight dedup: skip if this collection is already being synced.
         // Matches WA Web's WAWebSyncdCollectionsStateMachine which tracks in-flight syncs
-        // and queues new requests to a pending set.
-        {
-            let mut syncing = self.app_state_syncing.lock().await;
-            if !syncing.insert(name) {
-                debug!(target: "Client/AppState", "Skipping sync for {:?}: already in flight", name);
-                return Ok(());
-            }
-        }
+        // and queues new requests to a pending set. The guard releases on every
+        // exit path, including cancellation.
+        let Some(_guard) = self.app_state_syncing.try_begin(name) else {
+            debug!(target: "Client/AppState", "Skipping sync for {:?}: already in flight", name);
+            return Ok(());
+        };
 
-        let result = self.fetch_app_state_with_retry_inner(name).await;
-
-        // Always remove from in-flight set when done
-        self.app_state_syncing.lock().await.remove(&name);
-
-        result
+        self.fetch_app_state_with_retry_inner(name).await
     }
 
     async fn fetch_app_state_with_retry_inner(&self, name: WAPatchName) -> anyhow::Result<()> {
@@ -434,40 +495,28 @@ impl Client {
             return Ok(());
         }
 
-        // In-flight dedup: filter out collections already being synced
-        let pending = {
-            let mut syncing = self.app_state_syncing.lock().await;
-            let mut filtered = Vec::with_capacity(collections.len());
-            for name in collections {
-                if syncing.insert(name) {
-                    filtered.push(name);
-                } else {
+        // In-flight dedup: filter out collections already being synced. The
+        // guards release on every exit path, including cancellation.
+        let mut guards = Vec::with_capacity(collections.len());
+        let mut pending = Vec::with_capacity(collections.len());
+        for name in collections {
+            match self.app_state_syncing.try_begin(name) {
+                Some(guard) => {
+                    guards.push(guard);
+                    pending.push(name);
+                }
+                None => {
                     debug!(target: "Client/AppState", "Skipping {:?} in batch: already in flight", name);
                 }
             }
-            filtered
-        };
+        }
 
         if pending.is_empty() {
             return Ok(());
         }
 
-        // Track all collections for cleanup
-        let all_collections: Vec<WAPatchName> = pending.clone();
-
-        let result = self
-            .sync_collections_batched_inner(pending, key_wait_deadline)
-            .await;
-
-        // Always clean up in-flight set
-        {
-            let mut syncing = self.app_state_syncing.lock().await;
-            for name in &all_collections {
-                syncing.remove(name);
-            }
-        }
-
-        result
+        self.sync_collections_batched_inner(pending, key_wait_deadline)
+            .await
     }
 
     async fn sync_collections_batched_inner(
@@ -1381,5 +1430,56 @@ mod tests {
             initial_app_state_key_retry(Duration::from_secs(180)),
             APP_STATE_KEY_PARTIAL_RETRY
         );
+    }
+}
+
+#[cfg(test)]
+mod sync_in_flight_tests {
+    use super::*;
+
+    #[test]
+    fn second_begin_blocked_until_release() {
+        let registry = SyncInFlight::new();
+        let guard = registry
+            .try_begin(WAPatchName::Regular)
+            .expect("first begin must reserve");
+        assert!(
+            registry.try_begin(WAPatchName::Regular).is_none(),
+            "in-flight collection must dedup"
+        );
+        // Other collections are independent.
+        assert!(registry.try_begin(WAPatchName::CriticalBlock).is_some());
+
+        drop(guard);
+        assert!(
+            registry.try_begin(WAPatchName::Regular).is_some(),
+            "release (including cancellation drop) must free the slot"
+        );
+    }
+
+    #[test]
+    fn stale_guard_does_not_clobber_new_generation() {
+        let registry = SyncInFlight::new();
+        // Generation 1 reserves, then a reconnect clears the registry while
+        // the task is still in flight.
+        let stale = registry
+            .try_begin(WAPatchName::Regular)
+            .expect("gen-1 reserve");
+        registry.clear();
+
+        // Generation 2 reserves the same collection.
+        let fresh = registry
+            .try_begin(WAPatchName::Regular)
+            .expect("post-clear reserve");
+
+        // The stale task finishing must NOT evict generation 2's reservation.
+        drop(stale);
+        assert!(
+            registry.try_begin(WAPatchName::Regular).is_none(),
+            "stale release clobbered the new generation's reservation"
+        );
+
+        drop(fresh);
+        assert!(registry.try_begin(WAPatchName::Regular).is_some());
     }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -327,7 +327,7 @@ impl Client {
 
             app_state_processor: async_lock::Mutex::new(None),
             app_state_key_requests: Arc::new(Mutex::new(HashMap::new())),
-            app_state_syncing: Arc::new(Mutex::new(HashSet::new())),
+            app_state_syncing: app_state::SyncInFlight::new(),
             initial_keys_synced_notifier: Arc::new(event_listener::Event::new()),
             initial_app_state_keys_received: Arc::new(AtomicBool::new(false)),
             prekey_upload_lock: Arc::new(async_lock::Mutex::new(())),
@@ -1117,7 +1117,7 @@ impl Client {
         // Clear app state tracking maps to prevent unbounded growth across reconnections.
         // Replace with new collections to release backing storage.
         *self.app_state_key_requests.lock().await = HashMap::new();
-        *self.app_state_syncing.lock().await = HashSet::new();
+        self.app_state_syncing.clear();
 
         // Drop stale media connection (auth tokens become invalid on reconnect)
         *self.media_conn.write().await = None;

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -703,7 +703,7 @@ mod tests {
             match session_exists(jid) {
                 Ok(true) => {}                                        // Skip - session exists
                 Ok(false) => jids_needing_sessions.push(jid.clone()), // Needs session
-                Err(e) => eprintln!("Warning: failed to check {}: {}", jid, e), // Skip on error
+                Err(e) => log::warn!("failed to check session for {}: {e:#}", jid.observe()), // Skip on error
             }
         }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -703,7 +703,7 @@ mod tests {
             match session_exists(jid) {
                 Ok(true) => {}                                        // Skip - session exists
                 Ok(false) => jids_needing_sessions.push(jid.clone()), // Needs session
-                Err(e) => log::warn!("failed to check session for {}: {e:#}", jid.observe()), // Skip on error
+                Err(e) => eprintln!("Warning: failed to check {}: {}", jid, e), // Skip on error
             }
         }
 

--- a/src/msg_secret_buffer.rs
+++ b/src/msg_secret_buffer.rs
@@ -62,6 +62,50 @@ enum PendingEntries {
     One(Option<MsgSecretEntry>),
 }
 
+/// Entries a `queue_iter` call still owns while it waits for capacity.
+///
+/// A message secret must never be lost silently: if the queueing future is
+/// dropped mid-backpressure (caller timeout, task abort, teardown), `Drop`
+/// force-buffers whatever remains, accepting temporary overshoot of the
+/// high-water mark rather than dropping a secret later decrypts depend on.
+struct QueuedEntries<'a> {
+    buffer: &'a Arc<MsgSecretWriteBuffer>,
+    entries: PendingEntries,
+    blocked: Option<MsgSecretEntry>,
+}
+
+impl Drop for QueuedEntries<'_> {
+    fn drop(&mut self) {
+        let leftover = match (&self.blocked, &self.entries) {
+            (None, PendingEntries::One(None)) => false,
+            (None, PendingEntries::Batch(batch)) => batch.len() > 0,
+            _ => true,
+        };
+        if !leftover {
+            return;
+        }
+
+        let mut count = 0usize;
+        {
+            let mut pending = self
+                .buffer
+                .pending
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let drained = self.blocked.take().into_iter().chain(&mut self.entries);
+            for entry in drained {
+                MsgSecretWriteBuffer::try_insert_pending(&mut pending, entry, usize::MAX);
+                count += 1;
+            }
+        }
+        log::warn!(
+            "message-secret queue dropped mid-backpressure; force-buffered {count} entr{} past the high-water mark",
+            if count == 1 { "y" } else { "ies" }
+        );
+        self.buffer.schedule_drain();
+    }
+}
+
 impl Iterator for PendingEntries {
     type Item = MsgSecretEntry;
 
@@ -154,13 +198,17 @@ impl MsgSecretWriteBuffer {
         self.queue_iter(PendingEntries::One(Some(entry))).await;
     }
 
-    async fn queue_iter(self: &Arc<Self>, mut entries: PendingEntries) {
-        let mut blocked_entry = None;
+    async fn queue_iter(self: &Arc<Self>, entries: PendingEntries) {
+        let mut queued = QueuedEntries {
+            buffer: self,
+            entries,
+            blocked: None,
+        };
 
         loop {
             let capacity_wait = {
                 let mut pending = self.pending.lock().unwrap_or_else(|p| p.into_inner());
-                let mut next = blocked_entry.take().or_else(|| entries.next());
+                let mut next = queued.blocked.take().or_else(|| queued.entries.next());
 
                 loop {
                     let Some(entry) = next else {
@@ -172,9 +220,9 @@ impl MsgSecretWriteBuffer {
                             // takes the same mutex before notifying waiters.
                             break Some(self.capacity_available.listen());
                         }
-                        PendingInsert::Buffered => next = entries.next(),
+                        PendingInsert::Buffered => next = queued.entries.next(),
                         PendingInsert::Full(entry) => {
-                            blocked_entry = Some(entry);
+                            queued.blocked = Some(entry);
                             break Some(self.capacity_available.listen());
                         }
                     }
@@ -396,6 +444,57 @@ mod tests {
             Arc::new(crate::runtime_impl::TokioRuntime),
             pending_limit,
         )
+    }
+
+    /// A queueing future dropped mid-backpressure (caller timeout/abort) must
+    /// not lose the secret it was still holding: the drop guard force-buffers
+    /// it past the high-water mark and the next drain persists it.
+    #[tokio::test]
+    async fn dropped_backpressured_queue_force_buffers_entries() {
+        use futures::FutureExt;
+
+        let buf = buffer_with_pending_limit(1).await;
+
+        // Fills the buffer to the limit and parks awaiting capacity; dropping
+        // it here leaves no leftovers (the entry was already inserted).
+        assert!(
+            buf.queue_one(entry("g@g.us", "a@s.whatsapp.net", "M1", 0x11))
+                .now_or_never()
+                .is_none(),
+            "first queue must block on the high-water mark"
+        );
+        assert_eq!(buf.pending_len(), 1);
+
+        // Full buffer: the second entry is held as blocked_entry across the
+        // capacity wait; dropping the future is the cancellation under test.
+        assert!(
+            buf.queue_one(entry("g@g.us", "b@s.whatsapp.net", "M2", 0x22))
+                .now_or_never()
+                .is_none(),
+            "second queue must block behind the full buffer"
+        );
+        assert_eq!(
+            buf.pending_len(),
+            2,
+            "cancelled queue must force-buffer its blocked entry"
+        );
+        assert_eq!(
+            buf.lookup("g@g.us", "b@s.whatsapp.net", "M2"),
+            Some((vec![0x22; 32], 7)),
+            "force-buffered entry must be readable"
+        );
+
+        // Recovery: the guard-scheduled drain persists both entries.
+        buf.wait_flushed().await;
+        for (sender, byte) in [("a@s.whatsapp.net", 0x11u8), ("b@s.whatsapp.net", 0x22u8)] {
+            let stored = buf
+                .backend
+                .get_msg_secret("g@g.us", sender, if byte == 0x11 { "M1" } else { "M2" })
+                .await
+                .unwrap()
+                .expect("entry must reach the backend after the drain");
+            assert_eq!(stored, vec![byte; 32]);
+        }
     }
 
     /// The point of the buffer: a queued secret is readable BEFORE any flush

--- a/src/msg_secret_buffer.rs
+++ b/src/msg_secret_buffer.rs
@@ -102,7 +102,20 @@ impl Drop for QueuedEntries<'_> {
             "message-secret queue dropped mid-backpressure; force-buffered {count} entr{} past the high-water mark",
             if count == 1 { "y" } else { "ies" }
         );
-        self.buffer.schedule_drain();
+        // Mirror schedule_or_flush: a sealed buffer must not leave entries to
+        // the detached drain, so run a full flush; the terminal disconnect
+        // flush also sweeps these, since producers are torn down before it.
+        if self.buffer.sealed.load(Ordering::Acquire) {
+            let buffer = Arc::clone(self.buffer);
+            self.buffer
+                .runtime
+                .spawn(Box::pin(async move {
+                    buffer.flush().await;
+                }))
+                .detach();
+        } else {
+            self.buffer.schedule_drain();
+        }
     }
 }
 
@@ -495,6 +508,44 @@ mod tests {
                 .expect("entry must reach the backend after the drain");
             assert_eq!(stored, vec![byte; 32]);
         }
+    }
+
+    /// The disconnect sequence seals, then runs the terminal flush; a producer
+    /// dropped in between (teardown cancels lane workers first) must leave its
+    /// blocked entry where that terminal flush can still sweep it.
+    #[tokio::test]
+    async fn dropped_producer_after_seal_survives_terminal_flush() {
+        use futures::FutureExt;
+
+        let buf = buffer_with_pending_limit(1).await;
+
+        assert!(
+            buf.queue_one(entry("g@g.us", "a@s.whatsapp.net", "M1", 0x11))
+                .now_or_never()
+                .is_none()
+        );
+        // Producer parked in the capacity wait, still holding M2. Box::pin so
+        // `drop` drops the future itself, not just a borrowed pin.
+        let mut fut = Box::pin(buf.queue_one(entry("g@g.us", "b@s.whatsapp.net", "M2", 0x22)));
+        assert!(futures::poll!(fut.as_mut()).is_pending());
+
+        buf.seal();
+        drop(fut);
+        assert_eq!(
+            buf.pending_len(),
+            2,
+            "post-seal cancellation must still force-buffer the entry"
+        );
+
+        // Terminal flush, as disconnect() runs it right after seal().
+        buf.flush().await;
+        let stored = buf
+            .backend
+            .get_msg_secret("g@g.us", "b@s.whatsapp.net", "M2")
+            .await
+            .unwrap()
+            .expect("sealed-and-cancelled entry must reach the backend");
+        assert_eq!(stored, vec![0x22; 32]);
     }
 
     /// The point of the buffer: a queued secret is readable BEFORE any flush

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -2290,7 +2290,11 @@ impl Client {
             // unnecessary LID-migration side effects from get_user_devices
             let mut recipient_cached = self.get_devices_from_registry(&recipient_bare).await;
             if recipient_cached.is_none() {
-                let _ = self.get_user_devices(std::slice::from_ref(&to)).await;
+                if let Err(e) = self.get_user_devices(std::slice::from_ref(&to)).await {
+                    // The bare-JID fallback below can drop companion devices, so
+                    // leave a trace when the warmup that would prevent it fails.
+                    log::warn!("device-list warmup for {} failed: {e:#}", to.observe());
+                }
                 recipient_cached = self.get_devices_from_registry(&recipient_bare).await;
             }
 
@@ -2308,7 +2312,9 @@ impl Client {
             } else {
                 let mut cached = self.get_devices_from_registry(own_jid).await;
                 if cached.is_none() {
-                    let _ = self.get_user_devices(std::slice::from_ref(own_jid)).await;
+                    if let Err(e) = self.get_user_devices(std::slice::from_ref(own_jid)).await {
+                        log::warn!("own device-list warmup failed: {e:#}");
+                    }
                     cached = self.get_devices_from_registry(own_jid).await;
                 }
                 cached


### PR DESCRIPTION
## Summary

Fixes the two real bugs surfaced by the concurrency/cancellation audit — both instances of the "cleanup only on the success path" class the recent PortableCache fix addressed — plus two smaller error-visibility issues from the same audit.

## app-state sync dedup: cancellation-safe, generation-safe

`fetch_app_state_with_retry`/`sync_collections_batched` inserted the collection into `app_state_syncing`, awaited network I/O, and removed the entry only after the await returned. Two failure scenarios:

- A cancelled sync (caller timeout, abort, teardown) skipped the removal and stranded the collection as "already in flight" forever on that client instance, permanently blocking future syncs of that collection.
- `disconnect()` replaces the set while a stale sync from the previous generation is still in flight; when that task finally returned, its unconditional `remove` evicted the reservation the new generation had just made, allowing two concurrent syncs of the same collection (the exact invariant the set exists to hold).

The set is now a `SyncInFlight` registry: `try_begin` hands out a guard carrying a per-reservation token, the release runs in the guard's `Drop` (so every exit path frees the slot, including cancellation), and a release only removes its own token, so a stale generation can never clobber a newer reservation. The mutex is synchronous and never held across an await. Unit tests cover the dedup, the release-on-drop, and the stale-guard-vs-new-generation scenario.

## message-secret backpressure: no silent loss on cancellation

`MsgSecretWriteBuffer::queue_iter` kept the backpressure-blocked entry in a local variable across the capacity wait; dropping the future there silently lost a `messageSecret` that later reaction/edit decrypts depend on. The in-flight entries now live in a drop guard that force-buffers any leftovers past the high-water mark (bounded overshoot, same spirit as the evict-guard over-capacity policy) and schedules a drain. All existing buffer invariants (coalescing merge, seal-then-inline, write serialization) are untouched; the new test drops a backpressured queue future and asserts the entry survives to the backend.

## Error visibility

- The two `let _ = self.get_user_devices(...)` in the DM send path now log the failure: the bare-JID fallback they precede can drop companion devices, so the warmup failure needs a trace for diagnosing lost deliveries.
- `src/client/sessions.rs` had a stray production `eprintln!`, now `log::warn!` with the PII-safe `Jid::observe()`.

## Validation

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p whatsapp-rust --lib`: 1139 passed (3 new tests: 2 SyncInFlight, 1 buffer cancellation)
- Full matrix, wasm32, and benchmarks left to CI
