### PR TITLE
ci: skip the mock-server jobs on fork PRs instead of failing their template

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -91,6 +91,11 @@ jobs:
   # separate job so the unit-bench job above stays fast and mock-server-free.
   integration-benchmarks:
     name: Run CodSpeed integration benchmarks
+    # Fork PRs get no secrets, so they can't pull the private mock-server image.
+    # `credentials.password` rejects the empty string while the job template is
+    # being prepared, so the job fails before any step runs and a step-level
+    # `if:` cannot save it — the guard has to sit here. Same condition as e2e.yml.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-24.04
     # These benches drive the real client (connect/reconnect handshakes) under
     # Valgrind, so they are slow; cap the job so a stuck run can't hang CI
@@ -101,7 +106,12 @@ jobs:
       id-token: write # for OpenID Connect authentication with CodSpeed
     services:
       mock-server:
-        image: ghcr.io/whiskeysockets-devtools/bartender:latest
+        # Pinned by digest, not `:latest`: send_and_receive measures a live
+        # round-trip and the mock server is the other end of it, so a tag moving
+        # under us shifts the instruction counts with no code change and
+        # pollutes the CodSpeed baseline. Same freeze rationale as the malloc
+        # thresholds above. Keep in sync with e2e.yml.
+        image: ghcr.io/whiskeysockets-devtools/bartender@sha256:975e9ce5143b56b527deea1afb5aed9423461671c546fc521473a25d1ffe26fa
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.BARTENDER_GHCR_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   copilot-setup-steps:
+    # Fork PRs get no secrets, so they can't pull the private mock-server image.
+    # Without this the job template fails to prepare (empty
+    # `credentials.password`) the first time an external contributor edits this
+    # file — the same failure codspeed.yml hit. Same condition as e2e.yml.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Every pull request opened from a fork failed `Run CodSpeed integration benchmarks` before a single step executed:

```
##[error]The template is not valid. .github/workflows/codspeed.yml (Line: 107, Col: 21): Unexpected value ''
```

GitHub does not expose repository secrets to fork-triggered workflows, so `${{ secrets.BARTENDER_GHCR_TOKEN }}` resolved to the empty string. `credentials.password` on a service container rejects an empty value, and it rejects it while the job template is being *prepared* — not at runtime. That is why the job produced no step log, and why a step-level `if:` could never have helped: the guard has to be job-level.

Fixes #1108.

## The fix was already in the repository

`.github/workflows/e2e.yml:28` guards the identical service block with a job-level condition. That is the whole reason `E2E Tests` reported **skipped** on the same fork PRs (#1104, #1107) where the integration benchmarks reported **failed** — one workflow had the guard and the other did not. This applies the same condition to `integration-benchmarks`, turning a red check into an honest skip: the benchmark genuinely cannot run without the mock server, and fork PRs already had no integration-benchmark coverage. They were getting a failure in place of a skip, not losing anything real.

`copilot-setup-steps.yml` carried the same unguarded service block. It only triggers on changes to itself, so it is quiet today, but it would have failed identically the first time an external contributor touched that file. Guarded too, rather than left as a tripwire.

I deliberately did not reach for `pull_request_target`. It would make the secrets available, but it runs with the base repository's permissions against fork-authored code — not a trade worth making for a benchmark job. Making the mock-server image public would be the strictly better outcome, since it would let fork PRs actually run the benchmarks instead of skipping them, but that is a decision for `whiskeysockets-devtools` and is not blocked by this change.

## Also: pinning the mock server by digest

`codspeed.yml` pulled `bartender:latest` while `e2e.yml` pins the digest. That asymmetry matters more for the benchmark than for the test. `send_and_receive` measures a live round-trip and the mock server is the other end of it, so a tag moving under us shifts the instruction counts with no code change — drift that lands silently in the CodSpeed baseline and then reads as a regression on some unrelated PR. This pins the same digest `e2e.yml` already uses (`@sha256:975e9ce…`), for the same reason the workflow already freezes the glibc malloc thresholds a few lines above: a deterministic instrument is only as reproducible as its environment.

`copilot-setup-steps.yml` keeps `:latest`. It fetches dependencies and health-checks the container; nothing it does is a measurement, so a pin there would be ceremony.

## Validation

Workflow YAML only — no Rust changes. Both files parse, and the guard expression is copied verbatim from the one `e2e.yml` has been running on since it was added, so its behavior on push / internal-branch PR / fork PR is already established rather than newly asserted. The real check is the next fork PR reporting *skipped* instead of *failed*; internal branches see no change at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CooWtwqmtQ92ZVUFFZBtNW)_