### PR TITLE
test: replace fixed sleeps with bounded polling and add negative coverage for server-controlled parsers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,8 @@ aes = { workspace = true }
 async-trait = { workspace = true }
 cbc = { workspace = true, features = ["block-padding"] }
 env_logger = { workspace = true }
+# `total_listeners()` (how tests observe that a waiter parked) is std-gated.
+event-listener = { workspace = true, features = ["std"] }
 flate2 = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -64,12 +64,15 @@ Reference: `groups.rs` uses zero sleeps and runs at ~2.2s/test. Follow this patt
 
 ## Offline Testing Pattern
 
-When testing offline event delivery, use short sleeps (100ms) after `reconnect()` or `disconnect()` to let the server detect the TCP close. Localhost connections close nearly instantly:
+`reconnect()` tears the socket down in a background task, so the client is still
+online when it returns. Poll for the transition with `wait_for_disconnected()`
+instead of sleeping — `Event::Disconnected` is suppressed for expected
+disconnects, so the connection flag is the observable:
 
 ```rust
 // Client goes offline (triggers auto-reconnect in background)
 client_b.client.reconnect().await;
-tokio::time::sleep(Duration::from_millis(100)).await;
+client_b.wait_for_disconnected(5).await?;
 
 // Now send while client is offline — server queues it
 client_a.client.send_message(jid_b.clone(), message).await?;
@@ -78,10 +81,11 @@ client_a.client.send_message(jid_b.clone(), message).await?;
 let event = client_b.wait_for_event(30, |e| matches!(e, Event::Messages(_))).await?;
 ```
 
-For full disconnects (no auto-reconnect):
+Full disconnects need nothing: `TestClient::disconnect()` awaits the run task, so
+the client is already offline when it returns.
+
 ```rust
 client_b.disconnect().await;
-tokio::time::sleep(Duration::from_millis(100)).await;
 ```
 
 ## `reconnect_and_wait()` Helper
@@ -100,13 +104,16 @@ Do NOT use this for offline tests — it waits for the client to be back online,
 - **Event waits in online flows**: 10-15s (events arrive in <1s normally)
 - **Event waits after offline reconnect**: 30s (reconnect + offline queue drain)
 - **Negative assertions** (event should NOT arrive): 3-5s
-- **Post-disconnect sleeps**: 100ms (TCP close detection)
-- **Sequential processing delays**: 50ms (ensure server ordering)
+- **Going offline** (`wait_for_disconnected`): 5s
+
+Never synchronize on a fixed sleep: long enough to be reliable is slow, short
+enough to be fast is flaky. Wait on the condition itself — an event, or a poll
+with a bounded deadline that fails with a clear message.
 
 ## Writing New E2E Tests
 
 1. Use `TestClient::connect("unique_prefix")` with a unique prefix per client per test.
-2. Use `wait_for_event()` for all assertions — avoid polling or sleeping.
+2. Use `wait_for_event()` for all assertions; for state with no event, poll it with a bounded deadline. Never sleep.
 3. Always call `disconnect()` on all clients at the end (cleanup).
 4. Return `anyhow::Result<()>` for clean error propagation.
 5. Use `env_logger` for debug output: `let _ = env_logger::builder().is_test(true).try_init();`

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -82,7 +82,9 @@ let event = client_b.wait_for_event(30, |e| matches!(e, Event::Messages(_))).awa
 ```
 
 Full disconnects need nothing: `TestClient::disconnect()` awaits the run task, so
-the client is already offline when it returns.
+the client is normally already offline when it returns. It caps that wait at 5s
+and warns instead of failing, so a test that depends on the client being offline
+afterwards should still assert it rather than assume it.
 
 ```rust
 client_b.disconnect().await;

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -2050,7 +2050,13 @@ mod tests {
         removed.wait();
         let shutdown_registration = Arc::clone(&registration);
         let shutdown = tokio::spawn(async move { shutdown_registration.shutdown().await });
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        // `terminal` flips inside signal_shutdown_sync, right before it reaches for
+        // the `scopes` lock the blocked close callback is holding. Once it is set,
+        // shutdown provably cannot get past that lock until `release` is waited.
+        crate::test_utils::poll_until("shutdown to reach the scope registry", || {
+            registration.terminal.load(Ordering::Acquire)
+        })
+        .await;
         assert!(!shutdown.is_finished());
 
         release.wait();

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3681,17 +3681,12 @@ async fn ack_miss_path_does_not_heap_allocate() {
 
     let node = Arc::new(owned_ack_node("3EB0A9252A8F12B7E2"));
 
-    // Min-delta over many windows: sibling tests share the process-global
-    // counter, but their allocations are sporadic. A per-call String shows up
-    // in every window, so the minimum only reaches 0 when the path is clean.
-    let mut min_delta = u64::MAX;
-    for _ in 0..100 {
-        let before = crate::test_alloc::ALLOCS.load(Ordering::Relaxed);
+    // A per-call String shows up in every window, so the minimum only reaches 0
+    // when the path is clean.
+    let min_delta = crate::test_alloc::min_allocs(0, || {
         let handled = client.handle_ack_response_arc(&node);
-        let after = crate::test_alloc::ALLOCS.load(Ordering::Relaxed);
         assert!(!handled, "no waiter is registered for this id");
-        min_delta = min_delta.min(after - before);
-    }
+    });
     assert_eq!(min_delta, 0, "ack miss path must not allocate");
 }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -830,7 +830,9 @@ async fn test_offline_sync_lifecycle() {
         true // Return that we completed
     });
 
-    // Wait until the waiter is actually parked on the notifier
+    // A registered listener proves the waiter reached its await point, so the
+    // "still waiting" assertion below cannot pass just because the spawned task
+    // never got scheduled.
     crate::test_utils::wait_for_notifier_listeners(&client.offline_sync_notifier, 1).await;
 
     // Verify waiter hasn't completed yet
@@ -954,7 +956,9 @@ async fn test_ensure_e2e_sessions_waits_for_offline_sync() {
         start.elapsed()
     });
 
-    // Wait until it is parked on the offline-sync notifier
+    // Registration is what makes the assertion below scheduler-independent: it
+    // pins down that `ensure_e2e_sessions` is blocked on offline sync rather than
+    // simply not started yet.
     crate::test_utils::wait_for_notifier_listeners(&client.offline_sync_notifier, 1).await;
 
     // It should still be waiting (offline sync not complete)

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -830,8 +830,8 @@ async fn test_offline_sync_lifecycle() {
         true // Return that we completed
     });
 
-    // Give the waiter time to start waiting
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    // Wait until the waiter is actually parked on the notifier
+    crate::test_utils::wait_for_notifier_listeners(&client.offline_sync_notifier, 1).await;
 
     // Verify waiter hasn't completed yet
     assert!(
@@ -936,12 +936,13 @@ async fn test_ensure_e2e_sessions_waits_for_offline_sync() {
         client_clone.ensure_e2e_sessions(&[]).await
     });
 
-    // Wait a bit - ensure_e2e_sessions should return immediately for empty list
-    tokio::time::sleep(Duration::from_millis(10)).await;
-    assert!(
-        ensure_handle.is_finished(),
-        "ensure_e2e_sessions should return immediately for empty JID list"
-    );
+    // An empty list must not wait for offline sync: the flag is still false, so a
+    // waiting call would hang until DEFAULT_OFFLINE_SYNC_TIMEOUT.
+    tokio::time::timeout(Duration::from_secs(5), ensure_handle)
+        .await
+        .expect("ensure_e2e_sessions should return immediately for empty JID list")
+        .expect("ensure_e2e_sessions task should not panic")
+        .expect("empty JID list should succeed");
 
     // Now test with actual JIDs - it should wait for offline sync
     let client_clone = client.clone();
@@ -953,8 +954,8 @@ async fn test_ensure_e2e_sessions_waits_for_offline_sync() {
         start.elapsed()
     });
 
-    // Give it a moment to start
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    // Wait until it is parked on the offline-sync notifier
+    crate::test_utils::wait_for_notifier_listeners(&client.offline_sync_notifier, 1).await;
 
     // It should still be waiting (offline sync not complete)
     assert!(
@@ -3276,7 +3277,12 @@ async fn disconnect_does_not_signal_connection_cleanup_before_outbound_flush() {
         disconnect_client.disconnect().await;
     });
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // disconnect() closes the scope and then parks in `outbound_flush.flush`; the
+    // parked flusher is what proves it got that far and is stuck there.
+    crate::test_utils::poll_until("disconnect to park on the outbound flush", || {
+        client.outbound_flush.flush_waiters() >= 1
+    })
+    .await;
     assert!(
         !client.connection_shutdown_signal().is_fired(),
         "connection cleanup must not fire while outbound flush is blocked"
@@ -3477,7 +3483,10 @@ async fn flush_waits_for_queued_delivery_receipts() {
             .flush(&*flush_client.runtime, Duration::from_secs(5))
             .await;
     });
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    crate::test_utils::poll_until("the flusher to park on the outbound scope", || {
+        client.outbound_flush.flush_waiters() >= 1
+    })
+    .await;
     assert!(
         !flush_task.is_finished(),
         "flush must wait while receipts are queued or in flight"

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -120,6 +120,14 @@ impl FlushScope {
         self.count.load(Ordering::Relaxed)
     }
 
+    /// Number of tasks parked inside [`Self::flush`]. `flush` registers its
+    /// listener before checking the counter, so a listener here means a flusher
+    /// really is waiting — what tests poll instead of sleeping.
+    #[cfg(test)]
+    pub fn flush_waiters(&self) -> usize {
+        self.idle.total_listeners()
+    }
+
     #[cfg(test)]
     pub fn track_rejections(&self) -> usize {
         self.track_rejections.load(Ordering::Relaxed)
@@ -297,7 +305,10 @@ mod tests {
                 .flush(&*flush_runtime, Duration::from_secs(5))
                 .await;
         });
-        tokio::time::sleep(Duration::from_millis(30)).await;
+        crate::test_utils::poll_until("the flusher to park on the scope", || {
+            scope.flush_waiters() >= 1
+        })
+        .await;
         assert!(
             !flush_task.is_finished(),
             "flush must wait while a tracked guard is alive"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@
 // `tracing` + `tracing-pii` paths combine. Raise it (compile-time only).
 #![recursion_limit = "512"]
 
-// Process-wide allocation counter shared by empirical unit-test guards. Tests
-// use minimum deltas across repeated windows so allocations from sibling test
-// threads cannot create false passes.
+// Process-wide allocation counter shared by empirical unit-test guards. It sees
+// every thread, so measurements go through `min_allocs`, which retries until a
+// window lands quiet rather than trusting any single one.
 #[cfg(test)]
 #[allow(clippy::disallowed_types)]
 pub(crate) mod test_alloc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,36 @@ pub(crate) mod test_alloc {
 
     #[global_allocator]
     static GLOBAL: CountingAlloc = CountingAlloc;
+
+    /// Smallest allocation delta observed while running `op`, retrying until it
+    /// reaches `expected`.
+    ///
+    /// `ALLOCS` counts every allocation in the process, so a sibling test thread
+    /// allocating inside the window inflates that window's delta. A fixed
+    /// iteration count only hopes one of its windows lands quiet, which is a
+    /// flake under a loaded CI runner; retrying until the delta reaches
+    /// `expected` makes ambient traffic cost iterations instead of a false
+    /// failure. A real regression never reaches `expected`, so the caller's
+    /// assertion still fires — with the count actually observed.
+    pub(crate) fn min_allocs<T>(expected: u64, mut op: impl FnMut() -> T) -> u64 {
+        // Bounded so a genuine regression fails instead of spinning forever.
+        // The happy path exits on its first quiet window, so a budget this
+        // large is free unless something is actually wrong.
+        const BUDGET: u32 = 100_000;
+
+        let mut min = u64::MAX;
+        for _ in 0..BUDGET {
+            let before = ALLOCS.load(Ordering::Relaxed);
+            let value = std::hint::black_box(op());
+            let after = ALLOCS.load(Ordering::Relaxed);
+            drop(value);
+            min = min.min(after - before);
+            if min <= expected {
+                break;
+            }
+        }
+        min
+    }
 }
 
 pub use wacore::appstate::schemas;

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -3713,8 +3713,8 @@ async fn test_spawn_retry_receipt_basic_flow() {
     let info = Arc::new(info);
     client.spawn_retry_receipt(&info, RetryReason::UnknownError);
 
-    // Give the spawned task time to execute
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // Let the spawned task run to completion
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
 
     // Verify count was incremented (the actual send will fail due to no connection, but count should update)
     let stored = client
@@ -3756,8 +3756,9 @@ async fn test_spawn_retry_receipt_respects_max_retries() {
     let info = Arc::new(info);
     client.spawn_retry_receipt(&info, RetryReason::UnknownError);
 
-    // Give the spawned task time to execute
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // Draining the scope is what makes the negative assertion below meaningful:
+    // the task really ran, and chose not to increment.
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
 
     // Count should still be at max (not incremented)
     let stored = client
@@ -5007,7 +5008,7 @@ async fn test_undecryptable_fires_before_retry_task() {
         "retry task has not progressed yet",
     );
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
     assert_eq!(
         client
             .message_retry_counts
@@ -5102,8 +5103,13 @@ async fn test_pdo_armed_for_status_broadcast() {
 
     assert_eq!(info.source.chat.server, wacore_binary::Server::Broadcast);
 
-    client.run_pdo_request(&info).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // `run_pdo_request` is fully awaited, so its return value is the outcome:
+    // `false` means the request was built and the (offline) send failed, while a
+    // skipped request returns `true` without ever reaching the transport.
+    assert!(
+        !client.run_pdo_request(&info).await,
+        "status@broadcast must arm a PDO request, not skip it",
+    );
 }
 
 /// Broadcast lists share the same code path; locks the guard for both.
@@ -5119,8 +5125,13 @@ async fn test_pdo_armed_for_any_broadcast_chat() {
 
     assert_eq!(info.source.chat.server, wacore_binary::Server::Broadcast);
 
-    client.run_pdo_request(&info).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // `run_pdo_request` is fully awaited, so its return value is the outcome:
+    // `false` means the request was built and the (offline) send failed, while a
+    // skipped request returns `true` without ever reaching the transport.
+    assert!(
+        !client.run_pdo_request(&info).await,
+        "broadcast lists must arm a PDO request, not skip it",
+    );
 }
 
 #[tokio::test]
@@ -5135,8 +5146,13 @@ async fn test_pdo_armed_for_one_on_one() {
 
     assert_ne!(info.source.chat.server, wacore_binary::Server::Broadcast);
 
-    client.run_pdo_request(&info).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // `run_pdo_request` is fully awaited, so its return value is the outcome:
+    // `false` means the request was built and the (offline) send failed, while a
+    // skipped request returns `true` without ever reaching the transport.
+    assert!(
+        !client.run_pdo_request(&info).await,
+        "one-on-one chats must arm a PDO request, not skip it",
+    );
 }
 
 /// fromMe messages fanned out to a linked device can still fail decrypt
@@ -5151,8 +5167,13 @@ async fn test_pdo_armed_for_from_me() {
     info.source.is_from_me = true;
     let info = Arc::new(info);
 
-    client.run_pdo_request(&info).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // `run_pdo_request` is fully awaited, so its return value is the outcome:
+    // `false` means the request was built and the (offline) send failed, while a
+    // skipped request returns `true` without ever reaching the transport.
+    assert!(
+        !client.run_pdo_request(&info).await,
+        "fromMe fanouts must arm a PDO request, not skip it",
+    );
 }
 
 /// Stops offline-sync / reconnect tails from flooding the phone with
@@ -5170,8 +5191,12 @@ async fn test_pdo_skipped_for_ancient_messages() {
 
     let cache_key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());
 
-    client.run_pdo_request(&info).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // Fully awaited, and the age gate returns before any send, so the pending map
+    // is already settled when this returns.
+    assert!(
+        client.run_pdo_request(&info).await,
+        "an over-age message must be skipped, not attempted",
+    );
 
     assert!(
         client.pdo_pending_requests.get(&cache_key).await.is_none(),
@@ -5196,8 +5221,12 @@ async fn test_pdo_rejects_just_past_14d_boundary() {
 
     let cache_key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());
 
-    client.run_pdo_request(&info).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // Fully awaited, and the age gate returns before any send, so the pending map
+    // is already settled when this returns.
+    assert!(
+        client.run_pdo_request(&info).await,
+        "an over-age message must be skipped, not attempted",
+    );
 
     assert!(
         client.pdo_pending_requests.get(&cache_key).await.is_none(),

--- a/src/msg_secret_buffer.rs
+++ b/src/msg_secret_buffer.rs
@@ -582,17 +582,17 @@ mod tests {
         buf.queue_one(entry("g@g.us", "a@s.whatsapp.net", "M1", 0x11))
             .await;
 
-        // Sibling tests share the process-wide counter, so take the minimum of
-        // repeated windows. The result Vec costs exactly one allocation; an
-        // owned lookup key would add one allocation per component every time.
-        let mut min_delta = u64::MAX;
-        for _ in 0..100 {
-            let before = crate::test_alloc::ALLOCS.load(Ordering::Relaxed);
-            let result = buf.lookup("g@g.us", "a@s.whatsapp.net", "M1");
-            std::hint::black_box(&result);
-            let after = crate::test_alloc::ALLOCS.load(Ordering::Relaxed);
-            min_delta = min_delta.min(after - before);
-        }
+        // A miss would also be allocation-free, which would read as a pass for
+        // the wrong reason.
+        assert!(
+            buf.lookup("g@g.us", "a@s.whatsapp.net", "M1").is_some(),
+            "the queued secret must be buffered before measuring"
+        );
+
+        // The result Vec costs exactly one allocation; an owned lookup key would
+        // add one allocation per component every time.
+        let min_delta =
+            crate::test_alloc::min_allocs(1, || buf.lookup("g@g.us", "a@s.whatsapp.net", "M1"));
         assert_eq!(min_delta, 1, "only the returned secret Vec may allocate");
 
         buf.wait_flushed().await;
@@ -603,14 +603,7 @@ mod tests {
     #[test]
     fn entry_clone_does_not_heap_allocate() {
         let entry = entry("g@g.us", "a@s.whatsapp.net", "M1", 0x11);
-        let mut min_delta = u64::MAX;
-        for _ in 0..100 {
-            let before = crate::test_alloc::ALLOCS.load(Ordering::Relaxed);
-            let cloned = std::hint::black_box(&entry).clone();
-            std::hint::black_box(cloned);
-            let after = crate::test_alloc::ALLOCS.load(Ordering::Relaxed);
-            min_delta = min_delta.min(after - before);
-        }
+        let min_delta = crate::test_alloc::min_allocs(0, || std::hint::black_box(&entry).clone());
         assert_eq!(min_delta, 0, "an entry clone must not allocate");
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -34,7 +34,10 @@ pub async fn poll_until(what: &str, mut cond: impl FnMut() -> bool) {
     // time (and would otherwise burn a core for the whole deadline).
     const YIELDS: u32 = 64;
 
-    let started = wacore::time::Instant::now();
+    // Tokio's clock, not the wall clock: the timed step below is a tokio sleep, so
+    // measuring the deadline on the same clock keeps the two in agreement even
+    // under `tokio::time::pause()`.
+    let started = tokio::time::Instant::now();
     let mut spins = 0u32;
     loop {
         if cond() {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,13 +15,68 @@ pub fn node_to_owned_ref(node: &Node) -> Arc<OwnedNodeRef> {
 }
 
 pub async fn wait_for_lock_waiter(lock: &Arc<async_lock::Mutex<()>>, baseline: usize) {
-    tokio::time::timeout(std::time::Duration::from_secs(5), async {
-        while Arc::strong_count(lock) <= baseline {
-            tokio::task::yield_now().await;
-        }
+    poll_until("a task to reach the contested lock", || {
+        Arc::strong_count(lock) > baseline
     })
-    .await
-    .expect("task must reach the contested lock");
+    .await;
+}
+
+/// Polls `cond` until it holds, panicking once a bounded deadline passes.
+///
+/// A fixed sleep can only be wrong: long enough to be reliable makes the suite
+/// slow, short enough to be fast makes it flaky on a loaded CI runner. Polling
+/// the real condition is both fast on the happy path and stable under load.
+pub async fn poll_until(what: &str, mut cond: impl FnMut() -> bool) {
+    const DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
+    const STEP: std::time::Duration = std::time::Duration::from_millis(2);
+    // Most waits here are satisfied by letting a sibling task run once, so yield
+    // first and only fall back to a timed step for waits that need real elapsed
+    // time (and would otherwise burn a core for the whole deadline).
+    const YIELDS: u32 = 64;
+
+    let started = wacore::time::Instant::now();
+    let mut spins = 0u32;
+    loop {
+        if cond() {
+            return;
+        }
+        assert!(
+            started.elapsed() < DEADLINE,
+            "timed out after {DEADLINE:?} waiting for {what}",
+        );
+        if spins < YIELDS {
+            spins += 1;
+            tokio::task::yield_now().await;
+        } else {
+            tokio::time::sleep(STEP).await;
+        }
+    }
+}
+
+/// Waits until every task tracked by the client's outbound flush scope has run.
+///
+/// Retry receipts, PDO fallbacks and transport acks are all spawned there, and
+/// the guard is taken synchronously by the spawn, so a drained scope proves the
+/// spawned side effect completed — including the cases where it must
+/// deliberately do nothing.
+pub async fn wait_for_outbound_tasks(client: &Arc<Client>) {
+    poll_until("the outbound flush scope to drain", || {
+        client.outbound_flush.pending() == 0
+    })
+    .await;
+}
+
+/// Waits until at least `count` tasks are parked on `notifier`.
+///
+/// Every waiter in this codebase registers its listener before re-checking the
+/// condition it waits on, so a registered listener is proof the task reached its
+/// await point — the observable a "still waiting" assertion needs instead of a
+/// sleep long enough to hope the scheduler got there.
+pub async fn wait_for_notifier_listeners(notifier: &event_listener::Event, count: usize) {
+    poll_until(&format!("{count} task(s) parked on the notifier"), || {
+        notifier.total_listeners() >= count
+    })
+    .await;
 }
 
 use crate::http::{HttpClient, HttpRequest, HttpResponse};

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -486,6 +486,31 @@ impl TestClient {
 
     // ── Connection lifecycle ────────────────────────────────────────────────
 
+    /// Wait until the current connection is torn down.
+    ///
+    /// `reconnect()` / `reconnect_immediately()` only ask the transport to
+    /// close; the client is still bookkeeping-connected until the run loop
+    /// finishes `cleanup_connection_state`. Offline tests must observe that
+    /// transition before acting, and polling it is bounded and self-reporting
+    /// where a fixed sleep is neither.
+    pub async fn wait_for_disconnected(&self, timeout_secs: u64) -> anyhow::Result<()> {
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(timeout_secs);
+
+        loop {
+            if !self.client.is_connected() {
+                return Ok(());
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                return Err(anyhow::anyhow!(
+                    "Timed out after {timeout_secs}s waiting for the client to go offline"
+                ));
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        }
+    }
+
     /// Reconnect and wait for the Connected event.
     pub async fn reconnect_and_wait(&mut self) -> anyhow::Result<()> {
         // Drain any buffered Connected events from prior connections
@@ -518,6 +543,57 @@ impl TestClient {
 }
 
 // ── Free-standing test helpers ──────────────────────────────────────────────
+
+/// True when `node` has a direct child with the given tag.
+pub fn has_child(node: &Node, tag: &str) -> bool {
+    node.children()
+        .map(|children| children.iter().any(|child| child.tag == tag))
+        .unwrap_or(false)
+}
+
+/// Backend session-store key for a peer's `(user, server, device)`, matching the
+/// `<user>[:dev]@<server>.0` protocol-address form the Signal store keys on.
+pub fn peer_session_addr(user: &str, server: &str, device: u16) -> String {
+    if device == 0 {
+        format!("{user}@{server}.0")
+    } else {
+        format!("{user}:{device}@{server}.0")
+    }
+}
+
+/// Scan the backend for sessions matching `user` across device IDs 0..=99,
+/// returning `(address, has_pending_pre_key)` for each one found.
+///
+/// The range must cover the peer's real companion device (a paired client is a
+/// non-zero device, e.g. 33), not just low ids — otherwise the only session
+/// found is the phantom device-0 one, whose pending_pre_key never clears
+/// (device 0 never completes the X3DH handshake).
+///
+/// A record that deserializes without a current state is still reported (with
+/// `has_pending_pre_key = false`), so absence in the result means "no session
+/// stored", which is what the LID-only assertions rely on.
+pub async fn scan_sessions(
+    backend: &dyn wacore::store::traits::SignalStore,
+    user: &str,
+    server: &str,
+) -> anyhow::Result<Vec<(String, bool)>> {
+    let mut results = Vec::new();
+    for device_id in 0..=99u16 {
+        let addr = peer_session_addr(user, server, device_id);
+        if let Some(data) = backend.get_session(&addr).await? {
+            let record = wacore::libsignal::protocol::SessionRecord::deserialize(&data)?;
+            let has_pending = match record.session_state() {
+                Some(state) => state
+                    .unacknowledged_pre_key_message_items()
+                    .map_err(|e| anyhow::anyhow!("invalid session state: {e}"))?
+                    .is_some(),
+                None => false,
+            };
+            results.push((addr, has_pending));
+        }
+    }
+    Ok(results)
+}
 
 /// Build a simple text message.
 pub fn text_msg(text: &str) -> wa::Message {

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -501,7 +501,10 @@ impl TestClient {
                 return Ok(());
             }
 
-            if tokio::time::Instant::now() >= deadline {
+            // Re-sample the flag: the teardown runs on another task and can flip it
+            // between the check above and the deadline expiring, and a disconnect
+            // that lands in that window is a success, not a timeout.
+            if tokio::time::Instant::now() >= deadline && self.client.is_connected() {
                 return Err(anyhow::anyhow!(
                     "Timed out after {timeout_secs}s waiting for the client to go offline"
                 ));

--- a/tests/e2e/tests/chatstate_ttl.rs
+++ b/tests/e2e/tests/chatstate_ttl.rs
@@ -19,7 +19,7 @@ async fn test_expired_chatstate_not_delivered() -> anyhow::Result<()> {
     // at ~5s, so the drain filters it out.
     client_b.client.reconnect().await;
     info!("B disconnected (will auto-reconnect after backoff)");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     client_a.client.chatstate().send_composing(&jid_b).await?;
     info!("A sent typing indicator to offline B");
@@ -58,7 +58,7 @@ async fn test_fresh_chatstate_delivered_on_reconnect() -> anyhow::Result<()> {
     // well within the 3s TTL window
     client_b.client.reconnect_immediately().await;
     info!("B disconnected (will reconnect immediately)");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     client_a.client.chatstate().send_composing(&jid_b).await?;
     info!("A sent typing indicator to offline B");

--- a/tests/e2e/tests/lid_sessions.rs
+++ b/tests/e2e/tests/lid_sessions.rs
@@ -11,7 +11,7 @@
 //! - No UndecryptableMessage events during normal messaging
 //! - Multiple sequential sends don't regress to PN sessions
 
-use e2e_tests::{TestClient, send_and_expect_text};
+use e2e_tests::{TestClient, peer_session_addr, scan_sessions, send_and_expect_text};
 use log::info;
 use wacore::store::traits::SignalStore;
 use wacore::types::events::Event;
@@ -28,32 +28,6 @@ fn mask_addr(addr: &str) -> String {
     } else {
         addr.to_string()
     }
-}
-
-/// Backend session-store key for a peer's `(user, server, device)`, matching the
-/// `<user>[:dev]@<server>.0` protocol-address form the Signal store keys on.
-fn peer_session_addr(user: &str, server: &str, device: u16) -> String {
-    if device == 0 {
-        format!("{user}@{server}.0")
-    } else {
-        format!("{user}:{device}@{server}.0")
-    }
-}
-
-/// Scan backend for sessions matching a user across device IDs 0..=99.
-async fn scan_sessions(
-    backend: &dyn SignalStore,
-    user: &str,
-    server: &str,
-) -> anyhow::Result<Vec<String>> {
-    let mut results = Vec::new();
-    for device_id in 0..=99u16 {
-        let addr = peer_session_addr(user, server, device_id);
-        if backend.get_session(&addr).await?.is_some() {
-            results.push(addr);
-        }
-    }
-    Ok(results)
 }
 
 /// Assert that ALL sessions for a user are under LID, NONE under PN.
@@ -87,7 +61,7 @@ async fn assert_lid_only_sessions(
         lid_sessions.len(),
         lid_sessions
             .first()
-            .map(|s| mask_addr(s))
+            .map(|(addr, _)| mask_addr(addr))
             .unwrap_or_default()
     );
 }

--- a/tests/e2e/tests/offline_groups.rs
+++ b/tests/e2e/tests/offline_groups.rs
@@ -42,7 +42,7 @@ async fn test_offline_group_notification() -> anyhow::Result<()> {
 
     client_c.client.reconnect().await;
     info!("C disconnected (will auto-reconnect)");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_c.wait_for_disconnected(5).await?;
 
     let add_result = client_a
         .client
@@ -105,7 +105,7 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
 
     client_c.client.reconnect().await;
     info!("C disconnected");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_c.wait_for_disconnected(5).await?;
 
     let text_1 = "First message while C offline";
     client_a
@@ -114,10 +114,9 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
         .await?;
     info!("A sent first message");
 
+    // B receiving text_1 is the server-side confirmation that it was processed,
+    // so the add below is already ordered after it.
     client_b.wait_for_text(text_1, 10).await?;
-
-    // Small delay to ensure server processes sequentially
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     // A adds D to group
     let add_result = client_a
@@ -129,8 +128,6 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
     info!("A added D to group");
 
     client_b.wait_for_group_notification(10).await?;
-
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let text_2 = "Second message after D was added";
     client_a
@@ -231,7 +228,7 @@ async fn test_offline_group_message_delivery() -> anyhow::Result<()> {
 
     client_c.client.reconnect().await;
     info!("C disconnected");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_c.wait_for_disconnected(5).await?;
 
     let text = "Group message while C offline";
     client_a
@@ -343,12 +340,12 @@ async fn test_offline_multi_sender_group_messages() -> anyhow::Result<()> {
 
     // Take C offline. We use reconnect() (NOT reconnect_and_wait()) because we
     // need C to be offline while messages are sent. reconnect() triggers a
-    // disconnect + background auto-reconnect; the 100ms sleep gives the server
-    // time to detect the TCP close and start queuing messages for C.
+    // disconnect + background auto-reconnect; waiting for the teardown to land
+    // is what makes the server queue the messages below for C.
     // This is the standard offline simulation pattern used by all offline tests.
     client_c.client.reconnect().await;
     info!("C disconnected (will auto-reconnect)");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_c.wait_for_disconnected(5).await?;
 
     // Send multiple messages from multiple senders across both groups while C is offline.
     // This creates the conditions for the semaphore transition bug:

--- a/tests/e2e/tests/offline_messages.rs
+++ b/tests/e2e/tests/offline_messages.rs
@@ -14,7 +14,7 @@ async fn test_offline_message_delivery_on_reconnect() -> anyhow::Result<()> {
     // Triggers auto-reconnect
     client_b.client.reconnect().await;
     info!("Client B connection dropped, will auto-reconnect");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     let text = "Hello from offline queue!";
     let msg_id = client_a
@@ -44,7 +44,7 @@ async fn test_offline_message_ordering() -> anyhow::Result<()> {
     let jid_b = client_b.jid().await;
 
     client_b.client.reconnect().await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     let messages = vec!["first", "second", "third"];
     for text in &messages {
@@ -117,7 +117,6 @@ async fn test_server_accepts_messages_for_offline_recipient() -> anyhow::Result<
     let jid_b = client_b.jid().await;
 
     client_b.disconnect().await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     let mut msg_ids = Vec::new();
     for i in 1..=5 {

--- a/tests/e2e/tests/offline_receipts.rs
+++ b/tests/e2e/tests/offline_receipts.rs
@@ -14,7 +14,6 @@ async fn test_deferred_delivery_receipt() -> anyhow::Result<()> {
 
     client_b.disconnect().await;
     info!("Client B fully disconnected");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     let text = "Hello offline B!";
     let msg_id = client_a
@@ -60,7 +59,7 @@ async fn test_bidirectional_offline_receipt() -> anyhow::Result<()> {
 
     client_b.client.reconnect().await;
     info!("B disconnected");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     let text = "Bidirectional offline test";
     let msg_id = client_a
@@ -72,7 +71,7 @@ async fn test_bidirectional_offline_receipt() -> anyhow::Result<()> {
 
     client_a.client.reconnect().await;
     info!("A disconnected");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_a.wait_for_disconnected(5).await?;
 
     // B reconnects and receives the message
     client_b.wait_for_text(text, 30).await?;
@@ -111,7 +110,7 @@ async fn test_deferred_delivery_receipt_on_reconnect() -> anyhow::Result<()> {
 
     client_b.client.reconnect().await;
     info!("B disconnected (will auto-reconnect)");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     let text = "Waiting for delivery receipt";
     let msg_id = client_a
@@ -184,16 +183,16 @@ async fn test_offline_presence_coalescing() -> anyhow::Result<()> {
 
     client_b.client.reconnect().await;
     info!("B disconnected (will auto-reconnect)");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
-    // A changes presence multiple times while B is offline
+    // A changes presence multiple times while B is offline. Both stanzas go out
+    // over A's single socket, so the server already sees them in send order —
+    // no pacing needed for the coalescing check below.
     client_a.client.presence().set_unavailable().await?;
     info!("A set unavailable");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     client_a.client.presence().set_available().await?;
     info!("A set available again");
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // B reconnects — coalescing means only the latest state arrives, not all 3
     let presence_event = client_b

--- a/tests/e2e/tests/privacy_tokens.rs
+++ b/tests/e2e/tests/privacy_tokens.rs
@@ -1,5 +1,5 @@
 use e2e_tests::{
-    TestClient, restricted_push_name, scenario_push_name, send_and_expect_text, text_msg,
+    TestClient, has_child, restricted_push_name, scenario_push_name, send_and_expect_text, text_msg,
 };
 use log::info;
 use std::sync::Arc;
@@ -8,12 +8,6 @@ use wacore::types::events::Event;
 use wacore_binary::OwnedNodeRef;
 use wacore_binary::node::Node;
 use whatsapp_rust::{NodeFilter, SendOptions};
-
-fn has_child(node: &Node, tag: &str) -> bool {
-    node.children()
-        .map(|children| children.iter().any(|child| child.tag == tag))
-        .unwrap_or(false)
-}
 
 fn has_descendant(node: &Node, tag: &str) -> bool {
     node.children().is_some_and(|children| {

--- a/tests/e2e/tests/receipts.rs
+++ b/tests/e2e/tests/receipts.rs
@@ -271,8 +271,9 @@ async fn test_no_delivery_receipt_for_fully_offline() -> anyhow::Result<()> {
 
     let jid_b = client_b.jid().await;
 
-    // TestClient::disconnect awaits the run task, so B's socket is already
-    // closed when this returns.
+    // Nothing reconnects B afterwards, so the assert_no_event window below is
+    // what actually establishes "never came back" — disconnect() only has to get
+    // B off the socket, and it logs a WARN if its own wait times out.
     client_b.disconnect().await;
     info!("B fully disconnected");
 

--- a/tests/e2e/tests/receipts.rs
+++ b/tests/e2e/tests/receipts.rs
@@ -107,7 +107,7 @@ async fn test_delivery_receipt_offline_reconnect() -> anyhow::Result<()> {
 
     client_b.client.reconnect().await;
     info!("B disconnected (will auto-reconnect)");
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
 
     let msg_id = client_a
         .client
@@ -187,7 +187,7 @@ async fn test_read_receipt_queued_for_offline_sender() -> anyhow::Result<()> {
 
     client_a.client.reconnect().await;
     info!("A disconnected (will auto-reconnect)");
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    client_a.wait_for_disconnected(5).await?;
 
     client_b
         .client
@@ -225,7 +225,7 @@ async fn test_delivery_receipt_bidirectional_offline() -> anyhow::Result<()> {
     let jid_b = client_b.jid().await;
 
     client_b.client.reconnect().await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    client_b.wait_for_disconnected(5).await?;
     info!("B offline");
 
     let msg_id = client_a
@@ -236,7 +236,7 @@ async fn test_delivery_receipt_bidirectional_offline() -> anyhow::Result<()> {
     info!("A sent to offline B: {msg_id}");
 
     client_a.client.reconnect().await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    client_a.wait_for_disconnected(5).await?;
     info!("A offline");
 
     // B reconnects, receives message, sends delivery receipt (queued since A is offline)
@@ -271,8 +271,9 @@ async fn test_no_delivery_receipt_for_fully_offline() -> anyhow::Result<()> {
 
     let jid_b = client_b.jid().await;
 
+    // TestClient::disconnect awaits the run task, so B's socket is already
+    // closed when this returns.
     client_b.disconnect().await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
     info!("B fully disconnected");
 
     let msg_id = client_a

--- a/tests/e2e/tests/session_reuse.rs
+++ b/tests/e2e/tests/session_reuse.rs
@@ -1,41 +1,8 @@
 //! Signal session management e2e tests.
 
-use e2e_tests::{TestClient, send_and_expect_text};
+use e2e_tests::{TestClient, scan_sessions, send_and_expect_text};
 use log::info;
 use wacore::libsignal::protocol::SessionRecord;
-
-/// Scan backend for sessions matching a user across device IDs 0..=99.
-/// Returns Vec<(address, has_pending_pre_key)> for all found sessions.
-///
-/// The range must cover the peer's real companion device (a paired client is a
-/// non-zero device, e.g. 33), not just low ids — otherwise the only session found
-/// is the phantom device-0 one, whose pending_pre_key never clears (device 0 never
-/// completes the X3DH handshake).
-async fn scan_sessions(
-    backend: &dyn wacore::store::traits::SignalStore,
-    user: &str,
-    server: &str,
-) -> anyhow::Result<Vec<(String, bool)>> {
-    let mut results = Vec::new();
-    for device_id in 0..=99u16 {
-        let addr = if device_id == 0 {
-            format!("{user}@{server}.0")
-        } else {
-            format!("{user}:{device_id}@{server}.0")
-        };
-        if let Some(data) = backend.get_session(&addr).await? {
-            let record = SessionRecord::deserialize(&data)?;
-            if let Some(state) = record.session_state() {
-                let has_pending = state
-                    .unacknowledged_pre_key_message_items()
-                    .map_err(|e| anyhow::anyhow!("invalid session state: {e}"))?
-                    .is_some();
-                results.push((addr, has_pending));
-            }
-        }
-    }
-    Ok(results)
-}
 
 /// Read the sender-chain counter of the first established session for `user`
 /// straight from the backend (no cache, no settle) — the durable outbound

--- a/tests/e2e/tests/status.rs
+++ b/tests/e2e/tests/status.rs
@@ -1,16 +1,10 @@
 //! status@broadcast send: must go out as `<message>` (not `<status>`) with no
 //! addressing_mode, matching WA Web. The gate is status-specific — groups keep it.
 
-use e2e_tests::{TestClient, text_msg};
+use e2e_tests::{TestClient, has_child, text_msg};
 use wacore_binary::node::Node;
 use whatsapp_rust::Jid;
 use whatsapp_rust::features::{GroupCreateOptions, GroupParticipantOptions};
-
-fn has_child(node: &Node, tag: &str) -> bool {
-    node.children()
-        .map(|children| children.iter().any(|child| child.tag == tag))
-        .unwrap_or(false)
-}
 
 fn child_attr(node: &Node, child_tag: &str, attr: &str) -> Option<String> {
     node.children()?

--- a/wacore/appstate/src/decode.rs
+++ b/wacore/appstate/src/decode.rs
@@ -321,6 +321,262 @@ mod tests {
         assert!(matches!(err, AppStateError::MismatchingIndexMAC));
     }
 
+    // ── Negative cases ──────────────────────────────────────────────────────
+    //
+    // Every input here is server-controlled, so each rejection branch of
+    // `decode_record` needs a test: a silently-accepted malformed record either
+    // corrupts local app state or lets a tampered mutation through.
+
+    const MASTER_KEY: [u8; 32] = [7u8; 32];
+
+    fn test_keys() -> (ExpandedAppStateKeys, Vec<u8>) {
+        (expand_app_state_keys(&MASTER_KEY), b"test_key_id".to_vec())
+    }
+
+    fn valid_action_data() -> wa::SyncActionData {
+        wa::SyncActionData {
+            index: Some(br#"["mute","1555550100@s.whatsapp.net"]"#.to_vec()),
+            value: buffa::MessageField::some(wa::SyncActionValue {
+                timestamp: Some(1234567890),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Build a record whose value blob wraps `plaintext` verbatim, so a test can
+    /// hand `decode_record` bytes that decrypt fine but aren't a SyncActionData.
+    fn record_from_plaintext(
+        op: wa::syncd_mutation::SyncdOperation,
+        keys: &ExpandedAppStateKeys,
+        key_id: &[u8],
+        plaintext: &[u8],
+        index_bytes: &[u8],
+    ) -> wa::SyncdRecord {
+        let iv = vec![0u8; 16];
+        let mut ciphertext = Vec::new();
+        aes_256_cbc_encrypt_into(plaintext, &keys.value_encryption, &iv, &mut ciphertext)
+            .expect("test encryption should succeed");
+
+        let mut value_with_iv = iv;
+        value_with_iv.extend_from_slice(&ciphertext);
+        let value_mac = generate_content_mac(op, &value_with_iv, key_id, &keys.value_mac);
+        let mut value_blob = value_with_iv;
+        value_blob.extend_from_slice(&value_mac);
+
+        wa::SyncdRecord {
+            index: buffa::MessageField::some(wa::SyncdIndex {
+                blob: Some(generate_index_mac(index_bytes, &keys.index)),
+            }),
+            value: buffa::MessageField::some(wa::SyncdValue {
+                blob: Some(value_blob),
+            }),
+            key_id: buffa::MessageField::some(wa::KeyId {
+                id: Some(key_id.to_vec()),
+            }),
+        }
+    }
+
+    /// Rewrite a record's value blob through `f` (MessageField has no DerefMut).
+    fn map_value_blob(record: &mut wa::SyncdRecord, f: impl FnOnce(&mut Vec<u8>)) {
+        let mut blob = record
+            .value
+            .as_option()
+            .and_then(|v| v.blob.clone())
+            .expect("fixture record has a value blob");
+        f(&mut blob);
+        record.value = buffa::MessageField::some(wa::SyncdValue { blob: Some(blob) });
+    }
+
+    fn decode(record: &wa::SyncdRecord, validate_macs: bool) -> Result<Mutation, AppStateError> {
+        let (keys, key_id) = test_keys();
+        decode_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            record,
+            &keys,
+            &key_id,
+            validate_macs,
+        )
+        .map(|(mutation, _)| mutation)
+    }
+
+    #[test]
+    fn decode_record_rejects_missing_value_blob() {
+        let (keys, key_id) = test_keys();
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+        record.value = buffa::MessageField::some(wa::SyncdValue { blob: None });
+
+        assert!(matches!(
+            decode(&record, true).unwrap_err(),
+            AppStateError::MissingValueBlob
+        ));
+    }
+
+    #[test]
+    fn decode_record_rejects_truncated_value_blob() {
+        let (keys, key_id) = test_keys();
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+
+        // One byte short of the IV + MAC floor: the split_at calls below would
+        // otherwise panic instead of erroring.
+        map_value_blob(&mut record, |blob| blob.truncate(16 + 32 - 1));
+
+        assert!(matches!(
+            decode(&record, true).unwrap_err(),
+            AppStateError::ValueBlobTooShort
+        ));
+    }
+
+    #[test]
+    fn decode_record_rejects_tampered_content_mac() {
+        let (keys, key_id) = test_keys();
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+
+        map_value_blob(&mut record, |blob| {
+            let last = blob.len() - 1;
+            blob[last] ^= 0xFF;
+        });
+
+        assert!(matches!(
+            decode(&record, true).unwrap_err(),
+            AppStateError::MismatchingContentMAC
+        ));
+        // Without validation the same record decodes: the rejection above comes
+        // from the MAC check, not from a knock-on decrypt failure.
+        assert!(decode(&record, false).is_ok());
+    }
+
+    #[test]
+    fn decode_record_rejects_corrupt_ciphertext() {
+        let (keys, key_id) = test_keys();
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+
+        // Drop a single ciphertext byte so the remainder is no longer
+        // block-aligned — an unconditional CBC failure, unlike a bit flip whose
+        // padding can survive by chance.
+        map_value_blob(&mut record, |blob| {
+            blob.remove(16);
+        });
+
+        assert!(matches!(
+            decode(&record, false).unwrap_err(),
+            AppStateError::DecryptionFailed
+        ));
+    }
+
+    #[test]
+    fn decode_record_rejects_garbage_protobuf() {
+        let (keys, key_id) = test_keys();
+        // Field 1, length-delimited, length 255, no payload: decodes past the
+        // buffer end whatever the field means.
+        let record = record_from_plaintext(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &[0x0A, 0xFF],
+            &[],
+        );
+
+        assert!(matches!(
+            decode(&record, false).unwrap_err(),
+            AppStateError::DecodeFailed
+        ));
+    }
+
+    #[test]
+    fn decode_record_rejects_missing_index_mac_when_validating() {
+        let (keys, key_id) = test_keys();
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+        record.index = buffa::MessageField::none();
+
+        assert!(matches!(
+            decode(&record, true).unwrap_err(),
+            AppStateError::MissingIndexMAC
+        ));
+    }
+
+    #[test]
+    fn decode_record_rejects_missing_index_mac_without_validation() {
+        let (keys, key_id) = test_keys();
+        let mut record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+        // Skipping MAC validation must not turn a MAC-less record into an
+        // empty persisted MAC.
+        record.index = buffa::MessageField::some(wa::SyncdIndex { blob: None });
+
+        assert!(matches!(
+            decode(&record, false).unwrap_err(),
+            AppStateError::MissingIndexMAC
+        ));
+    }
+
+    #[test]
+    fn decode_record_parses_index_json_into_components() {
+        let (keys, key_id) = test_keys();
+        let record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &valid_action_data(),
+        );
+
+        let mutation = decode(&record, true).expect("valid record should decode");
+        assert_eq!(mutation.index, vec!["mute", "1555550100@s.whatsapp.net"]);
+    }
+
+    #[test]
+    fn decode_record_tolerates_non_json_index() {
+        let (keys, key_id) = test_keys();
+        let action_data = wa::SyncActionData {
+            index: Some(b"not-json".to_vec()),
+            value: buffa::MessageField::some(wa::SyncActionValue {
+                timestamp: Some(1),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let record = create_test_record(
+            wa::syncd_mutation::SyncdOperation::SET,
+            &keys,
+            &key_id,
+            &action_data,
+        );
+
+        // The index MAC still covers the raw bytes, so the record is authentic —
+        // only the component split is skipped.
+        let mutation = decode(&record, true).expect("authentic record should decode");
+        assert!(mutation.index.is_empty());
+    }
+
     #[test]
     fn test_collect_key_ids_from_patch_list() {
         let key_id_1 = vec![1, 2, 3];

--- a/wacore/appstate/src/patch_decode.rs
+++ b/wacore/appstate/src/patch_decode.rs
@@ -204,3 +204,389 @@ fn parse_collection_error(
         _ => CollectionSyncError::Retry { code, text },
     })
 }
+
+#[cfg(test)]
+// Fixtures encode protos the pinned `waproto::codec` wrappers don't cover; the
+// binary-size reason for pinning them doesn't apply to test code.
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+    use buffa::Message;
+    use wacore_binary::builder::NodeBuilder;
+
+    /// Length-delimited field 1 announcing 5 bytes but carrying 1, so every
+    /// protobuf decoder in the tests below fails deterministically.
+    const TRUNCATED_PROTOBUF: [u8; 3] = [0x0A, 0x05, 0x01];
+
+    fn patch_bytes(version: u64) -> Vec<u8> {
+        waproto::codec::syncd_patch_to_vec(&wa::SyncdPatch {
+            version: buffa::MessageField::some(wa::SyncdVersion {
+                version: Some(version),
+            }),
+            snapshot_mac: Some(vec![0xAB; 32]),
+            ..Default::default()
+        })
+    }
+
+    fn snapshot_ref_bytes(direct_path: &str) -> Vec<u8> {
+        wa::ExternalBlobReference {
+            direct_path: Some(direct_path.to_string()),
+            file_size_bytes: Some(4096),
+            ..Default::default()
+        }
+        .encode_to_vec()
+    }
+
+    /// `<collection>` carrying a snapshot ref and two patches.
+    fn full_collection() -> Node {
+        NodeBuilder::new("collection")
+            .attr("name", "regular")
+            .attr("has_more_patches", "true")
+            .children([
+                NodeBuilder::new("snapshot")
+                    .bytes(snapshot_ref_bytes("/appstate/snapshot.enc"))
+                    .build(),
+                NodeBuilder::new("patches")
+                    .children([
+                        NodeBuilder::new("patch").bytes(patch_bytes(1)).build(),
+                        NodeBuilder::new("patch").bytes(patch_bytes(2)).build(),
+                    ])
+                    .build(),
+            ])
+            .build()
+    }
+
+    fn sync_node(collections: impl IntoIterator<Item = Node>) -> Node {
+        NodeBuilder::new("sync").children(collections).build()
+    }
+
+    fn iq_with(collections: impl IntoIterator<Item = Node>) -> Node {
+        NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([sync_node(collections)])
+            .build()
+    }
+
+    #[test]
+    fn patch_name_roundtrips_every_wire_string() {
+        for name in [
+            WAPatchName::CriticalBlock,
+            WAPatchName::CriticalUnblockLow,
+            WAPatchName::RegularLow,
+            WAPatchName::RegularHigh,
+            WAPatchName::Regular,
+        ] {
+            assert_eq!(WAPatchName::from_str(name.as_str()), Ok(name));
+        }
+        assert_eq!(
+            WAPatchName::from_str("something_new"),
+            Ok(WAPatchName::Unknown)
+        );
+    }
+
+    #[test]
+    fn parse_patch_list_reads_name_patches_and_snapshot_ref() {
+        let list = parse_patch_list(&iq_with([full_collection()])).expect("well-formed collection");
+
+        assert_eq!(list.name, WAPatchName::Regular);
+        assert!(list.has_more_patches);
+        assert!(list.error.is_none());
+        // Inline snapshots are never sent; only the external reference is parsed.
+        assert!(list.snapshot.is_none());
+        assert_eq!(
+            list.snapshot_ref
+                .as_ref()
+                .and_then(|r| r.direct_path.as_deref()),
+            Some("/appstate/snapshot.enc")
+        );
+
+        let versions: Vec<Option<u64>> = list
+            .patches
+            .iter()
+            .map(|p| p.version.as_option().and_then(|v| v.version))
+            .collect();
+        assert_eq!(versions, vec![Some(1), Some(2)]);
+    }
+
+    #[test]
+    fn parse_patch_list_ref_matches_owned_path() {
+        let node = iq_with([full_collection()]);
+        let list = parse_patch_list_ref(&node.as_node_ref()).expect("well-formed collection");
+
+        assert_eq!(list.name, WAPatchName::Regular);
+        assert_eq!(list.patches.len(), 2);
+    }
+
+    #[test]
+    fn parse_patch_list_defaults_missing_optional_fields() {
+        let collection = NodeBuilder::new("collection")
+            .attr("name", "critical_block")
+            .build();
+        let list = parse_patch_list(&iq_with([collection])).expect("name alone is enough");
+
+        assert_eq!(list.name, WAPatchName::CriticalBlock);
+        assert!(!list.has_more_patches);
+        assert!(list.patches.is_empty());
+        assert!(list.snapshot_ref.is_none());
+        assert!(list.error.is_none());
+    }
+
+    #[test]
+    fn parse_patch_list_maps_unknown_collection_name() {
+        let collection = NodeBuilder::new("collection")
+            .attr("name", "collection_from_the_future")
+            .build();
+        let list = parse_patch_list(&iq_with([collection])).expect("unknown names are tolerated");
+
+        assert_eq!(list.name, WAPatchName::Unknown);
+    }
+
+    #[test]
+    fn parse_patch_list_rejects_missing_sync_collection_path() {
+        let err = parse_patch_list(&NodeBuilder::new("iq").build())
+            .expect_err("no sync/collection to descend into");
+        assert!(err.to_string().contains("missing sync/collection"));
+
+        let err = parse_patch_list(&iq_with([]))
+            .expect_err("a sync node without collections is still unusable here");
+        assert!(err.to_string().contains("missing sync/collection"));
+    }
+
+    #[test]
+    fn parse_single_collection_rejects_missing_name() {
+        let collection = NodeBuilder::new("collection")
+            .attr("has_more_patches", "true")
+            .build();
+        let err = parse_patch_list(&iq_with([collection]))
+            .expect_err("a nameless collection cannot be routed anywhere");
+        assert!(
+            err.to_string()
+                .contains("collection missing 'name' attribute")
+        );
+    }
+
+    #[test]
+    fn parse_single_collection_rejects_undecodable_patch() {
+        let collection = NodeBuilder::new("collection")
+            .attr("name", "regular")
+            .children([NodeBuilder::new("patches")
+                .children([
+                    NodeBuilder::new("patch").bytes(patch_bytes(1)).build(),
+                    NodeBuilder::new("patch")
+                        .bytes(TRUNCATED_PROTOBUF.to_vec())
+                        .build(),
+                ])
+                .build()])
+            .build();
+
+        let err = parse_patch_list(&iq_with([collection]))
+            .expect_err("a garbled patch must not be silently dropped");
+        assert!(err.to_string().contains("failed to unmarshal patch"));
+    }
+
+    #[test]
+    fn parse_single_collection_skips_unusable_snapshot_nodes() {
+        // Unlike patches, a snapshot that fails to decode is tolerated: the
+        // caller falls back to applying patches from the current version.
+        let collection = NodeBuilder::new("collection")
+            .attr("name", "regular")
+            .children([NodeBuilder::new("snapshot")
+                .bytes(TRUNCATED_PROTOBUF.to_vec())
+                .build()])
+            .build();
+        let list = parse_patch_list(&iq_with([collection])).expect("snapshot errors are tolerated");
+        assert!(list.snapshot_ref.is_none());
+
+        // A snapshot carrying a string instead of bytes is likewise ignored.
+        let collection = NodeBuilder::new("collection")
+            .attr("name", "regular")
+            .children([NodeBuilder::new("snapshot")
+                .string_content("not-bytes")
+                .build()])
+            .build();
+        let list = parse_patch_list(&iq_with([collection])).expect("snapshot errors are tolerated");
+        assert!(list.snapshot_ref.is_none());
+    }
+
+    #[test]
+    fn parse_patch_lists_accepts_both_iq_and_bare_sync_roots() {
+        let collections = || {
+            [
+                full_collection(),
+                NodeBuilder::new("collection")
+                    .attr("name", "regular_high")
+                    .build(),
+            ]
+        };
+
+        for root in [iq_with(collections()), sync_node(collections())] {
+            let lists = parse_patch_lists(&root).expect("well-formed sync node");
+            let names: Vec<WAPatchName> = lists.iter().map(|l| l.name).collect();
+            assert_eq!(names, vec![WAPatchName::Regular, WAPatchName::RegularHigh]);
+        }
+    }
+
+    #[test]
+    fn parse_patch_lists_ref_matches_owned_path() {
+        let node = sync_node([full_collection()]);
+        let lists = parse_patch_lists_ref(&node.as_node_ref()).expect("well-formed sync node");
+        assert_eq!(lists.len(), 1);
+    }
+
+    #[test]
+    fn parse_patch_lists_ignores_non_collection_children() {
+        let root = NodeBuilder::new("sync")
+            .children([NodeBuilder::new("unexpected").build(), full_collection()])
+            .build();
+        let lists = parse_patch_lists(&root).expect("unknown siblings are skipped");
+        assert_eq!(lists.len(), 1);
+    }
+
+    #[test]
+    fn parse_patch_lists_rejects_missing_sync_node() {
+        let err = parse_patch_lists(&NodeBuilder::new("iq").build())
+            .expect_err("no sync node to read collections from");
+        assert!(err.to_string().contains("missing sync node in response"));
+    }
+
+    #[test]
+    fn parse_patch_lists_returns_empty_for_childless_sync() {
+        let lists = parse_patch_lists(&NodeBuilder::new("sync").build())
+            .expect("an empty sync node is not an error");
+        assert!(lists.is_empty());
+    }
+
+    #[test]
+    fn parse_patch_lists_propagates_a_single_bad_collection() {
+        let root = sync_node([
+            full_collection(),
+            NodeBuilder::new("collection").build(), // no name
+        ]);
+        let err = parse_patch_lists(&root).expect_err("one bad collection fails the batch");
+        assert!(
+            err.to_string()
+                .contains("collection missing 'name' attribute")
+        );
+    }
+
+    fn error_collection(error_child: Option<Node>) -> Node {
+        let mut children = Vec::new();
+        children.extend(error_child);
+        NodeBuilder::new("collection")
+            .attr("name", "regular")
+            .attr("type", "error")
+            .attr("has_more_patches", "true")
+            .children(children)
+            .build()
+    }
+
+    fn parse_error(collection: Node) -> Option<CollectionSyncError> {
+        parse_patch_list(&iq_with([collection]))
+            .expect("an error collection still parses")
+            .error
+    }
+
+    #[test]
+    fn collection_error_409_becomes_conflict_carrying_has_more() {
+        let error = parse_error(error_collection(Some(
+            NodeBuilder::new("error").attr("code", "409").build(),
+        )));
+        assert!(matches!(
+            error,
+            Some(CollectionSyncError::Conflict { has_more: true })
+        ));
+    }
+
+    #[test]
+    fn collection_errors_400_and_404_are_fatal() {
+        for code in ["400", "404"] {
+            let error = parse_error(error_collection(Some(
+                NodeBuilder::new("error")
+                    .attr("code", code)
+                    .attr("text", "bad request")
+                    .build(),
+            )));
+            let Some(CollectionSyncError::Fatal { code: got, text }) = error else {
+                panic!("expected a fatal error for code {code}, got {error:?}");
+            };
+            assert_eq!(got.to_string(), code);
+            assert_eq!(text, "bad request");
+        }
+    }
+
+    #[test]
+    fn other_collection_errors_are_retryable() {
+        let error = parse_error(error_collection(Some(
+            NodeBuilder::new("error")
+                .attr("code", "500")
+                .attr("text", "internal")
+                .build(),
+        )));
+        assert!(matches!(
+            error,
+            Some(CollectionSyncError::Retry { code: 500, .. })
+        ));
+    }
+
+    #[test]
+    fn unparseable_error_codes_fall_back_to_retry() {
+        // Missing child, missing code and a non-numeric code all land on the
+        // same conservative "retry with code 0" answer.
+        let cases = [
+            (None, "missing <error> child"),
+            (Some(NodeBuilder::new("error").build()), ""),
+            (
+                Some(
+                    NodeBuilder::new("error")
+                        .attr("code", "not-a-number")
+                        .build(),
+                ),
+                "",
+            ),
+        ];
+
+        for (child, expected_text) in cases {
+            let error = parse_error(error_collection(child));
+            let Some(CollectionSyncError::Retry { code, text }) = error else {
+                panic!("expected a retryable error, got {error:?}");
+            };
+            assert_eq!(code, 0);
+            assert_eq!(text, expected_text);
+        }
+    }
+
+    #[test]
+    fn non_error_collection_type_yields_no_error() {
+        let collection = NodeBuilder::new("collection")
+            .attr("name", "regular")
+            .attr("type", "result")
+            .children([NodeBuilder::new("error").attr("code", "500").build()])
+            .build();
+        // The `<error>` child only counts when the collection is typed as one.
+        assert!(parse_error(collection).is_none());
+    }
+
+    #[test]
+    fn collection_sync_error_display_names_each_variant() {
+        assert_eq!(
+            CollectionSyncError::Conflict { has_more: false }.to_string(),
+            "conflict (has_more=false)"
+        );
+        assert_eq!(
+            CollectionSyncError::Fatal {
+                code: 404,
+                text: "not found".to_string(),
+            }
+            .to_string(),
+            "fatal error 404: not found"
+        );
+        assert_eq!(
+            CollectionSyncError::Retry {
+                code: 503,
+                text: "try later".to_string(),
+            }
+            .to_string(),
+            "retryable error 503: try later"
+        );
+    }
+}

--- a/wacore/binary/fuzz/Cargo.toml
+++ b/wacore/binary/fuzz/Cargo.toml
@@ -26,6 +26,13 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "parse_jid"
+path = "fuzz_targets/parse_jid.rs"
+test = false
+doc = false
+bench = false
+
 # libFuzzer needs debug info and benefits from optimization; mirror the
 # defaults `cargo fuzz init` generates.
 [profile.release]

--- a/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
+++ b/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
@@ -99,12 +99,18 @@ fuzz_target!(|data: &[u8]| {
             // `to_ad_string` gets no check at all: it always emits
             // `user.agent:device`, which the parser does not always read back as an
             // agent, so it is not round-trippable even for clean users.
-            if !jid.user.is_empty()
-                && !jid.user.contains(['.', ':'])
-                && let Ok(bare) = jid.to_non_ad_string().parse::<Jid>()
-            {
+            if !jid.user.is_empty() && !jid.user.contains(['.', ':']) {
+                let bare = jid.to_non_ad_string();
+                let reparsed = bare.parse::<Jid>().unwrap_or_else(|e| {
+                    panic!("to_non_ad_string produced unparseable {bare:?}: {e}")
+                });
                 assert_eq!(
-                    (&bare.user, bare.server, bare.agent, bare.device),
+                    (
+                        &reparsed.user,
+                        reparsed.server,
+                        reparsed.agent,
+                        reparsed.device
+                    ),
                     (&jid.user, jid.server, 0, 0),
                     "to_non_ad_string lost identity for {jid:?}"
                 );

--- a/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
+++ b/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
@@ -90,10 +90,17 @@ fuzz_target!(|data: &[u8]| {
             assert!(jid.display_eq(&jid.to_string()));
 
             // The non-AD form drops the agent and device by definition, so it must
-            // re-parse to the same identity with both cleared. `to_ad_string` gets
-            // no such check: it always emits `user.agent:device`, which the parser
-            // does not always read back as an agent, so it is not round-trippable.
+            // re-parse to the same identity with both cleared — but only while the
+            // user part is separator-free. The parse fallback can leave `.` or `:`
+            // inside `user` (`"0.1:@s.whatsapp.net"` parses to user `"0.1"`), and
+            // rendering that back as `user@server` invites the parser to read those
+            // separators as an agent/device on the way in.
+            //
+            // `to_ad_string` gets no check at all: it always emits
+            // `user.agent:device`, which the parser does not always read back as an
+            // agent, so it is not round-trippable even for clean users.
             if !jid.user.is_empty()
+                && !jid.user.contains(['.', ':'])
                 && let Ok(bare) = jid.to_non_ad_string().parse::<Jid>()
             {
                 assert_eq!(

--- a/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
+++ b/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
@@ -89,16 +89,11 @@ fuzz_target!(|data: &[u8]| {
             let _ = jid.device_key();
             assert!(jid.display_eq(&jid.to_string()));
 
-            // The non-AD form drops the agent and device by definition, so it must
-            // re-parse to the same identity with both cleared — but only while the
-            // user part is separator-free. The parse fallback can leave `.` or `:`
-            // inside `user` (`"0.1:@s.whatsapp.net"` parses to user `"0.1"`), and
-            // rendering that back as `user@server` invites the parser to read those
-            // separators as an agent/device on the way in.
-            //
-            // `to_ad_string` gets no check at all: it always emits
-            // `user.agent:device`, which the parser does not always read back as an
-            // agent, so it is not round-trippable even for clean users.
+            // The non-AD form drops agent and device by definition, so it must
+            // re-parse to the same identity with both cleared. Users holding a `.`
+            // or `:` are excluded: rendering them back invites the parser to read
+            // those separators as an agent/device. `to_ad_string` is checked only
+            // for panics, since it is not round-trippable at all.
             if !jid.user.is_empty() && !jid.user.contains(['.', ':']) {
                 let bare = jid.to_non_ad_string();
                 let reparsed = bare.parse::<Jid>().unwrap_or_else(|e| {

--- a/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
+++ b/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
@@ -1,0 +1,100 @@
+#![no_main]
+
+//! Fuzz the JID parser and formatter.
+//!
+//! JID strings arrive as attacker-controlled attribute values on every stanza,
+//! and `Jid`'s parse path mixes a hand-rolled fast scanner with a string-slicing
+//! fallback — exactly the shape where a stray index panics the whole client.
+//!
+//! Two properties are checked:
+//!
+//! 1. **Parsing arbitrary text never panics.** Any input either yields a `Jid`
+//!    or an error; slicing, `u16` parsing and the agent range check must all
+//!    stay inside the `Result`. Display of a parsed JID must not panic either.
+//! 2. **A valid JID round-trips.** JIDs built from the fuzz bytes (rather than
+//!    from arbitrary text) are rendered and re-parsed, and must come back
+//!    unchanged. Only constructed JIDs are held to this: `Display` is
+//!    deliberately lossy for an empty user (renders the bare server) and for
+//!    servers that suppress the agent byte, so parsed-from-text inputs cannot
+//!    all be canonical.
+
+use libfuzzer_sys::fuzz_target;
+use wacore_binary::jid::{Jid, Server, parse_jid_fast, parse_jid_ref};
+
+const SERVERS: [Server; 12] = [
+    Server::Pn,
+    Server::Lid,
+    Server::Group,
+    Server::Broadcast,
+    Server::Newsletter,
+    Server::Hosted,
+    Server::HostedLid,
+    Server::Messenger,
+    Server::Interop,
+    Server::Bot,
+    Server::Legacy,
+    Server::Call,
+];
+
+/// Characters real user parts are made of (phone numbers, group ids). `@`, `:`
+/// and `.` are excluded on purpose: they are the parser's separators, so a user
+/// containing them is not expected to survive a display round-trip.
+const USER_CHARS: &[u8] = b"0123456789-";
+
+/// Build a JID that is valid by construction, driven by the fuzz bytes.
+fn build_jid(data: &[u8]) -> Jid {
+    let byte = |i: usize| data.get(i).copied().unwrap_or(0);
+
+    let server = SERVERS[byte(0) as usize % SERVERS.len()];
+    let device = u16::from_le_bytes([byte(1), byte(2)]);
+    // The formatter suppresses the agent for AD servers, so only ask for one
+    // where it is actually rendered.
+    let agent = if server.renders_agent() { byte(3) } else { 0 };
+
+    let mut user: String = data
+        .iter()
+        .skip(4)
+        .take(32)
+        .map(|b| USER_CHARS[*b as usize % USER_CHARS.len()] as char)
+        .collect();
+    if user.is_empty() {
+        // A bare server carries neither agent nor device, so it cannot
+        // round-trip one; give the JID a user part.
+        user.push('1');
+    }
+
+    let mut jid = Jid::new(user, server);
+    jid.agent = agent;
+    jid.device = device;
+    jid
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = parse_jid_fast(text);
+        let _ = parse_jid_ref(text);
+
+        if let Ok(jid) = text.parse::<Jid>() {
+            let _ = jid.to_string();
+            let _ = jid.to_ad_string();
+            let _ = jid.to_non_ad_string();
+            let _ = jid.device_key();
+            assert!(jid.display_eq(&jid.to_string()));
+        }
+    }
+
+    let jid = build_jid(data);
+    let rendered = jid.to_string();
+    let Ok(reparsed) = rendered.parse::<Jid>() else {
+        panic!("valid JID {rendered:?} failed to re-parse (built from {jid:?})");
+    };
+    assert_eq!(
+        reparsed, jid,
+        "display/parse round-trip lost data for {rendered:?}"
+    );
+    assert_eq!(
+        reparsed.to_string(),
+        rendered,
+        "re-rendering a re-parsed JID must be stable"
+    );
+});

--- a/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
+++ b/wacore/binary/fuzz/fuzz_targets/parse_jid.rs
@@ -71,15 +71,37 @@ fn build_jid(data: &[u8]) -> Jid {
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(text) = std::str::from_utf8(data) {
-        let _ = parse_jid_fast(text);
-        let _ = parse_jid_ref(text);
+        // `parse_jid_ref` layers server validation over `parse_jid_fast`, so it may
+        // only ever reject more — never accept text the scanner turned down, and
+        // never disagree about the parts it keeps.
+        let fast = parse_jid_fast(text);
+        if let Some(r) = parse_jid_ref(text) {
+            let parts = fast.expect("parse_jid_ref accepted text parse_jid_fast rejected");
+            assert_eq!(
+                (r.user.as_ref(), r.agent, r.device, r.integrator),
+                (parts.user, parts.agent, parts.device, parts.integrator),
+                "the two parse paths disagree on {text:?}"
+            );
+        }
 
         if let Ok(jid) = text.parse::<Jid>() {
-            let _ = jid.to_string();
             let _ = jid.to_ad_string();
-            let _ = jid.to_non_ad_string();
             let _ = jid.device_key();
             assert!(jid.display_eq(&jid.to_string()));
+
+            // The non-AD form drops the agent and device by definition, so it must
+            // re-parse to the same identity with both cleared. `to_ad_string` gets
+            // no such check: it always emits `user.agent:device`, which the parser
+            // does not always read back as an agent, so it is not round-trippable.
+            if !jid.user.is_empty()
+                && let Ok(bare) = jid.to_non_ad_string().parse::<Jid>()
+            {
+                assert_eq!(
+                    (&bare.user, bare.server, bare.agent, bare.device),
+                    (&jid.user, jid.server, 0, 0),
+                    "to_non_ad_string lost identity for {jid:?}"
+                );
+            }
         }
     }
 

--- a/wacore/src/iq/privacy.rs
+++ b/wacore/src/iq/privacy.rs
@@ -520,6 +520,140 @@ mod tests {
         assert_eq!(result.settings[8].value, PrivacyValue::Off);
     }
 
+    // --- Malformed response tests ---
+    //
+    // Every field below is server-controlled, so each rejection branch needs a
+    // test: accepting a half-filled `<category>` would surface a privacy setting
+    // the server never actually reported.
+
+    #[test]
+    fn test_privacy_settings_parse_response_rejects_missing_privacy_child() {
+        let spec = PrivacySettingsSpec::new();
+        let response = NodeBuilder::new("iq").attr("type", "result").build();
+
+        let err = spec
+            .parse_response(&response.as_node_ref())
+            .expect_err("a response without <privacy> must be a hard error");
+        assert!(err.to_string().contains("<privacy> child not found"));
+    }
+
+    #[test]
+    fn test_privacy_settings_parse_response_rejects_category_without_name() {
+        let spec = PrivacySettingsSpec::new();
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy")
+                .children([NodeBuilder::new("category").attr("value", "all").build()])
+                .build()])
+            .build();
+
+        let err = spec
+            .parse_response(&response.as_node_ref())
+            .expect_err("a nameless category cannot be mapped to a setting");
+        assert!(err.to_string().contains("missing name in category"));
+    }
+
+    #[test]
+    fn test_privacy_settings_parse_response_rejects_category_without_value() {
+        let spec = PrivacySettingsSpec::new();
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy")
+                .children([NodeBuilder::new("category").attr("name", "last").build()])
+                .build()])
+            .build();
+
+        let err = spec
+            .parse_response(&response.as_node_ref())
+            .expect_err("a valueless category cannot be mapped to a setting");
+        assert!(err.to_string().contains("missing value in category"));
+    }
+
+    #[test]
+    fn test_privacy_settings_parse_response_fails_on_first_bad_category() {
+        // A good category ahead of a bad one must not mask the failure.
+        let spec = PrivacySettingsSpec::new();
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy")
+                .children([
+                    NodeBuilder::new("category")
+                        .attr("name", "last")
+                        .attr("value", "all")
+                        .build(),
+                    NodeBuilder::new("category").attr("name", "status").build(),
+                ])
+                .build()])
+            .build();
+
+        let err = spec
+            .parse_response(&response.as_node_ref())
+            .expect_err("one malformed category fails the whole response");
+        assert!(err.to_string().contains("missing value in category"));
+    }
+
+    #[test]
+    fn test_privacy_settings_parse_response_tolerates_empty_and_unknown() {
+        let spec = PrivacySettingsSpec::new();
+
+        // An empty <privacy> is a valid (if unusual) answer, not an error.
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy").build()])
+            .build();
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert!(result.settings.is_empty());
+
+        // Unknown names/values fall through to the WireEnum fallbacks so a new
+        // server-side category does not break the whole fetch.
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("privacy")
+                .children([
+                    NodeBuilder::new("unexpected").build(),
+                    NodeBuilder::new("category")
+                        .attr("name", "brand_new")
+                        .attr("value", "brand_new_value")
+                        .build(),
+                ])
+                .build()])
+            .build();
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(result.settings.len(), 1);
+        assert_eq!(
+            result.settings[0].category,
+            PrivacyCategory::Other("brand_new".to_string())
+        );
+        assert_eq!(
+            result.settings[0].value,
+            PrivacyValue::Other("brand_new_value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_privacy_parse_response_tolerates_missing_nodes() {
+        // The SET response only mines an optional dhash, so a bare <iq> or an
+        // empty <privacy> must yield None rather than an error.
+        let spec = SetPrivacySettingSpec::new(PrivacyCategory::Last, PrivacyValue::All);
+
+        for response in [
+            NodeBuilder::new("iq").attr("type", "result").build(),
+            NodeBuilder::new("iq")
+                .attr("type", "result")
+                .children([NodeBuilder::new("privacy").build()])
+                .build(),
+            NodeBuilder::new("iq")
+                .attr("type", "result")
+                .children([NodeBuilder::new("privacy")
+                    .children([NodeBuilder::new("category").build()])
+                    .build()])
+                .build(),
+        ] {
+            let result = spec.parse_response(&response.as_node_ref()).unwrap();
+            assert!(result.dhash.is_none());
+        }
+    }
+
     #[test]
     fn test_privacy_settings_response_get() {
         let response = PrivacySettingsResponse {

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -422,14 +422,20 @@ mod tokio_runtime_tests {
     /// before its first poll.
     async fn spawn_parked_task() -> (AbortHandle, futures::channel::oneshot::Receiver<()>) {
         let (tx, rx) = futures::channel::oneshot::channel();
+        let (started_tx, started_rx) = futures::channel::oneshot::channel();
         let dropped_on_cancel = DropSignal(Some(tx));
         let handle = TokioTestRuntime.spawn(Box::pin(async move {
             let _dropped_on_cancel = dropped_on_cancel;
+            let _ = started_tx.send(());
             std::future::pending::<()>().await;
         }));
-        // Let the task reach its park point so the abort below exercises the
-        // cancel-a-running-task path rather than cancel-before-first-poll.
-        tokio::task::yield_now().await;
+        // Wait for the task to report its first poll: a yield only requeues the
+        // current task, so without this the abort could land before the spawned
+        // future ever ran and the cancel-a-running-task path would go untested.
+        tokio::time::timeout(TEST_TIMEOUT, started_rx)
+            .await
+            .expect("timed out waiting for the spawned task to start")
+            .expect("the spawned task was cancelled before it started");
         (handle, rx)
     }
 
@@ -506,7 +512,12 @@ mod tokio_runtime_tests {
 
     #[tokio::test]
     async fn blocking_ferries_the_closure_result_back() {
-        let value = super::blocking(&TokioTestRuntime, || 6 * 7).await;
+        // Bounded so a `blocking` that never hands the result back fails here
+        // instead of hanging the job.
+        let value =
+            tokio::time::timeout(TEST_TIMEOUT, super::blocking(&TokioTestRuntime, || 6 * 7))
+                .await
+                .expect("timed out waiting for the blocking closure");
         assert_eq!(value, 42);
     }
 }

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -311,6 +311,207 @@ pub async fn blocking<T: 'static>(_rt: &dyn Runtime, f: impl FnOnce() -> T + 'st
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
+mod abort_handle_tests {
+    use super::AbortHandle;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn counting_handle() -> (AbortHandle, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handle = {
+            let calls = Arc::clone(&calls);
+            AbortHandle::new(move || {
+                calls.fetch_add(1, Ordering::SeqCst);
+            })
+        };
+        (handle, calls)
+    }
+
+    #[test]
+    fn abort_runs_the_callback_exactly_once() {
+        let (handle, calls) = counting_handle();
+
+        handle.abort();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // The callback is FnOnce, so a second abort (and the Drop that follows)
+        // must be a no-op rather than a double cancellation.
+        handle.abort();
+        drop(handle);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn drop_aborts_an_unaborted_handle() {
+        let (handle, calls) = counting_handle();
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        drop(handle);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn detach_disarms_the_abort_on_drop() {
+        let (handle, calls) = counting_handle();
+
+        handle.detach();
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "a detached handle must leave the task running"
+        );
+    }
+
+    #[test]
+    fn noop_handle_is_inert() {
+        let handle = AbortHandle::noop();
+        handle.abort();
+        drop(handle);
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tokio_runtime_tests {
+    use super::{AbortHandle, Elapsed, Runtime, timeout};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::time::Duration;
+
+    /// Bound for every await below: a test that hangs should fail, not stall CI.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+    struct TokioTestRuntime;
+
+    #[async_trait::async_trait]
+    impl Runtime for TokioTestRuntime {
+        fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+            let handle = tokio::spawn(future);
+            AbortHandle::new(move || handle.abort())
+        }
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            Box::pin(tokio::time::sleep(duration))
+        }
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            Box::pin(async move {
+                let _ = tokio::task::spawn_blocking(f).await;
+            })
+        }
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            None
+        }
+    }
+
+    /// Fires its channel when dropped, so a test can observe that a spawned
+    /// future was cancelled without racing a sleep against the abort.
+    struct DropSignal(Option<futures::channel::oneshot::Sender<()>>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(tx) = self.0.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    /// Spawn a task that parks forever, returning its handle plus a receiver
+    /// that resolves once the task's future has been dropped. The signal is
+    /// built before the future so it fires even if the task is cancelled
+    /// before its first poll.
+    async fn spawn_parked_task() -> (AbortHandle, futures::channel::oneshot::Receiver<()>) {
+        let (tx, rx) = futures::channel::oneshot::channel();
+        let dropped_on_cancel = DropSignal(Some(tx));
+        let handle = TokioTestRuntime.spawn(Box::pin(async move {
+            let _dropped_on_cancel = dropped_on_cancel;
+            std::future::pending::<()>().await;
+        }));
+        // Let the task reach its park point so the abort below exercises the
+        // cancel-a-running-task path rather than cancel-before-first-poll.
+        tokio::task::yield_now().await;
+        (handle, rx)
+    }
+
+    async fn expect_cancelled(rx: futures::channel::oneshot::Receiver<()>) {
+        tokio::time::timeout(TEST_TIMEOUT, rx)
+            .await
+            .expect("timed out waiting for the spawned task to be cancelled")
+            .expect("the task's drop signal was lost");
+    }
+
+    #[tokio::test]
+    async fn abort_cancels_a_spawned_task() {
+        let (handle, rx) = spawn_parked_task().await;
+        handle.abort();
+        expect_cancelled(rx).await;
+    }
+
+    #[tokio::test]
+    async fn dropping_the_handle_cancels_a_spawned_task() {
+        let (handle, rx) = spawn_parked_task().await;
+        drop(handle);
+        expect_cancelled(rx).await;
+    }
+
+    #[tokio::test]
+    async fn detached_task_survives_its_handle() {
+        let (tx, rx) = futures::channel::oneshot::channel();
+        TokioTestRuntime
+            .spawn(Box::pin(async move {
+                let _ = tx.send(7u32);
+            }))
+            .detach();
+
+        let value = tokio::time::timeout(TEST_TIMEOUT, rx)
+            .await
+            .expect("timed out waiting for the detached task")
+            .expect("the detached task was cancelled");
+        assert_eq!(value, 7);
+    }
+
+    #[tokio::test]
+    async fn timeout_returns_the_value_when_the_future_wins() {
+        // A generous budget against an immediately-ready future: the only way
+        // this fails is if timeout drops the result.
+        let result = timeout(&TokioTestRuntime, Duration::from_secs(30), async { 42u32 }).await;
+        assert_eq!(result, Ok(42));
+    }
+
+    #[tokio::test]
+    async fn timeout_elapses_when_the_future_never_completes() {
+        // `pending()` can never win the race, so the deadline is deterministic
+        // and can be short.
+        let result = timeout(
+            &TokioTestRuntime,
+            Duration::from_millis(5),
+            std::future::pending::<()>(),
+        )
+        .await;
+        assert_eq!(result, Err(Elapsed));
+        assert_eq!(Elapsed.to_string(), "operation timed out");
+    }
+
+    #[tokio::test]
+    async fn timeout_does_not_wait_out_the_duration_on_success() {
+        // The sleep must be dropped as soon as the future resolves; a timeout
+        // that awaited both would take a minute here.
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let result = timeout(&TokioTestRuntime, Duration::from_secs(60), async { "ok" }).await;
+            assert_eq!(result, Ok("ok"));
+        })
+        .await
+        .expect("timeout() must return as soon as the inner future completes");
+    }
+
+    #[tokio::test]
+    async fn blocking_ferries_the_closure_result_back() {
+        let value = super::blocking(&TokioTestRuntime, || 6 * 7).await;
+        assert_eq!(value, 42);
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod shutdown_tests {
     use super::{ShutdownNotifier, ShutdownSignal, wait_for_shutdown};
     use futures::FutureExt;
@@ -350,6 +551,71 @@ mod shutdown_tests {
 
         notifier.notify();
         block_on(fut);
+    }
+
+    // notify() wakes every registered listener, not just the first one:
+    // event_listener's notify takes a count, so a wrong count here would strand
+    // all but one of the tasks waiting on shutdown.
+    #[test]
+    fn notify_wakes_every_registered_listener() {
+        let notifier = ShutdownNotifier::new();
+        let signals: Vec<_> = (0..4).map(|_| notifier.subscribe()).collect();
+        let waiters: Vec<_> = signals.iter().map(wait_for_shutdown).collect();
+        let publisher_side = notifier.listen();
+
+        notifier.notify();
+
+        block_on(futures::future::join_all(waiters));
+        block_on(publisher_side);
+        assert!(signals.iter().all(|s| s.is_fired()));
+    }
+
+    // Repeated notifies are harmless, and a subscriber that arrives after the
+    // last one still sees the sticky flag.
+    #[test]
+    fn notify_is_idempotent_for_late_subscribers() {
+        let notifier = ShutdownNotifier::new();
+        let early = notifier.subscribe();
+        notifier.notify();
+        notifier.notify();
+
+        let late = notifier.subscribe();
+        assert!(early.is_fired());
+        assert!(late.is_fired());
+        block_on(futures::future::join(
+            wait_for_shutdown(&early),
+            wait_for_shutdown(&late),
+        ));
+    }
+
+    // Clones share the notifier's inner state, so one notify covers all of them.
+    #[test]
+    fn cloned_signals_observe_the_same_notify() {
+        let notifier = ShutdownNotifier::new();
+        let signal = notifier.subscribe();
+        let clone = signal.clone();
+
+        assert!(!signal.is_fired());
+        assert!(!clone.is_fired());
+
+        notifier.notify();
+
+        assert!(signal.is_fired());
+        assert!(clone.is_fired());
+        block_on(wait_for_shutdown(&clone));
+    }
+
+    // A fresh notifier must not look fired, and its listeners must stay pending
+    // until someone notifies.
+    #[test]
+    fn unfired_notifier_leaves_listeners_pending() {
+        let notifier = ShutdownNotifier::default();
+        let signal = notifier.subscribe();
+        assert!(!signal.is_fired());
+
+        let mut fut = Box::pin(wait_for_shutdown(&signal).fuse());
+        let mut ctx = futures::task::Context::from_waker(futures::task::noop_waker_ref());
+        assert!(fut.as_mut().poll_unpin(&mut ctx).is_pending());
     }
 
     // never() must never resolve. Poll once manually and assert Pending.

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -556,14 +556,60 @@ mod shutdown_tests {
     // notify() wakes every registered listener, not just the first one:
     // event_listener's notify takes a count, so a wrong count here would strand
     // all but one of the tasks waiting on shutdown.
+    //
+    // Resolution is the wrong observable for that: the sticky flag makes a
+    // re-polled waiter finish whether or not it was ever woken, so `block_on`
+    // alone still passes with notify(1). Count the wakeups instead, and poll
+    // each waiter to Pending first — registration happens on that first poll,
+    // so a still-lazy future is not yet listening when notify fires.
     #[test]
     fn notify_wakes_every_registered_listener() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingWaker(AtomicUsize);
+        impl futures::task::ArcWake for CountingWaker {
+            fn wake_by_ref(arc_self: &Arc<Self>) {
+                arc_self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
         let notifier = ShutdownNotifier::new();
         let signals: Vec<_> = (0..4).map(|_| notifier.subscribe()).collect();
-        let waiters: Vec<_> = signals.iter().map(wait_for_shutdown).collect();
-        let publisher_side = notifier.listen();
+        let mut waiters: Vec<_> = signals
+            .iter()
+            .map(|s| Box::pin(wait_for_shutdown(s).fuse()))
+            .collect();
+        let mut publisher_side = Box::pin(notifier.listen().fuse());
+
+        // One waker per subscriber, plus one for the publisher-side listener.
+        let wakers: Vec<_> = (0..signals.len() + 1)
+            .map(|_| Arc::new(CountingWaker(AtomicUsize::new(0))))
+            .collect();
+        for (fut, waker) in waiters.iter_mut().zip(&wakers) {
+            let waker = futures::task::waker_ref(waker);
+            let mut ctx = futures::task::Context::from_waker(&waker);
+            assert!(fut.as_mut().poll_unpin(&mut ctx).is_pending());
+        }
+        {
+            let waker = futures::task::waker_ref(wakers.last().expect("wakers is non-empty"));
+            let mut ctx = futures::task::Context::from_waker(&waker);
+            assert!(publisher_side.as_mut().poll_unpin(&mut ctx).is_pending());
+        }
+        assert!(
+            wakers.iter().all(|w| w.0.load(Ordering::Relaxed) == 0),
+            "no listener may be woken before notify()"
+        );
 
         notifier.notify();
+
+        for (i, waker) in wakers.iter().enumerate() {
+            assert!(
+                waker.0.load(Ordering::Relaxed) > 0,
+                "listener {i} of {} was never woken by notify()",
+                wakers.len()
+            );
+        }
 
         block_on(futures::future::join_all(waiters));
         block_on(publisher_side);


### PR DESCRIPTION
## Summary

Two kinds of gap in the suite: tests that synchronize on a fixed sleep, and parsers that reject malformed server data along branches nothing ever exercised. The sleeps are the more urgent half — every one of them is a bet on the scheduler, so it either flakes on a loaded runner or makes the suite slower on every single run. All of them are gone; the rule going forward is that a test waits on the condition itself, or polls it with a bounded deadline that fails with a clear message.

No production behavior changes here. The one non-test change is a `#[cfg(test)]` accessor on `FlushScope` so tests can see how many flushers are parked on it.

## Changes

**Anti-flakiness**

`TestClient::wait_for_disconnected()` replaces the 100ms sleeps that followed `reconnect()` across the offline e2e tests. `reconnect()` tears the socket down in a background task, so the sleep was the only thing standing between the test and a client that had not gone offline yet — and `Event::Disconnected` is suppressed for expected disconnects, which leaves the connection flag as the observable. Sleeps that followed `disconnect()` are dropped outright rather than converted: it already awaits the run task, so there was nothing to wait for.

In the unit tests, a shared `poll_until` helper (5s deadline, names what it was waiting for on failure) replaces the `sleep(10ms); assert!(task.is_finished())` pattern. Each site polls a real observable:

- registered `event_listener` listeners as the proof that "a task is parked here" — the offline-sync notifier and `FlushScope::idle` both register their listener *before* re-checking their condition, so a listener means the waiter genuinely reached its await point;
- the lifecycle `terminal` flag, which is set immediately before shutdown reaches for the scope-registry lock the blocked close callback holds;
- `FlushScope::pending()` for the retry-receipt counter tests — `spawn` takes its guard synchronously, so a drained scope proves the spawned task ran, including the cases where it must deliberately do nothing.

The PDO sleeps turned out to be guarding nothing: `run_pdo_request` is fully awaited, and four of those tests asserted nothing at all after sleeping. They now assert on its return value, which is what actually distinguishes an armed request from a skipped one.

`agent_docs/e2e_testing.md` is updated because it still told people to sleep 100ms after `reconnect()`, which would have let the pattern grow back.

**Negative coverage**

`decode_record` rejects seven distinct shapes of malformed server data and had none of them under test; `patch_decode` had no tests at all. Both get a happy path plus a case per rejection, so a regression that starts accepting a truncated index or a mismatched MAC fails at the parser instead of somewhere downstream. Same treatment for the privacy IQ parser, following the malformed-response tests already in `iq::groups`.

`wacore::runtime` gets direct tests for `ShutdownNotifier` with multiple listeners, `AbortHandle::abort()` and abort-on-drop, and `timeout` both expiring and completing — previously only covered indirectly through callers.

**Fuzz**

New `parse_jid` target next to `unmarshal_ref`. JIDs are attacker-controlled attribute values on every stanza and the parse path mixes a hand-rolled scanner with string slicing, so it checks two properties: arbitrary text never panics, and a JID built from the fuzz bytes survives a render/re-parse round-trip unchanged.

**Helpers**

`has_child` was copied into two e2e test files and `scan_sessions` existed in two divergent forms. Both are hoisted into the shared e2e crate, keeping the single form that reports the JID along with whether a session record exists.

## Validation

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy --workspace --all-features --all-targets -- -D warnings
cargo test -p wacore-appstate --lib     # 74 passed
cargo test -p wacore --lib              # 1214 passed
cargo test -p whatsapp-rust --lib       # 1136 passed
cargo test -p whatsapp-rust --lib --features client-lifecycle   # 1168 passed
```

The touched e2e tests are left to CI — no mock server available locally.

One deviation worth flagging: the branch is `claude/test-suite-quality-t2n6bf` rather than `test/polling-and-negative-coverage`, because the branch name was fixed by the environment this ran in.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gdAtRiRPGeWi2DWYYW82H)_