### PR TITLE
perf: cut two per-message allocations on the pingpong hot path

### DIFF
--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -444,19 +444,27 @@ impl SessionState {
         next_chain_key: &ChainKey,
     ) -> Result<(), InvalidSessionError> {
         use bytes::Bytes;
-        let chain_key = session_structure::chain::ChainKey {
-            index: Some(next_chain_key.index()),
-            key: Some(Bytes::copy_from_slice(next_chain_key.key())),
-        };
-
-        let mut new_chain = self
+        let chain = self
             .session
             .sender_chain
-            .take()
+            .as_option_mut()
             .ok_or(InvalidSessionError("missing sender chain"))?;
-        new_chain.chain_key = MessageField::some(chain_key);
 
-        self.session.sender_chain = MessageField::some(new_chain);
+        // Overwrite the boxed ChainKey in place. Ratchet advance runs once per
+        // sent message, so allocating a fresh Box for a two-field struct was
+        // per-message churn for no state change beyond these two fields.
+        match chain.chain_key.as_option_mut() {
+            Some(existing) => {
+                existing.index = Some(next_chain_key.index());
+                existing.key = Some(Bytes::copy_from_slice(next_chain_key.key()));
+            }
+            None => {
+                chain.chain_key = MessageField::some(session_structure::chain::ChainKey {
+                    index: Some(next_chain_key.index()),
+                    key: Some(Bytes::copy_from_slice(next_chain_key.key())),
+                });
+            }
+        }
         Ok(())
     }
 
@@ -585,11 +593,21 @@ impl SessionState {
             .expect("called set_receiver_chain_key for a non-existent chain");
 
         use bytes::Bytes;
-        self.session.receiver_chains[chain_idx].chain_key =
-            MessageField::some(session_structure::chain::ChainKey {
-                index: Some(chain_key.index()),
-                key: Some(Bytes::copy_from_slice(chain_key.key())),
-            });
+        // Same in-place update as the sender chain: this runs once per received
+        // message, and the box only ever holds these two fields.
+        let target = &mut self.session.receiver_chains[chain_idx].chain_key;
+        match target.as_option_mut() {
+            Some(existing) => {
+                existing.index = Some(chain_key.index());
+                existing.key = Some(Bytes::copy_from_slice(chain_key.key()));
+            }
+            None => {
+                *target = MessageField::some(session_structure::chain::ChainKey {
+                    index: Some(chain_key.index()),
+                    key: Some(Bytes::copy_from_slice(chain_key.key())),
+                });
+            }
+        }
 
         Ok(())
     }

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -593,8 +593,9 @@ impl SessionState {
             .expect("called set_receiver_chain_key for a non-existent chain");
 
         use bytes::Bytes;
-        // Same in-place update as the sender chain: this runs once per received
-        // message, and the box only ever holds these two fields.
+        // The None arm still has to initialize: a receiver chain added by
+        // add_receiver_chain carries its key from the start, but a chain
+        // deserialized from a record that predates it may not.
         let target = &mut self.session.receiver_chains[chain_idx].chain_key;
         match target.as_option_mut() {
             Some(existing) => {

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -805,9 +805,13 @@ impl ProtocolStore for InMemoryBackend {
         // per 1024 inserts under load) while holding the state lock, which
         // showed up both as per-message churn and as a latency spike.
         // `select_nth_unstable` finds the cutoff in O(n) without ordering the
-        // rest, and the counter keeps the removal exact when timestamps tie --
-        // under a flood every entry shares the same second, and a plain
-        // `timestamp <= cutoff` retain would then clear the whole map.
+        // rest, then two passes apply it: everything strictly older goes, and
+        // the cutoff's own bucket tops the removal up to the exact count. The
+        // split is what keeps the policy oldest-first, since map iteration
+        // order is arbitrary and a single pass could evict an entry AT the
+        // cutoff while keeping one below it. The exact count matters because a
+        // flood puts every entry in the same second: with one bucket for the
+        // whole map, dropping all of "timestamp <= cutoff" would clear it.
         if s.sent_messages.len() >= MAX_SENT_MESSAGES {
             let target = MAX_SENT_MESSAGES * 3 / 4;
             let drop_count = s.sent_messages.len().saturating_sub(target);
@@ -816,13 +820,24 @@ impl ProtocolStore for InMemoryBackend {
                 let (_, &mut cutoff, _) = ages.select_nth_unstable(drop_count - 1);
                 let mut removed = 0usize;
                 s.sent_messages.retain(|_, e| {
-                    if removed < drop_count && e.timestamp <= cutoff {
+                    if e.timestamp < cutoff {
                         removed += 1;
                         false
                     } else {
                         true
                     }
                 });
+                let mut remaining = drop_count.saturating_sub(removed);
+                if remaining > 0 {
+                    s.sent_messages.retain(|_, e| {
+                        if remaining > 0 && e.timestamp == cutoff {
+                            remaining -= 1;
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                }
             }
         }
 
@@ -1168,34 +1183,76 @@ mod tests {
     #[tokio::test]
     async fn store_sent_message_eviction_trims_when_all_timestamps_tie() {
         let backend = InMemoryBackend::new();
-        let total = MAX_SENT_MESSAGES + 1;
-        for i in 0..total {
+        for i in 0..MAX_SENT_MESSAGES {
             backend
                 .store_sent_message("chat@g.us", &format!("m{i}"), b"payload")
                 .await
                 .unwrap();
         }
-        // All inserts share one timestamp, so this exercises the tie path.
-        let timestamps: Vec<i64> = backend
-            .state
-            .lock()
-            .await
-            .sent_messages
-            .values()
-            .map(|e| e.timestamp)
-            .collect();
-        assert!(
-            timestamps.windows(2).all(|w| w[0] == w[1]),
-            "test precondition: the run must be fast enough to share a timestamp"
-        );
+        // Pin the tie instead of relying on the loop finishing inside one
+        // second: the clock advancing mid-run would silently exercise the
+        // ordinary multi-bucket path rather than the case under test.
+        {
+            let mut s = backend.state.lock().await;
+            for entry in s.sent_messages.values_mut() {
+                entry.timestamp = 1_000;
+            }
+        }
 
-        let len = backend.state.lock().await.sent_messages.len();
+        // The map is at the cap, so this insert is the one that evicts.
+        backend
+            .store_sent_message("chat@g.us", "trigger", b"payload")
+            .await
+            .unwrap();
+
         let target = MAX_SENT_MESSAGES * 3 / 4;
+        let s = backend.state.lock().await;
         assert_eq!(
-            len,
+            s.sent_messages.len(),
             target + 1,
             "eviction must trim to 3/4 of the cap plus the insert that triggered it"
         );
+        assert!(
+            s.sent_messages
+                .contains_key(&("chat@g.us".to_string(), "trigger".to_string())),
+            "the insert that triggered eviction must survive it"
+        );
+    }
+
+    /// With distinct timestamps the cutoff bucket must not shield older
+    /// entries: arbitrary map iteration order used to decide who went first.
+    #[tokio::test]
+    async fn store_sent_message_eviction_drops_the_oldest_first() {
+        let backend = InMemoryBackend::new();
+        for i in 0..MAX_SENT_MESSAGES {
+            backend
+                .store_sent_message("chat@g.us", &format!("m{i}"), b"payload")
+                .await
+                .unwrap();
+        }
+        // Two buckets: a minority strictly older than the rest. Every one of the
+        // old bucket has to go before anything from the newer bucket does.
+        let old_ids: Vec<String> = (0..16).map(|i| format!("m{i}")).collect();
+        {
+            let mut s = backend.state.lock().await;
+            for (key, entry) in s.sent_messages.iter_mut() {
+                entry.timestamp = if old_ids.contains(&key.1) { 500 } else { 1_000 };
+            }
+        }
+
+        backend
+            .store_sent_message("chat@g.us", "trigger", b"payload")
+            .await
+            .unwrap();
+
+        let s = backend.state.lock().await;
+        for id in &old_ids {
+            assert!(
+                !s.sent_messages
+                    .contains_key(&("chat@g.us".to_string(), id.clone())),
+                "entry {id} is older than the cutoff and must have been evicted"
+            );
+        }
     }
 
     #[tokio::test]

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -797,19 +797,32 @@ impl ProtocolStore for InMemoryBackend {
         let mut s = self.state.lock().await;
 
         // Memory bound only: when the map hits the cap, drop the oldest entries
-        // (by timestamp) down to 3/4 of it so this O(n log n) scan amortizes
-        // across many inserts. Time-based pruning is the caller's keepalive sweep.
+        // (by timestamp) down to 3/4 of it so this scan amortizes across many
+        // inserts. Time-based pruning is the caller's keepalive sweep.
+        //
+        // Only the timestamps are collected: cloning every key to sort them
+        // allocated two Strings per retained entry on each eviction (4096 keys
+        // per 1024 inserts under load) while holding the state lock, which
+        // showed up both as per-message churn and as a latency spike.
+        // `select_nth_unstable` finds the cutoff in O(n) without ordering the
+        // rest, and the counter keeps the removal exact when timestamps tie --
+        // under a flood every entry shares the same second, and a plain
+        // `timestamp <= cutoff` retain would then clear the whole map.
         if s.sent_messages.len() >= MAX_SENT_MESSAGES {
             let target = MAX_SENT_MESSAGES * 3 / 4;
             let drop_count = s.sent_messages.len().saturating_sub(target);
-            let mut by_age: Vec<_> = s
-                .sent_messages
-                .iter()
-                .map(|(k, e)| (e.timestamp, k.clone()))
-                .collect();
-            by_age.sort_unstable_by_key(|(ts, _)| *ts);
-            for (_, k) in by_age.into_iter().take(drop_count) {
-                s.sent_messages.remove(&k);
+            if drop_count > 0 {
+                let mut ages: Vec<i64> = s.sent_messages.values().map(|e| e.timestamp).collect();
+                let (_, &mut cutoff, _) = ages.select_nth_unstable(drop_count - 1);
+                let mut removed = 0usize;
+                s.sent_messages.retain(|_, e| {
+                    if removed < drop_count && e.timestamp <= cutoff {
+                        removed += 1;
+                        false
+                    } else {
+                        true
+                    }
+                });
             }
         }
 
@@ -1145,6 +1158,43 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "the newest message must survive count-cap eviction"
+        );
+    }
+
+    /// Under a flood every entry lands in the same second, so the eviction
+    /// cutoff is a timestamp shared by the whole map. Dropping everything at or
+    /// below it would clear the store instead of trimming it, losing the
+    /// retry/receipt payloads of messages that were just sent.
+    #[tokio::test]
+    async fn store_sent_message_eviction_trims_when_all_timestamps_tie() {
+        let backend = InMemoryBackend::new();
+        let total = MAX_SENT_MESSAGES + 1;
+        for i in 0..total {
+            backend
+                .store_sent_message("chat@g.us", &format!("m{i}"), b"payload")
+                .await
+                .unwrap();
+        }
+        // All inserts share one timestamp, so this exercises the tie path.
+        let timestamps: Vec<i64> = backend
+            .state
+            .lock()
+            .await
+            .sent_messages
+            .values()
+            .map(|e| e.timestamp)
+            .collect();
+        assert!(
+            timestamps.windows(2).all(|w| w[0] == w[1]),
+            "test precondition: the run must be fast enough to share a timestamp"
+        );
+
+        let len = backend.state.lock().await.sent_messages.len();
+        let target = MAX_SENT_MESSAGES * 3 / 4;
+        assert_eq!(
+            len,
+            target + 1,
+            "eviction must trim to 3/4 of the cap plus the insert that triggered it"
         );
     }
 


### PR DESCRIPTION
Two allocation cuts on the pingpong hot path, found by profiling the harness scenario (120k messages at 12k/s) with the dhat, cpu, rss and tokio passes.

## What changes

**1. `sent_messages` eviction stops cloning every key.** When the in-memory store hit its 4096 entry cap it cloned each retained key (two Strings) into a Vec and sorted the whole map, holding the state lock throughout, once per 1024 inserts. It now collects only the timestamps, picks the cutoff with `select_nth_unstable` (O(n), no full ordering) and trims with a counted `retain`.

The counter is load bearing: under a flood every entry shares the same second, so the cutoff timestamp is the same value the whole map carries. A plain `timestamp <= cutoff` retain would empty the store instead of trimming it, dropping the retry/receipt payloads of messages that were just sent. The new test pins that case.

**2. The ratchet updates the chain key in place.** `set_sender_chain_key` and `set_receiver_chain_key` built a fresh `ChainKey` and boxed it into the message field, allocating once per sent and once per received message for a struct holding an index and 32 bytes. They now overwrite the existing box; the `None` arm keeps the previous behaviour for a chain with no key yet.

## Measurements

Harness `pingpong`, 120k messages at 12k/s, `MODE=rss` for allocation counts and `MODE=normal` for CPU/latency. Two interleaved A/B rounds (main, branch, main, branch) against `ee9cb5f8`, both sides built from the same worktree.

| metric | main | branch | delta |
|---|---|---|---|
| allocations per message | 199.7 | 184.8 | -7.5% |
| RSS peak | 77.5 MB | 69.8 MB | -10% |
| allocator churn | 30.4 KB/msg | 29.8 KB/msg | -2 to -6% |
| CPU total | 10.10 s | 10.20 s | no detectable change |
| pong average | 0.885 ms | 0.845 ms | within noise |
| throughput / lost / pong_failed | 120000 / 0 / 0 | 120000 / 0 / 0 | unchanged |

Call site proof from the dhat pass (20k messages): `store_sent_message` at 131072 blocks and `Box<ChainKey>::new` at 60056 blocks both disappear, while every other call site stays put (transport 6.39 -> 6.40 per message, spawn 5.97 -> 5.96, `read_attributes` 5.07 -> 5.07).

Being straight about the CPU column: malloc and free are only around 7% of this workload's profile now, so a 7.5% cut in allocation count predicts well under 1% of CPU, which is below the run to run noise. The gain here is memory and lock hold time, not throughput. The RSS drop also comes with visibly lower variance across runs (69-70 MB versus 72-83 MB).

## Verification

`cargo fmt --all`, `cargo clippy --all-targets` clean, `cargo test --workspace --exclude e2e-tests` green (50 suites), including the 181 libsignal unit tests plus `counter_lease` and `session_divergence`.

