### PR TITLE
refactor(errors): make the public error surface recoverable without string matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "syn 3.0.3",
  "thiserror 2.0.19",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,9 @@ hmac = { workspace = true }
 libc = "0.2"
 metrics-exporter-prometheus = "0.18"
 sha2 = { workspace = true }
+# Parses the crate sources in tests/error_surface.rs. Text scanning silently
+# missed error enums whose doc comments carried unbalanced braces.
+syn = { version = "3.0", features = ["full", "parsing"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -89,7 +89,7 @@ pub enum BotBuilderError {
     /// Initializing the device row in the storage backend failed.
     #[error("failed to initialize the device store: {0}")]
     Store(#[from] StoreError),
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientBuilderError),
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -569,9 +569,9 @@ pub enum ClientError {
     #[error("IQ request failed: {0}")]
     Iq(#[from] crate::request::IqError),
     /// Last-resort catch-all for internal failures threaded through `?` that do
-    /// not (yet) have a dedicated variant. Transparent so the underlying
-    /// error's `Display`/source chain is preserved.
-    #[error(transparent)]
+    /// not (yet) have a dedicated variant. `Display` forwards to the inner
+    /// error while `source()` still exposes it for downcast.
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 
@@ -625,7 +625,7 @@ pub enum ConnectError {
     #[error("failed to open transport")]
     Transport(#[source] anyhow::Error),
     /// The noise handshake failed after the transport was up.
-    #[error(transparent)]
+    #[error("{0}")]
     Handshake(#[from] handshake::HandshakeError),
 }
 
@@ -650,7 +650,7 @@ pub enum SignalMaintenanceError {
     #[error("IQ request failed: {0}")]
     Iq(#[from] crate::request::IqError),
     /// A Signal primitive failed (e.g. signing the new signed pre-key).
-    #[error(transparent)]
+    #[error("{0}")]
     Signal(#[from] wacore::libsignal::protocol::SignalProtocolError),
     /// The inbound drain batch could not be committed, so the Signal cache was
     /// left unflushed on purpose and the server redelivers those messages.

--- a/src/client.rs
+++ b/src/client.rs
@@ -664,6 +664,23 @@ pub enum SignalMaintenanceError {
     DrainShuttingDown,
 }
 
+impl ConnectError {
+    /// A step of the connect flow ran out of time.
+    ///
+    /// Matched exhaustively so a new variant has to be classified here rather
+    /// than defaulting to "not a timeout" unnoticed.
+    pub fn is_timeout(&self) -> bool {
+        match self {
+            ConnectError::Timeout { .. } => true,
+            ConnectError::Handshake(handshake) => handshake.is_timeout(),
+            ConnectError::AlreadyConnected
+            | ConnectError::NotActivated
+            | ConnectError::Version(_)
+            | ConnectError::Transport(_) => false,
+        }
+    }
+}
+
 impl ClientError {
     pub fn is_transport_unavailable(&self) -> bool {
         match self {

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -36,7 +36,7 @@ impl Client {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum CallError {
-    #[error(transparent)]
+    #[error("{0}")]
     Send(#[from] ClientError),
     #[error("call_id cannot be empty")]
     EmptyCallId,

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,14 @@
 //! It is a read-only view over the existing errors. It defines no new error
 //! type, and the per-domain enums remain the return types.
 //!
+//! # Rendering
+//!
+//! A wrapping variant renders exactly what it wraps, so each error's own
+//! `Display` is unchanged. A caller that concatenates the whole chain will see
+//! consecutive nodes repeat the same sentence, which is the cosmetic price of
+//! keeping the wrapped error downcastable. Print the innermost cause, or
+//! collapse equal neighbours, rather than joining every node.
+//!
 //! # Scope
 //!
 //! Only questions the crate already answers internally are exposed. There is
@@ -125,7 +133,10 @@ pub trait ErrorChainExt {
         self.sources().find_map(server_rejection_of)
     }
 
-    /// Whether a request went out and no answer came back in time.
+    /// Whether the operation ran out of time waiting for the server.
+    ///
+    /// Covers a request that got no answer and a connect or handshake step
+    /// that never completed.
     fn is_timeout(&self) -> bool {
         self.sources().any(|cause| {
             matches!(
@@ -134,6 +145,12 @@ pub trait ErrorChainExt {
             ) || matches!(
                 cause.downcast_ref::<CoreIqError>(),
                 Some(CoreIqError::Timeout)
+            ) || matches!(
+                cause.downcast_ref::<crate::client::ConnectError>(),
+                Some(crate::client::ConnectError::Timeout { .. })
+            ) || matches!(
+                cause.downcast_ref::<crate::handshake::HandshakeError>(),
+                Some(crate::handshake::HandshakeError::Timeout)
             )
         })
     }
@@ -154,11 +171,9 @@ pub trait ErrorChainExt {
             if let Some(encrypt) = cause.downcast_ref::<crate::socket::error::EncryptSendError>() {
                 return encrypt.is_transport_unavailable();
             }
-            matches!(
-                cause.downcast_ref::<CoreIqError>(),
-                Some(CoreIqError::NotConnected | CoreIqError::Disconnected(_))
-                    | Some(CoreIqError::InternalChannelClosed)
-            )
+            cause
+                .downcast_ref::<CoreIqError>()
+                .is_some_and(CoreIqError::is_transport_unavailable)
         })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,45 +1,11 @@
 //! Typed recovery over the error chain.
 //!
-//! Every public error in this crate is a `thiserror` enum whose wrapping
-//! variants keep the error they wrap reachable through
-//! [`std::error::Error::source`]. That makes the failure recoverable by type,
-//! but only if the caller is willing to write a chain walk and to know which
-//! concrete types can carry a given fact. Two types carry a server rejection
-//! ([`wacore::request::IqError`] and [`crate::request::IqError`]) and a third
-//! ([`wacore::request::ServerErrorCode`]) exists purely to move one across a
-//! crate boundary, so that walk is neither short nor obvious.
-//!
-//! [`ErrorChainExt`] is that walk, written once. It is an extension trait with
-//! a blanket impl over [`std::error::Error`], so a domain error added tomorrow
-//! answers these questions without implementing anything: the guarantee comes
-//! from the chain being lossless, not from per-enum bookkeeping.
-//!
-//! It is a read-only view over the existing errors. It defines no new error
-//! type, and the per-domain enums remain the return types.
-//!
-//! # Rendering
-//!
-//! A wrapping variant renders exactly what it wraps, so each error's own
-//! `Display` is unchanged. A caller that concatenates the whole chain will see
-//! consecutive nodes repeat the same sentence, which is the cosmetic price of
-//! keeping the wrapped error downcastable. Print the innermost cause, or
-//! collapse equal neighbours, rather than joining every node.
-//!
-//! # Scope
-//!
-//! Only questions the crate already answers internally are exposed. There is
-//! deliberately no "invalid input", "protocol violation" or "internal" query:
-//! each domain spells those as its own `InvalidRequest(String)`-style variant
-//! with no shared representation, so any such split would be invented here
-//! rather than recovered. [`crate::features::MexError::ExtensionError`] is
-//! likewise not reported as a server rejection: its `code` is a GraphQL
-//! extension code, a different space from the IQ `code` attribute, and merging
-//! the two would make the number meaningless.
-//!
-//! # Cost
-//!
-//! Nothing runs unless a caller asks, on an error value it already holds. The
-//! walk borrows; it allocates nothing and formats nothing.
+//! [`ErrorChainExt`] answers a few questions about any error without the caller
+//! knowing its concrete type, so it need not walk [`std::error::Error::source`]
+//! itself nor learn that three different types can carry a server rejection. It
+//! is a read-only view with a blanket impl: a domain error added later answers
+//! the same questions without implementing anything, and no new error type or
+//! parallel hierarchy exists.
 //!
 //! ```no_run
 //! use whatsapp_rust::ErrorChainExt;
@@ -53,17 +19,35 @@
 //! # }
 //! ```
 //!
-//! An `anyhow::Error` needs an annotation to reach the same methods, because
-//! it carries two `AsRef<dyn Error>` impls and both are covered here:
+//! From an `anyhow::Error`, annotate the cast: it carries two
+//! `AsRef<dyn Error>` impls and both are covered here.
 //!
 //! ```no_run
-//! use whatsapp_rust::ErrorChainExt;
-//!
+//! # use whatsapp_rust::ErrorChainExt;
 //! # fn demo(err: whatsapp_rust::anyhow::Error) {
 //! let cause: &(dyn std::error::Error + 'static) = err.as_ref();
 //! let _ = cause.server_rejection();
 //! # }
 //! ```
+//!
+//! # Scope
+//!
+//! Only questions the crate already answers internally are exposed. There is
+//! deliberately no "invalid input", "protocol violation" or "internal" query:
+//! each domain spells those as its own `InvalidRequest(String)`-style variant
+//! with no shared representation, so any such split would be invented here
+//! rather than recovered. [`crate::features::MexError::ExtensionError`] is
+//! likewise not reported as a server rejection: its `code` is a GraphQL
+//! extension code, a different space from the IQ `code` attribute, and merging
+//! the two would make the number meaningless.
+//!
+//! # Rendering
+//!
+//! A wrapping variant renders exactly what it wraps, so each error's own
+//! `Display` is unchanged. A caller that concatenates the whole chain will see
+//! consecutive nodes repeat the same sentence, which is the price of keeping
+//! the wrapped error downcastable. Print the innermost cause, or collapse equal
+//! neighbours, rather than joining every node.
 
 use std::error::Error as StdError;
 
@@ -139,19 +123,18 @@ pub trait ErrorChainExt {
     /// that never completed.
     fn is_timeout(&self) -> bool {
         self.sources().any(|cause| {
-            matches!(
-                cause.downcast_ref::<ClientIqError>(),
-                Some(ClientIqError::Timeout)
-            ) || matches!(
-                cause.downcast_ref::<CoreIqError>(),
-                Some(CoreIqError::Timeout)
-            ) || matches!(
-                cause.downcast_ref::<crate::client::ConnectError>(),
-                Some(crate::client::ConnectError::Timeout { .. })
-            ) || matches!(
-                cause.downcast_ref::<crate::handshake::HandshakeError>(),
-                Some(crate::handshake::HandshakeError::Timeout)
-            )
+            if let Some(iq) = cause.downcast_ref::<ClientIqError>() {
+                return iq.is_timeout();
+            }
+            if let Some(iq) = cause.downcast_ref::<CoreIqError>() {
+                return iq.is_timeout();
+            }
+            if let Some(connect) = cause.downcast_ref::<crate::client::ConnectError>() {
+                return connect.is_timeout();
+            }
+            cause
+                .downcast_ref::<crate::handshake::HandshakeError>()
+                .is_some_and(crate::handshake::HandshakeError::is_timeout)
         })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,227 @@
+//! Typed recovery over the error chain.
+//!
+//! Every public error in this crate is a `thiserror` enum whose wrapping
+//! variants keep the error they wrap reachable through
+//! [`std::error::Error::source`]. That makes the failure recoverable by type,
+//! but only if the caller is willing to write a chain walk and to know which
+//! concrete types can carry a given fact. Two types carry a server rejection
+//! ([`wacore::request::IqError`] and [`crate::request::IqError`]) and a third
+//! ([`wacore::request::ServerErrorCode`]) exists purely to move one across a
+//! crate boundary, so that walk is neither short nor obvious.
+//!
+//! [`ErrorChainExt`] is that walk, written once. It is an extension trait with
+//! a blanket impl over [`std::error::Error`], so a domain error added tomorrow
+//! answers these questions without implementing anything: the guarantee comes
+//! from the chain being lossless, not from per-enum bookkeeping.
+//!
+//! It is a read-only view over the existing errors. It defines no new error
+//! type, and the per-domain enums remain the return types.
+//!
+//! # Scope
+//!
+//! Only questions the crate already answers internally are exposed. There is
+//! deliberately no "invalid input", "protocol violation" or "internal" query:
+//! each domain spells those as its own `InvalidRequest(String)`-style variant
+//! with no shared representation, so any such split would be invented here
+//! rather than recovered. [`crate::features::MexError::ExtensionError`] is
+//! likewise not reported as a server rejection: its `code` is a GraphQL
+//! extension code, a different space from the IQ `code` attribute, and merging
+//! the two would make the number meaningless.
+//!
+//! # Cost
+//!
+//! Nothing runs unless a caller asks, on an error value it already holds. The
+//! walk borrows; it allocates nothing and formats nothing.
+//!
+//! ```no_run
+//! use whatsapp_rust::ErrorChainExt;
+//!
+//! # fn demo(err: whatsapp_rust::features::GroupError) {
+//! if let Some(rejection) = err.server_rejection() {
+//!     eprintln!("server said {}: {}", rejection.code, rejection.text);
+//! } else if err.is_transport_unavailable() {
+//!     eprintln!("offline, will retry");
+//! }
+//! # }
+//! ```
+//!
+//! An `anyhow::Error` needs an annotation to reach the same methods, because
+//! it carries two `AsRef<dyn Error>` impls and both are covered here:
+//!
+//! ```no_run
+//! use whatsapp_rust::ErrorChainExt;
+//!
+//! # fn demo(err: whatsapp_rust::anyhow::Error) {
+//! let cause: &(dyn std::error::Error + 'static) = err.as_ref();
+//! let _ = cause.server_rejection();
+//! # }
+//! ```
+
+use std::error::Error as StdError;
+
+use crate::request::IqError as ClientIqError;
+use wacore::request::{IqError as CoreIqError, ServerErrorCode};
+use wacore::store::error::StoreError;
+
+/// A rejection the server sent in response to a request.
+///
+/// Borrowed from whichever error in the chain carried it, so recovering one
+/// costs no allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ServerRejection<'a> {
+    /// The `code` attribute of the `<error>` node.
+    pub code: u16,
+    /// The `text` attribute; empty when the server sent none.
+    pub text: &'a str,
+    /// XMPP error class from the `type` attribute (e.g. `"wait"` vs
+    /// `"cancel"`); `None` if absent.
+    pub error_type: Option<&'a str>,
+    /// Server-directed retry delay in seconds from the `backoff` attribute;
+    /// `None` if absent.
+    pub backoff: Option<u32>,
+}
+
+/// Iterator over an error and everything reachable from its
+/// [`source`](StdError::source).
+#[derive(Clone)]
+pub struct Sources<'a> {
+    next: Option<&'a (dyn StdError + 'static)>,
+}
+
+impl<'a> Iterator for Sources<'a> {
+    type Item = &'a (dyn StdError + 'static);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.next?;
+        self.next = current.source();
+        Some(current)
+    }
+}
+
+/// Answers a few questions about any error without knowing its concrete type.
+///
+/// Implemented for every [`std::error::Error`]; see the [module
+/// docs](self) for what is deliberately left out.
+pub trait ErrorChainExt {
+    /// The receiver as a trait object, so the provided methods can walk it.
+    #[doc(hidden)]
+    fn as_dyn_error(&self) -> &(dyn StdError + 'static);
+
+    /// This error and every error reachable from it, nearest first.
+    ///
+    /// Use this to recover a domain type this trait does not model.
+    fn sources(&self) -> Sources<'_> {
+        Sources {
+            next: Some(self.as_dyn_error()),
+        }
+    }
+
+    /// The server rejection behind this error, if any.
+    ///
+    /// Reports IQ-level rejections only. See the [module docs](self) for why
+    /// MEX extension errors are excluded.
+    fn server_rejection(&self) -> Option<ServerRejection<'_>> {
+        self.sources().find_map(server_rejection_of)
+    }
+
+    /// Whether a request went out and no answer came back in time.
+    fn is_timeout(&self) -> bool {
+        self.sources().any(|cause| {
+            matches!(
+                cause.downcast_ref::<ClientIqError>(),
+                Some(ClientIqError::Timeout)
+            ) || matches!(
+                cause.downcast_ref::<CoreIqError>(),
+                Some(CoreIqError::Timeout)
+            )
+        })
+    }
+
+    /// Whether the failure was the transport being gone rather than the
+    /// operation being refused.
+    ///
+    /// Mirrors the judgement the send and receive paths already make when
+    /// deciding whether a failure is worth retrying.
+    fn is_transport_unavailable(&self) -> bool {
+        self.sources().any(|cause| {
+            if let Some(client) = cause.downcast_ref::<crate::client::ClientError>() {
+                return client.is_transport_unavailable();
+            }
+            if let Some(iq) = cause.downcast_ref::<ClientIqError>() {
+                return iq.is_transport_unavailable();
+            }
+            if let Some(encrypt) = cause.downcast_ref::<crate::socket::error::EncryptSendError>() {
+                return encrypt.is_transport_unavailable();
+            }
+            matches!(
+                cause.downcast_ref::<CoreIqError>(),
+                Some(CoreIqError::NotConnected | CoreIqError::Disconnected(_))
+                    | Some(CoreIqError::InternalChannelClosed)
+            )
+        })
+    }
+
+    /// The persistence failure behind this error, if any.
+    fn store_failure(&self) -> Option<&StoreError> {
+        self.sources().find_map(|cause| cause.downcast_ref())
+    }
+}
+
+fn server_rejection_of<'a>(cause: &'a (dyn StdError + 'static)) -> Option<ServerRejection<'a>> {
+    if let Some(CoreIqError::ServerError {
+        code,
+        text,
+        error_type,
+        backoff,
+    }) = cause.downcast_ref::<CoreIqError>()
+    {
+        return Some(ServerRejection {
+            code: *code,
+            text,
+            error_type: error_type.as_deref(),
+            backoff: *backoff,
+        });
+    }
+    if let Some(ClientIqError::ServerError {
+        code,
+        text,
+        error_type,
+        backoff,
+    }) = cause.downcast_ref::<ClientIqError>()
+    {
+        return Some(ServerRejection {
+            code: *code,
+            text,
+            error_type: error_type.as_deref(),
+            backoff: *backoff,
+        });
+    }
+    let shared = cause.downcast_ref::<ServerErrorCode>()?;
+    Some(ServerRejection {
+        code: shared.code,
+        text: &shared.text,
+        error_type: shared.error_type.as_deref(),
+        backoff: shared.backoff,
+    })
+}
+
+impl<E: StdError + 'static> ErrorChainExt for E {
+    fn as_dyn_error(&self) -> &(dyn StdError + 'static) {
+        self
+    }
+}
+
+impl ErrorChainExt for dyn StdError + 'static {
+    fn as_dyn_error(&self) -> &(dyn StdError + 'static) {
+        self
+    }
+}
+
+// `anyhow::Error` derefs to this shape, so a caller holding one can reach the
+// same answers via `err.as_ref()` without this crate naming `anyhow` in the API.
+impl ErrorChainExt for dyn StdError + Send + Sync + 'static {
+    fn as_dyn_error(&self) -> &(dyn StdError + 'static) {
+        self
+    }
+}

--- a/src/features/blocking.rs
+++ b/src/features/blocking.rs
@@ -16,14 +16,14 @@ use wacore_binary::Jid;
 #[non_exhaustive]
 pub enum BlockingError {
     /// The IQ to the server failed (transport, timeout, server rejection).
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// The target JID is not a user JID, or has no resolvable LID↔PN mapping
     /// (modern WA requires both sides for a block).
     #[error("invalid blocklist target: {0}")]
     InvalidJid(String),
     /// Catch-all for internal failures (e.g. LID/PN store lookup).
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/chat_actions.rs
+++ b/src/features/chat_actions.rs
@@ -29,7 +29,7 @@ pub enum AppStateError {
     #[error("invalid app-state request: {0}")]
     InvalidRequest(String),
     /// Encoding, key lookup, or sending the app-state patch failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/chatstate.rs
+++ b/src/features/chatstate.rs
@@ -12,7 +12,7 @@ use wacore_binary::builder::NodeBuilder;
 #[non_exhaustive]
 pub enum ChatStateError {
     /// Connection/transport failure sending the `<chatstate>` stanza.
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
 }
 

--- a/src/features/community.rs
+++ b/src/features/community.rs
@@ -26,13 +26,13 @@ use wacore_binary::Jid;
 #[non_exhaustive]
 pub enum CommunityError {
     /// A `w:g2` IQ to the server failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// A MEX (GraphQL) metadata query/mutation failed or returned bad data.
-    #[error(transparent)]
+    #[error("{0}")]
     Mex(#[from] MexError),
     /// A delegated group operation failed (e.g. setting the community description).
-    #[error(transparent)]
+    #[error("{0}")]
     Group(#[from] GroupError),
     /// The request was malformed or the server response was missing required data.
     #[error("invalid community request: {0}")]

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -24,7 +24,7 @@ pub use wacore::stanza::business::VerifiedName;
 #[non_exhaustive]
 pub enum ContactError {
     /// The usync/profile IQ to the server failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// An input JID is not supported for this query (only PN and LID are).
     #[error("unsupported contact JID: {0}")]

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -40,10 +40,10 @@ pub use wacore::iq::groups::{
 #[non_exhaustive]
 pub enum GroupError {
     /// A `w:g2` IQ to the server failed (transport, timeout, server rejection).
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// A MEX (GraphQL) group-property mutation failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Mex(#[from] MexError),
     /// The request was malformed (e.g. empty invite code, batch over the limit,
     /// expired V4 invite, non-group JID where one is required).
@@ -57,7 +57,7 @@ pub enum GroupError {
     DescriptionConflict,
     /// Catch-all for internal failures (LID/PN resolution, the protocol-message
     /// send path behind `update_member_label`, cache plumbing).
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/media_reupload.rs
+++ b/src/features/media_reupload.rs
@@ -31,7 +31,7 @@ const MEDIA_REUPLOAD_CONCURRENCY: usize = 32;
 #[non_exhaustive]
 pub enum MediaReuploadError {
     /// Connection/transport failure sending the server-error receipt.
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
     /// The client is not logged in.
     #[error("client is not logged in")]
@@ -44,7 +44,7 @@ pub enum MediaReuploadError {
     #[error("media retry notification timed out")]
     Timeout,
     /// Catch-all for internal failures (receipt encryption, response parsing).
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -27,20 +27,20 @@ use waproto::whatsapp as wa;
 #[non_exhaustive]
 pub enum NewsletterError {
     /// A MEX (GraphQL) query/mutation failed or returned malformed data.
-    #[error(transparent)]
+    #[error("{0}")]
     Mex(#[from] MexError),
     /// An IQ (message history, live updates) failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// Connection/transport failure sending a plaintext stanza (edit/revoke).
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
     /// The request was malformed (e.g. a non-newsletter JID, an empty target
     /// message id, or a missing element in the server response).
     #[error("invalid newsletter request: {0}")]
     InvalidRequest(String),
     /// Catch-all for internal failures with no dedicated variant.
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -17,7 +17,7 @@ pub use wacore::poll::PollVoteCiphertext;
 #[non_exhaustive]
 pub enum PollError {
     /// Sending the poll/vote stanza failed (embeds the send path error).
-    #[error(transparent)]
+    #[error("{0}")]
     Send(#[from] SendError),
     /// The poll definition is invalid (option count, duplicate names, bad
     /// quiz index, selectable count out of range).

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -13,10 +13,10 @@ pub enum PresenceError {
     #[error("cannot send presence without a push name set")]
     PushNameEmpty,
     /// Connection/transport failure sending the `<presence>` stanza.
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
     /// Catch-all for internal failures with no dedicated variant.
-    #[error(transparent)]
+    #[error("{0}")]
     Other(#[from] anyhow::Error),
 }
 

--- a/src/features/profile.rs
+++ b/src/features/profile.rs
@@ -19,16 +19,16 @@ pub use wacore::iq::contacts::SetProfilePictureResponse;
 #[non_exhaustive]
 pub enum ProfileError {
     /// An IQ to the server failed (status text / profile picture).
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// Connection/transport failure sending a stanza (push-name presence).
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
     /// A provided argument is invalid (e.g. an empty push name).
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
     /// Catch-all for internal failures with no dedicated variant.
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -22,7 +22,7 @@ use crate::client::Client;
 #[non_exhaustive]
 pub enum SignalError {
     /// A Signal protocol primitive (encrypt/decrypt/session) failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Protocol(#[from] SignalProtocolError),
     /// The requested operation is not valid for this input (e.g. a sender-key
     /// or message-secret envelope passed to the pairwise decrypt path).
@@ -32,7 +32,7 @@ pub enum SignalError {
     #[error("invalid signal input: {0}")]
     InvalidInput(String),
     /// Catch-all for internal failures (device resolution, cache flush).
-    #[error(transparent)]
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/src/features/stanza.rs
+++ b/src/features/stanza.rs
@@ -73,7 +73,7 @@ pub enum StanzaResponseError {
     UnsupportedStanzaClass,
     #[error("failed to encode stanza response")]
     Encoding(#[from] wacore_binary::error::BinaryError),
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
 }
 
@@ -155,7 +155,7 @@ pub enum RetryRequestError {
     MissingLocalIdentity,
     #[error("invalid message stanza")]
     InvalidStanza(#[source] anyhow::Error),
-    #[error(transparent)]
+    #[error("{0}")]
     Client(#[from] ClientError),
     #[error("failed to prepare retry request")]
     Internal(#[from] anyhow::Error),

--- a/src/features/tctoken.rs
+++ b/src/features/tctoken.rs
@@ -32,10 +32,10 @@ use wacore_binary::Jid;
 #[non_exhaustive]
 pub enum TcTokenError {
     /// The IQ requesting tokens from the server failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
     /// A token store (persistence) operation failed.
-    #[error(transparent)]
+    #[error("{0}")]
     Store(#[from] StoreError),
 }
 

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -43,6 +43,23 @@ pub enum HandshakeError {
 }
 
 impl HandshakeError {
+    /// The handshake ran out of time, as opposed to being torn down.
+    ///
+    /// Matched exhaustively so a new variant has to be classified here rather
+    /// than defaulting to "not a timeout" unnoticed.
+    pub fn is_timeout(&self) -> bool {
+        match self {
+            HandshakeError::Timeout => true,
+            HandshakeError::Transport(_)
+            | HandshakeError::Core(_)
+            | HandshakeError::StreamClosed
+            | HandshakeError::Disconnected
+            | HandshakeError::UnexpectedEvent(_) => false,
+        }
+    }
+}
+
+impl HandshakeError {
     /// Transient errors that are expected during reconnect and will resolve
     /// on retry. These never invalidate the cached server static.
     pub fn is_transient(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ pub use client::{ConnectError, ConnectStage, SignalMaintenanceError};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
 pub mod download;
+pub mod error;
+pub use error::{ErrorChainExt, ServerRejection, Sources};
 pub mod handlers;
 pub use handlers::chatstate::ChatStateEvent;
 pub mod handshake;

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -6,17 +6,9 @@ const APP_STATE_KEY_SHARE_SEND_ATTEMPTS: u8 = 3;
 const APP_STATE_KEY_SHARE_SEND_RETRY: std::time::Duration = std::time::Duration::from_secs(1);
 
 fn app_state_key_share_requires_reconnect(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| {
-        cause
-            .downcast_ref::<crate::client::ClientError>()
-            .is_some_and(crate::client::ClientError::is_transport_unavailable)
-            || cause
-                .downcast_ref::<crate::request::IqError>()
-                .is_some_and(crate::request::IqError::is_transport_unavailable)
-            || cause
-                .downcast_ref::<crate::socket::error::EncryptSendError>()
-                .is_some_and(crate::socket::error::EncryptSendError::is_transport_unavailable)
-    })
+    // Annotated because `anyhow::Error` has two `AsRef<dyn Error>` impls.
+    let cause: &(dyn std::error::Error + 'static) = error.as_ref();
+    crate::ErrorChainExt::is_transport_unavailable(cause)
 }
 
 impl Client {

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -66,7 +66,7 @@ pub use wacore::pair_code::{PairCodeError, PairCodeOptions};
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum PairError {
-    #[error(transparent)]
+    #[error("{0}")]
     PairCode(#[from] PairCodeError),
 
     /// The pair-code IQ was rejected by the server.
@@ -590,18 +590,22 @@ mod tests {
     }
 
     #[test]
-    fn pair_error_paircode_transparent_walks_to_curve_error() {
+    fn pair_error_paircode_walks_to_curve_error() {
         use wacore::libsignal::protocol::CurveError;
         // Wrap a wacore PairCodeError that itself carries a CurveError source.
-        // Because PairError::PairCode is `transparent`, walking source() once
-        // skips the transparent layer and lands directly on the CurveError.
         let pe: PairError =
             PairCodeError::EphemeralKeyAgreement(CurveError::NoKeyTypeIdentifier).into();
         assert_eq!(pe.to_string(), "ephemeral key agreement failed");
+        // Hop 1 is the PairCodeError itself: the wrapper no longer erases it.
         let src = std::error::Error::source(&pe).expect("source preserved");
-        let curve = src
+        let pce = src
+            .downcast_ref::<PairCodeError>()
+            .expect("downcasts to PairCodeError");
+        assert!(matches!(pce, PairCodeError::EphemeralKeyAgreement(_)));
+        let curve = std::error::Error::source(pce)
+            .expect("inner source preserved")
             .downcast_ref::<CurveError>()
-            .expect("downcasts to CurveError through transparent wrapper");
+            .expect("downcasts to CurveError");
         assert!(matches!(curve, CurveError::NoKeyTypeIdentifier));
     }
 

--- a/src/plugins/events.rs
+++ b/src/plugins/events.rs
@@ -164,7 +164,7 @@ pub enum PluginEventRouteError {
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum PluginEventSubscribeError {
-    #[error(transparent)]
+    #[error("{0}")]
     Resource(#[from] PluginResourceError),
     #[error("at least one plugin event selector is required")]
     EmptySelectors,
@@ -184,7 +184,7 @@ pub enum PluginEventSubscribeError {
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum PluginEventPublishError {
-    #[error(transparent)]
+    #[error("{0}")]
     Resource(#[from] PluginResourceError),
     #[error("plugin event schema version must be greater than zero")]
     InvalidSchemaVersion,

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -290,18 +290,18 @@ pub enum PluginResourceError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum PluginMessagingError {
-    #[error(transparent)]
+    #[error("{0}")]
     Resource(#[from] PluginResourceError),
-    #[error(transparent)]
+    #[error("{0}")]
     Send(#[from] SendError),
 }
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum PluginIqError {
-    #[error(transparent)]
+    #[error("{0}")]
     Resource(#[from] PluginResourceError),
-    #[error(transparent)]
+    #[error("{0}")]
     Iq(#[from] IqError),
 }
 
@@ -2585,7 +2585,7 @@ enum PluginCallbackError {
         "callback timed out after {timeout_seconds:.3} seconds and panicked while being cancelled"
     )]
     TimeoutCancellationPanic { timeout_seconds: f64 },
-    #[error(transparent)]
+    #[error("{0}")]
     Callback(#[from] anyhow::Error),
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -111,6 +111,27 @@ impl IqError {
             _ => false,
         }
     }
+
+    /// The request went out and no answer came back in time.
+    ///
+    /// Matched exhaustively so a new variant has to be classified here rather
+    /// than defaulting to "not a timeout" unnoticed.
+    pub(crate) fn is_timeout(&self) -> bool {
+        match self {
+            IqError::Timeout => true,
+            IqError::NotConnected
+            | IqError::Socket(_)
+            | IqError::EncryptSend(_)
+            | IqError::ClientState(_)
+            | IqError::Disconnected(_)
+            | IqError::ServerError { .. }
+            | IqError::UnexpectedResponseType { .. }
+            | IqError::InternalChannelClosed
+            | IqError::DuplicateRequestId(_)
+            | IqError::EncodeError(_)
+            | IqError::ParseError(_) => false,
+        }
+    }
 }
 
 impl From<wacore::request::IqError> for IqError {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -35,8 +35,8 @@ pub enum SendError {
     /// Connection/transport/IQ failure (embeds the shared base error).
     // No `#[from]`: the manual `From<ClientError>` impl flattens a bare `?` so
     // `NotLoggedIn`/`Iq` stay matchable instead of nesting under `Client(..)`.
-    #[error(transparent)]
-    Client(ClientError),
+    #[error("{0}")]
+    Client(#[source] ClientError),
     /// The client has no PN/LID identity yet (not paired / mid LID migration).
     #[error("client is not logged in")]
     NotLoggedIn,
@@ -48,9 +48,9 @@ pub enum SendError {
     #[error("invalid send request: {0}")]
     InvalidRequest(String),
     /// Catch-all for internal send failures (Signal encrypt, protobuf, group
-    /// resolution) that have no dedicated variant yet. Transparent so the
-    /// underlying error's `Display`/source chain is preserved.
-    #[error(transparent)]
+    /// resolution) that have no dedicated variant yet. `Display` forwards to
+    /// the inner error while `source()` still exposes it for downcast.
+    #[error("{0}")]
     Internal(#[from] anyhow::Error),
 }
 

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -7,6 +7,10 @@
 
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use whatsapp_rust::client::{ConnectError, ConnectStage};
+use whatsapp_rust::handshake::HandshakeError;
 
 use wacore::request::{IqError as CoreIqError, ServerErrorCode};
 use wacore::store::error::StoreError;
@@ -79,6 +83,12 @@ fn is_error_enum(lines: &[&str], index: usize) -> bool {
 /// `#[error(transparent)]` delegates `source()` to the *wrapped error's own*
 /// source, so a wrapped leaf disappears from the chain entirely and can never
 /// be downcast. `#[error("{0}")]` renders identically and keeps it reachable.
+///
+/// This is a blanket policy, deliberately wider than the reported symptom: it
+/// covers private enums too, because today's private error is tomorrow's public
+/// one and the attribute is invisible at the point where it hurts. Waiving it
+/// for a case where erasure is genuinely wanted is a decision to argue for in
+/// review, not to make silently.
 #[test]
 fn surface_has_no_transparent_error_attribute() {
     let mut offenders = Vec::new();
@@ -294,6 +304,25 @@ fn timeout_is_recovered_across_domains() {
     assert!(ProfileError::Iq(IqError::Timeout).is_timeout());
     assert!(CommunityError::Group(GroupError::Iq(IqError::Timeout)).is_timeout());
     assert!(!GroupError::Iq(rejected(403)).is_timeout());
+}
+
+/// Connect and handshake run out of time without any `IqError` involved, and
+/// the crate already tells those apart from every other connect failure.
+#[test]
+fn connect_and_handshake_timeouts_are_recovered_too() {
+    let connect = ConnectError::Timeout {
+        stage: ConnectStage::Socket,
+        timeout: Duration::from_secs(10),
+    };
+    assert!(connect.is_timeout());
+    assert!(HandshakeError::Timeout.is_timeout());
+    // Reached through the wrapper as well.
+    assert!(ConnectError::Handshake(HandshakeError::Timeout).is_timeout());
+
+    // Neighbouring failures of the same flow are not timeouts.
+    assert!(!ConnectError::AlreadyConnected.is_timeout());
+    assert!(!HandshakeError::StreamClosed.is_timeout());
+    assert!(!ConnectError::Handshake(HandshakeError::Disconnected).is_timeout());
 }
 
 #[test]

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -1,0 +1,392 @@
+//! The contract for the public error surface.
+//!
+//! Two kinds of test live here. The `surface_*` ones read the crate sources and
+//! fail on any error type that departs from the pattern, including one added in
+//! a future PR that never touches this file. The rest pin the behaviour that
+//! makes a failure recoverable by type.
+
+use std::error::Error as StdError;
+use std::path::{Path, PathBuf};
+
+use wacore::request::{IqError as CoreIqError, ServerErrorCode};
+use wacore::store::error::StoreError;
+use whatsapp_rust::features::{
+    BlockingError, ChatStateError, CommunityError, ContactError, GroupError, MediaReuploadError,
+    MexError, NewsletterError, PollError, PresenceError, ProfileError, StanzaResponseError,
+    TcTokenError,
+};
+use whatsapp_rust::{ClientError, ErrorChainExt, IqError, SendError, ServerRejection};
+
+// ── Source scan ─────────────────────────────────────────────────────────────
+
+fn rust_sources() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read {dir:?}: {e}"));
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut out = Vec::new();
+    walk(&root.join("src"), &mut out);
+    walk(&root.join("wacore/src"), &mut out);
+    out.sort();
+    out
+}
+
+/// Everything between the previous item and `lines[index]`: attributes and doc
+/// comments, however they are wrapped.
+fn preceding_attributes(lines: &[&str], index: usize) -> String {
+    let mut block = Vec::new();
+    for line in lines[..index].iter().rev() {
+        let trimmed = line.trim_end();
+        let ends_previous_item =
+            trimmed.is_empty() || trimmed.ends_with('}') || trimmed.ends_with(';');
+        if ends_previous_item {
+            break;
+        }
+        block.push(trimmed.trim_start());
+    }
+    block.join("\n")
+}
+
+/// The body of the enum declared at `lines[index]`, by brace balance.
+fn enum_body(lines: &[&str], index: usize) -> String {
+    let mut depth = 0usize;
+    let mut body = Vec::new();
+    for line in &lines[index..] {
+        depth += line.matches('{').count();
+        body.push(*line);
+        depth -= line.matches('}').count();
+        if depth == 0 && !body.is_empty() && body.len() > 1 {
+            break;
+        }
+    }
+    body.join("\n")
+}
+
+/// A `thiserror` enum, identified by its variants rather than by its derive, so
+/// a multi-line `#[derive(..)]` cannot hide one.
+fn is_error_enum(lines: &[&str], index: usize) -> bool {
+    enum_body(lines, index).contains("#[error(")
+}
+
+/// `#[error(transparent)]` delegates `source()` to the *wrapped error's own*
+/// source, so a wrapped leaf disappears from the chain entirely and can never
+/// be downcast. `#[error("{0}")]` renders identically and keeps it reachable.
+#[test]
+fn surface_has_no_transparent_error_attribute() {
+    let mut offenders = Vec::new();
+    for file in rust_sources() {
+        let text = std::fs::read_to_string(&file).expect("read source");
+        for (n, line) in text.lines().enumerate() {
+            if line.trim() == "#[error(transparent)]" {
+                offenders.push(format!("{}:{}", file.display(), n + 1));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "`#[error(transparent)]` erases the wrapped error from the source chain. \
+         Use `#[error(\"{{0}}\")]`, which renders the same text and keeps it \
+         downcastable. Found at:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// A new variant is a breaking change for anyone matching exhaustively unless
+/// the enum is sealed against it.
+#[test]
+fn surface_error_enums_are_non_exhaustive() {
+    let mut offenders = Vec::new();
+    for file in rust_sources() {
+        let text = std::fs::read_to_string(&file).expect("read source");
+        let lines: Vec<&str> = text.lines().collect();
+        for (n, line) in lines.iter().enumerate() {
+            let Some(rest) = line.trim_start().strip_prefix("pub enum ") else {
+                continue;
+            };
+            if is_error_enum(&lines, n)
+                && !preceding_attributes(&lines, n).contains("non_exhaustive")
+            {
+                let name = rest.split(['{', ' ']).next().unwrap_or(rest);
+                offenders.push(format!("{}:{} {}", file.display(), n + 1, name));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "public error enums must be `#[non_exhaustive]` so a new variant is not \
+         a breaking change. Found without it:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn rejected(code: u16) -> IqError {
+    IqError::ServerError {
+        code,
+        text: "forbidden".to_string(),
+        error_type: Some("cancel".to_string()),
+        backoff: None,
+    }
+}
+
+#[track_caller]
+fn assert_source_is<T: StdError + 'static>(err: &(dyn StdError + 'static), what: &str) {
+    let source = err
+        .source()
+        .unwrap_or_else(|| panic!("{what}: source() is None, the wrapped error was erased"));
+    assert!(
+        source.downcast_ref::<T>().is_some(),
+        "{what}: source() is not a {}",
+        std::any::type_name::<T>()
+    );
+}
+
+// ── Every wrapping variant keeps its typed source ───────────────────────────
+
+/// One sample per public variant that wraps a typed error. Complements
+/// [`surface_has_no_transparent_error_attribute`]: the scan proves the
+/// attribute is right, this proves the resulting chain actually is.
+#[test]
+fn wrapping_variants_preserve_their_typed_source() {
+    assert_source_is::<IqError>(&BlockingError::Iq(rejected(403)), "BlockingError::Iq");
+    assert_source_is::<IqError>(&ContactError::Iq(rejected(403)), "ContactError::Iq");
+    assert_source_is::<IqError>(&GroupError::Iq(rejected(403)), "GroupError::Iq");
+    assert_source_is::<IqError>(&NewsletterError::Iq(rejected(403)), "NewsletterError::Iq");
+    assert_source_is::<IqError>(&ProfileError::Iq(rejected(403)), "ProfileError::Iq");
+    assert_source_is::<IqError>(&CommunityError::Iq(rejected(403)), "CommunityError::Iq");
+    assert_source_is::<IqError>(&TcTokenError::Iq(rejected(403)), "TcTokenError::Iq");
+
+    let mex = || MexError::ExtensionError {
+        code: 1,
+        message: "denied".to_string(),
+    };
+    assert_source_is::<MexError>(&GroupError::Mex(mex()), "GroupError::Mex");
+    assert_source_is::<MexError>(&CommunityError::Mex(mex()), "CommunityError::Mex");
+    assert_source_is::<MexError>(&NewsletterError::Mex(mex()), "NewsletterError::Mex");
+
+    let client = || ClientError::NotConnected;
+    assert_source_is::<ClientError>(&PresenceError::Client(client()), "PresenceError::Client");
+    assert_source_is::<ClientError>(&ChatStateError::Client(client()), "ChatStateError::Client");
+    assert_source_is::<ClientError>(&ProfileError::Client(client()), "ProfileError::Client");
+    assert_source_is::<ClientError>(
+        &NewsletterError::Client(client()),
+        "NewsletterError::Client",
+    );
+    assert_source_is::<ClientError>(
+        &MediaReuploadError::Client(client()),
+        "MediaReuploadError::Client",
+    );
+    assert_source_is::<ClientError>(
+        &StanzaResponseError::Client(client()),
+        "StanzaResponseError::Client",
+    );
+    assert_source_is::<ClientError>(&SendError::Client(client()), "SendError::Client");
+
+    assert_source_is::<StoreError>(
+        &TcTokenError::Store(StoreError::DeviceNotFound(1)),
+        "TcTokenError::Store",
+    );
+    assert_source_is::<SendError>(&PollError::Send(SendError::NotLoggedIn), "PollError::Send");
+    assert_source_is::<GroupError>(
+        &CommunityError::Group(GroupError::DescriptionConflict),
+        "CommunityError::Group",
+    );
+}
+
+// ── The reported symptom ────────────────────────────────────────────────────
+
+/// Regression for the original report: a `403` from a group operation was
+/// unrecoverable because `GroupError::Iq` erased the `IqError`.
+#[test]
+fn group_server_rejection_exposes_code_and_text() {
+    let err = GroupError::Iq(rejected(403));
+
+    let rejection = err
+        .server_rejection()
+        .expect("a server rejection is recoverable from a group error");
+    assert_eq!(rejection.code, 403);
+    assert_eq!(rejection.text, "forbidden");
+    assert_eq!(rejection.error_type, Some("cancel"));
+
+    // The same fact is reachable by hand, for a consumer that walks the chain
+    // itself rather than using the trait.
+    let source = StdError::source(&err).expect("source preserved");
+    assert!(matches!(
+        source.downcast_ref::<IqError>(),
+        Some(IqError::ServerError { code: 403, .. })
+    ));
+}
+
+/// The other half of the report: the `409` a group description update gets when
+/// the `prev` token is stale.
+#[test]
+fn group_description_conflict_409_exposes_its_code() {
+    let err = GroupError::Iq(IqError::ServerError {
+        code: 409,
+        text: "conflict".to_string(),
+        error_type: None,
+        backoff: None,
+    });
+    let rejection = err.server_rejection().expect("409 is recoverable");
+    assert_eq!(rejection.code, 409);
+    assert_eq!(rejection.error_type, None);
+}
+
+/// `Display` is unchanged by the switch away from `transparent`: it still
+/// renders the wrapped error verbatim.
+#[test]
+fn wrapping_variants_render_the_wrapped_error_verbatim() {
+    let inner = rejected(403);
+    let rendered = inner.to_string();
+    assert_eq!(GroupError::Iq(rejected(403)).to_string(), rendered);
+    assert_eq!(ProfileError::Iq(rejected(403)).to_string(), rendered);
+    assert_eq!(
+        PresenceError::Client(ClientError::NotConnected).to_string(),
+        ClientError::NotConnected.to_string()
+    );
+}
+
+// ── Domain-agnostic recovery ────────────────────────────────────────────────
+
+/// Goal: code written against one domain works for every other. The helper
+/// below names no concrete error type.
+fn code_of(err: &(dyn StdError + 'static)) -> Option<u16> {
+    err.server_rejection().map(|r: ServerRejection<'_>| r.code)
+}
+
+#[test]
+fn server_rejection_is_recovered_the_same_way_in_every_domain() {
+    let domains: Vec<Box<dyn StdError>> = vec![
+        Box::new(GroupError::Iq(rejected(403))),
+        Box::new(NewsletterError::Iq(rejected(403))),
+        Box::new(ProfileError::Iq(rejected(403))),
+        Box::new(BlockingError::Iq(rejected(403))),
+        Box::new(CommunityError::Iq(rejected(403))),
+        Box::new(ContactError::Iq(rejected(403))),
+        Box::new(TcTokenError::Iq(rejected(403))),
+        // Nested two domains deep.
+        Box::new(CommunityError::Group(GroupError::Iq(rejected(403)))),
+        // Reached through the shared cross-crate carrier instead of an IqError.
+        Box::new(GroupError::Internal(anyhow::Error::new(ServerErrorCode {
+            code: 403,
+            text: "forbidden".to_string(),
+            error_type: None,
+            backoff: None,
+        }))),
+    ];
+    for err in &domains {
+        assert_eq!(code_of(err.as_ref()), Some(403), "failed for {err:?}");
+    }
+}
+
+#[test]
+fn timeout_is_recovered_across_domains() {
+    assert!(GroupError::Iq(IqError::Timeout).is_timeout());
+    assert!(ProfileError::Iq(IqError::Timeout).is_timeout());
+    assert!(CommunityError::Group(GroupError::Iq(IqError::Timeout)).is_timeout());
+    assert!(!GroupError::Iq(rejected(403)).is_timeout());
+}
+
+#[test]
+fn transport_loss_is_recovered_across_domains() {
+    assert!(PresenceError::Client(ClientError::NotConnected).is_transport_unavailable());
+    assert!(NewsletterError::Client(ClientError::NotConnected).is_transport_unavailable());
+    assert!(GroupError::Iq(IqError::NotConnected).is_transport_unavailable());
+    assert!(SendError::Client(ClientError::NotConnected).is_transport_unavailable());
+    // A refusal is not a disconnection.
+    assert!(!GroupError::Iq(rejected(403)).is_transport_unavailable());
+}
+
+#[test]
+fn store_failure_is_recovered_across_domains() {
+    let err = TcTokenError::Store(StoreError::DeviceNotFound(7));
+    assert!(matches!(
+        err.store_failure(),
+        Some(StoreError::DeviceNotFound(7))
+    ));
+    assert!(GroupError::Iq(rejected(403)).store_failure().is_none());
+}
+
+/// A `wacore` error reaches the same answers, so the two `IqError` types are
+/// not a distinction the consumer has to know about.
+#[test]
+fn the_wacore_iq_error_answers_identically() {
+    let core = CoreIqError::ServerError {
+        code: 401,
+        text: "unauthorized".to_string(),
+        error_type: None,
+        backoff: Some(30),
+    };
+    let rejection = core.server_rejection().expect("recoverable");
+    assert_eq!(rejection.code, 401);
+    assert_eq!(rejection.backoff, Some(30));
+    assert!(CoreIqError::Timeout.is_timeout());
+    assert!(CoreIqError::NotConnected.is_transport_unavailable());
+}
+
+/// `Internal(anyhow)` is not a dead end: the head of the `anyhow` chain is
+/// exposed as `source()` and stays downcastable.
+#[test]
+fn internal_anyhow_still_exposes_its_head() {
+    let err = GroupError::Internal(anyhow::Error::new(rejected(403)));
+    let source = StdError::source(&err).expect("anyhow head is exposed");
+    assert!(source.downcast_ref::<IqError>().is_some());
+    assert_eq!(code_of(&err), Some(403));
+}
+
+// ── Categories are recovered, never invented ────────────────────────────────
+
+/// A MEX extension `code` is a GraphQL extension code, a different space from
+/// the IQ `code` attribute. Reporting it as a server rejection would make the
+/// number mean two things.
+#[test]
+fn mex_extension_error_is_not_reported_as_a_server_rejection() {
+    let err = GroupError::Mex(MexError::ExtensionError {
+        code: 403,
+        message: "denied".to_string(),
+    });
+    assert_eq!(err.server_rejection(), None);
+    // It is still recoverable by type, just not under a category it does not
+    // belong to.
+    let source = StdError::source(&err).expect("source preserved");
+    assert!(matches!(
+        source.downcast_ref::<MexError>(),
+        Some(MexError::ExtensionError { code: 403, .. })
+    ));
+}
+
+/// Errors that carry none of the modelled facts answer `None`/`false` rather
+/// than being forced into some bucket.
+#[test]
+fn errors_without_a_modelled_category_report_nothing() {
+    let err = GroupError::InvalidRequest("empty invite code".to_string());
+    assert_eq!(err.server_rejection(), None);
+    assert!(!err.is_timeout());
+    assert!(!err.is_transport_unavailable());
+    assert!(err.store_failure().is_none());
+
+    let conflict = GroupError::DescriptionConflict;
+    assert_eq!(conflict.server_rejection(), None);
+    assert!(!conflict.is_transport_unavailable());
+}
+
+// ── Chain access for facts the trait does not model ─────────────────────────
+
+#[test]
+fn sources_walks_the_whole_chain_nearest_first() {
+    let err = CommunityError::Group(GroupError::Iq(rejected(403)));
+    let chain: Vec<&(dyn StdError + 'static)> = err.sources().collect();
+    assert_eq!(chain.len(), 3, "community -> group -> iq");
+    assert!(chain[0].downcast_ref::<CommunityError>().is_some());
+    assert!(chain[1].downcast_ref::<GroupError>().is_some());
+    assert!(chain[2].downcast_ref::<IqError>().is_some());
+}

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -43,49 +43,76 @@ fn rust_sources() -> Vec<PathBuf> {
     out
 }
 
-/// Everything between the previous item and `lines[index]`: attributes and doc
-/// comments, however they are wrapped.
-fn preceding_attributes(lines: &[&str], index: usize) -> String {
-    let mut block = Vec::new();
-    for line in lines[..index].iter().rev() {
-        let trimmed = line.trim_end();
-        let ends_previous_item =
-            trimmed.is_empty() || trimmed.ends_with('}') || trimmed.ends_with(';');
-        if ends_previous_item {
-            break;
-        }
-        block.push(trimmed.trim_start());
-    }
-    block.join("\n")
-}
-
-/// The body of the enum declared at `lines[index]`, by brace balance.
-fn enum_body(lines: &[&str], index: usize) -> String {
-    let mut depth = 0usize;
-    let mut body = Vec::new();
-    for line in &lines[index..] {
-        depth += line.matches('{').count();
-        body.push(*line);
-        depth -= line.matches('}').count();
-        if depth == 0 && !body.is_empty() && body.len() > 1 {
-            break;
+/// Every `enum` in `text`, including those nested in inline modules.
+fn enums_of(text: &str) -> Vec<syn::ItemEnum> {
+    fn collect(items: &[syn::Item], out: &mut Vec<syn::ItemEnum>) {
+        for item in items {
+            match item {
+                syn::Item::Enum(item) => out.push(item.clone()),
+                syn::Item::Mod(module) => {
+                    if let Some((_, items)) = &module.content {
+                        collect(items, out);
+                    }
+                }
+                _ => {}
+            }
         }
     }
-    body.join("\n")
+    // A parse failure must be loud: silently skipping a file would let an
+    // unchecked error enum through, which is the whole thing this guards.
+    let file = syn::parse_file(text).expect("parse Rust source");
+    let mut out = Vec::new();
+    collect(&file.items, &mut out);
+    out
 }
 
-/// A `thiserror` enum, identified by its variants rather than by its derive, so
-/// a multi-line `#[derive(..)]` cannot hide one.
-fn is_error_enum(lines: &[&str], index: usize) -> bool {
-    enum_body(lines, index).contains("#[error(")
+fn has_attribute(attrs: &[syn::Attribute], name: &str) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident(name))
 }
 
-/// `#[error(transparent)]` delegates `source()` to the *wrapped error's own*
+/// A `thiserror` enum, identified by its variants carrying `#[error(..)]`.
+fn is_error_enum(item: &syn::ItemEnum) -> bool {
+    item.variants
+        .iter()
+        .any(|variant| has_attribute(&variant.attrs, "error"))
+}
+
+/// Names of error enums in `text` that are `pub` and lack `#[non_exhaustive]`.
+fn error_enums_missing_non_exhaustive(text: &str) -> Vec<String> {
+    enums_of(text)
+        .iter()
+        .filter(|item| matches!(item.vis, syn::Visibility::Public(_)))
+        .filter(|item| is_error_enum(item))
+        .filter(|item| !has_attribute(&item.attrs, "non_exhaustive"))
+        .map(|item| item.ident.to_string())
+        .collect()
+}
+
+/// Names of variants in `text` annotated `#[error(transparent)]`.
+fn transparent_variants(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for item in enums_of(text) {
+        for variant in &item.variants {
+            for attr in &variant.attrs {
+                if attr.path().is_ident("error")
+                    && attr
+                        .parse_args::<syn::Ident>()
+                        .is_ok_and(|arg| arg == "transparent")
+                {
+                    out.push(format!("{}::{}", item.ident, variant.ident));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// `#[error(transparent)]` delegates `source()` to the *wrapped error\'s own*
 /// source, so a wrapped leaf disappears from the chain entirely and can never
 /// be downcast. `#[error("{0}")]` renders identically and keeps it reachable.
 ///
 /// This is a blanket policy, deliberately wider than the reported symptom: it
-/// covers private enums too, because today's private error is tomorrow's public
+/// covers private enums too, because today\'s private error is tomorrow\'s public
 /// one and the attribute is invisible at the point where it hurts. Waiving it
 /// for a case where erasure is genuinely wanted is a decision to argue for in
 /// review, not to make silently.
@@ -94,10 +121,8 @@ fn surface_has_no_transparent_error_attribute() {
     let mut offenders = Vec::new();
     for file in rust_sources() {
         let text = std::fs::read_to_string(&file).expect("read source");
-        for (n, line) in text.lines().enumerate() {
-            if line.trim() == "#[error(transparent)]" {
-                offenders.push(format!("{}:{}", file.display(), n + 1));
-            }
+        for variant in transparent_variants(&text) {
+            offenders.push(format!("{} {}", file.display(), variant));
         }
     }
     assert!(
@@ -116,17 +141,8 @@ fn surface_error_enums_are_non_exhaustive() {
     let mut offenders = Vec::new();
     for file in rust_sources() {
         let text = std::fs::read_to_string(&file).expect("read source");
-        let lines: Vec<&str> = text.lines().collect();
-        for (n, line) in lines.iter().enumerate() {
-            let Some(rest) = line.trim_start().strip_prefix("pub enum ") else {
-                continue;
-            };
-            if is_error_enum(&lines, n)
-                && !preceding_attributes(&lines, n).contains("non_exhaustive")
-            {
-                let name = rest.split(['{', ' ']).next().unwrap_or(rest);
-                offenders.push(format!("{}:{} {}", file.display(), n + 1, name));
-            }
+        for name in error_enums_missing_non_exhaustive(&text) {
+            offenders.push(format!("{} {}", file.display(), name));
         }
     }
     assert!(
@@ -135,6 +151,60 @@ fn surface_error_enums_are_non_exhaustive() {
          a breaking change. Found without it:\n  {}",
         offenders.join("\n  ")
     );
+}
+
+// ── The scanner guards itself ───────────────────────────────────────────────
+//
+// Text scanning got both of these wrong: a blank line between the attribute and
+// the declaration hid `#[non_exhaustive]`, and an unbalanced brace in a doc
+// comment truncated the enum so it stopped looking like an error enum at all.
+// The second was fail-open, which is why this is parsed rather than scanned.
+
+#[test]
+fn scanner_sees_attributes_separated_by_a_blank_line() {
+    let source = "#[derive(Debug, thiserror::Error)]\n#[non_exhaustive]\n\npub enum E {\n    #[error(\"x\")]\n    V,\n}";
+    assert!(error_enums_missing_non_exhaustive(source).is_empty());
+}
+
+#[test]
+fn scanner_sees_through_unbalanced_braces_in_doc_comments() {
+    let source = "#[derive(Debug, thiserror::Error)]\npub enum E {\n    /// shape: { \"k\": v }}\n    #[error(\"x\")]\n    V,\n}";
+    assert_eq!(error_enums_missing_non_exhaustive(source), vec!["E"]);
+}
+
+#[test]
+fn scanner_sees_transparent_followed_by_other_text() {
+    let source =
+        "pub enum E {\n    #[error(transparent)] // legacy\n    V(#[from] std::fmt::Error),\n}";
+    assert_eq!(transparent_variants(source), vec!["E::V"]);
+}
+
+#[test]
+fn scanner_reads_a_declaration_whose_header_wraps() {
+    let source =
+        "#[derive(Debug, thiserror::Error)]\npub enum\n    E\n{\n    #[error(\"x\")]\n    V,\n}";
+    assert_eq!(error_enums_missing_non_exhaustive(source), vec!["E"]);
+}
+
+#[test]
+fn scanner_ignores_enums_that_are_not_errors() {
+    // Prose mentioning Error, and a variant named Error, must not be enough.
+    let source = "/// Errors are boxed here.\n#[derive(Debug)]\npub enum Outcome {\n    Value(u8),\n    Error(Box<u8>),\n}";
+    assert!(error_enums_missing_non_exhaustive(source).is_empty());
+}
+
+#[test]
+fn scanner_ignores_private_and_empty_enums_for_non_exhaustive() {
+    let private = "#[derive(Debug, thiserror::Error)]\nenum E {\n    #[error(\"x\")]\n    V,\n}";
+    assert!(error_enums_missing_non_exhaustive(private).is_empty());
+    let empty = "#[derive(Debug)]\npub enum E {}";
+    assert!(error_enums_missing_non_exhaustive(empty).is_empty());
+}
+
+#[test]
+fn scanner_finds_enums_nested_in_modules() {
+    let source = "mod inner {\n    #[derive(Debug, thiserror::Error)]\n    pub enum E {\n        #[error(\"x\")]\n        V,\n    }\n}";
+    assert_eq!(error_enums_missing_non_exhaustive(source), vec!["E"]);
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -133,7 +133,7 @@ pub enum AppStateSyncError {
     KeyNotFound(String),
     #[error("store error")]
     Store(#[from] crate::store::error::StoreError),
-    #[error(transparent)]
+    #[error("{0}")]
     Other(#[from] anyhow::Error),
 }
 

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -28,7 +28,7 @@ pub enum MediaDecryptionError {
     Decryption(#[source] AesCbcDecryptionError),
     #[error("HMAC initialization failed")]
     Mac(#[source] CryptoError),
-    #[error(transparent)]
+    #[error("{0}")]
     Other(#[from] anyhow::Error),
 }
 

--- a/wacore/src/iq/chatstate.rs
+++ b/wacore/src/iq/chatstate.rs
@@ -29,6 +29,7 @@ use wacore_binary::NodeRef;
 
 /// Error type for chatstate parsing failures.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ChatstateParseError {
     /// Stanza has wrong tag (not `<chatstate>`)
     #[error("expected <chatstate>, got <{0}>")]

--- a/wacore/src/iq/dirty.rs
+++ b/wacore/src/iq/dirty.rs
@@ -22,6 +22,7 @@ pub enum DirtyType {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DirtyBitParseError {
     #[error("invalid timestamp '{value}': {source}")]
     InvalidTimestamp {

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -517,6 +517,7 @@ impl PairCodeUtils {
 /// `whatsapp_rust::pair_code::PairError` and adds an IQ-failure variant for the
 /// transport layer.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PairCodeError {
     #[error("phone number is required")]
     PhoneNumberRequired,

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -114,6 +114,21 @@ impl IqError {
             IqError::NotConnected | IqError::Disconnected(_) | IqError::InternalChannelClosed
         )
     }
+
+    /// The request went out and no answer came back in time.
+    ///
+    /// Matched exhaustively so a new variant has to be classified here rather
+    /// than defaulting to "not a timeout" unnoticed.
+    pub fn is_timeout(&self) -> bool {
+        match self {
+            IqError::Timeout => true,
+            IqError::NotConnected
+            | IqError::Disconnected(_)
+            | IqError::ServerError { .. }
+            | IqError::UnexpectedResponseType { .. }
+            | IqError::InternalChannelClosed => false,
+        }
+    }
 }
 
 /// Lightweight server error that can be embedded in `anyhow::Error` and

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -103,6 +103,19 @@ pub enum IqError {
     InternalChannelClosed,
 }
 
+impl IqError {
+    /// The transport is gone rather than the request having been refused.
+    ///
+    /// Sole owner of that judgement for this type: callers that classify an
+    /// error chain read it here instead of restating the variant list.
+    pub fn is_transport_unavailable(&self) -> bool {
+        matches!(
+            self,
+            IqError::NotConnected | IqError::Disconnected(_) | IqError::InternalChannelClosed
+        )
+    }
+}
+
 /// Lightweight server error that can be embedded in `anyhow::Error` and
 /// downcast from any crate. Used as a shared type across crate boundaries
 /// when `wacore::request::IqError` isn't directly available (e.g., errors

--- a/wacore/src/shortcake.rs
+++ b/wacore/src/shortcake.rs
@@ -47,6 +47,7 @@ const ENC_KEY_INFO: &[u8] = b"Pairing Information Encryption Key";
 const VERIFICATION_CODE_BYTES: usize = 5;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ShortcakeError {
     #[error("invalid primary public key: {0}")]
     InvalidPrimaryKey(CurveError),


### PR DESCRIPTION
## Summary

A consumer classifying failures by walking `std::error::Error::source()` got a `403` back from a group operation and could recover neither the code nor the type: `GroupError::Iq` is `#[error(transparent)]`, and `transparent` delegates `source()` to the wrapped error's *own* source. `IqError::ServerError` is a leaf, so the chain ended before it and the typed node vanished, leaving only `Display` text to parse. The same held for the `409` on a group description update.

The fix turns out to be free. `#[error("{0}")]` renders byte-for-byte the same text as `transparent` while keeping the wrapped error reachable as `source()`, so making the chain lossless changes no message anywhere. That is done for all 46 occurrences.

Losslessness alone still leaves every consumer writing a chain walk and knowing that three different types can carry a server rejection (`wacore::request::IqError`, `crate::request::IqError`, and `ServerErrorCode`, which exists only to move one across a crate boundary). `ErrorChainExt` is that walk written once, as an extension trait with a blanket impl over `std::error::Error` — so a domain error added next month answers the same questions without implementing anything.

## Audit

53 public error enums (38 in `src/`, 15 in `wacore/src/`) and 46 `#[error(transparent)]` occurrences, 45 of them on public enums and one on the private `PluginCallbackError`.

Classifying the 46 against "does it hide a typed leaf":

| Class | Count | Verdict |
|---|---|---|
| (a) hides a typed leaf | 33 | Broken. Every non-`anyhow` `transparent` in the crate falls here — each wraps a type whose common variants are leaves (`IqError`, `MexError`, `StoreError`, `ClientError::NotConnected`, `SignalProtocolError`, …). |
| (b) harmless passthrough | 0 | None found. |
| (c) `Internal(#[from] anyhow::Error)` | 13 | Also broken, conditionally. `transparent` skips the `anyhow` head, so a bare `anyhow::Error::new(leaf)` loses the leaf outright; only a `.context()`-wrapped value survives. `context_impl.rs:40` builds exactly the bare form around a `ServerErrorCode`. |

So all 46 were converted, not just the 33. I verified the `thiserror` semantics empirically rather than from the docs, for both the `.context()` and bare cases, before touching the repo.

**`#[non_exhaustive]`**: 4 of the 53 lacked it (`ShortcakeError`, `PairCodeError`, `ChatstateParseError`, `DirtyBitParseError`). Added.

**`anyhow` on the surface**: 31 public variants carry `anyhow::Error` and all 31 stay. The policy this PR sets is that they stop being dead ends rather than being erased: after the change the head of the `anyhow` chain is exposed as `source()` and is downcastable, so a `ServerErrorCode` or `IqError` buried in one is recoverable by type. What a consumer may assume about an `Internal` variant is only that: it is a failure with no dedicated variant yet, whose chain is walkable. Not eradicating them here keeps this batch to the shape of errors, which is what it is about.

**Two `IqError` types**: left as-is. They are not trivially unifiable (the `src` one adds `Socket`, `EncryptSend`, `ClientState`, `Disconnected`, `EncodeError`, `ParseError`), and collapsing them is a separate refactor touching ~49 match sites. What made the duplication a *consumer* problem was having to downcast both; `ErrorChainExt` absorbs that, and a test pins that both answer identically.

## Changes

- Replace all 46 `#[error(transparent)]` with `#[error("{0}")]`, adding `#[source]` to the one field that had neither `#[from]` nor `#[source]` (`SendError::Client`). Each error's own `Display` output is unchanged, which a test asserts.
  - **Migration, chain rendering.** Per-variant `Display` is identical, but the *chain* now renders differently: a wrapping variant prints what it wraps, so code that concatenates every node sees the same sentence repeated. `CommunityError::Group(GroupError::Iq(..))` is three nodes rendering one sentence three times. Avoiding that is precisely what `transparent` bought, and it is the cosmetic price of keeping the wrapped error downcastable. Consumers that join the chain (a `display_chain` helper, a `tracing` layer printing causes) should print the innermost cause or collapse equal neighbours.
- Add `src/error.rs`: `ErrorChainExt`, `ServerRejection<'a>`, `Sources<'a>`, re-exported from the crate root. Read-only view over the existing errors; no new error type, no parallel hierarchy.
- Add `#[non_exhaustive]` to the 4 error enums missing it (`ShortcakeError`, `PairCodeError`, `ChatstateParseError`, `DirtyBitParseError`). **Breaking** for anyone matching them exhaustively outside the crate, which fails to compile with `E0004`. Migration: add a `_ => {}` arm. `PairCodeError` is the one with a known external matcher, so expect that build to need the arm.
- Give `wacore::request::IqError` an `is_transport_unavailable()` method (new public API, non-breaking) and call it, instead of restating its transport variant list at the call site. Its two sibling types already owned that judgement as a method; the inline copy would have diverged in silence if a transport variant were added.
- Give `ConnectError`, `HandshakeError` and both `IqError` types an `is_timeout()` method, each an exhaustive match, instead of restating variant lists at the call site. Same reasoning as the transport fix above: a second timeout variant would otherwise have diverged unnoticed, and an exhaustive match forces a new variant to be classified rather than silently defaulting to false.
- `is_timeout()` also recovers `ConnectError::Timeout` and `HandshakeError::Timeout`. Both are timeouts the crate already distinguishes, so this recovers a distinction rather than inventing one; before, a connect that ran out of time answered `false`.
- Replace the hand-written 3-way downcast walker in `src/message/special.rs` with `ErrorChainExt::is_transport_unavailable`. Behaviour-identical: the only downcast target it adds is `wacore::request::IqError`, which cannot appear in that chain (the sole conversion site, `src/request.rs:116`, maps it into `crate::request::IqError` immediately). The 5 existing assertions for that function pass untouched.
- Update `pair_error_paircode_transparent_walks_to_curve_error` — see below.

### The one test that had to change

`src/pair_code.rs` had a test asserting the *lossy* behaviour by name: it walked one hop from `PairError::PairCode` and expected to land on `CurveError`, "because `PairError::PairCode` is `transparent`". With the wrapper no longer erasing itself, hop 1 is the `PairCodeError` and `CurveError` is hop 2. Rewritten to assert the stronger chain, keeping its `Display` assertion as-is (it still passes, which is itself evidence the text did not move). No other test in the repo needed adapting.

## Guarantees

Given any public error from this crate, without string matching and without knowing the concrete domain enum:

- `server_rejection()` returns the code, text, XMPP error class and backoff of an IQ-level rejection, wherever in the chain it sits and whichever of the three carrier types holds it.
- `is_timeout()` answers the same way, and covers a connect or handshake step that never completed as well as a request that got no answer.
- `is_transport_unavailable()` and `store_failure()` answer the same way.
- The answer is identical across group, newsletter, profile, blocking, community, contacts and tctoken — a test runs one type-agnostic helper over all of them, including two-domain nesting and the `anyhow`-carried case.
- `sources()` exposes the raw chain for anything not modelled above.
- Adding a variant to any error enum does not break consumers.
- No `anyhow`, `serde` or extra runtime is required to use any of this.

Out of contract, deliberately: there is no "invalid input", "protocol violation" or "internal" category. Each domain spells those as its own `InvalidRequest(String)`-style variant with no shared representation, so exposing them would mean inventing a taxonomy rather than recovering one. `MexError::ExtensionError` is not reported by `server_rejection()` either — its `code` is a GraphQL extension code, a different space from the IQ `code` attribute, and merging them would make the number mean two things. A negative test pins both.

## Cost

- **`size_of`**: unchanged for all 51 public error types measurable under `--all-features` (checked before/after; the diff is empty). Expected, since the change is attribute-only and touches no field. Nothing needed boxing.
- **Hot path**: zero. No `format!`, `to_string()` or allocation moved out of a failure branch. `ErrorChainExt` runs only when a caller asks, on an error value it already holds; it borrows and allocates nothing. The single production call site is `special.rs`, already inside an error branch, and it replaced a walk that did strictly more downcasts.
- **Binary size**: left to the `binary-size` job, which measures against the `main` baseline — more trustworthy than two local fat-LTO builds. I will report the delta from the PR comment.

## Validation

```
cargo fmt --all --check
cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings
cargo test -p wacore --lib            # 1220 passed
cargo test -p whatsapp-rust --lib     # 1163 passed
cargo test --tests                    # all green, incl. 23 in tests/error_surface.rs
cargo test --doc -p whatsapp-rust
cargo doc --no-deps -p whatsapp-rust -p wacore
```

Both surface guards were verified to actually fail: reintroducing one `transparent` and removing one `#[non_exhaustive]` fails them, plus 7 behavioural tests independently.

They parse the sources with `syn` rather than scanning them as text, which is a change of mechanism worth calling out. The text version fell to two shapes, both reproduced before being fixed: a blank line between `#[non_exhaustive]` and the declaration hid the attribute (a loud false positive), and an unbalanced brace inside a doc comment truncated the enum body by brace balance, so the enum stopped looking like an error enum and a public one missing `#[non_exhaustive]` **passed the guard in silence**. A guard that backs a "cannot be forgotten later" claim must not fail open. Seven fixtures now pin the shapes that used to defeat it. `syn` is added as a **dev-dependency** and is already in `Cargo.lock` via `wacore/derive`, so this adds a dependency edge and no new crate, and nothing reaches the shipped library.

The no-`transparent` scan is deliberately a blanket policy rather than a narrow fix: it covers private enums too (the private `PluginCallbackError` was converted for that reason), because today's private error is tomorrow's public one and the attribute is invisible at the point where it hurts. A future case where erasure is genuinely wanted should be argued in review, not waived silently.

**Semver Checks** is red, as it is on `main`: it compares against the last *published release*, so it carries every change since then. Of the 10 enums it lists under `enum_marked_non_exhaustive`, this PR is responsible for 3 (`ChatstateParseError`, `DirtyBitParseError`, `PairCodeError`; `ShortcakeError` is the fourth marker added here but does not appear in its output). The other 7 (`AppStateSyncError`, `CallAction`, `HistorySyncError`, `IqError`, `MediaDecryptionError`, `ReceiptType`, `StoreError`) are pre-existing drift: `git diff main...HEAD` shows this branch adds `#[non_exhaustive]` in exactly four files, none of them theirs. The remaining lint categories are likewise untouched by this branch, and the additions it does make (the new `is_timeout`/`is_transport_unavailable` methods and the `error` module) are non-breaking.

Full matrix (incl. wasm32) left to CI.



