### PR TITLE
feat(waproto): pinned HistorySync encode wrappers in codec

### DIFF
--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -2125,7 +2125,7 @@ mod tests {
 
     /// Encode a HistorySync proto and zlib-compress it.
     fn encode_and_compress(hs: &wa::HistorySync) -> Vec<u8> {
-        let proto_bytes = hs.encode_to_vec();
+        let proto_bytes = waproto::codec::history_sync_to_vec(hs);
         let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(&proto_bytes).unwrap();
         encoder.finish().unwrap()
@@ -4103,7 +4103,9 @@ mod tests {
         // encoder without finish(): a valid prefix with no terminator, so the
         // inflater exhausts input cleanly right at the field boundary.
         let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(&hs.encode_to_vec()).unwrap();
+        encoder
+            .write_all(&waproto::codec::history_sync_to_vec(&hs))
+            .unwrap();
         encoder.flush().unwrap();
         let truncated = encoder.get_ref().clone();
 
@@ -4206,7 +4208,7 @@ mod tests {
     #[test]
     fn extraction_reports_exact_decompressed_size() {
         let hs = parity_fixture("5511000000000");
-        let raw_len = hs.encode_to_vec().len();
+        let raw_len = waproto::codec::history_sync_to_vec(&hs).len();
         let compressed = encode_and_compress(&hs);
         let result = process_history_sync(compressed, None, false).unwrap();
         assert_eq!(result.decompressed_size, raw_len);

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -157,6 +157,17 @@ pub mod codec {
         whatsapp::HistorySync::decode_from_slice(bytes)
     }
 
+    /// Append the encoded `HistorySync` to `out`. Infallible into a `Vec`.
+    #[inline(never)]
+    pub fn history_sync_encode_into(msg: &whatsapp::HistorySync, out: &mut Vec<u8>) {
+        msg.encode(out);
+    }
+
+    #[inline(never)]
+    pub fn history_sync_to_vec(msg: &whatsapp::HistorySync) -> Vec<u8> {
+        msg.encode_to_vec()
+    }
+
     /// History-sync streaming decodes individual `HistorySyncMsg`/`Conversation`
     /// records; pinning them here keeps their nested `WebMessageInfo`/`Message`
     /// decode tree from being re-instantiated in the calling crate.


### PR DESCRIPTION
## Summary

`waproto::codec` is the single sanctioned instantiation site for buffa codec calls, per the policy spelled out in `clippy.toml`: the generic `Message` methods get stamped into every calling crate and LTO cannot merge the copies. `HistorySync` already had a pinned decode wrapper but no encode one, so in-repo call sites leaned on a scoped `allow(clippy::disallowed_methods)` and crates outside the workspace had no compliant way to serialize a `HistorySync` at all (for example handing a decoded remainder back to an embedding host).

This adds the missing encode pair, mirroring the existing `message_encode_into` / `message_to_vec` shape. Purely additive, no behavior change.

## Changes

- Two new wrappers in `waproto::codec`: `history_sync_encode_into`, which appends the encoded `HistorySync` to a caller-owned byte vec, and `history_sync_to_vec`, which returns a fresh one. Both are `#[inline(never)]` so MIR inlining does not reintroduce the per-crate copies.
- The three `HistorySync` encode call sites in the `wacore::history_sync` test module now go through `history_sync_to_vec`. The module-level scoped allow stays: other protos in that module (`HistorySyncMsg`, `MessageKey`, `Message`, ...) still encode directly.

No other types were given wrappers in this PR.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p waproto -p wacore --all-targets -- -D warnings` (the full `--workspace` run does not build in my sandbox: `alsa-sys` needs system `libasound2-dev`, unrelated to this change)
- `cargo test -p wacore --lib history_sync`, 54 passed

Full matrix, including wasm32, left to CI.