### PR TITLE
fix(voip): dial the relay endpoint on the web client port

### DIFF
--- a/wacore/src/voip/relay_parse.rs
+++ b/wacore/src/voip/relay_parse.rs
@@ -330,12 +330,9 @@ pub fn merge_relay_data(base: RelayData, patch: RelayData) -> RelayData {
     }
 }
 
-/// The port a web client's relay media rides on. WA Web dials every relay candidate here regardless
-/// of the port the `<te2>` advertised, keeping the advertised one only as `originalPort`
-/// (`WAWebVoipSctpConnectionManager`: `TRUE_WEB_CLIENT_RELAY_PORT`, next to `FAUX_WEB_CLIENT_RELAY_PORT`
-/// = 3478). Relays that answer here are the ones that route a web client's media in BOTH directions:
-/// an endpoint on 3478 completes the handshake and accepts our uplink, but never forwards the peer's
-/// stream back (issue #1098).
+/// The port a web client's relay media rides on. Only relays answering here route a web client's
+/// media in both directions; one on 3478 completes the handshake and carries our uplink but never
+/// forwards the peer's stream back (issue #1098).
 pub const WEB_CLIENT_RELAY_PORT: u16 = 3480;
 
 /// FNA relays (is_fna=1, auth_token_id=0) are inbound-only; not for outbound relaylatency.
@@ -359,11 +356,8 @@ pub fn get_outbound_relay_endpoints(relay_data: &RelayData) -> Vec<RelayEndpoint
 
 /// The relay endpoint to connect the MEDIA transport to.
 ///
-/// Prefer an endpoint on [`WEB_CLIENT_RELAY_PORT`]: those are the ones that route a web client's
-/// media in BOTH directions. An endpoint on 3478 completes the handshake and happily carries our
-/// uplink -- the peer hears us -- but the relay never forwards the peer's stream back, so the call
-/// is silently one-way (issue #1098). This mirrors WA Web, which dials every candidate on 3480 and
-/// therefore only ever reaches the relays answering there.
+/// Prefer an endpoint on [`WEB_CLIENT_RELAY_PORT`], or the call goes silently one-way: the other
+/// endpoints connect and carry our uplink without ever delivering the peer's media.
 ///
 /// Below that: `auth_token_id` only gates relaylatency probes, so an offer that carries every
 /// endpoint with `auth_token_id=0` has no relaylatency candidate yet must still connect for media.
@@ -638,9 +632,8 @@ mod tests {
         assert_eq!(selected.relay_name, "real");
     }
 
-    /// A `<relay>` shaped like the ones WhatsApp actually hands an outgoing 1:1 call: three relays,
-    /// each with one IPv4 and one IPv6 address, and only the "true web client" one listening on
-    /// [`WEB_CLIENT_RELAY_PORT`]. Captured from a live call (issue #1098).
+    /// Captured from a live outgoing call: the mix that matters is one endpoint on
+    /// [`WEB_CLIENT_RELAY_PORT`] against lower-RTT ones on 3478.
     fn live_outgoing_relay() -> RelayData {
         let ep = |name: &str, id: u32, fna: bool, token_id: u32, auth: u32, ip: &str, port: u16| {
             RelayEndpoint {
@@ -686,12 +679,8 @@ mod tests {
         }
     }
 
-    /// The regression this whole module exists for: dialing a relay that does not listen on the web
-    /// client port gets an allocate-success and carries our uplink, but the relay never forwards the
-    /// peer's media back, so the call is one-way silent. WA Web pins every relay connection to 3480
-    /// (`WAWebVoipSctpConnectionManager`: `TRUE_WEB_CLIENT_RELAY_PORT`), which in practice selects the
-    /// only endpoint that answers there. Verified live: 3478 endpoints connect but never receive RTP;
-    /// the 3480 endpoint receives immediately.
+    /// Selecting by tier alone picks the lowest-RTT non-FNA endpoint, which is the one-way silent
+    /// case from issue #1098.
     #[test]
     fn media_relay_prefers_the_web_client_port_endpoint() {
         let rd = live_outgoing_relay();

--- a/wacore/src/voip/relay_parse.rs
+++ b/wacore/src/voip/relay_parse.rs
@@ -330,6 +330,14 @@ pub fn merge_relay_data(base: RelayData, patch: RelayData) -> RelayData {
     }
 }
 
+/// The port a web client's relay media rides on. WA Web dials every relay candidate here regardless
+/// of the port the `<te2>` advertised, keeping the advertised one only as `originalPort`
+/// (`WAWebVoipSctpConnectionManager`: `TRUE_WEB_CLIENT_RELAY_PORT`, next to `FAUX_WEB_CLIENT_RELAY_PORT`
+/// = 3478). Relays that answer here are the ones that route a web client's media in BOTH directions:
+/// an endpoint on 3478 completes the handshake and accepts our uplink, but never forwards the peer's
+/// stream back (issue #1098).
+pub const WEB_CLIENT_RELAY_PORT: u16 = 3480;
+
 /// FNA relays (is_fna=1, auth_token_id=0) are inbound-only; not for outbound relaylatency.
 pub fn is_outbound_relay_candidate(endpoint: &RelayEndpoint) -> bool {
     !endpoint.is_fna && endpoint.auth_token_id != 0
@@ -349,10 +357,18 @@ pub fn get_outbound_relay_endpoints(relay_data: &RelayData) -> Vec<RelayEndpoint
     out
 }
 
-/// The relay endpoint to connect the MEDIA transport to. `auth_token_id` only gates relaylatency
-/// probes, so an offer that carries every endpoint with `auth_token_id=0` has no relaylatency
-/// candidate yet must still connect for media. Prefer a relaylatency candidate, else any non-FNA
-/// endpoint, else the first; otherwise the call is dropped with no media.
+/// The relay endpoint to connect the MEDIA transport to.
+///
+/// Prefer an endpoint on [`WEB_CLIENT_RELAY_PORT`]: those are the ones that route a web client's
+/// media in BOTH directions. An endpoint on 3478 completes the handshake and happily carries our
+/// uplink -- the peer hears us -- but the relay never forwards the peer's stream back, so the call
+/// is silently one-way (issue #1098). This mirrors WA Web, which dials every candidate on 3480 and
+/// therefore only ever reaches the relays answering there.
+///
+/// Below that: `auth_token_id` only gates relaylatency probes, so an offer that carries every
+/// endpoint with `auth_token_id=0` has no relaylatency candidate yet must still connect for media.
+/// Prefer a relaylatency candidate, else any non-FNA endpoint, else the first; otherwise the call is
+/// dropped with no media.
 ///
 /// At each tier prefer a USABLE endpoint -- one with an IPv4 address to dial AND a token we hold --
 /// so a preferred-but-unusable endpoint doesn't drop a call that a later fallback endpoint in the
@@ -369,11 +385,22 @@ pub fn get_media_relay_endpoint(relay_data: &RelayData) -> Option<&RelayEndpoint
                 .get(e.token_id as usize)
                 .is_some_and(|t| !t.is_empty())
     };
+    // Judged on the IPv4 address the transport actually dials, not on any address the endpoint
+    // happens to carry: an IPv6-only 3480 entry would not change where we connect.
+    let on_web_client_port = |e: &RelayEndpoint| {
+        get_primary_ipv4_address(e).is_some_and(|(_, port)| port == WEB_CLIENT_RELAY_PORT)
+    };
     let pick = |usable_only: bool| {
         relay_data
             .endpoints
             .iter()
-            .find(|e| is_outbound_relay_candidate(e) && (!usable_only || usable(e)))
+            .find(|e| on_web_client_port(e) && (!usable_only || usable(e)))
+            .or_else(|| {
+                relay_data
+                    .endpoints
+                    .iter()
+                    .find(|e| is_outbound_relay_candidate(e) && (!usable_only || usable(e)))
+            })
             .or_else(|| {
                 relay_data
                     .endpoints
@@ -609,6 +636,106 @@ mod tests {
         let selected =
             get_media_relay_endpoint(&rd).expect("the real-token endpoint must be picked");
         assert_eq!(selected.relay_name, "real");
+    }
+
+    /// A `<relay>` shaped like the ones WhatsApp actually hands an outgoing 1:1 call: three relays,
+    /// each with one IPv4 and one IPv6 address, and only the "true web client" one listening on
+    /// [`WEB_CLIENT_RELAY_PORT`]. Captured from a live call (issue #1098).
+    fn live_outgoing_relay() -> RelayData {
+        let ep = |name: &str, id: u32, fna: bool, token_id: u32, auth: u32, ip: &str, port: u16| {
+            RelayEndpoint {
+                relay_id: id,
+                relay_name: name.into(),
+                token_id,
+                auth_token_id: auth,
+                is_fna: fna,
+                addresses: vec![
+                    RelayAddress {
+                        protocol: 0,
+                        ipv4: Some(ip.into()),
+                        ipv6: None,
+                        port,
+                    },
+                    RelayAddress {
+                        protocol: 0,
+                        ipv4: None,
+                        ipv6: Some("2804:3504:ffff:1:face:b00c:3333:4df0".into()),
+                        port,
+                    },
+                ],
+                ..RelayEndpoint::default()
+            }
+        };
+        RelayData {
+            relay_tokens: vec![vec![0xA0], vec![0xA1], vec![0xA2]],
+            auth_tokens: vec![vec![0xB0], vec![0xB1]],
+            endpoints: vec![
+                ep(
+                    "fimp3c01",
+                    0,
+                    true,
+                    0,
+                    0,
+                    "170.78.54.98",
+                    WEB_CLIENT_RELAY_PORT,
+                ),
+                ep("for2c01", 1, false, 1, 1, "57.144.129.57", 3478),
+                ep("bsb1c01", 2, false, 2, 1, "57.144.137.57", 3478),
+            ],
+            ..RelayData::default()
+        }
+    }
+
+    /// The regression this whole module exists for: dialing a relay that does not listen on the web
+    /// client port gets an allocate-success and carries our uplink, but the relay never forwards the
+    /// peer's media back, so the call is one-way silent. WA Web pins every relay connection to 3480
+    /// (`WAWebVoipSctpConnectionManager`: `TRUE_WEB_CLIENT_RELAY_PORT`), which in practice selects the
+    /// only endpoint that answers there. Verified live: 3478 endpoints connect but never receive RTP;
+    /// the 3480 endpoint receives immediately.
+    #[test]
+    fn media_relay_prefers_the_web_client_port_endpoint() {
+        let rd = live_outgoing_relay();
+        let selected = get_media_relay_endpoint(&rd).expect("an endpoint must be selectable");
+        assert_eq!(
+            selected.relay_name, "fimp3c01",
+            "must dial the relay listening on the web client port, not the lowest-RTT non-FNA one"
+        );
+        assert_eq!(
+            get_primary_ipv4_address(selected),
+            Some(("170.78.54.98".to_string(), WEB_CLIENT_RELAY_PORT))
+        );
+    }
+
+    /// The preference must not override usability: an endpoint on the web client port whose token we
+    /// don't hold is undialable, so a usable endpoint elsewhere in the block still wins.
+    #[test]
+    fn web_client_port_preference_yields_to_usability() {
+        let mut rd = live_outgoing_relay();
+        // Point the 3480 endpoint at a token index the block never sent.
+        rd.endpoints[0].token_id = 9;
+        let selected = get_media_relay_endpoint(&rd).expect("a usable endpoint must be selectable");
+        assert_eq!(selected.relay_name, "for2c01");
+    }
+
+    /// No endpoint on the web client port (some blocks carry none): selection must fall back to the
+    /// previous behavior rather than failing the call.
+    #[test]
+    fn falls_back_when_no_endpoint_uses_the_web_client_port() {
+        let mut rd = live_outgoing_relay();
+        rd.endpoints.remove(0);
+        let selected = get_media_relay_endpoint(&rd).expect("an endpoint must still be selectable");
+        assert_eq!(selected.relay_name, "for2c01");
+    }
+
+    /// An endpoint is only "on the web client port" if the address we would actually dial (IPv4) uses
+    /// it; a block whose IPv6 alone sits on 3480 must not be picked on that basis, since the transport
+    /// dials IPv4.
+    #[test]
+    fn web_client_port_is_judged_by_the_dialed_ipv4_address() {
+        let mut rd = live_outgoing_relay();
+        rd.endpoints[0].addresses[0].port = 3478; // IPv4 moved off 3480, IPv6 left on it
+        let selected = get_media_relay_endpoint(&rd).expect("an endpoint must be selectable");
+        assert_eq!(selected.relay_name, "for2c01");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1098. An outgoing 1:1 call connected and our uplink reached the callee, but the caller received **zero inbound RTP** for the entire call: the peer heard us, we heard silence. The same build receives audio correctly when it is the callee.

The `<relay>` block offers several endpoints and only one of them listens on port **3480**; the others listen on 3478. Media selection preferred the lowest tier non-FNA endpoint, which always landed on 3478. Such an endpoint completes DTLS, answers the allocate, and accepts our uplink, so nothing surfaces as an error anywhere — but the relay never forwards the peer's stream back.

The fix prefers an endpoint whose dialed IPv4 address is on the web client port, mirroring what WA Web effectively does.

## Protocol evidence

`WAWebVoipSctpConnectionManager` builds its relay connection map like this:

```js
var de = {
  FAUX_WEB_CLIENT_RELAY_PORT: 3478,
  TRUE_WEB_CLIENT_RELAY_PORT: 3480,
  USE_AUTH_TOKEN_FOR_ICE: true
};
...
var _ = be(m, de.TRUE_WEB_CLIENT_RELAY_PORT);
var f = { ip: m, port: de.TRUE_WEB_CLIENT_RELAY_PORT, originalPort: p, ... };
```

WA Web dials **every** candidate on 3480 regardless of the port the `<te2>` advertised, keeping the advertised one only as `originalPort`. Since a relay only answers on the port it advertises, that means WA Web only ever reaches the relays listening on 3480. Its own name for 3478 is `FAUX_WEB_CLIENT_RELAY_PORT`.

We connect to a single endpoint rather than to all candidates, so the equivalent behavior is to *select* the endpoint already on that port. Blocks that offer none keep the previous selection, so this cannot make a working call worse.

Worth recording: `is_fna` — which the current heuristic keys on — appears in **neither** the Android native library nor the web WASM module. No official client reads that attribute; it only correlated with the working endpoint by accident in the blocks we sampled. `prefer_relay` does exist in both, but it is P2P-versus-relay policy, not endpoint selection.

## Changes

- `WEB_CLIENT_RELAY_PORT` (3480) as a named constant, documenting why an endpoint on 3478 looks healthy but is one-way.
- `get_media_relay_endpoint` gains a top tier preferring endpoints on that port. It sits above the existing tiers and stays subordinate to the usability check, so an endpoint on the web client port whose token we do not hold still yields to a dialable one.
- Port is judged on the endpoint's IPv4 address, since that is what the transport dials; an IPv6-only entry on 3480 does not qualify.

No public API change, no wire change, no new dependency.

## Validation

Live calls between this client (linked companion) and a real WhatsApp Android client, instrumented with temporary per-class socket tallies:

| endpoint | dialed address | inbound RTP |
|---|---|---|
| `fimp3c01` | `…:3480` | flows immediately, audio both ways |
| `for2c01` | `…:3478` | none for the whole call (uplink fine) |
| `bsb1c01` | `…:3478` | none for the whole call (uplink fine) |

Forcing the port instead of the endpoint ruled out the port as an independent variable: 3480 on a 3478-only relay and 3478 on the 3480 relay both fail the DTLS handshake outright. With the fix and no overrides, outgoing and incoming calls were both verified to carry audio in both directions.

Two hypotheses were tested and refuted along the way, recorded here so they are not retried: the answering-device LID that the issue points at (the `<accept>` LID matched the relay's `peer_pid` participant, and the recv keying was already correct), and the relay election (`<relaylatency>`/`<transport>`) — inbound RTP arrives ~80ms *before* the first `<relaylatency>`, so media does not wait on it.

Tests, written before the fix:

- `media_relay_prefers_the_web_client_port_endpoint` — the regression itself, over a fixture captured from a live call; fails on `main`
- `web_client_port_preference_yields_to_usability` — the preference cannot select an undialable endpoint
- `falls_back_when_no_endpoint_uses_the_web_client_port` — blocks without one keep the old behavior
- `web_client_port_is_judged_by_the_dialed_ipv4_address` — an IPv6-only 3480 entry does not qualify

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p wacore --lib   # 1220 passed
```

Full matrix left to CI.
