### PR TITLE
fix(groups): send the previous description id when updating a group description

### DIFF
--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -9,6 +9,7 @@ use crate::features::groups::GroupMetadata;
 use crate::features::groups::GroupParticipant;
 use crate::features::groups::GroupParticipantOptions;
 use crate::features::groups::ParticipantChangeResponse;
+use crate::features::groups::PreviousDescription;
 use crate::features::mex::{MexError, mex_request};
 use crate::request::IqError;
 use log::warn;
@@ -176,7 +177,9 @@ impl<'a> Community<'a> {
         {
             self.client
                 .groups()
-                .set_description(&metadata.id, Some(desc), None)
+                // The group was just created, so nothing can have set a
+                // description ahead of us.
+                .set_description(&metadata.id, Some(desc), PreviousDescription::Absent)
                 .await?;
             metadata.description = Some(desc_text);
         }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -1,6 +1,7 @@
 use crate::client::Client;
 use crate::features::mex::{MexError, mex_request};
 use crate::request::IqError;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
@@ -48,11 +49,61 @@ pub enum GroupError {
     /// expired V4 invite, non-group JID where one is required).
     #[error("invalid group request: {0}")]
     InvalidRequest(String),
+    /// The server refused a description update because the `prev` token no
+    /// longer matches the group's current description: another device changed
+    /// it first. Distinct from a permission refusal, so a caller can re-read
+    /// the description and retry instead of giving up.
+    #[error("the group description changed since it was read")]
+    DescriptionConflict,
     /// Catch-all for internal failures (LID/PN resolution, the protocol-message
     /// send path behind `update_member_label`, cache plumbing).
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }
+
+/// The description a [`Groups::set_description`] call expects to replace.
+///
+/// The server takes the `prev` attribute as an optimistic-concurrency token: it
+/// applies the update only when the token matches the group's current
+/// description id, and answers `409 conflict` otherwise. A group with no
+/// description expects no token at all.
+///
+/// The default is [`PreviousDescription::Resolve`] because it is the only
+/// variant that is correct without knowing anything about the group. Note that
+/// it is also the only one that costs a round trip.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PreviousDescription<'a> {
+    /// Read the group's current description id from the server before sending.
+    /// The right choice when the caller holds no fresh metadata.
+    #[default]
+    Resolve,
+    /// The group carries no description yet (a freshly created group), so no
+    /// token is sent.
+    Absent,
+    /// A description id the caller already holds, typically
+    /// [`GroupMetadata::description_id`] from a recent [`Groups::get_metadata`].
+    Id(&'a str),
+}
+
+/// Turns a held [`GroupMetadata::description_id`] into a token.
+///
+/// `None` means "that metadata says the group has no description", so it maps
+/// to [`PreviousDescription::Absent`] and not to a fresh read. Metadata stale
+/// enough to have missed a description added since is therefore answered with
+/// [`GroupError::DescriptionConflict`]; pass [`PreviousDescription::Resolve`]
+/// when the age of the metadata is unknown.
+impl<'a> From<Option<&'a str>> for PreviousDescription<'a> {
+    fn from(description_id: Option<&'a str>) -> Self {
+        match description_id {
+            Some(id) => Self::Id(id),
+            None => Self::Absent,
+        }
+    }
+}
+
+/// `<error code="409" text="conflict"/>` on a `w:g2` set: the request lost an
+/// optimistic-concurrency check.
+const CONFLICT_STATUS_CODE: u16 = 409;
 
 /// Typed `update` payload for the `update_group_property` mex mutation. The
 /// generated mirror types this op's `update` as a `String`, but it is a one-of
@@ -706,21 +757,66 @@ impl<'a> Groups<'a> {
             .await?)
     }
 
-    /// Sets or deletes a group's description.
+    /// Set or delete a group's description.
     ///
-    /// `prev` is the current description ID (from group metadata) used for
-    /// conflict detection. Pass `None` if unknown.
+    /// Pass `None` as the description to delete it. `prev` names the
+    /// description this update replaces; the server accepts the change only
+    /// when that token matches the group's current description, so a group that
+    /// already has one cannot be updated without it. With
+    /// [`PreviousDescription::Resolve`] the token is read from the server first,
+    /// which costs one extra query but is always current; a caller holding
+    /// fresh [`GroupMetadata::description_id`] can pass it directly instead.
+    ///
+    /// Returns [`GroupError::DescriptionConflict`] when the group's description
+    /// changed between the read and this update.
     pub async fn set_description(
         &self,
         jid: impl Into<Jid>,
         description: Option<GroupDescription>,
-        prev: Option<&str>,
+        prev: PreviousDescription<'_>,
     ) -> Result<(), GroupError> {
         let jid = &jid.into();
-        Ok(self
-            .client
-            .execute(SetGroupDescriptionIq::new(jid, description, prev))
-            .await?)
+        let prev: Option<Cow<'_, str>> = match prev {
+            PreviousDescription::Absent => None,
+            PreviousDescription::Id(id) => Some(Cow::Borrowed(id)),
+            // Resolution runs first so a failed read never sends an update
+            // carrying a token the server would reject or, worse, accept
+            // against a description the caller never saw.
+            PreviousDescription::Resolve => self.query_description_id(jid).await?.map(Cow::Owned),
+        };
+
+        self.client
+            .execute(SetGroupDescriptionIq::new(
+                jid,
+                description,
+                prev.as_deref(),
+            ))
+            .await
+            .map_err(|err| match err {
+                IqError::ServerError {
+                    code: CONFLICT_STATUS_CODE,
+                    ..
+                } => GroupError::DescriptionConflict,
+                other => other.into(),
+            })
+    }
+
+    /// Read just the group's current description id from the server.
+    ///
+    /// Deliberately not served from the group cache: that snapshot is the slim
+    /// send-path view, and its refresh is conditional on the participant phash,
+    /// so it can be current for participants while the description behind it
+    /// has already moved. For the same reason the query carries no phash, which
+    /// makes the server answer with the whole group; on a large community that
+    /// is a full participant list downloaded for one attribute. The protocol
+    /// offers no narrower read, so the cost is the price of a correct token.
+    async fn query_description_id(&self, jid: &Jid) -> Result<Option<String>, GroupError> {
+        match self.client.execute(GroupQueryIq::new(jid)).await? {
+            GroupInfoOutcome::Full(group) => Ok(group.description_id),
+            GroupInfoOutcome::NotModified => Err(GroupError::InvalidRequest(
+                "group query returned not-modified without a phash".into(),
+            )),
+        }
     }
 
     pub async fn leave(&self, jid: impl Into<Jid>) -> Result<(), GroupError> {
@@ -1798,6 +1894,495 @@ mod tests {
                     "limit_sharing_trigger": "CHAT_SETTING"
                 }
             })
+        );
+    }
+
+    /// Fictitious group used by the description round-trip tests.
+    fn description_test_group() -> Jid {
+        "120363000000000001@g.us"
+            .parse()
+            .expect("test group JID should be valid")
+    }
+
+    /// `<iq type="result">` carrying a `<group>` with (optionally) a current
+    /// description, i.e. what the server answers a metadata query with.
+    fn group_result_with_description(
+        request_id: &str,
+        group: &Jid,
+        description_id: Option<&str>,
+    ) -> wacore_binary::Node {
+        use wacore_binary::builder::NodeBuilder;
+
+        let mut group_node = NodeBuilder::new("group")
+            .attr("id", group.to_string())
+            .attr("subject", "Test Group");
+        if let Some(description_id) = description_id {
+            group_node = group_node.children([NodeBuilder::new("description")
+                .attr("id", description_id)
+                .children([NodeBuilder::new("body")
+                    .string_content("current description")
+                    .build()])
+                .build()]);
+        }
+
+        NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("id", request_id)
+            .attr("from", group)
+            .children([group_node.build()])
+            .build()
+    }
+
+    fn iq_error(request_id: &str, group: &Jid, code: &str, text: &str) -> wacore_binary::Node {
+        use wacore_binary::builder::NodeBuilder;
+
+        NodeBuilder::new("iq")
+            .attr("type", "error")
+            .attr("id", request_id)
+            .attr("from", group)
+            .children([NodeBuilder::new("error")
+                .attr("code", code)
+                .attr("text", text)
+                .build()])
+            .build()
+    }
+
+    fn iq_result(request_id: &str, group: &Jid) -> wacore_binary::Node {
+        use wacore_binary::builder::NodeBuilder;
+
+        NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("id", request_id)
+            .attr("from", group)
+            .build()
+    }
+
+    /// A group that already has a description can only be updated by naming the
+    /// id it replaces, so the update must carry both a fresh `id` and the
+    /// current one as `prev`.
+    #[tokio::test]
+    async fn set_description_sends_the_current_description_id_as_prev() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(
+                        group,
+                        Some(GroupDescription::new("new description").unwrap()),
+                        PreviousDescription::Resolve,
+                    )
+                    .await
+            })
+        };
+
+        let query = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let query = query.get();
+        assert_eq!(query.tag.as_ref(), "iq");
+        assert_eq!(
+            query.attrs().optional_string("type").as_deref(),
+            Some("get")
+        );
+        assert!(
+            query.get_optional_child("query").is_some(),
+            "the resolution step must be a group metadata query"
+        );
+        let query_id = query
+            .attrs()
+            .optional_string("id")
+            .expect("query carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &query_id,
+            &group_result_with_description(&query_id, &group, Some("D1D2D3D4")),
+        )
+        .await;
+
+        let set = crate::test_utils::decode_sent_iq(&transport, 1).await;
+        let set = set.get();
+        assert_eq!(set.attrs().optional_string("type").as_deref(), Some("set"));
+        let description = set
+            .get_optional_child("description")
+            .expect("the update carries a <description>");
+        let id = description
+            .attrs()
+            .optional_string("id")
+            .expect("a new id is minted");
+        assert_eq!(id.len(), 8);
+        assert_ne!(id, "D1D2D3D4", "the new id must not reuse prev");
+        assert_eq!(
+            description.attrs().optional_string("prev").as_deref(),
+            Some("D1D2D3D4"),
+            "the update must name the description it replaces"
+        );
+        let body = description
+            .get_optional_child("body")
+            .expect("a set carries a <body>");
+        assert_eq!(body.content_as_string().as_deref(), Some("new description"));
+
+        let set_id = set
+            .attrs()
+            .optional_string("id")
+            .expect("the update carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(&client, &set_id, &iq_result(&set_id, &group)).await;
+        update
+            .await
+            .expect("the update task should not panic")
+            .expect("the update should succeed");
+    }
+
+    /// Deleting a description is the same optimistic-concurrency check, so the
+    /// `delete` marker travels with the token it replaces.
+    #[tokio::test]
+    async fn delete_description_sends_prev_alongside_the_delete_marker() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(group, None, PreviousDescription::Resolve)
+                    .await
+            })
+        };
+
+        let query = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let query_id = query
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("query carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &query_id,
+            &group_result_with_description(&query_id, &group, Some("AABBCCDD")),
+        )
+        .await;
+
+        let set = crate::test_utils::decode_sent_iq(&transport, 1).await;
+        let set = set.get();
+        let description = set
+            .get_optional_child("description")
+            .expect("the delete carries a <description>");
+        assert_eq!(
+            description.attrs().optional_string("delete").as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            description.attrs().optional_string("prev").as_deref(),
+            Some("AABBCCDD")
+        );
+        assert!(
+            description.get_optional_child("body").is_none(),
+            "a delete carries no body"
+        );
+
+        let set_id = set
+            .attrs()
+            .optional_string("id")
+            .expect("the delete carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(&client, &set_id, &iq_result(&set_id, &group)).await;
+        update
+            .await
+            .expect("the delete task should not panic")
+            .expect("the delete should succeed");
+    }
+
+    /// The path that already worked: a group with no description expects no
+    /// token, and sending one would be rejected.
+    #[tokio::test]
+    async fn set_description_on_a_group_without_one_omits_prev() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(
+                        group,
+                        Some(GroupDescription::new("first description").unwrap()),
+                        PreviousDescription::Resolve,
+                    )
+                    .await
+            })
+        };
+
+        let query = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let query_id = query
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("query carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &query_id,
+            &group_result_with_description(&query_id, &group, None),
+        )
+        .await;
+
+        let set = crate::test_utils::decode_sent_iq(&transport, 1).await;
+        let set = set.get();
+        let description = set
+            .get_optional_child("description")
+            .expect("the update carries a <description>");
+        assert!(
+            description.attrs().optional_string("prev").is_none(),
+            "a group with no description must not carry a prev token"
+        );
+        assert!(description.attrs().optional_string("id").is_some());
+
+        let set_id = set
+            .attrs()
+            .optional_string("id")
+            .expect("the update carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(&client, &set_id, &iq_result(&set_id, &group)).await;
+        update
+            .await
+            .expect("the update task should not panic")
+            .expect("the update should succeed");
+    }
+
+    /// A caller that already holds the id (the community create path holds
+    /// "none") skips the resolution query entirely.
+    #[tokio::test]
+    async fn set_description_with_a_known_token_skips_the_resolution_query() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(
+                        group,
+                        Some(GroupDescription::new("known token").unwrap()),
+                        PreviousDescription::Id("KNOWNID1"),
+                    )
+                    .await
+            })
+        };
+
+        let set = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let set = set.get();
+        assert_eq!(
+            set.attrs().optional_string("type").as_deref(),
+            Some("set"),
+            "the first stanza must be the update itself, not a query"
+        );
+        let description = set
+            .get_optional_child("description")
+            .expect("the update carries a <description>");
+        assert_eq!(
+            description.attrs().optional_string("prev").as_deref(),
+            Some("KNOWNID1")
+        );
+
+        let set_id = set
+            .attrs()
+            .optional_string("id")
+            .expect("the update carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(&client, &set_id, &iq_result(&set_id, &group)).await;
+        update
+            .await
+            .expect("the update task should not panic")
+            .expect("the update should succeed");
+        assert_eq!(transport.sent_count(), 1);
+    }
+
+    /// If the resolution query fails there is no token to send, and guessing
+    /// one (or omitting it) would either be rejected or silently overwrite a
+    /// description the caller never read.
+    #[tokio::test]
+    async fn a_failed_resolution_sends_no_update() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(
+                        group,
+                        Some(GroupDescription::new("new description").unwrap()),
+                        PreviousDescription::Resolve,
+                    )
+                    .await
+            })
+        };
+
+        let query = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let query_id = query
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("query carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &query_id,
+            &iq_error(&query_id, &group, "403", "forbidden"),
+        )
+        .await;
+
+        let error = update
+            .await
+            .expect("the update task should not panic")
+            .expect_err("a failed resolution must fail the update");
+        assert!(
+            matches!(
+                error,
+                GroupError::Iq(IqError::ServerError { code: 403, .. })
+            ),
+            "the resolution failure must surface as-is, got {error:?}"
+        );
+        assert_eq!(
+            transport.sent_count(),
+            1,
+            "no update may be sent once resolution failed"
+        );
+    }
+
+    /// Another device changing the description between the read and the update
+    /// is exactly what the token guards against; the server's `409 conflict`
+    /// must stay distinguishable from a permission refusal.
+    #[tokio::test]
+    async fn a_concurrent_change_surfaces_as_a_description_conflict() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(
+                        group,
+                        Some(GroupDescription::new("new description").unwrap()),
+                        PreviousDescription::Resolve,
+                    )
+                    .await
+            })
+        };
+
+        let query = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let query_id = query
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("query carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &query_id,
+            &group_result_with_description(&query_id, &group, Some("STALE001")),
+        )
+        .await;
+
+        let set = crate::test_utils::decode_sent_iq(&transport, 1).await;
+        let set_id = set
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("the update carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &set_id,
+            &iq_error(&set_id, &group, "409", "conflict"),
+        )
+        .await;
+
+        let error = update
+            .await
+            .expect("the update task should not panic")
+            .expect_err("a conflict must fail the update");
+        assert!(
+            matches!(error, GroupError::DescriptionConflict),
+            "a 409 on a description update is a conflict, got {error:?}"
+        );
+    }
+
+    /// A refusal that is not a conflict keeps its server code, so a caller can
+    /// still tell "no permission" from "someone else changed it".
+    #[tokio::test]
+    async fn a_forbidden_update_is_not_reported_as_a_conflict() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let update = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                client
+                    .groups()
+                    .set_description(
+                        group,
+                        Some(GroupDescription::new("new description").unwrap()),
+                        PreviousDescription::Id("KNOWNID1"),
+                    )
+                    .await
+            })
+        };
+
+        let set = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let set_id = set
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("the update carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &set_id,
+            &iq_error(&set_id, &group, "403", "forbidden"),
+        )
+        .await;
+
+        let error = update
+            .await
+            .expect("the update task should not panic")
+            .expect_err("a forbidden update must fail");
+        assert!(
+            matches!(
+                error,
+                GroupError::Iq(IqError::ServerError { code: 403, .. })
+            ),
+            "a non-conflict refusal must keep its code, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn previous_description_from_optional_id() {
+        assert_eq!(
+            PreviousDescription::from(Some("ABCD1234")),
+            PreviousDescription::Id("ABCD1234")
+        );
+        assert_eq!(
+            PreviousDescription::from(None),
+            PreviousDescription::Absent,
+            "a group with no description resolves to no token, not to a query"
         );
     }
 }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -49,7 +49,7 @@ pub use groups::{
     GroupParticipantDetails, GroupParticipantOptions, GroupProfilePicture, GroupSubject, Groups,
     GrowthLockInfo, InviteInfoError, JoinGroupResult, MemberAddMode, MemberLinkMode,
     MemberShareHistoryMode, MembershipApprovalMode, MembershipRequest, ParticipantChangeResponse,
-    ParticipantType, PictureType,
+    ParticipantType, PictureType, PreviousDescription,
 };
 
 pub use labels::Labels;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,12 +179,12 @@ pub use features::{
     NewsletterMessageType, NewsletterMetadata, NewsletterReactionCount, NewsletterRole,
     NewsletterState, NewsletterVerification, ParticipantChangeResponse, ParticipantType,
     PictureType, PollError, PollOptionResult, PollVoteCiphertext, Polls, Presence, PresenceError,
-    PresenceStatus, Profile, ProfileError, ProfilePicture, ReachoutTimelock, RetryReason,
-    RetryRequestError, RetryRequestOptions, RetryRequestOutcome, SecretEncKind, SecretEncrypted,
-    SetProfilePictureResponse, Signal, SignalError, SignalSessionInfo, SignalSessionMigration,
-    StanzaRejection, StanzaResponseError, Status, StatusPrivacySetting, StatusSendOptions,
-    SyncActionMessageRange, TcToken, TcTokenError, UnlinkSubgroupsResult, UserInfo,
-    UsyncSubprotocolError, VerifiedName, group_type, message_key, message_range,
+    PresenceStatus, PreviousDescription, Profile, ProfileError, ProfilePicture, ReachoutTimelock,
+    RetryReason, RetryRequestError, RetryRequestOptions, RetryRequestOutcome, SecretEncKind,
+    SecretEncrypted, SetProfilePictureResponse, Signal, SignalError, SignalSessionInfo,
+    SignalSessionMigration, StanzaRejection, StanzaResponseError, Status, StatusPrivacySetting,
+    StatusSendOptions, SyncActionMessageRange, TcToken, TcTokenError, UnlinkSubgroupsResult,
+    UserInfo, UsyncSubprotocolError, VerifiedName, group_type, message_key, message_range,
 };
 
 pub mod bot;

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -101,9 +101,12 @@ impl From<GroupError> for SendError {
             GroupError::Iq(iq) => SendError::Iq(iq),
             GroupError::InvalidRequest(msg) => SendError::InvalidRequest(msg),
             GroupError::Internal(e) => SendError::from_anyhow(e),
-            // No dedicated variant for MEX mutations; preserve the full typed
-            // error as the `Internal` source so its Display/source chain survives.
-            group @ GroupError::Mex(_) => SendError::Internal(group.into()),
+            // No dedicated variant for MEX mutations or description conflicts;
+            // preserve the full typed error as the `Internal` source so its
+            // Display/source chain survives.
+            group @ (GroupError::Mex(_) | GroupError::DescriptionConflict) => {
+                SendError::Internal(group.into())
+            }
         }
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -233,3 +233,100 @@ pub async fn create_test_backend() -> Arc<dyn Backend> {
             .expect("test backend should initialize"),
     ) as Arc<dyn Backend>
 }
+
+/// A test client that can complete a full IQ round trip: outgoing frames are
+/// captured (and decodable with [`decode_sent_iq`]) and responses are injected
+/// with [`answer_iq`], with no server or socket involved.
+#[cfg(test)]
+pub(crate) async fn create_iq_test_client() -> (
+    Arc<Client>,
+    Arc<crate::transport::mock::CapturingMockTransport>,
+) {
+    use crate::transport::mock::CapturingMockTransportFactory;
+    use wacore::handshake::NoiseCipher;
+
+    let backend = create_test_backend().await;
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager should initialize"),
+    );
+    let factory = CapturingMockTransportFactory::new();
+    let transport = factory.transport();
+    let (client, _sync_rx) = Client::new(
+        Arc::new(TokioRuntime),
+        pm,
+        Arc::new(factory),
+        Arc::new(MockHttpClient),
+        None,
+    )
+    .await;
+
+    let noise_socket = crate::socket::NoiseSocket::new(
+        Arc::new(TokioRuntime),
+        transport.clone() as Arc<dyn crate::transport::Transport>,
+        NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+        NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+    );
+    *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+    client.set_connected_for_test(true);
+    client
+        .is_running
+        .store(true, std::sync::atomic::Ordering::Release);
+    client.enter_live_mode_for_tests();
+
+    (client, transport)
+}
+
+/// Wait for the client to write the `index`-th frame and decode it.
+///
+/// Frames are encrypted with the counter-based noise cipher, so the index is
+/// part of the key material and frames must be read in order. This assumes the
+/// client under test writes nothing the test did not ask for: a stray frame
+/// (a keepalive, a background query) shifts every later index and the decrypt
+/// fails. The harness sends no keepalives, so a test that only drives explicit
+/// calls holds that assumption.
+#[cfg(test)]
+pub(crate) async fn decode_sent_iq(
+    transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+    index: usize,
+) -> Arc<OwnedNodeRef> {
+    use wacore::handshake::NoiseCipher;
+
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let frames = transport.sent();
+            if let Some(frame) = frames.get(index) {
+                return frame.clone();
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("frame {index} should reach the transport"));
+
+    let cipher = NoiseCipher::new(&[0u8; 32]).expect("32-byte key");
+    let mut buf = frame[3..].to_vec();
+    cipher
+        .decrypt_in_place_with_counter(index as u32, &mut buf)
+        .expect("captured frame should decrypt");
+    // The decrypted payload keeps marshal()'s leading format byte.
+    Arc::new(OwnedNodeRef::new(buf[1..].to_vec()).expect("captured frame should decode"))
+}
+
+/// Deliver `response` to the pending IQ waiter registered under `request_id`.
+#[cfg(test)]
+pub(crate) async fn answer_iq(client: &Arc<Client>, request_id: &str, response: &Node) {
+    let sender = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(sender) = client.response_waiters_guard().remove(request_id) {
+                return sender;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("an IQ waiter should be registered for {request_id}"));
+
+    let _ = sender.send(node_to_owned_ref(response));
+}

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -3838,6 +3838,58 @@ mod tests {
     }
 
     #[test]
+    fn test_set_group_description_without_prev_omits_the_attr() {
+        let jid: Jid = "120363000000000001@g.us".parse().unwrap();
+        let desc = GroupDescription::new("First description").unwrap();
+        let iq = SetGroupDescriptionIq::new(&jid, Some(desc), None).build_iq();
+
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected nodes content");
+        };
+        let desc_node = &nodes[0];
+        assert_eq!(desc_node.attrs().optional_string("id").unwrap().len(), 8);
+        assert!(
+            desc_node.attrs().optional_string("prev").is_none(),
+            "a group with no description must not carry a prev token"
+        );
+        assert!(desc_node.get_children_by_tag("body").next().is_some());
+    }
+
+    #[test]
+    fn test_set_group_description_delete_without_prev_omits_the_attr() {
+        let jid: Jid = "120363000000000001@g.us".parse().unwrap();
+        let iq = SetGroupDescriptionIq::new(&jid, None, None).build_iq();
+
+        let Some(NodeContent::Nodes(nodes)) = &iq.content else {
+            panic!("expected nodes content");
+        };
+        let desc_node = &nodes[0];
+        assert_eq!(
+            desc_node.attrs().optional_string("delete").as_deref(),
+            Some("true")
+        );
+        assert!(desc_node.attrs().optional_string("prev").is_none());
+    }
+
+    #[test]
+    fn test_set_group_description_ids_are_distinct_per_request() {
+        let jid: Jid = "120363000000000001@g.us".parse().unwrap();
+        let desc = GroupDescription::new("Description").unwrap();
+        let first = SetGroupDescriptionIq::new(&jid, Some(desc.clone()), Some("AABBCCDD"));
+        let second = SetGroupDescriptionIq::new(&jid, Some(desc), Some("AABBCCDD"));
+
+        assert_ne!(
+            first.id, second.id,
+            "each update must mint a new description id"
+        );
+        assert_ne!(
+            first.id,
+            first.prev.clone().unwrap(),
+            "the new id must not reuse the token it replaces"
+        );
+    }
+
+    #[test]
     fn test_leave_group_iq() {
         let jid: Jid = "120363000000000001@g.us".parse().unwrap();
         let spec = LeaveGroupIq::new(&jid);


### PR DESCRIPTION
## Summary

Changing the description of a group that already had one always failed with `409 conflict`, while setting a description on a group without one worked. The `<description>` element's `prev` attribute is the server's optimistic-concurrency token: the update is applied only when `prev` matches the group's current description id. `Groups::set_description` did accept a `prev: Option<&str>`, but nothing could fill it — the only in-tree call site is community creation, which legitimately has no previous description, and an external caller has no id to pass. The core now owns resolving that token: `PreviousDescription` distinguishes "read the current id first" from "this group has no description" and "here is the id I already hold", so the parameter is one a caller can always answer honestly.

Resolution pays a group query instead of reading the group cache. That snapshot is the slim send-path view (`GroupInfo`), it carries no description id at all, and its refresh is conditional on the participant phash, so it can be perfectly current for participants while the description behind it has already moved — using it would trade a deterministic failure for an intermittent one. The read runs before the update, so a failed resolution sends nothing.

## Changes

- **breaking** `Groups::set_description` now takes `PreviousDescription<'_>` instead of `prev: Option<&str>` — the old parameter had no correct value a caller could supply.
- New `PreviousDescription` enum (`Resolve` / `Absent` / `Id(&str)`), `Copy` and borrowing, with `From<Option<&str>>` so a caller holding `GroupMetadata::description_id` can pass `meta.description_id.as_deref().into()`. Only `Resolve` costs a round trip; the borrowed variants allocate nothing. Both the default-is-`Resolve` round trip and the `None → Absent` staleness caveat are spelled out in the docs.
- `Groups::query_description_id` reads the current id via `GroupQueryIq`, skipping the `GroupMetadata` conversion and the LID/PN backfill `get_metadata` does. It runs before the update, so a network or permission failure fails the call instead of sending an update with a wrong or missing token. The query carries no phash and so pulls the whole group for one attribute; the protocol offers no narrower read, and that is noted at the call.
- New `GroupError::DescriptionConflict` for the server's `<error code="409" text="conflict"/>`, which until now reached callers as a generic server error indistinguishable from a permission refusal. Mapped only on the description update, where 409 has exactly this meaning. `GroupError` is already `#[non_exhaustive]`, so the variant breaks no downstream match; `From<GroupError> for SendError` carries it through as a typed `Internal` source.
- `create_community` passes `PreviousDescription::Absent`: the group was just created, so nothing can have set a description ahead of us. Delete goes through the same path, so it carries the token too.
- Test-only: `create_iq_test_client` / `decode_sent_iq` / `answer_iq` in `test_utils` drive a full IQ round trip over the capturing transport, so the wire of a feature call can be asserted without a server.

## Protocol evidence

- `WAWeb/Set/DescAction.js` — `setGroupDescription(chatId, text, randomHex(8), groupMetadata?.descId)`: the third argument is always a freshly minted id, the fourth (`descriptionPrev`) is the current description id taken from local metadata. When the group has no description, `descId` is `undefined` and the attribute is simply not serialized.
- `WAWeb/Group/ModifyInfoJob.js` — forwards `descriptionId`/`descriptionPrev` unchanged for both the set and the delete (`hasDescriptionDeleteTrue: true`); no extra policy.
- `WA/Smax/OutGroupsSetDescriptionRequest.js` — renders `<description id? prev? delete?>` with an optional `body`; `id` and `prev` are both `OPTIONAL`.
- `WA/Smax/InGroupsSetDescriptionClientErrors.js` + `WA/Smax/InGroupsIQErrorConflictMixin.js` — `IQErrorConflict` is a modeled client error of this exact RPC, parsed as `literal(attrInt, "code", 409)` and `literal(attrString, "text", "conflict")`, which is what pins the typed error to that code.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib iq::groups
cargo test -p whatsapp-rust --lib features::groups
cargo test -p whatsapp-rust --lib features::community
```

Covered: update with an existing description (new `id` + `prev` equal to the current id + `<body>`), delete (`delete="true"` with `prev`, no body), group with no description (`prev` absent), a known token skipping the query entirely, a failed resolution sending no update at all, a concurrent change surfacing as `DescriptionConflict`, and a 403 staying a plain server error. Full matrix (clippy `-D warnings`, wasm32, e2e) left to CI.

`Semver Checks (informational)` is red on this branch and on `main` alike: it is `continue-on-error`, checks `wacore`/`wacore-binary`/`waproto` against the last published release, and every finding is pre-existing proto drift unrelated to this diff.

Downstream note: the WASM bridge passes `None` at `wasm_client.rs:2421` and needs `PreviousDescription::Resolve`; the `groupUpdateDescription(jid, description?)` signature there does not change.