### PR TITLE
fix(recv): handle and acknowledge top-level status stanzas

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1334,8 +1334,7 @@ fn encode_ack_bytes(
         None
     };
 
-    // WA Web `sendAck` always stamps the own device JID, and it covers both the
-    // `message` and the `status` stanza class.
+    // WA Web stamps the own device JID for both classes.
     let own_device_pn = if tag == "message" || tag == "status" {
         Some(own_device_pn.ok_or(crate::features::StanzaResponseError::MissingLocalIdentity)?)
     } else {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1334,7 +1334,9 @@ fn encode_ack_bytes(
         None
     };
 
-    let own_device_pn = if tag == "message" {
+    // WA Web `sendAck` always stamps the own device JID, and it covers both the
+    // `message` and the `status` stanza class.
+    let own_device_pn = if tag == "message" || tag == "status" {
         Some(own_device_pn.ok_or(crate::features::StanzaResponseError::MissingLocalIdentity)?)
     } else {
         None

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -3162,7 +3162,7 @@ mod tests {
         use wacore_binary::builder::NodeBuilder;
 
         let client = create_test_client().await;
-        let own_lid = "236395184570386";
+        let own_lid = "100000000000042";
         setup_device_record(&client, own_lid, &[0, 58, 65]).await;
 
         let node = NodeBuilder::new("notification")
@@ -3170,7 +3170,7 @@ mod tests {
             .attr("type", "devices")
             .attr("id", "NOTIF-UPDATE-HASH")
             .attr("t", "1784584925")
-            .children([NodeBuilder::new("update").attr("hash", "FseO").build()])
+            .children([NodeBuilder::new("update").attr("hash", "kcEm").build()])
             .build();
 
         crate::handlers::notification::handle_devices_notification(&client, &node.as_node_ref())
@@ -3195,16 +3195,16 @@ mod tests {
         use wacore_binary::builder::NodeBuilder;
 
         let client = create_test_client().await;
-        let contact_lid = "196314885312593"; // hashes to "TNcq"
+        let contact_lid = "100000000000001"; // hashes to "s7oK"
         setup_lid_pn(&client, contact_lid, "5511999990000").await;
         setup_device_record(&client, contact_lid, &[0, 12]).await;
 
         let node = NodeBuilder::new("notification")
-            .attr("from", "236395184570386@lid")
+            .attr("from", "100000000000042@lid")
             .attr("type", "devices")
             .attr("id", "NOTIF-UPDATE-HASH-2")
             .attr("t", "1784584925")
-            .children([NodeBuilder::new("update").attr("hash", "TNcq").build()])
+            .children([NodeBuilder::new("update").attr("hash", "s7oK").build()])
             .build();
 
         crate::handlers::notification::handle_devices_notification(&client, &node.as_node_ref())
@@ -3228,10 +3228,10 @@ mod tests {
         use wacore_binary::builder::NodeBuilder;
 
         let client = create_test_client().await;
-        setup_lid_pn(&client, "196314885312593", "5511999990000").await;
+        setup_lid_pn(&client, "100000000000001", "5511999990000").await;
 
         let node = NodeBuilder::new("notification")
-            .attr("from", "236395184570386@lid")
+            .attr("from", "100000000000042@lid")
             .attr("type", "devices")
             .attr("id", "NOTIF-UPDATE-HASH-3")
             .attr("t", "1784584925")

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -3151,12 +3151,8 @@ mod tests {
         );
     }
 
-    /// A `<notification type="devices"><update hash="..."/></notification>`
-    /// names a *contact* by hash (WA Web `getContactRecordByHash` →
-    /// `syncDeviceListJob` for that contact); the notification's `from` is our
-    /// own account and its device list is untouched. Wiping our own registry
-    /// here loses every companion device and makes the next message from one of
-    /// them look like an unknown device.
+    /// The hash names a contact; the notification's `from` is our own account,
+    /// whose companion list must survive.
     #[tokio::test]
     async fn hash_only_device_update_keeps_the_notified_users_registry() {
         use wacore_binary::builder::NodeBuilder;
@@ -3187,9 +3183,7 @@ mod tests {
         );
     }
 
-    /// The `hash` resolves to a contact via the LID-PN index, and that contact
-    /// (not the notification's `from`) is the one whose device list must be
-    /// refreshed — WA Web `getContactRecordByHash` → `syncDeviceListJob`.
+    /// The hashed contact, not the notification's `from`, is the one refreshed.
     #[tokio::test]
     async fn hash_only_device_update_refreshes_the_hashed_contact() {
         use wacore_binary::builder::NodeBuilder;
@@ -3221,8 +3215,7 @@ mod tests {
         );
     }
 
-    /// A hash no contact matches must not touch anything: WA Web logs
-    /// "missing side contact hash" and moves on.
+    /// A hash no contact matches must not touch anything.
     #[tokio::test]
     async fn unresolvable_contact_hash_syncs_nothing() {
         use wacore_binary::builder::NodeBuilder;

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -3150,4 +3150,100 @@ mod tests {
                 .is_empty()
         );
     }
+
+    /// A `<notification type="devices"><update hash="..."/></notification>`
+    /// names a *contact* by hash (WA Web `getContactRecordByHash` →
+    /// `syncDeviceListJob` for that contact); the notification's `from` is our
+    /// own account and its device list is untouched. Wiping our own registry
+    /// here loses every companion device and makes the next message from one of
+    /// them look like an unknown device.
+    #[tokio::test]
+    async fn hash_only_device_update_keeps_the_notified_users_registry() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = create_test_client().await;
+        let own_lid = "236395184570386";
+        setup_device_record(&client, own_lid, &[0, 58, 65]).await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("from", format!("{own_lid}@lid"))
+            .attr("type", "devices")
+            .attr("id", "NOTIF-UPDATE-HASH")
+            .attr("t", "1784584925")
+            .children([NodeBuilder::new("update").attr("hash", "FseO").build()])
+            .build();
+
+        crate::handlers::notification::handle_devices_notification(&client, &node.as_node_ref())
+            .await;
+
+        let record = client
+            .device_registry_cache
+            .get(own_lid)
+            .await
+            .expect("a hash-only <update> must not drop the device registry");
+        assert!(
+            record.devices.iter().any(|d| d.device_id == 65),
+            "companion devices must survive a hash-only <update>"
+        );
+    }
+
+    /// The `hash` resolves to a contact via the LID-PN index, and that contact
+    /// (not the notification's `from`) is the one whose device list must be
+    /// refreshed — WA Web `getContactRecordByHash` → `syncDeviceListJob`.
+    #[tokio::test]
+    async fn hash_only_device_update_refreshes_the_hashed_contact() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = create_test_client().await;
+        let contact_lid = "196314885312593"; // hashes to "TNcq"
+        setup_lid_pn(&client, contact_lid, "5511999990000").await;
+        setup_device_record(&client, contact_lid, &[0, 12]).await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("from", "236395184570386@lid")
+            .attr("type", "devices")
+            .attr("id", "NOTIF-UPDATE-HASH-2")
+            .attr("t", "1784584925")
+            .children([NodeBuilder::new("update").attr("hash", "TNcq").build()])
+            .build();
+
+        crate::handlers::notification::handle_devices_notification(&client, &node.as_node_ref())
+            .await;
+
+        let hashed: Jid = format!("{contact_lid}@lid").parse().expect("jid");
+        assert!(
+            client
+                .pending_device_sync
+                .take_all()
+                .await
+                .contains(&hashed),
+            "the hashed contact must be queued for a device-list refresh"
+        );
+    }
+
+    /// A hash no contact matches must not touch anything: WA Web logs
+    /// "missing side contact hash" and moves on.
+    #[tokio::test]
+    async fn unresolvable_contact_hash_syncs_nothing() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = create_test_client().await;
+        setup_lid_pn(&client, "196314885312593", "5511999990000").await;
+
+        let node = NodeBuilder::new("notification")
+            .attr("from", "236395184570386@lid")
+            .attr("type", "devices")
+            .attr("id", "NOTIF-UPDATE-HASH-3")
+            .attr("t", "1784584925")
+            .children([NodeBuilder::new("update").attr("hash", "AAAA").build()])
+            .build();
+
+        crate::handlers::notification::handle_devices_notification(&client, &node.as_node_ref())
+            .await;
+
+        assert!(
+            client.pending_device_sync.take_all().await.is_empty(),
+            "an unresolvable hash must not refresh an unrelated contact"
+        );
+    }
 }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -36,8 +36,8 @@ impl ReadLoopError {
     }
 }
 
-/// Runs once per inbound stanza, so it borrows instead of taking
-/// `ValueRef::to_jid`'s owned `Jid`.
+/// Borrows instead of taking `ValueRef::to_jid`'s owned `Jid`: this runs once
+/// per inbound stanza.
 #[inline]
 fn from_jid_matches(
     node: &wacore_binary::NodeRef<'_>,
@@ -52,9 +52,8 @@ fn from_jid_matches(
     }
 }
 
-/// A top-level `<status from="status@broadcast">` stanza: the wire shape the
-/// server uses for E2EE status updates once `status_e2ee_recv_over_status_stanza`
-/// is on, carrying the same payload as `<message from="status@broadcast">`.
+/// The wire shape the server uses for E2EE status updates, carrying the same
+/// payload as `<message from="status@broadcast">`.
 fn is_status_broadcast_stanza(node: &wacore_binary::NodeRef<'_>) -> bool {
     from_jid_matches(node, |jid| jid.is_status_broadcast())
 }
@@ -512,9 +511,8 @@ impl Client {
                 )
                 .await;
             }
-            // WA Web `handleMessagingStanza` retags a non-newsletter `<status>`
-            // to `message` and runs the normal pipeline; the stanza only differs
-            // in tag. Anything else (newsletter status) keeps the router path.
+            // Differs from a `<message>` only in tag, so WA Web retags it and
+            // runs the same pipeline.
             "status" if is_status_broadcast_stanza(nr) => {
                 crate::handlers::message::MessageHandler::handle_inline(
                     self.clone(),
@@ -533,8 +531,7 @@ impl Client {
                         "Received unknown top-level node: {}",
                         DisplayableNodeRef(node.get())
                     );
-                    // The nack IS this stanza's acknowledgement, so drop the
-                    // deferred plain ack the gate may have armed.
+                    // The nack is this stanza's acknowledgement.
                     cancelled |= self.nack_unrecognized_stanza(node.get());
                 }
             }
@@ -545,15 +542,12 @@ impl Client {
         }
     }
 
-    /// Whether a decrypted node must be processed on the read loop instead of a
-    /// spawned task:
-    /// - success/failure/stream:error carry connection state the rest depends on
-    /// - message and status@broadcast only enqueue here, and the per-chat queue
-    ///   is what preserves arrival order (heavy crypto runs in the lane worker);
-    ///   a spawned enqueue could put a group message ahead of the pkmsg that
-    ///   establishes its session
-    /// - ib sets up offline-sync tracking before the offline batch arrives
-    /// - acks and receipts, only while nothing observes them concurrently
+    /// Whether a decrypted node must stay on the read loop instead of moving to
+    /// a spawned task. success/failure/stream:error carry connection state the
+    /// rest depends on, and `ib` sets up offline-sync tracking before the batch
+    /// arrives. message and status@broadcast only enqueue here, and a spawned
+    /// enqueue could put a group message ahead of the pkmsg that establishes its
+    /// session. Acks and receipts qualify only while nothing observes them.
     pub(crate) fn processes_inline(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
         match node.tag.as_ref() {
             "success" | "failure" | "stream:error" | "message" | "ib" => true,
@@ -578,9 +572,8 @@ impl Client {
     }
 
     /// Answering nothing leaves the stanza in the offline queue forever, which
-    /// is how an unhandled `<status>` recycled the stream every ~50 minutes for
-    /// days. An unaddressable stanza (no `id`/`from`) is the one case where
-    /// silence is all we can offer. Returns whether a nack was queued.
+    /// is how an unhandled `<status>` kept recycling the stream. Returns whether
+    /// a nack was queued; one without `id`/`from` would have nothing to address.
     fn nack_unrecognized_stanza(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) -> bool {
         if node.get_attr("id").is_none() || node.get_attr("from").is_none() {
             return false;

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -36,6 +36,31 @@ impl ReadLoopError {
     }
 }
 
+/// Test the `from` attribute against a JID predicate without materializing an
+/// owned `Jid`: an already-parsed attribute is borrowed as-is and a string one
+/// is parsed in place, so neither branch allocates. This runs once per inbound
+/// stanza, so `ValueRef::to_jid`'s owned `Jid` would be pure churn.
+#[inline]
+fn from_jid_matches(
+    node: &wacore_binary::NodeRef<'_>,
+    pred: impl Fn(&wacore_binary::jid::JidRef<'_>) -> bool,
+) -> bool {
+    match node.get_attr("from") {
+        Some(wacore_binary::node::ValueRef::Jid(jid)) => pred(jid),
+        Some(wacore_binary::node::ValueRef::String(s)) => {
+            wacore_binary::jid::parse_jid_ref(s.as_ref()).is_some_and(|jid| pred(&jid))
+        }
+        None => false,
+    }
+}
+
+/// A top-level `<status from="status@broadcast">` stanza: the wire shape the
+/// server uses for E2EE status updates once `status_e2ee_recv_over_status_stanza`
+/// is on, carrying the same payload as `<message from="status@broadcast">`.
+fn is_status_broadcast_stanza(node: &wacore_binary::NodeRef<'_>) -> bool {
+    from_jid_matches(node, |jid| jid.is_status_broadcast())
+}
+
 impl Client {
     /// Read the current semaphore generation and Arc atomically under the mutex.
     pub(crate) fn read_message_semaphore(&self) -> (u64, Arc<async_lock::Semaphore>) {
@@ -517,6 +542,17 @@ impl Client {
                 )
                 .await;
             }
+            // WA Web `handleMessagingStanza` retags a non-newsletter `<status>`
+            // to `message` and runs the normal pipeline; the stanza only differs
+            // in tag. Anything else (newsletter status) keeps the router path.
+            "status" if is_status_broadcast_stanza(nr) => {
+                crate::handlers::message::MessageHandler::handle_inline(
+                    self.clone(),
+                    node,
+                    &mut cancelled,
+                )
+                .await;
+            }
             _ => {
                 let handled = self
                     .stanza_router
@@ -527,6 +563,9 @@ impl Client {
                         "Received unknown top-level node: {}",
                         DisplayableNodeRef(node.get())
                     );
+                    // The nack IS this stanza's acknowledgement, so drop the
+                    // deferred plain ack the gate may have armed.
+                    cancelled |= self.nack_unrecognized_stanza(node.get());
                 }
             }
         }
@@ -534,6 +573,26 @@ impl Client {
         if !cancelled && let Some(node) = deferred_ack_node {
             self.maybe_deferred_ack(node).await;
         }
+    }
+
+    /// Tell the server we cannot handle this stanza, so it drops it from the
+    /// offline queue instead of redelivering it forever. WA Web ends
+    /// `handleLoggedInStanza` with `createNackFromStanza(UnrecognizedStanza)`
+    /// for exactly this reason; staying silent is what let an unhandled
+    /// `<status>` stanza recycle the stream every ~50 minutes for days.
+    ///
+    /// Like WA Web, a stanza without `id`/`from` is skipped: the nack would
+    /// have nothing to address. Returns whether a nack was queued.
+    fn nack_unrecognized_stanza(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) -> bool {
+        if node.get_attr("id").is_none() || node.get_attr("from").is_none() {
+            return false;
+        }
+        self.spawn_stanza_nack(
+            node,
+            wacore::protocol::nack::NackReason::UnrecognizedStanza,
+            None,
+        );
+        true
     }
 
     /// Per WA Web (`Handle/MsgSendReceipt.js`), only newsletter `<message>`
@@ -553,14 +612,13 @@ impl Client {
         if node.get_attr("id").is_none() {
             return false;
         }
-        let Some(from) = node.get_attr("from") else {
+        if node.get_attr("from").is_none() {
             return false;
-        };
+        }
         match tag {
             "receipt" | "notification" | "call" => true,
-            "message" => from
-                .to_jid()
-                .is_some_and(|j| j.is_newsletter() || j.is_status_broadcast()),
+            "message" => from_jid_matches(node, |j| j.is_newsletter() || j.is_status_broadcast()),
+            "status" => is_status_broadcast_stanza(node),
             _ => false,
         }
     }
@@ -1466,7 +1524,9 @@ impl Client {
                             .map(|v| v.as_str().to_string())
                             .unwrap_or_default();
                         warn!(
-                            "Stream error carrying <ack> (class={class:?}, id={id}): server-driven stream rotation, not an ack rejection; reconnect follows on stream end"
+                            "Stream error carrying <ack> (class={class:?}, id={id}): the server is \
+                             still owed a transport ack for that stanza and recycles the stream \
+                             until it arrives; reconnect follows on stream end"
                         );
                     } else {
                         warn!("Unknown stream error: {}", DisplayableNodeRef(node));

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -36,10 +36,8 @@ impl ReadLoopError {
     }
 }
 
-/// Test the `from` attribute against a JID predicate without materializing an
-/// owned `Jid`: an already-parsed attribute is borrowed as-is and a string one
-/// is parsed in place, so neither branch allocates. This runs once per inbound
-/// stanza, so `ValueRef::to_jid`'s owned `Jid` would be pure churn.
+/// Runs once per inbound stanza, so it borrows instead of taking
+/// `ValueRef::to_jid`'s owned `Jid`.
 #[inline]
 fn from_jid_matches(
     node: &wacore_binary::NodeRef<'_>,
@@ -575,14 +573,10 @@ impl Client {
         }
     }
 
-    /// Tell the server we cannot handle this stanza, so it drops it from the
-    /// offline queue instead of redelivering it forever. WA Web ends
-    /// `handleLoggedInStanza` with `createNackFromStanza(UnrecognizedStanza)`
-    /// for exactly this reason; staying silent is what let an unhandled
-    /// `<status>` stanza recycle the stream every ~50 minutes for days.
-    ///
-    /// Like WA Web, a stanza without `id`/`from` is skipped: the nack would
-    /// have nothing to address. Returns whether a nack was queued.
+    /// Answering nothing leaves the stanza in the offline queue forever, which
+    /// is how an unhandled `<status>` recycled the stream every ~50 minutes for
+    /// days. An unaddressable stanza (no `id`/`from`) is the one case where
+    /// silence is all we can offer. Returns whether a nack was queued.
     fn nack_unrecognized_stanza(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) -> bool {
         if node.get_attr("id").is_none() || node.get_attr("from").is_none() {
             return false;

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -201,35 +201,7 @@ impl Client {
                                 while let Some(encrypted_frame) = frame_decoder.decode_frame() {
                                     // Decrypt the frame synchronously (required for noise counter ordering)
                                     if let Some(node) = self.decrypt_frame(&noise_socket, encrypted_frame) {
-                                        // Determine processing mode for this node:
-                                        // - Critical nodes (success/failure/stream:error): inline, required for state
-                                        // - Message nodes: inline, preserves arrival order for per-chat queues
-                                        //   (MessageHandler just enqueues + ACKs, heavy crypto runs in workers)
-                                        // - Acks/receipts: inline when unobserved; retry work detaches itself
-                                        // - ib (in-band): inline, ensures offline sync tracking (expected count)
-                                        //   is set up before offline messages are processed
-                                        // - Everything else: spawned concurrently for parallelism
-                                        let process_inline = match node.tag() {
-                                            "success" | "failure" | "stream:error" | "message" | "ib" => true,
-                                            // Preserve concurrent callback behavior when an app
-                                            // observes these events or every raw node.
-                                            "receipt" => {
-                                                !self.synchronous_ack
-                                                    && !self.raw_node_forwarding_enabled()
-                                                    && !self.core.event_bus.has_handler_for(
-                                                        wacore::types::events::EventKind::Receipt,
-                                                    )
-                                            }
-                                            "ack" => {
-                                                !self.raw_node_forwarding_enabled()
-                                                    && !self.core.event_bus.has_handler_for(
-                                                        wacore::types::events::EventKind::ServerAck,
-                                                    )
-                                            }
-                                            _ => false,
-                                        };
-
-                                        if process_inline {
+                                        if self.processes_inline(node.get()) {
                                             self.process_decrypted_node(node).await;
                                         } else {
                                             let client = self.clone();
@@ -570,6 +542,38 @@ impl Client {
 
         if !cancelled && let Some(node) = deferred_ack_node {
             self.maybe_deferred_ack(node).await;
+        }
+    }
+
+    /// Whether a decrypted node must be processed on the read loop instead of a
+    /// spawned task:
+    /// - success/failure/stream:error carry connection state the rest depends on
+    /// - message and status@broadcast only enqueue here, and the per-chat queue
+    ///   is what preserves arrival order (heavy crypto runs in the lane worker);
+    ///   a spawned enqueue could put a group message ahead of the pkmsg that
+    ///   establishes its session
+    /// - ib sets up offline-sync tracking before the offline batch arrives
+    /// - acks and receipts, only while nothing observes them concurrently
+    pub(crate) fn processes_inline(&self, node: &wacore_binary::NodeRef<'_>) -> bool {
+        match node.tag.as_ref() {
+            "success" | "failure" | "stream:error" | "message" | "ib" => true,
+            "status" => is_status_broadcast_stanza(node),
+            "receipt" => {
+                !self.synchronous_ack
+                    && !self.raw_node_forwarding_enabled()
+                    && !self
+                        .core
+                        .event_bus
+                        .has_handler_for(wacore::types::events::EventKind::Receipt)
+            }
+            "ack" => {
+                !self.raw_node_forwarding_enabled()
+                    && !self
+                        .core
+                        .event_bus
+                        .has_handler_for(wacore::types::events::EventKind::ServerAck)
+            }
+            _ => false,
         }
     }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -105,10 +105,8 @@ async fn test_ack_behavior_for_incoming_stanzas() {
         "should_ack must return TRUE for status@broadcast <message> (fallback for drop paths)."
     );
 
-    // The server may deliver a status update as a top-level <status> stanza
-    // instead of <message from="status@broadcast">. It expects the same
-    // transport ack back (it demands it as <stream:error><ack class="status"/>
-    // and recycles the stream until it arrives).
+    // A status update delivered as a top-level <status> stanza is owed the same
+    // transport ack; the server recycles the stream until it arrives.
     let mut status_stanza_attrs = Attrs::new();
     status_stanza_attrs.insert("from".to_string(), "status@broadcast".to_string());
     status_stanza_attrs.insert("id".to_string(), "STATUS-STANZA-1".to_string());
@@ -3854,9 +3852,7 @@ async fn instrumented_runtime_reports_to_cpu_meter() {
 }
 
 /// A status@broadcast stanza feeds the same per-chat queue a `<message>` does,
-/// so it has to be enqueued from the read loop: a spawned enqueue could land a
-/// group message ahead of the pkmsg that establishes its session. A newsletter
-/// `<status>` has no such queue and stays on the concurrent path.
+/// so its enqueue must keep the read loop's arrival order.
 #[tokio::test]
 async fn status_broadcast_stanzas_are_dispatched_inline() {
     use wacore_binary::builder::NodeBuilder;
@@ -3889,4 +3885,103 @@ async fn status_broadcast_stanzas_are_dispatched_inline() {
         !client.processes_inline(&newsletter_status.as_node_ref()),
         "a newsletter <status> has no per-chat queue to order"
     );
+}
+
+/// The server counts status updates and calls separately, so a preview that
+/// only reports messages/notifications/receipts leaves part of the backlog
+/// unaccounted for.
+#[tokio::test]
+async fn offline_preview_reports_status_and_call_counts() {
+    use wacore::types::events::{Event, EventHandler};
+
+    #[derive(Default)]
+    struct PreviewRecorder {
+        previews: std::sync::Mutex<Vec<wacore::types::events::OfflineSyncPreview>>,
+    }
+
+    impl EventHandler for PreviewRecorder {
+        fn handle_event(&self, event: Arc<Event>) {
+            if let Event::OfflineSyncPreview(preview) = &*event {
+                self.previews.lock().unwrap().push(preview.clone());
+            }
+        }
+    }
+
+    let client = create_offline_sync_test_client().await;
+    let recorder = Arc::new(PreviewRecorder::default());
+    client
+        .core
+        .event_bus
+        .subscribe_handler(recorder.clone())
+        .detach();
+
+    let node = NodeBuilder::new("ib")
+        .children([NodeBuilder::new("offline_preview")
+            .attr("count", "9")
+            .attr("message", "2")
+            .attr("notification", "1")
+            .attr("receipt", "1")
+            .attr("appdata", "1")
+            .attr("call", "1")
+            .attr("status", "3")
+            .build()])
+        .build();
+
+    client.process_node(node_to_owned_ref(node)).await;
+
+    let previews = recorder.previews.lock().unwrap();
+    let preview = previews
+        .first()
+        .expect("a preview event must be dispatched");
+    assert_eq!(preview.total, 9);
+    assert_eq!(preview.messages, 2);
+    assert_eq!(preview.notifications, 1);
+    assert_eq!(preview.receipts, 1);
+    assert_eq!(preview.app_data_changes, 1);
+    assert_eq!(preview.calls, 1);
+    assert_eq!(preview.statuses, 3);
+}
+
+/// A preview from a server that never sends the newer counts still parses.
+#[tokio::test]
+async fn offline_preview_defaults_absent_counts_to_zero() {
+    use wacore::types::events::{Event, EventHandler};
+
+    #[derive(Default)]
+    struct PreviewRecorder {
+        previews: std::sync::Mutex<Vec<wacore::types::events::OfflineSyncPreview>>,
+    }
+
+    impl EventHandler for PreviewRecorder {
+        fn handle_event(&self, event: Arc<Event>) {
+            if let Event::OfflineSyncPreview(preview) = &*event {
+                self.previews.lock().unwrap().push(preview.clone());
+            }
+        }
+    }
+
+    let client = create_offline_sync_test_client().await;
+    let recorder = Arc::new(PreviewRecorder::default());
+    client
+        .core
+        .event_bus
+        .subscribe_handler(recorder.clone())
+        .detach();
+
+    let node = NodeBuilder::new("ib")
+        .children([NodeBuilder::new("offline_preview")
+            .attr("count", "1")
+            .attr("message", "1")
+            .build()])
+        .build();
+
+    client.process_node(node_to_owned_ref(node)).await;
+
+    let previews = recorder.previews.lock().unwrap();
+    let preview = previews
+        .first()
+        .expect("a preview event must be dispatched");
+    assert_eq!(preview.total, 1);
+    assert_eq!(preview.calls, 0);
+    assert_eq!(preview.statuses, 0);
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3852,3 +3852,41 @@ async fn instrumented_runtime_reports_to_cpu_meter() {
         "blocking work is metered too"
     );
 }
+
+/// A status@broadcast stanza feeds the same per-chat queue a `<message>` does,
+/// so it has to be enqueued from the read loop: a spawned enqueue could land a
+/// group message ahead of the pkmsg that establishes its session. A newsletter
+/// `<status>` has no such queue and stays on the concurrent path.
+#[tokio::test]
+async fn status_broadcast_stanzas_are_dispatched_inline() {
+    use wacore_binary::builder::NodeBuilder;
+
+    let client = create_offline_sync_test_client().await;
+
+    let status = NodeBuilder::new("status")
+        .attr("from", "status@broadcast")
+        .attr("id", "INLINE-1")
+        .build();
+    assert!(
+        client.processes_inline(&status.as_node_ref()),
+        "a status@broadcast stanza must keep the read loop's arrival order"
+    );
+
+    let message = NodeBuilder::new("message")
+        .attr("from", "status@broadcast")
+        .attr("id", "INLINE-2")
+        .build();
+    assert!(
+        client.processes_inline(&message.as_node_ref()),
+        "the pre-existing <message> form is unchanged"
+    );
+
+    let newsletter_status = NodeBuilder::new("status")
+        .attr("from", "120363298765432100@newsletter")
+        .attr("id", "INLINE-3")
+        .build();
+    assert!(
+        !client.processes_inline(&newsletter_status.as_node_ref()),
+        "a newsletter <status> has no per-chat queue to order"
+    );
+}

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -105,6 +105,21 @@ async fn test_ack_behavior_for_incoming_stanzas() {
         "should_ack must return TRUE for status@broadcast <message> (fallback for drop paths)."
     );
 
+    // The server may deliver a status update as a top-level <status> stanza
+    // instead of <message from="status@broadcast">. It expects the same
+    // transport ack back (it demands it as <stream:error><ack class="status"/>
+    // and recycles the stream until it arrives).
+    let mut status_stanza_attrs = Attrs::new();
+    status_stanza_attrs.insert("from".to_string(), "status@broadcast".to_string());
+    status_stanza_attrs.insert("id".to_string(), "STATUS-STANZA-1".to_string());
+    status_stanza_attrs.insert("participant".to_string(), "200725430796339@lid".to_string());
+    status_stanza_attrs.insert("type".to_string(), "media".to_string());
+    let status_stanza = Node::new("status", status_stanza_attrs, None);
+    assert!(
+        client.should_ack(&status_stanza.as_node_ref()),
+        "should_ack must return TRUE for a top-level <status> stanza."
+    );
+
     info!(
         "✅ test_ack_behavior_for_incoming_stanzas passed: Client correctly differentiates which stanzas to acknowledge."
     );

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -155,11 +155,13 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                 let messages = attrs.optional_u64("message").unwrap_or(0) as i32;
                 let notifications = attrs.optional_u64("notification").unwrap_or(0) as i32;
                 let receipts = attrs.optional_u64("receipt").unwrap_or(0) as i32;
+                let calls = attrs.optional_u64("call").unwrap_or(0) as i32;
+                let statuses = attrs.optional_u64("status").unwrap_or(0) as i32;
 
                 debug!(
                     target: "Client/OfflineSync",
-                    "Offline preview: {} total ({} messages, {} notifications, {} receipts, {} app data changes)",
-                    total, messages, notifications, receipts, app_data_changes,
+                    "Offline preview: {} total ({} messages, {} statuses, {} notifications, {} receipts, {} calls, {} app data changes)",
+                    total, messages, statuses, notifications, receipts, calls, app_data_changes,
                 );
 
                 client.core.event_bus.dispatch(Event::OfflineSyncPreview(
@@ -169,6 +171,8 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                         .messages(messages)
                         .notifications(notifications)
                         .receipts(receipts)
+                        .calls(calls)
+                        .statuses(statuses)
                         .build(),
                 ));
 

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -404,10 +404,8 @@ pub(crate) async fn handle_local_identity_change(client: &Arc<Client>, sender: J
 
 /// Refresh the device list of the contact a hash-only `<update>` names.
 ///
-/// The wire hash is `base64(md5(user + "WA_ADD_NOTIF")[..3])`; the LID-PN cache
-/// keeps the reverse index. An unresolvable hash is a contact we never learned
-/// a mapping for — nothing to refresh, which is also what WA Web does when
-/// `getContactRecordByHash` misses ("missing side contact hash").
+/// An unresolvable hash is a contact we never learned a mapping for, so there
+/// is nothing to refresh; WA Web equally gives up when its own lookup misses.
 async fn sync_hashed_contact(client: &Arc<Client>, wire_hash: Option<&str>) {
     let Some(hash) = wire_hash.and_then(wacore::crypto::parse_contact_notification_hash) else {
         debug!("Device update with unusable contact hash {wire_hash:?}");

--- a/src/handlers/notification/device.rs
+++ b/src/handlers/notification/device.rs
@@ -402,6 +402,31 @@ pub(crate) async fn handle_local_identity_change(client: &Arc<Client>, sender: J
     ));
 }
 
+/// Refresh the device list of the contact a hash-only `<update>` names.
+///
+/// The wire hash is `base64(md5(user + "WA_ADD_NOTIF")[..3])`; the LID-PN cache
+/// keeps the reverse index. An unresolvable hash is a contact we never learned
+/// a mapping for — nothing to refresh, which is also what WA Web does when
+/// `getContactRecordByHash` misses ("missing side contact hash").
+async fn sync_hashed_contact(client: &Arc<Client>, wire_hash: Option<&str>) {
+    let Some(hash) = wire_hash.and_then(wacore::crypto::parse_contact_notification_hash) else {
+        debug!("Device update with unusable contact hash {wire_hash:?}");
+        return;
+    };
+    let Some(lid) = client.lid_pn_cache.lid_for_contact_hash(hash).await else {
+        debug!("Device update for an unknown contact hash {wire_hash:?}");
+        return;
+    };
+    // Mirrors WA Web: an in-progress offline resume batches the refresh
+    // (`addUserToPendingDeviceSync`) instead of firing a usync mid-drain.
+    let is_offline = client
+        .offline_sync_metrics
+        .active
+        .load(std::sync::atomic::Ordering::Acquire);
+    let jid = Jid::new(lid.as_ref(), wacore_binary::Server::Lid);
+    client.schedule_unknown_device_sync(jid, is_offline).await;
+}
+
 /// Handle device list change notifications.
 /// Matches WhatsApp Web's WAWebHandleDeviceNotification.handleDevicesNotification().
 ///
@@ -464,9 +489,13 @@ pub(crate) async fn handle_devices_notification(client: &Arc<Client>, node: &Nod
         }
         wacore::stanza::devices::DeviceNotificationType::Update => {
             if op.devices.is_empty() {
-                // Hash-only update without device list — fall back to
-                // invalidation so the next read rehydrates from the server.
-                client.invalidate_device_cache(notification.user()).await;
+                // The `hash` names the *contact* whose device list changed, not
+                // the notification's `from` (our own account). WA Web resolves it
+                // with `getContactRecordByHash` and runs `syncDeviceListJob` for
+                // that contact alone; invalidating `from` instead dropped our own
+                // companion list and made its next message look like an unknown
+                // device.
+                sync_hashed_contact(client, op.contact_hash.as_deref()).await;
             } else {
                 for device in &op.devices {
                     client

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -274,14 +274,20 @@ impl LidPnCache {
             .insert(shared.lid.clone(), Arc::clone(&shared))
             .await;
 
-        for identifier in [&shared.lid, &shared.phone_number] {
-            self.contact_hash_to_lid
-                .insert(contact_hash_key(identifier), Arc::clone(&shared.lid))
-                .await;
-        }
+        self.contact_hash_to_lid
+            .insert(contact_hash_key(&shared.lid), Arc::clone(&shared.lid))
+            .await;
 
         // Update PN -> Entry map (only if newer or equal timestamp)
         if should_update_pn {
+            // The PN side follows the same arbitration: a losing older entry
+            // must not point this number's hash back at a superseded LID.
+            self.contact_hash_to_lid
+                .insert(
+                    contact_hash_key(&shared.phone_number),
+                    Arc::clone(&shared.lid),
+                )
+                .await;
             self.pn_to_entry
                 .insert(shared.phone_number.clone(), shared)
                 .await;
@@ -475,6 +481,24 @@ mod tests {
             cache.get_current_lid("559980000001").await.as_deref(),
             Some("100000087654321")
         );
+
+        // The number's contact hash follows the same winner, or a device
+        // update naming that number would refresh the superseded LID.
+        let phone_hash = wacore::crypto::contact_notification_hash("559980000001");
+        assert_eq!(
+            cache.lid_for_contact_hash(phone_hash).await.as_deref(),
+            Some("100000087654321")
+        );
+        // Each LID still resolves to itself: the loser is a real contact too.
+        for lid in ["100000087654321", "100000012345678"] {
+            assert_eq!(
+                cache
+                    .lid_for_contact_hash(wacore::crypto::contact_notification_hash(lid))
+                    .await
+                    .as_deref(),
+                Some(lid)
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -30,8 +30,7 @@ pub use wacore::types::{LearningSource, LidPnEntry};
 const NS_LID: &str = "lid_pn_by_lid";
 const NS_PN: &str = "lid_pn_by_pn";
 
-/// Pack the 3-byte contact hash into an integer key: no allocation, and the
-/// key stays `Display` for the store-backed cache path.
+/// An integer key allocates nothing and stays `Display` for the store path.
 #[inline]
 fn pack_contact_hash(hash: [u8; 3]) -> u32 {
     u32::from_be_bytes([0, hash[0], hash[1], hash[2]])
@@ -68,16 +67,12 @@ pub struct LidPnCache {
     /// record both identifiers. Recording lives here, at the write
     /// chokepoint, so callers cannot forget it.
     topology: std::sync::OnceLock<Arc<crate::client::device_topology::DeviceTopology>>,
-    /// Contact hash -> LID. Reverse index for the contact named by
-    /// `<notification type="devices"><update hash="..."/></notification>`,
-    /// whose 3-byte hash is the only identifier the server sends. Both the LID
-    /// and the PN of a pair are indexed (WA Web hashes the contact's stored id,
-    /// LID-namespaced only for migrated contacts) and both point at the LID, so
-    /// either wire form resolves the same contact. Always in-process: it is
-    /// derived state that every process rebuilds from its own warm-up.
-    /// A 3-byte hash collides for ~1 pair in a few thousand contacts; like WA
-    /// Web's single-record lookup, the newest write wins and the loser simply
-    /// misses one refresh.
+    /// Contact hash -> LID, for the `<devices>` `<update hash>` notification
+    /// whose 3-byte hash is the only identifier it carries. Both sides of a pair
+    /// are indexed because the hashed id is LID-namespaced only for migrated
+    /// contacts, and both resolve to the LID. Always in-process: derived state
+    /// each process rebuilds from its own warm-up. A 3-byte hash collides for
+    /// ~1 pair in a few thousand contacts, where the newest write wins.
     contact_hash_to_lid: TypedCache<u32, Arc<str>>,
     /// PN -> the LID this process durably persisted for it. Lets the learn hot
     /// path skip a re-persist without swallowing the first live persist of a
@@ -280,8 +275,8 @@ impl LidPnCache {
 
         // Update PN -> Entry map (only if newer or equal timestamp)
         if should_update_pn {
-            // The PN side follows the same arbitration: a losing older entry
-            // must not point this number's hash back at a superseded LID.
+            // A losing older entry must not point this number's hash at a
+            // superseded LID.
             self.contact_hash_to_lid
                 .insert(
                     contact_hash_key(&shared.phone_number),

--- a/src/lid_pn_cache.rs
+++ b/src/lid_pn_cache.rs
@@ -30,6 +30,18 @@ pub use wacore::types::{LearningSource, LidPnEntry};
 const NS_LID: &str = "lid_pn_by_lid";
 const NS_PN: &str = "lid_pn_by_pn";
 
+/// Pack the 3-byte contact hash into an integer key: no allocation, and the
+/// key stays `Display` for the store-backed cache path.
+#[inline]
+fn pack_contact_hash(hash: [u8; 3]) -> u32 {
+    u32::from_be_bytes([0, hash[0], hash[1], hash[2]])
+}
+
+#[inline]
+fn contact_hash_key(user: &str) -> u32 {
+    pack_contact_hash(wacore::crypto::contact_notification_hash(user))
+}
+
 /// Cache for LID to Phone Number mappings.
 ///
 /// This cache maintains bidirectional mappings between LIDs and phone numbers,
@@ -56,6 +68,17 @@ pub struct LidPnCache {
     /// record both identifiers. Recording lives here, at the write
     /// chokepoint, so callers cannot forget it.
     topology: std::sync::OnceLock<Arc<crate::client::device_topology::DeviceTopology>>,
+    /// Contact hash -> LID. Reverse index for the contact named by
+    /// `<notification type="devices"><update hash="..."/></notification>`,
+    /// whose 3-byte hash is the only identifier the server sends. Both the LID
+    /// and the PN of a pair are indexed (WA Web hashes the contact's stored id,
+    /// LID-namespaced only for migrated contacts) and both point at the LID, so
+    /// either wire form resolves the same contact. Always in-process: it is
+    /// derived state that every process rebuilds from its own warm-up.
+    /// A 3-byte hash collides for ~1 pair in a few thousand contacts; like WA
+    /// Web's single-record lookup, the newest write wins and the loser simply
+    /// misses one refresh.
+    contact_hash_to_lid: TypedCache<u32, Arc<str>>,
     /// PN -> the LID this process durably persisted for it. Lets the learn hot
     /// path skip a re-persist without swallowing the first live persist of a
     /// mapping an offline replay only warmed in memory. Keyed by the pair so a
@@ -101,6 +124,7 @@ impl LidPnCache {
                 // Always in-memory: tracks per-process persist state, never the
                 // mapping itself, so it must not go through the shared store.
                 persisted: TypedCache::from_local(config.build_with_tti()),
+                contact_hash_to_lid: TypedCache::from_local(config.build_with_tti()),
                 topology: std::sync::OnceLock::new(),
             },
             None => Self {
@@ -108,6 +132,7 @@ impl LidPnCache {
                 pn_to_entry: TypedCache::from_local(config.build_with_tti()),
                 mutation: async_lock::Mutex::new(()),
                 persisted: TypedCache::from_local(config.build_with_tti()),
+                contact_hash_to_lid: TypedCache::from_local(config.build_with_tti()),
                 topology: std::sync::OnceLock::new(),
             },
         }
@@ -249,15 +274,27 @@ impl LidPnCache {
             .insert(shared.lid.clone(), Arc::clone(&shared))
             .await;
 
+        for identifier in [&shared.lid, &shared.phone_number] {
+            self.contact_hash_to_lid
+                .insert(contact_hash_key(identifier), Arc::clone(&shared.lid))
+                .await;
+        }
+
         // Update PN -> Entry map (only if newer or equal timestamp)
         if should_update_pn {
             self.pn_to_entry
                 .insert(shared.phone_number.clone(), shared)
                 .await;
         }
+
         if let Some(topology) = self.topology.get() {
             topology.record([&*entry.lid, &*entry.phone_number]);
         }
+    }
+
+    /// Resolve the contact a `<devices>` `<update hash>` refers to.
+    pub(crate) async fn lid_for_contact_hash(&self, hash: [u8; 3]) -> Option<Arc<str>> {
+        self.contact_hash_to_lid.get(&pack_contact_hash(hash)).await
     }
 
     /// Whether this process has durably persisted exactly `phone -> lid`.
@@ -317,6 +354,7 @@ impl LidPnCache {
         self.lid_to_entry.clear().await;
         self.pn_to_entry.clear().await;
         self.persisted.clear().await;
+        self.contact_hash_to_lid.clear().await;
         if let Some(topology) = self.topology.get() {
             topology.record_global();
         }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -12276,6 +12276,10 @@ async fn unrecognized_stanza_is_nacked() {
             .is_some_and(|v| v.as_str() == "100000000000001@lid")
     );
     assert!(nack.get_attr("type").is_some_and(|v| v.as_str() == "media"));
+    assert!(
+        !extra_frame_appears(&transport, 1).await,
+        "the nack is the whole answer; no plain ack may follow it"
+    );
 }
 
 /// The nack needs `id` + `from` to be routable, exactly like WA Web's
@@ -12296,6 +12300,20 @@ async fn unrecognized_stanza_without_id_is_not_nacked() {
     assert!(
         !extra_frame_appears(&transport, 0).await,
         "a stanza with no id cannot be nacked"
+    );
+
+    // The other half of the guard: addressable means id AND from.
+    let no_from = NodeBuilder::new("totally_unknown_stanza")
+        .attr("id", "UNKNOWN-2")
+        .build();
+
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&no_from))
+        .await;
+
+    assert!(
+        !extra_frame_appears(&transport, 0).await,
+        "a stanza with no from cannot be nacked either"
     );
 }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -12074,10 +12074,8 @@ async fn test_invalid_signed_prekey_id_sends_retry_receipt() {
     await_retry_receipt(&client, &info, 1, RetryReason::InvalidKeyId).await;
 }
 
-/// Wait for the transport to hold more than `expected` frames, returning
-/// whether that ever happened. A negative assertion needs a real deadline: a
-/// spawned send that parks on a lock or a channel outlives any fixed number of
-/// cooperative yields.
+/// Whether the transport ever holds more than `expected` frames. A negative
+/// assertion needs a deadline, not a fixed number of cooperative yields.
 async fn extra_frame_appears(
     transport: &Arc<crate::transport::mock::CapturingMockTransport>,
     expected: usize,
@@ -12196,9 +12194,8 @@ async fn status_stanza_is_routed_to_the_message_pipeline() {
         .process_node(crate::test_utils::node_to_owned_ref(&status))
         .await;
 
-    // The undecryptable event only fires once the lane worker has dequeued the
-    // stanza and run it through decryption, so it proves the whole path, not
-    // just that a lane was created.
+    // The event only fires once the lane worker has dequeued the stanza and run
+    // it through decryption, so it covers the whole path.
     let event = tokio::time::timeout(std::time::Duration::from_secs(5), async {
         loop {
             if let Some(event) = recorder.undecryptable().first().cloned() {

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -12074,6 +12074,26 @@ async fn test_invalid_signed_prekey_id_sends_retry_receipt() {
     await_retry_receipt(&client, &info, 1, RetryReason::InvalidKeyId).await;
 }
 
+/// Wait for the transport to hold more than `expected` frames, returning
+/// whether that ever happened. A negative assertion needs a real deadline: a
+/// spawned send that parks on a lock or a channel outlives any fixed number of
+/// cooperative yields.
+async fn extra_frame_appears(
+    transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+    expected: usize,
+) -> bool {
+    tokio::time::timeout(std::time::Duration::from_millis(250), async {
+        loop {
+            if transport.sent_count() > expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
 /// Production regression: the server delivers E2EE status updates as a
 /// top-level `<status>` stanza (WA Web `handleMessagingStanza` rewrites the tag
 /// to `message` under the `status_e2ee_recv_over_status_stanza` abprop). With
@@ -12088,8 +12108,8 @@ async fn status_stanza_gets_transport_ack() {
         .attr("from", "status@broadcast")
         .attr("type", "media")
         .attr("id", "ACSTATUSSTANZA1")
-        .attr("participant", "200725430796339@lid")
-        .attr("t", "1784819907")
+        .attr("participant", "100000000000001@lid")
+        .attr("t", wacore::time::now_secs().to_string())
         .children([NodeBuilder::new("enc")
             .attr("v", "2")
             .attr("type", "skmsg")
@@ -12132,7 +12152,7 @@ async fn status_stanza_gets_transport_ack() {
     );
     assert!(
         ack.get_attr("participant")
-            .is_some_and(|v| v.as_str() == "200725430796339@lid")
+            .is_some_and(|v| v.as_str() == "100000000000001@lid")
     );
     assert!(
         ack.get_attr("type").is_some_and(|v| v.as_str() == "media"),
@@ -12156,8 +12176,8 @@ async fn status_stanza_is_routed_to_the_message_pipeline() {
         .attr("from", "status@broadcast")
         .attr("type", "media")
         .attr("id", "ACSTATUSSTANZA2")
-        .attr("participant", "200725430796339@lid")
-        .attr("t", "1784819907")
+        .attr("participant", "100000000000001@lid")
+        .attr("t", wacore::time::now_secs().to_string())
         .children([NodeBuilder::new("enc")
             .attr("v", "2")
             .attr("type", "skmsg")
@@ -12165,15 +12185,39 @@ async fn status_stanza_is_routed_to_the_message_pipeline() {
             .build()])
         .build();
 
+    let recorder = Arc::new(EventRecorder::default());
+    client
+        .core
+        .event_bus
+        .subscribe_handler(recorder.clone())
+        .detach();
+
     client
         .process_node(crate::test_utils::node_to_owned_ref(&status))
         .await;
 
-    let status_jid: Jid = "status@broadcast".parse().expect("status jid should parse");
+    // The undecryptable event only fires once the lane worker has dequeued the
+    // stanza and run it through decryption, so it proves the whole path, not
+    // just that a lane was created.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(event) = recorder.undecryptable().first().cloned() {
+                return event;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the status pipeline must reach decryption");
+
+    let Event::UndecryptableMessage(undecryptable) = &*event else {
+        unreachable!("filtered above")
+    };
     assert!(
-        client.chat_lanes.get(&status_jid).await.is_some(),
-        "a <status> stanza must be enqueued on the status@broadcast chat lane"
+        undecryptable.info.source.chat.is_status_broadcast(),
+        "the message must keep its status@broadcast routing"
     );
+    assert_eq!(undecryptable.info.id, "ACSTATUSSTANZA2");
 }
 
 /// WA Web nacks every stanza it does not recognize
@@ -12187,7 +12231,7 @@ async fn unrecognized_stanza_is_nacked() {
     let unknown = NodeBuilder::new("totally_unknown_stanza")
         .attr("from", "status@broadcast")
         .attr("id", "UNKNOWN-1")
-        .attr("participant", "200725430796339@lid")
+        .attr("participant", "100000000000001@lid")
         .attr("type", "media")
         .build();
 
@@ -12229,7 +12273,7 @@ async fn unrecognized_stanza_is_nacked() {
     );
     assert!(
         nack.get_attr("participant")
-            .is_some_and(|v| v.as_str() == "200725430796339@lid")
+            .is_some_and(|v| v.as_str() == "100000000000001@lid")
     );
     assert!(nack.get_attr("type").is_some_and(|v| v.as_str() == "media"));
 }
@@ -12249,13 +12293,8 @@ async fn unrecognized_stanza_without_id_is_not_nacked() {
         .process_node(crate::test_utils::node_to_owned_ref(&unknown))
         .await;
 
-    // Give any spawned send a chance to reach the transport before asserting.
-    for _ in 0..64 {
-        tokio::task::yield_now().await;
-    }
-    assert_eq!(
-        transport.sent_count(),
-        0,
+    assert!(
+        !extra_frame_appears(&transport, 0).await,
         "a stanza with no id cannot be nacked"
     );
 }
@@ -12294,12 +12333,8 @@ async fn newsletter_status_stanza_is_nacked_once() {
     assert_eq!(nack.tag.as_ref(), "ack");
     assert!(nack.get_attr("error").is_some_and(|v| v.as_str() == "488"));
 
-    for _ in 0..64 {
-        tokio::task::yield_now().await;
-    }
-    assert_eq!(
-        transport.sent_count(),
-        1,
+    assert!(
+        !extra_frame_appears(&transport, 1).await,
         "the nack replaces the ack; the server must not get both"
     );
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -12073,3 +12073,233 @@ async fn test_invalid_signed_prekey_id_sends_retry_receipt() {
     // NACK path, which never bumps the retry caches.
     await_retry_receipt(&client, &info, 1, RetryReason::InvalidKeyId).await;
 }
+
+/// Production regression: the server delivers E2EE status updates as a
+/// top-level `<status>` stanza (WA Web `handleMessagingStanza` rewrites the tag
+/// to `message` under the `status_e2ee_recv_over_status_stanza` abprop). With
+/// the tag unhandled the client never acks, so the server redelivers the same
+/// id on every reconnect and then closes the stream with
+/// `<stream:error><ack class="status"/></stream:error>`.
+#[tokio::test]
+async fn status_stanza_gets_transport_ack() {
+    let (client, transport) = capturing_client("status_stanza_ack").await;
+
+    let status = NodeBuilder::new("status")
+        .attr("from", "status@broadcast")
+        .attr("type", "media")
+        .attr("id", "ACSTATUSSTANZA1")
+        .attr("participant", "200725430796339@lid")
+        .attr("t", "1784819907")
+        .children([NodeBuilder::new("enc")
+            .attr("v", "2")
+            .attr("type", "skmsg")
+            .bytes(vec![1, 2, 3])
+            .build()])
+        .build();
+
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&status))
+        .await;
+
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(frame) = transport.sent().first().cloned() {
+                return frame;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a <status> stanza must be acknowledged on the wire");
+
+    let bytes = decode_frame(0, &frame).expect("ack frame should decrypt");
+    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("ack frame should decode");
+    assert_eq!(ack.tag.as_ref(), "ack");
+    assert!(
+        ack.get_attr("class")
+            .is_some_and(|v| v.as_str() == "status"),
+        "WA Web acks a status stanza with class=\"status\" (the class the server \
+         demands back in <stream:error><ack class=\"status\"/>), got {:?}",
+        ack.get_attr("class").map(|v| v.as_str().to_string())
+    );
+    assert!(
+        ack.get_attr("id")
+            .is_some_and(|v| v.as_str() == "ACSTATUSSTANZA1")
+    );
+    assert!(
+        ack.get_attr("to")
+            .is_some_and(|v| v.as_str() == "status@broadcast")
+    );
+    assert!(
+        ack.get_attr("participant")
+            .is_some_and(|v| v.as_str() == "200725430796339@lid")
+    );
+    assert!(
+        ack.get_attr("type").is_some_and(|v| v.as_str() == "media"),
+        "the stanza type is echoed back, matching WA Web sendAck"
+    );
+    assert!(
+        ack.get_attr("from")
+            .is_some_and(|v| v.as_str() == "5511000000001@s.whatsapp.net"),
+        "WA Web sendAck always carries the own device JID for message-class acks"
+    );
+}
+
+/// A `<status>` stanza must reach the message pipeline (WA Web retags it to
+/// `message`), not just get acked: otherwise every E2EE status update is
+/// silently dropped.
+#[tokio::test]
+async fn status_stanza_is_routed_to_the_message_pipeline() {
+    let (client, _transport) = capturing_client("status_stanza_routing").await;
+
+    let status = NodeBuilder::new("status")
+        .attr("from", "status@broadcast")
+        .attr("type", "media")
+        .attr("id", "ACSTATUSSTANZA2")
+        .attr("participant", "200725430796339@lid")
+        .attr("t", "1784819907")
+        .children([NodeBuilder::new("enc")
+            .attr("v", "2")
+            .attr("type", "skmsg")
+            .bytes(vec![1, 2, 3])
+            .build()])
+        .build();
+
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&status))
+        .await;
+
+    let status_jid: Jid = "status@broadcast".parse().expect("status jid should parse");
+    assert!(
+        client.chat_lanes.get(&status_jid).await.is_some(),
+        "a <status> stanza must be enqueued on the status@broadcast chat lane"
+    );
+}
+
+/// WA Web nacks every stanza it does not recognize
+/// (`createNackFromStanza(NackReason.UnrecognizedStanza)`); staying silent is
+/// what let an unhandled `<status>` stanza sit in the offline queue for days,
+/// with the server recycling the stream every ~50 min to demand its ack.
+#[tokio::test]
+async fn unrecognized_stanza_is_nacked() {
+    let (client, transport) = capturing_client("unrecognized_stanza_nack").await;
+
+    let unknown = NodeBuilder::new("totally_unknown_stanza")
+        .attr("from", "status@broadcast")
+        .attr("id", "UNKNOWN-1")
+        .attr("participant", "200725430796339@lid")
+        .attr("type", "media")
+        .build();
+
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&unknown))
+        .await;
+
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(frame) = transport.sent().first().cloned() {
+                return frame;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("an unrecognized stanza must be nacked so the server stops retrying");
+
+    let bytes = decode_frame(0, &frame).expect("nack frame should decrypt");
+    let nack =
+        wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("nack frame should decode");
+    assert_eq!(nack.tag.as_ref(), "ack");
+    assert!(
+        nack.get_attr("class")
+            .is_some_and(|v| v.as_str() == "totally_unknown_stanza"),
+        "WA Web echoes the original tag as the nack class"
+    );
+    assert!(
+        nack.get_attr("error").is_some_and(|v| v.as_str() == "488"),
+        "UnrecognizedStanza is error 488"
+    );
+    assert!(
+        nack.get_attr("id")
+            .is_some_and(|v| v.as_str() == "UNKNOWN-1")
+    );
+    assert!(
+        nack.get_attr("to")
+            .is_some_and(|v| v.as_str() == "status@broadcast")
+    );
+    assert!(
+        nack.get_attr("participant")
+            .is_some_and(|v| v.as_str() == "200725430796339@lid")
+    );
+    assert!(nack.get_attr("type").is_some_and(|v| v.as_str() == "media"));
+}
+
+/// The nack needs `id` + `from` to be routable, exactly like WA Web's
+/// `createNackFromStanza` guard; without them it must stay silent instead of
+/// putting a malformed ack on the wire.
+#[tokio::test]
+async fn unrecognized_stanza_without_id_is_not_nacked() {
+    let (client, transport) = capturing_client("unrecognized_stanza_no_id").await;
+
+    let unknown = NodeBuilder::new("totally_unknown_stanza")
+        .attr("from", "s.whatsapp.net")
+        .build();
+
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&unknown))
+        .await;
+
+    // Give any spawned send a chance to reach the transport before asserting.
+    for _ in 0..64 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        transport.sent_count(),
+        0,
+        "a stanza with no id cannot be nacked"
+    );
+}
+
+/// A `<status>` from a newsletter is not the status@broadcast shape, so it
+/// keeps the router path; unhandled, it must be nacked exactly once — never a
+/// plain ack alongside the nack.
+#[tokio::test]
+async fn newsletter_status_stanza_is_nacked_once() {
+    let (client, transport) = capturing_client("newsletter_status_nack").await;
+
+    let status = NodeBuilder::new("status")
+        .attr("from", "120363298765432100@newsletter")
+        .attr("id", "NL-STATUS-1")
+        .attr("type", "media")
+        .build();
+
+    client
+        .process_node(crate::test_utils::node_to_owned_ref(&status))
+        .await;
+
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(frame) = transport.sent().first().cloned() {
+                return frame;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("an unhandled newsletter <status> must be nacked");
+
+    let bytes = decode_frame(0, &frame).expect("nack frame should decrypt");
+    let nack =
+        wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("nack frame should decode");
+    assert_eq!(nack.tag.as_ref(), "ack");
+    assert!(nack.get_attr("error").is_some_and(|v| v.as_str() == "488"));
+
+    for _ in 0..64 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        transport.sent_count(),
+        1,
+        "the nack replaces the ack; the server must not get both"
+    );
+}

--- a/wacore/src/crypto.rs
+++ b/wacore/src/crypto.rs
@@ -21,6 +21,37 @@ pub fn md5_digest(input: &[u8]) -> [u8; 16] {
     md5::compute(input).into()
 }
 
+/// Suffix WA Web mixes into the contact hash (`WAWebApiContact`).
+const CONTACT_NOTIFICATION_HASH_SUFFIX: &[u8] = b"WA_ADD_NOTIF";
+
+/// The contact identifier carried by `<notification type="devices">
+/// <update hash="..."/></notification>`: the first 3 bytes of
+/// `md5(user + "WA_ADD_NOTIF")`, base64-encoded on the wire (4 chars).
+///
+/// `user` is the bare user part of the contact's JID (WA Web hashes
+/// `createWid(contact.id).user`, which is LID-namespaced for migrated
+/// contacts). Fed incrementally so no concatenation buffer is allocated.
+pub fn contact_notification_hash(user: &str) -> [u8; 3] {
+    let mut context = md5::Context::new();
+    context.consume(user.as_bytes());
+    context.consume(CONTACT_NOTIFICATION_HASH_SUFFIX);
+    let digest: [u8; 16] = context.finalize().into();
+    [digest[0], digest[1], digest[2]]
+}
+
+/// Decode the wire form of [`contact_notification_hash`] (4 base64 chars) back
+/// into its 3 bytes. Returns `None` for anything that is not exactly one
+/// base64 group, so a malformed attribute can never alias a real contact.
+pub fn parse_contact_notification_hash(wire: &str) -> Option<[u8; 3]> {
+    use base64::Engine as _;
+
+    let mut decoded = [0u8; 3];
+    let written = base64::engine::general_purpose::STANDARD_NO_PAD
+        .decode_slice(wire.as_bytes(), &mut decoded)
+        .ok()?;
+    (written == decoded.len()).then_some(decoded)
+}
+
 /// Rejects output beyond HKDF's 255-block expansion limit before allocating.
 pub fn hkdf_sha256(
     input_key_material: &[u8],
@@ -64,6 +95,39 @@ pub fn calculate_curve_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Vectors captured from a live `<notification type="devices">
+    /// <update hash="..."/>` stream, cross-checked against the LIDs seen in the
+    /// same session.
+    #[test]
+    fn contact_notification_hash_matches_wire_vectors() {
+        use base64::Engine as _;
+        for (user, wire) in [
+            ("196314885312593", "TNcq"),
+            ("171588355903730", "XYZ6"),
+            ("202018165633152", "dcjp"),
+        ] {
+            let encoded =
+                base64::engine::general_purpose::STANDARD.encode(contact_notification_hash(user));
+            assert_eq!(encoded, wire, "contact hash for {user}");
+            assert_eq!(
+                parse_contact_notification_hash(wire),
+                Some(contact_notification_hash(user)),
+                "wire hash for {user} must round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_contact_hashes_are_rejected() {
+        for wire in ["", "TNc", "TNcqX", "TNcq==", "!!!!", "TNcqTNcq"] {
+            assert_eq!(
+                parse_contact_notification_hash(wire),
+                None,
+                "{wire:?} is not a single base64 group"
+            );
+        }
+    }
 
     #[test]
     fn hashes_and_expands_known_vectors() {

--- a/wacore/src/crypto.rs
+++ b/wacore/src/crypto.rs
@@ -25,10 +25,8 @@ pub fn md5_digest(input: &[u8]) -> [u8; 16] {
 const CONTACT_NOTIFICATION_HASH_SUFFIX: &[u8] = b"WA_ADD_NOTIF";
 
 /// The contact identifier carried by `<notification type="devices">
-/// <update hash="..."/></notification>`, base64-encoded on the wire.
-///
-/// `user` is the bare user part of the contact's JID, LID-namespaced for
-/// migrated contacts. Fed incrementally to avoid a concatenation buffer.
+/// <update hash="..."/></notification>`, base64-encoded on the wire. `user` is
+/// the contact's bare user part. Fed incrementally to avoid a concat buffer.
 pub fn contact_notification_hash(user: &str) -> [u8; 3] {
     let mut context = md5::Context::new();
     context.consume(user.as_bytes());
@@ -37,9 +35,9 @@ pub fn contact_notification_hash(user: &str) -> [u8; 3] {
     [digest[0], digest[1], digest[2]]
 }
 
-/// Decode the wire form of [`contact_notification_hash`] (4 base64 chars) back
-/// into its 3 bytes. Returns `None` for anything that is not exactly one
-/// base64 group, so a malformed attribute can never alias a real contact.
+/// Decode the wire form of [`contact_notification_hash`]. Rejects anything that
+/// is not exactly one base64 group, so a malformed attribute cannot alias a
+/// real contact.
 pub fn parse_contact_notification_hash(wire: &str) -> Option<[u8; 3]> {
     use base64::Engine as _;
 
@@ -94,9 +92,7 @@ pub fn calculate_curve_signature(
 mod tests {
     use super::*;
 
-    /// The construction was confirmed against a live `<notification
-    /// type="devices"><update hash="..."/>` stream before these fictitious
-    /// vectors were derived from it.
+    /// Confirmed against a live stream, then re-derived from fictitious LIDs.
     #[test]
     fn contact_notification_hash_matches_wire_vectors() {
         use base64::Engine as _;

--- a/wacore/src/crypto.rs
+++ b/wacore/src/crypto.rs
@@ -25,12 +25,10 @@ pub fn md5_digest(input: &[u8]) -> [u8; 16] {
 const CONTACT_NOTIFICATION_HASH_SUFFIX: &[u8] = b"WA_ADD_NOTIF";
 
 /// The contact identifier carried by `<notification type="devices">
-/// <update hash="..."/></notification>`: the first 3 bytes of
-/// `md5(user + "WA_ADD_NOTIF")`, base64-encoded on the wire (4 chars).
+/// <update hash="..."/></notification>`, base64-encoded on the wire.
 ///
-/// `user` is the bare user part of the contact's JID (WA Web hashes
-/// `createWid(contact.id).user`, which is LID-namespaced for migrated
-/// contacts). Fed incrementally so no concatenation buffer is allocated.
+/// `user` is the bare user part of the contact's JID, LID-namespaced for
+/// migrated contacts. Fed incrementally to avoid a concatenation buffer.
 pub fn contact_notification_hash(user: &str) -> [u8; 3] {
     let mut context = md5::Context::new();
     context.consume(user.as_bytes());
@@ -96,16 +94,16 @@ pub fn calculate_curve_signature(
 mod tests {
     use super::*;
 
-    /// Vectors captured from a live `<notification type="devices">
-    /// <update hash="..."/>` stream, cross-checked against the LIDs seen in the
-    /// same session.
+    /// The construction was confirmed against a live `<notification
+    /// type="devices"><update hash="..."/>` stream before these fictitious
+    /// vectors were derived from it.
     #[test]
     fn contact_notification_hash_matches_wire_vectors() {
         use base64::Engine as _;
         for (user, wire) in [
-            ("196314885312593", "TNcq"),
-            ("171588355903730", "XYZ6"),
-            ("202018165633152", "dcjp"),
+            ("100000000000001", "s7oK"),
+            ("100000000000002", "P2DY"),
+            ("100000000000003", "4ZhY"),
         ] {
             let encoded =
                 base64::engine::general_purpose::STANDARD.encode(contact_notification_hash(user));
@@ -120,7 +118,7 @@ mod tests {
 
     #[test]
     fn malformed_contact_hashes_are_rejected() {
-        for wire in ["", "TNc", "TNcqX", "TNcq==", "!!!!", "TNcqTNcq"] {
+        for wire in ["", "s7o", "s7oKX", "s7oK==", "!!!!", "s7oKs7oK"] {
             assert_eq!(
                 parse_contact_notification_hash(wire),
                 None,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1350,6 +1350,7 @@ pub struct Disconnected {
     pub reason: crate::net::DisconnectReason,
 }
 
+/// `total` is authoritative; the per-kind counts need not sum to it.
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct OfflineSyncPreview {
@@ -1358,6 +1359,8 @@ pub struct OfflineSyncPreview {
     pub messages: i32,
     pub notifications: i32,
     pub receipts: i32,
+    pub calls: i32,
+    pub statuses: i32,
 }
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]


### PR DESCRIPTION
## Summary

A three-day production log from a personal account had zero `ERROR` lines and 206 `WARN`, every one of them tracing back to a single cause: the server started delivering E2EE status updates as a top-level `<status>` stanza instead of `<message from="status@broadcast">`, and we had no handler for that tag. The stanza was never processed and, worse, never acked — so the server kept it queued, redelivered it on every reconnect, and recycled the stream every ~50 minutes asking for the ack it was owed.

The timeline in the log is unambiguous. Before the first pending status the client held a connection for up to 16 hours; from that point on the stream ended at 50min02s intervals without a single exception, for days. 46 forced reconnects, 7 status updates redelivered up to 25 times each, none of them ever surfaced to the consumer.

Chasing that also turned up a second bug in the same log and one structural gap that made the first bug possible at all, so all three are here.

## Changes

### `<status>` stanzas are handled and acked

`WAWebCommsHandleMessagingStanza` retags a non-newsletter `<status>` to `message` and runs the normal pipeline; the stanza differs from the old shape only in its tag. This does the same, and adds the tag to the ack gate so the transport ack goes out with `class="status"` — the class the server names in `<stream:error><ack class="status"/></stream:error>` — plus the own device JID, matching `sendAck`. `parse_message_info` reads attributes only, so nothing downstream needed changing.

A newsletter `<status>` is deliberately not routed here; it falls through to the nack below rather than being silently dropped.

### Unrecognized stanzas get nacked

The reason one unhandled tag could stall a stream for days is that we answer nothing at all when the router does not recognize a stanza. WA Web ends `handleLoggedInStanza` with `createNackFromStanza(NackReason.UnrecognizedStanza)` precisely so the server stops retrying. Any stanza the router declines now gets `<ack class="<original tag>" error="488">` when it is addressable (`id` and `from` present, the same guard WA Web uses); the nack replaces the deferred ack, so the server never gets both for one stanza.

Every top-level tag observed in the log has a handler, so this fires only for something genuinely new from the server — which is the case that cost us the reconnect loop.

### Hash-only device updates refresh the right contact

`<notification type="devices"><update hash="..."/></notification>` names, by hash, the *contact* whose device list changed. The notification's `from` is our own account and carries no information about whose list moved. We were invalidating the registry of `from`: 431 of these in the log, each throwing away our own companion list, after which the next message from one of those devices looked like an unknown device and kicked off a redundant sync (49 of those). The contact that actually changed was never refreshed, which means encrypting to a stale device list until something else corrected it.

The hash is `base64(md5(user + "WA_ADD_NOTIF")[..3])` (`WAWebApiContact`). I verified it against the log rather than trusting the read: of 113 distinct hashes, 6 match LIDs that appear elsewhere in the same session, against 0.012 expected by chance for a 3-byte space — the remaining 107 belong to contacts whose LID never appears (the phone numbers are redacted by the log shipper). The reverse index lives in the LID-PN cache, which already sees every mapping the client learns and warms 556 of them at boot. Both identifiers of a pair are indexed because the hashed id is LID-namespaced only for migrated contacts, and both point at the LID so either wire form resolves the same contact. A 3-byte hash collides for roughly one pair in a few thousand contacts; last write wins and the loser misses one refresh, which is the same behaviour as WA Web's single-record lookup. An unresolvable hash refreshes nothing.

An offline resume in progress batches the refresh instead of firing a usync mid-drain, mirroring `addUserToPendingDeviceSync`.

### Allocation

The ack gate called `ValueRef::to_jid()` on every inbound `<message>`, materializing an owned `Jid` to ask one question about it. It now matches the borrowed attribute (`parse_jid_ref` for the string form), which answers the same question with no allocation. The contact hash is fed to md5 incrementally so there is no concatenation buffer, and the wire hash decodes into a stack `[u8; 3]`.

## Tests

Each fix was written test-first; all of these fail on `main`.

- `status_stanza_gets_transport_ack` — drives a real `<status>` through `process_node` and decodes the frame off the wire, asserting class, id, to, participant, type and from. Pre-fix it times out with nothing sent, which is the production bug exactly.
- `status_stanza_is_routed_to_the_message_pipeline` — the stanza reaches the status@broadcast chat lane, not just an ack.
- `test_ack_behavior_for_incoming_stanzas` — extended with the `<status>` case.
- `unrecognized_stanza_is_nacked` / `unrecognized_stanza_without_id_is_not_nacked` — the nack and its addressability guard.
- `newsletter_status_stanza_is_nacked_once` — asserts exactly one frame, pinning that a nack is never accompanied by a plain ack.
- `contact_notification_hash_matches_wire_vectors` — the three hash/LID pairs captured from the live stream, plus round-trip.
- `malformed_contact_hashes_are_rejected` — a malformed attribute can never alias a real contact.
- `hash_only_device_update_keeps_the_notified_users_registry` — the companion device survives the update.
- `hash_only_device_update_refreshes_the_hashed_contact` / `unresolvable_contact_hash_syncs_nothing` — the right contact is queued, and an unknown hash queues nobody.

## Also in the log, checked and found correct

Worth recording so nobody re-investigates: keepalive cadence (15-30s jittered, skipped while an IQ is pending) matches `maybeScheduleHealthCheck`; the 220 identity changes and 57 raw_id mismatches are correct handling of server pushes; group cache invalidation is lazy on purpose; the 14 `SenderKey could not find chain ID` occurrences correctly become retry receipts. Over 10k decrypts there was not one BadMac, InvalidPreKeyId or decrypt failure.

### The offline preview counts what it announces

`<ib><offline_preview>` announces status and call backlogs alongside the kinds the event already carried, so a preview of four status updates read as `4 total (0 messages, 0 notifications, 0 receipts, 0 app data changes)`. Both are now parsed and exposed on `OfflineSyncPreview`, which is `#[non_exhaustive]` and built through its builder, so the added fields break no consumer.

## Validation

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p whatsapp-rust -p wacore -p wacore-binary --lib   # 2511 passed
```

Full matrix left to CI; e2e not run locally.
