### PR TITLE
fix(chat-store): key receipts and contacts by the peer's bare identity

### DIFF
--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -807,7 +807,7 @@ fn client_weak(client: &Client) -> std::sync::Weak<Client> {
 }
 
 /// Time to wait for the server's `<ack type=offer>` carrying the relay before giving up.
-const OFFER_ACK_RELAY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const OFFER_ACK_RELAY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Three 60 ms frames absorb scheduling jitter without building a long capture delay.
 const MIC_CHANNEL_CAPACITY: usize = 3;
@@ -2151,7 +2151,7 @@ mod tests {
             if !sent.lock().unwrap().is_empty() {
                 break;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
         assert!(
             !sent.lock().unwrap().is_empty(),
@@ -2165,7 +2165,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("wait_ended must resolve after the relay disconnects");
         assert_eq!(
@@ -2220,7 +2220,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("wait_ended must resolve after the relay disconnects");
 
@@ -2369,7 +2369,7 @@ mod tests {
         .expect("replacement spawn_call");
 
         // The replacement aborted the stale task; its wait_ended must still resolve.
-        tokio::time::timeout(std::time::Duration::from_secs(2), stale.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), stale.wait_ended())
             .await
             .expect("stale handle wait_ended must resolve, not hang");
     }
@@ -2409,9 +2409,9 @@ mod tests {
         };
         // Let the waiter register its listener and pass the still-present phase check, so it is truly
         // parked on `listener.await` (the path the guard must cover), not the early return.
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
         handle.hangup().await;
-        tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("wait_ended must resolve after hangup aborts the task")
             .expect("waiter task");
@@ -2606,7 +2606,7 @@ mod tests {
             "the relay-attach material must be parked pending the relay"
         );
 
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("offer must be sent")
             .expect("waiter");
@@ -2740,7 +2740,7 @@ mod tests {
         .await
         .expect("place encoded call");
 
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("offer must be sent")
             .expect("waiter");
@@ -2812,7 +2812,7 @@ mod tests {
         .await
         .expect("place_call");
 
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("offer must be sent")
             .expect("waiter");
@@ -2871,7 +2871,7 @@ mod tests {
             "the offer for the surviving devices must be sent"
         );
 
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("offer must be sent")
             .expect("waiter");
@@ -3015,7 +3015,7 @@ mod tests {
             0,
             "hangup must deregister the dormant call"
         );
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("dormant hangup must resolve wait_ended (no engine task to notify it)");
     }
@@ -3033,7 +3033,7 @@ mod tests {
             client.pending_outgoing_calls.lock().unwrap().is_empty(),
             "disconnect must drain dormant outgoing calls"
         );
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("disconnect must resolve a dormant call's wait_ended");
     }
@@ -3106,7 +3106,7 @@ mod tests {
             if client.call_registry().active_count() == 1 {
                 break;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
         assert_eq!(
             client.call_registry().active_count(),
@@ -3124,7 +3124,7 @@ mod tests {
             0,
             "the spawned task must not resurrect a stale entry after cleanup"
         );
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("an aborted-before-poll task must still notify ended via the drop-guard");
     }
@@ -3233,17 +3233,17 @@ mod tests {
             }
         });
         // Let attach_engine reach the gated connect before hanging up.
-        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
 
         handle.hangup().await;
 
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect(
                 "hangup in the connect window must wake wait_ended without the dial completing",
             );
 
-        let res = tokio::time::timeout(std::time::Duration::from_secs(2), attach)
+        let res = tokio::time::timeout(Duration::from_secs(2), attach)
             .await
             .expect("attach_engine must return once hangup aborts the dial")
             .expect("attach task");
@@ -3310,18 +3310,18 @@ mod tests {
             }
         });
         // Let attach_engine park in the gated connect.
-        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
 
         // A disconnect clears the task-less registry entry, whose on_terminal hook wakes `ended`.
         client.call_registry().abort_all();
 
-        tokio::time::timeout(std::time::Duration::from_secs(2), ended.wait())
+        tokio::time::timeout(Duration::from_secs(2), ended.wait())
             .await
             .expect(
                 "a disconnect in the connect window must wake `ended` without the dial completing",
             );
 
-        let res = tokio::time::timeout(std::time::Duration::from_secs(2), attach)
+        let res = tokio::time::timeout(Duration::from_secs(2), attach)
             .await
             .expect("attach_engine must return once the disconnect aborts the dial")
             .expect("attach task");
@@ -3380,16 +3380,16 @@ mod tests {
                 .await
             }
         });
-        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
 
         // The peer terminal-stanza path (no pending entry; entry has no media task yet).
         terminate_call(&client, "CID-FACADE");
 
-        tokio::time::timeout(std::time::Duration::from_secs(2), ended.wait())
+        tokio::time::timeout(Duration::from_secs(2), ended.wait())
             .await
             .expect("a peer terminate in the connect window must wake `ended`");
 
-        let res = tokio::time::timeout(std::time::Duration::from_secs(2), attach)
+        let res = tokio::time::timeout(Duration::from_secs(2), attach)
             .await
             .expect("attach_engine must return once the terminate aborts the dial")
             .expect("attach task");
@@ -3555,7 +3555,7 @@ mod tests {
             0,
             "a setup error in attach_outgoing_relay must reap the registry generation"
         );
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("a setup error must resolve the handle's wait_ended, not hang it");
     }
@@ -3578,7 +3578,7 @@ mod tests {
             matches!(res, Ok(true)),
             "a superseded attach returns Ok(true)"
         );
-        tokio::time::timeout(std::time::Duration::from_secs(2), handle.wait_ended())
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("a superseded attach must resolve the handle's wait_ended, not hang it");
     }
@@ -3624,7 +3624,7 @@ mod tests {
             {
                 break;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
         assert!(
             !client
@@ -3875,7 +3875,7 @@ mod tests {
         let (vsrc, vsink) = video_endpoints();
         let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
         handle.start_video(vsrc, vsink).await.expect("start_video");
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("upgrade request must be sent")
             .expect("waiter");
@@ -3993,7 +3993,7 @@ mod tests {
             2,
             "accept_video sends UpgradeAccept then Enabled"
         );
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("accept must be sent")
             .expect("waiter");
@@ -4188,7 +4188,7 @@ mod tests {
 
         let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
         handle.stop_video().await.expect("stop_video");
-        let node = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("downgrade must be sent")
             .expect("waiter");
@@ -4288,7 +4288,7 @@ mod tests {
         );
 
         src_tx.send(vec![1, 2, 3]).await.expect("feed source");
-        let got = tokio::time::timeout(std::time::Duration::from_secs(2), in_rx.recv())
+        let got = tokio::time::timeout(Duration::from_secs(2), in_rx.recv())
             .await
             .expect("AU must be forwarded")
             .expect("channel open");
@@ -4300,7 +4300,7 @@ mod tests {
         ended.notify();
         tokio::task::yield_now().await;
         src_tx.send(vec![9, 9, 9]).await.expect("source still open");
-        let after = tokio::time::timeout(std::time::Duration::from_millis(300), in_rx.recv()).await;
+        let after = tokio::time::timeout(Duration::from_millis(300), in_rx.recv()).await;
         assert!(
             after.is_err(),
             "an AU sent after ended must not be forwarded (feed stopped)"

--- a/storages/chat-store/migrations/2026-07-24-000000_bare_identity_keys/down.sql
+++ b/storages/chat-store/migrations/2026-07-24-000000_bare_identity_keys/down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the device that keyed each folded row is not recorded
+-- anywhere, and the rows it produced were unreachable artifacts. Nothing to
+-- restore.

--- a/storages/chat-store/migrations/2026-07-24-000000_bare_identity_keys/up.sql
+++ b/storages/chat-store/migrations/2026-07-24-000000_bare_identity_keys/up.sql
@@ -20,7 +20,10 @@ DELETE FROM chats
         AND messages.chat_jid = chats.jid);
 
 -- Contacts. An existing bare row wins (a live path wrote it with the same or
--- newer data); otherwise the device-keyed names carry over to it.
+-- newer data); otherwise the device-keyed names carry over to it. Two devices
+-- of the same peer can disagree, so the newest row is inserted first and the
+-- rest lose to it — OR IGNORE resolves in SELECT order, which makes the pick
+-- deterministic instead of scan-dependent.
 INSERT OR IGNORE INTO contacts (device_id, jid, push_name, full_name, first_name, business_name)
 SELECT device_id,
        substr(jid, 1, instr(jid, ':') - 1) || substr(jid, instr(jid, '@')),
@@ -29,9 +32,11 @@ SELECT device_id,
        first_name,
        business_name
   FROM contacts
- WHERE jid LIKE '%:%@%';
+ WHERE jid LIKE '%:%@%'
+ ORDER BY rowid DESC;
 
-DELETE FROM contacts WHERE jid LIKE '%:%@%';
+DELETE FROM contacts
+ WHERE jid LIKE '%:%@%';
 
 -- Read-by rows. Highest receipt type per participant wins, the live path's
 -- monotonic rule: drop every row a sibling of the same bare identity beats,
@@ -61,4 +66,5 @@ UPDATE OR IGNORE message_receipts
                   || substr(user_jid, instr(user_jid, '@'))
  WHERE user_jid LIKE '%:%@%';
 
-DELETE FROM message_receipts WHERE user_jid LIKE '%:%@%';
+DELETE FROM message_receipts
+ WHERE user_jid LIKE '%:%@%';

--- a/storages/chat-store/migrations/2026-07-24-000000_bare_identity_keys/up.sql
+++ b/storages/chat-store/migrations/2026-07-24-000000_bare_identity_keys/up.sql
@@ -1,0 +1,64 @@
+-- Fold rows written under a device-suffixed JID (`user:48@lid`) onto the bare
+-- identity every lookup uses.
+--
+-- Receipts were the one event that reached the store with the peer's wire
+-- identity intact, so a companion device's traffic was filed under keys
+-- nothing reads: phantom chat rows, one read-by row per device instead of per
+-- participant, and contact names the bare lookup never finds. The writers
+-- normalize now; this heals what they left behind. A chat, contact or
+-- participant key never legitimately carries a device, so `LIKE '%:%@%'`
+-- selects exactly those artifacts.
+
+-- Phantom chats. Only a receipt could key a chat by device and messages always
+-- landed on the bare thread, so these are empty; the guard keeps a row that
+-- somehow owns messages rather than orphaning them.
+DELETE FROM chats
+ WHERE jid LIKE '%:%@%'
+   AND NOT EXISTS (
+     SELECT 1 FROM messages
+      WHERE messages.device_id = chats.device_id
+        AND messages.chat_jid = chats.jid);
+
+-- Contacts. An existing bare row wins (a live path wrote it with the same or
+-- newer data); otherwise the device-keyed names carry over to it.
+INSERT OR IGNORE INTO contacts (device_id, jid, push_name, full_name, first_name, business_name)
+SELECT device_id,
+       substr(jid, 1, instr(jid, ':') - 1) || substr(jid, instr(jid, '@')),
+       push_name,
+       full_name,
+       first_name,
+       business_name
+  FROM contacts
+ WHERE jid LIKE '%:%@%';
+
+DELETE FROM contacts WHERE jid LIKE '%:%@%';
+
+-- Read-by rows. Highest receipt type per participant wins, the live path's
+-- monotonic rule: drop every row a sibling of the same bare identity beats,
+-- then rename what survives (UPDATE OR IGNORE leaves same-type ties behind,
+-- which the final DELETE clears).
+DELETE FROM message_receipts
+ WHERE EXISTS (
+   SELECT 1 FROM message_receipts s
+    WHERE s.device_id = message_receipts.device_id
+      AND s.chat_jid = message_receipts.chat_jid
+      AND s.msg_id = message_receipts.msg_id
+      AND s.receipt_type > message_receipts.receipt_type
+      AND CASE
+            WHEN instr(s.user_jid, ':') > 0
+            THEN substr(s.user_jid, 1, instr(s.user_jid, ':') - 1)
+                 || substr(s.user_jid, instr(s.user_jid, '@'))
+            ELSE s.user_jid
+          END = CASE
+            WHEN instr(message_receipts.user_jid, ':') > 0
+            THEN substr(message_receipts.user_jid, 1, instr(message_receipts.user_jid, ':') - 1)
+                 || substr(message_receipts.user_jid, instr(message_receipts.user_jid, '@'))
+            ELSE message_receipts.user_jid
+          END);
+
+UPDATE OR IGNORE message_receipts
+   SET user_jid = substr(user_jid, 1, instr(user_jid, ':') - 1)
+                  || substr(user_jid, instr(user_jid, '@'))
+ WHERE user_jid LIKE '%:%@%';
+
+DELETE FROM message_receipts WHERE user_jid LIKE '%:%@%';

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -24,10 +24,15 @@ use crate::store::ChangeSet;
 
 /// Bare 1:1 user chat key — the only namespace with a PN/LID alias. Hosted
 /// and interop namespaces alias differently and are left alone.
+///
+/// A device-suffixed input normalizes rather than being rejected: a peer's
+/// companion device addresses traffic as `user:48@lid`, and every row of that
+/// thread is keyed by the bare identity, so the device must not decide
+/// whether a chat resolves.
 fn user_chat(chat: &str) -> Option<Jid> {
     let jid: Jid = chat.parse().ok()?;
-    (jid.device == 0 && jid.integrator == 0 && matches!(jid.server, Server::Pn | Server::Lid))
-        .then_some(jid)
+    (jid.integrator == 0 && matches!(jid.server, Server::Pn | Server::Lid))
+        .then(|| jid.into_non_ad())
 }
 
 #[derive(QueryableByName)]
@@ -47,6 +52,16 @@ pub(crate) fn counterpart_chat_key(
     let Some(jid) = user_chat(chat) else {
         return Ok(None);
     };
+    counterpart_of(conn, device_id, &jid)
+}
+
+/// [`counterpart_chat_key`] for an already-normalized key, so callers that
+/// need the normalized form themselves don't parse twice.
+fn counterpart_of(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    jid: &Jid,
+) -> QueryResult<Option<String>> {
     let (sql, server) = if jid.is_lid() {
         (
             "SELECT phone_number AS user FROM lid_pn_mapping \
@@ -79,8 +94,11 @@ pub(crate) fn chat_key_candidates(
     device_id: i32,
     chat: &str,
 ) -> QueryResult<Vec<String>> {
-    let mut keys = vec![chat.to_string()];
-    if let Some(alt) = counterpart_chat_key(conn, device_id, chat)? {
+    let Some(jid) = user_chat(chat) else {
+        return Ok(vec![chat.to_string()]);
+    };
+    let mut keys = vec![jid.to_string()];
+    if let Some(alt) = counterpart_of(conn, device_id, &jid)? {
         keys.push(alt);
     }
     Ok(keys)
@@ -90,15 +108,21 @@ pub(crate) fn chat_key_candidates(
 /// `selectChatForOneOnOneMessage` parity: an existing thread keeps its key
 /// whichever identity addressed it; a brand-new chat with a known LID is
 /// keyed by the LID. Rows split across both keys (the state receipts dropped
-/// under the wrong identity leave behind) are merged before routing.
+/// under the wrong identity leave behind) are merged before routing. A
+/// device-suffixed input is normalized even when no counterpart is known, so
+/// a companion device can never materialize a thread of its own.
 pub(crate) fn route_chat_key(
     conn: &mut SqliteConnection,
     device_id: i32,
     wire_chat: &str,
     cs: &mut ChangeSet,
 ) -> QueryResult<String> {
-    let Some(alt) = counterpart_chat_key(conn, device_id, wire_chat)? else {
+    let Some(jid) = user_chat(wire_chat) else {
         return Ok(wire_chat.to_string());
+    };
+    let key = jid.to_string();
+    let Some(alt) = counterpart_of(conn, device_id, &jid)? else {
+        return Ok(key);
     };
     let existing: Vec<String> = {
         use schema::chats::dsl;
@@ -106,19 +130,16 @@ pub(crate) fn route_chat_key(
             .filter(
                 dsl::device_id
                     .eq(device_id)
-                    .and(dsl::jid.eq_any([wire_chat, alt.as_str()])),
+                    .and(dsl::jid.eq_any([key.as_str(), alt.as_str()])),
             )
             .select(dsl::jid)
             .load(conn)?
     };
-    match (
-        existing.iter().any(|j| j == wire_chat),
-        existing.contains(&alt),
-    ) {
-        (true, true) => merge_split_chat(conn, device_id, wire_chat, &alt, cs),
-        (true, false) => Ok(wire_chat.to_string()),
+    match (existing.contains(&key), existing.contains(&alt)) {
+        (true, true) => merge_split_chat(conn, device_id, &key, &alt, cs),
+        (true, false) => Ok(key),
         (false, true) => Ok(alt),
-        (false, false) => Ok(lid_side(wire_chat, &alt).to_string()),
+        (false, false) => Ok(lid_side(&key, &alt).to_string()),
     }
 }
 

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -309,7 +309,9 @@ impl ChatStore {
     pub async fn contact(&self, jid: &Jid) -> Result<Option<ContactEntry>> {
         use schema::contacts::dsl;
         let device_id = self.device_id();
-        let jid_str = jid.to_string();
+        // Bare key, matching how the writers file contacts: a caller holding a
+        // message's `sender` has the device on it.
+        let jid_str = jid.to_non_ad_string();
         let row: Option<ContactRow> = self
             .db()
             .run(move |conn| {

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -3,6 +3,7 @@
 //! (one transaction per drained batch), so event order is preserved and fan-in
 //! bursts don't pay per-event commit costs.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -1255,7 +1256,11 @@ fn apply_receipt(
     receipt: &wacore::types::events::Receipt,
     cs: &mut ChangeSet,
 ) -> QueryResult<()> {
-    let chat = receipt.source.chat.to_string();
+    // Receipts are the one event that carries the peer's wire identity
+    // verbatim: the parser keeps the device on `chat` because the retry
+    // pipeline and the receipt echo need the full JID, so a companion device
+    // acking a DM arrives as `user:48@lid`. Rows are keyed bare.
+    let chat = receipt.source.chat.to_non_ad_string();
     let ts_ms = receipt.timestamp.timestamp_millis();
 
     let status = match receipt.r#type {
@@ -1326,7 +1331,9 @@ fn apply_receipt(
         _ => return Ok(()),
     };
 
-    let user = receipt.source.sender.to_string();
+    // One read-by row per participant, not per device: a member reading on
+    // their phone and on Web emits one receipt each.
+    let user = receipt.source.sender.to_non_ad_string();
     let mut missed: Vec<&String> = Vec::new();
     for msg_id in &receipt.message_ids {
         // Peer receipts only ever advance the delivery state of our own
@@ -1909,6 +1916,20 @@ pub(crate) fn merge_chat_metadata(
     Ok(())
 }
 
+/// Contacts are keyed by the peer's bare identity, the canonical form
+/// [`ChatStore::contact`] looks up. Message senders keep their device by
+/// design (a peer texting from WhatsApp Web is `user:48@lid`), so writing the
+/// sender verbatim would file the name under a key nothing ever reads.
+fn contact_key(jid: &str) -> Cow<'_, str> {
+    match jid.parse::<Jid>() {
+        // Bare already renders identically; only pay the allocation otherwise.
+        Ok(parsed) if parsed.device != 0 || parsed.agent != 0 => {
+            Cow::Owned(parsed.to_non_ad_string())
+        }
+        _ => Cow::Borrowed(jid),
+    }
+}
+
 fn upsert_contact_push_name(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1916,10 +1937,11 @@ fn upsert_contact_push_name(
     push_name: &str,
 ) -> QueryResult<()> {
     use schema::contacts::dsl;
+    let jid = contact_key(jid);
     diesel::insert_into(dsl::contacts)
         .values((
             dsl::device_id.eq(device_id),
-            dsl::jid.eq(jid),
+            dsl::jid.eq(&jid),
             dsl::push_name.eq(push_name),
         ))
         .on_conflict((dsl::device_id, dsl::jid))
@@ -1936,10 +1958,11 @@ fn upsert_contact_business_name(
     business_name: &str,
 ) -> QueryResult<()> {
     use schema::contacts::dsl;
+    let jid = contact_key(jid);
     diesel::insert_into(dsl::contacts)
         .values((
             dsl::device_id.eq(device_id),
-            dsl::jid.eq(jid),
+            dsl::jid.eq(&jid),
             dsl::business_name.eq(business_name),
         ))
         .on_conflict((dsl::device_id, dsl::jid))
@@ -1957,10 +1980,11 @@ fn upsert_contact_names(
     first_name: Option<&str>,
 ) -> QueryResult<()> {
     use schema::contacts::dsl;
+    let jid = contact_key(jid);
     diesel::insert_into(dsl::contacts)
         .values((
             dsl::device_id.eq(device_id),
-            dsl::jid.eq(jid),
+            dsl::jid.eq(&jid),
             dsl::full_name.eq(full_name),
             dsl::first_name.eq(first_name),
         ))

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3183,3 +3183,376 @@ async fn merge_keeps_strictly_newer_edit_across_sides() {
     assert_eq!(ce2.text.as_deref(), Some("lid mais nova"));
     assert_eq!(ce2.edited_at.map(|t| t.timestamp()), Some(1_700_000_080));
 }
+
+// ── Companion-device (device-suffixed) identities (issue #1095) ─────────────
+
+/// A peer's linked device as the binary decoder yields it: `user:48@lid`,
+/// carrying the LID domain-type byte in `agent`.
+fn companion(user: &str, device: u16) -> Jid {
+    Jid {
+        user: user.into(),
+        server: wacore_binary::Server::Lid,
+        agent: 1,
+        device,
+        integrator: 0,
+    }
+}
+
+fn peer_receipt(source: Jid, ids: Vec<&str>, ty: ReceiptType, ts: i64) -> Event {
+    Event::Receipt(
+        Receipt::builder()
+            .source(MessageSource {
+                chat: source.clone(),
+                sender: source,
+                ..Default::default()
+            })
+            .message_ids(ids.into_iter().map(String::from).collect())
+            .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+            .r#type(ty)
+            .offline(false)
+            .build(),
+    )
+}
+
+/// A fresh LID-only thread has no counterpart to fall back to, so the direct
+/// match has to succeed on the normalized key.
+#[tokio::test]
+async fn companion_device_receipt_advances_status() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid("10203040506070@lid");
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-AD-1",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    feed(
+        &chat_store,
+        [peer_receipt(
+            companion("10203040506070", 48),
+            vec!["OUT-AD-1"],
+            ReceiptType::Delivered,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&chat, "OUT-AD-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Delivered);
+    // The receipt keyed no thread of its own.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, chat);
+}
+
+/// Multi-device emits the read once, from whichever device read first. The
+/// primary never re-sends it, so a companion read has to land.
+#[tokio::test]
+async fn companion_read_advances_past_primary_delivered() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid("10203040506070@lid");
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-AD-2",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    feed(
+        &chat_store,
+        [
+            peer_receipt(
+                chat.clone(),
+                vec!["OUT-AD-2"],
+                ReceiptType::Delivered,
+                1_700_000_200,
+            ),
+            peer_receipt(
+                companion("10203040506070", 48),
+                vec!["OUT-AD-2"],
+                ReceiptType::Read,
+                1_700_000_300,
+            ),
+        ],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&chat, "OUT-AD-2")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+/// Device-suffixed *and* addressed by the identity the rows are not keyed
+/// under: normalization has to happen before the alternate-key retry, or the
+/// mapping is never consulted.
+#[tokio::test]
+async fn companion_receipt_resolves_across_pn_lid_mapping() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-AD-3",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    add_lid_mapping(&store).await;
+
+    feed(
+        &chat_store,
+        [peer_receipt(
+            companion("111000011112222", 12),
+            vec!["OUT-AD-3"],
+            ReceiptType::Read,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&jid(PEER), "OUT-AD-3")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1);
+    assert_eq!(chats[0].jid, jid(PEER));
+}
+
+/// A self receipt carrying a device must recount the real thread instead of
+/// materializing a twin of it.
+#[tokio::test]
+async fn companion_read_self_recounts_the_real_chat() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid("10203040506070@lid");
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("oi"),
+            incoming_info(
+                "10203040506070@lid",
+                "10203040506070@lid",
+                "IN-AD-1",
+                1_700_000_000,
+            ),
+        )],
+    )
+    .await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].unread_count, 1);
+
+    feed(
+        &chat_store,
+        [peer_receipt(
+            companion("10203040506070", 48),
+            vec!["IN-AD-1"],
+            ReceiptType::ReadSelf,
+            1_700_000_100,
+        )],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats.len(), 1, "no phantom chat: {chats:?}");
+    assert_eq!(chats[0].jid, chat);
+    assert_eq!(chats[0].unread_count, 0);
+}
+
+/// Messages keep the device on `sender` by design, so the push name of a peer
+/// texting from WhatsApp Web has to be filed under the bare identity anyway.
+#[tokio::test]
+async fn companion_sender_push_name_lands_on_the_bare_contact() {
+    let (_store, chat_store) = test_store().await;
+    let bare = jid("10203040506070@lid");
+    let device = companion("10203040506070", 48);
+
+    let mut info = MessageInfo {
+        source: MessageSource {
+            chat: bare.clone(),
+            sender: device.clone(),
+            is_from_me: false,
+            ..Default::default()
+        },
+        id: "IN-AD-2".to_string(),
+        timestamp: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        ..Default::default()
+    };
+    info.push_name = "Alice Example".into();
+    feed(&chat_store, [message_event(wa::Message::text("oi"), info)]).await;
+
+    let contact = chat_store.contact(&bare).await.unwrap().unwrap();
+    assert_eq!(contact.push_name.as_deref(), Some("Alice Example"));
+    // And a caller holding the message's `sender` finds the same row.
+    let via_device = chat_store.contact(&device).await.unwrap().unwrap();
+    assert_eq!(via_device.jid, bare);
+}
+
+/// One read-by row per participant, not per device: a member reading on their
+/// phone and on Web emits one receipt each.
+#[tokio::test]
+async fn group_receipts_from_two_devices_keep_one_row_per_participant() {
+    let (_store, chat_store) = test_store().await;
+    let group = jid(GROUP);
+
+    chat_store
+        .record_outgoing(
+            &group,
+            "OUT-G-AD",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    for (device, ty, ts) in [
+        (0u16, ReceiptType::Delivered, 1_700_000_200),
+        (48u16, ReceiptType::Read, 1_700_000_300),
+    ] {
+        feed(
+            &chat_store,
+            [Event::Receipt(
+                Receipt::builder()
+                    .source(MessageSource {
+                        chat: group.clone(),
+                        sender: companion("111000011112222", device),
+                        ..Default::default()
+                    })
+                    .message_ids(vec!["OUT-G-AD".to_string()])
+                    .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+                    .r#type(ty)
+                    .offline(false)
+                    .build(),
+            )],
+        )
+        .await;
+    }
+
+    let receipts = chat_store.receipts(&group, "OUT-G-AD").await.unwrap();
+    assert_eq!(receipts.len(), 1, "{receipts:?}");
+    assert_eq!(receipts[0].user_jid, jid("111000011112222@lid"));
+    assert_eq!(receipts[0].status, MessageStatus::Read);
+}
+
+#[derive(diesel::QueryableByName, Debug)]
+struct JidRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    jid: String,
+}
+
+#[derive(diesel::QueryableByName, Debug)]
+struct ReceiptKeyRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    user_jid: String,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    receipt_type: i32,
+}
+
+/// The heal migration, replayed over rows the pre-fix writers left behind.
+/// Migrations run at open, so the artifacts are seeded afterwards and the
+/// statements re-applied — they are idempotent by construction.
+#[tokio::test]
+async fn migration_folds_device_suffixed_rows() {
+    let (store, _chat_store) = test_store().await;
+
+    store
+        .shared()
+        .run(|conn| {
+            let seed = [
+                // Phantom chat from a read-self, plus the real thread.
+                "INSERT INTO chats (device_id, jid) VALUES (1, '10203040506070:48@lid')",
+                "INSERT INTO chats (device_id, jid) VALUES (1, '10203040506070@lid')",
+                // A device-keyed chat that somehow owns messages is left alone.
+                "INSERT INTO chats (device_id, jid) VALUES (1, '20304050607080:7@lid')",
+                "INSERT INTO messages (device_id, chat_jid, msg_id, sender_jid, timestamp_ms, kind) \
+                 VALUES (1, '20304050607080:7@lid', 'M-1', '', 1, 'text')",
+                // Contact reachable only under the device key…
+                "INSERT INTO contacts (device_id, jid, push_name) VALUES (1, '30405060708090:5@lid', 'Bob')",
+                // …and one whose bare row already exists and must win.
+                "INSERT INTO contacts (device_id, jid, push_name) VALUES (1, '10203040506070:48@lid', 'stale')",
+                "INSERT INTO contacts (device_id, jid, push_name) VALUES (1, '10203040506070@lid', 'Alice')",
+                // Same participant split across phone and Web: Read wins.
+                "INSERT INTO message_receipts (device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms) \
+                 VALUES (1, '120363000000000001@g.us', 'G-1', '111000011112222@lid', 3, 10)",
+                "INSERT INTO message_receipts (device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms) \
+                 VALUES (1, '120363000000000001@g.us', 'G-1', '111000011112222:48@lid', 4, 20)",
+                // Two device rows and no bare row: the highest still survives.
+                "INSERT INTO message_receipts (device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms) \
+                 VALUES (1, '120363000000000001@g.us', 'G-1', '222000011112222:3@lid', 4, 30)",
+                "INSERT INTO message_receipts (device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms) \
+                 VALUES (1, '120363000000000001@g.us', 'G-1', '222000011112222:9@lid', 3, 40)",
+            ];
+            for stmt in seed {
+                diesel::sql_query(stmt)
+                    .execute(conn)
+                    .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            }
+            // Run the file the way the migration harness does, statements and
+            // comments included.
+            diesel::connection::SimpleConnection::batch_execute(
+                conn,
+                include_str!("../migrations/2026-07-24-000000_bare_identity_keys/up.sql"),
+            )
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    let (chats, contacts, receipts) = store
+        .shared()
+        .run(|conn| {
+            let chats: Vec<JidRow> =
+                diesel::sql_query("SELECT jid FROM chats WHERE device_id = 1 ORDER BY jid")
+                    .load(conn)
+                    .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            let contacts: Vec<JidRow> = diesel::sql_query(
+                "SELECT jid || '=' || push_name AS jid FROM contacts WHERE device_id = 1 ORDER BY jid",
+            )
+            .load(conn)
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            let receipts: Vec<ReceiptKeyRow> = diesel::sql_query(
+                "SELECT user_jid, receipt_type FROM message_receipts WHERE device_id = 1 ORDER BY user_jid",
+            )
+            .load(conn)
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))?;
+            Ok((chats, contacts, receipts))
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        chats.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
+        ["10203040506070@lid", "20304050607080:7@lid"]
+    );
+    assert_eq!(
+        contacts.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
+        ["10203040506070@lid=Alice", "30405060708090@lid=Bob"]
+    );
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.user_jid.as_str(), r.receipt_type))
+            .collect::<Vec<_>>(),
+        [("111000011112222@lid", 4), ("222000011112222@lid", 4)]
+    );
+}

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -899,7 +899,7 @@ mod tests {
         reg.set_video_channels("CID", generation, event_tx.clone(), ctl_tx, Box::new(|| {}));
 
         let event = || CallEvent::VideoStateChanged {
-            state: crate::types::call::VideoState::Enabled,
+            state: VideoState::Enabled,
             orientation: None,
             upgrade_token: None,
         };


### PR DESCRIPTION
## Summary

Delivery and read receipts sent by a peer's **companion device** (WhatsApp Web/Desktop, a device-suffixed JID like `10203040506070:48@lid`) never advanced `messages.status`. Reproduced on `main`; the issue's repro test is included verbatim.

`apply_receipt` derived its SQL key from `receipt.source.chat.to_string()`, and receipts are the one event that reaches the store with the peer's wire identity intact — `src/receipt.rs` keeps the device on `chat` because the retry pipeline and the receipt echo need the full JID, while inbound messages normalize (`chat: from.to_non_ad()` in `wacore/src/messages.rs`). So the row lived under `10203040506070@lid`, the receipt rendered `10203040506070:48@lid`, and the UPDATE matched zero rows. The #1083 alternate-key fallback could not rescue it either: `lid::user_chat` was gated on `device == 0`, so `counterpart_chat_key` returned `None` for a device-suffixed key and the miss was silently discarded.

For reads that is permanent rather than delayed. Multi-device emits the read receipt once, from whichever device the user read on first; the primary never re-sends it, so a message read on Web stays below `Read` forever. Official semantics are any-device ("delivered to the recipient's phone **or any of their linked devices**"), and `messages.status` is already a monotonic max, so matching companion receipts is sufficient for parity.

The normalization belongs at the store boundary, not in the parser: `buildBaseReceipt` needs the `to` of an echoed receipt to repeat `from` verbatim or the LID server rejects it for multi-device DMs, and `resolve_retry_chat_info` reads the device off `receipt.source.chat`. WA Web normalizes at match time for the same reason (`fixMsgKeysWithPnMapping` / `getAlternateMsgKey` operate on bare chat keys), which is the model #1083 followed.

Three more defects fall out of the same root, all confirmed before the fix:

- a device-suffixed `read-self` materialized a stray `user:48@lid` chat row, and the unread recount landed on the phantom instead of the real thread;
- one group participant reading on phone and on Web produced two `message_receipts` rows, since the upsert keyed on the device-suffixed `sender`;
- a peer texting from Web wrote its push name under `user:48@lid`, which `ChatStore::contact` (exact lookup) never finds.

## Changes

- **`apply_receipt` keys rows bare.** `chat` and the per-participant `user` both go through `Jid::to_non_ad_string()`, so the direct match, the `ReadSelf` routing and the read-by rows all land on the identity the rows are stored under. Read-by is now one row per member, not per device.
- **`lid::user_chat` normalizes instead of rejecting.** Dropping the `device == 0` gate makes `counterpart_chat_key`, `chat_key_candidates`, `route_chat_key` and `reconcile_chat` device-tolerant even if another AD form slips in later. `counterpart_of` is split out so callers that need the normalized key themselves don't parse twice.
- **`route_chat_key` returns the normalized key even with no counterpart.** Normalizing inside `user_chat` alone is not enough: the no-mapping path returned `wire_chat` verbatim, so a device-suffixed key with no `lid_pn_mapping` row still reached `ensure_chat`. This is what stops the phantom thread.
- **Contacts agree on the bare key on both sides.** A `contact_key` helper normalizes in the three `upsert_contact_*` writers (covering the history-sync call sites, which pass raw strings), and `ChatStore::contact` looks up with `to_non_ad_string()`. The helper only allocates when the JID actually carries a device or agent.
- **New migration `2026-07-24-000000_bare_identity_keys`** folds what the old writers left behind, since none of it self-heals: phantom chats are deleted (guarded by `NOT EXISTS` on `messages`, so a device-keyed row that somehow owns messages is left alone rather than orphaned), device-keyed contacts fold onto the bare key with an existing bare row winning, and split read-by rows collapse keeping the highest receipt type — the same monotonic rule `merge_split_chat` already applies. `down.sql` documents that the fold is irreversible: the device that keyed each row is recorded nowhere.

## Coverage

Seven tests in `storages/chat-store/tests/chat_store_test.rs`. Every pre-existing receipt test builds `MessageSource` with bare JIDs, which is why the otherwise thorough #1083 coverage did not catch this.

- `companion_device_receipt_advances_status` — the issue's repro, deliberately with no `lid_pn_mapping` row: a fresh LID-only thread has no counterpart, so the direct match must succeed on the normalized key.
- `companion_read_advances_past_primary_delivered` — `Read` from a companion after `Delivered` from device 0.
- `companion_receipt_resolves_across_pn_lid_mapping` — device-suffixed *and* addressed by the other identity, which only works if normalization happens before the alternate-key retry.
- `companion_read_self_recounts_the_real_chat` — unread recount on the real thread, no phantom row.
- `companion_sender_push_name_lands_on_the_bare_contact` — including that a caller holding the message's `sender` still finds the row.
- `group_receipts_from_two_devices_keep_one_row_per_participant`.
- `migration_folds_device_suffixed_rows` — seeds the artifacts and replays `up.sql` through `batch_execute` (the file is run exactly as the migration harness runs it), covering the guarded phantom chat, the bare-row-wins contact fold, and both the bare-plus-device and device-only receipt splits.

## Validation

```
cargo fmt --all --check
cargo clippy -p whatsapp-rust-chat-store --all-targets --all-features -- -D warnings
cargo test -p whatsapp-rust-chat-store --all-features   # 69 passed
RUSTDOCFLAGS="-D warnings" cargo doc -p whatsapp-rust-chat-store --no-deps
```

Full matrix left to CI.

Fixes #1095.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ur24DTyLiy2NuR1HhTJ9AE)_