### PR TITLE
docs(agents): correct stale agent docs and add a WA Web verification path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,58 @@
 # WhatsApp-Rust
 
-Rust implementation of the WhatsApp protocol, inspired by **whatsmeow** (Go), **Baileys** (TypeScript), and real **WhatsApp Web** behavior. Covers QR pairing, E2E encrypted messaging (1-on-1 + group), media upload/download, and connection management.
+Rust implementation of the WhatsApp protocol: QR pairing, E2E encrypted messaging (1-on-1 + group), media, VoIP, connection management.
 
-## Crate Structure
+Ground truth for protocol behavior is WhatsApp Web itself: query the structured [whatspec](https://github.com/oxidezap/whatspec) IR first, drop to the raw bundle in `docs/captured-js/` when it can't answer, and treat **whatsmeow** (Go) and **Baileys** (TypeScript) as second opinions. See `agent_docs/wa_web_reference.md`.
 
-- **wacore** — Platform-agnostic core: binary protocol, crypto, IQ types, state traits. No Tokio dependency.
-- **waproto** — Protobuf definitions (`whatsapp.proto`) compiled via prost. No feature logic here.
-- **whatsapp-rust** — Main client: Tokio runtime, SQLite persistence (Diesel), high-level API.
+## Crates
 
-## Build & Verify
+- **wacore** — platform-agnostic core: binary protocol, crypto, IQ types, state traits. Also builds for wasm32 and ESP32, so no Tokio here.
+- **waproto** — prost-generated protobufs from `whatsapp.proto`. No feature logic.
+- **whatsapp-rust** — Tokio runtime, SQLite persistence (Diesel), high-level API.
+
+## Build & verify
 
 ```bash
 cargo fmt --all
-cargo clippy --all --tests
-cargo test --all
-cargo test -p e2e-tests          # requires mock server running
+cargo test -p <touched crate> --lib                     # fast local loop
+cargo clippy --workspace --all-targets -- -D warnings   # what CI enforces
 ```
 
-## Rust Style
+Workspace clippy takes minutes — pushing and letting CI parallelize the matrix is usually faster. E2E tests (`cargo test -p e2e-tests`) need the mock server running; see `agent_docs/e2e_testing.md`.
 
-- **Collapsible if**: Always use let-chains (`if let Some(x) = foo && let Some(y) = x.bar { ... }`) instead of nested `if let` blocks. Clippy's `collapsible_if` lint will reject the nested form.
-- **No real PII in tests**: Use fictitious phone numbers and JIDs in test code. Never commit real user numbers.
+## Gotchas
 
-## Critical Conventions
+Things that look correct and are not:
 
-- **State**: Never modify Device state directly (not even in tests — a write-lock mutation bypasses the cached snapshot). Use `DeviceCommand` + `PersistenceManager::process_command()` (or `modify_device` internally). Read via `get_device_snapshot()` — it returns a cached `Arc<Device>` (sync, refcount-cheap, safe to call per message); borrow fields from the held snapshot instead of cloning them. `get_device_arc()` is only for store adapters that need `&mut Device` trait access.
-- **Async**: All I/O uses Tokio. Wrap blocking I/O (`ureq`) and heavy CPU work in `tokio::task::spawn_blocking`.
-- **Concurrency**: `session_locks` serializes per-sender Signal encrypt/decrypt. `message_enqueue_locks` serializes per-chat incoming message processing. Outgoing sends are not per-chat locked (matches WA Web).
-- **Errors**: `thiserror` for typed errors, `anyhow` for multi-failure functions. No `.unwrap()` outside tests.
-- **Protocol**: Cross-reference **whatsmeow**, **Baileys**, and captured WhatsApp Web JS (`docs/captured-js/`) to verify implementations.
-- **IQ Requests**: Use `client.execute(Spec::new(&jid)).await?` pattern. IqSpec constructors take `&Jid` not `Jid`.
-- **New features**: Expose via `src/features/mod.rs`, re-export in `src/lib.rs`.
-- **Event payloads**: Seal each payload struct with `#[non_exhaustive]` + `#[derive(bon::Builder)]` so fields can be added without breaking consumers; construct via the generated builder (`Type::builder()…build()`), not a struct literal. Model a maybe-absent field as `Option<T>` (gets a `maybe_*` setter), never an empty-string/zero sentinel. Every event payload is sealed this way (unit-marker events too, as empty sealed structs built via `X::builder().build()`); see the `Event` doc in `wacore/src/types/events.rs` for the full stability policy.
-- **Wire-tagged enums**: Every protocol enum uses `#[derive(WireEnum)]`. The `#[wire = "..."]` (or `#[wire = NUM]` for int mode) attribute is the SINGLE source of truth for each variant's wire value. Do NOT also derive `serde::Serialize`/`Deserialize` or add `#[serde(rename_all)]` — the derive owns both. Three modes: unit-string (default), tagged-with-payload (`#[wire(tag = "type")]` on the enum, optional `#[wire_alias = "..."]` and `#[wire(skip)]` on fields, `#[wire_fallback]` for catch-all), and int (`#[wire(kind = "int")]`). In tagged mode the derive auto-generates a sibling `<Name>Tag` enum; parsers must dispatch via `<Name>Tag::try_from(node.tag.as_ref())` instead of matching string literals, so renaming a wire tag stays a single-attribute change.
+- **Device state.** Never mutate `Device` directly, not even in tests — a write-lock mutation bypasses the cached snapshot. Mutate through `DeviceCommand` + `PersistenceManager::process_command()`; read through `get_device_snapshot()`, which returns a cached `Arc<Device>` (sync, refcount-cheap, safe per message) — hold it and borrow fields instead of cloning them. `get_device_arc()` exists only for store adapters that need `&mut Device` trait access.
+- **Locks.** `session_locks` serializes Signal encrypt/decrypt per protocol address; `chat_lanes` (`ChatLane::enqueue_lock` in `src/client.rs`) serializes *incoming* processing per chat. Outgoing sends are deliberately not per-chat locked — WA Web doesn't lock them either.
+- **Wire-tagged enums.** Every protocol enum derives `WireEnum`, and its `#[wire = ...]` attribute is the single source of truth for the wire value. Do not also derive `serde::Serialize`/`Deserialize` or add `#[serde(rename_all)]` — the derive owns both. In tagged mode it generates a sibling `<Name>Tag`; parsers must dispatch on `<Name>Tag::try_from(node.tag.as_ref())` rather than string literals, so renaming a tag stays a one-attribute change. Modes and attributes: `agent_docs/protocol_architecture.md`.
+- **Event payloads are a frozen API.** Sealed with `#[non_exhaustive]` + `#[derive(bon::Builder)]` and constructed via `Type::builder()…build()`; a maybe-absent field is `Option<T>`, never an empty-string or zero sentinel. The full stability policy is the `Event` doc comment in `wacore/src/types/events.rs`.
+- **Blocking work** — `ureq`, heavy CPU — belongs in `tokio::task::spawn_blocking`; it shares a runtime with the read loop.
+- **let-chains**, never nested `if let`. Clippy's `collapsible_if` is denied in CI.
+- **No real PII in tests**, including vectors derived from production captures. Regenerate them from fictitious JIDs and numbers.
+- **Errors**: `thiserror` for typed errors, `anyhow` where several failure kinds meet. No `.unwrap()` outside tests.
 
-## Detailed Docs
+## Adding a feature
 
-Read these when working on the relevant area:
+Find the wire format before designing anything — see `agent_docs/feature_implementation.md`. IQ requests go through `client.execute(Spec::new(&jid)).await?`, and `IqSpec` constructors take `&Jid` so callers need not clone. Public surface is `pub use` in `src/features/*.rs`, re-exported from `src/features/mod.rs` and `src/lib.rs`.
 
-- `agent_docs/protocol_architecture.md` — ProtocolNode, IqSpec, derive macros, node parsing
-- `agent_docs/feature_implementation.md` — Step-by-step feature implementation flow
-- `agent_docs/e2e_testing.md` — E2E test patterns, file organization, event-driven waiting
-- `agent_docs/debugging.md` — evcxr REPL, binary protocol debugging
-- `agent_docs/binary_size_ci.md` — size-tracking CI: metrics, budgets, baseline semantics
-- `agent_docs/observability.md` — per-session stats (I/O, memory report, TaskInstrument/CPU), design rules
-- `agent_docs/plugin_architecture.md` — native plugin host, lifecycle/capability invariants, future foreign adapter seam
-- `agent_docs/signal_durability.md` — Signal counter leases, pre-wire gates, crash recovery, review checklist
+Comments carry the *why* of a decision, at the single point where it is made. Repeating a rationale at call sites is how it goes stale.
 
-When adding comments to the code, dont be so verbose, also only explain why, not what
+## Detailed docs
+
+Read the one that covers what you are touching:
+
+| Doc | Read it when |
+| --- | --- |
+| `agent_docs/wa_web_reference.md` | Confirming any protocol behavior, limit, enum value, or stanza shape against real WA Web |
+| `agent_docs/protocol_architecture.md` | Building or parsing stanzas: `ProtocolNode`, `IqSpec`, derive macros, node helpers |
+| `agent_docs/noise_handshake.md` | Connection setup: XX/IK/fallback selection, server cert cache, failure classification |
+| `agent_docs/feature_implementation.md` | Starting a feature and needing its wire format from captured WA Web JS |
+| `agent_docs/signal_durability.md` | Any code that reads, mutates, persists, or sends Signal state |
+| `agent_docs/e2e_testing.md` | Writing or fixing tests under `tests/e2e/` |
+| `agent_docs/observability.md` | Adding a cache, counter, or anything reported by `memory_report()` / `stats()` |
+| `agent_docs/plugin_architecture.md` | Touching the `plugins` / `client-lifecycle` feature surface |
+| `agent_docs/voip_audio_codecs.md` | VoIP media: codec profiles, negotiation, encoded audio API |
+| `agent_docs/binary_size_ci.md` | A size gate failed, or a change adds dependencies or generic instantiations |
+| `agent_docs/debugging.md` | Decoding raw binary-protocol bytes by hand |

--- a/agent_docs/debugging.md
+++ b/agent_docs/debugging.md
@@ -62,4 +62,4 @@ WhatsApp binary protocol uses nibble encoding for numeric strings. Each byte con
 // Encode: "100000000000001" -> "100000000000001f"
 ```
 
-See `wacore/binary/src/nibble.rs` for the implementation.
+The implementation is split across `wacore/binary/src/encoder.rs` and `decoder.rs`. The full token dictionaries WhatsApp Web uses are in whatspec's `generated/tokens/index.json` (see `wa_web_reference.md`) when a byte doesn't decode to what you expect.

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -1,121 +1,55 @@
-# E2E Testing Best Practices
+# E2E tests
 
-E2E tests live in `tests/e2e/` and run against a mock WhatsApp server. They test real connection flows, encryption, and event delivery.
+`tests/e2e/` runs real connection, encryption, and event-delivery flows against a mock WhatsApp server. `tests/e2e/src/lib.rs` holds `TestClient`, which connects, waits for pairing and sync, and provides the event-based assertions.
 
-## Test Infrastructure
+## The one rule
 
-- **`tests/e2e/src/lib.rs`**: `TestClient` helper — connects to mock server, waits for pairing + sync, provides event-based assertions.
-- Each `TestClient` owns an isolated `InMemoryBackend`; the mock server is shared.
-- Libtest runs tests within a test binary **in parallel** by default. Never rely on test order.
-- Use `unique_push_name()` for server-side account isolation. For a multi-device test,
-  create one unique name and pass it only to that test's related clients.
-- CI pins the mock-server image by digest. Update it deliberately with the matching
-  server change so an unchanged client commit always runs against the same protocol peer.
-- Local runs must start the mock with `CHATSTATE_TTL_SECS=3`; `chatstate_ttl.rs`
-  intentionally uses the same shortened expiry as CI.
-
-## File Organization
-
-Split test files by domain so ownership and failures stay clear. Do not use file boundaries
-as a synchronization mechanism; correctness must not depend on how Cargo schedules test targets.
-
-```
-tests/e2e/tests/
-├── chat_actions.rs      # Pin, mute, archive, star
-├── connection.rs        # Connect, reconnect
-├── groups.rs            # Group CRUD, admin, settings
-├── media.rs             # Upload, download, send media
-├── messaging.rs         # Send/receive text messages
-├── chatstate_ttl.rs     # Chatstate expiry with the CI's 3-second mock TTL
-├── offline_groups.rs    # Offline group notifications
-├── offline_messages.rs  # Offline message queuing + delivery
-├── offline_receipts.rs  # Offline receipt + presence delivery
-├── presence.rs          # Typing indicators, availability
-├── profile.rs           # Push name, status text
-├── profile_picture.rs   # Profile picture CRUD
-└── receipts.rs          # Online receipt routing
-```
-
-When adding new tests, place them in the file matching their domain. If a file grows beyond ~10-15 tests, consider splitting further.
-
-## Recovery and Race Regressions
-
-Make recovery tests deterministic with narrow `test-util` fault hooks, then wait for an
-observable event, stanza, or bounded state transition. Do not depend on CPU load to hit a race, and
-do not raise a readiness timeout to hide a failed bootstrap phase. `app_state.rs`'s missing-key
-test is the reference pattern: remove exactly the required state, trigger a real sync, and
-assert that recovery reaches the wire.
-
-## Event-Driven Waiting (Preferred)
-
-Use `wait_for_event()` with predicates instead of arbitrary sleeps. This is both faster and more reliable:
+**Never synchronize on a fixed sleep.** Long enough to be reliable is slow; short enough to be fast is flaky. Wait on the condition itself — an event, or a bounded poll that fails with a clear message.
 
 ```rust
-// GOOD: event-driven — returns as soon as the event arrives
+// Returns as soon as the event arrives
 let event = client_b
     .wait_for_event(15, |e| e.messages().any(|m| m.message.conversation.as_deref() == Some("hello")))
     .await?;
-
-// BAD: arbitrary sleep — wastes time or causes flaky failures
-tokio::time::sleep(Duration::from_secs(2)).await;
 ```
 
-Reference: `groups.rs` uses zero sleeps and runs at ~2.2s/test. Follow this pattern for new tests.
+`groups.rs` uses zero sleeps and runs at ~2.2s per test. For state with no corresponding event, poll it with a deadline; raising a readiness timeout to make a failing bootstrap pass is not a fix.
 
-## Offline Testing Pattern
+Timeouts that hold up in practice: 10-15s for event waits in online flows (events normally arrive in under a second), 30s after an offline reconnect (reconnect plus queue drain), 3-5s for negative assertions, 5s for `wait_for_disconnected`.
 
-`reconnect()` tears the socket down in a background task, so the client is still
-online when it returns. Poll for the transition with `wait_for_disconnected()`
-instead of sleeping — `Event::Disconnected` is suppressed for expected
-disconnects, so the connection flag is the observable:
+## Isolation
+
+Each `TestClient` owns an isolated `InMemoryBackend`; the mock server is shared. Libtest runs tests inside a binary in parallel, so nothing may depend on test order — and file boundaries are organization, not synchronization.
+
+`unique_push_name()` gives server-side account isolation. In a multi-device test, create one unique name and pass it only to the clients that must share an account.
+
+CI pins the mock-server image by digest, so an unchanged client commit always runs against the same protocol peer; bump it deliberately, together with the matching server change. Local runs need `CHATSTATE_TTL_SECS=3` on the mock — `chatstate_ttl.rs` depends on the same shortened expiry CI uses.
+
+## Connect, disconnect, reconnect
+
+The distinction that catches people: **`reconnect()` tears the socket down in a background task**, so the client is still online when it returns. `Event::Disconnected` is suppressed for expected disconnects, which makes the connection flag the only observable.
 
 ```rust
-// Client goes offline (triggers auto-reconnect in background)
 client_b.client.reconnect().await;
 client_b.wait_for_disconnected(5).await?;
 
-// Now send while client is offline — server queues it
+// Now offline — the server queues this
 client_a.client.send_message(jid_b.clone(), message).await?;
 
-// Client reconnects automatically and receives from offline queue
+// Auto-reconnect drains the offline queue
 let event = client_b.wait_for_event(30, |e| matches!(e, Event::Messages(_))).await?;
 ```
 
-Full disconnects need nothing: `TestClient::disconnect()` awaits the run task, so
-the client is normally already offline when it returns. It caps that wait at 5s
-and warns instead of failing, so a test that depends on the client being offline
-afterwards should still assert it rather than assume it.
+`TestClient::disconnect()` awaits the run task, so the client is normally already offline on return — but it caps that wait at 5s and warns rather than failing, so a test that depends on being offline afterwards should assert it.
 
-```rust
-client_b.disconnect().await;
-```
+`reconnect_and_wait()` waits for the client to come back online. Using it in an offline test defeats the test.
 
-## `reconnect_and_wait()` Helper
+## Recovery and race regressions
 
-Use `TestClient::reconnect_and_wait()` when you need the client back online (not testing offline behavior):
+Make these deterministic with narrow `test-util` fault hooks, then wait for an observable event, stanza, or bounded state transition. Never depend on CPU load to hit a race. The reference pattern is `app_state.rs`'s missing-key test: remove exactly the required state, trigger a real sync, assert that recovery reaches the wire.
 
-```rust
-// Reconnects and waits for Connected event — no arbitrary sleep needed
-client_b.reconnect_and_wait().await?;
-```
+## Writing a new test
 
-Do NOT use this for offline tests — it waits for the client to be back online, defeating the purpose.
+Put it in the file matching its domain, or add one — if a file passes ~10-15 tests, split it. Use `TestClient::connect("unique_prefix")` with a prefix unique per client per test, return `anyhow::Result<()>`, `disconnect()` every client at the end, and initialize logging with `let _ = env_logger::builder().is_test(true).try_init();`.
 
-## Timeout Guidelines
-
-- **Event waits in online flows**: 10-15s (events arrive in <1s normally)
-- **Event waits after offline reconnect**: 30s (reconnect + offline queue drain)
-- **Negative assertions** (event should NOT arrive): 3-5s
-- **Going offline** (`wait_for_disconnected`): 5s
-
-Never synchronize on a fixed sleep: long enough to be reliable is slow, short
-enough to be fast is flaky. Wait on the condition itself — an event, or a poll
-with a bounded deadline that fails with a clear message.
-
-## Writing New E2E Tests
-
-1. Use `TestClient::connect("unique_prefix")` with a unique prefix per client per test.
-2. Use `wait_for_event()` for all assertions; for state with no event, poll it with a bounded deadline. Never sleep.
-3. Always call `disconnect()` on all clients at the end (cleanup).
-4. Return `anyhow::Result<()>` for clean error propagation.
-5. Use `env_logger` for debug output: `let _ = env_logger::builder().is_test(true).try_init();`
+Cover the failure alongside the success: a guard with two conditions needs both negatives.

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -27,7 +27,7 @@ CI pins the mock-server image by digest, so an unchanged client commit always ru
 
 ## Connect, disconnect, reconnect
 
-The distinction that catches people: **`reconnect()` tears the socket down in a background task**, so the client is still online when it returns. `Event::Disconnected` is suppressed for expected disconnects, which makes the connection flag the only observable.
+The distinction that catches people: **`reconnect()` tears the socket down in a background task**, so the client is still online when it returns. Do not wait for `Event::Disconnected` — it is suppressed for expected disconnects and will never arrive. Observe the connection state instead, which is what `wait_for_disconnected()` polls.
 
 ```rust
 client_b.client.reconnect().await;

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -21,7 +21,7 @@ Timeouts that hold up in practice: 10-15s for event waits in online flows (event
 
 Each `TestClient` owns an isolated `InMemoryBackend`; the mock server is shared. Libtest runs tests inside a binary in parallel, so nothing may depend on test order — and file boundaries are organization, not synchronization.
 
-`unique_push_name()` gives server-side account isolation. In a multi-device test, create one unique name and pass it only to the clients that must share an account.
+`unique_push_name()` gives server-side account isolation — it appends a fresh UUID, so two clients built from the same prefix still land on different accounts. Sharing an account is therefore explicit: build one name and hand it to each device with `connect_as(prefix, &name)`, which pairs them to the same phone number under different device IDs.
 
 CI pins the mock-server image by digest, so an unchanged client commit always runs against the same protocol peer; bump it deliberately, together with the matching server change. Local runs need `CHATSTATE_TTL_SECS=3` on the mock — `chatstate_ttl.rs` depends on the same shortened expiry CI uses.
 

--- a/agent_docs/feature_implementation.md
+++ b/agent_docs/feature_implementation.md
@@ -22,6 +22,8 @@ Patterns worth grepping across the dump: `xmlns:` for namespaces, `action:` for 
 
 Reading the JS gives you a hypothesis. If a capture yields an algorithm — a hash, a key derivation, a constant — run it against real captured data and report the hit rate against chance before building on it. "6 of 113 matched, 0.012 expected by chance" is evidence; "the code says md5" is a reading.
 
+The capture stays local, and only the aggregate leaves it: report the rate, never the rows. Real JIDs, phone numbers, and vectors derived from them do not belong in tests, commits, PR bodies, or issues — regenerate fixtures from fictitious identifiers once the hypothesis holds.
+
 ## Which crate
 
 - **wacore** — protocol logic, state traits, crypto helpers, data models. Platform-agnostic: it also builds for wasm32 and ESP32.

--- a/agent_docs/feature_implementation.md
+++ b/agent_docs/feature_implementation.md
@@ -1,59 +1,43 @@
-# Feature Implementation Guide
+# Finding a feature's wire format
 
-When adding a new feature, follow this flow that mirrors WhatsApp Web behavior while staying aligned with the project's architecture.
+The wire format is the ground truth, and it is discovered, not designed. Everything else — layering, ergonomics, tests — follows from it. This doc covers reading the raw bundle; conventions live in `AGENTS.md`, stanza mechanics in `protocol_architecture.md`.
 
-## Step-by-Step
+**Try the structured IR first.** `wa_web_reference.md` covers whatspec, which already extracts stanza shapes, enums, protocol limits, and notification dispatch into queryable JSON. Come back here when it can't answer — when the question is about control flow, ordering, or *when* a request is sent rather than what it contains.
 
-1. **Identify the wire format first**
-   - Capture or locate the WhatsApp Web request/response for the feature
-   - Extract the exact stanza structure: tags, attributes, and children
-   - Treat this as the ground truth for what must be sent and parsed
+## Where to look
 
-2. **Map the feature to the right layer**
-   - **wacore**: protocol logic, state traits, cryptographic helpers, data models (platform-agnostic)
-   - **whatsapp-rust**: runtime orchestration, storage integration, user-facing API
-   - **waproto**: protobuf structures only (no feature logic)
+`docs/captured-js/` is a local, untracked dump of WhatsApp Web (~3200 files under `WA/Smax/` alone). It is the highest-fidelity source available; whatsmeow and Baileys are second opinions when it is ambiguous.
 
-3. **Build minimal primitives before high-level APIs**
-   - Start with the smallest IQ/message builder that can successfully round-trip
-   - Parse and validate the response path before adding options or convenience
+Navigation that actually works:
 
-4. **Keep state changes behind the PersistenceManager**
-   - Use `DeviceCommand` + `PersistenceManager::process_command()` for mutations
-   - Use `get_device_snapshot()` for read access — sync, returns a cached `Arc<Device>` (refcount bump, no Device clone, no lock); hold it and borrow fields rather than cloning them
+- **`WA/Smax/Out*.js`** — outgoing request builders. `OutGroupsAddParticipantsRequest.js` is the shape of the stanza the client sends.
+- **`WA/Smax/In*.js`** — incoming response parsers, usually split into a success file and several error files per operation. The error files are where the server's failure taxonomy is written down.
+- Filenames repeat with a `__<hash>` suffix across bundle versions. Read the unsuffixed one; diff against a suffixed one only if you suspect the behavior changed between captures.
+- **`exports-map.json`** and **`dep-graph.json`** resolve a symbol to its module and find callers, which is faster than grepping 3000 files.
+- **`metadata.json`** lists GK gates — useful when a code path looks dead and is really feature-flagged.
 
-5. **Confirm concurrency requirements**
-   - Network I/O stays async
-   - Blocking or heavy CPU work goes into `tokio::task::spawn_blocking`
-   - Use `Client::chat_locks` to serialize per-chat operations when needed
+Patterns worth grepping across the dump: `xmlns:` for namespaces, `action:` for action attributes, `smax("tag", { attrs })` for node construction.
 
-6. **Add ergonomic API last**
-   - Once the protocol is stable, add Rust builders, enums, and result types
-   - Expose via `src/features/mod.rs` and re-export in `src/lib.rs`
+## Reading evidence honestly
 
-7. **Test and verify**
-   - Run `cargo fmt`, `cargo clippy --all-targets`, and `cargo test --all`
-   - Use logging to compare with WhatsApp Web traffic where applicable
+Reading the JS gives you a hypothesis. If a capture yields an algorithm — a hash, a key derivation, a constant — run it against real captured data and report the hit rate against chance before building on it. "6 of 113 matched, 0.012 expected by chance" is evidence; "the code says md5" is a reading.
 
-## Protocol Architecture
+## Which crate
 
-For implementing `ProtocolNode`, `IqSpec`, derive macros, and node parsing patterns, read `agent_docs/protocol_architecture.md`.
+- **wacore** — protocol logic, state traits, crypto helpers, data models. Platform-agnostic: it also builds for wasm32 and ESP32.
+- **whatsapp-rust** — runtime orchestration, storage, user-facing API.
+- **waproto** — protobuf structures only.
 
-## Reverse Engineering Reference
+If a feature seems to need Tokio inside `wacore`, the split is wrong: the runtime-dependent half belongs in `whatsapp-rust`.
 
-The `docs/captured-js/` directory contains captured WhatsApp Web JavaScript. Use these to verify protocol implementations:
+## Order of construction
 
-**Key patterns to look for:**
-- `xmlns: "namespace"` - IQ namespaces
-- `action: "value"` - Action attributes
-- `smax("tag", { attrs })` - Node construction
-- Module names like `WASmaxOutBlocklists*` - Outgoing request builders
-- Module names like `WASmaxInBlocklists*` - Incoming response parsers
+Build the smallest builder that round-trips against the real server, and parse the response path before adding options or convenience. An ergonomic API built on an unverified stanza shape has to be rebuilt. Logging the client's own traffic next to a WA Web capture is the cheapest confirmation you get.
 
-## Quick Structure Guide
+## Map
 
-- **Protocol entry points**: `src/send.rs`, `src/message.rs`, `src/socket/`, `src/handshake.rs`
-- **Feature modules**: `src/features/`
-- **State + storage**: `src/store/` + `PersistenceManager`
-- **Core protocol & crypto**: `wacore/`
-- **Protobufs**: `waproto/`
+- Protocol entry points: `src/send.rs`, `src/message.rs`, `src/socket/`, `src/handshake.rs`
+- Feature modules: `src/features/`
+- State and storage: `src/store/` + `PersistenceManager`
+- Core protocol and crypto: `wacore/`
+- Protobufs: `waproto/`

--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -1,0 +1,52 @@
+# Noise handshake
+
+Three Noise patterns coexist, mirroring WA Web's `WAWebOpenChatSocket`.
+
+| Pattern | When | State machine | Cost |
+| --- | --- | --- | --- |
+| **XX** | First connect / pairing / forced fallback | `XxHandshakeState` | 1.5 RTT |
+| **IK** | Reconnect with a valid cached `serverStaticPub` | `IkHandshakeState` | 1 RTT, ships 0-RTT login payload |
+| **XXfallback** | Server rejects an in-flight IK (reply has `static != null`) | `XxFallbackHandshakeState` | 1 RTT, reuses the already-sent ephemeral |
+
+## Selection (`src/handshake.rs::select_pattern`)
+
+```text
+ik_failures >= 1  ───────────────────────────────────────► XX
+no cached server_cert_chain ─────────────────────────────► XX
+leaf.not_after < now OR intermediate.not_after < now ────► XX
+otherwise ──────────────────────────────────────────────► IK with leaf.key
+```
+
+`Client.ik_handshake_failures: AtomicU32` is per-process and deliberately not persisted, matching WA Web's `K = 0` reset on process start.
+
+## Invalidation policy
+
+| Error | `ik_handshake_failures` | `server_cert_chain` |
+| --- | --- | --- |
+| Transient (timeout, disconnect, transport) | unchanged | unchanged |
+| Crypto-fatal during IK (cert MAC, decrypt, proto) | `+= 1` | cleared via `DeviceCommand::ClearServerCertChain` |
+| XX or XX-fallback failure | unchanged | unchanged (XX never reads the cache) |
+| Any successful handshake | reset to `0` | repopulated (XX, XX-fallback) or kept (IK Continue) |
+
+The split is `HandshakeError::is_transient()` vs `is_crypto_fatal()`. Misclassifying either way is the failure mode to watch for: too eager and the client oscillates back to XX for nothing, too lax and it loops on a stale cache.
+
+## Persisted state
+
+`Device.server_cert_chain` holds `CachedServerCertChain { intermediate, leaf }`, each cert reduced to `{ key: [u8; 32], not_before: i64, not_after: i64 }` — the same fields WA Web writes in `PrefsInfoStore.js:setCertificateChain`.
+
+`verify_server_cert` checks structural shape, the issuer-serial pin, the chain link, and that `leaf.key` matches the decrypted Noise static. Ed25519 signature verification against `WA_CERT_PUB_KEY` is intentionally skipped — it would break the e2e mock server, and whatsmeow takes the same posture. The constant staying unused is deliberate.
+
+## Logs
+
+These lines mirror WA Web's `[socket]` output, which makes a captured session and a local run directly comparable:
+
+```text
+[socket] doFullHandshake: openChatSocket send hello
+[socket] resumeNoiseHandshake started
+[socket] resumeNoiseHandshake send hello
+[socket] resumeNoiseHandshake rcv hello
+[socket] resumeNoiseHandshake deriving secrets
+[socket] resumeNoiseHandshake failed: serverStaticCiphertext not null —
+  doFallbackHandshake continuing handshake with given server hello
+[socket] continueFullHandshakeCore client finish and deriving secrets
+```

--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -11,11 +11,14 @@ Three Noise patterns coexist, mirroring WA Web's `WAWebOpenChatSocket`.
 ## Selection (`src/handshake.rs::select_pattern`)
 
 ```text
-ik_failures >= 1  ───────────────────────────────────────► XX
+device not registered ───────────────────────────────────► XX
+ik_failures >= IK_FAILURE_THRESHOLD ─────────────────────► XX
 no cached server_cert_chain ─────────────────────────────► XX
-leaf.not_after < now OR intermediate.not_after < now ────► XX
+now outside [not_before, not_after) of leaf OR intermediate ► XX
 otherwise ──────────────────────────────────────────────► IK with leaf.key
 ```
+
+Both ends of the validity window are checked on both certs: `not_after` is ordinary expiry, `not_before` catches backwards clock skew. The unregistered gate exists for legacy databases written before the registration gate, which can hold a cached chain that IK must refuse.
 
 `Client.ik_handshake_failures: AtomicU32` is per-process and deliberately not persisted, matching WA Web's `K = 0` reset on process start.
 
@@ -34,7 +37,9 @@ The split is `HandshakeError::is_transient()` vs `is_crypto_fatal()`. Misclassif
 
 `Device.server_cert_chain` holds `CachedServerCertChain { intermediate, leaf }`, each cert reduced to `{ key: [u8; 32], not_before: i64, not_after: i64 }` — the same fields WA Web writes in `PrefsInfoStore.js:setCertificateChain`.
 
-`verify_server_cert` checks structural shape, the issuer-serial pin, the chain link, and that `leaf.key` matches the decrypted Noise static. Ed25519 signature verification against `WA_CERT_PUB_KEY` is intentionally skipped — it would break the e2e mock server, and whatsmeow takes the same posture. The constant staying unused is deliberate.
+`verify_server_cert` checks structural shape, the issuer-serial pin against `WA_CERT_ISSUER_SERIAL`, the chain link (the leaf's issuer serial must equal the intermediate's serial), that `leaf.key` equals the decrypted Noise static, and **both XEdDSA signatures**: the intermediate's over `WA_CERT_PUB_KEY`, then the leaf's over the intermediate's key.
+
+Signature verification is bypassed only under `cfg(test)` and the `danger-skip-cert-chain-verify` feature, which exist so callers can drive the surrounding code against zero-signed fixtures — `tests/e2e` enables the feature because the mock server does not sign its chain. **Production builds verify.** If you are changing this path, `wacore/noise/tests/cert_chain_verify.rs` is compiled with `#![cfg(not(feature = "danger-skip-cert-chain-verify"))]` precisely so the real path keeps coverage.
 
 ## Logs
 

--- a/agent_docs/protocol_architecture.md
+++ b/agent_docs/protocol_architecture.md
@@ -1,187 +1,52 @@
-# Type-Safe Protocol Node Architecture
+# Protocol node architecture
 
-All protocol stanza builders use the declarative, type-safe pattern defined in `wacore/src/iq/`. This architecture provides compile-time safety, validation, and clear separation between request building and response parsing.
+Stanza builders and parsers live in `wacore/src/iq/`. Read this before adding a request type; the canonical worked examples are `wacore/src/iq/groups.rs` (rich: newtypes, nested children, enums) and `wacore/src/iq/blocklist.rs` (small).
 
-## Core Traits
+## The two traits
 
-### `ProtocolNode` (`wacore/src/protocol.rs`)
+- `ProtocolNode` (`wacore/src/protocol/mod.rs`) maps a struct to a node.
+- `IqSpec` (`wacore/src/iq/spec.rs`) pairs a request with its typed response.
 
-Maps Rust structs to WhatsApp protocol nodes:
+Both carry doc comments on every method; read the source rather than a copy here.
 
-```rust
-pub trait ProtocolNode: Sized {
-    fn tag(&self) -> &'static str;
-    fn into_node(self) -> Node;
-    fn try_from_node(node: &Node) -> Result<Self>;
-}
-```
+Non-obvious parts:
 
-### `IqSpec` (`wacore/src/iq/spec.rs`)
+- **`try_from_node_ref(&NodeRef<'_>)` is the canonical parse path**, not the owned `try_from_node`. The owned form is a defaulted convenience that borrows and delegates. Implement and call the ref form.
+- **`IqSpec` has an optional encode fast path** that writes the `<iq>` stanza straight into a pre-sized buffer and skips the `Node` intermediate. Returning `false` falls back to `build_iq()` + marshal, so it is safe to leave unimplemented — but do not add a second hand-rolled encoder next to it.
+- **Constructors take `&Jid`**, never `Jid`, so callers are not forced to clone.
 
-Pairs IQ requests with their typed responses:
+## Derive macros
 
-```rust
-pub trait IqSpec {
-    type Response;
-    fn build_iq(&self) -> InfoQuery<'static>;
-    fn parse_response(&self, response: &Node) -> Result<Self::Response>;
-}
-```
+`wacore` re-exports exactly three, from `wacore-derive`:
 
-## Derive Macros (Recommended)
+| Derive | For |
+| --- | --- |
+| `EmptyNode` | Nodes that are only a tag |
+| `ProtocolNode` | Nodes with attributes and children |
+| `WireEnum` | Every protocol enum |
 
-Use the derive macros from `wacore-derive` (re-exported via `wacore`):
+`StringEnum` is **not** a derive — it is an internal attribute kind inside the `ProtocolNode` derive. Protocol enums use `WireEnum`.
 
-```rust
-use wacore::{ProtocolNode, EmptyNode, StringEnum};
+### `WireEnum` modes
 
-// Empty node (tag only)
-#[derive(EmptyNode)]
-#[protocol(tag = "participants")]
-pub struct ParticipantsRequest;
+The `#[wire = ...]` attribute is the single source of truth for a variant's wire value. Do not also derive serde or add `#[serde(rename_all)]` on these types — the derive owns both directions.
 
-// Node with string attributes
-#[derive(ProtocolNode)]
-#[protocol(tag = "query")]
-pub struct QueryRequest {
-    #[attr(name = "request", default = "interactive")]
-    pub request_type: String,
-}
+- **unit-string** (default) — `#[wire = "block"]` per variant.
+- **int** — `#[wire(kind = "int")]` on the enum, `#[wire = 3]` per variant.
+- **tagged with payload** — `#[wire(tag = "type")]` on the enum. Fields accept `#[wire_alias = "..."]` and `#[wire(skip)]`; `#[wire_fallback]` marks the catch-all variant, `#[wire_default]` the default.
 
-// Enum with string representations
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
-pub enum BlocklistAction {
-    #[str = "block"]
-    Block,
-    #[str = "unblock"]
-    Unblock,
-}
-```
+Tagged mode generates a sibling `<Name>Tag` enum. **Parsers must dispatch through `<Name>Tag::try_from(node.tag.as_ref())`** instead of matching string literals, so renaming a wire tag stays a single-attribute change. The generator is `wacore/derive/src/lib.rs`.
 
-**Available derive macros:**
-- `EmptyNode` - For nodes with only a tag (no attributes)
-- `ProtocolNode` - For nodes with string attributes
-- `StringEnum` - For enums with string representations (generates `as_str()`, `Display`, `TryFrom<&str>`, `Default`)
+The declarative `define_empty_node!` / `define_simple_node!` macros in `wacore/src/protocol/mod.rs` predate the derives. Do not reach for them in new code.
 
-For enums where the default should not be the first variant, use `#[string_default]`.
+## Parsing helpers
 
-### Legacy Declarative Macros
+`wacore/src/iq/node.rs` holds crate-internal helpers: `required_child`, `optional_child`, `required_attr`, `optional_attr`, `collect_children`, `extract_content_bytes`, `extract_content_uint`. They exist so error messages about missing tags and attributes stay uniform — prefer them over open-coding `get_optional_child` with a bespoke `anyhow!`.
 
-Prefer derive macros for new code. Declarative macros in `wacore/src/protocol.rs` (`define_empty_node!`, `define_simple_node!`) are also available but considered legacy.
+## Validated newtypes
 
-## Implementation Pattern
+Protocol limits belong in the type, not in a check at the call site. `GroupSubject` in `wacore/src/iq/groups.rs` is the pattern. The limits themselves (`GROUP_SUBJECT_MAX_LENGTH`, `GROUP_DESCRIPTION_MAX_LENGTH`, `GROUP_SIZE_LIMIT`) come from WhatsApp Web's A/B props registry — confirm one against the registry before changing it, in one command; see `wa_web_reference.md`.
 
-1. Define request struct with `ProtocolNode` (or derive macro)
-2. Define response struct with `ProtocolNode`
-3. Create `IqSpec` implementation pairing them
-4. Use `client.execute(Spec::new(&jid)).await?` in feature code
+## File layout
 
-See `wacore/src/iq/groups.rs` and `wacore/src/iq/blocklist.rs` for complete examples.
-
-## IQ Executor
-
-Use `Client::execute()` for simplified IQ request/response handling:
-
-```rust
-// Single call replaces manual build + send + parse
-let response = client.execute(GroupQueryIq::new(&jid)).await?;
-```
-
-**API Design Note**: IqSpec constructors should take `&Jid` (not `Jid`) to avoid forcing callers to clone.
-
-## Node Parsing Helpers
-
-Use helpers from `wacore/src/iq/node.rs`:
-
-```rust
-use crate::iq::node::{required_child, required_attr, optional_attr, optional_jid};
-
-fn try_from_node(node: &Node) -> Result<Self> {
-    let id = required_attr(node, "id")?;
-    let name = optional_attr(node, "name");
-    let jid = optional_jid(node, "jid")?;
-    let child = required_child(node, "group")?;
-}
-```
-
-## Validated Newtypes
-
-Use newtypes to enforce protocol constraints at compile time. See `GroupSubject` in `wacore/src/iq/groups.rs` for examples.
-
-Constants from WhatsApp Web A/B props:
-- `GROUP_SUBJECT_MAX_LENGTH`: 100 characters
-- `GROUP_DESCRIPTION_MAX_LENGTH`: 2048 characters
-- `GROUP_SIZE_LIMIT`: 257 participants
-
-## File Organization
-
-```text
-wacore/src/iq/
-├── mod.rs          # Re-exports
-├── spec.rs         # IqSpec trait definition
-├── node.rs         # Helper functions
-├── groups.rs       # Group types + IqSpec impls
-└── blocklist.rs    # Blocklist types + IqSpec impls
-```
-
-Each feature file contains: constants, enums (`StringEnum`), request/response structs (`ProtocolNode`), `IqSpec` impls, and unit tests.
-
-## Noise Handshake Patterns
-
-Three Noise patterns coexist, mirroring WA Web's `WAWebOpenChatSocket`:
-
-| Pattern        | When                                                          | State machine               | Cost                              |
-| -------------- | ------------------------------------------------------------- | --------------------------- | --------------------------------- |
-| **XX**         | First connect / pairing / forced fallback                     | `XxHandshakeState`          | 1.5 RTT                           |
-| **IK**         | Reconnect with valid cached `serverStaticPub`                 | `IkHandshakeState`          | 1 RTT, ships 0-RTT login payload  |
-| **XXfallback** | Server rejects in-flight IK (reply has `static != null`)      | `XxFallbackHandshakeState`  | 1 RTT (reuses already-sent eph.)  |
-
-### Selection (`src/handshake.rs::select_pattern`)
-
-```text
-ik_failures >= 1  ───────────────────────────────────────► XX
-no cached server_cert_chain ─────────────────────────────► XX
-leaf.not_after < now OR intermediate.not_after < now ────► XX
-otherwise ──────────────────────────────────────────────► IK with leaf.key
-```
-
-The counter `Client.ik_handshake_failures: AtomicU32` is per-process and
-not persisted (matches WA Web's `K = 0` reset on process start).
-
-### Invalidation policy
-
-| Error                                              | `ik_handshake_failures` | `server_cert_chain`                              |
-| -------------------------------------------------- | ----------------------- | ------------------------------------------------ |
-| Transient (timeout, disconnect, transport)         | unchanged               | unchanged                                        |
-| Crypto-fatal during IK (cert MAC, decrypt, proto)  | `+= 1`                  | cleared via `DeviceCommand::ClearServerCertChain`|
-| XX or XX-fallback failure                          | unchanged               | unchanged (XX never reads the cache)             |
-| Any successful handshake                           | reset to `0`            | repopulated (XX, XX-fallback) or kept (IK Continue)|
-
-Distinguishing transient from crypto-fatal is via `HandshakeError::is_transient()`
-and `HandshakeError::is_crypto_fatal()`. Getting the classification wrong leads
-to either oscillating back to XX needlessly or looping on a stale cache.
-
-### Persisted state (`Device.server_cert_chain`)
-
-`CachedServerCertChain { intermediate, leaf }` with each cert reduced to
-`{ key: [u8; 32], not_before: i64, not_after: i64 }`. Mirrors the
-storage layout WA Web uses in `PrefsInfoStore.js:setCertificateChain` —
-only those fields end up on disk.
-
-`verify_server_cert` checks structural shape, the issuer-serial pin, the
-chain link, and that `leaf.key` matches the decrypted Noise static.
-Ed25519 signature verification against `WA_CERT_PUB_KEY` is intentionally
-skipped (would break the e2e mock server). Same posture as whatsmeow.
-
-### Logs (matching WA Web's `[socket]` lines)
-
-```text
-[socket] doFullHandshake: openChatSocket send hello
-[socket] resumeNoiseHandshake started
-[socket] resumeNoiseHandshake send hello
-[socket] resumeNoiseHandshake rcv hello
-[socket] resumeNoiseHandshake deriving secrets
-[socket] resumeNoiseHandshake failed: serverStaticCiphertext not null —
-  doFallbackHandshake continuing handshake with given server hello
-[socket] continueFullHandshakeCore client finish and deriving secrets
-```
+One file per feature under `wacore/src/iq/`, each holding its constants, enums, request/response structs, `IqSpec` impls, and unit tests. `mod.rs` re-exports, `spec.rs` and `node.rs` are shared infrastructure.

--- a/agent_docs/wa_web_reference.md
+++ b/agent_docs/wa_web_reference.md
@@ -14,7 +14,7 @@ Before adding or changing protocol logic, check it against what the official cli
 This repo already vendors parts of it — `wacore/src/iq/mex_operations.rs` is copied verbatim from `generated/mex/operations.rs`, and the protobuf and app-state work came from the same place. Refreshing a vendored file is a `cp`.
 
 ```sh
-git clone https://github.com/oxidezap/whatspec   # locally: ~/projects/wa-forge
+git clone https://github.com/oxidezap/whatspec
 cd whatspec
 
 ./scripts/regen.sh                      # offline: rebuild generated/ from pinned bundles and verify it
@@ -43,8 +43,9 @@ Each has a JSON Schema under `generated/schema/`.
 
 ### Queries that work
 
+Run these from the checkout's `generated/` directory:
+
 ```sh
-cd ~/projects/wa-forge/generated
 
 # Which group requests does WA Web build?
 jq -r '.stanzas[] | select(.namespace=="w:g2") | .exportedFunction' iq/index.json

--- a/agent_docs/wa_web_reference.md
+++ b/agent_docs/wa_web_reference.md
@@ -1,0 +1,89 @@
+# Checking an implementation against real WhatsApp Web
+
+Before adding or changing protocol logic, check it against what the official client actually does. There are two sources, and the cheap one comes first.
+
+| Source | Use it for |
+| --- | --- |
+| **whatspec IR** — `generated/*/index.json` | Structured, queryable answers: does this stanza exist, what attributes does it carry, what is this enum's wire value, what is this limit |
+| **Raw bundle** — `docs/captured-js/` | Everything the extractor doesn't model: control flow, ordering, retry policy, when a request is sent at all |
+
+## whatspec
+
+[`oxidezap/whatspec`](https://github.com/oxidezap/whatspec) parses the WhatsApp Web JS bundle with an `oxc` AST and emits a language-neutral IR: IQ stanzas, protobuf schemas, GraphQL persisted operations, app-state actions, feature flags, wire enums, notification dispatch, binary-protocol token dictionaries. The IR is the contract; the committed Rust modules are a reference consumer.
+
+This repo already vendors parts of it — `wacore/src/iq/mex_operations.rs` is copied verbatim from `generated/mex/operations.rs`, and the protobuf and app-state work came from the same place. Refreshing a vendored file is a `cp`.
+
+```sh
+git clone https://github.com/oxidezap/whatspec   # locally: ~/projects/wa-forge
+cd whatspec
+
+./scripts/regen.sh                      # offline: rebuild generated/ from pinned bundles and verify it
+cargo run --release -p whatspec -- update    # fetch the current bundle and regenerate
+cargo run --release -p whatspec -- diff old-generated/ generated/   # what a WA version bump changed
+```
+
+`generated/` is committed, so **reading the IR needs no build at all** — clone and query the JSON. `generated/manifest.json` stamps the WhatsApp version, per-domain counts, content hashes, and extraction diagnostics.
+
+### Domains
+
+| Domain | Answers |
+| --- | --- |
+| `iq` | Every `<iq>` request builder and response parser, per namespace |
+| `stanza`, `srvreq`, `incoming` | Non-IQ outgoing stanzas, server requests, incoming stanza shapes |
+| `notif` | `<notification type="…">` kinds, their handlers, and typed content |
+| `proto` | `WAProto.proto` — diff against `waproto/` |
+| `mex` | Relay/GraphQL persisted operations: doc id, kind, typed variables and response |
+| `appstate` | App-state (syncd) action schemas and their indexing |
+| `abprops` | ~2400 A/B feature flags: name, code, type, default. Where protocol limits actually live |
+| `enums` | Wire-enum catalog — nack codes, chat and receipt types |
+| `tokens` | Binary-protocol token dictionaries (single-byte + double-byte) |
+| `wam` | Client telemetry event schemas |
+
+Each has a JSON Schema under `generated/schema/`.
+
+### Queries that work
+
+```sh
+cd ~/projects/wa-forge/generated
+
+# Which group requests does WA Web build?
+jq -r '.stanzas[] | select(.namespace=="w:g2") | .exportedFunction' iq/index.json
+
+# The exact request shape — tags, attrs, which are required, which are constants
+jq '.stanzas[] | select(.exportedFunction=="makeGetLinkedGroupRequest") | .request' iq/index.json
+
+# What the official parser reads out of the response, with wire names and types
+jq '.stanzas[] | select(.exportedFunction=="makeGetLinkedGroupRequest") | .response.fields' iq/index.json
+
+# A wire enum's real values
+jq '.enums[] | select(.name=="…") | .variants' enums/index.json
+
+# A protocol limit, straight from the flag registry
+jq -r '.configs[] | select(.name|test("group.*(size|subject|description)";"i")) | "\(.name) = \(.default)"' abprops/index.json
+
+# Notification types and their handlers
+jq -r '.notifications[] | "\(.type) -> \(.handlerFunction)"' notif/index.json
+```
+
+### A worked check
+
+`wacore/src/iq/groups.rs` declares `GROUP_SUBJECT_MAX_LENGTH = 100`, `GROUP_DESCRIPTION_MAX_LENGTH = 2048`, `GROUP_SIZE_LIMIT = 257`. The registry gives `group_max_subject = 100`, `group_description_length = 2048`, `group_size_limit = 257`. Three for three — the constants are confirmed, not folklore, and the next person to doubt them has a one-line command instead of an argument.
+
+That is the shape of a good check: name the value in our code, name the field in the IR, report the comparison. A mismatch is a finding either way — our bug, or a WhatsApp change worth a PR note.
+
+## Where the IR is not the truth
+
+The extractor is a static analysis of minified code, and it says so in the manifest — `diagnostics` carries per-domain `unparseable`, `degradedResponses`, and drop reasons. Check them before concluding a stanza doesn't exist.
+
+Known sharp edges:
+
+- **Generated `Response` types are heuristic mirrors, not safe deserialize targets.** They carry no enums and type some string fields as numbers, so `serde_json::from_value` breaks on real payloads. Take the typed *input* (`Variables`); parse the output in a domain layer. This is why `NewsletterMetadata` and friends parse `data: serde_json::Value` by hand.
+- **One-of objects flatten to `String`.** `update_group_property`'s `update` field is the known case; `GroupPropertyUpdate` in `src/features/groups.rs` corrects it and a wire-shape test locks it.
+- **`waVersion` moves.** A doc id or default that matched last month may not match today; `whatspec diff` is how you tell a real change from a stale memory.
+- **The IR describes shape, never sequencing.** Whether a request is sent eagerly, retried, debounced, or gated on a flag is control flow — that lives in the bundle.
+
+## Falling back to the bundle
+
+`docs/captured-js/` is the raw dump (untracked, local). Navigation and grep patterns are in `feature_implementation.md`. Go there when the IR is silent, degraded, or when the question is *when* rather than *what*.
+
+Either way, reading gives you a hypothesis. If the answer is an algorithm — a hash, a derivation, a constant — run it against real captured data and report the hit rate against chance before building on it.

--- a/agent_docs/wa_web_reference.md
+++ b/agent_docs/wa_web_reference.md
@@ -9,7 +9,7 @@ Before adding or changing protocol logic, check it against what the official cli
 
 ## whatspec
 
-[`oxidezap/whatspec`](https://github.com/oxidezap/whatspec) parses the WhatsApp Web JS bundle with an `oxc` AST and emits a language-neutral IR: IQ stanzas, protobuf schemas, GraphQL persisted operations, app-state actions, feature flags, wire enums, notification dispatch, binary-protocol token dictionaries. The IR is the contract; the committed Rust modules are a reference consumer.
+[`oxidezap/whatspec`](https://github.com/oxidezap/whatspec) parses the WhatsApp Web JS bundle with an `oxc` AST and emits a language-neutral IR: IQ stanzas, protobuf schemas, GraphQL persisted operations, app-state actions, feature flags, wire enums, notification dispatch, binary-protocol token dictionaries. The IR is a derived model of the contract — a static reading of minified code, not the contract itself — and the committed Rust modules are one consumer of that model. Treat it as high-quality evidence, not as a specification; the limits are spelled out below.
 
 This repo already vendors parts of it — `wacore/src/iq/mex_operations.rs` is copied verbatim from `generated/mex/operations.rs`, and the protobuf and app-state work came from the same place. Refreshing a vendored file is a `cp`.
 

--- a/agent_docs/wa_web_reference.md
+++ b/agent_docs/wa_web_reference.md
@@ -86,4 +86,4 @@ Known sharp edges:
 
 `docs/captured-js/` is the raw dump (untracked, local). Navigation and grep patterns are in `feature_implementation.md`. Go there when the IR is silent, degraded, or when the question is *when* rather than *what*.
 
-Either way, reading gives you a hypothesis. If the answer is an algorithm — a hash, a derivation, a constant — run it against real captured data and report the hit rate against chance before building on it.
+Either way, reading gives you a hypothesis, not a fact. Validating one against a real capture — and keeping that capture's contents out of tests, commits, and PR bodies — is covered under "Reading evidence honestly" in `feature_implementation.md`.


### PR DESCRIPTION
## Summary

The docs under `agent_docs/` had drifted into asserting things the code does not do. That is worse than being verbose: an agent that trusts a stale doc writes wrong code confidently, and the doc is the one source it has no way to check against. This pass verifies every factual claim against the tree, restructures the entry point around progressive disclosure, and adds a doc for the thing that was missing entirely — how to check an implementation against real WhatsApp Web.

## Corrections

Each of these was confirmed by reading the current code, not by memory:

- **`message_enqueue_locks` and `Client::chat_locks` do not exist.** `AGENTS.md` named the first, `feature_implementation.md` told you to use the second. Incoming per-chat serialization is `chat_lanes` / `ChatLane::enqueue_lock` in `src/client.rs`; `session_locks` covers Signal operations per protocol address.
- **`StringEnum` is not a derive.** `protocol_architecture.md` listed it under "Available derive macros". It is an internal `AttrType` inside the `ProtocolNode` derive, has zero uses as a derive, and recommending it contradicted the `WireEnum` policy stated one file away. A contradiction between two context layers is the most expensive kind of documentation bug.
- **The canonical parse path is `try_from_node_ref(&NodeRef)`**, not the owned `try_from_node` the doc showed as the trait method.
- **Nibble coding lives in `encoder.rs`/`decoder.rs`.** `debugging.md` pointed at a `wacore/binary/src/nibble.rs` that does not exist.
- **The e2e file listing named 13 of the 26 test files.** A directory tree in a doc cannot stay true, so it is gone — `ls` does that job.

## Structure

`AGENTS.md` now holds the repo shape and the gotchas — things that look correct and are not — and routes to one doc per area with an explicit "read it when". Three of the eleven docs (`voip_audio_codecs.md` among them) were previously unreachable from it.

- The Noise handshake section moved out of the protocol-node doc into `agent_docs/noise_handshake.md`. Someone adding an IQ spec should not page in 60 lines of handshake state machine.
- `feature_implementation.md` dropped the parts that restated `AGENTS.md` and kept what is specific: navigating the captured bundle.
- The "never synchronize on a fixed sleep" rule appeared four times in `e2e_testing.md`. It appears once.

## New: `agent_docs/wa_web_reference.md`

Protocol work in this repo lives or dies on matching the official client, and there was no doc explaining how to actually check that. This one covers querying the [whatspec](https://github.com/oxidezap/whatspec) IR first — stanza shapes, wire enums, protocol limits, notification dispatch, all as queryable JSON — and falling back to the raw bundle when the question is about control flow rather than shape.

Every `jq` recipe in it was run against a live `generated/` tree rather than written from the schema. The worked example checks the three group limits in `wacore/src/iq/groups.rs` against the A/B props registry: `group_max_subject = 100`, `group_description_length = 2048`, `group_size_limit = 257`, three for three. The constants are confirmed rather than folklore, and the next person to doubt them has a one-line command instead of an argument.

It also documents where the IR is not the truth: generated `Response` types are heuristic mirrors that break `serde_json::from_value`, one-of objects flatten to `String` (the `update_group_property` case we already correct by hand), and `waVersion` moves under you.

## Validation

Docs only — no code changes. Link check across `AGENTS.md`, `agent_docs/`, and `README.md` passes with no broken references; every file path, symbol, trait method, cargo feature, and constant cited in the changed docs was grepped for before it was written. Full matrix left to CI.
